### PR TITLE
Run jac run passes on modules one by one

### DIFF
--- a/jac/jaclang/compiler/compile.py
+++ b/jac/jaclang/compiler/compile.py
@@ -17,6 +17,8 @@ from jaclang.compiler.passes.tool.schedules import format_pass
 
 def compile_jac(file_path: str, cache_result: bool = False) -> Pass:
     """Start Compile for Jac file and return python code as string."""
+    from jaclang.runtimelib.machine import JacMachine
+
     code = jac_file_to_pass(
         file_path=file_path,
         schedule=pass_schedule,
@@ -25,8 +27,8 @@ def compile_jac(file_path: str, cache_result: bool = False) -> Pass:
     # no more passes were processed, in that case we can ignore it.
     had_syntax_error = isinstance(code, JacParser) and len(code.errors_had) != 0
     if cache_result and (not had_syntax_error) and isinstance(code.ir, ast.Module):
-        print_pass = PyOutPass(input_ir=code.ir, prior=code)
-        return print_pass
+        for _, module in JacMachine.get().jac_program.modules.items():
+            PyOutPass(input_ir=module, prior=code)
     return code
 
 
@@ -65,6 +67,7 @@ def jac_str_to_pass(
         return ast_ret
 
     machine = JacMachine.get()
+    top_mod = ast_ret.ir
     assert isinstance(ast_ret.ir, ast.Module)
     machine.jac_program.last_imported.append(ast_ret.ir)
     machine.jac_program.modules[ast_ret.ir.loc.mod_path] = ast_ret.ir
@@ -77,11 +80,18 @@ def jac_str_to_pass(
     if len(ast_ret.errors_had) != 0:
         return ast_ret
 
-    for i in schedule:
-        if i == target:
-            break
-        ast_ret = i(input_ir=ast_ret.ir, prior=ast_ret)
-    ast_ret = target(input_ir=ast_ret.ir, prior=ast_ret) if target else ast_ret
+    def run_schedule(mod: ast.Module) -> None:
+        nonlocal ast_ret
+        for i in schedule:
+            if i == target:
+                break
+            ast_ret = i(mod, prior=ast_ret)
+        ast_ret = target(mod, prior=ast_ret) if target else ast_ret
+
+    for mod in machine.jac_program.modules.values():
+        run_schedule(mod)
+
+    ast_ret.ir = top_mod
     return ast_ret
 
 

--- a/jac/jaclang/compiler/passes/main/import_pass.py
+++ b/jac/jaclang/compiler/passes/main/import_pass.py
@@ -61,10 +61,7 @@ class JacImportPass(Pass):
         if mod and mod.loc.mod_path not in current_machine.jac_program.modules:
             current_machine.jac_program.modules[mod.loc.mod_path] = mod
             current_machine.jac_program.last_imported.append(mod)
-            node.sub_module = mod
             self.annex_impl(mod)
-            node.add_kids_right([mod], pos_update=False)
-            mod.parent = node
 
     def annex_impl(self, node: ast.Module) -> None:
         """Annex impl and test modules."""

--- a/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
+++ b/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
@@ -169,28 +169,29 @@ class SymTabBuildPass(Pass):
         """
         self.sync_node_to_scope(node)
 
-    def exit_import(self, node: ast.Import) -> None:
-        """Sub objects.
+    # TODO: This should be moved to SymTableLink
+    # def exit_import(self, node: ast.Import) -> None:
+    #     """Sub objects.
 
-        lang: Name,
-        path: ModulePath,
-        alias: Optional[Name],
-        items: Optional[ModuleItems],
-        is_absorb: bool,
-        sub_module: Optional[Module],
-        """
-        if not node.is_absorb:
-            for i in node.items.items:
-                i.sym_tab.def_insert(i, single_decl="import item")
-        elif node.is_absorb and node.is_jac:
-            source = node.items.items[0]
-            if not isinstance(source, ast.ModulePath) or not source.sub_module:
-                self.error(
-                    f"Module {node.from_loc.dot_path_str if node.from_loc else 'from location'}"
-                    f" not found to include *, or ICE occurred!"
-                )
-            else:
-                node.sym_tab.inherit_sym_tab(source.sub_module.sym_tab)
+    #     lang: Name,
+    #     path: ModulePath,
+    #     alias: Optional[Name],
+    #     items: Optional[ModuleItems],
+    #     is_absorb: bool,
+    #     sub_module: Optional[Module],
+    #     """
+    #     if not node.is_absorb:
+    #         for i in node.items.items:
+    #             i.sym_tab.def_insert(i, single_decl="import item")
+    #     elif node.is_absorb and node.is_jac:
+    #         source = node.items.items[0]
+    #         if not isinstance(source, ast.ModulePath) or not source.sub_module:
+    #             self.error(
+    #                 f"Module {node.from_loc.dot_path_str if node.from_loc else 'from location'}"
+    #                 f" not found to include *, or ICE occurred!"
+    #             )
+    #         else:
+    #             node.sym_tab.inherit_sym_tab(source.sub_module.sym_tab)
 
     def enter_module_path(self, node: ast.ModulePath) -> None:
         """Sub objects.


### PR DESCRIPTION
## **Description**

- Stop attaching the sub modules for the imported modules in the main module (no more giant AST)
- Run the `jac run` passes run on the modules one by one
- Comment out exit_import from SymbolTableBuildPass (Should be moved into SymTableLink)