### PR TITLE
Add .gitattributes for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jac linguist-language=Python


### PR DESCRIPTION
This PR adds a .gitattributes file to mark .jac files as Python for GitHub's language statistics.

This ensures that .jac files are properly recognized and counted as Python in the repository's language breakdown.