### PR TITLE
Refactor: update pre-build hook to remove existing jac-lang zip file and recreate

### DIFF
--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -30,10 +30,11 @@ def pre_build_hook(**kwargs: dict) -> None:
     """
     print("Running pre-build hook...")
     copy_example_folder()
-    if not os.path.exists(PLAYGROUND_ZIP_PATH):
-        create_playground_zip()
-    else:
-        print(f"Zip file already exists: {PLAYGROUND_ZIP_PATH}. Skipping creation.")
+    if os.path.exists(PLAYGROUND_ZIP_PATH):
+        print(f"Removing existing zip file: {PLAYGROUND_ZIP_PATH}")
+        os.remove(PLAYGROUND_ZIP_PATH)
+    create_playground_zip()
+    print("Jaclang zip file created successfully.")
 
     if is_file_older_than_minutes(UNIIR_NODE_DOC, 5):
         with open(UNIIR_NODE_DOC, "w") as f:

--- a/docs/scripts/mkdocs_serve.py
+++ b/docs/scripts/mkdocs_serve.py
@@ -133,7 +133,10 @@ def serve_with_watch() -> None:
     port = 8000
     root_dir = os.path.dirname(os.path.dirname(__file__))
     site_dir = os.path.join(root_dir, "site")
-    ignore_paths = [os.path.join(root_dir, "docs", "assets")]
+    ignore_paths = [
+        os.path.join(root_dir, "docs", "assets"),
+        os.path.join(root_dir, "docs", "playground", "jaclang.zip"),
+    ]
 
     print("Initial build of MkDocs site...")
     subprocess.run(["mkdocs", "build"], check=True, cwd=root_dir)


### PR DESCRIPTION
This approach ensures that the zip file always contains the latest version of the jaclang folder and its contents. It prevents issues where stale or outdated files might remain in the zip archive if files are deleted or updated in the source directory. By recreating the zip file on every rebuild, we guarantee that the playground always serves the most up-to-date and consistent version of the codebase.