### PR TITLE
Switch Test.body to sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -321,7 +321,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             codeblock = self.consume(uni.SubNodeList)
             return uni.Test(
                 name=name,
-                body=codeblock,
+                body=codeblock.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1096,7 +1096,7 @@ class Test(AstSymbolNode, ElementStmt, UniScopeNode):
     def __init__(
         self,
         name: Name | Token,
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
     ) -> None:
@@ -1139,14 +1139,18 @@ class Test(AstSymbolNode, ElementStmt, UniScopeNode):
         res = True
         if deep:
             res = self.name.normalize(deep)
-            res = res and self.body.normalize(deep)
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
             res = res and self.doc.normalize(deep) if self.doc else res
         new_kid: list[UniNode] = []
         if self.doc:
             new_kid.append(self.doc)
         new_kid.append(self.gen_token(Tok.KW_TEST))
         new_kid.append(self.name)
-        new_kid.append(self.body)
+        new_kid.append(self.gen_token(Tok.LBRACE))
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- update `Test` AST node body type to `Sequence[CodeBlockStmt]`
- adapt parser to pass sequence of statements
- update normalization for `Test`
- handle sequences in `resolve_stmt_block`
- adjust PyAST generation for test module location

## Testing
- `source scripts/check.sh` *(fails: cannot fetch pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683a7011e8cc8322a22cf7dcc00495c9