### PR TITLE
Remove `incl_info` usages in repo and docs 

### DIFF
--- a/docs/docs/jac_book/chapter_5.md
+++ b/docs/docs/jac_book/chapter_5.md
@@ -324,13 +324,13 @@ sem PhotoAnalyzer.style_preference = "Preferred photography style (artistic, doc
 
 
 """Generate caption considering photographer's style preference."""
-def generate_styled_caption(pa: PhotoAnalyzer) -> str by vision_llm(incl_info=(pa.style_preference));
+def generate_styled_caption(pa: PhotoAnalyzer) -> str by vision_llm();
 
 """Provide technical photography feedback."""
 def analyze_composition(pa: PhotoAnalyzer) -> list[str] by vision_llm();
 
 """Suggest improvements for the photo."""
-def suggest_improvements(pa: PhotoAnalyzer) -> list[str] by vision_llm(incl_info=(pa.photographer_name, pa.style_preference));
+def suggest_improvements(pa: PhotoAnalyzer) -> list[str] by vision_llm();
 
 
 with entry {

--- a/docs/docs/jac_book/chapter_9.md
+++ b/docs/docs/jac_book/chapter_9.md
@@ -203,7 +203,7 @@ import from byllm { Model }
 glob npc_model = Model(model_name="gpt-4.1-mini");
 
 """Adjusts the tone or personality of the shop keeper npc depending on weather/time."""
-def get_ambient_mood(state: dict) -> str by npc_model(incl_info=(state));
+def get_ambient_mood(state: dict) -> str by npc_model();
 ```
 This function, `get_ambient_mood`, takes a dictionary (the walker’s state) and sends it to the model. The model interprets the contents like `temperature` and `time`—and returns a textual mood that fits the situation.
 
@@ -274,7 +274,7 @@ node Time(Service) {
 }
 
 """Adjusts the tone or personality of the shop keeper npc depending on weather/time."""
-def get_ambient_mood(state: dict) -> str by npc_model(incl_info=(state));
+def get_ambient_mood(state: dict) -> str by npc_model();
 
 node NPC {
     can get with StateAgent entry {

--- a/docs/docs/learn/examples/littleX/src/byllm_example.jac
+++ b/docs/docs/learn/examples/littleX/src/byllm_example.jac
@@ -24,8 +24,7 @@ walker get_summary {
 }
 
 """Answer a question based on the provided qusetion parameter."""
-def answer_question(question: str) -> str
-    by llm(incl_info=(question));
+def answer_question(question: str) -> str by llm();
 
 with entry {
     # get_summary() spawn root;

--- a/jac-byllm/examples/essay_review.jac
+++ b/jac-byllm/examples/essay_review.jac
@@ -5,8 +5,8 @@ glob llm = Model(model_name="gpt-4o");
 obj Essay {
     has essay: str;
 
-    def essay_judge(criteria: str) -> str by llm(incl_info={"essay": self.essay});
-    def generate_summary(judgements: dict) -> str by llm(incl_info={"essay": self.essay});
+    def essay_judge(criteria: str) -> str by llm();
+    def generate_summary(judgements: dict) -> str by llm();
     def give_grade(summary: str) -> str by llm();
 }
 

--- a/jac-byllm/examples/joke_gen.jac
+++ b/jac-byllm/examples/joke_gen.jac
@@ -17,7 +17,7 @@ obj PunclineJokes {
         }
     ];
 
-    def generate_joke -> dict[str, str] by llm(incl_info={"jokes_example" : self.jokes}, temperature=0.0);
+    def generate_joke -> dict[str, str] by llm();
     def generate {
         joke_punchline = self.generate_joke();
         self.jokes.append(joke_punchline);

--- a/jac-byllm/examples/text_to_type.jac
+++ b/jac-byllm/examples/text_to_type.jac
@@ -1,14 +1,5 @@
 import from byllm { Model }
 
-glob llm = Model(
-    # model_name="gpt-4o",
-    model_name="mockllm",
-    print_prompt=True,
-    outputs=[
-        Person(name='Chandra', age=28, employer=Employer(employer_name='Jaseci Labs', location='Sri Lanka'), job='ML Engineer')
-    ]
-);
-
 
 obj Employer {
     has employer_name: str,
@@ -22,14 +13,19 @@ obj Person {
         job: str;
 }
 
-def generate_person() -> Person by llm(
-    incl_info={
-        "info": "Chandra is a 28 years old and works as an ML engineer at Jaseci Labs in Sri Lanka."
-    }
+glob llm = Model(
+    # model_name="gpt-4o",
+    model_name="mockllm",
+    print_prompt=True,
+    outputs=[
+        Person(name='Steve Jobs', age=56, employer=Employer(employer_name='Apple Inc.', location='California'), job='CEO')
+    ]
 );
 
+def generate_person(info:str) -> Person by llm();
+
 with entry {
-    person = generate_person();
+    person = generate_person("Steve Jobs was 56 years old and worked as the CEO of Apple Inc. in California.");
     print(
         f"Person's name is {person.name} and works at {person.employer.employer_name} which is located in {person.employer.location}."
     );

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/simple_walk_fmt.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/simple_walk_fmt.jac
@@ -53,7 +53,4 @@ with entry {
 }
 
 
-def generate_joke -> dict[str, str] by llm(
-    incl_info={"jokes_example" : self.jokes },
-    temperature=0.0
-);
+def generate_joke -> dict[str, str] by llm();


### PR DESCRIPTION
## **Description**

incl_info should be used pass in timly information such as datetime, as an expression evaluated at call time.