### PR TITLE
🏗️ [Refactor] Type evaluator moved to program member

### DIFF
--- a/jac/jaclang/compiler/passes/main/type_checker_pass.py
+++ b/jac/jaclang/compiler/passes/main/type_checker_pass.py
@@ -9,57 +9,19 @@ Reference:
     craizy_type_expr branch: type_checker_pass.py
 """
 
-import ast as py_ast
-import os
-
 import jaclang.compiler.unitree as uni
 from jaclang.compiler.passes import UniPass
 from jaclang.compiler.type_system import types as jtypes
-from jaclang.compiler.type_system.type_evaluator import TypeEvaluator
-from jaclang.runtimelib.utils import read_file_with_encoding
-
-from .pyast_load_pass import PyastBuildPass
-from .sym_tab_build_pass import SymTabBuildPass
 
 
 class TypeCheckPass(UniPass):
     """Type checker pass for JacLang."""
 
-    # NOTE: This is done in the binder pass of pyright, however I'm doing this
-    # here, cause this will be the entry point of the type checker and we're not
-    # relying on the binder pass at the moment and we can go back to binder pass
-    # in the future if we needed it.
-    _BUILTINS_STUB_FILE_PATH = os.path.join(
-        os.path.dirname(__file__),
-        "../../../vendor/typeshed/stdlib/builtins.pyi",
-    )
-
-    # Cache the builtins module once it parsed.
-    _BUILTINS_MODULE: uni.Module | None = None
-
-    # REVIEW: Making the evaluator a static (singleton) variable to make sure only one
-    # instance is used across mulitple compilation units. This can also be attached to an
-    # attribute of JacProgram, however the evaluator is a temproary object that we dont
-    # want bound to the program for long term, Also the program is the one that will be
-    # dumped in the compiled bundle.
-    _EVALUATOR: TypeEvaluator | None = None
-
     def before_pass(self) -> None:
         """Initialize the checker pass."""
-        self._load_builtins_stub_module()
+        self.evaluator = self.prog.get_type_evaluator()
+        self.evaluator.diagnostic_callback = self._add_diagnostic
         self._insert_builtin_symbols()
-
-    @property
-    def evaluator(self) -> TypeEvaluator:
-        """Return the type evaluator."""
-        if TypeCheckPass._EVALUATOR is None:
-            assert TypeCheckPass._BUILTINS_MODULE is not None
-            TypeCheckPass._EVALUATOR = TypeEvaluator(
-                builtins_module=TypeCheckPass._BUILTINS_MODULE,
-                program=self.prog,
-                callback=self._add_diagnostic,
-            )
-        return TypeCheckPass._EVALUATOR
 
     def _add_diagnostic(self, node: uni.UniNode, message: str, warning: bool) -> None:
         """Add a diagnostic message to the pass."""
@@ -72,38 +34,9 @@ class TypeCheckPass(UniPass):
     # Internal helper functions
     # --------------------------------------------------------------------------
 
-    def _binding_builtins(self) -> bool:
-        """Return true if we're binding the builtins stub file."""
-        return self.ir_in == TypeCheckPass._BUILTINS_MODULE
-
-    def _load_builtins_stub_module(self) -> None:
-        """Return the builtins stub module.
-
-        This will parse and cache the stub file and return the cached module on
-        subsequent calls.
-        """
-        if self._binding_builtins() or TypeCheckPass._BUILTINS_MODULE is not None:
-            return
-
-        if not os.path.exists(TypeCheckPass._BUILTINS_STUB_FILE_PATH):
-            raise FileNotFoundError(
-                f"Builtins stub file not found at {TypeCheckPass._BUILTINS_STUB_FILE_PATH}"
-            )
-
-        file_content = read_file_with_encoding(TypeCheckPass._BUILTINS_STUB_FILE_PATH)
-        uni_source = uni.Source(file_content, TypeCheckPass._BUILTINS_STUB_FILE_PATH)
-        mod = PyastBuildPass(
-            ir_in=uni.PythonModuleAst(
-                py_ast.parse(file_content),
-                orig_src=uni_source,
-            ),
-            prog=self.prog,
-        ).ir_out
-        SymTabBuildPass(ir_in=mod, prog=self.prog)
-        TypeCheckPass._BUILTINS_MODULE = mod
-
     def _insert_builtin_symbols(self) -> None:
-        if self._binding_builtins():
+        # Don't insert builtin symbols into the builtin module itself.
+        if self.ir_in == self.evaluator.builtins_module:
             return
 
         # TODO: Insert these symbols.
@@ -113,15 +46,12 @@ class TypeCheckPass(UniPass):
         # '__name__', '__loader__', '__package__', '__spec__', '__path__',
         # '__file__', '__cached__', '__dict__', '__annotations__',
         # '__builtins__', '__doc__',
-        assert (
-            TypeCheckPass._BUILTINS_MODULE is not None
-        ), "Builtins module is not loaded"
         if self.ir_in.parent_scope is not None:
             self.log_info("Builtins module is already bound, skipping.")
             return
         # Review: If we ever assume a module cannot have a parent scope, this will
         # break that contract.
-        self.ir_in.parent_scope = TypeCheckPass._BUILTINS_MODULE
+        self.ir_in.parent_scope = self.evaluator.builtins_module
 
     # --------------------------------------------------------------------------
     # Ast walker hooks

--- a/jac/jaclang/compiler/program.py
+++ b/jac/jaclang/compiler/program.py
@@ -32,6 +32,7 @@ from jaclang.compiler.passes.tool import (
     FuseCommentsPass,
     JacFormatPass,
 )
+from jaclang.compiler.type_system.type_evaluator import TypeEvaluator
 from jaclang.runtimelib.utils import read_file_with_encoding
 from jaclang.settings import settings
 from jaclang.utils.log import logging
@@ -66,6 +67,13 @@ class JacProgram:
         self.py_raise_map: dict[str, str] = {}
         self.errors_had: list[Alert] = []
         self.warnings_had: list[Alert] = []
+        self.type_evaluator: TypeEvaluator | None = None
+
+    def get_type_evaluator(self) -> TypeEvaluator:
+        """Return the type evaluator."""
+        if not self.type_evaluator:
+            self.type_evaluator = TypeEvaluator(program=self)
+        return self.type_evaluator
 
     def get_bytecode(self, full_target: str) -> Optional[types.CodeType]:
         """Get the bytecode for a specific module."""

--- a/jac/jaclang/compiler/type_system/type_evaluator.py
+++ b/jac/jaclang/compiler/type_system/type_evaluator.py
@@ -6,13 +6,18 @@ PyrightReference:
     packages/pyright-internal/src/analyzer/typeEvaluatorTypes.ts
 """
 
+import ast as py_ast
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, TYPE_CHECKING, cast
 
 import jaclang.compiler.unitree as uni
 from jaclang.compiler.constant import Tokens as Tok
+from jaclang.compiler.passes.main.pyast_load_pass import PyastBuildPass
+from jaclang.compiler.passes.main.sym_tab_build_pass import SymTabBuildPass
 from jaclang.compiler.type_system import types
+from jaclang.runtimelib.utils import read_file_with_encoding
 
 if TYPE_CHECKING:
     from jaclang.compiler.program import JacProgram
@@ -81,11 +86,18 @@ class MatchArgsToParamsResult:
 class TypeEvaluator:
     """Type evaluator for JacLang."""
 
+    # NOTE: This is done in the binder pass of pyright, however I'm doing this
+    # here, cause this will be the entry point of the type checker and we're not
+    # relying on the binder pass at the moment and we can go back to binder pass
+    # in the future if we needed it.
+    _BUILTINS_STUB_FILE_PATH = os.path.join(
+        os.path.dirname(__file__),
+        "../../vendor/typeshed/stdlib/builtins.pyi",
+    )
+
     def __init__(
         self,
-        builtins_module: uni.Module,
         program: "JacProgram",
-        callback: DiagnosticCallback,
     ) -> None:
         """Initialize the type evaluator with prefetched types.
 
@@ -97,17 +109,68 @@ class TypeEvaluator:
         in some place then it will not be available in the evaluator, So we
         are prefetching the builtins at the constructor level once.
         """
-        self.symbol_resolution_stack: list[SymbolResolutionStackEntry] = []
-        self.builtins_module = builtins_module
         self.program = program
+        self.symbol_resolution_stack: list[SymbolResolutionStackEntry] = []
+        self.builtins_module = self._load_builtins_stub_module()
         self.prefetch = self._prefetch_types()
-        self.callback = callback
+        self.diagnostic_callback: DiagnosticCallback | None = None
+
+    def _load_builtins_stub_module(self) -> uni.Module:
+        """Load and return the builtins stub module."""
+        if not os.path.exists(TypeEvaluator._BUILTINS_STUB_FILE_PATH):
+            raise FileNotFoundError(
+                f"Builtins stub file not found at {TypeEvaluator._BUILTINS_STUB_FILE_PATH}"
+            )
+        file_content = read_file_with_encoding(TypeEvaluator._BUILTINS_STUB_FILE_PATH)
+        uni_source = uni.Source(file_content, TypeEvaluator._BUILTINS_STUB_FILE_PATH)
+        mod = PyastBuildPass(
+            ir_in=uni.PythonModuleAst(
+                py_ast.parse(file_content),
+                orig_src=uni_source,
+            ),
+            prog=self.program,
+        ).ir_out
+        SymTabBuildPass(ir_in=mod, prog=self.program)
+        return mod
+
+    def _get_builtin_type(self, name: str) -> TypeBase:
+        """Return the built-in type with the given name."""
+        if (symbol := self.builtins_module.lookup(name)) is not None:
+            return self.get_type_of_symbol(symbol)
+        return types.UnknownType()
+
+    def _prefetch_types(self) -> "PrefetchedTypes":
+        """Return the prefetched types for the type evaluator."""
+        return PrefetchedTypes(
+            # TODO: Pyright first try load NoneType from typeshed and if it cannot
+            # then it set to unknown type.
+            none_type_class=types.UnknownType(),
+            object_class=self._get_builtin_type("object"),
+            type_class=self._get_builtin_type("type"),
+            # union_type_class=
+            # awaitable_class=
+            # function_class=
+            # method_class=
+            tuple_class=self._get_builtin_type("tuple"),
+            bool_class=self._get_builtin_type("bool"),
+            int_class=self._get_builtin_type("int"),
+            float_class=self._get_builtin_type("float"),
+            str_class=self._get_builtin_type("str"),
+            dict_class=self._get_builtin_type("dict"),
+            # module_type_class=
+            # typed_dict_class=
+            # typed_dict_private_class=
+            # supports_keys_and_get_item_class=
+            # mapping_class=
+            # template_class=
+        )
 
     def add_diagnostic(
         self, node: uni.UniNode, message: str, warning: bool = False
     ) -> None:
         """Add a diagnostic message to the program."""
-        self.callback(node, message, warning)
+        if self.diagnostic_callback:
+            self.diagnostic_callback(node, message, warning)
 
     # -------------------------------------------------------------------------
     # Symbol resolution stack
@@ -418,38 +481,6 @@ class TypeEvaluator:
 
         # TODO: Search base classes and everything else pyright is doing.
         return False
-
-    def _prefetch_types(self) -> "PrefetchedTypes":
-        """Return the prefetched types for the type evaluator."""
-        return PrefetchedTypes(
-            # TODO: Pyright first try load NoneType from typeshed and if it cannot
-            # then it set to unknown type.
-            none_type_class=types.UnknownType(),
-            object_class=self._get_builtin_type("object"),
-            type_class=self._get_builtin_type("type"),
-            # union_type_class=
-            # awaitable_class=
-            # function_class=
-            # method_class=
-            tuple_class=self._get_builtin_type("tuple"),
-            bool_class=self._get_builtin_type("bool"),
-            int_class=self._get_builtin_type("int"),
-            float_class=self._get_builtin_type("float"),
-            str_class=self._get_builtin_type("str"),
-            dict_class=self._get_builtin_type("dict"),
-            # module_type_class=
-            # typed_dict_class=
-            # typed_dict_private_class=
-            # supports_keys_and_get_item_class=
-            # mapping_class=
-            # template_class=
-        )
-
-    def _get_builtin_type(self, name: str) -> TypeBase:
-        """Return the built-in type with the given name."""
-        if (symbol := self.builtins_module.lookup(name)) is not None:
-            return self.get_type_of_symbol(symbol)
-        return types.UnknownType()
 
     # This function is a combination of the bellow pyright functions.
     #  - getDeclaredTypeOfSymbol


### PR DESCRIPTION
Type evaluator is currently a singleton (Which is an anti-pattern) that is problematic when there are multiple programs instances are created in a single execution since, it assumes and have a persistant reference to the one program it was created with, this break certain tests when the tests ran parallelly with different programs, so this refactor is necessary to address.