### PR TITLE
[FEATURE-REQUEST]: Simplified Dot

### DIFF
--- a/jaseci_core/jaseci/api/graph_api.py
+++ b/jaseci_core/jaseci/api/graph_api.py
@@ -38,7 +38,7 @@ class graph_api:
         Valid modes: {default, dot, }
         """
         if mode == "dot":
-            return gph.graph_dot_str()
+            return gph.graph_dot_str(detailed)
         else:
             items = []
             for i in gph.get_all_nodes():

--- a/jaseci_core/jaseci/graph/edge.py
+++ b/jaseci_core/jaseci/graph/edge.py
@@ -144,7 +144,10 @@ class edge(element, anchored):
             target.edge_ids.remove_obj(self)
         element.destroy(self)
 
-    def dot_str(self, node_map=None, edge_map=None):
+    def handle_str(self, str):
+        return str[:32].replace('"', '\\"')
+
+    def dot_str(self, node_map=None, edge_map=None, detailed=False):
         """
         DOT representation
         from_node -> to_node [context_key=contect_value]
@@ -174,11 +177,11 @@ class edge(element, anchored):
 
         edge_dict = self.context
 
-        if edge_dict:
+        if edge_dict and detailed:
             for k, v in edge_dict.items():
                 if not isinstance(v, str) or v == "":
                     continue
-                dstr += f', {k}="{v[:32]}"'
+                dstr += f', {k}="{self.handle_str(v)}"'
 
         dstr += " ]"
 

--- a/jaseci_core/jaseci/graph/graph.py
+++ b/jaseci_core/jaseci/graph/graph.py
@@ -45,7 +45,7 @@ class graph(node):
 
         return list(edge_set)
 
-    def graph_dot_str(self):
+    def graph_dot_str(self, detailed=False):
         """
         DOT representation for graph.
         NOTE: This is different from the dot_str method for node intentionally
@@ -60,9 +60,9 @@ class graph(node):
         dstr = ""
         dstr += f"strict digraph {self.name} {{\n"
         for n in node_list:
-            dstr += f"    {n.dot_str(node_map)}"
+            dstr += f"    {n.dot_str(node_map, detailed)}"
         for e in edge_list:
-            dstr += f"    {e.dot_str(node_map, edge_map)}"
+            dstr += f"    {e.dot_str(node_map, edge_map, detailed)}"
         dstr += "}"
         return dstr
 

--- a/jaseci_core/jaseci/graph/node.py
+++ b/jaseci_core/jaseci/graph/node.py
@@ -354,7 +354,10 @@ class node(element, anchored):
             i.destroy()
         super().destroy()
 
-    def dot_str(self, node_map=None):
+    def handle_str(self, str):
+        return str[:32].replace('"', '\\"')
+
+    def dot_str(self, node_map=None, detailed=False):
         """
         DOT representation
         """
@@ -368,11 +371,11 @@ class node(element, anchored):
 
         node_dict = self.context
 
-        if node_dict:
+        if node_dict and detailed:
             for k, v in node_dict.items():
                 if not isinstance(v, str) or v == "":
                     continue
-                dstr += f', {k}="{v[:32]}"'
+                dstr += f', {k}="{self.handle_str(v)}"'
 
         dstr += " ]"
 

--- a/jaseci_core/jaseci/jsctl/tests/test_jsctl.py
+++ b/jaseci_core/jaseci/jsctl/tests/test_jsctl.py
@@ -78,6 +78,10 @@ class jsctl_test(TestCaseHelper, TestCase):
         self.call("walker run gen_rand_life")
         r = self.call("graph get -mode dot")
         self.assertIn('"n0" -> "n', r)
+        self.assertNotIn('week="', r)
+
+        r = self.call("graph get -mode dot -detailed true")
+        self.assertIn('"n0" -> "n', r)
         self.assertIn('week="', r)
 
     def test_jsctl_aliases(self):


### PR DESCRIPTION
## Describe your changes
Dot mode now have `detailed` param. Default dot mode will now include the label only. Detailed dot mode will include every attributes of the node/edge

## Link to related issue
N/A

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
Yes, Unit test for `dot` is now updated

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
Yes, existing graph_get should now have `detailed: true` but if they doesn't use the node/edge attributes it should work fine

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
Yes, existing graph_get usage