### PR TITLE
[TEST]: Multi Import Tests

### DIFF
--- a/jac/jaclang/plugin/tests/fixtures/multi_import2.jac
+++ b/jac/jaclang/plugin/tests/fixtures/multi_import2.jac
@@ -1,0 +1,7 @@
+node A {}
+
+walker create_node {
+    can enter with `root entry {
+        here ++> A();
+    }
+}

--- a/jac/jaclang/plugin/tests/fixtures/multi_import_correct.jac
+++ b/jac/jaclang/plugin/tests/fixtures/multi_import_correct.jac
@@ -1,0 +1,11 @@
+import:jac from .multi_import2 {A, create_node}
+
+walker check_node {
+    can enter with `root entry {
+        visit [-->(`?A)];
+    }
+
+    can enter2 with A entry {
+        print(here);
+    }
+}

--- a/jac/jaclang/plugin/tests/fixtures/multi_import_wrong.jac
+++ b/jac/jaclang/plugin/tests/fixtures/multi_import_wrong.jac
@@ -1,0 +1,12 @@
+import:jac from .multi_import2 {A, create_node, B} # B is not existing
+
+walker check_node {
+    can enter with `root entry {
+        visit [-->(`?A)];
+    }
+
+    can enter2 with A entry {
+        print(here);
+    }
+}
+

--- a/jac/jaclang/plugin/tests/test_jaseci.py
+++ b/jac/jaclang/plugin/tests/test_jaseci.py
@@ -3,6 +3,7 @@
 import io
 import os
 import sys
+from pickle import PickleError
 
 from jaclang.cli import cli
 from jaclang.utils.test import TestCase
@@ -816,3 +817,73 @@ class TestJaseciPlugin(TestCase):
             session=session,
         )
         self.assertEqual("None", self.capturedOutput.getvalue().strip())
+
+    def test_multi_imports(self) -> None:
+        """Test filtering on node, then visit."""
+        global session
+        session = self.fixture_abs_path("multi_imports.session")
+
+        ##############################################
+        #                 SCENARIO 1                 #
+        ##############################################
+
+        self._output2buffer()
+
+        # created with correct import
+        cli.enter(
+            filename=self.fixture_abs_path("multi_import_correct.jac"),
+            entrypoint="create_node",
+            args=[],
+            session=session,
+        )
+
+        # access with correct import - able to print
+        cli.enter(
+            filename=self.fixture_abs_path("multi_import_correct.jac"),
+            entrypoint="check_node",
+            args=[],
+            session=session,
+        )
+
+        self.assertEqual(self.capturedOutput.getvalue().strip(), "A()")
+        self._output2buffer()
+
+        # access with wrong import (undeclared/missing B) - not able to print BUT
+        # IT SHOULD OR ATLEAST THROW ERROR ON BUILD TIME
+        cli.enter(
+            filename=self.fixture_abs_path("multi_import_wrong.jac"),
+            entrypoint="check_node",
+            args=[],
+            session=session,
+        )
+
+        self.assertEqual(self.capturedOutput.getvalue().strip(), "A()")
+
+        self._del_session(session)
+
+        ##############################################
+        #                 SCENARIO 2                 #
+        ##############################################
+
+        try:
+            # created with wrong import (undeclared/missing B)
+            cli.enter(
+                filename=self.fixture_abs_path("multi_import_wrong.jac"),
+                entrypoint="create_node",
+                args=[],
+                session=session,
+            )
+        except PickleError as e:
+            # THIS SHOULD RETURN DIFFERENT ERROR FOR WRONG IMPORT or NO ERROR IF MODULLE IS PROPERLY HANDLED
+            self.assertNotEqual(
+                "Can't pickle <class 'multi_import2.A'>: it's not the same object as multi_import2.A",
+                str(e),
+            )
+
+            raise e
+        finally:
+            self._del_session(session)
+
+        ##############################################
+        #            TEST CORRECT - WRONG            #
+        ##############################################


### PR DESCRIPTION
> pytest -s ./jac/jaclang/plugin/tests/test_jaseci.py::TestJaseciPlugin::test_multi_imports

jac_import triggers class initialization when you have imported non existing module
Ex:
```python
# test2.jac
node A {}

# test1.jac
import:jac from test2 {A,B,C}
```
For some reason this will initialize class `A` 3 times (1 for actual class and 1 for each undefined module - B & C)
This will corrupt pickle dumps and loads. This also affects Jac-Cloud