### PR TITLE
Replace body fields with sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -338,7 +338,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             codeblock = self.consume(uni.SubNodeList)
             return uni.ModuleCode(
                 name=name,
-                body=codeblock,
+                body=codeblock.items,
                 kid=self.cur_nodes,
             )
 
@@ -1114,7 +1114,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             body = self.consume(uni.SubNodeList)
             return uni.TypedCtxBlock(
                 type_ctx=ctx,
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 
@@ -1129,7 +1129,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else_body = self.match(uni.ElseStmt) or self.match(uni.ElseIf)
             return uni.IfStmt(
                 condition=condition,
-                body=body,
+                body=body.items,
                 else_body=else_body,
                 kid=self.cur_nodes,
             )
@@ -1145,7 +1145,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else_body = self.match(uni.ElseStmt) or self.match(uni.ElseIf)
             return uni.ElseIf(
                 condition=condition,
-                body=body,
+                body=body.items,
                 else_body=else_body,
                 kid=self.cur_nodes,
             )
@@ -1158,7 +1158,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.consume_token(Tok.KW_ELSE)
             body = self.consume(uni.SubNodeList)
             return uni.ElseStmt(
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 
@@ -1173,7 +1173,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else_stmt = self.match(uni.ElseStmt)
             finally_stmt = self.match(uni.FinallyStmt)
             return uni.TryStmt(
-                body=block,
+                body=block.items,
                 excepts=except_list,
                 else_body=else_stmt,
                 finally_body=finally_stmt,


### PR DESCRIPTION
## Summary
- convert ModuleCode, TypedCtxBlock, IfStmt, ElseStmt, and TryStmt body fields to use `Sequence`
- update parser to supply sequences for these classes
- adjust normalization and unparse logic
- keep tests passing

## Testing
- `pytest jac/jaclang/compiler/tests/test_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683b08fb6bc08322807a5bfe101ba1b2