### PR TITLE
docs: fix misleading example on walker traversal of FriendsWith edges

### DIFF
--- a/docs/docs/jac_book/chapter_1.md
+++ b/docs/docs/jac_book/chapter_1.md
@@ -182,7 +182,7 @@ walker GreetFriends {
             print(f"Hello, {here.name}!");
 
             # Now, tell the walker to go to all connected friends
-            visit [->:FriendsWith:->];
+            visit [<-:FriendsWith:->];
         }
     }
 }


### PR DESCRIPTION
The current documentation for walker traversal shows the example:

    # Now, tell the walker to go to all connected friends
    visit [->:FriendsWith:->];

However, this is misleading. The walker does *not* visit "all connected friends" if  the graph contains edges pointing into the current node. For example, starting  the walker from Bob or Charlie in a simple FriendsWith network will skip some  connections, because [->:FriendsWith:->] only follows *outgoing* edges.

To correctly traverse all connected friends regardless of edge direction, the  example should use:

    visit [<-:FriendsWith:->];

This tells the walker to follow both incoming (<-) and outgoing (->)  FriendsWith edges, which matches the intended "all connected friends" behavior.

This commit updates the example code in the docs to prevent  confusion for new Jac learners. It also aligns the explanation with the actual  runtime behavior.

## **Description**
