### PR TITLE
Removing all uses of sub_nodes_of_type

### DIFF
--- a/jac/jaclang/compiler/absyntree.py
+++ b/jac/jaclang/compiler/absyntree.py
@@ -627,6 +627,7 @@ class Module(AstDocNode):
         kid: Sequence[AstNode],
         stub_only: bool = False,
         registry: Optional[SemRegistry] = None,
+        import_path: Optional[list[ModulePath]] = None,
     ) -> None:
         """Initialize whole program node."""
         self.name = name
@@ -640,6 +641,7 @@ class Module(AstDocNode):
         self.registry = registry
         self.terminals: list[Token] = terminals
         self.py_info: PyInfo = PyInfo()
+        self.import_path: list[ModulePath] = import_path if import_path else []
 
         AstNode.__init__(self, kid=kid)
         AstDocNode.__init__(self, doc=doc)

--- a/jac/jaclang/compiler/passes/main/tests/test_import_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_import_pass.py
@@ -110,7 +110,7 @@ class ImportPassPassTests(TestCase):
                     )
                 )
             ),
-            11,  # TODO: Need to only link the modules one time
+            5,  # TODO: Need to only link the modules one time
         )
 
     def test_double_empty_anx(self) -> None:

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -665,7 +665,7 @@ class JacLanguageTests(TestCase):
 
         ir = jac_pass_to_pass(py_ast_build_pass, schedule=py_code_gen_typed).ir
         self.assertEqual(
-            len(ir.get_all_sub_nodes(ast.Architype)), 75
+            len(ir.get_all_sub_nodes(ast.Architype)), 43
         )  # Because of the Architype from other imports
         captured_output = io.StringIO()
         sys.stdout = captured_output


### PR DESCRIPTION
## **Description**

- Add correct type annotations to the cache decorator in the parser
- Removed all `get_all_subnode` from import pass