### PR TITLE
Allocate more memory to the node process for jaseci docs

### DIFF
--- a/docs/jaseci-docs.yaml
+++ b/docs/jaseci-docs.yaml
@@ -44,11 +44,17 @@ spec:
           image: awesometic/docusaurus
           imagePullPolicy: IfNotPresent
           command: [bash, -c, "source /script/prod_up"]
+          resources:
+            requests:
+              memory: "2Gi"
           ports:
             - containerPort: 80
           volumeMounts:
             - name: prod-script
               mountPath: /script
+          env:
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=2048"
       volumes:
         - name: prod-script
           configMap:


### PR DESCRIPTION
## Describe your changes
Allocate more memory to the node process for jaseci docs

## Link to related issue
The node process of jaseci docs run out of memory when compiling the latest version of  the docs.

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
No

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
No

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
No
