### PR TITLE
[Lark-PR-2] Module rule simplified

### DIFF
--- a/jac/jaclang/compiler/constant.py
+++ b/jac/jaclang/compiler/constant.py
@@ -152,7 +152,6 @@ class Tokens(str, Enum):
 
     FLOAT = "FLOAT"
     STRING = "STRING"
-    DOC_STRING = "DOC_STRING"
     PYNLINE = "PYNLINE"
     BOOL = "BOOL"
     INT = "INT"
@@ -355,7 +354,7 @@ colors = [
     "#F0FFF0",
     "#F5E5FF",
     "#FFFFE0",
-    "#D2FEFF ",
+    "#D2FEFF",
     "#E8FFD7",
     "#FFDEAD",
     "#FFF0F5",

--- a/jac/jaclang/compiler/jac.lark
+++ b/jac/jaclang/compiler/jac.lark
@@ -1,13 +1,21 @@
 // [Heading]: Base Module structure.
 start: module
 
-module: (doc_tag? element (element_with_doc | element)*)?
-      | doc_tag (element_with_doc (element_with_doc | element)*)?
+// TODO:AST: We should allow the very first top level statement to have
+// docstring but not the module to have one. After allowing that
+// the rule for the module would be:
+//
+// module: STRING? toplevel_stmt*
+//
+module: (toplevel_stmt (tl_stmt_with_doc | toplevel_stmt)*)?
+       | STRING        (tl_stmt_with_doc | toplevel_stmt)*
 
-doc_tag: STRING | DOC_STRING
-element_with_doc: doc_tag element
-
-element: import_stmt
+// AST:TODO: Docstring should be part of the definition of the statement
+// and not all toplevel statement have docstring, example: ImportStmt.
+//
+// Statements that are only valid at the toplevel.
+tl_stmt_with_doc: STRING toplevel_stmt
+toplevel_stmt: import_stmt
        | architype
        | ability
        | global_var
@@ -51,7 +59,7 @@ arch_type: KW_WALKER
 
 // [Heading]: Architype bodies.
 member_block: LBRACE member_stmt* RBRACE
-member_stmt: doc_tag? (py_code_block | abstract_ability | ability | architype | has_stmt | free_code)
+member_stmt: STRING? (py_code_block | abstract_ability | ability | architype | has_stmt | free_code)
 has_stmt: KW_STATIC? (KW_LET | KW_HAS) access_tag? has_assign_list SEMI
 has_assign_list: (has_assign_list COMMA)? typed_has_clause
 typed_has_clause: named_ref (COLON STRING)? type_tag (EQ expression | KW_BY KW_POST_INIT)?
@@ -388,7 +396,7 @@ atom_literal: builtin_type
 
 type_ref: TYPE_OP (named_ref | builtin_type)
 
-multistring: (fstring | STRING | DOC_STRING)+
+multistring: (fstring | STRING)+
 
 fstring: FSTR_START fstr_parts FSTR_END
        | FSTR_SQ_START fstr_sq_parts FSTR_SQ_END
@@ -604,10 +612,11 @@ NOT: "not" // TODO:AST: Rename to KW_NOT
 
 // Literals ---------------------------------------------------------------- //
 
+STRING: /(r?b?|b?r?)("[^"\r\n]*"|'[^'\r\n]*')/
+       | /(r?b?|b?r?)("""(.|\r|\n)*?"""|'''(.|\r|\n)*?''')/
+
 NULL.1: "None"
 BOOL.1: /True|False/
-STRING: /(r?b?|b?r?)"[^"\r\n]*"|(r?b?|b?r?)'[^'\r\n]*'/
-DOC_STRING.1: /"""(.|\n|\r)*?"""|'''(.|\n|\r)*?'''/
 FLOAT: /(\d+(\.\d*)|\.\d+)([eE][+-]?\d+)?|\d+([eE][-+]?\d+)/
 HEX.1: /0[xX][0-9a-fA-F_]+/
 BIN.1: /0[bB][01_]+/

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -252,8 +252,8 @@ class JacParser(Pass):
         def module(self, _: None) -> ast.Module:
             """Grammar rule.
 
-            module: (doc_tag? element (element_with_doc | element)*)?
-            doc_tag (element_with_doc (element_with_doc | element)*)?
+            module: (toplevel_stmt (tl_stmt_with_doc | toplevel_stmt)*)?
+                | STRING (tl_stmt_with_doc | toplevel_stmt)*
             """
             doc = self.match(ast.String)
             body = self.match_many(ast.ElementStmt)
@@ -271,10 +271,10 @@ class JacParser(Pass):
             )
             return mod
 
-        def element_with_doc(self, _: None) -> ast.ElementStmt:
+        def tl_stmt_with_doc(self, _: None) -> ast.ElementStmt:
             """Grammar rule.
 
-            element_with_doc: doc_tag element
+            tl_stmt_with_doc: doc_tag toplevel_stmt
             """
             doc = self.consume(ast.String)
             element = self.consume(ast.ElementStmt)
@@ -282,7 +282,7 @@ class JacParser(Pass):
             element.add_kids_left([doc])
             return element
 
-        def element(self, _: None) -> ast.ElementStmt:
+        def toplevel_stmt(self, _: None) -> ast.ElementStmt:
             """Grammar rule.
 
             element: py_code_block
@@ -348,13 +348,6 @@ class JacParser(Pass):
                 body=codeblock,
                 kid=self.cur_nodes,
             )
-
-        def doc_tag(self, _: None) -> ast.String:
-            """Grammar rule.
-
-            doc_tag: ( STRING | DOC_STRING )
-            """
-            return self.consume(ast.String)
 
         def py_code_block(self, _: None) -> ast.PyInlineCode:
             """Grammar rule.
@@ -2304,7 +2297,7 @@ class JacParser(Pass):
         def multistring(self, kid: list[ast.AstNode]) -> ast.AtomExpr:
             """Grammar rule.
 
-            multistring: (fstring | STRING | DOC_STRING)+
+            multistring: (fstring | STRING)+
             """
             valid_strs = [i for i in kid if isinstance(i, (ast.String, ast.FString))]
             if len(valid_strs) == len(kid):
@@ -3593,7 +3586,6 @@ class JacParser(Pass):
                 Tok.FSTR_BESC,
                 Tok.FSTR_PIECE,
                 Tok.FSTR_SQ_PIECE,
-                Tok.DOC_STRING,
             ]:
                 ret_type = ast.String
                 if token.type == Tok.FSTR_BESC:

--- a/jac/support/jac-lang.org/docs/lang_ref/jac_ref.md
+++ b/jac/support/jac-lang.org/docs/lang_ref/jac_ref.md
@@ -14,7 +14,7 @@
     ```
 ??? example "Jac Grammar Snippet"
     ```yaml linenums="2"
-    --8<-- "jaclang/compiler/jac.lark:2:16"
+    --8<-- "jaclang/compiler/jac.lark:2:24"
     ```
 **Description**
 
@@ -31,8 +31,8 @@
     --8<-- "examples/reference/import_include_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="19"
-    --8<-- "jaclang/compiler/jac.lark:19:31"
+    ```yaml linenums="27"
+    --8<-- "jaclang/compiler/jac.lark:27:39"
     ```
 **Description**
 
@@ -49,8 +49,8 @@
     --8<-- "examples/reference/architypes.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="34"
-    --8<-- "jaclang/compiler/jac.lark:34:50"
+    ```yaml linenums="42"
+    --8<-- "jaclang/compiler/jac.lark:42:58"
     ```
 **Description**
 
@@ -67,8 +67,8 @@
     --8<-- "examples/reference/architype_bodies.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="53"
-    --8<-- "jaclang/compiler/jac.lark:53:58"
+    ```yaml linenums="61"
+    --8<-- "jaclang/compiler/jac.lark:61:66"
     ```
 **Description**
 
@@ -85,8 +85,8 @@
     --8<-- "examples/reference/enumerations.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="61"
-    --8<-- "jaclang/compiler/jac.lark:61:73"
+    ```yaml linenums="69"
+    --8<-- "jaclang/compiler/jac.lark:69:81"
     ```
 **Description**
 
@@ -103,8 +103,8 @@
     --8<-- "examples/reference/abilities.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="76"
-    --8<-- "jaclang/compiler/jac.lark:76:87"
+    ```yaml linenums="84"
+    --8<-- "jaclang/compiler/jac.lark:84:95"
     ```
 **Description**
 
@@ -121,8 +121,8 @@
     --8<-- "examples/reference/global_variables.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="90"
-    --8<-- "jaclang/compiler/jac.lark:90:91"
+    ```yaml linenums="98"
+    --8<-- "jaclang/compiler/jac.lark:98:99"
     ```
 **Description**
 
@@ -139,8 +139,8 @@
     --8<-- "examples/reference/free_code.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="94"
-    --8<-- "jaclang/compiler/jac.lark:94:94"
+    ```yaml linenums="102"
+    --8<-- "jaclang/compiler/jac.lark:102:102"
     ```
 **Description**
 
@@ -157,8 +157,8 @@
     --8<-- "examples/reference/inline_python.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="97"
-    --8<-- "jaclang/compiler/jac.lark:97:97"
+    ```yaml linenums="105"
+    --8<-- "jaclang/compiler/jac.lark:105:105"
     ```
 **Description**
 
@@ -175,8 +175,8 @@
     --8<-- "examples/reference/tests.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="100"
-    --8<-- "jaclang/compiler/jac.lark:100:100"
+    ```yaml linenums="108"
+    --8<-- "jaclang/compiler/jac.lark:108:108"
     ```
 **Description**
 
@@ -193,8 +193,8 @@
     --8<-- "examples/reference/implementations.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="103"
-    --8<-- "jaclang/compiler/jac.lark:103:120"
+    ```yaml linenums="111"
+    --8<-- "jaclang/compiler/jac.lark:111:128"
     ```
 **Description**
 
@@ -211,8 +211,8 @@
     --8<-- "examples/reference/codeblocks_and_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="123"
-    --8<-- "jaclang/compiler/jac.lark:123:150"
+    ```yaml linenums="131"
+    --8<-- "jaclang/compiler/jac.lark:131:158"
     ```
 **Description**
 
@@ -229,8 +229,8 @@
     --8<-- "examples/reference/if_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="153"
-    --8<-- "jaclang/compiler/jac.lark:153:155"
+    ```yaml linenums="161"
+    --8<-- "jaclang/compiler/jac.lark:161:163"
     ```
 **Description**
 
@@ -247,8 +247,8 @@
     --8<-- "examples/reference/while_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="158"
-    --8<-- "jaclang/compiler/jac.lark:158:158"
+    ```yaml linenums="166"
+    --8<-- "jaclang/compiler/jac.lark:166:166"
     ```
 **Description**
 
@@ -265,8 +265,8 @@
     --8<-- "examples/reference/for_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="161"
-    --8<-- "jaclang/compiler/jac.lark:161:162"
+    ```yaml linenums="169"
+    --8<-- "jaclang/compiler/jac.lark:169:170"
     ```
 **Description**
 
@@ -283,8 +283,8 @@
     --8<-- "examples/reference/try_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="165"
-    --8<-- "jaclang/compiler/jac.lark:165:168"
+    ```yaml linenums="173"
+    --8<-- "jaclang/compiler/jac.lark:173:176"
     ```
 **Description**
 
@@ -301,8 +301,8 @@
     --8<-- "examples/reference/match_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="171"
-    --8<-- "jaclang/compiler/jac.lark:171:172"
+    ```yaml linenums="179"
+    --8<-- "jaclang/compiler/jac.lark:179:180"
     ```
 **Description**
 
@@ -319,8 +319,8 @@
     --8<-- "examples/reference/match_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="175"
-    --8<-- "jaclang/compiler/jac.lark:175:185"
+    ```yaml linenums="183"
+    --8<-- "jaclang/compiler/jac.lark:183:193"
     ```
 **Description**
 
@@ -337,8 +337,8 @@
     --8<-- "examples/reference/match_litteral_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="188"
-    --8<-- "jaclang/compiler/jac.lark:188:188"
+    ```yaml linenums="196"
+    --8<-- "jaclang/compiler/jac.lark:196:196"
     ```
 **Description**
 
@@ -355,8 +355,8 @@
     --8<-- "examples/reference/match_singleton_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="191"
-    --8<-- "jaclang/compiler/jac.lark:191:191"
+    ```yaml linenums="199"
+    --8<-- "jaclang/compiler/jac.lark:199:199"
     ```
 **Description**
 
@@ -373,8 +373,8 @@
     --8<-- "examples/reference/match_capture_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="194"
-    --8<-- "jaclang/compiler/jac.lark:194:194"
+    ```yaml linenums="202"
+    --8<-- "jaclang/compiler/jac.lark:202:202"
     ```
 **Description**
 
@@ -391,8 +391,8 @@
     --8<-- "examples/reference/match_sequence_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="197"
-    --8<-- "jaclang/compiler/jac.lark:197:198"
+    ```yaml linenums="205"
+    --8<-- "jaclang/compiler/jac.lark:205:206"
     ```
 **Description**
 
@@ -409,8 +409,8 @@
     --8<-- "examples/reference/match_mapping_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="201"
-    --8<-- "jaclang/compiler/jac.lark:201:203"
+    ```yaml linenums="209"
+    --8<-- "jaclang/compiler/jac.lark:209:211"
     ```
 **Description**
 
@@ -427,8 +427,8 @@
     --8<-- "examples/reference/match_class_patterns.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="206"
-    --8<-- "jaclang/compiler/jac.lark:206:210"
+    ```yaml linenums="214"
+    --8<-- "jaclang/compiler/jac.lark:214:218"
     ```
 **Description**
 
@@ -445,8 +445,8 @@
     --8<-- "examples/reference/context_managers.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="213"
-    --8<-- "jaclang/compiler/jac.lark:213:215"
+    ```yaml linenums="221"
+    --8<-- "jaclang/compiler/jac.lark:221:223"
     ```
 **Description**
 
@@ -463,8 +463,8 @@
     --8<-- "examples/reference/global_and_nonlocal_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="218"
-    --8<-- "jaclang/compiler/jac.lark:218:220"
+    ```yaml linenums="226"
+    --8<-- "jaclang/compiler/jac.lark:226:228"
     ```
 **Description**
 
@@ -481,8 +481,8 @@
     --8<-- "examples/reference/data_spatial_typed_context_blocks.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="223"
-    --8<-- "jaclang/compiler/jac.lark:223:223"
+    ```yaml linenums="231"
+    --8<-- "jaclang/compiler/jac.lark:231:231"
     ```
 **Description**
 
@@ -499,8 +499,8 @@
     --8<-- "examples/reference/return_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="226"
-    --8<-- "jaclang/compiler/jac.lark:226:226"
+    ```yaml linenums="234"
+    --8<-- "jaclang/compiler/jac.lark:234:234"
     ```
 **Description**
 
@@ -517,8 +517,8 @@
     --8<-- "examples/reference/yield_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="229"
-    --8<-- "jaclang/compiler/jac.lark:229:229"
+    ```yaml linenums="237"
+    --8<-- "jaclang/compiler/jac.lark:237:237"
     ```
 **Description**
 
@@ -535,8 +535,8 @@
     --8<-- "examples/reference/raise_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="232"
-    --8<-- "jaclang/compiler/jac.lark:232:232"
+    ```yaml linenums="240"
+    --8<-- "jaclang/compiler/jac.lark:240:240"
     ```
 **Description**
 
@@ -553,8 +553,8 @@
     --8<-- "examples/reference/assert_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="235"
-    --8<-- "jaclang/compiler/jac.lark:235:235"
+    ```yaml linenums="243"
+    --8<-- "jaclang/compiler/jac.lark:243:243"
     ```
 **Description**
 
@@ -571,8 +571,8 @@
     --8<-- "examples/reference/check_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="238"
-    --8<-- "jaclang/compiler/jac.lark:238:238"
+    ```yaml linenums="246"
+    --8<-- "jaclang/compiler/jac.lark:246:246"
     ```
 **Description**
 
@@ -589,8 +589,8 @@
     --8<-- "examples/reference/delete_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="241"
-    --8<-- "jaclang/compiler/jac.lark:241:241"
+    ```yaml linenums="249"
+    --8<-- "jaclang/compiler/jac.lark:249:249"
     ```
 **Description**
 
@@ -607,8 +607,8 @@
     --8<-- "examples/reference/report_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="244"
-    --8<-- "jaclang/compiler/jac.lark:244:244"
+    ```yaml linenums="252"
+    --8<-- "jaclang/compiler/jac.lark:252:252"
     ```
 **Description**
 
@@ -625,8 +625,8 @@
     --8<-- "examples/reference/control_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="247"
-    --8<-- "jaclang/compiler/jac.lark:247:247"
+    ```yaml linenums="255"
+    --8<-- "jaclang/compiler/jac.lark:255:255"
     ```
 **Description**
 
@@ -643,8 +643,8 @@
     --8<-- "examples/reference/data_spatial_walker_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="250"
-    --8<-- "jaclang/compiler/jac.lark:250:253"
+    ```yaml linenums="258"
+    --8<-- "jaclang/compiler/jac.lark:258:261"
     ```
 **Description**
 
@@ -661,8 +661,8 @@
     --8<-- "examples/reference/visit_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="256"
-    --8<-- "jaclang/compiler/jac.lark:256:256"
+    ```yaml linenums="264"
+    --8<-- "jaclang/compiler/jac.lark:264:264"
     ```
 **Description**
 
@@ -679,8 +679,8 @@
     --8<-- "examples/reference/revisit_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="259"
-    --8<-- "jaclang/compiler/jac.lark:259:259"
+    ```yaml linenums="267"
+    --8<-- "jaclang/compiler/jac.lark:267:267"
     ```
 **Description**
 
@@ -697,8 +697,8 @@
     --8<-- "examples/reference/disengage_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="262"
-    --8<-- "jaclang/compiler/jac.lark:262:262"
+    ```yaml linenums="270"
+    --8<-- "jaclang/compiler/jac.lark:270:270"
     ```
 **Description**
 
@@ -715,8 +715,8 @@
     --8<-- "examples/reference/ignore_statements.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="265"
-    --8<-- "jaclang/compiler/jac.lark:265:265"
+    ```yaml linenums="273"
+    --8<-- "jaclang/compiler/jac.lark:273:273"
     ```
 **Description**
 
@@ -733,8 +733,8 @@
     --8<-- "examples/reference/assignments.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="268"
-    --8<-- "jaclang/compiler/jac.lark:268:285"
+    ```yaml linenums="276"
+    --8<-- "jaclang/compiler/jac.lark:276:293"
     ```
 **Description**
 
@@ -751,8 +751,8 @@
     --8<-- "examples/reference/expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="288"
-    --8<-- "jaclang/compiler/jac.lark:288:289"
+    ```yaml linenums="296"
+    --8<-- "jaclang/compiler/jac.lark:296:297"
     ```
 **Description**
 
@@ -769,8 +769,8 @@
     --8<-- "examples/reference/walrus_assignments.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="292"
-    --8<-- "jaclang/compiler/jac.lark:292:292"
+    ```yaml linenums="300"
+    --8<-- "jaclang/compiler/jac.lark:300:300"
     ```
 **Description**
 
@@ -787,8 +787,8 @@
     --8<-- "examples/reference/lambda_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="295"
-    --8<-- "jaclang/compiler/jac.lark:295:295"
+    ```yaml linenums="303"
+    --8<-- "jaclang/compiler/jac.lark:303:303"
     ```
 **Description**
 
@@ -805,8 +805,8 @@
     --8<-- "examples/reference/pipe_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="298"
-    --8<-- "jaclang/compiler/jac.lark:298:298"
+    ```yaml linenums="306"
+    --8<-- "jaclang/compiler/jac.lark:306:306"
     ```
 **Description**
 
@@ -823,8 +823,8 @@
     --8<-- "examples/reference/pipe_back_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="301"
-    --8<-- "jaclang/compiler/jac.lark:301:301"
+    ```yaml linenums="309"
+    --8<-- "jaclang/compiler/jac.lark:309:309"
     ```
 **Description**
 
@@ -841,8 +841,8 @@
     --8<-- "examples/reference/bitwise_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="304"
-    --8<-- "jaclang/compiler/jac.lark:304:307"
+    ```yaml linenums="312"
+    --8<-- "jaclang/compiler/jac.lark:312:315"
     ```
 **Description**
 
@@ -859,8 +859,8 @@
     --8<-- "examples/reference/logical_and_compare_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="310"
-    --8<-- "jaclang/compiler/jac.lark:310:324"
+    ```yaml linenums="318"
+    --8<-- "jaclang/compiler/jac.lark:318:332"
     ```
 **Description**
 
@@ -877,8 +877,8 @@
     --8<-- "examples/reference/arithmetic_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="327"
-    --8<-- "jaclang/compiler/jac.lark:327:330"
+    ```yaml linenums="335"
+    --8<-- "jaclang/compiler/jac.lark:335:338"
     ```
 **Description**
 
@@ -895,8 +895,8 @@
     --8<-- "examples/reference/connect_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="333"
-    --8<-- "jaclang/compiler/jac.lark:333:333"
+    ```yaml linenums="341"
+    --8<-- "jaclang/compiler/jac.lark:341:341"
     ```
 **Description**
 
@@ -913,8 +913,8 @@
     --8<-- "examples/reference/atomic_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="336"
-    --8<-- "jaclang/compiler/jac.lark:336:336"
+    ```yaml linenums="344"
+    --8<-- "jaclang/compiler/jac.lark:344:344"
     ```
 **Description**
 
@@ -931,8 +931,8 @@
     --8<-- "examples/reference/atomic_pipe_back_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="339"
-    --8<-- "jaclang/compiler/jac.lark:339:339"
+    ```yaml linenums="347"
+    --8<-- "jaclang/compiler/jac.lark:347:347"
     ```
 **Description**
 
@@ -949,8 +949,8 @@
     --8<-- "examples/reference/data_spatial_spawn_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="342"
-    --8<-- "jaclang/compiler/jac.lark:342:342"
+    ```yaml linenums="350"
+    --8<-- "jaclang/compiler/jac.lark:350:350"
     ```
 **Description**
 
@@ -967,8 +967,8 @@
     --8<-- "examples/reference/unpack_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="345"
-    --8<-- "jaclang/compiler/jac.lark:345:345"
+    ```yaml linenums="353"
+    --8<-- "jaclang/compiler/jac.lark:353:353"
     ```
 **Description**
 
@@ -985,8 +985,8 @@
     --8<-- "examples/reference/references_(unused).py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="348"
-    --8<-- "jaclang/compiler/jac.lark:348:348"
+    ```yaml linenums="356"
+    --8<-- "jaclang/compiler/jac.lark:356:356"
     ```
 **Description**
 
@@ -1003,8 +1003,8 @@
     --8<-- "examples/reference/data_spatial_calls.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="351"
-    --8<-- "jaclang/compiler/jac.lark:351:351"
+    ```yaml linenums="359"
+    --8<-- "jaclang/compiler/jac.lark:359:359"
     ```
 **Description**
 
@@ -1021,8 +1021,8 @@
     --8<-- "examples/reference/subscripted_and_dotted_expressions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="354"
-    --8<-- "jaclang/compiler/jac.lark:354:362"
+    ```yaml linenums="362"
+    --8<-- "jaclang/compiler/jac.lark:362:370"
     ```
 **Description**
 
@@ -1039,8 +1039,8 @@
     --8<-- "examples/reference/function_calls.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="365"
-    --8<-- "jaclang/compiler/jac.lark:365:369"
+    ```yaml linenums="373"
+    --8<-- "jaclang/compiler/jac.lark:373:377"
     ```
 **Description**
 
@@ -1057,8 +1057,8 @@
     --8<-- "examples/reference/atom.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="372"
-    --8<-- "jaclang/compiler/jac.lark:372:397"
+    ```yaml linenums="380"
+    --8<-- "jaclang/compiler/jac.lark:380:405"
     ```
 **Description**
 
@@ -1075,8 +1075,8 @@
     --8<-- "examples/reference/collection_values.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="400"
-    --8<-- "jaclang/compiler/jac.lark:400:421"
+    ```yaml linenums="408"
+    --8<-- "jaclang/compiler/jac.lark:408:429"
     ```
 **Description**
 
@@ -1093,8 +1093,8 @@
     --8<-- "examples/reference/tuples_and_jac_tuples.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="424"
-    --8<-- "jaclang/compiler/jac.lark:424:431"
+    ```yaml linenums="432"
+    --8<-- "jaclang/compiler/jac.lark:432:439"
     ```
 **Description**
 
@@ -1111,8 +1111,8 @@
     --8<-- "examples/reference/data_spatial_references.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="434"
-    --8<-- "jaclang/compiler/jac.lark:434:443"
+    ```yaml linenums="442"
+    --8<-- "jaclang/compiler/jac.lark:442:451"
     ```
 **Description**
 
@@ -1129,8 +1129,8 @@
     --8<-- "examples/reference/special_comprehensions.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="446"
-    --8<-- "jaclang/compiler/jac.lark:446:451"
+    ```yaml linenums="454"
+    --8<-- "jaclang/compiler/jac.lark:454:459"
     ```
 **Description**
 
@@ -1147,8 +1147,8 @@
     --8<-- "examples/reference/names_and_references.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="454"
-    --8<-- "jaclang/compiler/jac.lark:454:463"
+    ```yaml linenums="462"
+    --8<-- "jaclang/compiler/jac.lark:462:471"
     ```
 **Description**
 
@@ -1165,8 +1165,8 @@
     --8<-- "examples/reference/builtin_types.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="466"
-    --8<-- "jaclang/compiler/jac.lark:466:492"
+    ```yaml linenums="474"
+    --8<-- "jaclang/compiler/jac.lark:474:500"
     ```
 **Description**
 
@@ -1183,8 +1183,8 @@
     --8<-- "examples/reference/f_string_tokens.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="495"
-    --8<-- "jaclang/compiler/jac.lark:495:518"
+    ```yaml linenums="503"
+    --8<-- "jaclang/compiler/jac.lark:503:526"
     ```
 **Description**
 
@@ -1201,8 +1201,8 @@
     --8<-- "examples/reference/lexer_tokens.py"
     ```
 ??? example "Jac Grammar Snippet"
-    ```yaml linenums="521"
-    --8<-- "jaclang/compiler/jac.lark:521:706"
+    ```yaml linenums="529"
+    --8<-- "jaclang/compiler/jac.lark:529:715"
     ```
 **Description**
 


### PR DESCRIPTION
## **Description**

## Depends on Lark-PR-1 #1522

* Both STRING and DOC_STRING are now strings in terms of literal values
* `module` rule in lark is simplified.
