### PR TITLE
[TRY-ELSE]: Improve exception backtracking when using Try/Else

### DIFF
--- a/jaseci_core/jaseci/jac/interpreter/interp.py
+++ b/jaseci_core/jaseci/jac/interpreter/interp.py
@@ -4,7 +4,6 @@ Interpreter for jac code in AST form
 This interpreter should be inhereted from the class that manages state
 referenced through self.
 """
-import logging
 from jaseci.utils.utils import is_jsonable, is_urn, parse_str_token
 from jaseci.element.element import element
 from jaseci.graph.node import node
@@ -13,7 +12,7 @@ from jaseci.attr.action import action
 from jaseci.jac.jac_set import jac_set
 from jaseci.jac.ir.jac_code import jac_ast_to_ir, jac_ir_to_ast
 from jaseci.jac.machine.jac_scope import jac_scope
-from jaseci.jac.machine.machine_state import machine_state
+from jaseci.jac.machine.machine_state import machine_state, TryException
 
 from jaseci.jac.machine.jac_value import jac_value
 from jaseci.jac.machine.jac_value import jac_elem_unwrap as jeu
@@ -539,10 +538,7 @@ class interp(machine_state):
                             j.attach_bidirected(i, [use_edge])
             return tret
         except Exception as e:
-            if isinstance(e, TryException):
-                raise e
-            else:
-                raise TryException(self.jac_exception(e, jac_ast))
+            self.jac_try_exception(e, jac_ast)
 
     def run_logical(self, jac_ast):
         """
@@ -700,10 +696,7 @@ class interp(machine_state):
                 return jac_value(self, ctx=self.parent().global_vars, name=token)
 
         except Exception as e:
-            if isinstance(e, TryException):
-                raise e
-            else:
-                raise TryException(self.jac_exception(e, jac_ast))
+            self.jac_try_exception(e, jac_ast)
 
     def run_atom(self, jac_ast):
         """
@@ -762,10 +755,7 @@ class interp(machine_state):
                 return self.run_rule(kid[0])
 
         except Exception as e:
-            if isinstance(e, TryException):
-                raise e
-            else:
-                raise TryException(self.jac_exception(e, jac_ast))
+            self.jac_try_exception(e, jac_ast)
 
     def run_atom_trailer(self, jac_ast, atom_res):
         """
@@ -817,10 +807,7 @@ class interp(machine_state):
                 )
                 return atom_res
         except Exception as e:
-            if isinstance(e, TryException):
-                raise e
-            else:
-                raise TryException(self.jac_exception(e, jac_ast))
+            self.jac_try_exception(e, jac_ast)
 
     def run_ability_op(self, jac_ast, atom_res):
         """
@@ -1648,9 +1635,3 @@ class interp(machine_state):
         #     self.rt_error(
         #         f"Cannot execute this type of code here! {e}", jac_ast)
         #     return None
-
-
-class TryException(Exception):
-    def __init__(self, ref: dict):
-        super().__init__(ref["msg"])
-        self.ref = ref

--- a/jaseci_core/jaseci/jac/machine/machine_state.py
+++ b/jaseci_core/jaseci/jac/machine/machine_state.py
@@ -124,6 +124,12 @@ class machine_state:
             self.rt_error(f"Builtin action not found - {func_name}", jac_ast)
         return func_name
 
+    def jac_try_exception(self, e: Exception, jac_ast):
+        if isinstance(e, TryException):
+            raise e
+        else:
+            raise TryException(self.jac_exception(e, jac_ast))
+
     def jac_exception(self, e: Exception, jac_ast):
         return {
             "type": type(e).__name__,
@@ -189,3 +195,9 @@ class machine_state:
             "request_context": self.request_context,
             "runtime_errors": self.runtime_errors,
         }
+
+
+class TryException(Exception):
+    def __init__(self, ref: dict):
+        super().__init__(ref["msg"])
+        self.ref = ref

--- a/jaseci_core/jaseci/jac/machine/machine_state.py
+++ b/jaseci_core/jaseci/jac/machine/machine_state.py
@@ -132,6 +132,8 @@ class machine_state:
             "args": e.args,
             "line": jac_ast.line,
             "col": jac_ast.column,
+            "name": self.name if hasattr(self, "name") else "blank",
+            "rule": jac_ast.name,
         }
 
     def rt_log_str(self, msg, jac_ast=None):

--- a/jaseci_core/jaseci/tests/test_jac.py
+++ b/jaseci_core/jaseci/tests/test_jac.py
@@ -590,11 +590,13 @@ class jac_tests(TestCaseHelper, TestCase):
             rep[0],
             {
                 "args": ("division by zero",),
-                "col": 8,
-                "line": 5,
+                "col": 15,
+                "line": 4,
                 "mod": "basic",
                 "msg": "division by zero",
                 "type": "ZeroDivisionError",
+                "name": "init",
+                "rule": "connect",
             },
         )
         self.assertEqual(rep[1], "dont need err")

--- a/jaseci_serv/jaseci_serv/jac_api/tests/zsb.jac
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/zsb.jac
@@ -264,3 +264,44 @@ walker simple_custom_payload_with_file {
         report global.info['request_context']["body"]["fileTypeField"];
     }
 }
+
+walker walker_exception_no_try_else {
+    can request.get;
+    with entry {
+        request.get("invalidUrl");
+    }
+}
+
+walker walker_exception_with_try_else {
+    can request.get;
+    with entry {
+        try {
+            request.get("invalidUrl");
+        } else with error {
+            report error;
+            report:error = error;
+        }
+    }
+}
+
+walker walker_exception_with_try_else_multiple_line {
+    can request.get;
+    with entry {
+        try {
+            std.log("######");
+            std.log("######");
+
+
+            std.log("######");
+
+            request.get("invalidUrl", {}, {});
+
+            std.log("######");
+            std.log("######");
+            std.log("######");
+        } else with error {
+            report error;
+            report:error = error;
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes
 - Added TryException class to improved Try/Else backtracking
 - Removal of default exception handling on actions trigger interp to enable Try/Else on jaseci actions

## Link to related issue
N/A

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
Yes, you can now use Try/Else on Jaseci Actions
No, It's supposed to be an improvement for Try/Else backtracking

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
Yes, Try/Else can now determine the exact line of the error.
Jaseci Actions now throws exception to be handled on Jac side

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
Jaseci Actions, the removal of exception handling might need changes on current/existing jac projects since exception should be handled "mandatorily" instead of having fix handling