### PR TITLE
[ENHANCEMENTS]: MInor changes and bugfixes: MailService, TaskService, DateAction

### DIFF
--- a/jaseci_core/jaseci/extens/act_lib/date.py
+++ b/jaseci_core/jaseci/extens/act_lib/date.py
@@ -1,7 +1,7 @@
 """Built in actions for Jaseci"""
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from jaseci.jsorc.live_actions import jaseci_action
+from dateutil.relativedelta import relativedelta
 
 
 @jaseci_action()
@@ -35,13 +35,13 @@ def quantize_to_day(date: str):
 
 @jaseci_action()
 def datetime_now():
-    """Get utc date time for now in iso format"""
+    """Get utc date time now in iso format"""
     return datetime.utcnow().isoformat()
 
 
 @jaseci_action()
 def date_now():
-    """Get utc date time for now in iso format"""
+    """Get utc date now in iso format"""
     return datetime.utcnow().date().isoformat()
 
 
@@ -49,6 +49,55 @@ def date_now():
 def timestamp_now():
     """Get utc date time for now in iso format"""
     return int(datetime.utcnow().timestamp())
+
+
+@jaseci_action()
+def datetime_obj(date: str = None):
+    """Get utc date time now or parse one to dict format"""
+    if date:
+        date = datetime.fromisoformat(date)
+    else:
+        date = datetime.utcnow()
+
+    return {
+        "year": date.year,
+        "month": date.month,
+        "weekday": date.isoweekday(),
+        "day": date.day,
+        "hour": date.hour,
+        "minute": date.minute,
+        "second": date.second,
+        "microsecond": date.microsecond,
+        "iso": date.isoformat(),
+    }
+
+
+@jaseci_action()
+def datetime_add(date: str = None, **kwargs):
+    """
+    Get utc date time now or parse one then add timedelta
+    kwargs: this should be valid timedelta arguments
+    """
+    if date:
+        date = datetime.fromisoformat(date)
+    else:
+        date = datetime.utcnow()
+
+    return (date + relativedelta(**kwargs)).isoformat()
+
+
+@jaseci_action()
+def datetime_sub(date: str = None, **kwargs):
+    """
+    Get utc date time now or parse one then subtract timedelta
+    kwargs: this should be valid timedelta arguments
+    """
+    if date:
+        date = datetime.fromisoformat(date)
+    else:
+        date = datetime.utcnow()
+
+    return (date - relativedelta(**kwargs)).isoformat()
 
 
 @jaseci_action()

--- a/jaseci_core/jaseci/extens/act_lib/tests/fixtures/date.jac
+++ b/jaseci_core/jaseci/extens/act_lib/tests/fixtures/date.jac
@@ -1,0 +1,7 @@
+walker sample {
+    with entry {
+        report date.datetime_obj("2023-04-26T07:42:53.093606");
+        report date.datetime_add("2023-04-26T07:42:53.093606", days = 10, months = 1);
+        report date.datetime_sub("2023-04-26T07:42:53.093606", hours = 7);
+    }
+}

--- a/jaseci_core/jaseci/extens/act_lib/tests/test_date.py
+++ b/jaseci_core/jaseci/extens/act_lib/tests/test_date.py
@@ -1,0 +1,26 @@
+from jaseci.utils.test_core import CoreTest, jac_testcase
+
+
+class DateTest(CoreTest):
+    fixture_src = __file__
+
+    @jac_testcase("date.jac", "sample")
+    def test_date_syntax(self, ret):
+        self.assertEqual(
+            ret["report"],
+            [
+                {
+                    "day": 26,
+                    "hour": 7,
+                    "microsecond": 93606,
+                    "minute": 42,
+                    "month": 4,
+                    "second": 53,
+                    "weekday": 3,
+                    "year": 2023,
+                    "iso": "2023-04-26T07:42:53.093606",
+                },
+                "2023-06-05T07:42:53.093606",
+                "2023-04-26T00:42:53.093606",
+            ],
+        )

--- a/jaseci_core/jaseci/extens/svc/mail_svc.py
+++ b/jaseci_core/jaseci/extens/svc/mail_svc.py
@@ -72,8 +72,21 @@ class MailService(JsOrc.CommonService):
             )
 
             if migrate:
-                self.config["migrate"] = False
-                hook.save_glob("MAIL_CONFIG", dumps(self.config))
+                hook.save_glob(
+                    "MAIL_CONFIG",
+                    dumps(
+                        {
+                            **{
+                                "enabled": self.enabled,
+                                "quiet": self.quiet,
+                                "automated": self.automated,
+                            },
+                            **self.config,
+                            "migrate": False,
+                        }
+                    ),
+                )
+                hook.commit()
 
     ###################################################
     #                     CLEANER                     #

--- a/jaseci_core/jaseci/extens/svc/tasks.py
+++ b/jaseci_core/jaseci/extens/svc/tasks.py
@@ -34,7 +34,7 @@ class ScheduledWalker(Task):
     def get_obj(self, jid):
         return self.hook.get_obj_from_store(jid)
 
-    def run(self, name, ctx, nd=None, snt=None, mst=None):
+    def run(self, mst, wlk, ctx, nd=None, snt=None):
         self.hook = JsOrc.hook()
 
         if mst:
@@ -71,7 +71,7 @@ class ScheduledWalker(Task):
             if not nd:
                 return f"{DEFAULT_MSG} Invalid Node!"
 
-            return mst.walker_run(name, nd, ctx, ctx, snt, False, False)
+            return mst.walker_run(wlk, nd, ctx, ctx, snt, False, False)
         except Exception as e:
             return f"{DEFAULT_MSG} Error occured: {e}"
 
@@ -205,7 +205,7 @@ class ScheduledSequence(Task):
 
         return getattr(caller, f"{trigger_type}_interface_to_api")(body, api)
 
-    def run(self, *args, **kwargs):
+    def run(self, **kwargs):
         requests = kwargs.get("requests")
         persistence = kwargs.get("persistence", {})
         container = kwargs.get("container", {"current": persistence})


### PR DESCRIPTION
# Migration from old config version should work fine now as before
```js
- EMAIL_BACKEND
- EMAIL_HOST
- EMAIL_PORT
- EMAIL_HOST_USER
- EMAIL_HOST_PASSWORD
- EMAIL_DEFAULT_FROM
- EMAIL_USE_TLS
- EMAIL_ACTIVATION_SUBJ
- EMAIL_ACTIVATION_BODY
- EMAIL_ACTIVATION_HTML_BODY
- EMAIL_RESETPASS_SUBJ
- EMAIL_RESETPASS_BODY
- EMAIL_RESETPASS_HTML_BODY

to

MAIL_CONFIG
{
    **
    "tls": true,
    "host": "",
    "port": 587,
    "sender": "",
    "user": "",
    "pass": "",
    "backend": "smtp",
    "templates": {
        "activation_subj": "Please activate your account!",
        "activation_body": "Thank you for creating an account!\n\n"
        "Activation Code: {{code}}\n"
        "Please click below to activate:\n{{link}}",
        "activation_html_body": "Thank you for creating an account!<br><br>"
        "Activation Code: {{code}}<br>"
        "Please click below to activate:<br>"
        "{{link}}",
        "resetpass_subj": "Password Reset for Jaseci Account",
        "resetpass_body": "Your Jaseci password reset token is: {{token}}",
        "resetpass_html_body": "Your Jaseci password reset"
        "token is: {{token}}"
    }
}
```
---
# Rearrange ScheduledWalker arguments
---
# Add new tools for date actions
## date.**`datetime_obj`**
> **`Arguments`:** \
> **date**: *str in isoformat* *(`optional`)*
> 
> **`Return`:** \
> datetime in json format *(`dict`)*
> 
> **`Usage`:** \
> to get specify datetime attribute like day, hour or minute
>
##### **`HOW TO TRIGGER`**
```js
date.datetime_obj("2023-06-05T07:42:53.093606");
date.datetime_obj(); # current date
```
---
## date.**`datetime_add`**
> **`Arguments`:** \
> **date**: *str in isoformat* *(`optional`)*
> **kwargs**: valid arguments for python's dateutil.relativedelta *(`optional`)*
> 
> **`Return`:** \
> datetime in isoformat *(`str`)*
> 
> **`Usage`:** \
> to add datetime using python's dateutil.relativedelta
>
##### **`HOW TO TRIGGER`**
```js
date.datetime_add("2023-04-26T07:42:53.093606", days = 10, months = 1);
date.datetime_add(days = 10, months = 1); # current date
```
---
## date.**`datetime_sub`**
> **`Arguments`:** \
> **date**: *str in isoformat* *(`optional`)*
> **kwargs**: valid arguments for python's dateutil.relativedelta *(`optional`)*
> 
> **`Return`:** \
> datetime in isoformat *(`str`)*
> 
> **`Usage`:** \
> to subtract datetime using python's dateutil.relativedelta
>
##### **`HOW TO TRIGGER`**
```js
date.datetime_sub("2023-04-26T07:42:53.093606", days = 10, months = 1);
date.datetime_sub(days = 10, months = 1); # current date
```
---