### PR TITLE
Temporary disable Jivas and jac playground from the leaderboard

### DIFF
--- a/scripts/top_contributors.py
+++ b/scripts/top_contributors.py
@@ -342,7 +342,8 @@ def print_tabbed_tables(
 
 
 DEFAULT_MAIN_REPO = "jaclang/jaclang"
-DEFAULT_EXTRA_REPOS = ["TrueSelph/jivas", "jaseci-labs/jac_playground"]
+# DEFAULT_EXTRA_REPOS = ["TrueSelph/jivas", "jaseci-labs/jac_playground"]
+DEFAULT_EXTRA_REPOS: list = []
 GITHUB_STATS_PATH = os.path.join(
     os.path.dirname(__file__), "../docs/docs/assets/github_stats.json"
 )
@@ -412,7 +413,7 @@ def main() -> None:
         parser.print_help()
         return
 
-    repos = [args.repo] + args.extra_repos
+    repos = [args.repo]  # + args.extra_repos
 
     periods = []
     if args.days is not None:


### PR DESCRIPTION
### Changes to repository handling:

* [`scripts/top_contributors.py`](diffhunk://#diff-8f3c1b955ade1203f0bdcacff3b0f50630e4f79ad76de9a6931299670918ebf3L345-R346): Commented out the `DEFAULT_EXTRA_REPOS` list and replaced it with an empty list.
* [`scripts/top_contributors.py`](diffhunk://#diff-8f3c1b955ade1203f0bdcacff3b0f50630e4f79ad76de9a6931299670918ebf3L415-R416): Updated the `repos` list in the `main` function to exclude `args.extra_repos` by commenting out its inclusion.