### PR TITLE
Add global person_record initialization for player-NPC interactions

### DIFF
--- a/docs/docs/learn/examples/mtp_examples/fantasy_trading_game.md
+++ b/docs/docs/learn/examples/mtp_examples/fantasy_trading_game.md
@@ -47,6 +47,8 @@ obj Chat {
     has person: str;
     has message: str;
 }
+
+glob person_record: dict[str, Person] = {};
 ```
 
 **Structure definitions:**


### PR DESCRIPTION
The original implementation did not include a `person_record`, leading to missing context in player-NPC interactions.   By introducing this variable globally, the system can now store player information.