### PR TITLE
Correctly format function args in both func declaration and function calls

### DIFF
--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -275,8 +275,17 @@ class DocIRGenPass(UniPass):
             elif isinstance(i, uni.Token) and i.name == Tok.RPAREN and node.params:
                 in_params = False
                 has_parens = True
+                if isinstance(indent_parts[-1], doc.Line):
+                    indent_parts.pop()
                 parts.append(
-                    self.indent(self.concat([self.tight_line(), *indent_parts]))
+                    self.indent(
+                        self.concat(
+                            [
+                                self.tight_line(),
+                                self.group(self.concat([*indent_parts])),
+                            ]
+                        )
+                    )
                 )
                 parts.append(self.tight_line())
                 parts.append(i.gen.doc_ir)
@@ -471,8 +480,17 @@ class DocIRGenPass(UniPass):
                 parts.append(i.gen.doc_ir)
             elif isinstance(i, uni.Token) and i.name == Tok.RPAREN and node.params:
                 in_params = False
+                if isinstance(indent_parts[-1], doc.Line):
+                    indent_parts.pop()
                 parts.append(
-                    self.indent(self.concat([self.tight_line(), *indent_parts]))
+                    self.indent(
+                        self.concat(
+                            [
+                                self.tight_line(),
+                                self.group(self.concat([*indent_parts])),
+                            ]
+                        )
+                    )
                 )
                 parts.append(self.tight_line())
                 parts.append(i.gen.doc_ir)

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
@@ -72,3 +72,28 @@ class ModuleManager {
         );
     }
 }
+
+
+def func_with_very_long_params(
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int,
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: int,
+) -> None {
+    print(
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+    );
+}
+
+
+def func_with_long_params(
+    aaaaaaaaaaaaaaaaaaaaaa: int, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: int,
+) -> None {
+    print(
+        aaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, 1111111111111
+    );
+}
+
+
+def func_with_short_params(a: int, b: int) -> None {
+    print(a + b);
+}


### PR DESCRIPTION
## **Description**

correctly format function calls and function decls in case of long args
```jac
def func_with_very_long_params(
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int,
    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: int,
) -> None {
    print(
        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
        bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
    );
}


def func_with_long_params(
    aaaaaaaaaaaaaaaaaaaaaa: int, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb: int,
) -> None {
    print(
        aaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, 1111111111111
    );
}


def func_with_short_params(a: int, b: int) -> None {
    print(a + b);
}
```
