### PR TITLE
Better elastic configuration for production

### DIFF
--- a/jaseci_core/jaseci/extens/svc/elastic_svc.py
+++ b/jaseci_core/jaseci/extens/svc/elastic_svc.py
@@ -66,7 +66,7 @@ class ElasticService(JsOrc.CommonService):
         - Data stream for core* and app* index pattern
         - Index template with the data-streams-mappings component mapping rules
             - @timestamp is converted to date field type
-            - text fields are coverted as keywords for search
+            - text fields are converted as keywords for search
         - An index lifecycle management (ILM) policy
             - hot index for 7 days or 5GB max size
             - delete indices older than 30 days
@@ -104,11 +104,13 @@ class ElasticService(JsOrc.CommonService):
                         # Strip out color code from message before sending to elastic
                         msg = record.getMessage()
                         msg = re.sub(r"\033\[[0-9]*m", "", msg)
+                        ts = "%s.%03d" % (
+                            logging.Formatter().formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+                            record.msecs,
+                        )
 
                         elastic_record = {
-                            "@timestamp": logging.Formatter().formatTime(
-                                record, "%Y-%m-%dT%H:%M:%S"
-                            ),
+                            "@timestamp": ts,
                             "message": msg,
                             "level": record.levelname,
                         }

--- a/jaseci_core/jaseci/jsorc/jsorc_settings.py
+++ b/jaseci_core/jaseci/jsorc/jsorc_settings.py
@@ -140,6 +140,26 @@ class JsOrcSettings:
     # ------------------------------------------------ ELASTIC -------------------------------------------------- #
     ###############################################################################################################
 
+    ELASTIC_ILM_POLICY_NAME = "jaseci-logs-ilm-policy"
+
+    ELASTIC_ILM_POLICY = {
+        "policy": {
+            "phases": {
+                "hot": {"actions": {"rollover": {"max_size": "5gb", "max_age": "7d"}}},
+                "delete": {"min_age": "30d", "actions": {"delete": {}}},
+            }
+        }
+    }
+
+    ELASTIC_INDEX_TEMPLATE_NAME = "jaseci-logs-index-template"
+
+    ELASTIC_INDEX_TEMPLATE = {
+        "index_patterns": ["core*", "app*"],
+        "data_stream": {},
+        "composed_of": ["data-streams-mappings"],
+        "template": {"settings": {"index.lifecycle.name": ELASTIC_ILM_POLICY_NAME}},
+    }
+
     ELASTIC_CONFIG = {
         "enabled": bool(os.getenv("ELASTIC_HOST")),
         "quiet": False,
@@ -151,6 +171,10 @@ class JsOrcSettings:
         "auth": os.getenv("ELASTIC_AUTH"),
         "common_index": f"{KUBE_NAMESPACE}-common",
         "activity_index": f"{KUBE_NAMESPACE}-activity",
+        "ilm_policy_name": ELASTIC_ILM_POLICY_NAME,
+        "ilm_policy": ELASTIC_ILM_POLICY,
+        "index_template_name": ELASTIC_INDEX_TEMPLATE_NAME,
+        "index_template": ELASTIC_INDEX_TEMPLATE,
     }
 
     ELASTIC_MANIFEST = load_default_yaml("elastic")

--- a/jaseci_core/jaseci/jsorc/jsorc_settings.py
+++ b/jaseci_core/jaseci/jsorc/jsorc_settings.py
@@ -145,8 +145,8 @@ class JsOrcSettings:
     ELASTIC_ILM_POLICY = {
         "policy": {
             "phases": {
-                "hot": {"actions": {"rollover": {"max_size": "5gb", "max_age": "7d"}}},
-                "delete": {"min_age": "30d", "actions": {"delete": {}}},
+                "hot": {"actions": {"rollover": {"max_size": "1gb", "max_age": "7d"}}},
+                "delete": {"min_age": "14d", "actions": {"delete": {}}},
             }
         }
     }

--- a/jaseci_core/jaseci/jsorc/jsorc_settings.py
+++ b/jaseci_core/jaseci/jsorc/jsorc_settings.py
@@ -157,6 +157,7 @@ class JsOrcSettings:
         "index_patterns": ["core*", "app*"],
         "data_stream": {},
         "composed_of": ["data-streams-mappings"],
+        "priority": 500,
         "template": {"settings": {"index.lifecycle.name": ELASTIC_ILM_POLICY_NAME}},
     }
 

--- a/jaseci_core/jaseci/jsorc/manifests/elastic.yaml
+++ b/jaseci_core/jaseci/jsorc/manifests/elastic.yaml
@@ -6000,7 +6000,16 @@ spec:
     count: 1
     config:
       node.store.allow_mmap: false
-
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+        namespace: elastic
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
 ---
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana

--- a/jaseci_core/jaseci/jsorc/manifests/elastic.yaml
+++ b/jaseci_core/jaseci/jsorc/manifests/elastic.yaml
@@ -6009,7 +6009,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 10Gi
 ---
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana

--- a/jaseci_serv/jaseci_serv/base/example_jac/discussion_analysis.jac
+++ b/jaseci_serv/jaseci_serv/base/example_jac/discussion_analysis.jac
@@ -29,8 +29,6 @@ walker discussion_analysis {
         "I think what's interesting from the conversation is that the more sustainably idea encompasses a whole wide spread of different approaches and encompass everything from plastics to plant based foods.",
         "I think you're right about that sustainable food would mean adding something like plant based materials to um"
     ];
-    std.log("I AM IN HERE");
-    std.log("APP LOGS");
     # summarization
     all_text = "";
     for tran in transcripts {

--- a/jaseci_serv/jaseci_serv/base/example_jac/discussion_analysis.jac
+++ b/jaseci_serv/jaseci_serv/base/example_jac/discussion_analysis.jac
@@ -29,6 +29,8 @@ walker discussion_analysis {
         "I think what's interesting from the conversation is that the more sustainably idea encompasses a whole wide spread of different approaches and encompass everything from plastics to plant based foods.",
         "I think you're right about that sustainable food would mean adding something like plant based materials to um"
     ];
+    std.log("I AM IN HERE");
+    std.log("APP LOGS");
     # summarization
     all_text = "";
     for tran in transcripts {

--- a/jaseci_serv/jaseci_serv/jac_api/tests/test_logging.py
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/test_logging.py
@@ -36,9 +36,6 @@ class LoggingTests(TestCaseHelper, TestCase):
         )
         self.sauth_client = APIClient()
         self.sauth_client.force_authenticate(self.suser)
-        self.mocked_es_post = patch(
-            "jaseci.extens.svc.elastic_svc.Elastic._post"
-        ).start()
 
         JsOrcSettings.KUBE_CONFIG["enabled"] = True
         JsOrcSettings.ELASTIC_CONFIG["enabled"] = True

--- a/jaseci_serv/jaseci_serv/jac_api/tests/test_logging.py
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/test_logging.py
@@ -12,6 +12,7 @@ from jaseci.jsorc.jsorc import JsOrc
 from kubernetes import config as kubernetes_config, client
 from unittest.mock import patch, Mock
 from jaseci.jsorc.jsorc_settings import JsOrcSettings
+from jaseci.extens.svc.elastic_svc import LOG_QUEUES, format_elastic_record
 
 
 class LoggingTests(TestCaseHelper, TestCase):
@@ -35,9 +36,13 @@ class LoggingTests(TestCaseHelper, TestCase):
         )
         self.sauth_client = APIClient()
         self.sauth_client.force_authenticate(self.suser)
+        self.mocked_es_post = patch(
+            "jaseci.extens.svc.elastic_svc.Elastic._post"
+        ).start()
 
         JsOrcSettings.KUBE_CONFIG["enabled"] = True
         JsOrcSettings.ELASTIC_CONFIG["enabled"] = True
+        JsOrcSettings.ELASTIC_CONFIG["under_test"] = True
         self.kube = JsOrc.svc("kube")
         with patch.object(self.kube, "read") as mock_read, patch.object(
             self.kube, "patch"
@@ -54,58 +59,126 @@ class LoggingTests(TestCaseHelper, TestCase):
         super().tearDown()
         JsOrcSettings.KUBE_CONFIG["enabled"] = False
         JsOrcSettings.ELASTIC_CONFIG["enabled"] = False
+        JsOrcSettings.ELASTIC_CONFIG["under_test"] = False
         JsOrc.svc_reset("elastic")
         JsOrc.svc_reset("kube")
         self.logger_off()
 
     def test_elastic_logging_objects(self):
         """Test sentinel register and walker run is logged properly"""
-        with patch("jaseci.extens.svc.elastic_svc.Elastic._post") as mocked_es_post:
-            self.logger_on()
-            zsb_file = open(os.path.dirname(__file__) + "/general.jac").read()
-            payload = {"op": "sentinel_register", "name": "general", "code": zsb_file}
-            self.auth_client.post(
-                reverse(f'jac_api:{payload["op"]}'), payload, format="json"
-            )
-            self.assertEqual(mocked_es_post.call_count, 2)
-            pre_request_args, _ = mocked_es_post.call_args_list[0]
-            self.assertEqual(pre_request_args[0], "/core/_doc?")
-            self.assertEqual(
-                set(pre_request_args[1].keys()),
-                set(
-                    [
-                        "@timestamp",
-                        "message",
-                        "level",
-                        "api_name",
-                        "caller_name",
-                        "caller_jid",
-                        "request_user_agent",
-                        "request_payload",
-                    ]
-                ),
-            )
+        self.logger_on()
+        jac_file = open(os.path.dirname(__file__) + "/general.jac").read()
+        payload = {"op": "sentinel_register", "name": "general", "code": jac_file}
+        self.auth_client.post(
+            reverse(f'jac_api:{payload["op"]}'), payload, format="json"
+        )
 
-            post_request_args, _ = mocked_es_post.call_args_list[1]
-            self.assertEqual(post_request_args[0], "/core/_doc?")
-            self.assertEqual(
-                set(post_request_args[1].keys()),
-                set(
-                    [
-                        "@timestamp",
-                        "message",
-                        "level",
-                        "api_name",
-                        "request_latency",
-                        "objects_touched",
-                        "redis_touches",
-                        "db_touches",
-                        "objects_touched_size",
-                        "objects_saved",
-                        "caller_name",
-                        "caller_jid",
-                        "api_response",
-                    ]
-                ),
-            )
-            self.logger_off()
+        # There should be two entries in the log queue
+        log_queue = LOG_QUEUES["core"]
+        self.assertEqual(log_queue.qsize(), 2)
+
+        # Validate the first entry
+        record = log_queue.get_nowait()
+        elastic_record = format_elastic_record(record)
+
+        self.assertEqual(
+            set(elastic_record.keys()),
+            set(
+                [
+                    "@timestamp",
+                    "message",
+                    "level",
+                    "api_name",
+                    "caller_name",
+                    "caller_jid",
+                    "request_user_agent",
+                    "request_payload",
+                ]
+            ),
+        )
+
+        # Validate the second entry
+        record = log_queue.get_nowait()
+        elastic_record = format_elastic_record(record)
+
+        self.assertEqual(
+            set(elastic_record.keys()),
+            set(
+                [
+                    "@timestamp",
+                    "message",
+                    "level",
+                    "api_name",
+                    "request_latency",
+                    "objects_touched",
+                    "redis_touches",
+                    "db_touches",
+                    "objects_touched_size",
+                    "objects_saved",
+                    "caller_name",
+                    "caller_jid",
+                    "api_response",
+                ]
+            ),
+        )
+
+        # Validate walker run
+        # Walker run will have walker_name and success in the log record
+        payload = {"op": "walker_run", "name": "here_fix_create"}
+        self.auth_client.post(
+            reverse(f'jac_api:{payload["op"]}'), payload, format="json"
+        )
+
+        # There should be two entries in the log queue
+        log_queue = LOG_QUEUES["core"]
+        self.assertEqual(log_queue.qsize(), 2)
+
+        # Validate the first entry
+        record = log_queue.get_nowait()
+        elastic_record = format_elastic_record(record)
+
+        self.assertEqual(
+            set(elastic_record.keys()),
+            set(
+                [
+                    "@timestamp",
+                    "message",
+                    "level",
+                    "api_name",
+                    "caller_name",
+                    "caller_jid",
+                    "request_user_agent",
+                    "request_payload",
+                    "walker_name",
+                ]
+            ),
+        )
+
+        # Validate the second entry
+        record = log_queue.get_nowait()
+        elastic_record = format_elastic_record(record)
+
+        self.assertEqual(
+            set(elastic_record.keys()),
+            set(
+                [
+                    "@timestamp",
+                    "message",
+                    "level",
+                    "api_name",
+                    "request_latency",
+                    "objects_touched",
+                    "redis_touches",
+                    "db_touches",
+                    "objects_touched_size",
+                    "objects_saved",
+                    "caller_name",
+                    "caller_jid",
+                    "api_response",
+                    "walker_name",
+                    "success",
+                ]
+            ),
+        )
+
+        self.logger_off()

--- a/jaseci_serv/jaseci_serv/jac_api/views.py
+++ b/jaseci_serv/jaseci_serv/jac_api/views.py
@@ -102,6 +102,10 @@ class AbstractJacAPIView(APIView):
             "caller_name": self.caller.name,
             "caller_jid": self.caller.jid,
         }
+        # Add custom fields depending on the type of API
+        if log_dict["api_name"] == "walker_run":
+            log_dict["walker_name"] = self.cmd.get("name", "")
+            log_dict["success"] = (api_result.get("success", True),)
         try:
             api_result_str = json.dumps(api_result)[:OBJECT_LOG_LIMIT]
         except TypeError:
@@ -183,6 +187,9 @@ class AbstractJacAPIView(APIView):
             "caller_jid": self.caller.jid,
             "request_user_agent": user_agent,
         }
+        # Add custom field based on type of API
+        if log_dict["api_name"] == "walker_run":
+            log_dict["walker_name"] = request.data.get("name", "")
         try:
             request_payload_str = json.dumps(dict(request.data))[:OBJECT_LOG_LIMIT]
         except TypeError:


### PR DESCRIPTION
This PR changes a number of configurations for the elastic stack to make it more scalable and suitable for production logging usage. Specifically,
* Configure a `data stream` for core and app logs.
* The data stream is configured with an elastic index lifecycle management (ILM) that
  * Automatically rollover to create backing index for every 7 days or when the current index size reaches 1GB in size
  * Automatically delete indices that are older than 14 days
 * The data stream is also configured with a index template with useful mapping rules for ingesting logs
  * `@timestamp` is mapped to `date` field in elastic so logs can be viewed/searched as timeseries data in Kibana
  * text fields (except for `message`) are mapped to `keyword` field so they can be searched.
* Increase the storage size of the PVC for elasticsearch data to 10GB
* Added additional fields to record for `walker_run` requests
  * success
  * walker_name
* Use multiprocess to handle request to log to elastic instead of thread.