### PR TITLE
add fileTypes to textmate syntax

### DIFF
--- a/jac/support/vscode_ext/jac/syntaxes/jac.tmLanguage.json
+++ b/jac/support/vscode_ext/jac/syntaxes/jac.tmLanguage.json
@@ -1,6 +1,7 @@
 {
 	"name": "The Jac Programming Language",
 	"scopeName": "source.jac",
+	"fileTypes": ["jac"],
 	"patterns": [
 		{
 			"include": "#elements"


### PR DESCRIPTION
I'm adding support to highlighting this language in [babi](https://github.com/asottile/babi) (my text editor).  babi uses vs code grammars which roughly use textmate syntax in json form.  this is one of the hints in the grammar file to tell the editor which file extensions are supported by a grammar (I assume the vs code extension does this through other means and doesn't need `fileTypes`)