### PR TITLE
Playground - send the graph at the end of the Execution 

### DIFF
--- a/docs/docs/playground/python/debugger.py
+++ b/docs/docs/playground/python/debugger.py
@@ -1,8 +1,6 @@
+import time
 import bdb
-
-import sys
 from typing import Callable
-
 
 class Debugger(bdb.Bdb):
 
@@ -61,6 +59,8 @@ class Debugger(bdb.Bdb):
             self.set_break(self.filepath, lineno)
         self.breakpoint_buff.clear()
         self.run(self.code)
+        time.sleep(0.2)
+        self._send_graph()
 
     def do_continue(self) -> None:
         self.set_continue()

--- a/docs/docs/playground/python/main_playground.py
+++ b/docs/docs/playground/python/main_playground.py
@@ -1,8 +1,6 @@
 import io
-import os
-import sys
-
 import contextlib
+
 from collections.abc import Iterable
 
 # If these variables are not set by the pyodide this will raise an exception.


### PR DESCRIPTION
* `debugger.py` - Added a call to `time.sleep(0.2)` and `_send_graph()` in the `do_run` method to introduce a delay and send a graph after running the code.

[Screencast from 2025-06-04 17-38-00.webm](https://github.com/user-attachments/assets/7f141020-396f-453f-b526-8303ae73f0f7)
