### PR TITLE
Refactor FuncCall params to sequence

### DIFF
--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -28,7 +28,7 @@ def extract_params(
     include_info = []
     exclude_info = []
     if body.params:
-        for param in body.params.items:
+        for param in body.params:
             if isinstance(param, uni.KWPair) and isinstance(param.key, uni.Name):
                 key = param.key.value
                 value = param.value
@@ -570,7 +570,7 @@ class JacMachine:
                 keywords=[],
             )
         )
-        if node.params and node.params.items:
+        if node.params:
             inputs = [
                 _pass.sync(
                     ast3.Tuple(
@@ -655,7 +655,7 @@ class JacMachine:
                         ctx=ast3.Load(),
                     )
                 )
-                for kw_pair in node.params.items
+                for kw_pair in node.params
                 if isinstance(kw_pair, uni.KWPair)
             ]
         else:

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1925,13 +1925,13 @@ class JacParser(Transform[uni.Source, uni.Module]):
             genai_call: uni.FuncCall | None = None
             target = self.consume(uni.Expr)
             self.consume_token(Tok.LPAREN)
-            params = self.match(uni.SubNodeList)
+            params_sn = self.match(uni.SubNodeList)
             if self.match_token(Tok.KW_BY):
                 genai_call = self.consume(uni.FuncCall)
             self.consume_token(Tok.RPAREN)
             return uni.FuncCall(
                 target=target,
-                params=params,
+                params=params_sn.items if params_sn else [],
                 genai_call=genai_call,
                 kid=self.cur_nodes,
             )

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1012,17 +1012,18 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             if isinstance(i, uni.KWPair):
                 params_in.append(i)
         if len(params_in) != 0:
-            params_in2 = uni.SubNodeList[uni.Expr | uni.KWPair](
+            params_sn = uni.SubNodeList[uni.Expr | uni.KWPair](
                 items=params_in, delim=Tok.COMMA, kid=params_in
             )
+            kids = [func, params_sn]
         else:
-            params_in2 = None
+            kids = [func]
         if isinstance(func, uni.Expr):
             return uni.FuncCall(
                 target=func,
-                params=params_in2,
+                params=params_in,
                 genai_call=None,
-                kid=[func, params_in2] if params_in2 else [func],
+                kid=kids,
             )
         else:
             raise self.ice()

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -335,25 +335,8 @@ class DocIRGenPass(UniPass):
     def exit_func_call(self, node: uni.FuncCall) -> None:
         """Generate DocIR for function calls."""
         parts: list[doc.DocType] = []
-        skip_params = False
         for i in node.kid:
-            if isinstance(i, uni.Token) and i.name == Tok.LPAREN and node.params:
-                parts.append(i.gen.doc_ir)
-                if node.params.items:
-                    parts.append(
-                        self.indent(
-                            self.concat([self.tight_line(), node.params.gen.doc_ir])
-                        )
-                    )
-                    parts.append(self.tight_line())
-                    skip_params = True
-                else:
-                    skip_params = False
-            elif i == node.params:
-                if not skip_params:
-                    parts.append(i.gen.doc_ir)
-            else:
-                parts.append(i.gen.doc_ir)
+            parts.append(i.gen.doc_ir)
         node.gen.doc_ir = self.group(self.concat(parts))
 
     def exit_atom_trailer(self, node: uni.AtomTrailer) -> None:

--- a/jac/jaclang/runtimelib/utils.py
+++ b/jac/jaclang/runtimelib/utils.py
@@ -133,7 +133,7 @@ def extract_params(
     include_info = []
     exclude_info = []
     if body.params:
-        for param in body.params.items:
+        for param in body.params:
             if isinstance(param, uni.KWPair) and isinstance(param.key, uni.Name):
                 key = param.key.value
                 value = param.value


### PR DESCRIPTION
## Summary
- change `FuncCall.params` from optional SubNodeList to a plain sequence
- update parser and pyast loader to build new sequence-based param lists
- adjust generator passes and utilities to work with sequences
- simplify DocIR generator's handling of function calls
- update mtllm plugin and runtime utils for new API

## Testing
- `source scripts/check.sh` *(fails: could not fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683a2a5b6ea08322b26baf987b7c7b95