### PR TITLE
Api to set default permissions on future objects added, not tested

### DIFF
--- a/jaseci_core/jaseci/api/object_api.py
+++ b/jaseci_core/jaseci/api/object_api.py
@@ -11,6 +11,10 @@ class object_api:
     ...
     """
 
+    def __init__(self):
+        self.perm_default = "private"
+        self._valid_perms = ["public", "private", "read_only"]
+
     @interface.private_api(cli_args=["name"])
     def global_get(self, name: str):
         """
@@ -31,15 +35,27 @@ class object_api:
     @interface.private_api(cli_args=["obj"])
     def object_perms_set(self, obj: element, mode: str):
         """Sets object access mode for any Jaseci object."""
-        valid_perms = ["public", "private", "read_only"]
         ret = {}
-        if mode not in valid_perms:
+        if mode not in self._valid_perms:
             ret["success"] = False
-            ret["response"] = f"{mode} not valid, must be in {valid_perms}"
+            ret["response"] = f"{mode} not valid, must be in {self._valid_perms}"
         else:
             getattr(obj, "make_" + mode)()
             ret["success"] = True
             ret["response"] = f"{obj} set to {mode}"
+        return ret
+
+    @interface.private_api(cli_args=["mode"])
+    def object_perms_default(self, mode: str):
+        """Sets object access mode for any Jaseci object."""
+        ret = {}
+        if mode not in self._valid_perms:
+            ret["success"] = False
+            ret["response"] = f"{mode} not valid, must be in {self._valid_perms}"
+        else:
+            self.perm_default = mode
+            ret["success"] = True
+            ret["response"] = f"Default access for future objects set to {mode}"
         return ret
 
     @interface.private_api(cli_args=["obj"])

--- a/jaseci_core/jaseci/element/master.py
+++ b/jaseci_core/jaseci/element/master.py
@@ -37,6 +37,7 @@ class master(
         master_api.__init__(self, head_master)
         alias_api.__init__(self)
         config_api.__init__(self)
+        object_api.__init__(self)
         graph_api.__init__(self)
         walker_api.__init__(self)
         sentinel_api.__init__(self)

--- a/jaseci_core/jaseci/element/obj_mixins.py
+++ b/jaseci_core/jaseci/element/obj_mixins.py
@@ -24,9 +24,15 @@ class anchored:
 class sharable:
     """Utility class for objects that are sharable between users"""
 
-    def __init__(self, m_id, mode="private"):
+    def __init__(self, m_id, mode=None):
         self.set_master(m_id)
-        self.j_access = mode
+        self.j_access = (
+            mode
+            if mode is not None
+            else self._h.get_obj(self._m_id, uuid.UUID(self._m_id)).perm_default
+            if self._h.get_obj(self._m_id, uuid.UUID(self._m_id))
+            else "private"
+        )
         self.j_r_acc_ids = id_list(self)
         self.j_rw_acc_ids = id_list(self)
 

--- a/jaseci_core/jaseci/utils/mem_hook.py
+++ b/jaseci_core/jaseci/utils/mem_hook.py
@@ -43,7 +43,7 @@ class mem_hook:
         """
         if item_id in self.mem.keys():
             ret = self.mem[item_id]
-            if override or ret.check_read_access(caller_id):
+            if override or (ret is not None and ret.check_read_access(caller_id)):
                 return ret
         else:
             ret = self.get_obj_from_store(item_id)


### PR DESCRIPTION
## Describe your changes
Added new api object_perms_default or object perms default for setting a default permissions mode (other than private) for all objects created by a master
## Link to related issue

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
Yes

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
A new feature they can use

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
