### PR TITLE
Refactor GlobalStmt target

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -1476,7 +1476,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.consume_token(Tok.GLOBAL_OP)
             target = self.consume(uni.SubNodeList)
             return uni.GlobalStmt(
-                target=target,
+                target=target.items,
                 kid=self.cur_nodes,
             )
 
@@ -1488,7 +1488,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.consume_token(Tok.NONLOCAL_OP)
             target = self.consume(uni.SubNodeList)
             return uni.NonLocalStmt(
-                target=target,
+                target=target.items,
                 kid=self.cur_nodes,
             )
 

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1886,7 +1886,7 @@ class PyastGenPass(UniPass):
 
     def exit_global_stmt(self, node: uni.GlobalStmt) -> None:
         py_nodes = []
-        for x in node.target.items:
+        for x in node.target:
             py_nodes.append(
                 self.sync(
                     ast3.Global(names=[x.sym_name]),
@@ -1897,7 +1897,7 @@ class PyastGenPass(UniPass):
 
     def exit_non_local_stmt(self, node: uni.NonLocalStmt) -> None:
         py_nodes = []
-        for x in node.target.items:
+        for x in node.target:
             py_nodes.append(
                 self.sync(
                     ast3.Nonlocal(names=[x.sym_name]),

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1263,8 +1263,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                     pos_end=0,
                 )
             )
-        target = uni.SubNodeList[uni.NameAtom](items=names, delim=Tok.COMMA, kid=names)
-        return uni.GlobalStmt(target=target, kid=[target])
+        return uni.GlobalStmt(target=names, kid=names)
 
     def proc_if_exp(self, node: py_ast.IfExp) -> uni.IfElseExpr:
         """Process python node.
@@ -1790,8 +1789,7 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
                     pos_end=0,
                 )
             )
-        target = uni.SubNodeList[uni.NameAtom](items=names, delim=Tok.COMMA, kid=names)
-        return uni.NonLocalStmt(target=target, kid=names)
+        return uni.NonLocalStmt(target=names, kid=names)
 
     def proc_pass(self, node: py_ast.Pass) -> uni.Semi:
         """Process python node."""

--- a/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyjac_ast_link_pass.py
@@ -108,11 +108,11 @@ class PyJacAstLinkPass(UniPass):
             self.link_jac_py_nodes(jac_node=node.alias, py_nodes=node.gen.py_ast)
 
     def exit_global_stmt(self, node: uni.GlobalStmt) -> None:
-        for x, y in enumerate(node.target.items):
+        for x, y in enumerate(node.target):
             self.link_jac_py_nodes(jac_node=y, py_nodes=[node.gen.py_ast[x]])
 
     def exit_non_local_stmt(self, node: uni.NonLocalStmt) -> None:
-        for x, y in enumerate(node.target.items):
+        for x, y in enumerate(node.target):
             self.link_jac_py_nodes(jac_node=y, py_nodes=[node.gen.py_ast[x]])
 
     def exit_k_w_pair(self, node: uni.KWPair) -> None:

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -2862,22 +2862,24 @@ class GlobalStmt(CodeBlockStmt):
 
     def __init__(
         self,
-        target: SubNodeList[NameAtom],
+        target: Sequence[NameAtom],
         kid: Sequence[UniNode],
     ) -> None:
-        self.target = target
+        self.target: list[NameAtom] = list(target)
         UniNode.__init__(self, kid=kid)
         CodeBlockStmt.__init__(self)
 
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.target.normalize(deep)
-        new_kid: list[UniNode] = [
-            self.gen_token(Tok.GLOBAL_OP),
-            self.target,
-            self.gen_token(Tok.SEMI),
-        ]
+            for item in self.target:
+                res = res and item.normalize(deep)
+        new_kid: list[UniNode] = [self.gen_token(Tok.GLOBAL_OP)]
+        for idx, item in enumerate(self.target):
+            new_kid.append(item)
+            if idx < len(self.target) - 1:
+                new_kid.append(self.gen_token(Tok.COMMA))
+        new_kid.append(self.gen_token(Tok.SEMI))
         self.set_kids(nodes=new_kid)
         return res
 
@@ -2888,12 +2890,14 @@ class NonLocalStmt(GlobalStmt):
     def normalize(self, deep: bool = False) -> bool:
         res = True
         if deep:
-            res = self.target.normalize(deep)
-        new_kid: list[UniNode] = [
-            self.gen_token(Tok.NONLOCAL_OP),
-            self.target,
-            self.gen_token(Tok.SEMI),
-        ]
+            for item in self.target:
+                res = res and item.normalize(deep)
+        new_kid: list[UniNode] = [self.gen_token(Tok.NONLOCAL_OP)]
+        for idx, item in enumerate(self.target):
+            new_kid.append(item)
+            if idx < len(self.target) - 1:
+                new_kid.append(self.gen_token(Tok.COMMA))
+        new_kid.append(self.gen_token(Tok.SEMI))
         self.set_kids(nodes=new_kid)
         return res
 


### PR DESCRIPTION
## Summary
- refactor `GlobalStmt` and `NonLocalStmt` to store their targets as a sequence of `NameAtom`
- update parser and passes for new target structure
- adjust python AST generation and linking logic
- simplify Python AST load logic

## Testing
- `pre-commit run --all-files` *(fails: cannot access network)*

------
https://chatgpt.com/codex/tasks/task_e_683bc43dd6c8832286f0bcdeb2e3109d