### PR TITLE
Fix: Webtool returning a forbidden error response.

### DIFF
--- a/jaseci_core/jaseci/actions/standard/tests/fixtures/webtool.jac
+++ b/jaseci_core/jaseci/actions/standard/tests/fixtures/webtool.jac
@@ -12,6 +12,20 @@ walker get_meta_valid {
     }
 }
 
+walker get_meta_403_response {
+    has url = "https://www.wsj.com/articles/why-this-housing-downturn-isnt-like-the-last-one-11671273004?mod=hp_lead_pos1";
+    can webtool.get_page_meta;
+
+    root {
+        try {
+            report webtool.get_page_meta(url);
+        } else with error {
+            report error;
+            report:error = error;
+        }
+    }
+}
+
 
 walker get_meta_invalid {
     has url = "";

--- a/jaseci_core/jaseci/actions/standard/tests/test_webtool.py
+++ b/jaseci_core/jaseci/actions/standard/tests/test_webtool.py
@@ -14,6 +14,14 @@ class WebtoolTest(CoreTest):
         self.assertTrue("dc" in ret["report"][0])
         self.assertTrue("page" in ret["report"][0])
 
+    @jac_testcase("webtool.jac", "get_meta_403_response")
+    def test_get_meta_403_response(self, ret):
+        self.assertTrue(ret["success"])
+        self.assertTrue("og" in ret["report"][0])
+        self.assertTrue("meta" in ret["report"][0])
+        self.assertTrue("dc" in ret["report"][0])
+        self.assertTrue("page" in ret["report"][0])
+
     @jac_testcase("webtool.jac", "get_meta_invalid")
     def test_get_meta_invalid(self, ret):
         self.assertFalse(ret["success"])

--- a/jaseci_core/jaseci/actions/standard/webtool.py
+++ b/jaseci_core/jaseci/actions/standard/webtool.py
@@ -13,5 +13,13 @@ def get_page_meta(url: str = ""):
     if url == "":
         raise HTTPException(status_code=400, detail=str("No url provided"))
 
-    page = metadata_parser.MetadataParser(url=url)
-    return page.metadata
+    try:
+        page = metadata_parser.MetadataParser(
+            url=url,
+            url_headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0",
+            },
+        )
+        return page.metadata
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Describe your changes
Some URL's doesn't allow metadata scrapping, it's returning a forbidden error (403) response.

Added user-agent header to `metadata_parser.MetadataParser` call.



## Link to related issue

## Does this introduce new feature or change existing feature of Jaseci? If so, please add tests.

## Will this impact Jaseci users? If so, please write a paragraph describing the impact.

## Anything in this PR should the Jaseci developer/contributor community pay particular attention to? If so, please describe.
