### PR TITLE
Fix assignment for a target with a moduleType value

### DIFF
--- a/jac/jaclang/compiler/passes/main/fuse_typeinfo_pass.py
+++ b/jac/jaclang/compiler/passes/main/fuse_typeinfo_pass.py
@@ -483,6 +483,21 @@ class FuseTypeInfoPass(Pass):
                 if self_obj.type_sym_tab and isinstance(right_obj, ast.AstSymbolNode):
                     self_obj.type_sym_tab.def_insert(right_obj)
 
+        # Support adding the correct type symbol table in case of ModuleType
+        # This will only work for target=Val & target1=target2=val and
+        #   target is a moduleType
+        # it won't work in case of
+        #   - target1, target2 = Val1, Val2  <-- tuples need more attention
+        #   - target = a.b.c                 <-- will be fixed after thakee's PR
+        #   - a.b.c = val                    <-- will be fixed after thakee's PR
+        for target in node.target.items:
+            if (
+                isinstance(target, ast.Name)
+                and target.sym_type == "types.ModuleType"
+                and isinstance(node.value, ast.Name)
+            ):
+                target.type_sym_tab = node.value.type_sym_tab
+
     def expand_atom_trailer(self, node_list: list[ast.AstNode]) -> list[ast.AstNode]:
         """Expand the atom trailer object in a list of AstNode."""
         out: list[ast.AstNode] = []

--- a/jac/jaclang/compiler/passes/main/tests/fixtures/mod_type_assign.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/mod_type_assign.jac
@@ -1,0 +1,7 @@
+import:jac blip;
+
+
+with entry{
+    kl = blip;
+    l1 = l2 = blip;
+}

--- a/jac/jaclang/compiler/passes/main/tests/test_typeinfo_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_typeinfo_pass.py
@@ -1,7 +1,29 @@
 """Test pass module."""
 
+from jaclang.compiler.compile import jac_file_to_pass
+from jaclang.compiler.passes.main.fuse_typeinfo_pass import FuseTypeInfoPass
+from jaclang.compiler.passes.main.schedules import py_code_gen_typed
 from jaclang.utils.test import TestCase
 
 
 class TestFuseTypeInfo(TestCase):
-    """Test pass module."""
+    """Test FuseTypeInfoPass module."""
+
+    def setUp(self) -> None:
+        """Set up test."""
+        return super().setUp()
+
+    def test_mod_type_assign(self) -> None:
+        """Test module type assignment."""
+        gen_ast = jac_file_to_pass(
+            self.fixture_abs_path("mod_type_assign.jac"),
+            FuseTypeInfoPass,
+            schedule=py_code_gen_typed,
+        ).ir.pp()
+        type_info_list = [
+            "kl - Type: types.ModuleType,  SymbolTable: blip",
+            "l1 - Type: types.ModuleType,  SymbolTable: blip",
+            "l2 - Type: types.ModuleType,  SymbolTable: blip",
+        ]
+        for type_info in type_info_list:
+            self.assertIn(type_info, str(gen_ast))


### PR DESCRIPTION
## **Description**

This PR enhances the handling of `Assignment` nodes to correctly assign types and Symbol tables for variables when dealing with `ModuleType`. It now supports cases like `target = module` and ` target1 = target2 = module`.

In the example:

-  kl, l1, and l2 now have the correct type (Module) and are associated with the appropriate SymbolTable.


![image](https://github.com/user-attachments/assets/3a072c2a-e556-4da3-ac15-c6fc0599eedd)


### Future works 

 - target1, target2 = Val1, Val2 
 - target = a.b.c                
 - a.b.c = val  
