### PR TITLE
Modify Enum body to use Sequence

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -693,7 +693,8 @@ class JacParser(Transform[uni.Source, uni.Module]):
             if self.match_token(Tok.SEMI):
                 inh, body = sub_list1, None
             else:
-                body = sub_list2 or sub_list1
+                body_sn = sub_list2 or sub_list1
+                body = body_sn.items if body_sn else []
                 inh = sub_list2 and sub_list1
             return uni.Enum(
                 name=name,

--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -226,6 +226,7 @@ class PyastGenPass(UniPass):
         self,
         node: (
             Sequence[uni.CodeBlockStmt]
+            | Sequence[uni.EnumBlockStmt]
             | uni.SubNodeList[uni.CodeBlockStmt]
             | uni.SubNodeList[uni.ArchBlockStmt]
             | uni.SubNodeList[uni.EnumBlockStmt]


### PR DESCRIPTION
## Summary
- change `Enum.body` type to `Sequence[EnumBlockStmt] | ImplDef | None`
- adjust parser to populate new body format
- update normalize logic for Enum
- allow `resolve_stmt_block` to handle `Sequence[EnumBlockStmt]`

## Testing
- `pre-commit` *(fails: unable to fetch hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683ca91942ec832289d43acecc80d981