### PR TITLE
Refactor enum body to use sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -692,15 +692,15 @@ class JacParser(Transform[uni.Source, uni.Module]):
             sub_list1 = self.match(uni.SubNodeList)
             sub_list2 = self.match(uni.SubNodeList)
             if self.match_token(Tok.SEMI):
-                inh, body = sub_list1, None
+                inh, body_node = sub_list1, None
             else:
-                body = sub_list2 or sub_list1
+                body_node = sub_list2 or sub_list1
                 inh = sub_list2 and sub_list1
             return uni.Enum(
                 name=name,
                 access=access,
                 base_classes=inh.items if inh else [],
-                body=body,
+                body=body_node.items if body_node else None,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -226,6 +226,7 @@ class PyastGenPass(UniPass):
         self,
         node: (
             Sequence[uni.CodeBlockStmt]
+            | Sequence[uni.EnumBlockStmt]
             | uni.SubNodeList[uni.CodeBlockStmt]
             | uni.SubNodeList[uni.ArchBlockStmt]
             | uni.SubNodeList[uni.EnumBlockStmt]
@@ -803,7 +804,7 @@ class PyastGenPass(UniPass):
             inner = (
                 node.body.body if not isinstance(node.body.body, uni.FuncCall) else None
             )
-        elif not isinstance(node.body, uni.FuncCall):
+        elif node.body is not None:
             inner = node.body
         body = self.resolve_stmt_block(inner, doc=node.doc)
 
@@ -854,7 +855,7 @@ class PyastGenPass(UniPass):
             inner = (
                 node.body.body if not isinstance(node.body.body, uni.FuncCall) else None
             )
-        elif not isinstance(node.body, uni.FuncCall):
+        elif node.body is not None:
             inner = node.body
         body = self.resolve_stmt_block(inner, doc=node.doc)
         decorators = (


### PR DESCRIPTION
## Summary
- refactor Enum body to store as Sequence
- update parser to extract enum body items
- allow resolve_stmt_block to accept enum body sequences

## Testing
- `pre-commit` *(fails: unable to access network)*
- `pytest -q` *(fails: ModuleNotFoundError: 'dotenv')*
- `mypy jac/jaclang/compiler/unitree.py jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py`

------
https://chatgpt.com/codex/tasks/task_e_683b11c28bc08322b1929cfd4f323e67