### PR TITLE
Refactor value containers to use sequences

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1949,14 +1949,14 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 index = self.consume(uni.ListVal)
                 if not index.values:
                     raise self.ice()
-                if len(index.values.items) == 1:
-                    expr = index.values.items[0] if index.values else None
+                if len(index.values) == 1:
+                    expr = index.values[0]
                     kid = self.cur_nodes
                 else:
                     sublist = uni.SubNodeList[uni.Expr | uni.KWPair](
-                        items=[*index.values.items], delim=Tok.COMMA, kid=index.kid
+                        items=[*index.values], delim=Tok.COMMA, kid=index.kid
                     )
-                    expr = uni.TupleVal(values=sublist, kid=[sublist])
+                    expr = uni.TupleVal(values=list(index.values), kid=index.kid)
                     kid = [expr]
                 return uni.IndexSlice(
                     slices=[uni.IndexSlice.Slice(start=expr, stop=None, step=None)],
@@ -2119,7 +2119,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.match_token(Tok.COMMA)
             self.consume_token(Tok.RSQUARE)
             return uni.ListVal(
-                values=values,
+                values=values.items if values else None,
                 kid=self.cur_nodes,
             )
 
@@ -2132,7 +2132,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             target = self.match(uni.SubNodeList)
             self.consume_token(Tok.RPAREN)
             return uni.TupleVal(
-                values=target,
+                values=target.items if target else None,
                 kid=self.cur_nodes,
             )
 
@@ -2146,7 +2146,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.match_token(Tok.COMMA)
             self.match_token(Tok.RBRACE)
             return uni.SetVal(
-                values=expr_list,
+                values=expr_list.items if expr_list else None,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -2097,7 +2097,11 @@ class PyastGenPass(UniPass):
             func_node = uni.FuncCall(
                 target=node.right,
                 params=(
-                    node.left.values
+                    uni.SubNodeList(
+                        items=list(node.left.values),
+                        delim=Tok.COMMA,
+                        kid=list(node.left.values),
+                    )
                     if isinstance(node.left, uni.TupleVal)
                     else uni.SubNodeList(
                         items=[node.left], delim=Tok.COMMA, kid=[node.left]
@@ -2129,7 +2133,11 @@ class PyastGenPass(UniPass):
             func_node = uni.FuncCall(
                 target=node.left,
                 params=(
-                    node.right.values
+                    uni.SubNodeList(
+                        items=list(node.right.values),
+                        delim=Tok.COMMA,
+                        kid=list(node.right.values),
+                    )
                     if isinstance(node.right, uni.TupleVal)
                     else uni.SubNodeList(
                         items=[node.right], delim=Tok.COMMA, kid=[node.right]
@@ -2344,7 +2352,7 @@ class PyastGenPass(UniPass):
                 self.sync(
                     ast3.List(
                         elts=(
-                            cast(list[ast3.expr], node.values.gen.py_ast)
+                            [cast(ast3.expr, v.gen.py_ast[0]) for v in node.values]
                             if node.values
                             else []
                         ),
@@ -2357,8 +2365,8 @@ class PyastGenPass(UniPass):
                 self.sync(
                     ast3.List(
                         elts=(
-                            [cast(ast3.expr, item) for item in node.values.gen.py_ast]
-                            if node.values and node.values.gen.py_ast
+                            [cast(ast3.expr, item.gen.py_ast[0]) for item in node.values]
+                            if node.values
                             else []
                         ),
                         ctx=cast(ast3.expr_context, node.py_ctx_func()),
@@ -2371,7 +2379,7 @@ class PyastGenPass(UniPass):
             self.sync(
                 ast3.Set(
                     elts=(
-                        [cast(ast3.expr, i) for i in node.values.gen.py_ast]
+                        [cast(ast3.expr, i.gen.py_ast[0]) for i in node.values]
                         if node.values
                         else []
                     ),
@@ -2384,7 +2392,7 @@ class PyastGenPass(UniPass):
             self.sync(
                 ast3.Tuple(
                     elts=(
-                        cast(list[ast3.expr], node.values.gen.py_ast)
+                        [cast(ast3.expr, v.gen.py_ast[0]) for v in node.values]
                         if node.values
                         else []
                     ),

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -410,7 +410,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         target_1 = (
             valid_exprs[0]
             if len(valid_exprs) > 1
-            else uni.TupleVal(values=target, kid=[target])
+            else uni.TupleVal(values=target.items, kid=target.kid)
         )
         return uni.DeleteStmt(
             target=target_1,
@@ -1555,13 +1555,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         l_square = self.operator(Tok.LSQUARE, "[")
         r_square = self.operator(Tok.RSQUARE, "]")
         return uni.ListVal(
-            values=(
-                uni.SubNodeList[uni.Expr](
-                    items=valid_elts, delim=Tok.COMMA, kid=valid_elts
-                )
-                if valid_elts
-                else None
-            ),
+            values=valid_elts if valid_elts else None,
             kid=[*valid_elts] if valid_elts else [l_square, r_square],
         )
 
@@ -1931,9 +1925,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             valid = [i for i in elts if isinstance(i, (uni.Expr))]
             if len(valid) != len(elts):
                 raise self.ice("Length mismatch in set body")
-            valid_elts = uni.SubNodeList[uni.Expr](
-                items=valid, delim=Tok.COMMA, kid=valid
-            )
+            valid_elts = valid
             kid: list[uni.UniNode] = [*valid]
         else:
             valid_elts = None
@@ -2024,7 +2016,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         ):
 
             slices: list[uni.IndexSlice.Slice] = []
-            for index_slice in slice.values.items:
+            for index_slice in slice.values:
                 if not isinstance(index_slice, uni.IndexSlice):
                     raise self.ice()
                 slices.append(index_slice.slices[0])
@@ -2148,9 +2140,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             valid = [i for i in elts if isinstance(i, (uni.Expr, uni.KWPair))]
             if len(elts) != len(valid):
                 raise self.ice("Length mismatch in tuple elts")
-            valid_elts = uni.SubNodeList[uni.Expr | uni.KWPair](
-                items=valid, delim=Tok.COMMA, kid=valid
-            )
+            valid_elts = valid
             kid = elts
         else:
             l_paren = self.operator(Tok.LPAREN, "(")

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -471,7 +471,7 @@ class UniScopeNode(UniNode):
                     if isinstance(item.operand, AstSymbolNode):
                         item.operand.name_spec.py_ctx_func = ast3.Store
                 elif isinstance(item, (TupleVal, ListVal)):
-                    for i in item.values.items if item.values else []:
+                    for i in item.values if item.values else []:
                         if isinstance(i, AstSymbolNode):
                             i.name_spec.py_ctx_func = ast3.Store
                         elif isinstance(i, AtomTrailer):
@@ -2548,7 +2548,7 @@ class DeleteStmt(CodeBlockStmt):
     def py_ast_targets(self) -> list[ast3.AST]:
         """Get Python AST targets (without setting ctx)."""
         return (
-            self.target.values.gen.py_ast
+            [t.gen.py_ast[0] for t in self.target.values]
             if isinstance(self.target, TupleVal) and self.target.values
             else self.target.gen.py_ast
         )
@@ -3088,23 +3088,25 @@ class ListVal(AtomExpr):
 
     def __init__(
         self,
-        values: Optional[SubNodeList[Expr]],
+        values: Optional[Sequence[Expr]],
         kid: Sequence[UniNode],
     ) -> None:
-        self.values = values
+        self.values = list(values) if values is not None else None
         UniNode.__init__(self, kid=kid)
         Expr.__init__(self)
         AstSymbolStubNode.__init__(self, sym_type=SymbolType.SEQUENCE)
 
     def normalize(self, deep: bool = False) -> bool:
         res = True
-        if deep:
-            res = self.values.normalize(deep) if self.values else res
-        new_kid: list[UniNode] = [
-            self.gen_token(Tok.LSQUARE),
-        ]
+        if deep and self.values:
+            for val in self.values:
+                res = res and val.normalize(deep)
+        new_kid: list[UniNode] = [self.gen_token(Tok.LSQUARE)]
         if self.values:
-            new_kid.append(self.values)
+            for i, val in enumerate(self.values):
+                new_kid.append(val)
+                if i < len(self.values) - 1:
+                    new_kid.append(self.gen_token(Tok.COMMA))
         new_kid.append(self.gen_token(Tok.RSQUARE))
         self.set_kids(nodes=new_kid)
         return res
@@ -3115,23 +3117,25 @@ class SetVal(AtomExpr):
 
     def __init__(
         self,
-        values: Optional[SubNodeList[Expr]],
+        values: Optional[Sequence[Expr]],
         kid: Sequence[UniNode],
     ) -> None:
-        self.values = values
+        self.values = list(values) if values is not None else None
         UniNode.__init__(self, kid=kid)
         Expr.__init__(self)
         AstSymbolStubNode.__init__(self, sym_type=SymbolType.SEQUENCE)
 
     def normalize(self, deep: bool = False) -> bool:
         res = True
-        if deep:
-            res = self.values.normalize(deep) if self.values else res
-        new_kid: list[UniNode] = [
-            self.gen_token(Tok.LBRACE),
-        ]
+        if deep and self.values:
+            for val in self.values:
+                res = res and val.normalize(deep)
+        new_kid: list[UniNode] = [self.gen_token(Tok.LBRACE)]
         if self.values:
-            new_kid.append(self.values)
+            for i, val in enumerate(self.values):
+                new_kid.append(val)
+                if i < len(self.values) - 1:
+                    new_kid.append(self.gen_token(Tok.COMMA))
         new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
@@ -3142,18 +3146,19 @@ class TupleVal(AtomExpr):
 
     def __init__(
         self,
-        values: Optional[SubNodeList[Expr | KWPair]],
+        values: Optional[Sequence[Expr | KWPair]],
         kid: Sequence[UniNode],
     ) -> None:
-        self.values = values
+        self.values = list(values) if values is not None else None
         UniNode.__init__(self, kid=kid)
         Expr.__init__(self)
         AstSymbolStubNode.__init__(self, sym_type=SymbolType.SEQUENCE)
 
     def normalize(self, deep: bool = False) -> bool:
         res = True
-        if deep:
-            res = self.values.normalize(deep) if self.values else res
+        if deep and self.values:
+            for val in self.values:
+                res = res and val.normalize(deep)
         in_ret_type = (
             self.parent
             and isinstance(self.parent, IndexSlice)
@@ -3170,8 +3175,11 @@ class TupleVal(AtomExpr):
             else []
         )
         if self.values:
-            new_kid.append(self.values)
-            if len(self.values.items) < 2:
+            for i, val in enumerate(self.values):
+                new_kid.append(val)
+                if i < len(self.values) - 1:
+                    new_kid.append(self.gen_token(Tok.COMMA))
+            if len(self.values) < 2:
                 new_kid.append(self.gen_token(Tok.COMMA))
         if not in_ret_type:
             new_kid.append(self.gen_token(Tok.RPAREN))

--- a/jac/jaclang/runtimelib/utils.py
+++ b/jac/jaclang/runtimelib/utils.py
@@ -153,7 +153,7 @@ def extract_params(
                         )
                         include_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)
@@ -175,7 +175,7 @@ def extract_params(
                         )
                         exclude_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)


### PR DESCRIPTION
## Summary
- store sequence of values for `TupleVal`, `SetVal` and `ListVal`
- adjust parser and AST generation for new container types
- update runtime utils to iterate over sequences
- update python AST generation logic

## Testing
- `pre-commit` *(fails: unable to access network)*
- `python -m py_compile jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py jac/jaclang/runtimelib/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683a2bcb36108322bdda92e1af0ad8d2