### PR TITLE
Fixing CCAI_codelab DOT language graph n1 type: faq_state --> faq_root

### DIFF
--- a/examples/CanoniCAI/CCAI_codelab.md
+++ b/examples/CanoniCAI/CCAI_codelab.md
@@ -208,7 +208,7 @@ The output should look something like this
 ```dot
 strict digraph root {
     "n0" [ id="0955c04e4ff945b4b836748ef2bbd98a", label="n0:root"  ]
-    "n1" [ id="c1240d79110941c1bc2feb18581951bd", label="n1:faq_state"  ]
+    "n1" [ id="c1240d79110941c1bc2feb18581951bd", label="n1:faq_root"  ]
     "n2" [ id="55333be285c246db88181ac34d16cd20", label="n2:faq_state"  ]
     "n3" [ id="d4fa8f2c46ca463f9237ef818e086a29", label="n3:faq_state"  ]
     "n4" [ id="f7b1c8ae82af4063ad53646adc5544e9", label="n4:faq_state"  ]


### PR DESCRIPTION
## Describe your changes
Changing CanoniCAI Init Walker DOT graph representation typo. The node n1 has type"faq_state" when it should have type "faq_root" (as the diagram below designates).
![dot_1](https://user-images.githubusercontent.com/25558290/189375850-02ab72aa-465f-417e-bb8e-5ff99bf6e413.png)
## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
This will enhance understanding of DOT lanugage syntax and the code-along instructions as it remedies a typo that directly affects new users.


