### PR TITLE
Switch tuple/list/set values to sequences

### DIFF
--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -48,7 +48,7 @@ def extract_params(
                         )
                         include_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)
@@ -70,7 +70,7 @@ def extract_params(
                         )
                         exclude_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1949,14 +1949,11 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 index = self.consume(uni.ListVal)
                 if not index.values:
                     raise self.ice()
-                if len(index.values.items) == 1:
-                    expr = index.values.items[0] if index.values else None
+                if len(index.values) == 1:
+                    expr = index.values[0]
                     kid = self.cur_nodes
                 else:
-                    sublist = uni.SubNodeList[uni.Expr | uni.KWPair](
-                        items=[*index.values.items], delim=Tok.COMMA, kid=index.kid
-                    )
-                    expr = uni.TupleVal(values=sublist, kid=[sublist])
+                    expr = uni.TupleVal(values=index.values, kid=index.kid)
                     kid = [expr]
                 return uni.IndexSlice(
                     slices=[uni.IndexSlice.Slice(start=expr, stop=None, step=None)],
@@ -2115,11 +2112,11 @@ class JacParser(Transform[uni.Source, uni.Module]):
             list_val: LSQUARE (expr_list COMMA?)? RSQUARE
             """
             self.consume_token(Tok.LSQUARE)
-            values = self.match(uni.SubNodeList)
+            values_sn = self.match(uni.SubNodeList)
             self.match_token(Tok.COMMA)
             self.consume_token(Tok.RSQUARE)
             return uni.ListVal(
-                values=values,
+                values=values_sn.items if values_sn else None,
                 kid=self.cur_nodes,
             )
 
@@ -2129,10 +2126,10 @@ class JacParser(Transform[uni.Source, uni.Module]):
             tuple_val: LPAREN tuple_list? RPAREN
             """
             self.consume_token(Tok.LPAREN)
-            target = self.match(uni.SubNodeList)
+            target_sn = self.match(uni.SubNodeList)
             self.consume_token(Tok.RPAREN)
             return uni.TupleVal(
-                values=target,
+                values=target_sn.items if target_sn else None,
                 kid=self.cur_nodes,
             )
 
@@ -2142,11 +2139,11 @@ class JacParser(Transform[uni.Source, uni.Module]):
             set_val: LBRACE expr_list COMMA? RBRACE
             """
             self.match_token(Tok.LBRACE)
-            expr_list = self.match(uni.SubNodeList)
+            expr_list_sn = self.match(uni.SubNodeList)
             self.match_token(Tok.COMMA)
             self.match_token(Tok.RBRACE)
             return uni.SetVal(
-                values=expr_list,
+                values=expr_list_sn.items if expr_list_sn else None,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -404,17 +404,15 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_exprs = [expr for expr in exprs if isinstance(expr, uni.Expr)]
         if not len(valid_exprs) or len(valid_exprs) != len(exprs):
             raise self.ice("Length mismatch in delete targets")
-        target = uni.SubNodeList[uni.Expr | uni.KWPair](
-            items=[*valid_exprs], delim=Tok.COMMA, kid=exprs
-        )
+        target = valid_exprs
         target_1 = (
             valid_exprs[0]
             if len(valid_exprs) > 1
-            else uni.TupleVal(values=target, kid=[target])
+            else uni.TupleVal(values=valid_exprs, kid=exprs)
         )
         return uni.DeleteStmt(
             target=target_1,
-            kid=[target],
+            kid=exprs,
         )
 
     def proc_assign(self, node: py_ast.Assign) -> uni.Assignment:
@@ -1555,13 +1553,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         l_square = self.operator(Tok.LSQUARE, "[")
         r_square = self.operator(Tok.RSQUARE, "]")
         return uni.ListVal(
-            values=(
-                uni.SubNodeList[uni.Expr](
-                    items=valid_elts, delim=Tok.COMMA, kid=valid_elts
-                )
-                if valid_elts
-                else None
-            ),
+            values=valid_elts if valid_elts else None,
             kid=[*valid_elts] if valid_elts else [l_square, r_square],
         )
 
@@ -1931,9 +1923,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             valid = [i for i in elts if isinstance(i, (uni.Expr))]
             if len(valid) != len(elts):
                 raise self.ice("Length mismatch in set body")
-            valid_elts = uni.SubNodeList[uni.Expr](
-                items=valid, delim=Tok.COMMA, kid=valid
-            )
+            valid_elts = valid
             kid: list[uni.UniNode] = [*valid]
         else:
             valid_elts = None
@@ -2024,7 +2014,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         ):
 
             slices: list[uni.IndexSlice.Slice] = []
-            for index_slice in slice.values.items:
+            for index_slice in slice.values:
                 if not isinstance(index_slice, uni.IndexSlice):
                     raise self.ice()
                 slices.append(index_slice.slices[0])
@@ -2148,9 +2138,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             valid = [i for i in elts if isinstance(i, (uni.Expr, uni.KWPair))]
             if len(elts) != len(valid):
                 raise self.ice("Length mismatch in tuple elts")
-            valid_elts = uni.SubNodeList[uni.Expr | uni.KWPair](
-                items=valid, delim=Tok.COMMA, kid=valid
-            )
+            valid_elts = valid
             kid = elts
         else:
             l_paren = self.operator(Tok.LPAREN, "(")

--- a/jac/jaclang/runtimelib/utils.py
+++ b/jac/jaclang/runtimelib/utils.py
@@ -153,7 +153,7 @@ def extract_params(
                         )
                         include_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)
@@ -175,7 +175,7 @@ def extract_params(
                         )
                         exclude_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)


### PR DESCRIPTION
## Summary
- refactor `TupleVal`, `ListVal` and `SetVal` to store `Sequence` values
- adjust parser to pass `Sequence` instead of `SubNodeList`
- update passes and utilities for new value types

## Testing
- `pre-commit run --all-files` *(fails: unable to access network)*

------
https://chatgpt.com/codex/tasks/task_e_683a3196f0f48322bf2a18246fa9a538