### PR TITLE
Update mermaid in mkdocs

### DIFF
--- a/docs/docs/js/mermaid-init.js
+++ b/docs/docs/js/mermaid-init.js
@@ -1,0 +1,3 @@
+if (typeof mermaid !== 'undefined') {
+  mermaid.initialize({ startOnLoad: true });
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -175,6 +175,8 @@ extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js
   - js/run-code.js
+  - https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
+  - js/mermaid-init.js
 
 plugins:
   - search


### PR DESCRIPTION
## Summary
- add CDN for mermaid 11 and init script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*