### PR TITLE
Remote action call kwargs fix

### DIFF
--- a/jaseci_core/jaseci/actions/live_actions.py
+++ b/jaseci_core/jaseci/actions/live_actions.py
@@ -291,9 +291,6 @@ def gen_remote_func_hook(url, act_name, param_names):
     """Generater for function calls for remote action calls"""
 
     def func(*args, **kwargs):
-        logger.info(args)
-        logger.info(kwargs)
-        logger.info(param_names)
         params = {}
         for i in range(len(param_names)):
             if i < len(args):
@@ -304,9 +301,7 @@ def gen_remote_func_hook(url, act_name, param_names):
             if i in param_names:
                 params[i] = kwargs[i]
         # Remove any None-valued parameters to use the default value of the action def
-        logger.info(params)
         params = dict([(k, v) for k, v in params.items() if v is not None])
-        logger.info(params)
         act_url = f"{url.rstrip('/')}/{act_name.split('.')[-1]}"
         res = requests.post(
             act_url, headers={"content-type": "application/json"}, json=params
@@ -325,8 +320,6 @@ def call_action(action_name: str, ctx: dict = {}) -> None:
     try:
         action_name = action_name.strip()
         if action_name in live_actions.keys():
-            logger.info(live_actions[action_name])
-            logger.info(ctx)
             res = live_actions[action_name](**ctx)
             return res, True
         else:

--- a/jaseci_core/jaseci/actions/tests/test_actions.py
+++ b/jaseci_core/jaseci/actions/tests/test_actions.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
+from unittest.mock import patch
 from jaseci.utils.utils import TestCaseHelper
 import jaseci.actions.live_actions as jla
 import jaseci.actions.remote_actions as jra
+from jaseci.actions.live_actions import gen_remote_func_hook
 
 
 class JacActionsTests(TestCaseHelper, TestCase):
@@ -52,3 +54,19 @@ class JacActionsTests(TestCaseHelper, TestCase):
 
     def test_live_action_globals(self):
         self.assertGreater(len(jla.live_actions), 25)
+
+    @patch("requests.post")
+    def test_remote_action_kwargs(self, mock_post):
+        remote_action = gen_remote_func_hook(
+            url="https://example.com/api/v1/endpoint",
+            act_name="example.action",
+            param_names=["param1", "param2"],
+        )
+        payload = {"param1": "value1"}
+        remote_action(**payload)
+
+        mock_post.assert_called_once()
+
+        _, kwargs = mock_post.call_args
+
+        assert kwargs["json"] == payload


### PR DESCRIPTION
Fix an issue where using kwargs for remote action call do not use default value set in the action definition