### PR TITLE
Refactor Archetype body to use Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -598,9 +598,8 @@ class JacParser(Transform[uni.Source, uni.Module]):
             if self.match_token(Tok.SEMI):
                 inh, body = sub_list1, None
             else:
-                body = (
-                    sub_list2 or sub_list1
-                )  # if sub_list2 is None then body is sub_list1
+                body_sn = sub_list2 or sub_list1
+                body = body_sn.items if body_sn else []
                 inh = sub_list2 and sub_list1  # if sub_list2 is None then inh is None.
             return uni.Archetype(
                 arch_type=arch_type,

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -21,6 +21,7 @@ import jaclang.compiler.unitree as uni
 from jaclang.compiler.constant import Tokens as Tok
 from jaclang.compiler.passes.transform import Transform
 from jaclang.compiler.unitree import Symbol, UniScopeNode
+from typing import Sequence
 
 
 class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
@@ -183,11 +184,11 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
     def check_archetype(self, node: uni.Archetype) -> None:
         """Check a single archetype for issues."""
         if node.arch_type.name == Tok.KW_OBJECT and isinstance(
-            node.body, uni.SubNodeList
+            node.body, Sequence
         ):
             self.cur_node = node
             found_default_init = False
-            for stmnt in node.body.items:
+            for stmnt in node.body:
                 if not isinstance(stmnt, uni.ArchHas):
                     continue
                 for var in stmnt.vars.items:
@@ -204,7 +205,7 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
             post_init_vars: list[uni.HasVar] = []
             postinit_method: uni.Ability | None = None
 
-            for item in node.body.items:
+            for item in node.body:
 
                 if isinstance(item, uni.ArchHas):
                     for var in item.vars.items:

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -246,7 +246,7 @@ class PyastGenPass(UniPass):
                     ast3.Pass(), node if isinstance(node, uni.SubNodeList) else None
                 )
             ]
-            if not valid_stmts
+            if isinstance(node, (uni.SubNodeList, Sequence)) and not valid_stmts
             else (
                 self.flatten(
                     [
@@ -806,7 +806,11 @@ class PyastGenPass(UniPass):
         elif not isinstance(node.body, uni.FuncCall):
             inner = node.body
         body = self.resolve_stmt_block(inner, doc=node.doc)
-
+        if not body and not isinstance(node.body, uni.FuncCall):
+            self.log_error(
+                "Archetype has no body. Perhaps an impl must be imported.", node
+            )
+            body = [self.sync(ast3.Pass(), node)]
         if node.is_async:
             body.insert(
                 0,

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -246,7 +246,7 @@ class PyastGenPass(UniPass):
                     ast3.Pass(), node if isinstance(node, uni.SubNodeList) else None
                 )
             ]
-            if isinstance(node, uni.SubNodeList) and not valid_stmts
+            if not valid_stmts
             else (
                 self.flatten(
                     [

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -359,7 +359,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             name=name,
             access=None,
             base_classes=base_classes,
-            body=valid_body,
+            body=valid,
             kid=kid,
             doc=doc,
             decorators=valid_decorators,

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -3,7 +3,7 @@
 This is a pass for generating DocIr for Jac code.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import jaclang.compiler.passes.tool.doc_ir as doc
 import jaclang.compiler.unitree as uni
@@ -179,6 +179,9 @@ class DocIRGenPass(UniPass):
     def exit_archetype(self, node: uni.Archetype) -> None:
         """Generate DocIR for archetypes."""
         parts: list[doc.DocType] = []
+        body_parts: list[doc.DocType] = []
+        prev_item = None
+        in_body = False
         for i in node.kid:
             if (node.doc and i is node.doc) or (
                 node.decorators and i in node.decorators
@@ -188,6 +191,23 @@ class DocIRGenPass(UniPass):
             elif i == node.name:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.space())
+            elif isinstance(node.body, Sequence) and i in node.body:
+                if not in_body:
+                    body_parts.append(self.hard_line())
+                body_parts.append(i.gen.doc_ir)
+                body_parts.append(self.hard_line())
+                if type(prev_item) is not type(i) or (
+                    prev_item and not self.is_one_line(prev_item)
+                ):
+                    body_parts.append(self.hard_line())
+                in_body = True
+            elif in_body:
+                in_body = False
+                body_parts.pop()
+                parts.append(self.indent(self.concat(body_parts)))
+                parts.append(self.hard_line())
+                parts.append(i.gen.doc_ir)
+                parts.append(self.space())
             elif isinstance(i, uni.Token) and i.name == Tok.SEMI:
                 parts.pop()
                 parts.append(i.gen.doc_ir)
@@ -195,6 +215,7 @@ class DocIRGenPass(UniPass):
             else:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.space())
+            prev_item = i
         node.gen.doc_ir = self.finalize(parts)
 
     def exit_ability(self, node: uni.Ability) -> None:

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -193,6 +193,7 @@ class DocIRGenPass(UniPass):
                 parts.append(self.space())
             elif isinstance(node.body, Sequence) and i in node.body:
                 if not in_body:
+                    parts.pop()
                     body_parts.append(self.hard_line())
                 body_parts.append(i.gen.doc_ir)
                 body_parts.append(self.hard_line())
@@ -1073,10 +1074,8 @@ class DocIRGenPass(UniPass):
         indent_parts: list[doc.DocType] = []
         prev_item: Optional[uni.UniNode] = None
         in_codeblock = node.delim and node.delim.name == Tok.WS
-        in_archetype = (
-            node.parent
-            and isinstance(node.parent, (uni.Archetype, uni.Enum))
-            and node == node.parent.body
+        in_archetype = node.parent and isinstance(
+            node.parent, (uni.Archetype, uni.Enum)
         )
         is_assignment = node.delim and node.delim.name == Tok.EQ
         for i in node.kid:


### PR DESCRIPTION
## Summary
- adjust `Archetype.body` to store a sequence of statements
- update parser, loader and validation passes for new type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683b11a5dc908322ab1d036ff850304a