### PR TITLE
Refactor func_decl_params to return list

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -880,9 +880,9 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 if self.match_token(Tok.RETURN_HINT):
                     return_spec = self.consume(uni.Expr)
                 return uni.FuncSignature(
-                    params=self.extract_from_list(params, uni.ParamVar)
-                    if params
-                    else [],
+                    params=(
+                        self.extract_from_list(params, uni.ParamVar) if params else []
+                    ),
                     return_type=return_spec,
                     kid=self.flat_cur_nodes,
                 )
@@ -892,10 +892,6 @@ class JacParser(Transform[uni.Source, uni.Module]):
 
             func_decl_params: (param_var COMMA)* param_var COMMA?
             """
-            params = [self.consume(uni.ParamVar)]
-            while self.match_token(Tok.COMMA):
-                if param_stmt := self.match(uni.ParamVar):
-                    params.append(param_stmt)
             return [*self.cur_nodes]
 
         def param_var(self, _: None) -> uni.ParamVar:
@@ -1623,14 +1619,14 @@ class JacParser(Transform[uni.Source, uni.Module]):
             self.consume_token(Tok.COLON)
             body = self.consume(uni.Expr)
             if params:
-                sig_kid.append(params)
+                sig_kid.extend(params)
             if return_type:
                 sig_kid.append(return_type)
             signature = (
                 uni.FuncSignature(
-                    params=self.extract_from_list(params, uni.ParamVar)
-                    if params
-                    else [],
+                    params=(
+                        self.extract_from_list(params, uni.ParamVar) if params else []
+                    ),
                     return_type=return_type,
                     kid=sig_kid,
                 )

--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -861,7 +861,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             func_decl: (LPAREN func_decl_params? RPAREN) (RETURN_HINT expression)?
                     | (RETURN_HINT expression)
             """
-            params: uni.SubNodeList | None = None
+            params: list[uni.UniNode] | None = None
             return_spec: uni.Expr | None = None
 
             # Check if starting with RETURN_HINT
@@ -870,35 +870,33 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 return uni.FuncSignature(
                     params=[],
                     return_type=return_spec,
-                    kid=self.cur_nodes,
+                    kid=self.flat_cur_nodes,
                 )
             # Otherwise, parse the traditional parameter list form
             else:
                 self.consume_token(Tok.LPAREN)
-                params = self.match(uni.SubNodeList)
+                params = self.match(list)
                 self.consume_token(Tok.RPAREN)
                 if self.match_token(Tok.RETURN_HINT):
                     return_spec = self.consume(uni.Expr)
                 return uni.FuncSignature(
-                    params=params.items if params else [],
+                    params=self.extract_from_list(params, uni.ParamVar)
+                    if params
+                    else [],
                     return_type=return_spec,
-                    kid=self.cur_nodes,
+                    kid=self.flat_cur_nodes,
                 )
 
-        def func_decl_params(self, _: None) -> uni.SubNodeList[uni.ParamVar]:
+        def func_decl_params(self, _: None) -> list[uni.UniNode]:
             """Grammar rule.
 
             func_decl_params: (param_var COMMA)* param_var COMMA?
             """
-            paramvar: list = []
-            while param_stmt := self.match(uni.ParamVar):
-                paramvar.append(param_stmt)
-                self.match_token(Tok.COMMA)
-            return uni.SubNodeList[uni.ParamVar](
-                items=paramvar,
-                delim=Tok.COMMA,
-                kid=self.cur_nodes,
-            )
+            params = [self.consume(uni.ParamVar)]
+            while self.match_token(Tok.COMMA):
+                if param_stmt := self.match(uni.ParamVar):
+                    params.append(param_stmt)
+            return [*self.cur_nodes]
 
         def param_var(self, _: None) -> uni.ParamVar:
             """Grammar rule.
@@ -1619,7 +1617,7 @@ class JacParser(Transform[uni.Source, uni.Module]):
             return_type: uni.Expr | None = None
             sig_kid: list[uni.UniNode] = []
             self.consume_token(Tok.KW_LAMBDA)
-            params = self.match(uni.SubNodeList)
+            params = self.match(list)
             if self.match_token(Tok.RETURN_HINT):
                 return_type = self.consume(uni.Expr)
             self.consume_token(Tok.COLON)
@@ -1630,7 +1628,9 @@ class JacParser(Transform[uni.Source, uni.Module]):
                 sig_kid.append(return_type)
             signature = (
                 uni.FuncSignature(
-                    params=params.items if params else [],
+                    params=self.extract_from_list(params, uni.ParamVar)
+                    if params
+                    else [],
                     return_type=return_type,
                     kid=sig_kid,
                 )


### PR DESCRIPTION
## Summary
- refactor `func_decl_params` rule in parser to return regular lists
- update `func_decl` and `lambda_expr` to use `extract_from_list`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683ceb3911f8832289b441e14a627af4