### PR TITLE
Update SetVal and ListVal to use sequences

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1949,12 +1949,12 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 index = self.consume(uni.ListVal)
                 if not index.values:
                     raise self.ice()
-                if len(index.values.items) == 1:
-                    expr = index.values.items[0] if index.values else None
+                if len(index.values) == 1:
+                    expr = index.values[0]
                     kid = self.cur_nodes
                 else:
                     sublist = uni.SubNodeList[uni.Expr | uni.KWPair](
-                        items=[*index.values.items], delim=Tok.COMMA, kid=index.kid
+                        items=[*index.values], delim=Tok.COMMA, kid=index.kid
                     )
                     expr = uni.TupleVal(values=sublist, kid=[sublist])
                     kid = [expr]
@@ -2115,9 +2115,10 @@ class JacParser(Transform[uni.Source, uni.Module]):
             list_val: LSQUARE (expr_list COMMA?)? RSQUARE
             """
             self.consume_token(Tok.LSQUARE)
-            values = self.match(uni.SubNodeList)
+            values_node = self.match(uni.SubNodeList)
             self.match_token(Tok.COMMA)
             self.consume_token(Tok.RSQUARE)
+            values = values_node.items if values_node else []
             return uni.ListVal(
                 values=values,
                 kid=self.cur_nodes,
@@ -2145,8 +2146,9 @@ class JacParser(Transform[uni.Source, uni.Module]):
             expr_list = self.match(uni.SubNodeList)
             self.match_token(Tok.COMMA)
             self.match_token(Tok.RBRACE)
+            values = expr_list.items if expr_list else []
             return uni.SetVal(
-                values=expr_list,
+                values=values,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -2332,45 +2332,17 @@ class PyastGenPass(UniPass):
         )
 
     def exit_list_val(self, node: uni.ListVal) -> None:
-        if isinstance(node.py_ctx_func(), ast3.Load):
-            node.gen.py_ast = [
-                self.sync(
-                    ast3.List(
-                        elts=(
-                            cast(list[ast3.expr], node.values.gen.py_ast)
-                            if node.values
-                            else []
-                        ),
-                        ctx=ast3.Load(),
-                    )
-                )
-            ]
-        else:
-            node.gen.py_ast = [
-                self.sync(
-                    ast3.List(
-                        elts=(
-                            [cast(ast3.expr, item) for item in node.values.gen.py_ast]
-                            if node.values and node.values.gen.py_ast
-                            else []
-                        ),
-                        ctx=cast(ast3.expr_context, node.py_ctx_func()),
-                    )
-                )
-            ]
+        elts = [cast(ast3.expr, v.gen.py_ast[0]) for v in node.values]
+        ctx = (
+            ast3.Load()
+            if isinstance(node.py_ctx_func(), ast3.Load)
+            else cast(ast3.expr_context, node.py_ctx_func())
+        )
+        node.gen.py_ast = [self.sync(ast3.List(elts=elts, ctx=ctx))]
 
     def exit_set_val(self, node: uni.SetVal) -> None:
-        node.gen.py_ast = [
-            self.sync(
-                ast3.Set(
-                    elts=(
-                        [cast(ast3.expr, i) for i in node.values.gen.py_ast]
-                        if node.values
-                        else []
-                    ),
-                )
-            )
-        ]
+        elts = [cast(ast3.expr, i.gen.py_ast[0]) for i in node.values]
+        node.gen.py_ast = [self.sync(ast3.Set(elts=elts))]
 
     def exit_tuple_val(self, node: uni.TupleVal) -> None:
         node.gen.py_ast = [

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1556,13 +1556,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         l_square = self.operator(Tok.LSQUARE, "[")
         r_square = self.operator(Tok.RSQUARE, "]")
         return uni.ListVal(
-            values=(
-                uni.SubNodeList[uni.Expr](
-                    items=valid_elts, delim=Tok.COMMA, kid=valid_elts
-                )
-                if valid_elts
-                else None
-            ),
+            values=valid_elts,
             kid=[*valid_elts] if valid_elts else [l_square, r_square],
         )
 
@@ -1932,16 +1926,13 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             valid = [i for i in elts if isinstance(i, (uni.Expr))]
             if len(valid) != len(elts):
                 raise self.ice("Length mismatch in set body")
-            valid_elts = uni.SubNodeList[uni.Expr](
-                items=valid, delim=Tok.COMMA, kid=valid
-            )
             kid: list[uni.UniNode] = [*valid]
         else:
-            valid_elts = None
+            valid = []
             l_brace = self.operator(Tok.LBRACE, "{")
             r_brace = self.operator(Tok.RBRACE, "}")
             kid = [l_brace, r_brace]
-        return uni.SetVal(values=valid_elts, kid=kid)
+        return uni.SetVal(values=valid, kid=kid)
 
     def proc_set_comp(self, node: py_ast.SetComp) -> uni.ListCompr:
         """Process python node.

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -491,12 +491,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for set values."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if isinstance(i, uni.Token):
-                parts.append(i.gen.doc_ir)
-            elif isinstance(i, uni.SubNodeList):
-                parts.append(self.if_break(self.line(), self.space()))
-                parts.append(i.gen.doc_ir)
-                parts.append(self.if_break(self.line(), self.space()))
+            parts.append(i.gen.doc_ir)
 
         node.gen.doc_ir = self.group(self.concat(parts))
 


### PR DESCRIPTION
## Summary
- refactor `ListVal` and `SetVal` AST nodes to store sequences of expressions
- parse list and set literals as simple lists
- adjust normalization and generation logic for new value type
- update doc IR generation for sets
- update parsing of slice indices

## Testing
- `pre-commit run --all-files` *(fails: unable to access internet)*
- `pytest -q` *(fails: ModuleNotFoundError: 'dotenv', 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_683a5d063e2083228aa58deb00d207e1