### PR TITLE
refactor: use sequence for withstmt exprs

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1274,11 +1274,11 @@ class JacParser(Transform[uni.Source, uni.Module]):
             """
             is_async = bool(self.match_token(Tok.KW_ASYNC))
             self.consume_token(Tok.KW_WITH)
-            exprs = self.consume(uni.SubNodeList)
+            exprs_node = self.consume(uni.SubNodeList)
             body = self.consume(uni.SubNodeList)
             return uni.WithStmt(
                 is_async=is_async,
-                exprs=exprs,
+                exprs=exprs_node.items,
                 body=body,
                 kid=self.cur_nodes,
             )

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1432,7 +1432,10 @@ class PyastGenPass(UniPass):
         node.gen.py_ast = [
             self.sync(
                 with_node(
-                    items=[cast(ast3.withitem, item) for item in node.exprs.gen.py_ast],
+                    items=[
+                        cast(ast3.withitem, item.gen.py_ast[0])
+                        for item in node.exprs
+                    ],
                     body=[
                         cast(ast3.stmt, stmt)
                         for stmt in self.resolve_stmt_block(node.body)

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -733,9 +733,6 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_items = [item for item in items if isinstance(item, uni.ExprAsItem)]
         if len(valid_items) != len(items):
             raise self.ice("Length mismatch in with items")
-        items_sub = uni.SubNodeList[uni.ExprAsItem](
-            items=valid_items, delim=Tok.COMMA, kid=items
-        )
         body = [self.convert(stmt) for stmt in node.body]
         valid_body = [stmt for stmt in body if isinstance(stmt, uni.CodeBlockStmt)]
         if len(valid_body) != len(body):
@@ -748,7 +745,10 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             right_enc=self.operator(Tok.RBRACE, "}"),
         )
         return uni.WithStmt(
-            is_async=False, exprs=items_sub, body=body_sub, kid=[items_sub, body_sub]
+            is_async=False,
+            exprs=valid_items,
+            body=body_sub,
+            kid=[*valid_items, body_sub],
         )
 
     def proc_async_with(self, node: py_ast.AsyncWith) -> uni.WithStmt:
@@ -763,9 +763,6 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_items = [item for item in items if isinstance(item, uni.ExprAsItem)]
         if len(valid_items) != len(items):
             raise self.ice("Length mismatch in with items")
-        items_sub = uni.SubNodeList[uni.ExprAsItem](
-            items=valid_items, delim=Tok.COMMA, kid=items
-        )
         body = [self.convert(stmt) for stmt in node.body]
         valid_body = [stmt for stmt in body if isinstance(stmt, uni.CodeBlockStmt)]
         if len(valid_body) != len(body):
@@ -778,7 +775,10 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             right_enc=self.operator(Tok.RBRACE, "}"),
         )
         return uni.WithStmt(
-            is_async=True, exprs=items_sub, body=body_sub, kid=[items_sub, body_sub]
+            is_async=True,
+            exprs=valid_items,
+            body=body_sub,
+            kid=[*valid_items, body_sub],
         )
 
     def proc_raise(self, node: py_ast.Raise) -> uni.RaiseStmt:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2377,7 +2377,7 @@ class WithStmt(AstAsyncNode, CodeBlockStmt, UniScopeNode):
     def __init__(
         self,
         is_async: bool,
-        exprs: SubNodeList[ExprAsItem],
+        exprs: Sequence[ExprAsItem],
         body: SubNodeList[CodeBlockStmt],
         kid: Sequence[UniNode],
     ) -> None:
@@ -2391,13 +2391,17 @@ class WithStmt(AstAsyncNode, CodeBlockStmt, UniScopeNode):
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.exprs.normalize(deep)
+            for item in self.exprs:
+                res = res and item.normalize(deep)
             res = res and self.body.normalize(deep)
         new_kid: list[UniNode] = []
         if self.is_async:
             new_kid.append(self.gen_token(Tok.KW_ASYNC))
         new_kid.append(self.gen_token(Tok.KW_WITH))
-        new_kid.append(self.exprs)
+        for idx, item in enumerate(self.exprs):
+            new_kid.append(item)
+            if idx < len(self.exprs) - 1:
+                new_kid.append(self.gen_token(Tok.COMMA))
         new_kid.append(self.body)
         self.set_kids(nodes=new_kid)
         return res

--- a/jac/jaclang/utils/tests/test_lang_tools.py
+++ b/jac/jaclang/utils/tests/test_lang_tools.py
@@ -21,7 +21,7 @@ class JacAstToolTests(TestCase):
         out = self.tool.pass_template()
         self.assertIn("target: Expr,", out)
         self.assertIn("self, node: ast.ReturnStmt", out)
-        self.assertIn("exprs: SubNodeList[ExprAsItem],", out)
+        self.assertIn("exprs: Sequence[ExprAsItem],", out)
         self.assertIn("value: str,", out)
         self.assertIn("def exit_module(self, node: ast.Module)", out)
         self.assertGreater(out.count("def exit_"), 20)


### PR DESCRIPTION
## Summary
- update WithStmt.exprs type to `Sequence[ExprAsItem]`
- adjust parser, unitree normalize, and passes for sequence
- update AstTool tests for new type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dotenv, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_683ae2eacd208322be1185d9cae82019