### PR TITLE
[TRY-CATCH]: Improve message and code position

### DIFF
--- a/jaseci_core/jaseci/cli_tools/tests/ll.jac
+++ b/jaseci_core/jaseci/cli_tools/tests/ll.jac
@@ -131,7 +131,7 @@ walker get_gen_day {
                 new.order = latest_day.order;
                 new.ll_version = latest_day.ll_version;
                 spawn latest_day walker::carry_forward(parent=new);
-                for i=0 to i<new.order.length by i+=1:
+                if new.order: for i=0 to i<new.order.length by i+=1:
                     new.order[i] = &(spawn new.order[i] walker::past_to_now);
                 take new;
             }
@@ -282,7 +282,7 @@ walker carry_forward {
         if(new_workette.is_ritual): new_workette.status="open";
         spawn -[parent]-> node::workette
             walker::carry_forward(parent=new_workette);
-        for i=0 to i<new_workette.order.length by i+=1:
+        if new_workette.order: for i=0 to i<new_workette.order.length by i+=1:
             new_workette.order[i] = &(spawn new_workette.order[i]
                                       walker::past_to_now);
     }

--- a/jaseci_core/jaseci/cli_tools/tests/ll_base.jac
+++ b/jaseci_core/jaseci/cli_tools/tests/ll_base.jac
@@ -79,7 +79,7 @@ walker get_gen_day {
                 new.order = latest_day.order;
                 new.ll_version = latest_day.ll_version;
                 spawn latest_day walker::carry_forward(parent=new);
-                for i=0 to i<new.order.length by i+=1:
+                if new.order: for i=0 to i<new.order.length by i+=1:
                     new.order[i] = &(spawn new.order[i] walker::past_to_now);
                 take new;
             }
@@ -230,7 +230,7 @@ walker carry_forward {
         if(new_workette.is_ritual): new_workette.status="open";
         spawn -[parent]-> node::workette
             walker::carry_forward(parent=new_workette);
-        for i=0 to i<new_workette.order.length by i+=1:
+        if new_workette.order: for i=0 to i<new_workette.order.length by i+=1:
             new_workette.order[i] = &(spawn new_workette.order[i]
                                       walker::past_to_now);
     }

--- a/jaseci_core/jaseci/extens/act_lib/std.py
+++ b/jaseci_core/jaseci/extens/act_lib/std.py
@@ -111,8 +111,9 @@ def actload_local(filename: str, meta):
     """
     mast = master_from_meta(meta)
     if not mast.is_master(super_check=True, silent=True):
-        meta["interp"].rt_error("Only super master can load actions.")
-        return False
+        meta["interp"].rt_error(
+            "Only super master can load actions.", meta["interp"]._cur_jac_ast
+        )
     return mast.actions_load_local(file=filename)["success"]
 
 
@@ -123,8 +124,9 @@ def actload_remote(url: str, meta):
     """
     mast = master_from_meta(meta)
     if not mast.is_master(super_check=True, silent=True):
-        meta["interp"].rt_error("Only super master can load actions.")
-        return False
+        meta["interp"].rt_error(
+            "Only super master can load actions.", meta["interp"]._cur_jac_ast
+        )
     return mast.actions_load_remote(url=url)["success"]
 
 
@@ -135,8 +137,9 @@ def actload_module(module: str, meta):
     """
     mast = master_from_meta(meta)
     if not mast.is_master(super_check=True, silent=True):
-        meta["interp"].rt_error("Only super master can load actions.")
-        return False
+        meta["interp"].rt_error(
+            "Only super master can load actions.", meta["interp"]._cur_jac_ast
+        )
     return mast.actions_load_module(mod=module)["success"]
 
 

--- a/jaseci_core/jaseci/jac/interpreter/walker_interp.py
+++ b/jaseci_core/jaseci/jac/interpreter/walker_interp.py
@@ -202,9 +202,9 @@ class WalkerInterp(Interp):
         if kid[1].name == "param_list":
             param_list = self.run_param_list(kid[1]).value
         try:
-            result = act.run_action(param_list, self._jac_scope, self)
+            result = act.run_action(param_list, self._jac_scope, self, jac_ast)
         except Exception as e:
-            self.rt_error(f"Internal Exception: {e}", self._cur_jac_ast)
+            self.rt_error(e, jac_ast)
             result = None
         if kid[-1].name == "expression":
             self.run_expression(kid[-1])

--- a/jaseci_core/jaseci/jac/machine/jac_value.py
+++ b/jaseci_core/jaseci/jac/machine/jac_value.py
@@ -168,7 +168,10 @@ class JacValue:
                     or self.name not in self.is_element.get_architype().has_vars
                 )
             ):
-                self.parent.rt_error(f"Key {self.name} not found in object/dict.")
+                self.parent.rt_error(
+                    f"Key {self.name} not found in object/dict.",
+                    self.parent._cur_jac_ast,
+                )
         else:
             return None
 

--- a/jaseci_core/jaseci/jac/machine/machine_state.py
+++ b/jaseci_core/jaseci/jac/machine/machine_state.py
@@ -5,7 +5,7 @@ This interpreter should be inhereted from the class that manages state
 referenced through self.
 """
 from copy import copy
-from jaseci.utils.utils import logger
+from jaseci.utils.utils import logger, exc_stack_as_str_list, generate_stack_as_str_list
 from jaseci.jsorc.live_actions import live_actions, load_preconfig_actions
 
 # from jaseci.actions.find_action import find_action
@@ -34,6 +34,7 @@ class MachineState:
         self.report_custom = None
         self.request_context = None
         self.runtime_errors = []
+        self.runtime_stack_trace = []
         self.yielded_walkers_ids = IdList(self)
         self.ignore_node_ids = IdList(self)
         self._scope_stack = [None]
@@ -59,6 +60,7 @@ class MachineState:
         self.report_status = None
         self.report_custom = None
         self.runtime_errors = []
+        self.runtime_stack_trace = []
         self._scope_stack = [None]
         self._jac_scope = None
         self._loop_ctrl = None
@@ -157,7 +159,9 @@ class MachineState:
             name, create_mode=self._assign_mode if assign_mode is None else assign_mode
         )
         if val is None:
-            self.rt_error(f"Variable not defined - {name}", jac_ast)
+            self.rt_error(
+                f"Variable not defined - {name}", jac_ast or self._cur_jac_ast
+            )
             self.push(JacValue(self))
         else:
             self.push(val)
@@ -274,6 +278,7 @@ class MachineState:
             "col": jac_ast.loc[1],
             "name": self.name if hasattr(self, "name") else "blank",
             "rule": jac_ast.name,
+            "stack_trace": exc_stack_as_str_list(),
         }
 
     def rt_log_str(self, msg, jac_ast=None):
@@ -295,13 +300,39 @@ class MachineState:
         error = self.rt_log_str(error, jac_ast)
         logger.warning(str(error))
 
-    def rt_error(self, error, jac_ast=None):
+    def rt_error(self, error, jac_ast, append=False):
         """Prints runtime error to screen"""
-        if self._jac_try_mode:
-            raise Exception(error)
-        error = self.rt_log_str(error, jac_ast)
-        logger.error(str(error))
-        self.runtime_errors.append(error)
+
+        if isinstance(error, Exception):
+            if self._jac_try_mode:
+                self.jac_try_exception(error, jac_ast)
+            else:
+                if append:
+                    msg = self.rt_log_str(error, jac_ast)
+                    logger.error(msg)
+                    self.runtime_errors.append(msg)
+                raise error
+        else:
+            if self._jac_try_mode:
+                raise TryException(
+                    {
+                        "type": "RunTimeException",
+                        "mod": jac_ast.loc[2],
+                        "msg": error,
+                        "args": [],
+                        "line": jac_ast.loc[0],
+                        "col": jac_ast.loc[1],
+                        "name": self.name if hasattr(self, "name") else "blank",
+                        "rule": jac_ast.name,
+                        "stack_trace": generate_stack_as_str_list(error),
+                    }
+                )
+            else:
+                msg = self.rt_log_str(error, jac_ast)
+                logger.error(msg)
+                self.runtime_errors.append(msg)
+                error = Exception(error)
+                raise error
 
     def rt_info(self, msg, jac_ast=None):
         """Prints runtime info to screen"""

--- a/jaseci_core/jaseci/prim/ability.py
+++ b/jaseci_core/jaseci/prim/ability.py
@@ -47,7 +47,7 @@ class Ability(Element, JacCode, Interp):
         self.run_code_block(self.get_jac_ast())
         self.pop_scope()
 
-    def run_action(self, param_list, scope, interp):
+    def run_action(self, param_list, scope, interp, jac_ast):
         """
         param_list should be passed as list of values to lib functions
         Also note that Jac stores preset_in_out as input/output list of hex
@@ -55,7 +55,7 @@ class Ability(Element, JacCode, Interp):
         """
         action_name = self.name
         if not interp.check_builtin_action(action_name):
-            interp.rt_error(f"Cannot execute {action_name} - Not Found")
+            interp.rt_error(f"Cannot execute {action_name} - Not Found", jac_ast)
             return None
         func = live_actions[action_name]
         args = inspect.getfullargspec(func)
@@ -84,15 +84,10 @@ class Ability(Element, JacCode, Interp):
                 params = str(inspect.signature(func))
                 interp.rt_error(
                     f"Invalid arguments {param_list} to action call {self.name}! Valid paramters are {params}.",
-                    interp._cur_jac_ast,
+                    jac_ast,
                 )
-                raise
             except Exception as e:
-                interp.rt_error(
-                    f"Execption within action call {self.name}! {e}",
-                    interp._cur_jac_ast,
-                )
-                raise
+                interp.rt_error(e, jac_ast, True)
         t = time.time() - ts
         action_manager.post_action_call_hook(action_name, t)
         return result

--- a/jaseci_core/jaseci/prim/sentinel.py
+++ b/jaseci_core/jaseci/prim/sentinel.py
@@ -218,11 +218,13 @@ class Sentinel(Element, JacCode, SentinelInterp):
                 sys.stdout, sys.stderr = screen_out[0], screen_out[1]
                 if i["assert_block"]:
                     wlk._loop_ctrl = None
+                    wlk._jac_try_mode += 1
                     wlk.scope_and_run(
                         jac_ir_to_ast(i["assert_block"]),
                         run_func=wlk.run_code_block,
                         scope_name="assert_block",
                     )
+                    wlk._jac_try_mode -= 1
                 i["passed"] = True
                 if not silent:
                     print(

--- a/jaseci_core/jaseci/tests/fixtures/ll.jac
+++ b/jaseci_core/jaseci/tests/fixtures/ll.jac
@@ -131,7 +131,7 @@ walker get_gen_day {
                 new.order = latest_day.order;
                 new.ll_version = latest_day.ll_version;
                 spawn latest_day walker::carry_forward(parent=new);
-                for i=0 to i<new.order.length by i+=1:
+                if new.order: for i=0 to i<new.order.length by i+=1:
                     new.order[i] = &(spawn new.order[i] walker::past_to_now);
                 take new;
             }
@@ -282,7 +282,7 @@ walker carry_forward {
         if(new_workette.is_ritual): new_workette.status="open";
         spawn -[parent]-> node::workette
             walker::carry_forward(parent=new_workette);
-        for i=0 to i<new_workette.order.length by i+=1:
+        if new_workette.order: for i=0 to i<new_workette.order.length by i+=1:
             new_workette.order[i] = &(spawn new_workette.order[i]
                                       walker::past_to_now);
     }

--- a/jaseci_core/jaseci/tests/jac_test_code.py
+++ b/jaseci_core/jaseci/tests/jac_test_code.py
@@ -644,7 +644,11 @@ typecasts_error = """
         report (a+2);
         report (a+2).int;
         report (a+2).str;
-        report (a+2).edge;
+
+        try {
+            report (a+2).edge;
+        } else with error: report:error = error;
+
         report ("a+2").int.float;
 
         if(a.str.type == str and !(a.int.type == str)
@@ -818,8 +822,12 @@ destroy_and_misc = """
         a[2:4]=[45,33];
         report a;
         destroy a;
-        report a;
-        person1.banana=45;
+        try {
+            report a;
+        } else with error: report:error = error;
+        try {
+            person1.banana=45;
+        } else with error: report:error = error;
         report person1.context;
         report 'age' in person1.context;
     }
@@ -829,7 +837,10 @@ arbitrary_assign_on_element = """
     node person: has name, age, birthday, profession;
     walker init {
         some = spawn here ++> node::person;
-        some.apple = 45;
+        try {
+            some.apple = 45;
+        } else with error: report:error = error;
+
         report some.context;
     }
     """
@@ -846,6 +857,23 @@ try_else_stmts = """
         report a;
         try {a=2/1;}
         report a;
+    }
+
+    walker sample {
+        with entry {
+            try {
+                a = {};
+                b = {};
+
+                b.dict::update({
+                    "test2": 1,
+                    "test": a["test"]
+                });
+                report b;
+            } else with error {
+                report:error = error;
+            }
+        }
     }
     """
 

--- a/jaseci_core/jaseci/tests/jac_test_progs.py
+++ b/jaseci_core/jaseci/tests/jac_test_progs.py
@@ -545,14 +545,17 @@ check_dict_for_in_loop = """
     walker var_as_key_for_dict {
         with entry {
             key = "key1";
-            not_str_key = 1;
             testing = {
                 key: key,
-                "key2": 2,
-                not_str_key: not_str_key
+                "key2": 2
             };
 
             report testing;
+
+            not_str_key = 1;
+            testing = {
+                not_str_key: not_str_key
+            };
         }
     }
 """

--- a/jaseci_core/jaseci/tests/test_progs.py
+++ b/jaseci_core/jaseci/tests/test_progs.py
@@ -45,8 +45,13 @@ class ProgTests(TestCaseHelper, TestCase):
         report = mast.general_interface_to_api(
             api_name="walker_run", params={"name": "aload"}
         )
-        report = report["report"]
-        self.assertEqual(report[0], False)
+        self.assertFalse(report["success"])
+        self.assertEqual(
+            [
+                "test:aload - line 3, col 33 - rule expr_list - Only super master can load actions."
+            ],
+            report["errors"],
+        )
 
     def test_globals(self):
         sent = Sentinel(m_id=0, h=JsOrc.hook())
@@ -329,7 +334,10 @@ class ProgTests(TestCaseHelper, TestCase):
         )
 
         self.assertEqual(res["report"], [{"key1": "key1", "key2": 2}])
-        self.assertIn("Key is not str type : <class 'int'>!", res["errors"][0])
+        self.assertEqual(
+            "test:var_as_key_for_dict - line 42, col 16 - rule expression - Key is not str type : <class 'int'>!",
+            res["errors"][0],
+        )
 
     def test_list_pairwise(self):
         mast = JsOrc.master()

--- a/jaseci_core/jaseci/utils/utils.py
+++ b/jaseci_core/jaseci/utils/utils.py
@@ -113,6 +113,15 @@ def exc_stack_as_str_list():
     return traceback.format_exception(*sys.exc_info())
 
 
+def generate_stack_as_str_list(error=None):
+    stack = traceback.format_stack()
+    stack.pop()  # format_stack
+    stack.pop()  # generate_stack_as_str_list
+    if error:
+        stack.append(error)
+    return stack
+
+
 uuid_re = re.compile(
     "([a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89aAbB][a-f0-9]{3}-?[a-f0-9]{12})"
 )

--- a/jaseci_serv/jaseci_serv/jac_api/tests/ll.jac
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/ll.jac
@@ -131,7 +131,7 @@ walker get_gen_day {
                 new.order = latest_day.order;
                 new.ll_version = latest_day.ll_version;
                 spawn latest_day walker::carry_forward(parent=new);
-                for i=0 to i<new.order.length by i+=1:
+                if new.order: for i=0 to i<new.order.length by i+=1:
                     new.order[i] = &(spawn new.order[i] walker::past_to_now);
                 take new;
             }
@@ -282,7 +282,7 @@ walker carry_forward {
         if(new_workette.is_ritual): new_workette.status="open";
         spawn -[parent]-> node::workette
             walker::carry_forward(parent=new_workette);
-        for i=0 to i<new_workette.order.length by i+=1:
+        if new_workette.order: for i=0 to i<new_workette.order.length by i+=1:
             new_workette.order[i] = &(spawn new_workette.order[i]
                                       walker::past_to_now);
     }

--- a/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/test_jac_api.py
@@ -1551,7 +1551,8 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
         ).data
 
         self.assertFalse(res["success"])
-        self.assertEqual(payload, res["report"][4]["body"])
+        self.assertEqual(payload, res["report"][3]["body"])
+        self.assertIn("Global not defined - b", res["errors"][0])
 
     def test_multipart_json_file(self):
         """Test multipart using json file as ctx parameter"""
@@ -1775,17 +1776,8 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
             reverse(f'jac_api:{payload["op"]}'), payload, format="json"
         ).data
 
-        self.assertIn("in jac_try_exception", " ".join(res["stack_trace"]))
         self.assertIn(
-            "raise TryException(self.jac_exception(e, jac_ast))",
-            " ".join(res["stack_trace"]),
-        )
-        self.assertIn(
-            "jaseci.jac.machine.machine_state.TryException: ",
-            " ".join(res["stack_trace"]),
-        )
-        self.assertIn(
-            "zsb:walker_exception_no_try_else - line 6, col 20",
+            "zsb:walker_exception_no_try_else - line 6, col 19",
             res["errors"][0],
         )
 
@@ -1794,13 +1786,12 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
             reverse(f'jac_api:{payload["op"]}'), payload, format="json"
         ).data
 
-        self.assertFalse("stack_trace" in res)
+        self.assertTrue("stack_trace" in res)
         self.assertEqual("walker_exception_with_try_else", res["report"][0]["name"])
         self.assertEqual(14, res["report"][0]["line"])
         self.assertEqual(23, res["report"][0]["col"])
         self.assertIn(
-            "zsb:walker_exception_with_try_else -"
-            " line 14, col 23 - rule atom_trailer - ",
+            "zsb:walker_exception_with_try_else - line 14, col 23 - rule ability_call - Invalid arguments {'args': ['invalidUrl'], 'kwargs': {}} to action call request.get! Valid paramters are (url: str, data: dict, header: dict).",
             res["errors"][0],
         )
 
@@ -1813,15 +1804,14 @@ class PrivateJacApiTests(TestCaseHelper, TestCase):
             reverse(f'jac_api:{payload["op"]}'), payload, format="json"
         ).data
 
-        self.assertFalse("stack_trace" in res)
+        self.assertTrue("stack_trace" in res)
         self.assertEqual(
             "walker_exception_with_try_else_multiple_line", res["report"][0]["name"]
         )
         self.assertEqual(32, res["report"][0]["line"])
         self.assertEqual(23, res["report"][0]["col"])
         self.assertIn(
-            "zsb:walker_exception_with_try_else_multiple_line "
-            "- line 32, col 23 - rule atom_trailer - ",
+            "zsb:walker_exception_with_try_else_multiple_line - line 32, col 23 - rule ability_call - Invalid URL 'invalidUrl': No scheme supplied. Perhaps you meant https://invalidUrl?",
             res["errors"][0],
         )
 

--- a/jaseci_serv/jaseci_serv/jac_api/tests/zsb.jac
+++ b/jaseci_serv/jaseci_serv/jac_api/tests/zsb.jac
@@ -226,10 +226,10 @@ global a = "test";
 walker global_actions {
     with entry {
         report global.a;
-        report global.b;
         report global.context;
         report global.info;
         report global.info['request_context'];
+        report global.b;
     }
 }
 


### PR DESCRIPTION
# **`CHANGES`**

## **GENERAL:**
- Improved error pointer.
- Most of the exception should return the actual exception instead of the custom message.
- library from actions should return the actual exception instead of just returning error occured triggering call ability

## **EXECUTION BREAKER/STOPPER:**
- Code will now stop executing when error occures. This will be safer on process as it will immediately halt the process and avoid further breakage due to unexpected data created by the error. This is similar to current Try-Catch behavior. Even without using Try-Catch, developer should be able to get the exact error and position of the Exception including the stack trace for internal jaseci debugging.

## **TRY CATCH:**
- Try catch should include proper stack trace

---
# **`EXAMPLE`**
```js
walker t1 {
    a = {};
    report a["a"];
}

walker t2 {
    a = [];
    report a[1];
}

walker t3 {
    try {
        a = {};
        report a["a"];
    }
}

walker t4 {
    try {
        a = {};
        report a["a"];
    } else with error {}
}

walker t5 {
    try {
        a = {};
        report a["a"];
    } else with error: report error["msg"];
}

walker t6 {
    try {
        a = {};
        report a["a"];
    } else with error {
        error.dict::pop("stack_trace", null);
        report:error = error;
    }
}
```
---
### **walker run t1:** `With Exception`
```json
{
  "success": false,
  "stack_trace": [
    "Traceback (most recent call last):\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/prim/walker.py\", line 173, in run\n    while self.step() and not self.yielded:\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/prim/walker.py\", line 95, in step\n    self.run_walker(jac_ast=self.get_architype().get_jac_ast())\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 24, in run_walker\n    self.scope_and_run(\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 248, in scope_and_run\n    run_func(jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 46, in run_walker_block\n    self.run_statement(i)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 127, in run_statement\n    self.run_rule(kid[0])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1777, in run_rule\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 367, in run_report_action\n    self.run_expression(kid[1])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 405, in run_expression\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 382, in run_expression\n    self.push(self.run_rule(kid[0]))\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1777, in run_rule\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 712, in run_atom\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 693, in run_atom\n    ret = self.run_atom_trailer(i, ret)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 758, in run_atom_trailer\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 754, in run_atom_trailer\n    return self.run_index_slice(kid[0], atom_res)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1406, in run_index_slice\n    self.rt_error(e, jac_ast, isinstance(e, IndexError))\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1404, in run_index_slice\n    return JacValue(self, ctx=atom_res.value, name=idx)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/jac_value.py\", line 148, in __init__\n    self.value = self.setup_value(value, create_mode=create_mode)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/jac_value.py\", line 171, in setup_value\n    self.parent.rt_error(\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 335, in rt_error\n    raise error\n",
    "Exception: Key a not found in object/dict.\n"
  ],
  "report": [],
  "final_node": "urn:uuid:41a8bfe3-ab94-415c-9aac-4a32df084eea",
  "yielded": false,
  "errors": [
    "testing:t1 - line 3, col 12 - rule index_slice - Key a not found in object/dict."
  ]
}
```
## **walker run t2:** `With Exception`
```json
{
  "success": false,
  "stack_trace": [
    "Traceback (most recent call last):\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/prim/walker.py\", line 173, in run\n    while self.step() and not self.yielded:\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/prim/walker.py\", line 95, in step\n    self.run_walker(jac_ast=self.get_architype().get_jac_ast())\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 24, in run_walker\n    self.scope_and_run(\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 248, in scope_and_run\n    run_func(jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 46, in run_walker_block\n    self.run_statement(i)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 127, in run_statement\n    self.run_rule(kid[0])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1777, in run_rule\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 367, in run_report_action\n    self.run_expression(kid[1])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 405, in run_expression\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 382, in run_expression\n    self.push(self.run_rule(kid[0]))\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1777, in run_rule\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 712, in run_atom\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 693, in run_atom\n    ret = self.run_atom_trailer(i, ret)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 758, in run_atom_trailer\n    self.rt_error(e, jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 754, in run_atom_trailer\n    return self.run_index_slice(kid[0], atom_res)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1406, in run_index_slice\n    self.rt_error(e, jac_ast, isinstance(e, IndexError))\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/machine_state.py\", line 314, in rt_error\n    raise error\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1404, in run_index_slice\n    return JacValue(self, ctx=atom_res.value, name=idx)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/jac_value.py\", line 148, in __init__\n    self.value = self.setup_value(value, create_mode=create_mode)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/jac_value.py\", line 162, in setup_value\n    return self.ctx[self.name]\n",
    "IndexError: list index out of range\n"
  ],
  "report": [],
  "final_node": "urn:uuid:41a8bfe3-ab94-415c-9aac-4a32df084eea",
  "yielded": false,
  "errors": [
    "testing:t2 - line 8, col 12 - rule index_slice - list index out of range"
  ]
}
```
## **walker run t3:** `Try only`
```json
{
  "success": true,
  "report": [],
  "final_node": "urn:uuid:41a8bfe3-ab94-415c-9aac-4a32df084eea",
  "yielded": false
}
```
## **walker run t4:** `Try Catch with Raise Exception`
```json
{
  "success": false,
  "report": [],
  "final_node": "urn:uuid:41a8bfe3-ab94-415c-9aac-4a32df084eea",
  "yielded": false,
  "errors": [
    "testing:t4 - line 21, col 16 - rule index_slice - Key a not found in object/dict."
  ],
  "stack_trace": [
    "  File \"/home/boyong/jaseci/venv/bin/jsctl\", line 33, in <module>\n    sys.exit(load_entry_point('jaseci', 'console_scripts', 'jsctl')())\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click/core.py\", line 1130, in __call__\n    return self.main(*args, **kwargs)\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click/core.py\", line 1055, in main\n    rv = self.invoke(ctx)\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click_shell/core.py\", line 174, in invoke\n    return self.shell.cmdloop()\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click_shell/_cmd.py\", line 109, in cmdloop\n    stop = self.onecmd(line)\n",
    "  File \"/usr/lib/python3.10/cmd.py\", line 217, in onecmd\n    return func(arg)\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click_shell/core.py\", line 34, in invoke_\n    command.main(args=shlex.split(arg),\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click/core.py\", line 1055, in main\n    rv = self.invoke(ctx)\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click/core.py\", line 1657, in invoke\n    return _process_result(sub_ctx.command.invoke(sub_ctx))\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click/core.py\", line 1404, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n",
    "  File \"/home/boyong/jaseci/venv/lib/python3.10/site-packages/click/core.py\", line 760, in invoke\n    return __callback(*args, **kwargs)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/cli_tools/jsctl.py\", line 173, in interface_api\n    out = session[\"master\"].general_interface_to_api(kwargs, api_name)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/extens/api/interface.py\", line 192, in general_interface_to_api\n    ret = getattr(_caller, api_name)(**param_map)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/extens/api/walker_api.py\", line 217, in walker_run\n    res = self.walker_execute(\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/extens/api/walker_api.py\", line 175, in walker_execute\n    return wlk.run(\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/prim/walker.py\", line 173, in run\n    while self.step() and not self.yielded:\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/prim/walker.py\", line 95, in step\n    self.run_walker(jac_ast=self.get_architype().get_jac_ast())\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 24, in run_walker\n    self.scope_and_run(\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 248, in scope_and_run\n    run_func(jac_ast)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/walker_interp.py\", line 46, in run_walker_block\n    self.run_statement(i)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 127, in run_statement\n    self.run_rule(kid[0])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 158, in run_try_stmt\n    self.run_code_block(kid[1])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 106, in run_code_block\n    self.run_statement(jac_ast=i)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 127, in run_statement\n    self.run_rule(kid[0])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 367, in run_report_action\n    self.run_expression(kid[1])\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 382, in run_expression\n    self.push(self.run_rule(kid[0]))\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1744, in run_rule\n    val = getattr(self, f\"run_{jac_ast.name}\")(jac_ast, *args)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 693, in run_atom\n    ret = self.run_atom_trailer(i, ret)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 754, in run_atom_trailer\n    return self.run_index_slice(kid[0], atom_res)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/interpreter/interp.py\", line 1404, in run_index_slice\n    return JacValue(self, ctx=atom_res.value, name=idx)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/jac_value.py\", line 148, in __init__\n    self.value = self.setup_value(value, create_mode=create_mode)\n",
    "  File \"/home/boyong/jaseci/jaseci_core/jaseci/jac/machine/jac_value.py\", line 171, in setup_value\n    self.parent.rt_error(\n",
    "Key a not found in object/dict."
  ]
}
```
## **walker run t5:** `Report Error Message`
```json
{
  "success": true,
  "report": [
    "Key a not found in object/dict."
  ],
  "final_node": "urn:uuid:41a8bfe3-ab94-415c-9aac-4a32df084eea",
  "yielded": false
}
```
## **walker run t6:** `No Stack Trace`
```json
{
  "success": false,
  "report": [],
  "final_node": "urn:uuid:41a8bfe3-ab94-415c-9aac-4a32df084eea",
  "yielded": false,
  "errors": [
    "testing:t6 - line 35, col 16 - rule index_slice - Key a not found in object/dict."
  ]
}
```
