### PR TITLE
Refactor token handling

### DIFF
--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -2814,9 +2814,7 @@ class PyastGenPass(UniPass):
         node.gen.py_ast = [self.sync(ast3.Constant(value=float(node.value)))]
 
     def exit_int(self, node: uni.Int) -> None:
-        node.gen.py_ast = [
-            self.sync(ast3.Constant(value=int(node.value, 0)))
-        ]
+        node.gen.py_ast = [self.sync(ast3.Constant(value=int(node.value, 0)))]
 
     def exit_string(self, node: uni.String) -> None:
         node.gen.py_ast = [self.sync(ast3.Constant(value=node.lit_value))]


### PR DESCRIPTION
## Summary
- map tokens to AST nodes using dictionaries
- simplify unary expr generation
- simplify integer constant conversion

## Testing
- `pre-commit run --files jac/jaclang/compiler/passes/main/pyast_gen_pass.py` *(fails: CONNECT tunnel failed)*
- `pytest -k test_dummy` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684b327c56f4832280f749c8658cd96c