### PR TITLE
Code block enabling input handling | Getting Inputs from the User

### DIFF
--- a/docs/docs/js/pyodide-worker.js
+++ b/docs/docs/js/pyodide-worker.js
@@ -130,8 +130,6 @@ except Exception as e:
 # Restore original streams
 sys.stdout = original_stdout
 sys.stderr = original_stderr
-
-"Execution completed"
         `);
         self.postMessage({ type: "execution_complete" });
     } catch (error) {

--- a/docs/docs/js/pyodide-worker.js
+++ b/docs/docs/js/pyodide-worker.js
@@ -1,5 +1,4 @@
 let pyodide = null;
-var sharedInts = null;
 
 // Functions to load Pyodide and its jaclang
 async function readFileAsBytes(fileName) {
@@ -90,12 +89,6 @@ def pyodide_input(prompt=""):
 builtins.input = pyodide_input
         `);
         self.postMessage({ type: "ready" });
-        return;
-    }
-    if (type === "input_response") {
-        console.log("Input received:", value);
-        pyodide.runPython(`import builtins; builtins.input_value = ${JSON.stringify(value)}`);
-        Atomics.notify(sharedInts, 0, 1);
         return;
     }
 

--- a/docs/docs/js/pyodide-worker.js
+++ b/docs/docs/js/pyodide-worker.js
@@ -56,18 +56,18 @@ FLAG, LEN = 0, 1
 class StreamingOutput:
     def __init__(self, stream_type="stdout"):
         self.stream_type = stream_type
-    
+
     def write(self, text):
         if text:
             import json
             message = json.dumps({
-                "type": "streaming_output", 
+                "type": "streaming_output",
                 "output": text,
                 "stream": self.stream_type
             })
             postMessage(message)
         return len(text)
-    
+
     def flush(self):
         pass
 

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -11,6 +11,7 @@ const initializedBlocks = new WeakSet();
 function initPyodideWorker() {
     if (pyodideWorker) return pyodideInitPromise;
     if (pyodideInitPromise) return pyodideInitPromise;
+    
     const DATA_CAP = 4096;
     sab = new SharedArrayBuffer(8 + DATA_CAP);
     ctrl = new Int32Array(sab, 0, 2);
@@ -50,14 +51,11 @@ function runJacCodeInWorker(code) {
                 document.dispatchEvent(event);
             } else if (message.type === "execution_complete") {
                 pyodideWorker.removeEventListener("message", handleMessage);
-                resolve(""); // Empty string since output is already streamed
+                resolve("");
             } else if (message.type === "input_request") {
                 console.log("Input requested");
-                // const s = prompt(message.prompt || "Enter input:") ?? "";
-                // I need to add a delay here
-                await new Promise(resolve => setTimeout(resolve, 1000));
-                const s = "5";
-
+                const s = prompt(message.prompt || "Enter input:") ?? "";
+                
                 const enc = new TextEncoder();
                 const bytes = enc.encode(s);
                 const n = Math.min(bytes.length, dataBytes.length);

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -4,7 +4,6 @@ let pyodideInitPromise = null;
 let monacoLoaded = false;
 let monacoLoadPromise = null;
 let sab = null;
-let sharedInts = null;
 const initializedBlocks = new WeakSet();
 
 // Initialize Pyodide Worker

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -11,11 +11,11 @@ const initializedBlocks = new WeakSet();
 function initPyodideWorker() {
     if (pyodideWorker) return pyodideInitPromise;
     if (pyodideInitPromise) return pyodideInitPromise;
-    
+
     const DATA_CAP = 4096;
     sab = new SharedArrayBuffer(8 + DATA_CAP);
     ctrl = new Int32Array(sab, 0, 2);
-    dataBytes = new Uint8Array(sab, 8); 
+    dataBytes = new Uint8Array(sab, 8);
 
     pyodideWorker = new Worker("/js/pyodide-worker.js");
     pyodideInitPromise = new Promise((resolve, reject) => {
@@ -45,8 +45,8 @@ function runJacCodeInWorker(code, inputHandler) {
 
             if (message.type === "streaming_output") {
                 // Handle real-time output streaming
-                const event = new CustomEvent('jacOutputUpdate', { 
-                    detail: { output: message.output, stream: message.stream } 
+                const event = new CustomEvent('jacOutputUpdate', {
+                    detail: { output: message.output, stream: message.stream }
                 });
                 document.dispatchEvent(event);
             } else if (message.type === "execution_complete") {
@@ -56,7 +56,7 @@ function runJacCodeInWorker(code, inputHandler) {
                 console.log("Input requested");
                 try {
                     const userInput = await inputHandler(message.prompt || "Enter input:");
-                    
+
                     const enc = new TextEncoder();
                     const bytes = enc.encode(userInput);
                     const n = Math.min(bytes.length, dataBytes.length);
@@ -241,7 +241,7 @@ async function setupCodeBlock(div) {
             outputBlock.textContent += output;
             outputBlock.scrollTop = outputBlock.scrollHeight;
         };
-        
+
         document.addEventListener('jacOutputUpdate', outputHandler);
 
         try {

--- a/docs/docs/js/run-code.js
+++ b/docs/docs/js/run-code.js
@@ -32,7 +32,7 @@ function initPyodideWorker() {
 }
 
 // Run Jac Code in Worker
-function runJacCodeInWorker(code) {
+function runJacCodeInWorker(code, inputHandler) {
     return new Promise(async (resolve, reject) => {
         await initPyodideWorker();
         const handleMessage = async (event) => {
@@ -54,17 +54,21 @@ function runJacCodeInWorker(code) {
                 resolve("");
             } else if (message.type === "input_request") {
                 console.log("Input requested");
-                const s = prompt(message.prompt || "Enter input:") ?? "";
-                
-                const enc = new TextEncoder();
-                const bytes = enc.encode(s);
-                const n = Math.min(bytes.length, dataBytes.length);
-                dataBytes.set(bytes.subarray(0, n), 0);
+                try {
+                    const userInput = await inputHandler(message.prompt || "Enter input:");
+                    
+                    const enc = new TextEncoder();
+                    const bytes = enc.encode(userInput);
+                    const n = Math.min(bytes.length, dataBytes.length);
+                    dataBytes.set(bytes.subarray(0, n), 0);
 
-                Atomics.store(ctrl, 1, n);
-                Atomics.store(ctrl, 0, 1);
-                Atomics.notify(ctrl, 0, 1);
-
+                    Atomics.store(ctrl, 1, n);
+                    Atomics.store(ctrl, 0, 1);
+                    Atomics.notify(ctrl, 0, 1);
+                } catch (error) {
+                    pyodideWorker.removeEventListener("message", handleMessage);
+                    reject(error);
+                }
             } else if (message.type === "error") {
                 pyodideWorker.removeEventListener("message", handleMessage);
                 reject(message.error);
@@ -122,12 +126,25 @@ async function setupCodeBlock(div) {
     div.innerHTML = `
     <div class="jac-code" style="border: 1px solid #ccc;"></div>
     <button class="md-button md-button--primary run-code-btn">Run</button>
+    <div class="input-dialog" style="display: none; background: linear-gradient(135deg, #2a2a2a 0%, #1e1e1e 100%); border: 1px solid #4a90e2; padding: 12px; margin: 8px 0; border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.2);">
+        <div style="display: flex; gap: 10px; align-items: center;">
+            <div class="input-prompt" style="color: #ffffff; font-family: 'Segoe UI', sans-serif; font-size: 13px; font-weight: 500; white-space: nowrap; min-width: fit-content;"></div>
+            <input type="text" class="user-input" style="flex: 1; padding: 8px 12px; background: rgba(255,255,255,0.08); border: 1px solid #444; color: #ffffff; border-radius: 6px; font-family: 'Consolas', monospace; font-size: 13px; transition: all 0.2s ease; outline: none;" placeholder="Enter input...">
+            <button class="submit-input" style="padding: 8px 14px; background: linear-gradient(135deg, #4a90e2 0%, #357abd 100%); color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 12px; transition: all 0.2s ease; box-shadow: 0 2px 8px rgba(74, 144, 226, 0.3); white-space: nowrap;">Submit</button>
+            <button class="cancel-input" style="padding: 8px 14px; background: linear-gradient(135deg, #666 0%, #555 100%); color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 12px; transition: all 0.2s ease; box-shadow: 0 2px 8px rgba(0,0,0,0.2); white-space: nowrap;">Cancel</button>
+        </div>
+    </div>
     <pre class="code-output" style="display:none; white-space: pre-wrap; background: #1e1e1e; color: #d4d4d4; padding: 10px;"></pre>
     `;
 
     const container = div.querySelector(".jac-code");
     const runButton = div.querySelector(".run-code-btn");
     const outputBlock = div.querySelector(".code-output");
+    const inputDialog = div.querySelector(".input-dialog");
+    const inputPrompt = div.querySelector(".input-prompt");
+    const userInput = div.querySelector(".user-input");
+    const submitButton = div.querySelector(".submit-input");
+    const cancelButton = div.querySelector(".cancel-input");
 
     const editor = monaco.editor.create(container, {
         value: originalCode || '# Write your Jac code here',
@@ -159,33 +176,116 @@ async function setupCodeBlock(div) {
     updateEditorHeight();
     editor.onDidChangeModelContent(updateEditorHeight);
 
+    // Custom input handler function
+    function createInputHandler() {
+        return function(prompt) {
+            return new Promise((resolve, reject) => {
+                inputPrompt.textContent = prompt;
+                inputDialog.style.display = "block";
+                userInput.value = "";
+                userInput.focus();
+
+                const handleSubmit = () => {
+                    const value = userInput.value;
+                    inputDialog.style.display = "none";
+                    // Add the input to output for visibility
+                    outputBlock.textContent += `${prompt}${value}\n`;
+                    outputBlock.scrollTop = outputBlock.scrollHeight;
+                    resolve(value);
+                    cleanup();
+                };
+
+                const handleCancel = () => {
+                    inputDialog.style.display = "none";
+                    reject(new Error("Input cancelled by user"));
+                    cleanup();
+                };
+
+                const handleKeyPress = (e) => {
+                    if (e.key === "Enter") {
+                        e.preventDefault();
+                        handleSubmit();
+                    } else if (e.key === "Escape") {
+                        e.preventDefault();
+                        handleCancel();
+                    }
+                };
+
+                const cleanup = () => {
+                    submitButton.removeEventListener("click", handleSubmit);
+                    cancelButton.removeEventListener("click", handleCancel);
+                    userInput.removeEventListener("keypress", handleKeyPress);
+                };
+
+                submitButton.addEventListener("click", handleSubmit);
+                cancelButton.addEventListener("click", handleCancel);
+                userInput.addEventListener("keypress", handleKeyPress);
+            });
+        };
+    }
+
     runButton.addEventListener("click", async () => {
         outputBlock.style.display = "block";
-        outputBlock.textContent = ""; // Clear previous output
+        outputBlock.textContent = "";
+        inputDialog.style.display = "none";
 
         if (!pyodideReady) {
             outputBlock.textContent = "Loading Jac runner...";
             await initPyodideWorker();
-            outputBlock.textContent = ""; // Clear loading message
+            outputBlock.textContent = "";
         }
 
         // Listen for streaming output updates
         const outputHandler = (event) => {
             const { output, stream } = event.detail;
             outputBlock.textContent += output;
-            outputBlock.scrollTop = outputBlock.scrollHeight; // Auto-scroll to bottom
+            outputBlock.scrollTop = outputBlock.scrollHeight;
         };
         
         document.addEventListener('jacOutputUpdate', outputHandler);
 
         try {
             const codeToRun = editor.getValue();
-            await runJacCodeInWorker(codeToRun);
+            const inputHandler = createInputHandler();
+            await runJacCodeInWorker(codeToRun, inputHandler);
         } catch (error) {
             outputBlock.textContent += `\nError: ${error}`;
         } finally {
             document.removeEventListener('jacOutputUpdate', outputHandler);
+            inputDialog.style.display = "none";
         }
+    });
+
+    userInput.addEventListener('focus', () => {
+        userInput.style.borderColor = '#4a90e2';
+        userInput.style.boxShadow = '0 0 0 2px rgba(74, 144, 226, 0.15)';
+        userInput.style.background = 'rgba(255,255,255,0.12)';
+    });
+
+    userInput.addEventListener('blur', () => {
+        userInput.style.borderColor = '#444';
+        userInput.style.boxShadow = 'none';
+        userInput.style.background = 'rgba(255,255,255,0.08)';
+    });
+
+    submitButton.addEventListener('mouseenter', () => {
+        submitButton.style.transform = 'translateY(-1px)';
+        submitButton.style.boxShadow = '0 4px 12px rgba(74, 144, 226, 0.4)';
+    });
+
+    submitButton.addEventListener('mouseleave', () => {
+        submitButton.style.transform = 'translateY(0)';
+        submitButton.style.boxShadow = '0 2px 8px rgba(74, 144, 226, 0.3)';
+    });
+
+    cancelButton.addEventListener('mouseenter', () => {
+        cancelButton.style.transform = 'translateY(-1px)';
+        cancelButton.style.background = 'linear-gradient(135deg, #777 0%, #666 100%)';
+    });
+
+    cancelButton.addEventListener('mouseleave', () => {
+        cancelButton.style.transform = 'translateY(0)';
+        cancelButton.style.background = 'linear-gradient(135deg, #666 0%, #555 100%)';
     });
 }
 

--- a/docs/docs/learn/jac_in_a_flash.md
+++ b/docs/docs/learn/jac_in_a_flash.md
@@ -29,6 +29,12 @@ concepts map directly to Jac syntax.
     ```jac linenums="1"
     --8<-- "jac/examples/guess_game/guess_game1.jac"
     ```
+=== "Try it"
+    <div class="code-block">
+    ```jac
+    --8<-- "jac/examples/guess_game/guess_game1.jac"
+    ```
+    </div>
 
 ## Step&nbsp;2 – Declaring fields with `has`
 
@@ -41,6 +47,12 @@ signature, making the object definition concise.
     ```jac linenums="1"
     --8<-- "jac/examples/guess_game/guess_game2.jac"
     ```
+=== "Try it"
+    <div class="code-block">
+    ```jac
+    --8<-- "jac/examples/guess_game/guess_game2.jac"
+    ```
+    </div>
 
 ## Step&nbsp;3 – Separating implementation with `impl`
 
@@ -57,6 +69,13 @@ separation keeps the interface clean and helps organise larger codebases.
     ```jac linenums="1"
     --8<-- "jac/examples/guess_game/guess_game3.impl.jac"
     ```
+=== "Try it"
+    <div class="code-block">
+    ```jac
+    --8<-- "jac/examples/guess_game/guess_game3.jac"
+    --8<-- "jac/examples/guess_game/guess_game3.impl.jac"
+    ```
+    </div>
 
 ## Step&nbsp;4 – Walking the graph
 
@@ -74,6 +93,13 @@ This example shows how conventional logic can become graph traversal.
     ```jac linenums="1"
     --8<-- "jac/examples/guess_game/guess_game4.impl.jac"
     ```
+=== "Try it"
+    <div class="code-block">
+    ```jac
+    --8<-- "jac/examples/guess_game/guess_game4.jac"
+    --8<-- "jac/examples/guess_game/guess_game4.impl.jac"
+    ```
+    </div>
 
 ## Step&nbsp;5 – Scale Agnostic Approach
 
@@ -87,6 +113,13 @@ The fifth version demonstrates Jac's scale-agnostic design. The same code that r
     ```jac linenums="1"
     --8<-- "jac/examples/guess_game/guess_game5.impl.jac"
     ```
+=== "Try it"
+    <div class="code-block">
+    ```jac
+    --8<-- "jac/examples/guess_game/guess_game5.jac"
+    --8<-- "jac/examples/guess_game/guess_game5.impl.jac"
+    ```
+    </div>
 
 ## Step&nbsp;6 – AI-Enhanced Gameplay with MTLLM
 


### PR DESCRIPTION
This task is about enabling interactive input() support when running Jac code inside the Pyodide worker. Currently, code execution works, but when input() is called, the Python side blocks and cannot receive the user’s response from the main thread. The goal is to implement a communication mechanism (via postMessage, SharedArrayBuffer, and Atomics) that lets the worker pause for input requests, prompt the user in the browser, and then resume execution with the provided string. This will make the Jac playground interactive for programs requiring user input.