### PR TITLE
[UniiR] The CFG links are fixed and the tests are reinstated 

### DIFF
--- a/jac/jaclang/compiler/passes/main/cfg_build_pass.py
+++ b/jac/jaclang/compiler/passes/main/cfg_build_pass.py
@@ -12,6 +12,7 @@ The pass also includes functionality to coalesce basic blocks and generate visua
 
 import jaclang.compiler.unitree as uni
 from jaclang.compiler.passes import UniPass
+from typing import Sequence
 
 
 class CFGBuildPass(UniPass):
@@ -65,26 +66,49 @@ class CFGBuildPass(UniPass):
             else:
                 target.bb_in = [source]
 
+    def get_code_block_sequence(
+        self, node: uni.CodeBlockStmt
+    ) -> list[uni.UniCFGNode] | None:
+        """Get code block sequence."""
+        sequence: list[uni.UniCFGNode] = []
+        if hasattr(node, "body") and isinstance(node.body, Sequence):
+            for bbs in node.body:
+                if isinstance(bbs, uni.UniCFGNode):
+                    sequence.append(bbs.unparse())
+            if sequence:
+                return sequence
+            else:
+                return None
+        else:
+            return None
+
     def enter_node(self, node: uni.UniNode) -> None:
         """Enter BasicBlockStmt nodes."""
         if isinstance(node, uni.UniCFGNode) and not isinstance(node, uni.Semi):
-            if node.parent and isinstance(node, uni.CodeBlockStmt) and self.first_exit:
-                bb_stmts = [
-                    bbs for bbs in node.parent.kid if isinstance(bbs, uni.UniCFGNode)
-                ]
+            if (
+                isinstance(node, uni.CodeBlockStmt)
+                and node.parent
+                and (
+                    not (isinstance(node, uni.ElseIf) or isinstance(node, uni.ElseStmt))
+                )
+                and self.get_code_block_sequence(node.parent)
+                and self.first_exit
+            ):
+                bb_stmts = self.get_code_block_sequence(node.parent)
+                # bb_stmts = [
+                #     bbs for bbs in node.parent.body if isinstance(bbs, uni.UniCFGNode)
+                # ]
+                print(f"Node: {node.unparse()} | BB stmts: {bb_stmts}")
                 if (
-                    node.parent.parent
-                    and isinstance(node.parent.parent, uni.Archetype)
+                    node.parent
+                    and isinstance(node.parent, uni.Archetype)
                     # and isinstance(node.parent.parent, uni.BasicBlockStmt)
                 ):
-                    parent_obj = node.parent.parent
+                    parent_obj = node.parent
                     if parent_obj:
                         self.link_bbs(parent_obj, node)
                 elif bb_stmts[0] == node:
-                    if (
-                        isinstance(node.parent.parent, uni.ModuleCode)
-                        and self.to_connect
-                    ):
+                    if isinstance(node.parent, uni.ModuleCode) and self.to_connect:
                         for bb in self.to_connect:
                             self.link_bbs(bb, node)
                             self.to_connect.remove(bb)  # if self.to_connect:
@@ -93,6 +117,8 @@ class CFGBuildPass(UniPass):
                         if parent_bb:
                             self.link_bbs(parent_bb, node)
                 elif self.to_connect:
+                    print(f">>>>Node: {node.unparse()}")
+                    print(f"To connect: {self.to_connect}")
                     to_remove = []
                     for parent in self.to_connect:
                         if isinstance(parent, uni.UniCFGNode):
@@ -107,7 +133,9 @@ class CFGBuildPass(UniPass):
                             self.link_bbs(parent_bb, node)
 
             else:
+                print(f"---------Node: {node.unparse()}")
                 parent_bb = self.get_parent_bb_stmt(node)
+                print(f"Parent BB: {parent_bb}")
                 if parent_bb:
                     self.link_bbs(parent_bb, node)
             if isinstance(node, (uni.InForStmt, uni.IterForStmt, uni.WhileStmt)):
@@ -159,6 +187,16 @@ class CFGBuildPass(UniPass):
                     parent_bb = self.get_parent_bb_stmt(node)
                     if parent_bb:
                         self.link_bbs(parent_bb, node)
+
+        cfg_pass = CoalesceBBPass(
+            ir_in=self.ir_in,
+            prog=self.prog,
+        )
+
+        dot = cfg_pass.printgraph_cfg()
+
+        with open("cfg_gen.dot", "w") as f:
+            f.write(dot)
 
 
 class CoalesceBBPass(UniPass):

--- a/jac/jaclang/compiler/passes/main/tests/test_cfg_build_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_cfg_build_pass.py
@@ -5,7 +5,7 @@ from jaclang.utils.test import TestCase
 import unittest
 
 
-@unittest.skip("Skipping CFG build pass tests")
+# @unittest.skip("Skipping CFG build pass tests")
 class TestCFGBuildPass(TestCase):
     """Test FuseTypeInfoPass module."""
 
@@ -30,6 +30,9 @@ class TestCFGBuildPass(TestCase):
         )
 
         dot = cfg_pass.printgraph_cfg()
+
+        with open(self.fixture_abs_path("cfg_gen.dot"), "w") as f:
+            f.write(dot)
 
         expected_dot = (
             "digraph G {\n"


### PR DESCRIPTION
## **Description**
The CFG links were not created correctly since the removal of subnode list ast nodes which the underlying algorithm depended upon. Instead a new algorithm to get a sequence of operations are integrated, that made the existing tests pass.