### PR TITLE
Initial commit for creating Architype

### DIFF
--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -151,7 +151,11 @@ class JacMachine:
             logger.warning(f"Module {module_name} not found in loaded modules.")
         return ()
 
-    def spawn_node(self, node_name: str, attributes: dict) -> NodeArchitype:
+    def spawn_node(
+        self,
+        node_name: str,
+        attributes: Union[dict, None] = None,
+    ) -> NodeArchitype:
         """Spawn a node instance of the given node_name with attributes."""
         node_class = self.get_architype("__main__", node_name)
         if isinstance(node_class, type) and issubclass(node_class, NodeArchitype):
@@ -160,10 +164,16 @@ class JacMachine:
         else:
             raise ValueError(f"Node {node_name} not found.")
 
-    def spawn_walker(self, walker_name: str, attributes: dict) -> WalkerArchitype:
+    def spawn_walker(
+        self,
+        walker_name: str,
+        attributes: Union[dict, None] = None,
+    ) -> WalkerArchitype:
         """Spawn a walker instance of the given walker_name."""
         walker_class = self.get_architype("__main__", walker_name)
         if isinstance(walker_class, type) and issubclass(walker_class, WalkerArchitype):
+            if attributes is None:
+                attributes = {}
             walker_instance = walker_class(**attributes)
             return walker_instance
         else:

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -160,11 +160,11 @@ class JacMachine:
         else:
             raise ValueError(f"Node {node_name} not found.")
 
-    def spawn_walker(self, walker_name: str) -> WalkerArchitype:
+    def spawn_walker(self, walker_name: str, attributes: dict) -> WalkerArchitype:
         """Spawn a walker instance of the given walker_name."""
         walker_class = self.get_architype("__main__", walker_name)
         if isinstance(walker_class, type) and issubclass(walker_class, WalkerArchitype):
-            walker_instance = walker_class()
+            walker_instance = walker_class(**attributes)
             return walker_instance
         else:
             raise ValueError(f"Walker {walker_name} not found.")

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -11,7 +11,12 @@ from typing import Optional, Union
 from jaclang.compiler.absyntree import Module
 from jaclang.compiler.compile import compile_jac
 from jaclang.compiler.constant import Constants as Con
-from jaclang.runtimelib.architype import EdgeArchitype, NodeArchitype, WalkerArchitype
+from jaclang.runtimelib.architype import (
+    Architype,
+    EdgeArchitype,
+    NodeArchitype,
+    WalkerArchitype,
+)
 from jaclang.utils.log import logging
 
 
@@ -145,6 +150,31 @@ class JacMachine:
         else:
             logger.warning(f"Module {module_name} not found in loaded modules.")
         return ()
+
+    def spawn_node(self, node_name: str, attributes: dict) -> NodeArchitype:
+        """Spawn a node instance of the given node_name with attributes."""
+        node_class = self.get_architype("__main__", node_name)
+        if node_class and issubclass(node_class, NodeArchitype):
+            node_instance = node_class(**attributes)
+            return node_instance
+        else:
+            raise ValueError(f"Node {node_name} not found.")
+
+    def spawn_walker(self, walker_name: str) -> WalkerArchitype:
+        """Spawn a walker instance of the given walker_name."""
+        walker_class = self.get_architype("__main__", walker_name)
+        if walker_class and issubclass(walker_class, WalkerArchitype):
+            walker_instance = walker_class()
+            return walker_instance
+        else:
+            raise ValueError(f"Walker {walker_name} not found.")
+
+    def get_architype(self, module_name: str, architype_name: str) -> Architype:
+        """Retrieve an architype class from a module."""
+        module = self.loaded_modules.get(module_name)
+        if module:
+            return getattr(module, architype_name, None)
+        return None
 
     @staticmethod
     def get(base_path: str = "") -> "JacMachine":

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -154,7 +154,7 @@ class JacMachine:
     def spawn_node(self, node_name: str, attributes: dict) -> NodeArchitype:
         """Spawn a node instance of the given node_name with attributes."""
         node_class = self.get_architype("__main__", node_name)
-        if node_class and issubclass(node_class, NodeArchitype):
+        if isinstance(node_class, type) and issubclass(node_class, NodeArchitype):
             node_instance = node_class(**attributes)
             return node_instance
         else:
@@ -163,13 +163,15 @@ class JacMachine:
     def spawn_walker(self, walker_name: str) -> WalkerArchitype:
         """Spawn a walker instance of the given walker_name."""
         walker_class = self.get_architype("__main__", walker_name)
-        if walker_class and issubclass(walker_class, WalkerArchitype):
+        if isinstance(walker_class, type) and issubclass(walker_class, WalkerArchitype):
             walker_instance = walker_class()
             return walker_instance
         else:
             raise ValueError(f"Walker {walker_name} not found.")
 
-    def get_architype(self, module_name: str, architype_name: str) -> Architype:
+    def get_architype(
+        self, module_name: str, architype_name: str
+    ) -> Optional[Architype]:
         """Retrieve an architype class from a module."""
         module = self.loaded_modules.get(module_name)
         if module:

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -154,11 +154,13 @@ class JacMachine:
     def spawn_node(
         self,
         node_name: str,
-        attributes: Union[dict, None] = None,
+        attributes: Optional[dict] = None,
     ) -> NodeArchitype:
         """Spawn a node instance of the given node_name with attributes."""
         node_class = self.get_architype("__main__", node_name)
         if isinstance(node_class, type) and issubclass(node_class, NodeArchitype):
+            if attributes is None:
+                attributes = {}
             node_instance = node_class(**attributes)
             return node_instance
         else:
@@ -167,7 +169,7 @@ class JacMachine:
     def spawn_walker(
         self,
         walker_name: str,
-        attributes: Union[dict, None] = None,
+        attributes: Optional[dict] = None,
     ) -> WalkerArchitype:
         """Spawn a walker instance of the given walker_name."""
         walker_class = self.get_architype("__main__", walker_name)

--- a/jac/jaclang/tests/fixtures/dynamic_architype.jac
+++ b/jac/jaclang/tests/fixtures/dynamic_architype.jac
@@ -1,0 +1,26 @@
+import:py from jaclang.runtimelib.machine {JacMachine}
+
+walker test_walker {
+    can visit_nodes with `root entry {
+        visit [-->](`?test_node);
+    }
+}
+
+walker child_walker :test_walker: {}
+
+node test_node {
+    has value:int;
+
+    can print_value with test_walker entry {
+        print("Value:", f'{self.value}');
+    }
+}
+
+with entry {
+    for value in range(1, 4) {
+        root ++> test_node(value=value);
+    }
+    node_obj = JacMachine.get().spawn_node('test_node', {'value': 0});
+    walker_obj = JacMachine.get().spawn_walker('child_walker');
+    root spawn walker_obj;
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1010,6 +1010,18 @@ class JacLanguageTests(TestCase):
 
                 bar_file.write(original_content)
 
+    def test_dynamic_spawn_architype(self):
+        """Test that the walker and node can be spawned and behaves as expected."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        cli.run(self.fixture_abs_path("dynamic_architype.jac"))
+        output = captured_output.getvalue().strip()
+
+        expected_outputs = ["Value: 1", "Value: 3", "Value: 2"]
+
+        for expected in expected_outputs:
+            self.assertIn(expected, output.split("\n"))
+
     def test_object_ref_interface(self) -> None:
         """Test class method output."""
         captured_output = io.StringIO()

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1010,7 +1010,7 @@ class JacLanguageTests(TestCase):
 
                 bar_file.write(original_content)
 
-    def test_dynamic_spawn_architype(self):
+    def test_dynamic_spawn_architype(self) -> None:
         """Test that the walker and node can be spawned and behaves as expected."""
         captured_output = io.StringIO()
         sys.stdout = captured_output


### PR DESCRIPTION
## **Description**

This PR introduces the ability for JacMachine to dynamically instantiate nodes and walkers at runtime using `spawn_node` and `spawn_walker`. These features enhance flexibility by allowing users to create and manage architypes on-the-fly without reloading modules. 


