### PR TITLE
Fix ImplDef.spec to use sequences

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import keyword
 import logging
 import os
-from typing import Callable, TYPE_CHECKING, TypeAlias, TypeVar
+from typing import Callable, TYPE_CHECKING, TypeAlias, TypeVar, Sequence
 
 import jaclang.compiler.unitree as uni
 from jaclang.compiler import jac_lark as jl  # type: ignore
@@ -543,7 +543,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             impl = uni.ImplDef(
                 decorators=decorators,
                 target=target,
-                spec=valid_spec,
+                spec=valid_spec.items if isinstance(valid_spec, uni.SubNodeList) else valid_spec,
                 body=valid_tail,
                 kid=self.cur_nodes,
             )
@@ -551,7 +551,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
 
         def impl_spec(
             self, _: None
-        ) -> uni.SubNodeList[uni.Expr] | uni.FuncSignature | uni.EventSignature:
+        ) -> Sequence[uni.Expr] | uni.FuncSignature | uni.EventSignature:
             """Grammar rule.
 
             impl_spec: inherited_archs | func_decl | event_clause
@@ -561,7 +561,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 or self.match(uni.FuncSignature)  # func_decl
                 or self.consume(uni.EventSignature)  # event_clause
             )
-            return spec
+            return spec.items if isinstance(spec, uni.SubNodeList) else spec
 
         def impl_tail(
             self, _: None

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1535,7 +1535,7 @@ class ImplDef(CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScope
         self,
         decorators: Optional[SubNodeList[Expr]],
         target: SubNodeList[NameAtom],
-        spec: SubNodeList[Expr] | FuncSignature | EventSignature | None,
+        spec: Sequence[Expr] | FuncSignature | EventSignature | None,
         body: SubNodeList[CodeBlockStmt] | FuncCall,
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
@@ -1543,7 +1543,7 @@ class ImplDef(CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScope
     ) -> None:
         self.decorators = decorators
         self.target = target
-        self.spec = spec
+        self.spec = list(spec) if isinstance(spec, Sequence) else spec
         self.body = body
         self.doc = doc
         self.decl_link = decl_link
@@ -1576,7 +1576,11 @@ class ImplDef(CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScope
         res = True
         if deep:
             res = self.target.normalize(deep)
-            res = res and self.spec.normalize(deep) if self.spec else res
+            if isinstance(self.spec, Sequence):
+                for item in self.spec:
+                    res = res and item.normalize(deep)
+            else:
+                res = res and self.spec.normalize(deep) if self.spec else res
             res = res and self.body.normalize(deep)
             res = res and self.doc.normalize(deep) if self.doc else res
             res = res and self.decorators.normalize(deep) if self.decorators else res
@@ -1589,7 +1593,15 @@ class ImplDef(CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScope
         new_kid.append(self.gen_token(Tok.KW_IMPL))
         new_kid.append(self.target)
         if self.spec:
-            new_kid.append(self.spec)
+            if isinstance(self.spec, Sequence):
+                new_kid.append(self.gen_token(Tok.LPAREN))
+                for idx, item in enumerate(self.spec):
+                    new_kid.append(item)
+                    if idx < len(self.spec) - 1:
+                        new_kid.append(self.gen_token(Tok.COMMA))
+                new_kid.append(self.gen_token(Tok.RPAREN))
+            else:
+                new_kid.append(self.spec)
         new_kid.append(self.body)
         self.set_kids(nodes=new_kid)
         return res


### PR DESCRIPTION
## Summary
- store ImplDef.spec as Sequence instead of SubNodeList
- adapt parser for ImplDef spec

## Testing
- `pre-commit run --files jac/jaclang/compiler/unitree.py jac/jaclang/compiler/parser.py` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/')*
- `pytest -k 'impl' -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683ae993fc188322a85691674b16bed3