### PR TITLE
Syntax highlight update

### DIFF
--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -15,6 +15,9 @@
             "include": "#functional"
         },
         {
+            "include": "#assignment"
+        },
+        {
             "include": "#entity_block_definition"
         }
     ],
@@ -193,6 +196,28 @@
                     "name": "punctuation.definition.tag.jac"
                 }
             }
+        },
+        "assignment": {
+            "patterns": [
+                {
+                    "begin": "(^\\s|:?\\s|)(\\w+|\\w+(?:\\.\\w+)+)\\s*(=|\\+=|-=|\\+\\+|--)\\s*",
+                    "beginCaptures": {
+                        "1": {},
+                        "2": {
+                            "name": "variable.other.assignment.jac"
+                        },
+                        "3": {
+                            "name": "keyword.operator.terraform"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#functional"
+                        }
+                    ],
+                    "end": "\\n"
+                }
+            ]
         }
     },
     "scopeName": "source.jac"

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -37,7 +37,7 @@
             ]
         },
         "entity_block_definition": {
-            "begin": "^\\s*(node|walker)\\s+([A-Za-z][\\w]*)\\s*({)",
+            "begin": "^\\s*(node|walker)\\s+([A-Za-z][\\w]*)(\\s*({)|;)",
             "name": "source.jac.embedded.source",
             "beginCaptures": {
                 "1": {
@@ -50,7 +50,7 @@
                     "name": "punctuation.definition.tag.jac"
                 }
             },
-            "end": "\\s*\\}",
+            "end": "\\s*\\(}|;)",
             "endCaptures": {
                 "0": {
                     "name": "punctuation.definition.tag.prisma"

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -56,7 +56,7 @@
             "end": "\\s*\\(}|;)",
             "endCaptures": {
                 "0": {
-                    "name": "punctuation.definition.tag.prisma"
+                    "name": "punctuation.definition.tag.jac"
                 }
             }
         },
@@ -164,7 +164,7 @@
             }
         },
         "functional": {
-            "name": "source.prisma.value",
+            "name": "source.jac.value",
             "patterns": [
                 {
                     "include": "#function_calls"
@@ -190,7 +190,7 @@
             "end": "\\)",
             "endCaptures": {
                 "0": {
-                    "name": "punctuation.definition.tag.prisma"
+                    "name": "punctuation.definition.tag.jac"
                 }
             }
         }

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -26,15 +26,31 @@
             "patterns": [
                 {
                     "name": "storage.modifier.jac",
-                    "match": "\\b(import)\\b"
+                    "match": "\\b(import|ignore|with|strict|context|details|info|activity|length|keys)\\b"
                 },
                 {
-                    "match": "\\b(str|int|float|list|dict|bool|edge|digraph|subgraph|test)\\b",
+                    "match": "\\b(str|int|float|list|dict|bool|edge|digraph|subgraph|test|type)\\b",
                     "name": "support.type.jac"
                 },
                 {
                     "name": "keyword.control.jac",
-                    "match": "\\b(if|elif|else|while|for|take|ignore|skip|disengage|break|continue)\\b"
+                    "match": "\\b(if|elif|else|while|for|while|in|by|to|report|take|ignore|skip|disengage|break|continue|destroy|spawn|entry|exit|assert)\\b"
+                },
+                {
+                    "name": "keyword.operator.logical",
+                    "match": "\\b(not|and|or)\\b"
+                },
+                {
+                    "name": "variable.other.property",
+                    "match": "\\b(has|can|anchor|private)\\b"
+                },
+                {
+                    "name": "keyword.control.flow.jac",
+                    "match": "\\s*\\b(?<!\\.)(report|destroy|here|take|in)\\b(?=.*[-\\\\])"
+                },
+                {
+                    "name": "keyword.control.flow.jac",
+                    "match": "\\s*\\b(?<!\\.)(node|walker)\\b(?=.*[:\\\\])"
                 },
                 {
                     "match": "\\b(null|true|false)\\b",
@@ -167,7 +183,7 @@
             }
         },
         "functional": {
-            "name": "source.jac.value",
+            "name": "source.jac.functional",
             "patterns": [
                 {
                     "include": "#function_calls"

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -12,6 +12,9 @@
             "include": "#strings"
         },
         {
+            "include": "#functional"
+        },
+        {
             "include": "#entity_block_definition"
         }
     ],
@@ -23,7 +26,7 @@
                     "match": "\\b(import)\\b"
                 },
                 {
-                    "match": "\\b(str|int|float|list|dict|bool|edge|graph|digraph|subgraph|test)\\b",
+                    "match": "\\b(str|int|float|list|dict|bool|edge|digraph|subgraph|test)\\b",
                     "name": "support.type.jac"
                 },
                 {
@@ -37,7 +40,7 @@
             ]
         },
         "entity_block_definition": {
-            "begin": "^\\s*(node|walker)\\s+([A-Za-z][\\w]*)(\\s*({)|;)",
+            "begin": "^\\s*(node|walker|graph)\\s+([A-Za-z][\\w]*)(\\s*({)|;)",
             "name": "source.jac.embedded.source",
             "beginCaptures": {
                 "1": {
@@ -157,6 +160,37 @@
             "captures": {
                 "1": {
                     "name": "keyword.codetag.notation.jac"
+                }
+            }
+        },
+        "functional": {
+            "name": "source.prisma.value",
+            "patterns": [
+                {
+                    "include": "#function_calls"
+                }
+            ]
+        },
+        "function_calls": {
+            "name": "source.jac.functional_calls",
+            "begin": "(\\w+)(\\()",
+            "beginCaptures": {
+                "1": {
+                    "name": "support.function.functional_calls.jac"
+                },
+                "2": {
+                    "name": "punctuation.definition.tag.jac"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#functional"
+                }
+            ],
+            "end": "\\)",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.tag.prisma"
                 }
             }
         }

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -43,7 +43,7 @@
             ]
         },
         "entity_block_definition": {
-            "begin": "^\\s*(node|walker|graph)\\s+([A-Za-z][\\w]*)(\\s*({)|;)",
+            "begin": "^\\s*(node|walker|graph)\\s+([A-Za-z][\\w]*|(?:\\w+(?:(?:\\,\\s?|\\:)(?:\\w+|\\s\\w))+))(\\s*({)|;)",
             "name": "source.jac.embedded.source",
             "beginCaptures": {
                 "1": {

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -46,10 +46,12 @@
                 },
                 {
                     "name": "keyword.control.flow.jac",
+                    "comment": "Highlights 'report' et al. that preceeds a '-->'",
                     "match": "\\s*\\b(?<!\\.)(report|destroy|here|take|in)\\b(?=.*[-\\\\])"
                 },
                 {
                     "name": "keyword.control.flow.jac",
+                    "comment": "Highlights 'node' in node::name",
                     "match": "\\s*\\b(?<!\\.)(node|walker)\\b(?=.*[:\\\\])"
                 },
                 {

--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -10,6 +10,9 @@
         },
         {
             "include": "#strings"
+        },
+        {
+            "include": "#entity_block_definition"
         }
     ],
     "repository": {
@@ -20,7 +23,7 @@
                     "match": "\\b(import)\\b"
                 },
                 {
-                    "match": "\\b(str|int|float|list|dict|bool|node|edge|walker|graph|test)\\b",
+                    "match": "\\b(str|int|float|list|dict|bool|edge|graph|digraph|subgraph|test)\\b",
                     "name": "support.type.jac"
                 },
                 {
@@ -33,17 +36,38 @@
                 }
             ]
         },
+        "entity_block_definition": {
+            "begin": "^\\s*(node|walker)\\s+([A-Za-z][\\w]*)\\s*({)",
+            "name": "source.jac.embedded.source",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.entity.jac"
+                },
+                "2": {
+                    "name": "entity.name.type.entity.jac"
+                },
+                "3": {
+                    "name": "punctuation.definition.tag.jac"
+                }
+            },
+            "end": "\\s*\\}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.tag.prisma"
+                }
+            }
+        },
         "strings": {
             "patterns": [
                 {
-                    "include": "#doublequote"
+                    "include": "#double_quote"
                 },
                 {
-                    "include": "#singlequote"
+                    "include": "#single_quote"
                 }
             ]
         },
-        "doublequote": {
+        "double_quote": {
             "name": "string.quoted.double.jac",
             "begin": "\"",
             "end": "\"",
@@ -54,7 +78,7 @@
                 }
             ]
         },
-        "singlequote": {
+        "single_quote": {
             "name": "string.quoted.double.jac",
             "begin": "'",
             "end": "'",
@@ -68,17 +92,17 @@
         "comments": {
             "patterns": [
                 {
-                    "include": "#numbercomment"
+                    "include": "#number_comment"
                 },
                 {
-                    "include": "#dblslashcomment"
+                    "include": "#dblslash_comment"
                 },
                 {
-                    "include": "#commentblock"
+                    "include": "#comment_block"
                 }
             ]
         },
-        "numbercomment": {
+        "number_comment": {
             "name": "comment.line.number-sign.jac",
             "begin": "(\\#)",
             "beginCaptures": {
@@ -93,7 +117,7 @@
                 }
             ]
         },
-        "dblslashcomment": {
+        "dblslash_comment": {
             "name": "comment.line.double-slash.jac",
             "begin": "(\\/\\/)",
             "beginCaptures": {
@@ -108,7 +132,7 @@
                 }
             ]
         },
-        "commentblock": {
+        "comment_block": {
             "name": "comment.block.jac",
             "begin": "(\\/\\*)",
             "beginCaptures": {


### PR DESCRIPTION
Here is my attempt to address missing keywords and patterns for VSCode syntax highlighting.

### Todo

Highlight the following keywords:
- [x] Highlight the names of nodes, walkers, and graphs
- [x] Assignment, increment and decrement operators (=, +=, -=, ++, --) 
- [ ] Variable properties 
- [x] Function and method calls
- [ ] Node names under walkers
- [x] Keywords
     - [x] has
     - [x] can
     - [x] type
     - [x] strict
     - [x] ignore
     - [x] spawn
     - [x] with
     - [x] entry
     - [x] exit
     - [x] length
     - [x] keys
     - [x] context
     - [x]  info
     - [x] details
     - [x] import
     - [x] report
     - [x] digraph
     - [x] subgraph
     - [x] and
     - [x] or
     - [x] not
     - [x] activity
     - [x] assert