### PR TITLE
Enable natural import for language server

### DIFF
--- a/jac/examples/reference/concurrent_expressions.py
+++ b/jac/examples/reference/concurrent_expressions.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 from jaclang.runtimelib.builtin import *
 from jaclang import JacMachineInterface as _
+from time import sleep
 
 if _.TYPE_CHECKING:
     from time import sleep
-else:
-    (sleep,) = _.jac_import("time", __file__, items={"sleep": None})
 
 
 class A(_.Node):

--- a/jac/examples/reference/import_include_statements.py
+++ b/jac/examples/reference/import_include_statements.py
@@ -1,8 +1,10 @@
 import os
 import datetime as dt
 from math import sqrt as square_root, log
+import sys
 
-from .base_module_structure import add, subtract
+sys.path.append(os.path.dirname(__file__))
+from base_module_structure import add, subtract
 
 for i in range(int(square_root(dt.datetime.now().year))):
     print(os.getcwd(), add(i, subtract(i, 1)), int(log(i + 1)))

--- a/jac/examples/reference/import_include_statements.py
+++ b/jac/examples/reference/import_include_statements.py
@@ -1,13 +1,8 @@
-from jaclang import JacMachineInterface as _
 import os
 import datetime as dt
 from math import sqrt as square_root, log
 
-(add, subtract) = _.jac_import(
-    target="base_module_structure",
-    base_path=__file__,
-    items={"add": None, "subtract": None},
-)
+from .base_module_structure import add, subtract
 
 for i in range(int(square_root(dt.datetime.now().year))):
     print(os.getcwd(), add(i, subtract(i, 1)), int(log(i + 1)))

--- a/jac/examples/reference/special_comprehensions.py
+++ b/jac/examples/reference/special_comprehensions.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 from jaclang.runtimelib.builtin import *
 from jaclang import JacMachineInterface as _
+import random
 
 if _.TYPE_CHECKING:
     import random
-else:
-    (random,) = _.jac_import("random", __file__)
 
 
 class TestObj(_.Obj):

--- a/jac/jaclang/__init__.py
+++ b/jac/jaclang/__init__.py
@@ -1,5 +1,7 @@
 """The Jac Programming Language."""
 
+import sys
+
 from jaclang.runtimelib.machine import (
     JacMachine,
     JacMachineImpl,
@@ -7,7 +9,6 @@ from jaclang.runtimelib.machine import (
     plugin_manager,
 )
 from jaclang.runtimelib.meta_importer import JacMetaImporter
-import sys
 
 
 plugin_manager.register(JacMachineImpl)

--- a/jac/jaclang/__init__.py
+++ b/jac/jaclang/__init__.py
@@ -6,9 +6,14 @@ from jaclang.runtimelib.machine import (
     JacMachineInterface,
     plugin_manager,
 )
+from jaclang.runtimelib.meta_importer import JacMetaImporter
+import sys
 
 
 plugin_manager.register(JacMachineImpl)
 plugin_manager.load_setuptools_entrypoints("jac")
+
+if not any(isinstance(f, JacMetaImporter) for f in sys.meta_path):
+    sys.meta_path.insert(0, JacMetaImporter())
 
 __all__ = ["JacMachineInterface", "JacMachine"]

--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -272,12 +272,8 @@ def lsp() -> None:
     Examples:
         jac lsp
     """
-    from jaclang import JacMachineInterface as _
+    from jaclang.langserve.server import run_lang_server
 
-    run_lang_server_tuple = _.jac_import(
-        "...jaclang.langserve.server", __file__, items={"run_lang_server": None}
-    )
-    run_lang_server = run_lang_server_tuple[0]
     run_lang_server()  # type: ignore
 
 

--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -274,7 +274,7 @@ def lsp() -> None:
     """
     from jaclang.langserve.server import run_lang_server
 
-    run_lang_server()  # type: ignore
+    run_lang_server()
 
 
 @cmd_registry.register

--- a/jac/jaclang/compiler/tests/fixtures/pkg_import_lib_py/__init__.py
+++ b/jac/jaclang/compiler/tests/fixtures/pkg_import_lib_py/__init__.py
@@ -1,9 +1,5 @@
 from jaclang import JacMachineInterface as _
 
-(tool_func,) = _.jac_import(
-    target="tools",
-    base_path=__file__,
-    items={"tool_func": None},
-)
+from .tools import tool_func
 
 glob_var_lib = "pkg_import_lib_py.glob_var_lib"

--- a/jac/jaclang/compiler/tests/fixtures/pkg_import_lib_py/sub/__init__.py
+++ b/jac/jaclang/compiler/tests/fixtures/pkg_import_lib_py/sub/__init__.py
@@ -1,7 +1,3 @@
 from jaclang import JacMachineInterface as _
 
-(help_func,) = _.jac_import(
-    target=".helper",
-    base_path=__file__,
-    items={"help_func": None},
-)
+from .helper import help_func

--- a/jac/jaclang/langserve/__init__.jac
+++ b/jac/jaclang/langserve/__init__.jac
@@ -1,1 +1,1 @@
-"""Jac Language Server Protocol implementation."""
+"""Jaclang langserve package."""

--- a/jac/jaclang/langserve/tests/server_test/test_lang_serve.py
+++ b/jac/jaclang/langserve/tests/server_test/test_lang_serve.py
@@ -23,15 +23,8 @@ from jaclang.langserve.tests.server_test.utils import (
 from jaclang.vendor.pygls.uris import from_fs_path
 from jaclang.vendor.pygls.workspace import Workspace
 from jaclang import JacMachineInterface as _
-
-JacLangServer = _.jac_import(
-    "....langserve.engine", __file__, items={"JacLangServer": None}
-)[0]
-(did_open, did_save, did_change, formatting) = _.jac_import(
-    "....langserve.server",
-    __file__,
-    items={"did_open": None, "did_save": None, "did_change": None, "formatting": None},
-)
+from jaclang.langserve.engine import JacLangServer
+from jaclang.langserve.server import did_open, did_save, did_change, formatting
 
 JAC_FILE = get_jac_file_path()
 
@@ -331,7 +324,7 @@ class TestLangServe:
 
         before_sem_tokens_1 = ls.get_semantic_tokens(uri1)
         before_sem_tokens_2 = ls.get_semantic_tokens(uri2)
-        assert len(before_sem_tokens_1.data) ==15
+        assert len(before_sem_tokens_1.data) == 15
         assert len(before_sem_tokens_2.data) == 0
 
         changed_code = get_simple_code("glob x = 90;")

--- a/jac/jaclang/langserve/tests/server_test/utils.py
+++ b/jac/jaclang/langserve/tests/server_test/utils.py
@@ -7,11 +7,6 @@ from jaclang.vendor.pygls.uris import from_fs_path
 from jaclang.vendor.pygls.workspace import Workspace
 
 from textwrap import dedent
-from jaclang import JacMachineInterface as _
-
-JacLangServer = _.jac_import(
-    "....langserve.engine", __file__, items={"JacLangServer": None}
-)[0]
 
 
 def get_jac_file_path():
@@ -125,7 +120,7 @@ def get_code(code: str) -> str:
 def get_simple_code(code: str) -> str:
     """Generate a sample Jac code snippet with optional test code injected."""
     jac_code = dedent(
-        f'''
+        f"""
     
     # Unit Tests!
     glob expected_area0 = 78.53981633974483;
@@ -134,12 +129,15 @@ def get_simple_code(code: str) -> str:
     glob expected_area2 = 78.53981633974483;
 
 
-'''
+"""
     )
     return jac_code
 
+
 def create_ls_with_workspace(file_path: str):
     """Create JacLangServer and workspace for a given file path, return (uri, ls)."""
+    from jaclang.langserve.engine import JacLangServer
+
     ls = JacLangServer()
     uri = from_fs_path(file_path)
     ls.lsp._workspace = Workspace(os.path.dirname(file_path), ls)

--- a/jac/jaclang/langserve/tests/test_sem_tokens.py
+++ b/jac/jaclang/langserve/tests/test_sem_tokens.py
@@ -4,12 +4,9 @@ import copy
 import lsprotocol.types as lspt
 from jaclang import JacMachineInterface as _
 from jaclang.utils.test import TestCase
+from jaclang.langserve.sem_manager import SemTokManager
 
 from typing import Tuple
-
-SemTokManager = _.jac_import("..sem_manager", __file__, items={"SemTokManager": None})[
-    0
-]
 
 
 class TestUpdateSemTokens(TestCase):

--- a/jac/jaclang/langserve/tests/test_server.py
+++ b/jac/jaclang/langserve/tests/test_server.py
@@ -5,11 +5,8 @@ from jaclang.vendor.pygls.workspace import Workspace
 import lsprotocol.types as lspt
 import pytest
 from jaclang import JacMachineInterface as _
-
-JacLangServer = _.jac_import(
-    "...langserve.engine", __file__, items={"JacLangServer": None}
-)[0]
-LspSession = _.jac_import("session", __file__, items={"LspSession": None})[0]
+from jaclang.langserve.engine import JacLangServer
+from .session import LspSession
 
 
 class TestJacLangServer(TestCase):

--- a/jac/jaclang/runtimelib/meta_importer.py
+++ b/jac/jaclang/runtimelib/meta_importer.py
@@ -1,0 +1,49 @@
+import importlib.abc
+import importlib.util
+import os
+import sys
+from types import ModuleType
+
+from jaclang.utils import resolve_module
+from jaclang.runtimelib.machine import JacMachineInterface
+
+
+class JacMetaImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Meta path importer to load .jac modules via Python's import system."""
+
+    def find_spec(self, fullname: str, path=None, target=None):
+        search_path = path[0] if path else os.getcwd()
+        try:
+            file_path, lang = resolve_module(fullname, search_path)
+        except Exception:
+            return None
+        if lang != "jac":
+            return None
+        is_package = os.path.basename(file_path) == "__init__.jac"
+        loader = self
+        spec = importlib.util.spec_from_file_location(
+            fullname,
+            file_path,
+            loader=loader,
+            submodule_search_locations=[os.path.dirname(file_path)] if is_package else None,
+        )
+        return spec
+
+    def create_module(self, spec):
+        return None  # use default machinery
+
+    def exec_module(self, module: ModuleType) -> None:
+        file_path = module.__spec__.origin  # type: ignore
+        base_path = os.path.dirname(file_path)
+        target = os.path.splitext(os.path.basename(file_path))[0]
+        ret = JacMachineInterface.jac_import(
+            target=target,
+            base_path=base_path,
+            override_name=module.__name__,
+        )
+        if ret:
+            loaded_module = ret[0]
+            module.__dict__.update(loaded_module.__dict__)
+        else:
+            raise ImportError(f"Unable to import {module.__name__}")
+

--- a/jac/jaclang/runtimelib/meta_importer.py
+++ b/jac/jaclang/runtimelib/meta_importer.py
@@ -1,17 +1,26 @@
+"""Jac meta path importer."""
+
 import importlib.abc
+import importlib.machinery
 import importlib.util
 import os
-import sys
 from types import ModuleType
+from typing import Optional, Sequence
 
-from jaclang.utils import resolve_module
 from jaclang.runtimelib.machine import JacMachineInterface
+from jaclang.utils import resolve_module
 
 
 class JacMetaImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     """Meta path importer to load .jac modules via Python's import system."""
 
-    def find_spec(self, fullname: str, path=None, target=None):
+    def find_spec(
+        self,
+        fullname: str,
+        path: Optional[Sequence[str]] = None,
+        target: Optional[ModuleType] = None,
+    ) -> Optional[importlib.machinery.ModuleSpec]:
+        """Find the spec for the module."""
         search_path = path[0] if path else os.getcwd()
         try:
             file_path, lang = resolve_module(fullname, search_path)
@@ -25,15 +34,25 @@ class JacMetaImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
             fullname,
             file_path,
             loader=loader,
-            submodule_search_locations=[os.path.dirname(file_path)] if is_package else None,
+            submodule_search_locations=(
+                [os.path.dirname(file_path)] if is_package else None
+            ),
         )
         return spec
 
-    def create_module(self, spec):
+    def create_module(
+        self, spec: importlib.machinery.ModuleSpec
+    ) -> Optional[ModuleType]:
+        """Create the module."""
         return None  # use default machinery
 
     def exec_module(self, module: ModuleType) -> None:
-        file_path = module.__spec__.origin  # type: ignore
+        """Execute the module."""
+        if not module.__spec__ or not module.__spec__.origin:
+            raise ImportError(
+                f"Cannot find spec or origin for module {module.__name__}"
+            )
+        file_path = module.__spec__.origin
         base_path = os.path.dirname(file_path)
         target = os.path.splitext(os.path.basename(file_path))[0]
         ret = JacMachineInterface.jac_import(
@@ -46,4 +65,3 @@ class JacMetaImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
             module.__dict__.update(loaded_module.__dict__)
         else:
             raise ImportError(f"Unable to import {module.__name__}")
-


### PR DESCRIPTION
## Summary
- support loading `.jac` modules via a meta path importer
- register the importer when `jaclang` is imported
- use normal `import` in CLI for the language server

## Testing
- `pre-commit run --files jac/jaclang/cli/cli.py jac/jaclang/__init__.py jac/jaclang/runtimelib/meta_importer.py` *(fails: CONNECT tunnel failed)*
- `pytest jac/jaclang/langserve/tests/test_server.py::TestJacLangServer::test_formatting -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a4a1cfe0832292d86f58b8591b17