### PR TITLE
Fix typo in Multi-file section

### DIFF
--- a/examples/CanoniCAI/CCAI_codelab.md
+++ b/examples/CanoniCAI/CCAI_codelab.md
@@ -1227,7 +1227,7 @@ node cai_state {
 Note that the logic for `init_wlk_ctx` and the default `process` logic have been hoisted up into `cai_state` as they are shared by the dialogue system and FAQ system.
 You can remove these two abilities from `dialogue_state` node, as it will be inheriting them from `cai_state` now.
 
-We then update the defintion of `dialogue_state` in `dialogue.jac` to inherit from `cai_state`:
+We then update the definition of `dialogue_state` in `dialogue.jac` to inherit from `cai_state`:
 ```js
 node dialogue_state:cai_state{
     // Rest of dialogue_state code remain the same


### PR DESCRIPTION
## Describe your changes
Fixed a simple typo in the multi-file section for the CanoniCAI section.

## Link to related issue
This does not relate to a currently created issue.

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
No testing required.

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
This will not affect the user in any way other than easier readability.

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
