### PR TITLE
Make jskit CI pipeline mandatory again

### DIFF
--- a/.github/workflows/jaseci_kit_test.yml
+++ b/.github/workflows/jaseci_kit_test.yml
@@ -43,7 +43,6 @@ jobs:
         python -c "import jaseci_kit"
 
     - name: Run tests
-      continue-on-error: true
       run: |
         cd jaseci_kit/
         source test.sh


### PR DESCRIPTION
## Describe your changes
Currently, we allow the jskit pipeline to fail because sometimes github action will run out of memory when executing tests. We have resolved this and this PR will make jskit pipeline success a requirement **for any PRs that updates files in `jaseci_kit/`**
## Link to related issue

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
