### PR TITLE
Fix match Statement for Multiple Expressions in a single case

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -3587,7 +3587,7 @@ class JacParser(Pass):
             match_case_block: KW_CASE pattern_seq (KW_IF expression)? COLON statement_list
             """
             pattern = kid[1]
-            guard = kid[3] if len(kid) > 4 else None
+            guard = kid[3] if isinstance(kid[3], ast.Expr) else None
             stmts = [i for i in kid if isinstance(i, ast.CodeBlockStmt)]
             if isinstance(pattern, ast.MatchPattern) and isinstance(
                 guard, (ast.Expr, type(None))

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -3587,7 +3587,7 @@ class JacParser(Pass):
             match_case_block: KW_CASE pattern_seq (KW_IF expression)? COLON statement_list
             """
             pattern = kid[1]
-            guard = kid[3] if isinstance(kid[3], ast.Expr) else None
+            guard = kid[3] if isinstance(kid[3], ast.Expr) else None
             stmts = [i for i in kid if isinstance(i, ast.CodeBlockStmt)]
             if isinstance(pattern, ast.MatchPattern) and isinstance(
                 guard, (ast.Expr, type(None))

--- a/jac/jaclang/tests/fixtures/match_multi_ex.jac
+++ b/jac/jaclang/tests/fixtures/match_multi_ex.jac
@@ -1,0 +1,12 @@
+with entry{
+    Num =10;
+    match Num{
+        case 2:
+            print("Two");
+        case 10:
+            print("Ten");
+            print("ten");
+        case _:
+            print("nothing");
+    }
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1020,3 +1020,13 @@ class JacLanguageTests(TestCase):
         self.assertEqual(len(stdout_value[0]), 32)
         self.assertEqual("MyNode(value=0)", stdout_value[1])
         self.assertEqual("valid: True", stdout_value[2])
+
+    def test_match_multi_ex(self) -> None:
+        """Test match case with multiple expressions."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        jac_import("match_multi_ex", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue().split("\n")
+        self.assertEqual("Ten", stdout_value[0])
+        self.assertEqual("ten", stdout_value[1])


### PR DESCRIPTION
## **Description**
A bug in Jac's match statement fixed and enhanced its functionality by supporting multiple expressions within a single case.
Changes:
1. Bug fix in `parse.py`
2. Test file added (`match_multi_ex.jac`) in fixtures folder
3. New test function added (`test_match_multi_ex`) in `test_language.py` file
