### PR TITLE
A bug in targ argument of jaclib Node.refs() fixed

### DIFF
--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -3118,7 +3118,7 @@ class PyastGenPass(Pass):
                 self.sync(
                     ast3.keyword(
                         arg="target",
-                        value=self.sync(ast3.Constant(value=None)),
+                        value=targ,
                     )
                 )
             )

--- a/jac/jaclang/tests/fixtures/refs_target.jac
+++ b/jac/jaclang/tests/fixtures/refs_target.jac
@@ -1,0 +1,17 @@
+
+node a { has val:int=0; }
+node b { has val:int=0; }
+node c { has val:int=0; }
+
+with entry {
+
+    x = [a(val=i) for i in range(0,3)];
+    y = [b(val=i) for i in range(0,3)];
+    z = [c(val=i) for i in range(0,3)];
+
+    x ++> y;
+    y ++> z;
+
+    print([x-->y-->z]);  # [c(val=0), c(val=1), c(val=2)]
+    print([x-->y[:1]-->z[:1]]); # [c(val=0)]
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -694,6 +694,19 @@ class JacLanguageTests(TestCase):
         self.assertIn(" case Point(x = int(_), y = 0):\n", output)
         self.assertIn("class Sample {\n    can init", output)
 
+    def test_refs_target(self) -> None:
+        """
+        This test added after a bug in jaclib Node.refs() wasn't code gen as expected and it
+        wasn't captured with the tests.
+        """
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        jac_import("refs_target", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue()
+        self.assertIn("[c(val=0), c(val=1), c(val=2)]", stdout_value)
+        self.assertIn("[c(val=0)]", stdout_value)
+
     def test_py_kw_as_name_disallowed(self) -> None:
         """Basic precedence test."""
         prog = jac_str_to_pass("with entry {print.is.not.True(4-5-4);}", "test.jac")


### PR DESCRIPTION
## **Description**

A but in the codegen of `Node.refs()` fixed, The argument `target` was always `None`.

```
node a { has val:int=0; }
node b { has val:int=0; }
node c { has val:int=0; }

with entry {

    x = [a(val=i) for i in range(0,3)];
    y = [b(val=i) for i in range(0,3)];
    z = [c(val=i) for i in range(0,3)];

    x ++> y;
    y ++> z;

    print([x-->y-->z]);
    print([x-->y[:1]-->z[:1]]);

}
```