### PR TITLE
[AST-Refactor] AccessNode removed

### DIFF
--- a/jac/jaclang/compiler/constant.py
+++ b/jac/jaclang/compiler/constant.py
@@ -140,6 +140,19 @@ class SymbolAccess(Enum):
     PUBLIC = "public"
     PROTECTED = "protected"
 
+    @staticmethod
+    def from_token(token: str) -> "SymbolAccess":
+        """Convert token to access."""
+        # TODO: If the tokens have token type as an instance of the bellow Tokens enum,
+        # we don't have to use strings (ie. Token.name) and we can just pass the token type enum everywhere.
+        if token == Tokens.KW_PRIV:
+            return SymbolAccess.PRIVATE
+        if token == Tokens.KW_PUB:
+            return SymbolAccess.PUBLIC
+        if token == Tokens.KW_PROT:
+            return SymbolAccess.PROTECTED
+        raise ValueError(f"Invalid access token: {token}")
+
     def __str__(self) -> str:
         """Stringify."""
         return self.value

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -10,7 +10,7 @@ from typing import Callable, TypeAlias
 
 import jaclang.compiler.absyntree as ast
 from jaclang.compiler import jac_lark as jl  # type: ignore
-from jaclang.compiler.constant import EdgeDir, Tokens as Tok
+from jaclang.compiler.constant import EdgeDir, SymbolAccess, Tokens as Tok
 from jaclang.compiler.passes.ir_pass import Pass
 from jaclang.vendor.lark import Lark, Transformer, Tree, logger
 
@@ -215,7 +215,11 @@ class JacParser(Pass):
             global_var: (KW_LET | KW_GLOBAL) access_tag? assignment_list SEMI
             """
             is_frozen = isinstance(kid[0], ast.Token) and kid[0].name == Tok.KW_LET
-            access = kid[1] if isinstance(kid[1], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(kid[1].tag.name)  # type: ignore
+                if isinstance(kid[1], ast.SubTag)
+                else None
+            )
             assignments = kid[2] if access else kid[1]
             if isinstance(assignments, ast.SubNodeList):
                 return self.nu(
@@ -494,7 +498,11 @@ class JacParser(Pass):
             architype_decl: arch_type access_tag? STRING? NAME inherited_archs? (member_block | SEMI)
             """
             arch_type = kid[0]
-            access = kid[1] if isinstance(kid[1], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(kid[1].tag.name)  # type: ignore
+                if isinstance(kid[1], ast.SubTag)
+                else None
+            )
             semstr = (
                 kid[2]
                 if (access and isinstance(kid[2], ast.String))
@@ -651,7 +659,11 @@ class JacParser(Pass):
 
             enum_decl: KW_ENUM access_tag? STRING? NAME inherited_archs? (enum_block | SEMI)
             """
-            access = kid[1] if isinstance(kid[1], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(kid[1].tag.name)  # type: ignore
+                if isinstance(kid[1], ast.SubTag)
+                else None
+            )
             semstr = (
                 kid[2]
                 if (access and isinstance(kid[2], ast.String))
@@ -822,7 +834,11 @@ class JacParser(Pass):
                 isinstance(chomp[0], ast.Token) and chomp[0].name == Tok.KW_STATIC
             )
             chomp = chomp[2:] if is_static else chomp[1:]
-            access = chomp[0] if isinstance(chomp[0], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(chomp[0].tag.name)  # type: ignore
+                if isinstance(chomp[0], ast.SubTag)
+                else None
+            )
             chomp = chomp[1:] if access else chomp
             semstr = chomp[0] if isinstance(chomp[0], ast.String) else None
             chomp = chomp[1:] if semstr else chomp
@@ -890,7 +906,11 @@ class JacParser(Pass):
             )
             chomp = chomp[1:] if is_static else chomp
             chomp = chomp[1:]
-            access = chomp[0] if isinstance(chomp[0], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(chomp[0].tag.name)  # type: ignore
+                if isinstance(chomp[0], ast.SubTag)
+                else None
+            )
             chomp = chomp[1:] if access else chomp
             semstr = chomp[0] if isinstance(chomp[0], ast.String) else None
             chomp = chomp[1:] if semstr else chomp
@@ -934,7 +954,11 @@ class JacParser(Pass):
             )
             chomp = chomp[1:] if is_static else chomp
             chomp = chomp[1:]
-            access = chomp[0] if isinstance(chomp[0], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(chomp[0].tag.name)  # type: ignore
+                if isinstance(chomp[0], ast.SubTag)
+                else None
+            )
             chomp = chomp[1:] if access else chomp
             semstr = chomp[0] if isinstance(chomp[0], ast.String) else None
             chomp = chomp[1:] if semstr else chomp
@@ -1141,7 +1165,11 @@ class JacParser(Pass):
             chomp = chomp[1:] if is_static else chomp
             is_freeze = isinstance(chomp[0], ast.Token) and chomp[0].name == Tok.KW_LET
             chomp = chomp[1:]
-            access = chomp[0] if isinstance(chomp[0], ast.SubTag) else None
+            access = (
+                SymbolAccess.from_token(chomp[0].tag.name)  # type: ignore
+                if isinstance(chomp[0], ast.SubTag)
+                else None
+            )
             chomp = chomp[1:] if access else chomp
             assign = chomp[0]
             if isinstance(assign, ast.SubNodeList):

--- a/jac/jaclang/compiler/passes/main/def_use_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_use_pass.py
@@ -99,7 +99,7 @@ class DefUsePass(Pass):
             node.sym_tab.def_insert(
                 node,
                 single_decl="has var",
-                access_spec=node.parent.parent,
+                access=node.parent.parent.access,
             )
         else:
             self.ice("Inconsistency in AST, has var should be under arch has")

--- a/jac/jaclang/compiler/passes/main/import_pass.py
+++ b/jac/jaclang/compiler/passes/main/import_pass.py
@@ -347,7 +347,7 @@ class PyImportPass(JacImportPass):
         assert isinstance(sym.defn[0], ast.AstSymbolNode)
         sym_table.def_insert(
             node=sym.defn[0],
-            access_spec=sym.access,
+            access=sym.access,
             force_overwrite=True,
         )
 

--- a/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
+++ b/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
@@ -87,7 +87,9 @@ class SymTabBuildPass(Pass):
         for i in self.get_all_sub_nodes(node, ast.Assignment):
             for j in i.target.items:
                 if isinstance(j, ast.AstSymbolNode):
-                    j.sym_tab.def_insert(j, access_spec=node, single_decl="global var")
+                    j.sym_tab.def_insert(
+                        j, access=node.access, single_decl="global var"
+                    )
                 else:
                     self.ice("Expected name type for globabl vars")
 
@@ -236,7 +238,7 @@ class SymTabBuildPass(Pass):
         body: Optional[ArchBlock],
         """
         self.sync_node_to_scope(node)
-        node.sym_tab.def_insert(node, access_spec=node, single_decl="architype")
+        node.sym_tab.def_insert(node, access=node.access, single_decl="architype")
         self.push_scope(node.name.value, node)
         self.sync_node_to_scope(node)
 
@@ -290,7 +292,7 @@ class SymTabBuildPass(Pass):
         body: Optional[CodeBlock],
         """
         self.sync_node_to_scope(node)
-        node.sym_tab.def_insert(node, access_spec=node, single_decl="ability")
+        node.sym_tab.def_insert(node, access=node.access, single_decl="ability")
         self.push_scope(node.sym_name, node)
         self.sync_node_to_scope(node)
         if node.is_method:
@@ -385,7 +387,7 @@ class SymTabBuildPass(Pass):
         body: Optional['EnumBlock'],
         """
         self.sync_node_to_scope(node)
-        node.sym_tab.def_insert(node, access_spec=node, single_decl="enum")
+        node.sym_tab.def_insert(node, access=node.access, single_decl="enum")
         self.push_scope(node.sym_name, node)
         self.sync_node_to_scope(node)
 

--- a/jac/jaclang/compiler/symtable.py
+++ b/jac/jaclang/compiler/symtable.py
@@ -113,7 +113,7 @@ class SymbolTable:
     def insert(
         self,
         node: ast.AstSymbolNode,
-        access_spec: Optional[ast.AstAccessNode] | SymbolAccess = None,
+        access: SymbolAccess | None = None,
         single: bool = False,
         force_overwrite: bool = False,
     ) -> Optional[ast.AstNode]:
@@ -130,11 +130,7 @@ class SymbolTable:
         if force_overwrite or node.sym_name not in self.tab:
             self.tab[node.sym_name] = Symbol(
                 defn=node.name_spec,
-                access=(
-                    access_spec
-                    if isinstance(access_spec, SymbolAccess)
-                    else access_spec.access_type if access_spec else SymbolAccess.PUBLIC
-                ),
+                access=access or SymbolAccess.PUBLIC,
                 parent_tab=self,
             )
         else:
@@ -157,12 +153,12 @@ class SymbolTable:
     def inherit_sym_tab(self, target_sym_tab: SymbolTable) -> None:
         """Inherit symbol table."""
         for i in target_sym_tab.tab.values():
-            self.def_insert(i.decl, access_spec=i.access)
+            self.def_insert(i.decl, access=i.access)
 
     def def_insert(
         self,
         node: ast.AstSymbolNode,
-        access_spec: Optional[ast.AstAccessNode] | SymbolAccess = None,
+        access: SymbolAccess | None = None,
         single_decl: Optional[str] = None,
         force_overwrite: bool = False,
     ) -> Optional[Symbol]:
@@ -172,7 +168,7 @@ class SymbolTable:
         self.insert(
             node=node,
             single=single_decl is not None,
-            access_spec=access_spec,
+            access=access,
             force_overwrite=force_overwrite,
         )
         self.update_py_ctx_for_def(node)

--- a/jac/jaclang/utils/treeprinter.py
+++ b/jac/jaclang/utils/treeprinter.py
@@ -91,9 +91,19 @@ def print_ast_tree(
     print_py_raise: bool = settings.print_py_raised_ast
 
     def __node_repr_in_tree(node: AstNode) -> str:
+
+        # TODO: For now we're checking if the node has access tag by the bellow list however the tree printing
+        # method will be refactored by traversing the tree thus we can remove this check.
+        nodes_has_access = (
+            ast.GlobalVars,
+            ast.Architype,
+            ast.Enum,
+            ast.Ability,
+            ast.ArchHas,
+        )
         access = (
-            f"Access: {node.access.tag.value} ,"
-            if isinstance(node, ast.AstAccessNode) and node.access is not None
+            f"Access: {node.access.value} ,"
+            if isinstance(node, nodes_has_access) and node.access
             else ""
         )
         sym_table_link = (


### PR DESCRIPTION
## **Description**

This AccessNode is an abstract type of the AST, however, in the new AST (which is being refactored) it'll only be `Expression` and `Statement` abstract class, and we'll be removing everything else.

NOTE: Once all the dependent nodes of `SubTag` are removed, SubTag will also be removed.