### PR TITLE
Add 404 error handling in MkDocs Doc

### DIFF
--- a/docs/docs/404.md
+++ b/docs/docs/404.md
@@ -1,5 +1,0 @@
-# 404 - Page Not Found
-
-Sorry, the page you're looking for doesn't exist.
-
-[Go back to Home](index.md)

--- a/docs/docs/404.md
+++ b/docs/docs/404.md
@@ -1,0 +1,5 @@
+# 404 - Page Not Found
+
+Sorry, the page you're looking for doesn't exist.
+
+[Go back to Home](index.md)

--- a/docs/scripts/mkdocs_serve.py
+++ b/docs/scripts/mkdocs_serve.py
@@ -25,7 +25,9 @@ class CustomHeaderHandler(http.server.SimpleHTTPRequestHandler):
         self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
         super().end_headers()
 
-    def send_error(self, code, message=None, explain=None):
+    def send_error(
+        self, code: int, message: Optional[str] = None, explain: Optional[str] = None
+    ) -> None:
         """Serve custom 404.html page for 404 errors."""
         if code == 404:
             try:
@@ -36,7 +38,7 @@ class CustomHeaderHandler(http.server.SimpleHTTPRequestHandler):
                 self.send_header("Content-Length", str(len(content)))
                 self.end_headers()
                 self.wfile.write(content)
-            except Exception as e:
+            except Exception:
                 super().send_error(code, message, explain)
         else:
             super().send_error(code, message, explain)

--- a/docs/scripts/mkdocs_serve.py
+++ b/docs/scripts/mkdocs_serve.py
@@ -25,6 +25,22 @@ class CustomHeaderHandler(http.server.SimpleHTTPRequestHandler):
         self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
         super().end_headers()
 
+    def send_error(self, code, message=None, explain=None):
+        """Serve custom 404.html page for 404 errors."""
+        if code == 404:
+            try:
+                with open("404/index.html", "rb") as f:
+                    content = f.read()
+                self.send_response(404)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(content)))
+                self.end_headers()
+                self.wfile.write(content)
+            except Exception as e:
+                super().send_error(code, message, explain)
+        else:
+            super().send_error(code, message, explain)
+
 
 class DebouncedRebuildHandler(FileSystemEventHandler):
     """File system event handler for debounced MkDocs site rebuilding."""

--- a/docs/scripts/mkdocs_serve.py
+++ b/docs/scripts/mkdocs_serve.py
@@ -29,7 +29,7 @@ class CustomHeaderHandler(http.server.SimpleHTTPRequestHandler):
         """Serve custom 404.html page for 404 errors."""
         if code == 404:
             try:
-                with open("404/index.html", "rb") as f:
+                with open("404.html", "rb") as f:
                     content = f.read()
                 self.send_response(404)
                 self.send_header("Content-Type", "text/html")


### PR DESCRIPTION
### 404 Page Enable:

* `docs/scripts/mkdocs_serve.py`: Updated the `send_error` method to serve the 404 page (`404.html`) when a 404 error occurs.