### PR TITLE
Use sequence for Archetype.body

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -594,12 +594,13 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     sub_list2 or sub_list1
                 )  # if sub_list2 is None then body is sub_list1
                 inh = sub_list2 and sub_list1  # if sub_list2 is None then inh is None.
+            body_items = body.items if isinstance(body, uni.SubNodeList) else body
             return uni.Archetype(
                 arch_type=arch_type,
                 name=name,
                 access=access,
                 base_classes=inh,
-                body=body,
+                body=body_items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -182,12 +182,12 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
 
     def check_archetype(self, node: uni.Archetype) -> None:
         """Check a single archetype for issues."""
-        if node.arch_type.name == Tok.KW_OBJECT and isinstance(
-            node.body, uni.SubNodeList
+        if node.arch_type.name == Tok.KW_OBJECT and node.body and not isinstance(
+            node.body, uni.ImplDef
         ):
             self.cur_node = node
             found_default_init = False
-            for stmnt in node.body.items:
+            for stmnt in node.body:
                 if not isinstance(stmnt, uni.ArchHas):
                     continue
                 for var in stmnt.vars.items:
@@ -204,7 +204,7 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
             post_init_vars: list[uni.HasVar] = []
             postinit_method: uni.Ability | None = None
 
-            for item in node.body.items:
+            for item in node.body:
 
                 if isinstance(item, uni.ArchHas):
                     for var in item.vars.items:

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -797,7 +797,7 @@ class PyastGenPass(UniPass):
                 node.body.body
                 if isinstance(node.body, uni.ImplDef)
                 and isinstance(node.body.body, uni.SubNodeList)
-                else node.body if isinstance(node.body, uni.SubNodeList) else None
+                else node.body if node.body is not None and not isinstance(node.body, uni.ImplDef) else None
             ),
             doc=node.doc,
         )
@@ -849,7 +849,7 @@ class PyastGenPass(UniPass):
                 node.body.body
                 if isinstance(node.body, uni.ImplDef)
                 and isinstance(node.body.body, uni.SubNodeList)
-                else node.body if isinstance(node.body, uni.SubNodeList) else None
+                else node.body if node.body is not None and not isinstance(node.body, uni.ImplDef) else None
             ),
             doc=node.doc,
         )

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -370,7 +370,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             name=name,
             access=None,
             base_classes=valid_bases,
-            body=valid_body,
+            body=valid_body.items,
             kid=kid,
             doc=doc,
             decorators=valid_decorators,


### PR DESCRIPTION
## Summary
- replace optional subnodelist body type with a sequence for `Archetype`
- handle archetype body as sequence in parser and passes
- update archetype normalization and abstract check
- adjust def_impl_match_pass to iterate body as a sequence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683ae956287c832297908740eeeda340