### PR TITLE
Docs search bar fix

### DIFF
--- a/docs/docs/extra.css
+++ b/docs/docs/extra.css
@@ -797,4 +797,4 @@ body[data-domain="https://www.jac-lang.org/"] .feedback-container {
         width: 280px;
         right: 0;
     }
-}   
+}


### PR DESCRIPTION
Fixed search bar output being rendered under tab bar in docs