### PR TITLE
[ QuickFix- VSCE ] : getJacPath-fix

### DIFF
--- a/jac/support/vscode_ext/jac/src/commands/index.ts
+++ b/jac/support/vscode_ext/jac/src/commands/index.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
 import { runJacCommandForCurrentFile } from '../utils';
 import { COMMANDS } from '../constants';
 
@@ -21,6 +23,25 @@ export function registerAllCommands(context: vscode.ExtensionContext, envManager
     context.subscriptions.push(
         vscode.commands.registerCommand(COMMANDS.SERVE_FILE, () => {
             runJacCommandForCurrentFile('serve');
+        })
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('extension.jaclang-extension.getJacPath', config => {
+            const programName = (process.platform === 'win32') ? "jac.exe" : "jac";
+            const paths = process.env.PATH.split(path.delimiter);
+            for (const dir of paths) {
+                const fullPath = path.join(dir, programName);
+                try {
+                    fs.accessSync(fullPath, fs.constants.X_OK);
+                    return fullPath;
+                } catch (err) {
+                    // Not found or not executable
+                    // Ignore and continue searching
+                }
+            }
+            const err_msg = `Couldn't find ${programName} in the PATH.`;
+            vscode.window.showErrorMessage(err_msg);
+            return null;
         })
     );
 }


### PR DESCRIPTION
## **Description**

The `getJacPath` command was unintentionally removed in the last PR, which will break visual debugger. This PR restores it.
--------------------
![image](https://github.com/user-attachments/assets/d4c9fd0f-10e0-4adc-b270-f7cdc96a28d2)

--------
After Fix
----------

https://github.com/user-attachments/assets/e2516fd1-9217-4b68-8d91-cd61125d606c

