### PR TITLE
[WEBSOCKET]: Align websocket encoder to rest encoder

### DIFF
--- a/jac-cloud/jac_cloud/jaseci/routers/webhook.py
+++ b/jac-cloud/jac_cloud/jaseci/routers/webhook.py
@@ -140,9 +140,13 @@ def delete(key_ids: KeyIDs) -> ORJSONResponse:
         max_retry = BulkWrite.SESSION_MAX_TRANSACTION_RETRY
         while retry <= max_retry:
             try:
-                if Webhook.Collection.delete(
-                    {"_id": {"$in": [ObjectId(id) for id in key_ids.ids]}}, session
-                ).deleted_count == len(key_ids.ids):
+                filter = {"_id": {"$in": [ObjectId(id) for id in key_ids.ids]}}
+                whs = Webhook.Collection.find(filter)
+                if Webhook.Collection.delete(filter, session).deleted_count == len(
+                    key_ids.ids
+                ):
+                    for wh in whs:
+                        WebhookRedis.hdelete(wh.key)
                     BulkWrite.commit(session)
                     return ORJSONResponse({"message": "Successfully Deleted!"}, 200)
                 break

--- a/jac-cloud/jac_cloud/plugin/implementation/websocket.py
+++ b/jac-cloud/jac_cloud/plugin/implementation/websocket.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, WebSocket
 
 from jaclang.plugin.feature import JacFeature as Jac
 
-from orjson import loads
+from orjson import dumps, loads
 
 from pydantic import ValidationError
 
@@ -39,6 +39,22 @@ from ...jaseci.utils import utc_timestamp
 
 websocket_router = APIRouter(prefix="/websocket", tags=["walker"])
 websocket_events: dict[str, dict[str, Any]] = {}
+
+
+async def send_json(
+    self: WebSocket, data: Any, mode: str = "text"  # noqa: ANN401
+) -> None:
+    """Overide Websocket send_json."""
+    if mode not in {"text", "binary"}:
+        raise RuntimeError('The "mode" argument should be "text" or "binary".')
+    text = dumps(data)
+    if mode == "text":
+        await self.send({"type": "websocket.send", "text": text.decode()})
+    else:
+        await self.send({"type": "websocket.send", "bytes": text})
+
+
+WebSocket.send_json = send_json
 
 
 class WalkerExecutionError(Exception):


### PR DESCRIPTION
# This is to have the same encoding capabilities for REST Response and WebSocket event