### PR TITLE
Fixing the extra space printed after expr_as_item

### DIFF
--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -1186,6 +1186,7 @@ class DocIRGenPass(UniPass):
         for i in node.kid:
             parts.append(i.gen.doc_ir)
             parts.append(self.space())
+        parts.pop()
         node.gen.doc_ir = self.group(self.concat(parts))
 
     def exit_filter_compr(self, node: uni.FilterCompr) -> None:

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
@@ -72,3 +72,14 @@ class ModuleManager {
         );
     }
 }
+
+
+## expr as item extra space issue
+ with entry {
+    with open(f"Apple{apple}.txt") as f {
+        # Fix syntax highlighting
+        print(
+            f.read()
+        );
+    }
+}

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
@@ -94,6 +94,8 @@ class ModuleManager {
             f.read()
         );
     }
+}
+
 
 def func_with_very_long_params(
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: int,


### PR DESCRIPTION
## **Description**
Fix for extra space printed after expr_as_item nodes 
```
## expr as item extra space issue
 with entry {
    with open(f"Apple{apple}.txt") as f {
        # Fix syntax highlighting
        print(
            f.read()
        );
    }
}
```