### PR TITLE
Links update

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -53,11 +53,11 @@ const config = {
             type: 'doc',
             docId: 'intro',
             position: 'left',
-            label: 'Tutorial',
+            label: 'Docs',
           },
-          {to: '/blog', label: 'Blog', position: 'left'},
+          // {to: '/blog', label: 'Blog', position: 'left'},
           {
-            href: 'https://github.com/Jaseci-Labs',
+            href: 'https://github.com/Jaseci-Labs/jaseci',
             label: 'GitHub',
             position: 'right',
           },
@@ -67,41 +67,30 @@ const config = {
         style: 'dark',
         links: [
           {
-            title: 'Docs',
+            title: 'Tutorial',
             items: [
               {
-                label: 'Tutorial',
+                label: 'Docs',
                 to: '/docs/intro',
               },
             ],
           },
           {
-            title: 'Community',
+            title: 'Forum',
             items: [
               {
-                label: 'Stack Overflow',
-                href: 'https://stackoverflow.com/questions/tagged/jaseci',
+                label: 'Github Discussions',
+                href: 'https://github.com/Jaseci-Labs/jaseci/discussions',
               },
-              {
-                label: 'Discord',
-                href: 'https://discordapp.com/invite/jaseci',
-              },
-              {
-                label: 'Twitter',
-                href: 'https://twitter.com/jaseci',
-              },
+          
             ],
           },
           {
-            title: 'More',
+            title: 'Open source',
             items: [
               {
-                label: 'Blog',
-                to: '/blog',
-              },
-              {
                 label: 'GitHub',
-                href: 'https://github.com/Jaseci-Labs',
+                href: 'https://github.com/Jaseci-Labs/jaseci',
               },
             ],
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -94,6 +94,15 @@ const config = {
               },
             ],
           },
+          {
+            title: 'Official website',
+            items: [
+              {
+                label: 'Jaseci.org',
+                href: 'https://www.jaseci.org/',
+              },
+            ],
+          },
         ],
         copyright: `Copyright © ${new Date().getFullYear()} Jaseci Labs, Inc. Built with Docusaurus.`,
       },

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -17,7 +17,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            Jaseci Tutorial - 5min ⏱️
+            Get Started
           </Link>
         </div>
       </div>


### PR DESCRIPTION
# Change log

Add the following links to documentation website:

**Docs** --> /docs/intro
**GitHub** --> https://github.com/Jaseci-Labs/jaseci
**GitHub Discussions** --> https://github.com/Jaseci-Labs/jaseci/discussions
**Jaseci.org** --> https://www.jaseci.org/

See screenshot below:

![image](https://user-images.githubusercontent.com/74829200/144295721-1face813-7d6a-47a1-9d53-e73a092b1b1e.png)
