### PR TITLE
[Parser] match, consume methods added

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -201,9 +201,7 @@ class JacParser(Pass):
             return None
 
         def consume(self, ty: type[T]) -> T:
-            """
-            Consume and return the specified type, if it's not exists, will be an internal compiler error.
-            """
+            """Consume and return the specified type, if it's not exists, will be an internal compiler error."""
             if node := self.match(ty):
                 return node
             raise self.ice()

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import keyword
 import logging
 import os
-from typing import Callable, TypeAlias
-
+from typing import Callable, TypeAlias, TypeVar
 
 import jaclang.compiler.absyntree as ast
 from jaclang.compiler import jac_lark as jl  # type: ignore
 from jaclang.compiler.constant import EdgeDir, Tokens as Tok
 from jaclang.compiler.passes.ir_pass import Pass
 from jaclang.vendor.lark import Lark, Transformer, Tree, logger
+
+
+T = TypeVar("T", bound=ast.AstNode)
 
 
 class JacParser(Pass):
@@ -76,12 +78,12 @@ class JacParser(Pass):
             orig_src=mod.loc.orig_src,
             name=token.type,
             value=token.value,
-            line=token.line if token.line is not None else 0,
-            end_line=token.end_line if token.end_line is not None else 0,
-            col_start=token.column if token.column is not None else 0,
-            col_end=token.end_column if token.end_column is not None else 0,
-            pos_start=token.start_pos if token.start_pos is not None else 0,
-            pos_end=token.end_pos if token.end_pos is not None else 0,
+            line=token.line or 0,
+            end_line=token.end_line or 0,
+            col_start=token.column or 0,
+            col_end=token.end_column or 0,
+            pos_start=token.start_pos or 0,
+            pos_end=token.end_pos or 0,
             kid=[],
         )
 
@@ -130,6 +132,10 @@ class JacParser(Pass):
             super().__init__(*args, **kwargs)
             self.parse_ref = parser
             self.terminals: list[ast.Token] = []
+            # TODO: Once the kid is removed from the ast, we can get rid of this
+            # node_idx and directly pop(0) kid as we process the nodes.
+            self.node_idx = 0
+            self.nodes: list[ast.AstNode] = []
 
         def ice(self) -> Exception:
             """Raise internal compiler error."""
@@ -138,32 +144,121 @@ class JacParser(Pass):
                 f"{self.parse_ref.__class__.__name__} - Internal Compiler Error, Invalid Parse Tree!"
             )
 
-        def nu(self, node: ast.T) -> ast.T:
-            """Update node."""
+        def _node_update(self, node: T) -> T:
             self.parse_ref.cur_node = node
             if node not in self.parse_ref.node_list:
                 self.parse_ref.node_list.append(node)
             return node
 
-        def start(self, kid: list[ast.Module]) -> ast.Module:
+        def _call_userfunc(
+            self, tree: jl.Tree, new_children: None | list[ast.AstNode] = None
+        ) -> ast.AstNode:
+            self.nodes = new_children or tree.children  # type: ignore[assignment]
+            try:
+                return self._node_update(super()._call_userfunc(tree, new_children))
+            finally:
+                self.nodes = []
+                self.node_idx = 0
+
+        def _call_userfunc_token(self, token: jl.Token) -> ast.AstNode:
+            return self._node_update(super()._call_userfunc_token(token))
+
+        def _binary_expr_unwind(self, kid: list[ast.AstNode]) -> ast.Expr:
+            """Binary expression helper."""
+            if len(kid) > 1:
+                if (
+                    isinstance(kid[0], ast.Expr)
+                    and isinstance(
+                        kid[1],
+                        (ast.Token, ast.DisconnectOp, ast.ConnectOp),
+                    )
+                    and isinstance(kid[2], ast.Expr)
+                ):
+                    return ast.BinaryExpr(
+                        left=kid[0],
+                        op=kid[1],
+                        right=kid[2],
+                        kid=kid,
+                    )
+                else:
+                    raise self.ice()
+            elif isinstance(kid[0], ast.Expr):
+                return kid[0]
+            else:
+                raise self.ice()
+
+        # ******************************************************************* #
+        # Parser Helper functions.                                            #
+        # ******************************************************************* #
+
+        def match(self, ty: type[T]) -> T | None:
+            """Return a node matching type 'ty' if possible from the current nodes."""
+            if (self.node_idx < len(self.nodes)) and isinstance(
+                self.nodes[self.node_idx], ty
+            ):
+                self.node_idx += 1
+                return self.nodes[self.node_idx - 1]  # type: ignore[return-value]
+            return None
+
+        def consume(self, ty: type[T]) -> T:
+            """
+            Consume and return the specified type, if it's not exists, will be an internal compiler error.
+            """
+            if node := self.match(ty):
+                return node
+            raise self.ice()
+
+        def match_token(self, tok: Tok) -> ast.Token | None:
+            """Match a token with the given type and return it."""
+            if token := self.match(ast.Token):
+                if token.name == tok.name:
+                    return token
+                self.node_idx -= (
+                    1  # We're already matched but wrong token so undo matching it.
+                )
+            return None
+
+        def consume_token(self, tok: Tok) -> ast.Token:
+            """Consume a token with the given type and return it."""
+            if token := self.match_token(tok):
+                return token
+            raise self.ice()
+
+        def match_many(self, ty: type[T]) -> list[T]:
+            """Match 0 or more of the given type and return the list."""
+            nodes: list[ast.AstNode] = []
+            while node := self.match(ty):
+                nodes.append(node)
+            return nodes  # type: ignore[return-value]
+
+        def consume_many(self, ty: type[T]) -> list[T]:
+            """Match 1 or more of the given type and return the list."""
+            nodes: list[ast.AstNode] = [self.consume(ty)]
+            while node := self.match(ty):
+                nodes.append(node)
+            return nodes  # type: ignore[return-value]
+
+        # ******************************************************************* #
+        # Parsing Rules                                                       #
+        # ******************************************************************* #
+
+        def start(self, _: None) -> ast.Module:
             """Grammar rule.
 
             start: module
             """
-            kid[0]._in_mod_nodes = self.parse_ref.node_list
-            return self.nu(kid[0])
+            module = self.consume(ast.Module)
+            module._in_mod_nodes = self.parse_ref.node_list
+            return module
 
-        def module(
-            self, kid: list[ast.ElementStmt | ast.String | ast.EmptyToken]
-        ) -> ast.Module:
+        def module(self, _: None) -> ast.Module:
             """Grammar rule.
 
             module: (doc_tag? element (element_with_doc | element)*)?
             doc_tag (element_with_doc (element_with_doc | element)*)?
             """
-            doc = kid[0] if len(kid) and isinstance(kid[0], ast.String) else None
-            body = kid[1:] if doc else kid
-            body = [i for i in body if isinstance(i, ast.ElementStmt)]
+            doc = self.match(ast.String)
+            body = self.match_many(ast.ElementStmt)
             mod = ast.Module(
                 name=self.parse_ref.mod_path.split(os.path.sep)[-1].rstrip(".jac"),
                 source=self.parse_ref.source,
@@ -172,28 +267,24 @@ class JacParser(Pass):
                 is_imported=False,
                 terminals=self.terminals,
                 kid=(
-                    kid
-                    if len(kid)
-                    else [ast.EmptyToken(ast.JacSource("", self.parse_ref.mod_path))]
+                    self.nodes
+                    or [ast.EmptyToken(ast.JacSource("", self.parse_ref.mod_path))]
                 ),
             )
-            return self.nu(mod)
+            return mod
 
-        def element_with_doc(
-            self, kid: list[ast.ElementStmt | ast.String]
-        ) -> ast.ElementStmt:
+        def element_with_doc(self, _: None) -> ast.ElementStmt:
             """Grammar rule.
 
             element_with_doc: doc_tag element
             """
-            if isinstance(kid[1], ast.ElementStmt) and isinstance(kid[0], ast.String):
-                kid[1].doc = kid[0]
-                kid[1].add_kids_left([kid[0]])
-                return self.nu(kid[1])
-            else:
-                raise self.ice()
+            doc = self.consume(ast.String)
+            element = self.consume(ast.ElementStmt)
+            element.doc = doc
+            element.add_kids_left([doc])
+            return element
 
-        def element(self, kid: list[ast.AstNode]) -> ast.ElementStmt:
+        def element(self, _: None) -> ast.ElementStmt:
             """Grammar rule.
 
             element: py_code_block
@@ -204,206 +295,178 @@ class JacParser(Pass):
                 | test
                 | global_var
             """
-            if isinstance(kid[0], ast.ElementStmt):
-                return self.nu(kid[0])
-            else:
-                raise self.ice()
+            return self.consume(ast.ElementStmt)
 
-        def global_var(self, kid: list[ast.AstNode]) -> ast.GlobalVars:
+        def global_var(self, _: None) -> ast.GlobalVars:
             """Grammar rule.
 
             global_var: (KW_LET | KW_GLOBAL) access_tag? assignment_list SEMI
             """
-            is_frozen = isinstance(kid[0], ast.Token) and kid[0].name == Tok.KW_LET
-            access = kid[1] if isinstance(kid[1], ast.SubTag) else None
-            assignments = kid[2] if access else kid[1]
-            if isinstance(assignments, ast.SubNodeList):
-                return self.nu(
-                    ast.GlobalVars(
-                        access=access,
-                        assignments=assignments,
-                        is_frozen=is_frozen,
-                        kid=kid,
-                    )
-                )
-            else:
-                raise self.ice()
+            is_frozen = self.consume(ast.Token).name == Tok.KW_LET
+            access_tag = self.match(ast.SubTag)
+            assignments = self.consume(ast.SubNodeList)
+            self.consume_token(Tok.SEMI)
+            return ast.GlobalVars(
+                access=access_tag,
+                assignments=assignments,
+                is_frozen=is_frozen,
+                kid=self.nodes,
+            )
 
-        def access_tag(self, kid: list[ast.AstNode]) -> ast.SubTag[ast.Token]:
+        def access_tag(self, _: None) -> ast.SubTag[ast.Token]:
             """Grammar rule.
 
             access_tag: COLON ( KW_PROT | KW_PUB | KW_PRIV )
             """
-            if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.Token):
-                return self.nu(
-                    ast.SubTag[ast.Token](
-                        tag=kid[1],
-                        kid=kid,
-                    )
-                )
-            else:
-                raise self.ice()
+            self.consume_token(Tok.COLON)
+            access = self.consume(ast.Token)
+            return ast.SubTag[ast.Token](tag=access, kid=self.nodes)
 
-        def test(self, kid: list[ast.AstNode]) -> ast.Test:
+        def test(self, _: None) -> ast.Test:
             """Grammar rule.
 
             test: KW_TEST NAME? code_block
             """
-            name = kid[1] if isinstance(kid[1], ast.Name) else kid[0]
-            codeblock = kid[2] if name != kid[0] else kid[1]
-            if isinstance(codeblock, ast.SubNodeList) and isinstance(
-                name, (ast.Name, ast.Token)
-            ):
-                return self.nu(
-                    ast.Test(
-                        name=name,
-                        body=codeblock,
-                        kid=kid,
-                    )
-                )
-            else:
-                raise self.ice()
+            # Q(thakee): Why the name should be KW_TEST if no name present?
+            test_tok = self.consume_token(Tok.KW_TEST)
+            name = self.match(ast.Name) or test_tok
+            codeblock = self.consume(ast.SubNodeList)
+            return ast.Test(
+                name=name,
+                body=codeblock,
+                kid=self.nodes,
+            )
 
-        def free_code(self, kid: list[ast.AstNode]) -> ast.ModuleCode:
+        def free_code(self, _: None) -> ast.ModuleCode:
             """Grammar rule.
 
             free_code: KW_WITH KW_ENTRY sub_name? code_block
             """
-            name = kid[2] if isinstance(kid[2], ast.SubTag) else None
-            codeblock = kid[3] if name else kid[2]
-            if isinstance(codeblock, ast.SubNodeList):
-                return self.nu(
-                    ast.ModuleCode(
-                        name=name,
-                        body=codeblock,
-                        kid=kid,
-                    )
-                )
-            else:
-                raise self.ice()
+            self.consume_token(Tok.KW_WITH)
+            self.consume_token(Tok.KW_ENTRY)
+            name = self.match(ast.SubTag)
+            codeblock = self.consume(ast.SubNodeList)
+            return ast.ModuleCode(
+                name=name,
+                body=codeblock,
+                kid=self.nodes,
+            )
 
-        def doc_tag(self, kid: list[ast.AstNode]) -> ast.String:
+        def doc_tag(self, _: None) -> ast.String:
             """Grammar rule.
 
             doc_tag: ( STRING | DOC_STRING )
             """
-            if isinstance(kid[0], ast.String):
-                return self.nu(kid[0])
-            else:
-                raise self.ice()
+            return self.consume(ast.String)
 
-        def py_code_block(self, kid: list[ast.AstNode]) -> ast.PyInlineCode:
+        def py_code_block(self, _: None) -> ast.PyInlineCode:
             """Grammar rule.
 
             py_code_block: PYNLINE
             """
-            if isinstance(kid[0], ast.Token):
-                return self.nu(
-                    ast.PyInlineCode(
-                        code=kid[0],
-                        kid=kid,
-                    )
-                )
-            else:
-                raise self.ice()
+            pyinline = self.consume_token(Tok.PYNLINE)
+            return ast.PyInlineCode(
+                code=pyinline,
+                kid=self.nodes,
+            )
 
-        def import_stmt(self, kid: list[ast.AstNode]) -> ast.Import:
+        def import_stmt(self, _: None) -> ast.Import:
             """Grammar rule.
 
             import_stmt: KW_IMPORT sub_name? KW_FROM from_path LBRACE import_items RBRACE
-                    | KW_IMPORT sub_name? KW_FROM from_path COMMA import_items SEMI  //Deprecated
-                    | KW_IMPORT sub_name? import_path (COMMA import_path)* SEMI
-                    | include_stmt
+                       | KW_IMPORT sub_name? KW_FROM from_path COMMA import_items SEMI  //Deprecated
+                       | KW_IMPORT sub_name? import_path (COMMA import_path)* SEMI
+                       | include_stmt
             """
-            if len(kid) == 1 and isinstance(kid[0], ast.Import):
-                return self.nu(kid[0])
-            chomp = [*kid]
-            lang = kid[1] if isinstance(kid[1], ast.SubTag) else None
-            chomp = chomp[2:] if lang else chomp[1:]
-            from_path = chomp[1] if isinstance(chomp[1], ast.ModulePath) else None
-            if from_path:
-                items = kid[-2] if isinstance(kid[-2], ast.SubNodeList) else None
+            if import_stmt := self.match(ast.Import):  # Include Statement.
+                return import_stmt
+
+            # TODO: kid will be removed so let's keep as it is for now.
+            kid = self.nodes
+
+            from_path: ast.ModulePath | None = None
+            self.consume_token(Tok.KW_IMPORT)
+            lang = self.match(ast.SubTag)
+
+            if self.match_token(Tok.KW_FROM):
+                from_path = self.consume(ast.ModulePath)
+                self.consume(ast.Token)  # LBRACE or COMMA
+                items = self.consume(ast.SubNodeList)
+                if self.consume(ast.Token).name == Tok.SEMI:  # RBRACE or SEMI
+                    self.parse_ref.warning(
+                        "Deprecated syntax, use braces for multiple imports (e.g, import from mymod {a, b, c})",
+                    )
             else:
-                paths = [i for i in kid if isinstance(i, ast.ModulePath)]
+                paths = [self.consume(ast.ModulePath)]
+                while self.match_token(Tok.COMMA):
+                    paths.append(self.consume(ast.ModulePath))
+                self.consume_token(Tok.SEMI)
                 items = ast.SubNodeList[ast.ModulePath](
-                    items=paths, delim=Tok.COMMA, kid=kid[2 if lang else 1 : -1]
+                    items=paths,
+                    delim=Tok.COMMA,
+                    # TODO: kid will be removed so let's keep as it is for now.
+                    kid=self.nodes[2 if lang else 1 : -1],
                 )
                 kid = (kid[:2] if lang else kid[:1]) + [items] + kid[-1:]
 
             is_absorb = False
-            if isinstance(items, ast.SubNodeList):
-                ret = self.nu(
-                    ast.Import(
-                        hint=lang,
-                        from_loc=from_path,
-                        items=items,
-                        is_absorb=is_absorb,
-                        kid=kid,
-                    )
-                )
-                if (
-                    from_path
-                    and isinstance(kid[-1], ast.Token)
-                    and kid[-1].name == Tok.SEMI
-                ):
-                    self.parse_ref.warning(
-                        "Deprecated syntax, use braces for multiple imports (e.g, import from mymod {a, b, c})",
-                    )
-                return ret
-            else:
-                raise self.ice()
+            return ast.Import(
+                hint=lang,
+                from_loc=from_path,
+                items=items,
+                is_absorb=is_absorb,
+                kid=kid,
+            )
 
-        def from_path(self, kid: list[ast.AstNode]) -> ast.ModulePath:
+        def from_path(self, _: None) -> ast.ModulePath:
             """Grammar rule.
 
             from_path: (DOT | ELLIPSIS)* import_path
-                    | (DOT | ELLIPSIS)+
+                     | (DOT | ELLIPSIS)+
             """
             level = 0
-            for i in kid:
-                if isinstance(i, ast.Token):
-                    if i.name == Tok.DOT:
-                        level += 1
-                    elif i.name == Tok.ELLIPSIS:
-                        level += 3
-            if isinstance(kid[-1], ast.ModulePath):
-                ret = kid[-1]
-                adds = [i for i in kid if isinstance(i, ast.Token)]
-                ret.level = level
-                ret.add_kids_left(adds)
-                return ret
-            else:
-                return self.nu(
-                    ast.ModulePath(
-                        path=None,
-                        level=level,
-                        alias=None,
-                        kid=kid,
-                    )
-                )
+            while True:
+                if self.match_token(Tok.DOT):
+                    level += 1
+                elif self.match_token(Tok.ELLIPSIS):
+                    level += 3
+                else:
+                    break
+            if import_path := self.match(ast.ModulePath):
+                kids = [i for i in self.nodes if isinstance(i, ast.Token)]
+                import_path.level = level
+                import_path.add_kids_left(kids)
+                return import_path
 
-        def include_stmt(self, kid: list[ast.AstNode]) -> ast.Import:
+            return ast.ModulePath(
+                path=None,
+                level=level,
+                alias=None,
+                kid=self.nodes,
+            )
+
+        def include_stmt(self, _: None) -> ast.Import:
             """Grammar rule.
 
-            include_stmt: KW_INCLUDE sub_name import_path SEMI
+            include_stmt: KW_INCLUDE sub_name? import_path SEMI
             """
-            lang = kid[1] if isinstance(kid[1], ast.SubTag) else None
-            from_path = kid[2] if lang else kid[1]
-            if not isinstance(from_path, ast.ModulePath):
-                raise self.ice()
+            kid = self.nodes  # TODO: Will be removed.
+            self.consume_token(Tok.KW_INCLUDE)
+            lang = self.match(ast.SubTag)
+            from_path = self.consume(ast.ModulePath)
             items = ast.SubNodeList[ast.ModulePath](
                 items=[from_path], delim=Tok.COMMA, kid=[from_path]
             )
-            kid = (kid[:2] if lang else kid[:1]) + [items] + kid[-1:]
+            kid = (
+                (kid[:2] if lang else kid[:1]) + [items] + kid[-1:]
+            )  # TODO: Will be removed.
             is_absorb = True
-            return self.nu(
-                ast.Import(
-                    hint=lang,
-                    from_loc=None,
-                    items=items,
-                    is_absorb=is_absorb,
-                    kid=kid,
-                )
+            return ast.Import(
+                hint=lang,
+                from_loc=None,
+                items=items,
+                is_absorb=is_absorb,
+                kid=kid,
             )
 
         def import_path(self, kid: list[ast.AstNode]) -> ast.ModulePath:
@@ -423,13 +486,11 @@ class JacParser(Pass):
             if alias is not None:
                 valid_path = valid_path[:-1]
 
-            return self.nu(
-                ast.ModulePath(
-                    path=valid_path,
-                    level=0,
-                    alias=alias,
-                    kid=kid,
-                )
+            return ast.ModulePath(
+                path=valid_path,
+                level=0,
+                alias=alias,
+                kid=kid,
             )
 
         def import_items(
@@ -444,7 +505,7 @@ class JacParser(Pass):
                 delim=Tok.COMMA,
                 kid=kid,
             )
-            return self.nu(ret)
+            return ret
 
         def import_item(self, kid: list[ast.AstNode]) -> ast.ModuleItem:
             """Grammar rule.
@@ -456,12 +517,10 @@ class JacParser(Pass):
             if isinstance(name, ast.Name) and (
                 alias is None or isinstance(alias, ast.Name)
             ):
-                return self.nu(
-                    ast.ModuleItem(
-                        name=name,
-                        alias=alias,
-                        kid=kid,
-                    )
+                return ast.ModuleItem(
+                    name=name,
+                    alias=alias,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -479,12 +538,12 @@ class JacParser(Pass):
                 if isinstance(kid[1], ast.ArchSpec):
                     kid[1].decorators = kid[0]
                     kid[1].add_kids_left([kid[0]])
-                    return self.nu(kid[1])
+                    return kid[1]
                 else:
                     raise self.ice()
 
             elif isinstance(kid[0], (ast.ArchSpec, ast.ArchDef, ast.Enum, ast.EnumDef)):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -508,16 +567,14 @@ class JacParser(Pass):
             inh = kid[-2] if isinstance(kid[-2], ast.SubNodeList) else None
             body = kid[-1] if isinstance(kid[-1], ast.SubNodeList) else None
             if isinstance(arch_type, ast.Token) and isinstance(name, ast.Name):
-                return self.nu(
-                    ast.Architype(
-                        arch_type=arch_type,
-                        name=name,
-                        semstr=semstr,
-                        access=access,
-                        base_classes=inh,
-                        body=body,
-                        kid=kid,
-                    )
+                return ast.Architype(
+                    arch_type=arch_type,
+                    name=name,
+                    semstr=semstr,
+                    access=access,
+                    base_classes=inh,
+                    body=body,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -530,12 +587,10 @@ class JacParser(Pass):
             if isinstance(kid[0], ast.ArchRefChain) and isinstance(
                 kid[1], ast.SubNodeList
             ):
-                return self.nu(
-                    ast.ArchDef(
-                        target=kid[0],
-                        body=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchDef(
+                    target=kid[0],
+                    body=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -549,7 +604,7 @@ class JacParser(Pass):
                     | KW_NODE
             """
             if isinstance(kid[0], ast.Token):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -560,12 +615,10 @@ class JacParser(Pass):
             """
             valid_decors = [i for i in kid if isinstance(i, ast.Expr)]
             if len(valid_decors) == len(kid) / 2:
-                return self.nu(
-                    ast.SubNodeList[ast.Expr](
-                        items=valid_decors,
-                        delim=Tok.DECOR_OP,
-                        kid=kid,
-                    )
+                return ast.SubNodeList[ast.Expr](
+                    items=valid_decors,
+                    delim=Tok.DECOR_OP,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -577,12 +630,10 @@ class JacParser(Pass):
                            | COLON (atomic_chain COMMA)* atomic_chain COLON
             """
             valid_inh = [i for i in kid if isinstance(i, ast.Expr)]
-            return self.nu(
-                ast.SubNodeList[ast.Expr](
-                    items=valid_inh,
-                    delim=Tok.COMMA,
-                    kid=kid,
-                )
+            return ast.SubNodeList[ast.Expr](
+                items=valid_inh,
+                delim=Tok.COMMA,
+                kid=kid,
             )
 
         def sub_name(self, kid: list[ast.AstNode]) -> ast.SubTag[ast.Name]:
@@ -591,11 +642,9 @@ class JacParser(Pass):
             sub_name: COLON NAME
             """
             if isinstance(kid[1], ast.Name):
-                return self.nu(
-                    ast.SubTag[ast.Name](
-                        tag=kid[1],
-                        kid=kid,
-                    )
+                return ast.SubTag[ast.Name](
+                    tag=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -608,7 +657,7 @@ class JacParser(Pass):
                     | NAME
             """
             if isinstance(kid[0], ast.NameAtom):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -623,7 +672,7 @@ class JacParser(Pass):
                         | KW_HERE
             """
             if isinstance(kid[0], ast.Name):
-                return self.nu(ast.SpecialVarRef(var=kid[0]))
+                return ast.SpecialVarRef(var=kid[0])
             else:
                 raise self.ice()
 
@@ -637,11 +686,11 @@ class JacParser(Pass):
                 if isinstance(kid[1], ast.Enum):
                     kid[1].decorators = kid[0]
                     kid[1].add_kids_left([kid[0]])
-                    return self.nu(kid[1])
+                    return kid[1]
                 else:
                     raise self.ice()
             elif isinstance(kid[0], (ast.Enum, ast.EnumDef)):
-                return self.nu(kid[0])
+                return kid[0]
             else:
 
                 raise self.ice()
@@ -665,15 +714,13 @@ class JacParser(Pass):
             inh = kid[-2] if isinstance(kid[-2], ast.SubNodeList) else None
             body = kid[-1] if isinstance(kid[-1], ast.SubNodeList) else None
             if isinstance(name, ast.Name):
-                return self.nu(
-                    ast.Enum(
-                        semstr=semstr,
-                        name=name,
-                        access=access,
-                        base_classes=inh,
-                        body=body,
-                        kid=kid,
-                    )
+                return ast.Enum(
+                    semstr=semstr,
+                    name=name,
+                    access=access,
+                    base_classes=inh,
+                    body=body,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -686,12 +733,10 @@ class JacParser(Pass):
             if isinstance(kid[0], ast.ArchRefChain) and isinstance(
                 kid[1], ast.SubNodeList
             ):
-                return self.nu(
-                    ast.EnumDef(
-                        target=kid[0],
-                        body=kid[1],
-                        kid=kid,
-                    )
+                return ast.EnumDef(
+                    target=kid[0],
+                    body=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -705,7 +750,7 @@ class JacParser(Pass):
             """
             ret = ast.SubNodeList[ast.EnumBlockStmt](items=[], delim=Tok.COMMA, kid=kid)
             ret.items = [i for i in kid if isinstance(i, ast.EnumBlockStmt)]
-            return self.nu(ret)
+            return ret
 
         def enum_stmt(self, kid: list[ast.AstNode]) -> ast.EnumBlockStmt:
             """Grammar rule.
@@ -718,7 +763,7 @@ class JacParser(Pass):
                     | ability
             """
             if isinstance(kid[0], (ast.PyInlineCode, ast.Ability)):
-                return self.nu(kid[0])
+                return kid[0]
             elif isinstance(kid[0], (ast.Name)):
                 if (
                     len(kid) >= 3
@@ -734,15 +779,13 @@ class JacParser(Pass):
                         items=[kid[0]], delim=Tok.COMMA, kid=[kid[0]]
                     )
                     kid[0] = targ
-                    return self.nu(
-                        ast.Assignment(
-                            target=targ,
-                            value=kid[-1],
-                            type_tag=None,
-                            kid=kid,
-                            semstr=semstr,
-                            is_enum_stmt=True,
-                        )
+                    return ast.Assignment(
+                        target=targ,
+                        value=kid[-1],
+                        type_tag=None,
+                        kid=kid,
+                        semstr=semstr,
+                        is_enum_stmt=True,
                     )
                 else:
                     semstr = (
@@ -754,18 +797,16 @@ class JacParser(Pass):
                         items=[kid[0]], delim=Tok.COMMA, kid=[kid[0]]
                     )
                     kid[0] = targ
-                    return self.nu(
-                        ast.Assignment(
-                            target=targ,
-                            value=None,
-                            type_tag=None,
-                            kid=kid,
-                            semstr=semstr,
-                            is_enum_stmt=True,
-                        )
+                    return ast.Assignment(
+                        target=targ,
+                        value=None,
+                        type_tag=None,
+                        kid=kid,
+                        semstr=semstr,
+                        is_enum_stmt=True,
                     )
             elif isinstance(kid[0], (ast.PyInlineCode, ast.ModuleCode)):
-                return self.nu(kid[0])
+                return kid[0]
             raise self.ice()
 
         def ability(
@@ -804,8 +845,8 @@ class JacParser(Pass):
                 if len(decorators.items):
                     ability.decorators = decorators
                     ability.add_kids_left([decorators])
-                return self.nu(ability)
-            return self.nu(ability)
+                return ability
+            return ability
 
         def ability_decl(self, kid: list[ast.AstNode]) -> ast.Ability:
             """Grammar rule.
@@ -834,19 +875,17 @@ class JacParser(Pass):
             if isinstance(name, ast.NameAtom) and isinstance(
                 signature, (ast.FuncSignature, ast.EventSignature)
             ):
-                return self.nu(
-                    ast.Ability(
-                        name_ref=name,
-                        is_async=False,
-                        is_override=is_override,
-                        is_static=is_static,
-                        is_abstract=False,
-                        access=access,
-                        semstr=semstr,
-                        signature=signature,
-                        body=body,
-                        kid=kid,
-                    )
+                return ast.Ability(
+                    name_ref=name,
+                    is_async=False,
+                    is_override=is_override,
+                    is_static=is_static,
+                    is_abstract=False,
+                    access=access,
+                    semstr=semstr,
+                    signature=signature,
+                    body=body,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -861,13 +900,11 @@ class JacParser(Pass):
                 and isinstance(kid[1], (ast.FuncSignature, ast.EventSignature))
                 and isinstance(kid[2], ast.SubNodeList)
             ):
-                return self.nu(
-                    ast.AbilityDef(
-                        target=kid[0],
-                        signature=kid[1],
-                        body=kid[2],
-                        kid=kid,
-                    )
+                return ast.AbilityDef(
+                    target=kid[0],
+                    signature=kid[1],
+                    body=kid[2],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -901,19 +938,17 @@ class JacParser(Pass):
             if isinstance(name, ast.NameAtom) and isinstance(
                 signature, (ast.FuncSignature, ast.EventSignature)
             ):
-                return self.nu(
-                    ast.Ability(
-                        name_ref=name,
-                        is_async=False,
-                        is_override=is_override,
-                        is_static=is_static,
-                        is_abstract=True,
-                        access=access,
-                        semstr=semstr,
-                        signature=signature,
-                        body=None,
-                        kid=kid,
-                    )
+                return ast.Ability(
+                    name_ref=name,
+                    is_async=False,
+                    is_override=is_override,
+                    is_static=is_static,
+                    is_abstract=True,
+                    access=access,
+                    semstr=semstr,
+                    signature=signature,
+                    body=None,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -950,19 +985,17 @@ class JacParser(Pass):
                 and isinstance(chomp[0], ast.FuncCall)
                 and has_by
             ):
-                return self.nu(
-                    ast.Ability(
-                        name_ref=name,
-                        is_async=False,
-                        is_override=is_override,
-                        is_static=is_static,
-                        is_abstract=False,
-                        access=access,
-                        semstr=semstr,
-                        signature=signature,
-                        body=chomp[0],
-                        kid=kid,
-                    )
+                return ast.Ability(
+                    name_ref=name,
+                    is_async=False,
+                    is_override=is_override,
+                    is_static=is_static,
+                    is_abstract=False,
+                    access=access,
+                    semstr=semstr,
+                    signature=signature,
+                    body=chomp[0],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -981,14 +1014,12 @@ class JacParser(Pass):
             if isinstance(event, ast.Token) and (
                 isinstance(return_spec, ast.Expr) or return_spec is None
             ):
-                return self.nu(
-                    ast.EventSignature(
-                        semstr=semstr,
-                        event=event,
-                        arch_tag_info=type_specs,
-                        return_type=return_spec,
-                        kid=kid,
-                    )
+                return ast.EventSignature(
+                    semstr=semstr,
+                    event=event,
+                    arch_tag_info=type_specs,
+                    return_type=return_spec,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1012,21 +1043,17 @@ class JacParser(Pass):
             if (isinstance(params, ast.SubNodeList) or params is None) and (
                 isinstance(return_spec, ast.Expr) or return_spec is None
             ):
-                return self.nu(
-                    ast.FuncSignature(
-                        semstr=semstr,
-                        params=params,
-                        return_type=return_spec,
-                        kid=(
-                            kid
-                            if len(kid)
-                            else [
-                                ast.EmptyToken(
-                                    ast.JacSource("", self.parse_ref.mod_path)
-                                )
-                            ]
-                        ),
-                    )
+                return ast.FuncSignature(
+                    semstr=semstr,
+                    params=params,
+                    return_type=return_spec,
+                    kid=(
+                        kid
+                        if len(kid)
+                        else [
+                            ast.EmptyToken(ast.JacSource("", self.parse_ref.mod_path))
+                        ]
+                    ),
                 )
             else:
                 raise self.ice()
@@ -1043,7 +1070,7 @@ class JacParser(Pass):
                 delim=Tok.COMMA,
                 kid=kid,
             )
-            return self.nu(ret)
+            return ret
 
         def param_var(self, kid: list[ast.AstNode]) -> ast.ParamVar:
             """Grammar rule.
@@ -1074,15 +1101,13 @@ class JacParser(Pass):
                 )
             )
             if isinstance(name, ast.Name) and isinstance(type_tag, ast.SubTag):
-                return self.nu(
-                    ast.ParamVar(
-                        semstr=semstr,
-                        name=name,
-                        type_tag=type_tag,
-                        value=value,
-                        unpack=star,
-                        kid=kid,
-                    )
+                return ast.ParamVar(
+                    semstr=semstr,
+                    name=name,
+                    type_tag=type_tag,
+                    value=value,
+                    unpack=star,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1102,7 +1127,7 @@ class JacParser(Pass):
             ret.items = [i for i in kid if isinstance(i, ast.ArchBlockStmt)]
             ret.left_enc = kid[0] if isinstance(kid[0], ast.Token) else None
             ret.right_enc = kid[-1] if isinstance(kid[-1], ast.Token) else None
-            return self.nu(ret)
+            return ret
 
         def member_stmt(self, kid: list[ast.AstNode]) -> ast.ArchBlockStmt:
             """Grammar rule.
@@ -1114,7 +1139,7 @@ class JacParser(Pass):
                         | doc_tag? has_stmt
             """
             if isinstance(kid[0], ast.ArchBlockStmt):
-                ret = self.nu(kid[0])
+                ret = kid[0]
             elif (
                 isinstance(kid[1], ast.ArchBlockStmt)
                 and isinstance(kid[1], ast.AstDocNode)
@@ -1122,7 +1147,7 @@ class JacParser(Pass):
             ):
                 kid[1].doc = kid[0]
                 kid[1].add_kids_left([kid[0]])
-                ret = self.nu(kid[1])
+                ret = kid[1]
             else:
                 raise self.ice()
             if isinstance(ret, ast.Ability):
@@ -1145,14 +1170,12 @@ class JacParser(Pass):
             chomp = chomp[1:] if access else chomp
             assign = chomp[0]
             if isinstance(assign, ast.SubNodeList):
-                return self.nu(
-                    ast.ArchHas(
-                        vars=assign,
-                        is_static=is_static,
-                        is_frozen=is_freeze,
-                        access=access,
-                        kid=kid,
-                    )
+                return ast.ArchHas(
+                    vars=assign,
+                    is_static=is_static,
+                    is_frozen=is_freeze,
+                    access=access,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1176,12 +1199,10 @@ class JacParser(Pass):
                 assign = kid[0]
                 new_kid = [assign]
             valid_kid = [i for i in new_kid if isinstance(i, ast.HasVar)]
-            return self.nu(
-                ast.SubNodeList[ast.HasVar](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=new_kid,
-                )
+            return ast.SubNodeList[ast.HasVar](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=new_kid,
             )
 
         def typed_has_clause(self, kid: list[ast.AstNode]) -> ast.HasVar:
@@ -1195,15 +1216,13 @@ class JacParser(Pass):
             defer = isinstance(kid[-1], ast.Token) and kid[-1].name == Tok.KW_POST_INIT
             value = kid[-1] if not defer and isinstance(kid[-1], ast.Expr) else None
             if isinstance(name, ast.Name) and isinstance(type_tag, ast.SubTag):
-                return self.nu(
-                    ast.HasVar(
-                        semstr=semstr,
-                        name=name,
-                        type_tag=type_tag,
-                        defer=defer,
-                        value=value,
-                        kid=kid,
-                    )
+                return ast.HasVar(
+                    semstr=semstr,
+                    name=name,
+                    type_tag=type_tag,
+                    defer=defer,
+                    value=value,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1214,11 +1233,9 @@ class JacParser(Pass):
             type_tag: COLON expression
             """
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.SubTag[ast.Expr](
-                        tag=kid[1],
-                        kid=kid,
-                    )
+                return ast.SubTag[ast.Expr](
+                    tag=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1239,18 +1256,16 @@ class JacParser(Pass):
                         | TYP_STRING
             """
             if isinstance(kid[0], ast.Token):
-                return self.nu(
-                    ast.BuiltinType(
-                        name=kid[0].name,
-                        orig_src=self.parse_ref.source,
-                        value=kid[0].value,
-                        line=kid[0].loc.first_line,
-                        end_line=kid[0].loc.last_line,
-                        col_start=kid[0].loc.col_start,
-                        col_end=kid[0].loc.col_end,
-                        pos_start=kid[0].pos_start,
-                        pos_end=kid[0].pos_end,
-                    )
+                return ast.BuiltinType(
+                    name=kid[0].name,
+                    orig_src=self.parse_ref.source,
+                    value=kid[0].value,
+                    line=kid[0].loc.first_line,
+                    end_line=kid[0].loc.last_line,
+                    col_start=kid[0].loc.col_start,
+                    col_end=kid[0].loc.col_end,
+                    pos_start=kid[0].pos_start,
+                    pos_end=kid[0].pos_end,
                 )
             else:
                 raise self.ice()
@@ -1266,14 +1281,12 @@ class JacParser(Pass):
             right_enc = kid[-1] if isinstance(kid[-1], ast.Token) else None
             valid_stmt = [i for i in kid if isinstance(i, ast.CodeBlockStmt)]
             if len(valid_stmt) == len(kid) - 2:
-                return self.nu(
-                    ast.SubNodeList[ast.CodeBlockStmt](
-                        items=valid_stmt,
-                        delim=Tok.WS,
-                        left_enc=left_enc,
-                        right_enc=right_enc,
-                        kid=kid,
-                    )
+                return ast.SubNodeList[ast.CodeBlockStmt](
+                    items=valid_stmt,
+                    delim=Tok.WS,
+                    left_enc=left_enc,
+                    right_enc=right_enc,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1308,7 +1321,7 @@ class JacParser(Pass):
                     | SEMI
             """
             if isinstance(kid[0], ast.CodeBlockStmt) and len(kid) < 2:
-                return self.nu(kid[0])
+                return kid[0]
             elif isinstance(kid[0], ast.Token) and kid[0].name == Tok.KW_YIELD:
                 return ast.ExprStmt(
                     expr=(
@@ -1329,7 +1342,7 @@ class JacParser(Pass):
                 )
             elif isinstance(kid[0], ast.CodeBlockStmt):
                 kid[0].add_kids_right([kid[1]])
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -1339,12 +1352,10 @@ class JacParser(Pass):
             typed_ctx_block: RETURN_HINT expression code_block
             """
             if isinstance(kid[1], ast.Expr) and isinstance(kid[2], ast.SubNodeList):
-                return self.nu(
-                    ast.TypedCtxBlock(
-                        type_ctx=kid[1],
-                        body=kid[2],
-                        kid=kid,
-                    )
+                return ast.TypedCtxBlock(
+                    type_ctx=kid[1],
+                    body=kid[2],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1355,18 +1366,16 @@ class JacParser(Pass):
             if_stmt: KW_IF expression code_block (elif_stmt | else_stmt)?
             """
             if isinstance(kid[1], ast.Expr) and isinstance(kid[2], ast.SubNodeList):
-                return self.nu(
-                    ast.IfStmt(
-                        condition=kid[1],
-                        body=kid[2],
-                        else_body=(
-                            kid[3]
-                            if len(kid) > 3
-                            and isinstance(kid[3], (ast.ElseStmt, ast.ElseIf))
-                            else None
-                        ),
-                        kid=kid,
-                    )
+                return ast.IfStmt(
+                    condition=kid[1],
+                    body=kid[2],
+                    else_body=(
+                        kid[3]
+                        if len(kid) > 3
+                        and isinstance(kid[3], (ast.ElseStmt, ast.ElseIf))
+                        else None
+                    ),
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1377,18 +1386,16 @@ class JacParser(Pass):
             elif_stmt: KW_ELIF expression code_block (elif_stmt | else_stmt)?
             """
             if isinstance(kid[1], ast.Expr) and isinstance(kid[2], ast.SubNodeList):
-                return self.nu(
-                    ast.ElseIf(
-                        condition=kid[1],
-                        body=kid[2],
-                        else_body=(
-                            kid[3]
-                            if len(kid) > 3
-                            and isinstance(kid[3], (ast.ElseStmt, ast.ElseIf))
-                            else None
-                        ),
-                        kid=kid,
-                    )
+                return ast.ElseIf(
+                    condition=kid[1],
+                    body=kid[2],
+                    else_body=(
+                        kid[3]
+                        if len(kid) > 3
+                        and isinstance(kid[3], (ast.ElseStmt, ast.ElseIf))
+                        else None
+                    ),
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1399,11 +1406,9 @@ class JacParser(Pass):
             else_stmt: KW_ELSE code_block
             """
             if isinstance(kid[1], ast.SubNodeList):
-                return self.nu(
-                    ast.ElseStmt(
-                        body=kid[1],
-                        kid=kid,
-                    )
+                return ast.ElseStmt(
+                    body=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1432,14 +1437,12 @@ class JacParser(Pass):
                 else None
             )
             if isinstance(block, ast.SubNodeList):
-                return self.nu(
-                    ast.TryStmt(
-                        body=block,
-                        excepts=except_list,
-                        else_body=else_stmt,
-                        finally_body=finally_stmt,
-                        kid=kid,
-                    )
+                return ast.TryStmt(
+                    body=block,
+                    excepts=except_list,
+                    else_body=else_stmt,
+                    finally_body=finally_stmt,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1451,12 +1454,10 @@ class JacParser(Pass):
             """
             valid_kid = [i for i in kid if isinstance(i, ast.Except)]
             if len(valid_kid) == len(kid):
-                return self.nu(
-                    ast.SubNodeList[ast.Except](
-                        items=valid_kid,
-                        delim=Tok.WS,
-                        kid=kid,
-                    )
+                return ast.SubNodeList[ast.Except](
+                    items=valid_kid,
+                    delim=Tok.WS,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1470,13 +1471,11 @@ class JacParser(Pass):
             name = kid[3] if len(kid) > 3 and isinstance(kid[3], ast.Name) else None
             body = kid[-1]
             if isinstance(ex_type, ast.Expr) and isinstance(body, ast.SubNodeList):
-                return self.nu(
-                    ast.Except(
-                        ex_type=ex_type,
-                        name=name,
-                        body=body,
-                        kid=kid,
-                    )
+                return ast.Except(
+                    ex_type=ex_type,
+                    name=name,
+                    body=body,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1487,11 +1486,9 @@ class JacParser(Pass):
             finally_stmt: KW_FINALLY code_block
             """
             if isinstance(kid[1], ast.SubNodeList):
-                return self.nu(
-                    ast.FinallyStmt(
-                        body=kid[1],
-                        kid=kid,
-                    )
+                return ast.FinallyStmt(
+                    body=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1514,20 +1511,16 @@ class JacParser(Pass):
                     and isinstance(chomp[5], ast.Assignment)
                     and isinstance(chomp[6], ast.SubNodeList)
                 ):
-                    return self.nu(
-                        ast.IterForStmt(
-                            is_async=is_async,
-                            iter=chomp[1],
-                            condition=chomp[3],
-                            count_by=chomp[5],
-                            body=chomp[6],
-                            else_body=(
-                                chomp[-1]
-                                if isinstance(chomp[-1], ast.ElseStmt)
-                                else None
-                            ),
-                            kid=kid,
-                        )
+                    return ast.IterForStmt(
+                        is_async=is_async,
+                        iter=chomp[1],
+                        condition=chomp[3],
+                        count_by=chomp[5],
+                        body=chomp[6],
+                        else_body=(
+                            chomp[-1] if isinstance(chomp[-1], ast.ElseStmt) else None
+                        ),
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
@@ -1535,19 +1528,15 @@ class JacParser(Pass):
                 if isinstance(chomp[3], ast.Expr) and isinstance(
                     chomp[4], ast.SubNodeList
                 ):
-                    return self.nu(
-                        ast.InForStmt(
-                            is_async=is_async,
-                            target=chomp[1],
-                            collection=chomp[3],
-                            body=chomp[4],
-                            else_body=(
-                                chomp[-1]
-                                if isinstance(chomp[-1], ast.ElseStmt)
-                                else None
-                            ),
-                            kid=kid,
-                        )
+                    return ast.InForStmt(
+                        is_async=is_async,
+                        target=chomp[1],
+                        collection=chomp[3],
+                        body=chomp[4],
+                        else_body=(
+                            chomp[-1] if isinstance(chomp[-1], ast.ElseStmt) else None
+                        ),
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
@@ -1560,12 +1549,10 @@ class JacParser(Pass):
             while_stmt: KW_WHILE expression code_block
             """
             if isinstance(kid[1], ast.Expr) and isinstance(kid[2], ast.SubNodeList):
-                return self.nu(
-                    ast.WhileStmt(
-                        condition=kid[1],
-                        body=kid[2],
-                        kid=kid,
-                    )
+                return ast.WhileStmt(
+                    condition=kid[1],
+                    body=kid[2],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1583,13 +1570,11 @@ class JacParser(Pass):
             if isinstance(chomp[1], ast.SubNodeList) and isinstance(
                 chomp[2], ast.SubNodeList
             ):
-                return self.nu(
-                    ast.WithStmt(
-                        is_async=is_async,
-                        exprs=chomp[1],
-                        body=chomp[2],
-                        kid=kid,
-                    )
+                return ast.WithStmt(
+                    is_async=is_async,
+                    exprs=chomp[1],
+                    body=chomp[2],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1606,7 +1591,7 @@ class JacParser(Pass):
                 delim=Tok.COMMA,
                 kid=kid,
             )
-            return self.nu(ret)
+            return ret
 
         def expr_as(self, kid: list[ast.AstNode]) -> ast.ExprAsItem:
             """Grammar rule.
@@ -1618,12 +1603,10 @@ class JacParser(Pass):
             if isinstance(expr, ast.Expr) and (
                 alias is None or isinstance(alias, ast.Expr)
             ):
-                return self.nu(
-                    ast.ExprAsItem(
-                        expr=expr,
-                        alias=alias,
-                        kid=kid,
-                    )
+                return ast.ExprAsItem(
+                    expr=expr,
+                    alias=alias,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1639,12 +1622,10 @@ class JacParser(Pass):
             )
             chomp = chomp[2:] if e_type and len(chomp) > 1 else chomp[1:]
             e = chomp[0] if len(chomp) > 0 and isinstance(chomp[0], ast.Expr) else None
-            return self.nu(
-                ast.RaiseStmt(
-                    cause=e_type,
-                    from_target=e,
-                    kid=kid,
-                )
+            return ast.RaiseStmt(
+                cause=e_type,
+                from_target=e,
+                kid=kid,
             )
 
         def assert_stmt(self, kid: list[ast.AstNode]) -> ast.AssertStmt:
@@ -1655,14 +1636,10 @@ class JacParser(Pass):
             condition = kid[1]
             error_msg = kid[3] if len(kid) > 3 else None
             if isinstance(condition, ast.Expr):
-                return self.nu(
-                    ast.AssertStmt(
-                        condition=condition,
-                        error_msg=(
-                            error_msg if isinstance(error_msg, ast.Expr) else None
-                        ),
-                        kid=kid,
-                    )
+                return ast.AssertStmt(
+                    condition=condition,
+                    error_msg=(error_msg if isinstance(error_msg, ast.Expr) else None),
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1673,11 +1650,9 @@ class JacParser(Pass):
             check_stmt: KW_CHECK expression
             """
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.CheckStmt(
-                        target=kid[1],
-                        kid=kid,
-                    )
+                return ast.CheckStmt(
+                    target=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1688,11 +1663,9 @@ class JacParser(Pass):
             ctrl_stmt: KW_SKIP | KW_BREAK | KW_CONTINUE
             """
             if isinstance(kid[0], ast.Token):
-                return self.nu(
-                    ast.CtrlStmt(
-                        ctrl=kid[0],
-                        kid=kid,
-                    )
+                return ast.CtrlStmt(
+                    ctrl=kid[0],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1703,11 +1676,9 @@ class JacParser(Pass):
             delete_stmt: KW_DELETE expression
             """
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.DeleteStmt(
-                        target=kid[1],
-                        kid=kid,
-                    )
+                return ast.DeleteStmt(
+                    target=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1718,11 +1689,9 @@ class JacParser(Pass):
             report_stmt: KW_REPORT expression
             """
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.ReportStmt(
-                        expr=kid[1],
-                        kid=kid,
-                    )
+                return ast.ReportStmt(
+                    expr=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1733,18 +1702,14 @@ class JacParser(Pass):
             return_stmt: KW_RETURN expression?
             """
             if len(kid) > 1:
-                return self.nu(
-                    ast.ReturnStmt(
-                        expr=kid[1] if isinstance(kid[1], ast.Expr) else None,
-                        kid=kid,
-                    )
+                return ast.ReturnStmt(
+                    expr=kid[1] if isinstance(kid[1], ast.Expr) else None,
+                    kid=kid,
                 )
             else:
-                return self.nu(
-                    ast.ReturnStmt(
-                        expr=None,
-                        kid=kid,
-                    )
+                return ast.ReturnStmt(
+                    expr=None,
+                    kid=kid,
                 )
 
         def walker_stmt(self, kid: list[ast.AstNode]) -> ast.CodeBlockStmt:
@@ -1753,7 +1718,7 @@ class JacParser(Pass):
             walker_stmt: disengage_stmt | revisit_stmt | visit_stmt | ignore_stmt
             """
             if isinstance(kid[0], ast.CodeBlockStmt):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -1763,11 +1728,9 @@ class JacParser(Pass):
             ignore_stmt: KW_IGNORE expression SEMI
             """
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.IgnoreStmt(
-                        target=kid[1],
-                        kid=kid,
-                    )
+                return ast.IgnoreStmt(
+                    target=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1781,13 +1744,11 @@ class JacParser(Pass):
             target = kid[2] if sub_name else kid[1]
             else_body = kid[-1] if isinstance(kid[-1], ast.ElseStmt) else None
             if isinstance(target, ast.Expr):
-                return self.nu(
-                    ast.VisitStmt(
-                        vis_type=sub_name,
-                        target=target,
-                        else_body=else_body,
-                        kid=kid,
-                    )
+                return ast.VisitStmt(
+                    vis_type=sub_name,
+                    target=target,
+                    else_body=else_body,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -1799,12 +1760,10 @@ class JacParser(Pass):
             """
             target = kid[1] if isinstance(kid[1], ast.Expr) else None
             else_body = kid[-1] if isinstance(kid[-1], ast.ElseStmt) else None
-            return self.nu(
-                ast.RevisitStmt(
-                    hops=target,
-                    else_body=else_body,
-                    kid=kid,
-                )
+            return ast.RevisitStmt(
+                hops=target,
+                else_body=else_body,
+                kid=kid,
             )
 
         def disengage_stmt(self, kid: list[ast.AstNode]) -> ast.DisengageStmt:
@@ -1812,10 +1771,8 @@ class JacParser(Pass):
 
             disengage_stmt: KW_DISENGAGE SEMI
             """
-            return self.nu(
-                ast.DisengageStmt(
-                    kid=kid,
-                )
+            return ast.DisengageStmt(
+                kid=kid,
             )
 
         def global_ref(self, kid: list[ast.AstNode]) -> ast.GlobalStmt:
@@ -1824,7 +1781,7 @@ class JacParser(Pass):
             global_ref: GLOBAL_OP name_list
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.SubNodeList):
-                return self.nu(ast.GlobalStmt(target=kid[1], kid=kid))
+                return ast.GlobalStmt(target=kid[1], kid=kid)
             else:
                 raise self.ice()
 
@@ -1834,7 +1791,7 @@ class JacParser(Pass):
             nonlocal_ref: NONLOCAL_OP name_list
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.SubNodeList):
-                return self.nu(ast.NonLocalStmt(target=kid[1], kid=kid))
+                return ast.NonLocalStmt(target=kid[1], kid=kid)
             else:
                 raise self.ice()
 
@@ -1899,25 +1856,21 @@ class JacParser(Pass):
             kid = [x for x in kid if x not in assignees]
             kid.insert(1, new_targ) if is_frozen else kid.insert(0, new_targ)
             if is_aug:
-                return self.nu(
-                    ast.Assignment(
-                        target=new_targ,
-                        type_tag=type_tag if isinstance(type_tag, ast.SubTag) else None,
-                        value=value,
-                        mutable=is_frozen,
-                        aug_op=is_aug,
-                        kid=kid,
-                    )
-                )
-            return self.nu(
-                ast.Assignment(
+                return ast.Assignment(
                     target=new_targ,
                     type_tag=type_tag if isinstance(type_tag, ast.SubTag) else None,
                     value=value,
                     mutable=is_frozen,
+                    aug_op=is_aug,
                     kid=kid,
-                    semstr=semstr if isinstance(semstr, ast.String) else None,
                 )
+            return ast.Assignment(
+                target=new_targ,
+                type_tag=type_tag if isinstance(type_tag, ast.SubTag) else None,
+                value=value,
+                mutable=is_frozen,
+                kid=kid,
+                semstr=semstr if isinstance(semstr, ast.String) else None,
             )
 
         def expression(self, kid: list[ast.AstNode]) -> ast.Expr:
@@ -1933,18 +1886,16 @@ class JacParser(Pass):
                     and isinstance(kid[2], ast.Expr)
                     and isinstance(kid[4], ast.Expr)
                 ):
-                    return self.nu(
-                        ast.IfElseExpr(
-                            value=kid[0],
-                            condition=kid[2],
-                            else_value=kid[4],
-                            kid=kid,
-                        )
+                    return ast.IfElseExpr(
+                        value=kid[0],
+                        condition=kid[2],
+                        else_value=kid[4],
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
             elif isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -1953,34 +1904,7 @@ class JacParser(Pass):
 
             walrus_assign: (walrus_assign WALRUS_EQ)? pipe
             """
-            return self.binary_expr_unwind(kid)
-
-        def binary_expr_unwind(self, kid: list[ast.AstNode]) -> ast.Expr:
-            """Binary expression helper."""
-            if len(kid) > 1:
-                if (
-                    isinstance(kid[0], ast.Expr)
-                    and isinstance(
-                        kid[1],
-                        (ast.Token, ast.DisconnectOp, ast.ConnectOp),
-                    )
-                    and isinstance(kid[2], ast.Expr)
-                ):
-                    return self.nu(
-                        ast.BinaryExpr(
-                            left=kid[0],
-                            op=kid[1],
-                            right=kid[2],
-                            kid=kid,
-                        )
-                    )
-                else:
-                    raise self.ice()
-            elif isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
-            else:
-
-                raise self.ice()
+            return self._binary_expr_unwind(kid)
 
         def lambda_expr(self, kid: list[ast.AstNode]) -> ast.LambdaExpr:
             """Grammar rule.
@@ -2016,12 +1940,10 @@ class JacParser(Pass):
             new_kid = [i for i in kid if i != params and i != return_type]
             new_kid.insert(1, signature) if signature else None
             if isinstance(chomp[0], ast.Expr):
-                return self.nu(
-                    ast.LambdaExpr(
-                        signature=signature,
-                        body=chomp[0],
-                        kid=new_kid,
-                    )
+                return ast.LambdaExpr(
+                    signature=signature,
+                    body=chomp[0],
+                    kid=new_kid,
                 )
             else:
                 raise self.ice()
@@ -2032,7 +1954,7 @@ class JacParser(Pass):
             pipe: pipe_back PIPE_FWD pipe
                 | pipe_back
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def pipe_back(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2040,7 +1962,7 @@ class JacParser(Pass):
             pipe_back: bitwise_or PIPE_BKWD pipe_back
                      | bitwise_or
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def bitwise_or(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2048,7 +1970,7 @@ class JacParser(Pass):
             bitwise_or: bitwise_xor BW_OR bitwise_or
                       | bitwise_xor
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def bitwise_xor(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2056,7 +1978,7 @@ class JacParser(Pass):
             bitwise_xor: bitwise_and BW_XOR bitwise_xor
                        | bitwise_and
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def bitwise_and(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2064,14 +1986,14 @@ class JacParser(Pass):
             bitwise_and: shift BW_AND bitwise_and
                        | shift
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def shift(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             shift: (shift (RSHIFT | LSHIFT))? logical_or
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def logical_or(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2083,15 +2005,13 @@ class JacParser(Pass):
                 ops = kid[1] if isinstance(kid[1], ast.Token) else None
                 if not ops:
                     raise self.ice()
-                return self.nu(
-                    ast.BoolExpr(
-                        op=ops,
-                        values=values,
-                        kid=kid,
-                    )
+                return ast.BoolExpr(
+                    op=ops,
+                    values=values,
+                    kid=kid,
                 )
             elif isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
 
                 raise self.ice()
@@ -2106,15 +2026,13 @@ class JacParser(Pass):
                 ops = kid[1] if isinstance(kid[1], ast.Token) else None
                 if not ops:
                     raise self.ice()
-                return self.nu(
-                    ast.BoolExpr(
-                        op=ops,
-                        values=values,
-                        kid=kid,
-                    )
+                return ast.BoolExpr(
+                    op=ops,
+                    values=values,
+                    kid=kid,
                 )
             elif isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
 
                 raise self.ice()
@@ -2126,17 +2044,15 @@ class JacParser(Pass):
             """
             if len(kid) == 2:
                 if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.Expr):
-                    return self.nu(
-                        ast.UnaryExpr(
-                            op=kid[0],
-                            operand=kid[1],
-                            kid=kid,
-                        )
+                    return ast.UnaryExpr(
+                        op=kid[0],
+                        operand=kid[1],
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
             if isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -2150,18 +2066,16 @@ class JacParser(Pass):
                 left = kid[0]
                 rights = [i for i in kid[1:][1::2] if isinstance(i, ast.Expr)]
                 if isinstance(left, ast.Expr) and len(ops) == len(rights):
-                    return self.nu(
-                        ast.CompareExpr(
-                            left=left,
-                            ops=ops,
-                            rights=rights,
-                            kid=kid,
-                        )
+                    return ast.CompareExpr(
+                        left=left,
+                        ops=ops,
+                        rights=rights,
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
             elif isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -2180,7 +2094,7 @@ class JacParser(Pass):
                   | EE
             """
             if isinstance(kid[0], ast.Token):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -2189,14 +2103,14 @@ class JacParser(Pass):
 
             arithmetic: (arithmetic (MINUS | PLUS))? term
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def term(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             term: (term (MOD | DIV | FLOOR_DIV | STAR_MUL | DECOR_OP))? power
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def factor(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2205,51 +2119,49 @@ class JacParser(Pass):
             """
             if len(kid) == 2:
                 if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.Expr):
-                    return self.nu(
-                        ast.UnaryExpr(
-                            op=kid[0],
-                            operand=kid[1],
-                            kid=kid,
-                        )
+                    return ast.UnaryExpr(
+                        op=kid[0],
+                        operand=kid[1],
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def power(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             power: (power STAR_POW)? factor
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def connect(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             connect: (connect (connect_op | disconnect_op))? atomic_pipe
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def atomic_pipe(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             atomic_pipe: (atomic_pipe A_PIPE_FWD)? atomic_pipe_back
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def atomic_pipe_back(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             atomic_pipe_back: (atomic_pipe_back A_PIPE_BKWD)? ds_spawn
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def ds_spawn(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
 
             ds_spawn: (ds_spawn KW_SPAWN)? unpack
             """
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def unpack(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2258,16 +2170,14 @@ class JacParser(Pass):
             """
             if len(kid) == 2:
                 if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.Expr):
-                    return self.nu(
-                        ast.UnaryExpr(
-                            op=kid[0],
-                            operand=kid[1],
-                            kid=kid,
-                        )
+                    return ast.UnaryExpr(
+                        op=kid[0],
+                        operand=kid[1],
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def ref(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2277,16 +2187,14 @@ class JacParser(Pass):
             """
             if len(kid) == 2:
                 if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.Expr):
-                    return self.nu(
-                        ast.UnaryExpr(
-                            op=kid[0],
-                            operand=kid[1],
-                            kid=kid,
-                        )
+                    return ast.UnaryExpr(
+                        op=kid[0],
+                        operand=kid[1],
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def pipe_call(self, kid: list[ast.AstNode]) -> ast.Expr:
             """Grammar rule.
@@ -2303,23 +2211,19 @@ class JacParser(Pass):
                     and kid[0].name == Tok.KW_AWAIT
                     and isinstance(kid[1], ast.Expr)
                 ):
-                    return self.nu(
-                        ast.AwaitExpr(
-                            target=kid[1],
-                            kid=kid,
-                        )
+                    return ast.AwaitExpr(
+                        target=kid[1],
+                        kid=kid,
                     )
                 elif isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.Expr):
-                    return self.nu(
-                        ast.UnaryExpr(
-                            op=kid[0],
-                            operand=kid[1],
-                            kid=kid,
-                        )
+                    return ast.UnaryExpr(
+                        op=kid[0],
+                        operand=kid[1],
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
-            return self.binary_expr_unwind(kid)
+            return self._binary_expr_unwind(kid)
 
         def aug_op(self, kid: list[ast.AstNode]) -> ast.Token:
             """Grammar rule.
@@ -2339,7 +2243,7 @@ class JacParser(Pass):
                      | WALRUS_EQ
             """
             if isinstance(kid[0], ast.Token):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -2351,7 +2255,7 @@ class JacParser(Pass):
                         | (atomic_call | atom | edge_ref_chain)
             """
             if len(kid) < 2 and isinstance(kid[0], ast.Expr):
-                return self.nu(kid[0])
+                return kid[0]
             chomp = [*kid]
             target = chomp[0]
             chomp = chomp[1:]
@@ -2364,14 +2268,12 @@ class JacParser(Pass):
                 and isinstance(chomp[0], ast.AtomExpr)
                 and isinstance(target, ast.Expr)
             ):
-                return self.nu(
-                    ast.AtomTrailer(
-                        target=target,
-                        right=chomp[0],
-                        is_null_ok=is_null_ok,
-                        is_attr=False,
-                        kid=kid,
-                    )
+                return ast.AtomTrailer(
+                    target=target,
+                    right=chomp[0],
+                    is_null_ok=is_null_ok,
+                    is_attr=False,
+                    kid=kid,
                 )
             elif (
                 len(chomp) > 1
@@ -2379,14 +2281,12 @@ class JacParser(Pass):
                 and isinstance(chomp[1], (ast.AtomExpr, ast.AtomTrailer))
                 and isinstance(target, ast.Expr)
             ):
-                return self.nu(
-                    ast.AtomTrailer(
-                        target=(target if chomp[0].name != Tok.DOT_BKWD else chomp[1]),
-                        right=(chomp[1] if chomp[0].name != Tok.DOT_BKWD else target),
-                        is_null_ok=is_null_ok,
-                        is_attr=True,
-                        kid=kid,
-                    )
+                return ast.AtomTrailer(
+                    target=(target if chomp[0].name != Tok.DOT_BKWD else chomp[1]),
+                    right=(chomp[1] if chomp[0].name != Tok.DOT_BKWD else target),
+                    is_null_ok=is_null_ok,
+                    is_attr=True,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2402,25 +2302,23 @@ class JacParser(Pass):
                 and kid[-2]
                 and isinstance(kid[-2], ast.FuncCall)
             ):
-                return self.nu(
-                    ast.FuncCall(
-                        target=kid[0],
-                        params=kid[2] if isinstance(kid[2], ast.SubNodeList) else None,
-                        genai_call=kid[-2],
-                        kid=kid,
-                    )
+                return ast.FuncCall(
+                    target=kid[0],
+                    params=kid[2] if isinstance(kid[2], ast.SubNodeList) else None,
+                    genai_call=kid[-2],
+                    kid=kid,
                 )
             if (
                 len(kid) == 4
                 and isinstance(kid[0], ast.Expr)
                 and isinstance(kid[2], ast.SubNodeList)
             ):
-                return self.nu(
-                    ast.FuncCall(target=kid[0], params=kid[2], genai_call=None, kid=kid)
+                return ast.FuncCall(
+                    target=kid[0], params=kid[2], genai_call=None, kid=kid
                 )
             elif len(kid) == 3 and isinstance(kid[0], ast.Expr):
-                return self.nu(
-                    ast.FuncCall(target=kid[0], params=None, genai_call=None, kid=kid)
+                return ast.FuncCall(
+                    target=kid[0], params=None, genai_call=None, kid=kid
                 )
             else:
                 raise self.ice()
@@ -2447,14 +2345,10 @@ class JacParser(Pass):
                         )
                         expr = ast.TupleVal(values=sublist, kid=[sublist])
                         kid = [expr]
-                    return self.nu(
-                        ast.IndexSlice(
-                            slices=[
-                                ast.IndexSlice.Slice(start=expr, stop=None, step=None)
-                            ],
-                            is_range=False,
-                            kid=kid,
-                        )
+                    return ast.IndexSlice(
+                        slices=[ast.IndexSlice.Slice(start=expr, stop=None, step=None)],
+                        is_range=False,
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
@@ -2489,12 +2383,10 @@ class JacParser(Pass):
                         ast.IndexSlice.Slice(start=expr1, stop=expr2, step=expr3)
                     )
 
-                return self.nu(
-                    ast.IndexSlice(
-                        slices=slices,
-                        is_range=True,
-                        kid=kid,
-                    )
+                return ast.IndexSlice(
+                    slices=slices,
+                    is_range=True,
+                    kid=kid,
                 )
 
         def atom(self, kid: list[ast.AstNode]) -> ast.Expr:
@@ -2508,7 +2400,7 @@ class JacParser(Pass):
             """
             if len(kid) == 1:
                 if isinstance(kid[0], ast.AtomExpr):
-                    return self.nu(kid[0])
+                    return kid[0]
                 else:
                     raise self.ice()
             elif len(kid) == 3:
@@ -2518,7 +2410,7 @@ class JacParser(Pass):
                     and isinstance(kid[2], ast.Token)
                 ):
                     ret = ast.AtomUnit(value=kid[1], kid=kid)
-                    return self.nu(ret)
+                    return ret
                 else:
                     raise self.ice()
             else:
@@ -2530,12 +2422,10 @@ class JacParser(Pass):
             yield_expr: KW_YIELD KW_FROM? expression
             """
             if isinstance(kid[-1], ast.Expr):
-                return self.nu(
-                    ast.YieldExpr(
-                        expr=kid[-1],
-                        with_from=len(kid) > 2,
-                        kid=kid,
-                    )
+                return ast.YieldExpr(
+                    expr=kid[-1],
+                    with_from=len(kid) > 2,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2554,7 +2444,7 @@ class JacParser(Pass):
                         | INT
             """
             if isinstance(kid[0], ast.AtomExpr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -2571,7 +2461,7 @@ class JacParser(Pass):
                            | list_val
             """
             if isinstance(kid[0], ast.AtomExpr):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -2582,11 +2472,9 @@ class JacParser(Pass):
             """
             valid_strs = [i for i in kid if isinstance(i, (ast.String, ast.FString))]
             if len(valid_strs) == len(kid):
-                return self.nu(
-                    ast.MultiString(
-                        strings=valid_strs,
-                        kid=kid,
-                    )
+                return ast.MultiString(
+                    strings=valid_strs,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2598,18 +2486,14 @@ class JacParser(Pass):
                 | FSTR_SQ_START fstr_sq_parts FSTR_SQ_END
             """
             if len(kid) == 2:
-                return self.nu(
-                    ast.FString(
-                        parts=None,
-                        kid=kid,
-                    )
+                return ast.FString(
+                    parts=None,
+                    kid=kid,
                 )
             elif isinstance(kid[1], ast.SubNodeList):
-                return self.nu(
-                    ast.FString(
-                        parts=kid[1],
-                        kid=kid,
-                    )
+                return ast.FString(
+                    parts=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2630,12 +2514,10 @@ class JacParser(Pass):
                 for i in kid
                 if isinstance(i, ast.Expr)
             ]
-            return self.nu(
-                ast.SubNodeList[ast.String | ast.ExprStmt](
-                    items=valid_parts,
-                    delim=None,
-                    kid=valid_parts,
-                )
+            return ast.SubNodeList[ast.String | ast.ExprStmt](
+                items=valid_parts,
+                delim=None,
+                kid=valid_parts,
             )
 
         def fstr_sq_parts(
@@ -2654,12 +2536,10 @@ class JacParser(Pass):
                 for i in kid
                 if isinstance(i, ast.Expr)
             ]
-            return self.nu(
-                ast.SubNodeList[ast.String | ast.ExprStmt](
-                    items=valid_parts,
-                    delim=None,
-                    kid=valid_parts,
-                )
+            return ast.SubNodeList[ast.String | ast.ExprStmt](
+                items=valid_parts,
+                delim=None,
+                kid=valid_parts,
             )
 
         def list_val(self, kid: list[ast.AstNode]) -> ast.ListVal:
@@ -2668,18 +2548,14 @@ class JacParser(Pass):
             list_val: LSQUARE (expr_list COMMA?)? RSQUARE
             """
             if len(kid) == 2:
-                return self.nu(
-                    ast.ListVal(
-                        values=None,
-                        kid=kid,
-                    )
+                return ast.ListVal(
+                    values=None,
+                    kid=kid,
                 )
             elif isinstance(kid[1], ast.SubNodeList):
-                return self.nu(
-                    ast.ListVal(
-                        values=kid[1],
-                        kid=kid,
-                    )
+                return ast.ListVal(
+                    values=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2690,18 +2566,14 @@ class JacParser(Pass):
             tuple_val: LPAREN tuple_list? RPAREN
             """
             if len(kid) == 2:
-                return self.nu(
-                    ast.TupleVal(
-                        values=None,
-                        kid=kid,
-                    )
+                return ast.TupleVal(
+                    values=None,
+                    kid=kid,
                 )
             elif isinstance(kid[1], ast.SubNodeList):
-                return self.nu(
-                    ast.TupleVal(
-                        values=kid[1],
-                        kid=kid,
-                    )
+                return ast.TupleVal(
+                    values=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2712,18 +2584,14 @@ class JacParser(Pass):
             set_val: LBRACE expr_list COMMA? RBRACE
             """
             if len(kid) == 2:
-                return self.nu(
-                    ast.SetVal(
-                        values=None,
-                        kid=kid,
-                    )
+                return ast.SetVal(
+                    values=None,
+                    kid=kid,
                 )
             elif isinstance(kid[1], ast.SubNodeList):
-                return self.nu(
-                    ast.SetVal(
-                        values=kid[1],
-                        kid=kid,
-                    )
+                return ast.SetVal(
+                    values=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2745,12 +2613,10 @@ class JacParser(Pass):
                 expr = kid[0]
                 new_kid = [expr]
             valid_kid = [i for i in new_kid if isinstance(i, ast.Expr)]
-            return self.nu(
-                ast.SubNodeList[ast.Expr](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=new_kid,
-                )
+            return ast.SubNodeList[ast.Expr](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=new_kid,
             )
 
         def kw_expr_list(self, kid: list[ast.AstNode]) -> ast.SubNodeList[ast.KWPair]:
@@ -2770,12 +2636,10 @@ class JacParser(Pass):
                 expr = kid[0]
                 new_kid = [expr]
             valid_kid = [i for i in new_kid if isinstance(i, ast.KWPair)]
-            return self.nu(
-                ast.SubNodeList[ast.KWPair](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=new_kid,
-                )
+            return ast.SubNodeList[ast.KWPair](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=new_kid,
             )
 
         def kw_expr(self, kid: list[ast.AstNode]) -> ast.KWPair:
@@ -2788,20 +2652,16 @@ class JacParser(Pass):
                 and isinstance(kid[0], ast.NameAtom)
                 and isinstance(kid[2], ast.Expr)
             ):
-                return self.nu(
-                    ast.KWPair(
-                        key=kid[0],
-                        value=kid[2],
-                        kid=kid,
-                    )
+                return ast.KWPair(
+                    key=kid[0],
+                    value=kid[2],
+                    kid=kid,
                 )
             elif len(kid) == 2 and isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.KWPair(
-                        key=None,
-                        value=kid[1],
-                        kid=kid,
-                    )
+                return ast.KWPair(
+                    key=None,
+                    value=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2812,12 +2672,10 @@ class JacParser(Pass):
             name_list: (named_ref COMMA)* named_ref
             """
             valid_kid = [i for i in kid if isinstance(i, ast.Name)]
-            return self.nu(
-                ast.SubNodeList[ast.Name](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=kid,
-                )
+            return ast.SubNodeList[ast.Name](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=kid,
             )
 
         def tuple_list(
@@ -2840,7 +2698,7 @@ class JacParser(Pass):
                     # Add the comma to the subnode list if it exists, otherwise the last comma will not be a part of
                     # the ast, we need it for formatting.
                     chomp[0].kid.append(chomp[1])
-                return self.nu(chomp[0])
+                return chomp[0]
             else:
                 # The chomp will be like this:
                 #     expression, COMMA, [subnode_list, [COMMA, [kw_expr_list, [COMMA]]]]
@@ -2859,12 +2717,10 @@ class JacParser(Pass):
                     expr_list = [*expr_list, *chomp[0].kid]
             expr_list = [first_expr, *expr_list]
             valid_kid = [i for i in expr_list if isinstance(i, (ast.Expr, ast.KWPair))]
-            return self.nu(
-                ast.SubNodeList[ast.Expr | ast.KWPair](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=kid,
-                )
+            return ast.SubNodeList[ast.Expr | ast.KWPair](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=kid,
             )
 
         def dict_val(self, kid: list[ast.AstNode]) -> ast.DictVal:
@@ -2877,7 +2733,7 @@ class JacParser(Pass):
                 kid=kid,
             )
             ret.kv_pairs = [i for i in kid if isinstance(i, ast.KVPair)]
-            return self.nu(ret)
+            return ret
 
         def kv_pair(self, kid: list[ast.AstNode]) -> ast.KVPair:
             """Grammar rule.
@@ -2889,20 +2745,16 @@ class JacParser(Pass):
                 and isinstance(kid[0], ast.Expr)
                 and isinstance(kid[2], ast.Expr)
             ):
-                return self.nu(
-                    ast.KVPair(
-                        key=kid[0],
-                        value=kid[2],
-                        kid=kid,
-                    )
+                return ast.KVPair(
+                    key=kid[0],
+                    value=kid[2],
+                    kid=kid,
                 )
             elif len(kid) == 2 and isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.KVPair(
-                        key=None,
-                        value=kid[1],
-                        kid=kid,
-                    )
+                return ast.KVPair(
+                    key=None,
+                    value=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2914,12 +2766,10 @@ class JacParser(Pass):
             """
             comprs = [i for i in kid if isinstance(i, ast.InnerCompr)]
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.ListCompr(
-                        out_expr=kid[1],
-                        compr=comprs,
-                        kid=kid,
-                    )
+                return ast.ListCompr(
+                    out_expr=kid[1],
+                    compr=comprs,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2931,12 +2781,10 @@ class JacParser(Pass):
             """
             comprs = [i for i in kid if isinstance(i, ast.InnerCompr)]
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.GenCompr(
-                        out_expr=kid[1],
-                        compr=comprs,
-                        kid=kid,
-                    )
+                return ast.GenCompr(
+                    out_expr=kid[1],
+                    compr=comprs,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2948,12 +2796,10 @@ class JacParser(Pass):
             """
             comprs = [i for i in kid if isinstance(i, ast.InnerCompr)]
             if isinstance(kid[1], ast.Expr) and isinstance(kid[2], ast.InnerCompr):
-                return self.nu(
-                    ast.SetCompr(
-                        out_expr=kid[1],
-                        compr=comprs,
-                        kid=kid,
-                    )
+                return ast.SetCompr(
+                    out_expr=kid[1],
+                    compr=comprs,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2965,12 +2811,10 @@ class JacParser(Pass):
             """
             comprs = [i for i in kid if isinstance(i, ast.InnerCompr)]
             if isinstance(kid[1], ast.KVPair) and isinstance(kid[2], ast.InnerCompr):
-                return self.nu(
-                    ast.DictCompr(
-                        kv_pair=kid[1],
-                        compr=comprs,
-                        kid=kid,
-                    )
+                return ast.DictCompr(
+                    kv_pair=kid[1],
+                    compr=comprs,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -2987,18 +2831,16 @@ class JacParser(Pass):
             chomp = chomp[1:] if is_async else chomp
             chomp = chomp[1:]
             if isinstance(chomp[0], ast.Expr) and isinstance(chomp[2], ast.Expr):
-                return self.nu(
-                    ast.InnerCompr(
-                        is_async=is_async,
-                        target=chomp[0],
-                        collection=chomp[2],
-                        conditional=(
-                            [i for i in chomp[4:] if isinstance(i, ast.Expr)]
-                            if len(chomp) > 4 and isinstance(chomp[4], ast.Expr)
-                            else None
-                        ),
-                        kid=chomp,
-                    )
+                return ast.InnerCompr(
+                    is_async=is_async,
+                    target=chomp[0],
+                    collection=chomp[2],
+                    conditional=(
+                        [i for i in chomp[4:] if isinstance(i, ast.Expr)]
+                        if len(chomp) > 4 and isinstance(chomp[4], ast.Expr)
+                        else None
+                    ),
+                    kid=chomp,
                 )
             else:
                 raise self.ice()
@@ -3023,7 +2865,7 @@ class JacParser(Pass):
                         ends_with_comma
                     ):  # Append the trailing comma to the subnode list.
                         kid[0].kid.append(kid[1])
-                    return self.nu(kid[0])
+                    return kid[0]
                 else:
                     raise self.ice()
             elif isinstance(kid[0], ast.SubNodeList) and isinstance(
@@ -3035,12 +2877,10 @@ class JacParser(Pass):
                     if isinstance(i, (ast.Expr, ast.KWPair))
                 ]
                 if len(valid_kid) == len(kid[0].items) + len(kid[2].items):
-                    return self.nu(
-                        ast.SubNodeList[ast.Expr | ast.KWPair](
-                            items=valid_kid,
-                            delim=Tok.COMMA,
-                            kid=kid,
-                        )
+                    return ast.SubNodeList[ast.Expr | ast.KWPair](
+                        items=valid_kid,
+                        delim=Tok.COMMA,
+                        kid=kid,
                     )
                 else:
                     raise self.ice()
@@ -3065,12 +2905,10 @@ class JacParser(Pass):
                 assign = kid[0]
                 new_kid = [assign]
             valid_kid = [i for i in new_kid if isinstance(i, ast.Assignment)]
-            return self.nu(
-                ast.SubNodeList[ast.Assignment](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=new_kid,
-                )
+            return ast.SubNodeList[ast.Assignment](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=new_kid,
             )
 
         def arch_ref(self, kid: list[ast.AstNode]) -> ast.ArchRef:
@@ -3083,7 +2921,7 @@ class JacParser(Pass):
                     | type_ref
             """
             if isinstance(kid[0], ast.ArchRef):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -3093,12 +2931,10 @@ class JacParser(Pass):
             node_ref: NODE_OP NAME
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3109,12 +2945,10 @@ class JacParser(Pass):
             edge_ref: EDGE_OP NAME
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3125,12 +2959,10 @@ class JacParser(Pass):
             walker_ref: WALKER_OP NAME
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3141,12 +2973,10 @@ class JacParser(Pass):
             class_ref: CLASS_OP name_ref
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3157,12 +2987,10 @@ class JacParser(Pass):
             object_ref: OBJECT_OP name_ref
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3173,12 +3001,10 @@ class JacParser(Pass):
             type_ref: TYPE_OP (named_ref | builtin_type)
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3189,12 +3015,10 @@ class JacParser(Pass):
             enum_ref: ENUM_OP NAME
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3205,12 +3029,10 @@ class JacParser(Pass):
             ability_ref: ABILITY_OP (special_ref | name_ref)
             """
             if isinstance(kid[0], ast.Token) and isinstance(kid[1], ast.NameAtom):
-                return self.nu(
-                    ast.ArchRef(
-                        arch_type=kid[0],
-                        arch_name=kid[1],
-                        kid=kid,
-                    )
+                return ast.ArchRef(
+                    arch_type=kid[0],
+                    arch_name=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3230,11 +3052,9 @@ class JacParser(Pass):
             new_kid = [*consume.kid, name] if consume else [name]
             valid_kid = [i for i in new_kid if isinstance(i, ast.ArchRef)]
             if len(valid_kid) == len(new_kid):
-                return self.nu(
-                    ast.ArchRefChain(
-                        archs=valid_kid,
-                        kid=new_kid,
-                    )
+                return ast.ArchRefChain(
+                    archs=valid_kid,
+                    kid=new_kid,
                 )
             else:
                 raise self.ice()
@@ -3248,20 +3068,16 @@ class JacParser(Pass):
                 if isinstance(kid[1], ast.ArchRef) and isinstance(
                     kid[0], ast.ArchRefChain
                 ):
-                    return self.nu(
-                        ast.ArchRefChain(
-                            archs=[*(kid[0].archs), kid[1]],
-                            kid=[*(kid[0].kid), kid[1]],
-                        )
+                    return ast.ArchRefChain(
+                        archs=[*(kid[0].archs), kid[1]],
+                        kid=[*(kid[0].kid), kid[1]],
                     )
                 else:
                     raise self.ice()
             elif isinstance(kid[0], ast.ArchRef):
-                return self.nu(
-                    ast.ArchRefChain(
-                        archs=[kid[0]],
-                        kid=kid,
-                    )
+                return ast.ArchRefChain(
+                    archs=[kid[0]],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3275,20 +3091,16 @@ class JacParser(Pass):
                 if isinstance(kid[1], ast.ArchRef) and isinstance(
                     kid[0], ast.ArchRefChain
                 ):
-                    return self.nu(
-                        ast.ArchRefChain(
-                            archs=[*(kid[0].archs), kid[1]],
-                            kid=[*(kid[0].kid), kid[1]],
-                        )
+                    return ast.ArchRefChain(
+                        archs=[*(kid[0].archs), kid[1]],
+                        kid=[*(kid[0].kid), kid[1]],
                     )
                 else:
                     raise self.ice()
             elif isinstance(kid[0], ast.ArchRef):
-                return self.nu(
-                    ast.ArchRefChain(
-                        archs=[kid[0]],
-                        kid=kid,
-                    )
+                return ast.ArchRefChain(
+                    archs=[kid[0]],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3302,20 +3114,16 @@ class JacParser(Pass):
                 if isinstance(kid[1], ast.ArchRef) and isinstance(
                     kid[0], ast.ArchRefChain
                 ):
-                    return self.nu(
-                        ast.ArchRefChain(
-                            archs=[*(kid[0].archs), kid[1]],
-                            kid=[*(kid[0].kid), kid[1]],
-                        )
+                    return ast.ArchRefChain(
+                        archs=[*(kid[0].archs), kid[1]],
+                        kid=[*(kid[0].kid), kid[1]],
                     )
                 else:
                     raise self.ice()
             elif isinstance(kid[0], ast.ArchRef):
-                return self.nu(
-                    ast.ArchRefChain(
-                        archs=[kid[0]],
-                        kid=kid,
-                    )
+                return ast.ArchRefChain(
+                    archs=[kid[0]],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3326,13 +3134,10 @@ class JacParser(Pass):
             (EDGE_OP|NODE_OP)? LSQUARE expression? (edge_op_ref (filter_compr | expression)?)+ RSQUARE
             """
             valid_chain = [i for i in kid if isinstance(i, (ast.Expr, ast.FilterCompr))]
-            return self.nu(
-                ast.EdgeRefTrailer(
-                    chain=valid_chain,
-                    edges_only=isinstance(kid[0], ast.Token)
-                    and kid[0].name == Tok.EDGE_OP,
-                    kid=kid,
-                )
+            return ast.EdgeRefTrailer(
+                chain=valid_chain,
+                edges_only=isinstance(kid[0], ast.Token) and kid[0].name == Tok.EDGE_OP,
+                kid=kid,
             )
 
         def edge_op_ref(self, kid: list[ast.AstNode]) -> ast.EdgeOpRef:
@@ -3341,7 +3146,7 @@ class JacParser(Pass):
             edge_op_ref: (edge_any | edge_from | edge_to)
             """
             if isinstance(kid[0], ast.EdgeOpRef):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -3353,9 +3158,7 @@ class JacParser(Pass):
             """
             fcond = kid[1] if len(kid) > 1 else None
             if isinstance(fcond, ast.FilterCompr) or fcond is None:
-                return self.nu(
-                    ast.EdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.OUT, kid=kid)
-                )
+                return ast.EdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.OUT, kid=kid)
             else:
                 raise self.ice()
 
@@ -3367,9 +3170,7 @@ class JacParser(Pass):
             """
             fcond = kid[1] if len(kid) > 1 else None
             if isinstance(fcond, ast.FilterCompr) or fcond is None:
-                return self.nu(
-                    ast.EdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.IN, kid=kid)
-                )
+                return ast.EdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.IN, kid=kid)
             else:
                 raise self.ice()
 
@@ -3381,9 +3182,7 @@ class JacParser(Pass):
             """
             fcond = kid[1] if len(kid) > 1 else None
             if isinstance(fcond, ast.FilterCompr) or fcond is None:
-                return self.nu(
-                    ast.EdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.ANY, kid=kid)
-                )
+                return ast.EdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.ANY, kid=kid)
             else:
                 raise self.ice()
 
@@ -3393,7 +3192,7 @@ class JacParser(Pass):
             connect_op: connect_from | connect_to | connect_any
             """
             if len(kid) < 2 and isinstance(kid[0], ast.ConnectOp):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -3403,11 +3202,9 @@ class JacParser(Pass):
             disconnect_op: NOT edge_op_ref
             """
             if isinstance(kid[1], ast.EdgeOpRef):
-                return self.nu(
-                    ast.DisconnectOp(
-                        edge_spec=kid[1],
-                        kid=kid,
-                    )
+                return ast.DisconnectOp(
+                    edge_spec=kid[1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3430,13 +3227,11 @@ class JacParser(Pass):
                 )
                 if conn_assign:
                     kid[3] = conn_assign
-                return self.nu(
-                    ast.ConnectOp(
-                        conn_type=conn_type,
-                        conn_assign=conn_assign,
-                        edge_dir=EdgeDir.OUT,
-                        kid=kid,
-                    )
+                return ast.ConnectOp(
+                    conn_type=conn_type,
+                    conn_assign=conn_assign,
+                    edge_dir=EdgeDir.OUT,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3459,13 +3254,11 @@ class JacParser(Pass):
                 )
                 if conn_assign:
                     kid[3] = conn_assign
-                return self.nu(
-                    ast.ConnectOp(
-                        conn_type=conn_type,
-                        conn_assign=conn_assign,
-                        edge_dir=EdgeDir.IN,
-                        kid=kid,
-                    )
+                return ast.ConnectOp(
+                    conn_type=conn_type,
+                    conn_assign=conn_assign,
+                    edge_dir=EdgeDir.IN,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3487,13 +3280,11 @@ class JacParser(Pass):
                 )
                 if conn_assign:
                     kid[3] = conn_assign
-                return self.nu(
-                    ast.ConnectOp(
-                        conn_type=conn_type,
-                        conn_assign=conn_assign,
-                        edge_dir=EdgeDir.ANY,
-                        kid=kid,
-                    )
+                return ast.ConnectOp(
+                    conn_type=conn_type,
+                    conn_assign=conn_assign,
+                    edge_dir=EdgeDir.ANY,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3505,11 +3296,11 @@ class JacParser(Pass):
                         | LPAREN TYPE_OP NULL_OK typed_filter_compare_list RPAREN
             """
             if isinstance(kid[2], ast.SubNodeList):
-                return self.nu(ast.FilterCompr(compares=kid[2], f_type=None, kid=kid))
+                return ast.FilterCompr(compares=kid[2], f_type=None, kid=kid)
             elif isinstance(kid[3], ast.FilterCompr):
                 kid[3].add_kids_left(kid[:3])
                 kid[3].add_kids_right(kid[4:])
-                return self.nu(kid[3])
+                return kid[3]
             else:
                 raise self.ice()
 
@@ -3532,12 +3323,10 @@ class JacParser(Pass):
                 expr = kid[0]
                 new_kid = [expr]
             valid_kid = [i for i in new_kid if isinstance(i, ast.CompareExpr)]
-            return self.nu(
-                ast.SubNodeList[ast.CompareExpr](
-                    items=valid_kid,
-                    delim=Tok.COMMA,
-                    kid=new_kid,
-                )
+            return ast.SubNodeList[ast.CompareExpr](
+                items=valid_kid,
+                delim=Tok.COMMA,
+                kid=new_kid,
             )
 
         def typed_filter_compare_list(self, kid: list[ast.AstNode]) -> ast.FilterCompr:
@@ -3558,7 +3347,7 @@ class JacParser(Pass):
             if isinstance(expr, ast.Expr) and (
                 (isinstance(compares, ast.SubNodeList)) or compares is None
             ):
-                return self.nu(ast.FilterCompr(compares=compares, f_type=expr, kid=kid))
+                return ast.FilterCompr(compares=compares, f_type=expr, kid=kid)
             else:
                 raise self.ice()
 
@@ -3569,7 +3358,7 @@ class JacParser(Pass):
             """
             ret = self.compare(kid)
             if isinstance(ret, ast.CompareExpr):
-                return self.nu(ret)
+                return ret
             else:
                 raise self.ice()
 
@@ -3579,11 +3368,9 @@ class JacParser(Pass):
             filter_compr: LPAREN EQ kw_expr_list RPAREN
             """
             if isinstance(kid[2], ast.SubNodeList):
-                return self.nu(
-                    ast.AssignCompr(
-                        assigns=kid[2],
-                        kid=kid,
-                    )
+                return ast.AssignCompr(
+                    assigns=kid[2],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3595,12 +3382,10 @@ class JacParser(Pass):
             """
             cases = [i for i in kid if isinstance(i, ast.MatchCase)]
             if isinstance(kid[1], ast.Expr):
-                return self.nu(
-                    ast.MatchStmt(
-                        target=kid[1],
-                        cases=cases,
-                        kid=kid,
-                    )
+                return ast.MatchStmt(
+                    target=kid[1],
+                    cases=cases,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3616,13 +3401,11 @@ class JacParser(Pass):
             if isinstance(pattern, ast.MatchPattern) and isinstance(
                 guard, (ast.Expr, type(None))
             ):
-                return self.nu(
-                    ast.MatchCase(
-                        pattern=pattern,
-                        guard=guard,
-                        body=stmts,
-                        kid=kid,
-                    )
+                return ast.MatchCase(
+                    pattern=pattern,
+                    guard=guard,
+                    body=stmts,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3633,7 +3416,7 @@ class JacParser(Pass):
             pattern_seq: (or_pattern | as_pattern)
             """
             if isinstance(kid[0], ast.MatchPattern):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -3644,16 +3427,14 @@ class JacParser(Pass):
             """
             if len(kid) == 1:
                 if isinstance(kid[0], ast.MatchPattern):
-                    return self.nu(kid[0])
+                    return kid[0]
                 else:
                     raise self.ice()
             else:
                 patterns = [i for i in kid if isinstance(i, ast.MatchPattern)]
-                return self.nu(
-                    ast.MatchOr(
-                        patterns=patterns,
-                        kid=kid,
-                    )
+                return ast.MatchOr(
+                    patterns=patterns,
+                    kid=kid,
                 )
 
         def as_pattern(self, kid: list[ast.AstNode]) -> ast.MatchPattern:
@@ -3664,12 +3445,10 @@ class JacParser(Pass):
             if isinstance(kid[0], ast.MatchPattern) and isinstance(
                 kid[2], ast.NameAtom
             ):
-                return self.nu(
-                    ast.MatchAs(
-                        pattern=kid[0],
-                        name=kid[2],
-                        kid=kid,
-                    )
+                return ast.MatchAs(
+                    pattern=kid[0],
+                    name=kid[2],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3684,7 +3463,7 @@ class JacParser(Pass):
                 | class_pattern
             """
             if isinstance(kid[0], ast.MatchPattern):
-                return self.nu(kid[0])
+                return kid[0]
             else:
                 raise self.ice()
 
@@ -3694,11 +3473,9 @@ class JacParser(Pass):
             literal_pattern: (INT | FLOAT | multistring)
             """
             if isinstance(kid[0], ast.Expr):
-                return self.nu(
-                    ast.MatchValue(
-                        value=kid[0],
-                        kid=kid,
-                    )
+                return ast.MatchValue(
+                    value=kid[0],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3709,11 +3486,9 @@ class JacParser(Pass):
             singleton_pattern: (NULL | BOOL)
             """
             if isinstance(kid[0], (ast.Bool, ast.Null)):
-                return self.nu(
-                    ast.MatchSingleton(
-                        value=kid[0],
-                        kid=kid,
-                    )
+                return ast.MatchSingleton(
+                    value=kid[0],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3728,18 +3503,14 @@ class JacParser(Pass):
                 and isinstance(kid[0], ast.Name)
                 and kid[0].sym_name == "_"
             ):
-                return self.nu(
-                    ast.MatchWild(
-                        kid=kid,
-                    )
+                return ast.MatchWild(
+                    kid=kid,
                 )
             if isinstance(kid[0], ast.NameAtom):
-                return self.nu(
-                    ast.MatchAs(
-                        name=kid[0],
-                        pattern=None,
-                        kid=kid,
-                    )
+                return ast.MatchAs(
+                    name=kid[0],
+                    pattern=None,
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3751,11 +3522,9 @@ class JacParser(Pass):
                             | LPAREN list_inner_pattern (COMMA list_inner_pattern)* RPAREN
             """
             patterns = [i for i in kid if isinstance(i, ast.MatchPattern)]
-            return self.nu(
-                ast.MatchSequence(
-                    values=patterns,
-                    kid=kid,
-                )
+            return ast.MatchSequence(
+                values=patterns,
+                kid=kid,
             )
 
         def mapping_pattern(self, kid: list[ast.AstNode]) -> ast.MatchMapping:
@@ -3766,11 +3535,9 @@ class JacParser(Pass):
             patterns = [
                 i for i in kid if isinstance(i, (ast.MatchKVPair, ast.MatchStar))
             ]
-            return self.nu(
-                ast.MatchMapping(
-                    values=patterns,
-                    kid=kid,
-                )
+            return ast.MatchMapping(
+                values=patterns,
+                kid=kid,
             )
 
         def list_inner_pattern(self, kid: list[ast.AstNode]) -> ast.MatchPattern:
@@ -3779,14 +3546,12 @@ class JacParser(Pass):
             list_inner_pattern: (pattern_seq | STAR_MUL NAME)
             """
             if isinstance(kid[0], ast.MatchPattern):
-                return self.nu(kid[0])
+                return kid[0]
             elif isinstance(kid[-1], ast.Name):
-                return self.nu(
-                    ast.MatchStar(
-                        is_list=True,
-                        name=kid[-1],
-                        kid=kid,
-                    )
+                return ast.MatchStar(
+                    is_list=True,
+                    name=kid[-1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3801,20 +3566,16 @@ class JacParser(Pass):
             if isinstance(kid[0], ast.MatchPattern) and isinstance(
                 kid[2], ast.MatchPattern
             ):
-                return self.nu(
-                    ast.MatchKVPair(
-                        key=kid[0],
-                        value=kid[2],
-                        kid=kid,
-                    )
+                return ast.MatchKVPair(
+                    key=kid[0],
+                    value=kid[2],
+                    kid=kid,
                 )
             elif isinstance(kid[-1], ast.Name):
-                return self.nu(
-                    ast.MatchStar(
-                        is_list=False,
-                        name=kid[-1],
-                        kid=kid,
-                    )
+                return ast.MatchStar(
+                    is_list=False,
+                    name=kid[-1],
+                    kid=kid,
                 )
             else:
                 raise self.ice()
@@ -3886,13 +3647,11 @@ class JacParser(Pass):
                     kid_nodes.append(kw)
                 kid_nodes.append(rapren)
 
-                return self.nu(
-                    ast.MatchArch(
-                        name=name,
-                        arg_patterns=arg,
-                        kw_patterns=kw,
-                        kid=kid_nodes,
-                    )
+                return ast.MatchArch(
+                    name=name,
+                    arg_patterns=arg,
+                    kw_patterns=kw,
+                    kid=kid_nodes,
                 )
             else:
                 raise self.ice()
@@ -4027,4 +3786,4 @@ class JacParser(Pass):
                     err.column = ret.loc.col_start
                     raise err
             self.terminals.append(ret)
-            return self.nu(ret)
+            return ret

--- a/jac/jaclang/compiler/tests/test_parser.py
+++ b/jac/jaclang/compiler/tests/test_parser.py
@@ -89,12 +89,20 @@ class TestLarkParser(TestCaseMicroSuite):
                 JacParser.TreeToAST.__base__, value.__name__, False
             ):
                 parse_funcs.append(name)
-        for i in rules:
-            self.assertIn(i, parse_funcs)
-        for i in parse_funcs:
-            if i in ["binary_expr_unwind", "ice", "nu"]:
+        for rule in rules:
+            self.assertIn(rule, parse_funcs)
+        for fn in parse_funcs:
+            if fn.startswith("_") or fn in [
+                "ice",
+                "match",
+                "consume",
+                "match_token",
+                "consume_token",
+                "match_many",
+                "consume_many",
+            ]:
                 continue
-            self.assertIn(i, rules)
+            self.assertIn(fn, rules)
 
     def test_all_ast_has_normalize(self) -> None:
         """Test for enter/exit name diffs with parser."""


### PR DESCRIPTION
## **Description**

```py
# a b? c* d+ is parsed as:
self.consume(a) -> return the node
self.match(b)     -> return the node or none
self.match_many(c) -> 0 or more
self.consume_many(d) -> 1 or more

```
## Example 1

```py
#rule: name (COMMA name)*  // <-- This is parsed as:

names: listp[ast.Name] = []

names.append(self.consume(ast.Name))
while self.match_token(Tok.COMMA):
  names.append(self.consume(ast.Name))
```

## Example 2
```py
# rule: from ((DOT | ELIPSE)+) | (DOT | ELIPSE)*  attribute import name alias? (COMMA name alias?) SEMI

self.consume_token(Tok.FROM) # from
self.consume_token(Tok.DOT)  # ...

level = 0
while True:
  if self.match_token(Tok.DOT):
    level += 1
  elif self.match_token(Tok.ELIPSE):
    level += 3

attrib = self.match(ast.Attribute) # foo.bar.baz
# TODO: assert attrib target is attrib or base recursively. (ie, name.name.name.name)

self.consume_token(Tok.IMPORT) # import

items = []
while name := self.match(ast.Name): # foo as f, bar as b
  name.alias = self.match(ast.Alias)
  items.append(name)
  self.match_token(Tok.COMMA)

self.consume_token(Tok.SEMI)
```

## Before
```py
        def import_stmt(self, kid: list[ast.AstNode]) -> ast.Import:
            """Grammar rule.

            import_stmt: KW_IMPORT sub_name? KW_FROM from_path LBRACE import_items RBRACE
                    | KW_IMPORT sub_name? KW_FROM from_path COMMA import_items SEMI  //Deprecated
                    | KW_IMPORT sub_name? import_path (COMMA import_path)* SEMI
                    | include_stmt
            """
            if len(kid) == 1 and isinstance(kid[0], ast.Import):
                return self.nu(kid[0])
            chomp = [*kid]
            lang = kid[1] if isinstance(kid[1], ast.SubTag) else None
            chomp = chomp[2:] if lang else chomp[1:]
            from_path = chomp[1] if isinstance(chomp[1], ast.ModulePath) else None
            if from_path:
                items = kid[-2] if isinstance(kid[-2], ast.SubNodeList) else None
            else:
                paths = [i for i in kid if isinstance(i, ast.ModulePath)]
                items = ast.SubNodeList[ast.ModulePath](
                    items=paths, delim=Tok.COMMA, kid=kid[2 if lang else 1 : -1]
                )
                kid = (kid[:2] if lang else kid[:1]) + [items] + kid[-1:]

            is_absorb = False
            if isinstance(items, ast.SubNodeList):
                ret = self.nu(
                    ast.Import(
                        hint=lang,
                        from_loc=from_path,
                        items=items,
                        is_absorb=is_absorb,
                        kid=kid,
                    )
                )
                if (
                    from_path
                    and isinstance(kid[-1], ast.Token)
                    and kid[-1].name == Tok.SEMI
                ):
                    self.parse_ref.warning(
                        "Deprecated syntax, use braces for multiple imports (e.g, import from mymod {a, b, c})",
                    )
                return ret
            else:
                raise self.ice()

```

## After

```py
        def import_stmt(self, _) -> ast.Import:
            """Grammar rule.

            import_stmt: KW_IMPORT sub_name? KW_FROM from_path LBRACE import_items RBRACE
                       | KW_IMPORT sub_name? KW_FROM from_path COMMA import_items SEMI  //Deprecated
                       | KW_IMPORT sub_name? import_path (COMMA import_path)* SEMI
                       | include_stmt
            """
            if import_stmt := self.match(ast.Import):  # Include Statement.
                return import_stmt

            # TODO: kid will be removed so let's keep as it is for now.
            kid = self.nodes

            from_path: ast.ModulePath | None = None
            self.consume_token(Tok.KW_IMPORT)
            lang = self.match(ast.SubTag)

            if self.match_token(Tok.KW_FROM):
                from_path = self.consume(ast.ModulePath)
                self.consume(ast.Token)  # LBRACE or COMMA
                items = self.consume(ast.SubNodeList)
                if self.consume(ast.Token).name == Tok.SEMI:  # RBRACE or SEMI
                    self.parse_ref.warning(
                        "Deprecated syntax, use braces for multiple imports (e.g, import from mymod {a, b, c})",
                    )
            else:
                paths = [self.consume(ast.ModulePath)]
                while self.match_token(Tok.COMMA):
                    paths.append(self.consume(ast.ModulePath))
                self.consume_token(Tok.SEMI)
                items = ast.SubNodeList[ast.ModulePath](
                    items=paths,
                    delim=Tok.COMMA,
                    # TODO: kid will be removed so let's keep as it is for now.
                    kid=self.nodes[2 if lang else 1 : -1],
                )
                kid = (kid[:2] if lang else kid[:1]) + [items] + kid[-1:]

            is_absorb = False
            return ast.Import(
                hint=lang,
                from_loc=from_path,
                items=items,
                is_absorb=is_absorb,
                kid=kid,
            )
```