### PR TITLE
docs: update pip commands in Section 2

### DIFF
--- a/examples/CanoniCAI/codelabs/2_faq.md
+++ b/examples/CanoniCAI/codelabs/2_faq.md
@@ -263,12 +263,12 @@ The `jac_nlp` package contains the Universal Sentence Encoder QA model that we a
 To install `jac_nlp`:
 
 ```bash
-pip install jac_nlp[use_qa,bi_enc,tfm_ner] # This will install the models which we need for this example
+pip install "jac_nlp[use_qa,bi_enc,tfm_ner]" # This will install the models which we need for this example, make sure to include the quotations
 ```
 But if you want to install all the models in `jac_nlp`:
 
 ```bash
-pip install jac_nlp[all] # This will install all the models in jac_nlp
+pip install "jac_nlp[all]" # This will install all the models in jac_nlp, again making sure to include the quotations
 ```
 
 > **Note**


### PR DESCRIPTION
This PR is a docs fix addressing the pip commands in Section 2. When installing modules and wanting to specify optional dependencies to install, you need the module and brackets surrounded in quotations. This should fix the commands so students in the future are not confused.