### PR TITLE
fix warning jac tool gen_parser

### DIFF
--- a/jac/jaclang/utils/helpers.py
+++ b/jac/jaclang/utils/helpers.py
@@ -95,7 +95,7 @@ def auto_generate_refs() -> None:
     result = extract_headings(file_path)
     created_file_path = os.path.join(
         os.path.split(os.path.dirname(__file__))[0],
-        "../support/jac-lang.org/docs/learn/jac_ref.md",
+        "../support/jac-lang.org/docs/lang_ref/jac_ref.md",
     )
     destination_folder = os.path.join(
         os.path.split(os.path.dirname(__file__))[0], "../examples/reference/"


### PR DESCRIPTION
## **Description**
 fixed warning in jac tool gen_parser . i change the 'jac_ref.md' file path as '../support/jac-lang.org/docs/lang_ref/jac_ref.md' .