### PR TITLE
🪄 Magic __call__ type resolve

### DIFF
--- a/jac/jaclang/compiler/passes/main/tests/fixtures/checker_magic_call.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/checker_magic_call.jac
@@ -1,0 +1,17 @@
+
+node Bar {}
+
+node Foo {
+    def __call__() -> Bar {
+        return Bar();
+    }
+}
+
+def fn() -> Foo {
+    return Foo();
+}
+
+with entry{
+    b: Bar = fn()(); # <-- Ok
+    f: Foo = fn()(); # <-- Error
+}

--- a/jac/jaclang/compiler/passes/main/tests/test_checker_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_checker_pass.py
@@ -92,6 +92,18 @@ class TypeCheckerPassTests(TestCase):
           ^^^^^^^^^^^^^^
         """, program.errors_had[0].pretty_print())
 
+    def test_call_expr_magic(self) -> None:
+        path = self.fixture_abs_path("checker_magic_call.jac")
+        program = JacProgram()
+        mod = program.compile(path)
+        TypeCheckPass(ir_in=mod, prog=program)
+        self.assertEqual(len(program.errors_had), 1)
+        self._assert_error_pretty_found("""
+            b: Bar = fn()(); # <-- Ok
+            f: Foo = fn()(); # <-- Error
+            ^^^^^^^^^^^^^^^^
+        """, program.errors_had[0].pretty_print())
+
     def test_binary_op(self) -> None:
         program = JacProgram()
         mod = program.compile(self.fixture_abs_path("checker_binary_op.jac"))

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -496,7 +496,12 @@ class TypeEvaluator:
                     and caller_type.is_instantiable_class()
                 ):
                     return caller_type.clone_as_instance()
-                # TODO: Check if it has a `__call__` method if it's not a function type.
+                if caller_type.is_class_instance():
+                    magic_call_ret = self.get_type_of_magic_method_call(
+                        caller_type, "__call__"
+                    )
+                    if magic_call_ret:
+                        return magic_call_ret
 
             case uni.BinaryExpr():
                 return operations.get_type_of_binary_operation(self, expr)


### PR DESCRIPTION
```py

node Bar {}

node Foo {
    def __call__() -> Bar {
        return Bar();
    }
}

def fn() -> Foo {
    return Foo();
}

with entry{
    b: Bar = fn()(); # <-- Ok
    f: Foo = fn()(); # <-- Error
}
```