### PR TITLE
Switch Assignment target to Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1533,7 +1533,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             kid.insert(1, new_targ) if is_frozen else kid.insert(0, new_targ)
             if is_aug:
                 return uni.Assignment(
-                    target=new_targ,
+                    target=new_targ.items,
                     type_tag=type_tag,
                     value=value,
                     mutable=is_frozen,
@@ -1541,7 +1541,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     kid=kid,
                 )
             return uni.Assignment(
-                target=new_targ,
+                target=new_targ.items,
                 type_tag=type_tag,
                 value=value,
                 mutable=is_frozen,
@@ -2420,7 +2420,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                     items=[name_consume], delim=Tok.EQ, kid=[name_consume]
                 )
                 return uni.Assignment(
-                    target=target, value=None, type_tag=None, kid=[target]
+                    target=target.items, value=None, type_tag=None, kid=[target]
                 )
 
             if consume := self.match(uni.SubNodeList):

--- a/jac/jaclang/compiler/passes/main/def_use_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_use_pass.py
@@ -70,7 +70,7 @@ class DefUsePass(UniPass):
             self.ice("Inconsistency in AST, has var should be under arch has")
 
     def enter_assignment(self, node: uni.Assignment) -> None:
-        for i in node.target.items:
+        for i in node.target:
             if isinstance(i, uni.AtomTrailer):
                 i.sym_tab.chain_def_insert(i.as_attr_list)
             elif isinstance(i, uni.AstSymbolNode):

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1922,18 +1922,20 @@ class PyastGenPass(UniPass):
                 else None if node.type_tag else self.ice()
             )
         )
+        targets_ast = [cast(ast3.expr, t.gen.py_ast[0]) for t in node.target]
+
         if node.type_tag:
             node.gen.py_ast = [
                 self.sync(
                     ast3.AnnAssign(
-                        target=cast(ast3.Name, node.target.items[0].gen.py_ast[0]),
+                        target=cast(ast3.Name, targets_ast[0]),
                         annotation=cast(ast3.expr, node.type_tag.gen.py_ast[0]),
                         value=(
                             cast(ast3.expr, node.value.gen.py_ast[0])
                             if node.value
                             else None
                         ),
-                        simple=int(isinstance(node.target.gen.py_ast[0], ast3.Name)),
+                        simple=int(isinstance(targets_ast[0], ast3.Name)),
                     )
                 )
             ]
@@ -1941,7 +1943,7 @@ class PyastGenPass(UniPass):
             node.gen.py_ast = [
                 self.sync(
                     ast3.AugAssign(
-                        target=cast(ast3.Name, node.target.items[0].gen.py_ast[0]),
+                        target=cast(ast3.Name, targets_ast[0]),
                         op=cast(ast3.operator, node.aug_op.gen.py_ast[0]),
                         value=(
                             cast(ast3.expr, value)
@@ -1955,7 +1957,7 @@ class PyastGenPass(UniPass):
             node.gen.py_ast = [
                 self.sync(
                     ast3.Assign(
-                        targets=cast(list[ast3.expr], node.target.gen.py_ast),
+                        targets=cast(list[ast3.expr], targets_ast),
                         value=(
                             cast(ast3.expr, value)
                             if isinstance(value, ast3.expr)

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -411,7 +411,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             raise self.ice("Length mismatch in assignment targets")
         if isinstance(value, uni.Expr):
             return uni.Assignment(
-                target=valid_targets,
+                target=valid_targets.items,
                 value=value,
                 type_tag=None,
                 kid=[valid_targets, value],
@@ -444,7 +444,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 items=[target], delim=Tok.COMMA, kid=[target]
             )
             return uni.Assignment(
-                target=targ,
+                target=targ.items,
                 type_tag=None,
                 mutable=True,
                 aug_op=op,
@@ -476,17 +476,17 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             and isinstance(annotation, uni.Expr)
             and isinstance(target, uni.Expr)
         ):
-            target = uni.SubNodeList[uni.Expr](
+            target_sn = uni.SubNodeList[uni.Expr](
                 items=[target], delim=Tok.EQ, kid=[target]
             )
             return uni.Assignment(
-                target=target,
+                target=target_sn.items,
                 value=value if isinstance(value, (uni.Expr, uni.YieldExpr)) else None,
                 type_tag=annotation_subtag,
                 kid=(
-                    [target, annotation_subtag, value]
+                    [target_sn, annotation_subtag, value]
                     if value
-                    else [target, annotation_subtag]
+                    else [target_sn, annotation_subtag]
                 ),
             )
         else:

--- a/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
+++ b/jac/jaclang/compiler/passes/main/sym_tab_build_pass.py
@@ -54,7 +54,7 @@ class SymTabBuildPass(UniPass):
 
     def exit_global_vars(self, node: uni.GlobalVars) -> None:
         for i in self.get_all_sub_nodes(node, uni.Assignment):
-            for j in i.target.items:
+            for j in i.target:
                 if isinstance(j, uni.AstSymbolNode):
                     j.sym_tab.def_insert(j, access_spec=node, single_decl="global var")
                 else:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2433,7 +2433,8 @@ class InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.target.normalize(deep)
+            for t in self.target:
+                res = res and t.normalize(deep)
             res = res and self.collection.normalize(deep)
             for stmt in self.body:
                 res = res and stmt.normalize(deep)
@@ -2896,7 +2897,7 @@ class Assignment(AstTypedVarNode, EnumBlockStmt, CodeBlockStmt):
 
     def __init__(
         self,
-        target: SubNodeList[Expr],
+        target: Sequence[Expr],
         value: Optional[Expr | YieldExpr],
         type_tag: Optional[SubTag[Expr]],
         kid: Sequence[UniNode],
@@ -2904,7 +2905,7 @@ class Assignment(AstTypedVarNode, EnumBlockStmt, CodeBlockStmt):
         aug_op: Optional[Token] = None,
         is_enum_stmt: bool = False,
     ) -> None:
-        self.target = target
+        self.target: list[Expr] = list(target)
         self.value = value
         self.mutable = mutable
         self.aug_op = aug_op
@@ -2916,12 +2917,16 @@ class Assignment(AstTypedVarNode, EnumBlockStmt, CodeBlockStmt):
     def normalize(self, deep: bool = True) -> bool:
         res = True
         if deep:
-            res = self.target.normalize(deep)
+            for t in self.target:
+                res = res and t.normalize(deep)
             res = res and self.value.normalize(deep) if self.value else res
             res = res and self.type_tag.normalize(deep) if self.type_tag else res
             res = res and self.aug_op.normalize(deep) if self.aug_op else res
         new_kid: list[UniNode] = []
-        new_kid.append(self.target)
+        for idx, targ in enumerate(self.target):
+            new_kid.append(targ)
+            if idx < len(self.target) - 1:
+                new_kid.append(self.gen_token(Tok.EQ))
         if self.type_tag:
             new_kid.append(self.type_tag)
         if self.aug_op:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2433,8 +2433,7 @@ class InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode):
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            for t in self.target:
-                res = res and t.normalize(deep)
+            res = res and self.target.normalize(deep)
             res = res and self.collection.normalize(deep)
             for stmt in self.body:
                 res = res and stmt.normalize(deep)


### PR DESCRIPTION
## Summary
- store Assignment targets as a `Sequence[Expr]`
- adapt parser and passes for new Assignment target structure

## Testing
- `pre-commit run --all-files` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683bbfc79ebc8322b0d8f973c9246c2d