### PR TITLE
Fix the Issue in Custom HTML div

### DIFF
--- a/docs/docs/extra.css
+++ b/docs/docs/extra.css
@@ -68,6 +68,10 @@
     color: #fff;
 }
 
+.code-container .jac-code {
+    font-size: 15px !important;
+}
+
 .code-container .code-output {
     margin-top: 0.5em;
     background: #1e1e1e;
@@ -78,6 +82,7 @@
     max-height: 1000px;
     overflow: auto;
     transition: max-height 0.3s cubic-bezier(0.4,0,0.2,1), padding 0.3s;
+    font-size: 15px;
 }
 
 .code-container .code-output[style*="display: none"] {

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -58,7 +58,6 @@ function setupCodeBlock(div) {
 
         const runButton = container.querySelector(".run-code-btn");
         runButton.addEventListener("click", async () => {
-            allButtons.forEach(btn => btn.disabled = true);
             
             const outputBlock = container.querySelector(".code-output");
             const codeElem = container.querySelector(".jac-code");

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -35,57 +35,69 @@ function runJacCodeInWorker(code) {
     });
 }
 
-class CodeBlock extends HTMLElement {
-    constructor() {
-        super();
+function setupCodeBlock(div) {
+    if (div.shadowRoot) return;
 
-        const shadow = this.attachShadow({ mode: "open" });
-        const container = document.createElement("div");
-        container.className = "code-container";
+    const shadow = div.attachShadow({ mode: 'open' });
 
-        // Inject external CSS from extra.css
-        const link = document.createElement("link");
-        link.rel = "stylesheet";
-        link.href = "/extra.css";
-        shadow.appendChild(link);
+    const container = document.createElement('div');
+    container.className = 'code-container';
 
-        const code = this.textContent.trim() || "with entry{\n    print('Hello, Jac!');\n}";
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = '/extra.css';
+    shadow.appendChild(link);
+    shadow.appendChild(container);
 
+    const setupBlock = (code) => {
         container.innerHTML = `
             <pre><code class="jac-code" contenteditable="true" spellcheck="false" style="display:block; min-height:80px; padding: 5px;">${code}</code></pre>
             <button class="md-button md-button--primary run-code-btn">Run</button>
             <pre class="code-output" style="display:none;"></pre>
         `;
 
-        shadow.appendChild(container);
-
-        container.querySelector(".run-code-btn").addEventListener("click", async () => {
+        const runButton = container.querySelector(".run-code-btn");
+        runButton.addEventListener("click", async () => {
+            allButtons.forEach(btn => btn.disabled = true);
+            
             const outputBlock = container.querySelector(".code-output");
             const codeElem = container.querySelector(".jac-code");
             outputBlock.style.display = "block";
+
             if (!pyodideReady) {
                 outputBlock.textContent = "Loading Jac runner (Pyodide)...";
                 await initPyodideWorker();
             }
-            // Ensure Pyodide is ready before running code
+
             outputBlock.textContent = "Running...";
             try {
                 const codeToRun = codeElem.textContent.trim();
                 const result = await runJacCodeInWorker(codeToRun);
-                console.log(result);
                 outputBlock.textContent = `Output:\n${result}`;
             } catch (error) {
-                console.log(error);
                 outputBlock.textContent = `Error:\n${error}`;
             }
         });
-    }
+    };
+
+    const inlineCode = div.textContent.trim();
+    setupBlock(inlineCode);
 }
 
-// Define the custom element
-customElements.define("code-block", CodeBlock);
+// Observe and apply when .code-blocks are added
+const observer = new MutationObserver(() => {
+    document.querySelectorAll('.code-block').forEach(setupCodeBlock);
+});
 
+observer.observe(document.body, {
+    childList: true,
+    subtree: true
+});
 
+// Initial loading
+document.querySelectorAll('.code-block').forEach(setupCodeBlock);
+
+// Loading Pyodide worker
 document.addEventListener("DOMContentLoaded", () => {
     initPyodideWorker();
 });

--- a/docs/docs/learn/language_basics/basic_syntax.md
+++ b/docs/docs/learn/language_basics/basic_syntax.md
@@ -15,11 +15,15 @@ Every statement in Jac ends with a semicolon `;`.
 print("Hello, Jac!");
 ```
 
-<code-block>
+<div class="code-block">
 with entry {
-    print("Hello, Jac!");
+    print("Hello, Jac 1!");
 }
-</code-block>
+
+with entry {
+    print("Hello, Jac 2!");
+}
+</div>
 
 
 ## Variables
@@ -32,13 +36,13 @@ y = 20;
 print(x + y);
 ```
 
-<code-block>
+<div class="code-block">
 with entry {
     x = 10;
     y = 20;
     print(x + y);
 }
-</code-block>
+</div>
 
 ## Control Structures
 


### PR DESCRIPTION
This PR updates the code block component implementation:

* Replaced the use of the custom `<code-block>` tag with a standard `<div>` element having a specific class: `.code-block`.
* Followed this approach to resolve the newline spacing issue between two code blocks that occurred when using the custom `<code-block>` tag.
* Example usage after the change:
```
<div class="code-block">
with entry {
    print("Hello, Jac 1!");
}

with entry {
    print("Hello, Jac 2!");
}
</div>
```

![image](https://github.com/user-attachments/assets/40b78d3d-eb5f-4f3b-bf2d-03b18b7d83ba)