### PR TITLE
Fix: Support Any type from typing module

### DIFF
--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -336,7 +336,10 @@ impl TypeEvaluator._assign_class(
         return True;
     }
     # Everything is assignable to an object.
-    if dest_type.is_builtin("object") {
+    if (
+        dest_type.is_builtin("object")
+        or dest_type.shared == self.prefetch.any_class.shared
+    ) {
         # TODO: Invariance not handled yet
         # invariant contexts to avoid list[int] <: list[object] errors.
         return True;
@@ -519,6 +522,7 @@ impl TypeEvaluator._prefetch_types(self: TypeEvaluator) {
     # self.prefetch.mapping_class =
     # self.prefetch.template_class =
     self.prefetch.protocol_class = get_typing_type("Protocol");
+    self.prefetch.any_class = get_typing_type("Any");
     self.prefetch.root_class = get_jac_builtin_type("Root");
     self.prefetch.root_class.shared.is_root_class = True;
 }

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -65,6 +65,7 @@ obj PrefetchedTypes {
         type_var_class: TypeBase | None = None,
         # Prefetch from typing.pyi file
         protocol_class: TypeBase | None = None,
+        any_class: TypeBase | None = None,
         # Prefetched from jac_builtins.pyi file
         root_class: TypeBase | None = None;
 }

--- a/jac/tests/compiler/passes/main/fixtures/checker_any_type_works.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker_any_type_works.jac
@@ -1,0 +1,8 @@
+import from typing { Any }
+
+def takes_any(any: Any) { }
+
+def test_any_type_arg()  -> int {
+    val_int = 42;
+    takes_any(val_int);  # <-- Ok
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.py
+++ b/jac/tests/compiler/passes/main/test_checker_pass.py
@@ -872,3 +872,12 @@ def test_protocol(fixture_path: Callable[[str], str]) -> None:
     """,
         program.errors_had[1].pretty_print(),
     )
+
+
+def test_any_type_works_with_any_type(fixture_path: Callable[[str], str]) -> None:
+    """Test stdlib typing module imports and Any type work correctly."""
+    program = JacProgram()
+    mod = program.compile(fixture_path("checker_any_type_works.jac"))
+    TypeCheckPass(ir_in=mod, prog=program)
+    # There shouldn't be any errors - Any type accepts any value
+    assert len(program.errors_had) == 0


### PR DESCRIPTION
## Summary
This PR adds support for the  type from the  module in the Jac type checker.

## Changes
- Prefetch  type from typing module during type evaluation
- Allow assignment of any value to  type (Any acts as universal base type)
- Add test fixture  to verify Any type compatibility
- Add corresponding test case in 

## Fixes
Closes #3733