### PR TITLE
revisit the formatting of list_compr, gen_compr, dict_compr and set_compr

### DIFF
--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -756,10 +756,21 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for list comprehensions."""
         parts: list[doc.DocType] = []
         for i in node.kid:
+            if isinstance(i, uni.InnerCompr):
+                parts.append(self.tight_line())
             parts.append(i.gen.doc_ir)
             parts.append(self.space())
         parts.pop()
-        node.gen.doc_ir = self.group(self.concat(parts))
+        node.gen.doc_ir = self.group(
+            self.concat(
+                [
+                    parts[0],
+                    self.indent(self.concat([self.tight_line(), *parts[2:-2]])),
+                    self.tight_line(),
+                    parts[-1],
+                ]
+            )
+        )
 
     def exit_inner_compr(self, node: uni.InnerCompr) -> None:
         """Generate DocIR for inner comprehension clauses."""
@@ -892,19 +903,41 @@ class DocIRGenPass(UniPass):
         """Generate DocIR for generator comprehensions."""
         parts: list[doc.DocType] = []
         for i in node.kid:
+            if isinstance(i, uni.InnerCompr):
+                parts.append(self.tight_line())
             parts.append(i.gen.doc_ir)
             parts.append(self.space())
         parts.pop()
-        node.gen.doc_ir = self.group(self.concat(parts))
+        node.gen.doc_ir = self.group(
+            self.concat(
+                [
+                    parts[0],
+                    self.indent(self.concat([self.tight_line(), *parts[2:-2]])),
+                    self.tight_line(),
+                    parts[-1],
+                ]
+            )
+        )
 
     def exit_set_compr(self, node: uni.SetCompr) -> None:
         """Generate DocIR for set comprehensions."""
         parts: list[doc.DocType] = []
         for i in node.kid:
+            if isinstance(i, uni.InnerCompr):
+                parts.append(self.tight_line())
             parts.append(i.gen.doc_ir)
             parts.append(self.space())
         parts.pop()
-        node.gen.doc_ir = self.group(self.concat(parts))
+        node.gen.doc_ir = self.group(
+            self.concat(
+                [
+                    parts[0],
+                    self.indent(self.concat([self.tight_line(), *parts[2:-2]])),
+                    self.tight_line(),
+                    parts[-1],
+                ]
+            )
+        )
 
     def exit_dict_compr(self, node: uni.DictCompr) -> None:
         """Generate DocIR for dictionary comprehensions."""
@@ -913,10 +946,21 @@ class DocIRGenPass(UniPass):
             if isinstance(i, uni.Token) and i.name in [Tok.STAR_POW, Tok.STAR_MUL]:
                 parts.append(i.gen.doc_ir)
             else:
+                if isinstance(i, uni.InnerCompr):
+                    parts.append(self.tight_line())
                 parts.append(i.gen.doc_ir)
                 parts.append(self.space())
         parts.pop()
-        node.gen.doc_ir = self.group(self.concat(parts))
+        node.gen.doc_ir = self.group(
+            self.concat(
+                [
+                    parts[0],
+                    self.indent(self.concat([self.tight_line(), *parts[2:-2]])),
+                    self.tight_line(),
+                    parts[-1],
+                ]
+            )
+        )
 
     def exit_k_w_pair(self, node: uni.KWPair) -> None:
         """Generate DocIR for keyword arguments."""

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
@@ -1,4 +1,5 @@
-class SemTokManager {
+#this file is part of formatter tests and is not meant to be run
+ class SemTokManager {
     """Initialize semantic token manager."""
     def init(self: SemTokManager, ir: uni.Module) -> None {
         self.aaaaastatic_sem_tokens:
@@ -40,4 +41,34 @@ with entry {
         """This is a long
         line of code."""
     );
+}
+
+
+class ModuleManager {
+    def clear_alerts_for_file(self: ModuleManager, file_path_fs: str) -> None {
+        #list comprehension example
+        self.warnings_had = [w for w in self.program if w.loc.mod_path != file_path_fs];
+        self.program.errors_had = [
+            e
+            for e in self.program.errors_haddddddddddddddddddddddddddddddddddddddddd if e.loc.mod_path != file_path_fs
+        ];
+        # dict comprehension example
+        squares_dict = {x : x ** 2 for x in numbers};
+        squares_dict = {
+            x : x ** 2
+            for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+        };
+        # set comprehension example
+        squares_set = {x ** 2 for x in numbers};
+        squares_set = {
+            x ** 2
+            for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+        };
+        # generator comprehension example
+        squares_gen = (x ** 2 for x in numbers);
+        squares_gen = (
+            x ** 2
+            for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+        );
+    }
 }

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -518,7 +518,7 @@ class JacLanguageTests(TestCase):
         self.assertEqual(output.count("with entry {"), 14)
         self.assertIn("assert (x == 5) , 'x should be equal to 5' ;", output)
         self.assertIn("if not (x == y) {", output)
-        self.assertIn("squares_dict = { x : (x ** 2) for x in numbers };", output)
+        self.assertIn("squares_dict = {x : (x ** 2) for x in numbers};", output)
         self.assertIn(
             '\n\n"""Say hello"""\n@ my_decorator\n\n def say_hello() {', output
         )


### PR DESCRIPTION
## **Description**
The aim of this PR is to fix the formatting for the following expressions
```jac
class ModuleManager {
    def clear_alerts_for_file(self: ModuleManager, file_path_fs: str) -> None {
        #list comprehension example
        self.warnings_had = [w for w in self.program if w.loc.mod_path != file_path_fs];
        self.program.errors_had = [
            e
            for e in self.program.errors_haddddddddddddddddddddddddddddddddddddddddd if e.loc.mod_path != file_path_fs
        ];
        # dict comprehension example
        squares_dict = {x : x ** 2 for x in numbers};
        squares_dict = {
            x : x ** 2
            for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
        };
        # set comprehension example
        squares_set = {x ** 2 for x in numbers};
        squares_set = {
            x ** 2
            for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
        };
        # generator comprehension example
        squares_gen = (x ** 2 for x in numbers);
        squares_gen = (
            x ** 2
            for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
        );
    }
}

```