### PR TITLE
[FEATURE]: Architype Mongodb Indexing

### DIFF
--- a/jac-cloud/jac_cloud/jaseci/__init__.py
+++ b/jac-cloud/jac_cloud/jaseci/__init__.py
@@ -93,7 +93,7 @@ class FastAPI:
                 log: dict[str, Any] = {"request_url": str(request.url)}
                 log["extra_fields"] = list(log.keys())
                 logger.error(
-                    f"Call from to {log["request_url"]} returns unexpected errors: {response["errors"]}",
+                    f'Call from to {log["request_url"]} returns unexpected errors: {response["errors"]}',
                     extra=log,
                 )
 

--- a/jac-cloud/jac_cloud/jaseci/datasources/__init__.py
+++ b/jac-cloud/jac_cloud/jaseci/datasources/__init__.py
@@ -1,12 +1,13 @@
 """Jaseci Datasources."""
 
-from .collection import Collection
+from .collection import Collection, Index
 from .localdb import MontyClient
 from .redis import CodeRedis, Redis, TokenRedis
 
 
 __all__ = [
     "Collection",
+    "Index",
     "MontyClient",
     "CodeRedis",
     "Redis",

--- a/jac-cloud/jac_cloud/jaseci/utils/logger.py
+++ b/jac-cloud/jac_cloud/jaseci/utils/logger.py
@@ -307,10 +307,10 @@ def log_entry(
         "entry_node": node,
     }
     msg = str(
-        f"Incoming call from {log["caller_name"]}"
-        f" to {log["api_name"]}"
-        f" with payload: {log["payload"]}"
-        f" at entry node: {log["entry_node"]}"
+        f'Incoming call from {log["caller_name"]}'
+        f' to {log["api_name"]}'
+        f' with payload: {log["payload"]}'
+        f' at entry node: {log["entry_node"]}'
     )
     log["extra_fields"] = list(log.keys())
     logger.info(msg, extra=log)
@@ -324,11 +324,11 @@ def log_exit(response: dict[str, Any], log: dict[str, Any] | None = None) -> Non
     log["api_response"] = log_dumps(response)
     log["extra_fields"] = list(log.keys())
     log_msg = str(
-        f"Returning call from {log["caller_name"]}"
-        f" to {log["api_name"]}"
-        f" with payload: {log["payload"]}"
-        f" at entry node: {log["entry_node"]}"
-        f" with response: {log["api_response"]}"
+        f'Returning call from {log["caller_name"]}'
+        f' to {log["api_name"]}'
+        f' with payload: {log["payload"]}'
+        f' at entry node: {log["entry_node"]}'
+        f' with response: {log["api_response"]}'
     )
     logger.info(
         log_msg,

--- a/jac-cloud/jac_cloud/tests/openapi_specs.yaml
+++ b/jac-cloud/jac_cloud/tests/openapi_specs.yaml
@@ -2062,6 +2062,57 @@ paths:
       summary: Api Entry
       tags:
       - Walker APIs
+  /walker/create_unique_node:
+    post:
+      operationId: api_root_walker_create_unique_node_post
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Api Root Walker Create Unique Node Post
+          description: Successful Response
+      security:
+      - HTTPBearer: []
+      summary: Api Root
+      tags:
+      - Walker APIs
+  /walker/create_unique_node/{node}:
+    post:
+      operationId: api_entry_walker_create_unique_node__node__post
+      parameters:
+      - in: path
+        name: node
+        required: true
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Node
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Api Entry Walker Create Unique Node  Node  Post
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: Api Entry
+      tags:
+      - Walker APIs
   /walker/custom_report:
     post:
       operationId: api_root_walker_custom_report_post
@@ -4166,6 +4217,57 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
+      summary: Api Entry
+      tags:
+      - Walker APIs
+  /walker/visit_unique_node:
+    post:
+      operationId: api_root_walker_visit_unique_node_post
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Api Root Walker Visit Unique Node Post
+          description: Successful Response
+      security:
+      - HTTPBearer: []
+      summary: Api Root
+      tags:
+      - Walker APIs
+  /walker/visit_unique_node/{node}:
+    post:
+      operationId: api_entry_walker_visit_unique_node__node__post
+      parameters:
+      - in: path
+        name: node
+        required: true
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Node
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/ContextResponse_NoneType_'
+                - {}
+                title: Response Api Entry Walker Visit Unique Node  Node  Post
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
       summary: Api Entry
       tags:
       - Walker APIs

--- a/jac-cloud/jac_cloud/tests/simple_graph.jac
+++ b/jac-cloud/jac_cloud/tests/simple_graph.jac
@@ -83,6 +83,15 @@ obj Adult:Kid: {
     has kid: Kid, arr: list[Kid], data: dict[str, Kid];
 }
 
+node UniqueNode {
+    has id: str;
+
+    static has  __jac_indexes__: list = [{
+        "key": {"id": 1},
+        "constraints": {"unique": True}
+    }];
+}
+
 walker create_graph {
     can enter_root with `root entry {
         a = A(val=0);
@@ -892,6 +901,22 @@ walker visit_sequence {
 
     class __specs__ {
         has auth: bool = False;
+    }
+}
+
+walker create_unique_node {
+    can enter with `root entry {
+        here ++> UniqueNode(id="testing");
+    }
+}
+
+walker visit_unique_node {
+    can enter1 with `root entry {
+        visit [-->(`?UniqueNode)];
+    }
+
+    can enter2 with UniqueNode entry {
+        report here;
     }
 }
 

--- a/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud_env_vars.md
+++ b/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud_env_vars.md
@@ -14,6 +14,7 @@
 | DISABLE_AUTO_CLEANUP | Disable auto deletion of nodes that doesn't connect to anything | false |
 | SINGLE_QUERY | Every edge_ref will trigger query per anchor if not already cached instead of consolidating non cached anchor before querying. | false |
 | SESSION_MAX_TRANSACTION_RETRY | MongoDB's transactional retry | 1 |
+| ORDERED_BULK_WRITE | Sequential bulk writing that also raise proper operation error if occurs. Unordered approach is faster but the operation error would be generic | false
 | DISABLE_AUTO_ENDPOINT | Disable auto convertion of walker to api. It will now require inner class __specs__ or @specs decorator. | false |
 | SHOW_ENDPOINT_RETURNS | Include per visit return on api response | false |
 | SESSION_MAX_COMMIT_RETRY | MongoDB's transaction commit retry | 1 |

--- a/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud_indexing.md
+++ b/jac/support/jac-lang.org/docs/for_coders/jac-cloud/jac_cloud_indexing.md
@@ -1,0 +1,48 @@
+# Indexing
+* jac-cloud support indexing. However, it's limited to mongodb partialFilterExpression as we use a single collection for each architypes [`node`, `edge`, `object`, `walker`]
+- while index without contraints is still supported, it might not be as useful as we usually querying architype by `_id`. It will only be useful if we manually querying it.
+- **`by rule`**, this will always apply with partialFilterExpression constraints for name
+```python
+{
+  "partialFilterExpression": {
+    "name": {{the_name_of_the_architype}}
+  }
+}
+```
+# How To Use
+### `SINGLE INDEX`
+```python
+node UniqueNode {
+    has id: str;
+
+    static has  __jac_indexes__: list = [{
+        "key": {"id": 1} # 1 ASC, -1 DESC
+    }];
+}
+```
+
+### `COMPOUND INDEX`
+```python
+node UniqueNode {
+    has id1: str;
+    has id2: str;
+
+    static has  __jac_indexes__: list = [{
+        "key": {"id1": 1, "id2": 1} # 1 ASC, -1 DESC
+    }];
+}
+```
+
+### `UNIQUE CONSTRAINTS`
+```python
+node UniqueNode {
+    has id: str;
+
+    static has  __jac_indexes__: list = [{
+        "key": {"id": 1}, # 1 ASC, -1 DESC
+        "constraints": {"unique": True}
+    }];
+}
+```
+
+## For additional constraints options, you may check mongodb [docs](https://www.mongodb.com/docs/manual/indexes/) for indexing for more info.


### PR DESCRIPTION
# Indexing
* jac-cloud support indexing. However, it's limited to mongodb partialFilterExpression as we use a single collection for each architypes [`node`, `edge`, `object`, `walker`]
- while index without contraints is still supported, it might not be as useful as we usually querying architype by `_id`. It will only be useful if we manually querying it.
- **`by rule`**, this will always apply with partialFilterExpression constraints for name
```python
{
  "partialFilterExpression": {
    "name": {{the_name_of_the_architype}}
  }
}
```
# How To Use
### `SINGLE INDEX`
```python
node UniqueNode {
    has id: str;

    static has  __jac_indexes__: list = [{
        "key": {"id": 1} # 1 ASC, -1 DESC
    }];
}
```

### `COMPOUND INDEX`
```python
node UniqueNode {
    has id1: str;
    has id2: str;

    static has  __jac_indexes__: list = [{
        "key": {"id1": 1, "id2": 1} # 1 ASC, -1 DESC
    }];
}
```

### `UNIQUE CONSTRAINTS`
```python
node UniqueNode {
    has id: str;

    static has  __jac_indexes__: list = [{
        "key": {"id": 1}, # 1 ASC, -1 DESC
        "constraints": {"unique": True}
    }];
}
```

## For additional constraints options, you may check mongodb [docs](https://www.mongodb.com/docs/manual/indexes/) for indexing for more info.