### PR TITLE
Refactor PyImporter to load Python modules as Jac AST

### DIFF
--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -123,7 +123,7 @@ def run(
     """Run the specified .jac, .jir, or .py file.
 
     Executes a Jac program file or Python file, loading it into the Jac runtime environment
-    and running its code. This is the primary way to execute Jac programs and Python scripts.
+    and running its code. Python files are converted to Jac AST for execution.
 
     Args:
         filename: Path to the .jac, .jir, or .py file to run
@@ -142,7 +142,6 @@ def run(
     base, mod, mach = proc_file_sess(filename, session)
     Jac.set_base_path(base)
 
-    # if filename.endswith(".jac") or filename.endswith(".py"):
     if filename.endswith((".jac", ".py")):
         try:
             Jac.jac_import(
@@ -151,7 +150,7 @@ def run(
                 override_name="__main__" if main else None,
             )
         except Exception as e:
-            print(e, file=sys.stderr)
+            print(f"Error running {filename}: {e}", file=sys.stderr)
     elif filename.endswith(".jir"):
         try:
             with open(filename, "rb") as f:
@@ -162,9 +161,13 @@ def run(
                     override_name="__main__" if main else None,
                 )
         except Exception as e:
-            print(e, file=sys.stderr)
+            print(f"Error running {filename}: {e}", file=sys.stderr)
     else:
-        print("Not a valid file!\nOnly supports `.jac`, `.jir`, and `.py`")
+        print(
+            "Not a valid file!\nOnly supports `.jac`, `.jir`, and `.py`",
+            file=sys.stderr,
+        )
+
     mach.close()
 
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.py
@@ -1374,10 +1374,11 @@ class PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]):
         valid = [
             value for value in values if isinstance(value, (uni.String, uni.ExprStmt))
         ]
-        return uni.FString(
+        fstr = uni.FString(
             parts=valid,
             kid=[*valid] if valid else [uni.EmptyToken()],
         )
+        return uni.MultiString(strings=[fstr], kid=[fstr])
 
     def proc_lambda(self, node: py_ast.Lambda) -> uni.LambdaExpr:
         """Process python node.

--- a/jac/jaclang/runtimelib/importer.py
+++ b/jac/jaclang/runtimelib/importer.py
@@ -143,7 +143,7 @@ class Importer:
 
 
 class PythonImporter(Importer):
-    """Importer for Python modules."""
+    """Importer for Python modules using Jac AST conversion."""
 
     def __init__(self) -> None:
         """Initialize the Python importer."""
@@ -152,16 +152,34 @@ class PythonImporter(Importer):
 
         self.resolver = PythonModuleResolver()
 
+    def generate_jac_ast_from_python(self, file_path: str) -> types.ModuleType:
+        """Convert Python file to Jac AST and create module."""
+        module_name = os.path.splitext(os.path.basename(file_path))[0]
+        module = types.ModuleType(module_name)
+        module.__file__ = file_path
+        module.__name__ = "__main__"
+
+        from jaclang.runtimelib.machine import JacMachine
+
+        codeobj = JacMachine.program.get_bytecode(full_target=file_path)
+        if codeobj:
+            exec(codeobj, module.__dict__)
+        else:
+            raise ImportError(f"Failed to generate bytecode for {file_path}")
+
+        return module
+
     def run_import(self, spec: ImportPathSpec) -> ImportReturn:
-        """Run the import process for Python modules."""
+        """Run the import process for Python modules using Jac AST."""
         try:
-            imported_module = self.resolver.resolve_and_import(
+            python_file_path = self.resolver.resolve_module_path(
                 target=spec.target,
                 base_path=spec.base_path,
             )
+            imported_module = self.generate_jac_ast_from_python(python_file_path)
+            JacMachineInterface.load_module(imported_module.__name__, imported_module)
 
             loaded_items: list = []
-
             self.result = ImportReturn(imported_module, loaded_items, self)
             return self.result
 

--- a/jac/jaclang/runtimelib/importer.py
+++ b/jac/jaclang/runtimelib/importer.py
@@ -152,7 +152,7 @@ class PythonImporter(Importer):
 
         self.resolver = PythonModuleResolver()
 
-    def generate_jac_ast_from_python(self, file_path: str) -> types.ModuleType:
+    def load_and_execute(self, file_path: str) -> types.ModuleType:
         """Convert Python file to Jac AST and create module."""
         module_name = os.path.splitext(os.path.basename(file_path))[0]
         module = types.ModuleType(module_name)
@@ -176,8 +176,8 @@ class PythonImporter(Importer):
                 target=spec.target,
                 base_path=spec.base_path,
             )
-            imported_module = self.generate_jac_ast_from_python(python_file_path)
-            JacMachineInterface.load_module(imported_module.__name__, imported_module)
+            imported_module = self.load_and_execute(python_file_path)
+            # JacMachineInterface.load_module(imported_module.__name__, imported_module)
 
             loaded_items: list = []
             self.result = ImportReturn(imported_module, loaded_items, self)

--- a/jac/jaclang/tests/fixtures/pyfunc_fstr.py
+++ b/jac/jaclang/tests/fixtures/pyfunc_fstr.py
@@ -1,0 +1,25 @@
+
+
+
+
+
+name = 'Peter'
+relation = 'mother'
+mom_name = 'Mary'
+
+
+print(f"Hello {name}")
+print(f"Hello {name} {name}")
+print(f"{name} squared is {name} {name}")
+
+
+print(f"{name.upper()}!  wrong poem.")
+print(f"Hello {name} , yoo {relation} is {mom_name}. Myself, I am {name}.")
+
+
+
+item = "Apple"
+price = 1.23
+
+print(f"Left aligned: {item:<10} | Price: {price:.2f}")
+print(f"{name = } 🤔") 

--- a/jac/jaclang/tests/test_cli.py
+++ b/jac/jaclang/tests/test_cli.py
@@ -51,6 +51,24 @@ class JacCliTests(TestCase):
         self.assertIn("Python execution completed.", stdout_value)
         self.assertIn("10", stdout_value)
 
+    def test_jac_run_py_fstr(self) -> None:
+        """Test running Python files with jac run command."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        cli.run(self.fixture_abs_path("pyfunc_fstr.py"))
+
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue()
+
+        self.assertIn("Hello Peter", stdout_value)
+        self.assertIn("Hello Peter Peter", stdout_value)
+        self.assertIn("Peter squared is Peter Peter", stdout_value)
+        self.assertIn("PETER!  wrong poem", stdout_value)
+        self.assertIn("Hello Peter , yoo mother is Mary. Myself, I am Peter.", stdout_value)
+        self.assertIn("Left aligned: Apple | Price: 1.23", stdout_value)
+        self.assertIn("name = Peter 🤔", stdout_value)
+
     def test_jac_cli_alert_based_err(self) -> None:
         """Basic test for pass."""
         captured_output = io.StringIO()


### PR DESCRIPTION
## Description

- This PR refactors the PyImporter to support running Python files using the jac run py_filepath command.

---------------
### ✅ Additional Fix: Resolves f-string handling issue (#2424)
- Alongside the core refactor, this also fixes a key issue in parsing Python f-strings by properly mapping FString → MultiString.

-------
1. 
<img width="1838" height="808" alt="image" src="https://github.com/user-attachments/assets/e70b63dc-ceb3-40b4-a6ff-5df7e47c9122" />

---------
2. 
<img width="1339" height="896" alt="image" src="https://github.com/user-attachments/assets/b79c3579-8c23-490e-8660-8dfe886c99bb" />

------------