### PR TITLE
[REFACTOR]: Spawn Call

### DIFF
--- a/jac-cloud/jac_cloud/core/architype.py
+++ b/jac-cloud/jac_cloud/core/architype.py
@@ -557,7 +557,7 @@ class BaseAnchor:
             ############################################################
             #                   POPULATE ADDED EDGES                   #
             ############################################################
-            added_edges: set[BaseAnchor | Anchor] = (
+            added_edges: set[BaseAnchor] = (
                 changes.get("$addToSet", {}).get("edges", {}).get("$each", [])
             )
             if added_edges:
@@ -575,7 +575,7 @@ class BaseAnchor:
             ############################################################
             #                  POPULATE REMOVED EDGES                  #
             ############################################################
-            pulled_edges: set[BaseAnchor | Anchor] = (
+            pulled_edges: set[BaseAnchor] = (
                 changes.get("$pull", {}).get("edges", {}).get("$in", [])
             )
             if pulled_edges:
@@ -828,10 +828,10 @@ class WalkerAnchor(BaseAnchor, _WalkerAnchor):  # type: ignore[misc]
     """Walker Anchor."""
 
     architype: "WalkerArchitype"
-    path: list[Anchor] = field(default_factory=list)
-    next: list[Anchor] = field(default_factory=list)
+    path: list[NodeAnchor] = field(default_factory=list)  # type: ignore[assignment]
+    next: list[NodeAnchor] = field(default_factory=list)  # type: ignore[assignment]
     returns: list[Any] = field(default_factory=list)
-    ignores: list[Anchor] = field(default_factory=list)
+    ignores: list[NodeAnchor] = field(default_factory=list)  # type: ignore[assignment]
     disengaged: bool = False
 
     class Collection(BaseCollection["WalkerAnchor"]):

--- a/jac-cloud/jac_cloud/plugin/jaseci.py
+++ b/jac-cloud/jac_cloud/plugin/jaseci.py
@@ -30,6 +30,7 @@ from jaclang.plugin.default import (
 )
 from jaclang.plugin.feature import JacFeature as Jac
 from jaclang.runtimelib.architype import Architype, DSFunc
+from jaclang.runtimelib.utils import all_issubclass
 
 from orjson import loads
 
@@ -794,65 +795,85 @@ class JacPlugin(JacAccessValidationPlugin, JacNodePlugin, JacEdgePlugin):
         walker.path = []
         walker.next = [node]
         walker.returns = []
+        current_node = node.architype
 
-        if walker.next:
-            current_node = walker.next[-1].architype
-            for i in warch._jac_entry_funcs_:
-                trigger = i.get_funcparam_annotations(i.func)
-                if not trigger:
-                    if i.func:
-                        walker.returns.append(i.func(warch, current_node))
-                    else:
-                        raise ValueError(f"No function {i.name} to call.")
+        # walker entry
+        for i in warch._jac_entry_funcs_:
+            if i.func and not i.trigger:
+                walker.returns.append(i.func(warch, current_node))
+            if walker.disengaged:
+                return warch
+
         while len(walker.next):
             if current_node := walker.next.pop(0).architype:
-                for i in current_node._jac_entry_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(warch, trigger):
-                        if i.func:
-                            walker.returns.append(i.func(current_node, warch))
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
-                    if walker.disengaged:
-                        return warch
+                # walker entry with
                 for i in warch._jac_entry_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(current_node, trigger):
-                        if i.func and trigger:
-                            walker.returns.append(i.func(warch, current_node))
-                        elif not trigger:
-                            continue
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, NodeArchitype)
+                        and isinstance(current_node, i.trigger)
+                    ):
+                        walker.returns.append(i.func(warch, current_node))
                     if walker.disengaged:
                         return warch
-                for i in warch._jac_exit_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(current_node, trigger):
-                        if i.func and trigger:
-                            walker.returns.append(i.func(warch, current_node))
-                        elif not trigger:
-                            continue
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
+
+                # node entry
+                for i in current_node._jac_entry_funcs_:
+                    if i.func and not i.trigger:
+                        walker.returns.append(i.func(current_node, warch))
                     if walker.disengaged:
                         return warch
+
+                # node entry with
+                for i in current_node._jac_entry_funcs_:
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, WalkerArchitype)
+                        and isinstance(warch, i.trigger)
+                    ):
+                        walker.returns.append(i.func(current_node, warch))
+                    if walker.disengaged:
+                        return warch
+
+                # node exit with
                 for i in current_node._jac_exit_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(warch, trigger):
-                        if i.func:
-                            walker.returns.append(i.func(current_node, warch))
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, WalkerArchitype)
+                        and isinstance(warch, i.trigger)
+                    ):
+                        walker.returns.append(i.func(current_node, warch))
                     if walker.disengaged:
                         return warch
+
+                # node exit
+                for i in current_node._jac_exit_funcs_:
+                    if i.func and not i.trigger:
+                        walker.returns.append(i.func(current_node, warch))
+                    if walker.disengaged:
+                        return warch
+
+                # walker exit with
+                for i in warch._jac_exit_funcs_:
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, NodeArchitype)
+                        and isinstance(current_node, i.trigger)
+                    ):
+                        walker.returns.append(i.func(warch, current_node))
+                    if walker.disengaged:
+                        return warch
+        # walker exit
         for i in warch._jac_exit_funcs_:
-            trigger = i.get_funcparam_annotations(i.func)
-            if not trigger:
-                if i.func:
-                    walker.returns.append(i.func(warch, current_node))
-                else:
-                    raise ValueError(f"No function {i.name} to call.")
+            if i.func and not i.trigger:
+                walker.returns.append(i.func(warch, current_node))
+            if walker.disengaged:
+                return warch
+
         walker.ignores = []
         return warch
 

--- a/jac-cloud/jac_cloud/tests/openapi_specs.yaml
+++ b/jac-cloud/jac_cloud/tests/openapi_specs.yaml
@@ -4110,3 +4110,52 @@ paths:
       tags:
       - walker
       - walker
+  /walker/visit_sequence:
+    post:
+      operationId: api_root_walker_visit_sequence_post
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Api Root Walker Visit Sequence Post
+          description: Successful Response
+      summary: /visit_sequence
+      tags:
+      - walker
+      - walker
+  /walker/visit_sequence/{node}:
+    post:
+      operationId: api_entry_walker_visit_sequence__node__post
+      parameters:
+      - in: path
+        name: node
+        required: true
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Node
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Api Entry Walker Visit Sequence  Node  Post
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: /visit_sequence/{node}
+      tags:
+      - walker
+      - walker

--- a/jac-cloud/jac_cloud/tests/simple_graph.jac
+++ b/jac-cloud/jac_cloud/tests/simple_graph.jac
@@ -804,3 +804,57 @@ walker delete_custom_object {
         # load the actual object and just use it as reference
     }
 }
+
+##################################################################
+#                     FOR SPAWN CALL SEQUENCE                    #
+##################################################################
+
+node Node {
+    has val: str;
+
+    can entry1 with entry {
+        return f"{self.val}-2";
+    }
+
+    can entry3 with visit_sequence entry {
+        return f"{self.val}-3";
+    }
+
+    can exit1 with visit_sequence exit {
+        return f"{self.val}-4";
+    }
+
+    can exit2 with exit {
+        return f"{self.val}-5";
+    }
+}
+
+walker visit_sequence {
+    can entry1 with entry {
+        return "walker entry";
+    }
+
+    can entry2 with `root entry {
+        here ++> Node(val = "a");
+        here ++> Node(val = "b");
+        here ++> Node(val = "c");
+        visit [-->];
+        return "walker enter to root";
+    }
+
+    can entry3 with Node entry {
+        return f"{here.val}-1";
+    }
+
+    can exit1 with Node exit {
+        return f"{here.val}-6";
+    }
+
+    can exit2 with exit {
+        return "walker exit";
+    }
+
+    class __specs__ {
+        has auth: bool = False;
+    }
+}

--- a/jac-cloud/jac_cloud/tests/test_simple_graph.py
+++ b/jac-cloud/jac_cloud/tests/test_simple_graph.py
@@ -560,19 +560,19 @@ class SimpleGraphTest(JacCloudTest):
                             "single": {
                                 "name": "simple_graph.jac",
                                 "content_type": "application/octet-stream",
-                                "size": 17658,
+                                "size": 18748,
                             }
                         },
                         "multiple": [
                             {
                                 "name": "simple_graph.jac",
                                 "content_type": "application/octet-stream",
-                                "size": 17658,
+                                "size": 18748,
                             },
                             {
                                 "name": "simple_graph.jac",
                                 "content_type": "application/octet-stream",
-                                "size": 17658,
+                                "size": 18748,
                             },
                         ],
                         "singleOptional": None,
@@ -761,6 +761,38 @@ class SimpleGraphTest(JacCloudTest):
         self.assertEqual(200, res["status"])
         self.assertIsNone(obj)
 
+    def trigger_visit_sequence(self) -> None:
+        """Test visit sequence."""
+        res = self.post_api("visit_sequence")
+
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            [
+                "walker entry",
+                "walker enter to root",
+                "a-1",
+                "a-2",
+                "a-3",
+                "a-4",
+                "a-5",
+                "a-6",
+                "b-1",
+                "b-2",
+                "b-3",
+                "b-4",
+                "b-5",
+                "b-6",
+                "c-1",
+                "c-2",
+                "c-3",
+                "c-4",
+                "c-5",
+                "c-6",
+                "walker exit",
+            ],
+            res["returns"],
+        )
+
     def test_all_features(self) -> None:
         """Test Full Features."""
         self.trigger_openapi_specs_test()
@@ -864,10 +896,16 @@ class SimpleGraphTest(JacCloudTest):
 
         self.trigger_memory_sync()
 
-        ##################################################
+        ###################################################
         #                 SAVABLE OBJECT                  #
         ###################################################
 
         obj_id = self.trigger_create_custom_object_test()
         self.trigger_update_custom_object_test(obj_id)
         self.trigger_delete_custom_object_test(obj_id)
+
+        ###################################################
+        #                  VISIT SEQUENCE                 #
+        ###################################################
+
+        self.trigger_visit_sequence()

--- a/jac/jaclang/plugin/default.py
+++ b/jac/jaclang/plugin/default.py
@@ -42,8 +42,11 @@ from jaclang.runtimelib.constructs import (
 from jaclang.runtimelib.importer import ImportPathSpec, JacImporter, PythonImporter
 from jaclang.runtimelib.machine import JacMachine, JacProgram
 from jaclang.runtimelib.memory import Shelf, ShelfStorage
-from jaclang.runtimelib.utils import collect_node_connections, traverse_graph
-
+from jaclang.runtimelib.utils import (
+    all_issubclass,
+    collect_node_connections,
+    traverse_graph,
+)
 
 import pluggy
 
@@ -398,64 +401,85 @@ class JacWalkerImpl:
 
         walker.path = []
         walker.next = [node]
-        if walker.next:
-            current_node = walker.next[-1].architype
-            for i in warch._jac_entry_funcs_:
-                trigger = i.get_funcparam_annotations(i.func)
-                if not trigger:
-                    if i.func:
-                        i.func(warch, current_node)
-                    else:
-                        raise ValueError(f"No function {i.name} to call.")
+        current_node = node.architype
+
+        # walker entry
+        for i in warch._jac_entry_funcs_:
+            if i.func and not i.trigger:
+                i.func(warch, current_node)
+            if walker.disengaged:
+                return warch
+
         while len(walker.next):
             if current_node := walker.next.pop(0).architype:
-                for i in current_node._jac_entry_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(warch, trigger):
-                        if i.func:
-                            i.func(current_node, warch)
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
-                    if walker.disengaged:
-                        return warch
+                # walker entry with
                 for i in warch._jac_entry_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(current_node, trigger):
-                        if i.func and trigger:
-                            i.func(warch, current_node)
-                        elif not trigger:
-                            continue
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, NodeArchitype)
+                        and isinstance(current_node, i.trigger)
+                    ):
+                        i.func(warch, current_node)
                     if walker.disengaged:
                         return warch
-                for i in warch._jac_exit_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(current_node, trigger):
-                        if i.func and trigger:
-                            i.func(warch, current_node)
-                        elif not trigger:
-                            continue
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
+
+                # node entry
+                for i in current_node._jac_entry_funcs_:
+                    if i.func and not i.trigger:
+                        i.func(current_node, warch)
                     if walker.disengaged:
                         return warch
+
+                # node entry with
+                for i in current_node._jac_entry_funcs_:
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, WalkerArchitype)
+                        and isinstance(warch, i.trigger)
+                    ):
+                        i.func(current_node, warch)
+                    if walker.disengaged:
+                        return warch
+
+                # node exit with
                 for i in current_node._jac_exit_funcs_:
-                    trigger = i.get_funcparam_annotations(i.func)
-                    if not trigger or isinstance(warch, trigger):
-                        if i.func:
-                            i.func(current_node, warch)
-                        else:
-                            raise ValueError(f"No function {i.name} to call.")
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, WalkerArchitype)
+                        and isinstance(warch, i.trigger)
+                    ):
+                        i.func(current_node, warch)
                     if walker.disengaged:
                         return warch
+
+                # node exit
+                for i in current_node._jac_exit_funcs_:
+                    if i.func and not i.trigger:
+                        i.func(current_node, warch)
+                    if walker.disengaged:
+                        return warch
+
+                # walker exit with
+                for i in warch._jac_exit_funcs_:
+                    if (
+                        i.func
+                        and i.trigger
+                        and all_issubclass(i.trigger, NodeArchitype)
+                        and isinstance(current_node, i.trigger)
+                    ):
+                        i.func(warch, current_node)
+                    if walker.disengaged:
+                        return warch
+        # walker exit
         for i in warch._jac_exit_funcs_:
-            trigger = i.get_funcparam_annotations(i.func)
-            if not trigger:
-                if i.func:
-                    i.func(warch, current_node)
-                else:
-                    raise ValueError(f"No function {i.name} to call.")
+            if i.func and not i.trigger:
+                i.func(warch, current_node)
+            if walker.disengaged:
+                return warch
+
         walker.ignores = []
         return warch
 

--- a/jac/jaclang/runtimelib/architype.py
+++ b/jac/jaclang/runtimelib/architype.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 from dataclasses import asdict, dataclass, field, fields, is_dataclass
 from enum import IntEnum
+from functools import cached_property
 from logging import getLogger
 from pickle import dumps
 from types import UnionType
@@ -220,9 +221,9 @@ class WalkerAnchor(Anchor):
     """Walker Anchor."""
 
     architype: WalkerArchitype
-    path: list[Anchor] = field(default_factory=list)
-    next: list[Anchor] = field(default_factory=list)
-    ignores: list[Anchor] = field(default_factory=list)
+    path: list[NodeAnchor] = field(default_factory=list)
+    next: list[NodeAnchor] = field(default_factory=list)
+    ignores: list[NodeAnchor] = field(default_factory=list)
     disengaged: bool = False
 
 
@@ -311,17 +312,20 @@ class DSFunc:
     name: str
     func: Callable[[Any, Any], Any] | None = None
 
+    @cached_property
+    def trigger(self) -> type | UnionType | tuple[type | UnionType, ...] | None:
+        """Get function parameter annotations."""
+        t = (
+            (
+                inspect.signature(self.func, eval_str=True)
+                .parameters["_jac_here_"]
+                .annotation
+            )
+            if self.func
+            else None
+        )
+        return None if t is inspect._empty else t
+
     def resolve(self, cls: type) -> None:
         """Resolve the function."""
         self.func = getattr(cls, self.name)
-
-    def get_funcparam_annotations(
-        self, func: Callable[[Any, Any], Any] | None
-    ) -> type | UnionType | tuple[type | UnionType, ...] | None:
-        """Get function parameter annotations."""
-        if not func:
-            return None
-        annotation = (
-            inspect.signature(func, eval_str=True).parameters["_jac_here_"].annotation
-        )
-        return annotation if annotation != inspect._empty else None

--- a/jac/jaclang/runtimelib/utils.py
+++ b/jac/jaclang/runtimelib/utils.py
@@ -231,3 +231,18 @@ def is_instance(
             return isinstance(obj, target)
         case _:
             return False
+
+
+def all_issubclass(
+    classes: type | UnionType | tuple[type | UnionType, ...], target: type
+) -> bool:
+    """Check if all classes is subclass of target type."""
+    match classes:
+        case type():
+            return issubclass(classes, target)
+        case UnionType():
+            return all((all_issubclass(cls, target) for cls in classes.__args__))
+        case tuple():
+            return all((all_issubclass(cls, target) for cls in classes))
+        case _:
+            return False

--- a/jac/jaclang/tests/fixtures/visit_sequence.jac
+++ b/jac/jaclang/tests/fixtures/visit_sequence.jac
@@ -1,0 +1,50 @@
+node Node {
+    has val: str;
+
+    can entry1 with entry {
+        print(f"{self.val}-2");
+    }
+
+    can entry2 with Walker entry {
+        print(f"{self.val}-3");
+    }
+
+    can exit1 with Walker exit {
+        print(f"{self.val}-4");
+    }
+
+    can exit2 with exit {
+        print(f"{self.val}-5");
+    }
+}
+
+walker Walker {
+    can entry1 with entry {
+        print("walker entry");
+    }
+
+    can entry2 with `root entry {
+        print("walker enter to root");
+        visit [-->];
+    }
+
+    can entry3 with Node entry {
+        print(f"{here.val}-1");
+    }
+
+    can exit1 with Node exit {
+        print(f"{here.val}-6");
+    }
+
+    can exit2 with exit {
+        print("walker exit");
+    }
+}
+
+with entry{
+    root ++> Node(val = "a");
+    root ++> Node(val = "b");
+    root ++> Node(val = "c");
+
+    Walker() spawn root;
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1230,5 +1230,20 @@ class JacLanguageTests(TestCase):
         jac_import("architype_def_bug", base_path=self.fixture_abs_path("./"))
         sys.stdout = sys.__stdout__
         stdout_value = captured_output.getvalue().split("\n")
-        self.assertIn("MyNode", stdout_value[0])
-        self.assertIn("MyWalker", stdout_value[1])
+        self.assertIn("MyWalker", stdout_value[0])
+        self.assertIn("MyNode", stdout_value[1])
+
+    def test_visit_sequence(self) -> None:
+        """Test conn assign on edges."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        jac_import("visit_sequence", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        self.assertEqual(
+            "walker entry\nwalker enter to root\n"
+            "a-1\na-2\na-3\na-4\na-5\na-6\n"
+            "b-1\nb-2\nb-3\nb-4\nb-5\nb-6\n"
+            "c-1\nc-2\nc-3\nc-4\nc-5\nc-6\n"
+            "walker exit\n",
+            captured_output.getvalue(),
+        )

--- a/jac/support/jac-lang.org/docs/learn/data_spatial/sequence.md
+++ b/jac/support/jac-lang.org/docs/learn/data_spatial/sequence.md
@@ -1,0 +1,116 @@
+# **`SPAWN CALL SEQUENCE`**
+```
+node Node {
+    has val: str;
+
+    can entry1 with entry {
+        print(f"{self.val}-2");
+    }
+
+    can entry2 with Walker entry {
+        print(f"{self.val}-3");
+    }
+
+    can exit1 with Walker exit {
+        print(f"{self.val}-4");
+    }
+
+    can exit2 with exit {
+        print(f"{self.val}-5");
+    }
+}
+
+walker Walker {
+    can entry1 with entry {
+        print("walker entry");
+    }
+
+    can entry2 with `root entry {
+        print("walker enter to root");
+        visit [-->];
+    }
+
+    can entry3 with Node entry {
+        print(f"{here.val}-1");
+    }
+
+    can exit1 with Node exit {
+        print(f"{here.val}-6");
+    }
+
+    can exit2 with exit {
+        print("walker exit");
+    }
+}
+
+with entry{
+    root ++> Node(val = "a");
+    root ++> Node(val = "b");
+    root ++> Node(val = "c");
+
+    Walker() spawn root;
+}
+```
+
+## **Jac version >= 0.7.26**
+> **walker generic entry** => \
+> **node entries (generic/typed)** => \
+> **back to walker typed entry** => \
+> **walker typed exit** => \
+> **back to node exits (generic/typed)** => \
+> **back to walker generic exit**
+```
+walker entry
+walker enter to root
+a-2
+a-3
+a-1
+a-6
+a-4
+a-5
+b-2
+b-3
+b-1
+b-6
+b-4
+b-5
+c-2
+c-3
+c-1
+c-6
+c-4
+c-5
+walker exit
+```
+## **After Refactor**
+> **walker generic entry** => \
+> **walker typed entry** => \
+> **node generic entry** => \
+> **node typed entry** => \
+> **node typed exit** => \
+> **node generic exit** => \
+> **back to walker typed exit** => \
+> **walker generic exit**
+```
+walker entry
+walker enter to root
+a-1
+a-2
+a-3
+a-4
+a-5
+a-6
+b-1
+b-2
+b-3
+b-4
+b-5
+b-6
+c-1
+c-2
+c-3
+c-4
+c-5
+c-6
+walker exit
+```

--- a/jac/support/jac-lang.org/docs/learn/data_spatial/sequence.md
+++ b/jac/support/jac-lang.org/docs/learn/data_spatial/sequence.md
@@ -51,38 +51,7 @@ with entry{
     Walker() spawn root;
 }
 ```
-
-## **Jac version >= 0.7.26**
-> **walker generic entry** => \
-> **node entries (generic/typed)** => \
-> **back to walker typed entry** => \
-> **walker typed exit** => \
-> **back to node exits (generic/typed)** => \
-> **back to walker generic exit**
-```
-walker entry
-walker enter to root
-a-2
-a-3
-a-1
-a-6
-a-4
-a-5
-b-2
-b-3
-b-1
-b-6
-b-4
-b-5
-c-2
-c-3
-c-1
-c-6
-c-4
-c-5
-walker exit
-```
-## **After Refactor**
+## Current triggering sequence (jaclang version >= 0.7.29)
 > **walker generic entry** => \
 > **walker typed entry** => \
 > **node generic entry** => \
@@ -112,5 +81,35 @@ c-3
 c-4
 c-5
 c-6
+walker exit
+```
+## For jaclang version <= 0.7.28
+> **walker generic entry** => \
+> **node entries (generic/typed)** => \
+> **back to walker typed entry** => \
+> **walker typed exit** => \
+> **back to node exits (generic/typed)** => \
+> **back to walker generic exit**
+```
+walker entry
+walker enter to root
+a-2
+a-3
+a-1
+a-6
+a-4
+a-5
+b-2
+b-3
+b-1
+b-6
+b-4
+b-5
+c-2
+c-3
+c-1
+c-6
+c-4
+c-5
 walker exit
 ```

--- a/jac/support/jac-lang.org/mkdocs.yml
+++ b/jac/support/jac-lang.org/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
           - "learn/impl_docs.md"
           - Data Spatial:
               - "learn/data_spatial/examples.md"
+              - "learn/data_spatial/sequence.md"
               - "learn/data_spatial/FAQ.md"
           - Jac Cloud:
               - "learn/coders/jac-cloud/docs/jac_cloud.md"


### PR DESCRIPTION
PREVIOUS BEHAVIOR:
`walker generic entry` **=>** `node entries (generic/typed)` **=>** _back to_ `walker typed entry` **=>** `walker typed exit` **=>** _back to_ `node exits (generic/typed)` => _back to_ `walker generic exit`

REFACTORED BEHAVIOR:
`walker generic entry` **=>** `walker typed entry` **=>** `node generic entry` **=>** `node typed entry` **=>** `node typed exit` **=>** `node generic exit` **=>** _back to_ `walker typed exit` **=>** `walker generic exit`

In this approach, we limit the back and forth of execution to `walker -> node -> walker`. It can also make the execution more "declarative".

It's also more direct if we plan in future to support the `with entry` and `with exit` approach