### PR TITLE
Switch Except body to use sequences

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1203,11 +1203,11 @@ class JacParser(Transform[uni.Source, uni.Module]):
             ex_type = self.consume(uni.Expr)
             if self.match_token(Tok.KW_AS):
                 name = self.consume(uni.Name)
-            body = self.consume(uni.SubNodeList)
+            body_node = self.consume(uni.SubNodeList)
             return uni.Except(
                 ex_type=ex_type,
                 name=name,
-                body=body,
+                body=body_node.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1215,7 +1215,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             return uni.Except(
                 ex_type=type,
                 name=name,
-                body=valid_body,
+                body=valid_body.items,
                 kid=kid,
             )
         else:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2292,12 +2292,12 @@ class Except(CodeBlockStmt, UniScopeNode):
         self,
         ex_type: Expr,
         name: Optional[Name],
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
     ) -> None:
         self.ex_type = ex_type
         self.name = name
-        self.body = body
+        self.body: list[CodeBlockStmt] = list(body)
         UniNode.__init__(self, kid=kid)
         UniScopeNode.__init__(self, name=f"{self.__class__.__name__}")
         CodeBlockStmt.__init__(self)
@@ -2307,7 +2307,8 @@ class Except(CodeBlockStmt, UniScopeNode):
         if deep:
             res = self.ex_type.normalize(deep)
             res = res and self.name.normalize(deep) if self.name else res
-            res = res and self.body.normalize(deep) if self.body else res
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
         new_kid: list[UniNode] = [
             self.gen_token(Tok.KW_EXCEPT),
             self.ex_type,
@@ -2315,7 +2316,10 @@ class Except(CodeBlockStmt, UniScopeNode):
         if self.name:
             new_kid.append(self.gen_token(Tok.KW_AS))
             new_kid.append(self.name)
-        new_kid.append(self.body)
+        new_kid.append(self.gen_token(Tok.LBRACE))
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- adjust `Except` body to store plain sequence of statements
- update parser and pyast loader to populate new attribute

## Testing
- `pre-commit` *(fails: unable to access network for hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683bb1e4df708322ad6bd6bcb1d641eb