### PR TITLE
Populate introduction sections

### DIFF
--- a/docs/docs/learn/introduction.md
+++ b/docs/docs/learn/introduction.md
@@ -1,15 +1,75 @@
 <h1 style="color: orange; font-weight: bold; text-align: center;">Tour to Jac</h1>
 
 # All of Python Plus More Phylosophy
+Jac is a drop-in replacement for Python and supersets Python, much like Typescript supersets Javascript or C++ supersets C. It extends Python's semantics while maintaining full interoperability with the Python ecosystem, introducing cutting-edge abstractions designed to minimize complexity and embrace AI-forward development【F:docs/docs/learn/getting_started.md†L1-L4】【F:docs/docs/index.md†L26-L28】.
 
+```jac
+def add(x: int, y: int) -> int {
+    return x + y;
+}
+
+with entry {
+    print(add(2, 3));
+}
+```
+This snippet runs identically to its Python counterpart, illustrating Jac's compatibility.
 # Beyond OOP with Data Spatial Programming
+Data Spatial Programming (DSP) inverts the traditional relationship between data and computation. Rather than moving data to computation, DSP moves computation to data through topologically aware constructs. This paradigm introduces specialized archetypes—objects, nodes, edges and walkers—that model spatial relationships directly in the language and enable optimizations around data locality and distributed execution【F:docs/docs/learn/dspfoundation.md†L16-L32】.
 
+```jac
+node Place { has name: str; }
+
+walker tour {
+    can at Place entry {
+        print("Visiting " + here.name);
+        visit [-->];
+    }
+}
+
+with entry {
+    start = Place(name="Home");
+    end = Place(name="Work");
+    start ++> end;
+    :> tour spawn start;
+}
+```
+A walker moves between nodes using edges, demonstrating Data Spatial Programming.
 # Programming Abstractions for AI
+Jac provides novel constructs for integrating LLMs into code. A function body can simply be replaced with a call to an LLM, removing the need for prompt engineering or extensive new libraries【F:docs/docs/index.md†L30-L34】.
 
+```jac
+can summarize(text: str) -> str by llm();
+
+with entry {
+    print(summarize("Jac simplifies LLM integration."));
+}
+```
+`by llm()` delegates execution to an LLM without any extra library code.
 # Zero to Infinite Scale with no Code Changes
+Jac's cloud-native abstractions make persistence and user concepts part of the language so that simple programs can run unchanged locally or in the cloud【F:docs/docs/index.md†L44-L48】. Deployments can be scaled by increasing replicas of the `jac-cloud` service when needed【F:docs/docs/learn/jac-cloud/cloud-orc-integration.md†L170-L178】.
 
+```jac
+walker ping {
+    can handle with root entry {
+        report {"status": "ok"};
+    }
+}
+```
+Deployed with `jac-cloud`, this walker becomes a scalable REST endpoint.
 # Better Organized and Well Typed Codebases
+Jac focuses on type safety and readability. Type hints are required and the built-in typing system eliminates boilerplate imports. Code structure can be split across multiple files, allowing definitions and implementations to be organized separately while still being checked by Jac's native type system【F:docs/docs/learn/jac_coding_manual.md†L196-L216】【F:docs/docs/learn/jac_coding_manual.md†L218-L252】.
 
+```jac
+walker Greeter {
+    def hello(name: str) -> None;
+}
+```
+```jac
+impl Greeter.hello(name: str) {
+    print("Hello, " + name);
+}
+```
+This shows how declarations and implementations can live in separate files for maintainable, typed codebases.
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
## Summary
- populate introduction sections with content from across the docs
- add small Jac code snippets showing each concept

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: command not found)*
- `mkdocs build` *(fails: command not found)*