### PR TITLE
Update WhileStmt/WithStmt body handling

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1271,7 +1271,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             body = self.consume(uni.SubNodeList)
             return uni.WhileStmt(
                 condition=condition,
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 
@@ -1287,7 +1287,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             return uni.WithStmt(
                 is_async=is_async,
                 exprs=exprs_node.items,
-                body=body,
+                body=body.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -590,18 +590,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_body = [stmt for stmt in body if isinstance(stmt, uni.CodeBlockStmt)]
         if len(valid_body) != len(body):
             raise self.ice("Length mismatch in while body")
-        fin_body = uni.SubNodeList[uni.CodeBlockStmt](
-            items=valid_body,
-            delim=Tok.WS,
-            kid=valid_body,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
         if isinstance(test, uni.Expr):
             return uni.WhileStmt(
                 condition=test,
-                body=fin_body,
-                kid=[test, fin_body],
+                body=valid_body,
+                kid=[test, *valid_body],
             )
         else:
             raise self.ice()
@@ -666,18 +659,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_body = [stmt for stmt in body if isinstance(stmt, uni.CodeBlockStmt)]
         if len(valid_body) != len(body):
             raise self.ice("Length mismatch in async for body")
-        body_sub = uni.SubNodeList[uni.CodeBlockStmt](
-            items=valid_body,
-            delim=Tok.WS,
-            kid=body,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
         return uni.WithStmt(
             is_async=False,
             exprs=valid_items,
-            body=body_sub,
-            kid=[*valid_items, body_sub],
+            body=valid_body,
+            kid=[*valid_items, *valid_body],
         )
 
     def proc_async_with(self, node: py_ast.AsyncWith) -> uni.WithStmt:
@@ -696,18 +682,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid_body = [stmt for stmt in body if isinstance(stmt, uni.CodeBlockStmt)]
         if len(valid_body) != len(body):
             raise self.ice("Length mismatch in async for body")
-        body_sub = uni.SubNodeList[uni.CodeBlockStmt](
-            items=valid_body,
-            delim=Tok.WS,
-            kid=body,
-            left_enc=self.operator(Tok.LBRACE, "{"),
-            right_enc=self.operator(Tok.RBRACE, "}"),
-        )
         return uni.WithStmt(
             is_async=True,
             exprs=valid_items,
-            body=body_sub,
-            kid=[*valid_items, body_sub],
+            body=valid_body,
+            kid=[*valid_items, *valid_body],
         )
 
     def proc_raise(self, node: py_ast.Raise) -> uni.RaiseStmt:


### PR DESCRIPTION
## Summary
- refactor `WhileStmt` and `WithStmt` to store simple sequences of `CodeBlockStmt`
- update parser to pass lists instead of `SubNodeList`
- adjust Python AST loader for the new body representation

## Testing
- `source scripts/check.sh` *(fails: couldn't access network to install pre-commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_683bbf3fa83c832298aab9c26c5c7e27