### PR TITLE
Refactor TryStmt body and excepts types

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1172,8 +1172,8 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else_stmt = self.match(uni.ElseStmt)
             finally_stmt = self.match(uni.FinallyStmt)
             return uni.TryStmt(
-                body=block,
-                excepts=except_list,
+                body=block.items,
+                excepts=except_list.items if except_list else [],
                 else_body=else_stmt,
                 finally_body=finally_stmt,
                 kid=self.cur_nodes,

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1349,11 +1349,9 @@ class PyastGenPass(UniPass):
             self.sync(
                 ast3.Try(
                     body=cast(list[ast3.stmt], self.resolve_stmt_block(node.body)),
-                    handlers=(
-                        [cast(ast3.ExceptHandler, i) for i in node.excepts.gen.py_ast]
-                        if node.excepts
-                        else []
-                    ),
+                    handlers=[
+                        cast(ast3.ExceptHandler, i.gen.py_ast[0]) for i in node.excepts
+                    ],
                     orelse=(
                         [cast(ast3.stmt, i) for i in node.else_body.gen.py_ast]
                         if node.else_body

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1976,26 +1976,18 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid = [i for i in body if isinstance(i, (uni.CodeBlockStmt))]
         if len(valid) != len(body):
             raise self.ice("Length mismatch in try body")
-        valid_body = uni.SubNodeList[uni.CodeBlockStmt](
-            items=valid,
-            delim=Tok.WS,
-            kid=valid,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
-        kid: list[uni.UniNode] = [valid_body]
+        valid_body = valid
+        kid: list[uni.UniNode] = [*valid_body]
 
         if len(node.handlers) != 0:
             handlers = [self.convert(i) for i in node.handlers]
             valid_handlers = [i for i in handlers if isinstance(i, (uni.Except))]
             if len(handlers) != len(valid_handlers):
                 raise self.ice("Length mismatch in try handlers")
-            excepts = uni.SubNodeList[uni.Except](
-                items=valid_handlers, delim=Tok.WS, kid=valid_handlers
-            )
-            kid.append(excepts)
+            excepts = valid_handlers
+            kid.extend(valid_handlers)
         else:
-            excepts = None
+            excepts = []
 
         if len(node.orelse) != 0:
             orelse = [self.convert(i) for i in node.orelse]


### PR DESCRIPTION
## Summary
- simplify `TryStmt` to store standard sequences for `body` and `excepts`
- update parser and loaders to emit lists instead of `SubNodeList`
- adapt python AST generation for new list fields

## Testing
- `mypy jac/jaclang/compiler/parser.py jac/jaclang/compiler/passes/main/pyast_gen_pass.py jac/jaclang/compiler/passes/main/pyast_load_pass.py jac/jaclang/compiler/unitree.py`
- `pre-commit` *(fails: unable to access pre-commit hooks repository)*

------
https://chatgpt.com/codex/tasks/task_e_683bb0cd758c83228e60b2c000f678b0