### PR TITLE
Update TypedCtxBlock body handling

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1113,7 +1113,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             body = self.consume(uni.SubNodeList)
             return uni.TypedCtxBlock(
                 type_ctx=ctx,
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2095,7 +2095,7 @@ class TypedCtxBlock(CodeBlockStmt, UniScopeNode):
     def __init__(
         self,
         type_ctx: Expr,
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
     ) -> None:
         self.type_ctx = type_ctx
@@ -2108,12 +2108,16 @@ class TypedCtxBlock(CodeBlockStmt, UniScopeNode):
         res = True
         if deep:
             res = self.type_ctx.normalize(deep)
-            res = res and self.body.normalize(deep)
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
         new_kid: list[UniNode] = [
             self.gen_token(Tok.RETURN_HINT),
             self.type_ctx,
-            self.body,
+            self.gen_token(Tok.LBRACE),
         ]
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- refactor `TypedCtxBlock` to store a simple `Sequence[CodeBlockStmt]`
- adjust parser to pass plain statement sequence

## Testing
- `pre-commit` *(fails: unable to access 'https://github.com/pre-commit/pre-commit-hooks/')*

------
https://chatgpt.com/codex/tasks/task_e_683ba54486308322afca0fd3ad2b03b7