### PR TITLE
Create a Custom div to execute the jac code in MKDOCS

### DIFF
--- a/docs/docs/extra.css
+++ b/docs/docs/extra.css
@@ -22,3 +22,67 @@
 .md-typeset details > summary:after {
     color: #ffab40 !important;
 }
+
+.code-container {
+    margin: 1em 0;
+    padding: 1em;
+    background: #282c34;
+    color: #abb2bf;
+    border-radius: 4px;
+}
+
+.code-container pre {
+    background: #1e1e1e;
+    color: #dcdcdc;
+    padding: 0.5em;
+    margin: 0;
+    overflow-x: auto;
+    border-radius: 4px;
+}
+
+.code-container button {
+    margin-top: 0.5em;
+    padding: 0.4em 1.2em;
+    background: linear-gradient(90deg, #ff9800 0%, #ffab40 100%);
+    color: #1e1e1e;
+    border: none;
+    border-radius: 3px;
+    font-weight: 600;
+    font-size: 1em;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+    outline: none;
+    letter-spacing: 0.03em;
+}
+
+.code-container button:hover,
+.code-container button:focus {
+    background: linear-gradient(90deg, #ffa726 0%, #ffd180 100%);
+    color: #111;
+    box-shadow: 0 4px 16px rgba(255,171,64,0.15);
+}
+
+.code-container button:active {
+    background: #ff9800;
+    color: #fff;
+}
+
+.code-container .code-output {
+    margin-top: 0.5em;
+    background: #1e1e1e;
+    color: #98c379;
+    padding: 0.5em;
+    border-radius: 4px;
+    font-family: monospace;
+    max-height: 1000px;
+    overflow: auto;
+    transition: max-height 0.3s cubic-bezier(0.4,0,0.2,1), padding 0.3s;
+}
+
+.code-container .code-output[style*="display: none"] {
+    max-height: 0;
+    padding: 0;
+    overflow: hidden;
+    margin-top: 0;
+}

--- a/docs/docs/js/pyodide-worker.js
+++ b/docs/docs/js/pyodide-worker.js
@@ -14,7 +14,7 @@ await micropip.install("jaclang==0.7.0")
         self.postMessage({ type: "ready" });
     }
 
-    if (type === "run" && pyodide) {
+    if (pyodide) {
         try {
             const jacCode = JSON.stringify(code);
             const output = await pyodide.runPythonAsync(`

--- a/docs/docs/js/pyodide-worker.js
+++ b/docs/docs/js/pyodide-worker.js
@@ -1,0 +1,43 @@
+let pyodide = null;
+
+self.onmessage = async (event) => {
+    const { type, code } = event.data;
+
+    if (type === "init") {
+        importScripts("https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js");
+        pyodide = await loadPyodide();
+        await pyodide.loadPackage("micropip");
+        await pyodide.runPythonAsync(`
+import micropip
+await micropip.install("jaclang==0.7.0")
+        `);
+        self.postMessage({ type: "ready" });
+    }
+
+    if (type === "run" && pyodide) {
+        try {
+            const jacCode = JSON.stringify(code);
+            const output = await pyodide.runPythonAsync(`
+from jaclang.cli.cli import run
+import sys
+from io import StringIO
+
+captured_output = StringIO()
+sys.stdout = captured_output
+sys.stderr = captured_output
+
+jac_code = ${jacCode}
+with open("/tmp/temp.jac", "w") as f:
+    f.write(jac_code)
+run("/tmp/temp.jac")
+
+sys.stdout = sys.__stdout__
+sys.stderr = sys.__stderr__
+captured_output.getvalue()
+            `);
+            self.postMessage({ type: "result", output });
+        } catch (error) {
+            self.postMessage({ type: "error", error: error.toString() });
+        }
+    }
+};

--- a/docs/docs/js/pyodide-worker.js
+++ b/docs/docs/js/pyodide-worker.js
@@ -10,14 +10,19 @@ self.onmessage = async (event) => {
         await pyodide.runPythonAsync(`
 import micropip
 await micropip.install("jaclang==0.7.0")
+from jaclang.cli.cli import run
         `);
         self.postMessage({ type: "ready" });
+        return;
     }
 
-    if (pyodide) {
-        try {
-            const jacCode = JSON.stringify(code);
-            const output = await pyodide.runPythonAsync(`
+    if (!pyodide) {
+        return;
+    }
+
+    try {
+        const jacCode = JSON.stringify(code);
+        const output = await pyodide.runPythonAsync(`
 from jaclang.cli.cli import run
 import sys
 from io import StringIO
@@ -34,10 +39,9 @@ run("/tmp/temp.jac")
 sys.stdout = sys.__stdout__
 sys.stderr = sys.__stderr__
 captured_output.getvalue()
-            `);
-            self.postMessage({ type: "result", output });
-        } catch (error) {
-            self.postMessage({ type: "error", error: error.toString() });
-        }
+        `);
+        self.postMessage({ type: "result", output });
+    } catch (error) {
+        self.postMessage({ type: "error", error: error.toString() });
     }
 };

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -67,12 +67,15 @@ class CodeBlock extends HTMLElement {
                 outputBlock.textContent = "Loading Jac runner (Pyodide)...";
                 await initPyodideWorker();
             }
+            // Ensure Pyodide is ready before running code
             outputBlock.textContent = "Running...";
             try {
                 const codeToRun = codeElem.textContent.trim();
-                const result = await runJacCodeInWorker(codeToRun, outputBlock);
+                const result = await runJacCodeInWorker(codeToRun);
+                console.log(result);
                 outputBlock.textContent = `Output:\n${result}`;
             } catch (error) {
+                console.log(error);
                 outputBlock.textContent = `Error:\n${error}`;
             }
         });

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -1,0 +1,129 @@
+let pyodideWorker = null;
+let pyodideReady = false;
+let pyodideInitPromise = null;
+
+function initPyodideWorker() {
+    if (pyodideWorker) return pyodideInitPromise;
+    pyodideWorker = new Worker("/js/pyodide-worker.js");
+    pyodideInitPromise = new Promise((resolve, reject) => {
+        pyodideWorker.onmessage = (event) => {
+            if (event.data.type === "ready") {
+                pyodideReady = true;
+                resolve();
+            }
+        };
+        pyodideWorker.onerror = (e) => reject(e);
+    });
+    pyodideWorker.postMessage({ type: "init" });
+    return pyodideInitPromise;
+}
+
+function runJacCodeInWorker(code, outputBlock) {
+    return new Promise(async (resolve, reject) => {
+        await initPyodideWorker();
+        const handleMessage = (event) => {
+            if (event.data.type === "result") {
+                pyodideWorker.removeEventListener("message", handleMessage);
+                resolve(event.data.output);
+            } else if (event.data.type === "error") {
+                pyodideWorker.removeEventListener("message", handleMessage);
+                reject(event.data.error);
+            }
+        };
+        pyodideWorker.addEventListener("message", handleMessage);
+        pyodideWorker.postMessage({ type: "run", code });
+    });
+}
+
+class CodeBlock extends HTMLElement {
+    constructor() {
+        super();
+
+        const shadow = this.attachShadow({ mode: "open" });
+        const container = document.createElement("div");
+        container.className = "code-container";
+
+        // Inject external CSS from extra.css
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        link.href = "/extra.css";
+        shadow.appendChild(link);
+
+        const code = this.textContent.trim() || "print('Hello, Jac!')";
+
+        container.innerHTML = `
+            <pre>${code}</pre>
+            <button class="md-button md-button--primary run-code-btn">Run</button>
+            <pre class="code-output" style="display:none;"></pre>
+        `;
+
+        shadow.appendChild(container);
+
+        container.querySelector(".run-code-btn").addEventListener("click", async () => {
+            const outputBlock = container.querySelector(".code-output");
+            outputBlock.style.display = "block";
+            if (!pyodideReady) {
+                outputBlock.textContent = "Loading Jac runner (Pyodide)...";
+                await initPyodideWorker();
+            }
+            outputBlock.textContent = "Running...";
+            try {
+                const result = await runJacCodeInWorker(code, outputBlock);
+                outputBlock.textContent = `Output:\n${result}`;
+            } catch (error) {
+                outputBlock.textContent = `Error:\n${error}`;
+            }
+        });
+    }
+}
+
+// Define the custom element
+customElements.define("code-block", CodeBlock);
+
+
+function attachRunCodeListeners() {
+    document.querySelectorAll(".run-code-btn").forEach((button) => {
+        if (!button.dataset.listenerAttached) {
+            button.dataset.listenerAttached = true; // Prevent duplicate listeners
+            button.addEventListener("click", async (e) => {
+                console.log("Run code button clicked!");
+                const container = e.target.closest(".code-container");
+                const codeBlock = container.querySelector("pre");
+                const outputBlock = container.querySelector(".code-output");
+
+                if (!codeBlock || !outputBlock) {
+                    console.error("Code block or output block not found!");
+                    return;
+                }
+
+                const code = codeBlock.textContent.trim();
+                try {
+                    const result = await runJacCodeInWorker(code, outputBlock);
+                    outputBlock.textContent = `Output:\n${result}`;
+                } catch (error) {
+                    outputBlock.textContent = `Error:\n${error}`;
+                }
+            });
+        }
+    });
+}
+
+
+function observeDOMChanges() {
+    const observer = new MutationObserver(() => {
+        attachRunCodeListeners();
+    });
+
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+    });
+}
+
+
+document.addEventListener("DOMContentLoaded", () => {
+    attachRunCodeListeners();
+    observeDOMChanges();
+    // Preload Pyodide in the background as soon as the site loads
+    initPyodideWorker();
+});

--- a/docs/docs/learn/language_basics/basic_syntax.md
+++ b/docs/docs/learn/language_basics/basic_syntax.md
@@ -32,6 +32,14 @@ y = 20;
 print(x + y);
 ```
 
+<code-block>
+with entry {
+    x = 10;
+    y = 20;
+    print(x + y);
+}
+</code-block>
+
 ## Control Structures
 
 Control structures in Jac are defined using curly braces `{}` and not indentation.

--- a/docs/docs/learn/language_basics/basic_syntax.md
+++ b/docs/docs/learn/language_basics/basic_syntax.md
@@ -15,6 +15,13 @@ Every statement in Jac ends with a semicolon `;`.
 print("Hello, Jac!");
 ```
 
+<code-block>
+with entry {
+    print("Hello, Jac!");
+}
+</code-block>
+
+
 ## Variables
 
 Variable declaration and assignment remain identical to Python though its not the line break that signifies the end of a statement, it's the semicolon.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -172,6 +172,8 @@ extra_javascript:
   - assets/mathjax-config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js
+  - js/run-code.js
 
 plugins:
   - search


### PR DESCRIPTION
### New Jac Code Execution Feature

* Added a Pyodide-based web worker in `docs/docs/js/pyodide-worker.js` to load the Pyodide environment, install the `jaclang` package, and execute Jac code. The worker handles messages for initialization and code execution, returning the output or errors to the main thread.
* Implemented `run-code.js` to manage the interaction with the Pyodide worker, including initializing the worker, running Jac code, and defining a custom `code-block` HTML element for interactive code snippets.

### Styling for Code Snippets

* Updated `docs/docs/extra.css` to include styles for the new `.code-container` class, which provides a styled container for code snippets, buttons, and output blocks. The styles include hover and active states for buttons and transitions for the output area.

### Configuration Updates

* Updated `docs/mkdocs.yml` to include the Pyodide library and the new `run-code.js` script in the `extra_javascript` section, ensuring the required scripts are loaded for the interactive feature.