### PR TITLE
Update ElseStmt body to Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1157,7 +1157,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.consume_token(Tok.KW_ELSE)
             body = self.consume(uni.SubNodeList)
             return uni.ElseStmt(
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -521,20 +521,9 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         if len(val_orelse) != len(orelse):
             raise self.ice("Length mismatch in for orelse")
         if orelse:
-            valid_orelse = uni.SubNodeList[uni.CodeBlockStmt](
-                items=val_orelse,
-                delim=Tok.WS,
-                kid=orelse,
-                left_enc=self.operator(Tok.LBRACE, "{"),
-                right_enc=self.operator(Tok.RBRACE, "}"),
-            )
+            fin_orelse = uni.ElseStmt(body=val_orelse, kid=val_orelse)
         else:
-            valid_orelse = None
-        fin_orelse = (
-            uni.ElseStmt(body=valid_orelse, kid=[valid_orelse])
-            if valid_orelse
-            else None
-        )
+            fin_orelse = None
         if isinstance(target, uni.Expr) and isinstance(iter, uni.Expr):
             return uni.InForStmt(
                 target=target,
@@ -580,20 +569,9 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         if len(val_orelse) != len(orelse):
             raise self.ice("Length mismatch in for orelse")
         if orelse:
-            valid_orelse = uni.SubNodeList[uni.CodeBlockStmt](
-                items=val_orelse,
-                delim=Tok.WS,
-                kid=orelse,
-                left_enc=self.operator(Tok.LBRACE, "{"),
-                right_enc=self.operator(Tok.RBRACE, "}"),
-            )
+            fin_orelse = uni.ElseStmt(body=val_orelse, kid=val_orelse)
         else:
-            valid_orelse = None
-        fin_orelse = (
-            uni.ElseStmt(body=valid_orelse, kid=[valid_orelse])
-            if valid_orelse
-            else None
-        )
+            fin_orelse = None
         if isinstance(target, uni.Expr) and isinstance(iter, uni.Expr):
             return uni.InForStmt(
                 target=target,
@@ -670,14 +648,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                     kid=first_elm.kid,
                 )
             else:
-                orelse2 = uni.SubNodeList[uni.CodeBlockStmt](
-                    items=valid_orelse,
-                    delim=Tok.WS,
-                    kid=orelse,
-                    left_enc=self.operator(Tok.LBRACE, "{"),
-                    right_enc=self.operator(Tok.RBRACE, "}"),
-                )
-                else_body = uni.ElseStmt(body=orelse2, kid=[orelse2])
+                else_body = uni.ElseStmt(body=valid_orelse, kid=valid_orelse)
         else:
             else_body = None
         if isinstance(test, uni.Expr):
@@ -2031,15 +2002,9 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             valid_orelse = [i for i in orelse if isinstance(i, (uni.CodeBlockStmt))]
             if len(orelse) != len(valid_orelse):
                 raise self.ice("Length mismatch in try orelse")
-            else_body = uni.SubNodeList[uni.CodeBlockStmt](
-                items=valid_orelse,
-                delim=Tok.WS,
-                kid=valid_orelse,
-                left_enc=self.operator(Tok.LBRACE, "{"),
-                right_enc=self.operator(Tok.RBRACE, "}"),
-            )
-            elsestmt = uni.ElseStmt(body=else_body, kid=[else_body])
-            kid.append(else_body)
+            else_body = valid_orelse
+            elsestmt = uni.ElseStmt(body=else_body, kid=else_body)
+            kid.extend(else_body)
         else:
             else_body = None
 

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2193,21 +2193,25 @@ class ElseStmt(UniScopeNode):
 
     def __init__(
         self,
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
     ) -> None:
-        self.body = body
+        self.body: list[CodeBlockStmt] = list(body)
         UniNode.__init__(self, kid=kid)
         UniScopeNode.__init__(self, name=f"{self.__class__.__name__}")
 
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.body.normalize(deep)
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
         new_kid: list[UniNode] = [
             self.gen_token(Tok.KW_ELSE),
-            self.body,
+            self.gen_token(Tok.LBRACE),
         ]
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- refactor `ElseStmt` AST node to use `Sequence[CodeBlockStmt]`
- update parser to supply lists for `ElseStmt`
- update `pyast_load_pass` to build `ElseStmt` with lists

## Testing
- `pre-commit` *(fails: couldn't access network)*

------
https://chatgpt.com/codex/tasks/task_e_683bae0fb2988322816cf67ba38d9f93