### PR TITLE
Hotfix: jsctl remote calls bug

### DIFF
--- a/jaseci_core/jaseci/jsctl/jsctl.py
+++ b/jaseci_core/jaseci/jsctl/jsctl.py
@@ -91,7 +91,7 @@ def remote_api_call(payload, api_name):
     )
 
     method = requests.post
-    if "post" not in api["allowed_methods"]:
+    if api["allowed_methods"] != None and "post" not in api["allowed_methods"]:
         method = requests.get
 
     ret = method(

--- a/jaseci_core/jaseci/jsorc_settings.py
+++ b/jaseci_core/jaseci/jsorc_settings.py
@@ -59,7 +59,7 @@ class JsOrcSettings:
 
     REDIS_CONFIG = {
         "enabled": True,
-        "quiet": False,
+        "quiet": True,
         "automated": True,
         "host": os.getenv("REDIS_HOST", "localhost"),
         "port": os.getenv("REDIS_PORT", "6379"),

--- a/jaseci_serv/jaseci_serv/__init__.py
+++ b/jaseci_serv/jaseci_serv/__init__.py
@@ -12,7 +12,7 @@ class JsOrcSettings(jss):
 
     TASK_CONFIG = {
         "enabled": True,
-        "quiet": False,
+        "quiet": True,
         "automated": True,
         "broker_url": f'redis://{os.getenv("REDIS_HOST", "localhost")}:{os.getenv("REDIS_PORT", "6379")}/{os.getenv("REDIS_DB", "1")}',
         "beat_scheduler": "django_celery_beat.schedulers:DatabaseScheduler",
@@ -33,7 +33,7 @@ class JsOrcSettings(jss):
 
     REDIS_CONFIG = {
         "enabled": os.getenv("REDIS_ENABLED", "true") == "true",
-        "quiet": False,
+        "quiet": True,
         "automated": True,
         "host": os.getenv("REDIS_HOST", "localhost"),
         "port": os.getenv("REDIS_PORT", "6379"),


### PR DESCRIPTION
Also, temporarily suppress the warning messages from initializing redis service and task service because local jsserv logs are unusable because of it.