### PR TITLE
Update RAG chatbot with agentic rag

### DIFF
--- a/docs/docs/learn/examples/rag_chatbot/Overview.md
+++ b/docs/docs/learn/examples/rag_chatbot/Overview.md
@@ -1,11 +1,12 @@
 # RAG Chatbot Overview
 
-This project demonstrates a modern Retrieval-Augmented Generation (RAG) chatbot built using the Jac programming language, MTLLM, Jac Cloud. It combines document ingestion, semantic search, and large language models (LLMs) to deliver a conversational AI experience that can answer questions based on your own documents.
+This project demonstrates a modern Retrieval-Augmented Generation (RAG) chatbot built using the Jac programming language, MTLLM, and Jac Cloud. It combines document ingestion, semantic search, and large language models (LLMs) to deliver a conversational AI experience that can answer questions based on your own documents. The latest version uses **Agentic RAG** where the LLM autonomously decides when to retrieve documents or search the web using the ReAct method.
 
 ## Key Features
 
 - **Document Upload & Ingestion**: Upload PDF files, which are automatically processed and indexed for semantic search.
 - **Retrieval-Augmented Generation**: Combines LLMs with document retrieval for accurate, context-aware answers.
+- **Agentic RAG with ReAct**: The LLM decides when to fetch documents or perform web search using specialized tools.
 - **Web Search Integration**: Optionally augments responses with real-time web search results.
 - **Streamlit Frontend**: User-friendly chat interface for interacting with the bot and uploading documents.
 - **API Server**: RESTful endpoints for chat, document upload, and more, powered by Jac Cloud.

--- a/docs/docs/learn/examples/rag_chatbot/Tutorial.md
+++ b/docs/docs/learn/examples/rag_chatbot/Tutorial.md
@@ -154,7 +154,8 @@ node Session {
     has id: str;
     has chat_history: list[dict];
     ...
-    def respond(message:str, chat_history:str, agent_role:str,  context:str) -> str by llm();
+    def respond(message:str, chat_history:list[dict]) -> str
+        by llm(method="ReAct", tools=[search_docs, search_web]);
 }
 ```
 - Each user session has a unique ID and chat history. The `respond` method uses an LLM to generate answers, optionally using context from documents and web search.
@@ -167,16 +168,17 @@ walker interact {
     ...
     can chat with Session entry {
         here.chat_history.append({"role": "user", "content": self.message});
-        docs = rag_engine.get_from_chroma(query=self.message);
-        web = web_search.search(query=self.message);
-        context = {"docs": docs, "web": web};
-        response = here.respond(..., context=context);
+        response = here.respond(
+            message=self.message,
+            chat_history=here.chat_history
+        );
         here.chat_history.append({"role": "assistant", "content": response});
         report {"response": response};
     }
 }
 ```
 - Handles incoming chat messages, retrieves relevant docs and web results, and generates a response using the LLM.
+- Handles incoming messages and lets the LLM use tools to search docs or the web when needed, producing a final answer.
 
 **PDF Upload Walker:**
 ```jac

--- a/docs/docs/learn/examples/rag_chatbot/solution/rag.jac
+++ b/docs/docs/learn/examples/rag_chatbot/solution/rag.jac
@@ -106,4 +106,16 @@ obj RagEngine {
         results = db.similarity_search_with_score(query,k=chunck_nos);
         return results;
     }
+
+    def search(query: str, chunck_nos: int=5) {
+        results = self.get_from_chroma(query=query, chunck_nos=chunck_nos);
+        summary = "";
+        for (doc, score) in results {
+            page = doc.metadata.get('page');
+            source = doc.metadata.get('source');
+            chunk_txt = doc.page_content[:400];
+            summary += f"{source} page {page}: {chunk_txt}\n";
+        }
+        return summary;
+    }
 }

--- a/docs/docs/learn/examples/rag_chatbot/solution/server.jac
+++ b/docs/docs/learn/examples/rag_chatbot/solution/server.jac
@@ -36,12 +36,26 @@ obj WebSearch {
 
 glob web_search: WebSearch = WebSearch();
 
+def search_web(query: str) -> str {
+    return web_search.search(query=query);
+}
+
+def search_docs(query: str) -> str {
+    return rag_engine.search(query=query);
+}
+
 node Session {
     has id: str;
     has chat_history: list[dict];
     has status: int = 1;
 
-    def respond(message:str, chat_history:str, agent_role:str,  context:str) -> str by llm();
+    """Generate a response using uploaded documents and web search."""
+    def respond(message:str, chat_history:list[dict]) -> str
+        by llm(
+            method="ReAct",
+            tools=[search_docs, search_web],
+            max_react_iterations=6
+        );
 }
 
 
@@ -60,14 +74,9 @@ walker interact {
 
     can chat with Session entry {
         here.chat_history.append({"role": "user", "content": self.message});
-        docs = rag_engine.get_from_chroma(query=self.message);
-        web = web_search.search(query=self.message);
-        context = {"docs": docs, "web": web};
         response = here.respond(
             message=self.message,
-            chat_history=here.chat_history,
-            agent_role="You are a conversation agent designed to help users with their queries based on the documents provided and web search results",
-            context=context
+            chat_history=here.chat_history
         );
 
         here.chat_history.append({"role": "assistant", "content": response});


### PR DESCRIPTION
## Summary
- add search method to `RagEngine` for summarised retrieval results
- expose retrieval and search tools in `server.jac`
- make the session responder agentic with ReAct
- simplify chat walker and update documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_686b40d6f4a88323a85b3cec1feb159d