### PR TITLE
Fix: namespace problem in monitoring document

### DIFF
--- a/support/monitoring/README.md
+++ b/support/monitoring/README.md
@@ -46,9 +46,9 @@ If you are using Cloud , For example here we use AWS :
 ```
 
 After this run the Prometheus server can be accessed via port 80 on the following DNS name from within your cluster:
-prometheus-server.<namespace>.svc.cluster.local
+prometheus-server.\<namespace\>.svc.cluster.local
 
-Here, in place of <namespace> put the name of namespace where your service lies. Note this URL for reference to put in Grafana setup later.
+Here, in place of \<namespace\> put the name of namespace where your service lies. Note this URL for reference to put in Grafana setup later.
 
 #### Step 3 ####
 
@@ -88,7 +88,9 @@ kubectl port-forward deploy/prometheus-server 8080:9090
 
 ##### Go to grafana.yaml under grafana  Directory in the code and update the values of promethues URL as required #####
 
-In the cloned repository folder , go to grafana/grafana.yaml file and update the URL to the promethues service URL as we noted doen in step 2 above, i.e prometheus-server.<namespace>.svc.cluster.local
+In the cloned repository folder , go to grafana/grafana.yaml file and update the URL to the promethues service URL as we noted doen in step 2 above, i.e prometheus-server.\<namespace\>.svc.cluster.local
+
+Please note that in the previous example, we did not create any specific namespace for prometheus so the \<namespace\> here (and later) should be replaced with **default** if you follow the tutorial completely. 
 
 This is required to connect Grafana to collect data from promethues .
 

--- a/support/monitoring/README.md
+++ b/support/monitoring/README.md
@@ -77,7 +77,7 @@ promethues-server - It is the main promethues server pod which is responsible fo
 Use Port-forward to test if promethues is running in your local browser to check if all setup works and you are able to get the promethues running.
 
 ```console
-kubectl port-forward -n prometheus deploy/prometheus-server 8080:9090 
+kubectl port-forward deploy/prometheus-server 8080:9090 
 ```
 
 
@@ -144,7 +144,7 @@ Now, try to run grafana in your browser:
 If you running in your local kubernetes, run below :
 
 ```console
-kubectl port-forward -n prometheus deploy/grafana 80:80 
+kubectl port-forward deploy/grafana 80:80 
 ```
 
 

--- a/support/monitoring/grafana/grafana.yaml
+++ b/support/monitoring/grafana/grafana.yaml
@@ -5,6 +5,5 @@ datasources:
     - name: Prometheus
       type: prometheus
       url: http://prometheus-server.default.svc.cluster.local
-      # url: http://localhost:8080
       access: proxy
       isDefault: true

--- a/support/monitoring/grafana/grafana.yaml
+++ b/support/monitoring/grafana/grafana.yaml
@@ -5,5 +5,6 @@ datasources:
     - name: Prometheus
       type: prometheus
       url: http://prometheus-server.default.svc.cluster.local
+      # url: http://localhost:8080
       access: proxy
       isDefault: true


### PR DESCRIPTION
I think that at this point, the document has completely given up teaching people to establish prometheus in a namespace. 
Fix:
1. Deleted '-n prometheus' param in the commands given completely.
2. \<xxx\> is considered a macro substitution in markdown and we did not define \<namespace\> macro. So it is ignored. I replaced it with \\\<namespace\\\> and added some comments about the usage.