### PR TITLE
Refactor FuncSignature params to sequence

### DIFF
--- a/jac-mtllm/mtllm/plugin.py
+++ b/jac-mtllm/mtllm/plugin.py
@@ -274,7 +274,7 @@ class JacMachine:
                             ctx=ast3.Load(),
                         )
                     )
-                    for param in node.signature.params.items
+                    for param in node.signature.params
                 ]
                 if isinstance(node.signature, uni.FuncSignature)
                 and node.signature.params

--- a/jac-mtllm/mtllm/semtable.py
+++ b/jac-mtllm/mtllm/semtable.py
@@ -131,7 +131,7 @@ class SemRegistry:
             ret = "function("
             params = []
             if node.signature.params:
-                for param in node.signature.params.items:
+                for param in node.signature.params:
                     params.append(
                         param.name.value
                         + ":"

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1609,15 +1609,15 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 sig_kid.append(params)
             if return_type:
                 sig_kid.append(return_type)
-                signature = (
-                    uni.FuncSignature(
-                        params=params.items if params else [],
-                        return_type=return_type,
-                        kid=sig_kid,
-                    )
-                    if params or return_type
-                    else None
+            signature = (
+                uni.FuncSignature(
+                    params=params.items if params else [],
+                    return_type=return_type,
+                    kid=sig_kid,
                 )
+                if params or return_type
+                else None
+            )
             new_kid = [i for i in self.cur_nodes if i != params and i != return_type]
             new_kid.insert(1, signature) if signature else None
             return uni.LambdaExpr(

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -844,7 +844,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             if self.match_token(Tok.RETURN_HINT):
                 return_spec = self.consume(uni.Expr)
                 return uni.FuncSignature(
-                    params=None,
+                    params=[],
                     return_type=return_spec,
                     kid=self.cur_nodes,
                 )
@@ -856,7 +856,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 if self.match_token(Tok.RETURN_HINT):
                     return_spec = self.consume(uni.Expr)
                 return uni.FuncSignature(
-                    params=params,
+                    params=params.items if params else [],
                     return_type=return_spec,
                     kid=self.cur_nodes,
                 )
@@ -1608,15 +1608,15 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 sig_kid.append(params)
             if return_type:
                 sig_kid.append(return_type)
-            signature = (
-                uni.FuncSignature(
-                    params=params,
-                    return_type=return_type,
-                    kid=sig_kid,
+                signature = (
+                    uni.FuncSignature(
+                        params=params.items if params else [],
+                        return_type=return_type,
+                        kid=sig_kid,
+                    )
+                    if params or return_type
+                    else None
                 )
-                if params or return_type
-                else None
-            )
             new_kid = [i for i in self.cur_nodes if i != params and i != return_type]
             new_kid.insert(1, signature) if signature else None
             return uni.LambdaExpr(

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -173,6 +173,10 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
                 else:
                     # Copy the parameter names from the declaration to the definition.
                     for idx in range(len(params_defn)):
+                        # TODO: Refactor the below 2 lines when subnodelist goes away.
+                        loc_in_kid = params_decl[idx].parent.kid.index(params_decl[idx])  # type: ignore
+                        params_decl[idx].parent.kid[loc_in_kid] = params_defn[idx]  # type: ignore
+
                         params_decl[idx] = params_defn[idx]
 
     def check_archetypes(self, ir_in: uni.Module) -> None:

--- a/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/def_impl_match_pass.py
@@ -161,7 +161,7 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
 
             if params_decl and params_defn:
                 # Check if the parameter count is matched.
-                if len(params_defn.items) != len(params_decl.items):
+                if len(params_defn) != len(params_decl):
                     self.log_error(
                         f"Parameter count mismatch for ability {sym.sym_name}.",
                         sym.decl.name_of.name_spec,
@@ -172,10 +172,8 @@ class DeclImplMatchPass(Transform[uni.Module, uni.Module]):
                     )
                 else:
                     # Copy the parameter names from the declaration to the definition.
-                    for idx in range(len(params_defn.items)):
-                        params_decl.items[idx] = params_defn.items[idx]
-                    for idx in range(len(params_defn.kid)):
-                        params_decl.kid[idx] = params_defn.kid[idx]
+                    for idx in range(len(params_defn)):
+                        params_decl[idx] = params_defn[idx]
 
     def check_archetypes(self, ir_in: uni.Module) -> None:
         """Check all archetypes for issues with attributes and methods."""

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1030,23 +1030,18 @@ class PyastGenPass(UniPass):
         )
         vararg = None
         kwarg = None
-        if isinstance(node.params, uni.SubNodeList):
-            for i in node.params.items:
-                if i.unpack and i.unpack.value == "*":
-                    vararg = i.gen.py_ast[0]
-                elif i.unpack and i.unpack.value == "**":
-                    kwarg = i.gen.py_ast[0]
-                else:
-                    (
-                        params.append(i.gen.py_ast[0])
-                        if isinstance(i.gen.py_ast[0], ast3.arg)
-                        else self.ice("This list should only be Args")
-                    )
-        defaults = (
-            [x.value.gen.py_ast[0] for x in node.params.items if x.value]
-            if node.params
-            else []
-        )
+        for i in node.params:
+            if i.unpack and i.unpack.value == "*":
+                vararg = i.gen.py_ast[0]
+            elif i.unpack and i.unpack.value == "**":
+                kwarg = i.gen.py_ast[0]
+            else:
+                (
+                    params.append(i.gen.py_ast[0])
+                    if isinstance(i.gen.py_ast[0], ast3.arg)
+                    else self.ice("This list should only be Args")
+                )
+        defaults = [x.value.gen.py_ast[0] for x in node.params if x.value]
         node.gen.py_ast = [
             self.sync(
                 ast3.arguments(

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -2216,7 +2216,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
             return uni.FuncSignature(
                 params=[],
                 return_type=None,
-                kid=[],
+                kid=[self.operator(Tok.LPAREN, "("), self.operator(Tok.RPAREN, ")")],
             )
 
     def operator(self, tok: Tok, value: str) -> uni.Token:

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -193,7 +193,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         ret_sig = self.convert(node.returns) if node.returns else None
         if isinstance(ret_sig, uni.Expr):
             if not sig:
-                sig = uni.FuncSignature(params=None, return_type=ret_sig, kid=[ret_sig])
+                sig = uni.FuncSignature(params=[], return_type=ret_sig, kid=[ret_sig])
             else:
                 sig.return_type = ret_sig
                 sig.add_kids_right([sig.return_type])
@@ -296,7 +296,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                 and isinstance(body_stmt.signature, uni.FuncSignature)
                 and body_stmt.signature.params
             ):
-                for param in body_stmt.signature.params.items:
+                for param in body_stmt.signature.params:
                     if param.name.value == "self":
                         param.type_tag = uni.SubTag[uni.Expr](name, kid=[name])
         doc = (
@@ -2201,21 +2201,17 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
 
         valid_params = [param for param in params if isinstance(param, uni.ParamVar)]
         if valid_params:
-            fs_params = uni.SubNodeList[uni.ParamVar](
-                items=valid_params, delim=Tok.COMMA, kid=valid_params
-            )
+            fs_params = valid_params
             return uni.FuncSignature(
                 params=fs_params,
                 return_type=None,
-                kid=[fs_params],
+                kid=fs_params,
             )
         else:
-            _lparen = self.operator(Tok.LPAREN, "(")
-            _rparen = self.operator(Tok.RPAREN, ")")
             return uni.FuncSignature(
-                params=None,
+                params=[],
                 return_type=None,
-                kid=[_lparen, _rparen],
+                kid=[],
             )
 
     def operator(self, tok: Tok, value: str) -> uni.Token:

--- a/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
@@ -63,12 +63,12 @@ class PyJacAstLinkPass(UniPass):
 
         if isinstance(node.decl_link, uni.Ability) and node.decl_link.signature:
             if isinstance(node.spec, uni.FuncSignature) and node.spec.params:
-                for src_prm in node.spec.params.items:
+                for src_prm in node.spec.params:
                     if (
                         isinstance(node.decl_link.signature, uni.FuncSignature)
                         and node.decl_link.signature.params
                     ):
-                        for trg_prm in node.decl_link.signature.params.items:
+                        for trg_prm in node.decl_link.signature.params:
                             if src_prm.name.sym_name == trg_prm.name.sym_name:
                                 self.link_jac_py_nodes(
                                     jac_node=src_prm, py_nodes=trg_prm.gen.py_ast

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -250,9 +250,16 @@ class DocIRGenPass(UniPass):
                 parts.append(i.gen.doc_ir)
             elif isinstance(i, uni.Token) and i.name == Tok.RPAREN and node.params:
                 in_params = False
-                parts.append(self.indent(self.concat([self.tight_line(), *indent_parts])))
+                parts.append(
+                    self.indent(self.concat([self.tight_line(), *indent_parts]))
+                )
                 parts.append(self.tight_line())
                 parts.append(i.gen.doc_ir)
+                parts.append(self.space())
+            elif isinstance(i, uni.Token) and i.name == Tok.RPAREN:
+                parts.pop()
+                parts.append(i.gen.doc_ir)
+                parts.append(self.space())
             elif in_params:
                 if isinstance(i, uni.Token) and i.name == Tok.COMMA:
                     indent_parts.append(i.gen.doc_ir)

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -242,14 +242,23 @@ class DocIRGenPass(UniPass):
     def exit_func_signature(self, node: uni.FuncSignature) -> None:
         """Generate DocIR for function signatures."""
         parts: list[doc.DocType] = []
+        indent_parts: list[doc.DocType] = []
+        in_params = False
         for i in node.kid:
-            if isinstance(i, uni.Token) and i.name == Tok.LPAREN:
+            if isinstance(i, uni.Token) and i.name == Tok.LPAREN and node.params:
+                in_params = True
                 parts.append(i.gen.doc_ir)
-            elif i == node.params:
-                parts.append(
-                    self.indent(self.concat([self.tight_line(), i.gen.doc_ir]))
-                )
+            elif isinstance(i, uni.Token) and i.name == Tok.RPAREN and node.params:
+                in_params = False
+                parts.append(self.indent(self.concat([self.tight_line(), *indent_parts])))
                 parts.append(self.tight_line())
+                parts.append(i.gen.doc_ir)
+            elif in_params:
+                if isinstance(i, uni.Token) and i.name == Tok.COMMA:
+                    indent_parts.append(i.gen.doc_ir)
+                    indent_parts.append(self.space())
+                else:
+                    indent_parts.append(i.gen.doc_ir)
             else:
                 parts.append(i.gen.doc_ir)
                 parts.append(self.space())

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -1874,11 +1874,11 @@ class FuncSignature(UniNode):
 
     def __init__(
         self,
-        params: Optional[SubNodeList[ParamVar]],
+        params: Sequence[ParamVar] | None,
         return_type: Optional[Expr],
         kid: Sequence[UniNode],
     ) -> None:
-        self.params = params
+        self.params: list[ParamVar] = list(params) if params else []
         self.return_type = return_type
         UniNode.__init__(self, kid=kid)
 
@@ -1886,11 +1886,14 @@ class FuncSignature(UniNode):
         res = True
         is_lambda = self.parent and isinstance(self.parent, LambdaExpr)
         if deep:
-            res = self.params.normalize(deep) if self.params else res
+            for prm in self.params:
+                res = res and prm.normalize(deep)
             res = res and self.return_type.normalize(deep) if self.return_type else res
         new_kid: list[UniNode] = [self.gen_token(Tok.LPAREN)] if not is_lambda else []
-        if self.params:
-            new_kid.append(self.params)
+        for idx, prm in enumerate(self.params):
+            new_kid.append(prm)
+            if idx < len(self.params) - 1:
+                new_kid.append(self.gen_token(Tok.COMMA))
         if not is_lambda:
             new_kid.append(self.gen_token(Tok.RPAREN))
         if self.return_type:


### PR DESCRIPTION
## Summary
- refactor `FuncSignature` to store param variables as a sequence
- adjust parser and AST passes for new list-based parameters
- update MTLLM plugin and semtable for sequence params

## Testing
- `pre-commit` *(fails: unable to access pre-commit hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683bc39a76488322b3d551ab666c2cab