### PR TITLE
Add: Environment discovery and selection for Jac executable in VSCE

### DIFF
--- a/jac/support/vscode_ext/jac/package.json
+++ b/jac/support/vscode_ext/jac/package.json
@@ -51,6 +51,10 @@
       {
         "command": "jac.visualize",
         "title": "jacvis: Visualize Jaclang Graph"
+      },
+      {
+        "command": "jaclang-extension.selectEnv",
+        "title": "Jaclang: Select Environment"
       }
     ],
 
@@ -80,6 +84,11 @@
     ]
   },
   "main": "./out/extension.js",
+  "activationEvents": [
+    "onLanguage:jac",
+    "onCommand:jaclang-extension.selectEnv"
+  ],
+
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -b",

--- a/jac/support/vscode_ext/jac/src/extension.ts
+++ b/jac/support/vscode_ext/jac/src/extension.ts
@@ -14,6 +14,7 @@ import {
 } from './visual_debugger/visdbg';
 
 let client: LanguageClient;
+let jacEnvStatusBarItem: vscode.StatusBarItem;
 
 function getCondaEnvironment(): string | undefined {
     const condaPath = process.env.CONDA_PREFIX;
@@ -42,12 +43,23 @@ function getVenvEnvironment(): string | undefined {
     return undefined;
 }
 
-async function promptEnvironmentSelection(context: vscode.ExtensionContext) {
+function updateStatusBarLabel(envPath: string | undefined) {
+    if (!jacEnvStatusBarItem) return;
+
+    const shortLabel = envPath ? path.basename(envPath) : 'No Env';
+    jacEnvStatusBarItem.text = `Jac Env: ${shortLabel}`;
+    jacEnvStatusBarItem.tooltip = envPath || 'No Jac environment selected';
+    jacEnvStatusBarItem.show();
+}
+
+async function promptEnvironmentSelection(
+    context: vscode.ExtensionContext,
+    updateStatusBarLabel?: (envPath: string | undefined) => void
+) {
     const envs = await findPythonEnvsWithJac();
 
     if (envs.length === 0) {
         vscode.window.showWarningMessage("No environments with 'jac' executable found.");
-        // also show all the environments found
         const allEnvs = await findPythonEnvsWithJac();
         vscode.window.showInformationMessage(`Environments found: ${allEnvs.join(', ')}`);
         return;
@@ -60,6 +72,12 @@ async function promptEnvironmentSelection(context: vscode.ExtensionContext) {
     if (choice) {
         await context.globalState.update('jacEnvPath', choice);
         vscode.window.showInformationMessage(`Jac environment set to: ${choice}`);
+
+        // 🟡 Update the label on selection
+        if (updateStatusBarLabel) {
+            updateStatusBarLabel(choice);
+        }
+
         vscode.commands.executeCommand("workbench.action.reloadWindow");
     }
 }
@@ -88,7 +106,11 @@ function getJacInterpreterPath(): string {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    // const jacCommand = getJacInterpreterPath();
+    // 🔵 Create and register the status bar item
+    jacEnvStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    jacEnvStatusBarItem.command = 'jaclang-extension.selectEnv'; // clicking it triggers this
+    context.subscriptions.push(jacEnvStatusBarItem);
+
     if (!context.globalState.get('jacEnvPath')) {
         promptEnvironmentSelection(context);
     }
@@ -96,6 +118,7 @@ export function activate(context: vscode.ExtensionContext) {
     const savedJacPath = context.globalState.get<string>('jacEnvPath');
     const jacCommand = savedJacPath || getJacInterpreterPath();
 
+    updateStatusBarLabel(savedJacPath);
 
     let serverOptions: ServerOptions = {
         run: { command: jacCommand, args: ["lsp"] },
@@ -122,7 +145,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(vscode.commands.registerCommand(
         'jaclang-extension.selectEnv',
-        () => promptEnvironmentSelection(context)
+        () => promptEnvironmentSelection(context, updateStatusBarLabel)
     ));
 
     // Find and return the jac executable's absolute path.

--- a/jac/support/vscode_ext/jac/src/extension.ts
+++ b/jac/support/vscode_ext/jac/src/extension.ts
@@ -60,8 +60,6 @@ async function promptEnvironmentSelection(
 
     if (envs.length === 0) {
         vscode.window.showWarningMessage("No environments with 'jac' executable found.");
-        const allEnvs = await findPythonEnvsWithJac();
-        vscode.window.showInformationMessage(`Environments found: ${allEnvs.join(', ')}`);
         return;
     }
 

--- a/jac/support/vscode_ext/jac/src/utils.ts
+++ b/jac/support/vscode_ext/jac/src/utils.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as cp from 'child_process';
+
+export async function findPythonEnvsWithJac(): Promise<string[]> {
+    const envs: string[] = [];
+
+    // 1. Check PATH
+    const searchDirs = process.env.PATH?.split(path.delimiter) || [];
+    for (const dir of searchDirs) {
+        const jacPath = path.join(dir, process.platform === 'win32' ? 'jac.exe' : 'jac');
+        if (fs.existsSync(jacPath)) {
+            envs.push(jacPath);
+        }
+    }
+
+    // 2. Check Conda environments
+    try {
+        const condaInfo = cp.execSync('conda env list', { encoding: 'utf8' });
+        const condaLines = condaInfo.split('\n');
+        for (const line of condaLines) {
+            const match = line.match(/^(.*?)\s+(\S+)/);
+            if (match) {
+                const envPath = match[2];
+                const jacPath = path.join(envPath, 'bin', 'jac');
+                const jacPathWin = path.join(envPath, 'Scripts', 'jac.exe');
+                if (fs.existsSync(jacPath)) envs.push(jacPath);
+                if (fs.existsSync(jacPathWin)) envs.push(jacPathWin);
+            }
+        }
+    } catch (err) {
+        console.warn('conda env list failed:', err);
+    }
+
+    // 3. Check WSL Conda environments
+    try {
+        const wslCondaInfo = cp.execSync('wsl conda env list', { encoding: 'utf8' });
+        const wslCondaLines = wslCondaInfo.split('\n');
+        for (const line of wslCondaLines) {
+            const match = line.match(/^(.*?)\s+(\S+)/);
+            if (match) {
+                const envPath = match[2];
+                const jacPath = `/mnt/${envPath.replace(/^\/mnt\//, '').replace(/\\/g, '/')}/bin/jac`;
+                try {
+                    const wslCheck = cp.execSync(`wsl test -f ${jacPath} && echo exists || echo missing`, { encoding: 'utf8' }).trim();
+                    if (wslCheck === 'exists') envs.push(`wsl:${jacPath}`);
+                } catch {}
+            }
+        }
+    } catch (err) {
+        console.warn('wsl conda env list failed:', err);
+    }
+
+    // 4. Deduplicate
+    const uniqueEnvs = [...new Set(envs)];
+    return uniqueEnvs;
+}

--- a/jac/support/vscode_ext/jac/src/utils.ts
+++ b/jac/support/vscode_ext/jac/src/utils.ts
@@ -2,7 +2,39 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as cp from 'child_process';
 
-export async function findPythonEnvsWithJac(): Promise<string[]> {
+function isJacInVenv(venvPath: string): string | null {
+    const jacPath = path.join(venvPath, 'bin', 'jac');
+    const jacPathWin = path.join(venvPath, 'Scripts', 'jac.exe');
+    if (fs.existsSync(jacPath)) return jacPath;
+    if (fs.existsSync(jacPathWin)) return jacPathWin;
+    return null;
+}
+
+function walkForVenvs(baseDir: string, depth = 3): string[] {
+    const found: string[] = [];
+    if (depth === 0) return found;
+
+    const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            const fullPath = path.join(baseDir, entry.name);
+
+            const jacPath = isJacInVenv(fullPath);
+            if (jacPath) {
+                found.push(jacPath);
+            }
+
+            // Continue walking deeper
+            try {
+                found.push(...walkForVenvs(fullPath, depth - 1));
+            } catch {}
+        }
+    }
+    return found;
+}
+
+
+export async function findPythonEnvsWithJac(workspaceRoot: string = process.cwd()): Promise<string[]> {
     const envs: string[] = [];
 
     // 1. Check PATH
@@ -14,7 +46,7 @@ export async function findPythonEnvsWithJac(): Promise<string[]> {
         }
     }
 
-    // 2. Check Conda environments
+    // 2. Conda environments
     try {
         const condaInfo = cp.execSync('conda env list', { encoding: 'utf8' });
         const condaLines = condaInfo.split('\n');
@@ -22,36 +54,53 @@ export async function findPythonEnvsWithJac(): Promise<string[]> {
             const match = line.match(/^(.*?)\s+(\S+)/);
             if (match) {
                 const envPath = match[2];
-                const jacPath = path.join(envPath, 'bin', 'jac');
-                const jacPathWin = path.join(envPath, 'Scripts', 'jac.exe');
-                if (fs.existsSync(jacPath)) envs.push(jacPath);
-                if (fs.existsSync(jacPathWin)) envs.push(jacPathWin);
+                const jacPath = isJacInVenv(envPath);
+                if (jacPath) envs.push(jacPath);
             }
         }
     } catch (err) {
         console.warn('conda env list failed:', err);
     }
 
-    // 3. Check WSL Conda environments
-    try {
-        const wslCondaInfo = cp.execSync('wsl conda env list', { encoding: 'utf8' });
-        const wslCondaLines = wslCondaInfo.split('\n');
-        for (const line of wslCondaLines) {
-            const match = line.match(/^(.*?)\s+(\S+)/);
-            if (match) {
-                const envPath = match[2];
-                const jacPath = `/mnt/${envPath.replace(/^\/mnt\//, '').replace(/\\/g, '/')}/bin/jac`;
-                try {
-                    const wslCheck = cp.execSync(`wsl test -f ${jacPath} && echo exists || echo missing`, { encoding: 'utf8' }).trim();
-                    if (wslCheck === 'exists') envs.push(`wsl:${jacPath}`);
-                } catch {}
+    // 3. WSL Conda environments (skip if already inside WSL)
+    if (!process.env.WSL_DISTRO_NAME) {
+        try {
+            const wslCondaInfo = cp.execSync('wsl conda env list', { encoding: 'utf8' });
+            const wslCondaLines = wslCondaInfo.split('\n');
+            for (const line of wslCondaLines) {
+                const match = line.match(/^(.*?)\s+(\S+)/);
+                if (match) {
+                    const envPath = match[2];
+                    const jacPath = `/mnt/${envPath.replace(/^\/mnt\//, '').replace(/\\/g, '/')}/bin/jac`;
+                    try {
+                        const wslCheck = cp.execSync(`wsl test -f ${jacPath} && echo exists || echo missing`, { encoding: 'utf8' }).trim();
+                        if (wslCheck === 'exists') envs.push(`wsl:${jacPath}`);
+                    } catch {}
+                }
             }
+        } catch {
+            console.warn('Skipping WSL conda env list (likely inside WSL or no permission)');
         }
-    } catch (err) {
-        console.warn('wsl conda env list failed:', err);
     }
 
-    // 4. Deduplicate
-    const uniqueEnvs = [...new Set(envs)];
+    // 4. Local venvs in workspace
+    const localVenvDirs = ['.venv', 'venv', 'env'];
+    for (const dirName of localVenvDirs) {
+        const jacPath = isJacInVenv(path.join(workspaceRoot, dirName));
+        if (jacPath) envs.push(jacPath);
+    }
+
+    // 5. Walk home directory (or workspace) to find other venvs
+    const homeDir = process.env.HOME || process.env.USERPROFILE || workspaceRoot;
+    envs.push(...walkForVenvs(homeDir, 6));  // limit search to depth 3
+    const venvWrapperDir = path.join(homeDir, '.virtualenvs');
+    if (fs.existsSync(venvWrapperDir)) {
+        envs.push(...walkForVenvs(venvWrapperDir, 2));
+    }
+
+    // 6. Deduplicate
+    // const uniqueEnvs = [...new Set(envs)];
+    const uniqueEnvs = Array.from(new Set(envs));
+
     return uniqueEnvs;
 }

--- a/jac/support/vscode_ext/jac/src/utils.ts
+++ b/jac/support/vscode_ext/jac/src/utils.ts
@@ -92,14 +92,13 @@ export async function findPythonEnvsWithJac(workspaceRoot: string = process.cwd(
 
     // 5. Walk home directory (or workspace) to find other venvs
     const homeDir = process.env.HOME || process.env.USERPROFILE || workspaceRoot;
-    envs.push(...walkForVenvs(homeDir, 6));  // limit search to depth 3
+    envs.push(...walkForVenvs(homeDir, 6));  // limit search to depth 6
     const venvWrapperDir = path.join(homeDir, '.virtualenvs');
     if (fs.existsSync(venvWrapperDir)) {
         envs.push(...walkForVenvs(venvWrapperDir, 2));
     }
 
     // 6. Deduplicate
-    // const uniqueEnvs = [...new Set(envs)];
     const uniqueEnvs = Array.from(new Set(envs));
 
     return uniqueEnvs;


### PR DESCRIPTION
 ## ✨ Feature: Jac Environment Selector

This PR adds support for discovering and selecting the jac executable environment in the VS Code extension. Users can now switch between environments via a new status bar item.

### 🧪 How to Test (QA Checklist)
#### 1. Install the extension (*.vsix)
Clone and build the extension:
```
git clone https://github.com/Jaseci-Labs/jaseci.git
cd ~/jaseci/jac/support/vscode_ext/jac
npm install
npm install -g @vscode/vsce
vsce package
code --install-extension <path-to-generated-vsix>
```
Replace <path-to-generated-vsix> with the actual filename (e.g., jaclang-extension-2024.x.x.vsix).

#### 2. Reload the VS Code window
Press Ctrl+Shift+P → Select Reload Window.

#### 3. Click the Jac environment status bar item
This is located at the bottom of the VS Code window.

#### 4. Select a Jac environment from the prompted list.

https://github.com/user-attachments/assets/a6a6c96e-db18-4748-96c6-62f715656e68



![Screenshot 2025-05-06 154348](https://github.com/user-attachments/assets/2edb14d4-525c-4c49-849b-64ad0a4309fb)

🎉 Happy Coding!