### PR TITLE
Fixing a crash due to complex base class expressions not supported

### DIFF
--- a/jac/jaclang/tests/fixtures/base_class_complex_expr.jac
+++ b/jac/jaclang/tests/fixtures/base_class_complex_expr.jac
@@ -1,0 +1,38 @@
+class Apple {
+    with entry {
+        a = 1;
+    }
+}
+
+class Orange {
+    with entry {
+        b = 2;
+    }
+}
+
+with entry {
+    mm = [Apple, Orange];
+}
+
+class Banana :mm[1]: {
+    with entry {
+        c = 3;
+    }
+}
+
+can return_class() -> `Type[Apple] {
+    print('Returning Apple');
+    return Apple;
+}
+
+class Kiwi :return_class(): {
+    with entry {
+        d = 4;
+        ;
+    }
+}
+
+with entry {
+    a = Kiwi();
+    print(Kiwi.d);
+}

--- a/jac/jaclang/tests/test_cli.py
+++ b/jac/jaclang/tests/test_cli.py
@@ -294,6 +294,27 @@ class JacCliTests(TestCase):
             r"10:7 - 10:12.*Name - start - Type.*SymbolPath: base_class2.B.start",
         )
 
+    def test_base_class_complex_expr(self) -> None:
+        """Testing for print AstTool."""
+        from jaclang.settings import settings
+
+        # settings.ast_symbol_info_detailed = True
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        cli.tool(
+            "ir", ["ast", f"{self.fixture_abs_path('base_class_complex_expr.jac')}"]
+        )
+
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue()
+        settings.ast_symbol_info_detailed = False
+
+        self.assertRegex(
+            stdout_value,
+            r"36\:9 \- 36\:13.*Name \- Kiwi \- Type\: base_class_complex_expr.Kiwi,  SymbolTable\: Kiwi",
+        )
+
     def test_expr_types(self) -> None:
         """Testing for print AstTool."""
         captured_output = io.StringIO()


### PR DESCRIPTION
## **Description**
Fixing a crash due to two unsupported forms of base class. The fix is just reporting that this is not supported. The issue here is that the inheritance pass depends on fuse type info to get the types of the complex base class expressions, fuse type info depends on inheritance class too for atom trailers. so we need some iterative process to run both of them multiple times. 