### PR TITLE
Annex build refactored

### DIFF
--- a/jac/jaclang/langserve/utils.py
+++ b/jac/jaclang/langserve/utils.py
@@ -132,8 +132,6 @@ def find_index(
     char: int,
 ) -> Optional[int]:
     """Find index."""
-    index = None
-
     # A list contains all the token start positions.
     token_start_list = [
         get_token_start(i, sem_tokens) for i in range(0, len(sem_tokens), 5)
@@ -142,7 +140,7 @@ def find_index(
         if j[0] == line and j[1] <= char <= j[2]:
             return i
 
-    return index
+    return None
 
 
 def get_symbols_for_outline(node: SymbolTable) -> list[lspt.DocumentSymbol]:


### PR DESCRIPTION
## **Description**

`get_annex_paths`  function implemented and `annex_impl` method is simplified into the below:

```python
    def annex_impl(self, node: ast.Module) -> None:
        search_paths = self.get_annex_paths(node.loc.mod_path)
        for file_path in search_paths:
            mod = self.import_jac_mod_from_file(file_path)
            if mod:
                if file_path.endswith(".impl.jac"):
                    node.impl_mod.append(mod)
                else:
                    node.test_mod.append(mod)
                node.add_kids_right([mod], pos_update=False)
                mod.parent = node
```