### PR TITLE
Refactor Archetype base_classes handling

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -598,7 +598,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 arch_type=arch_type,
                 name=name,
                 access=access,
-                base_classes=inh,
+                base_classes=inh.items if inh else [],
                 body=body,
                 kid=self.cur_nodes,
             )
@@ -691,7 +691,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             return uni.Enum(
                 name=name,
                 access=access,
-                base_classes=inh,
+                base_classes=inh.items if inh else [],
                 body=body,
                 kid=self.cur_nodes,
             )

--- a/jac/jaclang/compiler/passes/main/inheritance_pass.py
+++ b/jac/jaclang/compiler/passes/main/inheritance_pass.py
@@ -36,11 +36,11 @@ class InheritancePass(Transform[uni.Module, uni.Module]):
 
     def process_archetype_inheritance(self, node: uni.Archetype) -> None:
         """Fill archetype symbol tables with abilities from parent archetypes."""
-        if node.base_classes is None:
+        if not node.base_classes:
             return
 
         self.cur_node = node
-        for item in node.base_classes.items:
+        for item in node.base_classes:
             # Handle different types of base class references
             if isinstance(item, uni.Name):
                 self.inherit_from_name(node, item)

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -241,14 +241,20 @@ class PyastGenPass(UniPass):
         )
         valid_stmts = [i for i in items if not isinstance(i, uni.Semi)]
         ret: list[ast3.AST] = (
-            [self.sync(ast3.Pass(), node if isinstance(node, uni.SubNodeList) else None)]
+            [
+                self.sync(
+                    ast3.Pass(), node if isinstance(node, uni.SubNodeList) else None
+                )
+            ]
             if isinstance(node, uni.SubNodeList) and not valid_stmts
             else (
-                self.flatten([
-                    x.gen.py_ast
-                    for x in valid_stmts
-                    if not isinstance(x, uni.ImplDef)
-                ])
+                self.flatten(
+                    [
+                        x.gen.py_ast
+                        for x in valid_stmts
+                        if not isinstance(x, uni.ImplDef)
+                    ]
+                )
                 if node is not None
                 else []
             )
@@ -821,7 +827,7 @@ class PyastGenPass(UniPass):
             else []
         )
 
-        base_classes = node.base_classes.gen.py_ast if node.base_classes else []
+        base_classes = [cast(ast3.expr, i.gen.py_ast[0]) for i in node.base_classes]
         if node.arch_type.name != Tok.KW_CLASS:
             base_classes.append(self.jaclib_obj(node.arch_type.value.capitalize()))
 
@@ -858,11 +864,8 @@ class PyastGenPass(UniPass):
             if isinstance(node.decorators, uni.SubNodeList)
             else []
         )
-        base_classes = node.base_classes.gen.py_ast if node.base_classes else []
-        if isinstance(base_classes, list):
-            base_classes.append(self.sync(ast3.Name(id="Enum", ctx=ast3.Load())))
-        else:
-            raise self.ice()
+        base_classes = [cast(ast3.expr, i.gen.py_ast[0]) for i in node.base_classes]
+        base_classes.append(self.sync(ast3.Name(id="Enum", ctx=ast3.Load())))
         node.gen.py_ast = [
             self.sync(
                 ast3.ClassDef(
@@ -1441,8 +1444,7 @@ class PyastGenPass(UniPass):
             self.sync(
                 with_node(
                     items=[
-                        cast(ast3.withitem, item.gen.py_ast[0])
-                        for item in node.exprs
+                        cast(ast3.withitem, item.gen.py_ast[0]) for item in node.exprs
                     ],
                     body=[
                         cast(ast3.stmt, stmt)

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -340,13 +340,6 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         base_classes: list[uni.Expr] = [
             base for base in converted_base_classes if isinstance(base, uni.Expr)
         ]
-        valid_bases = (
-            uni.SubNodeList[uni.Expr](
-                items=base_classes, delim=Tok.COMMA, kid=base_classes
-            )
-            if base_classes
-            else None
-        )
         converted_decorators_list = [self.convert(i) for i in node.decorator_list]
         decorators = [i for i in converted_decorators_list if isinstance(i, uni.Expr)]
         valid_decorators = (
@@ -357,11 +350,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             else None
         )
         kid = (
-            [name, valid_bases, valid_body, doc]
-            if doc and valid_bases
+            [name, *base_classes, valid_body, doc]
+            if doc and base_classes
             else (
-                [name, valid_bases, valid_body]
-                if valid_bases
+                [name, *base_classes, valid_body]
+                if base_classes
                 else [name, valid_body, doc] if doc else [name, valid_body]
             )
         )
@@ -369,7 +362,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             arch_type=arch_type,
             name=name,
             access=None,
-            base_classes=valid_bases,
+            base_classes=base_classes,
             body=valid_body,
             kid=kid,
             doc=doc,

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -484,7 +484,7 @@ class UniScopeNode(UniNode):
     def inherit_baseclasses_sym(self, node: Archetype | Enum) -> None:
         """Inherit base classes symbol tables."""
         if node.base_classes:
-            for base_cls in node.base_classes.items:
+            for base_cls in node.base_classes:
                 if (
                     isinstance(base_cls, AstSymbolNode)
                     and (found := self.use_lookup(base_cls))
@@ -1265,9 +1265,11 @@ class Import(ElementStmt, CodeBlockStmt):
                 ):
                     return True
                 for i in self.items:
-                    if isinstance(i, ModuleItem) and self.from_loc.resolve_relative_path(
-                        i.name.value
-                    ).endswith(".jac"):
+                    if isinstance(
+                        i, ModuleItem
+                    ) and self.from_loc.resolve_relative_path(i.name.value).endswith(
+                        ".jac"
+                    ):
                         return True
         return any(
             isinstance(i, ModulePath) and i.resolve_relative_path().endswith(".jac")
@@ -1436,7 +1438,7 @@ class Archetype(
         name: Name,
         arch_type: Token,
         access: Optional[SubTag[Token]],
-        base_classes: Optional[SubNodeList[Expr]],
+        base_classes: Sequence[Expr] | None,
         body: Optional[SubNodeList[ArchBlockStmt] | ImplDef],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
@@ -1444,7 +1446,7 @@ class Archetype(
     ) -> None:
         self.name = name
         self.arch_type = arch_type
-        self.base_classes = base_classes
+        self.base_classes: list[Expr] = list(base_classes) if base_classes else []
         UniNode.__init__(self, kid=kid)
         AstSymbolNode.__init__(
             self,
@@ -1495,9 +1497,8 @@ class Archetype(
             res = self.name.normalize(deep)
             res = res and self.arch_type.normalize(deep)
             res = res and self.access.normalize(deep) if self.access else res
-            res = (
-                res and self.base_classes.normalize(deep) if self.base_classes else res
-            )
+            for base in self.base_classes:
+                res = res and base.normalize(deep)
             res = res and self.body.normalize(deep) if self.body else res
             res = res and self.doc.normalize(deep) if self.doc else res
             res = res and self.decorators.normalize(deep) if self.decorators else res
@@ -1515,7 +1516,10 @@ class Archetype(
         new_kid.append(self.name)
         if self.base_classes:
             new_kid.append(self.gen_token(Tok.LPAREN))
-            new_kid.append(self.base_classes)
+            for idx, base in enumerate(self.base_classes):
+                new_kid.append(base)
+                if idx < len(self.base_classes) - 1:
+                    new_kid.append(self.gen_token(Tok.COMMA))
             new_kid.append(self.gen_token(Tok.RPAREN))
         if self.body:
             if isinstance(self.body, ImplDef):
@@ -1602,14 +1606,14 @@ class Enum(ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBlockStmt, UniScopeN
         self,
         name: Name,
         access: Optional[SubTag[Token]],
-        base_classes: Optional[SubNodeList[Expr]],
+        base_classes: Sequence[Expr] | None,
         body: Optional[SubNodeList[Assignment] | ImplDef],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
         decorators: Optional[SubNodeList[Expr]] = None,
     ) -> None:
         self.name = name
-        self.base_classes = base_classes
+        self.base_classes: list[Expr] = list(base_classes) if base_classes else []
         UniNode.__init__(self, kid=kid)
         AstSymbolNode.__init__(
             self,
@@ -1628,9 +1632,8 @@ class Enum(ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBlockStmt, UniScopeN
         if deep:
             res = self.name.normalize(deep)
             res = res and self.access.normalize(deep) if self.access else res
-            res = (
-                res and self.base_classes.normalize(deep) if self.base_classes else res
-            )
+            for base in self.base_classes:
+                res = res and base.normalize(deep)
             res = res and self.body.normalize(deep) if self.body else res
             res = res and self.doc.normalize(deep) if self.doc else res
             res = res and self.decorators.normalize(deep) if self.decorators else res
@@ -1646,7 +1649,10 @@ class Enum(ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBlockStmt, UniScopeN
         new_kid.append(self.name)
         if self.base_classes:
             new_kid.append(self.gen_token(Tok.COLON))
-            new_kid.append(self.base_classes)
+            for idx, base in enumerate(self.base_classes):
+                new_kid.append(base)
+                if idx < len(self.base_classes) - 1:
+                    new_kid.append(self.gen_token(Tok.COMMA))
             new_kid.append(self.gen_token(Tok.COLON))
         if self.body:
             if isinstance(self.body, ImplDef):

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -279,7 +279,7 @@ LanguageServer) {
                 );
                 if isinstance(temp_tab, uni.Archetype) and temp_tab.base_classes  {
                     base = [];
-                    for base_name in temp_tab.base_classes.items {
+                    for base_name in temp_tab.base_classes {
                         if isinstance(base_name, uni.Name) and base_name.sym  {
                             base.append(base_name.sym);
                         }


### PR DESCRIPTION
## Summary
- handle `Archetype.base_classes` as sequence of expressions
- update parser and passes to work with base class lists
- normalise arch base classes without SubNodeList
- adjust inheritance logic and language server

## Testing
- `black jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/inheritance_pass.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py --check`
- `mypy jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/inheritance_pass.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py` *(fails: Incompatible types in assignment)*
- `pytest -k archetype` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683ae94125088322860e0153f1f3fded