### PR TITLE
🎯 Semstring are codegenerated to python (this is required to remove SemRegistry)

### DIFF
--- a/jac/jaclang/compiler/passes/main/sem_def_match_pass.py
+++ b/jac/jaclang/compiler/passes/main/sem_def_match_pass.py
@@ -65,3 +65,4 @@ class SemDefMatchPass(Transform[uni.Module, uni.Module]):
             target_sym = self.find_symbol_from_dotted_name(sym.sym_name, target_sym_tab)
             if target_sym is not None:
                 target_sym.decl.name_of.semstr = semdef.value.lit_value
+                target_sym.semstr = semdef.value.lit_value

--- a/jac/jaclang/compiler/passes/main/tests/fixtures/codegen_sem.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/codegen_sem.jac
@@ -1,0 +1,53 @@
+
+# Function (full).
+def fn1(bar: int, baz: int) -> None {}
+sem fn1 = "A function that takes two integers and returns nothing.";
+sem fn1.bar = "The first integer parameter.";
+sem fn1.baz = "The second integer parameter.";
+
+# Function (Missing baz)
+def fn2(bar: int, baz: int) -> None {}
+sem fn2 = "A function that takes one integer and returns nothing.";
+sem fn2.bar = "The first integer parameter.";
+
+# Function (Without sem at all)
+def fn3(bar: int, baz: int) -> None {}
+
+# Architype (with body).
+obj Arch1 {
+    has bar: int;
+    has baz: int;
+}
+sem Arch1 = "An object that contains two integer properties.";
+sem Arch1.bar = "The first integer property.";
+sem Arch1.baz = "The second integer property.";
+
+# Architype (without body).
+obj Arch2;
+impl Arch2 {
+    has bar: int;
+    has baz: int;
+}
+sem Arch2 = "An object that contains two integer properties.";
+sem Arch2.bar = "The first integer property.";
+sem Arch2.baz = "The second integer property.";
+
+# Enum (with body).
+enum Enum1 {
+    Bar,
+    Baz,
+}
+sem Enum1 = "An enumeration that defines two values: Bar and Baz.";
+sem Enum1.Bar = "The Bar value of the Enum1 enumeration.";
+sem Enum1.Baz = "The Baz value of the Enum1 enumeration.";
+
+# Enum (without body).
+enum Enum2;
+impl Enum2 {
+    Bar,
+    Baz,
+}
+sem Enum2 = "An enumeration that defines two values: Bar and Baz.";
+sem Enum2.Bar = "The Bar value of the Enum2 enumeration.";
+sem Enum2.Baz = "The Baz value of the Enum2 enumeration.";
+

--- a/jac/jaclang/compiler/passes/main/tests/test_pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_pyast_gen_pass.py
@@ -41,6 +41,51 @@ class PyastGenPassTests(TestCaseMicroSuite, AstSyncTestMixin):
 
         self.assertFalse(out.errors_had)
 
+    def test_sem_decorator(self) -> None:
+        """Test for @_.sem(...) decorator."""
+        code_gen = (out := JacProgram()).compile(
+            self.fixture_abs_path("codegen_sem.jac"),
+        )
+        if code_gen.gen.py_ast and isinstance(code_gen.gen.py_ast[0], ast3.Module):
+            prog = compile(code_gen.gen.py_ast[0], filename="<ast>", mode="exec")
+            module = types.ModuleType("__main__")
+            module.__dict__["__file__"] = code_gen.loc.mod_path
+            exec(prog, module.__dict__)
+
+            # Function (full).
+            self.assertEqual(getattr(module.fn1, '_jac_semstr'), "A function that takes two integers and returns nothing.")
+            self.assertEqual(getattr(module.fn1, '_jac_semstr_inner')['bar'], "The first integer parameter.")
+            self.assertEqual(getattr(module.fn1, '_jac_semstr_inner')['baz'], "The second integer parameter.")
+
+            # Function (Missing baz)
+            self.assertEqual(getattr(module.fn2, '_jac_semstr'), "A function that takes one integer and returns nothing.")
+            self.assertEqual(getattr(module.fn2, '_jac_semstr_inner')['bar'], "The first integer parameter.")
+            self.assertNotIn('baz', getattr(module.fn2, '_jac_semstr_inner'))
+
+            # Function (Without sem at all)
+            self.assertFalse(hasattr(module.fn3, '_jac_semstr'))
+
+            # Architype (with body).
+            self.assertEqual(getattr(module.Arch1, '_jac_semstr'), "An object that contains two integer properties.")
+            self.assertEqual(getattr(module.Arch1, '_jac_semstr_inner')['bar'], "The first integer property.")
+            self.assertEqual(getattr(module.Arch1, '_jac_semstr_inner')['baz'], "The second integer property.")
+
+            # Architype (without body).
+            self.assertEqual(getattr(module.Arch2, '_jac_semstr'), "An object that contains two integer properties.")
+            self.assertEqual(getattr(module.Arch2, '_jac_semstr_inner')['bar'], "The first integer property.")
+            self.assertEqual(getattr(module.Arch2, '_jac_semstr_inner')['baz'], "The second integer property.")
+
+            # Enum (with body).
+            self.assertEqual(getattr(module.Enum1, '_jac_semstr'), "An enumeration that defines two values: Bar and Baz.")
+            self.assertEqual(getattr(module.Enum1, '_jac_semstr_inner')['Bar'], "The Bar value of the Enum1 enumeration.")
+            self.assertEqual(getattr(module.Enum1, '_jac_semstr_inner')['Baz'], "The Baz value of the Enum1 enumeration.")
+
+            # Enum (without body).
+            self.assertEqual(getattr(module.Enum2, '_jac_semstr'), "An enumeration that defines two values: Bar and Baz.")
+            self.assertEqual(getattr(module.Enum2, '_jac_semstr_inner')['Bar'], "The Bar value of the Enum2 enumeration.")
+            self.assertEqual(getattr(module.Enum2, '_jac_semstr_inner')['Baz'], "The Baz value of the Enum2 enumeration.")
+
+
     def test_circle_py_ast(self) -> None:
         """Basic test for pass."""
         code_gen = (out := JacProgram()).compile(

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -242,6 +242,7 @@ class Symbol:
         defn.sym = self
         self.access: SymbolAccess = access
         self.parent_tab = parent_tab
+        self.semstr: str = ""
 
     @property
     def decl(self) -> NameAtom:

--- a/jac/jaclang/runtimelib/machine.py
+++ b/jac/jaclang/runtimelib/machine.py
@@ -1341,6 +1341,17 @@ class JacBasics:
         return func
 
     @staticmethod
+    def sem(semstr: str, inner_semstr: dict[str, str]) -> Callable:
+        """Attach the semstring to the given object."""
+
+        def decorator(obj: object) -> object:
+            setattr(obj, "_jac_semstr", semstr)  # noqa:B010
+            setattr(obj, "_jac_semstr_inner", inner_semstr)  # noqa:B010
+            return obj
+
+        return decorator
+
+    @staticmethod
     def with_llm(
         file_loc: str,
         model: Any,  # noqa: ANN401


### PR DESCRIPTION
### Jac syntax to codegen
```py
def get_weather(city: str) -> str by llm();

sem get_weather = "Returns the weather for a given city.";
sem get_weather.city = "Name of the city to get the weather for.";
```

### Here is the generated code
```py
@_.sem(
    "Returns the weather for a given city.", {
        "city" : "Name of the city to get the weather for.",
    }
)
def get_weather(city: str):
   ...
```

closes: https://github.com/jaseci-labs/jaseci/issues/2211