### PR TITLE
Refactor loop statement bodies to sequences

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1172,8 +1172,8 @@ class JacParser(Transform[uni.Source, uni.Module]):
             else_stmt = self.match(uni.ElseStmt)
             finally_stmt = self.match(uni.FinallyStmt)
             return uni.TryStmt(
-                body=block,
-                excepts=except_list,
+                body=block.items,
+                excepts=except_list.items if except_list else [],
                 else_body=else_stmt,
                 finally_body=finally_stmt,
                 kid=self.cur_nodes,
@@ -1219,7 +1219,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.consume_token(Tok.KW_FINALLY)
             body = self.consume(uni.SubNodeList)
             return uni.FinallyStmt(
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 
@@ -1243,7 +1243,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     iter=iter,
                     condition=condition,
                     count_by=count_by,
-                    body=body,
+                    body=body.items,
                     else_body=else_body,
                     kid=self.cur_nodes,
                 )
@@ -1256,7 +1256,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 is_async=is_async,
                 target=target,
                 collection=collection,
-                body=body,
+                body=body.items,
                 else_body=else_body,
                 kid=self.cur_nodes,
             )

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1203,11 +1203,11 @@ class JacParser(Transform[uni.Source, uni.Module]):
             ex_type = self.consume(uni.Expr)
             if self.match_token(Tok.KW_AS):
                 name = self.consume(uni.Name)
-            body = self.consume(uni.SubNodeList)
+            body_node = self.consume(uni.SubNodeList)
             return uni.Except(
                 ex_type=ex_type,
                 name=name,
-                body=body,
+                body=body_node.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1349,11 +1349,9 @@ class PyastGenPass(UniPass):
             self.sync(
                 ast3.Try(
                     body=cast(list[ast3.stmt], self.resolve_stmt_block(node.body)),
-                    handlers=(
-                        [cast(ast3.ExceptHandler, i) for i in node.excepts.gen.py_ast]
-                        if node.excepts
-                        else []
-                    ),
+                    handlers=[
+                        cast(ast3.ExceptHandler, i.gen.py_ast[0]) for i in node.excepts
+                    ],
                     orelse=(
                         [cast(ast3.stmt, i) for i in node.else_body.gen.py_ast]
                         if node.else_body
@@ -1391,7 +1389,7 @@ class PyastGenPass(UniPass):
 
     def exit_iter_for_stmt(self, node: uni.IterForStmt) -> None:
         py_nodes: list[ast3.AST] = []
-        body = node.body.gen.py_ast
+        body = self.resolve_stmt_block(node.body)
         if (
             isinstance(body, list)
             and isinstance(node.count_by.gen.py_ast[0], ast3.AST)

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1215,7 +1215,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             return uni.Except(
                 ex_type=type,
                 name=name,
-                body=valid_body,
+                body=valid_body.items,
                 kid=kid,
             )
         else:

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1995,12 +1995,13 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             ]
             if len(finalbody) != len(valid_finalbody):
                 raise self.ice("Length mismatch in try finalbody")
-            finally_stmt_obj: Optional[uni.FinallyStmt] = uni.FinallyStmt(
-                body=valid_finalbody,
-                kid=valid_finalbody,
+            finally_stmt_obj: Optional[uni.FinallyStmt] = (
+                fin_append := uni.FinallyStmt(
+                    body=valid_finalbody,
+                    kid=valid_finalbody,
+                )
             )
-
-            kid.append(finally_stmt_obj)
+            kid.append(fin_append)
         else:
             finally_stmt_obj = None
         ret = uni.TryStmt(

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -509,13 +509,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         if len(val_body) != len(body):
             raise self.ice("Length mismatch in for body")
 
-        valid_body = uni.SubNodeList[uni.CodeBlockStmt](
-            items=val_body,
-            delim=Tok.WS,
-            kid=val_body,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
+        valid_body = val_body
         orelse = [self.convert(i) for i in node.orelse]
         val_orelse = [i for i in orelse if isinstance(i, uni.CodeBlockStmt)]
         if len(val_orelse) != len(orelse):
@@ -532,9 +526,9 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 body=valid_body,
                 else_body=fin_orelse,
                 kid=(
-                    [target, iter, valid_body, fin_orelse]
+                    [target, iter, *valid_body, fin_orelse]
                     if fin_orelse
-                    else [target, iter, valid_body]
+                    else [target, iter, *valid_body]
                 ),
             )
         else:
@@ -557,13 +551,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         if len(val_body) != len(body):
             raise self.ice("Length mismatch in for body")
 
-        valid_body = uni.SubNodeList[uni.CodeBlockStmt](
-            items=val_body,
-            delim=Tok.WS,
-            kid=val_body,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
+        valid_body = val_body
         orelse = [self.convert(i) for i in node.orelse]
         val_orelse = [i for i in orelse if isinstance(i, uni.CodeBlockStmt)]
         if len(val_orelse) != len(orelse):
@@ -580,9 +568,9 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 body=valid_body,
                 else_body=fin_orelse,
                 kid=(
-                    [target, iter, valid_body, fin_orelse]
+                    [target, iter, *valid_body, fin_orelse]
                     if fin_orelse
-                    else [target, iter, valid_body]
+                    else [target, iter, *valid_body]
                 ),
             )
         else:
@@ -1976,26 +1964,18 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid = [i for i in body if isinstance(i, (uni.CodeBlockStmt))]
         if len(valid) != len(body):
             raise self.ice("Length mismatch in try body")
-        valid_body = uni.SubNodeList[uni.CodeBlockStmt](
-            items=valid,
-            delim=Tok.WS,
-            kid=valid,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
-        kid: list[uni.UniNode] = [valid_body]
+        valid_body = valid
+        kid: list[uni.UniNode] = [*valid_body]
 
         if len(node.handlers) != 0:
             handlers = [self.convert(i) for i in node.handlers]
             valid_handlers = [i for i in handlers if isinstance(i, (uni.Except))]
             if len(handlers) != len(valid_handlers):
                 raise self.ice("Length mismatch in try handlers")
-            excepts = uni.SubNodeList[uni.Except](
-                items=valid_handlers, delim=Tok.WS, kid=valid_handlers
-            )
-            kid.append(excepts)
+            excepts = valid_handlers
+            kid.extend(valid_handlers)
         else:
-            excepts = None
+            excepts = []
 
         if len(node.orelse) != 0:
             orelse = [self.convert(i) for i in node.orelse]
@@ -2015,23 +1995,19 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             ]
             if len(finalbody) != len(valid_finalbody):
                 raise self.ice("Length mismatch in try finalbody")
-            finally_body = uni.SubNodeList[uni.CodeBlockStmt](
-                items=valid_finalbody,
-                delim=Tok.WS,
+            finally_stmt_obj: Optional[uni.FinallyStmt] = uni.FinallyStmt(
+                body=valid_finalbody,
                 kid=valid_finalbody,
-                left_enc=self.operator(Tok.LBRACE, "{"),
-                right_enc=self.operator(Tok.RBRACE, "}"),
             )
-            finally_stmt = uni.FinallyStmt(body=finally_body, kid=[finally_body])
 
-            kid.append(finally_stmt)
+            kid.append(finally_stmt_obj)
         else:
-            finally_body = None
+            finally_stmt_obj = None
         ret = uni.TryStmt(
             body=valid_body,
             excepts=excepts,
             else_body=elsestmt if else_body else None,
-            finally_body=finally_stmt if finally_body else None,
+            finally_body=finally_stmt_obj,
             kid=kid,
         )
         return ret

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2248,14 +2248,14 @@ class TryStmt(AstElseBodyNode, CodeBlockStmt, UniScopeNode):
 
     def __init__(
         self,
-        body: SubNodeList[CodeBlockStmt],
-        excepts: Optional[SubNodeList[Except]],
+        body: Sequence[CodeBlockStmt],
+        excepts: Sequence[Except],
         else_body: Optional[ElseStmt],
         finally_body: Optional[FinallyStmt],
         kid: Sequence[UniNode],
     ) -> None:
-        self.body = body
-        self.excepts = excepts
+        self.body: list[CodeBlockStmt] = list(body)
+        self.excepts: list[Except] = list(excepts)
         self.finally_body = finally_body
         UniNode.__init__(self, kid=kid)
         AstElseBodyNode.__init__(self, else_body=else_body)
@@ -2265,18 +2265,23 @@ class TryStmt(AstElseBodyNode, CodeBlockStmt, UniScopeNode):
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.body.normalize(deep)
-            res = res and self.excepts.normalize(deep) if self.excepts else res
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
+            for exc in self.excepts:
+                res = res and exc.normalize(deep)
             res = res and self.else_body.normalize(deep) if self.else_body else res
             res = (
                 res and self.finally_body.normalize(deep) if self.finally_body else res
             )
         new_kid: list[UniNode] = [
             self.gen_token(Tok.KW_TRY),
+            self.gen_token(Tok.LBRACE),
         ]
-        new_kid.append(self.body)
-        if self.excepts:
-            new_kid.append(self.excepts)
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
+        for exc in self.excepts:
+            new_kid.append(exc)
         if self.else_body:
             new_kid.append(self.else_body)
         if self.finally_body:
@@ -2329,10 +2334,10 @@ class FinallyStmt(CodeBlockStmt, UniScopeNode):
 
     def __init__(
         self,
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
     ) -> None:
-        self.body = body
+        self.body: list[CodeBlockStmt] = list(body)
         UniNode.__init__(self, kid=kid)
         UniScopeNode.__init__(self, name=f"{self.__class__.__name__}")
         CodeBlockStmt.__init__(self)
@@ -2340,11 +2345,15 @@ class FinallyStmt(CodeBlockStmt, UniScopeNode):
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.body.normalize(deep)
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
         new_kid: list[UniNode] = [
             self.gen_token(Tok.KW_FINALLY),
+            self.gen_token(Tok.LBRACE),
         ]
-        new_kid.append(self.body)
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 
@@ -2358,14 +2367,14 @@ class IterForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
         is_async: bool,
         condition: Expr,
         count_by: Assignment,
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         else_body: Optional[ElseStmt],
         kid: Sequence[UniNode],
     ) -> None:
         self.iter = iter
         self.condition = condition
         self.count_by = count_by
-        self.body = body
+        self.body: list[CodeBlockStmt] = list(body)
         UniNode.__init__(self, kid=kid)
         AstAsyncNode.__init__(self, is_async=is_async)
         AstElseBodyNode.__init__(self, else_body=else_body)
@@ -2378,8 +2387,9 @@ class IterForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
             res = self.iter.normalize(deep)
             res = self.condition.normalize(deep)
             res = self.count_by.normalize(deep)
-            res = self.body.normalize(deep)
-            res = self.else_body.normalize(deep) if self.else_body else res
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
+            res = res and self.else_body.normalize(deep) if self.else_body else res
         new_kid: list[UniNode] = []
         if self.is_async:
             new_kid.append(self.gen_token(Tok.KW_ASYNC))
@@ -2389,7 +2399,10 @@ class IterForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
         new_kid.append(self.condition)
         new_kid.append(self.gen_token(Tok.KW_BY))
         new_kid.append(self.count_by)
-        new_kid.append(self.body)
+        new_kid.append(self.gen_token(Tok.LBRACE))
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         if self.else_body:
             new_kid.append(self.else_body)
         self.set_kids(nodes=new_kid)
@@ -2404,13 +2417,13 @@ class InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
         target: Expr,
         is_async: bool,
         collection: Expr,
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         else_body: Optional[ElseStmt],
         kid: Sequence[UniNode],
     ) -> None:
         self.target = target
         self.collection = collection
-        self.body = body
+        self.body: list[CodeBlockStmt] = list(body)
         UniNode.__init__(self, kid=kid)
         AstAsyncNode.__init__(self, is_async=is_async)
         AstElseBodyNode.__init__(self, else_body=else_body)
@@ -2422,7 +2435,8 @@ class InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
         if deep:
             res = self.target.normalize(deep)
             res = res and self.collection.normalize(deep)
-            res = res and self.body.normalize(deep)
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
             res = res and self.else_body.normalize(deep) if self.else_body else res
         new_kid: list[UniNode] = []
         if self.is_async:
@@ -2432,8 +2446,10 @@ class InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
         new_kid.append(self.gen_token(Tok.KW_IN))
         new_kid.append(self.collection)
 
-        if self.body:
-            new_kid.append(self.body)
+        new_kid.append(self.gen_token(Tok.LBRACE))
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         if self.else_body:
             new_kid.append(self.else_body)
         self.set_kids(nodes=new_kid)

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2933,7 +2933,10 @@ class Assignment(AstTypedVarNode, EnumBlockStmt, CodeBlockStmt):
         if isinstance(self.parent, GlobalVars):
             if self.parent.assignments.index(self) == len(self.parent.assignments) - 1:
                 new_kid.append(self.gen_token(Tok.SEMI))
-        elif (not self.is_enum_stmt) and not isinstance(self.parent, IterForStmt):
+        elif (not self.is_enum_stmt) and not (
+            isinstance(self.parent, IterForStmt)
+            and self in [self.parent.iter, self.parent.count_by]
+        ):
             new_kid.append(self.gen_token(Tok.SEMI))
         self.set_kids(nodes=new_kid)
         return res

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2292,12 +2292,12 @@ class Except(CodeBlockStmt, UniScopeNode):
         self,
         ex_type: Expr,
         name: Optional[Name],
-        body: SubNodeList[CodeBlockStmt],
+        body: Sequence[CodeBlockStmt],
         kid: Sequence[UniNode],
     ) -> None:
         self.ex_type = ex_type
         self.name = name
-        self.body = body
+        self.body: list[CodeBlockStmt] = list(body)
         UniNode.__init__(self, kid=kid)
         UniScopeNode.__init__(self, name=f"{self.__class__.__name__}")
         CodeBlockStmt.__init__(self)
@@ -2307,7 +2307,8 @@ class Except(CodeBlockStmt, UniScopeNode):
         if deep:
             res = self.ex_type.normalize(deep)
             res = res and self.name.normalize(deep) if self.name else res
-            res = res and self.body.normalize(deep) if self.body else res
+            for stmt in self.body:
+                res = res and stmt.normalize(deep)
         new_kid: list[UniNode] = [
             self.gen_token(Tok.KW_EXCEPT),
             self.ex_type,
@@ -2315,7 +2316,10 @@ class Except(CodeBlockStmt, UniScopeNode):
         if self.name:
             new_kid.append(self.gen_token(Tok.KW_AS))
             new_kid.append(self.name)
-        new_kid.append(self.body)
+        new_kid.append(self.gen_token(Tok.LBRACE))
+        for stmt in self.body:
+            new_kid.append(stmt)
+        new_kid.append(self.gen_token(Tok.RBRACE))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- refactor `FinallyStmt`, `IterForStmt`, and `InForStmt` to store bodies as `Sequence[CodeBlockStmt]`
- adapt parser to provide lists to these nodes
- update pyast load/gen passes for new body representation

## Testing
- `source scripts/check.sh` *(fails: couldn't access network for pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683bb38118f88322bc53d224e62d48a4