### PR TITLE
New PyPI version upgrade to allow byLLM

### DIFF
--- a/docs/docs/communityhub/release_notes.md
+++ b/docs/docs/communityhub/release_notes.md
@@ -2,10 +2,11 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of Jac and Jaseci. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](./breaking_changes.md) page.
 
-## jaclang 0.8.6 / jac-cloud 0.2.6 / byllm 0.4.1 (Unreleased)
+## jaclang 0.8.7 / jac-cloud 0.2.7 / byllm 0.4.2 (Unreleased)
+
+## jaclang 0.8.6 / jac-cloud 0.2.6 / byllm 0.4.1
 
 - **byLLM transition**: MTLLM has been transitioned to byLLM and PyPi package is renamed to `byllm`. Github actions are changed to push byllm PyPi. Alongside an mtllm PyPi will be pushed which installs latest `byllm` and produces a deprecation warning when imported as `mtllm`.
-
 
 ## jaclang 0.8.5 / jac-cloud 0.2.5 / mtllm 0.4.0
 

--- a/jac-byllm/pyproject.toml
+++ b/jac-byllm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "byllm"
-version = "0.4.1"
+version = "0.4.1.post1"
 description = "byLLM Provides Easy to use APIs for different LLM Providers to be used with Jaseci's Jaclang Programming Language."
 authors = ["Jason Mars <jason@jaseci.org>"]
 maintainers = ["Jason Mars <jason@jaseci.org>"]
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["llm", "jaclang", "jaseci", "byLLM"]
 
 [tool.poetry.dependencies]
-jaclang = "0.8.5"
+jaclang = ">=0.8.6"
 litellm = ">=1.75.5.post1"
 loguru = "~0.7.2"
 pillow = "~10.4.0"

--- a/jac-cloud/pyproject.toml
+++ b/jac-cloud/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jac-cloud"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["Jason Mars <jason@jaseci.org>"]
 readme = "README.md"
@@ -8,7 +8,7 @@ packages = [{include = "jac_cloud"}]
 
 [tool.poetry.dependencies]
 python = "^3.12.0"
-jaclang = "0.8.5"
+jaclang = "0.8.6"
 fastapi = "0.115.11"
 orjson = "3.10.15"
 uvicorn = {version = "0.34.0", extras = ["standard"]}

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jaclang"
-version = "0.8.5"
+version = "0.8.6"
 description = "Jac is a unique and powerful programming language that runs on top of Python, offering an unprecedented level of intelligence and intuitive understanding."
 authors = ["Jason Mars <jason@jaseci.org>"]
 maintainers = ["Jason Mars <jason@jaseci.org>"]


### PR DESCRIPTION
## **Description**

The byLLM transitioning changed jaclang when recognizing the byllm plugin which is not pushed before byllm 0.4.1.

This PR bumps the version of all three to make sure everything remain compatible.