### PR TITLE
Improved tutorial documentation for parts 1 and 2: MongoDB setup with alternative port configuration, multi-LLM integration and path handling adjustments

### DIFF
--- a/jac/support/jac-lang.org/docs/learn/tutorial/1_setting-up-jac-cloud.md
+++ b/jac/support/jac-lang.org/docs/learn/tutorial/1_setting-up-jac-cloud.md
@@ -33,6 +33,12 @@ To set up a mongodb replica set, follow these steps:
         This command will initiate the replica set with the default configuration. You can customize the configuration as needed.
         - Run `Exit` to exit the mongo shell.
 
+(Added) Note: If you encounter a port conflict with port 27017 (as some users did, including the author), switch to a different port like 27018. For example:
+
+```bash
+mongosh --port 27018
+```
+
 ### Running a Mongodb Replica Set using Docker
 To set up a mongodb replica set using Docker, follow these steps:
 
@@ -45,8 +51,12 @@ docker pull mongodb/mongodb-community-server:latest
 ```bash
 docker run --name mongodb -p 27017:27017 -d mongodb/mongodb-community-server:latest --replSet my-rs
 ```
-This command will start a mongoDB container with the name `mongodb` and expose port `27017` to the host machine.
+This command will start a mongoDB container with the name `mongodb` and expose port `27017` to the host machine. 
 
+(Added) If port 27018 is in use, change it as needed:
+```bash
+docker run --name mongodb -p 27018:27018 -d mongodb/mongodb-community-server:latest --replSet my-rs
+```
 To check that the docker is up and running, run `docker ps` to get the lists of running container and you should see the following:
 ```
 CONTAINER ID   IMAGE                                     COMMAND                  CREATED          STATUS              PORTS                       NAMES
@@ -57,12 +67,22 @@ d289c01c3f1c   mongodb/mongodb-community-server:latest   "python3 /usr/local/…
 ```bash
 mongosh --port 27017
 ```
+(Added) Or if using a different port (e.g., 27018):
+```bash
+mongosh --port 27018
+```
+
 - **First time only**: The first time you start the mongodb, do the following two quick steps
     - Run the command `mongosh` in another terminal to open the mongo shell.
     - In the mongo shell, run the following command to initiate the replica set. This command will initiate the replica set with the default configuration. Feel free to learn more about mongodb replica set [here](https://docs.mongodb.com/manual/tutorial/deploy-replica-set/).
     ```bash
     rs.initiate({_id: "my-rs", members: [{_id: 0, host: "localhost"}]})
     ```
+    (Added) If using port 27018:
+    ```bash
+    rs.initiate({_id: "my-rs", members: [{_id: 0, host: "localhost:27018"}]})
+    ```
+    
     We should see the following output:
     ```
     { ok: 1 }
@@ -106,6 +126,10 @@ Now, let's serve this code using Jac Cloud by running the following command:
 ```bash
 DATABASE_HOST=mongodb://localhost:27017/?replicaSet=my-rs jac serve server.jac
 ```
+(Added) If you are using a different port like 27018:
+```bash
+DATABASE_HOST=mongodb://localhost:27018/?replicaSet=my-rs jac serve server.jac
+````
 
 This command starts the Jac Cloud server with the database host set to `mongodb://localhost:27017/?replicaSet=my-rs`. The server will serve the code in `server.jac` as an API. You can now access the API at `http://localhost:8000`. Go to `http://localhost:8000/docs` to see the Swagger documentation for the API. It should look something like this:
 

--- a/jac/support/jac-lang.org/docs/learn/tutorial/2_building-a-rag-chatbot.md
+++ b/jac/support/jac-lang.org/docs/learn/tutorial/2_building-a-rag-chatbot.md
@@ -163,11 +163,25 @@ In the entry block:
 - Once logged in, the token is extracted and printed.
 - Finally, `bootstrap_frontend(token)` is called with the obtained token.
 
+### (Added) Working with Multiple LLMs
+If you plan to integrate multiple LLMs such as GPT-2 and GPT-4 into the same Jac backend, you might face conflicts or challenges in managing different model configurations. In such cases, it's better to separate the models into different backend scripts.
+
+Solution: In this tutorial, we’ll demonstrate a simple workaround by creating two separate files:
+1. server_1.jac - for one LLM (e.g., GPT-4 or Ollama)
+2. server_2.jac - for the second LLM (e.g., GPT-2)
+
+### (Added) Avoiding Unicode Path Conflicts
+While working with your project files, be aware that special characters in directory names, like backslashes (\), can cause issues. 
+- For example, directory names such as \UM might be interpreted as Unicode due to the \U sequence. 
+- To avoid this issue, consider renaming directories to avoid backslashes or use forward slashes (/).
+
+### Final Steps
 Now you can run the frontend using the following command:
 
 ```bash
 jac streamlit client.jac
 ```
+Make sure your backend server (either server.jac or gpt_server.jac) is running correctly. You can switch between them as needed. This solution should help you avoid integration issues and special character conflicts, ensuring a smooth experience when building your chatbot.
 
 If your server is still running, you can chat with your assistant using the streamlit interface. The response will only be "Hello, world!" for now, but we will update it to be a fully working chatbot next.
 


### PR DESCRIPTION
## **Description**
This pull request addresses three main issues: 1) Providing an alternative port (27018) setup option based on common port conflicts with the default port (27017) faced by users. The changes were made in `1_setting-up-jac-cloud.md` .  2) Integrating multiple LLMs into separate backend files (`server.jac` and `gpt_server.jac`) to avoid conflicts. 3) Resolving path conflicts with directory names containing special characters like \U. These changes were made in `2_building-a-rag-chatbot.md` files to improve the clarity and smooth setup for new users.