### PR TITLE
feat: add initial type system and lsp scaffolding

### DIFF
--- a/jac/jaclang/compiler/passes/main/type_check_pass.py
+++ b/jac/jaclang/compiler/passes/main/type_check_pass.py
@@ -1,0 +1,29 @@
+"""AST pass that annotates nodes with inferred types."""
+
+from __future__ import annotations
+
+import jac.jaclang.compiler.unitree as uni
+from jac.jaclang.compiler.passes import UniPass
+
+from ...type_system.type_evaluator import TypeEvaluator
+from ...type_system.type_factory import TypeFactory
+
+
+class TypeCheckPass(UniPass):
+    """Lightweight type checking pass.
+
+    The pass currently performs a post-order traversal and attaches a
+    ``inferred_type`` attribute to each AST node using
+    :class:`TypeEvaluator`.  The design mirrors the structure of Pyright's
+    ``TypeEvaluator`` but only covers a minimal subset of Jac at the moment.
+    """
+
+    def before_pass(self) -> None:  # pragma: no cover - thin wrapper
+        """Initialize evaluator before traversal."""
+        factory = TypeFactory()
+        self.evaluator = TypeEvaluator(factory)
+
+    def exit_node(self, node: uni.UniNode) -> None:
+        """Annotate each node with an inferred type."""
+        node.inferred_type = self.evaluator.evaluate(node)  # type: ignore[attr-defined]
+        super().exit_node(node)

--- a/jac/jaclang/compiler/type_system/__init__.py
+++ b/jac/jaclang/compiler/type_system/__init__.py
@@ -1,0 +1,26 @@
+"""Core type system for Jac language.
+
+This package provides a minimal, Pyright-inspired type framework used by
+the Jac compiler and language server.  The implementation focuses on a
+simple object-based hierarchy with caching hooks that can be extended as the
+type checker matures.
+"""
+
+from .flow_analyzer import FlowAnalyzer
+from .type_cache import TypeCache
+from .type_evaluator import TypeEvaluator
+from .type_factory import TypeFactory
+from .types import AbilityType, AnyType, ArchetypeType, NoneType, Type, WalkerType
+
+__all__ = [
+    "Type",
+    "AnyType",
+    "NoneType",
+    "ArchetypeType",
+    "AbilityType",
+    "WalkerType",
+    "TypeFactory",
+    "TypeCache",
+    "TypeEvaluator",
+    "FlowAnalyzer",
+]

--- a/jac/jaclang/compiler/type_system/flow_analyzer.py
+++ b/jac/jaclang/compiler/type_system/flow_analyzer.py
@@ -1,0 +1,28 @@
+"""Control-flow analysis for type narrowing (placeholder)."""
+
+from __future__ import annotations
+
+import jac.jaclang.compiler.unitree as uni
+
+from .type_evaluator import TypeEvaluator
+
+
+class FlowAnalyzer:
+    """Performs extremely small-scale flow analysis.
+
+    At the moment this class simply walks the AST and asks the provided
+    :class:`TypeEvaluator` for the type of each node.  In the future it will
+    handle control-flow graphs and type narrowing similar to Pyright's
+    implementation.
+    """
+
+    def __init__(self, evaluator: TypeEvaluator) -> None:
+        """Store the evaluator used for type inference."""
+        self.evaluator = evaluator
+
+    def analyze(self, node: uni.UniNode) -> None:
+        """Traverse *node* to prime type inference caches."""
+        for child in node.kid:
+            if child:
+                self.evaluator.evaluate(child)
+                self.analyze(child)

--- a/jac/jaclang/compiler/type_system/type_cache.py
+++ b/jac/jaclang/compiler/type_system/type_cache.py
@@ -1,0 +1,22 @@
+"""Simple cache for type instances."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Generic, Hashable, Tuple, TypeVar
+
+
+T = TypeVar("T")
+
+
+class TypeCache(Generic[T]):
+    """Cache used by :class:`TypeFactory` to intern type instances."""
+
+    def __init__(self) -> None:
+        """Create an empty cache."""
+        self._cache: Dict[Tuple[Hashable, ...], T] = {}
+
+    def get(self, key: Tuple[Hashable, ...], creator: Callable[[], T]) -> T:
+        """Retrieve a cached value, creating it if necessary."""
+        if key not in self._cache:
+            self._cache[key] = creator()
+        return self._cache[key]

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -1,0 +1,36 @@
+"""Expression type evaluation engine."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import jac.jaclang.compiler.unitree as uni
+
+from .type_factory import TypeFactory
+from .types import Type
+
+
+class TypeEvaluator:
+    """Very small subset of an expression evaluator.
+
+    The real implementation will perform comprehensive type inference and
+    flow-sensitive analysis.  For now we map a few literal nodes to builtin
+    archetype types and fall back to ``Any`` for everything else.
+    """
+
+    def __init__(self, factory: Optional[TypeFactory] = None) -> None:
+        """Create an evaluator using *factory* for type instances."""
+        self.factory = factory or TypeFactory()
+
+    # ------------------------------------------------------------------
+    def evaluate(self, node: uni.UniNode) -> Type:
+        """Return the :class:`Type` for *node*."""
+        if isinstance(node, uni.Int):
+            return self.factory.archetype("int")
+        if isinstance(node, uni.Float):
+            return self.factory.archetype("float")
+        if isinstance(node, uni.String):
+            return self.factory.archetype("str")
+        if isinstance(node, uni.Bool):
+            return self.factory.archetype("bool")
+        return self.factory.any()

--- a/jac/jaclang/compiler/type_system/type_factory.py
+++ b/jac/jaclang/compiler/type_system/type_factory.py
@@ -1,0 +1,35 @@
+"""Factory that creates and caches common Jac types."""
+
+from __future__ import annotations
+
+from typing import Optional, cast
+
+from .type_cache import TypeCache
+from .types import AnyType, ArchetypeType, NoneType, Type
+
+
+class TypeFactory:
+    """Centralized type construction with caching."""
+
+    def __init__(self) -> None:
+        """Create a new :class:`TypeFactory`."""
+        self._cache: TypeCache[Type] = TypeCache()
+
+    # Builtin singletons -------------------------------------------------
+    def any(self) -> AnyType:
+        """Return the shared ``Any`` instance."""
+        return cast(AnyType, self._cache.get(("any",), AnyType))
+
+    def none(self) -> NoneType:
+        """Return the shared ``None`` instance."""
+        return cast(NoneType, self._cache.get(("none",), NoneType))
+
+    # Archetypes ---------------------------------------------------------
+    def archetype(
+        self, name: str, base: Optional[ArchetypeType] = None
+    ) -> ArchetypeType:
+        """Create or reuse an :class:`ArchetypeType`."""
+        return cast(
+            ArchetypeType,
+            self._cache.get(("arch", name, base), lambda: ArchetypeType(name, base)),
+        )

--- a/jac/jaclang/compiler/type_system/types.py
+++ b/jac/jaclang/compiler/type_system/types.py
@@ -1,0 +1,79 @@
+"""Basic type hierarchy for Jac language.
+
+The classes defined here intentionally provide only the minimum functionality
+required for early type checking experiments.  They are designed to mirror
+Pyright's object-based representation while remaining lightweight enough to
+extend incrementally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+class Type:
+    """Base class for all Jac types."""
+
+    name: str
+
+    def __init__(self, name: str) -> None:
+        """Initialize a type with *name*."""
+        self.name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        """Return ``repr(self)``."""
+        return self.name
+
+
+class AnyType(Type):
+    """Represents an unconstrained type."""
+
+    def __init__(self) -> None:
+        """Initialize ``Any`` type."""
+        super().__init__("Any")
+
+
+class NoneType(Type):
+    """Represents the ``None`` type."""
+
+    def __init__(self) -> None:
+        """Initialize ``None`` type."""
+        super().__init__("None")
+
+
+class BuiltinType(Type):
+    """Simple built-in type wrapper."""
+
+    pass
+
+
+class ArchetypeType(Type):
+    """Jac archetype (class) type."""
+
+    def __init__(self, name: str, base: Optional["ArchetypeType"] = None) -> None:
+        """Create a new archetype type."""
+        super().__init__(name)
+        self.base = base
+
+
+class WalkerType(ArchetypeType):
+    """Jac walker type."""
+
+    pass
+
+
+@dataclass
+class AbilityType(Type):
+    """Ability (method) type with parameter and return annotations."""
+
+    params: List[Type]
+    returns: Type
+
+    def __init__(
+        self, params: Optional[List[Type]] = None, returns: Optional[Type] = None
+    ) -> None:
+        """Create an ability type."""
+        Type.__init__(self, "Ability")
+        self.params = params or []
+        self.returns = returns or AnyType()

--- a/jac/jaclang/langserve/type_features.py
+++ b/jac/jaclang/langserve/type_features.py
@@ -1,0 +1,37 @@
+"""Type-aware language server features (placeholder)."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from jac.jaclang.compiler.type_system import TypeEvaluator, TypeFactory
+
+_factory = TypeFactory()
+_evaluator = TypeEvaluator(_factory)
+
+
+def get_completions(source: str, position: Tuple[int, int]) -> List[str]:
+    """Return completion items at *position*.
+
+    This placeholder simply returns an empty list but establishes the API for
+    future type-aware completions.
+    """
+    return []
+
+
+def get_hover(source: str, position: Tuple[int, int]) -> str:
+    """Return hover information for symbol at *position*.
+
+    For now we return a generic ``Any`` type string to demonstrate the flow from
+    the language server to the type evaluation engine.
+    """
+    return str(_factory.any())
+
+
+def get_diagnostics(source: str) -> List[str]:
+    """Return diagnostics for *source*.
+
+    Diagnostics require a full type checker; this placeholder simply returns an
+    empty list to keep the LSP pipeline exercised.
+    """
+    return []

--- a/jac/support/vscode_ext/jac/src/extension.ts
+++ b/jac/support/vscode_ext/jac/src/extension.ts
@@ -3,6 +3,7 @@ import { setupLspClient, client } from './lsp/client';
 import { EnvManager } from './environment/manager';
 import { registerAllCommands } from './commands';
 import { setupVisualDebuggerWebview } from './webview/visualDebugger';
+import { JacSemanticTokensProvider, legend as semanticLegend } from './lsp/semanticTokens';
 
 export async function activate(context: vscode.ExtensionContext) {
     // Environment manager: handles env detection, selection, status bar
@@ -12,6 +13,16 @@ export async function activate(context: vscode.ExtensionContext) {
     // LSP client: starts Jac language server using selected environment
     const lspClient = setupLspClient(envManager);
     context.subscriptions.push(lspClient);
+
+    // Minimal semantic token provider.  Real semantic classifications will be
+    // supplied by the language server once the type checker matures.
+    context.subscriptions.push(
+        vscode.languages.registerDocumentSemanticTokensProvider(
+            { language: 'jac' },
+            new JacSemanticTokensProvider(),
+            semanticLegend,
+        ),
+    );
 
     // Register all extension commands (run, check, serve, env select, etc)
     registerAllCommands(context, envManager);

--- a/jac/support/vscode_ext/jac/src/lsp/semanticTokens.ts
+++ b/jac/support/vscode_ext/jac/src/lsp/semanticTokens.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+// Minimal semantic tokens provider.  The real implementation will ask the
+// Jac language server for token data; for now it returns an empty result so the
+// extension can register the capability without errors.
+
+export const legend = new vscode.SemanticTokensLegend([], []);
+
+export class JacSemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
+    async provideDocumentSemanticTokens(): Promise<vscode.SemanticTokens> {
+        const builder = new vscode.SemanticTokensBuilder(legend);
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold core type hierarchy and factory for Jac
- add minimal type evaluator, flow analyzer, and type checking pass
- introduce placeholder language server features and VSCode semantic tokens

## Testing
- `pre-commit run --files jac/jaclang/compiler/passes/main/type_check_pass.py jac/jaclang/compiler/type_system/__init__.py jac/jaclang/compiler/type_system/types.py jac/jaclang/compiler/type_system/type_cache.py jac/jaclang/compiler/type_system/type_factory.py jac/jaclang/compiler/type_system/type_evaluator.py jac/jaclang/compiler/type_system/flow_analyzer.py jac/jaclang/langserve/type_features.py`
- `pytest jac/jaclang/tests/test_settings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689365f143d88323a5f7e54425c5a86e