### PR TITLE
Fix the case where an older version of jaseci is installed with jac_nlp/speech/vision

### DIFF
--- a/jaseci_ai_kit/jac_misc/setup.py
+++ b/jaseci_ai_kit/jac_misc/setup.py
@@ -22,7 +22,11 @@ setup(
     name="jac_misc",
     version=get_ver(),
     packages=find_packages(include=["jac_misc", "jac_misc.*"]),
-    install_requires=["jaseci", "pytest>=7.0.1,<7.1", "pytest-order>=1.0.1,<1.1"],
+    install_requires=[
+        f"jaseci=={get_ver()}",
+        "pytest>=7.0.1,<7.1",
+        "pytest-order>=1.0.1,<1.1",
+    ],
     extras_require=get_extras_requires(),
     package_data={
         "": ["*.json", "*.cfg", "VERSION", "*.yaml", "requirements.txt", "*.jac"],

--- a/jaseci_ai_kit/jac_nlp/jac_nlp/bart_sum/requirements.txt
+++ b/jaseci_ai_kit/jac_nlp/jac_nlp/bart_sum/requirements.txt
@@ -1,3 +1,3 @@
 transformers>=4.25.1
-beautifulsoup4 >= 4.10.0, < 4.11.0
+beautifulsoup4 >= 4.12.2, < 4.13.0
 torch>=1.10.2,<2.0.0

--- a/jaseci_ai_kit/jac_nlp/setup.py
+++ b/jaseci_ai_kit/jac_nlp/setup.py
@@ -32,8 +32,6 @@ def get_ver():
 def get_extras_requires():
     extras_requires = {"all": []}
     for module in MODULES:
-        print("==============")
-        print(module)
         with open(join("./jac_nlp", module, "requirements.txt")) as req_file:
             extras_requires[module] = req_file.read().splitlines()
             extras_requires["all"].extend(extras_requires[module])

--- a/jaseci_ai_kit/jac_nlp/setup.py
+++ b/jaseci_ai_kit/jac_nlp/setup.py
@@ -32,9 +32,12 @@ def get_ver():
 def get_extras_requires():
     extras_requires = {"all": []}
     for module in MODULES:
+        print("==============")
+        print(module)
         with open(join("./jac_nlp", module, "requirements.txt")) as req_file:
             extras_requires[module] = req_file.read().splitlines()
             extras_requires["all"].extend(extras_requires[module])
+            print(extras_requires[module])
     return extras_requires
 
 
@@ -42,7 +45,11 @@ setup(
     name="jac_nlp",
     version=get_ver(),
     packages=find_packages(include=["jac_nlp", "jac_nlp.*"]),
-    install_requires=["jaseci", "pytest>=7.0.1,<7.1", "pytest-order>=1.0.1,<1.1"],
+    install_requires=[
+        f"jaseci=={get_ver()}",
+        "pytest>=7.0.1,<7.1",
+        "pytest-order>=1.0.1,<1.1",
+    ],
     extras_require=get_extras_requires(),
     package_data={
         "": ["*.json", "*.cfg", "VERSION", "*.yaml", "requirements.txt", "*.jac"],

--- a/jaseci_ai_kit/jac_nlp/setup.py
+++ b/jaseci_ai_kit/jac_nlp/setup.py
@@ -35,7 +35,6 @@ def get_extras_requires():
         with open(join("./jac_nlp", module, "requirements.txt")) as req_file:
             extras_requires[module] = req_file.read().splitlines()
             extras_requires["all"].extend(extras_requires[module])
-            print(extras_requires[module])
     return extras_requires
 
 

--- a/jaseci_ai_kit/jac_speech/setup.py
+++ b/jaseci_ai_kit/jac_speech/setup.py
@@ -40,7 +40,11 @@ setup(
     name="jac_speech",
     version=get_ver(),
     packages=find_packages(include=["jac_speech", "jac_speech.*"]),
-    install_requires=["jaseci", "pytest>=7.0.1,<7.1", "pytest-order>=1.0.1,<1.1"],
+    install_requires=[
+        f"jaseci=={get_ver()}",
+        "pytest>=7.0.1,<7.1",
+        "pytest-order>=1.0.1,<1.1",
+    ],
     cmdclass={"install": OrderedInstall},
     extras_require=get_extras_requires(),
     package_data={

--- a/jaseci_ai_kit/jac_vision/setup.py
+++ b/jaseci_ai_kit/jac_vision/setup.py
@@ -22,7 +22,11 @@ setup(
     name="jac_vision",
     version=get_ver(),
     packages=find_packages(include=["jac_vision", "jac_vision.*"]),
-    install_requires=["jaseci", "pytest>=7.0.1,<7.1", "pytest-order>=1.0.1,<1.1"],
+    install_requires=[
+        f"jaseci=={get_ver()}",
+        "pytest>=7.0.1,<7.1",
+        "pytest-order>=1.0.1,<1.1",
+    ],
     extras_require=get_extras_requires(),
     package_data={
         "": ["*.json", "*.cfg", "VERSION", "*.yaml", "requirements.txt", "*.jac"],

--- a/support/docker/jaseci.Dockerfile
+++ b/support/docker/jaseci.Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_WITH
 WORKDIR /
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update; apt -y upgrade; apt -y install --no-install-recommends git g++ build-essential pkg-config cmake
-RUN pip3 install jaseci==$JASECI_PYPI_VERSION
-RUN pip3 install jaseci-serv==$JASECI_SERV_PYPI_VERSION
-RUN if [ -n "$BUILD_WITH" ]; then pip3 install "$BUILD_WITH"[all]==$JASECI_AI_KIT_PYPI_VERSION --extra-index-url https://download.pytorch.org/whl/cpu; fi
+RUN pip3 install jaseci==$JASECI_PYPI_VERSION --no-cache-dir
+RUN pip3 install jaseci-serv==$JASECI_SERV_PYPI_VERSION --no-cache-dir
+RUN if [ -n "$BUILD_WITH" ]; then pip3 install "$BUILD_WITH"[all]==$JASECI_AI_KIT_PYPI_VERSION --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu; fi
 CMD ["echo", "Ready"]


### PR DESCRIPTION
* Fixes an issue where installing jac_nlp/jac_speech/jac_vision/jac_misc use cached pip wheel and could install older jaseci versions.
* We are now requiring a specific version of jaseci in setup.py for jac_*
* Also add `--no-cache-dir` to pip install when building docker image.