### PR TITLE
Filter Comprehensation type check

### DIFF
--- a/jac/jaclang/compiler/passes/main/type_checker_pass.py
+++ b/jac/jaclang/compiler/passes/main/type_checker_pass.py
@@ -117,3 +117,9 @@ class TypeCheckPass(UniPass):
     def exit_formatted_value(self, node: uni.FormattedValue) -> None:
         """Handle the formatted value node."""
         self.evaluator.get_type_of_expression(node.format_part)
+
+    def exit_edge_ref_trailer(self, node: uni.EdgeRefTrailer) -> None:
+        """Handle the edge reference trailer node."""
+        for chain in node.chain:
+            if isinstance(chain, uni.FilterCompr) and chain.f_type:
+                self.evaluator.get_type_of_expression(chain.f_type)

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -491,9 +491,9 @@ class JacLangServer(JacProgram , LanguageServer) {
         }
         node_type = node_selected.type;
         ####################################################################
-         ##          Handle go to def for types and variables               ##
-         ####################################################################
-         if node_type {
+        ##          Handle go to def for types and variables              ##
+        ####################################################################
+        if node_type {
             if isinstance(node_type, ModuleType) {
                 return make_location(node_selected, is_module=True);
             } elif isinstance(node_type, ClassType) {

--- a/jac/jaclang/langserve/tests/fixtures/goto_def_tests.jac
+++ b/jac/jaclang/langserve/tests/fixtures/goto_def_tests.jac
@@ -1,0 +1,9 @@
+
+
+node SomeNode { }
+
+walker SomeWalker {
+    can with `root entry {
+        visit [-->(`?SomeNode)];
+    }
+}

--- a/jac/jaclang/langserve/tests/test_server.py
+++ b/jac/jaclang/langserve/tests/test_server.py
@@ -81,6 +81,13 @@ class TestJacLangServer(TestCase):
             str(lsp.get_definition(circle_file, lspt.Position(20, 16))),
         )
 
+        goto_defs_file = uris.from_fs_path(self.fixture_abs_path("goto_def_tests.jac"))
+        lsp.type_check_file(goto_defs_file)
+        self.assertIn(
+            "fixtures/goto_def_tests.jac:1:5-1:13",
+            str(lsp.get_definition(goto_defs_file, lspt.Position(5, 21))),
+        )
+
     def test_go_to_definition_method_manual_impl(self) -> None:
         """Test that the go to definition is correct."""
         lsp = JacLangServer()


### PR DESCRIPTION
## **Description**

Goto definition works for `SomeNode` inside the filter comprehensation

<img width="834" height="392" alt="image" src="https://github.com/user-attachments/assets/45ee57e1-28c9-4fe3-9cdd-47b873ff52e5" />
