### PR TITLE
[Lark-PR-1] lark tokens are grouped

### DIFF
--- a/jac/jaclang/compiler/jac.lark
+++ b/jac/jaclang/compiler/jac.lark
@@ -1,4 +1,4 @@
-// Base Module structure
+// [Heading]: Base Module structure.
 start: module
 
 module: (doc_tag? element (element_with_doc | element)*)?
@@ -15,7 +15,7 @@ element: import_stmt
        | py_code_block
        | test
 
-// Import/Include Statements
+// [Heading]: Import/Include Statements.
 import_stmt: KW_IMPORT sub_name? KW_FROM from_path LBRACE import_items RBRACE
            | KW_IMPORT sub_name? KW_FROM from_path COMMA import_items SEMI  //Deprecated
            | KW_IMPORT sub_name? import_path (COMMA import_path)* SEMI
@@ -30,7 +30,7 @@ import_item: named_ref (KW_AS NAME)?
 sub_name: COLON NAME
 include_stmt: KW_INCLUDE sub_name? import_path SEMI
 
-// Architypes
+// [Heading]: Architypes.
 architype: decorators? architype_decl
          | architype_def
          | enum
@@ -49,7 +49,7 @@ arch_type: KW_WALKER
           | KW_NODE
           | KW_CLASS
 
-// Architype bodies
+// [Heading]: Architype bodies.
 member_block: LBRACE member_stmt* RBRACE
 member_stmt: doc_tag? (py_code_block | abstract_ability | ability | architype | has_stmt | free_code)
 has_stmt: KW_STATIC? (KW_LET | KW_HAS) access_tag? has_assign_list SEMI
@@ -57,7 +57,7 @@ has_assign_list: (has_assign_list COMMA)? typed_has_clause
 typed_has_clause: named_ref (COLON STRING)? type_tag (EQ expression | KW_BY KW_POST_INIT)?
 type_tag: COLON expression
 
-// Enumerations
+// [Heading]: Enumerations.
 enum: decorators? enum_decl
      | enum_def
 
@@ -72,7 +72,7 @@ enum_stmt: NAME (COLON STRING)? EQ expression
          | abstract_ability
          | ability
 
-// Abilities
+// [Heading]: Abilities.
 ability: decorators? KW_ASYNC? ability_decl
         | decorators? genai_ability
         | ability_def
@@ -86,20 +86,20 @@ func_decl: (LPAREN func_decl_params? RPAREN)? (RETURN_HINT (STRING COLON)? expre
 func_decl_params: (param_var COMMA)* param_var COMMA?
 param_var: (STAR_POW | STAR_MUL)? NAME (COLON STRING)? type_tag (EQ expression)?
 
-// Global variables
+// [Heading]: Global variables.
 global_var: (KW_LET | KW_GLOBAL) access_tag? assignment_list SEMI
 assignment_list: (assignment_list COMMA)? assignment
 
-// Free code
+// [Heading]: Free code.
 free_code: KW_WITH KW_ENTRY sub_name? code_block
 
-// Inline python
+// [Heading]: Inline python.
 py_code_block: PYNLINE
 
-// Tests
+// [Heading]: Tests.
 test: KW_TEST NAME? code_block
 
-// Implementations
+// [Heading]: Implementations.
 arch_or_ability_chain: arch_or_ability_chain? (ability_ref | arch_ref)
 abil_to_arch_chain: arch_or_ability_chain? arch_ref
 arch_to_abil_chain: arch_or_ability_chain? ability_ref
@@ -119,7 +119,7 @@ object_ref: OBJECT_OP named_ref
 enum_ref: ENUM_OP named_ref
 ability_ref: ABILITY_OP named_ref
 
-// Codeblocks and Statements
+// [Heading]: Codeblocks and Statements.
 code_block: LBRACE statement* RBRACE
 
 statement: import_stmt
@@ -149,29 +149,29 @@ statement: import_stmt
        | SEMI
 
 
-// If statements
+// [Heading]: If statements.
 if_stmt: KW_IF expression code_block (elif_stmt | else_stmt)?
 elif_stmt: KW_ELIF expression code_block (elif_stmt | else_stmt)?
 else_stmt: KW_ELSE code_block
 
-// While statements
+// [Heading]: While statements.
 while_stmt: KW_WHILE expression code_block
 
-// For statements
+// [Heading]: For statements.
 for_stmt: KW_ASYNC? KW_FOR assignment KW_TO expression KW_BY assignment code_block else_stmt?
        | KW_ASYNC? KW_FOR atomic_chain KW_IN expression code_block else_stmt?
 
-// Try statements
+// [Heading]: Try statements.
 try_stmt: KW_TRY code_block except_list? else_stmt? finally_stmt?
 except_list: except_def+
 except_def: KW_EXCEPT expression (KW_AS NAME)? code_block
 finally_stmt: KW_FINALLY code_block
 
-// Match statements
+// [Heading]: Match statements.
 match_stmt: KW_MATCH expression LBRACE match_case_block+ RBRACE
 match_case_block: KW_CASE pattern_seq (KW_IF expression)? COLON statement+
 
-// Match patterns
+// [Heading]: Match patterns.
 pattern_seq: (or_pattern | as_pattern)
 or_pattern: (pattern BW_OR)* pattern
 as_pattern: or_pattern KW_AS NAME
@@ -184,87 +184,87 @@ pattern: literal_pattern
     | class_pattern
 
 
-// Match litteral patterns
+// [Heading]: Match litteral patterns.
 literal_pattern: (INT | FLOAT | multistring)
 
-// Match singleton patterns
+// [Heading]: Match singleton patterns.
 singleton_pattern: (NULL | BOOL)
 
-// Match capture patterns
+// [Heading]: Match capture patterns.
 capture_pattern: NAME
 
-// Match sequence patterns
+// [Heading]: Match sequence patterns.
 sequence_pattern: LSQUARE list_inner_pattern (COMMA list_inner_pattern)* RSQUARE
                 | LPAREN list_inner_pattern (COMMA list_inner_pattern)* RPAREN
 
-// Match mapping patterns
+// [Heading]: Match mapping patterns.
 mapping_pattern: LBRACE (dict_inner_pattern (COMMA dict_inner_pattern)*)? RBRACE
 list_inner_pattern: (pattern_seq | STAR_MUL NAME)
 dict_inner_pattern: (literal_pattern COLON pattern_seq | STAR_POW NAME)
 
-// Match class patterns
+// [Heading]: Match class patterns.
 class_pattern: NAME (DOT NAME)* LPAREN kw_pattern_list? RPAREN
              | NAME (DOT NAME)* LPAREN pattern_list (COMMA kw_pattern_list)? RPAREN
 
 pattern_list: (pattern_list COMMA)? pattern_seq
 kw_pattern_list: (kw_pattern_list COMMA)? named_ref EQ pattern_seq
 
-// Context managers
+// [Heading]: Context managers.
 with_stmt: KW_ASYNC? KW_WITH expr_as_list code_block
 expr_as_list: (expr_as COMMA)* expr_as
 expr_as: expression (KW_AS expression)?
 
-// Global and nonlocal statements
+// [Heading]: Global and nonlocal statements.
 global_ref: GLOBAL_OP name_list
 nonlocal_ref: NONLOCAL_OP name_list
 name_list: (named_ref COMMA)* named_ref
 
-// Data spatial typed context blocks
+// [Heading]: Data spatial typed context blocks.
 typed_ctx_block: RETURN_HINT expression code_block
 
-// Return statements
+// [Heading]: Return statements.
 return_stmt: KW_RETURN expression?
 
-// Yield statements
+// [Heading]: Yield statements.
 yield_expr: KW_YIELD KW_FROM? expression
 
-// Raise statements
+// [Heading]: Raise statements.
 raise_stmt: KW_RAISE (expression (KW_FROM expression)?)?
 
-// Assert statements
+// [Heading]: Assert statements.
 assert_stmt: KW_ASSERT expression (COMMA expression)?
 
-// Check statements
+// [Heading]: Check statements.
 check_stmt: KW_CHECK expression
 
-// Delete statements
+// [Heading]: Delete statements.
 delete_stmt: KW_DELETE expression
 
-// Report statements
+// [Heading]: Report statements.
 report_stmt: KW_REPORT expression
 
-// Control statements
+// [Heading]: Control statements.
 ctrl_stmt: KW_SKIP | KW_BREAK | KW_CONTINUE
 
-// Data spatial Walker statements
+// [Heading]: Data spatial Walker statements.
 walker_stmt: visit_stmt
        | revisit_stmt
        | disengage_stmt
        | ignore_stmt
 
-// Visit statements
+// [Heading]: Visit statements.
 visit_stmt: KW_VISIT (inherited_archs)? expression (else_stmt | SEMI)
 
-// Revisit statements
+// [Heading]: Revisit statements.
 revisit_stmt: KW_REVISIT expression? (else_stmt | SEMI)
 
-// Disengage statements
+// [Heading]: Disengage statements.
 disengage_stmt: KW_DISENGAGE SEMI
 
-// Ignore statements
+// [Heading]: Ignore statements.
 ignore_stmt: KW_IGNORE expression SEMI
 
-// Assignments
+// [Heading]: Assignments.
 assignment: KW_LET? (atomic_chain EQ)+ (yield_expr | expression)
           | atomic_chain (COLON STRING)? type_tag (EQ (yield_expr | expression))?
           | atomic_chain aug_op (yield_expr | expression)
@@ -284,29 +284,29 @@ aug_op: RSHIFT_EQ
        | MATMUL_EQ
        | STAR_POW_EQ
 
-// Expressions
+// [Heading]: Expressions.
 expression: walrus_assign (KW_IF expression KW_ELSE expression)?
           | lambda_expr
 
-// Walrus assignments
+// [Heading]: Walrus assignments.
 walrus_assign: (named_ref WALRUS_EQ)? pipe
 
-// Lambda expressions
+// [Heading]: Lambda expressions.
 lambda_expr: KW_WITH func_decl_params? (RETURN_HINT expression)? KW_CAN expression
 
-// Pipe expressions
+// [Heading]: Pipe expressions.
 pipe: (pipe PIPE_FWD)? pipe_back
 
-// Pipe back expressions
+// [Heading]: Pipe back expressions.
 pipe_back: (pipe_back PIPE_BKWD)? bitwise_or
 
-// Bitwise expressions
+// [Heading]: Bitwise expressions.
 bitwise_or: (bitwise_or BW_OR)? bitwise_xor
 bitwise_xor: (bitwise_xor BW_XOR)? bitwise_and
 bitwise_and: (bitwise_and BW_AND)? shift
 shift: (shift (RSHIFT | LSHIFT))? logical_or
 
-// Logical and compare expressions
+// [Heading]: Logical and compare expressions.
 logical_or: logical_and (KW_OR logical_and)*
 logical_and: logical_not (KW_AND logical_not)*
 logical_not: NOT logical_not | compare
@@ -323,34 +323,34 @@ cmp_op: KW_ISN
       | LT
       | EE
 
-// Arithmetic expressions
+// [Heading]: Arithmetic expressions.
 arithmetic: (arithmetic (MINUS | PLUS))? term
 term: (term (MOD | DIV | FLOOR_DIV | STAR_MUL | DECOR_OP))? power
 power: (power STAR_POW)? factor
 factor: (BW_NOT | MINUS | PLUS) factor | connect
 
-// Connect expressions
+// [Heading]: Connect expressions.
 connect: (connect (connect_op | disconnect_op))? atomic_pipe
 
-// Atomic expressions
+// [Heading]: Atomic expressions.
 atomic_pipe: (atomic_pipe A_PIPE_FWD)? atomic_pipe_back
 
-// Atomic pipe back expressions
+// [Heading]: Atomic pipe back expressions.
 atomic_pipe_back: (atomic_pipe_back A_PIPE_BKWD)? ds_spawn
 
-// Data spatial spawn expressions
+// [Heading]: Data spatial spawn expressions.
 ds_spawn: (ds_spawn KW_SPAWN)? unpack
 
-// Unpack expressions
+// [Heading]: Unpack expressions.
 unpack: STAR_MUL? ref
 
-// References (unused)
+// [Heading]: References (unused).
 ref: BW_AND? pipe_call
 
-// Data spatial calls
+// [Heading]: Data spatial calls.
 pipe_call: (PIPE_FWD | A_PIPE_FWD | KW_SPAWN | KW_AWAIT)? atomic_chain
 
-// Subscripted and dotted expressions
+// [Heading]: Subscripted and dotted expressions.
 atomic_chain: atomic_chain NULL_OK? (filter_compr | assign_compr | index_slice)
             | atomic_chain NULL_OK? (DOT_BKWD | DOT_FWD | DOT) named_ref
             | (atomic_call | atom | edge_ref_chain)
@@ -361,14 +361,14 @@ index_slice: LSQUARE                                                            
               RSQUARE
            | list_val
 
-// Function calls
+// [Heading]: Function calls.
 atomic_call: atomic_chain LPAREN param_list? (KW_BY atomic_call)? RPAREN
 
 param_list: expr_list COMMA kw_expr_list COMMA?
           | kw_expr_list COMMA?
           | expr_list COMMA?
 
-// Atom
+// [Heading]: Atom.
 atom: named_ref
     | LPAREN (expression | yield_expr) RPAREN
     | atom_collection
@@ -396,7 +396,7 @@ fstring: FSTR_START fstr_parts FSTR_END
 fstr_parts: (FSTR_PIECE | FSTR_BESC | LBRACE expression RBRACE )*
 fstr_sq_parts: (FSTR_SQ_PIECE | FSTR_BESC | LBRACE expression RBRACE )*
 
-// Collection values
+// [Heading]: Collection values.
 atom_collection: dict_compr
                | set_compr
                | gen_compr
@@ -420,7 +420,7 @@ set_val: LBRACE expr_list COMMA? RBRACE
 kv_pair: expression COLON expression | STAR_POW expression
 expr_list: (expr_list COMMA)? expression
 
-// Tuples and Jac Tuples
+// [Heading]: Tuples and Jac Tuples.
 tuple_list: expression COMMA expr_list COMMA kw_expr_list COMMA?
           | expression COMMA kw_expr_list COMMA?
           | expression COMMA expr_list COMMA?
@@ -430,7 +430,7 @@ tuple_list: expression COMMA expr_list COMMA kw_expr_list COMMA?
 kw_expr_list: (kw_expr_list COMMA)? kw_expr
 kw_expr: named_ref EQ expression | STAR_POW expression
 
-// Data Spatial References
+// [Heading]: Data Spatial References.
 edge_ref_chain: (EDGE_OP|NODE_OP)? LSQUARE expression? (edge_op_ref (filter_compr | expression)?)+ RSQUARE
 edge_op_ref: edge_any | edge_from | edge_to
 edge_to: ARROW_R | ARROW_R_P1 typed_filter_compare_list ARROW_R_P2
@@ -442,7 +442,7 @@ connect_to: CARROW_R | CARROW_R_P1 expression (COLON kw_expr_list)? CARROW_R_P2
 connect_from: CARROW_L | CARROW_L_P1 expression (COLON kw_expr_list)? CARROW_L_P2
 connect_any: CARROW_BI | CARROW_L_P1 expression (COLON kw_expr_list)? CARROW_R_P2
 
-// Special Comprehensions
+// [Heading]: Special Comprehensions.
 filter_compr: LPAREN NULL_OK filter_compare_list RPAREN
             | LPAREN TYPE_OP NULL_OK typed_filter_compare_list RPAREN
 assign_compr: LPAREN EQ kw_expr_list RPAREN
@@ -450,7 +450,7 @@ filter_compare_list: (filter_compare_list COMMA)? filter_compare_item
 typed_filter_compare_list: expression (COLON filter_compare_list)?
 filter_compare_item: named_ref cmp_op expression
 
-// Names and references
+// [Heading]: Names and references.
 named_ref: special_ref
          | KWESC_NAME
          | NAME
@@ -462,7 +462,7 @@ special_ref: KW_INIT
             | KW_SELF
             | KW_HERE
 
-// Builtin types
+// [Heading]: Builtin types.
 builtin_type: TYP_TYPE
             | TYP_ANY
             | TYP_BOOL
@@ -475,7 +475,49 @@ builtin_type: TYP_TYPE
             | TYP_BYTES
             | TYP_STRING
 
-// Lexer Tokens
+// ************************************************************************* //
+// Terminals                                                                 //
+// ************************************************************************* //
+
+PYNLINE: /::py::(.|\n|\r)*?::py::/
+GLOBAL_OP: /:g:|:global:/
+NONLOCAL_OP: /:nl:|:nonlocal:/
+WALKER_OP: /:w:|:walker:/
+NODE_OP: /:n:|:node:/
+EDGE_OP: /:e:|:edge:/
+CLASS_OP: /:cls:|:class:/
+OBJECT_OP: /:o:|:obj:/
+TYPE_OP: /`|:t:|:type:/
+ENUM_OP: /:enum:/
+ABILITY_OP: /:c:|:can:/
+
+// [Heading]: f-string tokens.
+FSTR_START.1: "f\""
+FSTR_END: "\""
+FSTR_SQ_START.1: "f'"
+FSTR_SQ_END: "'"
+FSTR_PIECE.-1: /[^\{\}\"]+/
+FSTR_SQ_PIECE.-1: /[^\{\}\']+/
+FSTR_BESC.1: /{{|}}/
+
+RETURN_HINT: "->"
+NULL_OK: "?"
+COLON: ":"
+SEMI: ";"
+ELLIPSIS: "..."
+DOT: "."
+COMMA: ","
+
+LBRACE: "{"
+RBRACE: "}"
+LPAREN: "("
+RPAREN: ")"
+LSQUARE: "["
+RSQUARE: "]"
+
+// TODO:AST: These should be just NAME for tokenizer and the parser (or even higher)
+// Should treat them as type names.
+// [Heading]: Lexer Tokens.
 TYP_STRING: "str"
 TYP_INT: "int"
 TYP_FLOAT: "float"
@@ -487,6 +529,9 @@ TYP_BOOL: "bool"
 TYP_BYTES: "bytes"
 TYP_ANY: "any"
 TYP_TYPE: "type"
+
+// Keywords ---------------------------------------------------------------- //
+
 KW_LET: "let"
 KW_ABSTRACT: "abs"
 KW_CLASS: "class"
@@ -542,121 +587,118 @@ KW_STATIC: "static"
 KW_OVERRIDE: "override"
 KW_MATCH: "match"
 KW_CASE: "case"
-KW_HERE: "here"
-KW_SELF: "self"
+
 KW_INIT: "init"
 KW_POST_INIT: "postinit"
+
+KW_HERE: "here"
+KW_SELF: "self"
 KW_SUPER: "super"
 KW_ROOT: "root"
 
-FLOAT: /(\d+(\.\d*)|\.\d+)([eE][+-]?\d+)?|\d+([eE][-+]?\d+)/
-DOC_STRING.1: /"""(.|\n|\r)*?"""|'''(.|\n|\r)*?'''/
-PYNLINE: /::py::(.|\n|\r)*?::py::/
-STRING: /(r?b?|b?r?)"[^"\r\n]*"|(r?b?|b?r?)'[^'\r\n]*'/
-BOOL.1: /True|False/
 KW_NIN.1: /\bnot\s+in\b/
 KW_ISN.1: /\bis\s+not\b/
+KW_AND.1: /&&|and/
+KW_OR.1:  /\|\||or/
+NOT: "not" // TODO:AST: Rename to KW_NOT
+
+// Literals ---------------------------------------------------------------- //
+
+NULL.1: "None"
+BOOL.1: /True|False/
+STRING: /(r?b?|b?r?)"[^"\r\n]*"|(r?b?|b?r?)'[^'\r\n]*'/
+DOC_STRING.1: /"""(.|\n|\r)*?"""|'''(.|\n|\r)*?'''/
+FLOAT: /(\d+(\.\d*)|\.\d+)([eE][+-]?\d+)?|\d+([eE][-+]?\d+)/
 HEX.1: /0[xX][0-9a-fA-F_]+/
 BIN.1: /0[bB][01_]+/
 OCT.1: /0[oO][0-7_]+/
 INT: /[0-9][0-9_]*/
-NULL.1: /None/
+
+
+// Identifier -------------------------------------------------------------- //
+
 KWESC_NAME: /<>[a-zA-Z_][a-zA-Z0-9_]*/
 NAME: /[a-zA-Z_][a-zA-Z0-9_]*/
 
-ARROW_BI: /<-->/
-ARROW_L: /<--/
-ARROW_R: /-->/
-ARROW_L_P1: /<-\:/
-ARROW_R_P2: /:->/
-ARROW_L_P2: /:-/
-ARROW_R_P1: /-\:/
-CARROW_BI: /<\+\+>/
-CARROW_L: /<\+\+/
-CARROW_R: /\+\+>/
-CARROW_L_P1: /<\+\:/
-CARROW_R_P2: /:\+>/
-CARROW_L_P2: /:\+/
-CARROW_R_P1: /\+\:/
 
-GLOBAL_OP: /:g:|:global:/
-NONLOCAL_OP: /:nl:|:nonlocal:/
-WALKER_OP: /:w:|:walker:/
-NODE_OP: /:n:|:node:/
-EDGE_OP: /:e:|:edge:/
-CLASS_OP: /:cls:|:class:/
-OBJECT_OP: /:o:|:obj:/
-TYPE_OP: /`|:t:|:type:/
-ENUM_OP: /:enum:/
-ABILITY_OP: /:c:|:can:/
-A_PIPE_FWD: /:>/
-A_PIPE_BKWD: /<:/
-PIPE_FWD: /\|>/
-PIPE_BKWD: /<\|/
-DOT_FWD: /\.>/
-DOT_BKWD: /<\./
-RETURN_HINT: /->/
-NULL_OK: /\?/
-MATMUL_EQ: /@=/
-DECOR_OP: /@/
+// Data Spatial Operators -------------------------------------------------- //
 
-KW_AND.1: /&&|and/
-KW_OR.1:  /\|\||or/
-ADD_EQ: /\+=/
-SUB_EQ: /-=/
-STAR_POW_EQ: /\*\*\=/
-MUL_EQ: /\*=/
-FLOOR_DIV_EQ: /\/\/=/
-DIV_EQ: /\/=/
-MOD_EQ: /%=/
-BW_AND_EQ: /&=/
-BW_OR_EQ: /\|=/
-BW_XOR_EQ: /\^=/
-BW_NOT_EQ: /~=/
-LSHIFT_EQ: /<<=/
-RSHIFT_EQ: />>=/
-LSHIFT: /<</
-RSHIFT: />>/
-LTE: /<=/
-GTE: />=/
-NE: /!=/
-NOT: "not"
-WALRUS_EQ: /:=/
-COLON: /:/
-LBRACE: /{/
-RBRACE: /}/
-SEMI: /;/
-EE: /==/
-EQ: /=/
-ELLIPSIS: /\.\.\./
-DOT: /\./
-LT: /</
-GT: />/
-COMMA: /,/
-PLUS: /\+/
-MINUS: /-/
-STAR_POW: /\*\*/
-STAR_MUL: /\*/
-FLOOR_DIV: /\/\//
-DIV: /\//
-MOD: /%/
-BW_AND: /&/
-BW_OR: /\|/
-BW_XOR: /\^/
-BW_NOT: /~/
-LPAREN: /\(/
-RPAREN: /\)/
-LSQUARE: /\[/
-RSQUARE: /\]/
+ARROW_BI: "<-->"
+ARROW_L: "<--"
+ARROW_R: "-->"
+ARROW_L_P1: "<-:"
+ARROW_R_P2: ":->"
+ARROW_L_P2: ":-"
+ARROW_R_P1: "-:"
+CARROW_BI: "<++>"
+CARROW_L: "<++"
+CARROW_R: "++>"
+CARROW_L_P1: "<+:"
+CARROW_R_P2: ":+>"
+CARROW_L_P2: ":+"
+CARROW_R_P1: "+:"
 
-// f-string tokens
-FSTR_START.1: "f\""
-FSTR_END: "\""
-FSTR_SQ_START.1: "f'"
-FSTR_SQ_END: "'"
-FSTR_PIECE.-1: /[^\{\}\"]+/
-FSTR_SQ_PIECE.-1: /[^\{\}\']+/
-FSTR_BESC.1: /{{|}}/
+
+// Assignment Operator ----------------------------------------------------- //
+
+EQ: "="
+WALRUS_EQ: ":="
+
+ADD_EQ: "+="
+SUB_EQ: "-="
+MUL_EQ: "*="
+DIV_EQ: "/="
+MOD_EQ: "%="
+MATMUL_EQ: "@="
+STAR_POW_EQ: "**="
+FLOOR_DIV_EQ: "//="
+
+BW_AND_EQ: "&="
+BW_OR_EQ: "|="
+BW_XOR_EQ: "^="
+BW_NOT_EQ: "~="
+LSHIFT_EQ: "<<="
+RSHIFT_EQ: ">>="
+
+
+// Arithmatic -------------------------------------------------------------- //
+
+EE: "=="
+LT: "<"
+GT: ">"
+LTE: "<="
+GTE: ">="
+NE: "!="
+
+PLUS: "+"
+MINUS: "-"
+STAR_MUL: "*"
+DIV: "/"
+MOD: "%"
+STAR_POW: "**"
+FLOOR_DIV: "//"
+DECOR_OP: "@"
+
+BW_AND: "&"
+BW_OR: "|"
+BW_XOR: "^"
+BW_NOT: "~"
+LSHIFT: "<<"
+RSHIFT: ">>"
+
+// Other Operator ---------------------------------------------------------- //
+
+A_PIPE_FWD: ":>"
+A_PIPE_BKWD: "<:"
+PIPE_FWD: "|>"
+PIPE_BKWD: "<|"
+DOT_FWD: ".>"
+DOT_BKWD: "<."
+
+
+// ************************************************************************* //
+// Comments and Whitespace                                                   //
+// ************************************************************************* //
 
 COMMENT: /#\*(.|\n|\r)*?\*#|#.*/
 WS.-2: /[ \t\f\r\n]/+

--- a/jac/jaclang/utils/helpers.py
+++ b/jac/jaclang/utils/helpers.py
@@ -73,13 +73,14 @@ def extract_headings(file_path: str) -> dict[str, tuple[int, int]]:
     current_heading = None
     start_line = 0
     for idx, line in enumerate(lines, start=1):
-        if line.strip().startswith("//"):
+        line = line.strip().removesuffix(".")
+        if line.startswith("// [Heading]:"):
             if current_heading is not None:
                 headings[current_heading] = (
                     start_line,
                     idx - 2,
                 )  # Subtract 1 to get the correct end line
-            current_heading = line.strip()[2:]
+            current_heading = line.removeprefix("// [Heading]:")
             start_line = idx + 1
     # Add the last heading
     if current_heading is not None:

--- a/jac/support/jac-lang.org/docs/lang_ref/jac_ref.md
+++ b/jac/support/jac-lang.org/docs/lang_ref/jac_ref.md
@@ -1166,29 +1166,11 @@
     ```
 ??? example "Jac Grammar Snippet"
     ```yaml linenums="466"
-    --8<-- "jaclang/compiler/jac.lark:466:476"
+    --8<-- "jaclang/compiler/jac.lark:466:492"
     ```
 **Description**
 
 --8<-- "examples/reference/builtin_types.md"
-
-## Lexer Tokens
-**Code Example**
-=== "Jac"
-    ```jac linenums="1"
-    --8<-- "examples/reference/lexer_tokens.jac"
-    ```
-=== "Python"
-    ```python linenums="1"
-    --8<-- "examples/reference/lexer_tokens.py"
-    ```
-??? example "Jac Grammar Snippet"
-    ```yaml linenums="479"
-    --8<-- "jaclang/compiler/jac.lark:479:650"
-    ```
-**Description**
-
---8<-- "examples/reference/lexer_tokens.md"
 
 ## f-string tokens
 **Code Example**
@@ -1201,10 +1183,28 @@
     --8<-- "examples/reference/f_string_tokens.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="653"
-    --8<-- "jaclang/compiler/jac.lark:653:664"
+    ```yaml linenums="495"
+    --8<-- "jaclang/compiler/jac.lark:495:518"
     ```
 **Description**
 
 --8<-- "examples/reference/f_string_tokens.md"
+
+## Lexer Tokens
+**Code Example**
+=== "Jac"
+    ```jac linenums="1"
+    --8<-- "examples/reference/lexer_tokens.jac"
+    ```
+=== "Python"
+    ```python linenums="1"
+    --8<-- "examples/reference/lexer_tokens.py"
+    ```
+??? example "Jac Grammar Snippet"
+    ```yaml linenums="521"
+    --8<-- "jaclang/compiler/jac.lark:521:706"
+    ```
+**Description**
+
+--8<-- "examples/reference/lexer_tokens.md"
 


### PR DESCRIPTION
## **Description**

* Lark reference heading line should starts with `// [Heading]:`. Now we can write our own comments without messing with the reference generator.

* Terminals / Tokens are the lego blocks of a language (ast) so I've grouped them together in a meaningful way.