### PR TITLE
definition and declaration can have different parameter names

### DIFF
--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -129,19 +129,8 @@ class DeclImplMatchPass(Pass):
                         valid_decl.name_spec,
                     )
                 else:
+                    # Copy the parameter names from the declaration to the definition.
                     for idx in range(len(params_defn.items)):
-                        # Check if all the parameter names are matched.
-                        # TODO: This shouldn't be an issue however if the names are not matched, it doesn't
-                        # work as expected like in C++, for now I'm adding this validation, however this
-                        # needs to be fixed to have a C++ style.
-                        param_name_decl = params_decl.items[idx].name.value
-                        param_name_defn = params_defn.items[idx].name.value
-                        if param_name_defn != param_name_decl:
-                            self.error(
-                                f"Parameter name mismatch for ability {sym.sym_name}.",
-                                params_defn.items[idx].name,
-                            )
-                            self.error(
-                                f"From the declaration of {valid_decl.name_spec.sym_name}.",
-                                params_decl.items[idx].name,
-                            )
+                        params_decl.items[idx] = params_defn.items[idx]
+                    for idx in range(len(params_defn.kid)):
+                        params_decl.kid[idx] = params_defn.kid[idx]

--- a/jac/jaclang/compiler/passes/main/tests/test_decl_def_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_decl_def_match_pass.py
@@ -43,35 +43,6 @@ class DeclImplMatchPassTests(TestCase):
         for exp in expected_stdout_values:
             self.assertIn(exp, errors_output)
 
-    def test_parameter_name_mismatch(self) -> None:
-        """Basic test for pass."""
-        state = jac_file_to_pass(
-            self.fixture_abs_path("defn_decl_mismatch.jac"), DeclImplMatchPass
-        )
-
-        expected_stdout_values = (
-            "Parameter name mismatch for ability (o)SomeObj.(c)bar.",
-            "   14 |",
-            "   15 | # Mis matching parameter name.",
-            "   16 | :obj:SomeObj:can:bar(param1: str, praam2:int) -> str {",
-            "      |                                   ^^^^^^",
-            '   17 |     return "bar";',
-            "   18 | }",
-            "From the declaration of bar.",
-            "    3 | obj SomeObj {",
-            "    4 |     can foo(param1: str, param2:int) -> str;",
-            "    5 |     can bar(param1: str, param2:int) -> str;",
-            "      |                          ^^^^^^",
-            "    6 | }",
-        )
-
-        errors_output = ""
-        for error in state.errors_had:
-            errors_output += error.pretty_print() + "\n"
-
-        for exp in expected_stdout_values:
-            self.assertIn(exp, errors_output)
-
     def test_ability_connected_to_decl(self) -> None:
         """Basic test for pass."""
         state = jac_file_to_pass(self.fixture_abs_path("base.jac"), DeclImplMatchPass)

--- a/jac/jaclang/compiler/passes/main/tests/test_def_use_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_def_use_pass.py
@@ -19,7 +19,7 @@ class DefUsePassTests(TestCase):
             target=DefUsePass,
         )
         uses = [i.uses for i in state.ir.sym_tab.kid[0].tab.values()]
+        self.assertEqual(len(uses[0]), 1)
         self.assertEqual(len(uses[1]), 1)
-        self.assertEqual(len(uses[2]), 1)
-        self.assertIn("output", [uses[1][0].sym_name, uses[2][0].sym_name])
-        self.assertIn("message", [uses[1][0].sym_name, uses[2][0].sym_name])
+        self.assertIn("output", [uses[0][0].sym_name, uses[1][0].sym_name])
+        self.assertIn("message", [uses[0][0].sym_name, uses[1][0].sym_name])

--- a/jac/jaclang/tests/fixtures/decl_defn_param_name.jac
+++ b/jac/jaclang/tests/fixtures/decl_defn_param_name.jac
@@ -1,0 +1,19 @@
+
+obj SomeClass {
+    can method1(some_long_paramenter_name: int) -> None;
+    can method2(param1:int, param2:str) -> None;
+}
+
+:o:SomeClass:c:method1(short_name:int) -> None {
+  print("short_name =", short_name);
+}
+
+:o:SomeClass:c:method2(p1:int, p2: str) -> None {
+  print("p1 =", p1, ", p2 =", p2);
+}
+
+with entry {
+  sc = SomeClass();
+  sc.method1(42);
+  sc.method2(64, "foobar");
+}

--- a/jac/jaclang/tests/test_cli.py
+++ b/jac/jaclang/tests/test_cli.py
@@ -94,6 +94,24 @@ class JacCliTests(TestCase):
         path_to_file = self.fixture_abs_path("err.impl.jac")
         self.assertIn(f'"{path_to_file}", line 2', stdout_value)
 
+    def test_param_name_diff(self) -> None:
+        """Test when parameter name from definitinon and declaration are mismatched."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        sys.stderr = captured_output
+        with contextlib.suppress(Exception):
+            cli.run(self.fixture_abs_path("decl_defn_param_name.jac"))
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+        expected_stdout_values = (
+            "short_name = 42",
+            "p1 = 64 , p2 = foobar",
+        )
+        output = captured_output.getvalue()
+        for exp in expected_stdout_values:
+            self.assertIn(exp, output)
+
     def test_jac_test_err(self) -> None:
         """Basic test for pass."""
         captured_output = io.StringIO()


### PR DESCRIPTION
```py

obj SomeClass {
    can method1(some_long_paramenter_name: int) -> None;
    can method2(param1:int, param2:str) -> None;
}

:o:SomeClass:c:method1(short_name:int) -> None {
  print("short_name =", short_name);
}

:o:SomeClass:c:method2(p1:int, p2: str) -> None {
  print("p1 =", p1, ", p2 =", p2);
}

with entry {
  sc = SomeClass();
  sc.method1(42);
  sc.method2(64, "foobar");
}
```