### PR TITLE
Refactor enum_block list handling

### DIFF
--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -229,7 +229,6 @@ class PyastGenPass(UniPass):
             | Sequence[uni.EnumBlockStmt]
             | uni.SubNodeList[uni.CodeBlockStmt]
             | uni.SubNodeList[uni.ArchBlockStmt]
-            | uni.SubNodeList[uni.EnumBlockStmt]
             | None
         ),
         doc: Optional[uni.String] = None,


### PR DESCRIPTION
## Summary
- replace `enum_block` SubNodeList with plain list of `EnumBlockStmt`
- adapt `enum_decl`, `impl_def`, and `impl_tail` for new list usage
- update `resolve_stmt_block` typing in `pyast_gen_pass`

## Testing
- `pre-commit` *(fails: Couldn't connect to server)*
- `pytest -q jac/jaclang/compiler/tests/test_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_683ceb2535508322a1a878172a58c894