### PR TITLE
Rearranging Docs: Learn Folders

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,22 +6,14 @@ use_directory_urls: true
 nav:
   - Learn:
     # - Getting Started: "learn/getting_started.md"
-    - Installation: "learn/installation.md"
-    - Native Superset of Python: "learn/superset_python.md"
-    - Jac Library in Pure Python: "learn/library_mode.md"
-    - Tour of Jac/Jaseci: "learn/tour.md"
-    - Jac as Your First Programming Language: "learn/beginners_guide_to_jac.md"
-    - Learn Jac in 5 Minutes: "learn/jac_in_a_flash.md"
-    - Run Jac In Browser: "learn/jac_playground.md"
-    - Learn By Example:
-      - LittleX (your own twitter): "learn/examples/littleX/tutorial.md"
-      - Jac MCP Conversational Chatbot: "learn/examples/rag_chatbot/Overview.md"
-      - RPG game with AI Genarated Maps: "learn/examples/mtp_examples/rpg_game.md"
-      - Agentic Fantasy Trading Game: "learn/examples/mtp_examples/fantasy_trading_game.md"
-      - Friendzone Lite: "learn/examples/agentic_ai/friendzone-lite/friendzone-lite.md"
-      - Aider Genius Lite: "learn/examples/agentic_ai/aider-genius-lite/aider-genius-lite.md"
-      - Task Manager Lite: "learn/examples/agentic_ai/task-manager-lite/task-manager-lite.md"
-    - Learn Jac Language (WIP):
+    - Getting Started:
+      - Installation: "learn/installation.md"
+      - Tour of Jac/Jaseci: "learn/tour.md"
+      - Jac as Your First Programming Language: "learn/beginners_guide_to_jac.md"
+      - Native Superset of Python: "learn/superset_python.md"
+      - Jac Library in Pure Python: "learn/library_mode.md"
+      - Learn Jac in 5 Minutes: "learn/jac_in_a_flash.md"
+    - The Jac Book:
       - Introduction: "jac_book/index.md"
       - 1. Welcome to Jac: "jac_book/chapter_1.md"
       - 2. Variables, Types, and Basic Syntax: "jac_book/chapter_2.md"
@@ -43,6 +35,16 @@ nav:
       - 18. Deployment Strategies: "jac_book/chapter_18.md"
       - 19. Performance Optimization: "jac_book/chapter_19.md"
       - 20. Python to Jac Migration: "jac_book/chapter_20.md"
+      - Specifications:
+        - Jac Keywords: "learn/keywords.md"
+        - Object-Spatial Programming Specification: "learn/dspfoundation.md"
+      - Misc Docs:
+        - Understanding Object-Spatial:
+          - "learn/data_spatial/nodes_and_edges.md" # Introduction to DS primitives
+          - "learn/data_spatial/walkers.md" # Walker
+          - "learn/data_spatial/filtering.md" # Filtering
+          - "learn/data_spatial/sequence.md"
+        - FAQ: "learn/data_spatial/FAQ.md" # faq
     - Programming 'by' LLM:
         - byLLM: "learn/jac-byllm/with_llm.md"
         - Quick-start: "learn/jac-byllm/quickstart.md"
@@ -70,19 +72,18 @@ nav:
         - "learn/jac-cloud/utilities.md"
       - Jac Lens: "learn/jac-lens.md"
     - Tooling:
+      - Run Jac In Browser: "learn/jac_playground.md"
       - "learn/tools/cli.md"
       - "learn/tools/jac_serve.md"
       - "learn/tools/streamlit.md"
-    - Specifications:
-      - Jac Keywords: "learn/keywords.md"
-      - Object-Spatial Programming Specification: "learn/dspfoundation.md"
-    - Misc Docs:
-      - Understanding Object-Spatial:
-        - "learn/data_spatial/nodes_and_edges.md" # Introduction to DS primitives
-        - "learn/data_spatial/walkers.md" # Walker
-        - "learn/data_spatial/filtering.md" # Filtering
-        - "learn/data_spatial/sequence.md"
-      - FAQ: "learn/data_spatial/FAQ.md" # faq
+    - Examples:
+      - LittleX (your own twitter): "learn/examples/littleX/tutorial.md"
+      - Jac MCP Conversational Chatbot: "learn/examples/rag_chatbot/Overview.md"
+      - RPG game with AI Genarated Maps: "learn/examples/mtp_examples/rpg_game.md"
+      - Agentic Fantasy Trading Game: "learn/examples/mtp_examples/fantasy_trading_game.md"
+      - Friendzone Lite: "learn/examples/agentic_ai/friendzone-lite/friendzone-lite.md"
+      - Aider Genius Lite: "learn/examples/agentic_ai/aider-genius-lite/aider-genius-lite.md"
+      - Task Manager Lite: "learn/examples/agentic_ai/task-manager-lite/task-manager-lite.md"
   - Full Jac Specification:
     - Introduction: "learn/jac_ref.md"
     - Base Module structure: "learn/jac_ref/base_module_structure.md"


### PR DESCRIPTION
## **Description**
This PR is about reorganizing the folders in the learn section of the docs. Goal is to minimize the the top level clutter to make it easier for users to find pages.

Currently, have not cut any content that was already there. May consider unlinking less hot pages like "misc docs" in the future. As we edit or change existing pages, others page get removed or moved further.

