### PR TITLE
[MULTIPART-FORMDATA-ENHANCEMENT]: Allow file type field to be access using `has fieldName`

### DIFF
--- a/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
@@ -1349,3 +1349,56 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
             ],
         }
         self.assertEquals(res, default_res)
+
+    def test_multipart_with_additional_file(self):
+        """Test global action triggers"""
+        zsb_file = open(os.path.dirname(__file__) + "/zsb.jac").read()
+        payload = {"op": "sentinel_register", "name": "zsb", "code": zsb_file}
+        self.client.post(reverse(f'jac_api:{payload["op"]}'), payload, format="json")
+        with open(os.path.dirname(__file__) + "/test.json", "rb") as ctx, open(
+            os.path.dirname(__file__) + "/test.json", "rb"
+        ) as ctx2:
+            form = {
+                "name": "simple_with_file",
+                "ctx": ctx,
+                "nd": "active:graph",
+                "snt": "active:sentinel",
+                "fileTypeField": ctx2,
+            }
+            res = self.client.post(reverse(f'jac_api:{"walker_run"}'), data=form).data
+
+        default_file = [
+            {
+                "name": "test.json",
+                "base64": "eyJzYW1wbGUiOiJzYW1wbGUifQ==",
+                "content-type": "application/json",
+            }
+        ]
+        default_res = {"success": True, "report": [default_file, default_file]}
+        self.assertEquals(res, default_res)
+
+    def test_multipart_custom_payload_with_additional_file(self):
+        """Test global action triggers"""
+        zsb_file = open(os.path.dirname(__file__) + "/zsb.jac").read()
+        payload = {"op": "sentinel_register", "name": "zsb", "code": zsb_file}
+        self.client.post(reverse(f'jac_api:{payload["op"]}'), payload, format="json")
+        with open(os.path.dirname(__file__) + "/test.json", "rb") as ctx:
+            form = {
+                "name": "simple_custom_payload_with_file",
+                "ctx": "",
+                "nd": "active:graph",
+                "snt": "active:sentinel",
+                "fileTypeField": ctx,
+            }
+            res = self.client.post(reverse(f'jac_api:{"walker_run"}'), data=form).data
+
+        default_file = [
+            {
+                "name": "test.json",
+                "base64": "eyJzYW1wbGUiOiJzYW1wbGUifQ==",
+                "content-type": "application/json",
+            }
+        ]
+
+        default_res = {"success": True, "report": [True, True, default_file]}
+        self.assertEquals(res, default_res)

--- a/jaseci_serv/jaseci_serv/jac_api/tests/zsb.jac
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/zsb.jac
@@ -238,3 +238,29 @@ walker simple {
         report global.info['request_context']["body"];
     }
 }
+
+walker simple_with_file {
+    has fileTypeField;
+
+    with entry {
+        report global.info['request_context']["body"]["ctx"]["fileTypeField"];
+        report fileTypeField;
+    }
+}
+
+walker simple_custom_payload_with_file {
+    has fileTypeField;
+
+    with entry {
+
+        if not(fileTypeField) {
+            report true;
+        }
+
+        if not(global.info['request_context']["body"]["ctx"]) {
+            report true;
+        }
+
+        report global.info['request_context']["body"]["fileTypeField"];
+    }
+}


### PR DESCRIPTION
## Describe your changes
 - File type field will now be able to access via `has fieldName`
 - Update file parser to be able to read large file

## Link to related issue
N/A

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
Nope, tho I have added unit tests for different multipart scenarios

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
Slightly, file type field will now be accessible via `has fieldName` instead of using `global.info["request_context"]["body"]["fieldName"]`

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
multipart/form-data approach with files