### PR TITLE
[HOTFIX]: Removing django.contrib.sites

### DIFF
--- a/jaseci_serv/jaseci_serv/jsx_oauth/config.py
+++ b/jaseci_serv/jaseci_serv/jsx_oauth/config.py
@@ -3,7 +3,6 @@ import os
 OAUTH_APPS = [
     "rest_framework.authtoken",
     "dj_rest_auth",
-    "django.contrib.sites",
     "allauth",
     "allauth.account",
     "dj_rest_auth.registration",

--- a/jaseci_serv/jaseci_serv/jsx_oauth/tests/test_social_auth.py
+++ b/jaseci_serv/jaseci_serv/jsx_oauth/tests/test_social_auth.py
@@ -3,7 +3,6 @@ from time import time
 from rest_framework.test import APIClient
 from jaseci.utils.utils import TestCaseHelper
 from django.test import TestCase
-from django.contrib.sites.models import Site
 from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from jaseci_serv.base.models import User
@@ -53,9 +52,6 @@ class SocialAuthTest(TestCaseHelper, TestCase):
             name="Google OAuth",
             client_id="384752611190-e04jb43i8cnfp953r1m1f5mq5abd919i.apps.googleusercontent.com",
             secret="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",
-        )
-        self.google_app.sites.add(
-            Site.objects.create(domain="testserver", name="testserver"),
         )
         self.google_app.save()
 


### PR DESCRIPTION
Removing django.contrib.sites to removed the issue on clean build.
Also, we don't use the sites validation anymore in jsx-auth

![image](https://user-images.githubusercontent.com/74129725/223127276-c60245b6-a7e4-4331-804b-b1daf653a422.png)
