### PR TITLE
Fix: walker run command  Delete: a duplicated part in Adding an AI Component

### DIFF
--- a/docs/docs/jsctl/a-simple-workflow-for-tinkering.md
+++ b/docs/docs/jsctl/a-simple-workflow-for-tinkering.md
@@ -225,7 +225,7 @@ Here, we’re using this call to see the objects that were created for our toy p
 Now, for the big moment! lets run our walker on the root node of the graph we created and see what happens!
 
 ```
-jaseci > walker run -name create_fam
+jaseci > walker run create_fam
 I didn’t do any of the hard work.
 []
 jaseci >

--- a/docs/docs/your-first-jac-program/adding-an-ai-component.md
+++ b/docs/docs/your-first-jac-program/adding-an-ai-component.md
@@ -67,23 +67,6 @@ walker get_interests {
 }
 ```
 
-For this we'll create a walker that returns a static list of interests.
-
-```
-walker get_interests {
-    has anchor interests;
-
-    with entry {
-        interests = ['Movies', 'Education', 'Food', 'Cars', 'Music'];
-    }
-
-    with exit {
-        for i in interests {
-            report i;
-        }
-    }
-}
-```
 
 ## Creating a post and inferring interest
 


### PR DESCRIPTION
1. It seems that the `walker run -name` command has deprecated so I fixed it.
2. Deleted a duplicated part ( a mistake ).