### PR TITLE
Fix reference doc headings

### DIFF
--- a/jac/examples/reference/arithmetic_expressions.md
+++ b/jac/examples/reference/arithmetic_expressions.md
@@ -1,3 +1,4 @@
+### Arithmetic Expressions
 Jac supports a comprehensive set of arithmetic operations that follow the standard mathematical precedence rules. The arithmetic expression system in Jac is designed to be intuitive and consistent with mathematical conventions while maintaining compatibility with Python's arithmetic operations.
 
 **Basic Arithmetic Operators**

--- a/jac/examples/reference/assert_statements.md
+++ b/jac/examples/reference/assert_statements.md
@@ -1,3 +1,4 @@
+### Assert Statements
 Assert statements in Jac provide a mechanism for debugging and testing by allowing developers to verify that certain conditions hold true during program execution. When an assertion fails, it raises an `AssertionError` exception, which can be caught and handled like any other exception.
 
 **Basic Assert Syntax**

--- a/jac/examples/reference/atom.md
+++ b/jac/examples/reference/atom.md
@@ -1,3 +1,4 @@
+### Atom
 Atomic expressions in Jac represent the most basic building blocks of expressions - the fundamental units that cannot be broken down further. These include literals, references, collections, and other primary elements that form the foundation of more complex expressions.
 
 **Atomic Expression Types**

--- a/jac/examples/reference/atomic_expressions.md
+++ b/jac/examples/reference/atomic_expressions.md
@@ -1,3 +1,4 @@
+### Atomic Expressions
 Atomic expressions in Jac represent the most fundamental and indivisible units of expression evaluation. They serve as building blocks for more complex expressions and include literals, identifiers, and other primary expression forms.
 
 **Atomic Pipe Forward Expressions**

--- a/jac/examples/reference/atomic_pipe_back_expressions.md
+++ b/jac/examples/reference/atomic_pipe_back_expressions.md
@@ -1,3 +1,4 @@
+### Atomic Pipe Back Expressions
 Atomic pipe back expressions in Jac provide an alternative directional flow for data processing using the `<:` operator. This feature complements the pipe forward operator (`:>`) by enabling right-to-left data flow, offering flexibility in expression composition and readability.
 
 **Atomic Pipe Back Syntax**

--- a/jac/examples/reference/base_module_structure.md
+++ b/jac/examples/reference/base_module_structure.md
@@ -1,3 +1,4 @@
+### Base Module Structure
 In Jac, a module is analogous to a Python module, serving as a container for various elements such as functions, classes (referred to as "archetypes" later in this document), global variables, and other constructs that facilitate code organization and reusability. Each module begins with an optional module-level docstring, which provides a high-level overview of the module's purpose and functionality. This docstring, if present, is positioned at the very start of the module, before any other elements.
 
 ???+ Note "Docstrings"

--- a/jac/examples/reference/bitwise_expressions.md
+++ b/jac/examples/reference/bitwise_expressions.md
@@ -1,3 +1,4 @@
+### Bitwise Expressions
 Bitwise expressions in Jac provide low-level bit manipulation operations that work directly on the binary representation of integer values. These operations are essential for systems programming, data encoding, optimization algorithms, and working with binary data formats.
 
 **Bitwise Operators**

--- a/jac/examples/reference/builtin_types.md
+++ b/jac/examples/reference/builtin_types.md
@@ -1,3 +1,4 @@
+### Builtin Types
 Jac provides a rich set of built-in data types that cover the fundamental data structures needed for most programming tasks. These types are similar to Python's built-in types but are integrated into Jac's type system and syntax.
 
 **Primitive Types**

--- a/jac/examples/reference/check_statements.md
+++ b/jac/examples/reference/check_statements.md
@@ -1,3 +1,4 @@
+### Check Statements
 Check statements in Jac provide a built-in testing mechanism that integrates directly into the language syntax. They are primarily used within test blocks to verify that specific conditions hold true, forming the foundation of Jac's integrated testing framework.
 
 **Basic Syntax**

--- a/jac/examples/reference/collection_values.md
+++ b/jac/examples/reference/collection_values.md
@@ -1,3 +1,4 @@
+### Collection Values
 Collection values in Jac provide rich data structures for organizing and manipulating groups of related data. Jac supports all major collection types found in modern programming languages, along with powerful comprehension syntax for creating collections programmatically.
 
 **Basic Collection Types**

--- a/jac/examples/reference/concurrent_expressions.md
+++ b/jac/examples/reference/concurrent_expressions.md
@@ -1,8 +1,8 @@
-# Concurrent Expressions
+### Concurrent Expressions
 
 Concurrent expressions enable parallel and asynchronous execution in Jac through the `flow` and `wait` modifiers. These constructs provide built-in concurrency support, allowing efficient parallel processing while maintaining clean, readable code.
 
-## Flow Modifier
+#### Flow Modifier
 
 The `flow` modifier initiates parallel execution of expressions:
 
@@ -13,7 +13,7 @@ flow process_data(chunk2);
 flow process_data(chunk3);
 ```
 
-## Wait Modifier
+#### Wait Modifier
 
 The `wait` modifier synchronizes parallel operations:
 
@@ -25,7 +25,7 @@ result = wait async_operation();
 wait all_tasks_complete();
 ```
 
-## Combined Usage
+#### Combined Usage
 
 Flow and wait work together for parallel patterns:
 
@@ -48,7 +48,7 @@ walker ParallelProcessor {
 }
 ```
 
-## Parallel Walker Spawning
+#### Parallel Walker Spawning
 
 Concurrent execution with walkers:
 
@@ -66,7 +66,7 @@ walker Analyzer {
 }
 ```
 
-## Async Graph Operations
+#### Async Graph Operations
 
 Parallel graph traversal:
 
@@ -94,7 +94,7 @@ walker ParallelTraverser {
 }
 ```
 
-## Error Handling
+#### Error Handling
 
 Managing errors in concurrent operations:
 
@@ -128,9 +128,9 @@ can parallel_safe_process(items: list) -> list {
 }
 ```
 
-## Concurrency Patterns
+#### Concurrency Patterns
 
-### Map-Reduce Pattern
+##### Map-Reduce Pattern
 ```jac
 can map_reduce(data: list, mapper: func, reducer: func) -> any {
     # Map phase - parallel
@@ -152,7 +152,7 @@ can map_reduce(data: list, mapper: func, reducer: func) -> any {
 }
 ```
 
-### Pipeline Pattern
+##### Pipeline Pattern
 ```jac
 walker Pipeline {
     can process with entry {
@@ -178,7 +178,7 @@ walker Pipeline {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Granularity**: Balance task size for efficient parallelism
 2. **Dependencies**: Clearly manage data dependencies
@@ -186,7 +186,7 @@ walker Pipeline {
 4. **Resource Limits**: Consider system constraints
 5. **Synchronization**: Use wait appropriately to avoid race conditions
 
-## Integration with Data Spatial
+#### Integration with Data Spatial
 
 Concurrent expressions enhance graph processing:
 

--- a/jac/examples/reference/connect_expressions.md
+++ b/jac/examples/reference/connect_expressions.md
@@ -1,3 +1,4 @@
+### Connect Expressions
 Connect expressions in Jac provide the fundamental mechanism for creating topological relationships between nodes, implementing the edge creation and management aspects of Data Spatial Programming. These expressions enable the construction of graph structures where computation can flow through connected data locations.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/context_managers.md
+++ b/jac/examples/reference/context_managers.md
@@ -1,8 +1,8 @@
-# Context Managers
+### Context Managers
 
 Context managers in Jac provide automatic resource management through `with` statements, ensuring proper acquisition and release of resources. This feature supports the context management protocol for clean handling of files, connections, locks, and other resources.
 
-## Syntax
+#### Syntax
 
 ```jac
 with expression as variable {
@@ -20,7 +20,7 @@ async with async_expression as variable {
 }
 ```
 
-## Basic Usage
+#### Basic Usage
 
 ```jac
 # File handling
@@ -37,7 +37,7 @@ with get_connection() as conn {
 }  # Connection automatically closed
 ```
 
-## Multiple Context Managers
+#### Multiple Context Managers
 
 Manage multiple resources simultaneously:
 
@@ -51,7 +51,7 @@ with open("input.txt", "r") as infile,
 }  # Both files automatically closed
 ```
 
-## Custom Context Managers
+#### Custom Context Managers
 
 Create your own context managers:
 
@@ -79,7 +79,7 @@ with TimedOperation("data_processing") as timer {
 }
 ```
 
-## Graph Lock Management
+#### Graph Lock Management
 
 Context managers for thread-safe graph operations:
 
@@ -98,7 +98,7 @@ node ThreadSafeNode {
 }
 ```
 
-## Transaction Management
+#### Transaction Management
 
 Database-style transactions:
 
@@ -139,7 +139,7 @@ obj Transaction {
 }
 ```
 
-## Walker State Management
+#### Walker State Management
 
 Manage walker state during traversal:
 
@@ -179,7 +179,7 @@ walker StatefulWalker {
 }
 ```
 
-## Async Context Managers
+#### Async Context Managers
 
 For asynchronous resource management:
 
@@ -191,7 +191,7 @@ async with acquire_async_resource() as resource {
 }
 ```
 
-## Graph Session Management
+#### Graph Session Management
 
 ```jac
 obj GraphSession {
@@ -236,7 +236,7 @@ with GraphSession(root) as session {
 }  # Changes committed atomically
 ```
 
-## Temporary State Changes
+#### Temporary State Changes
 
 ```jac
 obj TemporaryState {
@@ -271,7 +271,7 @@ node ConfigNode {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Always Use With**: For resources that need cleanup
 2. **Don't Suppress Exceptions**: Return False from __exit__
@@ -279,9 +279,9 @@ node ConfigNode {
 4. **Document Side Effects**: Clear about what's managed
 5. **Test Error Cases**: Ensure cleanup on exceptions
 
-## Common Patterns
+#### Common Patterns
 
-### Resource Pool
+##### Resource Pool
 ```jac
 with get_resource_from_pool() as resource {
     # Use resource
@@ -289,7 +289,7 @@ with get_resource_from_pool() as resource {
 }  # Resource returned to pool
 ```
 
-### Nested Contexts
+##### Nested Contexts
 ```jac
 with outer_context() as outer {
     # Outer resource acquired
@@ -300,7 +300,7 @@ with outer_context() as outer {
 }  # Outer released
 ```
 
-### Optional Context
+##### Optional Context
 ```jac
 context = get_optional_context() if condition else nullcontext();
 with context as ctx {

--- a/jac/examples/reference/data_spatial_spawn_expressions.md
+++ b/jac/examples/reference/data_spatial_spawn_expressions.md
@@ -1,3 +1,4 @@
+### Data Spatial Spawn Expressions
 Data spatial spawn expressions in Jac implement the fundamental mechanism for activating walkers within the topological structure, transitioning them from inactive objects to active participants in the distributed computational system. This operation embodies the initialization phase of the "computation moving to data" paradigm that characterizes Data Spatial Programming.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/delete_statements.md
+++ b/jac/examples/reference/delete_statements.md
@@ -1,14 +1,14 @@
-# Delete Statements
+### Delete Statements
 
 Delete statements in Jac remove objects, nodes, edges, or properties from memory and graph structures. The `del` keyword provides a unified interface for deletion operations across different contexts.
 
-## Syntax
+#### Syntax
 
 ```jac
 del expression;
 ```
 
-## Deleting Variables
+#### Deleting Variables
 
 Remove variables from the current scope:
 
@@ -22,7 +22,7 @@ a, b, c = 1, 2, 3;
 del a, b, c;
 ```
 
-## Deleting Object Properties
+#### Deleting Object Properties
 
 Remove attributes from objects:
 
@@ -43,7 +43,7 @@ with entry {
 }
 ```
 
-## Deleting List Elements
+#### Deleting List Elements
 
 Remove items from lists by index:
 
@@ -60,7 +60,7 @@ del items[1:3];  # items = [1, 5]
 del items[-1];  # items = [1]
 ```
 
-## Deleting Dictionary Entries
+#### Deleting Dictionary Entries
 
 Remove key-value pairs:
 
@@ -76,7 +76,7 @@ if "c" in data {
 }
 ```
 
-## Deleting Nodes
+#### Deleting Nodes
 
 Remove nodes from the graph structure:
 
@@ -97,7 +97,7 @@ walker Cleaner {
 }
 ```
 
-## Deleting Edges
+#### Deleting Edges
 
 Remove connections between nodes:
 
@@ -112,7 +112,7 @@ del node [-->];
 del node [-->(?.weight < threshold)];
 ```
 
-## Graph Operations
+#### Graph Operations
 
 Complex deletion patterns:
 
@@ -137,7 +137,7 @@ walker GraphPruner {
 }
 ```
 
-## Edge Deletion Patterns
+#### Edge Deletion Patterns
 
 ```jac
 node Network {
@@ -158,7 +158,7 @@ node Network {
 }
 ```
 
-## Cascading Deletions
+#### Cascading Deletions
 
 When nodes are deleted, associated edges are automatically removed:
 
@@ -178,7 +178,7 @@ with entry {
 }
 ```
 
-## Memory Management
+#### Memory Management
 
 Jac handles cleanup automatically:
 
@@ -203,7 +203,7 @@ walker MemoryManager {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Check Before Delete**: Verify existence before deletion
 2. **Handle Dependencies**: Consider edge deletion when removing nodes  
@@ -211,9 +211,9 @@ walker MemoryManager {
 4. **Clean Up Resources**: Delete temporary nodes/edges after use
 5. **Document Side Effects**: Deletion can affect graph connectivity
 
-## Common Patterns
+#### Common Patterns
 
-### Filtered Node Deletion
+##### Filtered Node Deletion
 ```jac
 walker FilterDelete {
     can delete_by_type(type_name: str) {
@@ -225,7 +225,7 @@ walker FilterDelete {
 }
 ```
 
-### Conditional Edge Removal
+##### Conditional Edge Removal
 ```jac
 can prune_edges(node: node, condition: func) {
     edges = node[<-->];
@@ -237,7 +237,7 @@ can prune_edges(node: node, condition: func) {
 }
 ```
 
-### Safe Deletion
+##### Safe Deletion
 ```jac
 can safe_delete(item: any) -> bool {
     try {

--- a/jac/examples/reference/disengage_statements.md
+++ b/jac/examples/reference/disengage_statements.md
@@ -1,3 +1,4 @@
+### Disengage Statements
 Disengage statements in Jac provide a mechanism for terminating walker traversal within the data spatial topology. This statement enables walkers to exit their active traversal state and return to inactive object status, representing a controlled termination of the "computation moving to data" process that characterizes Data Spatial Programming.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/expressions.md
+++ b/jac/examples/reference/expressions.md
@@ -1,0 +1,1 @@
+### Expressions

--- a/jac/examples/reference/f_string_tokens.md
+++ b/jac/examples/reference/f_string_tokens.md
@@ -1,0 +1,1 @@
+### F String Tokens

--- a/jac/examples/reference/free_code.md
+++ b/jac/examples/reference/free_code.md
@@ -1,3 +1,4 @@
+### Free Code
 Free code in Jac refers to executable statements that exist at the module level but are not part of a function, class, or other structural element. Unlike many programming languages that allow loose statements to float freely in a module, Jac requires such code to be explicitly wrapped in `with entry` blocks for better code organization and clarity.
 
 **Entry Blocks**

--- a/jac/examples/reference/function_calls.md
+++ b/jac/examples/reference/function_calls.md
@@ -1,3 +1,4 @@
+### Function Calls
 Function calls in Jac provide the fundamental mechanism for invoking defined functions and methods, supporting both traditional positional arguments and named keyword arguments. The function call system integrates seamlessly with Jac's type system and expression evaluation, enabling flexible and expressive function invocation patterns.
 
 **Basic Function Call Syntax**

--- a/jac/examples/reference/global_and_nonlocal_statements.md
+++ b/jac/examples/reference/global_and_nonlocal_statements.md
@@ -1,8 +1,8 @@
-# Global and Nonlocal Statements
+### Global and Nonlocal Statements
 
 Global and nonlocal statements in Jac provide mechanisms for accessing and modifying variables from outer scopes. These statements enable controlled access to variables defined outside the current function or ability scope.
 
-## Global Statement
+#### Global Statement
 
 The global statement declares that variables refer to globally scoped names:
 
@@ -14,7 +14,7 @@ The global statement declares that variables refer to globally scoped names:
 :global: config, state;
 ```
 
-### Basic Usage
+##### Basic Usage
 
 ```jac
 # Global variable
@@ -33,7 +33,7 @@ obj Controller {
 }
 ```
 
-### Multiple Global Variables
+##### Multiple Global Variables
 
 ```jac
 glob counter: int = 0;
@@ -49,7 +49,7 @@ can process_item(value: float) {
 }
 ```
 
-## Nonlocal Statement
+#### Nonlocal Statement
 
 The nonlocal statement declares that variables refer to names in the nearest enclosing scope:
 
@@ -61,7 +61,7 @@ The nonlocal statement declares that variables refer to names in the nearest enc
 :nonlocal: outer_counter;
 ```
 
-### Nested Function Scopes
+##### Nested Function Scopes
 
 ```jac
 can create_counter -> (func) {
@@ -77,7 +77,7 @@ can create_counter -> (func) {
 }
 ```
 
-### In Walker Abilities
+##### In Walker Abilities
 
 ```jac
 walker StateTracker {
@@ -103,26 +103,26 @@ walker StateTracker {
 }
 ```
 
-## Scope Resolution Rules
+#### Scope Resolution Rules
 
-### Global Scope
+##### Global Scope
 - Variables declared at module level
 - Accessible throughout the module
 - Require explicit `global` declaration to modify
 
-### Nonlocal Scope
+##### Nonlocal Scope
 - Variables in enclosing function/ability scope
 - Not global, not local
 - Require explicit `nonlocal` declaration to modify
 
-### Local Scope
+##### Local Scope
 - Variables defined within current function/ability
 - Default scope for assignments
 - Shadow outer scope variables
 
-## Common Patterns
+#### Common Patterns
 
-### Configuration Management
+##### Configuration Management
 ```jac
 glob config: dict = {
     "debug": False,
@@ -149,7 +149,7 @@ obj App {
 }
 ```
 
-### Counter Patterns
+##### Counter Patterns
 ```jac
 can create_id_generator -> func {
     next_id = 1000;
@@ -165,7 +165,7 @@ can create_id_generator -> func {
 }
 ```
 
-### State Accumulation
+##### State Accumulation
 ```jac
 walker Collector {
     can collect with entry {
@@ -193,7 +193,7 @@ walker Collector {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Minimize Global State**: Use sparingly for truly global concerns
 2. **Prefer Parameters**: Pass values explicitly when possible
@@ -201,7 +201,7 @@ walker Collector {
 4. **Use Nonlocal for Closures**: Appropriate for nested function state
 5. **Consider Alternatives**: Class attributes or node properties
 
-## Integration with Data Spatial
+#### Integration with Data Spatial
 
 In data spatial contexts, consider using node/edge properties instead of global state:
 

--- a/jac/examples/reference/ignore_statements.md
+++ b/jac/examples/reference/ignore_statements.md
@@ -1,14 +1,14 @@
-# Ignore Statements
+### Ignore Statements
 
 Ignore statements provide a mechanism to exclude specific nodes or edges from walker traversal paths. This feature enables selective graph navigation by marking elements that should be skipped during traversal operations.
 
-## Syntax
+#### Syntax
 
 ```jac
 ignore expression;
 ```
 
-## Purpose
+#### Purpose
 
 Ignore statements allow walkers to:
 - Skip specific nodes during traversal
@@ -16,7 +16,7 @@ Ignore statements allow walkers to:
 - Create filtered traversal patterns
 - Optimize navigation by avoiding irrelevant paths
 
-## Basic Usage
+#### Basic Usage
 
 ```jac
 walker Traverser {
@@ -30,7 +30,7 @@ walker Traverser {
 }
 ```
 
-## Ignoring Nodes
+#### Ignoring Nodes
 
 Mark nodes to be skipped:
 
@@ -55,7 +55,7 @@ walker Searcher {
 }
 ```
 
-## Ignoring Edges
+#### Ignoring Edges
 
 Exclude specific connections:
 
@@ -72,7 +72,7 @@ walker PathFinder {
 }
 ```
 
-## Conditional Ignoring
+#### Conditional Ignoring
 
 Dynamic exclusion based on conditions:
 
@@ -96,7 +96,7 @@ walker ConditionalTraverser {
 }
 ```
 
-## Pattern-Based Ignoring
+#### Pattern-Based Ignoring
 
 Use type and property filters:
 
@@ -115,7 +115,7 @@ walker TypedExplorer {
 }
 ```
 
-## Integration with Visit
+#### Integration with Visit
 
 Combine ignore and visit for precise control:
 
@@ -149,7 +149,7 @@ walker SmartNavigator {
 }
 ```
 
-## Temporary Ignoring
+#### Temporary Ignoring
 
 Ignore within specific contexts:
 
@@ -176,7 +176,7 @@ walker ContextualWalker {
 }
 ```
 
-## Performance Optimization
+#### Performance Optimization
 
 Use ignore to prune search spaces:
 
@@ -207,7 +207,7 @@ walker EfficientSearcher {
 }
 ```
 
-## Relationship with Graph Structure
+#### Relationship with Graph Structure
 
 Ignore statements don't modify the graph:
 
@@ -229,7 +229,7 @@ walker Observer {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Clear Criteria**: Use explicit conditions for ignoring
 2. **Document Reasons**: Explain why nodes are ignored
@@ -237,9 +237,9 @@ walker Observer {
 4. **Reset State**: Clear ignore lists when appropriate
 5. **Performance**: Ignore early to avoid unnecessary computation
 
-## Common Patterns
+#### Common Patterns
 
-### Visited Set Pattern
+##### Visited Set Pattern
 ```jac
 walker DepthFirst {
     has visited: set = {};
@@ -255,7 +255,7 @@ walker DepthFirst {
 }
 ```
 
-### Type-Based Filtering
+##### Type-Based Filtering
 ```jac
 walker TypeFilter {
     has allowed_types: list;
@@ -271,7 +271,7 @@ walker TypeFilter {
 }
 ```
 
-### Threshold-Based Pruning
+##### Threshold-Based Pruning
 ```jac
 walker ThresholdWalker {
     has min_score: float;

--- a/jac/examples/reference/implementations.md
+++ b/jac/examples/reference/implementations.md
@@ -1,3 +1,4 @@
+### Implementations
 Implementations in Jac provide a powerful mechanism for separating interface declarations from their concrete implementations. This feature supports modular programming, interface segregation, and flexible code organization patterns common in modern software development.
 
 **Implementation Concept**

--- a/jac/examples/reference/inline_python.md
+++ b/jac/examples/reference/inline_python.md
@@ -1,3 +1,4 @@
+### Inline Python
 Inline Python in Jac provides a powerful mechanism to seamlessly integrate native Python code within Jac programs. This feature enables developers to leverage the vast Python ecosystem and existing Python libraries directly within their Jac applications.
 
 **Inline Python Syntax**

--- a/jac/examples/reference/introduction.md
+++ b/jac/examples/reference/introduction.md
@@ -1,4 +1,4 @@
-## Introduction
+### Introduction
 
 Welcome to the official reference guide for the Jac programming language. This document is designed to serve as a comprehensive reference manual as well as a formal specification of the language. The mission of this guide is to be a resource for developers seeking to answer the question, "How do I code X in Jac?"
 

--- a/jac/examples/reference/lambda_expressions.md
+++ b/jac/examples/reference/lambda_expressions.md
@@ -1,3 +1,4 @@
+### Lambda Expressions
 Lambda expressions in Jac provide a concise way to create anonymous functions for functional programming patterns. These expressions enable the creation of small, single-expression functions without the overhead of formal function definitions, supporting Jac's functional programming capabilities while maintaining type safety through required parameter annotations.
 
 **Basic Lambda Syntax**

--- a/jac/examples/reference/lexer_tokens.md
+++ b/jac/examples/reference/lexer_tokens.md
@@ -1,0 +1,1 @@
+### Lexer Tokens

--- a/jac/examples/reference/logical_and_compare_expressions.md
+++ b/jac/examples/reference/logical_and_compare_expressions.md
@@ -1,0 +1,1 @@
+### Logical And Compare Expressions

--- a/jac/examples/reference/match_capture_patterns.md
+++ b/jac/examples/reference/match_capture_patterns.md
@@ -1,0 +1,1 @@
+### Match Capture Patterns

--- a/jac/examples/reference/match_class_patterns.md
+++ b/jac/examples/reference/match_class_patterns.md
@@ -1,0 +1,1 @@
+### Match Class Patterns

--- a/jac/examples/reference/match_litteral_patterns.md
+++ b/jac/examples/reference/match_litteral_patterns.md
@@ -1,0 +1,1 @@
+### Match Litteral Patterns

--- a/jac/examples/reference/match_mapping_patterns.md
+++ b/jac/examples/reference/match_mapping_patterns.md
@@ -1,0 +1,1 @@
+### Match Mapping Patterns

--- a/jac/examples/reference/match_patterns.md
+++ b/jac/examples/reference/match_patterns.md
@@ -1,0 +1,1 @@
+### Match Patterns

--- a/jac/examples/reference/match_sequence_patterns.md
+++ b/jac/examples/reference/match_sequence_patterns.md
@@ -1,0 +1,1 @@
+### Match Sequence Patterns

--- a/jac/examples/reference/match_singleton_patterns.md
+++ b/jac/examples/reference/match_singleton_patterns.md
@@ -1,0 +1,1 @@
+### Match Singleton Patterns

--- a/jac/examples/reference/match_statements.md
+++ b/jac/examples/reference/match_statements.md
@@ -1,8 +1,8 @@
-# Match Statements
+### Match Statements
 
 Match statements provide powerful pattern matching capabilities in Jac, enabling elegant handling of complex data structures and control flow based on value patterns. This feature supports structural pattern matching similar to modern programming languages.
 
-## Syntax
+#### Syntax
 
 ```jac
 match expression {
@@ -13,9 +13,9 @@ match expression {
 }
 ```
 
-## Pattern Types
+#### Pattern Types
 
-### Literal Patterns
+##### Literal Patterns
 Match specific literal values:
 ```jac
 match value {
@@ -28,7 +28,7 @@ match value {
 }
 ```
 
-### Capture Patterns
+##### Capture Patterns
 Bind matched values to variables:
 ```jac
 match data {
@@ -37,7 +37,7 @@ match data {
 }
 ```
 
-### Sequence Patterns
+##### Sequence Patterns
 Match lists and tuples:
 ```jac
 match point {
@@ -50,7 +50,7 @@ match point {
 }
 ```
 
-### Mapping Patterns
+##### Mapping Patterns
 Match dictionary structures:
 ```jac
 match config {
@@ -61,7 +61,7 @@ match config {
 }
 ```
 
-### Class Patterns
+##### Class Patterns
 Match object instances and extract attributes:
 ```jac
 match shape {
@@ -72,7 +72,7 @@ match shape {
 }
 ```
 
-### OR Patterns
+##### OR Patterns
 Match multiple patterns:
 ```jac
 match command {
@@ -83,7 +83,7 @@ match command {
 }
 ```
 
-### AS Patterns
+##### AS Patterns
 Bind the entire match while matching pattern:
 ```jac
 match data {
@@ -92,7 +92,7 @@ match data {
 }
 ```
 
-## Guard Conditions
+#### Guard Conditions
 
 Add conditions to patterns:
 ```jac
@@ -104,7 +104,7 @@ match user {
 }
 ```
 
-## Singleton Patterns
+#### Singleton Patterns
 
 Match None and boolean values:
 ```jac
@@ -118,7 +118,7 @@ match result {
 }
 ```
 
-## Practical Example
+#### Practical Example
 
 ```jac
 node RequestHandler {

--- a/jac/examples/reference/pipe_back_expressions.md
+++ b/jac/examples/reference/pipe_back_expressions.md
@@ -1,8 +1,8 @@
-# Pipe Back Expressions
+### Pipe Back Expressions
 
 Pipe back expressions provide the reverse flow of pipe forward expressions, passing the result of the right expression as the last argument to the left expression. This operator enables different composition patterns that can be more natural for certain operations.
 
-## Backward Pipe Operator (`<|`)
+#### Backward Pipe Operator (`<|`)
 
 The backward pipe operator flows data from right to left:
 
@@ -14,9 +14,9 @@ result = data |> process |> format;
 result = format <| process <| data;
 ```
 
-## Use Cases
+#### Use Cases
 
-### Building Processing Pipelines
+##### Building Processing Pipelines
 ```jac
 # Define a processing pipeline right-to-left
 processor = output_formatter
@@ -27,7 +27,7 @@ processor = output_formatter
 result = processor(raw_input);
 ```
 
-### Partial Application Patterns
+##### Partial Application Patterns
 ```jac
 # Create specialized functions
 process_users = save_to_database
@@ -38,7 +38,7 @@ process_users = save_to_database
 process_users(user_list);
 ```
 
-## Combining with Forward Pipes
+#### Combining with Forward Pipes
 
 Mix both operators for expressive code:
 
@@ -52,7 +52,7 @@ final_result = formatter <| (
 );
 ```
 
-## Graph Operations
+#### Graph Operations
 
 In data spatial contexts:
 
@@ -72,7 +72,7 @@ walker Analyzer {
 }
 ```
 
-## Function Composition
+#### Function Composition
 
 Create reusable processing chains:
 
@@ -91,7 +91,7 @@ transform_all = final_format
 process = transform_all <| validate_all;
 ```
 
-## Precedence and Grouping
+#### Precedence and Grouping
 
 Understanding operator precedence:
 
@@ -105,9 +105,9 @@ output = final_step <| (
 );
 ```
 
-## Common Patterns
+#### Common Patterns
 
-### Builder Pattern
+##### Builder Pattern
 ```jac
 # Build configuration right-to-left
 config = apply_overrides
@@ -116,7 +116,7 @@ config = apply_overrides
     <| "config.json";
 ```
 
-### Middleware Chain
+##### Middleware Chain
 ```jac
 # Web request processing
 handle_request = send_response
@@ -125,7 +125,7 @@ handle_request = send_response
     <| parse_request;
 ```
 
-### Data Validation Pipeline
+##### Data Validation Pipeline
 ```jac
 # Validation stages
 validate = report_errors
@@ -134,14 +134,14 @@ validate = report_errors
     <| sanitize_input;
 ```
 
-## Best Practices
+#### Best Practices
 
 - **Use `<|` when**: Building processing chains where later stages depend on earlier ones
 - **Use `|>` when**: Transforming data through sequential steps
 - **Mix operators**: When it improves readability
 - **Group with parentheses**: To make precedence explicit
 
-## Comparison with Forward Pipe
+#### Comparison with Forward Pipe
 
 ```jac
 # Forward pipe - follows data flow

--- a/jac/examples/reference/raise_statements.md
+++ b/jac/examples/reference/raise_statements.md
@@ -1,3 +1,4 @@
+### Raise Statements
 Raise statements in Jac provide the mechanism for explicitly throwing exceptions, enabling structured error handling and control flow disruption. These statements allow functions and methods to signal error conditions, invalid states, or exceptional circumstances that require special handling by calling code.
 
 **Basic Raise Statement Syntax**

--- a/jac/examples/reference/references_(unused).md
+++ b/jac/examples/reference/references_(unused).md
@@ -1,0 +1,1 @@
+### References Unused

--- a/jac/examples/reference/report_statements.md
+++ b/jac/examples/reference/report_statements.md
@@ -1,14 +1,14 @@
-# Report Statements
+### Report Statements
 
 Report statements provide a mechanism for walkers to communicate results back to their spawning context. This feature is essential for extracting information from graph traversals and data spatial computations.
 
-## Syntax
+#### Syntax
 
 ```jac
 report expression;
 ```
 
-## Purpose
+#### Purpose
 
 Report statements allow walkers to:
 - Return computed results from traversals
@@ -16,7 +16,7 @@ Report statements allow walkers to:
 - Communicate findings to the calling context
 - Build up results incrementally during traversal
 
-## Basic Usage
+#### Basic Usage
 
 ```jac
 walker DataCollector {
@@ -36,7 +36,7 @@ with entry {
 }
 ```
 
-## Multiple Reports
+#### Multiple Reports
 
 Walkers can report multiple times during traversal:
 
@@ -65,7 +65,7 @@ walker PathFinder {
 }
 ```
 
-## Aggregating Results
+#### Aggregating Results
 
 Common pattern for collecting data:
 
@@ -96,7 +96,7 @@ walker Aggregator {
 }
 ```
 
-## Conditional Reporting
+#### Conditional Reporting
 
 Report based on conditions:
 
@@ -120,7 +120,7 @@ walker SearchWalker {
 }
 ```
 
-## Report vs Return
+#### Report vs Return
 
 Key differences:
 - `report`: Accumulates values, continues execution
@@ -138,7 +138,7 @@ walker Finder {
 }
 ```
 
-## Integration with Data Spatial
+#### Integration with Data Spatial
 
 Reports work seamlessly with graph traversal:
 
@@ -174,9 +174,9 @@ with entry {
 }
 ```
 
-## Advanced Patterns
+#### Advanced Patterns
 
-### Path Tracking
+##### Path Tracking
 ```jac
 walker PathTracker {
     has path: list = [];
@@ -198,7 +198,7 @@ walker PathTracker {
 }
 ```
 
-### Hierarchical Aggregation
+##### Hierarchical Aggregation
 ```jac
 walker TreeAggregator {
     can aggregate with entry {
@@ -220,7 +220,7 @@ walker TreeAggregator {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Report Meaningful Data**: Include context with reported values
 2. **Use Structured Reports**: Return dictionaries for complex data

--- a/jac/examples/reference/return_statements.md
+++ b/jac/examples/reference/return_statements.md
@@ -1,3 +1,4 @@
+### Return Statements
 Return statements in Jac provide the mechanism for functions and methods to exit and optionally return values to their callers. The return statement syntax supports both value-returning and void functions, enabling clear control flow and data passing in function-based programming.
 
 **Basic Return Statement Syntax**

--- a/jac/examples/reference/special_comprehensions.md
+++ b/jac/examples/reference/special_comprehensions.md
@@ -1,8 +1,8 @@
-# Special Comprehensions
+### Special Comprehensions
 
 Special comprehensions in Jac extend traditional list comprehensions with powerful filtering and assignment capabilities. These constructs enable concise manipulation of data structures, particularly in graph traversal contexts.
 
-## Filter Comprehensions
+#### Filter Comprehensions
 
 Filter comprehensions apply conditional filtering with optional null-safety:
 
@@ -26,7 +26,7 @@ filtered_nodes = [-->(?score > 0.5)];
 typed_edges = [<--(`Connection: weight > 10)];
 ```
 
-## Assignment Comprehensions
+#### Assignment Comprehensions
 
 Assignment comprehensions enable in-place property updates:
 
@@ -51,7 +51,7 @@ walker Updater {
 }
 ```
 
-## Filter Compare Lists
+#### Filter Compare Lists
 
 Complex filtering with multiple conditions:
 
@@ -63,7 +63,7 @@ Complex filtering with multiple conditions:
 (name != "admin", role in ["user", "guest"])
 ```
 
-## Typed Filter Compare Lists
+#### Typed Filter Compare Lists
 
 Type-specific filtering with property constraints:
 
@@ -75,7 +75,7 @@ Type-specific filtering with property constraints:
 `FriendEdge: (mutual == True, years > 2)
 ```
 
-## Integration with Data Spatial Operations
+#### Integration with Data Spatial Operations
 
 Special comprehensions shine in graph operations:
 
@@ -105,7 +105,7 @@ walker Processor {
 }
 ```
 
-## Comparison Operators
+#### Comparison Operators
 
 Available operators for filter comprehensions:
 - `==`, `!=`: Equality comparisons
@@ -113,7 +113,7 @@ Available operators for filter comprehensions:
 - `in`, `not in`: Membership tests
 - `is`, `is not`: Identity comparisons
 
-## Null-Safe Operations
+#### Null-Safe Operations
 
 The `?` operator enables safe property access:
 

--- a/jac/examples/reference/tests.md
+++ b/jac/examples/reference/tests.md
@@ -1,8 +1,8 @@
-# Tests
+### Tests
 
 Tests in Jac provide built-in support for unit testing and validation of code functionality. The `test` keyword creates test blocks that can be executed to verify program correctness.
 
-## Syntax
+#### Syntax
 
 ```jac
 test {
@@ -14,7 +14,7 @@ test "descriptive test name" {
 }
 ```
 
-## Basic Testing
+#### Basic Testing
 
 Simple test assertions:
 
@@ -35,7 +35,7 @@ test {
 }
 ```
 
-## Testing Functions
+#### Testing Functions
 
 Validate function behavior:
 
@@ -51,7 +51,7 @@ test "area calculation" {
 }
 ```
 
-## Testing Objects and Classes
+#### Testing Objects and Classes
 
 Test object creation and methods:
 
@@ -81,7 +81,7 @@ test "rectangle operations" {
 }
 ```
 
-## Testing Graph Operations
+#### Testing Graph Operations
 
 Test node and edge functionality:
 
@@ -115,7 +115,7 @@ test "graph construction" {
 }
 ```
 
-## Testing Walkers
+#### Testing Walkers
 
 Verify walker behavior:
 
@@ -149,7 +149,7 @@ test "walker traversal" {
 }
 ```
 
-## Exception Testing
+#### Exception Testing
 
 Test error handling:
 
@@ -176,7 +176,7 @@ test "exception handling" {
 }
 ```
 
-## Parameterized Testing
+#### Parameterized Testing
 
 Test with multiple inputs:
 
@@ -195,7 +195,7 @@ test "parameterized validation" {
 }
 ```
 
-## Setup and Teardown
+#### Setup and Teardown
 
 Organize test environment:
 
@@ -218,7 +218,7 @@ test "with setup and cleanup" {
 }
 ```
 
-## Testing Async Operations
+#### Testing Async Operations
 
 Test asynchronous code:
 
@@ -235,7 +235,7 @@ test "async operations" {
 }
 ```
 
-## Test Organization
+#### Test Organization
 
 Group related tests:
 
@@ -261,7 +261,7 @@ test "string manipulation" {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Descriptive Names**: Use clear test names that explain what's being tested
 2. **Single Responsibility**: Each test should verify one specific behavior
@@ -269,7 +269,7 @@ test "string manipulation" {
 4. **Clear Assertions**: Make test expectations obvious
 5. **Test Edge Cases**: Include boundary conditions and error cases
 
-## Running Tests
+#### Running Tests
 
 Tests can be executed:
 - Individually by name
@@ -277,7 +277,7 @@ Tests can be executed:
 - Tests matching a pattern
 - With verbose output for debugging
 
-## Integration Testing
+#### Integration Testing
 
 Test complete workflows:
 

--- a/jac/examples/reference/try_statements.md
+++ b/jac/examples/reference/try_statements.md
@@ -1,8 +1,8 @@
-# Try Statements
+### Try Statements
 
 Try statements provide exception handling mechanisms in Jac, enabling robust error management and graceful recovery from runtime errors. This construct supports structured exception handling with try, except, else, and finally blocks.
 
-## Syntax
+#### Syntax
 
 ```jac
 try {
@@ -18,7 +18,7 @@ try {
 }
 ```
 
-## Basic Exception Handling
+#### Basic Exception Handling
 
 ```jac
 try {
@@ -31,7 +31,7 @@ try {
 }
 ```
 
-## Multiple Exception Types
+#### Multiple Exception Types
 
 Handle different exceptions with specific responses:
 
@@ -53,7 +53,7 @@ walker DataProcessor {
 }
 ```
 
-## Else Clause
+#### Else Clause
 
 Execute code only when no exceptions occur:
 
@@ -71,7 +71,7 @@ can safe_divide(a: float, b: float) -> float {
 }
 ```
 
-## Finally Clause
+#### Finally Clause
 
 Guarantee cleanup code execution:
 
@@ -94,7 +94,7 @@ can process_file(filename: str) -> dict {
 }
 ```
 
-## Graph Operations Error Handling
+#### Graph Operations Error Handling
 
 Robust walker traversal:
 
@@ -130,7 +130,7 @@ walker SafeTraverser {
 }
 ```
 
-## Resource Management Pattern
+#### Resource Management Pattern
 
 Using try-finally for resource cleanup:
 
@@ -162,7 +162,7 @@ node DatabaseNode {
 }
 ```
 
-## Nested Try Blocks
+#### Nested Try Blocks
 
 Handle errors at multiple levels:
 
@@ -188,7 +188,7 @@ can complex_operation(data: dict) -> any {
 }
 ```
 
-## Custom Exception Handling
+#### Custom Exception Handling
 
 Define and handle custom exceptions:
 
@@ -214,7 +214,7 @@ walker GraphValidator {
 }
 ```
 
-## Best Practices
+#### Best Practices
 
 1. **Specific Exceptions First**: Order except blocks from most to least specific
 2. **Minimal Try Blocks**: Keep try blocks focused on code that may fail
@@ -222,7 +222,7 @@ walker GraphValidator {
 4. **Meaningful Error Messages**: Provide context in error handling
 5. **Don't Suppress Errors**: Avoid empty except blocks
 
-## Integration with Data Spatial
+#### Integration with Data Spatial
 
 Exception handling in graph contexts:
 

--- a/jac/examples/reference/visit_statements.md
+++ b/jac/examples/reference/visit_statements.md
@@ -1,3 +1,4 @@
+### Visit Statements
 Visit statements in Jac implement the fundamental data spatial operation that enables walkers to traverse through node-edge topological structures. This statement embodies the core Data Spatial Programming (DSP) paradigm of "computation moving to data" rather than the traditional approach of moving data to computation.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/walrus_assignments.md
+++ b/jac/examples/reference/walrus_assignments.md
@@ -1,0 +1,1 @@
+### Walrus Assignments

--- a/jac/examples/reference/while_statements.md
+++ b/jac/examples/reference/while_statements.md
@@ -1,3 +1,4 @@
+### While Statements
 While statements in Jac provide iterative execution based on conditional expressions, enabling loops that continue as long as a specified condition remains true. The while loop syntax offers a fundamental control structure for implementing algorithms that require repeated execution with dynamic termination conditions.
 
 **Basic While Loop Syntax**

--- a/jac/examples/reference/yield_statements.md
+++ b/jac/examples/reference/yield_statements.md
@@ -1,3 +1,4 @@
+### Yield Statements
 Yield statements in Jac provide the foundation for generator functions and iterative computation patterns. These statements enable functions to produce sequences of values on-demand rather than computing and returning entire collections at once, supporting memory-efficient iteration and lazy evaluation.
 
 **Basic Yield Statement Syntax**


### PR DESCRIPTION
## Summary
- unify heading levels in Jaseci reference files
- ensure top-level headings use `###`
- add missing headings and newlines

## Testing
- `pre-commit run --files $(cat /tmp/changed_files.txt)` *(fails: couldn't connect to server)*