### PR TITLE
semantic errors for uninitialized obj hasvars

### DIFF
--- a/jac/examples/micro/jac_cli.jac
+++ b/jac/examples/micro/jac_cli.jac
@@ -19,8 +19,8 @@ obj Interface {
 }
 
 obj ShellCmd :cmd.Cmd: {
-    has prompt: str = "> ",
-        reg: Interface;
+    has reg: Interface,
+        prompt: str = "> ";
 
     can init(registry: Interface, *args: list, **kwargs: dict);
     can default(line: str);

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -7,6 +7,7 @@ body field.
 """
 
 import jaclang.compiler.absyntree as ast
+from jaclang.compiler.constant import Tokens as Tok
 from jaclang.compiler.passes import Pass
 from jaclang.compiler.passes.main import SubNodeTabPass
 from jaclang.compiler.symtable import Symbol, SymbolTable
@@ -134,3 +135,50 @@ class DeclImplMatchPass(Pass):
                         params_decl.items[idx] = params_defn.items[idx]
                     for idx in range(len(params_defn.kid)):
                         params_decl.kid[idx] = params_defn.kid[idx]
+
+    def exit_architype(self, node: ast.Architype) -> None:
+        """Exit Architype."""
+        if node.arch_type.name == Tok.KW_OBJECT and isinstance(
+            node.body, ast.SubNodeList
+        ):
+
+            found_default_init = False
+            for stmnt in node.body.items:
+                if not isinstance(stmnt, ast.ArchHas):
+                    continue
+                for var in stmnt.vars.items:
+                    if (var.value is not None) or (var.defer):
+                        found_default_init = True
+                    else:
+                        if found_default_init:
+                            self.error(
+                                f"Non default attribute '{var.name.value}' follows default attribute",
+                                node_override=var.name,
+                            )
+                            break
+
+            post_init_vars: list[ast.HasVar] = []
+            postinit_method: ast.Ability | None = None
+
+            for item in node.body.items:
+
+                if isinstance(item, ast.ArchHas):
+                    for var in item.vars.items:
+                        if var.defer:
+                            post_init_vars.append(var)
+
+                elif isinstance(item, ast.Ability):
+                    if item.is_abstract:
+                        continue
+                    if (
+                        isinstance(item.name_ref, ast.SpecialVarRef)
+                        and item.name_ref.name == "KW_POST_INIT"
+                    ):
+                        postinit_method = item
+
+            # Check if postinit needed and not provided.
+            if len(post_init_vars) != 0 and (postinit_method is None):
+                self.error(
+                    'Missing "postinit" method required by un initialized attribute(s).',
+                    node_override=post_init_vars[0].name_spec,
+                )  # We show the error on the first uninitialized var.

--- a/jac/jaclang/compiler/passes/main/tests/fixtures/uninitialized_hasvars.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/uninitialized_hasvars.jac
@@ -1,0 +1,26 @@
+
+# 1. Test initialization order.
+obj Test1 {
+    has var1: int;
+    has var2: int = 42;
+    has var3: int; # <-- This should be syntax error.
+}
+
+
+# 2. Test if postinit is needed but not provided.
+obj Test2 {
+    has var1: str;
+    has var2: int by postinit;
+}
+
+# 3. Postinit should be considered as has default initialization.
+obj Test3 {
+    has var1: int;
+    has var2: int = 42;
+    has var3: int by postinit;  # <-- This is fine.
+    has var4: int;  # <-- This should be syntax error.
+
+    can postinit() {
+        self.var3 = 3;
+    }
+}

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/corelib.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/corelib.jac
@@ -34,6 +34,8 @@ glob exec_ctx = ExecutionContext();
 
 obj Anchor :ArchitypeProtocol: {
     has ob: object,
+        ds_entry_funcs: list[DSFunc],
+        ds_exit_funcs: list[DSFunc],
         jid: UUID = :> uuid4,
         timestamp: datetime = :> datetime.now,
         persist: bool = False,
@@ -41,9 +43,7 @@ obj Anchor :ArchitypeProtocol: {
         rw_access: set = :> set,
         ro_access: set = :> set,
         owner_id: UUID = exec_ctx.master,
-        mem: Memory = exec_ctx.memory,
-        ds_entry_funcs: list[DSFunc],
-        ds_exit_funcs: list[DSFunc];
+        mem: Memory = exec_ctx.memory;
 
     static can on_entry(cls: type, triggers: list[type]);
     static can on_exit(cls: type, triggers: list[type]);

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/corelib_fmt.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/corelib_fmt.jac
@@ -33,6 +33,8 @@ glob exec_ctx = ExecutionContext();
 
 obj Anchor :ArchitypeProtocol: {
     has ob: object,
+        ds_entry_funcs: list[DSFunc],
+        ds_exit_funcs: list[DSFunc],
         jid: UUID = :> uuid4,
         timestamp: datetime = :> datetime.now,
         persist: bool = False,
@@ -40,9 +42,7 @@ obj Anchor :ArchitypeProtocol: {
         rw_access: set = :> set,
         ro_access: set = :> set,
         owner_id: UUID = exec_ctx.master,
-        mem: Memory = exec_ctx.memory,
-        ds_entry_funcs: list[DSFunc],
-        ds_exit_funcs: list[DSFunc];
+        mem: Memory = exec_ctx.memory;
 
     static can on_entry(cls: type, triggers: list[type]);
     static can on_exit(cls: type, triggers: list[type]);

--- a/jac/jaclang/compiler/tests/test_parser.py
+++ b/jac/jaclang/compiler/tests/test_parser.py
@@ -1,6 +1,7 @@
 """Tests for Jac parser."""
 
 import inspect
+import os
 
 from jaclang.compiler import jac_lark as jl
 from jaclang.compiler.absyntree import JacSource
@@ -27,7 +28,12 @@ class TestLarkParser(TestCaseMicroSuite):
         prse = JacParser(
             input_ir=JacSource(self.file_to_str(filename), mod_path=filename),
         )
-        self.assertFalse(prse.errors_had)
+        # A list of files where the errors are expected.
+        files_expected_errors = [
+            "uninitialized_hasvars.jac",
+        ]
+        if os.path.basename(filename) not in files_expected_errors:
+            self.assertFalse(prse.errors_had)
 
     def test_parser_fam(self) -> None:
         """Parse micro jac file."""


### PR DESCRIPTION
## **Description**

```py

# 1. Test initialization order.
obj Test1 {
    has var1: int;
    has var2: int = 42;
    has var3: int; # <-- This should be syntax error.
}

# 2. Test if all un initialized vars are initialized in the init method.
obj Test2 {
    has var1: int;
    has var2: int;
    has var3: int;
    has var4: int = 42;

    can init() {  # <-- Should be error because "var2", "var3" are not initialized.
        self.var1 = 1;
    }
}

# 3. Test the same of Test2 but the init is defined somewhere else.
obj Test3 {
    has var1: int;
    has var2: int;
    has var3: int;
    has var4: int = 42;

    can init();
}

:obj:Test3:can:init() {
    self.var1 = 1;
}

```

![image](https://github.com/user-attachments/assets/9e37c2c5-b01b-477a-8e67-0aeb3afb78de)

