### PR TITLE
Fix command for example in 2_faq.md

### DIFF
--- a/examples/CanoniCAI/codelabs/2_faq.md
+++ b/examples/CanoniCAI/codelabs/2_faq.md
@@ -263,7 +263,7 @@ The `jac_nlp` package contains the Universal Sentence Encoder QA model that we a
 To install `jac_nlp`:
 
 ```bash
-pip install jac_nlp[use_qa, bi_enc, tfm_ner] # This will install the models which we need for this example
+pip install jac_nlp[use_qa,bi_enc,tfm_ner] # This will install the models which we need for this example
 ```
 But if you want to install all the models in `jac_nlp`:
 
@@ -406,4 +406,3 @@ On the right is the architecture diagram of the complete system we are going to 
 - Testing.
 - Deploying your Jac application to a production environment.
 - Training data collection and curation.
-


### PR DESCRIPTION
[sidganti](https://github.com/sidganti) commented [7 minutes ago](https://github.com/Jaseci-Labs/jaseci/pull/867#issue-1561659324)
The white now removed whitespaces makes violated bash syntax.
Now, it will be easier for individuals to copy the command into their terminal without having to manually diagnose and fix this.

Error the old line returned :
ERROR: Invalid requirement: 'jac_nlp[use_qa,'