### PR TITLE
Switch ability decorators to Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -759,7 +759,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                                 ability.insert_kids_at_pos([static_kw], 1)
                         break
                 if decorators.items:
-                    ability.decorators = decorators
+                    ability.decorators = decorators.items
                     ability.add_kids_left([decorators])
 
             return ability

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -943,7 +943,11 @@ class PyastGenPass(UniPass):
                 f"Abstract ability {node.sym_name} should not have a body.",
                 node,
             )
-        decorator_list = node.decorators.gen.py_ast if node.decorators else []
+        decorator_list = (
+            [cast(ast3.expr, i.gen.py_ast[0]) for i in node.decorators]
+            if node.decorators
+            else []
+        )
         if isinstance(node.signature, uni.EventSignature):
             decorator_list.append(
                 self.jaclib_obj(

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -192,13 +192,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_dec = [i for i in decorators if isinstance(i, uni.Expr)]
         if len(valid_dec) != len(decorators):
             raise self.ice("Length mismatch in decorators on function")
-        valid_decorators = (
-            uni.SubNodeList[uni.Expr](
-                items=valid_dec, delim=Tok.DECOR_OP, kid=decorators
-            )
-            if len(valid_dec)
-            else None
-        )
+        valid_decorators = valid_dec if valid_dec else None
         res = self.convert(node.args)
         sig: Optional[uni.FuncSignature] = (
             res if isinstance(res, uni.FuncSignature) else None

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -223,7 +223,7 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for abilities."""
         parts: list[doc.DocType] = []
         for i in node.kid:
-            if i in [node.doc, node.decorators]:
+            if i == node.doc or (node.decorators and i in node.decorators):
                 parts.append(i.gen.doc_ir)
                 parts.append(self.hard_line())
             elif i == node.name_ref:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1751,7 +1751,7 @@ class Ability(
         body: Optional[SubNodeList[CodeBlockStmt] | ImplDef | FuncCall],
         kid: Sequence[UniNode],
         doc: Optional[String] = None,
-        decorators: Optional[SubNodeList[Expr]] = None,
+        decorators: Sequence[Expr] | None = None,
     ) -> None:
         self.name_ref = name_ref
         self.is_override = is_override
@@ -1819,14 +1819,18 @@ class Ability(
             res = res and self.access.normalize(deep) if self.access else res
             res = res and self.signature.normalize(deep) if self.signature else res
             res = res and self.body.normalize(deep) if self.body else res
-            res = res and self.decorators.normalize(deep) if self.decorators else res
+            for dec in self.decorators or []:
+                res = res and dec.normalize(deep)
             res = res and self.doc.normalize(deep) if self.doc else res
         new_kid: list[UniNode] = []
         if self.doc:
             new_kid.append(self.doc)
         if self.decorators:
             new_kid.append(self.gen_token(Tok.DECOR_OP))
-            new_kid.append(self.decorators)
+            for idx, dec in enumerate(self.decorators):
+                new_kid.append(dec)
+                if idx < len(self.decorators) - 1:
+                    new_kid.append(self.gen_token(Tok.DECOR_OP))
             new_kid.append(self.gen_token(Tok.WS))
         if self.is_async:
             new_kid.append(self.gen_token(Tok.KW_ASYNC))


### PR DESCRIPTION
## Summary
- refactor `Ability` decorators to use a `Sequence[Expr]`
- adapt parser to store decorators as lists
- update Python AST generation/loading to work with new type
- tweak doc generation for ability decorators

## Testing
- `pre-commit` *(fails: couldn't access network to fetch hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683ba25145ec83228f72cc60a10f9bc0