### PR TITLE
--install-types breaks the pre-commit cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,9 +32,7 @@ repos:
         args:
           - --follow-imports=silent
           - --ignore-missing-imports
-          - --install-types
-          - --non-interactive
           - --config-file=mypy.ini
           - --explicit-package-bases
           - --exclude=jac-byllm/scripts
-        additional_dependencies: [types-PyYAML]
+        additional_dependencies: [types-PyYAML, types-requests]


### PR DESCRIPTION
the pre-commit cache is meant to be immutable -- `--install-types` breaks the cachability (and can result in corruption if executed in parallel!).  instead this patch lists all of the types that would have been installed otherwise (just `types-requests`?)