### PR TITLE
Remove redundant logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,3 @@ All Jaseci open source software is distributed under the terms of both the MIT l
 within with various other licenses that are very permissive.
 
 See [LICENSE-MIT](.github/LICENSE) for details.
-
-<div align="center">
-  <a href="https://www.jaseci.org">
-    <img src="https://www.jac-lang.org//assets/logo.png" width="40px" alt="Jaseci Logo">
-  </a>
-</div>


### PR DESCRIPTION
Removed the Jaseci logo at the bottom and alignment from README.
