### PR TITLE
Fix walrus conversion

### DIFF
--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1837,7 +1837,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         )
         return ret
 
-    def proc_named_expr(self, node: py_ast.NamedExpr) -> uni.BinaryExpr:
+    def proc_named_expr(self, node: py_ast.NamedExpr) -> uni.AtomUnit:
         """Process python node.
 
         class NamedExpr(expr):
@@ -1847,11 +1847,20 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         target = self.convert(node.target)
         value = self.convert(node.value)
         if isinstance(value, uni.Expr) and isinstance(target, uni.Name):
-            return uni.BinaryExpr(
+            op = self.operator(Tok.WALRUS_EQ, ":=")
+            expr = uni.BinaryExpr(
                 left=target,
-                op=self.operator(Tok.WALRUS_EQ, ":="),
+                op=op,
                 right=value,
-                kid=[target, value],
+                kid=[target, op, value],
+            )
+            return uni.AtomUnit(
+                value=expr,
+                kid=[
+                    self.operator(Tok.RPAREN, "("),
+                    expr,
+                    self.operator(Tok.LPAREN, ")"),
+                ],
             )
         else:
             raise self.ice()

--- a/jac/jaclang/tests/fixtures/py_namedexpr.py
+++ b/jac/jaclang/tests/fixtures/py_namedexpr.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+# flake8: noqa
+
+def walrus_example():
+    if (x := 10) > 5:
+        print(x)

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1229,3 +1229,21 @@ class JacLanguageTests(TestCase):
             "Value: -1\nValue: 0\nValue: 1\nValue: 2\nValue: 3\nValue: 4"
             "\nValue: 5\nValue: 6\nValue: 7\nFinal Value: 8\nDone walking.\n",
         )
+
+    def test_py_namedexpr(self) -> None:
+        """Ensure NamedExpr nodes are converted to AtomUnit."""
+        from jaclang.compiler.passes.main import PyastBuildPass
+        import jaclang.compiler.unitree as uni
+        import ast as py_ast
+
+        py_out_path = os.path.join(self.fixture_abs_path("./"), "py_namedexpr.py")
+        with open(py_out_path) as f:
+            file_source = f.read()
+            output = PyastBuildPass(
+                ir_in=uni.PythonModuleAst(
+                    py_ast.parse(file_source),
+                    orig_src=uni.Source(file_source, py_out_path),
+                ),
+                prog=JacProgram(),
+            ).ir_out.unparse()
+        self.assertIn("(x := 10)", output)


### PR DESCRIPTION
## Summary
- build NamedExpr as AtomUnit for walrus operator
- add regression test for NamedExpr

## Testing
- `pre-commit run --files jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/tests/fixtures/py_namedexpr.py jac/jaclang/tests/test_language.py` *(fails: command not found)*