### PR TITLE
Global root removed and root() returns the ctx root.

### DIFF
--- a/jac/jaclang/__init__.py
+++ b/jac/jaclang/__init__.py
@@ -416,13 +416,6 @@ def field(
 jac_test = Jac.create_test
 static = ClassVar
 
-root = cast(Root, Jac.get_root())
 
-
-# Listen to context change and update the above global root here.
-def _update_root() -> None:
-    global root
-    root = cast(Root, ExecutionContext.get_root())
-
-
-ExecutionContext.on_ctx_change.append(lambda ctx: _update_root())
+def root() -> Root:
+    return cast(Root, ExecutionContext.get_root())

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -2937,7 +2937,15 @@ class PyastGenPass(Pass):
                 )
             ]
         elif node.name == Tok.KW_ROOT:
-            node.gen.py_ast = [self.jaclib_obj("root")]
+            node.gen.py_ast = [
+                self.sync(
+                    ast3.Call(
+                        func=self.jaclib_obj("root"),
+                        args=[],
+                        keywords=[],
+                    )
+                )
+            ]
 
         else:
             node.gen.py_ast = [

--- a/jac/jaclang/runtimelib/context.py
+++ b/jac/jaclang/runtimelib/context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import unittest
 from contextvars import ContextVar
 from dataclasses import MISSING
-from typing import Any, Callable, ClassVar, Optional, cast
+from typing import Any, Callable, Optional, cast
 from uuid import UUID
 
 from .architype import NodeAnchor, Root
@@ -25,9 +25,6 @@ class ExecutionContext:
     system_root: NodeAnchor
     root: NodeAnchor
     entry_node: NodeAnchor
-
-    # A context change event subscription list, those who want to listen ctx change will register here.
-    on_ctx_change: ClassVar[list[Callable[[ExecutionContext | None], None]]] = []
 
     def init_anchor(
         self,
@@ -49,8 +46,6 @@ class ExecutionContext:
         """Close current ExecutionContext."""
         self.mem.close()
         EXECUTION_CONTEXT.set(None)
-        for func in ExecutionContext.on_ctx_change:
-            func(EXECUTION_CONTEXT.get(None))
 
     @staticmethod
     def create(
@@ -80,8 +75,6 @@ class ExecutionContext:
             old_ctx.close()
 
         EXECUTION_CONTEXT.set(ctx)
-        for func in ExecutionContext.on_ctx_change:
-            func(EXECUTION_CONTEXT.get(None))
 
         return ctx
 


### PR DESCRIPTION
## **Description**

In jaclib `root` changed into `root()`

FIX: https://github.com/Jaseci-Labs/jaseci/issues/1600
