### PR TITLE
Fix plugin registration collision

### DIFF
--- a/jac/sitecustomize.py
+++ b/jac/sitecustomize.py
@@ -3,6 +3,11 @@
 import sys
 
 from jaclang.runtimelib.meta_importer import JacMetaImporter
+from typing_extensions import override as _override
+import typing
 
 if not any(isinstance(f, JacMetaImporter) for f in sys.meta_path):
     sys.meta_path.insert(0, JacMetaImporter())
+
+if not hasattr(typing, "override"):
+    typing.override = _override  # type: ignore[attr-defined]

--- a/jac/support/plugins/streamlit/jaclang_streamlit/__init__.py
+++ b/jac/support/plugins/streamlit/jaclang_streamlit/__init__.py
@@ -2,6 +2,15 @@
 
 from jaclang_streamlit.app_test import JacAppTest as AppTest
 
+import typing
+
+try:  # pragma: no cover - provide fallback for Python<3.12
+    typing.override  # type: ignore[attr-defined]
+except AttributeError:  # pragma: no cover
+    from typing_extensions import override as _override
+
+    typing.override = _override  # type: ignore[attr-defined]
+
 
 def run_streamlit(basename: str, dirname: str) -> None:
     """Run the Streamlit application."""

--- a/jac/support/plugins/streamlit/jaclang_streamlit/commands.py
+++ b/jac/support/plugins/streamlit/jaclang_streamlit/commands.py
@@ -5,11 +5,13 @@ import sys
 import tempfile
 
 from jaclang.cli.cmdreg import cmd_registry
-# from jaclang.plugin.default import hookimpl
 
-from jaclang.runtimelib.machine import hookimpl
+from pluggy import HookimplMarker
+
+hookimpl = HookimplMarker("jac")
 
 import streamlit.web.bootstrap as bootstrap
+
 
 class JacCmd:
     """Jac CLI."""

--- a/jac/support/plugins/streamlit/sitecustomize.py
+++ b/jac/support/plugins/streamlit/sitecustomize.py
@@ -1,0 +1,14 @@
+import typing
+from typing_extensions import override as _override
+
+if not hasattr(typing, "override"):
+    typing.override = _override  # type: ignore[attr-defined]
+
+try:
+    from jaclang.runtimelib.machine import plugin_manager
+    from jaclang_streamlit.commands import JacCmd
+
+    if "streamlit" not in plugin_manager.get_plugins():  # pragma: no cover
+        plugin_manager.register(JacCmd, name="streamlit")
+except Exception:  # pragma: no cover - ignore failures during early import
+    pass

--- a/jac/support/plugins/streamlit/tests/test_jac_streamlit.py
+++ b/jac/support/plugins/streamlit/tests/test_jac_streamlit.py
@@ -1,6 +1,8 @@
 """Test Jac Plugins."""
 
+import os
 import subprocess
+from pathlib import Path
 
 
 from jaclang.utils.test import TestCase
@@ -19,13 +21,24 @@ class JacStreamlitPlugin(TestCase):
         """Basic test for pass."""
         command_streamlit = "jac streamlit -h"
         command_dot_view = "jac dot_view -h"
-        
-        result = subprocess.run(command_streamlit, shell=True, capture_output=True, text=True)
-        dot_result = subprocess.run(command_dot_view, shell=True, capture_output=True, text=True)
+
+        env = os.environ.copy()
+        plugin_root = Path(__file__).resolve().parents[1]
+        project_root = Path(__file__).resolve().parents[4]
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(plugin_root), str(project_root), env.get("PYTHONPATH", "")]
+        )
+
+        result = subprocess.run(
+            command_streamlit, shell=True, capture_output=True, text=True, env=env
+        )
+        dot_result = subprocess.run(
+            command_dot_view, shell=True, capture_output=True, text=True, env=env
+        )
 
         # Check basic description
         self.assertIn("Streamlit the specified .jac file", result.stdout)
-        
+
         # Check CLI structure
         self.assertIn("positional arguments:", result.stdout)
         self.assertIn("filename", result.stdout)
@@ -34,7 +47,6 @@ class JacStreamlitPlugin(TestCase):
         self.assertIn("View the content of a DOT file", dot_result.stdout)
         self.assertIn("positional arguments:", dot_result.stdout)
         self.assertIn("filename", dot_result.stdout)
-
 
     def test_app(self) -> None:
         """Test Jac Streamlit App."""


### PR DESCRIPTION
## Summary
- guard internal plugin registration
- avoid importing Jac early in the Streamlit plugin
- patch typing override in sitecustomize
- register Streamlit plugin automatically
- ensure tests configure PYTHONPATH so CLI finds commands

## Testing
- `black jac/support/plugins/streamlit/jaclang_streamlit/__init__.py jac/support/plugins/streamlit/sitecustomize.py jac/support/plugins/streamlit/tests/test_jac_streamlit.py jac/sitecustomize.py`
- `mypy jac/support/plugins/streamlit/jaclang_streamlit/commands.py jac/support/plugins/streamlit/jaclang_streamlit/__init__.py` *(fails: Source file found twice)*
- `PYTHONPATH=jac/support/plugins/streamlit:./jac pytest jac/support/plugins/streamlit/tests/test_jac_streamlit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866494079e483238791b1458a8f68ac