### PR TITLE
 Update VSIX installation instructions to use GitHub releases

### DIFF
--- a/docs/docs/learn/getting_started.md
+++ b/docs/docs/learn/getting_started.md
@@ -36,11 +36,13 @@ In addition to setting up JacLang itself, you may also want to take advantage of
 - Visit the VS Code marketplace and install the [Jac Extension](https://marketplace.visualstudio.com/items?itemName=jaseci-labs.jaclang-extension)
 
 **For Cursor users:**
-1. Download the VSIX file: [jaclang-extension-2025.7.17.vsix](../../assets/vsce/jaclang-extension-2025.7.17.vsix)
-2. Open Cursor
-3. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
-4. Type `>install from vsix` and select the command
-5. Select the downloaded `jaclang-extension-2025.7.17.vsix` file
+1. Go to the [latest Jaseci release page](https://github.com/Jaseci-Labs/jaseci/releases/latest)
+2. Download the latest `jaclang-extension-*.vsix` file from the release assets
+3. Open Cursor
+4. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
+5. Type `>install from vsix` and select the command
+6. Select the downloaded VSIX file
+7. The extension will be installed and ready to use
 
 ## Next Steps
 

--- a/docs/docs/learn/installation.md
+++ b/docs/docs/learn/installation.md
@@ -72,12 +72,13 @@ For the best development experience, install the Jac VS Code extension:
 
 **For Cursor users:**
 
-1. Download the VSIX file: [jaclang-extension-2025.7.17.vsix](../../assets/vsce/jaclang-extension-2025.7.17.vsix)
-2. Open Cursor
-3. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
-4. Type `>install from vsix` and select the command
-5. Select the downloaded `jaclang-extension-2025.7.17.vsix` file
-6. The extension will be installed and ready to use
+1. Go to the [latest Jaseci release page](https://github.com/Jaseci-Labs/jaseci/releases/latest)
+2. Download the latest `jaclang-extension-*.vsix` file from the release assets
+3. Open Cursor
+4. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
+5. Type `>install from vsix` and select the command
+6. Select the downloaded VSIX file
+7. The extension will be installed and ready to use
 
 Alternatively, visit the [VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=jaseci-labs.jaclang-extension) directly.
 

--- a/jac/support/vscode_ext/jac/CHANGELOG.md
+++ b/jac/support/vscode_ext/jac/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "jac" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [2025.9.25] - Latest Release
+
+- Extension published to VS Code Marketplace
+- VSIX file available for manual installation via GitHub releases
+- Enhanced language features and debugging support
+
 ## [Unreleased]
 
 - Initial release

--- a/jac/support/vscode_ext/jac/README.md
+++ b/jac/support/vscode_ext/jac/README.md
@@ -20,11 +20,13 @@ Alternatively, install directly from the [VS Code marketplace](https://marketpla
 
 **For Cursor users:**
 
-1. Download the VSIX file: [jaclang-extension-2025.7.17.vsix](../../../assets/vsce/jaclang-extension-2025.7.17.vsix)
-2. Open Cursor
-3. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
-4. Type `>install from vsix` and select the command
-5. Select the downloaded VSIX file
+1. Go to the [latest Jaseci release page](https://github.com/Jaseci-Labs/jaseci/releases/latest)
+2. Download the latest `jaclang-extension-*.vsix` file from the release assets
+3. Open Cursor
+4. Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
+5. Type `>install from vsix` and select the command
+6. Select the downloaded VSIX file
+7. The extension will be installed and ready to use
 
 # Debugging Jaclang
 


### PR DESCRIPTION
Replace hardcoded VSIX file paths with dynamic GitHub releases links in documentation. This change ensures users always access the latest extension version and eliminates the need to update version numbers across multiple documentation files.


<img width="1396" height="775" alt="image" src="https://github.com/user-attachments/assets/af1b9c21-b961-449b-86c4-61e9814da25d" />
