### PR TITLE
Temporary Patch: Avoid Format Failures during py2jac Conversion

### DIFF
--- a/jac/jaclang/cli/cli.py
+++ b/jac/jaclang/cli/cli.py
@@ -601,8 +601,14 @@ def py2jac(filename: str) -> None:
                 orig_src=uni.Source(file_source, filename),
             ),
             prog=JacProgram(),
-        ).ir_out.unparse()
-        print(code)
+        ).ir_out.unparse(requires_format=False)
+        formatted_code = JacProgram().jac_str_formatter(
+            source_str=code, file_path=filename
+        )
+        if formatted_code:
+            print(formatted_code)
+        else:
+            print("Error converting Python code to Jac.", file=sys.stderr)
     else:
         print("Not a .py file.")
 

--- a/jac/jaclang/compiler/unitree.py
+++ b/jac/jaclang/compiler/unitree.py
@@ -973,8 +973,10 @@ class Module(AstDocNode, UniScopeNode):
             prog=JacProgram(),
         ).ir_out.gen.jac
 
-    def unparse(self) -> str:
-        super().unparse()
+    def unparse(self, requires_format: bool = True) -> str:
+        unparsed = super().unparse()
+        if not requires_format:
+            return unparsed
         return self.format()
 
     @staticmethod

--- a/jac/jaclang/tests/fixtures/pyfunc_fmt.py
+++ b/jac/jaclang/tests/fixtures/pyfunc_fmt.py
@@ -1,0 +1,60 @@
+
+
+
+
+if __name__ == "__main__":
+
+    def foo():
+        print("One")
+        return "foo"
+    foo()
+
+condition = True
+
+if condition:
+
+    print("Two")
+    
+    def bar():
+        return 
+    
+    main_mod = None
+    bar()
+
+def baz():
+    print("Three")
+    return "baz"
+
+print(baz())    
+
+
+
+
+
+
+
+
+condition = 10
+
+
+while condition:
+    print("Processing...")
+
+    while condition:
+        print("Four")
+        condition -= 10
+        break 
+
+if condition:
+
+    def foo():
+        return 
+    foo()
+    print("Exiting the loop.")
+
+if condition:
+    print("still +")
+    def foo():
+        return 
+
+print("The End.")

--- a/jac/jaclang/tests/fixtures/pyfunc_fmt.py
+++ b/jac/jaclang/tests/fixtures/pyfunc_fmt.py
@@ -28,10 +28,10 @@ def baz():
 print(baz())    
 
 
-
-
-
-
+try:
+    a = 90
+except FileNotFoundError:
+    pass
 
 
 condition = 10

--- a/jac/jaclang/tests/test_cli.py
+++ b/jac/jaclang/tests/test_cli.py
@@ -69,6 +69,24 @@ class JacCliTests(TestCase):
         self.assertIn("Left aligned: Apple | Price: 1.23", stdout_value)
         self.assertIn("name = Peter 🤔", stdout_value)
 
+    def test_jac_run_py_fmt(self) -> None:
+        """Test running Python files with jac run command."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+
+        cli.run(self.fixture_abs_path("pyfunc_fmt.py"))
+
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue()
+
+        self.assertIn("One", stdout_value)
+        self.assertIn("Two", stdout_value)
+        self.assertIn("Three", stdout_value)
+        self.assertIn("baz", stdout_value)
+        self.assertIn("Processing...", stdout_value)
+        self.assertIn("Four", stdout_value)
+        self.assertIn("The End.", stdout_value)
+
     def test_jac_cli_alert_based_err(self) -> None:
         """Basic test for pass."""
         captured_output = io.StringIO()


### PR DESCRIPTION
## **Description**

----
### This PR introduces a temporary workaround to support 
 - running Python files via `jac run`
 - py2jac conversion
 
----------------

#### ⚠️ This is not a proper fix.
-------------
<img width="966" height="1012" alt="image" src="https://github.com/user-attachments/assets/20a2591c-2fe8-461f-8ac7-f082ab0e6a55" />

----------
<img width="1432" height="997" alt="image" src="https://github.com/user-attachments/assets/f40401a4-0364-4300-9198-3d65f108bfac" />

