### PR TITLE
Use non-allocating probe instead of fully format the subtree in case of group nodes

### DIFF
--- a/jac/jaclang/compiler/passes/tool/jac_formatter_pass.py
+++ b/jac/jaclang/compiler/passes/tool/jac_formatter_pass.py
@@ -3,7 +3,8 @@
 This is a pass for formatting Jac code.
 """
 
-from typing import Optional
+from collections import deque
+from typing import Deque, Optional, Tuple
 
 import jaclang.compiler.passes.tool.doc_ir as doc
 import jaclang.compiler.unitree as uni
@@ -18,6 +19,83 @@ class JacFormatPass(Transform[uni.Module, uni.Module]):
         """Initialize pass."""
         self.indent_size = 4
         self.MAX_LINE_LENGTH = settings.max_line_length
+
+    def _probe_fits(
+        self,
+        node: doc.DocType,
+        indent_level: int,
+        width_remaining: int,
+        *,
+        max_steps: int = 2000,
+    ) -> bool:
+        """
+        Check if flat can be used early.
+
+        returns True if `node` could be printed *flat* on the current line within
+        `width_remaining` columns at `indent_level`.
+        Stops early on overflow or hard/literal lines.
+        """
+        # Worklist holds (node, indent_level). We only ever push FLAT in a probe.
+        work: Deque[Tuple[object, int]] = deque()
+        work.append((node, indent_level))
+        steps = 0
+        remaining = width_remaining
+
+        while work:
+            if steps >= max_steps:
+                # Safety cutoff: if it's *that* complex, assume it doesn't fit.
+                return False
+            steps += 1
+
+            cur, lvl = work.pop()
+
+            if isinstance(cur, doc.Text):
+                remaining -= len(cur.text)
+                if remaining < 0:
+                    return False
+
+            elif isinstance(cur, doc.Line):
+                if cur.hard or cur.literal:
+                    # Any *real* newline (hard or literal) in FLAT means "doesn't fit"
+                    return False
+                if cur.tight:
+                    # tight softline disappears in flat mode
+                    continue
+                # regular soft line becomes a single space in flat mode
+                remaining -= 1
+                if remaining < 0:
+                    return False
+
+            # --- Structural nodes (walk children in LIFO) ---
+            elif isinstance(cur, doc.Concat):
+                # push reversed so we process left-to-right as work is a stack
+                for p in reversed(cur.parts):
+                    work.append((p, lvl))
+
+            elif isinstance(cur, doc.Group):
+                # Probe is always FLAT for groups.
+                work.append((cur.contents, lvl))
+
+            elif isinstance(cur, doc.Indent):
+                # In flat mode, indentation has no effect until a newline; keep lvl in case
+                # children contain Lines (which would have already returned False).
+                work.append((cur.contents, lvl + 1))
+
+            elif isinstance(cur, doc.Align):
+                # In flat mode, alignment doesn’t change width immediately (no newline),
+                # but we carry its virtual indent so nested (illegal) Line would be caught.
+                align_spaces = cur.n if cur.n is not None else self.indent_size
+                extra_levels = align_spaces // self.indent_size
+                work.append((cur.contents, lvl + extra_levels))
+
+            elif isinstance(cur, doc.IfBreak):
+                # Flat branch while probing
+                work.append((cur.flat_contents, lvl))
+
+            else:
+                raise ValueError(f"Unknown DocType in probe: {type(cur)}")
+
+        return True
 
     def transform(self, ir_in: uni.Module) -> uni.Module:
         """After pass."""
@@ -52,22 +130,17 @@ class JacFormatPass(Transform[uni.Module, uni.Module]):
                 return " "
 
         elif isinstance(doc_node, doc.Group):
-            # Try to print flat first. For this attempt, the group itself isn't forced to break.
-            flat_contents_str = self.format_doc_ir(
-                doc_node.contents, indent_level, width_remaining, is_broken=False
+            fits_flat = self._probe_fits(
+                doc_node.contents,
+                indent_level=indent_level,
+                width_remaining=width_remaining,
             )
-            if (
-                "\n" not in flat_contents_str
-                and len(flat_contents_str) <= width_remaining
-            ):
-                return flat_contents_str
-            else:
-                return self.format_doc_ir(
-                    doc_node.contents,
-                    indent_level,
-                    width_remaining,  # full_width_for_broken_content,
-                    is_broken=True,
-                )
+            return self.format_doc_ir(
+                doc_node.contents,
+                indent_level,
+                width_remaining,
+                is_broken=not fits_flat,
+            )
 
         elif isinstance(doc_node, doc.Indent):
             new_indent_level = indent_level + 1
@@ -79,72 +152,56 @@ class JacFormatPass(Transform[uni.Module, uni.Module]):
             )
 
         elif isinstance(doc_node, doc.Concat):
-            result = ""
-            # current_line_budget is the space left on the current line for the current part.
+            result: list[str] = []
             current_line_budget = width_remaining
 
             for part in doc_node.parts:
                 part_str = self.format_doc_ir(
                     part, indent_level, current_line_budget, is_broken
                 )
-                if part_str.startswith("\n"):
-                    result = result.rstrip(" ")
-                result += part_str
+
+                # Trim trailing spaces when a newline begins next
+                if part_str.startswith("\n") and result and result[-1].endswith(" "):
+                    result[-1] = result[-1].rstrip(" ")
+
+                result.append(part_str)
 
                 if "\n" in part_str:
-                    # part_str created a newline. The next part starts on a new line.
-                    # Its budget is the full width available at this indent level.
-                    current_line_budget = self.MAX_LINE_LENGTH - (
-                        indent_level * self.indent_size
+                    # After a newline, reset budget to full width at this indent.
+                    last_line = part_str.splitlines()[-1]
+                    full_budget = max(
+                        0, self.MAX_LINE_LENGTH - indent_level * self.indent_size
                     )
-                    # Subtract what the *last line* of part_str consumed from this budget.
-                    # The characters on the last line after the indent string.
-                    indent_str_len = indent_level * self.indent_size
-                    last_line_of_part = part_str.splitlines()[-1]
-
-                    content_on_last_line = 0
-                    if last_line_of_part.startswith(" " * indent_str_len):
-                        content_on_last_line = len(last_line_of_part) - indent_str_len
-                    else:  # It was a line not starting with the full indent (e.g. literal \n)
-                        content_on_last_line = len(last_line_of_part)
-
-                    current_line_budget -= content_on_last_line
+                    # Compute how many chars are already on the last line (after indent).
+                    indent_spaces = " " * (indent_level * self.indent_size)
+                    if last_line.startswith(indent_spaces):
+                        used = len(last_line) - len(indent_spaces)
+                    else:
+                        used = len(last_line)
+                    current_line_budget = max(0, full_budget - used)
                 else:
-                    # part_str stayed on the same line. Reduce budget for next part on this line.
-                    current_line_budget -= len(part_str)
+                    current_line_budget = max(0, current_line_budget - len(part_str))
 
-                if current_line_budget < 0:  # Ensure budget isn't negative
-                    current_line_budget = 0
-            return result
+            return "".join(result)
 
         elif isinstance(doc_node, doc.IfBreak):
-            if is_broken:
-                return self.format_doc_ir(
-                    doc_node.break_contents, indent_level, width_remaining, is_broken
-                )
-            else:
-                return self.format_doc_ir(
-                    doc_node.flat_contents, indent_level, width_remaining, is_broken
-                )
+            branch = doc_node.break_contents if is_broken else doc_node.flat_contents
+            return self.format_doc_ir(branch, indent_level, width_remaining, is_broken)
 
         elif isinstance(doc_node, doc.Align):
             align_spaces = doc_node.n if doc_node.n is not None else self.indent_size
-            # effective_total_indent_spaces_for_children = (
-            #     indent_level * self.indent_size
-            # ) + align_spaces
-            child_indent_level_for_align = indent_level + (
-                align_spaces // self.indent_size
-            )
+            extra_levels = align_spaces // self.indent_size
+            child_indent_level = indent_level + extra_levels
 
-            child_width_budget = width_remaining - align_spaces
-            if child_width_budget < 0:
-                child_width_budget = 0
+            # On the same line, alignment "consumes" part of the current budget.
+            child_width_budget = max(0, width_remaining - align_spaces)
 
             return self.format_doc_ir(
                 doc_node.contents,
-                child_indent_level_for_align,  # Approximated level for Lines inside
-                child_width_budget,  # Budget for content on first line
+                child_indent_level,
+                child_width_budget,
                 is_broken,
             )
+
         else:
             raise ValueError(f"Unknown DocType: {type(doc_node)}")


### PR DESCRIPTION
## **Description**

Previously, the formatter handled groups by **fully rendering their contents in flat mode**, then measuring the resulting string to see if it fit within the allowed line width.  
If it exceeded the limit, the formatter would retry with the group marked as broken.  

This approach caused **repeated full-tree formatting** and unnecessary string allocations, since the flat result was often discarded.  

This PR introduces a **non-allocating probe** to optimize group handling:

- Instead of formatting the entire group flat, the probe **walks the DocIR tree node by node**.
- At each step it updates the remaining width budget.
- If the width is exceeded (or a hard/literal line is encountered), the probe **immediately fails** and the group is marked as broken.

### ✅ Benefits
- Eliminates redundant string allocations for flat checks.
- Stops traversal early once it’s known a group cannot fit.
- Improves performance on large inputs with deeply nested groups.

### 📊 Performance Results
- **`engine.jac`**  
  - Before: ~**4.0 seconds**  
  - After: ~**0.009 seconds**  

- **`utils.jac`**  
  - Before: ~**13.0 seconds**  
  - After: ~**0.005 seconds**  
