### PR TITLE
[Jivas Fix] Handle __init__ Files in Package Imports 

### DIFF
--- a/jac/jaclang/compiler/passes/main/import_pass.py
+++ b/jac/jaclang/compiler/passes/main/import_pass.py
@@ -87,6 +87,15 @@ class JacImportPass(Transform[uni.Module, uni.Module]):
             if with_init in self.prog.mod.hub:
                 return self.prog.mod.hub[with_init]
             return self.prog.compile(file_path=with_init, mode=CMode.PARSE)
+        elif os.path.exists(a := os.path.join(target, "__init__.py")):
+            with open(a, "r") as f:
+                file_source = f.read()
+                mod = uni.Module.make_stub(
+                    inject_name=target.split(os.path.sep)[-1],
+                    inject_src=uni.Source(file_source, a),
+                )
+                self.prog.mod.hub[a] = mod
+                return mod
         else:
             return uni.Module.make_stub(
                 inject_name=target.split(os.path.sep)[-1],

--- a/jac/jaclang/compiler/passes/main/import_pass.py
+++ b/jac/jaclang/compiler/passes/main/import_pass.py
@@ -82,19 +82,19 @@ class JacImportPass(Transform[uni.Module, uni.Module]):
         """Import a module from a directory."""
         from jaclang.compiler.passes.main import CompilerMode as CMode
 
-        with_init = os.path.join(target, "__init__.jac")
-        if os.path.exists(with_init):
-            if with_init in self.prog.mod.hub:
-                return self.prog.mod.hub[with_init]
-            return self.prog.compile(file_path=with_init, mode=CMode.PARSE)
-        elif os.path.exists(a := os.path.join(target, "__init__.py")):
-            with open(a, "r") as f:
+        jac_init_path = os.path.join(target, "__init__.jac")
+        if os.path.exists(jac_init_path):
+            if jac_init_path in self.prog.mod.hub:
+                return self.prog.mod.hub[jac_init_path]
+            return self.prog.compile(file_path=jac_init_path, mode=CMode.PARSE)
+        elif os.path.exists(py_init_path := os.path.join(target, "__init__.py")):
+            with open(py_init_path, "r") as f:
                 file_source = f.read()
                 mod = uni.Module.make_stub(
                     inject_name=target.split(os.path.sep)[-1],
-                    inject_src=uni.Source(file_source, a),
+                    inject_src=uni.Source(file_source, py_init_path),
                 )
-                self.prog.mod.hub[a] = mod
+                self.prog.mod.hub[py_init_path] = mod
                 return mod
         else:
             return uni.Module.make_stub(

--- a/jac/jaclang/compiler/passes/main/sym_tab_link_pass.py
+++ b/jac/jaclang/compiler/passes/main/sym_tab_link_pass.py
@@ -17,7 +17,11 @@ class SymTabLinkPass(UniPass):
         if imp_node.is_jac:
             rel_path = node.resolve_relative_path()
             if os.path.isdir(rel_path):
-                rel_path = f"{rel_path}/__init__.jac"
+                init_path = os.path.join(rel_path, "__init__")
+                if os.path.isfile(f"{init_path}.jac"):
+                    rel_path = f"{init_path}.jac"
+                else:
+                    rel_path = f"{init_path}.py"
             if rel_path not in self.prog.mod.hub:
                 self.log_error(
                     f"Module {rel_path} not found in the program. Something went wrong.",

--- a/jac/jaclang/compiler/passes/main/tests/fixtures/symtab_link_tests/action/__init__.py
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/symtab_link_tests/action/__init__.py
@@ -1,0 +1,5 @@
+"""
+Test fixtures for the symtab link tests.
+
+This is a package which have __init__.py file.
+"""

--- a/jac/jaclang/compiler/passes/main/tests/fixtures/symtab_link_tests/action/actions.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/symtab_link_tests/action/actions.jac
@@ -1,0 +1,23 @@
+
+
+node LLM{
+
+    can infer with AgentNode entry{
+        return "LLM's response";
+    }
+
+    can testing_infer {
+        return "LLM's response";
+    }
+
+}
+
+
+obj AgentNode{
+    has describ :str = "AgentNode";
+
+    can connect with LLM entry{
+        return "AgentNode's response";
+
+    }
+}

--- a/jac/jaclang/compiler/passes/main/tests/fixtures/symtab_link_tests/main.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/symtab_link_tests/main.jac
@@ -1,0 +1,14 @@
+
+
+
+import from action {actions}
+
+
+with entry{
+
+        openai = actions.LLM();
+        agent = actions.AgentNode();
+        print("openai: response: ", openai.testing_infer());
+
+
+}

--- a/jac/jaclang/compiler/passes/main/tests/test_sym_tab_link_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_sym_tab_link_pass.py
@@ -15,7 +15,7 @@ class SymTabLinkPassTests(TestCase):
         """Set up test."""
         return super().setUp()
 
-    def test_registry_pass(self) -> None:
+    def test_no_dupl_symbols(self) -> None:
         """Basic test for pass."""
         file_path = os.path.join(
             os.path.dirname(__file__),
@@ -47,3 +47,16 @@ class SymTabLinkPassTests(TestCase):
             ),
             3,
         )
+
+    def test_package(self) -> None:
+        """Test package."""
+        file_path = os.path.join(
+            os.path.dirname(__file__),
+            "fixtures",
+            "symtab_link_tests",
+            "main.jac",
+        )
+        prog = JacProgram()
+        prog.compile(file_path, mode=CMode.COMPILE)
+        self.assertEqual(prog.errors_had, [])
+        self.assertEqual(prog.warnings_had, [])


### PR DESCRIPTION
## **Description**
Fix for : https://github.com/Jaseci-Labs/jaseci/issues/1750

This PR addresses a bug in the SymTabLinkPass where `__init__.jac` and `__init__.py` files were not handled correctly,
and this is now resolved.


Error Trace
```
File "/Users/chrisisking/dev/trueselph/jivas/venv/lib/python3.12/site-packages/jaclang/compiler/passes/main/sym_tab_link_pass.py", line 36, in enter_module_path
    imported_mod_symtab = self.prog.modules[rel_path].sym_tab
                          ~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: './jivas/agent/core/__init__.jac'
```