### PR TITLE
[POC][ABSTRACTION]: Initial

### DIFF
--- a/jac/jaclang/__init__.py
+++ b/jac/jaclang/__init__.py
@@ -1,17 +1,18 @@
 """The Jac Programming Language."""
 
-from jaclang.plugin.default import (  # noqa: E402
+from jaclang.plugin.default import (
     JacBuiltin,
     JacCmdDefaults,
-    JacFeatureDefaults,
+    JacFeatureImpl,
 )
-from jaclang.plugin.feature import JacFeature, pm  # noqa: E402
+from jaclang.plugin.feature import JacFeature, hookmanager
 
 jac_import = JacFeature.jac_import
 
-pm.register(JacFeatureDefaults)
-pm.register(JacBuiltin)
-pm.register(JacCmdDefaults)
-pm.load_setuptools_entrypoints("jac")
+
+hookmanager.register(JacFeatureImpl)
+hookmanager.register(JacBuiltin)
+hookmanager.register(JacCmdDefaults)
+hookmanager.load_setuptools_entrypoints("jac")
 
 __all__ = ["jac_import"]

--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -18,7 +18,6 @@ from jaclang.compiler.passes.main.pyast_load_pass import PyastBuildPass
 from jaclang.compiler.passes.main.schedules import py_code_gen_typed
 from jaclang.compiler.passes.tool.schedules import format_pass
 from jaclang.plugin.builtin import dotgen
-from jaclang.plugin.feature import JacCmd as Cmd
 from jaclang.plugin.feature import JacFeature as Jac
 from jaclang.runtimelib.constructs import WalkerArchitype
 from jaclang.runtimelib.context import ExecutionContext
@@ -27,7 +26,7 @@ from jaclang.utils.helpers import debugger as db
 from jaclang.utils.lang_tools import AstTool
 
 
-Cmd.create_cmd()
+Jac.create_cmd()
 Jac.setup()
 
 
@@ -161,7 +160,7 @@ def get_object(
     data = {}
     obj = Jac.get_object(id)
     if obj:
-        data = obj.__jac__.__getstate__()
+        data = obj.__jac__.__serialize__()
     else:
         print(f"Object with id {id} not found.")
 

--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -19,8 +19,8 @@ from jaclang.compiler.passes.main.schedules import py_code_gen_typed
 from jaclang.compiler.passes.tool.schedules import format_pass
 from jaclang.plugin.builtin import dotgen
 from jaclang.plugin.feature import JacFeature as Jac
-from jaclang.runtimelib.constructs import WalkerArchitype
 from jaclang.runtimelib.context import ExecutionContext
+from jaclang.runtimelib.implementation import WalkerArchitype
 from jaclang.runtimelib.machine import JacMachine, JacProgram
 from jaclang.utils.helpers import debugger as db
 from jaclang.utils.lang_tools import AstTool

--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -28,6 +28,7 @@ from jaclang.utils.lang_tools import AstTool
 
 
 Cmd.create_cmd()
+Jac.setup()
 
 
 @cmd_registry.register
@@ -283,7 +284,9 @@ def enter(
 
             jctx.set_entry_node(node)
 
-            if isinstance(architype, WalkerArchitype) and jctx.validate_access():
+            if isinstance(architype, WalkerArchitype) and Jac.check_read_access(
+                jctx.entry_node
+            ):
                 Jac.spawn_call(jctx.entry_node.architype, architype)
 
     jctx.close()

--- a/jac/jaclang/plugin/builtin.py
+++ b/jac/jaclang/plugin/builtin.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from jaclang.plugin.feature import JacFeature as Jac
-from jaclang.runtimelib.constructs import Architype, NodeArchitype
+from jaclang.plugin.feature import Architype, JacFeature as Jac, NodeArchitype
 
 
 def dotgen(
@@ -19,7 +18,7 @@ def dotgen(
     dot_file: Optional[str] = None,
 ) -> str:
     """Print the dot graph."""
-    from jaclang.plugin.feature import JacBuiltin as JacB, JacFeature as Jac
+    from jaclang.plugin.feature import JacFeature as Jac
 
     root = Jac.get_root()
     node = node if node is not None else root
@@ -29,7 +28,7 @@ def dotgen(
     edge_limit = edge_limit if edge_limit is not None else 512
     node_limit = node_limit if node_limit is not None else 512
 
-    return JacB.dotgen(
+    return Jac.dotgen(
         edge_type=edge_type,
         node=node,
         depth=depth,

--- a/jac/jaclang/plugin/builtin.py
+++ b/jac/jaclang/plugin/builtin.py
@@ -19,9 +19,9 @@ def dotgen(
     dot_file: Optional[str] = None,
 ) -> str:
     """Print the dot graph."""
-    from jaclang.plugin.feature import pm
+    from jaclang.plugin.feature import JacBuiltin as JacB, JacFeature as Jac
 
-    root = pm.hook.get_root()
+    root = Jac.get_root()
     node = node if node is not None else root
     depth = depth if depth is not None else -1
     traverse = traverse if traverse is not None else False
@@ -29,7 +29,7 @@ def dotgen(
     edge_limit = edge_limit if edge_limit is not None else 512
     node_limit = node_limit if node_limit is not None else 512
 
-    return pm.hook.dotgen(
+    return JacB.dotgen(
         edge_type=edge_type,
         node=node,
         depth=depth,

--- a/jac/jaclang/plugin/default.py
+++ b/jac/jaclang/plugin/default.py
@@ -11,59 +11,434 @@ import types
 from collections import OrderedDict
 from dataclasses import field
 from functools import wraps
+from logging import getLogger
 from typing import Any, Callable, Mapping, Optional, Sequence, Type, Union
 from uuid import UUID
 
-import jaclang.compiler.absyntree as ast
-from jaclang.compiler.constant import EdgeDir, colors
-from jaclang.compiler.passes.main.pyast_gen_pass import PyastGenPass
+from jaclang.compiler.constant import colors
 from jaclang.compiler.semtable import SemInfo, SemRegistry, SemScope
-from jaclang.runtimelib.constructs import (
+from jaclang.plugin.feature import (
+    AccessLevel,
+    Anchor,
     Architype,
     DSFunc,
     EdgeAnchor,
     EdgeArchitype,
+    EdgeDir,
     ExecutionContext,
-    GenericEdge,
-    JacTestCheck,
+    JacFeature as Jac,
     NodeAnchor,
     NodeArchitype,
+    P,
+    PyastGenPass,
     Root,
-    WalkerAnchor,
+    T,
     WalkerArchitype,
+    ast,
+)
+from jaclang.runtimelib.constructs import (
+    GenericEdge,
+    JacTestCheck,
 )
 from jaclang.runtimelib.importer import ImportPathSpec, JacImporter, PythonImporter
 from jaclang.runtimelib.machine import JacMachine, JacProgram
-from jaclang.runtimelib.utils import traverse_graph
-from jaclang.plugin.feature import JacFeature as Jac  # noqa: I100
-from jaclang.plugin.spec import P, T
+from jaclang.runtimelib.utils import collect_node_connections, traverse_graph
 
 
 import pluggy
 
 hookimpl = pluggy.HookimplMarker("jac")
-
-__all__ = [
-    "EdgeAnchor",
-    "GenericEdge",
-    "hookimpl",
-    "JacTestCheck",
-    "NodeAnchor",
-    "WalkerAnchor",
-    "NodeArchitype",
-    "EdgeArchitype",
-    "Root",
-    "WalkerArchitype",
-    "Architype",
-    "DSFunc",
-    "T",
-]
+logger = getLogger(__name__)
 
 
-class JacFeatureDefaults:
+class JacAccessValidationImpl:
+    """Jac Access Validation Implementations."""
+
+    @staticmethod
+    @hookimpl
+    def allow_root(
+        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Allow all access from target root graph to current Architype."""
+        level = AccessLevel.cast(level)
+        access = anchor.access.roots
+
+        _root_id = str(root_id)
+        if level != access.anchors.get(_root_id, AccessLevel.NO_ACCESS):
+            access.anchors[_root_id] = level
+
+    @staticmethod
+    @hookimpl
+    def disallow_root(
+        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Disallow all access from target root graph to current Architype."""
+        level = AccessLevel.cast(level)
+        access = anchor.access.roots
+
+        access.anchors.pop(str(root_id), None)
+
+    @staticmethod
+    @hookimpl
+    def unrestrict(
+        anchor: Anchor, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Allow everyone to access current Architype."""
+        level = AccessLevel.cast(level)
+        if level != anchor.access.all:
+            anchor.access.all = level
+
+    @staticmethod
+    @hookimpl
+    def restrict(anchor: Anchor) -> None:
+        """Disallow others to access current Architype."""
+        if anchor.access.all > AccessLevel.NO_ACCESS:
+            anchor.access.all = AccessLevel.NO_ACCESS
+
+    @staticmethod
+    @hookimpl
+    def check_read_access(to: Anchor) -> bool:
+        """Read Access Validation."""
+        if not (access_level := Jac.check_access_level(to) > AccessLevel.NO_ACCESS):
+            logger.info(
+                f"Current root doesn't have read access to {to.__class__.__name__}[{to.id}]"
+            )
+        return access_level
+
+    @staticmethod
+    @hookimpl
+    def check_connect_access(to: Anchor) -> bool:
+        """Write Access Validation."""
+        if not (access_level := Jac.check_access_level(to) > AccessLevel.READ):
+            logger.info(
+                f"Current root doesn't have connect access to {to.__class__.__name__}[{to.id}]"
+            )
+        return access_level
+
+    @staticmethod
+    @hookimpl
+    def check_write_access(to: Anchor) -> bool:
+        """Write Access Validation."""
+        if not (access_level := Jac.check_access_level(to) > AccessLevel.CONNECT):
+            logger.info(
+                f"Current root doesn't have write access to {to.__class__.__name__}[{to.id}]"
+            )
+        return access_level
+
+    @staticmethod
+    @hookimpl
+    def check_access_level(to: Anchor) -> AccessLevel:
+        """Access validation."""
+        if not to.persistent:
+            return AccessLevel.WRITE
+
+        jctx = Jac.get_context()
+
+        jroot = jctx.root
+
+        # if current root is system_root
+        # if current root id is equal to target anchor's root id
+        # if current root is the target anchor
+        if jroot == jctx.system_root or jroot.id == to.root or jroot == to:
+            return AccessLevel.WRITE
+
+        access_level = AccessLevel.NO_ACCESS
+
+        # if target anchor have set access.all
+        if (to_access := to.access).all > AccessLevel.NO_ACCESS:
+            access_level = to_access.all
+
+        # if target anchor's root have set allowed roots
+        # if current root is allowed to the whole graph of target anchor's root
+        if to.root and isinstance(to_root := jctx.mem.find_one(to.root), Anchor):
+            if to_root.access.all > access_level:
+                access_level = to_root.access.all
+
+            level = to_root.access.roots.check(str(jroot.id))
+            if level > AccessLevel.NO_ACCESS and access_level == AccessLevel.NO_ACCESS:
+                access_level = level
+
+        # if target anchor have set allowed roots
+        # if current root is allowed to target anchor
+        level = to_access.roots.check(str(jroot.id))
+        if level > AccessLevel.NO_ACCESS and access_level == AccessLevel.NO_ACCESS:
+            access_level = level
+
+        return access_level
+
+
+class JacNodeImpl:
+    """Jac Node Operations."""
+
+    @staticmethod
+    @hookimpl
+    def node_dot(node: NodeArchitype, dot_file: Optional[str] = None) -> str:
+        """Generate Dot file for visualizing nodes and edges."""
+        visited_nodes: set[NodeAnchor] = set()
+        connections: set[tuple[NodeArchitype, NodeArchitype, str]] = set()
+        unique_node_id_dict = {}
+
+        collect_node_connections(node.__jac__, visited_nodes, connections)
+        dot_content = 'digraph {\nnode [style="filled", shape="ellipse", fillcolor="invis", fontcolor="black"];\n'
+        for idx, i in enumerate([nodes_.architype for nodes_ in visited_nodes]):
+            unique_node_id_dict[i] = (i.__class__.__name__, str(idx))
+            dot_content += f'{idx} [label="{i}"];\n'
+        dot_content += 'edge [color="gray", style="solid"];\n'
+
+        for pair in list(set(connections)):
+            dot_content += (
+                f"{unique_node_id_dict[pair[0]][1]} -> {unique_node_id_dict[pair[1]][1]}"
+                f' [label="{pair[2]}"];\n'
+            )
+        if dot_file:
+            with open(dot_file, "w") as f:
+                f.write(dot_content + "}")
+        return dot_content + "}"
+
+    @staticmethod
+    @hookimpl
+    def get_edges(
+        node: NodeAnchor,
+        dir: EdgeDir,
+        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
+        target_obj: Optional[list[NodeArchitype]],
+    ) -> list[EdgeArchitype]:
+        """Get edges connected to this node."""
+        ret_edges: list[EdgeArchitype] = []
+        for anchor in node.edges:
+            if (
+                (source := anchor.source)
+                and (target := anchor.target)
+                and (not filter_func or filter_func([anchor.architype]))
+                and source.architype
+                and target.architype
+            ):
+                if (
+                    dir in [EdgeDir.OUT, EdgeDir.ANY]
+                    and node == source
+                    and (not target_obj or target.architype in target_obj)
+                    and Jac.check_read_access(target)
+                ):
+                    ret_edges.append(anchor.architype)
+                if (
+                    dir in [EdgeDir.IN, EdgeDir.ANY]
+                    and node == target
+                    and (not target_obj or source.architype in target_obj)
+                    and Jac.check_read_access(source)
+                ):
+                    ret_edges.append(anchor.architype)
+        return ret_edges
+
+    @staticmethod
+    @hookimpl
+    def edges_to_nodes(
+        node: NodeAnchor,
+        dir: EdgeDir,
+        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
+        target_obj: Optional[list[NodeArchitype]],
+    ) -> list[NodeArchitype]:
+        """Get set of nodes connected to this node."""
+        ret_edges: list[NodeArchitype] = []
+        for anchor in node.edges:
+            if (
+                (source := anchor.source)
+                and (target := anchor.target)
+                and (not filter_func or filter_func([anchor.architype]))
+                and source.architype
+                and target.architype
+            ):
+                if (
+                    dir in [EdgeDir.OUT, EdgeDir.ANY]
+                    and node == source
+                    and (not target_obj or target.architype in target_obj)
+                    and Jac.check_read_access(target)
+                ):
+                    ret_edges.append(target.architype)
+                if (
+                    dir in [EdgeDir.IN, EdgeDir.ANY]
+                    and node == target
+                    and (not target_obj or source.architype in target_obj)
+                    and Jac.check_read_access(source)
+                ):
+                    ret_edges.append(source.architype)
+        return ret_edges
+
+    @staticmethod
+    @hookimpl
+    def remove_edge(node: NodeAnchor, edge: EdgeAnchor) -> None:
+        """Remove reference without checking sync status."""
+        for idx, ed in enumerate(node.edges):
+            if ed.id == edge.id:
+                node.edges.pop(idx)
+                break
+
+
+class JacEdgeImpl:
+    """Jac Edge Operations."""
+
+    @staticmethod
+    @hookimpl
+    def detach(edge: EdgeAnchor) -> None:
+        """Detach edge from nodes."""
+        Jac.remove_edge(node=edge.source, edge=edge)
+        Jac.remove_edge(node=edge.target, edge=edge)
+
+
+class JacWalkerImpl:
+    """Jac Edge Operations."""
+
+    @staticmethod
+    @hookimpl
+    def visit_node(
+        walker: WalkerArchitype,
+        expr: (
+            list[NodeArchitype | EdgeArchitype]
+            | list[NodeArchitype]
+            | list[EdgeArchitype]
+            | NodeArchitype
+            | EdgeArchitype
+        ),
+    ) -> bool:
+        """Jac's visit stmt feature."""
+        if isinstance(walker, WalkerArchitype):
+            """Walker visits node."""
+            wanch = walker.__jac__
+            before_len = len(wanch.next)
+            for anchor in (
+                (i.__jac__ for i in expr) if isinstance(expr, list) else [expr.__jac__]
+            ):
+                if anchor not in wanch.ignores:
+                    if isinstance(anchor, NodeAnchor):
+                        wanch.next.append(anchor)
+                    elif isinstance(anchor, EdgeAnchor):
+                        if target := anchor.target:
+                            wanch.next.append(target)
+                        else:
+                            raise ValueError("Edge has no target.")
+            return len(wanch.next) > before_len
+        else:
+            raise TypeError("Invalid walker object")
+
+    @staticmethod
+    @hookimpl
+    def ignore(
+        walker: WalkerArchitype,
+        expr: (
+            list[NodeArchitype | EdgeArchitype]
+            | list[NodeArchitype]
+            | list[EdgeArchitype]
+            | NodeArchitype
+            | EdgeArchitype
+        ),
+    ) -> bool:
+        """Jac's ignore stmt feature."""
+        if isinstance(walker, WalkerArchitype):
+            wanch = walker.__jac__
+            before_len = len(wanch.ignores)
+            for anchor in (
+                (i.__jac__ for i in expr) if isinstance(expr, list) else [expr.__jac__]
+            ):
+                if anchor not in wanch.ignores:
+                    if isinstance(anchor, NodeAnchor):
+                        wanch.ignores.append(anchor)
+                    elif isinstance(anchor, EdgeAnchor):
+                        if target := anchor.target:
+                            wanch.ignores.append(target)
+                        else:
+                            raise ValueError("Edge has no target.")
+            return len(wanch.ignores) > before_len
+        else:
+            raise TypeError("Invalid walker object")
+
+    @staticmethod
+    @hookimpl
+    def spawn_call(op1: Architype, op2: Architype) -> WalkerArchitype:
+        """Invoke data spatial call."""
+        if isinstance(op1, WalkerArchitype):
+            warch = op1
+            walker = op1.__jac__
+            if isinstance(op2, NodeArchitype):
+                node = op2.__jac__
+            elif isinstance(op2, EdgeArchitype):
+                node = op2.__jac__.source
+            else:
+                raise TypeError("Invalid target object")
+        elif isinstance(op2, WalkerArchitype):
+            warch = op2
+            walker = op2.__jac__
+            if isinstance(op1, NodeArchitype):
+                node = op1.__jac__
+            elif isinstance(op1, EdgeArchitype):
+                node = op1.__jac__.source
+            else:
+                raise TypeError("Invalid target object")
+        else:
+            raise TypeError("Invalid walker object")
+
+        walker.path = []
+        walker.next = [node]
+        while len(walker.next):
+            if current_node := walker.next.pop(0).architype:
+                for i in current_node._jac_entry_funcs_:
+                    if not i.trigger or isinstance(warch, i.trigger):
+                        if i.func:
+                            i.func(current_node, warch)
+                        else:
+                            raise ValueError(f"No function {i.name} to call.")
+                    if walker.disengaged:
+                        return warch
+                for i in warch._jac_entry_funcs_:
+                    if not i.trigger or isinstance(current_node, i.trigger):
+                        if i.func:
+                            i.func(warch, current_node)
+                        else:
+                            raise ValueError(f"No function {i.name} to call.")
+                    if walker.disengaged:
+                        return warch
+                for i in warch._jac_exit_funcs_:
+                    if not i.trigger or isinstance(current_node, i.trigger):
+                        if i.func:
+                            i.func(warch, current_node)
+                        else:
+                            raise ValueError(f"No function {i.name} to call.")
+                    if walker.disengaged:
+                        return warch
+                for i in current_node._jac_exit_funcs_:
+                    if not i.trigger or isinstance(warch, i.trigger):
+                        if i.func:
+                            i.func(current_node, warch)
+                        else:
+                            raise ValueError(f"No function {i.name} to call.")
+                    if walker.disengaged:
+                        return warch
+        walker.ignores = []
+        return warch
+
+    @staticmethod
+    @hookimpl
+    def disengage(walker: WalkerArchitype) -> bool:  # noqa: ANN401
+        """Jac's disengage stmt feature."""
+        walker.__jac__.disengaged = True
+        return True
+
+
+class JacFeatureImpl(JacAccessValidationImpl, JacNodeImpl, JacEdgeImpl, JacWalkerImpl):
     """Jac Feature."""
 
-    pm = pluggy.PluginManager("jac")
+    @staticmethod
+    @hookimpl
+    def setup() -> None:
+        """Set Class References."""
+        ########################################################################################
+        #                                 REFERENCE FOR PLUGIN                                 #
+        ########################################################################################
+        # Jac.EdgeDir = EdgeDir
+        # Jac.DSFunc = DSFunc
+        # Jac.RootType = Root
+        # Jac.Obj = Architype
+        # Jac.Node = NodeArchitype
+        # Jac.Edge = EdgeArchitype
+        # Jac.Walker = WalkerArchitype
 
     @staticmethod
     @hookimpl
@@ -74,6 +449,7 @@ class JacFeatureDefaults:
     @staticmethod
     @hookimpl
     def get_object(id: str) -> Architype | None:
+        """Get object by id."""
         if id == "root":
             return Jac.get_context().root.architype
         elif obj := Jac.get_context().mem.find_by_id(UUID(id)):
@@ -84,6 +460,7 @@ class JacFeatureDefaults:
     @staticmethod
     @hookimpl
     def object_ref(obj: Architype) -> str:
+        """Get object's id."""
         return obj.__jac__.id.hex
 
     @staticmethod
@@ -363,66 +740,8 @@ class JacFeatureDefaults:
 
     @staticmethod
     @hookimpl
-    def spawn_call(op1: Architype, op2: Architype) -> WalkerArchitype:
-        """Jac's spawn operator feature."""
-        if isinstance(op1, WalkerArchitype):
-            return op1.__jac__.spawn_call(op2.__jac__)
-        elif isinstance(op2, WalkerArchitype):
-            return op2.__jac__.spawn_call(op1.__jac__)
-        else:
-            raise TypeError("Invalid walker object")
-
-    @staticmethod
-    @hookimpl
     def report(expr: Any) -> Any:  # noqa: ANN401
         """Jac's report stmt feature."""
-
-    @staticmethod
-    @hookimpl
-    def ignore(
-        walker: WalkerArchitype,
-        expr: (
-            list[NodeArchitype | EdgeArchitype]
-            | list[NodeArchitype]
-            | list[EdgeArchitype]
-            | NodeArchitype
-            | EdgeArchitype
-        ),
-    ) -> bool:
-        """Jac's ignore stmt feature."""
-        if isinstance(walker, WalkerArchitype):
-            return walker.__jac__.ignore_node(
-                (i.__jac__ for i in expr) if isinstance(expr, list) else [expr.__jac__]
-            )
-        else:
-            raise TypeError("Invalid walker object")
-
-    @staticmethod
-    @hookimpl
-    def visit_node(
-        walker: WalkerArchitype,
-        expr: (
-            list[NodeArchitype | EdgeArchitype]
-            | list[NodeArchitype]
-            | list[EdgeArchitype]
-            | NodeArchitype
-            | EdgeArchitype
-        ),
-    ) -> bool:
-        """Jac's visit stmt feature."""
-        if isinstance(walker, WalkerArchitype):
-            return walker.__jac__.visit_node(
-                (i.__jac__ for i in expr) if isinstance(expr, list) else [expr.__jac__]
-            )
-        else:
-            raise TypeError("Invalid walker object")
-
-    @staticmethod
-    @hookimpl
-    def disengage(walker: WalkerArchitype) -> bool:  # noqa: ANN401
-        """Jac's disengage stmt feature."""
-        walker.__jac__.disengage_now()
-        return True
 
     @staticmethod
     @hookimpl
@@ -444,16 +763,16 @@ class JacFeatureDefaults:
         if edges_only:
             connected_edges: list[EdgeArchitype] = []
             for node in node_obj:
-                connected_edges += node.__jac__.get_edges(
-                    dir, filter_func, target_obj=targ_obj_set
+                connected_edges += Jac.get_edges(
+                    node.__jac__, dir, filter_func, target_obj=targ_obj_set
                 )
             return list(set(connected_edges))
         else:
             connected_nodes: list[NodeArchitype] = []
             for node in node_obj:
                 connected_nodes.extend(
-                    node.__jac__.edges_to_nodes(
-                        dir, filter_func, target_obj=targ_obj_set
+                    Jac.edges_to_nodes(
+                        node.__jac__, dir, filter_func, target_obj=targ_obj_set
                     )
                 )
             return list(set(connected_nodes))
@@ -474,14 +793,12 @@ class JacFeatureDefaults:
         right = [right] if isinstance(right, NodeArchitype) else right
         edges = []
 
-        root = Jac.get_root().__jac__
-
         for i in left:
             _left = i.__jac__
-            if root.has_connect_access(_left):
+            if Jac.check_connect_access(_left):
                 for j in right:
                     _right = j.__jac__
-                    if root.has_connect_access(_right):
+                    if Jac.check_connect_access(_right):
                         edges.append(edge_spec(_left, _right))
         return right if not edges_only else edges
 
@@ -498,8 +815,6 @@ class JacFeatureDefaults:
         left = [left] if isinstance(left, NodeArchitype) else left
         right = [right] if isinstance(right, NodeArchitype) else right
 
-        root = Jac.get_root().__jac__
-
         for i in left:
             node = i.__jac__
             for anchor in set(node.edges):
@@ -514,17 +829,17 @@ class JacFeatureDefaults:
                         dir in [EdgeDir.OUT, EdgeDir.ANY]
                         and node == source
                         and target.architype in right
-                        and root.has_write_access(target)
+                        and Jac.check_write_access(target)
                     ):
-                        anchor.destroy() if anchor.persistent else anchor.detach()
+                        Jac.destroy(anchor) if anchor.persistent else Jac.detach(anchor)
                         disconnect_occurred = True
                     if (
                         dir in [EdgeDir.IN, EdgeDir.ANY]
                         and node == target
                         and source.architype in right
-                        and root.has_write_access(source)
+                        and Jac.check_write_access(source)
                     ):
-                        anchor.destroy() if anchor.persistent else anchor.detach()
+                        Jac.destroy(anchor) if anchor.persistent else Jac.detach(anchor)
                         disconnect_occurred = True
 
         return disconnect_occurred
@@ -565,7 +880,16 @@ class JacFeatureDefaults:
 
         def builder(source: NodeAnchor, target: NodeAnchor) -> EdgeArchitype:
             edge = conn_type() if isinstance(conn_type, type) else conn_type
-            edge.__attach__(source, target, is_undirected)
+
+            eanch = edge.__jac__ = EdgeAnchor(
+                architype=edge,
+                source=source,
+                target=target,
+                is_undirected=is_undirected,
+            )
+            source.edges.append(eanch)
+            target.edges.append(eanch)
+
             if conn_assign:
                 for fld, val in zip(conn_assign[0], conn_assign[1]):
                     if hasattr(edge, fld):
@@ -573,12 +897,43 @@ class JacFeatureDefaults:
                     else:
                         raise ValueError(f"Invalid attribute: {fld}")
             if source.persistent or target.persistent:
-                edge.__jac__.save()
-                target.save()
-                source.save()
+                Jac.save(eanch)
+                Jac.save(target)
+                Jac.save(source)
             return edge
 
         return builder
+
+    @staticmethod
+    @hookimpl
+    def save(obj: Architype | Anchor) -> None:
+        """Destroy object."""
+        anchor = obj.__jac__ if isinstance(obj, Architype) else obj
+
+        jctx = Jac.get_context()
+
+        anchor.persistent = True
+        anchor.root = jctx.root.id
+
+        jctx.mem.set(anchor.id, anchor)
+
+    @staticmethod
+    @hookimpl
+    def destroy(obj: Architype | Anchor) -> None:
+        """Destroy object."""
+        anchor = obj.__jac__ if isinstance(obj, Architype) else obj
+
+        if Jac.check_write_access(anchor):
+            match anchor:
+                case NodeAnchor():
+                    for edge in anchor.edges:
+                        Jac.destroy(edge)
+                case EdgeAnchor():
+                    Jac.detach(anchor)
+                case _:
+                    pass
+
+            Jac.get_context().mem.remove(anchor.id)
 
     @staticmethod
     @hookimpl
@@ -645,6 +1000,7 @@ class JacFeatureDefaults:
     @staticmethod
     @hookimpl
     def get_sem_type(file_loc: str, attr: str) -> tuple[str | None, str | None]:
+        """Jac's get_semstr_type implementation."""
         with open(
             os.path.join(
                 os.path.dirname(file_loc),
@@ -854,7 +1210,7 @@ class JacBuiltin:
         node: NodeArchitype,
         depth: int,
         traverse: bool,
-        edge_type: list[str],
+        edge_type: Optional[list[str]],
         bfs: bool,
         edge_limit: int,
         node_limit: int,

--- a/jac/jaclang/plugin/default.py
+++ b/jac/jaclang/plugin/default.py
@@ -106,7 +106,7 @@ class JacAccessValidationImpl:
         """Read Access Validation."""
         if not (access_level := Jac.check_access_level(to) > AccessLevel.NO_ACCESS):
             logger.info(
-                f"Current root doesn't have read access to {to.__class__.__name__}[{to.id}]"
+                f"Current root doesn't have read access to {to.__class__.__name__}[{to.jid}]"
             )
         return access_level
 
@@ -116,7 +116,7 @@ class JacAccessValidationImpl:
         """Write Access Validation."""
         if not (access_level := Jac.check_access_level(to) > AccessLevel.READ):
             logger.info(
-                f"Current root doesn't have connect access to {to.__class__.__name__}[{to.id}]"
+                f"Current root doesn't have connect access to {to.__class__.__name__}[{to.jid}]"
             )
         return access_level
 
@@ -126,7 +126,7 @@ class JacAccessValidationImpl:
         """Write Access Validation."""
         if not (access_level := Jac.check_access_level(to) > AccessLevel.CONNECT):
             logger.info(
-                f"Current root doesn't have write access to {to.__class__.__name__}[{to.id}]"
+                f"Current root doesn't have write access to {to.__class__.__name__}[{to.jid}]"
             )
         return access_level
 
@@ -138,13 +138,13 @@ class JacAccessValidationImpl:
             return AccessLevel.WRITE
 
         jctx = Jac.get_context()
-
+        jmem: ShelfStorage = jctx.mem
         jroot = jctx.root
 
         # if current root is system_root
         # if current root id is equal to target anchor's root id
         # if current root is the target anchor
-        if jroot == jctx.system_root or jroot.id == to.root or jroot == to:
+        if jroot == jctx.system_root or jroot.jid == to.root or jroot == to:
             return AccessLevel.WRITE
 
         access_level = AccessLevel.NO_ACCESS
@@ -155,7 +155,7 @@ class JacAccessValidationImpl:
 
         # if target anchor's root have set allowed roots
         # if current root is allowed to the whole graph of target anchor's root
-        if to.root and isinstance(to_root := jctx.mem.find_one(to.root), Anchor):
+        if to.root and isinstance(to_root := jmem.find_one(to.root), Anchor):
             if to_root.access.all > access_level:
                 access_level = to_root.access.all
 

--- a/jac/jaclang/plugin/feature.py
+++ b/jac/jaclang/plugin/feature.py
@@ -4,57 +4,213 @@ from __future__ import annotations
 
 import ast as ast3
 import types
-from typing import Any, Callable, Mapping, Optional, Sequence, Type, TypeAlias, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeAlias,
+    Union,
+)
+from uuid import UUID
 
-import jaclang.compiler.absyntree as ast
-from jaclang.compiler.passes.main.pyast_gen_pass import PyastGenPass
-from jaclang.plugin.spec import JacBuiltin, JacCmdSpec, JacFeatureSpec, P, T
-from jaclang.runtimelib.constructs import (
+from jaclang.plugin.spec import (
+    AccessLevel,
+    Anchor,
     Architype,
+    DSFunc,
+    EdgeAnchor,
     EdgeArchitype,
+    EdgeDir,
+    ExecutionContext,
     NodeAnchor,
     NodeArchitype,
+    P,
+    PyastGenPass,
     Root,
+    T,
     WalkerArchitype,
+    ast,
+    hookmanager,
 )
-from jaclang.runtimelib.context import ExecutionContext
-
-import pluggy
-
-pm = pluggy.PluginManager("jac")
-pm.add_hookspecs(JacFeatureSpec)
-pm.add_hookspecs(JacCmdSpec)
-pm.add_hookspecs(JacBuiltin)
 
 
-class JacFeature:
+class JacAccessValidation:
+    """Jac Access Validation Specs."""
+
+    @staticmethod
+    def allow_root(
+        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Allow all access from target root graph to current Architype."""
+        hookmanager.hook.allow_root(anchor=anchor, root_id=root_id, level=level)
+
+    @staticmethod
+    def disallow_root(
+        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Disallow all access from target root graph to current Architype."""
+        hookmanager.hook.disallow_root(anchor=anchor, root_id=root_id, level=level)
+
+    @staticmethod
+    def unrestrict(
+        anchor: Anchor, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Allow everyone to access current Architype."""
+        hookmanager.hook.unrestrict(anchor=anchor, level=level)
+
+    @staticmethod
+    def restrict(anchor: Anchor) -> None:
+        """Disallow others to access current Architype."""
+        hookmanager.hook.restrict(anchor=anchor)
+
+    @staticmethod
+    def check_read_access(to: Anchor) -> bool:
+        """Read Access Validation."""
+        return hookmanager.hook.check_read_access(to=to)
+
+    @staticmethod
+    def check_connect_access(to: Anchor) -> bool:
+        """Write Access Validation."""
+        return hookmanager.hook.check_connect_access(to=to)
+
+    @staticmethod
+    def check_write_access(to: Anchor) -> bool:
+        """Write Access Validation."""
+        return hookmanager.hook.check_write_access(to=to)
+
+    @staticmethod
+    def check_access_level(to: Anchor) -> AccessLevel:
+        """Access validation."""
+        return hookmanager.hook.check_access_level(to=to)
+
+
+class JacNode:
+    """Jac Node Operations."""
+
+    @staticmethod
+    def node_dot(node: NodeArchitype, dot_file: Optional[str] = None) -> str:
+        """Generate Dot file for visualizing nodes and edges."""
+        return hookmanager.hook.node_dot(node=node, dot_file=dot_file)
+
+    @staticmethod
+    def get_edges(
+        node: NodeAnchor,
+        dir: EdgeDir,
+        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
+        target_obj: Optional[list[NodeArchitype]],
+    ) -> list[EdgeArchitype]:
+        """Get edges connected to this node."""
+        return hookmanager.hook.get_edges(
+            node=node, dir=dir, filter_func=filter_func, target_obj=target_obj
+        )
+
+    @staticmethod
+    def edges_to_nodes(
+        node: NodeAnchor,
+        dir: EdgeDir,
+        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
+        target_obj: Optional[list[NodeArchitype]],
+    ) -> list[NodeArchitype]:
+        """Get set of nodes connected to this node."""
+        return hookmanager.hook.edges_to_nodes(
+            node=node, dir=dir, filter_func=filter_func, target_obj=target_obj
+        )
+
+    @staticmethod
+    def remove_edge(node: NodeAnchor, edge: EdgeAnchor) -> None:
+        """Remove reference without checking sync status."""
+        return hookmanager.hook.remove_edge(node=node, edge=edge)
+
+
+class JacEdge:
+    """Jac Edge Operations."""
+
+    @staticmethod
+    def detach(edge: EdgeAnchor) -> None:
+        """Detach edge from nodes."""
+        return hookmanager.hook.detach(edge=edge)
+
+
+class JacWalker:
+    """Jac Edge Operations."""
+
+    @staticmethod
+    def visit_node(
+        walker: WalkerArchitype,
+        expr: (
+            list[NodeArchitype | EdgeArchitype]
+            | list[NodeArchitype]
+            | list[EdgeArchitype]
+            | NodeArchitype
+            | EdgeArchitype
+        ),
+    ) -> bool:  # noqa: ANN401
+        """Jac's visit stmt feature."""
+        return hookmanager.hook.visit_node(walker=walker, expr=expr)
+
+    @staticmethod
+    def ignore(
+        walker: WalkerArchitype,
+        expr: (
+            list[NodeArchitype | EdgeArchitype]
+            | list[NodeArchitype]
+            | list[EdgeArchitype]
+            | NodeArchitype
+            | EdgeArchitype
+        ),
+    ) -> bool:  # noqa: ANN401
+        """Jac's ignore stmt feature."""
+        return hookmanager.hook.ignore(walker=walker, expr=expr)
+
+    @staticmethod
+    def spawn_call(op1: Architype, op2: Architype) -> WalkerArchitype:
+        """Jac's spawn operator feature."""
+        return hookmanager.hook.spawn_call(op1=op1, op2=op2)
+
+    @staticmethod
+    def disengage(walker: WalkerArchitype) -> bool:
+        """Jac's disengage stmt feature."""
+        return hookmanager.hook.disengage(walker=walker)
+
+
+class JacClassReferences:
+    """Default Classes References."""
+
+    EdgeDir: ClassVar[TypeAlias] = EdgeDir
+    DSFunc: ClassVar[TypeAlias] = DSFunc
+    RootType: ClassVar[TypeAlias] = Root
+    Obj: ClassVar[TypeAlias] = Architype
+    Node: ClassVar[TypeAlias] = NodeArchitype
+    Edge: ClassVar[TypeAlias] = EdgeArchitype
+    Walker: ClassVar[TypeAlias] = WalkerArchitype
+
+
+class JacFeature(JacClassReferences, JacAccessValidation, JacNode, JacEdge, JacWalker):
     """Jac Feature."""
 
-    from jaclang.compiler.constant import EdgeDir as EdgeDirType
-    from jaclang.runtimelib.constructs import DSFunc as DSFuncType
-
-    EdgeDir: TypeAlias = EdgeDirType
-    DSFunc: TypeAlias = DSFuncType
-    RootType: TypeAlias = Root
-    Obj: TypeAlias = Architype
-    Node: TypeAlias = NodeArchitype
-    Edge: TypeAlias = EdgeArchitype
-    Walker: TypeAlias = WalkerArchitype
+    @staticmethod
+    def setup() -> None:
+        """Set Class References."""
+        hookmanager.hook.setup()
 
     @staticmethod
     def get_context() -> ExecutionContext:
         """Get current execution context."""
-        return pm.hook.get_context()
+        return hookmanager.hook.get_context()
 
     @staticmethod
     def get_object(id: str) -> Architype | None:
         """Get object given id."""
-        return pm.hook.get_object(id=id)
+        return hookmanager.hook.get_object(id=id)
 
     @staticmethod
     def object_ref(obj: Architype) -> str:
         """Get object reference id."""
-        return pm.hook.object_ref(obj=obj)
+        return hookmanager.hook.object_ref(obj=obj)
 
     @staticmethod
     def make_architype(
@@ -64,7 +220,7 @@ class JacFeature:
         on_exit: list[DSFunc],
     ) -> Type[Architype]:
         """Create a obj architype."""
-        return pm.hook.make_architype(
+        return hookmanager.hook.make_architype(
             cls=cls, on_entry=on_entry, on_exit=on_exit, arch_base=arch_base
         )
 
@@ -73,35 +229,35 @@ class JacFeature:
         on_entry: list[DSFunc], on_exit: list[DSFunc]
     ) -> Callable[[type], type]:
         """Create a obj architype."""
-        return pm.hook.make_obj(on_entry=on_entry, on_exit=on_exit)
+        return hookmanager.hook.make_obj(on_entry=on_entry, on_exit=on_exit)
 
     @staticmethod
     def make_node(
         on_entry: list[DSFunc], on_exit: list[DSFunc]
     ) -> Callable[[type], type]:
         """Create a node architype."""
-        return pm.hook.make_node(on_entry=on_entry, on_exit=on_exit)
+        return hookmanager.hook.make_node(on_entry=on_entry, on_exit=on_exit)
 
     @staticmethod
     def make_edge(
         on_entry: list[DSFunc], on_exit: list[DSFunc]
     ) -> Callable[[type], type]:
         """Create a edge architype."""
-        return pm.hook.make_edge(on_entry=on_entry, on_exit=on_exit)
+        return hookmanager.hook.make_edge(on_entry=on_entry, on_exit=on_exit)
 
     @staticmethod
     def make_walker(
         on_entry: list[DSFunc], on_exit: list[DSFunc]
     ) -> Callable[[type], type]:
         """Create a walker architype."""
-        return pm.hook.make_walker(on_entry=on_entry, on_exit=on_exit)
+        return hookmanager.hook.make_walker(on_entry=on_entry, on_exit=on_exit)
 
     @staticmethod
     def impl_patch_filename(
         file_loc: str,
     ) -> Callable[[Callable[P, T]], Callable[P, T]]:
         """Update impl file location."""
-        return pm.hook.impl_patch_filename(file_loc=file_loc)
+        return hookmanager.hook.impl_patch_filename(file_loc=file_loc)
 
     @staticmethod
     def jac_import(
@@ -116,7 +272,7 @@ class JacFeature:
         reload_module: Optional[bool] = False,
     ) -> tuple[types.ModuleType, ...]:
         """Core Import Process."""
-        return pm.hook.jac_import(
+        return hookmanager.hook.jac_import(
             target=target,
             base_path=base_path,
             absorb=absorb,
@@ -131,7 +287,7 @@ class JacFeature:
     @staticmethod
     def create_test(test_fun: Callable) -> Callable:
         """Create a test."""
-        return pm.hook.create_test(test_fun=test_fun)
+        return hookmanager.hook.create_test(test_fun=test_fun)
 
     @staticmethod
     def run_test(
@@ -143,7 +299,7 @@ class JacFeature:
         verbose: bool = False,
     ) -> int:
         """Run the test suite in the specified .jac file."""
-        return pm.hook.run_test(
+        return hookmanager.hook.run_test(
             filepath=filepath,
             filter=filter,
             xit=xit,
@@ -155,55 +311,17 @@ class JacFeature:
     @staticmethod
     def elvis(op1: Optional[T], op2: T) -> T:
         """Jac's elvis operator feature."""
-        return pm.hook.elvis(op1=op1, op2=op2)
+        return hookmanager.hook.elvis(op1=op1, op2=op2)
 
     @staticmethod
     def has_instance_default(gen_func: Callable[[], T]) -> T:
         """Jac's has container default feature."""
-        return pm.hook.has_instance_default(gen_func=gen_func)
-
-    @staticmethod
-    def spawn_call(op1: Architype, op2: Architype) -> WalkerArchitype:
-        """Jac's spawn operator feature."""
-        return pm.hook.spawn_call(op1=op1, op2=op2)
+        return hookmanager.hook.has_instance_default(gen_func=gen_func)
 
     @staticmethod
     def report(expr: Any) -> Any:  # noqa: ANN401
         """Jac's report stmt feature."""
-        return pm.hook.report(expr=expr)
-
-    @staticmethod
-    def ignore(
-        walker: WalkerArchitype,
-        expr: (
-            list[NodeArchitype | EdgeArchitype]
-            | list[NodeArchitype]
-            | list[EdgeArchitype]
-            | NodeArchitype
-            | EdgeArchitype
-        ),
-    ) -> bool:  # noqa: ANN401
-        """Jac's ignore stmt feature."""
-        return pm.hook.ignore(walker=walker, expr=expr)
-
-    @staticmethod
-    def visit_node(
-        walker: WalkerArchitype,
-        expr: (
-            list[NodeArchitype | EdgeArchitype]
-            | list[NodeArchitype]
-            | list[EdgeArchitype]
-            | NodeArchitype
-            | EdgeArchitype
-        ),
-    ) -> bool:  # noqa: ANN401
-        """Jac's visit stmt feature."""
-        return pm.hook.visit_node(walker=walker, expr=expr)
-
-    @staticmethod
-    def disengage(walker: WalkerArchitype) -> bool:  # noqa: ANN401
-        """Jac's disengage stmt feature."""
-        return pm.hook.disengage(walker=walker)
+        return hookmanager.hook.report(expr=expr)
 
     @staticmethod
     def edge_ref(
@@ -214,7 +332,7 @@ class JacFeature:
         edges_only: bool = False,
     ) -> list[NodeArchitype] | list[EdgeArchitype]:
         """Jac's apply_dir stmt feature."""
-        return pm.hook.edge_ref(
+        return hookmanager.hook.edge_ref(
             node_obj=node_obj,
             target_obj=target_obj,
             dir=dir,
@@ -233,7 +351,7 @@ class JacFeature:
 
         Note: connect needs to call assign compr with tuple in op
         """
-        return pm.hook.connect(
+        return hookmanager.hook.connect(
             left=left, right=right, edge_spec=edge_spec, edges_only=edges_only
         )
 
@@ -245,7 +363,7 @@ class JacFeature:
         filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
     ) -> bool:
         """Jac's disconnect operator feature."""
-        return pm.hook.disconnect(
+        return hookmanager.hook.disconnect(
             left=left,
             right=right,
             dir=dir,
@@ -257,17 +375,17 @@ class JacFeature:
         target: list[T], attr_val: tuple[tuple[str], tuple[Any]]
     ) -> list[T]:
         """Jac's assign comprehension feature."""
-        return pm.hook.assign_compr(target=target, attr_val=attr_val)
+        return hookmanager.hook.assign_compr(target=target, attr_val=attr_val)
 
     @staticmethod
     def get_root() -> Root:
         """Jac's root getter."""
-        return pm.hook.get_root()
+        return hookmanager.hook.get_root()
 
     @staticmethod
     def get_root_type() -> Type[Root]:
         """Jac's root type getter."""
-        return pm.hook.get_root_type()
+        return hookmanager.hook.get_root_type()
 
     @staticmethod
     def build_edge(
@@ -276,28 +394,42 @@ class JacFeature:
         conn_assign: Optional[tuple[tuple, tuple]],
     ) -> Callable[[NodeAnchor, NodeAnchor], EdgeArchitype]:
         """Jac's root getter."""
-        return pm.hook.build_edge(
+        return hookmanager.hook.build_edge(
             is_undirected=is_undirected, conn_type=conn_type, conn_assign=conn_assign
         )
+
+    @staticmethod
+    def save(
+        obj: Architype | Anchor,
+    ) -> None:
+        """Destroy object."""
+        hookmanager.hook.save(obj=obj)
+
+    @staticmethod
+    def destroy(
+        obj: Architype | Anchor,
+    ) -> None:
+        """Destroy object."""
+        hookmanager.hook.destroy(obj=obj)
 
     @staticmethod
     def get_semstr_type(
         file_loc: str, scope: str, attr: str, return_semstr: bool
     ) -> Optional[str]:
         """Jac's get_semstr_type feature."""
-        return pm.hook.get_semstr_type(
+        return hookmanager.hook.get_semstr_type(
             file_loc=file_loc, scope=scope, attr=attr, return_semstr=return_semstr
         )
 
     @staticmethod
     def obj_scope(file_loc: str, attr: str) -> str:
         """Jac's get_semstr_type feature."""
-        return pm.hook.obj_scope(file_loc=file_loc, attr=attr)
+        return hookmanager.hook.obj_scope(file_loc=file_loc, attr=attr)
 
     @staticmethod
     def get_sem_type(file_loc: str, attr: str) -> tuple[str | None, str | None]:
         """Jac's get_semstr_type feature."""
-        return pm.hook.get_sem_type(file_loc=file_loc, attr=attr)
+        return hookmanager.hook.get_sem_type(file_loc=file_loc, attr=attr)
 
     @staticmethod
     def with_llm(
@@ -314,7 +446,7 @@ class JacFeature:
         _locals: Mapping,
     ) -> Any:  # noqa: ANN401
         """Jac's with_llm feature."""
-        return pm.hook.with_llm(
+        return hookmanager.hook.with_llm(
             file_loc=file_loc,
             model=model,
             model_params=model_params,
@@ -331,7 +463,7 @@ class JacFeature:
     @staticmethod
     def gen_llm_body(_pass: PyastGenPass, node: ast.Ability) -> list[ast3.AST]:
         """Generate the by LLM body."""
-        return pm.hook.gen_llm_body(_pass=_pass, node=node)
+        return hookmanager.hook.gen_llm_body(_pass=_pass, node=node)
 
     @staticmethod
     def by_llm_call(
@@ -346,7 +478,7 @@ class JacFeature:
         exclude_info: list[tuple[str, ast3.AST]],
     ) -> ast3.Call:
         """Return the LLM Call, e.g. _Jac.with_llm()."""
-        return pm.hook.by_llm_call(
+        return hookmanager.hook.by_llm_call(
             _pass=_pass,
             model=model,
             model_params=model_params,
@@ -361,7 +493,34 @@ class JacFeature:
     @staticmethod
     def get_by_llm_call_args(_pass: PyastGenPass, node: ast.FuncCall) -> dict:
         """Get the by LLM call args."""
-        return pm.hook.get_by_llm_call_args(_pass=_pass, node=node)
+        return hookmanager.hook.get_by_llm_call_args(_pass=_pass, node=node)
+
+
+class JacBuiltin:
+    """Jac Builtins."""
+
+    @staticmethod
+    def dotgen(
+        node: NodeArchitype,
+        depth: int,
+        traverse: bool,
+        edge_type: Optional[list[str]],
+        bfs: bool,
+        edge_limit: int,
+        node_limit: int,
+        dot_file: Optional[str],
+    ) -> str:
+        """Generate Dot file for visualizing nodes and edges."""
+        return hookmanager.hook.dotgen(
+            node=node,
+            depth=depth,
+            traverse=traverse,
+            edge_type=edge_type,
+            bfs=bfs,
+            edge_limit=edge_limit,
+            node_limit=node_limit,
+            dot_file=dot_file,
+        )
 
 
 class JacCmd:
@@ -370,4 +529,4 @@ class JacCmd:
     @staticmethod
     def create_cmd() -> None:
         """Create Jac CLI cmds."""
-        return pm.hook.create_cmd()
+        return hookmanager.hook.create_cmd()

--- a/jac/jaclang/plugin/feature.py
+++ b/jac/jaclang/plugin/feature.py
@@ -177,6 +177,42 @@ class JacWalker:
         return hookmanager.hook.disengage(walker=walker)
 
 
+class JacBuiltin:
+    """Jac Builtins."""
+
+    @staticmethod
+    def dotgen(
+        node: NodeArchitype,
+        depth: int,
+        traverse: bool,
+        edge_type: Optional[list[str]],
+        bfs: bool,
+        edge_limit: int,
+        node_limit: int,
+        dot_file: Optional[str],
+    ) -> str:
+        """Generate Dot file for visualizing nodes and edges."""
+        return hookmanager.hook.dotgen(
+            node=node,
+            depth=depth,
+            traverse=traverse,
+            edge_type=edge_type,
+            bfs=bfs,
+            edge_limit=edge_limit,
+            node_limit=node_limit,
+            dot_file=dot_file,
+        )
+
+
+class JacCmd:
+    """Jac CLI command."""
+
+    @staticmethod
+    def create_cmd() -> None:
+        """Create Jac CLI cmds."""
+        return hookmanager.hook.create_cmd()
+
+
 class JacClassReferences:
     """Default Classes References."""
 
@@ -189,7 +225,15 @@ class JacClassReferences:
     Walker: ClassVar[TypeAlias] = WalkerArchitype
 
 
-class JacFeature(JacClassReferences, JacAccessValidation, JacNode, JacEdge, JacWalker):
+class JacFeature(
+    JacClassReferences,
+    JacAccessValidation,
+    JacNode,
+    JacEdge,
+    JacWalker,
+    JacBuiltin,
+    JacCmd,
+):
     """Jac Feature."""
 
     @staticmethod
@@ -494,39 +538,3 @@ class JacFeature(JacClassReferences, JacAccessValidation, JacNode, JacEdge, JacW
     def get_by_llm_call_args(_pass: PyastGenPass, node: ast.FuncCall) -> dict:
         """Get the by LLM call args."""
         return hookmanager.hook.get_by_llm_call_args(_pass=_pass, node=node)
-
-
-class JacBuiltin:
-    """Jac Builtins."""
-
-    @staticmethod
-    def dotgen(
-        node: NodeArchitype,
-        depth: int,
-        traverse: bool,
-        edge_type: Optional[list[str]],
-        bfs: bool,
-        edge_limit: int,
-        node_limit: int,
-        dot_file: Optional[str],
-    ) -> str:
-        """Generate Dot file for visualizing nodes and edges."""
-        return hookmanager.hook.dotgen(
-            node=node,
-            depth=depth,
-            traverse=traverse,
-            edge_type=edge_type,
-            bfs=bfs,
-            edge_limit=edge_limit,
-            node_limit=node_limit,
-            dot_file=dot_file,
-        )
-
-
-class JacCmd:
-    """Jac CLI command."""
-
-    @staticmethod
-    def create_cmd() -> None:
-        """Create Jac CLI cmds."""
-        return hookmanager.hook.create_cmd()

--- a/jac/jaclang/plugin/feature.py
+++ b/jac/jaclang/plugin/feature.py
@@ -15,7 +15,6 @@ from typing import (
     TypeAlias,
     Union,
 )
-from uuid import UUID
 
 from jaclang.plugin.spec import (
     AccessLevel,
@@ -26,6 +25,7 @@ from jaclang.plugin.spec import (
     EdgeArchitype,
     EdgeDir,
     ExecutionContext,
+    JID,
     NodeAnchor,
     NodeArchitype,
     P,
@@ -43,17 +43,21 @@ class JacAccessValidation:
 
     @staticmethod
     def allow_root(
-        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+        anchor: Anchor,
+        root_jid: JID,
+        level: AccessLevel | int | str = AccessLevel.READ,
     ) -> None:
         """Allow all access from target root graph to current Architype."""
-        hookmanager.hook.allow_root(anchor=anchor, root_id=root_id, level=level)
+        hookmanager.hook.allow_root(anchor=anchor, root_jid=root_jid, level=level)
 
     @staticmethod
     def disallow_root(
-        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+        anchor: Anchor,
+        root_jid: JID,
+        level: AccessLevel | int | str = AccessLevel.READ,
     ) -> None:
         """Disallow all access from target root graph to current Architype."""
-        hookmanager.hook.disallow_root(anchor=anchor, root_id=root_id, level=level)
+        hookmanager.hook.disallow_root(anchor=anchor, root_jid=root_jid, level=level)
 
     @staticmethod
     def unrestrict(
@@ -247,9 +251,9 @@ class JacFeature(
         return hookmanager.hook.get_context()
 
     @staticmethod
-    def get_object(id: str) -> Architype | None:
+    def get_object(jid: JID) -> Architype | None:
         """Get object given id."""
-        return hookmanager.hook.get_object(id=id)
+        return hookmanager.hook.get_object(jid=jid)
 
     @staticmethod
     def object_ref(obj: Architype) -> str:

--- a/jac/jaclang/plugin/spec.py
+++ b/jac/jaclang/plugin/spec.py
@@ -16,17 +16,17 @@ from typing import (
     TypeVar,
     Union,
 )
-from uuid import UUID
 
 from jaclang.compiler import absyntree as ast
 from jaclang.compiler.constant import EdgeDir
 from jaclang.compiler.passes.main.pyast_gen_pass import PyastGenPass
-from jaclang.runtimelib.context import ExecutionContext
 from jaclang.runtimelib.interface import (
     AccessLevel,
     DSFunc,
     EdgeAnchor,
     EdgeArchitype,
+    ExecutionContext,
+    JID,
     NodeAnchor,
     NodeArchitype,
     Root,
@@ -52,7 +52,7 @@ class JacAccessValidationSpec:
     @staticmethod
     @hookspec(firstresult=True)
     def allow_root(
-        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+        anchor: Anchor, root_jid: JID, level: AccessLevel | int | str = AccessLevel.READ
     ) -> None:
         """Allow all access from target root graph to current Architype."""
         raise NotImplementedError
@@ -60,7 +60,7 @@ class JacAccessValidationSpec:
     @staticmethod
     @hookspec(firstresult=True)
     def disallow_root(
-        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+        anchor: Anchor, root_jid: JID, level: AccessLevel | int | str = AccessLevel.READ
     ) -> None:
         """Disallow all access from target root graph to current Architype."""
         raise NotImplementedError
@@ -251,7 +251,7 @@ class JacFeatureSpec(
 
     @staticmethod
     @hookspec(firstresult=True)
-    def get_object(id: str) -> Architype | None:
+    def get_object(jid: JID) -> Architype | None:
         """Get object by id."""
         raise NotImplementedError
 

--- a/jac/jaclang/plugin/spec.py
+++ b/jac/jaclang/plugin/spec.py
@@ -11,36 +11,198 @@ from typing import (
     Optional,
     ParamSpec,
     Sequence,
-    TYPE_CHECKING,
     Type,
     TypeVar,
     Union,
 )
+from uuid import UUID
 
-import jaclang.compiler.absyntree as ast
+from jaclang.compiler import absyntree as ast
+from jaclang.compiler.constant import EdgeDir
 from jaclang.compiler.passes.main.pyast_gen_pass import PyastGenPass
-
-if TYPE_CHECKING:
-    from jaclang.plugin.default import (
-        Architype,
-        EdgeDir,
-        WalkerArchitype,
-        Root,
-        DSFunc,
-    )
-    from jaclang.runtimelib.constructs import EdgeArchitype, NodeAnchor, NodeArchitype
-    from jaclang.runtimelib.context import ExecutionContext
+from jaclang.runtimelib.constructs import (
+    AccessLevel,
+    Anchor,
+    Architype,
+    DSFunc,
+    EdgeAnchor,
+    EdgeArchitype,
+    NodeAnchor,
+    NodeArchitype,
+    Root,
+    WalkerArchitype,
+)
+from jaclang.runtimelib.context import ExecutionContext
 
 import pluggy
 
 hookspec = pluggy.HookspecMarker("jac")
+hookmanager = pluggy.PluginManager("jac")
 
 T = TypeVar("T")
 P = ParamSpec("P")
 
 
-class JacFeatureSpec:
+class JacAccessValidationSpec:
+    """Jac Access Validation Specs."""
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def allow_root(
+        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Allow all access from target root graph to current Architype."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def disallow_root(
+        anchor: Anchor, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Disallow all access from target root graph to current Architype."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def unrestrict(
+        anchor: Anchor, level: AccessLevel | int | str = AccessLevel.READ
+    ) -> None:
+        """Allow everyone to access current Architype."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def restrict(anchor: Anchor) -> None:
+        """Disallow others to access current Architype."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def check_read_access(to: Anchor) -> bool:
+        """Read Access Validation."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def check_connect_access(to: Anchor) -> bool:
+        """Write Access Validation."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def check_write_access(to: Anchor) -> bool:
+        """Write Access Validation."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def check_access_level(to: Anchor) -> AccessLevel:
+        """Access validation."""
+        raise NotImplementedError
+
+
+class JacNodeSpec:
+    """Jac Node Operations."""
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def node_dot(node: NodeArchitype, dot_file: Optional[str] = None) -> str:
+        """Generate Dot file for visualizing nodes and edges."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def get_edges(
+        node: NodeAnchor,
+        dir: EdgeDir,
+        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
+        target_obj: Optional[list[NodeArchitype]],
+    ) -> list[EdgeArchitype]:
+        """Get edges connected to this node."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def edges_to_nodes(
+        node: NodeAnchor,
+        dir: EdgeDir,
+        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
+        target_obj: Optional[list[NodeArchitype]],
+    ) -> list[NodeArchitype]:
+        """Get set of nodes connected to this node."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def remove_edge(node: NodeAnchor, edge: EdgeAnchor) -> None:
+        """Remove reference without checking sync status."""
+        raise NotImplementedError
+
+
+class JacEdgeSpec:
+    """Jac Edge Operations."""
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def detach(edge: EdgeAnchor) -> None:
+        """Detach edge from nodes."""
+        raise NotImplementedError
+
+
+class JacWalkerSpec:
+    """Jac Edge Operations."""
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def visit_node(
+        walker: WalkerArchitype,
+        expr: (
+            list[NodeArchitype | EdgeArchitype]
+            | list[NodeArchitype]
+            | list[EdgeArchitype]
+            | NodeArchitype
+            | EdgeArchitype
+        ),
+    ) -> bool:  # noqa: ANN401
+        """Jac's visit stmt feature."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def ignore(
+        walker: WalkerArchitype,
+        expr: (
+            list[NodeArchitype | EdgeArchitype]
+            | list[NodeArchitype]
+            | list[EdgeArchitype]
+            | NodeArchitype
+            | EdgeArchitype
+        ),
+    ) -> bool:
+        """Jac's ignore stmt feature."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def spawn_call(op1: Architype, op2: Architype) -> WalkerArchitype:
+        """Invoke data spatial call."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def disengage(walker: WalkerArchitype) -> bool:
+        """Jac's disengage stmt feature."""
+        raise NotImplementedError
+
+
+class JacFeatureSpec(JacAccessValidationSpec, JacNodeSpec, JacEdgeSpec, JacWalkerSpec):
     """Jac Feature."""
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def setup() -> None:
+        """Set Class References."""
+        raise NotImplementedError
 
     @staticmethod
     @hookspec(firstresult=True)
@@ -51,13 +213,13 @@ class JacFeatureSpec:
     @staticmethod
     @hookspec(firstresult=True)
     def get_object(id: str) -> Architype | None:
-        """Get object given id.."""
+        """Get object by id."""
         raise NotImplementedError
 
     @staticmethod
     @hookspec(firstresult=True)
     def object_ref(obj: Architype) -> str:
-        """Get object given id.."""
+        """Get object's id."""
         raise NotImplementedError
 
     @staticmethod
@@ -160,50 +322,8 @@ class JacFeatureSpec:
 
     @staticmethod
     @hookspec(firstresult=True)
-    def spawn_call(op1: Architype, op2: Architype) -> WalkerArchitype:
-        """Jac's spawn operator feature."""
-        raise NotImplementedError
-
-    @staticmethod
-    @hookspec(firstresult=True)
     def report(expr: Any) -> Any:  # noqa: ANN401
         """Jac's report stmt feature."""
-        raise NotImplementedError
-
-    @staticmethod
-    @hookspec(firstresult=True)
-    def ignore(
-        walker: WalkerArchitype,
-        expr: (
-            list[NodeArchitype | EdgeArchitype]
-            | list[NodeArchitype]
-            | list[EdgeArchitype]
-            | NodeArchitype
-            | EdgeArchitype
-        ),
-    ) -> bool:
-        """Jac's ignore stmt feature."""
-        raise NotImplementedError
-
-    @staticmethod
-    @hookspec(firstresult=True)
-    def visit_node(
-        walker: WalkerArchitype,
-        expr: (
-            list[NodeArchitype | EdgeArchitype]
-            | list[NodeArchitype]
-            | list[EdgeArchitype]
-            | NodeArchitype
-            | EdgeArchitype
-        ),
-    ) -> bool:  # noqa: ANN401
-        """Jac's visit stmt feature."""
-        raise NotImplementedError
-
-    @staticmethod
-    @hookspec(firstresult=True)
-    def disengage(walker: WalkerArchitype) -> bool:  # noqa: ANN401
-        """Jac's disengage stmt feature."""
         raise NotImplementedError
 
     @staticmethod
@@ -271,6 +391,22 @@ class JacFeatureSpec:
         conn_assign: Optional[tuple[tuple, tuple]],
     ) -> Callable[[NodeAnchor, NodeAnchor], EdgeArchitype]:
         """Jac's root getter."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def save(
+        obj: Architype | Anchor,
+    ) -> None:
+        """Destroy object."""
+        raise NotImplementedError
+
+    @staticmethod
+    @hookspec(firstresult=True)
+    def destroy(
+        obj: Architype | Anchor,
+    ) -> None:
+        """Destroy object."""
         raise NotImplementedError
 
     @staticmethod
@@ -348,7 +484,7 @@ class JacBuiltin:
         node: NodeArchitype,
         depth: int,
         traverse: bool,
-        edge_type: list[str],
+        edge_type: Optional[list[str]],
         bfs: bool,
         edge_limit: int,
         node_limit: int,
@@ -366,3 +502,8 @@ class JacCmdSpec:
     def create_cmd() -> None:
         """Create Jac CLI cmds."""
         raise NotImplementedError
+
+
+hookmanager.add_hookspecs(JacFeatureSpec)
+hookmanager.add_hookspecs(JacCmdSpec)
+hookmanager.add_hookspecs(JacBuiltin)

--- a/jac/jaclang/plugin/tests/fixtures/other_root_access.jac
+++ b/jac/jaclang/plugin/tests/fixtures/other_root_access.jac
@@ -36,7 +36,7 @@ walker create_node {
 walker create_other_root {
     can enter with `root entry {
         other_root = `root().__jac__;
-        other_root.save();
+        Jac.save(other_root);
         print(other_root.id);
     }
 }
@@ -46,17 +46,17 @@ walker allow_other_root_access {
 
     can enter_root with `root entry {
         if self.via_all {
-            here.__jac__.unrestrict(self.level);
+            Jac.unrestrict(here.__jac__, self.level);
         } else {
-            here.__jac__.allow_root(UUID(self.root_id), self.level);
+            Jac.allow_root(here.__jac__, UUID(self.root_id), self.level);
         }
     }
 
     can enter_nested with A entry {
         if self.via_all {
-            here.__jac__.unrestrict(self.level);
+            Jac.unrestrict(here.__jac__, self.level);
         } else {
-            here.__jac__.allow_root(UUID(self.root_id), self.level);
+            Jac.allow_root(here.__jac__, UUID(self.root_id), self.level);
         }
     }
 }
@@ -66,17 +66,17 @@ walker disallow_other_root_access {
 
     can enter_root with `root entry {
         if self.via_all {
-            here.__jac__.restrict();
+            Jac.restrict(here.__jac__);
         } else {
-            here.__jac__.disallow_root(UUID(self.root_id));
+            Jac.disallow_root(here.__jac__, UUID(self.root_id));
         }
     }
 
     can enter_nested with A entry {
         if self.via_all {
-            here.__jac__.restrict();
+            Jac.restrict(here.__jac__);
         } else {
-            here.__jac__.disallow_root(UUID(self.root_id));
+            Jac.disallow_root(here.__jac__, UUID(self.root_id));
         }
     }
 }

--- a/jac/jaclang/plugin/tests/test_features.py
+++ b/jac/jaclang/plugin/tests/test_features.py
@@ -3,7 +3,7 @@
 import inspect
 from typing import List, Type
 
-from jaclang.plugin.default import JacFeatureDefaults
+from jaclang.plugin.default import JacFeatureImpl
 from jaclang.plugin.feature import JacFeature
 from jaclang.plugin.spec import JacFeatureSpec
 from jaclang.utils.test import TestCase
@@ -46,7 +46,7 @@ class TestFeatures(TestCase):
         """Test if JacFeature, JacFeatureDefaults, and JacFeatureSpec have synced methods."""
         # Get methods of each class
         jac_feature_methods = self.get_methods(JacFeature)
-        jac_feature_defaults_methods = self.get_methods(JacFeatureDefaults)
+        jac_feature_defaults_methods = self.get_methods(JacFeatureImpl)
         jac_feature_spec_methods = self.get_methods(JacFeatureSpec)
 
         # Check if all methods are the same in all classes

--- a/jac/jaclang/runtimelib/architype.py
+++ b/jac/jaclang/runtimelib/architype.py
@@ -7,11 +7,8 @@ from enum import IntEnum
 from logging import getLogger
 from pickle import dumps
 from types import UnionType
-from typing import Any, Callable, ClassVar, Iterable, Optional, TypeVar
+from typing import Any, Callable, ClassVar, Optional, TypeVar
 from uuid import UUID, uuid4
-
-from jaclang.compiler.constant import EdgeDir
-from jaclang.runtimelib.utils import collect_node_connections
 
 logger = getLogger(__name__)
 
@@ -76,128 +73,6 @@ class Anchor:
     access: Permission = field(default_factory=Permission)
     persistent: bool = False
     hash: int = 0
-
-    ##########################################################################
-    #                             ACCESS CONTROL: TODO: Make Base Type       #
-    ##########################################################################
-
-    def allow_root(
-        self, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
-    ) -> None:
-        """Allow all access from target root graph to current Architype."""
-        level = AccessLevel.cast(level)
-        access = self.access.roots
-
-        _root_id = str(root_id)
-        if level != access.anchors.get(_root_id, AccessLevel.NO_ACCESS):
-            access.anchors[_root_id] = level
-
-    def disallow_root(
-        self, root_id: UUID, level: AccessLevel | int | str = AccessLevel.READ
-    ) -> None:
-        """Disallow all access from target root graph to current Architype."""
-        level = AccessLevel.cast(level)
-        access = self.access.roots
-
-        access.anchors.pop(str(root_id), None)
-
-    def unrestrict(self, level: AccessLevel | int | str = AccessLevel.READ) -> None:
-        """Allow everyone to access current Architype."""
-        level = AccessLevel.cast(level)
-        if level != self.access.all:
-            self.access.all = level
-
-    def restrict(self) -> None:
-        """Disallow others to access current Architype."""
-        if self.access.all > AccessLevel.NO_ACCESS:
-            self.access.all = AccessLevel.NO_ACCESS
-
-    def has_read_access(self, to: Anchor) -> bool:
-        """Read Access Validation."""
-        if not (access_level := self.access_level(to) > AccessLevel.NO_ACCESS):
-            logger.info(
-                f"Current root doesn't have read access to {to.__class__.__name__}[{to.id}]"
-            )
-        return access_level
-
-    def has_connect_access(self, to: Anchor) -> bool:
-        """Write Access Validation."""
-        if not (access_level := self.access_level(to) > AccessLevel.READ):
-            logger.info(
-                f"Current root doesn't have connect access to {to.__class__.__name__}[{to.id}]"
-            )
-        return access_level
-
-    def has_write_access(self, to: Anchor) -> bool:
-        """Write Access Validation."""
-        if not (access_level := self.access_level(to) > AccessLevel.CONNECT):
-            logger.info(
-                f"Current root doesn't have write access to {to.__class__.__name__}[{to.id}]"
-            )
-        return access_level
-
-    def access_level(self, to: Anchor) -> AccessLevel:
-        """Access validation."""
-        if not to.persistent:
-            return AccessLevel.WRITE
-
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        jctx = Jac.get_context()
-
-        jroot = jctx.root
-
-        # if current root is system_root
-        # if current root id is equal to target anchor's root id
-        # if current root is the target anchor
-        if jroot == jctx.system_root or jroot.id == to.root or jroot == to:
-            return AccessLevel.WRITE
-
-        access_level = AccessLevel.NO_ACCESS
-
-        # if target anchor have set access.all
-        if (to_access := to.access).all > AccessLevel.NO_ACCESS:
-            access_level = to_access.all
-
-        # if target anchor's root have set allowed roots
-        # if current root is allowed to the whole graph of target anchor's root
-        if to.root and isinstance(to_root := jctx.mem.find_one(to.root), Anchor):
-            if to_root.access.all > access_level:
-                access_level = to_root.access.all
-
-            level = to_root.access.roots.check(str(jroot.id))
-            if level > AccessLevel.NO_ACCESS and access_level == AccessLevel.NO_ACCESS:
-                access_level = level
-
-        # if target anchor have set allowed roots
-        # if current root is allowed to target anchor
-        level = to_access.roots.check(str(jroot.id))
-        if level > AccessLevel.NO_ACCESS and access_level == AccessLevel.NO_ACCESS:
-            access_level = level
-
-        return access_level
-
-    # ---------------------------------------------------------------------- #
-
-    def save(self) -> None:
-        """Save Anchor."""
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        jctx = Jac.get_context()
-
-        self.persistent = True
-        self.root = jctx.root.id
-
-        jctx.mem.set(self.id, self)
-
-    def destroy(self) -> None:
-        """Destroy Anchor."""
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        jctx = Jac.get_context()
-
-        if jctx.root.has_write_access(self):
-            jctx.mem.remove(self.id)
 
     def is_populated(self) -> bool:
         """Check if state."""
@@ -304,122 +179,6 @@ class NodeAnchor(Anchor):
     architype: NodeArchitype
     edges: list[EdgeAnchor]
 
-    def get_edges(
-        self,
-        dir: EdgeDir,
-        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
-        target_obj: Optional[list[NodeArchitype]],
-    ) -> list[EdgeArchitype]:
-        """Get edges connected to this node."""
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        root = Jac.get_root().__jac__
-        ret_edges: list[EdgeArchitype] = []
-        for anchor in self.edges:
-            if (
-                (source := anchor.source)
-                and (target := anchor.target)
-                and (not filter_func or filter_func([anchor.architype]))
-                and source.architype
-                and target.architype
-            ):
-                if (
-                    dir in [EdgeDir.OUT, EdgeDir.ANY]
-                    and self == source
-                    and (not target_obj or target.architype in target_obj)
-                    and root.has_read_access(target)
-                ):
-                    ret_edges.append(anchor.architype)
-                if (
-                    dir in [EdgeDir.IN, EdgeDir.ANY]
-                    and self == target
-                    and (not target_obj or source.architype in target_obj)
-                    and root.has_read_access(source)
-                ):
-                    ret_edges.append(anchor.architype)
-        return ret_edges
-
-    def edges_to_nodes(
-        self,
-        dir: EdgeDir,
-        filter_func: Optional[Callable[[list[EdgeArchitype]], list[EdgeArchitype]]],
-        target_obj: Optional[list[NodeArchitype]],
-    ) -> list[NodeArchitype]:
-        """Get set of nodes connected to this node."""
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        root = Jac.get_root().__jac__
-        ret_edges: list[NodeArchitype] = []
-        for anchor in self.edges:
-            if (
-                (source := anchor.source)
-                and (target := anchor.target)
-                and (not filter_func or filter_func([anchor.architype]))
-                and source.architype
-                and target.architype
-            ):
-                if (
-                    dir in [EdgeDir.OUT, EdgeDir.ANY]
-                    and self == source
-                    and (not target_obj or target.architype in target_obj)
-                    and root.has_read_access(target)
-                ):
-                    ret_edges.append(target.architype)
-                if (
-                    dir in [EdgeDir.IN, EdgeDir.ANY]
-                    and self == target
-                    and (not target_obj or source.architype in target_obj)
-                    and root.has_read_access(source)
-                ):
-                    ret_edges.append(source.architype)
-        return ret_edges
-
-    def remove_edge(self, edge: EdgeAnchor) -> None:
-        """Remove reference without checking sync status."""
-        for idx, ed in enumerate(self.edges):
-            if ed.id == edge.id:
-                self.edges.pop(idx)
-                break
-
-    def gen_dot(self, dot_file: Optional[str] = None) -> str:
-        """Generate Dot file for visualizing nodes and edges."""
-        visited_nodes: set[NodeAnchor] = set()
-        connections: set[tuple[NodeArchitype, NodeArchitype, str]] = set()
-        unique_node_id_dict = {}
-
-        collect_node_connections(self, visited_nodes, connections)
-        dot_content = 'digraph {\nnode [style="filled", shape="ellipse", fillcolor="invis", fontcolor="black"];\n'
-        for idx, i in enumerate([nodes_.architype for nodes_ in visited_nodes]):
-            unique_node_id_dict[i] = (i.__class__.__name__, str(idx))
-            dot_content += f'{idx} [label="{i}"];\n'
-        dot_content += 'edge [color="gray", style="solid"];\n'
-
-        for pair in list(set(connections)):
-            dot_content += (
-                f"{unique_node_id_dict[pair[0]][1]} -> {unique_node_id_dict[pair[1]][1]}"
-                f' [label="{pair[2]}"];\n'
-            )
-        if dot_file:
-            with open(dot_file, "w") as f:
-                f.write(dot_content + "}")
-        return dot_content + "}"
-
-    def spawn_call(self, walk: WalkerAnchor) -> WalkerArchitype:
-        """Invoke data spatial call."""
-        return walk.spawn_call(self)
-
-    def destroy(self) -> None:
-        """Destroy Anchor."""
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        jctx = Jac.get_context()
-
-        if jctx.root.has_write_access(self):
-            for edge in self.edges:
-                edge.destroy()
-
-            jctx.mem.remove(self.id)
-
     def __getstate__(self) -> dict[str, object]:
         """Serialize Node Anchor."""
         state = super().__getstate__()
@@ -438,30 +197,6 @@ class EdgeAnchor(Anchor):
     source: NodeAnchor
     target: NodeAnchor
     is_undirected: bool
-
-    def __post_init__(self) -> None:
-        """Populate edge to source and target."""
-        self.source.edges.append(self)
-        self.target.edges.append(self)
-
-    def detach(self) -> None:
-        """Detach edge from nodes."""
-        self.source.remove_edge(self)
-        self.target.remove_edge(self)
-
-    def spawn_call(self, walk: WalkerAnchor) -> WalkerArchitype:
-        """Invoke data spatial call."""
-        return walk.spawn_call(self.target)
-
-    def destroy(self) -> None:
-        """Destroy Anchor."""
-        from jaclang.plugin.feature import JacFeature as Jac
-
-        jctx = Jac.get_context()
-
-        if jctx.root.has_write_access(self):
-            self.detach()
-            jctx.mem.remove(self.id)
 
     def __getstate__(self) -> dict[str, object]:
         """Serialize Node Anchor."""
@@ -488,81 +223,6 @@ class WalkerAnchor(Anchor):
     next: list[Anchor] = field(default_factory=list)
     ignores: list[Anchor] = field(default_factory=list)
     disengaged: bool = False
-
-    def visit_node(self, anchors: Iterable[NodeAnchor | EdgeAnchor]) -> bool:
-        """Walker visits node."""
-        before_len = len(self.next)
-        for anchor in anchors:
-            if anchor not in self.ignores:
-                if isinstance(anchor, NodeAnchor):
-                    self.next.append(anchor)
-                elif isinstance(anchor, EdgeAnchor):
-                    if target := anchor.target:
-                        self.next.append(target)
-                    else:
-                        raise ValueError("Edge has no target.")
-        return len(self.next) > before_len
-
-    def ignore_node(self, anchors: Iterable[NodeAnchor | EdgeAnchor]) -> bool:
-        """Walker ignores node."""
-        before_len = len(self.ignores)
-        for anchor in anchors:
-            if anchor not in self.ignores:
-                if isinstance(anchor, NodeAnchor):
-                    self.ignores.append(anchor)
-                elif isinstance(anchor, EdgeAnchor):
-                    if target := anchor.target:
-                        self.ignores.append(target)
-                    else:
-                        raise ValueError("Edge has no target.")
-        return len(self.ignores) > before_len
-
-    def disengage_now(self) -> None:
-        """Disengage walker from traversal."""
-        self.disengaged = True
-
-    def spawn_call(self, node: Anchor) -> WalkerArchitype:
-        """Invoke data spatial call."""
-        if walker := self.architype:
-            self.path = []
-            self.next = [node]
-            while len(self.next):
-                if current_node := self.next.pop(0).architype:
-                    for i in current_node._jac_entry_funcs_:
-                        if not i.trigger or isinstance(walker, i.trigger):
-                            if i.func:
-                                i.func(current_node, walker)
-                            else:
-                                raise ValueError(f"No function {i.name} to call.")
-                        if self.disengaged:
-                            return walker
-                    for i in walker._jac_entry_funcs_:
-                        if not i.trigger or isinstance(current_node, i.trigger):
-                            if i.func:
-                                i.func(walker, current_node)
-                            else:
-                                raise ValueError(f"No function {i.name} to call.")
-                        if self.disengaged:
-                            return walker
-                    for i in walker._jac_exit_funcs_:
-                        if not i.trigger or isinstance(current_node, i.trigger):
-                            if i.func:
-                                i.func(walker, current_node)
-                            else:
-                                raise ValueError(f"No function {i.name} to call.")
-                        if self.disengaged:
-                            return walker
-                    for i in current_node._jac_exit_funcs_:
-                        if not i.trigger or isinstance(walker, i.trigger):
-                            if i.func:
-                                i.func(current_node, walker)
-                            else:
-                                raise ValueError(f"No function {i.name} to call.")
-                        if self.disengaged:
-                            return walker
-            self.ignores = []
-            return walker
-        raise Exception(f"Invalid Reference {self.id}")
 
 
 class Architype:
@@ -594,17 +254,6 @@ class EdgeArchitype(Architype):
     """Edge Architype Protocol."""
 
     __jac__: EdgeAnchor
-
-    def __attach__(
-        self,
-        source: NodeAnchor,
-        target: NodeAnchor,
-        is_undirected: bool,
-    ) -> None:
-        """Attach EdgeAnchor properly."""
-        self.__jac__ = EdgeAnchor(
-            architype=self, source=source, target=target, is_undirected=is_undirected
-        )
 
 
 class WalkerArchitype(Architype):

--- a/jac/jaclang/runtimelib/constructs.py
+++ b/jac/jaclang/runtimelib/constructs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 
 from .architype import (
+    AccessLevel,
     Anchor,
     Architype,
     DSFunc,
@@ -21,6 +22,7 @@ from .memory import Memory, ShelfStorage
 from .test import JacTestCheck, JacTestResult, JacTextTestRunner
 
 __all__ = [
+    "AccessLevel",
     "Anchor",
     "NodeAnchor",
     "EdgeAnchor",

--- a/jac/jaclang/runtimelib/context.py
+++ b/jac/jaclang/runtimelib/context.py
@@ -14,9 +14,7 @@ from .memory import ShelfStorage
 
 EXECUTION_CONTEXT = ContextVar[Optional["ExecutionContext"]]("ExecutionContext")
 
-SUPER_ROOT_JID = JID[NodeAnchor](
-    id=UUID("00000000-0000-0000-0000-000000000000"), type=NodeAnchor
-)
+SUPER_ROOT_JID = JID(id=UUID("00000000-0000-0000-0000-000000000000"), type=NodeAnchor)
 SUPER_ROOT_ARCHITYPE = object.__new__(Root)
 SUPER_ROOT_ANCHOR = NodeAnchor(
     jid=SUPER_ROOT_JID, architype=SUPER_ROOT_ARCHITYPE, persistent=False, edge_ids=set()

--- a/jac/jaclang/runtimelib/context.py
+++ b/jac/jaclang/runtimelib/context.py
@@ -42,10 +42,6 @@ class ExecutionContext:
             raise ValueError(f"Invalid anchor id {anchor_id} !")
         return default
 
-    def validate_access(self) -> bool:
-        """Validate access."""
-        return self.root.has_read_access(self.entry_node)
-
     def set_entry_node(self, entry_node: str | None) -> None:
         """Override entry."""
         self.entry_node = self.init_anchor(entry_node, self.root)

--- a/jac/jaclang/runtimelib/context.py
+++ b/jac/jaclang/runtimelib/context.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import unittest
 from contextvars import ContextVar
-from typing import Any, Callable, Optional, cast
+from typing import Callable, Optional, cast
 from uuid import UUID
 
-from .interface import NodeAnchor, Root
-from .memory import Memory, ShelfStorage
+from .implementation import NodeAnchor, Root
+from .interface import ExecutionContext as BaseExecutionContext
+from .memory import ShelfStorage
 
 
 EXECUTION_CONTEXT = ContextVar[Optional["ExecutionContext"]]("ExecutionContext")
@@ -21,14 +22,8 @@ SUPER_ROOT_ANCHOR = NodeAnchor(
 SUPER_ROOT_ARCHITYPE.__jac__ = SUPER_ROOT_ANCHOR
 
 
-class ExecutionContext:
+class ExecutionContext(BaseExecutionContext):
     """Execution Context."""
-
-    mem: Memory
-    reports: list[Any]
-    system_root: NodeAnchor
-    root: NodeAnchor
-    entry_node: NodeAnchor
 
     def init_anchor(
         self,

--- a/jac/jaclang/runtimelib/context.py
+++ b/jac/jaclang/runtimelib/context.py
@@ -7,23 +7,27 @@ from contextvars import ContextVar
 from typing import Callable, Optional, cast
 from uuid import UUID
 
-from .implementation import NodeAnchor, Root
+from .implementation import JID, NodeAnchor, Root
 from .interface import ExecutionContext as BaseExecutionContext
 from .memory import ShelfStorage
 
 
 EXECUTION_CONTEXT = ContextVar[Optional["ExecutionContext"]]("ExecutionContext")
 
-SUPER_ROOT_UUID = UUID("00000000-0000-0000-0000-000000000000")
+SUPER_ROOT_JID = JID[NodeAnchor](
+    id=UUID("00000000-0000-0000-0000-000000000000"), type=NodeAnchor
+)
 SUPER_ROOT_ARCHITYPE = object.__new__(Root)
 SUPER_ROOT_ANCHOR = NodeAnchor(
-    id=SUPER_ROOT_UUID, architype=SUPER_ROOT_ARCHITYPE, persistent=False, edges=[]
+    jid=SUPER_ROOT_JID, architype=SUPER_ROOT_ARCHITYPE, persistent=False, edge_ids=set()
 )
 SUPER_ROOT_ARCHITYPE.__jac__ = SUPER_ROOT_ANCHOR
 
 
-class ExecutionContext(BaseExecutionContext):
+class ExecutionContext(BaseExecutionContext[NodeAnchor]):
     """Execution Context."""
+
+    mem: ShelfStorage
 
     def init_anchor(
         self,
@@ -32,7 +36,7 @@ class ExecutionContext(BaseExecutionContext):
     ) -> NodeAnchor:
         """Load initial anchors."""
         if anchor_id:
-            if isinstance(anchor := self.mem.find_by_id(UUID(anchor_id)), NodeAnchor):
+            if isinstance(anchor := self.mem.find_by_id(JID(anchor_id)), NodeAnchor):
                 return anchor
             raise ValueError(f"Invalid anchor id {anchor_id} !")
         return default
@@ -58,10 +62,10 @@ class ExecutionContext(BaseExecutionContext):
         ctx.reports = []
 
         if not isinstance(
-            system_root := ctx.mem.find_by_id(SUPER_ROOT_UUID), NodeAnchor
+            system_root := ctx.mem.find_by_id(SUPER_ROOT_JID), NodeAnchor
         ):
             system_root = Root().__jac__
-            system_root.id = SUPER_ROOT_UUID
+            system_root.id = SUPER_ROOT_JID
             ctx.mem.set(system_root.id, system_root)
 
         ctx.system_root = system_root

--- a/jac/jaclang/runtimelib/context.py
+++ b/jac/jaclang/runtimelib/context.py
@@ -7,7 +7,7 @@ from contextvars import ContextVar
 from typing import Any, Callable, Optional, cast
 from uuid import UUID
 
-from .architype import NodeAnchor, Root
+from .interface import NodeAnchor, Root
 from .memory import Memory, ShelfStorage
 
 

--- a/jac/jaclang/runtimelib/implementation.py
+++ b/jac/jaclang/runtimelib/implementation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from logging import getLogger
 from re import IGNORECASE, compile
-from typing import Type, TypeAlias, TypeVar
+from typing import Generic, Type, TypeAlias, TypeVar
 from uuid import UUID, uuid4
 
 from .interface import (
@@ -33,12 +33,11 @@ logger = getLogger(__name__)
 
 
 @dataclass(kw_only=True)
-class JID(_JID[UUID, Anchor]):
+class JID(Generic[_ANCHOR], _JID):
     """Jaclang Default JID."""
 
     id: UUID
-    type: Type[Anchor]
-    name: str
+    type: Type[_ANCHOR]
 
     def __init__(
         self,
@@ -52,13 +51,14 @@ class JID(_JID[UUID, Anchor]):
                 if matched := JID_REGEX.search(id):
                     self.id = UUID(matched.group(3))
                     self.name = matched.group(2)
+                    # currently no way to base hinting on string regex!
                     match matched.group(1).lower():
                         case "n":
-                            self.type = NodeAnchor
+                            self.type = NodeAnchor  # type: ignore [assignment]
                         case "e":
-                            self.type = EdgeAnchor
+                            self.type = EdgeAnchor  # type: ignore [assignment]
                         case _:
-                            self.type = WalkerAnchor
+                            self.type = WalkerAnchor  # type: ignore [assignment]
                     return
                 raise ValueError("Not a valid JID format!")
             case UUID():
@@ -103,9 +103,6 @@ class NodeAnchor(_NodeAnchor["NodeAnchor"]):
     def __deserialize__(cls, data: NodeAnchor) -> NodeAnchor:
         """Override deserialization."""
         return data
-
-
-aa = JID(id=UUID(), type=NodeAnchor)
 
 
 @dataclass(kw_only=True)

--- a/jac/jaclang/runtimelib/implementation.py
+++ b/jac/jaclang/runtimelib/implementation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from logging import getLogger
 from re import IGNORECASE, compile
-from typing import Type, TypeAlias
+from typing import Type, TypeAlias, TypeVar
 from uuid import UUID, uuid4
 
 from .interface import (
@@ -17,7 +17,6 @@ from .interface import (
     Permission,
     WalkerAnchor as _WalkerAnchor,
     WalkerArchitype as _WalkerArchitype,
-    _ANCHOR,
 )
 
 
@@ -27,22 +26,24 @@ JID_REGEX = compile(
 )
 
 
+_ANCHOR = TypeVar("_ANCHOR", "NodeAnchor", "EdgeAnchor", "WalkerAnchor", covariant=True)
 Anchor: TypeAlias = "NodeAnchor" | "EdgeAnchor" | "WalkerAnchor"
 Architype: TypeAlias = "NodeArchitype" | "EdgeArchitype" | "WalkerArchitype"
 logger = getLogger(__name__)
 
 
 @dataclass(kw_only=True)
-class JID(_JID[UUID, _ANCHOR]):
+class JID(_JID[UUID, Anchor]):
     """Jaclang Default JID."""
 
     id: UUID
+    type: Type[Anchor]
     name: str
 
     def __init__(
-        self: JID[Anchor],
+        self,
         id: str | UUID | None = None,
-        type: Type[Anchor] | None = None,
+        type: Type[_ANCHOR] | None = None,
         name: str = "",
     ) -> None:
         """Override JID initializer."""
@@ -85,7 +86,7 @@ class JID(_JID[UUID, _ANCHOR]):
 class NodeAnchor(_NodeAnchor["NodeAnchor"]):
     """NodeAnchor Interface."""
 
-    jid: JID[NodeAnchor] = field(default_factory=lambda: JID(type=NodeAnchor))
+    jid: JID["NodeAnchor"] = field(default_factory=lambda: JID(type=NodeAnchor))
     architype: "NodeArchitype"
     root: JID["NodeAnchor"] | None = None
     access: Permission = field(default_factory=Permission)
@@ -102,6 +103,9 @@ class NodeAnchor(_NodeAnchor["NodeAnchor"]):
     def __deserialize__(cls, data: NodeAnchor) -> NodeAnchor:
         """Override deserialization."""
         return data
+
+
+aa = JID(id=UUID(), type=NodeAnchor)
 
 
 @dataclass(kw_only=True)

--- a/jac/jaclang/runtimelib/implementation.py
+++ b/jac/jaclang/runtimelib/implementation.py
@@ -19,7 +19,8 @@ from .interface import (
     _ANCHOR,
 )
 
-ANCHOR_TYPES: TypeAlias = "NodeAnchor" | "EdgeAnchor" | "WalkerAnchor"
+Anchor: TypeAlias = "NodeAnchor" | "EdgeAnchor" | "WalkerAnchor"
+Architype: TypeAlias = "NodeArchitype" | "EdgeArchitype" | "WalkerArchitype"
 logger = getLogger(__name__)
 
 

--- a/jac/jaclang/runtimelib/implementation.py
+++ b/jac/jaclang/runtimelib/implementation.py
@@ -1,0 +1,162 @@
+"""Jaclang Runtimelib Implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from logging import getLogger
+from typing import ClassVar, TypeAlias
+from uuid import UUID, uuid4
+
+from .interface import (
+    EdgeAnchor as _EdgeAnchor,
+    EdgeArchitype as _EdgeArchitype,
+    JID as _JID,
+    NodeAnchor as _NodeAnchor,
+    NodeArchitype as _NodeArchitype,
+    Permission,
+    WalkerAnchor as _WalkerAnchor,
+    WalkerArchitype as _WalkerArchitype,
+    _ANCHOR,
+)
+
+ANCHOR_TYPES: TypeAlias = "NodeAnchor" | "EdgeAnchor" | "WalkerAnchor"
+logger = getLogger(__name__)
+
+
+@dataclass(kw_only=True)
+class JID(_JID[UUID, _ANCHOR]):
+    """Jaclang Default JID."""
+
+    id: UUID = field(default_factory=uuid4)
+    name: str = ""
+
+    def __repr__(self) -> str:
+        """Override string representation."""
+        return f"{self.type.__class__.__name__[:1].lower()}:{self.name}:{self.id}"
+
+    def __str__(self) -> str:
+        """Override string parsing."""
+        return f"{self.type.__class__.__name__[:1].lower()}:{self.name}:{self.id}"
+
+
+@dataclass(kw_only=True)
+class NodeAnchor(_NodeAnchor["NodeAnchor"]):
+    """NodeAnchor Interface."""
+
+    jid: JID[NodeAnchor] = field(default_factory=lambda: JID(type=NodeAnchor))
+    architype: "NodeArchitype"
+    root: JID["NodeAnchor"] | None = None
+    access: Permission = field(default_factory=Permission)
+    persistent: bool = False
+    hash: int = 0
+
+    edge_ids: set[JID[EdgeAnchor]] = field(default_factory=set)
+
+    def __serialize__(self) -> NodeAnchor:
+        """Override serialization."""
+        return self
+
+    @classmethod
+    def __deserialize__(cls, data: NodeAnchor) -> NodeAnchor:
+        """Override deserialization."""
+        return data
+
+
+@dataclass(kw_only=True)
+class EdgeAnchor(_EdgeAnchor["EdgeAnchor"]):
+    """NodeAnchor Interface."""
+
+    jid: JID[EdgeAnchor] = field(default_factory=lambda: JID(type=EdgeAnchor))
+    architype: "EdgeArchitype"
+    root: JID["NodeAnchor"] | None = None
+    access: Permission = field(default_factory=Permission)
+    persistent: bool = False
+    hash: int = 0
+
+    source_id: JID[NodeAnchor]
+    target_id: JID[NodeAnchor]
+
+    def __serialize__(self) -> EdgeAnchor:
+        """Override serialization."""
+        return self
+
+    @classmethod
+    def __deserialize__(cls, data: EdgeAnchor) -> EdgeAnchor:
+        """Override deserialization."""
+        return data
+
+
+@dataclass(kw_only=True)
+class WalkerAnchor(_WalkerAnchor["WalkerAnchor"]):
+    """NodeAnchor Interface."""
+
+    jid: JID[WalkerAnchor] = field(default_factory=lambda: JID(type=WalkerAnchor))
+    architype: "WalkerArchitype"
+    root: JID["NodeAnchor"] | None = None
+    access: Permission = field(default_factory=Permission)
+    persistent: bool = False
+    hash: int = 0
+
+    def __serialize__(self) -> WalkerAnchor:
+        """Override serialization."""
+        return self
+
+    @classmethod
+    def __deserialize__(cls, data: WalkerAnchor) -> WalkerAnchor:
+        """Override deserialization."""
+        return data
+
+
+class NodeArchitype(_NodeArchitype["NodeArchitype"]):
+    """NodeArchitype Interface."""
+
+    __jac__: ClassVar[NodeAnchor]
+
+    def __serialize__(self) -> NodeArchitype:
+        """Override serialization."""
+        return self
+
+    @classmethod
+    def __deserialize__(cls, data: NodeArchitype) -> NodeArchitype:
+        """Override deserialization."""
+        return data
+
+
+class EdgeArchitype(_EdgeArchitype["EdgeArchitype"]):
+    """EdgeArchitype Interface."""
+
+    __jac__: ClassVar[EdgeAnchor]
+
+    def __serialize__(self) -> EdgeArchitype:
+        """Override serialization."""
+        return self
+
+    @classmethod
+    def __deserialize__(cls, data: EdgeArchitype) -> EdgeArchitype:
+        """Override deserialization."""
+        return data
+
+
+class WalkerArchitype(_WalkerArchitype["WalkerArchitype"]):
+    """Walker Architype Interface."""
+
+    __jac__: ClassVar[WalkerAnchor]
+
+    def __serialize__(self) -> WalkerArchitype:
+        """Override serialization."""
+        return self
+
+    @classmethod
+    def __deserialize__(cls, data: WalkerArchitype) -> WalkerArchitype:
+        """Override deserialization."""
+        return data
+
+
+@dataclass(kw_only=True)
+class Root(NodeArchitype):
+    """Default Root Architype."""
+
+
+@dataclass(kw_only=True)
+class GenericEdge(EdgeArchitype):
+    """Default Edge Architype."""

--- a/jac/jaclang/runtimelib/interface.py
+++ b/jac/jaclang/runtimelib/interface.py
@@ -3,7 +3,8 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import ClassVar, Generic, Iterable, Type, TypeVar
+from types import UnionType
+from typing import Any, Callable, ClassVar, Generic, Iterable, Type, TypeVar
 
 
 _ID = TypeVar("_ID")
@@ -145,3 +146,16 @@ class Root(NodeArchitype[_SERIALIZE]):
 @dataclass(kw_only=True)
 class GenericEdge(EdgeArchitype[_SERIALIZE]):
     """Default Edge Architype."""
+
+
+@dataclass(eq=False)
+class DSFunc:
+    """Data Spatial Function."""
+
+    name: str
+    trigger: type | UnionType | tuple[type | UnionType, ...] | None
+    func: Callable[[Any, Any], Any] | None = None
+
+    def resolve(self, cls: type) -> None:
+        """Resolve the function."""
+        self.func = getattr(cls, self.name)

--- a/jac/jaclang/runtimelib/interface.py
+++ b/jac/jaclang/runtimelib/interface.py
@@ -6,11 +6,19 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import IntEnum
 from types import UnionType
-from typing import Any, Callable, Generator, Generic, Iterable, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Generic,
+    Iterable,
+    Type,
+    TypeVar,
+)
 
 
 _ID = TypeVar("_ID")
-_ANCHOR = TypeVar("_ANCHOR", bound="Anchor")
+_ANCHOR = TypeVar("_ANCHOR", "NodeAnchor", "EdgeAnchor", "WalkerAnchor", covariant=True)
 _NODE_ANCHOR = TypeVar("_NODE_ANCHOR", bound="NodeAnchor")
 
 _SERIALIZE = TypeVar("_SERIALIZE")
@@ -75,12 +83,12 @@ class Permission:
 
 
 @dataclass(kw_only=True)
-class Anchor(Generic[_SERIALIZE], ABC):
+class Anchor(Generic[_ID, _SERIALIZE], ABC):
     """Anchor Interface."""
 
-    jid: JID
-    architype: "Architype"
-    root: JID | None
+    jid: JID[_ID, NodeAnchor] | JID[_ID, EdgeAnchor] | JID[_ID, WalkerAnchor]
+    architype: "NodeArchitype" | "EdgeArchitype" | "WalkerArchitype"
+    root: JID[_ID, NodeAnchor] | None
     access: Permission
 
     @abstractmethod
@@ -94,26 +102,29 @@ class Anchor(Generic[_SERIALIZE], ABC):
 
 
 @dataclass(kw_only=True)
-class NodeAnchor(Anchor[_SERIALIZE]):
+class NodeAnchor(Anchor[_ID, _SERIALIZE]):
     """NodeAnchor Interface."""
 
+    jid: JID[_ID, NodeAnchor]
     architype: "NodeArchitype"
-    edge_ids: Iterable[JID]
+    edge_ids: Iterable[JID[_ID, EdgeAnchor]]
 
 
 @dataclass(kw_only=True)
-class EdgeAnchor(Anchor[_SERIALIZE]):
+class EdgeAnchor(Anchor[_ID, _SERIALIZE]):
     """EdgeAnchor Interface."""
 
+    jid: JID[_ID, EdgeAnchor]
     architype: "EdgeArchitype"
-    source_id: JID
-    target_id: JID
+    source_id: JID[_ID, NodeAnchor]
+    target_id: JID[_ID, NodeAnchor]
 
 
 @dataclass(kw_only=True)
-class WalkerAnchor(Anchor[_SERIALIZE]):
+class WalkerAnchor(Anchor[_ID, _SERIALIZE]):
     """WalkerAnchor Interface."""
 
+    jid: JID[_ID, WalkerAnchor]
     architype: "WalkerArchitype"
 
 
@@ -125,7 +136,7 @@ class WalkerAnchor(Anchor[_SERIALIZE]):
 class Architype(Generic[_SERIALIZE], ABC):
     """Architype Interface."""
 
-    __jac__: Anchor
+    __jac__: NodeAnchor | EdgeAnchor | WalkerAnchor
 
     @abstractmethod
     def __serialize__(self) -> _SERIALIZE:
@@ -187,8 +198,8 @@ class DSFunc:
 class Memory(Generic[_ID, _ANCHOR]):
     """Generic Memory Handler."""
 
-    __mem__: dict[_ID, _ANCHOR] = field(default_factory=dict)
-    __gc__: set[_ID] = field(default_factory=set)
+    __mem__: dict[JID[_ID, _ANCHOR], _ANCHOR] = field(default_factory=dict)
+    __gc__: set[JID[_ID, _ANCHOR]] = field(default_factory=set)
 
     def close(self) -> None:
         """Close memory handler."""
@@ -197,36 +208,38 @@ class Memory(Generic[_ID, _ANCHOR]):
 
     def find(
         self,
-        ids: _ID | Iterable[_ID],
+        ids: JID[_ID, _ANCHOR] | Iterable[JID[_ID, _ANCHOR]],
         filter: Callable[[_ANCHOR], _ANCHOR] | None = None,
     ) -> Generator[_ANCHOR, None, None]:
         """Find anchors from memory by ids with filter."""
         if not isinstance(ids, Iterable):
             ids = [ids]
 
-        return (
-            anchor
-            for id in ids
-            if (anchor := self.__mem__.get(id)) and (not filter or filter(anchor))
-        )
+        for id in ids:
+            if (
+                (anchor := self.__mem__.get(id))
+                and isinstance(anchor, id.type)
+                and (not filter or filter(anchor))
+            ):
+                yield anchor
 
     def find_one(
         self,
-        ids: _ID | Iterable[_ID],
+        ids: JID[_ID, _ANCHOR] | Iterable[JID[_ID, _ANCHOR]],
         filter: Callable[[_ANCHOR], _ANCHOR] | None = None,
     ) -> _ANCHOR | None:
         """Find one anchor from memory by ids with filter."""
         return next(self.find(ids, filter), None)
 
-    def find_by_id(self, id: _ID) -> _ANCHOR | None:
+    def find_by_id(self, id: JID[_ID, _ANCHOR]) -> _ANCHOR | None:
         """Find one by id."""
         return self.__mem__.get(id)
 
-    def set(self, id: _ID, data: _ANCHOR) -> None:
+    def set(self, data: _ANCHOR) -> None:
         """Save anchor to memory."""
-        self.__mem__[id] = data
+        self.__mem__[data.jid] = data
 
-    def remove(self, ids: _ID | Iterable[_ID]) -> None:
+    def remove(self, ids: JID[_ID, _ANCHOR] | Iterable[JID[_ID, _ANCHOR]]) -> None:
         """Remove anchor/s from memory."""
         if not isinstance(ids, Iterable):
             ids = [ids]
@@ -253,12 +266,12 @@ class ExecutionContext(Generic[_NODE_ANCHOR], ABC):
     @abstractmethod
     def init_anchor(
         self,
-        anchor_jid: JID | None,
+        anchor_jid: str | None,
         default: _NODE_ANCHOR,
     ) -> _NODE_ANCHOR:
         """Load initial anchors."""
 
-    def set_entry_node(self, entry_node: JID | None) -> None:
+    def set_entry_node(self, entry_node: str | None) -> None:
         """Override entry."""
         self.entry_node = self.init_anchor(entry_node, self.root)
 

--- a/jac/jaclang/runtimelib/interface.py
+++ b/jac/jaclang/runtimelib/interface.py
@@ -6,15 +6,15 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import IntEnum
 from types import UnionType
-from typing import Any, Callable, ClassVar, Generator, Generic, Iterable, Type, TypeVar
+from typing import Any, Callable, Generator, Generic, Iterable, Type, TypeVar
 
 
 _ID = TypeVar("_ID")
 _ANCHOR = TypeVar("_ANCHOR", bound="Anchor")
+_NODE_ANCHOR = TypeVar("_NODE_ANCHOR", bound="NodeAnchor")
 
 _SERIALIZE = TypeVar("_SERIALIZE")
 _DESERIALIZE = TypeVar("_DESERIALIZE")
-
 
 #########################################################################################
 #                                      ID / ACCESS                                      #
@@ -125,7 +125,7 @@ class WalkerAnchor(Anchor[_SERIALIZE]):
 class Architype(Generic[_SERIALIZE], ABC):
     """Architype Interface."""
 
-    __jac__: ClassVar[Anchor]
+    __jac__: Anchor
 
     @abstractmethod
     def __serialize__(self) -> _SERIALIZE:
@@ -140,19 +140,19 @@ class Architype(Generic[_SERIALIZE], ABC):
 class NodeArchitype(Architype[_SERIALIZE]):
     """NodeArchitype Interface."""
 
-    __jac__: ClassVar[NodeAnchor]
+    __jac__: NodeAnchor
 
 
 class EdgeArchitype(Architype[_SERIALIZE]):
     """EdgeArchitype Interface."""
 
-    __jac__: ClassVar[EdgeAnchor]
+    __jac__: EdgeAnchor
 
 
 class WalkerArchitype(Architype[_SERIALIZE]):
     """Walker Architype Interface."""
 
-    __jac__: ClassVar[WalkerAnchor]
+    __jac__: WalkerAnchor
 
 
 @dataclass(kw_only=True)
@@ -241,24 +241,24 @@ class Memory(Generic[_ID, _ANCHOR]):
 #########################################################################################
 
 
-class ExecutionContext(ABC):
+class ExecutionContext(Generic[_NODE_ANCHOR], ABC):
     """Execution Context."""
 
     mem: Memory
     reports: list[Any]
-    system_root: NodeAnchor
-    root: NodeAnchor
-    entry_node: NodeAnchor
+    system_root: _NODE_ANCHOR
+    root: _NODE_ANCHOR
+    entry_node: _NODE_ANCHOR
 
     @abstractmethod
     def init_anchor(
         self,
-        anchor_id: str | None,
-        default: NodeAnchor,
-    ) -> NodeAnchor:
+        anchor_jid: JID | None,
+        default: _NODE_ANCHOR,
+    ) -> _NODE_ANCHOR:
         """Load initial anchors."""
 
-    def set_entry_node(self, entry_node: str | None) -> None:
+    def set_entry_node(self, entry_node: JID | None) -> None:
         """Override entry."""
         self.entry_node = self.init_anchor(entry_node, self.root)
 

--- a/jac/jaclang/runtimelib/interface.py
+++ b/jac/jaclang/runtimelib/interface.py
@@ -1,0 +1,147 @@
+"""Jaclang Runtimelib interfaces."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import ClassVar, Generic, Iterable, Type, TypeVar
+
+
+_ID = TypeVar("_ID")
+_ANCHOR = TypeVar("_ANCHOR", bound="Anchor")
+
+_SERIALIZE = TypeVar("_SERIALIZE")
+_DESERIALIZE = TypeVar("_DESERIALIZE")
+
+
+@dataclass(kw_only=True)
+class JID(Generic[_ID, _ANCHOR], ABC):
+    """Jaclang ID Interface."""
+
+    id: _ID
+    type: Type[_ANCHOR]
+    name: str
+
+
+class AccessLevel(IntEnum):
+    """Access level enum."""
+
+    NO_ACCESS = -1
+    READ = 0
+    CONNECT = 1
+    WRITE = 2
+
+    @staticmethod
+    def cast(val: int | str | "AccessLevel") -> "AccessLevel":
+        """Cast access level."""
+        match val:
+            case int():
+                return AccessLevel(val)
+            case str():
+                return AccessLevel[val]
+            case _:
+                return val
+
+
+@dataclass
+class Access:
+    """Access Structure."""
+
+    anchors: dict[str, AccessLevel] = field(default_factory=dict)
+
+    def check(self, anchor: str) -> AccessLevel:
+        """Validate access."""
+        return self.anchors.get(anchor, AccessLevel.NO_ACCESS)
+
+
+@dataclass
+class Permission:
+    """Anchor Access Handler."""
+
+    all: AccessLevel = AccessLevel.NO_ACCESS
+    roots: Access = field(default_factory=Access)
+
+
+@dataclass(kw_only=True)
+class Anchor(Generic[_SERIALIZE], ABC):
+    """Anchor Interface."""
+
+    jid: JID
+    architype: "Architype"
+    root: JID | None
+    access: Permission
+
+    @abstractmethod
+    def __serialize__(self) -> _SERIALIZE:
+        """Override string representation."""
+
+    @classmethod
+    @abstractmethod
+    def __deserialize__(cls: Type[_DESERIALIZE], data: _SERIALIZE) -> _DESERIALIZE:
+        """Override string parsing."""
+
+
+@dataclass(kw_only=True)
+class NodeAnchor(Anchor[_SERIALIZE]):
+    """NodeAnchor Interface."""
+
+    architype: "NodeArchitype"
+    edge_ids: Iterable[JID]
+
+
+@dataclass(kw_only=True)
+class EdgeAnchor(Anchor[_SERIALIZE]):
+    """EdgeAnchor Interface."""
+
+    architype: "EdgeArchitype"
+    source_id: JID
+    target_id: JID
+
+
+@dataclass(kw_only=True)
+class WalkerAnchor(Anchor[_SERIALIZE]):
+    """WalkerAnchor Interface."""
+
+    architype: "WalkerArchitype"
+
+
+class Architype(Generic[_SERIALIZE], ABC):
+    """Architype Interface."""
+
+    __jac__: ClassVar[Anchor]
+
+    @abstractmethod
+    def __serialize__(self) -> _SERIALIZE:
+        """Override string representation."""
+
+    @classmethod
+    @abstractmethod
+    def __deserialize__(cls: Type[_DESERIALIZE], data: _SERIALIZE) -> _DESERIALIZE:
+        """Override string parsing."""
+
+
+class NodeArchitype(Architype[_SERIALIZE]):
+    """NodeArchitype Interface."""
+
+    __jac__: ClassVar[NodeAnchor]
+
+
+class EdgeArchitype(Architype[_SERIALIZE]):
+    """EdgeArchitype Interface."""
+
+    __jac__: ClassVar[EdgeAnchor]
+
+
+class WalkerArchitype(Architype[_SERIALIZE]):
+    """Walker Architype Interface."""
+
+    __jac__: ClassVar[WalkerAnchor]
+
+
+@dataclass(kw_only=True)
+class Root(NodeArchitype[_SERIALIZE]):
+    """Default Root Architype."""
+
+
+@dataclass(kw_only=True)
+class GenericEdge(EdgeArchitype[_SERIALIZE]):
+    """Default Edge Architype."""

--- a/jac/jaclang/runtimelib/interface.py
+++ b/jac/jaclang/runtimelib/interface.py
@@ -17,7 +17,6 @@ from typing import (
 )
 
 
-_ID = TypeVar("_ID")
 _ANCHOR = TypeVar("_ANCHOR", "NodeAnchor", "EdgeAnchor", "WalkerAnchor", covariant=True)
 _NODE_ANCHOR = TypeVar("_NODE_ANCHOR", bound="NodeAnchor")
 
@@ -30,10 +29,10 @@ _DESERIALIZE = TypeVar("_DESERIALIZE")
 
 
 @dataclass(kw_only=True)
-class JID(Generic[_ID, _ANCHOR], ABC):
+class JID(Generic[_ANCHOR], ABC):
     """Jaclang ID Interface."""
 
-    id: _ID
+    id: Any
     type: Type[_ANCHOR]
     name: str
 
@@ -83,12 +82,12 @@ class Permission:
 
 
 @dataclass(kw_only=True)
-class Anchor(Generic[_ID, _SERIALIZE], ABC):
+class Anchor(Generic[_SERIALIZE], ABC):
     """Anchor Interface."""
 
-    jid: JID[_ID, NodeAnchor] | JID[_ID, EdgeAnchor] | JID[_ID, WalkerAnchor]
+    jid: JID[NodeAnchor] | JID[EdgeAnchor] | JID[WalkerAnchor]
     architype: "NodeArchitype" | "EdgeArchitype" | "WalkerArchitype"
-    root: JID[_ID, NodeAnchor] | None
+    root: JID[NodeAnchor] | None
     access: Permission
 
     @abstractmethod
@@ -102,29 +101,29 @@ class Anchor(Generic[_ID, _SERIALIZE], ABC):
 
 
 @dataclass(kw_only=True)
-class NodeAnchor(Anchor[_ID, _SERIALIZE]):
+class NodeAnchor(Anchor[_SERIALIZE]):
     """NodeAnchor Interface."""
 
-    jid: JID[_ID, NodeAnchor]
+    jid: JID[NodeAnchor]
     architype: "NodeArchitype"
-    edge_ids: Iterable[JID[_ID, EdgeAnchor]]
+    edge_ids: Iterable[JID[EdgeAnchor]]
 
 
 @dataclass(kw_only=True)
-class EdgeAnchor(Anchor[_ID, _SERIALIZE]):
+class EdgeAnchor(Anchor[_SERIALIZE]):
     """EdgeAnchor Interface."""
 
-    jid: JID[_ID, EdgeAnchor]
+    jid: JID[EdgeAnchor]
     architype: "EdgeArchitype"
-    source_id: JID[_ID, NodeAnchor]
-    target_id: JID[_ID, NodeAnchor]
+    source_id: JID[NodeAnchor]
+    target_id: JID[NodeAnchor]
 
 
 @dataclass(kw_only=True)
-class WalkerAnchor(Anchor[_ID, _SERIALIZE]):
+class WalkerAnchor(Anchor[_SERIALIZE]):
     """WalkerAnchor Interface."""
 
-    jid: JID[_ID, WalkerAnchor]
+    jid: JID[WalkerAnchor]
     architype: "WalkerArchitype"
 
 
@@ -195,11 +194,11 @@ class DSFunc:
 
 
 @dataclass
-class Memory(Generic[_ID, _ANCHOR]):
+class Memory(Generic[_ANCHOR]):
     """Generic Memory Handler."""
 
-    __mem__: dict[JID[_ID, _ANCHOR], _ANCHOR] = field(default_factory=dict)
-    __gc__: set[JID[_ID, _ANCHOR]] = field(default_factory=set)
+    __mem__: dict[JID[_ANCHOR], _ANCHOR] = field(default_factory=dict)
+    __gc__: set[JID[_ANCHOR]] = field(default_factory=set)
 
     def close(self) -> None:
         """Close memory handler."""
@@ -208,7 +207,7 @@ class Memory(Generic[_ID, _ANCHOR]):
 
     def find(
         self,
-        ids: JID[_ID, _ANCHOR] | Iterable[JID[_ID, _ANCHOR]],
+        ids: JID[_ANCHOR] | Iterable[JID[_ANCHOR]],
         filter: Callable[[_ANCHOR], _ANCHOR] | None = None,
     ) -> Generator[_ANCHOR, None, None]:
         """Find anchors from memory by ids with filter."""
@@ -225,13 +224,13 @@ class Memory(Generic[_ID, _ANCHOR]):
 
     def find_one(
         self,
-        ids: JID[_ID, _ANCHOR] | Iterable[JID[_ID, _ANCHOR]],
+        ids: JID[_ANCHOR] | Iterable[JID[_ANCHOR]],
         filter: Callable[[_ANCHOR], _ANCHOR] | None = None,
     ) -> _ANCHOR | None:
         """Find one anchor from memory by ids with filter."""
         return next(self.find(ids, filter), None)
 
-    def find_by_id(self, id: JID[_ID, _ANCHOR]) -> _ANCHOR | None:
+    def find_by_id(self, id: JID[_ANCHOR]) -> _ANCHOR | None:
         """Find one by id."""
         return self.__mem__.get(id)
 
@@ -239,7 +238,7 @@ class Memory(Generic[_ID, _ANCHOR]):
         """Save anchor to memory."""
         self.__mem__[data.jid] = data
 
-    def remove(self, ids: JID[_ID, _ANCHOR] | Iterable[JID[_ID, _ANCHOR]]) -> None:
+    def remove(self, ids: JID[_ANCHOR] | Iterable[JID[_ANCHOR]]) -> None:
         """Remove anchor/s from memory."""
         if not isinstance(ids, Iterable):
             ids = [ids]

--- a/jac/jaclang/runtimelib/memory.py
+++ b/jac/jaclang/runtimelib/memory.py
@@ -7,14 +7,20 @@ from pickle import dumps
 from shelve import Shelf, open
 from typing import Callable, Generator, Iterable, TypeVar
 
-from .implementation import Anchor, JID, NodeAnchor, Root
+from .implementation import (
+    Anchor,
+    EdgeAnchor,
+    JID,
+    NodeAnchor,
+    Root,
+    WalkerAnchor,
+    _ANCHOR,
+)
 from .interface import Memory
-
-ID = TypeVar("ID")
 
 
 @dataclass
-class ShelfStorage(Memory[JID[Anchor], Anchor]):
+class ShelfStorage(Memory[JID, Anchor]):
     """Shelf Handler."""
 
     __shelf__: Shelf[Anchor] | None = None
@@ -69,9 +75,9 @@ class ShelfStorage(Memory[JID[Anchor], Anchor]):
 
     def find(
         self,
-        ids: JID[Anchor] | Iterable[JID[Anchor]],
-        filter: Callable[[Anchor], Anchor] | None = None,
-    ) -> Generator[Anchor, None, None]:
+        ids: JID[_ANCHOR] | Iterable[JID[_ANCHOR]],
+        filter: Callable[[_ANCHOR], _ANCHOR] | None = None,
+    ) -> Generator[_ANCHOR, None, None]:
         """Find anchors from datasource by ids with filter."""
         if not isinstance(ids, Iterable):
             ids = [ids]
@@ -91,7 +97,7 @@ class ShelfStorage(Memory[JID[Anchor], Anchor]):
         else:
             yield from super().find(ids, filter)
 
-    def find_by_id(self, id: JID[Anchor]) -> Anchor | None:
+    def find_by_id(self, id: JID[_ANCHOR]) -> _ANCHOR | None:
         """Find one by id."""
         data = super().find_by_id(id)
 

--- a/jac/jaclang/runtimelib/memory.py
+++ b/jac/jaclang/runtimelib/memory.py
@@ -82,8 +82,6 @@ class ShelfStorage(Memory[UUID, Anchor]):
         if isinstance(self.__shelf__, Shelf):
             from jaclang.plugin.feature import JacFeature as Jac
 
-            root = Jac.get_root().__jac__
-
             for anchor in self.__gc__:
                 self.__shelf__.pop(str(anchor.id), None)
                 self.__mem__.pop(anchor.id, None)
@@ -96,14 +94,14 @@ class ShelfStorage(Memory[UUID, Anchor]):
                             isinstance(p_d, NodeAnchor)
                             and isinstance(d, NodeAnchor)
                             and p_d.edges != d.edges
-                            and root.has_connect_access(d)
+                            and Jac.check_connect_access(d)
                         ):
                             if not d.edges:
                                 self.__shelf__.pop(_id, None)
                                 continue
                             p_d.edges = d.edges
 
-                        if root.has_write_access(d):
+                        if Jac.check_write_access(d):
                             if hash(dumps(p_d.access)) != hash(dumps(d.access)):
                                 p_d.access = d.access
                             if hash(dumps(d.architype)) != hash(dumps(d.architype)):

--- a/jac/jaclang/tests/fixtures/edge_node_walk.jac
+++ b/jac/jaclang/tests/fixtures/edge_node_walk.jac
@@ -37,7 +37,7 @@ edge Edge_c {
 
 with entry {
     print(root spawn creator());
-    print(root.__jac__.gen_dot());
+    print(Jac.node_dot(root));
     print([root-:Edge_a:->]);
     print([root-:Edge_c:->]);
     print([root-:Edge_a:->-:Edge_b:->]);

--- a/jac/jaclang/tests/fixtures/edges_walk.jac
+++ b/jac/jaclang/tests/fixtures/edges_walk.jac
@@ -30,7 +30,7 @@ edge Edge_c{
 
 with entry{
     print(root spawn creator());
-    print(root.__jac__.gen_dot());
+    print(Jac.node_dot(root));
     print([root -:Edge_a:->]);
     print([root -:Edge_c:->]);
     print([root -:Edge_a:-> -:Edge_b:->]);

--- a/jac/jaclang/tests/fixtures/gendot_bubble_sort.jac
+++ b/jac/jaclang/tests/fixtures/gendot_bubble_sort.jac
@@ -73,5 +73,5 @@ with entry {
     root spawn walker1();
     root spawn walker2();
     root spawn walker3();
-    print(root.__jac__.gen_dot());
+    print(Jac.node_dot(root));
 }


### PR DESCRIPTION
# **CHANGES**
## Abstraction (**_NOT YET INTEGRATED_**)
- jaclang/runtimelib/interface.py
  - Base Classes that will be used in `JacFeatureSpec` and `JacFeature`
  - Will be used by plugin as base class
- jaclang/runtimelib/implementation.py
  - Default implementation based on interface classes
  - Will be used on default `JacFeatureImpl`
- \_\_serialize\_\_ / \_\_deserialize\_\_
  - Common models (`Anchors`, `Architypes`, `Access`) now have overridable way of serialization/deserialization

## Anchor/Architype logical process migration
- All common logical process will now be on plugin, segregated by class (`JacAccessValidation`, `JacNode`, `JacEdge`, `JacWalker`) extended by `JacFeature`
- `Anchors` / `Architypes` only holds attributes and \_\_serialize\_\_ / \_\_deserialize\_\_ method by default.