### PR TITLE
Fix plugin registration collision

### DIFF
--- a/jac/support/plugins/streamlit/jaclang_streamlit/commands.py
+++ b/jac/support/plugins/streamlit/jaclang_streamlit/commands.py
@@ -5,11 +5,13 @@ import sys
 import tempfile
 
 from jaclang.cli.cmdreg import cmd_registry
-# from jaclang.plugin.default import hookimpl
 
-from jaclang.runtimelib.machine import hookimpl
+from pluggy import HookimplMarker
+
+hookimpl = HookimplMarker("jac")
 
 import streamlit.web.bootstrap as bootstrap
+
 
 class JacCmd:
     """Jac CLI."""


### PR DESCRIPTION
## Summary
- guard internal plugin registration
- avoid importing Jac early in the Streamlit plugin

## Testing
- `black jac/jaclang/__init__.py jac/support/plugins/streamlit/jaclang_streamlit/commands.py`
- `pytest jac/support/plugins/streamlit/tests/test_jac_streamlit.py -q` *(fails: ModuleNotFoundError)*
- `mypy jac/jaclang/__init__.py jac/support/plugins/streamlit/jaclang_streamlit/commands.py` *(fails: missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_6866494079e483238791b1458a8f68ac