### PR TITLE
syntax error pretty print implemented

### DIFF
--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -471,8 +471,12 @@ def py2jac(filename: str) -> None:
     """
     if filename.endswith(".py"):
         with open(filename, "r") as f:
+            file_source = f.read()
             code = PyastBuildPass(
-                input_ir=ast.PythonModuleAst(ast3.parse(f.read()), mod_path=filename),
+                input_ir=ast.PythonModuleAst(
+                    ast3.parse(file_source),
+                    orig_src=ast.JacSource(file_source, filename),
+                ),
             ).ir.unparse()
         print(code)
     else:

--- a/jac/jaclang/compiler/absyntree.py
+++ b/jac/jaclang/compiler/absyntree.py
@@ -139,7 +139,7 @@ class AstNode:
         return Token(
             name=name,
             value=value,
-            file_path=self.loc.mod_path,
+            orig_src=self.loc.orig_src,
             col_start=self.loc.col_start,
             col_end=0,
             line=self.loc.first_line,
@@ -398,7 +398,7 @@ class AstImplOnlyNode(CodeBlockStmt, ElementStmt, AstSymbolNode):
     def create_impl_name_node(self) -> Name:
         """Create impl name."""
         ret = Name(
-            file_path=self.target.archs[-1].loc.mod_path,
+            orig_src=self.target.archs[-1].loc.orig_src,
             name=Tok.NAME.value,
             value=self.target.py_resolve_name(),
             col_start=self.target.archs[0].loc.col_start,
@@ -745,7 +745,7 @@ class Test(AstSymbolNode, ElementStmt):
             name
             if isinstance(name, Name)
             else Name(
-                file_path=name.file_path,
+                orig_src=name.orig_src,
                 name=Tok.NAME.value,
                 value=f"_jac_gen_{Test.TEST_COUNT}",
                 col_start=name.loc.col_start,
@@ -3813,7 +3813,7 @@ class MatchWild(MatchPattern):
             self,
             nodes=[
                 Name(
-                    file_path=self.loc.mod_path,
+                    orig_src=self.loc.orig_src,
                     name=Tok.NAME,
                     value="_",
                     col_start=self.loc.col_start,
@@ -4023,7 +4023,7 @@ class Token(AstNode):
 
     def __init__(
         self,
-        file_path: str,
+        orig_src: JacSource,
         name: str,
         value: str,
         line: int,
@@ -4034,7 +4034,7 @@ class Token(AstNode):
         pos_end: int,
     ) -> None:
         """Initialize token."""
-        self.file_path = file_path
+        self.orig_src = orig_src
         self.name = name
         self.value = value
         self.line_no = line
@@ -4059,7 +4059,7 @@ class Name(Token, NameAtom):
 
     def __init__(
         self,
-        file_path: str,
+        orig_src: JacSource,
         name: str,
         value: str,
         line: int,
@@ -4076,7 +4076,7 @@ class Name(Token, NameAtom):
         self.is_kwesc = is_kwesc
         Token.__init__(
             self,
-            file_path=file_path,
+            orig_src=orig_src,
             name=name,
             value=value,
             line=line,
@@ -4107,7 +4107,7 @@ class Name(Token, NameAtom):
     ) -> Name:
         """Generate name from node."""
         ret = Name(
-            file_path=node.loc.mod_path,
+            orig_src=node.loc.orig_src,
             name=Tok.NAME.value,
             value=name_str,
             col_start=node.loc.col_start,
@@ -4134,7 +4134,7 @@ class SpecialVarRef(Name):
         self.orig = var
         Name.__init__(
             self,
-            file_path=var.file_path,
+            orig_src=var.orig_src,
             name=var.name,
             value=self.py_resolve_name(),  # TODO: This shouldnt be necessary
             line=var.line_no,
@@ -4190,7 +4190,7 @@ class Literal(Token, AtomExpr):
 
     def __init__(
         self,
-        file_path: str,
+        orig_src: JacSource,
         name: str,
         value: str,
         line: int,
@@ -4203,7 +4203,7 @@ class Literal(Token, AtomExpr):
         """Initialize token."""
         Token.__init__(
             self,
-            file_path=file_path,
+            orig_src=orig_src,
             name=name,
             value=value,
             line=line,
@@ -4343,11 +4343,11 @@ class Ellipsis(Literal):
 class EmptyToken(Token):
     """EmptyToken node type for Jac Ast."""
 
-    def __init__(self, file_path: str = "") -> None:
+    def __init__(self, orig_src: JacSource | None = None) -> None:
         """Initialize empty token."""
         super().__init__(
             name="EmptyToken",
-            file_path=file_path,
+            orig_src=orig_src or JacSource("", ""),
             value="",
             line=0,
             end_line=0,
@@ -4367,7 +4367,7 @@ class CommentToken(Token):
 
     def __init__(
         self,
-        file_path: str,
+        orig_src: JacSource,
         name: str,
         value: str,
         line: int,
@@ -4384,7 +4384,7 @@ class CommentToken(Token):
 
         Token.__init__(
             self,
-            file_path=file_path,
+            orig_src=orig_src,
             name=name,
             value=value,
             line=line,
@@ -4404,7 +4404,7 @@ class JacSource(EmptyToken):
 
     def __init__(self, source: str, mod_path: str) -> None:
         """Initialize source string."""
-        super().__init__()
+        super().__init__(self)
         self.value = source
         self.hash = md5(source.encode()).hexdigest()
         self.file_path = mod_path
@@ -4419,8 +4419,14 @@ class JacSource(EmptyToken):
 class PythonModuleAst(EmptyToken):
     """SourceString node type for Jac Ast."""
 
-    def __init__(self, ast: ast3.Module, mod_path: str) -> None:
+    def __init__(self, ast: ast3.Module, orig_src: JacSource) -> None:
         """Initialize source string."""
         super().__init__()
         self.ast = ast
-        self.file_path = mod_path
+        self.orig_src = orig_src
+
+        # This bellow attribute is un-necessary since it already exists in the orig_src
+        # however I'm keeping it here not to break existing code trying to access file_path.
+        # We can remove this in the future once we safley remove all references to it and
+        # use orig_src.
+        self.file_path = orig_src.file_path

--- a/jac/jaclang/compiler/codeloc.py
+++ b/jac/jaclang/compiler/codeloc.py
@@ -9,7 +9,7 @@ from typing import Optional, TYPE_CHECKING
 from jaclang.vendor.mypy.nodes import Node as MypyNode
 
 if TYPE_CHECKING:
-    from jaclang.compiler.absyntree import Token
+    from jaclang.compiler.absyntree import JacSource, Token
 
 
 @dataclass
@@ -43,9 +43,14 @@ class CodeLocInfo:
         self.last_tok = last_tok
 
     @property
+    def orig_src(self) -> JacSource:
+        """Get file source."""
+        return self.first_tok.orig_src
+
+    @property
     def mod_path(self) -> str:
         """Get line number."""
-        return self.first_tok.file_path
+        return self.first_tok.orig_src.file_path
 
     @property
     def first_line(self) -> int:

--- a/jac/jaclang/compiler/passes/ir_pass.py
+++ b/jac/jaclang/compiler/passes/ir_pass.py
@@ -140,11 +140,11 @@ class Pass(Transform[T]):
 
     def error(self, msg: str, node_override: Optional[ast.AstNode] = None) -> None:
         """Pass Error."""
-        self.log_error(f"{msg}", node_override=node_override)
+        self.log_error(msg, node_override=node_override)
 
     def warning(self, msg: str, node_override: Optional[ast.AstNode] = None) -> None:
         """Pass Error."""
-        self.log_warning(f"{msg}", node_override=node_override)
+        self.log_warning(msg, node_override=node_override)
 
     def ice(self, msg: str = "Something went horribly wrong!") -> RuntimeError:
         """Pass Error."""

--- a/jac/jaclang/compiler/passes/main/import_pass.py
+++ b/jac/jaclang/compiler/passes/main/import_pass.py
@@ -279,9 +279,11 @@ class PyImportPass(JacImportPass):
                     return self.import_table[file_to_raise]
 
                 with open(file_to_raise, "r", encoding="utf-8") as f:
+                    file_source = f.read()
                     mod = PyastBuildPass(
                         input_ir=ast.PythonModuleAst(
-                            py_ast.parse(f.read()), mod_path=file_to_raise
+                            py_ast.parse(file_source),
+                            orig_src=ast.JacSource(file_source, file_to_raise),
                         ),
                     ).ir
                     SubNodeTabPass(input_ir=mod, prior=self)
@@ -313,9 +315,11 @@ class PyImportPass(JacImportPass):
             / "builtins.pyi"
         )
         with open(file_to_raise, "r", encoding="utf-8") as f:
+            file_source = f.read()
             mod = PyastBuildPass(
                 input_ir=ast.PythonModuleAst(
-                    py_ast.parse(f.read()), mod_path=file_to_raise
+                    py_ast.parse(file_source),
+                    orig_src=ast.JacSource(file_source, file_to_raise),
                 ),
             ).ir
             mod.parent = self.ir

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -22,6 +22,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
     def __init__(self, input_ir: ast.PythonModuleAst) -> None:
         """Initialize parser."""
         self.mod_path = input_ir.loc.mod_path
+        self.orig_src = input_ir.loc.orig_src
         Pass.__init__(self, input_ir=input_ir, prior=None)
 
     def nu(self, node: T) -> T:
@@ -151,7 +152,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
 
         value = node.name if node.name not in reserved_keywords else f"<>{node.name}"
         name = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=value,
             line=node.lineno,
@@ -264,7 +265,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             type_params: list[type_param]
         """
         name = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=node.name,
             line=node.lineno,
@@ -275,7 +276,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             pos_end=0,
         )
         arch_type = ast.Token(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.KW_CLASS,
             value="class",
             line=node.lineno,
@@ -293,7 +294,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
                 and body_stmt.name_ref.value == "__init__"
             ):
                 tok = ast.Name(
-                    file_path=self.mod_path,
+                    orig_src=self.orig_src,
                     name=Tok.KW_INIT,
                     value="init",
                     line=node.lineno,
@@ -383,7 +384,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
                     ):
                         continue
                     pintok = ast.Token(
-                        file_path=self.mod_path,
+                        orig_src=self.orig_src,
                         name=Tok.PYNLINE,
                         value=py_ast.unparse(class_body_stmt),
                         line=node.lineno,
@@ -914,7 +915,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             and value.target.value == "super"
         ):
             tok = ast.Name(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.KW_SUPER,
                 value="super",
                 line=node.lineno,
@@ -927,7 +928,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             value = ast.SpecialVarRef(var=tok)
             # exit()
         attribute = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=(
                 ("<>" + node.attr)
@@ -1038,7 +1039,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
     def proc_break(self, node: py_ast.Break) -> ast.CtrlStmt:
         """Process python node."""
         break_tok = ast.Token(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.KW_BREAK,
             value="break",
             line=0,
@@ -1155,7 +1156,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             else:
                 value = str(node.value)
             return type_mapping[value_type](
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=token_type,
                 value=value,
                 line=node.lineno,
@@ -1167,7 +1168,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             )
         elif node.value == Ellipsis:
             return ast.Ellipsis(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.ELLIPSIS,
                 value="...",
                 line=node.lineno,
@@ -1183,7 +1184,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
     def proc_continue(self, node: py_ast.Continue) -> ast.CtrlStmt:
         """Process python node."""
         continue_tok = ast.Token(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.KW_CONTINUE,
             value="continue",
             line=0,
@@ -1260,7 +1261,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         name: ast.Name | None = None
         if not type and not node.name:
             type = ast.Name(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.NAME,
                 value="Exception",
                 line=node.lineno,
@@ -1271,7 +1272,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
                 pos_end=0,
             )
             name = ast.Name(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.NAME,
                 value="e",
                 line=node.lineno,
@@ -1283,7 +1284,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             )
         else:
             # type = ast.Name(
-            #     file_path=self.mod_path,
+            #     orig_src=self.orig_src,
             #     name=Tok.NAME,
             #     value=no,
             #     line=node.lineno,
@@ -1295,7 +1296,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             # )
             name = (
                 ast.Name(
-                    file_path=self.mod_path,
+                    orig_src=self.orig_src,
                     name=Tok.NAME,
                     value=node.name,
                     line=node.lineno,
@@ -1395,7 +1396,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         for id in node.names:
             names.append(
                 ast.Name(
-                    file_path=self.mod_path,
+                    orig_src=self.orig_src,
                     name=Tok.NAME,
                     value=id,
                     line=node.lineno,
@@ -1458,7 +1459,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             else:
                 raise self.ice()
         lang = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value="py",
             line=node.lineno,
@@ -1488,7 +1489,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             level: int
         """
         lang = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value="py",
             line=node.lineno,
@@ -1503,7 +1504,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             for i in node.module.split("."):
                 modpaths.append(
                     ast.Name(
-                        file_path=self.mod_path,
+                        orig_src=self.orig_src,
                         name=Tok.NAME,
                         value=i,
                         line=node.lineno,
@@ -1667,7 +1668,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         """
         pattern = self.convert(node.pattern) if node.pattern else None
         name = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=node.name if node.name else "_",
             line=node.lineno,
@@ -1721,7 +1722,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             for kwd_attrs in node.kwd_attrs:
                 names.append(
                     ast.Name(
-                        file_path=self.mod_path,
+                        orig_src=self.orig_src,
                         name=Tok.NAME,
                         value=kwd_attrs,
                         line=node.lineno,
@@ -1781,7 +1782,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             values.append(kv_pair)
         if node.rest:
             name = ast.Name(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.NAME,
                 value=node.rest,
                 line=node.lineno,
@@ -1826,7 +1827,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         type = Tok.NULL if node.value is None else Tok.BOOL
         ret_type = ast.Null if node.value is None else ast.Bool
         value = ret_type(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=type,
             value=str(node.value),
             line=node.lineno,
@@ -1848,7 +1849,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             name: _Identifier | None
         """
         name = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=node.name if node.name else "_",
             line=node.lineno,
@@ -1891,7 +1892,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
 
         value = node.id if node.id not in reserved_keywords else f"<>{node.id}"
         ret = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=value,
             line=node.lineno,
@@ -1937,7 +1938,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             value = name if name not in reserved_keywords else f"<>{name}"
             names.append(
                 ast.Name(
-                    file_path=self.mod_path,
+                    orig_src=self.orig_src,
                     name=Tok.NAME,
                     value=value,
                     line=node.lineno,
@@ -1954,7 +1955,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
     def proc_pass(self, node: py_ast.Pass) -> ast.Semi:
         """Process python node."""
         return ast.Semi(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.SEMI,
             value=";",
             line=0,
@@ -2222,7 +2223,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             asname: _Identifier | None
         """
         name = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=node.name,
             line=node.lineno,
@@ -2234,7 +2235,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         )
         asname = (
             ast.Name(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.NAME,
                 value=node.asname,
                 line=node.lineno,
@@ -2268,7 +2269,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
 
         value = node.arg if node.arg not in reserved_keywords else f"<>{node.arg}"
         name = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=value,
             line=node.lineno,
@@ -2282,7 +2283,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
             self.convert(node.annotation)
             if node.annotation
             else ast.Name(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.NAME,
                 value="Any",
                 line=node.lineno,
@@ -2316,7 +2317,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         vararg = self.convert(node.vararg) if node.vararg else None
         if vararg and isinstance(vararg, ast.ParamVar):
             vararg.unpack = ast.Token(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.STAR_MUL,
                 value="*",
                 line=vararg.loc.first_line,
@@ -2342,7 +2343,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         kwarg = self.convert(node.kwarg) if node.kwarg else None
         if kwarg and isinstance(kwarg, ast.ParamVar):
             kwarg.unpack = ast.Token(
-                file_path=self.mod_path,
+                orig_src=self.orig_src,
                 name=Tok.STAR_POW,
                 value="**",
                 line=kwarg.loc.first_line,
@@ -2388,7 +2389,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
     def operator(self, tok: Tok, value: str) -> ast.Token:
         """Create an operator token."""
         return ast.Token(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=tok,
             value=value,
             line=0,
@@ -2553,7 +2554,7 @@ class PyastBuildPass(Pass[ast.PythonModuleAst]):
         value: expr
         """
         arg = ast.Name(
-            file_path=self.mod_path,
+            orig_src=self.orig_src,
             name=Tok.NAME,
             value=node.arg if node.arg else "_",
             line=node.lineno,

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -292,10 +292,8 @@ class JacProgram:
 
         result = compile_jac(full_target, cache_result=cachable)
         if result.errors_had or not result.ir.gen.py_bytecode:
-            logger.error(
-                f"While importing {len(result.errors_had)} errors"
-                f" found in {full_target}"
-            )
+            for alrt in result.errors_had:
+                logger.error(alrt.pretty_print())
             return None
         if result.ir.gen.py_bytecode is not None:
             return marshal.loads(result.ir.gen.py_bytecode)

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -503,10 +503,13 @@ class JacLanguageTests(TestCase):
         import jaclang.compiler.absyntree as ast
 
         with open(file_name, "r") as f:
-            parsed_ast = py_ast.parse(f.read())
+            file_source = f.read()
+            parsed_ast = py_ast.parse(file_source)
             try:
                 py_ast_build_pass = PyastBuildPass(
-                    input_ir=ast.PythonModuleAst(parsed_ast, mod_path=file_name),
+                    input_ir=ast.PythonModuleAst(
+                        parsed_ast, orig_src=ast.JacSource(file_source, file_name)
+                    ),
                 )
             except Exception as e:
                 return f"Error While Jac to Py AST conversion: {e}"
@@ -528,9 +531,11 @@ class JacLanguageTests(TestCase):
 
         py_out_path = os.path.join(self.fixture_abs_path("./"), "pyfunc_1.py")
         with open(py_out_path) as f:
+            file_source = f.read()
             output = PyastBuildPass(
                 input_ir=ast.PythonModuleAst(
-                    py_ast.parse(f.read()), mod_path=py_out_path
+                    py_ast.parse(file_source),
+                    orig_src=ast.JacSource(file_source, py_out_path),
                 ),
             ).ir.unparse()
         # print(output)
@@ -559,10 +564,14 @@ class JacLanguageTests(TestCase):
         import jaclang.compiler.absyntree as ast
 
         with open(file_name, "r") as f:
-            parsed_ast = py_ast.parse(f.read())
+            file_source = f.read()
+            parsed_ast = py_ast.parse(file_source)
             try:
                 py_ast_build_pass = PyastBuildPass(
-                    input_ir=ast.PythonModuleAst(parsed_ast, mod_path=file_name),
+                    input_ir=ast.PythonModuleAst(
+                        parsed_ast,
+                        orig_src=ast.JacSource(file_source, file_name),
+                    ),
                 )
             except Exception as e:
                 return f"Error While Jac to Py AST conversion: {e}"
@@ -587,9 +596,11 @@ class JacLanguageTests(TestCase):
 
         py_out_path = os.path.join(self.fixture_abs_path("./"), "pyfunc_2.py")
         with open(py_out_path) as f:
+            file_source = f.read()
             output = PyastBuildPass(
                 input_ir=ast.PythonModuleAst(
-                    py_ast.parse(f.read()), mod_path=py_out_path
+                    py_ast.parse(file_source),
+                    orig_src=ast.JacSource(file_source, py_out_path),
                 ),
             ).ir.unparse()
         self.assertIn("class X {\n    with entry {\n\n        a_b = 67;", output)
@@ -607,10 +618,14 @@ class JacLanguageTests(TestCase):
         import jaclang.compiler.absyntree as ast
 
         with open(file_name, "r") as f:
-            parsed_ast = py_ast.parse(f.read())
+            file_source = f.read()
+            parsed_ast = py_ast.parse(file_source)
             try:
                 py_ast_build_pass = PyastBuildPass(
-                    input_ir=ast.PythonModuleAst(parsed_ast, mod_path=file_name),
+                    input_ir=ast.PythonModuleAst(
+                        parsed_ast,
+                        orig_src=ast.JacSource(file_source, file_name),
+                    ),
                 )
             except Exception as e:
                 return f"Error While Jac to Py AST conversion: {e}"
@@ -634,9 +649,11 @@ class JacLanguageTests(TestCase):
 
         py_out_path = os.path.join(self.fixture_abs_path("./"), "pyfunc_3.py")
         with open(py_out_path) as f:
+            file_source = f.read()
             output = PyastBuildPass(
                 input_ir=ast.PythonModuleAst(
-                    py_ast.parse(f.read()), mod_path=py_out_path
+                    py_ast.parse(file_source),
+                    orig_src=ast.JacSource(file_source, py_out_path),
                 ),
             ).ir.unparse()
         self.assertIn("if 0 <= x<= 5 {", output)
@@ -761,9 +778,11 @@ class JacLanguageTests(TestCase):
                 module_path + ".py",
             )
             with open(file_path) as f:
+                file_source = f.read()
                 jac_ast = PyastBuildPass(
                     input_ir=ast.PythonModuleAst(
-                        py_ast.parse(f.read()), mod_path=file_path
+                        py_ast.parse(file_source),
+                        orig_src=ast.JacSource(file_source, file_path),
                     )
                 )
             settings.print_py_raised_ast = True

--- a/jac/jaclang/utils/helpers.py
+++ b/jac/jaclang/utils/helpers.py
@@ -182,6 +182,76 @@ def dump_traceback(e: Exception) -> str:
     return trace_dump
 
 
+# TODO: After implementing the TextRange (or simillar named) class to mark a text range
+# refactor the parameter to accept an instace of that text range object.
+def pretty_print_source_location(
+    file_path: str,
+    file_source: str,
+    error_line: int,
+    pos_start: int,
+    pos_end: int,
+) -> str:
+    """Pretty print internal method for the pretty_print method."""
+    # NOTE: The Line numbers and the column numbers are starts with 1.
+    # We print totally 5 lines (error line and above 2 and bellow 2).
+
+    # The width of the line number we'll be printing (more of a settings).
+    line_num_width: int = 5
+
+    idx: int = pos_start  # Pointer for the current character.
+
+    if file_source == "" or file_path == "":
+        return ""
+
+    start_line: int = error_line - 2
+    if start_line < 1:
+        start_line = 1
+    end_line: int = start_line + 5  # Index is exclusive.
+
+    # Get the first character of the [start_line].
+    file_source.splitlines(True)[start_line - 1]
+    curr_line: int = error_line
+    while idx >= 0 and curr_line >= start_line:
+        idx -= 1
+        if idx < 0:
+            break
+        if file_source[idx] == "\n":
+            curr_line -= 1
+
+    idx += 1  # Enter the line.
+    assert idx == 0 or file_source[idx - 1] == "\n"
+
+    pretty_dump = ""
+
+    # Print each lines.
+    curr_line = start_line
+    while curr_line < end_line:
+        pretty_dump += f"%{line_num_width}d | " % curr_line
+
+        idx_line_start = idx
+        while idx < len(file_source) and file_source[idx] != "\n":
+            idx += 1  # Run to the line end.
+        pretty_dump += file_source[idx_line_start:idx]
+        pretty_dump += "\n"
+
+        if curr_line == error_line:  # Print the current line with indicator.
+            pretty_dump += f"%{line_num_width}s | " % " "
+
+            spaces = ""
+            for idx_pre in range(idx_line_start, pos_start):
+                spaces += "\t" if file_source[idx_pre] == "\t" else " "
+
+            err_token_len = pos_end - pos_start
+            pretty_dump += spaces + ("~" * err_token_len) + "\n"
+
+        if idx == len(file_source):
+            break
+        curr_line += 1
+        idx += 1
+
+    return pretty_dump
+
+
 class Jdb(pdb.Pdb):
     """Jac debugger."""
 

--- a/jac/jaclang/utils/lang_tools.py
+++ b/jac/jaclang/utils/lang_tools.py
@@ -215,12 +215,16 @@ class AstTool:
 
             if file_name.endswith(".py"):
                 with open(file_name, "r") as f:
-                    parsed_ast = py_ast.parse(f.read())
+                    file_source = f.read()
+                    parsed_ast = py_ast.parse(file_source)
                 if output == "pyast":
                     return f"\n{py_ast.dump(parsed_ast, indent=2)}"
                 try:
                     rep = PyastBuildPass(
-                        input_ir=ast.PythonModuleAst(parsed_ast, mod_path=file_name),
+                        input_ir=ast.PythonModuleAst(
+                            parsed_ast,
+                            orig_src=ast.JacSource(file_source, file_name),
+                        ),
                     ).ir
 
                     schedule = py_code_gen_typed


### PR DESCRIPTION
Description

Now the alerts are printed with the visual location indication for the end user to understand cleanly. Here are the screen shots of the implementation and the old one.

Current:
![image](https://github.com/user-attachments/assets/da5081d5-dc42-4d10-a77e-a06a98b14af2)

Previous:
![image](https://github.com/user-attachments/assets/031d1d41-5917-483b-a8aa-f86e4122f86d)