### PR TITLE
fix tests

### DIFF
--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -744,7 +744,7 @@ impl JacAPIServer.create_handler -> type[BaseHTTPRequestHandler] {
                     server.introspector.ensure_bundle();
                     Jac.send_javascript(self, server.introspector._bundle.code);
                 } except RuntimeError as exc {
-                    Jac.send_json(self, 503, {'error': str(exc)});
+                    Jac.send_json(self, 500, {'error': str(exc)});
                 }
                 return;
             }
@@ -894,7 +894,7 @@ impl JacAPIServer.create_handler -> type[BaseHTTPRequestHandler] {
                 } except ValueError as exc {
                     Jac.send_json(self, 404, {'error': str(exc)});
                 } except RuntimeError as exc {
-                    Jac.send_json(self, 503, {'error': str(exc)});
+                    Jac.send_json(self, 500, {'error': str(exc)});
                 }
                 return;
             }


### PR DESCRIPTION
## **Description**
1. Fix: Return 500 for compilation errors instead of 503
Problem
The server returned 503 (Service Unavailable) for compilation errors, which is incorrect:
503 indicates temporary unavailability (e.g., server overloaded, maintenance)
Compilation errors are permanent and should return 500 (Internal Server Error)
This caused tests to retry indefinitely on compilation failures instead of failing immediately.
