### PR TITLE
Auto infer jac_import language

### DIFF
--- a/jac/examples/reference/concurrent_expressions.py
+++ b/jac/examples/reference/concurrent_expressions.py
@@ -4,7 +4,7 @@ from jaclang import JacMachineInterface as _
 if _.TYPE_CHECKING:
     from time import sleep
 else:
-    sleep, = _.py_jac_import('time', __file__, lng='py', items={'sleep': None})
+    sleep, = _.py_jac_import('time', __file__, items={'sleep': None})
 
 class A(_.Node):
     val: int = 0

--- a/jac/examples/reference/special_comprehensions.py
+++ b/jac/examples/reference/special_comprehensions.py
@@ -5,7 +5,7 @@ from jaclang import JacMachineInterface as _
 if _.TYPE_CHECKING:
     import random
 else:
-    (random,) = _.py_jac_import("random", __file__, lng="py")
+    (random,) = _.py_jac_import("random", __file__)
 
 
 class TestObj(_.Obj):

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -514,19 +514,6 @@ class PyastGenPass(UniPass):
                     )
                 )
 
-            if node.is_py:
-                keywords.append(
-                    self.sync(
-                        ast3.keyword(
-                            arg="lng",
-                            value=self.sync(
-                                ast3.Constant(value="py"),
-                                node.hint,
-                            ),
-                        )
-                    )
-                )
-
             if item_keys and item_values:
                 keywords.append(
                     self.sync(

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -790,7 +790,7 @@ class JacBasics:
                 return lang
             target_jac = actual_parts[-1] + ".jac"
             target_py = actual_parts[-1] + ".py"
-            for root_dir, _, files in os.walk(jacpath):
+            for _, _, files in os.walk(jacpath):
                 if target_jac in files:
                     return "jac"
                 if target_py in files:


### PR DESCRIPTION
## Summary
- infer module language when importing
- stop passing `lng` arg when importing
- update examples using `py_jac_import`

## Testing
- `python -V`