### PR TITLE
[FEATURE]: Custom Access Validation

### DIFF
--- a/docs/docs/communityhub/release_notes.md
+++ b/docs/docs/communityhub/release_notes.md
@@ -6,6 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - **Support Spawning a Walker with List of Nodes and Edges**: Introduced the ability to spawn a walker on a list of nodes and edges. This feature enables initiating traversal across multiple graph elements simultaneously, providing greater flexibility and efficiency in handling complex graph structures.
 - **\_.save(...) should not override root in runtime**: The previous version bypassed access validation because the target archetype root was overridden by the current root, simulating ownership of the archetype.
+- **Support Custom Access Validation**: Introduced the ability to override access validation. `Node`/`Edge` can override `__jac_access__` reserved function (`builtin`) to have a different way of validating access. Either you cross-check it by current attribute, check from db or global vars or by just returning specific access level. [PR#1524](https://github.com/jaseci-labs/jaseci/pull/1524)
 
 - **`jac create_system_admin` cli now support local db**: `DATABASE_HOST` are now not required when creating system admin.
 

--- a/docs/docs/learn/jac-cloud/permission.md
+++ b/docs/docs/learn/jac-cloud/permission.md
@@ -261,3 +261,57 @@ walker check_access {
 - Learn about [WebSocket Communication](websocket.md) for real-time features
 - Explore [Webhook Integration](webhook.md) for third-party service integration
 - Set up [Logging & Monitoring](logging.md) to track access patterns
+
+# Custom Access Validation
+
+> This will only get triggered if the target node is not owned by current root
+
+```jac
+node A {
+    # suggested to be `with access {}`
+    def __jac_access__ {
+
+        ###############################################
+        #              YOUR PROCESS HERE              #
+        ###############################################
+
+        # Allowed string return "NO_ACCESS", "READ", "CONNECT", "WRITE"
+        return "NO_ACCESS";
+
+        # Allowed enum return AccessLevel.NO_ACCESS, AccessLevel.READ, AccessLevel.CONNECT, AccessLevel.WRITE
+        # return AccessLevel.NO_ACCESS;
+
+        # Not recommended as it may change in the future
+        # Allowed int return -1 (NO_ACCESS), 0 (READ), 1 (CONNECT), 2 (WRITE)
+        # return -1;
+
+    }
+}
+```
+
+> if you wish to prioritize current access validation and process it afterwards, you may follow this code
+
+```jac
+node A {
+    # suggested to be `with access {}`
+    def __jac_access__ {
+
+        level = _Jac.check_access_level(here, True); # True means skip custom access validation trigger to avoid infinite loop
+
+        ###############################################
+        #              YOUR PROCESS HERE              #
+        ###############################################
+
+        # Allowed string return "NO_ACCESS", "READ", "CONNECT", "WRITE"
+        return "NO_ACCESS";
+
+        # Allowed enum return AccessLevel.NO_ACCESS, AccessLevel.READ, AccessLevel.CONNECT, AccessLevel.WRITE
+        # return AccessLevel.NO_ACCESS;
+
+        # Not recommended as it may change in the future
+        # Allowed int return -1 (NO_ACCESS), 0 (READ), 1 (CONNECT), 2 (WRITE)
+        # return -1;
+
+    }
+}
+```

--- a/jac-cloud/jac_cloud/plugin/jaseci.py
+++ b/jac-cloud/jac_cloud/plugin/jaseci.py
@@ -114,10 +114,10 @@ class JacAccessValidationPlugin:
 
     @staticmethod
     @hookimpl
-    def check_access_level(to: Anchor) -> AccessLevel:
+    def check_access_level(to: Anchor, no_custom: bool) -> AccessLevel:
         """Access validation."""
         if not FastAPI.is_enabled():
-            return JacMachineImpl.check_access_level(to=to)
+            return JacMachineImpl.check_access_level(to=to, no_custom=no_custom)
 
         if not to.persistent:
             return AccessLevel.WRITE
@@ -133,6 +133,12 @@ class JacAccessValidationPlugin:
         # if current root is the target anchor
         if jroot == jctx.system_root or jroot.id == to.root or jroot == to:
             return AccessLevel.WRITE
+
+        if (
+            not no_custom
+            and (custom_level := to.archetype.__jac_access__()) is not None
+        ):
+            return AccessLevel.cast(custom_level)
 
         access_level = AccessLevel.NO_ACCESS
 

--- a/jac-cloud/jac_cloud/tests/openapi_specs.yaml
+++ b/jac-cloud/jac_cloud/tests/openapi_specs.yaml
@@ -516,6 +516,15 @@ components:
         - object_id
       title: update_custom_object_body_model
       type: object
+    update_nested_node_access_body_model:
+      properties:
+        access:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Access
+      title: update_nested_node_access_body_model
+      type: object
   securitySchemes:
     APIKeyHeader:
       in: header
@@ -3916,6 +3925,69 @@ paths:
               - type: string
               - type: "null"
             title: Node
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContextResponse_Any_"
+          description: Successful Response
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
+          description: Validation Error
+      security:
+        - HTTPBearer: []
+      summary: Api Entry
+      tags:
+        - Walker APIs
+  /walker/update_nested_node_access:
+    post:
+      operationId: api_root_walker_update_nested_node_access_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/update_nested_node_access_body_model"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContextResponse_Any_"
+          description: Successful Response
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
+          description: Validation Error
+      security:
+        - HTTPBearer: []
+      summary: Api Root
+      tags:
+        - Walker APIs
+  /walker/update_nested_node_access/{node}:
+    post:
+      operationId: api_entry_walker_update_nested_node_access__node__post
+      parameters:
+        - in: path
+          name: node
+          required: true
+          schema:
+            anyOf:
+              - type: string
+              - type: "null"
+            title: Node
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/update_nested_node_access_body_model"
+        required: true
       responses:
         "200":
           content:

--- a/jac-cloud/jac_cloud/tests/simple_graph.jac
+++ b/jac-cloud/jac_cloud/tests/simple_graph.jac
@@ -73,7 +73,11 @@ obj Parent(Child) {
 }
 
 node Nested {
-    has val: int, arr: list[int], data: dict[str, int], parent: Parent, enum_field: Enum;
+    has val: int, arr: list[int], data: dict[str, int], parent: Parent, enum_field: Enum, access: str | None = None;
+
+    def __jac_access__ {
+        return self.access;
+    }
 }
 
 obj Kid {
@@ -210,6 +214,15 @@ walker update_nested_node {
         here.arr.append(1);
         here.val = 1;
         here.enum_field = Enum.B;
+        report here;
+    }
+}
+
+walker update_nested_node_access {
+    has access: str | None = None;
+
+    can enter_nested with Nested entry {
+        here.access = self.access;
         report here;
     }
 }

--- a/jac-cloud/jac_cloud/tests/test_simple_graph.py
+++ b/jac-cloud/jac_cloud/tests/test_simple_graph.py
@@ -192,6 +192,7 @@ class SimpleGraphTest(JacCloudTest):
                     "enum_field": "B",
                 },
                 "enum_field": "A",
+                "access": None,
             },
             res["reports"][0]["context"],
         )
@@ -224,6 +225,7 @@ class SimpleGraphTest(JacCloudTest):
                         "enum_field": "C",
                     },
                     "enum_field": "B",
+                    "access": None,
                 },
                 res["reports"][0]["context"],
             )
@@ -289,6 +291,7 @@ class SimpleGraphTest(JacCloudTest):
                     "enum_field": "B",
                 },
                 "enum_field": "A",
+                "access": None,
             },
             nested_node["context"],
         )
@@ -336,6 +339,7 @@ class SimpleGraphTest(JacCloudTest):
                     "enum_field": "C",
                 },
                 "enum_field": "B",
+                "access": None,
             },
             res["reports"][0]["context"],
         )
@@ -365,6 +369,7 @@ class SimpleGraphTest(JacCloudTest):
                     "enum_field": "B",
                 },
                 "enum_field": "A",
+                "access": None,
             },
             res["reports"][0]["context"],
         )
@@ -404,6 +409,7 @@ class SimpleGraphTest(JacCloudTest):
                     "enum_field": "C",
                 },
                 "enum_field": "B",
+                "access": None,
             },
             res["reports"][0]["context"],
         )
@@ -430,6 +436,7 @@ class SimpleGraphTest(JacCloudTest):
                     "enum_field": "C",
                 },
                 "enum_field": "B",
+                "access": None,
             },
             res["reports"][0]["context"],
         )
@@ -1045,6 +1052,237 @@ class SimpleGraphTest(JacCloudTest):
             },
         )
 
+    def trigger_custom_access_validation_test(self) -> None:
+        """Test custom access validation."""
+        res = self.post_api("create_nested_node", user=1)
+
+        nested_node = res["reports"][0]
+
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 0,
+                "arr": [],
+                "data": {},
+                "parent": {
+                    "val": 1,
+                    "arr": [1],
+                    "data": {"a": 1},
+                    "child": {
+                        "val": 2,
+                        "arr": [1, 2],
+                        "data": {"a": 1, "b": 2},
+                        "enum_field": "C",
+                    },
+                    "enum_field": "B",
+                },
+                "enum_field": "A",
+                "access": None,
+            },
+            nested_node["context"],
+        )
+
+        ##########################################################
+        #                        NO ACCESS                       #
+        ##########################################################
+
+        self.assertEqual(
+            403,
+            self.post_api(f"visit_nested_node/{nested_node['id']}", expect_error=True),
+        )
+
+        ##########################################################
+        #           UPDATE NODE (WILL ALLOW READ ACESS)          #
+        ##########################################################
+
+        # BY OWNER
+        res = self.post_api(
+            f"update_nested_node_access/{nested_node['id']}",
+            json={"access": "READ"},
+            user=1,
+        )
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 0,
+                "arr": [],
+                "data": {},
+                "parent": {
+                    "val": 1,
+                    "arr": [1],
+                    "data": {"a": 1},
+                    "child": {
+                        "val": 2,
+                        "arr": [1, 2],
+                        "data": {"a": 1, "b": 2},
+                        "enum_field": "C",
+                    },
+                    "enum_field": "B",
+                },
+                "enum_field": "A",
+                "access": "READ",
+            },
+            res["reports"][0]["context"],
+        )
+
+        # BY OTHER
+        res = self.post_api(f"update_nested_node/{nested_node['id']}")
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 1,
+                "arr": [1],
+                "data": {"a": 1},
+                "parent": {
+                    "val": 2,
+                    "arr": [1, 2],
+                    "data": {"a": 1, "b": 2},
+                    "child": {
+                        "val": 3,
+                        "arr": [1, 2, 3],
+                        "data": {"a": 1, "b": 2, "c": 3},
+                        "enum_field": "A",
+                    },
+                    "enum_field": "C",
+                },
+                "enum_field": "B",
+                "access": "READ",
+            },
+            res["reports"][0]["context"],
+        )
+
+        # ---- NO UPDATE SHOULD HAPPEN BUT STILL ACCESSIBLE ---- #
+
+        res = self.post_api(f"visit_nested_node/{nested_node['id']}")
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 0,
+                "arr": [],
+                "data": {},
+                "parent": {
+                    "val": 1,
+                    "arr": [1],
+                    "data": {"a": 1},
+                    "child": {
+                        "val": 2,
+                        "arr": [1, 2],
+                        "data": {"a": 1, "b": 2},
+                        "enum_field": "C",
+                    },
+                    "enum_field": "B",
+                },
+                "enum_field": "A",
+                "access": "READ",
+            },
+            res["reports"][0]["context"],
+        )
+
+        ##########################################################
+        #          UPDATE NODE (WILL ALLOW WRITE ACESS)          #
+        ##########################################################
+
+        # BY OWNER
+        res = self.post_api(
+            f"update_nested_node_access/{nested_node['id']}",
+            json={"access": "WRITE"},
+            user=1,
+        )
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 0,
+                "arr": [],
+                "data": {},
+                "parent": {
+                    "val": 1,
+                    "arr": [1],
+                    "data": {"a": 1},
+                    "child": {
+                        "val": 2,
+                        "arr": [1, 2],
+                        "data": {"a": 1, "b": 2},
+                        "enum_field": "C",
+                    },
+                    "enum_field": "B",
+                },
+                "enum_field": "A",
+                "access": "WRITE",
+            },
+            res["reports"][0]["context"],
+        )
+
+        # BY OTHER
+        res = self.post_api(f"update_nested_node/{nested_node['id']}")
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 1,
+                "arr": [1],
+                "data": {"a": 1},
+                "parent": {
+                    "val": 2,
+                    "arr": [1, 2],
+                    "data": {"a": 1, "b": 2},
+                    "child": {
+                        "val": 3,
+                        "arr": [1, 2, 3],
+                        "data": {"a": 1, "b": 2, "c": 3},
+                        "enum_field": "A",
+                    },
+                    "enum_field": "C",
+                },
+                "enum_field": "B",
+                "access": "WRITE",
+            },
+            res["reports"][0]["context"],
+        )
+
+        # ---------------- UPDATE SHOULD HAPPEN ---------------- #
+
+        res = self.post_api(f"visit_nested_node/{nested_node['id']}")
+        self.assertEqual(200, res["status"])
+        self.assertEqual(
+            {
+                "val": 1,
+                "arr": [1],
+                "data": {"a": 1},
+                "parent": {
+                    "val": 2,
+                    "arr": [1, 2],
+                    "data": {"a": 1, "b": 2},
+                    "child": {
+                        "val": 3,
+                        "arr": [1, 2, 3],
+                        "data": {"a": 1, "b": 2, "c": 3},
+                        "enum_field": "A",
+                    },
+                    "enum_field": "C",
+                },
+                "enum_field": "B",
+                "access": "WRITE",
+            },
+            res["reports"][0]["context"],
+        )
+
+        ###################################################
+        #                REMOVE ROOT ACCESS               #
+        ###################################################
+
+        # UPDATE BY OWNER
+        res = self.post_api(
+            f"update_nested_node_access/{nested_node['id']}",
+            json={"access": None},
+            user=1,
+        )
+        self.assertEqual(200, res["status"])
+
+        # VISIT BY OTHER
+        self.assertEqual(
+            403,
+            self.post_api(f"visit_nested_node/{nested_node['id']}", expect_error=True),
+        )
+
     # Individual test methods for each feature
 
     def test_01_openapi_specs(self) -> None:
@@ -1164,9 +1402,9 @@ class SimpleGraphTest(JacCloudTest):
         """Test nested request payload."""
         self.trigger_nested_request_payload_test()
 
-        ##################################################
-        #              TASK CREATION TESTS               #
-        ##################################################
+    ##################################################
+    #              TASK CREATION TESTS               #
+    ##################################################
 
     def test_17_task_creation_and_scheduled_walker(self) -> None:
         """Test task creation and scheduled walker."""
@@ -1175,3 +1413,11 @@ class SimpleGraphTest(JacCloudTest):
     def test_18_async_walker(self) -> None:
         """Test async walker api call."""
         self.trigger_async_walker_test()
+
+    ###################################################
+    #             CUSTOM ACCESS VALIDATION            #
+    ###################################################
+
+    def test_19_custom_access_validation(self) -> None:
+        """Test custom access validation."""
+        self.trigger_custom_access_validation_test()

--- a/jac/jaclang/runtimelib/archetype.py
+++ b/jac/jaclang/runtimelib/archetype.py
@@ -37,7 +37,7 @@ class AccessLevel(IntEnum):
             case int():
                 return AccessLevel(val)
             case str():
-                return AccessLevel[val]
+                return AccessLevel[val.upper()]
             case _:
                 return val
 
@@ -379,6 +379,10 @@ class Archetype:
     def __repr__(self) -> str:
         """Override repr for archetype."""
         return f"{self.__class__.__name__}"
+
+    def __jac_access__(self) -> AccessLevel | str | int | None:
+        """Override access validation."""
+        return None
 
 
 class NodeArchetype(Archetype):

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -90,11 +90,6 @@ class ExecutionContext:
         """Initialize JacMachine."""
         self.mem: Memory = ShelfStorage(session)
         self.reports: list[Any] = []
-        sr_arch = Root()
-        sr_anch = sr_arch.__jac__
-        sr_anch.id = UUID(Con.SUPER_ROOT_UUID)
-        sr_anch.persistent = False
-        self.system_root = sr_anch
         self.custom: Any = MISSING
         if not isinstance(
             system_root := self.mem.find_by_id(UUID(Con.SUPER_ROOT_UUID)), NodeAnchor
@@ -197,7 +192,8 @@ class JacAccessValidation:
             > AccessLevel.NO_ACCESS
         ):
             logger.info(
-                f"Current root doesn't have read access to {to.__class__.__name__}[{to.id}]"
+                "Current root doesn't have read access to "
+                f"{to.__class__.__name__} {to.archetype.__class__.__name__}[{to.id}]"
             )
         return access_level
 
@@ -209,7 +205,8 @@ class JacAccessValidation:
             > AccessLevel.READ
         ):
             logger.info(
-                f"Current root doesn't have connect access to {to.__class__.__name__}[{to.id}]"
+                "Current root doesn't have connect access to "
+                f"{to.__class__.__name__} {to.archetype.__class__.__name__}[{to.id}]"
             )
         return access_level
 
@@ -221,14 +218,15 @@ class JacAccessValidation:
             > AccessLevel.CONNECT
         ):
             logger.info(
-                f"Current root doesn't have write access to {to.__class__.__name__}[{to.id}]"
+                "Current root doesn't have write access to "
+                f"{to.__class__.__name__} {to.archetype.__class__.__name__}[{to.id}]"
             )
         return access_level
 
     @staticmethod
-    def check_access_level(to: Anchor) -> AccessLevel:
+    def check_access_level(to: Anchor, no_custom: bool = False) -> AccessLevel:
         """Access validation."""
-        if not to.persistent:
+        if not to.persistent or to.hash == 0:
             return AccessLevel.WRITE
 
         jctx = JacMachineInterface.get_context()
@@ -240,6 +238,12 @@ class JacAccessValidation:
         # if current root is the target anchor
         if jroot == jctx.system_root or jroot.id == to.root or jroot == to:
             return AccessLevel.WRITE
+
+        if (
+            not no_custom
+            and (custom_level := to.archetype.__jac_access__()) is not None
+        ):
+            return AccessLevel.cast(custom_level)
 
         access_level = AccessLevel.NO_ACCESS
 

--- a/jac/jaclang/runtimelib/tests/fixtures/custom_access_validation.jac
+++ b/jac/jaclang/runtimelib/tests/fixtures/custom_access_validation.jac
@@ -1,0 +1,62 @@
+import from jaclang.runtimelib.archetype {AccessLevel}
+
+node A {
+    has val1: str = "NO_ACCESS";
+    has val2: int = 0;
+
+    # suggested to be `with access {}`
+    def __jac_access__ {
+
+        ###############################################
+        #              YOUR PROCESS HERE              #
+        ###############################################
+
+        # Allowed string return "NO_ACCESS", "READ", "CONNECT", "WRITE"
+        return self.val1;
+
+        # Allowed enum return AccessLevel.NO_ACCESS, AccessLevel.READ, AccessLevel.CONNECT, AccessLevel.WRITE
+        # return AccessLevel.NO_ACCESS;
+
+        # Not recommended as it may change in the future
+        # Allowed int return -1 (NO_ACCESS), 0 (READ), 1 (CONNECT), 2 (WRITE)
+        # return -1;
+
+    }
+}
+
+walker create_other_root {
+    can enter with `root entry {
+        other_root = `root().__jac__;
+        _.save(other_root);
+        print(other_root.id);
+    }
+}
+
+walker create {
+    can enter with `root entry {
+        a = root ++> A();
+        print(a[0].__jac__.id);
+    }
+}
+
+
+walker update {
+    has val1: str | None = None;
+    has val2: int | None = None;
+
+    can enter with A entry {
+        if self.val1 is not None {
+            here.val1 = self.val1;
+        }
+
+        if self.val2 is not None {
+            here.val2 = self.val2;
+        }
+    }
+}
+
+walker check {
+    can enter with A entry {
+        print(here);
+    }
+}

--- a/jac/jaclang/runtimelib/tests/test_jaseci.py
+++ b/jac/jaclang/runtimelib/tests/test_jaseci.py
@@ -852,3 +852,211 @@ class TestJaseciPlugin(TestCase):
         )
 
         self._del_session(session)
+
+    def test_custom_access_validation(self) -> None:
+        """Test custom access validation."""
+        global session
+        session = self.fixture_abs_path("custom_access_validation.session")
+
+        ##############################################
+        #              CREATE OTHER ROOT             #
+        ##############################################
+
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="create_other_root",
+            args=[],
+            session=session,
+        )
+
+        other_root = self.capturedOutput.getvalue().strip()
+
+        ##############################################
+        #                 CREATE NODE                #
+        ##############################################
+
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="create",
+            args=[],
+            session=session,
+        )
+        node = self.capturedOutput.getvalue().strip()
+
+        ##############################################
+        #                 CHECK NODE                 #
+        ##############################################
+
+        # BY OWNER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            node=node,
+        )
+
+        self.assertEqual(
+            "A(val1='NO_ACCESS', val2=0)", self.capturedOutput.getvalue().strip()
+        )
+
+        # BY OTHER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        self.assertEqual("", self.capturedOutput.getvalue().strip())
+
+        ##############################################
+        #       UPDATE NODE (GIVE READ ACCESS)       #
+        ##############################################
+
+        # UPDATE BY OWNER
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="update",
+            args=["READ", None],
+            session=session,
+            node=node,
+        )
+
+        # CHECK BY OTHER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        self.assertEqual(
+            "A(val1='READ', val2=0)", self.capturedOutput.getvalue().strip()
+        )
+
+        ##############################################
+        #     UPDATE NODE (BUT STILL READ ACCESS)    #
+        ##############################################
+
+        # UPDATE BY OTHER
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="update",
+            args=[None, 1],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        # CHECK BY OTHER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        self.assertEqual(
+            "A(val1='READ', val2=0)", self.capturedOutput.getvalue().strip()
+        )
+
+        ##############################################
+        #       UPDATE NODE (GIVE WRITE ACCESS)      #
+        ##############################################
+
+        # UPDATE BY OWNER
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="update",
+            args=["WRITE", None],
+            session=session,
+            node=node,
+        )
+
+        # UPDATE BY OTHER
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="update",
+            args=[None, 2],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        # CHECK BY OTHER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        self.assertEqual(
+            "A(val1='WRITE', val2=2)", self.capturedOutput.getvalue().strip()
+        )
+
+        ##############################################
+        #         UPDATE NODE (REMOVE ACCESS)        #
+        ##############################################
+
+        # UPDATE BY OWNER
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="update",
+            args=["NO_ACCESS", None],
+            session=session,
+            node=node,
+        )
+
+        # UPDATE BY OTHER
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="update",
+            args=[None, 5],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        # CHECK BY OTHER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            root=other_root,
+            node=node,
+        )
+
+        self.assertEqual("", self.capturedOutput.getvalue().strip())
+
+        # CHECK BY OWNER
+        self._output2buffer()
+        cli.enter(
+            filename=self.fixture_abs_path("custom_access_validation.jac"),
+            entrypoint="check",
+            args=[],
+            session=session,
+            node=node,
+        )
+
+        self.assertEqual(
+            "A(val1='NO_ACCESS', val2=2)", self.capturedOutput.getvalue().strip()
+        )


### PR DESCRIPTION
This is to support complex access validation. Since we can now do anything, dev should be able to implement/integrate access handler from other frameworks/library or at least replicate it.

!!! The only limitation right now is, we only validates it from current root. We don't implement "from" node yet. This means on `__jac_access__` you don't have direct reference of the node you are from. Please let me know if we still need to support that

# Scenario 1 - shared node permission
- access can now depends on attributes
  Ex:
```
node bot {
    has allowed_admins: list[str] = [];
    
    def __jac_access__ {
        current_root = Jac.get_root();

        if jid(current_root) in self.allowed_admins {
            return "WRITE"
        }
        return "NO_ACCESS"
    }
}
```

# Scenario 2 - Organization Group permission
- We can also query directly to DB
  Ex:
```
node bot {
    has allowed_admins: list[str] = [];
    
    def __jac_access__ {
        profile = NodeAnchor.Collection.find_one({"name": "user_profile", root: `root.__jac__.id}).architype;
        if profile.group == "GROUP 1" {
            return "WRITE"
        }
        return "NO_ACCESS"
    }
}
```

# OTHERS
- We can also optionally cache the final access level directly to instance variable
  Ex:
```python
def __jac_access__ {
    if level := getattr(self, "variable_for_your_cache", None):
        return level;
    # do your process here and save to cache
}
```