### PR TITLE
Fixing typecheck slowness by preventing the typecheck for jaclang.compiler

### DIFF
--- a/jac/jaclang/compiler/passes/utils/mypy_ast_build.py
+++ b/jac/jaclang/compiler/passes/utils/mypy_ast_build.py
@@ -618,7 +618,12 @@ def load_graph(
         dependencies = [
             dep
             for dep in st.dependencies
-            if st.priorities.get(dep) != PRI_INDIRECT and "jaclang.vendor" not in dep
+            if st.priorities.get(dep) != PRI_INDIRECT
+            and (
+                "jaclang.vendor" not in dep
+                and "jaclang.compiler" not in dep
+                and "jaclang.runtimelib" not in dep
+            )
         ]
         if not manager.use_fine_grained_cache():
             # TODO: Ideally we could skip here modules that appeared in st.suppressed


### PR DESCRIPTION

## **Description**
