### PR TITLE
[WIP][JSORC]: Version 3

### DIFF
--- a/.github/workflows/jaseci-core-test.yml
+++ b/.github/workflows/jaseci-core-test.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Verify installation
         run: |
           jsctl
+        env:
+          TASK_ENABLED: "false"
       - name: Linting
         continue-on-error: true
         run: |
@@ -47,3 +49,5 @@ jobs:
         run: |
           cd jaseci_core/
           pytest -x
+        env:
+          TASK_ENABLED: "true"

--- a/.github/workflows/jaseci-serv-test.yml
+++ b/.github/workflows/jaseci-serv-test.yml
@@ -55,6 +55,6 @@ jobs:
       - name: test jaseci_serv without redis
         run: |
           cd jaseci_serv/
-          pytest -x
+          jsserv test
         env:
           REDIS_ENABLED: "false"

--- a/.github/workflows/jaseci-serv-test.yml
+++ b/.github/workflows/jaseci-serv-test.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Verify installation
         run: |
           jsctl
+        env:
+          TASK_ENABLED: "false"
 
       - name: Install jaseci_serv and run tests
         if: always()
@@ -47,10 +49,12 @@ jobs:
           cd jaseci_serv/
           source install_live.sh
           jsserv test
+        env:
+          REDIS_ENABLED: "true"
 
       - name: test jaseci_serv without redis
         run: |
           cd jaseci_serv/
           pytest -x
         env:
-          REDIS_ENABLED: "False"
+          REDIS_ENABLED: "false"

--- a/jaseci_core/jaseci/actions/live_actions.py
+++ b/jaseci_core/jaseci/actions/live_actions.py
@@ -1,15 +1,16 @@
 """
 General action base class with automation for hot loading
 """
-from importlib.util import spec_from_file_location, module_from_spec
-from jaseci.utils.utils import logger
-from jaseci.actions.remote_actions import ACTIONS_SPEC_LOC
-from jaseci.actions.remote_actions import serv_actions, mark_as_remote, mark_as_endpoint
 import requests
 import os
 import sys
 import inspect
 import importlib
+
+from importlib.util import spec_from_file_location, module_from_spec
+from jaseci.utils.utils import logger
+from jaseci.actions.remote_actions import ACTIONS_SPEC_LOC
+from jaseci.actions.remote_actions import serv_actions, mark_as_remote, mark_as_endpoint
 
 live_actions = {}
 live_action_modules = {}
@@ -179,10 +180,10 @@ def get_global_actions():
     Attaches globals to mem_hook
     """
     from jaseci.attr.action import Action
-    from jaseci.hook.memory import MemoryHook
+    from jaseci.svc import MetaService
 
     global_action_list = []
-    hook = MemoryHook()
+    hook = MetaService(run_svcs=False).build_hook()
     for i in live_actions.keys():
         if (
             i.startswith("std.")

--- a/jaseci_core/jaseci/api/jsorc_api.py
+++ b/jaseci_core/jaseci/api/jsorc_api.py
@@ -81,7 +81,55 @@ class JsOrcApi:
         return new_config
 
     @Interface.admin_api(cli_args=["name"])
+    def service_info(self, name: str):
+        """
+        refreshing service's config. If JsOrc is not automated, service will restart else JsOrc will handle the rest
+        """
+
+        hook = self._h
+
+        to_start = not hook.meta.is_automated()
+
+        service = getattr(hook, name, None)
+
+        response = {"success": False}
+
+        if isinstance(service, CommonService):
+            service.reset(hook, to_start)
+            response["success"] = True
+        else:
+            response[
+                "message"
+            ] = f"{name} is not a valid service. Can not refresh config."
+
+        return response
+
+    @Interface.admin_api(cli_args=["name"])
     def service_refresh(self, name: str):
+        """
+        refreshing service's config. If JsOrc is not automated, service will restart else JsOrc will handle the rest
+        """
+
+        hook = self._h
+
+        to_start = not hook.meta.is_automated()
+
+        service = getattr(hook, name, None)
+
+        response = {"success": False}
+
+        if isinstance(service, CommonService):
+            service.reset(hook, to_start)
+            response["success"] = True
+        else:
+            response[
+                "message"
+            ] = f"{name} is not a valid service. Can not refresh config."
+
+        return response
+
+    @Interface.admin_api(cli_args=["name"])
+    def service_toggle(self, name: str):
         """
         refreshing service's config. If JsOrc is not automated, service will restart else JsOrc will handle the rest
         """

--- a/jaseci_core/jaseci/api/tests/test_logger_api.py
+++ b/jaseci_core/jaseci/api/tests/test_logger_api.py
@@ -31,9 +31,9 @@ class LoggerApiTest(CoreTest):
         self.logger_off()
 
         ret = self.call(self.smast, ["logger_get", {}])
-
-        self.assertEqual(len(ret), 1)
-        self.assertTrue(ret[0]["log"].endswith("Hello world!"))
+        self.assertEqual(len(ret), 2)
+        self.assertTrue(ret[0]["log"].endswith("JsOrc is not automated."))
+        self.assertTrue(ret[1]["log"].endswith("Hello world!"))
 
     def test_limited_sliding_buffer(self):
         buffer = LimitedSlidingBuffer(max_size=25)

--- a/jaseci_core/jaseci/element/element.py
+++ b/jaseci_core/jaseci/element/element.py
@@ -18,6 +18,7 @@ from jaseci.hook import MemoryHook
 from jaseci.utils.id_list import IdList
 from jaseci.utils.json_handler import JaseciJsonEncoder, json_str_to_jsci_dict
 from jaseci.utils.utils import log_var_out, logger, camel_to_snake
+from jaseci.svc import MetaService
 
 __version__ = "1.0.0"
 element_fields = None
@@ -135,7 +136,9 @@ class Element(Hookable):
         """
         global element_fields
         if element_fields is None:
-            element_fields = dir(Element(m_id=0, h=MemoryHook()))
+            element_fields = dir(
+                Element(m_id=0, h=MetaService(run_svcs=False).build_hook())
+            )
         obj_fields = []
         for i in vars(self).keys():
             if not i.startswith("_") and i not in element_fields:

--- a/jaseci_core/jaseci/hook/hook.py
+++ b/jaseci_core/jaseci/hook/hook.py
@@ -1,0 +1,50 @@
+from jaseci.svc import (
+    MetaService,
+    RedisService,
+    PrometheusService,
+    TaskService,
+    MailService,
+    ProxyService,
+)
+
+
+class Hook:
+    def __init__(self, meta: MetaService):
+        self._redis = None
+        self._promon = None
+        self._task = None
+        self._mail = None
+        self.meta = meta
+
+    @property
+    def redis(self) -> RedisService:
+        if not self._redis:
+            self._redis = ProxyService()
+            self._redis = self.meta.get_service("redis", hook=self)
+        return self._redis
+
+    @property
+    def promon(self) -> PrometheusService:
+        if not self._promo:
+            self._promo = self.meta.get_service("promon", hook=self)
+        return self._promon
+
+    @property
+    def task(self) -> TaskService:
+        if not self._task:
+            self._task = self.meta.get_service("task", hook=self)
+        return self._task
+
+    @property
+    def mail(self) -> MailService:
+        if not self._mail:
+            self._mail = self.meta.get_service("mail", hook=self)
+        return self._mail
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_redis"] = None
+        state["_promon"] = None
+        state["_task"] = None
+        state["_mail"] = None
+        return state

--- a/jaseci_core/jaseci/hook/memory.py
+++ b/jaseci_core/jaseci/hook/memory.py
@@ -1,9 +1,11 @@
-from json import dumps, loads
 import sys
+from json import dumps, loads
+
 from jaseci.utils.utils import find_class_and_import
+from .hook import Hook
 
 
-class MemoryHook:
+class MemoryHook(Hook):
     """
     Set of virtual functions to be used as hooks to allow access to
     the complete set of items across jaseci object types. This class contains
@@ -11,13 +13,12 @@ class MemoryHook:
     to the objects. They return jaseci core types.
     """
 
-    def __init__(self):
-        from jaseci.actions.live_actions import get_global_actions
-
+    def __init__(self, meta):
         self.mem = {"global": {}}
         self._machine = None
         self.save_obj_list = set()
         self.save_glob_dict = {}
+        super().__init__(meta)
 
     ####################################################
     #               COMMON GETTER/SETTER               #
@@ -228,4 +229,4 @@ class MemoryHook:
         return cls
 
     def clear_cache(self):
-        MemoryHook.__init__(self)
+        MemoryHook.__init__(self, self.meta)

--- a/jaseci_core/jaseci/hook/redis.py
+++ b/jaseci_core/jaseci/hook/redis.py
@@ -5,7 +5,6 @@ core engine.
 import json
 
 import jaseci as core_mod
-from jaseci.svc import ProxyService
 from jaseci.utils.json_handler import JaseciJsonDecoder
 from .memory import MemoryHook
 
@@ -16,13 +15,9 @@ from .memory import MemoryHook
 
 
 class RedisHook(MemoryHook):
-    def __init__(self):
-
-        # proxy redis, to be overriden by build_apps
-        self.redis = ProxyService()
+    def __init__(self, meta):
         self.red_touch_count = 0
-
-        super().__init__()
+        super().__init__(meta)
 
     ####################################################
     #        DATASOURCE METHOD (TO BE OVERRIDE)        #
@@ -134,7 +129,7 @@ class RedisHook(MemoryHook):
         if self.redis.is_running():
             self.redis.app.flushdb()
 
-        MemoryHook.__init__(self)
+        MemoryHook.__init__(self, self.meta)
 
 
 # ----------------------------------------------- #

--- a/jaseci_core/jaseci/jsctl/jsctl.py
+++ b/jaseci_core/jaseci/jsctl/jsctl.py
@@ -25,7 +25,7 @@ def reset_state():
     global session
     session = {
         "filename": "js.session",
-        "user": [MetaService(run_svcs=False).build_super_master(name="admin")],
+        "user": [MetaService().build_super_master(name="admin")],
         "mem-only": session["mem-only"] if session is not None else False,
         "connection": {"url": None, "token": None, "headers": None},
     }
@@ -342,8 +342,14 @@ def script(filename, profile, output):
     if output:
         with open(output, "w") as f:
             f.write("Multi Command Script Output:\n")
+
+    global session
+
     for i in cmds:
-        res = CliRunner(mix_stderr=False).invoke(jsctl, i.split())
+        addons = []
+        if session["mem-only"]:
+            addons = ["-m"]
+        res = CliRunner(mix_stderr=False).invoke(jsctl, addons + i.split())
         click.echo(res.stdout)
         if output:
             with open(output, "a") as f:

--- a/jaseci_core/jaseci/svc/common.py
+++ b/jaseci_core/jaseci/svc/common.py
@@ -111,6 +111,15 @@ class CommonService:
     def build_manifest(self, hook) -> dict:
         pass
 
+    def info(self):
+        return {
+            "state": self.state.name,
+            "enabled": self.enabled,
+            "quiet": self.quiet,
+            "config": self.config,
+            "manifest": self.manifest,
+        }
+
     # ------------------- DAEMON -------------------- #
 
     def spawn_daemon(self, **targets):
@@ -576,3 +585,15 @@ class MetaProperties:
     @running_interval.setter
     def running_interval(self, val: int):
         self.cls._running_interval = val
+
+    @property
+    def config(self) -> bool:
+        return self.cls._quiet
+
+    @property
+    def manifest(self) -> bool:
+        return self.cls._quiet
+
+    @property
+    def manifest_meta(self) -> bool:
+        return self.cls._quiet

--- a/jaseci_core/jaseci/svc/common.py
+++ b/jaseci_core/jaseci/svc/common.py
@@ -83,7 +83,7 @@ class CommonService:
     def has_failed(self):
         return self.state.has_failed()
 
-    def build_settings(self, hook) -> dict:
+    def build_settings(self, hook):
         try:
             self.manifest = self.build_manifest(hook)
             self.manifest_meta = {}
@@ -146,8 +146,8 @@ class CommonService:
 
 
 class ProxyService(CommonService):
-    def __init__(self):
-        super().__init__(__class__)
+    def build_settings(self, hook):
+        pass
 
 
 class Kube:
@@ -439,6 +439,8 @@ class JsOrc:
             logger.error(f"Service {name} is not yet set!")
             return None
 
+        if not kwargs.get("hook", None):
+            kwargs["hook"] = self.build_context("hook", self)
         svc = svc(*args, **kwargs)
 
         if background:

--- a/jaseci_core/jaseci/svc/meta.py
+++ b/jaseci_core/jaseci/svc/meta.py
@@ -30,12 +30,15 @@ class MetaService(CommonService, MetaProperties):
 
     def post_run(self, hook=None):
         if self.run_svcs:
-            self.app.build()
-            if self.is_automated():
-                logger.info("JsOrc is automated. Pushing interval check alarm...")
-                self.push_interval(1)
-            else:
-                logger.info("JsOrc is not automated.")
+            self.build()
+
+    def build(self):
+        self.app.build()
+        if self.is_automated():
+            logger.info("JsOrc is automated. Pushing interval check alarm...")
+            self.push_interval(1)
+        else:
+            logger.info("JsOrc is not automated.")
 
     def push_interval(self, interval):
         if self.running_interval == 0:
@@ -80,6 +83,9 @@ class MetaService(CommonService, MetaProperties):
     def in_cluster(self):
         return self.app.in_cluster()
 
+    def info(self):
+        return {"state": self.state.name, "automated": self.app.automated}
+
     ###################################################
     #                     BUILDER                     #
     ###################################################
@@ -110,10 +116,7 @@ class MetaService(CommonService, MetaProperties):
     ###################################################
 
     def reset(self, hook=None, start=True):
-        self.terminate_daemon("jsorc")
-        self.app = None
-        self.state = Ss.NOT_STARTED
-        self.__init__()
+        self.build()
 
     def populate_context(self):
         from jaseci.hook import RedisHook

--- a/jaseci_core/jaseci/svc/meta.py
+++ b/jaseci_core/jaseci/svc/meta.py
@@ -85,18 +85,11 @@ class MetaService(CommonService, MetaProperties):
     ###################################################
 
     def build_hook(self):
-        h = self.build_context("hook")
-        h.meta = self
-        if self.run_svcs:
-            h.promon = self.get_service("promon", h)
-            h.redis = self.get_service("redis", h)
-            h.task = self.get_service("task", h)
-            h.mail = self.get_service("mail", h)
-
-            if not self.is_automated():
-                h.mail.start(h)
-                h.redis.start(h)
-                h.task.start(h)
+        h = self.build_context("hook", self)
+        if self.run_svcs and not self.is_automated():
+            h.mail.start(h)
+            h.redis.start(h)
+            h.task.start(h)
 
         return h
 

--- a/jaseci_core/jaseci/svc/task/config.py
+++ b/jaseci_core/jaseci/svc/task/config.py
@@ -6,8 +6,11 @@ DEFAULT_URL = (
     f':{os.getenv("REDIS_PORT", "6379")}/{os.getenv("REDIS_DB", "1")}'
 )
 
+# default true
+TASK_ENABLED = os.getenv("TASK_ENABLED", "true") == "true"
+
 TASK_CONFIG = {
-    "enabled": True,
+    "enabled": TASK_ENABLED,
     "quiet": True,
     "broker_url": DEFAULT_URL,
     "result_backend": DEFAULT_URL,

--- a/jaseci_core/jaseci/svc/task/task.py
+++ b/jaseci_core/jaseci/svc/task/task.py
@@ -81,7 +81,7 @@ class TaskService(CommonService):
 
     def ping(self):  # will throw exception
         self.inspect.ping()
-        self.app.AsyncResult("").result
+        self.app.AsyncResult("00000000-0000-0000-0000-000000000000").result
 
     ###################################################
     #                     QUEUING                     #

--- a/jaseci_core/jaseci/utils/utils.py
+++ b/jaseci_core/jaseci/utils/utils.py
@@ -235,6 +235,10 @@ class TestCaseHelper:
     def setUp(self):
         self.logger_off()
         self.stime = time()
+        from jaseci.svc import MetaService
+
+        MetaService().get_service("redis").clear()
+
         return super().setUp()
 
     def tearDown(self):

--- a/jaseci_core/setup.py
+++ b/jaseci_core/setup.py
@@ -19,7 +19,7 @@ setup(
         "fastapi[all]>=0.75.0,<1.0.0",
         "requests",
         "redis",
-        "celery>=5,<6",
+        "celery>=5.3.0b1,<6",
         "flake8",
         "pep8-naming",
         "stripe",

--- a/jaseci_serv/jaseci_serv/hook/orm.py
+++ b/jaseci_serv/jaseci_serv/hook/orm.py
@@ -4,18 +4,18 @@ core engine.
 
 FIX: Serious permissions work needed
 """
+import json
 import uuid
 
+from datetime import datetime
 from django.core.exceptions import ObjectDoesNotExist
 
 import jaseci as core_mod
 from jaseci.hook import RedisHook
 from jaseci.utils import utils
-from jaseci.utils.json_handler import json_str_to_jsci_dict
 from jaseci.utils.id_list import IdList
 from jaseci.utils.utils import logger
-from datetime import datetime
-import json
+from jaseci_serv.base.models import GlobalVars, JaseciObject
 
 
 class OrmHook(RedisHook):
@@ -23,11 +23,11 @@ class OrmHook(RedisHook):
     Hooks Django ORM database for Jaseci objects to Jaseci's core engine.
     """
 
-    def __init__(self, objects, globs):
-        self.objects = objects
-        self.globs = globs
+    def __init__(self, meta):
+        self.objects = JaseciObject.objects
+        self.globs = GlobalVars.objects
         self.db_touch_count = 0
-        super().__init__()
+        super().__init__(meta)
 
     ####################################################
     #                DATASOURCE METHOD                 #

--- a/jaseci_serv/jaseci_serv/obj_api/views.py
+++ b/jaseci_serv/jaseci_serv/obj_api/views.py
@@ -5,8 +5,8 @@ from rest_framework import serializers as slzrs
 from rest_framework.serializers import HyperlinkedIdentityField
 from django.contrib.auth.models import AnonymousUser
 
+from jaseci.utils.json_handler import json_str_to_jsci_dict
 from jaseci_serv.base import models
-from jaseci_serv.hook.orm import json_str_to_jsci_dict
 
 
 class JaseciObjectSerializer(slzrs.HyperlinkedModelSerializer):

--- a/jaseci_serv/jaseci_serv/svc/meta.py
+++ b/jaseci_serv/jaseci_serv/svc/meta.py
@@ -17,16 +17,9 @@ class MetaService(Ms):
 
     def populate_context(self):
         from jaseci_serv.hook.orm import OrmHook
-        from jaseci_serv.base.models import (
-            Master,
-            SuperMaster,
-            GlobalVars,
-            JaseciObject,
-        )
+        from jaseci_serv.base.models import Master, SuperMaster
 
-        self.add_context(
-            "hook", OrmHook, objects=JaseciObject.objects, globs=GlobalVars.objects
-        )
+        self.add_context("hook", OrmHook)
         self.add_context("master", Master)
         self.add_context("super_master", SuperMaster)
 

--- a/jaseci_serv/jaseci_serv/svc/redis/config.py
+++ b/jaseci_serv/jaseci_serv/svc/redis/config.py
@@ -1,7 +1,10 @@
 import os
 
+# default true
+REDIS_ENABLED = os.getenv("REDIS_ENABLED", "true") == "true"
+
 REDIS_CONFIG = {
-    "enabled": True,
+    "enabled": REDIS_ENABLED,
     "quiet": False,
     "host": os.getenv("REDIS_HOST", "localhost"),
     "port": os.getenv("REDIS_PORT", "6379"),

--- a/jaseci_serv/jaseci_serv/svc/task/config.py
+++ b/jaseci_serv/jaseci_serv/svc/task/config.py
@@ -1,8 +1,11 @@
 import os
 import sys
 
+# default true
+REDIS_ENABLED = os.getenv("REDIS_ENABLED", "true") == "true"
+
 TASK_CONFIG = {
-    "enabled": True,
+    "enabled": REDIS_ENABLED,
     "quiet": False,
     "broker_url": f'redis://{os.getenv("REDIS_HOST", "localhost")}:{os.getenv("REDIS_PORT", "6379")}/{os.getenv("REDIS_DB", "1")}',
     "beat_scheduler": "django_celery_beat.schedulers:DatabaseScheduler",


### PR DESCRIPTION
CHANGE:


## Describe your changes
- Refactor Hooks. Hooks now hold the reference on the services instead on setting it after hook initialization
- JsOrc will now retain the instance even on service refresh (since it holds every services/context)
- Fix unit test on MailService
- Fix the unit with and without redis/task
- Allow services on jsctl and improving quiet logging specially on celery (adjust version to latest)
- New api for getting service info and toggle of enabling and disabling

## Link to related issue
 - N/A

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.
- Yes, soon...

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.
- No

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
- JsOrc