### PR TITLE
Update example paths and remove copy examples function

### DIFF
--- a/docs/docs/playground/jac_examples.json
+++ b/docs/docs/playground/jac_examples.json
@@ -1,13 +1,13 @@
 {
   "Basic": {
-    "For Loop": "reference/for_statements.jac",
-    "While Loop": "reference/while_statements.jac",
-    "Archetypes": "reference/archetype_bodies.jac",
-    "Code Block Statements": "reference/codeblocks_and_statements.jac",
-    "Assignments": "reference/assignments.jac",
-    "Conditional Statements": "reference/if_statements.jac"
+    "For Loop": "basic/for_statements.jac",
+    "While Loop": "basic/while_statements.jac",
+    "Archetypes": "basic/archetype_bodies.jac",
+    "Code Block Statements": "basic/codeblocks_and_statements.jac",
+    "Assignments": "basic/assignments.jac",
+    "Conditional Statements": "basic/if_statements.jac"
   },
-  "Data Spatial Programming": {
-    "Reference": "reference/data_spatial_references.jac"
+  "Object Spatial Programming": {
+    "Reference": "object_spatial/object_spatial_references.jac"
   }
 }

--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -4,7 +4,6 @@ This script is used to handle the jac compile data for jac playground.
 """
 
 import os
-import shutil
 import subprocess
 import time
 import zipfile

--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -29,7 +29,6 @@ def pre_build_hook(**kwargs: dict) -> None:
     This function is called before the build process starts.
     """
     print("Running pre-build hook...")
-    copy_example_folder()
     if os.path.exists(PLAYGROUND_ZIP_PATH):
         print(f"Removing existing zip file: {PLAYGROUND_ZIP_PATH}")
         os.remove(PLAYGROUND_ZIP_PATH)
@@ -94,35 +93,6 @@ def get_top_contributors() -> str:
     return subprocess.check_output(["python", "../scripts/top_contributors.py"]).decode(
         "utf-8"
     )
-
-
-def copy_example_folder() -> None:
-    """Copy only .jac files from the example folder to the documentation assets, preserving the folder structure."""
-    try:
-        if os.path.exists(EXAMPLE_TARGET_FOLDER):
-            print(
-                f"Destination folder '{EXAMPLE_TARGET_FOLDER}' already exists. Removing it..."
-            )
-            shutil.rmtree(EXAMPLE_TARGET_FOLDER)
-
-        for root, _dirs, files in os.walk(EXAMPLE_SOURCE_FOLDER):
-            rel_path = os.path.relpath(root, EXAMPLE_SOURCE_FOLDER)
-            target_dir = os.path.join(EXAMPLE_TARGET_FOLDER, rel_path)
-            os.makedirs(target_dir, exist_ok=True)
-
-            for file in files:
-                if file.endswith(".jac"):
-                    src_file = os.path.join(root, file)
-                    dst_file = os.path.join(target_dir, file)
-                    shutil.copy2(src_file, dst_file)
-
-        print(
-            f"Copied only .jac files from '{EXAMPLE_SOURCE_FOLDER}' to "
-            f"'{EXAMPLE_TARGET_FOLDER}' preserving folder structure."
-        )
-
-    except Exception as e:
-        print(f"Error occurred: {e}")
 
 
 pre_build_hook()


### PR DESCRIPTION
### Documentation structure updates:
* Updated example references to use a more intuitive folder structure by replacing "reference" with "basic" and renaming "Data Spatial Programming" to "Object Spatial Programming."

### Codebase simplification:
* Removed the `copy_example_folder` function, which handled copying `.jac` files to documentation assets. This function is no longer needed, simplifying the script.
* Updated the `pre_build_hook` function to remove the call to `copy_example_folder`, aligning with the removal of the function itself.