### PR TITLE
Fix lint issues

### DIFF
--- a/jac/jaclang/compiler/passes/main/type_checker_pass.py
+++ b/jac/jaclang/compiler/passes/main/type_checker_pass.py
@@ -13,7 +13,7 @@ Pyright Reference:
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional, Sequence, TYPE_CHECKING, Union
 
 import jaclang.compiler.unitree as uni
 from jaclang.compiler.constant import Tokens as Tok
@@ -344,7 +344,9 @@ class TypeCheckerPass(UniPass):
         except Exception as e:
             self.log_warning(f"Failed to define ability type: {e}")
 
-    def _get_assignment_target_type(self, target: Any) -> Optional[TypeBase]:
+    def _get_assignment_target_type(
+        self, target: Union[Sequence[uni.UniNode], uni.UniNode]
+    ) -> Optional[TypeBase]:
         """Get the type of an assignment target."""
         try:
             if hasattr(target, "__iter__") and not isinstance(target, str):
@@ -360,7 +362,7 @@ class TypeCheckerPass(UniPass):
 
         return None
 
-    def _get_single_target_type(self, target: Any) -> Optional[TypeBase]:
+    def _get_single_target_type(self, target: uni.UniNode) -> Optional[TypeBase]:
         """Get the type of a single assignment target."""
         try:
             # If target is a name, look up its current type
@@ -380,7 +382,7 @@ class TypeCheckerPass(UniPass):
             return self.type_factory.create_unknown_type()
 
     def _update_symbol_type_from_assignment(
-        self, target: Any, value_type: TypeBase
+        self, target: Union[Sequence[uni.UniNode], uni.UniNode], value_type: TypeBase
     ) -> None:
         """Update symbol type based on assignment."""
         try:
@@ -394,7 +396,7 @@ class TypeCheckerPass(UniPass):
         except Exception as e:
             self.log_warning(f"Error updating symbol type: {e}")
 
-    def _update_single_symbol_type(self, target: Any, value_type: TypeBase) -> None:
+    def _update_single_symbol_type(self, target: uni.UniNode, value_type: TypeBase) -> None:
         """Update a single symbol's type from assignment."""
         try:
             if (

--- a/jac/jaclang/compiler/type_system/diagnostics.py
+++ b/jac/jaclang/compiler/type_system/diagnostics.py
@@ -85,7 +85,7 @@ class TypeDiagnostic:
         return cls(message, DiagnosticSeverity.INFO, node, None, error_code)
 
     def __str__(self) -> str:
-        """String representation of the diagnostic."""
+        """Return string representation of the diagnostic."""
         location_str = f" at {self.location}" if self.location else ""
         error_code_str = f" [{self.error_code}]" if self.error_code else ""
         return f"{self.severity.value.upper()}: {self.message}{location_str}{error_code_str}"
@@ -200,7 +200,7 @@ class DiagnosticSink:
         return len(self.diagnostics)
 
     def __str__(self) -> str:
-        """String representation of the diagnostic sink."""
+        """Return string representation of the diagnostic sink."""
         summary = self.get_summary()
         return f"DiagnosticSink({summary})"
 

--- a/jac/jaclang/compiler/type_system/primitive_types.py
+++ b/jac/jaclang/compiler/type_system/primitive_types.py
@@ -9,7 +9,7 @@ Pyright Reference:
 - Collection type implementations for List, Dict, Set equivalents
 """
 
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 from .types import TypeBase, TypeCategory, TypeFlags
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class PrimitiveType(TypeBase):
     """Base class for primitive types like int, float, str, bool."""
 
-    def __init__(self, name: str, default_value: Any = None) -> None:
+    def __init__(self, name: str, default_value: object | None = None) -> None:
         """Initialize a primitive type."""
         super().__init__(TypeCategory.PRIMITIVE, TypeFlags.INSTANTIABLE_INSTANCE)
         self.name = name
@@ -53,7 +53,7 @@ class PrimitiveType(TypeBase):
         return self.name
 
     def __str__(self) -> str:
-        """String representation of the type."""
+        """Return string representation of the type."""
         return self.name
 
 

--- a/jac/jaclang/compiler/type_system/symbol_table.py
+++ b/jac/jaclang/compiler/type_system/symbol_table.py
@@ -80,7 +80,7 @@ class TypedSymbol:
         return f"{self.name}: {type_info}{constraint_info}"
 
     def __str__(self) -> str:
-        """String representation of the typed symbol."""
+        """Return string representation of the typed symbol."""
         return f"TypedSymbol({self.name}: {self.symbol_type.get_display_name()})"
 
     def __repr__(self) -> str:
@@ -252,14 +252,14 @@ class EnhancedSymbolTable:
         prefix = "  " * indent
         print(f"{prefix}EnhancedSymbolTable({self.scope_id}):")
 
-        for name, symbol in self.symbols.items():
+        for _, symbol in self.symbols.items():
             print(f"{prefix}  {symbol.get_display_info()}")
 
         for child in self.child_tables:
             child.debug_print(indent + 1)
 
     def __str__(self) -> str:
-        """String representation of the enhanced symbol table."""
+        """Return string representation of the enhanced symbol table."""
         return f"EnhancedSymbolTable({self.scope_id}, {len(self.symbols)} symbols)"
 
     def __repr__(self) -> str:

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -10,7 +10,7 @@ Pyright Reference:
 - Key methods: getType, getTypeOfExpression, assignType, etc.
 """
 
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
 import jaclang.compiler.unitree as uni
 
@@ -120,7 +120,7 @@ class TypeEvaluator:
         return result_type
 
     def _evaluate_expression_type(self, node: uni.UniNode) -> TypeBase:
-        """Internal method to evaluate expression types."""
+        """Evaluate expression type of the given node."""
         match type(node):
             case uni.Name:
                 return self._evaluate_name_type(node)
@@ -253,7 +253,11 @@ class TypeEvaluator:
         return self.type_factory.create_unknown_type()
 
     def _evaluate_arithmetic_binary_op(
-        self, left_type: TypeBase, op: Any, right_type: TypeBase, node: uni.UniNode
+        self,
+        left_type: TypeBase,
+        op: Union[uni.Token, uni.DisconnectOp, uni.ConnectOp],
+        right_type: TypeBase,
+        node: uni.UniNode,
     ) -> TypeBase:
         """Evaluate arithmetic binary operations."""
         # String concatenation
@@ -292,14 +296,22 @@ class TypeEvaluator:
         return self.type_factory.create_unknown_type()
 
     def _evaluate_comparison_binary_op(
-        self, left_type: TypeBase, op: Any, right_type: TypeBase, node: uni.UniNode
+        self,
+        left_type: TypeBase,
+        op: Union[uni.Token, uni.DisconnectOp, uni.ConnectOp],
+        right_type: TypeBase,
+        node: uni.UniNode,
     ) -> TypeBase:
         """Evaluate comparison binary operations."""
         # Comparison operations always return bool
         return self.type_factory.get_primitive_type("bool")
 
     def _evaluate_logical_binary_op(
-        self, left_type: TypeBase, op: Any, right_type: TypeBase, node: uni.UniNode
+        self,
+        left_type: TypeBase,
+        op: Union[uni.Token, uni.DisconnectOp, uni.ConnectOp],
+        right_type: TypeBase,
+        node: uni.UniNode,
     ) -> TypeBase:
         """Evaluate logical binary operations."""
         # Logical operations return bool

--- a/jac/jaclang/compiler/type_system/types.py
+++ b/jac/jaclang/compiler/type_system/types.py
@@ -72,7 +72,7 @@ class TypeBase(ABC):
         pass
 
     def __str__(self) -> str:
-        """String representation of the type."""
+        """Return string representation of the type."""
         return self.get_display_name()
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary
- fix typing annotations for target and op handling
- update string representation docstrings to imperative mood
- ensure primitive types avoid `Any`
- fix unused variable in symbol table

## Testing
- `pre-commit run --files jac/jaclang/compiler/passes/main/type_checker_pass.py jac/jaclang/compiler/type_system/diagnostics.py jac/jaclang/compiler/type_system/primitive_types.py jac/jaclang/compiler/type_system/symbol_table.py jac/jaclang/compiler/type_system/type_evaluator.py jac/jaclang/compiler/type_system/types.py`
- `pytest -k "nothing" -q`

------
https://chatgpt.com/codex/tasks/task_e_68425a268584832292373eb0c465d442