### PR TITLE
[TASK]: Add on wait result timeout

### DIFF
--- a/jaseci_core/jaseci/api/queue_api.py
+++ b/jaseci_core/jaseci/api/queue_api.py
@@ -25,7 +25,7 @@ class QueueApi:
             return self._h.task.get_by_task_id(task_id)
 
     @Interface.private_api(allowed_methods=["get"])
-    def walker_queue_wait(self, task_id: str):
+    def walker_queue_wait(self, task_id: str, timeout: int = 30):
         """
         Wait Queues
         """
@@ -35,4 +35,4 @@ class QueueApi:
         if not task_id:
             return "Task id is required!"
         else:
-            return self._h.task.get_by_task_id(task_id, True)
+            return self._h.task.get_by_task_id(task_id, True, timeout)

--- a/jaseci_core/jaseci/svc/task/config.py
+++ b/jaseci_core/jaseci/svc/task/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 DEFAULT_MSG = "Skipping scheduled walker!"
 DEFAULT_URL = (
@@ -15,3 +16,8 @@ TASK_CONFIG = {
     "task_track_started": True,
     "worker_redirect_stdouts": False,
 }
+
+
+if "python3 -m unittest" in sys.argv:
+    TASK_CONFIG["task_always_eager"] = True
+    TASK_CONFIG["task_store_eager_result"] = True

--- a/jaseci_core/jaseci/svc/task/task.py
+++ b/jaseci_core/jaseci/svc/task/task.py
@@ -54,7 +54,7 @@ class TaskService(CommonService):
     #              COMMON GETTER/SETTER               #
     ###################################################
 
-    def get_by_task_id(self, task_id, wait=False):
+    def get_by_task_id(self, task_id, wait=False, timeout=30):
         task = self.app.AsyncResult(task_id)
 
         if isinstance(task.backend, DisabledBackend):
@@ -68,7 +68,7 @@ class TaskService(CommonService):
             ret["result"] = task.result
         elif wait:
             ret["status"] = "SUCCESS"
-            ret["result"] = task.get(disable_sync_subtasks=False)
+            ret["result"] = task.get(timeout=timeout, disable_sync_subtasks=False)
 
         return ret
 

--- a/jaseci_core/jaseci/tests/test_progs.py
+++ b/jaseci_core/jaseci/tests/test_progs.py
@@ -374,7 +374,7 @@ class JacTests(TestCaseHelper, TestCase):
 
         res = mast.general_interface_to_api(
             api_name="walker_queue_wait",
-            params={"task_id": res["result"]},
+            params={"task_id": res["result"], "timeout": 15},
         )
 
         self.assertEqual("test", res["result"]["anchor"])
@@ -446,7 +446,7 @@ class JacTests(TestCaseHelper, TestCase):
 
         res = mast.general_interface_to_api(
             api_name="walker_queue_wait",
-            params={"task_id": res["result"]},
+            params={"task_id": res["result"], "timeout": 15},
         )
 
         self.assertEqual("test", res["result"]["anchor"])


### PR DESCRIPTION
## Describe your changes
 - Added timeout for AsyncResult.get
 - Adjust unit test to cover changes

## Link to related issue
current github workflow stuck on unit test

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
Yes, unit test adjusted

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
No

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
Github workflows