### PR TITLE
Architype def fix test cases added

### DIFF
--- a/jac/jaclang/tests/fixtures/architype_def_type1.jac
+++ b/jac/jaclang/tests/fixtures/architype_def_type1.jac
@@ -1,0 +1,17 @@
+# one way to fix this issue is allowing Declaration of architype before define it
+
+node MyNode;
+
+walker MyWalker{
+    can create with `root|MyNode entry{}
+}
+
+:node:MyNode{
+    can do with MyWalker entry{}
+}
+
+with entry{
+    Node_1 = MyNode();
+    Node_1 spawn MyWalker();
+}
+

--- a/jac/jaclang/tests/fixtures/architype_def_type2.jac
+++ b/jac/jaclang/tests/fixtures/architype_def_type2.jac
@@ -1,0 +1,18 @@
+# fix test type 2
+
+walker MyWalker{
+    can travel with `root|MyNode entry{
+        print("MyWalker");
+    }
+}
+
+node MyNode{
+    can work with MyWalker entry{
+        print("MyNode");
+    }
+}
+
+with entry{
+    Node_1=a();
+    Node_1 spawn MyWalker();
+}


### PR DESCRIPTION
## **Description**

# one way to fix this issue is allowing Declaration of architype before define it

```
node MyNode;

walker MyWalker{
    can create with `root|MyNode entry{}
}

:node:MyNode{
    can do with MyWalker entry{}
}

with entry{
    Node_1 = MyNode();
    Node_1 spawn MyWalker();
}
```

# fix test type 2

```
walker MyWalker{
    can travel with `root|MyNode entry{
        print("MyWalker");
    }
}

node MyNode{
    can work with MyWalker entry{
        print("MyNode");
    }
}

with entry{
    Node_1=a();
    Node_1 spawn MyWalker();
}
```
