### PR TITLE
refactor impl decorators to sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -527,7 +527,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
 
             impl_def: decorators? KW_IMPL dotted_name impl_spec? impl_tail
             """
-            decorators = self.match(uni.SubNodeList)
+            decorators_node = self.match(uni.SubNodeList)
             self.consume_token(Tok.KW_IMPL)
             target = self.consume(uni.SubNodeList)
             spec = (
@@ -541,7 +541,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             assert isinstance(valid_tail, (uni.SubNodeList, uni.FuncCall))
 
             impl = uni.ImplDef(
-                decorators=decorators,
+                decorators=decorators_node.items if decorators_node else None,
                 target=target,
                 spec=valid_spec,
                 body=valid_tail,

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -1109,7 +1109,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for implementation definitions."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if i == node.doc or (node.decorators and i in node.decorators):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.target:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1533,7 +1533,7 @@ class ImplDef(CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScope
 
     def __init__(
         self,
-        decorators: Optional[SubNodeList[Expr]],
+        decorators: Optional[Sequence[Expr]],
         target: SubNodeList[NameAtom],
         spec: SubNodeList[Expr] | FuncSignature | EventSignature | None,
         body: SubNodeList[CodeBlockStmt] | FuncCall,
@@ -1579,13 +1579,18 @@ class ImplDef(CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScope
             res = res and self.spec.normalize(deep) if self.spec else res
             res = res and self.body.normalize(deep)
             res = res and self.doc.normalize(deep) if self.doc else res
-            res = res and self.decorators.normalize(deep) if self.decorators else res
+            if self.decorators:
+                for item in self.decorators:
+                    res = res and item.normalize(deep)
         new_kid: list[UniNode] = []
         if self.doc:
             new_kid.append(self.doc)
         if self.decorators:
             new_kid.append(self.gen_token(Tok.DECOR_OP))
-            new_kid.append(self.decorators)
+            for i, dec in enumerate(self.decorators):
+                new_kid.append(dec)
+                if i < len(self.decorators) - 1:
+                    new_kid.append(self.gen_token(Tok.DECOR_OP))
         new_kid.append(self.gen_token(Tok.KW_IMPL))
         new_kid.append(self.target)
         if self.spec:


### PR DESCRIPTION
## Summary
- use `Sequence` type for `ImplDef.decorators`
- normalize new decorator sequence into kid list
- handle new decorators in parser
- update doc_ir generator for sequence decorators

## Testing
- `pytest jac/jaclang/utils/tests/test_lang_tools.py::JacAstToolTests::test_pass_template -q`
- `pytest jac/jaclang/tests/test_language.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae97ee0f88322b0ed2c0fc8fd1c18