### PR TITLE
Add support for separate output resolution model

### DIFF
--- a/jac-mtllm/examples/inherit_basellm.jac
+++ b/jac-mtllm/examples/inherit_basellm.jac
@@ -1,4 +1,5 @@
 import from mtllm.llms.base { BaseLLM }
+import:py from mtllm.llms { OpenAI }
 import:py from PIL { Image }
 import torch;
 import from transformers { AutoModelForCausalLM, AutoProcessor }
@@ -85,6 +86,7 @@ obj Florence :BaseLLM: {
 }
 
 glob llm = Florence('microsoft/Florence-2-base');
+glob llm2 = OpenAI(verbose=True, model_name="gpt-4o-mini");
 
 enum DamageType {
     NoDamage,
@@ -94,7 +96,8 @@ enum DamageType {
 }
 
 can ""
-predict_vehicle_damage(img: Image) -> DamageType by llm(is_custom=True,raw_output=True);
+# predict_vehicle_damage(img: Image) -> DamageType by llm(is_custom=True,raw_output=True);
+predict_vehicle_damage(img: Image) -> DamageType by llm(is_custom=True,resolve_with =llm2);
 
 with entry {
     img = 'car_scratch.jpg';

--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -121,10 +121,15 @@ class JacFeature:
             _globals,
             _locals,
         )
-        resolver_model = model_params.pop("resolve_with") if "resolve_with" in model_params else model
+        resolver_model = (
+            model_params.pop("resolve_with")
+            if "resolve_with" in model_params
+            else model
+        )
         _output = (
-            meaning_out if raw_output else
-            resolver_model.resolve_output(
+            meaning_out
+            if raw_output
+            else resolver_model.resolve_output(
                 meaning_out, output_hint, output_type_explanations, _globals, _locals
             )
         )

--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -121,12 +121,12 @@ class JacFeature:
             _globals,
             _locals,
         )
+        resolver_model = model_params.pop("resolve_with") if "resolve_with" in model_params else model
         _output = (
-            model.resolve_output(
+            meaning_out if raw_output else
+            resolver_model.resolve_output(
                 meaning_out, output_hint, output_type_explanations, _globals, _locals
             )
-            if not raw_output
-            else meaning_out
         )
         return _output
 


### PR DESCRIPTION
### Description
Implements dual-model processing capability in MTLLM by introducing 'resolve_with' parameter.
This allows output resolution to be handled by a different LLM than the one performing
the primary inference.

Example usage:
```
predict_vehicle_damage(img: Image) -> DamageType by llm(
    is_custom=True,
    resolve_with=llm2
);
```
