### PR TITLE
Fix parser AST kid lists

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -141,6 +141,17 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 self.parse_ref.cur_node = node
                 if node not in self.parse_ref.node_list:
                     self.parse_ref.node_list.append(node)
+                # Flatten kid to avoid nested list objects in AST
+                flat_kid: list[uni.UniNode] = []
+                changed = False
+                for k in node.kid:
+                    if isinstance(k, list):
+                        flat_kid.extend(k)
+                        changed = True
+                    else:
+                        flat_kid.append(k)
+                if changed:
+                    node.set_kids(flat_kid)
             return node
 
         def _call_userfunc(

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -45,7 +45,13 @@ class UniNode:
     def __init__(self, kid: Sequence[UniNode]) -> None:
         """Initialize ast."""
         self.parent: Optional[UniNode] = None
-        self.kid: list[UniNode] = [x.set_parent(self) for x in kid]
+        flat_kid: list[UniNode] = []
+        for k in kid:
+            if isinstance(k, list):
+                flat_kid.extend(k)
+            else:
+                flat_kid.append(k)
+        self.kid: list[UniNode] = [x.set_parent(self) for x in flat_kid]
         self._sub_node_tab: dict[type, list[UniNode]] = {}
         self.construct_sub_node_tab()
         self._in_mod_nodes: list[UniNode] = []


### PR DESCRIPTION
## Summary
- ensure AST nodes remove nested lists when converting parse trees
- flatten list arguments during UniNode initialization

## Testing
- `pytest -k parser -q` *(fails: environment lacks required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683cd37baef08322a4104aceaf9ea3b2