### PR TITLE
Fix parentheses in PyAST conversion

### DIFF
--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -953,7 +953,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         else:
             raise self.ice()
 
-    def proc_bool_op(self, node: py_ast.BoolOp) -> uni.BoolExpr:
+    def proc_bool_op(self, node: py_ast.BoolOp) -> uni.AtomUnit:
         """Process python node.
 
         class BoolOp(expr): a and b and c
@@ -967,7 +967,15 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             items=valid, delim=Tok.COMMA, kid=values
         )
         if isinstance(op, uni.Token) and len(valid) == len(values):
-            return uni.BoolExpr(op=op, values=valid, kid=[op, valid_values])
+            expr = uni.BoolExpr(op=op, values=valid, kid=[op, valid_values])
+            return uni.AtomUnit(
+                value=expr,
+                kid=[
+                    self.operator(Tok.RPAREN, "("),
+                    expr,
+                    self.operator(Tok.LPAREN, ")"),
+                ],
+            )
         else:
             raise self.ice()
 
@@ -1023,7 +1031,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         else:
             raise self.ice()
 
-    def proc_compare(self, node: py_ast.Compare) -> uni.CompareExpr:
+    def proc_compare(self, node: py_ast.Compare) -> uni.AtomUnit:
         """Process python node.
 
         class Compare(expr):
@@ -1051,8 +1059,16 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             and len(ops) == len(valid_ops)
             and len(comparators) == len(valid_comparators)
         ):
-            return uni.CompareExpr(
+            expr = uni.CompareExpr(
                 left=left, rights=valid_comparators, ops=valid_ops, kid=kids
+            )
+            return uni.AtomUnit(
+                value=expr,
+                kid=[
+                    self.operator(Tok.RPAREN, "("),
+                    expr,
+                    self.operator(Tok.LPAREN, ")"),
+                ],
             )
         else:
             raise self.ice()

--- a/jac/jaclang/tests/fixtures/py_bool_expr.py
+++ b/jac/jaclang/tests/fixtures/py_bool_expr.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+from __future__ import annotations
+
+def bool_expr(prev_token_index, next_token_index, tok, change_end_line, change_end_char):
+    if (not (prev_token_index is None or next_token_index is None)) and (tok[0] > change_end_line or (tok[0] == change_end_line and tok[1] > change_end_char)):
+        return True
+    return False

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1245,3 +1245,25 @@ class JacLanguageTests(TestCase):
                 prog=JacProgram(),
             ).ir_out.unparse()
         self.assertIn("(x := 10)", output)
+
+    def test_py_bool_parentheses(self) -> None:
+        """Ensure boolean expressions preserve parentheses during conversion."""
+        from jaclang.compiler.passes.main import PyastBuildPass
+        import jaclang.compiler.unitree as uni
+        import ast as py_ast
+
+        py_out_path = os.path.join(self.fixture_abs_path("./"), "py_bool_expr.py")
+        with open(py_out_path) as f:
+            file_source = f.read()
+            output = PyastBuildPass(
+                ir_in=uni.PythonModuleAst(
+                    py_ast.parse(file_source),
+                    orig_src=uni.Source(file_source, py_out_path),
+                ),
+                prog=JacProgram(),
+            ).ir_out.unparse()
+        self.assertIn("(prev_token_index is None)", output)
+        self.assertIn("(next_token_index is None)", output)
+        self.assertIn("(tok[ 0 ] > change_end_line)", output)
+        self.assertIn("(tok[ 0 ] == change_end_line)", output)
+        self.assertIn("(tok[ 1 ] > change_end_char)", output)


### PR DESCRIPTION
## Summary
- preserve parentheses when converting boolean and compare expressions
- test that Python boolean expressions keep parentheses when converting to Jac

## Testing
- `pytest -q` *(fails: No module named 'pytest')*