### PR TITLE
Refactor FilterCompr parameter

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -2645,10 +2645,10 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 self.consume_token(Tok.RPAREN)
                 return f_type
             self.consume_token(Tok.NULL_OK)
-            compares = self.consume(uni.SubNodeList)
+            compares_sn = self.consume(uni.SubNodeList)
             self.consume_token(Tok.RPAREN)
             return uni.FilterCompr(
-                compares=compares,
+                compares=compares_sn.items,
                 f_type=None,
                 kid=self.cur_nodes,
             )
@@ -2677,11 +2677,15 @@ class JacParser(Transform[uni.Source, uni.Module]):
 
             typed_filter_compare_list: expression (COLON filter_compare_list)?
             """
-            compares: uni.SubNodeList | None = None
+            compares_sn: uni.SubNodeList | None = None
             expr = self.consume(uni.Expr)
             if self.match_token(Tok.COLON):
-                compares = self.consume(uni.SubNodeList)
-            return uni.FilterCompr(compares=compares, f_type=expr, kid=self.cur_nodes)
+                compares_sn = self.consume(uni.SubNodeList)
+            return uni.FilterCompr(
+                compares=compares_sn.items if compares_sn else [],
+                f_type=expr,
+                kid=self.cur_nodes,
+            )
 
         def filter_compare_item(self, _: None) -> uni.CompareExpr:
             """Grammar rule.

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -2982,7 +2982,7 @@ class PyastGenPass(UniPass):
                 ),
                 jac_node=x,
             )
-            for x in (node.compares.items if node.compares else [])
+            for x in node.compares
             if isinstance(x.gen.py_ast[0], ast3.Compare)
             and isinstance(x.gen.py_ast[0].left, ast3.Name)
         )

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -3783,11 +3783,11 @@ class FilterCompr(AtomExpr):
     def __init__(
         self,
         f_type: Optional[Expr],
-        compares: Optional[SubNodeList[CompareExpr]],
+        compares: Sequence[CompareExpr],
         kid: Sequence[UniNode],
     ) -> None:
         self.f_type = f_type
-        self.compares = compares
+        self.compares = list(compares)
         UniNode.__init__(self, kid=kid)
         Expr.__init__(self)
         AstSymbolStubNode.__init__(self, sym_type=SymbolType.SEQUENCE)
@@ -3796,7 +3796,8 @@ class FilterCompr(AtomExpr):
         res = True
         if deep:
             res = self.f_type.normalize(deep) if self.f_type else res
-            res = res and self.compares.normalize(deep) if self.compares else res
+            for comp in self.compares:
+                res = res and comp.normalize(deep)
         new_kid: list[UniNode] = []
         if not isinstance(self.parent, EdgeOpRef):
             new_kid.append(self.gen_token(Tok.LPAREN))
@@ -3808,7 +3809,10 @@ class FilterCompr(AtomExpr):
         if self.compares:
             if self.f_type:
                 new_kid.append(self.gen_token(Tok.COLON))
-            new_kid.append(self.compares)
+            for i, comp in enumerate(self.compares):
+                new_kid.append(comp)
+                if i < len(self.compares) - 1:
+                    new_kid.append(self.gen_token(Tok.COMMA))
         if not isinstance(self.parent, EdgeOpRef):
             new_kid.append(self.gen_token(Tok.RPAREN))
         self.set_kids(nodes=new_kid)


### PR DESCRIPTION
## Summary
- change `FilterCompr` compares to use `Sequence[CompareExpr]`
- adapt parser to return lists instead of `SubNodeList`
- update Python AST generator for new field

## Testing
- `pre-commit` *(fails: unable to access remote pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683a2b0998948322a6189eaf055f820e