### PR TITLE
feat: switch to custom mkdocs_serve.py for playground support

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - feat/mkdocs-serve-playground-support
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yml'


### PR DESCRIPTION
- Replace nginx static serving with Python-based mkdocs_serve.py
- Adds proper security headers for SharedArrayBuffer (COOP/COEP)
- Required for Jac Playground WebAssembly/Pyodide functionality
- Uses Starlette + Uvicorn for better Python integration
- Includes file watching and automatic rebuilds
- Changes from port 80 to port 8000

## **Description**
