### PR TITLE
Enhance JacImporter to include site and user site packages in search path

### DIFF
--- a/jac/jaclang/runtimelib/importer.py
+++ b/jac/jaclang/runtimelib/importer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import os
+import site
 import sys
 import types
 from os import getcwd, path
@@ -325,7 +326,15 @@ class JacImporter(Importer):
                 if p and p not in search_paths:
                     search_paths.append(p)
 
-            # Attempt to locate the module file or directory
+            for site_dir in site.getsitepackages():
+                if site_dir and site_dir not in search_paths:
+                    search_paths.append(site_dir)
+            user_site = getattr(site, "getusersitepackages", None)
+            if user_site:
+                user_dir = site.getusersitepackages()
+                if user_dir and user_dir not in search_paths:
+                    search_paths.append(user_dir)
+
             found_path = None
             target_path_components = spec.target.split(".")
             for search_path in search_paths:


### PR DESCRIPTION
## **Description**
This PR updates the JacImporter Class in the importer.py file to enhance the search paths for importing Jac modules. The changes ensure that the [JacImporter](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) includes site-specific directories in the search paths, allowing for a more comprehensive module search.

Changes
* Added logic to include directories from site.getsitepackages()
* Added logic to include the user site directory from site.getusersitepackages()