### PR TITLE
[GRAPH-GET]: Allow Node entry instead of Graph; Some refactor for traversing

### DIFF
--- a/jaseci_core/jaseci/api/graph_api.py
+++ b/jaseci_core/jaseci/api/graph_api.py
@@ -31,7 +31,7 @@ class GraphApi:
     @Interface.private_api()
     def graph_get(
         self,
-        gph: Graph = None,
+        nd: Node = None,
         mode: str = "default",
         detailed: bool = False,
         depth: int = 0,
@@ -41,15 +41,15 @@ class GraphApi:
         Valid modes: {default, dot, }
         """
         if mode == "dot":
-            return gph.graph_dot_str(detailed=detailed, depth=depth)
-        else:
-            items = []
-            nodes = gph.get_all_nodes(depth=depth)
-            for i in nodes:
-                items.append(i.serialize(detailed=detailed))
-            for i in gph.get_all_edges(nodes=nodes):
-                items.append(i.serialize(detailed=detailed))
-            return items
+            return nd.traversing_dot_str(detailed, depth)
+
+        nodes, edges = nd.get_all_architypes(depth)
+        items = []
+        for i in nodes.values():
+            items.append(i.serialize(detailed=detailed))
+        for i in edges.values():
+            items.append(i.serialize(detailed=detailed))
+        return items
 
     @Interface.private_api()
     def graph_list(self, detailed: bool = False):

--- a/jaseci_core/jaseci/api/tests/test_graph_api.py
+++ b/jaseci_core/jaseci/api/tests/test_graph_api.py
@@ -15,7 +15,10 @@ class GraphApiTest(CoreTest):
         ret = self.call(self.mast, ["graph_get", {}])
         self.assertEqual(len(ret), 9)
         ret = self.call(self.mast, ["graph_get", {"depth": 2}])
-        self.assertEqual(len(ret), 6)
+
+        # old approach will include married edge
+        # but it shouldn't since it's considered a 3rd step
+        self.assertEqual(len(ret), 5)
         ret = self.call(self.mast, ["graph_get", {"depth": 1}])
         self.assertEqual(len(ret), 1)
 

--- a/jaseci_core/jaseci/graph/graph.py
+++ b/jaseci_core/jaseci/graph/graph.py
@@ -2,7 +2,6 @@
 Graph  class for Jaseci
 
 """
-from collections import OrderedDict
 from jaseci.graph.node import Node
 from jaseci.utils.id_list import IdList
 
@@ -17,65 +16,6 @@ class Graph(Node):
         self.kind = "node"
 
         # Node.__init__(self, name="root", kind="node", **kwargs)
-
-    def get_all_nodes(self, depth: int = 0):
-        """
-        Returns all reachable nodes
-        """
-
-        childs = {self.jid: self}
-        nodes = OrderedDict(childs)
-        depth -= 1
-
-        while len(childs) and depth != 0:
-            new_childs = OrderedDict()
-            for child in childs.values():
-                for _ch in child.attached_nodes():
-                    if not (_ch.jid in nodes):
-                        new_childs.update({_ch.jid: _ch})
-
-            childs = new_childs
-            nodes.update(childs)
-            depth -= 1
-
-        return nodes.values()
-
-    def get_all_edges(self, nodes: list = None, depth: int = 0):
-        """
-        Returns all reachable edges
-        """
-        edges = OrderedDict()
-        node_list = self.get_all_nodes(depth=depth) if nodes is None else nodes
-
-        for nd in node_list:
-            for _ch in nd.attached_edges():
-                if not (_ch.jid in edges) and (
-                    _ch.to_node() in node_list and _ch.from_node() in node_list
-                ):
-                    edges.update({_ch.jid: _ch})
-
-        return edges.values()
-
-    def graph_dot_str(self, detailed=False, depth: int = 0):
-        """
-        DOT representation for graph.
-        NOTE: This is different from the dot_str method for node intentionally
-        because graph inherits node.
-        """
-        node_list = self.get_all_nodes(depth=depth)
-        edge_list = self.get_all_edges(nodes=node_list)
-        node_map = [i.jid for i in node_list]
-        edge_map = [i.jid for i in edge_list]
-
-        # Construct the graph string
-        dstr = ""
-        dstr += f"strict digraph {self.name} {{\n"
-        for n in node_list:
-            dstr += f"    {n.dot_str(node_map, detailed)}"
-        for e in edge_list:
-            dstr += f"    {e.dot_str(node_map, edge_map, detailed)}"
-        dstr += "}"
-        return dstr
 
     def destroy(self):
         """

--- a/jaseci_core/jaseci/graph/node.py
+++ b/jaseci_core/jaseci/graph/node.py
@@ -4,6 +4,7 @@ Node class for Jaseci
 Each node has an id, name, timestamp and it's set of edges.
 First node in list of 'member_node_ids' is designated root node
 """
+from collections import OrderedDict
 from jaseci.element.element import Element
 from jaseci.element.obj_mixins import Anchored
 from jaseci.graph.edge import Edge
@@ -461,3 +462,59 @@ class Node(Element, Anchored):
         dstr += " ]"
 
         return dstr + "\n"
+
+    def get_all_architypes(self, depth: int = 0):
+        """
+        Returns all reachable architypes
+        """
+
+        childs = {self.jid: self}
+
+        edges = OrderedDict()
+        nodes = OrderedDict(childs)
+
+        depth -= 1
+
+        while len(childs) and depth != 0:
+            new_childs = OrderedDict()
+
+            for node in childs.values():
+                for edge in node.attached_edges():
+                    if not (edge.jid in edges):
+                        n_node = False
+                        to_node = edge.to_node()
+
+                        if to_node == node:
+                            n_node = edge.from_node()
+                        else:
+                            n_node = to_node
+
+                        if not (n_node.jid in nodes):
+                            edges.update({edge.jid: edge})
+                            new_childs.update({n_node.jid: n_node})
+                        else:
+                            edges.update({edge.jid: edge})
+
+            childs = new_childs
+            nodes.update(childs)
+            depth -= 1
+
+        return nodes, edges
+
+    def traversing_dot_str(self, detailed=False, depth: int = 0):
+        """
+        DOT representation for graph.
+        NOTE: This is different from the dot_str method for node intentionally
+        because graph inherits node.
+        """
+        nodes, edges = self.get_all_architypes(depth)
+
+        # Construct the graph string
+        dstr = ""
+        dstr += f"strict digraph {self.name} {{\n"
+        for n in nodes.values():
+            dstr += f"    {n.dot_str(list(nodes.keys()), detailed)}"
+        for e in edges.values():
+            dstr += f"    {e.dot_str(list(nodes.keys()), list(edges.keys()), detailed)}"
+        dstr += "}"
+        return dstr

--- a/jaseci_core/jaseci/jsctl/tests/test_jsctl.py
+++ b/jaseci_core/jaseci/jsctl/tests/test_jsctl.py
@@ -93,9 +93,9 @@ class JsctlTest(TestCaseHelper, TestCase):
         snt_id = self.call_cast("sentinel list")[0]["jid"]
         self.call(f"alias register s -value {snt_id}")
         self.call(f"alias register g -value {gph_id}")
-        self.assertEqual(len(self.call_cast("graph get -gph g")), 1)
+        self.assertEqual(len(self.call_cast("graph get -nd g")), 1)
         self.call("walker run init -snt s -nd g")
-        self.assertEqual(len(self.call_cast("graph get -gph g")), 3)
+        self.assertEqual(len(self.call_cast("graph get -nd g")), 3)
         self.call("alias clear")
         self.assertEqual(len(self.call_cast("alias list").keys()), 0)
 

--- a/jaseci_core/jaseci/tests/test_jac.py
+++ b/jaseci_core/jaseci/tests/test_jac.py
@@ -179,7 +179,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = list(gph.get_all_architypes()[1].values())
         self.assertEqual(len(edges), 3)
         edge_names = [edges[0].name, edges[1].name, edges[2].name]
         self.assertIn("generic", edge_names)
@@ -194,7 +194,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 0)
 
     def test_multiple_edged_between_nodes_delete_all_specific(self):
@@ -205,7 +205,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 1)
 
     def test_multiple_edged_between_nodes_delete_all_labeled(self):
@@ -216,7 +216,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 3)
 
     def test_multiple_edged_between_nodes_delete_filtered(self):
@@ -227,7 +227,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 5)
 
     def test_generic_can_be_used_to_specify_generic_edges(self):
@@ -238,7 +238,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 2)
 
     def test_can_disconnect_multi_nodes_simultaneously(self):
@@ -249,7 +249,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 2)
 
     def test_can_connect_multi_nodes_simultaneously(self):
@@ -260,7 +260,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 4)
 
     def test_can_disconnect_multi_nodes_advanced(self):
@@ -271,7 +271,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(gph.get_all_edges())
+        edges = gph.get_all_architypes()[1].values()
         self.assertEqual(len(edges), 3)
 
     def test_accessing_edges_basic(self):
@@ -282,7 +282,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        edges = list(list(gph.get_all_edges()))
+        edges = list(gph.get_all_architypes()[1].values())
         if edges[0].name == "apple":
             self.assertEqual(edges[0].context["v1"], 7)
             self.assertEqual(edges[1].context["x1"], 8)
@@ -298,7 +298,7 @@ class JacTests(TestCaseHelper, TestCase):
         test_walker = sent.run_architype("init")
         test_walker.prime(gph)
         test_walker.run()
-        nodes = gph.get_all_nodes()
+        nodes = gph.get_all_architypes()[0].values()
         self.assertEqual(len(nodes), 3)
         num = 0
         for i in nodes:

--- a/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
@@ -325,8 +325,10 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
         """Test API for getting graph in dot str"""
         payload = {"op": "graph_create"}
         res = self.client.post(reverse(f'jac_api:{payload["op"]}'), payload)
+
         gph = self.master._h.get_obj(self.master.j_master, res.data["jid"])
-        payload = {"op": "graph_get", "mode": "dot", "gph": gph.jid, "dot": True}
+        payload = {"op": "graph_get", "mode": "dot", "nd": gph.jid, "dot": True}
+
         res = self.client.post(reverse(f'jac_api:{payload["op"]}'), payload)
         self.assertTrue("graph root" in res.json())
 


### PR DESCRIPTION
## Describe your changes
 - Allow node as entry point for graph get
 - Refactor for traversing
 - Adjust unit test to cover changes

## Link to related issue
N/A

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
Yes, unit test are adjusted to cover changes

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
No

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
Graph get