### PR TITLE
[BUGFIX]: Allow none assignment on spawn walker

### DIFF
--- a/jaseci_core/jaseci/jac/machine/jac_value.py
+++ b/jaseci_core/jaseci/jac/machine/jac_value.py
@@ -160,7 +160,14 @@ class JacValue:
                 return self.ctx[self.name : self.end]
             elif type(self.name) == int or self.name in self.ctx.keys():
                 return self.ctx[self.name]
-            elif not self.parent._assign_mode and not create_mode:
+            elif (
+                not self.parent._assign_mode
+                and not create_mode
+                and (
+                    not self.is_element
+                    or self.name not in self.is_element.get_architype().has_vars
+                )
+            ):
                 self.parent.rt_error(f"Key {self.name} not found in object/dict.")
         else:
             return None

--- a/jaseci_core/jaseci/tests/jac_test_progs.py
+++ b/jaseci_core/jaseci/tests/jac_test_progs.py
@@ -692,3 +692,27 @@ async walker b {
     }
 }
 """
+
+walker_null_args = """
+node c {
+    has c1, c2;
+}
+
+walker b {
+    has anchor b1, b2;
+    with entry {
+        report b1;
+        report b2;
+    }
+}
+
+walker a {
+    has a1;
+
+    with entry {
+        a2 = null;
+        te = spawn here walker::b(b1 = a1, b2 = a2);
+        te = spawn here ++> node::c(c1=a1, c2=a2);
+    }
+}
+"""

--- a/jaseci_core/jaseci/tests/test_progs.py
+++ b/jaseci_core/jaseci/tests/test_progs.py
@@ -608,3 +608,16 @@ class JacTests(TestCaseHelper, TestCase):
             "Cannot execute sim1.tester - Not Found",
             res["result"]["response"]["errors"][0],
         )
+
+    def test_walker_run_with_null_arguments(self):
+        mast = JsOrc.master()
+        res = mast.sentinel_register(
+            name="test", code=jtp.walker_null_args, auto_run=""
+        )
+        res = mast.general_interface_to_api(
+            api_name="walker_run",
+            params={"name": "a", "ctx": {}},
+        )
+        self.assertTrue(res["success"])
+        self.assertTrue(res["report"], [None, None])
+        self.assertIsNone(res.get("errors"))


### PR DESCRIPTION
Scenario:

```js
node c {
    has c1, c2;
}

walker b {
    has anchor b1, b2;
    with entry {
        report b1;
        report b2;
    }
}

walker a {
    has a1;

    with entry {
        a2 = null;
        
        // this will not return errors as we always initialize node before assigning the arguments
        te = spawn here ++> node::c(c1=a1, c2=a2);

        // this will return errors since it will reference b1 in walker b even it's not yet present
        te = spawn here walker::b(b1 = a1, b2 = a2);
    }
}

#response
{
  "success": false,
  "report": [
    null,
    null
  ],
  "final_node": "urn:uuid:dcee518d-ee0e-439d-9d60-230b3c4cfd4d",
  "yielded": false,
  "errors": [
    "testing:a - line 18, col 34 - rule spawn_assign - Key b1 not found in object/dict.",
    "testing:a - line 18, col 43 - rule spawn_assign - Key b2 not found in object/dict."
  ]
}
```

I haven't fully understand the behavior but on testing, spawn walker syntax will not initialize the `has attr` until the argument process is finished. This argument processing will reference the key on ctx but walker is not yet initialize (ctx = {}), reason for returning "Key {self.name} not found in object/dict."

Adding checking of `has_vars` will bypass the error since it's will also check if argument key is a valid context key

Other solution is by initializing the default context on architype (or walker?) this is to ensure that every new walker will have the default context tho I'm not sure if it will affect other process