### PR TITLE
Fix: Consistent Node Traversal Order in Walk

### DIFF
--- a/jac/jaclang/plugin/default.py
+++ b/jac/jaclang/plugin/default.py
@@ -877,19 +877,23 @@ class JacFeatureImpl(
         if edges_only:
             connected_edges: list[EdgeArchitype] = []
             for node in node_obj:
-                connected_edges += Jac.get_edges(
+                edges = Jac.get_edges(
                     node.__jac__, dir, filter_func, target_obj=targ_obj_set
                 )
-            return list(set(connected_edges))
+                connected_edges.extend(
+                    edge for edge in edges if edge not in connected_edges
+                )
+            return connected_edges
         else:
             connected_nodes: list[NodeArchitype] = []
             for node in node_obj:
-                connected_nodes.extend(
-                    Jac.edges_to_nodes(
-                        node.__jac__, dir, filter_func, target_obj=targ_obj_set
-                    )
+                nodes = Jac.edges_to_nodes(
+                    node.__jac__, dir, filter_func, target_obj=targ_obj_set
                 )
-            return list(set(connected_nodes))
+                connected_nodes.extend(
+                    node for node in nodes if node not in connected_nodes
+                )
+            return connected_nodes
 
     @staticmethod
     @hookimpl

--- a/jac/jaclang/tests/fixtures/visit_order.jac
+++ b/jac/jaclang/tests/fixtures/visit_order.jac
@@ -1,0 +1,20 @@
+node MyNode{
+    has Name:str;
+}
+
+edge a{}
+
+edge b{}
+
+with entry{
+    Start = MyNode("Start");
+    End = MyNode("End");
+    mid = MyNode("Middle");
+    root <+:a:+ Start;
+    root +:a:+> End;
+    root +:b:+> mid;
+    root +:a:+> mid;
+
+    print([root-->]);
+
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1115,3 +1115,12 @@ class JacLanguageTests(TestCase):
         self.assertIn(
             "Exiting at the end of walker:  test_node(value=", stdout_value[11]
         )
+
+    def test_visit_order(self) -> None:
+        """Test entry and exit behavior of walker."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        jac_import("visit_order", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue()
+        self.assertEqual("[MyNode(Name='End'), MyNode(Name='Middle')]\n", stdout_value)


### PR DESCRIPTION
## **Description**

This PR addresses the issue #1350 of inconsistent node traversal order during graph walks. It ensures nodes are visited in the order they are attached to the root node, as expected.

![image](https://github.com/user-attachments/assets/827deae6-eb9b-4b88-9a68-71d1edf46953)
