### PR TITLE
Refactor TupleVal values to sequence

### DIFF
--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -48,7 +48,7 @@ def extract_params(
                         )
                         include_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)
@@ -70,7 +70,7 @@ def extract_params(
                         )
                         exclude_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)
@@ -289,8 +289,14 @@ class JacMachine:
                 else []
             )
             # Use the ability name as action, and if docstring exists, append it
-            docstr =  ((node.doc and node.doc.lit_value) or "") if isinstance(node, uni.AstDocNode) else ""
-            action = _pass.sync(ast3.Constant(value=f"{docstr.strip()} ({node.name_ref.sym_name})\n"))
+            docstr = (
+                ((node.doc and node.doc.lit_value) or "")
+                if isinstance(node, uni.AstDocNode)
+                else ""
+            )
+            action = _pass.sync(
+                ast3.Constant(value=f"{docstr.strip()} ({node.name_ref.sym_name})\n")
+            )
             return [
                 _pass.sync(
                     ast3.Return(

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1956,7 +1956,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     sublist = uni.SubNodeList[uni.Expr | uni.KWPair](
                         items=[*index.values.items], delim=Tok.COMMA, kid=index.kid
                     )
-                    expr = uni.TupleVal(values=sublist, kid=[sublist])
+                    expr = uni.TupleVal(values=sublist.items, kid=[sublist])
                     kid = [expr]
                 return uni.IndexSlice(
                     slices=[uni.IndexSlice.Slice(start=expr, stop=None, step=None)],
@@ -2132,7 +2132,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             target = self.match(uni.SubNodeList)
             self.consume_token(Tok.RPAREN)
             return uni.TupleVal(
-                values=target,
+                values=target.items if target else [],
                 kid=self.cur_nodes,
             )
 
@@ -2554,9 +2554,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else:
                 self.consume_token(Tok.CARROW_R)
             conn_assign = (
-                uni.AssignCompr(
-                    assigns=conn_assign_sub.items, kid=[conn_assign_sub]
-                )
+                uni.AssignCompr(assigns=conn_assign_sub.items, kid=[conn_assign_sub])
                 if conn_assign_sub
                 else None
             )
@@ -2587,9 +2585,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else:
                 self.consume_token(Tok.CARROW_L)
             conn_assign = (
-                uni.AssignCompr(
-                    assigns=conn_assign_sub.items, kid=[conn_assign_sub]
-                )
+                uni.AssignCompr(assigns=conn_assign_sub.items, kid=[conn_assign_sub])
                 if conn_assign_sub
                 else None
             )
@@ -2620,9 +2616,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else:
                 self.consume_token(Tok.CARROW_BI)
             conn_assign = (
-                uni.AssignCompr(
-                    assigns=conn_assign_sub.items, kid=[conn_assign_sub]
-                )
+                uni.AssignCompr(assigns=conn_assign_sub.items, kid=[conn_assign_sub])
                 if conn_assign_sub
                 else None
             )

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -2094,7 +2094,7 @@ class PyastGenPass(UniPass):
             func_node = uni.FuncCall(
                 target=node.right,
                 params=(
-                    node.left.values.items
+                    list(node.left.values)
                     if isinstance(node.left, uni.TupleVal) and node.left.values
                     else [node.left]
                 ),
@@ -2124,7 +2124,7 @@ class PyastGenPass(UniPass):
             func_node = uni.FuncCall(
                 target=node.left,
                 params=(
-                    node.right.values.items
+                    list(node.right.values)
                     if isinstance(node.right, uni.TupleVal) and node.right.values
                     else [node.right]
                 ),
@@ -2376,11 +2376,7 @@ class PyastGenPass(UniPass):
         node.gen.py_ast = [
             self.sync(
                 ast3.Tuple(
-                    elts=(
-                        cast(list[ast3.expr], node.values.gen.py_ast)
-                        if node.values
-                        else []
-                    ),
+                    elts=[cast(ast3.expr, i.gen.py_ast[0]) for i in node.values],
                     ctx=cast(ast3.expr_context, node.py_ctx_func()),
                 )
             )

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -410,7 +410,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         target_1 = (
             valid_exprs[0]
             if len(valid_exprs) > 1
-            else uni.TupleVal(values=target, kid=[target])
+            else uni.TupleVal(values=target.items, kid=[target])
         )
         return uni.DeleteStmt(
             target=target_1,
@@ -2021,11 +2021,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         if (
             not isinstance(slice, uni.IndexSlice)
             and isinstance(slice, uni.TupleVal)
-            and slice.values is not None
+            and slice.values
         ):
 
             slices: list[uni.IndexSlice.Slice] = []
-            for index_slice in slice.values.items:
+            for index_slice in slice.values:
                 if not isinstance(index_slice, uni.IndexSlice):
                     raise self.ice()
                 slices.append(index_slice.slices[0])
@@ -2146,17 +2146,14 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         """
         elts = [self.convert(elt) for elt in node.elts]
         if len(node.elts) != 0:
-            valid = [i for i in elts if isinstance(i, (uni.Expr, uni.KWPair))]
-            if len(elts) != len(valid):
+            valid_elts = [i for i in elts if isinstance(i, (uni.Expr, uni.KWPair))]
+            if len(elts) != len(valid_elts):
                 raise self.ice("Length mismatch in tuple elts")
-            valid_elts = uni.SubNodeList[uni.Expr | uni.KWPair](
-                items=valid, delim=Tok.COMMA, kid=valid
-            )
             kid = elts
         else:
             l_paren = self.operator(Tok.LPAREN, "(")
             r_paren = self.operator(Tok.RPAREN, ")")
-            valid_elts = None
+            valid_elts = []
             kid = [l_paren, r_paren]
         return uni.TupleVal(values=valid_elts, kid=kid)
 

--- a/jac/jaclang/runtimelib/utils.py
+++ b/jac/jaclang/runtimelib/utils.py
@@ -153,7 +153,7 @@ def extract_params(
                         )
                         include_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)
@@ -175,7 +175,7 @@ def extract_params(
                         )
                         exclude_info.append((var_name, value.gen.py_ast[0]))
                     elif isinstance(value, uni.TupleVal) and value.values:
-                        for i in value.values.items:
+                        for i in value.values:
                             var_name = (
                                 i.right.value
                                 if isinstance(i, uni.AtomTrailer)


### PR DESCRIPTION
## Summary
- change `TupleVal.values` from `Optional[SubNodeList]` to `Sequence`
- update normalization logic and tuple handling
- adjust parser and load/gen passes for new type
- fix runtime utils and plugin handling

## Testing
- `black --check jac-mtllm/mtllm/plugin.py jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py jac/jaclang/runtimelib/utils.py`
- `flake8 jac-mtllm/mtllm/plugin.py jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py jac/jaclang/runtimelib/utils.py` *(fails: command not found)*
- `mypy jac-mtllm/mtllm/plugin.py jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py jac/jaclang/runtimelib/utils.py` *(fails: see log)*
- `source scripts/check.sh` *(fails: cannot fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683a5d8d9e2883228836983258d88e38