### PR TITLE
refactor: store archetype decorators as sequences

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -504,12 +504,12 @@ class JacParser(Transform[uni.Source, uni.Module]):
             """
             archspec: uni.ArchSpec | uni.Enum | None = None
 
-            decorators = self.match(uni.SubNodeList)
+            decorators_node = self.match(uni.SubNodeList)
             is_async = self.match_token(Tok.KW_ASYNC)
-            if decorators is not None:
+            if decorators_node is not None:
                 archspec = self.consume(uni.ArchSpec)
-                archspec.decorators = decorators
-                archspec.add_kids_left([decorators])
+                archspec.decorators = decorators_node.items
+                archspec.add_kids_left([decorators_node])
             else:
                 archspec = self.match(uni.ArchSpec) or self.consume(uni.Enum)
             if is_async and isinstance(archspec, uni.ArchSpec):

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -668,7 +668,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             """
             if decorator := self.match(uni.SubNodeList):
                 enum_decl = self.consume(uni.Enum)
-                enum_decl.decorators = decorator
+                enum_decl.decorators = decorator.items
                 enum_decl.add_kids_left([decorator])
                 return enum_decl
             return self.consume(uni.Enum)

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -241,14 +241,20 @@ class PyastGenPass(UniPass):
         )
         valid_stmts = [i for i in items if not isinstance(i, uni.Semi)]
         ret: list[ast3.AST] = (
-            [self.sync(ast3.Pass(), node if isinstance(node, uni.SubNodeList) else None)]
+            [
+                self.sync(
+                    ast3.Pass(), node if isinstance(node, uni.SubNodeList) else None
+                )
+            ]
             if isinstance(node, uni.SubNodeList) and not valid_stmts
             else (
-                self.flatten([
-                    x.gen.py_ast
-                    for x in valid_stmts
-                    if not isinstance(x, uni.ImplDef)
-                ])
+                self.flatten(
+                    [
+                        x.gen.py_ast
+                        for x in valid_stmts
+                        if not isinstance(x, uni.ImplDef)
+                    ]
+                )
                 if node is not None
                 else []
             )
@@ -816,8 +822,8 @@ class PyastGenPass(UniPass):
             )
 
         decorators = (
-            node.decorators.gen.py_ast
-            if isinstance(node.decorators, uni.SubNodeList)
+            [cast(ast3.expr, i.gen.py_ast[0]) for i in node.decorators]
+            if node.decorators
             else []
         )
 
@@ -854,8 +860,8 @@ class PyastGenPass(UniPass):
             doc=node.doc,
         )
         decorators = (
-            node.decorators.gen.py_ast
-            if isinstance(node.decorators, uni.SubNodeList)
+            [cast(ast3.expr, i.gen.py_ast[0]) for i in node.decorators]
+            if node.decorators
             else []
         )
         base_classes = node.base_classes.gen.py_ast if node.base_classes else []
@@ -1441,8 +1447,7 @@ class PyastGenPass(UniPass):
             self.sync(
                 with_node(
                     items=[
-                        cast(ast3.withitem, item.gen.py_ast[0])
-                        for item in node.exprs
+                        cast(ast3.withitem, item.gen.py_ast[0]) for item in node.exprs
                     ],
                     body=[
                         cast(ast3.stmt, stmt)

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -349,13 +349,9 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         )
         converted_decorators_list = [self.convert(i) for i in node.decorator_list]
         decorators = [i for i in converted_decorators_list if isinstance(i, uni.Expr)]
-        valid_decorators = (
-            uni.SubNodeList[uni.Expr](
-                items=decorators, delim=Tok.DECOR_OP, kid=decorators
-            )
-            if decorators
-            else None
-        )
+        if len(decorators) != len(converted_decorators_list):
+            raise self.ice("Length mismatch in decorators on class")
+        valid_decorators = decorators if decorators else None
         kid = (
             [name, valid_bases, valid_body, doc]
             if doc and valid_bases

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -180,10 +180,9 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for archetypes."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if node.doc and i is node.doc:
-                parts.append(i.gen.doc_ir)
-                parts.append(self.hard_line())
-            elif node.decorators and i in node.decorators:
+            if (node.doc and i is node.doc) or (
+                node.decorators and i in node.decorators
+            ):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name:
@@ -202,10 +201,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for abilities."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if node.doc and i is node.doc:
-                parts.append(i.gen.doc_ir)
-                parts.append(self.hard_line())
-            elif node.decorators and i in node.decorators:
+            if i in [node.doc, node.decorators]:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name_ref:
@@ -1028,10 +1024,9 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for enum declarations."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if node.doc and i is node.doc:
-                parts.append(i.gen.doc_ir)
-                parts.append(self.hard_line())
-            elif node.decorators and i in node.decorators:
+            if (node.doc and i is node.doc) or (
+                node.decorators and i in node.decorators
+            ):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif isinstance(i, uni.Token) and i.name == Tok.SEMI:

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -180,7 +180,10 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for archetypes."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if node.doc and i is node.doc:
+                parts.append(i.gen.doc_ir)
+                parts.append(self.hard_line())
+            elif node.decorators and i in node.decorators:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name:
@@ -199,7 +202,10 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for abilities."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if node.doc and i is node.doc:
+                parts.append(i.gen.doc_ir)
+                parts.append(self.hard_line())
+            elif node.decorators and i in node.decorators:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name_ref:
@@ -1022,7 +1028,10 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for enum declarations."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if node.doc and i is node.doc:
+                parts.append(i.gen.doc_ir)
+                parts.append(self.hard_line())
+            elif node.decorators and i in node.decorators:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif isinstance(i, uni.Token) and i.name == Tok.SEMI:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -849,7 +849,7 @@ class ArchSpec(ElementStmt, CodeBlockStmt, AstSymbolNode, AstDocNode):
     """ArchSpec node type for Jac Ast."""
 
     def __init__(
-        self, decorators: Optional[SubNodeList[Expr]], is_async: bool = False
+        self, decorators: Sequence[Expr] | None, is_async: bool = False
     ) -> None:
         self.decorators = decorators
         self.is_async = is_async
@@ -1265,9 +1265,11 @@ class Import(ElementStmt, CodeBlockStmt):
                 ):
                     return True
                 for i in self.items:
-                    if isinstance(i, ModuleItem) and self.from_loc.resolve_relative_path(
-                        i.name.value
-                    ).endswith(".jac"):
+                    if isinstance(
+                        i, ModuleItem
+                    ) and self.from_loc.resolve_relative_path(i.name.value).endswith(
+                        ".jac"
+                    ):
                         return True
         return any(
             isinstance(i, ModulePath) and i.resolve_relative_path().endswith(".jac")
@@ -1440,7 +1442,7 @@ class Archetype(
         body: Optional[SubNodeList[ArchBlockStmt] | ImplDef],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
-        decorators: Optional[SubNodeList[Expr]] = None,
+        decorators: Sequence[Expr] | None = None,
     ) -> None:
         self.name = name
         self.arch_type = arch_type
@@ -1500,13 +1502,17 @@ class Archetype(
             )
             res = res and self.body.normalize(deep) if self.body else res
             res = res and self.doc.normalize(deep) if self.doc else res
-            res = res and self.decorators.normalize(deep) if self.decorators else res
+            for dec in self.decorators or []:
+                res = res and dec.normalize(deep)
         new_kid: list[UniNode] = []
         if self.doc:
             new_kid.append(self.doc)
         if self.decorators:
             new_kid.append(self.gen_token(Tok.DECOR_OP))
-            new_kid.append(self.decorators)
+            for idx, dec in enumerate(self.decorators):
+                new_kid.append(dec)
+                if idx < len(self.decorators) - 1:
+                    new_kid.append(self.gen_token(Tok.DECOR_OP))
         if self.is_async:
             new_kid.append(self.gen_token(Tok.KW_ASYNC))
         new_kid.append(self.arch_type)
@@ -1606,7 +1612,7 @@ class Enum(ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBlockStmt, UniScopeN
         body: Optional[SubNodeList[Assignment] | ImplDef],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
-        decorators: Optional[SubNodeList[Expr]] = None,
+        decorators: Sequence[Expr] | None = None,
     ) -> None:
         self.name = name
         self.base_classes = base_classes
@@ -1633,11 +1639,15 @@ class Enum(ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBlockStmt, UniScopeN
             )
             res = res and self.body.normalize(deep) if self.body else res
             res = res and self.doc.normalize(deep) if self.doc else res
-            res = res and self.decorators.normalize(deep) if self.decorators else res
+            for dec in self.decorators or []:
+                res = res and dec.normalize(deep)
         new_kid: list[UniNode] = []
         if self.decorators:
             new_kid.append(self.gen_token(Tok.DECOR_OP))
-            new_kid.append(self.decorators)
+            for idx, dec in enumerate(self.decorators):
+                new_kid.append(dec)
+                if idx < len(self.decorators) - 1:
+                    new_kid.append(self.gen_token(Tok.DECOR_OP))
         if self.doc:
             new_kid.append(self.doc)
         new_kid.append(self.gen_token(Tok.KW_ENUM))


### PR DESCRIPTION
## Summary
- replace `decorators` SubNodeList with `Sequence` in `Archetype`
- update parser and passes for new decorator type
- handle decorator sequences in doc generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dotenv and fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_683ae9723d708322aa35170d6c715da4