### PR TITLE
Master unbecome "bug" -- reproduce in test

### DIFF
--- a/jaseci_serv/jaseci_serv/base/models.py
+++ b/jaseci_serv/jaseci_serv/base/models.py
@@ -134,6 +134,9 @@ class SuperMaster(Master, JsOrcApi, CoreSuper):
                     "created_date": i.time_created.isoformat(),
                     "is_activated": i.is_activated,
                     "is_superuser": i.is_superuser,
+                    "last_login": i.last_login.isoformat()
+                    if i.last_login is not None
+                    else "",
                 }
             )
         ret = {"total": total, "data": filtered_users}

--- a/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
@@ -1470,13 +1470,11 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
         res = public_client.post(
             reverse(f'jac_api:{payload["op"]}'), payload, format="json"
         )
-        print(res.json())
         non_admin_user_id = res.json()["user"]["jid"]
         payload = {"op": "master_become", "mast": non_admin_user_id}
         res = self.sclient.post(
             reverse(f'jac_api:{payload["op"]}'), payload, format="json"
         )
-        print(res.json())
 
         # check no admin privilege
         payload = {"op": "master_allusers"}
@@ -1496,7 +1494,6 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
         res = self.sclient.post(
             reverse(f'jac_api:{payload["op"]}'), payload, format="json"
         )
-        print(res.json())
         self.assertTrue("data" in res.json())
 
     def test_jac_report_custom(self):

--- a/jaseci_serv/jaseci_serv/user_api/views.py
+++ b/jaseci_serv/jaseci_serv/user_api/views.py
@@ -16,6 +16,7 @@ from rest_framework.response import Response
 import base64
 
 from jaseci.jsorc.jsorc import JsOrc
+from jaseci.utils.utils import logger, ColCodes as Cc
 
 
 class CreateUserView(generics.CreateAPIView):
@@ -65,8 +66,28 @@ class CreateTokenView(KnoxLoginView):
         )
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data["user"]
+        user_agent = request.META.get("HTTP_USER_AGENT", "")
+        log_str = f"Login request from {Cc.TG}{user}{Cc.EC} via {user_agent}"
+        log_dict = {
+            "api_name": "login",
+            "caller_name": str(user),
+            "request_user_agent": user_agent,
+        }
+        log_dict["extra_fields"] = list(log_dict.keys())
+        logger.info(log_str, extra=log_dict)
+
         login(request, user)
-        return super(CreateTokenView, self).post(request, format=None)
+        res = super(CreateTokenView, self).post(request, format=None)
+
+        log_str = f"Login success for {Cc.TG}{user}{Cc.EC} via {user_agent}"
+        log_dict = {
+            "api_name": "login",
+            "caller_name": str(user),
+            "request_user_agent": user_agent,
+        }
+        log_dict["extra_fields"] = list(log_dict.keys())
+        logger.info(log_str, extra=log_dict)
+        return res
 
 
 class ManageUserView(generics.RetrieveUpdateAPIView):


### PR DESCRIPTION
This PR adds a test that is supposed to reproduce a master unbecome bug where an admin user would seem to lose its admin privilege after becoming and un-becoming a normal user. However, I am not able to reproduce this in a test. I can still make it happen in jsctl. @marsninja we should take a look at this together.