### PR TITLE
[MINOR]: Additional API Configuration for documentations

### DIFF
--- a/jac-cloud/jac_cloud/jaseci/routers/healthz.py
+++ b/jac-cloud/jac_cloud/jaseci/routers/healthz.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Response, status
 
-router = APIRouter(prefix="/healthz", tags=["monitoring"])
+router = APIRouter(prefix="/healthz", tags=["Monitoring APIs"])
 
 
 @router.get("", status_code=status.HTTP_200_OK)

--- a/jac-cloud/jac_cloud/jaseci/routers/sso.py
+++ b/jac-cloud/jac_cloud/jaseci/routers/sso.py
@@ -34,7 +34,7 @@ from ..sso import AppleSSO, GoogleSSO
 from ..utils import logger
 from ...core.architype import BulkWrite, NodeAnchor
 
-router = APIRouter(prefix="/sso", tags=["sso"])
+router = APIRouter(prefix="/sso", tags=["SSO APIs"])
 
 User = BaseUser.model()  # type: ignore[misc]
 

--- a/jac-cloud/jac_cloud/jaseci/routers/user.py
+++ b/jac-cloud/jac_cloud/jaseci/routers/user.py
@@ -30,7 +30,7 @@ from ...core.architype import BulkWrite, NodeAnchor
 
 
 RESTRICT_UNVERIFIED_USER = getenv("RESTRICT_UNVERIFIED_USER") == "true"
-router = APIRouter(prefix="/user", tags=["user"])
+router = APIRouter(prefix="/user", tags=["User APIs"])
 
 User = BaseUser.model()  # type: ignore[misc]
 

--- a/jac-cloud/jac_cloud/jaseci/routers/webhook.py
+++ b/jac-cloud/jac_cloud/jaseci/routers/webhook.py
@@ -16,7 +16,7 @@ from ..security import authenticator
 from ..utils import logger, random_string, utc_datetime, utc_timestamp
 from ...core.architype import BulkWrite
 
-router = APIRouter(prefix="/webhook", tags=["webhook"])
+router = APIRouter(prefix="/webhook", tags=["Webhook APIs"])
 
 
 @router.get("", status_code=status.HTTP_200_OK, dependencies=authenticator)

--- a/jac-cloud/jac_cloud/plugin/__init__.py
+++ b/jac-cloud/jac_cloud/plugin/__init__.py
@@ -1,6 +1,6 @@
 """Jaseci Plugins."""
 
-from .implementation import WEBSOCKET_MANAGER, specs
+from .implementation import EntryType, WEBSOCKET_MANAGER, specs
 
 
-__all__ = ["WEBSOCKET_MANAGER", "specs"]
+__all__ = ["EntryType", "WEBSOCKET_MANAGER", "specs"]

--- a/jac-cloud/jac_cloud/plugin/implementation/__init__.py
+++ b/jac-cloud/jac_cloud/plugin/implementation/__init__.py
@@ -1,9 +1,10 @@
 """Jaseci Plugin Implementations."""
 
-from .api import specs, walker_router, webhook_walker_router
+from .api import EntryType, specs, walker_router, webhook_walker_router
 from .websocket import WEBSOCKET_MANAGER, websocket_router
 
 __all__ = [
+    "EntryType",
     "specs",
     "walker_router",
     "webhook_walker_router",

--- a/jac-cloud/jac_cloud/plugin/implementation/api.py
+++ b/jac-cloud/jac_cloud/plugin/implementation/api.py
@@ -1,6 +1,7 @@
 """Jaseci API Implementations."""
 
 from dataclasses import Field, MISSING, fields, is_dataclass
+from enum import StrEnum
 from os import getenv
 from re import compile
 from types import NoneType
@@ -46,6 +47,18 @@ walker_router = APIRouter(prefix="/walker")
 webhook_walker_router = APIRouter(prefix="/webhook/walker")
 
 
+class EntryType(StrEnum):
+    """Entry Type."""
+
+    ROOT = "ROOT"
+    NODE = "NODE"
+    BOTH = "BOTH"
+
+
+ROOT_ENTRIES = [EntryType.ROOT, EntryType.BOTH]
+NODE_ENTRIES = [EntryType.NODE, EntryType.BOTH]
+
+
 class DefaultSpecs:
     """Default API specs."""
 
@@ -56,8 +69,16 @@ class DefaultSpecs:
     auth: bool = True
     private: bool = False
     webhook: dict | None = None
+    entry_type: EntryType = EntryType.BOTH
     tags: list[str] | None = None
-    allow_entry: bool | None = None
+    status_code: int | None = None
+    summary: str | None = None
+    description: str | None = None
+    response_description: str = "Successful Response"
+    responses: dict[int | str, dict[str, Any]] | None = None
+    deprecated: bool | None = None
+    name: str | None = None
+    openapi_extra: dict[str, Any] | None = None
 
 
 def get_specs(cls: type) -> Type["DefaultSpecs"] | None:
@@ -95,8 +116,16 @@ def populate_apis(cls: Type[WalkerArchitype]) -> None:
         excluded: str | list[str] = specs.excluded or []
         auth: bool = specs.auth or False
         webhook: dict | None = specs.webhook
+        entry_type: EntryType = specs.entry_type
         tags: list[str] | None = specs.tags
-        allow_entry: bool | None = specs.allow_entry
+        status_code: int | None = specs.status_code
+        summary: str | None = specs.summary
+        description: str | None = specs.description
+        response_description: str = specs.response_description
+        responses: dict[int | str, dict[str, Any]] | None = specs.responses
+        deprecated: bool | None = specs.deprecated
+        name: str | None = specs.name
+        openapi_extra: dict[str, Any] | None = specs.openapi_extra
 
         query: dict[str, Any] = {}
         body: dict[str, Any] = {}
@@ -224,11 +253,11 @@ def populate_apis(cls: Type[WalkerArchitype]) -> None:
         if webhook is None:
             target_authenticator = authenticator
             target_router = walker_router
-            default_tags = ["Walker"]
+            default_tags = ["Walker APIs"]
         else:
             target_authenticator = generate_webhook_auth(webhook)
             target_router = webhook_walker_router
-            default_tags = ["Webhook Walker"]
+            default_tags = ["Webhook Walker APIs"]
 
         for method in methods:
             method = method.lower()
@@ -261,20 +290,24 @@ def populate_apis(cls: Type[WalkerArchitype]) -> None:
                     settings: dict[str, Any] = {
                         "response_model": ContextResponse[ret_types] | Any,
                         "tags": default_tags if tags is None else tags,
+                        "status_code": status_code,
+                        "summary": summary,
+                        "description": description,
+                        "response_description": response_description,
+                        "responses": responses,
+                        "deprecated": deprecated,
+                        "name": name,
+                        "openapi_extra": openapi_extra,
                     }
                     if auth:
                         settings["dependencies"] = cast(list, target_authenticator)
 
-                    if not allow_entry:
-                        walker_method(
-                            url := f"/{cls.__name__}{path}", summary=url, **settings
-                        )(api_root)
-                    if allow_entry or allow_entry is None:
-                        walker_method(
-                            url := f"/{cls.__name__}/{{node}}{path}",
-                            summary=url,
-                            **settings,
-                        )(api_entry)
+                    if entry_type.upper() in ROOT_ENTRIES:
+                        walker_method(f"/{cls.__name__}{path}", **settings)(api_root)
+                    if entry_type.upper() in NODE_ENTRIES:
+                        walker_method(f"/{cls.__name__}/{{node}}{path}", **settings)(
+                            api_entry
+                        )
 
 
 def specs(
@@ -287,8 +320,16 @@ def specs(
     auth: bool = True,
     private: bool = False,
     webhook: dict | None = None,
+    entry_type: EntryType = EntryType.BOTH,
     tags: list[str] | None = None,
-    allow_entry: bool | None = None,
+    status_code: int | None = None,
+    summary: str | None = None,
+    description: str | None = None,
+    response_description: str = "Successful Response",
+    responses: dict[int | str, dict[str, Any]] | None = None,
+    deprecated: bool | None = None,
+    name: str | None = None,
+    openapi_extra: dict[str, Any] | None = None,
 ) -> Callable:
     """Walker Decorator."""
 
@@ -301,8 +342,16 @@ def specs(
             _auth = auth
             _private = private
             _webhook = webhook
+            _entry_type = entry_type
             _tags = tags
-            _allow_entry = allow_entry
+            _status_code = status_code
+            _summary = summary
+            _description = description
+            _response_description = response_description
+            _responses = responses
+            _deprecated = deprecated
+            _name = name
+            _openapi_extra = openapi_extra
 
             class __specs__(DefaultSpecs):  # noqa: N801
                 path: str = _path
@@ -312,8 +361,16 @@ def specs(
                 auth: bool = _auth
                 private: bool = _private
                 webhook: dict | None = _webhook
+                entry_type: EntryType = _entry_type
                 tags: list[str] | None = _tags
-                allow_entry: bool | None = _allow_entry
+                status_code: int | None = _status_code
+                summary: str | None = _summary
+                description: str | None = _description
+                response_description: str = _response_description
+                responses: dict[int | str, dict[str, Any]] | None = _responses
+                deprecated: bool | None = _deprecated
+                name: str | None = _name
+                openapi_extra: dict[str, Any] | None = _openapi_extra
 
             cls.__specs__ = __specs__  # type: ignore[attr-defined]
 

--- a/jac-cloud/jac_cloud/tests/openapi_specs.yaml
+++ b/jac-cloud/jac_cloud/tests/openapi_specs.yaml
@@ -446,7 +446,7 @@ paths:
           description: Successful Response
       summary: Healthz
       tags:
-      - monitoring
+      - Monitoring APIs
   /sso/attach:
     post:
       description: Generate token from user.
@@ -473,7 +473,7 @@ paths:
       - HTTPBearer: []
       summary: Sso Attach
       tags:
-      - sso
+      - SSO APIs
   /sso/detach:
     delete:
       description: Generate token from user.
@@ -500,7 +500,7 @@ paths:
       - HTTPBearer: []
       summary: Sso Detach
       tags:
-      - sso
+      - SSO APIs
   /sso/{platform}/{operation}:
     get:
       description: SSO Login API.
@@ -548,7 +548,7 @@ paths:
           description: Validation Error
       summary: Sso Operation
       tags:
-      - sso
+      - SSO APIs
   /sso/{platform}/{operation}/callback:
     get:
       description: SSO Login API.
@@ -588,7 +588,7 @@ paths:
           description: Validation Error
       summary: Sso Callback
       tags:
-      - sso
+      - SSO APIs
   /user/change_password:
     post:
       description: Register user API.
@@ -615,7 +615,7 @@ paths:
       - HTTPBearer: []
       summary: Change Password
       tags:
-      - user
+      - User APIs
   /user/forgot_password:
     post:
       description: Forgot password API.
@@ -640,7 +640,7 @@ paths:
           description: Validation Error
       summary: Forgot Password
       tags:
-      - user
+      - User APIs
   /user/login:
     post:
       description: Login user API.
@@ -665,7 +665,7 @@ paths:
           description: Validation Error
       summary: Login
       tags:
-      - user
+      - User APIs
   /user/register:
     post:
       description: Register user API.
@@ -690,7 +690,7 @@ paths:
           description: Validation Error
       summary: Register
       tags:
-      - user
+      - User APIs
   /user/reset_password:
     post:
       description: Reset password API.
@@ -715,7 +715,7 @@ paths:
           description: Validation Error
       summary: Reset Password
       tags:
-      - user
+      - User APIs
   /user/send-verification-code:
     post:
       description: Verify user API.
@@ -730,7 +730,7 @@ paths:
       - HTTPBearer: []
       summary: Send Verification Code
       tags:
-      - user
+      - User APIs
   /user/verify:
     post:
       description: Verify user API.
@@ -755,7 +755,7 @@ paths:
           description: Validation Error
       summary: Verify
       tags:
-      - user
+      - User APIs
   /walker/Walker:
     post:
       operationId: api_root_walker_Walker_post
@@ -771,9 +771,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /Walker
+      summary: Api Root
       tags:
-      - walker
+      - Walker APIs
   /walker/Walker/{node}:
     post:
       operationId: api_entry_walker_Walker__node__post
@@ -804,9 +804,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /Walker/{node}
+      summary: Api Entry
       tags:
-      - walker
+      - Walker APIs
   /walker/allow_other_root_access:
     post:
       operationId: api_root_walker_allow_other_root_access_post
@@ -834,9 +834,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /allow_other_root_access
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/allow_other_root_access/{node}:
     post:
       operationId: api_entry_walker_allow_other_root_access__node__post
@@ -873,9 +873,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /allow_other_root_access/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/check_memory_sync:
     post:
       operationId: api_root_walker_check_memory_sync_post
@@ -903,9 +903,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /check_memory_sync
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/check_memory_sync/{node}:
     post:
       operationId: api_entry_walker_check_memory_sync__node__post
@@ -942,9 +942,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /check_memory_sync/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/check_populated_graph:
     post:
       operationId: api_root_walker_check_populated_graph_post
@@ -960,9 +960,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /check_populated_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/check_populated_graph/{node}:
     post:
       operationId: api_entry_walker_check_populated_graph__node__post
@@ -993,9 +993,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /check_populated_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/combination1:
     get:
       operationId: api_root_walker_combination1_get
@@ -1036,9 +1036,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination1
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     post:
       operationId: api_root_walker_combination1_post
       parameters:
@@ -1078,9 +1078,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination1
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/combination1/{node}:
     get:
       operationId: api_entry_walker_combination1__node__get
@@ -1129,9 +1129,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination1/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     post:
       operationId: api_entry_walker_combination1__node__post
       parameters:
@@ -1179,9 +1179,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination1/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/combination2/{a}:
     delete:
       operationId: api_root_walker_combination2__a__delete
@@ -1222,9 +1222,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     get:
       operationId: api_root_walker_combination2__a__get
       parameters:
@@ -1264,9 +1264,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     head:
       operationId: api_root_walker_combination2__a__head
       parameters:
@@ -1306,9 +1306,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     options:
       operationId: api_root_walker_combination2__a__options
       parameters:
@@ -1342,9 +1342,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     patch:
       operationId: api_root_walker_combination2__a__patch
       parameters:
@@ -1384,9 +1384,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     post:
       operationId: api_root_walker_combination2__a__post
       parameters:
@@ -1426,9 +1426,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     put:
       operationId: api_root_walker_combination2__a__put
       parameters:
@@ -1468,9 +1468,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     trace:
       operationId: api_root_walker_combination2__a__trace
       parameters:
@@ -1504,9 +1504,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/combination2/{node}/{a}:
     delete:
       operationId: api_entry_walker_combination2__node___a__delete
@@ -1555,9 +1555,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     get:
       operationId: api_entry_walker_combination2__node___a__get
       parameters:
@@ -1605,9 +1605,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     head:
       operationId: api_entry_walker_combination2__node___a__head
       parameters:
@@ -1655,9 +1655,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     options:
       operationId: api_entry_walker_combination2__node___a__options
       parameters:
@@ -1699,9 +1699,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     patch:
       operationId: api_entry_walker_combination2__node___a__patch
       parameters:
@@ -1749,9 +1749,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     post:
       operationId: api_entry_walker_combination2__node___a__post
       parameters:
@@ -1799,9 +1799,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     put:
       operationId: api_entry_walker_combination2__node___a__put
       parameters:
@@ -1849,9 +1849,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     trace:
       operationId: api_entry_walker_combination2__node___a__trace
       parameters:
@@ -1893,9 +1893,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /combination2/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/create_custom_object:
     post:
       operationId: api_root_walker_create_custom_object_post
@@ -1911,9 +1911,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /create_custom_object
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/create_custom_object/{node}:
     post:
       operationId: api_entry_walker_create_custom_object__node__post
@@ -1944,9 +1944,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /create_custom_object/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/create_graph:
     post:
       operationId: api_root_walker_create_graph_post
@@ -1962,9 +1962,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /create_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/create_graph/{node}:
     post:
       operationId: api_entry_walker_create_graph__node__post
@@ -1995,9 +1995,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /create_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/create_nested_node:
     post:
       operationId: api_root_walker_create_nested_node_post
@@ -2013,9 +2013,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /create_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/create_nested_node/{node}:
     post:
       operationId: api_entry_walker_create_nested_node__node__post
@@ -2046,9 +2046,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /create_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/custom_report:
     post:
       operationId: api_root_walker_custom_report_post
@@ -2062,9 +2062,9 @@ paths:
                 - {}
                 title: Response Api Root Walker Custom Report Post
           description: Successful Response
-      summary: /custom_report
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/custom_report/{node}:
     post:
       operationId: api_entry_walker_custom_report__node__post
@@ -2093,9 +2093,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /custom_report/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/custom_status_code:
     post:
       operationId: api_root_walker_custom_status_code_post
@@ -2123,9 +2123,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /custom_status_code
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/custom_status_code/{node}:
     post:
       operationId: api_entry_walker_custom_status_code__node__post
@@ -2162,9 +2162,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /custom_status_code/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/delete_custom_object:
     post:
       operationId: api_root_walker_delete_custom_object_post
@@ -2192,9 +2192,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /delete_custom_object
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/delete_custom_object/{node}:
     post:
       operationId: api_entry_walker_delete_custom_object__node__post
@@ -2231,9 +2231,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /delete_custom_object/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/delete_nested_edge:
     post:
       operationId: api_root_walker_delete_nested_edge_post
@@ -2249,9 +2249,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /delete_nested_edge
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/delete_nested_edge/{node}:
     post:
       operationId: api_entry_walker_delete_nested_edge__node__post
@@ -2282,9 +2282,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /delete_nested_edge/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/delete_nested_node:
     post:
       operationId: api_root_walker_delete_nested_node_post
@@ -2300,9 +2300,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /delete_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/delete_nested_node/{node}:
     post:
       operationId: api_entry_walker_delete_nested_node__node__post
@@ -2333,9 +2333,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /delete_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/detach_nested_node:
     post:
       operationId: api_root_walker_detach_nested_node_post
@@ -2351,9 +2351,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /detach_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/detach_nested_node/{node}:
     post:
       operationId: api_entry_walker_detach_nested_node__node__post
@@ -2384,9 +2384,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /detach_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/detach_node:
     post:
       operationId: api_root_walker_detach_node_post
@@ -2402,9 +2402,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /detach_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/detach_node/{node}:
     post:
       operationId: api_entry_walker_detach_node__node__post
@@ -2435,9 +2435,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /detach_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/different_return:
     post:
       operationId: api_root_walker_different_return_post
@@ -2451,9 +2451,9 @@ paths:
                 - {}
                 title: Response Api Root Walker Different Return Post
           description: Successful Response
-      summary: /different_return
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/different_return/{node}:
     post:
       operationId: api_entry_walker_different_return__node__post
@@ -2482,9 +2482,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /different_return/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/disallow_other_root_access:
     post:
       operationId: api_root_walker_disallow_other_root_access_post
@@ -2512,9 +2512,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /disallow_other_root_access
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/disallow_other_root_access/{node}:
     post:
       operationId: api_entry_walker_disallow_other_root_access__node__post
@@ -2551,9 +2551,38 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /disallow_other_root_access/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
+  /walker/documentation:
+    post:
+      addons: true
+      deprecated: true
+      description: Enter description here!!!
+      operationId: Enter_name_here____walker_documentation_post
+      responses:
+        '200':
+          content:
+            application/json: {}
+          description: Enter response description for http status 200!!!
+          links:
+            sample_link:
+              description: Enter link description here!!!
+        '201':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Enter Name Here    Walker Documentation Post
+          description: Enter response description here!!! Defaults to 'Successful
+            Response'
+      security:
+      - HTTPBearer: []
+      summary: Enter summary here!!!
+      tags:
+      - Documented
   /walker/get_all_query:
     get:
       operationId: api_root_walker_get_all_query_get
@@ -2586,9 +2615,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /get_all_query
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_all_query/{node}:
     get:
       operationId: api_entry_walker_get_all_query__node__get
@@ -2629,9 +2658,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /get_all_query/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_custom_object:
     post:
       operationId: api_root_walker_get_custom_object_post
@@ -2659,9 +2688,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /get_custom_object
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_custom_object/{node}:
     post:
       operationId: api_entry_walker_get_custom_object__node__post
@@ -2698,9 +2727,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /get_custom_object/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_no_body:
     get:
       operationId: api_root_walker_get_no_body_get
@@ -2716,9 +2745,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /get_no_body
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_no_body/{node}:
     get:
       operationId: api_entry_walker_get_no_body__node__get
@@ -2749,9 +2778,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /get_no_body/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_with_query:
     get:
       operationId: api_root_walker_get_with_query_get
@@ -2780,9 +2809,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /get_with_query
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/get_with_query/{node}:
     get:
       operationId: api_entry_walker_get_with_query__node__get
@@ -2819,9 +2848,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /get_with_query/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_create_nested_node:
     post:
       operationId: api_root_walker_manual_create_nested_node_post
@@ -2837,9 +2866,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /manual_create_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_create_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_create_nested_node__node__post
@@ -2870,9 +2899,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /manual_create_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_delete_nested_edge:
     post:
       operationId: api_root_walker_manual_delete_nested_edge_post
@@ -2888,9 +2917,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /manual_delete_nested_edge
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_delete_nested_edge/{node}:
     post:
       operationId: api_entry_walker_manual_delete_nested_edge__node__post
@@ -2921,9 +2950,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /manual_delete_nested_edge/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_delete_nested_node:
     post:
       operationId: api_root_walker_manual_delete_nested_node_post
@@ -2939,9 +2968,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /manual_delete_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_delete_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_delete_nested_node__node__post
@@ -2972,9 +3001,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /manual_delete_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_detach_nested_node:
     post:
       operationId: api_root_walker_manual_detach_nested_node_post
@@ -2990,9 +3019,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /manual_detach_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_detach_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_detach_nested_node__node__post
@@ -3023,9 +3052,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /manual_detach_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_update_nested_node:
     post:
       operationId: api_root_walker_manual_update_nested_node_post
@@ -3041,9 +3070,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /manual_update_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/manual_update_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_update_nested_node__node__post
@@ -3074,9 +3103,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /manual_update_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/populate_graph:
     post:
       operationId: api_root_walker_populate_graph_post
@@ -3092,9 +3121,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /populate_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/populate_graph/{node}:
     post:
       operationId: api_entry_walker_populate_graph__node__post
@@ -3125,9 +3154,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /populate_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_all_excluded:
     post:
       operationId: api_root_walker_post_all_excluded_post
@@ -3141,9 +3170,9 @@ paths:
                 - {}
                 title: Response Api Root Walker Post All Excluded Post
           description: Successful Response
-      summary: /post_all_excluded
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_all_excluded/{node}:
     post:
       operationId: api_entry_walker_post_all_excluded__node__post
@@ -3172,9 +3201,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /post_all_excluded/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_no_body:
     post:
       operationId: api_root_walker_post_no_body_post
@@ -3190,9 +3219,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /post_no_body
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_no_body/{node}:
     post:
       operationId: api_entry_walker_post_no_body__node__post
@@ -3223,9 +3252,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_no_body/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_partial_excluded:
     post:
       operationId: api_root_walker_post_partial_excluded_post
@@ -3253,9 +3282,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_partial_excluded
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_partial_excluded/{node}:
     post:
       operationId: api_entry_walker_post_partial_excluded__node__post
@@ -3292,9 +3321,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_partial_excluded/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_path_var/{a}:
     get:
       operationId: api_root_walker_post_path_var__a__get
@@ -3323,9 +3352,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_path_var/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
     post:
       operationId: api_root_walker_post_path_var__a__post
       parameters:
@@ -3353,9 +3382,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_path_var/{a}
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_path_var/{node}/{a}:
     get:
       operationId: api_entry_walker_post_path_var__node___a__get
@@ -3392,9 +3421,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_path_var/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
     post:
       operationId: api_entry_walker_post_path_var__node___a__post
       parameters:
@@ -3430,9 +3459,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_path_var/{node}/{a}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_with_body:
     post:
       operationId: api_root_walker_post_with_body_post
@@ -3460,9 +3489,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_with_body
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_with_body/{node}:
     post:
       operationId: api_entry_walker_post_with_body__node__post
@@ -3499,9 +3528,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_with_body/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_with_body_and_file:
     post:
       operationId: api_root_walker_post_with_body_and_file_post
@@ -3527,9 +3556,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /post_with_body_and_file
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_with_body_and_file/{node}:
     post:
       operationId: api_entry_walker_post_with_body_and_file__node__post
@@ -3564,9 +3593,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /post_with_body_and_file/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_with_file:
     post:
       operationId: api_root_walker_post_with_file_post
@@ -3594,9 +3623,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_with_file
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/post_with_file/{node}:
     post:
       operationId: api_entry_walker_post_with_file__node__post
@@ -3633,9 +3662,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /post_with_file/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/purge_populated_graph:
     post:
       operationId: api_root_walker_purge_populated_graph_post
@@ -3651,9 +3680,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /purge_populated_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/purge_populated_graph/{node}:
     post:
       operationId: api_entry_walker_purge_populated_graph__node__post
@@ -3684,9 +3713,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /purge_populated_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/traverse_graph:
     post:
       operationId: api_root_walker_traverse_graph_post
@@ -3702,9 +3731,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /traverse_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/traverse_graph/{node}:
     post:
       operationId: api_entry_walker_traverse_graph__node__post
@@ -3735,9 +3764,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /traverse_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/traverse_populated_graph:
     post:
       operationId: api_root_walker_traverse_populated_graph_post
@@ -3753,9 +3782,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /traverse_populated_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/traverse_populated_graph/{node}:
     post:
       operationId: api_entry_walker_traverse_populated_graph__node__post
@@ -3786,9 +3815,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /traverse_populated_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/update_custom_object:
     post:
       operationId: api_root_walker_update_custom_object_post
@@ -3816,9 +3845,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /update_custom_object
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/update_custom_object/{node}:
     post:
       operationId: api_entry_walker_update_custom_object__node__post
@@ -3855,9 +3884,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /update_custom_object/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/update_graph:
     post:
       operationId: api_root_walker_update_graph_post
@@ -3873,9 +3902,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /update_graph
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/update_graph/{node}:
     post:
       operationId: api_entry_walker_update_graph__node__post
@@ -3906,9 +3935,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /update_graph/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/update_nested_node:
     post:
       operationId: api_root_walker_update_nested_node_post
@@ -3924,9 +3953,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /update_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/update_nested_node/{node}:
     post:
       operationId: api_entry_walker_update_nested_node__node__post
@@ -3957,9 +3986,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /update_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/visit_nested_node:
     post:
       operationId: api_root_walker_visit_nested_node_post
@@ -3975,9 +4004,9 @@ paths:
           description: Successful Response
       security:
       - HTTPBearer: []
-      summary: /visit_nested_node
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/visit_nested_node/{node}:
     post:
       operationId: api_entry_walker_visit_nested_node__node__post
@@ -4008,9 +4037,9 @@ paths:
           description: Validation Error
       security:
       - HTTPBearer: []
-      summary: /visit_nested_node/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /walker/visit_sequence:
     post:
       operationId: api_root_walker_visit_sequence_post
@@ -4024,9 +4053,9 @@ paths:
                 - {}
                 title: Response Api Root Walker Visit Sequence Post
           description: Successful Response
-      summary: /visit_sequence
+      summary: Api Root
       tags:
-      - Walker
+      - Walker APIs
   /walker/visit_sequence/{node}:
     post:
       operationId: api_entry_walker_visit_sequence__node__post
@@ -4055,9 +4084,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /visit_sequence/{node}
+      summary: Api Entry
       tags:
-      - Walker
+      - Walker APIs
   /webhook:
     get:
       description: Get keys API.
@@ -4072,7 +4101,7 @@ paths:
       - HTTPBearer: []
       summary: Get
       tags:
-      - webhook
+      - Webhook APIs
   /webhook/delete:
     delete:
       description: Delete keys API.
@@ -4099,7 +4128,7 @@ paths:
       - HTTPBearer: []
       summary: Delete
       tags:
-      - webhook
+      - Webhook APIs
   /webhook/extend/{id}:
     patch:
       description: Generate key API.
@@ -4133,7 +4162,7 @@ paths:
       - HTTPBearer: []
       summary: Extend
       tags:
-      - webhook
+      - Webhook APIs
   /webhook/generate-key:
     post:
       description: Generate key API.
@@ -4160,7 +4189,7 @@ paths:
       - HTTPBearer: []
       summary: Generate Key
       tags:
-      - webhook
+      - Webhook APIs
   /webhook/walker/webhook_by_body:
     post:
       operationId: api_root_webhook_walker_webhook_by_body_post
@@ -4174,9 +4203,9 @@ paths:
                 - {}
                 title: Response Api Root Webhook Walker Webhook By Body Post
           description: Successful Response
-      summary: /webhook_by_body
+      summary: Api Root
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_body/{node}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_body__node__post
@@ -4205,9 +4234,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /webhook_by_body/{node}
+      summary: Api Entry
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_header:
     post:
       operationId: api_root_webhook_walker_webhook_by_header_post
@@ -4223,9 +4252,9 @@ paths:
           description: Successful Response
       security:
       - APIKeyHeader: []
-      summary: /webhook_by_header
+      summary: Api Root
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_header/{node}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_header__node__post
@@ -4256,9 +4285,9 @@ paths:
           description: Validation Error
       security:
       - APIKeyHeader: []
-      summary: /webhook_by_header/{node}
+      summary: Api Entry
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_path/{node}/{test_key}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_path__node___test_key__post
@@ -4288,9 +4317,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
-      summary: /webhook_by_path/{node}/{test_key}
+      summary: Api Entry
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_path/{test_key}:
     post:
       operationId: api_root_webhook_walker_webhook_by_path__test_key__post
@@ -4304,9 +4333,9 @@ paths:
                 - {}
                 title: Response Api Root Webhook Walker Webhook By Path  Test Key  Post
           description: Successful Response
-      summary: /webhook_by_path/{test_key}
+      summary: Api Root
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_query:
     post:
       operationId: api_root_webhook_walker_webhook_by_query_post
@@ -4322,9 +4351,9 @@ paths:
           description: Successful Response
       security:
       - APIKeyQuery: []
-      summary: /webhook_by_query
+      summary: Api Root
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs
   /webhook/walker/webhook_by_query/{node}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_query__node__post
@@ -4355,6 +4384,6 @@ paths:
           description: Validation Error
       security:
       - APIKeyQuery: []
-      summary: /webhook_by_query/{node}
+      summary: Api Entry
       tags:
-      - Webhook Walker
+      - Webhook Walker APIs

--- a/jac-cloud/jac_cloud/tests/openapi_specs.yaml
+++ b/jac-cloud/jac_cloud/tests/openapi_specs.yaml
@@ -836,7 +836,7 @@ paths:
       - HTTPBearer: []
       summary: /allow_other_root_access
       tags:
-      - walker
+      - Walker
   /walker/allow_other_root_access/{node}:
     post:
       operationId: api_entry_walker_allow_other_root_access__node__post
@@ -875,7 +875,7 @@ paths:
       - HTTPBearer: []
       summary: /allow_other_root_access/{node}
       tags:
-      - walker
+      - Walker
   /walker/check_memory_sync:
     post:
       operationId: api_root_walker_check_memory_sync_post
@@ -905,7 +905,7 @@ paths:
       - HTTPBearer: []
       summary: /check_memory_sync
       tags:
-      - walker
+      - Walker
   /walker/check_memory_sync/{node}:
     post:
       operationId: api_entry_walker_check_memory_sync__node__post
@@ -944,7 +944,7 @@ paths:
       - HTTPBearer: []
       summary: /check_memory_sync/{node}
       tags:
-      - walker
+      - Walker
   /walker/check_populated_graph:
     post:
       operationId: api_root_walker_check_populated_graph_post
@@ -962,7 +962,7 @@ paths:
       - HTTPBearer: []
       summary: /check_populated_graph
       tags:
-      - walker
+      - Walker
   /walker/check_populated_graph/{node}:
     post:
       operationId: api_entry_walker_check_populated_graph__node__post
@@ -995,7 +995,7 @@ paths:
       - HTTPBearer: []
       summary: /check_populated_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/combination1:
     get:
       operationId: api_root_walker_combination1_get
@@ -1038,7 +1038,7 @@ paths:
       - HTTPBearer: []
       summary: /combination1
       tags:
-      - walker
+      - Walker
     post:
       operationId: api_root_walker_combination1_post
       parameters:
@@ -1080,7 +1080,7 @@ paths:
       - HTTPBearer: []
       summary: /combination1
       tags:
-      - walker
+      - Walker
   /walker/combination1/{node}:
     get:
       operationId: api_entry_walker_combination1__node__get
@@ -1131,7 +1131,7 @@ paths:
       - HTTPBearer: []
       summary: /combination1/{node}
       tags:
-      - walker
+      - Walker
     post:
       operationId: api_entry_walker_combination1__node__post
       parameters:
@@ -1181,7 +1181,7 @@ paths:
       - HTTPBearer: []
       summary: /combination1/{node}
       tags:
-      - walker
+      - Walker
   /walker/combination2/{a}:
     delete:
       operationId: api_root_walker_combination2__a__delete
@@ -1224,7 +1224,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     get:
       operationId: api_root_walker_combination2__a__get
       parameters:
@@ -1266,7 +1266,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     head:
       operationId: api_root_walker_combination2__a__head
       parameters:
@@ -1308,7 +1308,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     options:
       operationId: api_root_walker_combination2__a__options
       parameters:
@@ -1344,7 +1344,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     patch:
       operationId: api_root_walker_combination2__a__patch
       parameters:
@@ -1386,7 +1386,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     post:
       operationId: api_root_walker_combination2__a__post
       parameters:
@@ -1428,7 +1428,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     put:
       operationId: api_root_walker_combination2__a__put
       parameters:
@@ -1470,7 +1470,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
     trace:
       operationId: api_root_walker_combination2__a__trace
       parameters:
@@ -1506,7 +1506,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{a}
       tags:
-      - walker
+      - Walker
   /walker/combination2/{node}/{a}:
     delete:
       operationId: api_entry_walker_combination2__node___a__delete
@@ -1557,7 +1557,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     get:
       operationId: api_entry_walker_combination2__node___a__get
       parameters:
@@ -1607,7 +1607,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     head:
       operationId: api_entry_walker_combination2__node___a__head
       parameters:
@@ -1657,7 +1657,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     options:
       operationId: api_entry_walker_combination2__node___a__options
       parameters:
@@ -1701,7 +1701,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     patch:
       operationId: api_entry_walker_combination2__node___a__patch
       parameters:
@@ -1751,7 +1751,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     post:
       operationId: api_entry_walker_combination2__node___a__post
       parameters:
@@ -1801,7 +1801,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     put:
       operationId: api_entry_walker_combination2__node___a__put
       parameters:
@@ -1851,7 +1851,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
     trace:
       operationId: api_entry_walker_combination2__node___a__trace
       parameters:
@@ -1895,7 +1895,7 @@ paths:
       - HTTPBearer: []
       summary: /combination2/{node}/{a}
       tags:
-      - walker
+      - Walker
   /walker/create_custom_object:
     post:
       operationId: api_root_walker_create_custom_object_post
@@ -1913,7 +1913,7 @@ paths:
       - HTTPBearer: []
       summary: /create_custom_object
       tags:
-      - walker
+      - Walker
   /walker/create_custom_object/{node}:
     post:
       operationId: api_entry_walker_create_custom_object__node__post
@@ -1946,7 +1946,7 @@ paths:
       - HTTPBearer: []
       summary: /create_custom_object/{node}
       tags:
-      - walker
+      - Walker
   /walker/create_graph:
     post:
       operationId: api_root_walker_create_graph_post
@@ -1964,7 +1964,7 @@ paths:
       - HTTPBearer: []
       summary: /create_graph
       tags:
-      - walker
+      - Walker
   /walker/create_graph/{node}:
     post:
       operationId: api_entry_walker_create_graph__node__post
@@ -1997,7 +1997,7 @@ paths:
       - HTTPBearer: []
       summary: /create_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/create_nested_node:
     post:
       operationId: api_root_walker_create_nested_node_post
@@ -2015,7 +2015,7 @@ paths:
       - HTTPBearer: []
       summary: /create_nested_node
       tags:
-      - walker
+      - Walker
   /walker/create_nested_node/{node}:
     post:
       operationId: api_entry_walker_create_nested_node__node__post
@@ -2048,7 +2048,7 @@ paths:
       - HTTPBearer: []
       summary: /create_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/custom_report:
     post:
       operationId: api_root_walker_custom_report_post
@@ -2064,7 +2064,7 @@ paths:
           description: Successful Response
       summary: /custom_report
       tags:
-      - walker
+      - Walker
   /walker/custom_report/{node}:
     post:
       operationId: api_entry_walker_custom_report__node__post
@@ -2095,7 +2095,7 @@ paths:
           description: Validation Error
       summary: /custom_report/{node}
       tags:
-      - walker
+      - Walker
   /walker/custom_status_code:
     post:
       operationId: api_root_walker_custom_status_code_post
@@ -2125,7 +2125,7 @@ paths:
       - HTTPBearer: []
       summary: /custom_status_code
       tags:
-      - walker
+      - Walker
   /walker/custom_status_code/{node}:
     post:
       operationId: api_entry_walker_custom_status_code__node__post
@@ -2164,7 +2164,7 @@ paths:
       - HTTPBearer: []
       summary: /custom_status_code/{node}
       tags:
-      - walker
+      - Walker
   /walker/delete_custom_object:
     post:
       operationId: api_root_walker_delete_custom_object_post
@@ -2194,7 +2194,7 @@ paths:
       - HTTPBearer: []
       summary: /delete_custom_object
       tags:
-      - walker
+      - Walker
   /walker/delete_custom_object/{node}:
     post:
       operationId: api_entry_walker_delete_custom_object__node__post
@@ -2233,7 +2233,7 @@ paths:
       - HTTPBearer: []
       summary: /delete_custom_object/{node}
       tags:
-      - walker
+      - Walker
   /walker/delete_nested_edge:
     post:
       operationId: api_root_walker_delete_nested_edge_post
@@ -2251,7 +2251,7 @@ paths:
       - HTTPBearer: []
       summary: /delete_nested_edge
       tags:
-      - walker
+      - Walker
   /walker/delete_nested_edge/{node}:
     post:
       operationId: api_entry_walker_delete_nested_edge__node__post
@@ -2284,7 +2284,7 @@ paths:
       - HTTPBearer: []
       summary: /delete_nested_edge/{node}
       tags:
-      - walker
+      - Walker
   /walker/delete_nested_node:
     post:
       operationId: api_root_walker_delete_nested_node_post
@@ -2302,7 +2302,7 @@ paths:
       - HTTPBearer: []
       summary: /delete_nested_node
       tags:
-      - walker
+      - Walker
   /walker/delete_nested_node/{node}:
     post:
       operationId: api_entry_walker_delete_nested_node__node__post
@@ -2335,7 +2335,7 @@ paths:
       - HTTPBearer: []
       summary: /delete_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/detach_nested_node:
     post:
       operationId: api_root_walker_detach_nested_node_post
@@ -2353,7 +2353,7 @@ paths:
       - HTTPBearer: []
       summary: /detach_nested_node
       tags:
-      - walker
+      - Walker
   /walker/detach_nested_node/{node}:
     post:
       operationId: api_entry_walker_detach_nested_node__node__post
@@ -2386,7 +2386,7 @@ paths:
       - HTTPBearer: []
       summary: /detach_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/detach_node:
     post:
       operationId: api_root_walker_detach_node_post
@@ -2404,7 +2404,7 @@ paths:
       - HTTPBearer: []
       summary: /detach_node
       tags:
-      - walker
+      - Walker
   /walker/detach_node/{node}:
     post:
       operationId: api_entry_walker_detach_node__node__post
@@ -2437,7 +2437,7 @@ paths:
       - HTTPBearer: []
       summary: /detach_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/different_return:
     post:
       operationId: api_root_walker_different_return_post
@@ -2453,7 +2453,7 @@ paths:
           description: Successful Response
       summary: /different_return
       tags:
-      - walker
+      - Walker
   /walker/different_return/{node}:
     post:
       operationId: api_entry_walker_different_return__node__post
@@ -2484,7 +2484,7 @@ paths:
           description: Validation Error
       summary: /different_return/{node}
       tags:
-      - walker
+      - Walker
   /walker/disallow_other_root_access:
     post:
       operationId: api_root_walker_disallow_other_root_access_post
@@ -2514,7 +2514,7 @@ paths:
       - HTTPBearer: []
       summary: /disallow_other_root_access
       tags:
-      - walker
+      - Walker
   /walker/disallow_other_root_access/{node}:
     post:
       operationId: api_entry_walker_disallow_other_root_access__node__post
@@ -2553,7 +2553,7 @@ paths:
       - HTTPBearer: []
       summary: /disallow_other_root_access/{node}
       tags:
-      - walker
+      - Walker
   /walker/get_all_query:
     get:
       operationId: api_root_walker_get_all_query_get
@@ -2588,7 +2588,7 @@ paths:
           description: Validation Error
       summary: /get_all_query
       tags:
-      - walker
+      - Walker
   /walker/get_all_query/{node}:
     get:
       operationId: api_entry_walker_get_all_query__node__get
@@ -2631,7 +2631,7 @@ paths:
           description: Validation Error
       summary: /get_all_query/{node}
       tags:
-      - walker
+      - Walker
   /walker/get_custom_object:
     post:
       operationId: api_root_walker_get_custom_object_post
@@ -2661,7 +2661,7 @@ paths:
       - HTTPBearer: []
       summary: /get_custom_object
       tags:
-      - walker
+      - Walker
   /walker/get_custom_object/{node}:
     post:
       operationId: api_entry_walker_get_custom_object__node__post
@@ -2700,7 +2700,7 @@ paths:
       - HTTPBearer: []
       summary: /get_custom_object/{node}
       tags:
-      - walker
+      - Walker
   /walker/get_no_body:
     get:
       operationId: api_root_walker_get_no_body_get
@@ -2718,7 +2718,7 @@ paths:
       - HTTPBearer: []
       summary: /get_no_body
       tags:
-      - walker
+      - Walker
   /walker/get_no_body/{node}:
     get:
       operationId: api_entry_walker_get_no_body__node__get
@@ -2751,7 +2751,7 @@ paths:
       - HTTPBearer: []
       summary: /get_no_body/{node}
       tags:
-      - walker
+      - Walker
   /walker/get_with_query:
     get:
       operationId: api_root_walker_get_with_query_get
@@ -2782,7 +2782,7 @@ paths:
       - HTTPBearer: []
       summary: /get_with_query
       tags:
-      - walker
+      - Walker
   /walker/get_with_query/{node}:
     get:
       operationId: api_entry_walker_get_with_query__node__get
@@ -2821,7 +2821,7 @@ paths:
       - HTTPBearer: []
       summary: /get_with_query/{node}
       tags:
-      - walker
+      - Walker
   /walker/manual_create_nested_node:
     post:
       operationId: api_root_walker_manual_create_nested_node_post
@@ -2839,7 +2839,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_create_nested_node
       tags:
-      - walker
+      - Walker
   /walker/manual_create_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_create_nested_node__node__post
@@ -2872,7 +2872,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_create_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/manual_delete_nested_edge:
     post:
       operationId: api_root_walker_manual_delete_nested_edge_post
@@ -2890,7 +2890,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_delete_nested_edge
       tags:
-      - walker
+      - Walker
   /walker/manual_delete_nested_edge/{node}:
     post:
       operationId: api_entry_walker_manual_delete_nested_edge__node__post
@@ -2923,7 +2923,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_delete_nested_edge/{node}
       tags:
-      - walker
+      - Walker
   /walker/manual_delete_nested_node:
     post:
       operationId: api_root_walker_manual_delete_nested_node_post
@@ -2941,7 +2941,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_delete_nested_node
       tags:
-      - walker
+      - Walker
   /walker/manual_delete_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_delete_nested_node__node__post
@@ -2974,7 +2974,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_delete_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/manual_detach_nested_node:
     post:
       operationId: api_root_walker_manual_detach_nested_node_post
@@ -2992,7 +2992,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_detach_nested_node
       tags:
-      - walker
+      - Walker
   /walker/manual_detach_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_detach_nested_node__node__post
@@ -3025,7 +3025,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_detach_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/manual_update_nested_node:
     post:
       operationId: api_root_walker_manual_update_nested_node_post
@@ -3043,7 +3043,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_update_nested_node
       tags:
-      - walker
+      - Walker
   /walker/manual_update_nested_node/{node}:
     post:
       operationId: api_entry_walker_manual_update_nested_node__node__post
@@ -3076,7 +3076,7 @@ paths:
       - HTTPBearer: []
       summary: /manual_update_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/populate_graph:
     post:
       operationId: api_root_walker_populate_graph_post
@@ -3094,7 +3094,7 @@ paths:
       - HTTPBearer: []
       summary: /populate_graph
       tags:
-      - walker
+      - Walker
   /walker/populate_graph/{node}:
     post:
       operationId: api_entry_walker_populate_graph__node__post
@@ -3127,7 +3127,7 @@ paths:
       - HTTPBearer: []
       summary: /populate_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/post_all_excluded:
     post:
       operationId: api_root_walker_post_all_excluded_post
@@ -3143,7 +3143,7 @@ paths:
           description: Successful Response
       summary: /post_all_excluded
       tags:
-      - walker
+      - Walker
   /walker/post_all_excluded/{node}:
     post:
       operationId: api_entry_walker_post_all_excluded__node__post
@@ -3174,7 +3174,7 @@ paths:
           description: Validation Error
       summary: /post_all_excluded/{node}
       tags:
-      - walker
+      - Walker
   /walker/post_no_body:
     post:
       operationId: api_root_walker_post_no_body_post
@@ -3192,7 +3192,7 @@ paths:
       - HTTPBearer: []
       summary: /post_no_body
       tags:
-      - walker
+      - Walker
   /walker/post_no_body/{node}:
     post:
       operationId: api_entry_walker_post_no_body__node__post
@@ -3225,7 +3225,7 @@ paths:
       - HTTPBearer: []
       summary: /post_no_body/{node}
       tags:
-      - walker
+      - Walker
   /walker/post_partial_excluded:
     post:
       operationId: api_root_walker_post_partial_excluded_post
@@ -3255,7 +3255,7 @@ paths:
       - HTTPBearer: []
       summary: /post_partial_excluded
       tags:
-      - walker
+      - Walker
   /walker/post_partial_excluded/{node}:
     post:
       operationId: api_entry_walker_post_partial_excluded__node__post
@@ -3294,7 +3294,7 @@ paths:
       - HTTPBearer: []
       summary: /post_partial_excluded/{node}
       tags:
-      - walker
+      - Walker
   /walker/post_path_var/{a}:
     get:
       operationId: api_root_walker_post_path_var__a__get
@@ -3325,7 +3325,7 @@ paths:
       - HTTPBearer: []
       summary: /post_path_var/{a}
       tags:
-      - walker
+      - Walker
     post:
       operationId: api_root_walker_post_path_var__a__post
       parameters:
@@ -3355,7 +3355,7 @@ paths:
       - HTTPBearer: []
       summary: /post_path_var/{a}
       tags:
-      - walker
+      - Walker
   /walker/post_path_var/{node}/{a}:
     get:
       operationId: api_entry_walker_post_path_var__node___a__get
@@ -3394,7 +3394,7 @@ paths:
       - HTTPBearer: []
       summary: /post_path_var/{node}/{a}
       tags:
-      - walker
+      - Walker
     post:
       operationId: api_entry_walker_post_path_var__node___a__post
       parameters:
@@ -3432,7 +3432,7 @@ paths:
       - HTTPBearer: []
       summary: /post_path_var/{node}/{a}
       tags:
-      - walker
+      - Walker
   /walker/post_with_body:
     post:
       operationId: api_root_walker_post_with_body_post
@@ -3462,7 +3462,7 @@ paths:
       - HTTPBearer: []
       summary: /post_with_body
       tags:
-      - walker
+      - Walker
   /walker/post_with_body/{node}:
     post:
       operationId: api_entry_walker_post_with_body__node__post
@@ -3501,7 +3501,7 @@ paths:
       - HTTPBearer: []
       summary: /post_with_body/{node}
       tags:
-      - walker
+      - Walker
   /walker/post_with_body_and_file:
     post:
       operationId: api_root_walker_post_with_body_and_file_post
@@ -3529,7 +3529,7 @@ paths:
           description: Validation Error
       summary: /post_with_body_and_file
       tags:
-      - walker
+      - Walker
   /walker/post_with_body_and_file/{node}:
     post:
       operationId: api_entry_walker_post_with_body_and_file__node__post
@@ -3566,7 +3566,7 @@ paths:
           description: Validation Error
       summary: /post_with_body_and_file/{node}
       tags:
-      - walker
+      - Walker
   /walker/post_with_file:
     post:
       operationId: api_root_walker_post_with_file_post
@@ -3596,7 +3596,7 @@ paths:
       - HTTPBearer: []
       summary: /post_with_file
       tags:
-      - walker
+      - Walker
   /walker/post_with_file/{node}:
     post:
       operationId: api_entry_walker_post_with_file__node__post
@@ -3635,7 +3635,7 @@ paths:
       - HTTPBearer: []
       summary: /post_with_file/{node}
       tags:
-      - walker
+      - Walker
   /walker/purge_populated_graph:
     post:
       operationId: api_root_walker_purge_populated_graph_post
@@ -3653,7 +3653,7 @@ paths:
       - HTTPBearer: []
       summary: /purge_populated_graph
       tags:
-      - walker
+      - Walker
   /walker/purge_populated_graph/{node}:
     post:
       operationId: api_entry_walker_purge_populated_graph__node__post
@@ -3686,7 +3686,7 @@ paths:
       - HTTPBearer: []
       summary: /purge_populated_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/traverse_graph:
     post:
       operationId: api_root_walker_traverse_graph_post
@@ -3704,7 +3704,7 @@ paths:
       - HTTPBearer: []
       summary: /traverse_graph
       tags:
-      - walker
+      - Walker
   /walker/traverse_graph/{node}:
     post:
       operationId: api_entry_walker_traverse_graph__node__post
@@ -3737,7 +3737,7 @@ paths:
       - HTTPBearer: []
       summary: /traverse_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/traverse_populated_graph:
     post:
       operationId: api_root_walker_traverse_populated_graph_post
@@ -3755,7 +3755,7 @@ paths:
       - HTTPBearer: []
       summary: /traverse_populated_graph
       tags:
-      - walker
+      - Walker
   /walker/traverse_populated_graph/{node}:
     post:
       operationId: api_entry_walker_traverse_populated_graph__node__post
@@ -3788,7 +3788,7 @@ paths:
       - HTTPBearer: []
       summary: /traverse_populated_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/update_custom_object:
     post:
       operationId: api_root_walker_update_custom_object_post
@@ -3818,7 +3818,7 @@ paths:
       - HTTPBearer: []
       summary: /update_custom_object
       tags:
-      - walker
+      - Walker
   /walker/update_custom_object/{node}:
     post:
       operationId: api_entry_walker_update_custom_object__node__post
@@ -3857,7 +3857,7 @@ paths:
       - HTTPBearer: []
       summary: /update_custom_object/{node}
       tags:
-      - walker
+      - Walker
   /walker/update_graph:
     post:
       operationId: api_root_walker_update_graph_post
@@ -3875,7 +3875,7 @@ paths:
       - HTTPBearer: []
       summary: /update_graph
       tags:
-      - walker
+      - Walker
   /walker/update_graph/{node}:
     post:
       operationId: api_entry_walker_update_graph__node__post
@@ -3908,7 +3908,7 @@ paths:
       - HTTPBearer: []
       summary: /update_graph/{node}
       tags:
-      - walker
+      - Walker
   /walker/update_nested_node:
     post:
       operationId: api_root_walker_update_nested_node_post
@@ -3926,7 +3926,7 @@ paths:
       - HTTPBearer: []
       summary: /update_nested_node
       tags:
-      - walker
+      - Walker
   /walker/update_nested_node/{node}:
     post:
       operationId: api_entry_walker_update_nested_node__node__post
@@ -3959,7 +3959,7 @@ paths:
       - HTTPBearer: []
       summary: /update_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/visit_nested_node:
     post:
       operationId: api_root_walker_visit_nested_node_post
@@ -3977,7 +3977,7 @@ paths:
       - HTTPBearer: []
       summary: /visit_nested_node
       tags:
-      - walker
+      - Walker
   /walker/visit_nested_node/{node}:
     post:
       operationId: api_entry_walker_visit_nested_node__node__post
@@ -4010,7 +4010,7 @@ paths:
       - HTTPBearer: []
       summary: /visit_nested_node/{node}
       tags:
-      - walker
+      - Walker
   /walker/visit_sequence:
     post:
       operationId: api_root_walker_visit_sequence_post
@@ -4026,7 +4026,7 @@ paths:
           description: Successful Response
       summary: /visit_sequence
       tags:
-      - walker
+      - Walker
   /walker/visit_sequence/{node}:
     post:
       operationId: api_entry_walker_visit_sequence__node__post
@@ -4057,7 +4057,7 @@ paths:
           description: Validation Error
       summary: /visit_sequence/{node}
       tags:
-      - walker
+      - Walker
   /webhook:
     get:
       description: Get keys API.
@@ -4176,7 +4176,7 @@ paths:
           description: Successful Response
       summary: /webhook_by_body
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_body/{node}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_body__node__post
@@ -4207,7 +4207,7 @@ paths:
           description: Validation Error
       summary: /webhook_by_body/{node}
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_header:
     post:
       operationId: api_root_webhook_walker_webhook_by_header_post
@@ -4225,7 +4225,7 @@ paths:
       - APIKeyHeader: []
       summary: /webhook_by_header
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_header/{node}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_header__node__post
@@ -4258,7 +4258,7 @@ paths:
       - APIKeyHeader: []
       summary: /webhook_by_header/{node}
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_path/{node}/{test_key}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_path__node___test_key__post
@@ -4290,7 +4290,7 @@ paths:
           description: Validation Error
       summary: /webhook_by_path/{node}/{test_key}
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_path/{test_key}:
     post:
       operationId: api_root_webhook_walker_webhook_by_path__test_key__post
@@ -4306,7 +4306,7 @@ paths:
           description: Successful Response
       summary: /webhook_by_path/{test_key}
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_query:
     post:
       operationId: api_root_webhook_walker_webhook_by_query_post
@@ -4324,7 +4324,7 @@ paths:
       - APIKeyQuery: []
       summary: /webhook_by_query
       tags:
-      - webhook-walker
+      - Webhook Walker
   /webhook/walker/webhook_by_query/{node}:
     post:
       operationId: api_entry_webhook_walker_webhook_by_query__node__post
@@ -4357,4 +4357,4 @@ paths:
       - APIKeyQuery: []
       summary: /webhook_by_query/{node}
       tags:
-      - webhook-walker
+      - Webhook Walker

--- a/jac-cloud/jac_cloud/tests/simple_graph.jac
+++ b/jac-cloud/jac_cloud/tests/simple_graph.jac
@@ -926,3 +926,25 @@ walker websocket {
         has methods: list = ["websocket"];
     }
 }
+
+walker documentation {
+
+    class __specs__ {
+        has tags: list[str] | None = ["Documented"];
+        has entry_type: EntryType = "root";
+        has status_code: int | None = "201";
+        has summary: str | None = "Enter summary here!!!";
+        has description: str | None = "Enter description here!!!";
+        has response_description: str = "Enter response description here!!! Defaults to 'Successful Response'";
+        has responses: dict[int | str, dict[str, Any]] | None = {
+            200: {
+                "description": "Enter response description for http status 200!!!",
+                "content": {"application/json": {}},
+                "links": {"sample_link": {"description": "Enter link description here!!!"}}
+            }
+        };
+        has deprecated: bool | None = True;
+        has name: str | None = "Enter name here!!!";
+        has openapi_extra: dict[str, Any] | None = {"addons": True};
+    }
+}

--- a/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud.md
+++ b/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud.md
@@ -28,8 +28,19 @@ Once starts, navigate to `/docs` to access the built-in API docs.
 | auth      | bool      | if endpoint requires authentication or not | true
 | private   | bool      | only applicable if auto endpoint is enabled. This will skip the walker in auto generation. | false
 | webhook   | dict or None | [Webhook Configuration](./jac_cloud_webhook.md) | None
-| tags      | list[str] or None | Additional tags to segragate openapi docs | None
-| allow_entry | bool or None | True for generating api with node entry input. False for generating api without node entry input (always current root entry). None will support both. | None
+| entry_type | str or StrEnum (jac_cloud.plugin.EntryType) | "NODE" for generating api with node entry input. "ROOT" for generating api without node entry input (always current root entry). "BOTH" will support both. | `"BOTH"`|
+|||||
+|||**`Following fields is for configuring FastAPI's OpenAPI Specs / Swagger`**||
+|||||
+| tags          | list[str] or None |A list of tags to be applied to the *path operation*. It will be added to the generated OpenAPI (e.g. visible at `/docs`). Read more about it in the [FastAPI docs for Path Operation Configuration](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/#tags).| None
+| status_code   | int or None |The default status code to be used for the response. You could override the status code by returning a response directly. Read more about it in the [FastAPI docs for Response Status Code](https://fastapi.tiangolo.com/tutorial/response-status-code/). | None
+| summary       | str or None |A summary for the *path operation*. It will be added to the generated OpenAPI (e.g. visible at `/docs`). Read more about it in the [FastAPI docs for Path Operation Configuration](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/). | None
+| description   | str or None |A description for the *path operation*. If not provided, it will be extracted automatically from the docstring of the *path operation function*. It can contain Markdown. It will be added to the generated OpenAPI (e.g. visible at `/docs`). Read more about it in the [FastAPI docs for Path Operation Configuration](https://fastapi.tiangolo.com/tutorial/path-operation-configuration/). | None
+| response_description  | str | The description for the default response. It will be added to the generated OpenAPI (e.g. visible at `/docs`).| "Successful Response"
+| responses     | dict[int or str, dict[str, Any]] or None |Additional responses that could be returned by this *path operation*. It will be added to the generated OpenAPI (e.g. visible at `/docs`). | None
+| deprecated    | bool or None |Mark this *path operation* as deprecated. It will be added to the generated OpenAPI (e.g. visible at `/docs`).| None
+| name          | str or None | Name for this *path operation*. Only used internally. | None
+| openapi_extra | dict[str, Any] or None |Extra metadata to be included in the OpenAPI schema for this *path operation*. Read more about it in the [FastAPI docs for Path Operation Advanced Configuration](https://fastapi.tiangolo.com/advanced/path-operation-advanced-configuration/#custom-openapi-path-operation-schema).| None
 
 ## **Examples**
 ```python

--- a/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud.md
+++ b/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud.md
@@ -24,9 +24,12 @@ Once starts, navigate to `/docs` to access the built-in API docs.
 |-----------|-----------|-------------------|---------------|
 | path      | str       | additional path after default auto generated path **[root]:**`walker/{walker's name}`**/{your path}** or **[node]:**`walker/{walker's name}/{node id}`**/{your path}** | N/A |
 | methods   | list[str] | list of allowed http methods lowercase | ["post"] |
-| as_query  | str \| list[str] | list of declared fields that's intended to be query params. Setting it to `"*"` will set all fields to be query params | [] |
+| as_query  | str or list[str] | list of declared fields that's intended to be query params. Setting it to `"*"` will set all fields to be query params | [] |
 | auth      | bool      | if endpoint requires authentication or not | true
 | private   | bool      | only applicable if auto endpoint is enabled. This will skip the walker in auto generation. | false
+| webhook   | dict or None | [Webhook Configuration](./jac_cloud_webhook.md) | None
+| tags      | list[str] or None | Additional tags to segragate openapi docs | None
+| allow_entry | bool or None | True for generating api with node entry input. False for generating api without node entry input (always current root entry). None will support both. | None
 
 ## **Examples**
 ```python


### PR DESCRIPTION
```python
walker ask_question {
    class __specs__ {
        has allow_entry: bool = False, tags: list[str] = ["Chat APIs"];
    }
}
```

# `tags` 
- customization of tags to segregate OpenAPI specifications/docs
![image](https://github.com/user-attachments/assets/963a78e5-ba21-4ec4-8427-025a552787ec)

# `entry_type`
- "NODE" for generating api with `/{node}` entry input. "ROOT" for generating api without node entry input (always current root entry). "BOTH" will support both.

## entry_type="NODE"
![image](https://github.com/user-attachments/assets/9ab9771e-bb06-4fd9-8229-0b5e274d07fa)
## entry_type="ROOT"
![image](https://github.com/user-attachments/assets/5a994a83-7e32-4b5a-af64-066bf31056e1)
## entry_type="BOTH" or not set
![image](https://github.com/user-attachments/assets/88c26ba1-1d06-448d-9de7-4227b86c8ff0)

# Sample Documentations
```python
walker documentation {

    class __specs__ {
        has tags: list[str] | None = ["Documented"];
        has entry_type: EntryType = "root";
        has status_code: int | None = "201";
        has summary: str | None = "Enter summary here!!!";
        has description: str | None = "Enter description here!!!";
        has response_description: str = "Enter response description here!!! Defaults to 'Successful Response'";
        has responses: dict[int | str, dict[str, Any]] | None = {
            200: {
                "description": "Enter response description for http status 200!!!",
                "content": {"application/json": {}},
                "links": {"sample_link": {"description": "Enter link description here!!!"}}
            }
        };
        has deprecated: bool | None = True;
        has name: str | None = "Enter name here!!!";
        has openapi_extra: dict[str, Any] | None = {"addons": True};
    }
}
```
![image](https://github.com/user-attachments/assets/c4c225b9-ff36-4b06-adbf-383e43dca950)

