### PR TITLE
Extend leaderboard to jivas and playground

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -1595,7 +1595,7 @@
                         <p class="about-description">
                             Jac is an innovative programming language that extends Python's semantics while maintaining
                             full interoperability with the Python ecosystem. Created by <strong><a href="https://github.com/marsninja" target="_blank" class="fancy-link">@marsninja</a></strong>
-                            with contributions from <strong><a href="/communityhub/top_contributors/" target="_blank" class="fancy-link">Jac Hackers Everywhere</a></strong>,
+                            with contributors of <strong><a href="/communityhub/top_contributors/" target="_blank" class="fancy-link">Jac Hackers Everywhere</a></strong>,
                             it introduces cutting-edge programming models and abstractions specifically designed to minimize
                             complexity and embrace AI-forward development.
                         </p>

--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -53,8 +53,8 @@ def pre_build_hook(**kwargs: dict) -> None:
                 get_top_contributors(
                     [
                         "jaseci-labs/jaseci",
-                        "jaseci-labs/jac_playground",
                         "TrueSelph/jivas",
+                        "jaseci-labs/jac_playground",
                     ]
                 )
             )

--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -49,11 +49,15 @@ def pre_build_hook(**kwargs: dict) -> None:
     if is_file_older_than_minutes(TOP_CONTRIBUTORS_DOC, 5):
         with open(TOP_CONTRIBUTORS_DOC, "w") as f:
             # Add extra repos for tabbed view
-            f.write(get_top_contributors([
-                "jaseci-labs/jaseci",
-                "jaseci-labs/jac_playground",
-                "TrueSelph/jivas"
-            ]))
+            f.write(
+                get_top_contributors(
+                    [
+                        "jaseci-labs/jaseci",
+                        "jaseci-labs/jac_playground",
+                        "TrueSelph/jivas",
+                    ]
+                )
+            )
     else:
         print(f"File is recent: {TOP_CONTRIBUTORS_DOC}. Skipping creation.")
 
@@ -92,7 +96,7 @@ def create_playground_zip() -> None:
     print("Zip saved to:", PLAYGROUND_ZIP_PATH)
 
 
-def get_top_contributors(repos=None) -> str:
+def get_top_contributors(repos: list[str] | None = None) -> str:
     """Get the top contributors for the jaclang repository and extra repos as HTML tabs."""
     # Get the current directory (docs/scripts)
     current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -48,7 +48,12 @@ def pre_build_hook(**kwargs: dict) -> None:
 
     if is_file_older_than_minutes(TOP_CONTRIBUTORS_DOC, 5):
         with open(TOP_CONTRIBUTORS_DOC, "w") as f:
-            f.write(get_top_contributors())
+            # Add extra repos for tabbed view
+            f.write(get_top_contributors([
+                "jaseci-labs/jaseci",
+                "jaseci-labs/jac_playground",
+                "TrueSelph/jivas"
+            ]))
     else:
         print(f"File is recent: {TOP_CONTRIBUTORS_DOC}. Skipping creation.")
 
@@ -87,16 +92,16 @@ def create_playground_zip() -> None:
     print("Zip saved to:", PLAYGROUND_ZIP_PATH)
 
 
-def get_top_contributors() -> str:
-    """Get the top contributors for the jaclang repository."""
+def get_top_contributors(repos=None) -> str:
+    """Get the top contributors for the jaclang repository and extra repos as HTML tabs."""
     # Get the current directory (docs/scripts)
     current_dir = os.path.dirname(os.path.abspath(__file__))
     # Go to the root directory (two levels up from docs/scripts)
     root_dir = os.path.dirname(os.path.dirname(current_dir))
-
-    return subprocess.check_output(
-        ["python3", "scripts/top_contributors.py"], cwd=root_dir
-    ).decode("utf-8")
+    cmd = ["python3", "scripts/top_contributors.py"]
+    if repos:
+        cmd += ["--repo", repos[0], "--extra-repos"] + repos[1:]
+    return subprocess.check_output(cmd, cwd=root_dir).decode("utf-8")
 
 
 pre_build_hook()

--- a/scripts/top_contributors.py
+++ b/scripts/top_contributors.py
@@ -85,6 +85,16 @@ tabel_css = """
 </style>
 """
 
+def format_repo_name(repo: str) -> str:
+    """Convert a GitHub repo string to a title-cased display name.
+
+    Examples:
+        'jaclang/jac_playground' -> 'Jac Playground'
+    """
+    name = repo.split("/")[-1]
+    name = name.replace("_", " ").replace("-", " ")
+    return name.title()
+
 def get_repo_from_remote() -> Tuple[Optional[str], Optional[str]]:
     """Get repository owner and name from git remote URL."""
     try:
@@ -222,7 +232,7 @@ def generate_markdown_table(contributors: List[Dict[str, Any]], days: int, repo:
 def generate_html_table(contributors: List[Dict[str, Any]], days: int, repo: str) -> str:
     """Generate an HTML table from contributor data and return as string."""
     if not contributors:
-        return f"<p>No contributions found in the last {days} days for {repo}.</p>"
+        return f"<p>No contributions found in the last {days} days for {format_repo_name(repo)}.</p>"
 
     end_date = datetime.now(timezone.utc).date()
     start_date = end_date - timedelta(days=days)
@@ -268,17 +278,6 @@ function showTab(idx) {{
 }}
 </script>
 """
-
-def format_repo_name(repo: str) -> str:
-    """Convert a GitHub repo string to a title-cased display name.
-
-    Examples:
-        'jaclang/jac_playground' -> 'Jac Playground'
-    """
-    name = repo.split("/")[-1]
-    name = name.replace("_", " ").replace("-", " ")
-    return name.title()
-
 
 def get_tabs_html(repo_tables: list) -> str:
     """Return HTML for the tab headers, aligned across the page."""

--- a/scripts/top_contributors.py
+++ b/scripts/top_contributors.py
@@ -85,6 +85,7 @@ tabel_css = """
 </style>
 """
 
+
 def format_repo_name(repo: str) -> str:
     """Convert a GitHub repo string to a title-cased display name.
 
@@ -94,6 +95,7 @@ def format_repo_name(repo: str) -> str:
     name = repo.split("/")[-1]
     name = name.replace("_", " ").replace("-", " ")
     return name.title()
+
 
 def get_repo_from_remote() -> Tuple[Optional[str], Optional[str]]:
     """Get repository owner and name from git remote URL."""
@@ -205,8 +207,11 @@ def process_contributors(
         reverse=True,
     )
 
+
 # not using now since HTML tables have been used
-def generate_markdown_table(contributors: List[Dict[str, Any]], days: int, repo: str) -> str:
+def generate_markdown_table(
+    contributors: List[Dict[str, Any]], days: int, repo: str
+) -> str:
     """Generate a markdown table from contributor data and return as string."""
     if not contributors:
         return f"No contributions found in the last {days} days for {repo}.\n"
@@ -225,11 +230,16 @@ def generate_markdown_table(contributors: List[Dict[str, Any]], days: int, repo:
         login = contributor["login"]
         commits = contributor["commits"]
         active_days = contributor["active_days"]
-        lines.append(f"| [@{login}](https://github.com/{login}) | {commits} | {active_days} |")
+        lines.append(
+            f"| [@{login}](https://github.com/{login}) | {commits} | {active_days} |"
+        )
     lines.append("\n")
     return "\n".join(lines)
 
-def generate_html_table(contributors: List[Dict[str, Any]], days: int, repo: str) -> str:
+
+def generate_html_table(
+    contributors: List[Dict[str, Any]], days: int, repo: str
+) -> str:
     """Generate an HTML table from contributor data and return as string."""
     if not contributors:
         return f"<p>No contributions found in the last {days} days for {format_repo_name(repo)}.</p>"
@@ -239,26 +249,30 @@ def generate_html_table(contributors: List[Dict[str, Any]], days: int, repo: str
 
     lines = []
     lines.append(
-        f'<h3>Top contributors in the last {days} days '
+        f"<h3>Top contributors in the last {days} days "
         f'({start_date.strftime("%Y-%m-%d")} to {end_date.strftime("%Y-%m-%d")})</h3>'
     )
-    lines.append('<table>')
-    lines.append('<thead><tr><th>Contributor</th><th>Commits</th><th>Active Days</th></tr></thead>')
-    lines.append('<tbody>')
+    lines.append("<table>")
+    lines.append(
+        "<thead><tr><th>Contributor</th><th>Commits</th><th>Active Days</th></tr></thead>"
+    )
+    lines.append("<tbody>")
     for contributor in contributors:
         login = contributor["login"]
         commits = contributor["commits"]
         active_days = contributor["active_days"]
         lines.append(
             f'<tr><td><a href="https://github.com/{login}">@{login}</a></td>'
-            f'<td>{commits}</td><td>{active_days}</td></tr>'
+            f"<td>{commits}</td><td>{active_days}</td></tr>"
         )
-    lines.append('</tbody></table>')
+    lines.append("</tbody></table>")
     return "\n".join(lines)
+
 
 def get_tabs_css() -> str:
     """Return CSS for the tab and table design (dark tab bar, clear selection, aligned tabs, responsive)."""
     return tabel_css
+
 
 def get_tabs_js(num_tabs: int) -> str:
     """Return JS for tab switching."""
@@ -279,15 +293,21 @@ function showTab(idx) {{
 </script>
 """
 
+
 def get_tabs_html(repo_tables: list) -> str:
     """Return HTML for the tab headers, aligned across the page."""
     tabs = []
     for idx, (repo, _) in enumerate(repo_tables):
         active = "active" if idx == 0 else ""
-        tabs.append(f'<li class="{active}" onclick="showTab({idx})" id="tab{idx}">{format_repo_name(repo)}</li>')
-    return '<ul id="tabs">\n' + "\n".join(tabs) + '\n</ul>'
+        tabs.append(
+            f'<li class="{active}" onclick="showTab({idx})" id="tab{idx}">{format_repo_name(repo)}</li>'
+        )
+    return '<ul id="tabs">\n' + "\n".join(tabs) + "\n</ul>"
 
-def get_tab_contents_html(repo_tables: List[Tuple[str, List[List[Dict[str, Any]]]]], periods: List[int]) -> str:
+
+def get_tab_contents_html(
+    repo_tables: List[Tuple[str, List[List[Dict[str, Any]]]]], periods: List[int]
+) -> str:
     """Return HTML for the tab contents, using HTML tables."""
     contents = []
     for idx, (repo, contributors_by_period) in enumerate(repo_tables):
@@ -297,28 +317,30 @@ def get_tab_contents_html(repo_tables: List[Tuple[str, List[List[Dict[str, Any]]
             days = periods[period_idx]
             tab_html.append(generate_html_table(contributors, days, repo))
         contents.append(
-            f'<div id="tabcontent{idx}" class="tabcontent" style="display:{display};">\n' +
-            "\n".join(tab_html) +
-            '\n</div>'
+            f'<div id="tabcontent{idx}" class="tabcontent" style="display:{display};">\n'
+            + "\n".join(tab_html)
+            + "\n</div>"
         )
     return "\n".join(contents)
 
-def print_tabbed_tables(repo_tables: List[Tuple[str, List[List[Dict[str, Any]]]]], periods: List[int]) -> None:
-    """Prints HTML tabbed view for multiple repo tables with separated HTML/CSS/JS and HTML tables."""
+
+def print_tabbed_tables(
+    repo_tables: List[Tuple[str, List[List[Dict[str, Any]]]]], periods: List[int]
+) -> None:
+    """Print HTML tabbed view for multiple repo tables with separated HTML/CSS/JS and HTML tables."""
     html = []
     html.append(get_tabs_css())
     html.append('<div style="margin-bottom: 1em;">')
     html.append(get_tabs_html(repo_tables))
-    html.append('</div>')
+    html.append("</div>")
     html.append(get_tab_contents_html(repo_tables, periods))
     html.append(get_tabs_js(len(repo_tables)))
     print("\n".join(html))
 
+
 DEFAULT_MAIN_REPO = "jaclang/jaclang"
-DEFAULT_EXTRA_REPOS = [
-    "TrueSelph/jivas",
-    "jaseci-labs/jac_playground"
-]
+DEFAULT_EXTRA_REPOS = ["TrueSelph/jivas", "jaseci-labs/jac_playground"]
+
 
 def main() -> None:
     """Run the script."""
@@ -372,7 +394,7 @@ def main() -> None:
         max_days = max(periods)
         all_commits = fetch_commits(owner or "", repo or "", max_days, token)
         if all_commits is None:
-            contributors_by_period = [[] for _ in periods]
+            contributors_by_period: list = [[] for _ in periods]
             repo_tables.append((repo_full, contributors_by_period))
             continue
         contributors_by_period = []
@@ -382,6 +404,7 @@ def main() -> None:
         repo_tables.append((repo_full, contributors_by_period))
 
     print_tabbed_tables(repo_tables, periods)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/top_contributors.py
+++ b/scripts/top_contributors.py
@@ -13,6 +13,77 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+tabel_css = """
+<style>
+#tabs {
+    display: flex;
+    justify-content: space-between;
+    padding: 0;
+    margin: 0 0 1em 0;
+    border-bottom: 2px solid #222;
+    background: #23272e;
+    list-style: none;
+    width: 100%;
+}
+#tabs li {
+    flex: 1 1 0;
+    padding: 0.7em 1.5em;
+    margin: 0;
+    cursor: pointer;
+    border: 1px solid #222;
+    border-bottom: none;
+    background: #23272e;
+    color: #bfc7d5;
+    border-radius: 8px 8px 0 0;
+    transition: background 0.2s, color 0.2s;
+    font-weight: 500;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+#tabs li.active, #tabs li:hover {
+    background: #181b20;
+    color: #fff;
+    font-weight: bold;
+    border-bottom: 2px solid #181b20;
+    box-shadow: 0 -2px 8px #181b20;
+    z-index: 2;
+}
+.tabcontent {
+    border: 1px solid #222;
+    border-radius: 0 0 8px 8px;
+    padding: 1.5em;
+    margin-bottom: 2em;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+    color: #e0e6ed;
+}
+.tabcontent table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1em 0;
+    font-size: 1em;
+    background: #23272e;
+    color: #e0e6ed;
+}
+.tabcontent th, .tabcontent td {
+    border: 1px solid #222;
+    padding: 0.7em 1em;
+    text-align: left;
+}
+.tabcontent th {
+    background: #181b20;
+    color: #7ecfff;
+    font-weight: 600;
+}
+.tabcontent tr:nth-child(even) {
+    background: #23272e;
+}
+.tabcontent tr:hover {
+    background: #2a313a;
+}
+</style>
+"""
 
 def get_repo_from_remote() -> Tuple[Optional[str], Optional[str]]:
     """Get repository owner and name from git remote URL."""
@@ -124,7 +195,7 @@ def process_contributors(
         reverse=True,
     )
 
-
+# not using now since HTML tables have been used
 def generate_markdown_table(contributors: List[Dict[str, Any]], days: int, repo: str) -> str:
     """Generate a markdown table from contributor data and return as string."""
     if not contributors:
@@ -177,106 +248,7 @@ def generate_html_table(contributors: List[Dict[str, Any]], days: int, repo: str
 
 def get_tabs_css() -> str:
     """Return CSS for the tab and table design (dark tab bar, clear selection, aligned tabs, responsive)."""
-    return """
-<style>
-#tabs {
-    display: flex;
-    justify-content: space-between;
-    padding: 0;
-    margin: 0 0 1em 0;
-    border-bottom: 2px solid #222;
-    background: #23272e;
-    list-style: none;
-    width: 100%;
-}
-#tabs li {
-    flex: 1 1 0;
-    text-align: center;
-    padding: 0.7em 1.5em;
-    margin: 0;
-    cursor: pointer;
-    border: 1px solid #222;
-    border-bottom: none;
-    background: #23272e;
-    color: #bfc7d5;
-    border-radius: 8px 8px 0 0;
-    transition: background 0.2s, color 0.2s;
-    font-weight: 500;
-    min-width: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-#tabs li.active, #tabs li:hover {
-    background: #181b20;
-    color: #fff;
-    font-weight: bold;
-    border-bottom: 2px solid #181b20;
-    box-shadow: 0 -2px 8px #181b20;
-    z-index: 2;
-}
-#tabs li:first-child {
-    text-align: left;
-    justify-content: flex-start;
-}
-#tabs li:nth-child(2) {
-    text-align: center;
-    justify-content: center;
-}
-#tabs li:last-child {
-    text-align: right;
-    justify-content: flex-end;
-}
-@media (max-width: 700px) {
-    #tabs {
-        flex-direction: column;
-        border-bottom: none;
-    }
-    #tabs li {
-        border-radius: 8px 8px 0 0;
-        border-bottom: 1px solid #222;
-        border-right: none;
-        text-align: left;
-    }
-    #tabs li.active, #tabs li:hover {
-        border-bottom: 2px solid #181b20;
-    }
-}
-.tabcontent {
-    background: #181b20;
-    border: 1px solid #222;
-    border-radius: 0 0 8px 8px;
-    padding: 1.5em;
-    margin-bottom: 2em;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-    color: #e0e6ed;
-}
-.tabcontent table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 1em 0;
-    font-size: 1em;
-    background: #23272e;
-    color: #e0e6ed;
-}
-.tabcontent th, .tabcontent td {
-    border: 1px solid #222;
-    padding: 0.7em 1em;
-    text-align: left;
-}
-.tabcontent th {
-    background: #181b20;
-    color: #7ecfff;
-    font-weight: 600;
-}
-.tabcontent tr:nth-child(even) {
-    background: #23272e;
-}
-.tabcontent tr:hover {
-    background: #2a313a;
-}
-</style>
-"""
+    return tabel_css
 
 def get_tabs_js(num_tabs: int) -> str:
     """Return JS for tab switching."""
@@ -297,12 +269,23 @@ function showTab(idx) {{
 </script>
 """
 
+def format_repo_name(repo: str) -> str:
+    """Convert a GitHub repo string to a title-cased display name.
+
+    Examples:
+        'jaclang/jac_playground' -> 'Jac Playground'
+    """
+    name = repo.split("/")[-1]
+    name = name.replace("_", " ").replace("-", " ")
+    return name.title()
+
+
 def get_tabs_html(repo_tables: list) -> str:
     """Return HTML for the tab headers, aligned across the page."""
     tabs = []
     for idx, (repo, _) in enumerate(repo_tables):
         active = "active" if idx == 0 else ""
-        tabs.append(f'<li class="{active}" onclick="showTab({idx})" id="tab{idx}">{repo}</li>')
+        tabs.append(f'<li class="{active}" onclick="showTab({idx})" id="tab{idx}">{format_repo_name(repo)}</li>')
     return '<ul id="tabs">\n' + "\n".join(tabs) + '\n</ul>'
 
 def get_tab_contents_html(repo_tables: List[Tuple[str, List[List[Dict[str, Any]]]]], periods: List[int]) -> str:
@@ -332,11 +315,10 @@ def print_tabbed_tables(repo_tables: List[Tuple[str, List[List[Dict[str, Any]]]]
     html.append(get_tabs_js(len(repo_tables)))
     print("\n".join(html))
 
-# You can define your default repos here if you want to hardcode them
 DEFAULT_MAIN_REPO = "jaclang/jaclang"
 DEFAULT_EXTRA_REPOS = [
-    "jaclang/pyjac",
-    "jaclang/jaseci"
+    "TrueSelph/jivas",
+    "jaseci-labs/jac_playground"
 ]
 
 def main() -> None:

--- a/scripts/top_contributors.py
+++ b/scripts/top_contributors.py
@@ -149,18 +149,22 @@ def generate_markdown_table(contributors: List[Dict[str, Any]], days: int, repo:
     return "\n".join(lines)
 
 def get_tabs_css() -> str:
-    """Return CSS for the tab and table design (dark tab bar, clear selection)."""
+    """Return CSS for the tab and table design (dark tab bar, clear selection, aligned tabs, responsive)."""
     return """
 <style>
 #tabs {
-    list-style: none;
     display: flex;
+    justify-content: space-between;
     padding: 0;
     margin: 0 0 1em 0;
     border-bottom: 2px solid #222;
     background: #23272e;
+    list-style: none;
+    width: 100%;
 }
 #tabs li {
+    flex: 1 1 0;
+    text-align: center;
     padding: 0.7em 1.5em;
     margin: 0;
     cursor: pointer;
@@ -169,9 +173,12 @@ def get_tabs_css() -> str:
     background: #23272e;
     color: #bfc7d5;
     border-radius: 8px 8px 0 0;
-    margin-right: 0.5em;
     transition: background 0.2s, color 0.2s;
     font-weight: 500;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 #tabs li.active, #tabs li:hover {
     background: #181b20;
@@ -180,6 +187,33 @@ def get_tabs_css() -> str:
     border-bottom: 2px solid #181b20;
     box-shadow: 0 -2px 8px #181b20;
     z-index: 2;
+}
+#tabs li:first-child {
+    text-align: left;
+    justify-content: flex-start;
+}
+#tabs li:nth-child(2) {
+    text-align: center;
+    justify-content: center;
+}
+#tabs li:last-child {
+    text-align: right;
+    justify-content: flex-end;
+}
+@media (max-width: 700px) {
+    #tabs {
+        flex-direction: column;
+        border-bottom: none;
+    }
+    #tabs li {
+        border-radius: 8px 8px 0 0;
+        border-bottom: 1px solid #222;
+        border-right: none;
+        text-align: left;
+    }
+    #tabs li.active, #tabs li:hover {
+        border-bottom: 2px solid #181b20;
+    }
 }
 .tabcontent {
     background: #181b20;
@@ -236,8 +270,8 @@ function showTab(idx) {{
 </script>
 """
 
-def get_tabs_html(repo_tables: List[Tuple[str, str]]) -> str:
-    """Return HTML for the tab headers."""
+def get_tabs_html(repo_tables: list) -> str:
+    """Return HTML for the tab headers, aligned across the page."""
     tabs = []
     for idx, (repo, _) in enumerate(repo_tables):
         active = "active" if idx == 0 else ""


### PR DESCRIPTION
### Multi-Repository Support:
* Updated `get_top_contributors` in `handle_jac_compile_data.py` to accept a list of repositories, enabling the generation of contributor data for multiple repositories. [[1]](diffhunk://#diff-a685ea3ac80af296a291c1a1a266444af05166a7da9b5b409eaaca6d9805c861L51-R60) [[2]](diffhunk://#diff-a685ea3ac80af296a291c1a1a266444af05166a7da9b5b409eaaca6d9805c861L90-R108)
* Modified the `main` function in `scripts/top_contributors.py` to handle a primary repository and additional repositories via a new `--extra-repos` argument.

### Tabbed HTML Output:
* Added functions (`get_tabs_html`, `get_tab_contents_html`, `print_tabbed_tables`) in `scripts/top_contributors.py` to generate a tabbed HTML view for displaying contributor data across multiple repositories.
* Introduced CSS (`get_tabs_css`) and JavaScript (`get_tabs_js`) for styling and functionality of the tabbed interface.

### Refactoring and Enhancements:
* Replaced the markdown table generation with HTML table generation (`generate_html_table`) for a more polished and interactive presentation.
* Added a helper function `format_repo_name` to convert repository names into human-readable titles for display in the tabs.