### PR TITLE
🐛 Fix: `by llm` formatter

### DIFF
--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -484,6 +484,8 @@ class DocIRGenPass(UniPass):
                     indent_parts.append(i.gen.doc_ir)
             else:
                 parts.append(i.gen.doc_ir)
+                if isinstance(i, uni.Token) and i.name == Tok.KW_BY:
+                    parts.append(self.space())
         node.gen.doc_ir = self.group(self.concat(parts))
 
     def exit_atom_trailer(self, node: uni.AtomTrailer) -> None:

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/simple_walk_fmt.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/simple_walk_fmt.jac
@@ -51,3 +51,9 @@ def test_run {
 with entry {
     test_run();
 }
+
+
+def generate_joke -> dict[str, str] by llm(
+    incl_info={"jokes_example" : self.jokes },
+    temperature=0.0
+);


### PR DESCRIPTION
## **Description**
<img width="1040" height="877" alt="image" src="https://github.com/user-attachments/assets/cdfd0f3b-1e9c-40fb-aef4-eb208b81ea50" />
