### PR TITLE
🔣 [Refactor] Name symbols don't require def use pass

### DIFF
--- a/jac/jaclang/compiler/program.py
+++ b/jac/jaclang/compiler/program.py
@@ -24,7 +24,6 @@ from jaclang.compiler.passes.main import (
     PyastGenPass,
     SemDefMatchPass,
     SymTabBuildPass,
-    SymTabLinkPass,
     Transform,
     TypeCheckPass,
 )
@@ -136,11 +135,8 @@ class JacProgram:
     ) -> uni.Module:
         """Convert a Jac file to an AST."""
         mod_targ = self.compile(file_path, use_str, type_check=type_check)
-        JacImportDepsPass(ir_in=mod_targ, prog=self)
-        for mod in self.mod.hub.values():
-            SymTabLinkPass(ir_in=mod, prog=self)
-        for mod in self.mod.hub.values():
-            DefUsePass(mod, prog=self)
+        if not type_check:
+            JacImportDepsPass(ir_in=mod_targ, prog=self)
         return mod_targ
 
     def run_schedule(

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -503,6 +503,7 @@ class TypeEvaluator:
 
             case uni.Name():
                 if symbol := expr.sym_tab.lookup(expr.value, deep=True):
+                    expr.sym = symbol
                     return self.get_type_of_symbol(symbol)
 
             # TODO: More expressions.


### PR DESCRIPTION
## **Description**

Now go to definition will work on names without needing the DefUsePass