### PR TITLE
🛟 Float type check

### DIFF
--- a/jac/jaclang/compiler/passes/main/tests/fixtures/checker_float.jac
+++ b/jac/jaclang/compiler/passes/main/tests/fixtures/checker_float.jac
@@ -1,0 +1,7 @@
+
+
+with entry {
+    pi = 3.14;     # <-- infer the type
+    f: float = pi; # <-- OK
+    s: str = pi;   # <-- Error
+}

--- a/jac/jaclang/compiler/passes/main/tests/test_checker_pass.py
+++ b/jac/jaclang/compiler/passes/main/tests/test_checker_pass.py
@@ -28,6 +28,18 @@ class TypeCheckerPassTests(TestCase):
                  ^^^^^^^^^^^^^^^^^^^^^^
         """, program.errors_had[1].pretty_print())
 
+    def test_float_types(self) -> None:
+        program = JacProgram()
+        mod = program.compile(self.fixture_abs_path("checker_float.jac"))
+        TypeCheckPass(ir_in=mod, prog=program)
+        self.assertEqual(len(program.errors_had), 1)
+        self._assert_error_pretty_found("""
+            f: float = pi; # <-- OK
+            s: str = pi;   # <-- Error
+            ^^^^^^^^^^^
+        """, program.errors_had[0].pretty_print())
+
+
     def test_infer_type_of_assignment(self) -> None:
         program = JacProgram()
         mod = program.compile(self.fixture_abs_path("infer_type_assignment.jac"))

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -35,6 +35,7 @@ class PrefetchedTypes:
     tuple_class: TypeBase | None = None
     bool_class: TypeBase | None = None
     int_class: TypeBase | None = None
+    float_class: TypeBase | None = None
     str_class: TypeBase | None = None
     dict_class: TypeBase | None = None
     module_type_class: TypeBase | None = None
@@ -285,6 +286,11 @@ class TypeEvaluator:
         assert self.prefetch.int_class is not None
         return self.prefetch.int_class
 
+    def get_type_of_float(self, node: uni.Float) -> TypeBase:
+        """Return the effective type of the float."""
+        assert self.prefetch.float_class is not None
+        return self.prefetch.float_class
+
     # Pyright equivalent function name = getTypeOfExpression();
     def get_type_of_expression(self, node: uni.Expr) -> TypeBase:
         """Return the effective type of the expression."""
@@ -374,6 +380,7 @@ class TypeEvaluator:
             tuple_class=self._get_builtin_type("tuple"),
             bool_class=self._get_builtin_type("bool"),
             int_class=self._get_builtin_type("int"),
+            float_class=self._get_builtin_type("float"),
             str_class=self._get_builtin_type("str"),
             dict_class=self._get_builtin_type("dict"),
             # module_type_class=
@@ -450,6 +457,9 @@ class TypeEvaluator:
 
             case uni.Int():
                 return self._convert_to_instance(self.get_type_of_int(expr))
+
+            case uni.Float():
+                return self._convert_to_instance(self.get_type_of_float(expr))
 
             case uni.AtomTrailer():
                 # NOTE: Pyright is using CFG to figure out the member type by narrowing the base


### PR DESCRIPTION
```
with entry {
    pi = 3.14;     # <-- infer the type
    f: float = pi; # <-- OK
    s: str = pi;   # <-- Error
}
```