### PR TITLE
Fix comment syntax in Jac reference docs

### DIFF
--- a/jac/examples/reference/check_statements.md
+++ b/jac/examples/reference/check_statements.md
@@ -17,7 +17,7 @@ Check statements are most commonly used within `test` blocks, which are Jac's la
 test test_name {
     check condition1;
     check condition2;
-    // more checks...
+    # more checks...
 }
 ```
 

--- a/jac/examples/reference/context_managers.md
+++ b/jac/examples/reference/context_managers.md
@@ -4,17 +4,17 @@ Context managers in Jac provide automatic resource management through `with` sta
 
 ```jac
 with expression as variable {
-    // code using the resource
+    # code using the resource
 }
 
 # Multiple context managers
 with expr1 as var1, expr2 as var2 {
-    // code using both resources
+    # code using both resources
 }
 
 # Async context managers
 async with async_expression as variable {
-    // async code using the resource
+    # async code using the resource
 }
 ```
 

--- a/jac/examples/reference/control_statements.md
+++ b/jac/examples/reference/control_statements.md
@@ -62,12 +62,12 @@ Control statements work with all Jac loop constructs:
 ```jac
 for item in collection {
     if condition {
-        break;     // Exit loop
+        break;     # Exit loop
     }
     if other_condition {
-        continue;  // Skip to next item
+        continue;  # Skip to next item
     }
-    // Process item
+    # Process item
 }
 ```
 
@@ -75,12 +75,12 @@ for item in collection {
 ```jac
 for i=0 to i<10 by i+=1 {
     if i % 2 == 0 {
-        continue;  // Skip even numbers
+        continue;  # Skip even numbers
     }
     if i > 7 {
-        break;     // Stop when i exceeds 7
+        break;     # Stop when i exceeds 7
     }
-    print(i);      // Prints 1, 3, 5, 7
+    print(i);      # Prints 1, 3, 5, 7
 }
 ```
 
@@ -88,12 +88,12 @@ for i=0 to i<10 by i+=1 {
 ```jac
 while condition {
     if exit_condition {
-        break;     // Exit while loop
+        break;     # Exit while loop
     }
     if skip_condition {
-        continue;  // Skip to condition check
+        continue;  # Skip to condition check
     }
-    // Loop body
+    # Loop body
 }
 ```
 
@@ -105,7 +105,7 @@ Control statements affect only the innermost loop:
 for i in range(3) {
     for j in range(3) {
         if j == 1 {
-            break;     // Exits inner loop only
+            break;     # Exits inner loop only
         }
         print(i, j);
     }
@@ -126,7 +126,7 @@ Control statements work seamlessly with Jac's conditional expressions:
 ```jac
 for item in items {
     if item.is_valid() {
-        continue;  // Skip invalid items
+        continue;  # Skip invalid items
     }
     process(item);
 }
@@ -137,7 +137,7 @@ for item in items {
 for data in dataset {
     if data.type == "error" and data.severity > threshold {
         print("Critical error found");
-        break;     // Stop processing on critical error
+        break;     # Stop processing on critical error
     }
     analyze(data);
 }
@@ -152,10 +152,10 @@ def process_list(items: list) -> list {
     results = [];
     for item in items {
         if item < 0 {
-            continue;   // Skip negative values
+            continue;   # Skip negative values
         }
         if item > 100 {
-            break;      // Stop at first value over 100
+            break;      # Stop at first value over 100
         }
         results.append(item * 2);
     }
@@ -172,10 +172,10 @@ walker Processor {
     can process_nodes with `root entry {
         for node in [-->] {
             if node.should_skip {
-                continue;  // Skip certain nodes
+                continue;  # Skip certain nodes
             }
             if node.stop_condition {
-                break;     // Exit processing loop
+                break;     # Exit processing loop
             }
             node.process();
         }
@@ -202,7 +202,7 @@ for operation in operations {
 ```jac
 for record in data_records {
     if not record.is_valid() {
-        continue;  // Skip malformed records
+        continue;  # Skip malformed records
     }
     process_record(record);
 }

--- a/jac/examples/reference/data_spatial_spawn_expressions.md
+++ b/jac/examples/reference/data_spatial_spawn_expressions.md
@@ -70,8 +70,8 @@ Once spawned, walkers gain access to spatial context:
 
 ```jac
 impl Adder.do {
-    here ++> node_a();  // 'here' refers to current location (root)
-    visit [-->];        // Navigate to connected nodes
+    here ++> node_a();  # 'here' refers to current location (root)
+    visit [-->];        # Navigate to connected nodes
 }
 ```
 
@@ -86,13 +86,13 @@ Spawned walkers trigger location-bound computation:
 
 ```jac
 node node_a {
-    can add with Adder entry;  // Responds to Adder walker visits
+    can add with Adder entry;  # Responds to Adder walker visits
 }
 
 impl node_a.add {
-    self.x = 550;              // Node modifies its own state
-    self.y = 450;              // Access to node properties via 'self'
-    print(int(self.x) + int(self.y));  // Computation at data location
+    self.x = 550;              # Node modifies its own state
+    self.y = 450;              # Access to node properties via 'self'
+    print(int(self.x) + int(self.y));  # Computation at data location
 }
 ```
 

--- a/jac/examples/reference/data_spatial_typed_context_blocks.md
+++ b/jac/examples/reference/data_spatial_typed_context_blocks.md
@@ -4,7 +4,7 @@ Typed context blocks establish type-annotated scopes that provide compile-time t
 
 ```jac
 -> type_expression {
-    // type-constrained code block
+    # type-constrained code block
 }
 ```
 

--- a/jac/examples/reference/disengage_statements.md
+++ b/jac/examples/reference/disengage_statements.md
@@ -24,7 +24,7 @@ walker Visitor {
     can travel with `root entry {
         visit [-->] else {
             visit root;
-            // Walker disengages itself
+            # Walker disengages itself
         }
     }
 }
@@ -36,7 +36,7 @@ Nodes can disengage visiting walkers, as demonstrated in the example:
 node item {
     can speak with Visitor entry {
         print("Hey There!!!");
-        disengage;  // Node disengages the visiting walker
+        disengage;  # Node disengages the visiting walker
     }
 }
 ```

--- a/jac/examples/reference/free_code.md
+++ b/jac/examples/reference/free_code.md
@@ -12,7 +12,7 @@ The `with entry` construct serves as a container for free-floating code that sho
 
 ```jac
 with entry {
-    // executable statements here
+    # executable statements here
 }
 ```
 
@@ -22,7 +22,7 @@ Entry blocks can optionally be given names for specific execution contexts:
 
 ```jac
 with entry:name {
-    // named entry point code
+    # named entry point code
 }
 ```
 

--- a/jac/examples/reference/function_calls.md
+++ b/jac/examples/reference/function_calls.md
@@ -76,13 +76,13 @@ The `output` variable contains the returned tuple, which can be:
 
 Jac supports combining positional and keyword arguments:
 ```jac
-// Positional arguments first
+# Positional arguments first
 result = foo(4, y=3, z=9);
 
-// All keyword arguments
+# All keyword arguments
 result = foo(x=4, y=3, z=9);
 
-// All positional arguments
+# All positional arguments
 result = foo(4, 3, 9);
 ```
 

--- a/jac/examples/reference/lambda_expressions.md
+++ b/jac/examples/reference/lambda_expressions.md
@@ -12,7 +12,7 @@ lambda parameters : expression
 The provided example demonstrates basic lambda creation and invocation:
 ```jac
 x = lambda a: int, b: int : b + a;
-print(x(5, 4));  // Outputs: 9
+print(x(5, 4));  # Outputs: 9
 ```
 
 **Components breakdown:**
@@ -44,9 +44,9 @@ concat = lambda s1: str, s2: str : s1 + s2;
 
 Lambda return types are automatically inferred from the expression:
 ```jac
-lambda x: int : x * 2        // Returns int
-lambda x: float : x / 2.0    // Returns float
-lambda x: str : x.upper()    // Returns str
+lambda x: int : x * 2        # Returns int
+lambda x: float : x / 2.0    # Returns float
+lambda x: str : x.upper()    # Returns str
 ```
 
 **Functional Programming Patterns**
@@ -75,21 +75,21 @@ Lambda expressions are limited to single expressions:
 
 **Valid lambdas:**
 ```jac
-lambda x: int : x + 1                    // Arithmetic
-lambda x: int : x if x > 0 else -x       // Conditional expression  
-lambda pair: tuple : pair[0] + pair[1]   // Tuple access
-lambda obj: MyClass : obj.method()       // Method calls
+lambda x: int : x + 1                    # Arithmetic
+lambda x: int : x if x > 0 else -x       # Conditional expression  
+lambda pair: tuple : pair[0] + pair[1]   # Tuple access
+lambda obj: MyClass : obj.method()       # Method calls
 ```
 
 **Invalid lambdas (require full functions):**
 ```jac
-// Multiple statements not allowed
+# Multiple statements not allowed
 lambda x: int : {
     y = x * 2;
     return y + 1;
 }
 
-// Loops not allowed
+# Loops not allowed
 lambda items: list : for item in items { process(item); }
 ```
 
@@ -99,7 +99,7 @@ Lambdas can capture variables from their enclosing scope:
 ```jac
 multiplier = 3;
 triple = lambda x: int : x * multiplier;
-print(triple(5));  // Outputs: 15
+print(triple(5));  # Outputs: 15
 ```
 
 **Closure behavior:**

--- a/jac/examples/reference/match_statements.md
+++ b/jac/examples/reference/match_statements.md
@@ -5,9 +5,9 @@ Match statements provide powerful pattern matching capabilities in Jac, enabling
 ```jac
 match expression {
     case pattern: 
-        // statements
+        # statements
     case pattern if condition:
-        // guarded pattern statements
+        # guarded pattern statements
 }
 ```
 

--- a/jac/examples/reference/raise_statements.md
+++ b/jac/examples/reference/raise_statements.md
@@ -4,9 +4,9 @@ Raise statements in Jac provide the mechanism for explicitly throwing exceptions
 
 Raise statements follow this pattern from the grammar:
 ```jac
-raise exception_expression;           // Raise specific exception
-raise;                               // Re-raise current exception (in except block)
-raise exception_expression from cause; // Raise with explicit cause chain
+raise exception_expression;           # Raise specific exception
+raise;                               # Re-raise current exception (in except block)
+raise exception_expression from cause; # Raise with explicit cause chain
 ```
 
 **Example Implementation**
@@ -80,7 +80,7 @@ def process_data(data: list) {
     if len(data) == 0 {
         raise ValueError("Data cannot be empty");
     }
-    // Process data
+    # Process data
 }
 ```
 
@@ -105,7 +105,7 @@ def sensitive_operation() {
         risky_function();
     } except Exception as e {
         log_error("Operation failed", e);
-        raise;  // Re-raise the same exception
+        raise;  # Re-raise the same exception
     }
 }
 ```
@@ -160,7 +160,7 @@ def process_file(filename: str) {
     if not file_exists(filename) {
         raise FileNotFoundError("File does not exist");
     }
-    // Process file
+    # Process file
 }
 ```
 
@@ -270,7 +270,7 @@ def parse_config(config_data: str) {
 
 **Optimization Strategies**
 ```jac
-// Efficient: Check before expensive operation
+# Efficient: Check before expensive operation
 def safe_operation(data: list) {
     if not validate_data(data) {
         raise ValidationError("Invalid data");
@@ -278,7 +278,7 @@ def safe_operation(data: list) {
     return expensive_operation(data);
 }
 
-// Less efficient: Exception in expensive operation
+# Less efficient: Exception in expensive operation
 def unsafe_operation(data: list) {
     try {
         return expensive_operation(data);
@@ -356,7 +356,7 @@ def test_division_by_zero() {
         result = divide(10, 0);
         assert false, "Expected ZeroDivisionError";
     } except ZeroDivisionError {
-        // Test passes - expected exception
+        # Test passes - expected exception
         pass;
     }
 }

--- a/jac/examples/reference/return_statements.md
+++ b/jac/examples/reference/return_statements.md
@@ -4,8 +4,8 @@ Return statements in Jac provide the mechanism for functions and methods to exit
 
 Return statements follow this pattern from the grammar:
 ```jac
-return expression;  // Return a value
-return;             // Return without a value (void)
+return expression;  # Return a value
+return;             # Return without a value (void)
 ```
 
 **Example Implementation**
@@ -37,7 +37,7 @@ def calculate(x: int, y: int) -> int {
 **Expression Returns**
 ```jac
 def add(a: int, b: int) -> int {
-    return a + b;  // Return expression directly
+    return a + b;  # Return expression directly
 }
 ```
 
@@ -55,7 +55,7 @@ def absolute(x: int) -> int {
 ```jac
 def print_message(msg: str) {
     print(msg);
-    return;  // Optional - function ends here
+    return;  # Optional - function ends here
 }
 ```
 
@@ -67,12 +67,12 @@ Return statements enable early function exit:
 ```jac
 def process_data(data: list) -> bool {
     if data is None {
-        return false;  // Early exit for invalid input
+        return false;  # Early exit for invalid input
     }
     if len(data) == 0 {
-        return false;  // Early exit for empty data
+        return false;  # Early exit for empty data
     }
-    // Main processing logic
+    # Main processing logic
     return process(data);
 }
 ```
@@ -81,7 +81,7 @@ def process_data(data: list) -> bool {
 ```jac
 def divide(a: float, b: float) -> float {
     if b == 0.0 {
-        return float('inf');  // Early return for division by zero
+        return float('inf');  # Early return for division by zero
     }
     return a / b;
 }
@@ -111,10 +111,10 @@ def grade_score(score: int) -> str {
 def search_array(arr: list, target: int) -> int {
     for i=0 to i<len(arr) by i+=1 {
         if arr[i] == target {
-            return i;  // Return index when found
+            return i;  # Return index when found
         }
     }
-    return -1;  // Return -1 when not found
+    return -1;  # Return -1 when not found
 }
 ```
 
@@ -125,15 +125,15 @@ Jac enforces return type consistency:
 **Type Matching**
 ```jac
 def get_name() -> str {
-    return "John";     // Valid: string literal
-    // return 42;      // Error: int doesn't match str
+    return "John";     # Valid: string literal
+    # return 42;      # Error: int doesn't match str
 }
 ```
 
 **Multiple Value Returns**
 ```jac
 def get_coordinates() -> (int, int) {
-    return (10, 20);   // Return tuple
+    return (10, 20);   # Return tuple
 }
 
 def get_stats() -> dict {
@@ -148,7 +148,7 @@ def find_user(id: int) -> User? {
     if user.exists {
         return user;
     }
-    return None;       // Explicit null return
+    return None;       # Explicit null return
 }
 ```
 
@@ -175,7 +175,7 @@ walker DataCollector {
 
 **Lambda Returns**
 ```jac
-square = lambda x: int : x * x;  // Implicit return
+square = lambda x: int : x * x;  # Implicit return
 ```
 
 **Data Spatial Context Returns**
@@ -202,7 +202,7 @@ node DataNode {
         if visitor.has_permission {
             return self.value;
         }
-        return 0;  // Default value for unauthorized access
+        return 0;  # Default value for unauthorized access
     }
 }
 ```
@@ -218,9 +218,9 @@ node DataNode {
 ```jac
 def complex_function(x: int) -> str {
     if x > 0 {
-        return "positive";  // Exits entire function
+        return "positive";  # Exits entire function
     }
-    // This code executes only if x <= 0
+    # This code executes only if x <= 0
     return "non-positive";
 }
 ```
@@ -230,10 +230,10 @@ def complex_function(x: int) -> str {
 def find_first_even(numbers: list) -> int {
     for num in numbers {
         if num % 2 == 0 {
-            return num;     // Exits function and loop
+            return num;     # Exits function and loop
         }
     }
-    return -1;  // No even number found
+    return -1;  # No even number found
 }
 ```
 
@@ -243,9 +243,9 @@ def find_first_even(numbers: list) -> int {
 ```jac
 def expensive_computation(data: list) -> bool {
     if len(data) == 0 {
-        return false;      // Avoid expensive computation
+        return false;      # Avoid expensive computation
     }
-    // Expensive processing only if needed
+    # Expensive processing only if needed
     return process_data(data);
 }
 ```
@@ -254,7 +254,7 @@ def expensive_computation(data: list) -> bool {
 ```jac
 def validate_and_process(input: str) -> str {
     if not is_valid(input) {
-        return "Invalid input";  // Skip processing
+        return "Invalid input";  # Skip processing
     }
     return expensive_process(input);
 }
@@ -283,7 +283,7 @@ def calculate_tax(income: float) -> float {
     if income <= 0 {
         return 0.0;
     }
-    // Single calculation responsibility
+    # Single calculation responsibility
     return income * TAX_RATE;
 }
 ```
@@ -334,7 +334,7 @@ def risky_operation() -> int {
         return result;
     } except OperationError as e {
         log_error(e);
-        return -1;  // Error indicator
+        return -1;  # Error indicator
     }
 }
 ```

--- a/jac/examples/reference/tests.md
+++ b/jac/examples/reference/tests.md
@@ -4,11 +4,11 @@ Tests in Jac provide built-in support for unit testing and validation of code fu
 
 ```jac
 test {
-    // test code
+    # test code
 }
 
 test "descriptive test name" {
-    // named test code
+    # named test code
 }
 ```
 

--- a/jac/examples/reference/try_statements.md
+++ b/jac/examples/reference/try_statements.md
@@ -4,15 +4,15 @@ Try statements provide exception handling mechanisms in Jac, enabling robust err
 
 ```jac
 try {
-    // code that may raise exceptions
+    # code that may raise exceptions
 } except ExceptionType as e {
-    // handle specific exception
+    # handle specific exception
 } except {
-    // handle any exception
+    # handle any exception
 } else {
-    // executed if no exception occurs
+    # executed if no exception occurs
 } finally {
-    // always executed
+    # always executed
 }
 ```
 

--- a/jac/examples/reference/while_statements.md
+++ b/jac/examples/reference/while_statements.md
@@ -5,7 +5,7 @@ While statements in Jac provide iterative execution based on conditional express
 While statements follow this pattern from the grammar:
 ```jac
 while condition {
-    // code block
+    # code block
 }
 ```
 
@@ -51,7 +51,7 @@ While loops typically require explicit management of control variables:
 count = 0;
 while count < 10 {
     process_item(count);
-    count += 1;  // Manual increment required
+    count += 1;  # Manual increment required
 }
 ```
 
@@ -116,7 +116,7 @@ While loops require careful design to avoid infinite loops:
 attempts = 0;
 max_attempts = 100;
 while condition and attempts < max_attempts {
-    // loop body
+    # loop body
     attempts += 1;
 }
 ```
@@ -127,7 +127,7 @@ previous_value = initial_value;
 while not converged {
     current_value = compute_next();
     if current_value == previous_value {
-        break;  // Prevent infinite loop
+        break;  # Prevent infinite loop
     }
     previous_value = current_value;
 }
@@ -142,7 +142,7 @@ While loops work with control flow statements:
 while true {
     input = get_input();
     if input == "exit" {
-        break;  // Exit loop immediately
+        break;  # Exit loop immediately
     }
     process(input);
 }
@@ -154,7 +154,7 @@ i = 0;
 while i < 10 {
     i += 1;
     if i % 2 == 0 {
-        continue;  // Skip even numbers
+        continue;  # Skip even numbers
     }
     print(i);
 }
@@ -245,15 +245,15 @@ while queue.has_items() {
 
 **Loop Optimization**
 ```jac
-// Less efficient
+# Less efficient
 while expensive_function() < threshold {
-    // loop body
+    # loop body
 }
 
-// More efficient
+# More efficient
 limit = expensive_function();
 while counter < limit {
-    // loop body
+    # loop body
     counter += 1;
 }
 ```
@@ -283,10 +283,10 @@ while has_work() {
         task.execute();
     } except TaskError as e {
         log_error(e);
-        continue;  // Skip failed task, continue with next
+        continue;  # Skip failed task, continue with next
     } except CriticalError as e {
         log_critical(e);
-        break;     // Exit loop on critical error
+        break;     # Exit loop on critical error
     }
 }
 ```

--- a/jac/examples/reference/yield_statements.md
+++ b/jac/examples/reference/yield_statements.md
@@ -4,9 +4,9 @@ Yield statements in Jac provide the foundation for generator functions and itera
 
 Yield statements follow this pattern from the grammar:
 ```jac
-yield expression;     // Yield a value
-yield;               // Yield nothing (None/null)
-yield from iterable; // Yield all values from another iterable
+yield expression;     # Yield a value
+yield;               # Yield nothing (None/null)
+yield from iterable; # Yield all values from another iterable
 ```
 
 **Generator Function Example**
@@ -31,9 +31,9 @@ def myFunc {
 
 Generators are consumed through iteration:
 ```jac
-x = myFunc();        // Creates generator object
-for z in x {         // Iterates through yielded values
-    print(z);        // Prints: "Hello", 91, "Good Bye", None
+x = myFunc();        # Creates generator object
+for z in x {         # Iterates through yielded values
+    print(z);        # Prints: "Hello", 91, "Good Bye", None
 }
 ```
 
@@ -78,7 +78,7 @@ def data_generator {
 ```jac
 def sparse_generator {
     yield 1;
-    yield;        // Yields None/null
+    yield;        # Yields None/null
     yield 3;
 }
 ```
@@ -96,17 +96,17 @@ def sub_generator {
 
 def main_generator {
     yield 0;
-    yield from sub_generator();  // Yields 1, then 2
+    yield from sub_generator();  # Yields 1, then 2
     yield 3;
 }
-// Result sequence: 0, 1, 2, 3
+# Result sequence: 0, 1, 2, 3
 ```
 
 **Collection Delegation**
 ```jac
 def list_generator {
-    yield from [1, 2, 3];      // Yields each list element
-    yield from "abc";          // Yields each character
+    yield from [1, 2, 3];      # Yields each list element
+    yield from "abc";          # Yields each character
 }
 ```
 
@@ -120,7 +120,7 @@ def counter(start: int, end: int) {
     current = start;
     while current <= end {
         yield current;
-        current += 1;           // State persists between yields
+        current += 1;           # State persists between yields
     }
 }
 ```
@@ -132,7 +132,7 @@ def accumulator {
     values = [1, 2, 3, 4, 5];
     for value in values {
         total += value;
-        yield total;            // Yields running sum: 1, 3, 6, 10, 15
+        yield total;            # Yields running sum: 1, 3, 6, 10, 15
     }
 }
 ```
@@ -189,7 +189,7 @@ def batch_generator(data: list, batch_size: int) {
         }
     }
     if len(batch) > 0 {
-        yield batch;  // Final partial batch
+        yield batch;  # Final partial batch
     }
 }
 ```
@@ -257,14 +257,14 @@ node DataSource {
 
 **Memory Efficiency**
 ```jac
-// Memory efficient - generates values on demand
+# Memory efficient - generates values on demand
 def large_sequence {
     for i in range(1000000) {
         yield expensive_computation(i);
     }
 }
 
-// vs. Memory intensive - creates entire list
+# vs. Memory intensive - creates entire list
 def large_list {
     return [expensive_computation(i) for i in range(1000000)];
 }
@@ -331,7 +331,7 @@ def resource_generator {
             yield resource.next_item();
         }
     } finally {
-        resource.release();  // Cleanup when generator is destroyed
+        resource.release();  # Cleanup when generator is destroyed
     }
 }
 ```


### PR DESCRIPTION
## Summary
- correct comment syntax in reference Markdown files

## Testing
- `pre-commit run --files jac/examples/reference/check_statements.md jac/examples/reference/context_managers.md jac/examples/reference/control_statements.md jac/examples/reference/data_spatial_spawn_expressions.md jac/examples/reference/data_spatial_typed_context_blocks.md jac/examples/reference/disengage_statements.md jac/examples/reference/free_code.md jac/examples/reference/function_calls.md jac/examples/reference/lambda_expressions.md jac/examples/reference/match_statements.md jac/examples/reference/raise_statements.md jac/examples/reference/return_statements.md jac/examples/reference/tests.md jac/examples/reference/try_statements.md jac/examples/reference/while_statements.md jac/examples/reference/yield_statements.md` *(fails: couldn't fetch pre-commit hooks)*