### PR TITLE
Refactor assignment list parser

### DIFF
--- a/jac/jaclang/compiler/parser.py
+++ b/jac/jaclang/compiler/parser.py
@@ -311,11 +311,9 @@ class JacParser(Transform[uni.Source, uni.Module]):
             assignments_list = self.consume(list)
             return uni.GlobalVars(
                 access=access_tag,
-                assignments=self.extract_from_list(
-                    assignments_list, uni.Assignment
-                ),
+                assignments=self.extract_from_list(assignments_list, uni.Assignment),
                 is_frozen=is_frozen,
-                kid=self.cur_nodes,
+                kid=self.flat_cur_nodes,
             )
 
         def access_tag(self, _: None) -> uni.SubTag[uni.Token]:


### PR DESCRIPTION
## Summary
- replace SubNodeList usage for `assignment_list`
- handle assignments in enum and global var parsing

## Testing
- `pre-commit run --files jac/jaclang/compiler/parser.py` *(fails: pre-commit not installed)*
- `pytest jac/jaclang/compiler/tests/test_parser.py::TestLarkParser::test_parser_fam -q` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683d3fcbd7f883228ded4d8d2e4cb977