### PR TITLE
fix(infer): add response field to infer walker for p…

### DIFF
--- a/docs/docs/learn/examples/rag_chatbot/solution/server.jac
+++ b/docs/docs/learn/examples/rag_chatbot/solution/server.jac
@@ -28,6 +28,7 @@ node Chat {
 walker infer {
     has message: str;
     has chat_history: list[dict];
+    has response: str = "";
     has file_path: str = "";
 
     can init_router with `root entry {


### PR DESCRIPTION
Added a `response: str = ""` field to the infer walker to store and manage LLM-generated responses.  

Previously, the infer walker did not have a dedicated attribute to hold the assistant's output, which could lead to missing or undefined response values when used in the Session node or during chat interactions.

This small change ensures:
- The Session node can safely reference `response.response` without runtime errors.