### PR TITLE
Update FuncSignature.params to sequence

### DIFF
--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -274,7 +274,7 @@ class JacMachine:
                             ctx=ast3.Load(),
                         )
                     )
-                    for param in node.signature.params.items
+                    for param in node.signature.params
                 ]
                 if isinstance(node.signature, uni.FuncSignature)
                 and node.signature.params

--- a/jac-mtllm/mtllm/semtable.py
+++ b/jac-mtllm/mtllm/semtable.py
@@ -131,7 +131,7 @@ class SemRegistry:
             ret = "function("
             params = []
             if node.signature.params:
-                for param in node.signature.params.items:
+                for param in node.signature.params:
                     params.append(
                         param.name.value
                         + ":"
@@ -167,7 +167,9 @@ class SemRegistry:
         mod = None
         scope_obj = None
         # Find the relevant module and scope object
-        scope_stack = scope.get_scope_trace() if scope else self.by_scope.get_scope_trace()
+        scope_stack = (
+            scope.get_scope_trace() if scope else self.by_scope.get_scope_trace()
+        )
         expected_mod = scope_stack[-1]["scope"] if scope_stack else None
         for m in mods.values():
             if m.name == expected_mod:

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -852,12 +852,12 @@ class JacParser(Transform[uni.Source, uni.Module]):
             # Otherwise, parse the traditional parameter list form
             else:
                 self.consume_token(Tok.LPAREN)
-                params = self.match(uni.SubNodeList)
+                params_node = self.match(uni.SubNodeList)
                 self.consume_token(Tok.RPAREN)
                 if self.match_token(Tok.RETURN_HINT):
                     return_spec = self.consume(uni.Expr)
                 return uni.FuncSignature(
-                    params=params,
+                    params=params_node.items if params_node else None,
                     return_type=return_spec,
                     kid=self.cur_nodes,
                 )
@@ -1600,25 +1600,27 @@ class JacParser(Transform[uni.Source, uni.Module]):
             return_type: uni.Expr | None = None
             sig_kid: list[uni.UniNode] = []
             self.consume_token(Tok.KW_LAMBDA)
-            params = self.match(uni.SubNodeList)
+            params_node = self.match(uni.SubNodeList)
             if self.match_token(Tok.RETURN_HINT):
                 return_type = self.consume(uni.Expr)
             self.consume_token(Tok.COLON)
             body = self.consume(uni.Expr)
-            if params:
-                sig_kid.append(params)
+            if params_node:
+                sig_kid.append(params_node)
             if return_type:
                 sig_kid.append(return_type)
             signature = (
                 uni.FuncSignature(
-                    params=params,
+                    params=params_node.items if params_node else None,
                     return_type=return_type,
                     kid=sig_kid,
                 )
-                if params or return_type
+                if params_node or return_type
                 else None
             )
-            new_kid = [i for i in self.cur_nodes if i != params and i != return_type]
+            new_kid = [
+                i for i in self.cur_nodes if i != params_node and i != return_type
+            ]
             new_kid.insert(1, signature) if signature else None
             return uni.LambdaExpr(
                 signature=signature,

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -159,7 +159,7 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
 
             if params_decl and params_defn:
                 # Check if the parameter count is matched.
-                if len(params_defn.items) != len(params_decl.items):
+                if len(params_defn) != len(params_decl):
                     self.log_error(
                         f"Parameter count mismatch for ability {sym.sym_name}.",
                         sym.decl.name_of.name_spec,
@@ -170,10 +170,7 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
                     )
                 else:
                     # Copy the parameter names from the declaration to the definition.
-                    for idx in range(len(params_defn.items)):
-                        params_decl.items[idx] = params_defn.items[idx]
-                    for idx in range(len(params_defn.kid)):
-                        params_decl.kid[idx] = params_defn.kid[idx]
+                    valid_decl.signature.params = list(params_defn)
 
     def check_archetypes(self, ir_in: uni.Module) -> None:
         """Check all archetypes for issues with attributes and methods."""

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1022,23 +1022,18 @@ class PyastGenPass(UniPass):
         )
         vararg = None
         kwarg = None
-        if isinstance(node.params, uni.SubNodeList):
-            for i in node.params.items:
-                if i.unpack and i.unpack.value == "*":
-                    vararg = i.gen.py_ast[0]
-                elif i.unpack and i.unpack.value == "**":
-                    kwarg = i.gen.py_ast[0]
-                else:
-                    (
-                        params.append(i.gen.py_ast[0])
-                        if isinstance(i.gen.py_ast[0], ast3.arg)
-                        else self.ice("This list should only be Args")
-                    )
-        defaults = (
-            [x.value.gen.py_ast[0] for x in node.params.items if x.value]
-            if node.params
-            else []
-        )
+        for i in node.params:
+            if i.unpack and i.unpack.value == "*":
+                vararg = i.gen.py_ast[0]
+            elif i.unpack and i.unpack.value == "**":
+                kwarg = i.gen.py_ast[0]
+            else:
+                (
+                    params.append(i.gen.py_ast[0])
+                    if isinstance(i.gen.py_ast[0], ast3.arg)
+                    else self.ice("This list should only be Args")
+                )
+        defaults = [x.value.gen.py_ast[0] for x in node.params if x.value]
         node.gen.py_ast = [
             self.sync(
                 ast3.arguments(

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -309,7 +309,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 and isinstance(body_stmt.signature, uni.FuncSignature)
                 and body_stmt.signature.params
             ):
-                for param in body_stmt.signature.params.items:
+                for param in body_stmt.signature.params:
                     if param.name.value == "self":
                         param.type_tag = uni.SubTag[uni.Expr](name, kid=[name])
         doc = (
@@ -2299,13 +2299,10 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
 
         valid_params = [param for param in params if isinstance(param, uni.ParamVar)]
         if valid_params:
-            fs_params = uni.SubNodeList[uni.ParamVar](
-                items=valid_params, delim=Tok.COMMA, kid=valid_params
-            )
             return uni.FuncSignature(
-                params=fs_params,
+                params=valid_params,
                 return_type=None,
-                kid=[fs_params],
+                kid=[*valid_params],
             )
         else:
             _lparen = self.operator(Tok.LPAREN, "(")

--- a/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
@@ -63,12 +63,12 @@ class PyJacAstLinkPass(UniPass):
 
         if isinstance(node.decl_link, uni.Ability) and node.decl_link.signature:
             if isinstance(node.spec, uni.FuncSignature) and node.spec.params:
-                for src_prm in node.spec.params.items:
+                for src_prm in node.spec.params:
                     if (
                         isinstance(node.decl_link.signature, uni.FuncSignature)
                         and node.decl_link.signature.params
                     ):
-                        for trg_prm in node.decl_link.signature.params.items:
+                        for trg_prm in node.decl_link.signature.params:
                             if src_prm.name.sym_name == trg_prm.name.sym_name:
                                 self.link_jac_py_nodes(
                                     jac_node=src_prm, py_nodes=trg_prm.gen.py_ast

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1857,11 +1857,11 @@ class FuncSignature(UniNode):
 
     def __init__(
         self,
-        params: Optional[SubNodeList[ParamVar]],
+        params: Sequence[ParamVar] | None,
         return_type: Optional[Expr],
         kid: Sequence[UniNode],
     ) -> None:
-        self.params = params
+        self.params = list(params) if params else []
         self.return_type = return_type
         UniNode.__init__(self, kid=kid)
 
@@ -1869,11 +1869,14 @@ class FuncSignature(UniNode):
         res = True
         is_lambda = self.parent and isinstance(self.parent, LambdaExpr)
         if deep:
-            res = self.params.normalize(deep) if self.params else res
+            for prm in self.params:
+                res = res and prm.normalize(deep)
             res = res and self.return_type.normalize(deep) if self.return_type else res
         new_kid: list[UniNode] = [self.gen_token(Tok.LPAREN)] if not is_lambda else []
-        if self.params:
-            new_kid.append(self.params)
+        for idx, prm in enumerate(self.params):
+            new_kid.append(prm)
+            if idx < len(self.params) - 1:
+                new_kid.append(self.gen_token(Tok.COMMA))
         if not is_lambda:
             new_kid.append(self.gen_token(Tok.RPAREN))
         if self.return_type:


### PR DESCRIPTION
## Summary
- store `FuncSignature.params` as a list of parameters instead of a `SubNodeList`
- adjust parser generation of function signatures
- update passes and plugins to iterate sequences

## Testing
- `black jac/jaclang/compiler/unitree.py jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py jac/jaclang/compiler/passes/main/def_impl_match_pass.py jac-mtllm/mtllm/semtable.py jac-mtllm/mtllm/plugin.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683b11eae8bc83228cb63679b2e52e5a