### PR TITLE
Refactor ImplDef target type

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -542,7 +542,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
 
             impl = uni.ImplDef(
                 decorators=decorators,
-                target=target,
+                target=target.items,
                 spec=valid_spec,
                 body=valid_tail,
                 kid=self.cur_nodes,

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -124,7 +124,7 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
 
             valid_decl.body = sym.decl.name_of
             sym.decl.name_of.decl_link = valid_decl
-            for idx, a in enumerate(sym.decl.name_of.target.items):
+            for idx, a in enumerate(sym.decl.name_of.target):
                 if idx < len(name_of_links) and name_of_links[idx]:
                     a.name_spec.name_of = name_of_links[idx].name_of
                     a.name_spec.sym = name_of_links[idx].sym

--- a/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
@@ -15,6 +15,8 @@ relationships between the two AST representations throughout the compilation pro
 
 import ast as ast3
 
+from typing import Sequence
+
 import jaclang.compiler.unitree as uni
 from jaclang.compiler.passes import UniPass
 
@@ -50,7 +52,7 @@ class PyJacAstLinkPass(UniPass):
             self.link_jac_py_nodes(jac_node=node.body, py_nodes=node.gen.py_ast)
 
     def exit_impl_def(self, node: uni.ImplDef) -> None:
-        for i in node.target.items:
+        for i in node.target:
             if i.name_spec.name_of.sym:
                 self.link_jac_py_nodes(
                     jac_node=i, py_nodes=i.name_spec.name_of.sym.decl.gen.py_ast
@@ -88,9 +90,9 @@ class PyJacAstLinkPass(UniPass):
                 )
 
         if isinstance(node.decl_link, uni.Ability) and isinstance(
-            node.target, uni.SubNodeList
+            node.target, Sequence
         ):
-            for arch in node.target.items:
+            for arch in node.target:
                 if arch.name_spec.name_of.sym:
                     arch.name_spec.name_of.sym.add_use(arch.name_spec)
 


### PR DESCRIPTION
## Summary
- replace ImplDef.target SubNodeList with Sequence
- update parser and passes to handle Sequence targets

## Testing
- `pytest jac`
- `pytest jac-splice-orc` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest jac-cloud` *(fails: No module named 'dotenv')*
- `pytest jac-mtllm` *(fails: No module named 'mtllm')*
- `jac test jac/examples/littleX/littleX.test.jac` *(fails: No module named 'jac_cloud')*

------
https://chatgpt.com/codex/tasks/task_e_683ae98955588322b4dd49950889c061