### PR TITLE
✨ Add UnknownType fallback for unresolved imports

### DIFF
--- a/jac/jaclang/compiler/passes/main/tests/fixtures/checker_import_missing_module.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/checker_import_missing_module.jac
@@ -1,0 +1,13 @@
+import from scipy { stats, optimize }
+import from utils.fake_helpers { helper_func }
+import from non_existent_module { foo }
+import nonexistent_module as nm;
+
+
+with entry {
+    a: int = stats.norm.cdf(0);
+    d: float = optimize.minimize_scalar(lambda  x: int: x ** 2).fun;
+    result = helper_func();
+    b: int = foo();
+    c = nm.some_func();
+}

--- a/jac/jaclang/compiler/passes/main/tests/test_checker_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_checker_pass.py
@@ -128,6 +128,13 @@ class TypeCheckerPassTests(TestCase):
             ^^^^^^^^^^^^^^
         """, program.errors_had[0].pretty_print())
 
+    def test_checker_import_missing_module(self) -> None:
+        path = self.fixture_abs_path("checker_import_missing_module.jac")
+        program = JacProgram()
+        mod = program.compile(path)
+        TypeCheckPass(ir_in=mod, prog=program)
+        self.assertEqual(len(program.errors_had), 0)
+
     def test_cyclic_symbol(self) -> None:
         path = self.fixture_abs_path("checker_cyclic_symbol.jac")
         program = JacProgram()

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -149,10 +149,13 @@ class TypeEvaluator:
                 mod.parent_scope = self.builtins_module
         return mod
 
-    def get_type_of_module(self, node: uni.ModulePath) -> types.ModuleType:
+    def get_type_of_module(self, node: uni.ModulePath) -> types.TypeBase:
         """Return the effective type of the module."""
         if node.name_spec.type is not None:
             return cast(types.ModuleType, node.name_spec.type)
+        if not Path(node.resolve_relative_path()).exists():
+            node.name_spec.type = types.UnknownType()
+            return node.name_spec.type
 
         mod: uni.Module = self._import_module_from_path(node.resolve_relative_path())
         mod_type = types.ModuleType(
@@ -206,6 +209,11 @@ class TypeEvaluator:
             # import from mod { item }
             else:
                 mod_type = self.get_type_of_module(import_node.from_loc)
+                if not isinstance(mod_type, types.ModuleType):
+                    node.name_spec.type = types.UnknownType()
+                    # TODO: Add diagnostic that from_loc is not accessible.
+                    # Eg: 'Import "scipy" could not be resolved'
+                    return node.name_spec.type
                 if sym := mod_type.symbol_table.lookup(node.name.value, deep=True):
                     node.name.sym = sym
                     if node.alias:


### PR DESCRIPTION
## **Description**
-----------------------------

This PR updates the type checker to prevent crashes when a non-existent or uninstalled module is imported. Instead of raising an error, such imports are now resolved as `UnknownType`. 

##### 📌 TODO: 
-  Add user-friendly diagnostics for unresolved imports  
  _(e.g., `Import "scipy" could not be resolved`)_