### PR TITLE
Fix unnecessary print statements in llm.py

### DIFF
--- a/jac-byllm/byllm/llm.py
+++ b/jac-byllm/byllm/llm.py
@@ -138,8 +138,6 @@ class BaseLLM:
 
         tool_calls: list[ToolCall] = []
         for tool_call in message.tool_calls or []:  # type: ignore
-            print(tool_call)
-            print(type(tool_call))
             if tool := mtir.get_tool(tool_call.function.name):
                 args_json = json.loads(tool_call.function.arguments)
                 args = tool.parse_arguments(args_json)


### PR DESCRIPTION
Remove debug print statements from the `dispatch_no_streaming` method to clean up the code.

