### PR TITLE
Change SubNodeList Expr fields to Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -508,7 +508,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             is_async = self.match_token(Tok.KW_ASYNC)
             if decorators is not None:
                 archspec = self.consume(uni.ArchSpec)
-                archspec.decorators = decorators
+                archspec.decorators = decorators.items
                 archspec.add_kids_left([decorators])
             else:
                 archspec = self.match(uni.ArchSpec) or self.consume(uni.Enum)
@@ -541,10 +541,18 @@ class JacParser(Transform[uni.Source, uni.Module]):
             assert isinstance(valid_tail, (uni.SubNodeList, uni.FuncCall))
 
             impl = uni.ImplDef(
-                decorators=decorators,
+                decorators=decorators.items if decorators else None,
                 target=target,
-                spec=valid_spec,
-                body=valid_tail,
+                spec=(
+                    valid_spec.items
+                    if isinstance(valid_spec, uni.SubNodeList)
+                    else valid_spec
+                ),
+                body=(
+                    valid_tail.items
+                    if isinstance(valid_tail, uni.SubNodeList)
+                    else valid_tail
+                ),
                 kid=self.cur_nodes,
             )
             return impl
@@ -598,7 +606,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 arch_type=arch_type,
                 name=name,
                 access=access,
-                base_classes=inh,
+                base_classes=inh.items if inh else None,
                 body=body,
                 kid=self.cur_nodes,
             )
@@ -668,7 +676,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             """
             if decorator := self.match(uni.SubNodeList):
                 enum_decl = self.consume(uni.Enum)
-                enum_decl.decorators = decorator
+                enum_decl.decorators = decorator.items
                 enum_decl.add_kids_left([decorator])
                 return enum_decl
             return self.consume(uni.Enum)
@@ -691,7 +699,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             return uni.Enum(
                 name=name,
                 access=access,
-                base_classes=inh,
+                base_classes=inh.items if inh else None,
                 body=body,
                 kid=self.cur_nodes,
             )
@@ -751,7 +759,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                                 ability.insert_kids_at_pos([static_kw], 1)
                         break
                 if decorators.items:
-                    ability.decorators = decorators
+                    ability.decorators = decorators.items
                     ability.add_kids_left([decorators])
 
             return ability
@@ -1525,7 +1533,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             kid.insert(1, new_targ) if is_frozen else kid.insert(0, new_targ)
             if is_aug:
                 return uni.Assignment(
-                    target=new_targ,
+                    target=new_targ.items,
                     type_tag=type_tag,
                     value=value,
                     mutable=is_frozen,
@@ -1533,7 +1541,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     kid=kid,
                 )
             return uni.Assignment(
-                target=new_targ,
+                target=new_targ.items,
                 type_tag=type_tag,
                 value=value,
                 mutable=is_frozen,
@@ -2412,7 +2420,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     items=[name_consume], delim=Tok.EQ, kid=[name_consume]
                 )
                 return uni.Assignment(
-                    target=target, value=None, type_tag=None, kid=[target]
+                    target=target.items, value=None, type_tag=None, kid=[target]
                 )
 
             if consume := self.match(uni.SubNodeList):

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -806,12 +806,16 @@ class PyastGenPass(UniPass):
             )
 
         decorators = (
-            node.decorators.gen.py_ast
-            if isinstance(node.decorators, uni.SubNodeList)
+            [d.gen.py_ast[0] for d in node.decorators]
+            if node.decorators
             else []
         )
 
-        base_classes = node.base_classes.gen.py_ast if node.base_classes else []
+        base_classes = (
+            [b.gen.py_ast[0] for b in node.base_classes]
+            if node.base_classes
+            else []
+        )
         if node.arch_type.name != Tok.KW_CLASS:
             base_classes.append(self.jaclib_obj(node.arch_type.value.capitalize()))
 
@@ -844,11 +848,15 @@ class PyastGenPass(UniPass):
             doc=node.doc,
         )
         decorators = (
-            node.decorators.gen.py_ast
-            if isinstance(node.decorators, uni.SubNodeList)
+            [d.gen.py_ast[0] for d in node.decorators]
+            if node.decorators
             else []
         )
-        base_classes = node.base_classes.gen.py_ast if node.base_classes else []
+        base_classes = (
+            [b.gen.py_ast[0] for b in node.base_classes]
+            if node.base_classes
+            else []
+        )
         if isinstance(base_classes, list):
             base_classes.append(self.sync(ast3.Name(id="Enum", ctx=ast3.Load())))
         else:
@@ -922,7 +930,11 @@ class PyastGenPass(UniPass):
                 f"Abstract ability {node.sym_name} should not have a body.",
                 node,
             )
-        decorator_list = node.decorators.gen.py_ast if node.decorators else []
+        decorator_list = (
+            [d.gen.py_ast[0] for d in node.decorators]
+            if node.decorators
+            else []
+        )
         if isinstance(node.signature, uni.EventSignature):
             decorator_list.append(
                 self.jaclib_obj(

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -435,7 +435,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             raise self.ice("Length mismatch in assignment targets")
         if isinstance(value, uni.Expr):
             return uni.Assignment(
-                target=valid_targets,
+                target=valid_targets.items,
                 value=value,
                 type_tag=None,
                 kid=[valid_targets, value],
@@ -468,7 +468,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 items=[target], delim=Tok.COMMA, kid=[target]
             )
             return uni.Assignment(
-                target=targ,
+                target=targ.items,
                 type_tag=None,
                 mutable=True,
                 aug_op=op,
@@ -504,7 +504,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 items=[target], delim=Tok.EQ, kid=[target]
             )
             return uni.Assignment(
-                target=target,
+                target=target.items,
                 value=value if isinstance(value, (uni.Expr, uni.YieldExpr)) else None,
                 type_tag=annotation_subtag,
                 kid=(

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -180,7 +180,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for archetypes."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if i == node.doc or (node.decorators and i in node.decorators):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name:
@@ -199,7 +199,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for abilities."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if i == node.doc or (node.decorators and i in node.decorators):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name_ref:
@@ -1022,7 +1022,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for enum declarations."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if i == node.doc or (node.decorators and i in node.decorators):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif isinstance(i, uni.Token) and i.name == Tok.SEMI:
@@ -1109,7 +1109,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for implementation definitions."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if i == node.doc or (node.decorators and i in node.decorators):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.target:


### PR DESCRIPTION
## Summary
- replace `SubNodeList[Expr]` typed fields with `Sequence[Expr]`
- adapt parser to provide lists instead of `SubNodeList`
- update normalization and codegen passes for new Sequence types
- tweak doc IR generation to handle decorator sequences
- adjust pyast load paths to map Python AST into new types

## Testing
- `pre-commit` *(fails: unable to access pre-commit hooks in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_683a6fb030b083228f8dc6eddc715221