### PR TITLE
[BugFix] Support unicode

### DIFF
--- a/docs/docs/communityhub/release_notes.md
+++ b/docs/docs/communityhub/release_notes.md
@@ -7,6 +7,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 *   **JacMachine Interface Reorganization**: The machine and interface have been refactored to maintain a shared global state—similar to Python's `sys.modules`—removing the need to explicitly pass execution context and dramatically improving performance.
 *   **Async Walker Support**: Introduced comprehensive async walker functionality that brings Python's async/await paradigm to object-spatial programming. Async walkers enable non-blocking spawns during graph traversal, allowing for concurrent execution of multiple walkers and efficient handling of I/O-bound operations.
 *   **Native Jac Imports**: Native import statements can now be used to import Jac modules seamlessly into python code, eliminating the need to use `_.jac_import()`.
+*   **Unicode String Literal Support**: Fixed unicode character handling in string literals. Unicode characters like "✓", "○", emojis, and other international characters are now properly preserved during compilation instead of being corrupted into byte sequences.
 
 ## jaclang 0.8.1 / jac-cloud 0.2.1 / mtllm 0.3.6
 

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -4572,17 +4572,21 @@ class String(Literal):
             return eval(self.value)
 
         elif self.value.startswith(("'", '"')):
-            repr_str = self.value.encode().decode("unicode_escape")
-            if (
-                (self.value.startswith('"""') and self.value.endswith('"""'))
-                or (self.value.startswith("'''") and self.value.endswith("'''"))
-            ) and not self.find_parent_of_type(FString):
-                return repr_str[3:-3]
             if (not self.find_parent_of_type(FString)) or (
                 not (self.parent and isinstance(self.parent, FString))
             ):
-                return repr_str[1:-1]
-            return repr_str
+                try:
+                    return ast3.literal_eval(self.value)
+                except (ValueError, SyntaxError):
+                    if (
+                        self.value.startswith('"""') and self.value.endswith('"""')
+                    ) or (self.value.startswith("'''") and self.value.endswith("'''")):
+                        return self.value[3:-3]
+                    return self.value[1:-1]
+            try:
+                return ast3.literal_eval(self.value)
+            except (ValueError, SyntaxError):
+                return self.value
         else:
             return self.value
 

--- a/jac/jaclang/tests/fixtures/unicode_strings.jac
+++ b/jac/jaclang/tests/fixtures/unicode_strings.jac
@@ -1,0 +1,24 @@
+with entry {
+    # unicode characters
+    items = [{"title":"1st", "due":True, "completed":True}, {"title":"2nd", "due":False, "completed":False}];
+    for (i, item) in enumerate(items) {
+        status = "✓" if item["completed"] else "○";
+        due = f" (due: {item['due']})" if item["due"] else "";
+        print(f"{i+1}. {status} {item['title']}{due}");
+    }
+    
+    # unicode emojis and symbols
+    print("🌟 Star");    
+    
+    # unicode in triple quoted strings
+    multiline = """Multi-line with ✓ unicode and ○ symbols""";
+    print(multiline);
+    
+    # unicode in raw strings
+    raw_unicode = r"Raw string with ✓ and ○";
+    print(raw_unicode);
+    
+    # mixed unicode and escape sequences
+    mixed = "Tab ✓\nNewline ○";
+    print(mixed);
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1308,3 +1308,17 @@ class JacLanguageTests(TestCase):
         self.assertIn("foo1", stdout_value[5])
         self.assertIn("foo2", stdout_value[6])
         self.assertIn("Coroutine task is completed", stdout_value[17])
+
+    def test_unicode_string_literals(self) -> None:
+        """Test unicode characters in string literals are preserved correctly."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        Jac.jac_import("unicode_strings", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue().split("\n")
+        self.assertIn("1. ✓ 1st (due: True)", stdout_value[0])
+        self.assertIn("🌟 Star", stdout_value[2])
+        self.assertIn("Multi-line with ✓ unicode and ○ symbols", stdout_value[3])
+        self.assertIn("Raw string with ✓ and ○", stdout_value[4])
+        self.assertIn("Tab ✓", stdout_value[5])
+        self.assertIn("Newline ○", stdout_value[6])


### PR DESCRIPTION
## **Description**
Issue

- Unicode characters in Jac string literals were being corrupted during compilation
- Characters like "✓" and "○" were converted to byte sequences like `'â\x9c\x93'` and `'â\x97\x8b'`

Fix

- Removed `encode().decode("unicode_escape")` approach that was corrupting unicode characters
- Now uses Python's built-in `ast.literal_eval()` for safe and proper string literal evaluation
