### PR TITLE
Refactor import path handling

### DIFF
--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast as ast3
 import builtins
 import os
-import site
 from copy import copy
 from dataclasses import dataclass
 from hashlib import md5
@@ -1356,43 +1355,11 @@ class ModulePath(AstSymbolNode):
 
     def resolve_relative_path(self, target_item: Optional[str] = None) -> str:
         """Convert an import target string into a relative file path."""
-        # Build the target module name
+        from jaclang.utils import resolve_module_path
+
         target = self.dot_path_str + (f".{target_item}" if target_item else "")
-        site_packages = site.getsitepackages()[0]
-
-        # Split the target into parts and determine how many levels to traverse.
-        parts = target.split(".")
-        traversal_levels = max(self.level - 1, 0)
-        actual_parts = parts[traversal_levels:]
-
-        def candidate_from(base: str) -> str:
-            candidate = os.path.join(base, *actual_parts)
-            candidate_jac = candidate + ".jac"
-            return candidate_jac if os.path.exists(candidate_jac) else candidate
-
-        # 1. Try resolving using the first site-packages directory.
-        candidate = candidate_from(site_packages)
-        if os.path.exists(candidate):
-            return candidate
-
-        # 2. Adjust the base path by moving up for each traversal level.
-        base_path = (
-            os.getenv("JACPATH") or os.path.dirname(self.loc.mod_path) or os.getcwd()
-        )
-        for _ in range(traversal_levels):
-            base_path = os.path.dirname(base_path)
-        candidate = candidate_from(base_path)
-
-        # 3. If candidate doesn't exist and JACPATH is provided, search recursively.
-        jacpath = os.getenv("JACPATH")
-        if not os.path.exists(candidate) and jacpath:
-            target_filename = actual_parts[-1] + ".jac"
-            for root, _, files in os.walk(jacpath):
-                if target_filename in files:
-                    candidate = os.path.join(root, target_filename)
-                    break
-
-        return candidate
+        base_path = os.path.dirname(self.loc.mod_path)
+        return resolve_module_path(target, base_path)
 
 
 class ModuleItem(AstSymbolNode):

--- a/jac/jaclang/utils/__init__.py
+++ b/jac/jaclang/utils/__init__.py
@@ -1,1 +1,5 @@
 """Jaseci utility functions and libraries."""
+
+from .path import resolve_module_path, infer_language
+
+__all__ = ["resolve_module_path", "infer_language"]

--- a/jac/jaclang/utils/path.py
+++ b/jac/jaclang/utils/path.py
@@ -1,0 +1,76 @@
+"""Path resolution and language inference utilities."""
+
+import os
+import site
+from typing import Optional
+
+
+def _candidate_from(parts: list[str], base: str) -> Optional[str]:
+    """Return candidate path for the given base and module parts."""
+    candidate = os.path.join(base, *parts)
+    # Package directory
+    if os.path.isdir(candidate):
+        for init_file in ["__init__.jac", "__init__.py"]:
+            init_path = os.path.join(candidate, init_file)
+            if os.path.isfile(init_path):
+                return candidate
+        return candidate
+    # Module file
+    if os.path.isfile(candidate + ".jac") or os.path.isfile(candidate + ".py"):
+        return candidate
+    return None
+
+
+def resolve_module_path(target: str, base_path: str) -> str:
+    """Resolve a module name to an absolute path."""
+    parts = target.split(".")
+    level = 0
+    while level < len(parts) and parts[level] == "":
+        level += 1
+    actual_parts = parts[level:]
+    traversal = max(level - 1, 0)
+
+    # 1. Search site-packages
+    for sp in site.getsitepackages():
+        candidate = _candidate_from(actual_parts, sp)
+        if candidate:
+            return os.path.abspath(candidate)
+
+    # 2. Relative to caller
+    base_dir = base_path if os.path.isdir(base_path) else os.path.dirname(base_path)
+    for _ in range(traversal):
+        base_dir = os.path.dirname(base_dir)
+    candidate = _candidate_from(actual_parts, base_dir)
+    if candidate:
+        return os.path.abspath(candidate)
+
+    # 3. JACPATH search
+    jacpath = os.getenv("JACPATH")
+    if jacpath:
+        candidate = _candidate_from(actual_parts, jacpath)
+        if candidate:
+            return os.path.abspath(candidate)
+        target_files = [actual_parts[-1] + ".jac", actual_parts[-1] + ".py"]
+        for root, _, files in os.walk(jacpath):
+            for file in target_files:
+                if file in files:
+                    return os.path.abspath(os.path.join(root, file))
+
+    return os.path.abspath(os.path.join(base_dir, *actual_parts))
+
+
+def infer_language(target: str, base_path: str) -> str:
+    """Infer whether the module is Jac or Python based on the file system."""
+    path = resolve_module_path(target, base_path)
+    if os.path.isdir(path):
+        if os.path.isfile(os.path.join(path, "__init__.jac")):
+            return "jac"
+        if os.path.isfile(os.path.join(path, "__init__.py")):
+            return "py"
+    if path.endswith(".jac") or os.path.isfile(path + ".jac"):
+        return "jac"
+    if path.endswith(".py") or os.path.isfile(path + ".py"):
+        return "py"
+    return "py"
+
+__all__ = ["resolve_module_path", "infer_language"]


### PR DESCRIPTION
## Summary
- add `resolve_module_path` and `infer_language` helper
- use the new helpers in `jac_import` and compiler
- simplify importer logic
- fix path duplication when resolving modules

## Testing
- `python -m compileall -q jac/jaclang/utils/path.py jac/jaclang/runtimelib/importer.py`
- `python -m py_compile jac/jaclang/utils/path.py jac/jaclang/utils/__init__.py jac/jaclang/runtimelib/machine.py jac/jaclang/compiler/unitree.py jac/jaclang/runtimelib/importer.py`
