### PR TITLE
Update ModulePath.path to Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -446,7 +446,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             valid_path = self.consume(uni.SubNodeList)
             alias = self.consume(uni.Name) if self.match_token(Tok.KW_AS) else None
             return uni.ModulePath(
-                path=valid_path,
+                path=valid_path.items,
                 level=0,
                 alias=alias,
                 kid=self.cur_nodes,

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1397,9 +1397,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             ):
                 paths.append(
                     uni.ModulePath(
-                        path=uni.SubNodeList[uni.Name](
-                            items=[name.expr], delim=Tok.DOT, kid=[name.expr]
-                        ),
+                        path=[name.expr],
                         level=0,
                         alias=name.alias,
                         kid=[i for i in name.kid if i],
@@ -1408,12 +1406,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             # Need to unravel atom trailers
             else:
                 raise self.ice()
-        items = uni.SubNodeList[uni.ModulePath](items=paths, delim=Tok.COMMA, kid=paths)
         ret = uni.Import(
             from_loc=None,
-            items=items.items,
+            items=paths,
             is_absorb=False,
-            kid=[items],
+            kid=paths,
         )
         return ret
 
@@ -1455,11 +1452,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         moddots = [self.operator(Tok.DOT, ".") for _ in range(node.level)]
         modparts = moddots + modpaths
         path = uni.ModulePath(
-            path=(
-                uni.SubNodeList[uni.Name](items=modpaths, delim=Tok.DOT, kid=modpaths)
-                if modpaths
-                else None
-            ),
+            path=modpaths if modpaths else None,
             level=node.level,
             alias=None,
             kid=modparts,
@@ -1482,32 +1475,23 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 )
             else:
                 raise self.ice()
-        items = (
-            uni.SubNodeList[uni.ModuleItem](
-                items=valid_names, delim=Tok.COMMA, kid=valid_names
-            )
-            if valid_names
-            else None
-        )
+        items = valid_names
         if not items:
             raise self.ice("No valid names in import from")
         pytag = uni.SubTag[uni.Name](tag=lang, kid=[lang])
         if len(node.names) == 1 and node.names[0].name == "*":
-            path_in = uni.SubNodeList[uni.ModulePath](
-                items=[path], delim=Tok.COMMA, kid=[path]
-            )
             ret = uni.Import(
                 from_loc=None,
-                items=path_in.items,
+                items=[path],
                 is_absorb=True,
-                kid=[pytag, path_in],
+                kid=[pytag, path],
             )
             return ret
         ret = uni.Import(
             from_loc=path,
-            items=items.items,
+            items=items,
             is_absorb=False,
-            kid=[pytag, path, items],
+            kid=[pytag, path, *items],
         )
         return ret
 

--- a/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
+++ b/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
@@ -75,12 +75,12 @@ class SymTabBuildPass(UniPass):
     def exit_module_path(self, node: uni.ModulePath) -> None:
         if node.alias:
             node.alias.sym_tab.def_insert(node.alias, single_decl="import")
-        elif node.path and isinstance(node.path.items[0], uni.Name):
+        elif node.path and isinstance(node.path[0], uni.Name):
             if node.parent_of_type(uni.Import) and not (
                 node.parent_of_type(uni.Import).from_loc
                 and node.parent_of_type(uni.Import).is_jac
             ):
-                node.path.items[0].sym_tab.def_insert(node.path.items[0])
+                node.path[0].sym_tab.def_insert(node.path[0])
         else:
             pass  # Need to support pythonic import symbols with dots in it
 

--- a/jac/jaclang/utils/tests/test_lang_tools.py
+++ b/jac/jaclang/utils/tests/test_lang_tools.py
@@ -22,6 +22,7 @@ class JacAstToolTests(TestCase):
         self.assertIn("target: Expr,", out)
         self.assertIn("self, node: ast.ReturnStmt", out)
         self.assertIn("exprs: Sequence[ExprAsItem],", out)
+        self.assertIn("path: Optional[Sequence[Name]],", out)
         self.assertIn("value: str,", out)
         self.assertIn("def exit_module(self, node: ast.Module)", out)
         self.assertGreater(out.count("def exit_"), 20)


### PR DESCRIPTION
## Summary
- refactor ModulePath.path to be a Sequence of names
- adjust parser and loaders for sequence field
- update symbol table build logic
- extend pass template test for new field

## Testing
- `pytest -q jac/jaclang/utils/tests/test_lang_tools.py::JacAstToolTests::test_pass_template`
- `pre-commit run --files jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/passes/main/sym_tab_build_pass.py jac/jaclang/compiler/unitree.py jac/jaclang/utils/tests/test_lang_tools.py` *(fails: unable to access network)*

------
https://chatgpt.com/codex/tasks/task_e_683ae91d7154832299a36f49598efcfd