### PR TITLE
Jac-playground printgraph issue is fixed

### DIFF
--- a/docs/docs/playground/python/debugger.py
+++ b/docs/docs/playground/python/debugger.py
@@ -37,7 +37,7 @@ class Debugger(bdb.Bdb):
 
     def _send_graph(self) -> None:
         try:
-            graph_str = self.runeval("printgraph(as_json=True)")
+            graph_str = self.runeval("printgraph(format='json')")
             self.cb_graph(graph_str)
         except Exception as e:
             pass

--- a/docs/docs/playground/python/extract_jaclang.py
+++ b/docs/docs/playground/python/extract_jaclang.py
@@ -1,9 +1,8 @@
-import shutil
 import zipfile
-import os
+import sys
 
 with zipfile.ZipFile("/jaclang.zip", "r") as zip_ref:
     zip_ref.extractall("/jaclang")
 
-os.sys.path.append("/jaclang")
+sys.path.append("/jaclang")
 print("JacLang files loaded!")

--- a/docs/docs/playground/python/main_playground.py
+++ b/docs/docs/playground/python/main_playground.py
@@ -23,7 +23,7 @@ class JsIO(io.StringIO):
         self.callback(s)
         super().write(s)
 
-    def writelines(self, lines: Iterable[str], /) -> None:
+    def writelines(self, lines, /) -> None:
         for line in lines:
             self.callback(line)
         super().writelines(lines)


### PR DESCRIPTION
Updated the `user_line` method to use `format='json'` instead of `as_json=True` for better consistency with the `printgraph` function's expected parameters.