### PR TITLE
Newjapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Updates
 
+- New Feature: Added `jaseci` standard library as patch through to all jaseci core APIs
 - New Features: Report payloads can be customized with `report:custom`
 - Improvement: Disengage can now do disengage with report action
 - Improvement: import now works recursively through chain of files

--- a/jaseci_core/jaseci/__init__.py
+++ b/jaseci_core/jaseci/__init__.py
@@ -1,0 +1,12 @@
+def load_standard():
+    import jaseci.actions.standard.net  # noqa
+    import jaseci.actions.standard.rand  # noqa
+    import jaseci.actions.standard.request  # noqa
+    import jaseci.actions.standard.std  # noqa
+    import jaseci.actions.standard.file  # noqa
+    import jaseci.actions.standard.vector  # noqa
+    import jaseci.actions.standard.date  # noqa
+    import jaseci.actions.standard.jaseci  # noqa
+
+
+load_standard()

--- a/jaseci_core/jaseci/actions/live_actions.py
+++ b/jaseci_core/jaseci/actions/live_actions.py
@@ -62,17 +62,6 @@ def load_module_actions(mod):
     return False
 
 
-def load_standard():
-    import jaseci.actions.standard.net  # noqa
-    import jaseci.actions.standard.rand  # noqa
-    import jaseci.actions.standard.request  # noqa
-    import jaseci.actions.standard.std  # noqa
-    import jaseci.actions.standard.file  # noqa
-    import jaseci.actions.standard.vector  # noqa
-    import jaseci.actions.standard.date  # noqa
-    import jaseci.actions.standard.jaseci  # noqa
-
-
 def load_preconfig_actions(hook):
     import json
 
@@ -152,6 +141,3 @@ def gen_remote_func_hook(url, act_name, param_names):
         return res.json()
 
     return func
-
-
-load_standard()

--- a/jaseci_core/jaseci/actions/live_actions.py
+++ b/jaseci_core/jaseci/actions/live_actions.py
@@ -70,9 +70,7 @@ def load_standard():
     import jaseci.actions.standard.file  # noqa
     import jaseci.actions.standard.vector  # noqa
     import jaseci.actions.standard.date  # noqa
-
-
-load_standard()
+    import jaseci.actions.standard.jaseci  # noqa
 
 
 def load_preconfig_actions(hook):
@@ -106,6 +104,8 @@ def get_global_actions(hook):
             or i.startswith("rand.")
             or i.startswith("vector.")
             or i.startswith("request.")
+            or i.startswith("date.")
+            or i.startswith("jaseci.")
         ):
             global_action_list.append(
                 action(
@@ -152,3 +152,6 @@ def gen_remote_func_hook(url, act_name, param_names):
         return res.json()
 
     return func
+
+
+load_standard()

--- a/jaseci_core/jaseci/actions/standard/jaseci.py
+++ b/jaseci_core/jaseci/actions/standard/jaseci.py
@@ -1,0 +1,68 @@
+"""Built in actions for Jaseci"""
+from jaseci.actions.live_actions import jaseci_action
+from jaseci.utils.utils import master_from_meta, copy_func
+import functools
+
+
+def interface_api(api_name, is_public, meta, **kwargs):
+    """
+    Interfaces Master apis after processing arguments/parameters
+    from cli
+    """
+    mast = master_from_meta(meta)
+    if is_public:
+        return mast.public_interface_to_api(kwargs, api_name)
+    else:
+        return mast.general_interface_to_api(kwargs, api_name)
+
+
+def build_cmds():
+    """
+    Generates Click function with options for each command
+    group and leaf signatures
+    leaf is format: [api_name, func_sig, is_public, func_doc]
+    """
+    from jaseci.element.super_master import super_master
+
+    for i in super_master.all_apis(None):
+        func_name = "_".join(i["groups"])
+        f = functools.partial(
+            copy_func(interface_api, func_name),
+            api_name=func_name,
+            is_public=i in super_master._public_api,
+        )
+        f.__name__ = func_name
+        f.__doc__ = i["doc"]
+        f.__module__ = __name__
+
+        globals()[func_name] = jaseci_action()(f)
+
+        # func_sig = i["sig"]
+        # for i in func_sig.parameters.keys():
+        #     if i == "self":
+        #         continue
+        #     p_default = func_sig.parameters[i].default
+        #     p_type = func_sig.parameters[i].annotation
+        #     if p_type not in [int, bool, float]:
+        #         p_type = str
+        #     if i in cli_args:
+        #         f = click.argument(f"{i}", type=p_type)(f)
+        #     elif p_default is not func_sig.parameters[i].empty:
+        #         f = click.option(
+        #             f"-{i}", default=p_type(p_default), required=False, type=p_type
+        #         )(f)
+        #     else:
+        #         f = click.option(f"-{i}", required=True, type=p_type)(f)
+        # # to file option to dump response to a file
+        # f = click.option(
+        #     "--output",
+        #     "-o",
+        #     default="",
+        #     required=False,
+        #     type=str,
+        #     help="Filename to dump output of this command call.",
+        # )(f)
+        # return group_func.command()(f)
+
+
+build_cmds()

--- a/jaseci_core/jaseci/actions/standard/jaseci.py
+++ b/jaseci_core/jaseci/actions/standard/jaseci.py
@@ -1,6 +1,7 @@
 """Built in actions for Jaseci"""
 from jaseci.actions.live_actions import jaseci_action
 from jaseci.utils.utils import master_from_meta, copy_func
+from jaseci.element.super_master import super_master
 import functools
 
 
@@ -22,7 +23,6 @@ def build_cmds():
     group and leaf signatures
     leaf is format: [api_name, func_sig, is_public, func_doc]
     """
-    from jaseci.element.super_master import super_master
 
     for i in super_master.all_apis(None):
         func_name = "_".join(i["groups"])
@@ -36,33 +36,6 @@ def build_cmds():
         f.__module__ = __name__
 
         globals()[func_name] = jaseci_action()(f)
-
-        # func_sig = i["sig"]
-        # for i in func_sig.parameters.keys():
-        #     if i == "self":
-        #         continue
-        #     p_default = func_sig.parameters[i].default
-        #     p_type = func_sig.parameters[i].annotation
-        #     if p_type not in [int, bool, float]:
-        #         p_type = str
-        #     if i in cli_args:
-        #         f = click.argument(f"{i}", type=p_type)(f)
-        #     elif p_default is not func_sig.parameters[i].empty:
-        #         f = click.option(
-        #             f"-{i}", default=p_type(p_default), required=False, type=p_type
-        #         )(f)
-        #     else:
-        #         f = click.option(f"-{i}", required=True, type=p_type)(f)
-        # # to file option to dump response to a file
-        # f = click.option(
-        #     "--output",
-        #     "-o",
-        #     default="",
-        #     required=False,
-        #     type=str,
-        #     help="Filename to dump output of this command call.",
-        # )(f)
-        # return group_func.command()(f)
 
 
 build_cmds()

--- a/jaseci_core/jaseci/tests/jac_test_progs.py
+++ b/jaseci_core/jaseci/tests/jac_test_progs.py
@@ -297,3 +297,9 @@ jasecilib_alias_list = """
         report jaseci.alias_list();
     }
     """
+
+jasecilib_params = """
+    walker init {
+        report jaseci.graph_list(true);
+    }
+    """

--- a/jaseci_core/jaseci/tests/jac_test_progs.py
+++ b/jaseci_core/jaseci/tests/jac_test_progs.py
@@ -291,3 +291,9 @@ vanishing_can_check = """
         }
     }
     """
+
+jasecilib_alias_list = """
+    walker init {
+        report jaseci.alias_list();
+    }
+    """

--- a/jaseci_core/jaseci/tests/jac_test_progs.py
+++ b/jaseci_core/jaseci/tests/jac_test_progs.py
@@ -303,3 +303,9 @@ jasecilib_params = """
         report jaseci.graph_list(true);
     }
     """
+
+jasecilib_create_user = """
+    walker init {
+        report jaseci.master_create("daman@gmail.com");
+    }
+    """

--- a/jaseci_core/jaseci/tests/test_progs.py
+++ b/jaseci_core/jaseci/tests/test_progs.py
@@ -182,3 +182,11 @@ class jac_tests(TestCaseHelper, TestCase):
             api_name="walker_run", params={"name": "init"}
         )["report"]
         self.assertEqual(report, ["2022-01-01T00:00:00"])
+
+    def test_jasecilib_alias_list(self):
+        mast = master(h=mem_hook())
+        mast.sentinel_register(name="test", code=jtp.jasecilib_alias_list, auto_run="")
+        report = mast.general_interface_to_api(
+            api_name="walker_run", params={"name": "init"}
+        )["report"]
+        self.log(report)

--- a/jaseci_core/jaseci/tests/test_progs.py
+++ b/jaseci_core/jaseci/tests/test_progs.py
@@ -189,4 +189,12 @@ class jac_tests(TestCaseHelper, TestCase):
         report = mast.general_interface_to_api(
             api_name="walker_run", params={"name": "init"}
         )["report"]
-        self.log(report)
+        self.assertGreater(len(report[0].keys()), 3)
+
+    def test_jasecilib_params(self):
+        mast = master(h=mem_hook())
+        mast.sentinel_register(name="test", code=jtp.jasecilib_params, auto_run="")
+        report = mast.general_interface_to_api(
+            api_name="walker_run", params={"name": "init"}
+        )["report"]
+        self.assertIn("j_r_acc_ids", report[0][0].keys())

--- a/jaseci_core/jaseci/tests/test_progs.py
+++ b/jaseci_core/jaseci/tests/test_progs.py
@@ -198,3 +198,11 @@ class jac_tests(TestCaseHelper, TestCase):
             api_name="walker_run", params={"name": "init"}
         )["report"]
         self.assertIn("j_r_acc_ids", report[0][0].keys())
+
+    def test_jasecilib_create_user(self):
+        mast = master(h=mem_hook())
+        mast.sentinel_register(name="test", code=jtp.jasecilib_create_user, auto_run="")
+        report = mast.general_interface_to_api(
+            api_name="walker_run", params={"name": "init"}
+        )["report"]
+        self.assertEqual(report[0]["name"], ("daman@gmail.com",))

--- a/jaseci_core/setup.py
+++ b/jaseci_core/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="jaseci",
-    version="1.3.3.16",
+    version="1.3.3.17",
     packages=find_packages(include=["jaseci", "jaseci.*"]),
     install_requires=[
         "click>=8.1.0,<8.2.0",

--- a/jaseci_kit/setup.py
+++ b/jaseci_kit/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="jaseci_kit",
-    version="1.3.3.16",
+    version="1.3.3.17",
     packages=find_packages(include=["jaseci_kit", "jaseci_kit.*"]),
     install_requires=[
         "jaseci",

--- a/jaseci_serv/setup.py
+++ b/jaseci_serv/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="jaseci_serv",
-    version="1.3.3.16",
+    version="1.3.3.17",
     packages=find_packages(include=["jaseci_serv", "jaseci_serv.*"]),
     install_requires=[
         "jaseci",


### PR DESCRIPTION
## Describe your changes

Added a new standard library called `jaseci` that gives jac code access to all main apis (as per what jsctl and rest apis can call)

## Link to related issue

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.

Yes, adds a new jaseci std lib.

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.

Yes, adds a new jaseci std lib. Now users can have full range of capabilites that jaseci's main apis provide within a jac program. 

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
