### PR TITLE
fixed walker run command (missing quotes)

### DIFF
--- a/examples/CanoniCAI/CCAI_codelab.md
+++ b/examples/CanoniCAI/CCAI_codelab.md
@@ -1505,7 +1505,7 @@ The `jid` field is the ID for the sentinel. (`jid` stands for jaseci ID).
 
 With a sentinel and graph, we can now run walker with
 ```bash
-jaseci > walker run talk -ctx {\"question\": \"I want to schedule a test drive\"}
+jaseci > walker run talk -ctx "{\"question\": \"I want to schedule a test drive\"}"
 ```
 And with `yield`, the next walker run will pick up where it leaves off and retain its variable states and nodes traversal plan.
 


### PR DESCRIPTION
The walker run command was originally: walker run talk -ctx {\"question\": \"I want to schedule a test drive\"}
The command does not run as is, instead resulting in the following: Error: Got unexpected extra arguments ("I want to schedule a test drive"}). 
This is fixed by adding outer quotation marks around the brackets (as is consistent with the other -ctx arguments across the tutorial). 
