### PR TITLE
Remove headings from reference markdowns

### DIFF
--- a/jac/examples/reference/archetype_bodies.md
+++ b/jac/examples/reference/archetype_bodies.md
@@ -1,5 +1,3 @@
-### Archetype Bodies
-
 Archetype bodies define the internal structure and behavior of Jac's specialized class constructs. These bodies contain member declarations, abilities, and implementation details that enable both traditional object-oriented programming and data spatial computation patterns.
 
 #### Member Declaration Syntax

--- a/jac/examples/reference/archetypes.md
+++ b/jac/examples/reference/archetypes.md
@@ -1,5 +1,3 @@
-### Archetypes
-
 Archetypes represent Jac's extension of traditional object-oriented programming classes, providing specialized constructs that enable data spatial programming. Each archetype type serves a distinct role in building topological computational systems where data and computation are distributed across graph structures.
 
 #### Archetype Types

--- a/jac/examples/reference/arithmetic_expressions.md
+++ b/jac/examples/reference/arithmetic_expressions.md
@@ -1,4 +1,3 @@
-### Arithmetic Expressions
 Jac supports a comprehensive set of arithmetic operations that follow the standard mathematical precedence rules. The arithmetic expression system in Jac is designed to be intuitive and consistent with mathematical conventions while maintaining compatibility with Python's arithmetic operations.
 
 **Basic Arithmetic Operators**

--- a/jac/examples/reference/assert_statements.md
+++ b/jac/examples/reference/assert_statements.md
@@ -1,4 +1,3 @@
-### Assert Statements
 Assert statements in Jac provide a mechanism for debugging and testing by allowing developers to verify that certain conditions hold true during program execution. When an assertion fails, it raises an `AssertionError` exception, which can be caught and handled like any other exception.
 
 **Basic Assert Syntax**

--- a/jac/examples/reference/assignments.md
+++ b/jac/examples/reference/assignments.md
@@ -1,5 +1,3 @@
-### Assignments
-
 Jac provides comprehensive assignment operations that extend Python's familiar syntax with enhanced type safety and explicit variable declaration capabilities. These assignment patterns support both traditional programming and data spatial operations.
 
 #### Basic Assignment Operations

--- a/jac/examples/reference/atom.md
+++ b/jac/examples/reference/atom.md
@@ -1,4 +1,3 @@
-### Atom
 Atomic expressions in Jac represent the most basic building blocks of expressions - the fundamental units that cannot be broken down further. These include literals, references, collections, and other primary elements that form the foundation of more complex expressions.
 
 **Atomic Expression Types**

--- a/jac/examples/reference/atomic_expressions.md
+++ b/jac/examples/reference/atomic_expressions.md
@@ -1,4 +1,3 @@
-### Atomic Expressions
 Atomic expressions in Jac represent the most fundamental and indivisible units of expression evaluation. They serve as building blocks for more complex expressions and include literals, identifiers, and other primary expression forms.
 
 **Atomic Pipe Forward Expressions**

--- a/jac/examples/reference/atomic_pipe_back_expressions.md
+++ b/jac/examples/reference/atomic_pipe_back_expressions.md
@@ -1,4 +1,3 @@
-### Atomic Pipe Back Expressions
 Atomic pipe back expressions in Jac provide an alternative directional flow for data processing using the `<:` operator. This feature complements the pipe forward operator (`:>`) by enabling right-to-left data flow, offering flexibility in expression composition and readability.
 
 **Atomic Pipe Back Syntax**

--- a/jac/examples/reference/base_module_structure.md
+++ b/jac/examples/reference/base_module_structure.md
@@ -1,4 +1,3 @@
-### Base Module Structure
 In Jac, a module is analogous to a Python module, serving as a container for various elements such as functions, classes (referred to as "archetypes" later in this document), global variables, and other constructs that facilitate code organization and reusability. Each module begins with an optional module-level docstring, which provides a high-level overview of the module's purpose and functionality. This docstring, if present, is positioned at the very start of the module, before any other elements.
 
 ???+ Note "Docstrings"

--- a/jac/examples/reference/bitwise_expressions.md
+++ b/jac/examples/reference/bitwise_expressions.md
@@ -1,4 +1,3 @@
-### Bitwise Expressions
 Bitwise expressions in Jac provide low-level bit manipulation operations that work directly on the binary representation of integer values. These operations are essential for systems programming, data encoding, optimization algorithms, and working with binary data formats.
 
 **Bitwise Operators**

--- a/jac/examples/reference/builtin_types.md
+++ b/jac/examples/reference/builtin_types.md
@@ -1,4 +1,3 @@
-### Builtin Types
 Jac provides a rich set of built-in data types that cover the fundamental data structures needed for most programming tasks. These types are similar to Python's built-in types but are integrated into Jac's type system and syntax.
 
 **Primitive Types**

--- a/jac/examples/reference/check_statements.md
+++ b/jac/examples/reference/check_statements.md
@@ -1,4 +1,3 @@
-### Check Statements
 Check statements in Jac provide a built-in testing mechanism that integrates directly into the language syntax. They are primarily used within test blocks to verify that specific conditions hold true, forming the foundation of Jac's integrated testing framework.
 
 **Basic Syntax**

--- a/jac/examples/reference/codeblocks_and_statements.md
+++ b/jac/examples/reference/codeblocks_and_statements.md
@@ -1,5 +1,3 @@
-### Codeblocks and Statements
-
 Code blocks and statements form the structural foundation of Jac programs, organizing executable code into logical units and providing the syntactic framework for all program operations.
 
 #### Code Block Structure

--- a/jac/examples/reference/collection_values.md
+++ b/jac/examples/reference/collection_values.md
@@ -1,4 +1,3 @@
-### Collection Values
 Collection values in Jac provide rich data structures for organizing and manipulating groups of related data. Jac supports all major collection types found in modern programming languages, along with powerful comprehension syntax for creating collections programmatically.
 
 **Basic Collection Types**

--- a/jac/examples/reference/concurrent_expressions.md
+++ b/jac/examples/reference/concurrent_expressions.md
@@ -1,5 +1,3 @@
-### Concurrent Expressions
-
 Concurrent expressions enable parallel and asynchronous execution in Jac through the `flow` and `wait` modifiers. These constructs provide built-in concurrency support, allowing efficient parallel processing while maintaining clean, readable code.
 
 #### Flow Modifier

--- a/jac/examples/reference/connect_expressions.md
+++ b/jac/examples/reference/connect_expressions.md
@@ -1,4 +1,3 @@
-### Connect Expressions
 Connect expressions in Jac provide the fundamental mechanism for creating topological relationships between nodes, implementing the edge creation and management aspects of Data Spatial Programming. These expressions enable the construction of graph structures where computation can flow through connected data locations.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/context_managers.md
+++ b/jac/examples/reference/context_managers.md
@@ -1,5 +1,3 @@
-### Context Managers
-
 Context managers in Jac provide automatic resource management through `with` statements, ensuring proper acquisition and release of resources. This feature supports the context management protocol for clean handling of files, connections, locks, and other resources.
 
 #### Syntax

--- a/jac/examples/reference/control_statements.md
+++ b/jac/examples/reference/control_statements.md
@@ -1,5 +1,3 @@
-### Control Statements
-
 Control statements provide essential flow control mechanisms for managing program execution within loops and conditional structures. These statements enable precise control over iteration and branching, complementing Jac's data spatial features with traditional imperative programming constructs.
 
 #### Basic Control Operations

--- a/jac/examples/reference/data_spatial_calls.md
+++ b/jac/examples/reference/data_spatial_calls.md
@@ -1,5 +1,3 @@
-### Data Spatial Calls
-
 Data spatial calls represent specialized operators that enable computation to move through topological structures rather than data moving to computation. These operators fundamentally invert traditional programming paradigms by activating computational entities within graph structures and enabling fluid data transformations.
 
 #### Spawn Operator (`spawn`)

--- a/jac/examples/reference/data_spatial_references.md
+++ b/jac/examples/reference/data_spatial_references.md
@@ -1,5 +1,3 @@
-### Data Spatial References
-
 Data spatial references provide specialized syntax for navigating and manipulating topological structures, enabling direct expression of graph relationships and traversal patterns. These references make topological relationships first-class citizens in the programming model.
 
 #### Edge Reference Syntax

--- a/jac/examples/reference/data_spatial_spawn_expressions.md
+++ b/jac/examples/reference/data_spatial_spawn_expressions.md
@@ -1,4 +1,3 @@
-### Data Spatial Spawn Expressions
 Data spatial spawn expressions in Jac implement the fundamental mechanism for activating walkers within the topological structure, transitioning them from inactive objects to active participants in the distributed computational system. This operation embodies the initialization phase of the "computation moving to data" paradigm that characterizes Data Spatial Programming.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/data_spatial_typed_context_blocks.md
+++ b/jac/examples/reference/data_spatial_typed_context_blocks.md
@@ -1,5 +1,3 @@
-### Data Spatial Typed Context Blocks
-
 Typed context blocks establish type-annotated scopes that provide compile-time type safety and runtime type assertions within data spatial operations. These blocks enhance the reliability of graph traversal and data processing by ensuring type consistency across topological boundaries.
 
 #### Syntax and Structure

--- a/jac/examples/reference/data_spatial_walker_statements.md
+++ b/jac/examples/reference/data_spatial_walker_statements.md
@@ -1,5 +1,3 @@
-### Data Spatial Walker Statements
-
 Walker statements control the movement and lifecycle of computational entities within topological structures. These statements implement the core data spatial paradigm where computation moves to data through controlled traversal of nodes and edges.
 
 #### Visit Statement

--- a/jac/examples/reference/delete_statements.md
+++ b/jac/examples/reference/delete_statements.md
@@ -1,5 +1,3 @@
-### Delete Statements
-
 Delete statements in Jac remove objects, nodes, edges, or properties from memory and graph structures. The `del` keyword provides a unified interface for deletion operations across different contexts.
 
 #### Syntax

--- a/jac/examples/reference/disengage_statements.md
+++ b/jac/examples/reference/disengage_statements.md
@@ -1,4 +1,3 @@
-### Disengage Statements
 Disengage statements in Jac provide a mechanism for terminating walker traversal within the data spatial topology. This statement enables walkers to exit their active traversal state and return to inactive object status, representing a controlled termination of the "computation moving to data" process that characterizes Data Spatial Programming.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/enumerations.md
+++ b/jac/examples/reference/enumerations.md
@@ -1,5 +1,3 @@
-### Enumerations
-
 Jac provides native enumeration support through the `enum` construct, offering ordered sets of named constants with integrated access control and implementation capabilities. Enumerations behave similarly to Python's `enum.Enum` while supporting Jac's archetype system and data spatial programming features.
 
 #### Basic Enumeration Declaration

--- a/jac/examples/reference/expressions.md
+++ b/jac/examples/reference/expressions.md
@@ -1,1 +1,0 @@
-### Expressions

--- a/jac/examples/reference/f_string_tokens.md
+++ b/jac/examples/reference/f_string_tokens.md
@@ -1,1 +1,0 @@
-### F String Tokens

--- a/jac/examples/reference/for_statements.md
+++ b/jac/examples/reference/for_statements.md
@@ -1,5 +1,3 @@
-### For Statements
-
 For statements provide powerful iteration mechanisms with multiple syntax variants designed for different looping scenarios. Jac supports both traditional iteration patterns and expressive loop constructs that enhance readability while reducing common programming errors.
 
 #### For Loop Variants

--- a/jac/examples/reference/free_code.md
+++ b/jac/examples/reference/free_code.md
@@ -1,4 +1,3 @@
-### Free Code
 Free code in Jac refers to executable statements that exist at the module level but are not part of a function, class, or other structural element. Unlike many programming languages that allow loose statements to float freely in a module, Jac requires such code to be explicitly wrapped in `with entry` blocks for better code organization and clarity.
 
 **Entry Blocks**

--- a/jac/examples/reference/function_calls.md
+++ b/jac/examples/reference/function_calls.md
@@ -1,4 +1,3 @@
-### Function Calls
 Function calls in Jac provide the fundamental mechanism for invoking defined functions and methods, supporting both traditional positional arguments and named keyword arguments. The function call system integrates seamlessly with Jac's type system and expression evaluation, enabling flexible and expressive function invocation patterns.
 
 **Basic Function Call Syntax**

--- a/jac/examples/reference/functions_and_abilities.md
+++ b/jac/examples/reference/functions_and_abilities.md
@@ -1,5 +1,3 @@
-### Functions and Abilities
-
 Jac provides two complementary approaches to defining executable code: traditional functions using `def` and data spatial abilities using `can`. This dual system supports both conventional programming patterns and the unique requirements of computation moving through topological structures.
 
 #### Function Definitions

--- a/jac/examples/reference/global_and_nonlocal_statements.md
+++ b/jac/examples/reference/global_and_nonlocal_statements.md
@@ -1,5 +1,3 @@
-### Global and Nonlocal Statements
-
 Global and nonlocal statements in Jac provide mechanisms for accessing and modifying variables from outer scopes. These statements enable controlled access to variables defined outside the current function or ability scope.
 
 #### Global Statement

--- a/jac/examples/reference/global_variables.md
+++ b/jac/examples/reference/global_variables.md
@@ -1,5 +1,3 @@
-### Global Variables
-
 Global variables provide module-level data storage that persists throughout program execution and can be accessed across different scopes within a Jac program. Jac offers two declaration keywords with distinct semantic meanings and access control capabilities.
 
 #### Declaration Keywords

--- a/jac/examples/reference/if_statements.md
+++ b/jac/examples/reference/if_statements.md
@@ -1,5 +1,3 @@
-### If Statements
-
 If statements provide conditional execution control, enabling programs to make decisions based on boolean expressions. Jac's if statement syntax supports the familiar if-elif-else pattern with mandatory code blocks, ensuring clear and safe conditional logic.
 
 #### Basic Conditional Syntax

--- a/jac/examples/reference/ignore_statements.md
+++ b/jac/examples/reference/ignore_statements.md
@@ -1,5 +1,3 @@
-### Ignore Statements
-
 Ignore statements provide a mechanism to exclude specific nodes or edges from walker traversal paths. This feature enables selective graph navigation by marking elements that should be skipped during traversal operations.
 
 #### Syntax

--- a/jac/examples/reference/implementations.md
+++ b/jac/examples/reference/implementations.md
@@ -1,4 +1,3 @@
-### Implementations
 Implementations in Jac provide a powerful mechanism for separating interface declarations from their concrete implementations. This feature supports modular programming, interface segregation, and flexible code organization patterns common in modern software development.
 
 **Implementation Concept**

--- a/jac/examples/reference/import_include_statements.md
+++ b/jac/examples/reference/import_include_statements.md
@@ -1,5 +1,3 @@
-### Import and Include Statements
-
 Jac provides flexible module importing capabilities that extend Python's import system with additional convenience features and compile-time source inclusion. The language supports three distinct import mechanisms for different use cases.
 
 #### Standard Import

--- a/jac/examples/reference/inline_python.md
+++ b/jac/examples/reference/inline_python.md
@@ -1,4 +1,3 @@
-### Inline Python
 Inline Python in Jac provides a powerful mechanism to seamlessly integrate native Python code within Jac programs. This feature enables developers to leverage the vast Python ecosystem and existing Python libraries directly within their Jac applications.
 
 **Inline Python Syntax**

--- a/jac/examples/reference/introduction.md
+++ b/jac/examples/reference/introduction.md
@@ -1,5 +1,3 @@
-### Introduction
-
 Welcome to the official reference guide for the Jac programming language. This document is designed to serve as a comprehensive reference manual as well as a formal specification of the language. The mission of this guide is to be a resource for developers seeking to answer the question, "How do I code X in Jac?"
 
 This document is organized around the formal grammar for the language code examples and corresponding grammar snippets being directly generated from the actual grammar and test cases maintained in the official repository. We expect the descriptions may occasionally lag behind the rapid evolution of Jac in the early days. If you notice something, make a pull request and join our contributor community.

--- a/jac/examples/reference/lambda_expressions.md
+++ b/jac/examples/reference/lambda_expressions.md
@@ -1,4 +1,3 @@
-### Lambda Expressions
 Lambda expressions in Jac provide a concise way to create anonymous functions for functional programming patterns. These expressions enable the creation of small, single-expression functions without the overhead of formal function definitions, supporting Jac's functional programming capabilities while maintaining type safety through required parameter annotations.
 
 **Basic Lambda Syntax**

--- a/jac/examples/reference/lexer_tokens.md
+++ b/jac/examples/reference/lexer_tokens.md
@@ -1,1 +1,0 @@
-### Lexer Tokens

--- a/jac/examples/reference/logical_and_compare_expressions.md
+++ b/jac/examples/reference/logical_and_compare_expressions.md
@@ -1,1 +1,0 @@
-### Logical And Compare Expressions

--- a/jac/examples/reference/match_capture_patterns.md
+++ b/jac/examples/reference/match_capture_patterns.md
@@ -1,1 +1,0 @@
-### Match Capture Patterns

--- a/jac/examples/reference/match_class_patterns.md
+++ b/jac/examples/reference/match_class_patterns.md
@@ -1,1 +1,0 @@
-### Match Class Patterns

--- a/jac/examples/reference/match_litteral_patterns.md
+++ b/jac/examples/reference/match_litteral_patterns.md
@@ -1,1 +1,0 @@
-### Match Litteral Patterns

--- a/jac/examples/reference/match_mapping_patterns.md
+++ b/jac/examples/reference/match_mapping_patterns.md
@@ -1,1 +1,0 @@
-### Match Mapping Patterns

--- a/jac/examples/reference/match_patterns.md
+++ b/jac/examples/reference/match_patterns.md
@@ -1,1 +1,0 @@
-### Match Patterns

--- a/jac/examples/reference/match_sequence_patterns.md
+++ b/jac/examples/reference/match_sequence_patterns.md
@@ -1,1 +1,0 @@
-### Match Sequence Patterns

--- a/jac/examples/reference/match_singleton_patterns.md
+++ b/jac/examples/reference/match_singleton_patterns.md
@@ -1,1 +1,0 @@
-### Match Singleton Patterns

--- a/jac/examples/reference/match_statements.md
+++ b/jac/examples/reference/match_statements.md
@@ -1,5 +1,3 @@
-### Match Statements
-
 Match statements provide powerful pattern matching capabilities in Jac, enabling elegant handling of complex data structures and control flow based on value patterns. This feature supports structural pattern matching similar to modern programming languages.
 
 #### Syntax

--- a/jac/examples/reference/names_and_references.md
+++ b/jac/examples/reference/names_and_references.md
@@ -1,5 +1,3 @@
-### Names and References
-
 Jac employs a familiar identifier system similar to Python and C-style languages while introducing specialized references essential for data spatial programming. The naming system supports both traditional programming patterns and the unique requirements of computation moving through topological structures.
 
 #### Standard Identifiers

--- a/jac/examples/reference/pipe_back_expressions.md
+++ b/jac/examples/reference/pipe_back_expressions.md
@@ -1,5 +1,3 @@
-### Pipe Back Expressions
-
 Pipe back expressions provide the reverse flow of pipe forward expressions, passing the result of the right expression as the last argument to the left expression. This operator enables different composition patterns that can be more natural for certain operations.
 
 #### Backward Pipe Operator (`<|`)

--- a/jac/examples/reference/pipe_expressions.md
+++ b/jac/examples/reference/pipe_expressions.md
@@ -1,5 +1,3 @@
-### Pipe Expressions
-
 Pipe expressions enable functional-style data transformation through left-to-right value flow, eliminating deeply nested function calls and creating readable transformation chains. This feature is particularly powerful in data spatial contexts where computation flows through topological structures.
 
 #### Forward Pipe Operator (`|>`)

--- a/jac/examples/reference/raise_statements.md
+++ b/jac/examples/reference/raise_statements.md
@@ -1,4 +1,3 @@
-### Raise Statements
 Raise statements in Jac provide the mechanism for explicitly throwing exceptions, enabling structured error handling and control flow disruption. These statements allow functions and methods to signal error conditions, invalid states, or exceptional circumstances that require special handling by calling code.
 
 **Basic Raise Statement Syntax**

--- a/jac/examples/reference/references_(unused).md
+++ b/jac/examples/reference/references_(unused).md
@@ -1,1 +1,0 @@
-### References Unused

--- a/jac/examples/reference/report_statements.md
+++ b/jac/examples/reference/report_statements.md
@@ -1,5 +1,3 @@
-### Report Statements
-
 Report statements provide a mechanism for walkers to communicate results back to their spawning context. This feature is essential for extracting information from graph traversals and data spatial computations.
 
 #### Syntax

--- a/jac/examples/reference/return_statements.md
+++ b/jac/examples/reference/return_statements.md
@@ -1,4 +1,3 @@
-### Return Statements
 Return statements in Jac provide the mechanism for functions and methods to exit and optionally return values to their callers. The return statement syntax supports both value-returning and void functions, enabling clear control flow and data passing in function-based programming.
 
 **Basic Return Statement Syntax**

--- a/jac/examples/reference/special_comprehensions.md
+++ b/jac/examples/reference/special_comprehensions.md
@@ -1,5 +1,3 @@
-### Special Comprehensions
-
 Special comprehensions in Jac extend traditional list comprehensions with powerful filtering and assignment capabilities. These constructs enable concise manipulation of data structures, particularly in graph traversal contexts.
 
 #### Filter Comprehensions

--- a/jac/examples/reference/subscripted_and_dotted_expressions.md
+++ b/jac/examples/reference/subscripted_and_dotted_expressions.md
@@ -1,5 +1,3 @@
-### Subscripted and Dotted Expressions
-
 Jac provides comprehensive data access mechanisms through attribute access and subscript operations that extend Python's familiar syntax with additional conveniences for pipe operations and null-safe access patterns.
 
 #### Attribute Access

--- a/jac/examples/reference/tests.md
+++ b/jac/examples/reference/tests.md
@@ -1,5 +1,3 @@
-### Tests
-
 Tests in Jac provide built-in support for unit testing and validation of code functionality. The `test` keyword creates test blocks that can be executed to verify program correctness.
 
 #### Syntax

--- a/jac/examples/reference/try_statements.md
+++ b/jac/examples/reference/try_statements.md
@@ -1,5 +1,3 @@
-### Try Statements
-
 Try statements provide exception handling mechanisms in Jac, enabling robust error management and graceful recovery from runtime errors. This construct supports structured exception handling with try, except, else, and finally blocks.
 
 #### Syntax

--- a/jac/examples/reference/tuples_and_jac_tuples.md
+++ b/jac/examples/reference/tuples_and_jac_tuples.md
@@ -1,5 +1,3 @@
-### Tuples and Jac Tuples
-
 Jac provides two distinct tuple syntaxes that serve different programming needs: traditional positional tuples for ordered data and keyword tuples for labeled data structures that integrate seamlessly with pipe operations and data spatial programming.
 
 #### Positional Tuples

--- a/jac/examples/reference/unpack_expressions.md
+++ b/jac/examples/reference/unpack_expressions.md
@@ -1,5 +1,3 @@
-### Unpack Expressions
-
 Unpack expressions enable the expansion of iterables and mappings into their constituent elements using the `*` and `**` operators. Jac follows Python's unpacking semantics while integrating seamlessly with pipe operations and data spatial programming constructs.
 
 #### Iterable Unpacking

--- a/jac/examples/reference/visit_statements.md
+++ b/jac/examples/reference/visit_statements.md
@@ -1,4 +1,3 @@
-### Visit Statements
 Visit statements in Jac implement the fundamental data spatial operation that enables walkers to traverse through node-edge topological structures. This statement embodies the core Data Spatial Programming (DSP) paradigm of "computation moving to data" rather than the traditional approach of moving data to computation.
 
 **Theoretical Foundation**

--- a/jac/examples/reference/walrus_assignments.md
+++ b/jac/examples/reference/walrus_assignments.md
@@ -1,1 +1,0 @@
-### Walrus Assignments

--- a/jac/examples/reference/while_statements.md
+++ b/jac/examples/reference/while_statements.md
@@ -1,4 +1,3 @@
-### While Statements
 While statements in Jac provide iterative execution based on conditional expressions, enabling loops that continue as long as a specified condition remains true. The while loop syntax offers a fundamental control structure for implementing algorithms that require repeated execution with dynamic termination conditions.
 
 **Basic While Loop Syntax**

--- a/jac/examples/reference/yield_statements.md
+++ b/jac/examples/reference/yield_statements.md
@@ -1,4 +1,3 @@
-### Yield Statements
 Yield statements in Jac provide the foundation for generator functions and iterative computation patterns. These statements enable functions to produce sequences of values on-demand rather than computing and returning entire collections at once, supporting memory-efficient iteration and lazy evaluation.
 
 **Basic Yield Statement Syntax**


### PR DESCRIPTION
## Summary
- strip the leading `###` heading from reference docs

## Testing
- `pre-commit run --files *.md` *(fails: unable to access github)*