### PR TITLE
[GRAPH-GET]: Only include the id when detailed is true

### DIFF
--- a/jaseci_core/jaseci/graph/edge.py
+++ b/jaseci_core/jaseci/graph/edge.py
@@ -170,16 +170,19 @@ class edge(element, anchored):
             if node_map is None
             else node_map.index(self.to_node().jid)
         )
-        dstr = f'"n{from_name}" -> "n{to_name}" '
+        dstr = f'"n{from_name}" -> "n{to_name}" [ '
 
-        dstr += f'[ id="{uuid.UUID(self.jid).hex}"'
+        if detailed:
+            dstr += f'id="{uuid.UUID(self.jid).hex}", '
+
         label = ""
         if edge_map:
             label = f"e{edge_map.index(self.jid)}"
         if self.name != "generic":
             label += f":{self.name}"
-        if label:
-            dstr += f', label="{label}"'
+
+        dstr += f'label="{label}"'
+
         if self.bidirected:
             dstr += ', dir="both"'
 

--- a/jaseci_core/jaseci/graph/node.py
+++ b/jaseci_core/jaseci/graph/node.py
@@ -367,7 +367,11 @@ class node(element, anchored):
         else:
             nid = f"{node_map.index(self.jid)}"
 
-        dstr = f'"n{nid}" [ id="{uuid.UUID(self.jid).hex}", '
+        dstr = f'"n{nid}" [ '
+
+        if detailed:
+            dstr += f'id="{uuid.UUID(self.jid).hex}", '
+
         dstr += f'label="n{nid}:{self.name}" '
 
         node_dict = self.context


### PR DESCRIPTION
## Describe your changes
graph will now only include the id when detailed is true
## Link to related issue
N/A
## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
No
## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
Maybe? I'm not sure if "id" in dot is used on any 3rd party graph viewer
## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
Dot