### PR TITLE
Fix: iter_for bug with continue stmt

### DIFF
--- a/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
+++ b/jac/jaclang/compiler/passes/main/pyast_gen_pass.py
@@ -1684,7 +1684,11 @@ class PyastGenPass(BaseAstGenPass[ast3.AST]):
         if node.ctrl.name == Tok.KW_BREAK:
             node.gen.py_ast = [self.sync(ast3.Break())]
         elif node.ctrl.name == Tok.KW_CONTINUE:
-            node.gen.py_ast = [self.sync(ast3.Continue())]
+            if iter_for_parent := self.find_parent_of_type(node, uni.IterForStmt):
+                count_by = iter_for_parent.count_by
+                node.gen.py_ast = [count_by.gen.py_ast[0], self.sync(ast3.Continue())]
+            else:
+                node.gen.py_ast = [self.sync(ast3.Continue())]
         elif node.ctrl.name == Tok.KW_SKIP:
             node.gen.py_ast = [self.sync(ast3.Return(value=None))]
 

--- a/jac/jaclang/tests/fixtures/iter_for_continue.jac
+++ b/jac/jaclang/tests/fixtures/iter_for_continue.jac
@@ -1,0 +1,19 @@
+
+with entry{
+    
+    obj A{
+        has i: int = 0;
+
+    }
+    a = A();
+
+    # For-to-by loop
+    for a.i=0 to a.i<5 by a.i+=1 {
+        if a.i == 3 {
+            print("Skipping 3");
+            continue;
+        }
+        print(a.i);
+    }
+
+}

--- a/jac/jaclang/tests/test_language.py
+++ b/jac/jaclang/tests/test_language.py
@@ -1430,6 +1430,19 @@ class JacLanguageTests(TestCase):
         self.assertIn("foo2", stdout_value[6])
         self.assertIn("Coroutine task is completed", stdout_value[17])
 
+    def test_iter_for_continue(self) -> None:
+        """Test iter for continue."""
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        Jac.jac_import("iter_for_continue", base_path=self.fixture_abs_path("./"))
+        sys.stdout = sys.__stdout__
+        stdout_value = captured_output.getvalue().split("\n")
+        self.assertIn("0", stdout_value[0])
+        self.assertIn("1", stdout_value[1])
+        self.assertIn("2", stdout_value[2])
+        self.assertIn("Skipping 3", stdout_value[3])
+        self.assertIn("4", stdout_value[4])
+
     def test_unicode_string_literals(self) -> None:
         """Test unicode characters in string literals are preserved correctly."""
         captured_output = io.StringIO()


### PR DESCRIPTION
## **Description**


### Before:

<img width="1447" height="717" alt="image" src="https://github.com/user-attachments/assets/59d50caf-3601-4627-a93d-8203b3b33b27" />

### Now:
<img width="1377" height="671" alt="image" src="https://github.com/user-attachments/assets/cc6c72ee-f1a2-4ad8-af47-f8a5a1af9ab1" />

