### PR TITLE
refactor: use sequence for modulecode body

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -338,7 +338,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             codeblock = self.consume(uni.SubNodeList)
             return uni.ModuleCode(
                 name=name,
-                body=codeblock,
+                body=codeblock.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -71,7 +71,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             )
             return uni.ModuleCode(
                 name=None,
-                body=with_entry_subnodelist,
+                body=with_entry_body,
                 kid=[with_entry_subnodelist],
                 doc=None,
             )

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1161,7 +1161,7 @@ class ModuleCode(ElementStmt, ArchBlockStmt, EnumBlockStmt):
     def __init__(
         self,
         name: Optional[Name],
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
     ) -> None:
@@ -1174,7 +1174,8 @@ class ModuleCode(ElementStmt, ArchBlockStmt, EnumBlockStmt):
         res = True
         if deep:
             res = self.name.normalize(deep) if self.name else res
-            res = res and self.body.normalize(deep)
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
             res = res and self.doc.normalize(deep) if self.doc else res
         new_kid: list[UniNode] = []
         if self.doc:
@@ -1184,7 +1185,10 @@ class ModuleCode(ElementStmt, ArchBlockStmt, EnumBlockStmt):
         if self.name:
             new_kid.append(self.gen_token(Tok.COLON))
             new_kid.append(self.name)
-        new_kid.append(self.body)
+        new_kid.append(self.gen_token(Tok.LBRACE))
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- update ModuleCode to store body as `Sequence[CodeBlockStmt]`
- adjust parser and pyast load pass for new body type

## Testing
- `pre-commit run --all-files` *(fails: unable to access github.com)*
- `bash scripts/tests.sh` *(fails: No module named 'jac_cloud')*

------
https://chatgpt.com/codex/tasks/task_e_683ae907d54c8322858ade4200d1356c