### PR TITLE
[HOTFIX]: Fix saving bytes to db

### DIFF
--- a/jac-cloud/jac_cloud/core/architype.py
+++ b/jac-cloud/jac_cloud/core/architype.py
@@ -592,7 +592,7 @@ class BaseAnchor:
             architype, type
         ):
             self.state.context_hashes = {
-                key: hash(dumps(val))
+                key: hash(val if isinstance(val, bytes) else dumps(val))
                 for key, val in architype.__serialize__().items()  # type:ignore[attr-defined] # mypy issue
             }
             self.state.full_hash = hash(pdumps(self.serialize()))


### PR DESCRIPTION
### THIS SHOULD WORK WHEN SAVING TO DB
```python
node A {
    has data: bytes;
}
```
- this is still needed to be converted to serializable object when trying to return to API