### PR TITLE
Resolve Windows/WSL path mismatch in LSP diagnostics

### DIFF
--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -35,8 +35,6 @@ class ModuleManager {
         build: uni.Module,
         update_annexed: bool = True
     ) -> None {
-        import logging;
-        logging.info(f'before: \n{file_path}');
         file_path_normalized = extract_fs_path(file_path);
         self.program.mod.hub[file_path_normalized] = build;
         if update_annexed {
@@ -47,17 +45,11 @@ class ModuleManager {
                 }
             }
         }
-        logging.info(f'after: \n{file_path_normalized}');
     }
 
     """Remove errors and warnings for a specific file from the lists."""
     def clear_alerts_for_file(self: ModuleManager, file_path_fs: str) -> None {
-        import logging;
         file_path_normalized = extract_fs_path(file_path_fs);
-        for e in self.program.errors_had{
-            logging.info(f'error path >> {e.loc.mod_path}');
-            logging.info(f'file_path_fs>> {file_path_normalized}');
-        }
         self.program.errors_had =
             [ e for e in self.program.errors_had if not paths_equal(e.loc.mod_path, file_path_normalized) ];
         self.program.warnings_had =

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -14,6 +14,7 @@ import from jaclang.compiler.unitree { UniScopeNode }
 import from sem_manager { SemTokManager }
 import from jaclang.vendor.pygls { uris }
 import from jaclang.vendor.pygls.server { LanguageServer }
+import from path_utils { extract_fs_path, paths_equal }
 
 import lsprotocol.types as lspt;
 import utils;
@@ -36,30 +37,31 @@ class ModuleManager {
     ) -> None {
         import logging;
         logging.info(f'before: \n{file_path}');
-        file_path = file_path.removeprefix('file://');
-        self.program.mod.hub[file_path] = build;
+        file_path_normalized = extract_fs_path(file_path);
+        self.program.mod.hub[file_path_normalized] = build;
         if update_annexed {
-            self.sem_managers[file_path] = SemTokManager(ir=build);
+            self.sem_managers[file_path_normalized] = SemTokManager(ir=build);
             for (p, mod) in self.program.mod.hub.items() {
-                if p != file_path {
+                if p != file_path_normalized {
                     self.sem_managers[p] = SemTokManager(ir=mod);
                 }
             }
         }
-        logging.info(f'after: \n{file_path}');
+        logging.info(f'after: \n{file_path_normalized}');
     }
 
     """Remove errors and warnings for a specific file from the lists."""
     def clear_alerts_for_file(self: ModuleManager, file_path_fs: str) -> None {
         import logging;
+        file_path_normalized = extract_fs_path(file_path_fs);
         for e in self.program.errors_had{
             logging.info(f'error path >> {e.loc.mod_path}');
-            logging.info(f'file_path_fs>> {file_path_fs}');
+            logging.info(f'file_path_fs>> {file_path_normalized}');
         }
         self.program.errors_had =
-            [ e for e in self.program.errors_had if e.loc.mod_path != file_path_fs ];
+            [ e for e in self.program.errors_had if not paths_equal(e.loc.mod_path, file_path_normalized) ];
         self.program.warnings_had =
-            [ w for w in self.program.warnings_had if w.loc.mod_path != file_path_fs ];
+            [ w for w in self.program.warnings_had if not paths_equal(w.loc.mod_path, file_path_normalized) ];
     }
 }
 
@@ -95,8 +97,8 @@ class JacLangServer(JacProgram , LanguageServer) {
 
     """Get IR for a file path."""
     def get_ir(self: JacLangServer, file_path: str) -> Optional[uni.Module] {
-        file_path = file_path.removeprefix('file://');
-        return self.mod.hub.get(file_path);
+        file_path_normalized = extract_fs_path(file_path);
+        return self.mod.hub.get(file_path_normalized);
     }
 
     """Update modules in JacProgram's hub and semantic managers."""
@@ -107,13 +109,14 @@ class JacLangServer(JacProgram , LanguageServer) {
         need: bool = True
     ) -> None {
         self.log_py(f"'Updating modules for '{file_path}");
-        self.module_manager.update(file_path, build, update_annexed=need);
+        file_path_normalized = extract_fs_path(file_path);
+        self.module_manager.update(file_path_normalized, build, update_annexed=need);
     }
 
     """Rebuild a file (syntax only)."""
     def quick_check(self: JacLangServer, file_path: str) -> bool {
         try {
-            file_path_fs = file_path.removeprefix('file://');
+            file_path_fs = extract_fs_path(file_path);
             document = self.workspace.get_text_document(file_path);
             self._clear_alerts_for_file(file_path_fs);
             build = self.compile(use_str=document.source, file_path=document.path);
@@ -123,7 +126,7 @@ class JacLangServer(JacProgram , LanguageServer) {
                 utils.gen_diagnostics(file_path, self.errors_had, self.warnings_had)
             );
             build_errors =
-                [ e for e in self.errors_had if e.loc.mod_path == file_path_fs ];
+                [ e for e in self.errors_had if paths_equal(e.loc.mod_path, file_path_fs) ];
             return len(build_errors) == 0;
         } except Exception as e {
             self.log_error(f"'Error during syntax check: '{e}");
@@ -139,7 +142,7 @@ class JacLangServer(JacProgram , LanguageServer) {
     ) -> bool {
         try {
             start_time = time.time();
-            file_path_fs = file_path.removeprefix('file://');
+            file_path_fs = extract_fs_path(file_path);
             document = self.workspace.get_text_document(file_path);
             self._clear_alerts_for_file(file_path_fs);
             build = self.build(use_str=document.source, file_path=document.path);
@@ -373,7 +376,7 @@ class JacLangServer(JacProgram , LanguageServer) {
         file_path: str,
         position: lspt.Position
     ) -> Optional[lspt.Hover] {
-        file_path_fs = file_path.removeprefix('file://');
+        file_path_fs = extract_fs_path(file_path);
         if file_path_fs not in self.mod.hub {
             return None;
         }
@@ -425,7 +428,7 @@ class JacLangServer(JacProgram , LanguageServer) {
 
     """Return document symbols for a file."""
     def get_outline(self: JacLangServer, file_path: str) -> <>list[lspt.DocumentSymbol] {
-        file_path_fs = file_path.removeprefix('file://');
+        file_path_fs = extract_fs_path(file_path);
         if file_path_fs in self.mod.hub
         and (root_node := self.mod.hub[file_path_fs].sym_tab)
          {
@@ -440,7 +443,7 @@ class JacLangServer(JacProgram , LanguageServer) {
         file_path: str,
         position: lspt.Position
     ) -> Optional[lspt.Location] {
-        file_path_fs = file_path.removeprefix('file://');
+        file_path_fs = extract_fs_path(file_path);
         if file_path_fs not in self.mod.hub {
             return None;
         }
@@ -552,7 +555,7 @@ class JacLangServer(JacProgram , LanguageServer) {
         file_path: str,
         position: lspt.Position
     ) -> <>list[lspt.Location] {
-        file_path_fs = file_path.removeprefix('file://');
+        file_path_fs = extract_fs_path(file_path);
         if file_path_fs not in self.mod.hub {
             return [];
         }
@@ -584,7 +587,7 @@ class JacLangServer(JacProgram , LanguageServer) {
         position: lspt.Position,
         new_name: str
     ) -> Optional[lspt.WorkspaceEdit] {
-        file_path_fs = file_path.removeprefix('file://');
+        file_path_fs = extract_fs_path(file_path);
         if file_path_fs not in self.mod.hub {
             return None;
         }
@@ -616,7 +619,7 @@ class JacLangServer(JacProgram , LanguageServer) {
 
     """Return semantic tokens for a file."""
     def get_semantic_tokens(self: JacLangServer, file_path: str) -> lspt.SemanticTokens {
-        file_path_fs = file_path.removeprefix('file://');
+        file_path_fs = extract_fs_path(file_path);
         sem_mgr = self.sem_managers.get(file_path_fs);
         if not sem_mgr {
             return lspt.SemanticTokens(data=[]);

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -34,6 +34,8 @@ class ModuleManager {
         build: uni.Module,
         update_annexed: bool = True
     ) -> None {
+        import logging;
+        logging.info(f'before: \n{file_path}');
         file_path = file_path.removeprefix('file://');
         self.program.mod.hub[file_path] = build;
         if update_annexed {
@@ -44,10 +46,16 @@ class ModuleManager {
                 }
             }
         }
+        logging.info(f'after: \n{file_path}');
     }
 
     """Remove errors and warnings for a specific file from the lists."""
     def clear_alerts_for_file(self: ModuleManager, file_path_fs: str) -> None {
+        import logging;
+        for e in self.program.errors_had{
+            logging.info(f'error path >> {e.loc.mod_path}');
+            logging.info(f'file_path_fs>> {file_path_fs}');
+        }
         self.program.errors_had =
             [ e for e in self.program.errors_had if e.loc.mod_path != file_path_fs ];
         self.program.warnings_had =

--- a/jac/jaclang/langserve/path_utils.jac
+++ b/jac/jaclang/langserve/path_utils.jac
@@ -1,0 +1,138 @@
+"""Cross-platform path utility functions for the language server."""
+
+import os;
+import from pathlib { Path }
+import from urllib.parse { unquote }
+import from jaclang.vendor.pygls { uris }
+
+
+"""Normalize a filesystem path to be platform-independent."""
+def normalize_fs_path(path: str) -> str {
+    # Handle empty paths
+    if path == "" or path is None {
+        return path;
+    }
+    
+    # Convert backslashes to forward slashes for consistency
+    normalized = path.replace('\\', '/');
+    
+    # Try to resolve using pathlib for better cross-platform handling
+    try {
+        path_obj = Path(normalized);
+        # Only resolve if it's an absolute path or we want to keep it relative
+        if path_obj.is_absolute() {
+            resolved = path_obj.resolve();
+            return str(resolved).replace('\\', '/');
+        } else {
+            # For relative paths, just normalize separators
+            return normalized;
+        }
+    } except Exception {
+        # If path resolution fails, just normalize separators
+        return normalized;
+    }
+}
+
+
+"""Convert URI to normalized filesystem path."""
+def uri_to_fs_path(uri: str) -> str {
+    if uri == "" or uri is None {
+        return uri;
+    }
+    
+    # Remove file:// prefix if present
+    cleaned_uri = uri;
+    if uri.startswith('file://') {
+        cleaned_uri = uri[7:];  # Remove 'file://'
+    }
+    
+    # URL decode to handle encoded characters like %3A for :
+    decoded_path = unquote(cleaned_uri);
+    
+    # Handle Windows paths that start with /C: pattern
+    if len(decoded_path) > 2 and decoded_path[0] == '/' and decoded_path[2] == ':' {
+        decoded_path = decoded_path[1:];  # Remove leading /
+    }
+    
+    return normalize_fs_path(decoded_path);
+}
+
+
+"""Convert filesystem path to URI."""
+def fs_path_to_uri(path: str) -> str {
+    if path == "" or path is None {
+        return path;
+    }
+    
+    # Handle Windows paths - detect if it's a Windows path even on Unix
+    is_windows_path = len(path) > 1 and path[1] == ':';
+    
+    if is_windows_path {
+        # For Windows paths, ensure proper format for URI conversion
+        # Convert c:\path or c:/path to proper format
+        clean_path = path.replace('\\', '/');
+        if not clean_path.startswith('/') {
+            clean_path = '/' + clean_path;
+        }
+        # Use pygls uris.from_fs_path but with the corrected path
+        return uris.from_fs_path(clean_path[1:]);  # Remove the leading / we added
+    } else {
+        # For Unix paths, normalize and use pygls directly
+        normalized_path = normalize_fs_path(path);
+        return uris.from_fs_path(normalized_path);
+    }
+}
+
+
+"""Check if two paths refer to the same file."""
+def paths_equal(path1: str, path2: str) -> bool {
+    if (path1 == "" or path1 is None) or (path2 == "" or path2 is None) {
+        return path1 == path2;
+    }
+    
+    # Convert both to normalized filesystem paths
+    norm_path1 = uri_to_fs_path(path1) if path1.startswith('file://') else extract_fs_path(path1);
+    norm_path2 = uri_to_fs_path(path2) if path2.startswith('file://') else extract_fs_path(path2);
+    
+    # Normalize both paths to handle Windows vs Unix differences
+    # Convert both to a canonical format for comparison
+    def canonicalize(p: str) -> str {
+        # Normalize path separators
+        canonical = p.replace('\\', '/');
+        
+        # Handle Windows drive letters consistently
+        if len(canonical) > 1 and canonical[1] == ':' {
+            # Windows path like c:/path -> /c:/path for comparison
+            return '/' + canonical.lower();
+        } elif len(canonical) > 2 and canonical[0] == '/' and canonical[2] == ':' {
+            # Already in /c:/path format -> normalize to lowercase
+            return canonical.lower();
+        } else {
+            # Unix path
+            return canonical;
+        }
+    }
+    
+    canon1 = canonicalize(norm_path1);
+    canon2 = canonicalize(norm_path2);
+    
+    # Compare normalized paths
+    return canon1 == canon2;
+}
+
+
+"""Extract the actual filesystem path from various path formats."""
+def extract_fs_path(path: str) -> str {
+    if path == "" or path is None {
+        return path;
+    }
+    
+    if path.startswith('file://') {
+        return uri_to_fs_path(path);
+    } elif '%' in path {
+        # Handle URL-encoded paths that don't have file:// prefix
+        return uri_to_fs_path(path);
+    } else {
+        return normalize_fs_path(path);
+    }
+}

--- a/jac/jaclang/langserve/path_utils.jac
+++ b/jac/jaclang/langserve/path_utils.jac
@@ -12,10 +12,10 @@ def normalize_fs_path(path: str) -> str {
     if path == "" or path is None {
         return path;
     }
-    
+
     # Convert backslashes to forward slashes for consistency
     normalized = path.replace('\\', '/');
-    
+
     # Try to resolve using pathlib for better cross-platform handling
     try {
         path_obj = Path(normalized);
@@ -39,21 +39,21 @@ def uri_to_fs_path(uri: str) -> str {
     if uri == "" or uri is None {
         return uri;
     }
-    
+
     # Remove file:// prefix if present
     cleaned_uri = uri;
     if uri.startswith('file://') {
         cleaned_uri = uri[7:];  # Remove 'file://'
     }
-    
+
     # URL decode to handle encoded characters like %3A for :
     decoded_path = unquote(cleaned_uri);
-    
+
     # Handle Windows paths that start with /C: pattern
     if len(decoded_path) > 2 and decoded_path[0] == '/' and decoded_path[2] == ':' {
         decoded_path = decoded_path[1:];  # Remove leading /
     }
-    
+
     return normalize_fs_path(decoded_path);
 }
 
@@ -63,10 +63,10 @@ def fs_path_to_uri(path: str) -> str {
     if path == "" or path is None {
         return path;
     }
-    
+
     # Handle Windows paths - detect if it's a Windows path even on Unix
     is_windows_path = len(path) > 1 and path[1] == ':';
-    
+
     if is_windows_path {
         # For Windows paths, ensure proper format for URI conversion
         # Convert c:\path or c:/path to proper format
@@ -89,17 +89,17 @@ def paths_equal(path1: str, path2: str) -> bool {
     if (path1 == "" or path1 is None) or (path2 == "" or path2 is None) {
         return path1 == path2;
     }
-    
+
     # Convert both to normalized filesystem paths
     norm_path1 = uri_to_fs_path(path1) if path1.startswith('file://') else extract_fs_path(path1);
     norm_path2 = uri_to_fs_path(path2) if path2.startswith('file://') else extract_fs_path(path2);
-    
+
     # Normalize both paths to handle Windows vs Unix differences
     # Convert both to a canonical format for comparison
     def canonicalize(p: str) -> str {
         # Normalize path separators
         canonical = p.replace('\\', '/');
-        
+
         # Handle Windows drive letters consistently
         if len(canonical) > 1 and canonical[1] == ':' {
             # Windows path like c:/path -> /c:/path for comparison
@@ -112,10 +112,10 @@ def paths_equal(path1: str, path2: str) -> bool {
             return canonical;
         }
     }
-    
+
     canon1 = canonicalize(norm_path1);
     canon2 = canonicalize(norm_path2);
-    
+
     # Compare normalized paths
     return canon1 == canon2;
 }
@@ -126,7 +126,7 @@ def extract_fs_path(path: str) -> str {
     if path == "" or path is None {
         return path;
     }
-    
+
     if path.startswith('file://') {
         return uri_to_fs_path(path);
     } elif '%' in path {

--- a/jac/jaclang/langserve/test_path_utils.jac
+++ b/jac/jaclang/langserve/test_path_utils.jac
@@ -1,0 +1,89 @@
+"""Test script for path utilities."""
+
+import from path_utils {
+    normalize_fs_path,
+    uri_to_fs_path,
+    fs_path_to_uri,
+    paths_equal,
+    extract_fs_path
+}
+
+
+"""Test the path utilities with various inputs."""
+def test_path_utilities() -> None {
+    print("=== Testing Path Utilities ===");
+    
+    # Test normalize_fs_path
+    print("\n--- Testing normalize_fs_path ---");
+    test_path1 = "/home/user/file.jac";  # Unix absolute path
+    test_path2 = "relative/path/file.jac";  # Relative path
+    test_path3 = "c:/Users/USER/file.jac";  # Windows absolute path
+    test_path4 = "c:\\Users\\USER\\file.jac";  # Windows path with backslashes
+    
+    normalized1 = normalize_fs_path(test_path1);
+    normalized2 = normalize_fs_path(test_path2);
+    normalized3 = normalize_fs_path(test_path3);
+    normalized4 = normalize_fs_path(test_path4);
+    
+    print(f"Unix absolute: {test_path1} -> {normalized1}");
+    print(f"Relative: {test_path2} -> {normalized2}");
+    print(f"Windows path: {test_path3} -> {normalized3}");
+    print(f"Windows backslashes: {test_path4} -> {normalized4}");
+    
+    # Test URI conversion
+    print("\n--- Testing URI to FS path ---");
+    test_uri1 = "file:///c%3A/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
+    test_uri2 = "file:///home/user/test.jac";
+    
+    fs_path1 = uri_to_fs_path(test_uri1);
+    fs_path2 = uri_to_fs_path(test_uri2);
+    
+    print(f"Windows URI: {test_uri1} -> {fs_path1}");
+    print(f"Unix URI: {test_uri2} -> {fs_path2}");
+    
+    # Test URI creation
+    print("\n--- Testing FS path to URI ---");
+    test_fs_path1 = "c:/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
+    test_fs_path2 = "/home/user/test.jac";
+    
+    uri_path1 = fs_path_to_uri(test_fs_path1);
+    uri_path2 = fs_path_to_uri(test_fs_path2);
+    
+    print(f"Windows FS: {test_fs_path1} -> {uri_path1}");
+    print(f"Unix FS: {test_fs_path2} -> {uri_path2}");
+    
+    # Test paths_equal
+    print("\n--- Testing paths_equal ---");
+    path1 = "c:\\Users\\USER\\jaseci\\jac\\jaclang\\tests\\fixtures\\hello.jac";
+    path2 = "/c%3A/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
+    path3 = "file:///c%3A/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
+    path4 = "c:/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
+    
+    are_equal_1_2 = paths_equal(path1, path2);
+    are_equal_1_3 = paths_equal(path1, path3);
+    are_equal_1_4 = paths_equal(path1, path4);
+    are_equal_2_3 = paths_equal(path2, path3);
+    
+    print(f"Windows backslash vs encoded: {are_equal_1_2} ✓");
+    print(f"Windows backslash vs URI: {are_equal_1_3} ✓");
+    print(f"Windows backslash vs forward: {are_equal_1_4} ✓");
+    print(f"Encoded vs URI: {are_equal_2_3} ✓");
+    
+    # Test extract_fs_path
+    print("\n--- Testing extract_fs_path ---");
+    extracted1 = extract_fs_path("file:///c%3A/Users/USER/test.jac");
+    extracted2 = extract_fs_path("/home/user/test.jac");
+    extracted3 = extract_fs_path("c:\\Windows\\test.jac");
+    
+    print(f"Extract from URI: {extracted1}");
+    print(f"Extract from Unix: {extracted2}");
+    print(f"Extract from Windows: {extracted3}");
+    
+    print("\n=== Test Complete ===");
+}
+
+
+# Test the functions
+with entry {
+    test_path_utilities();
+}

--- a/jac/jaclang/langserve/tests/fixtures/path_utility.jac
+++ b/jac/jaclang/langserve/tests/fixtures/path_utility.jac
@@ -1,89 +1,92 @@
 """Test script for path utilities."""
 
-import from path_utils {
-    normalize_fs_path,
-    uri_to_fs_path,
-    fs_path_to_uri,
-    paths_equal,
-    extract_fs_path
+import from jaclang.langserve.path_utils { 
+    normalize_fs_path, 
+    uri_to_fs_path, 
+    fs_path_to_uri, 
+    paths_equal, 
+    extract_fs_path 
 }
 
 
 """Test the path utilities with various inputs."""
-def test_path_utilities() -> None {
+def test_path_utilities()  -> None {
     print("=== Testing Path Utilities ===");
-    
     # Test normalize_fs_path
-    print("\n--- Testing normalize_fs_path ---");
-    test_path1 = "/home/user/file.jac";  # Unix absolute path
-    test_path2 = "relative/path/file.jac";  # Relative path
-    test_path3 = "c:/Users/USER/file.jac";  # Windows absolute path
-    test_path4 = "c:\\Users\\USER\\file.jac";  # Windows path with backslashes
-    
-    normalized1 = normalize_fs_path(test_path1);
+    print(
+        "\n--- Testing normalize_fs_path ---"
+    );
+    test_path1 = "/home/user/file.jac";
+    # Unix absolute path
+    test_path2 =
+        "relative/path/file.jac";
+    # Relative path
+    test_path3 =
+        "c:/Users/USER/file.jac";
+    # Windows absolute path
+    test_path4 =
+        "c:\\Users\\USER\\file.jac";
+    # Windows path with backslashes
+    normalized1 =
+        normalize_fs_path(test_path1);
     normalized2 = normalize_fs_path(test_path2);
     normalized3 = normalize_fs_path(test_path3);
     normalized4 = normalize_fs_path(test_path4);
-    
     print(f"Unix absolute: {test_path1} -> {normalized1}");
     print(f"Relative: {test_path2} -> {normalized2}");
     print(f"Windows path: {test_path3} -> {normalized3}");
     print(f"Windows backslashes: {test_path4} -> {normalized4}");
-    
     # Test URI conversion
-    print("\n--- Testing URI to FS path ---");
+    print(
+        "\n--- Testing URI to FS path ---"
+    );
     test_uri1 = "file:///c%3A/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
     test_uri2 = "file:///home/user/test.jac";
-    
     fs_path1 = uri_to_fs_path(test_uri1);
     fs_path2 = uri_to_fs_path(test_uri2);
-    
     print(f"Windows URI: {test_uri1} -> {fs_path1}");
     print(f"Unix URI: {test_uri2} -> {fs_path2}");
-    
     # Test URI creation
-    print("\n--- Testing FS path to URI ---");
+    print(
+        "\n--- Testing FS path to URI ---"
+    );
     test_fs_path1 = "c:/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
     test_fs_path2 = "/home/user/test.jac";
-    
     uri_path1 = fs_path_to_uri(test_fs_path1);
     uri_path2 = fs_path_to_uri(test_fs_path2);
-    
     print(f"Windows FS: {test_fs_path1} -> {uri_path1}");
     print(f"Unix FS: {test_fs_path2} -> {uri_path2}");
-    
     # Test paths_equal
-    print("\n--- Testing paths_equal ---");
+    print(
+        "\n--- Testing paths_equal ---"
+    );
     path1 = "c:\\Users\\USER\\jaseci\\jac\\jaclang\\tests\\fixtures\\hello.jac";
     path2 = "/c%3A/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
     path3 = "file:///c%3A/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
     path4 = "c:/Users/USER/jaseci/jac/jaclang/tests/fixtures/hello.jac";
-    
     are_equal_1_2 = paths_equal(path1, path2);
     are_equal_1_3 = paths_equal(path1, path3);
     are_equal_1_4 = paths_equal(path1, path4);
     are_equal_2_3 = paths_equal(path2, path3);
-    
     print(f"Windows backslash vs encoded: {are_equal_1_2} ✓");
     print(f"Windows backslash vs URI: {are_equal_1_3} ✓");
     print(f"Windows backslash vs forward: {are_equal_1_4} ✓");
     print(f"Encoded vs URI: {are_equal_2_3} ✓");
-    
     # Test extract_fs_path
-    print("\n--- Testing extract_fs_path ---");
+    print(
+        "\n--- Testing extract_fs_path ---"
+    );
     extracted1 = extract_fs_path("file:///c%3A/Users/USER/test.jac");
     extracted2 = extract_fs_path("/home/user/test.jac");
     extracted3 = extract_fs_path("c:\\Windows\\test.jac");
-    
     print(f"Extract from URI: {extracted1}");
     print(f"Extract from Unix: {extracted2}");
     print(f"Extract from Windows: {extracted3}");
-    
     print("\n=== Test Complete ===");
 }
 
 
 # Test the functions
-with entry {
+ with entry {
     test_path_utilities();
 }

--- a/jac/jaclang/langserve/utils.jac
+++ b/jac/jaclang/langserve/utils.jac
@@ -20,6 +20,7 @@ import from jaclang.compiler.constant { SymbolType }
 import from jaclang.compiler.passes.transform { Alert }
 import from jaclang.compiler.unitree { Symbol, UniScopeNode }
 import from jaclang.vendor.pygls { uris }
+import from path_utils { extract_fs_path, paths_equal }
 
 import lsprotocol.types as lspt;
 
@@ -34,15 +35,16 @@ def gen_diagnostics(
     errors: <>list[Alert],
     warnings: <>list[Alert]
 ) -> <>list[lspt.Diagnostic] {
+    from_path_normalized = extract_fs_path(from_path);
     return [ lspt.Diagnostic(
         range=create_range(error.loc),
         message=error.msg,
         severity=lspt.DiagnosticSeverity.Error
-    ) for error in errors if error.loc.mod_path == uris.to_fs_path(from_path) ] + [ lspt.Diagnostic(
+    ) for error in errors if paths_equal(error.loc.mod_path, from_path_normalized) ] + [ lspt.Diagnostic(
         range=create_range(warning.loc),
         message=warning.msg,
         severity=lspt.DiagnosticSeverity.Warning
-    ) for warning in warnings if warning.loc.mod_path == uris.to_fs_path(from_path) ];
+    ) for warning in warnings if paths_equal(warning.loc.mod_path, from_path_normalized) ];
 }
 
 

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1287,6 +1287,16 @@ class JacLanguageTests(TestCase):
         self.assertIn("MyWalker() from edge MyEdge(path=3)", stdout_value[6])
         self.assertIn("MyWalker() from node MyNode(val=40)", stdout_value[9])
 
+    def test_path_utils(self) -> None:
+        """Test path utilities in jaclang."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        path_util_file = os.path.join(self.fixture_abs_path("./../../langserve/tests/fixtures"), "path_utility.jac")
+        cli.run(path_util_file)
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue().split("\n")
+        self.assertEqual(4, str(stdout_value).count('True ✓'))
+
     def test_visit_traversal(self) -> None:
         """Test visit traversal semantic in jaclang."""
         captured_output = io.StringIO()


### PR DESCRIPTION
## **Description**

#### Eliminates path-mismatches between wsl  and windows in language server.
#### ensuring consistent behavior and preventing the accumulation of errors.
Before:
<img width="597" height="828" alt="image" src="https://github.com/user-attachments/assets/08559608-4c9a-4128-b04b-1dd073cdc012" />

After:
<img width="719" height="893" alt="image" src="https://github.com/user-attachments/assets/eb0e306f-b4ef-4fca-83e6-900f4cae56da" />

