### PR TITLE
fix: remove unnecessary match regex

### DIFF
--- a/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
+++ b/support/vscode_extension/jac/syntaxes/jac.tmLanguage.json
@@ -50,21 +50,6 @@
                     "match": "\\s*\\b(?<!\\.)(report|destroy|here|take|in)\\b(?=.*[-\\\\])"
                 },
                 {
-                    "comment": "Highlights 'node' in node::name",
-                    "match": "\\s*\\b(?<!\\.)(node|walker|graph)\\b(.*[:\\\\])(\\w+)\\b",
-                    "captures": {
-                        "1": {
-                            "name": "keyword.control.flow.jac"
-                        },
-                        "2": {
-                            "name": "keyword.operator.jac"
-                        },
-                        "3": {
-                            "name": "support.function.functional_calls.jac"
-                        }
-                    }
-                },
-                {
                     "match": "\\b(null|true|false)\\b",
                     "name": "constant.language.c"
                 }


### PR DESCRIPTION
## Describe your changes
Regex no longer necessary; breaks syntax highlighting.

## Link to related issue

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
