### PR TITLE
Centralize path inference utilities

### DIFF
--- a/jac-splice-orc/jac_splice_orc/plugin/splice_plugin.py
+++ b/jac-splice-orc/jac_splice_orc/plugin/splice_plugin.py
@@ -16,6 +16,7 @@ from jac_splice_orc.managers.proxy_manager import ModuleProxy, RemoteObjectProxy
 
 from jaclang.cli.cmdreg import cmd_registry
 from jaclang.runtimelib.machine import JacMachine, JacMachineInterface, JacProgram
+from jaclang.utils import infer_language
 
 
 from kubernetes import client, config
@@ -591,7 +592,7 @@ class SpliceOrcPlugin:
             PythonImporter,
         )
 
-        lng = JacMachine.infer_language(target, base_path)
+        lng = infer_language(target, base_path)
         module_config_path = os.getenv("MODULE_CONFIG_PATH", "/cfg/module_config.json")
         try:
             logging.debug(f"Loading from {module_config_path} for module_config...")

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast as ast3
 import builtins
 import os
-import site
 from copy import copy
 from dataclasses import dataclass
 from hashlib import md5
@@ -37,6 +36,7 @@ from jaclang.utils.treeprinter import (
     print_ast_tree,
     print_symtab_tree,
 )
+from jaclang.utils import resolve_relative_path
 
 
 class UniNode:
@@ -1356,43 +1356,8 @@ class ModulePath(AstSymbolNode):
 
     def resolve_relative_path(self, target_item: Optional[str] = None) -> str:
         """Convert an import target string into a relative file path."""
-        # Build the target module name
         target = self.dot_path_str + (f".{target_item}" if target_item else "")
-        site_packages = site.getsitepackages()[0]
-
-        # Split the target into parts and determine how many levels to traverse.
-        parts = target.split(".")
-        traversal_levels = max(self.level - 1, 0)
-        actual_parts = parts[traversal_levels:]
-
-        def candidate_from(base: str) -> str:
-            candidate = os.path.join(base, *actual_parts)
-            candidate_jac = candidate + ".jac"
-            return candidate_jac if os.path.exists(candidate_jac) else candidate
-
-        # 1. Try resolving using the first site-packages directory.
-        candidate = candidate_from(site_packages)
-        if os.path.exists(candidate):
-            return candidate
-
-        # 2. Adjust the base path by moving up for each traversal level.
-        base_path = (
-            os.getenv("JACPATH") or os.path.dirname(self.loc.mod_path) or os.getcwd()
-        )
-        for _ in range(traversal_levels):
-            base_path = os.path.dirname(base_path)
-        candidate = candidate_from(base_path)
-
-        # 3. If candidate doesn't exist and JACPATH is provided, search recursively.
-        jacpath = os.getenv("JACPATH")
-        if not os.path.exists(candidate) and jacpath:
-            target_filename = actual_parts[-1] + ".jac"
-            for root, _, files in os.walk(jacpath):
-                if target_filename in files:
-                    candidate = os.path.join(root, target_filename)
-                    break
-
-        return candidate
+        return resolve_relative_path(target, self.loc.mod_path)
 
 
 class ModuleItem(AstSymbolNode):

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -30,13 +30,13 @@ from jaclang.compiler.constant import (
     SymbolType,
 )
 from jaclang.compiler.constant import DELIM_MAP, SymbolAccess, Tokens as Tok
+from jaclang.utils import resolve_relative_path
 from jaclang.utils.treeprinter import (
     dotgen_ast_tree,
     dotgen_symtab_tree,
     print_ast_tree,
     print_symtab_tree,
 )
-from jaclang.utils import resolve_relative_path
 
 
 class UniNode:

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -748,7 +748,6 @@ class JacBasics:
                 break
         return machine
 
-
     @staticmethod
     def py_jac_import(
         target: str,

--- a/jac/jaclang/utils/__init__.py
+++ b/jac/jaclang/utils/__init__.py
@@ -1,1 +1,3 @@
 """Jaseci utility functions and libraries."""
+
+from .module_resolver import resolve_module, infer_language, resolve_relative_path

--- a/jac/jaclang/utils/__init__.py
+++ b/jac/jaclang/utils/__init__.py
@@ -1,3 +1,5 @@
 """Jaseci utility functions and libraries."""
 
-from .module_resolver import resolve_module, infer_language, resolve_relative_path
+from .module_resolver import infer_language, resolve_module, resolve_relative_path
+
+__all__ = ["infer_language", "resolve_module", "resolve_relative_path"]

--- a/jac/jaclang/utils/module_resolver.py
+++ b/jac/jaclang/utils/module_resolver.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import site
+from typing import Optional, Tuple
+
+
+def _candidate_from(base: str, parts: list[str]) -> Optional[Tuple[str, str]]:
+    candidate = os.path.join(base, *parts)
+    if os.path.isdir(candidate):
+        if os.path.isfile(os.path.join(candidate, "__init__.jac")):
+            return os.path.join(candidate, "__init__.jac"), "jac"
+        if os.path.isfile(os.path.join(candidate, "__init__.py")):
+            return os.path.join(candidate, "__init__.py"), "py"
+    if os.path.isfile(candidate + ".jac"):
+        return candidate + ".jac", "jac"
+    if os.path.isfile(candidate + ".py"):
+        return candidate + ".py", "py"
+    return None
+
+
+def resolve_module(target: str, base_path: str) -> Tuple[str, str]:
+    """Resolve module path and infer language."""
+    parts = target.split(".")
+    level = 0
+    while level < len(parts) and parts[level] == "":
+        level += 1
+    actual_parts = parts[level:]
+
+    for sp in site.getsitepackages():
+        res = _candidate_from(sp, actual_parts)
+        if res:
+            return res
+
+    base_dir = base_path if os.path.isdir(base_path) else os.path.dirname(base_path)
+    for _ in range(max(level - 1, 0)):
+        base_dir = os.path.dirname(base_dir)
+    res = _candidate_from(base_dir, actual_parts)
+    if res:
+        return res
+
+    jacpath = os.getenv("JACPATH")
+    if jacpath:
+        res = _candidate_from(jacpath, actual_parts)
+        if res:
+            return res
+        target_jac = actual_parts[-1] + ".jac"
+        target_py = actual_parts[-1] + ".py"
+        for root, _, files in os.walk(jacpath):
+            if target_jac in files:
+                return os.path.join(root, target_jac), "jac"
+            if target_py in files:
+                return os.path.join(root, target_py), "py"
+
+    return os.path.join(base_dir, *actual_parts), "py"
+
+
+def infer_language(target: str, base_path: str) -> str:
+    """Infer language for target relative to base path."""
+    _, lang = resolve_module(target, base_path)
+    return lang
+
+
+def resolve_relative_path(target: str, base_path: str) -> str:
+    """Resolve only the path component for a target."""
+    path, _ = resolve_module(target, base_path)
+    return path

--- a/jac/jaclang/utils/module_resolver.py
+++ b/jac/jaclang/utils/module_resolver.py
@@ -1,3 +1,5 @@
+"""Module resolver utilities."""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
- provide new module_resolver with functions to locate module paths and infer language
- use infer_language from module_resolver in machine and splice plugin
- update unitree to delegate path resolution to new utility
- expose utilities via jaclang.utils
- remove old infer_language implementation

## Testing
- `python -m py_compile jac/jaclang/utils/module_resolver.py jac/jaclang/runtimelib/machine.py jac/jaclang/compiler/unitree.py jac-splice-orc/jac_splice_orc/plugin/splice_plugin.py`
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*