### PR TITLE
Fix the issue of extra line in list/dict/set compr

### DIFF
--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.py
@@ -757,8 +757,9 @@ class DocIRGenPass(UniPass):
         parts: list[doc.DocType] = []
         for i in node.kid:
             if isinstance(i, uni.InnerCompr):
-                parts.append(self.tight_line())
-            parts.append(i.gen.doc_ir)
+                parts.append(self.group(self.concat([self.tight_line(), i.gen.doc_ir])))
+            else:
+                parts.append(i.gen.doc_ir)
             parts.append(self.space())
         parts.pop()
         node.gen.doc_ir = self.group(
@@ -904,8 +905,9 @@ class DocIRGenPass(UniPass):
         parts: list[doc.DocType] = []
         for i in node.kid:
             if isinstance(i, uni.InnerCompr):
-                parts.append(self.tight_line())
-            parts.append(i.gen.doc_ir)
+                parts.append(self.group(self.concat([self.tight_line(), i.gen.doc_ir])))
+            else:
+                parts.append(i.gen.doc_ir)
             parts.append(self.space())
         parts.pop()
         node.gen.doc_ir = self.group(
@@ -924,8 +926,9 @@ class DocIRGenPass(UniPass):
         parts: list[doc.DocType] = []
         for i in node.kid:
             if isinstance(i, uni.InnerCompr):
-                parts.append(self.tight_line())
-            parts.append(i.gen.doc_ir)
+                parts.append(self.group(self.concat([self.tight_line(), i.gen.doc_ir])))
+            else:
+                parts.append(i.gen.doc_ir)
             parts.append(self.space())
         parts.pop()
         node.gen.doc_ir = self.group(
@@ -947,8 +950,11 @@ class DocIRGenPass(UniPass):
                 parts.append(i.gen.doc_ir)
             else:
                 if isinstance(i, uni.InnerCompr):
-                    parts.append(self.tight_line())
-                parts.append(i.gen.doc_ir)
+                    parts.append(
+                        self.group(self.concat([self.tight_line(), i.gen.doc_ir]))
+                    )
+                else:
+                    parts.append(i.gen.doc_ir)
                 parts.append(self.space())
         parts.pop()
         node.gen.doc_ir = self.group(
@@ -1186,6 +1192,7 @@ class DocIRGenPass(UniPass):
         for i in node.kid:
             parts.append(i.gen.doc_ir)
             parts.append(self.space())
+        parts.pop()
         node.gen.doc_ir = self.group(self.concat(parts))
 
     def exit_filter_compr(self, node: uni.FilterCompr) -> None:

--- a/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
+++ b/jac/jaclang/compiler/passes/tool/tests/fixtures/tagbreak.jac
@@ -49,11 +49,17 @@ class ModuleManager {
         #list comprehension example
         self.warnings_had = [w for w in self.program if w.loc.mod_path != file_path_fs];
         self.program.errors_had = [
+            e for e in self.program.errors_haddddddddd if e.loc.mod_path != file_path_fs
+        ];
+        self.program.errors_had = [
             e
             for e in self.program.errors_haddddddddddddddddddddddddddddddddddddddddd if e.loc.mod_path != file_path_fs
         ];
         # dict comprehension example
         squares_dict = {x : x ** 2 for x in numbers};
+        squares_dict = {
+            x : x ** 2 for x in numberssssssssssssssssssssssssssssssssssssssssssssss
+        };
         squares_dict = {
             x : x ** 2
             for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
@@ -61,11 +67,17 @@ class ModuleManager {
         # set comprehension example
         squares_set = {x ** 2 for x in numbers};
         squares_set = {
+            x ** 2 for x in numberssssssssssssssssssssssssssssssssssssssssssssssss
+        };
+        squares_set = {
             x ** 2
             for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
         };
         # generator comprehension example
         squares_gen = (x ** 2 for x in numbers);
+        squares_gen = (
+            x ** 2 for x in numberssssssssssssssssssssssssssssssssssssssssssssssssssss
+        );
         squares_gen = (
             x ** 2
             for x in numbersssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss


### PR DESCRIPTION
## **Description**
Fix an issue with the extra line in the inner compr that is part of list/set/dict compr 
```
self.program.errors_had = [
    e for e in self.program.errors_haddddddddd if e.loc.mod_path != file_path_fs
];
```
