### PR TITLE
Fix connection operation type checking for any types

### DIFF
--- a/jac/jaclang/compiler/type_system/impl/types.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/types.impl.jac
@@ -297,3 +297,16 @@ impl TypeBase.category(self: TypeBase) -> TypeCategory {
 impl TypeBase.init(self: TypeBase, flags: TypeFlags = TypeFlags.Null) -> None {
     self.flags: TypeFlags = flags;
 }
+
+"""Return true if this type is UnknownType, AnyType, TypeVarType, or object."""
+impl TypeBase.is_any_type(self: TypeBase) -> bool {
+    # Check for UnknownType, AnyType, or TypeVarType using category
+    if self.category in (TypeCategory.Unknown, TypeCategory.Any, TypeCategory.TypeVar) {
+        return True;
+    }
+    # Check for object type
+    if isinstance(self, ClassType) {
+        return self.is_builtin("object");
+    }
+    return False;
+}

--- a/jac/jaclang/compiler/type_system/operations.jac
+++ b/jac/jaclang/compiler/type_system/operations.jac
@@ -79,19 +79,27 @@ def get_type_of_binary_operation(
 
     # Connection operations
     if isinstance(expr.op, (uni.ConnectOp, uni.DisconnectOp)) {
+        # TODO: In strict mode, UnknownType, AnyType, TypeVarType, and object should be errors
         if (
-            not isinstance(left_type, jtypes.ClassType)
-            or not left_type.is_node_type()
-            or not left_type.is_instance()
+            not left_type.is_any_type()
+            and (
+                not isinstance(left_type, jtypes.ClassType)
+                or not left_type.is_node_type()
+                or not left_type.is_instance()
+            )
         ) {
             evaluator.add_diagnostic(
                 expr.left, 'Connection left operand must be a node instance'
             );
         }
+        # TODO: In strict mode, UnknownType, AnyType, TypeVarType, and object should be errors
         if (
-            not isinstance(right_type, jtypes.ClassType)
-            or not right_type.is_node_type()
-            or not right_type.is_instance()
+            not right_type.is_any_type()
+            and (
+                not isinstance(right_type, jtypes.ClassType)
+                or not right_type.is_node_type()
+                or not right_type.is_instance()
+            )
         ) {
             evaluator.add_diagnostic(
                 expr.right, 'Connection right operand must be a node instance'

--- a/jac/jaclang/compiler/type_system/types.jac
+++ b/jac/jaclang/compiler/type_system/types.jac
@@ -79,6 +79,7 @@ class TypeBase(ABC) {
     def is_instance(self: TypeBase) -> bool;
     def is_instantiable_class(self: TypeBase) -> bool;
     def is_class_instance(self: TypeBase) -> bool;
+    def is_any_type(self: TypeBase) -> bool;
 }
 
 """Represents a type that is not bound to a specific value or context."""

--- a/jac/tests/compiler/passes/main/fixtures/checker_connect_any_type.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker_connect_any_type.jac
@@ -1,0 +1,15 @@
+node MyNode {
+    has val: int;
+}
+
+walker MyWalker {
+    can do with MyNode entry {
+        # List annotated as list (not list[MyNode]), so accessing list[0] gives any type
+        nodes: list = [MyNode(0)];
+        # Explicitly get the element which should be any type when list is untyped
+        node_from_list = nodes[0];
+        # Using any type in connection should not produce an error (for now)
+        # TODO: In strict mode, this should be an error
+        here ++> node_from_list;
+    }
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.py
+++ b/jac/tests/compiler/passes/main/test_checker_pass.py
@@ -726,6 +726,17 @@ def test_connect_filter(fixture_path: Callable[[str], str]) -> None:
         _assert_error_pretty_found(expected, program.errors_had[i].pretty_print())
 
 
+def test_connect_any_type(fixture_path: Callable[[str], str]) -> None:
+    """Test that connection operations with any type (from untyped list) don't produce errors."""
+    program = JacProgram()
+    path = fixture_path("checker_connect_any_type.jac")
+    mod = program.compile(path)
+    TypeCheckPass(ir_in=mod, prog=program)
+    # Should have no errors - any type in connection operations is allowed (for now)
+    # TODO: In strict mode, this should produce an error
+    assert len(program.errors_had) == 0
+
+
 def test_root_type(fixture_path: Callable[[str], str]) -> None:
     program = JacProgram()
     path = fixture_path("checker_root_type.jac")


### PR DESCRIPTION

<img width="694" height="392" alt="image" src="https://github.com/user-attachments/assets/5945dd48-4a67-474e-a9b3-24cdcf091a3d" />


<img width="2355" height="1658" alt="error_report" src="https://github.com/user-attachments/assets/2185774f-7f3b-4a3a-907c-8629890bbd13" />

<img width="2635" height="1630" alt="error_diff_report" src="https://github.com/user-attachments/assets/6c15ba77-f57e-4fbb-a380-4d5d5ae1ddb9" />

```
📊 Diff report saved to: build/error_diff_report.png

================================================================================
TYPE CHECKER ERROR DIFF REPORT
================================================================================

Comparing: fix/connection-any-type-check vs main

--------------------------------------------------------------------------------
SUMMARY
--------------------------------------------------------------------------------
Output file lines:
  Main branch (main):      2,205 lines
  Current branch (fix/connection-any-type-check):  2,080 lines
  Net change:                      -125 lines

Total errors:
  Main branch (main):     817 errors
  Current branch (fix/connection-any-type-check): 692 errors
  Net change:                    -125 errors

================================================================================
COMPLETE ERROR DIFF TABLE - All Errors from Both Branches
================================================================================

Total unique error types: 41
Total errors in main branch:     817
Total errors in current branch:  692
Net change:                      -125

    Main |  Current |     Diff | Level           | Error Message
--------------------------------------------------------------------------------
      81 |        9 |      -72 | Error           | Connection right operand must be a node instance
      67 |       14 |      -53 | Error           | Connection left operand must be a node instance
     104 |      104 |       +0 | Error           | Cannot assign <TYPE> to parameter 'PARAM' of type <TYPE>
      83 |       83 |       +0 | Error           | No matching overload found for method "TOKEN" with the given...
      64 |       64 |       +0 | Error           | No matching overload found for the function call with the gi...
      58 |       58 |       +0 | Error           | Not all required parameters were provided in the function ca...
      58 |       58 |       +0 | Error           | Too many positional arguments
      50 |       50 |       +0 | Error           | Cannot assign <TYPE> to <TYPE>
      33 |       33 |       +0 | Error           | Cannot return <TYPE>, expected <TYPE>
      29 |       29 |       +0 | Error           | Connection type must be an edge instance
      24 |       24 |       +0 | Error           | Cannot assign <TYPE_OBJ> to parameter 'PARAM' of type <TYPE>
      23 |       23 |       +0 | Error checking  | Could not read file <FILE>: [Errno 21] Is a directory: '<DIR...
      22 |       22 |       +0 | Error checking  | 'PARAM' object has no attribute 'PARAM'
      16 |       16 |       +0 | Error           | Cannot return <TYPE_OBJ>, expected <TYPE>
      15 |       15 |       +0 | Error           | Not all required parameters were provided in the function ca...
      14 |       14 |       +0 | Error           | Cannot assign <TYPE> to <TYPE_OBJ>
      10 |       10 |       +0 | Error           | Cannot perform assignment comprehension on type "TOKEN"
      10 |       10 |       +0 | Error           | Cannot assign <TYPE> to parameter 'PARAM' of type <TYPE_OBJ>
       7 |        7 |       +0 | Error           | Positional only parameter 'PARAM' cannot be matched with a n...
       6 |        6 |       +0 | Error           | Named argument 'PARAM' does not match any parameter
       5 |        5 |       +0 | Error           | Non default attribute 'PARAM' follows default attribute
       5 |        5 |       +0 | Error           | Invalid syntax in function parameters: '/' cannot appear aft...
       4 |        4 |       +0 | Error checking  | type object 'PARAM' has no attribute 'PARAM'
       3 |        3 |       +0 | Error           | Type "TOKEN" is not assignable to type "TOKEN"
       3 |        3 |       +0 | Error           | Invalid syntax in function parameters: '*' cannot appear aft...
       2 |        2 |       +0 | Error           | Cannot return <TYPE>, expected <TYPE_OBJ>
       2 |        2 |       +0 | Error           | Not all required parameters were provided in the function ca...
       2 |        2 |       +0 | Error           | Missing COMMA
       2 |        2 |       +0 | Error           | Member "TOKEN"
       2 |        2 |       +0 | Error           | The 'PARAM' keyword is not supported in Jac
       2 |        2 |       +0 | Error           | Use `Reflect.construct(target, argumentsList)` method to cre...
       2 |        2 |       +0 | Error           | Parameter 'PARAM' already matched
       1 |        1 |       +0 | Error           | Cannot assign <TYPE_OBJ> to parameter 'PARAM' of type <TYPE_...
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.SomeObj.foo.
       1 |        1 |       +0 | Error           | Incomplete member access
       1 |        1 |       +0 | Error           | Type "TOKEN"
       1 |        1 |       +0 | Error           | From the declaration of foo.
       1 |        1 |       +0 | Error           | Missing "TOKEN" method required by un initialized attribute(...
       1 |        1 |       +0 | Error           | Cannot return <TYPE_OBJ>, expected <TYPE_OBJ>
       1 |        1 |       +0 | Error           | Edge type "TOKEN" has no member named "TOKEN"
       1 |        1 |       +0 | Error           | Missing RPAREN

--------------------------------------------------------------------------------
SUMMARY BREAKDOWN
--------------------------------------------------------------------------------
Errors removed (main only):           0 unique types
Errors introduced (current only):     0 unique types
Errors changed (both, diff != 0):      2 unique types
Errors unchanged (both, same):        39 unique types
```


---

## Summary
Fixes connection operation type checking to properly handle UnknownType, AnyType, TypeVarType, and object types.

## Changes
- Added `is_any_type()` method to `TypeBase` that checks for UnknownType, AnyType, TypeVarType, and object
- Updated connection operation checks to skip errors when operand is any type (for now)
- Added test case to verify connection operations with TypeVarType (from untyped lists) don't produce errors

## Problem
When accessing elements from an untyped list (e.g., `nodes[0]` where `nodes: list`), the type checker returns `TypeVarType` instead of `UnknownType`. The connection operation check was not recognizing `TypeVarType` as an "any" type, causing false positive errors.

## Solution
- Extended `is_any_type()` to also check for `TypeVarType` category
- Updated connection operation validation to use `is_any_type()` method

## Testing
- Added test case `test_connect_any_type` that verifies connection operations with TypeVarType don't produce errors
- All existing tests pass

## TODO
In strict mode, UnknownType, AnyType, TypeVarType, and object should be errors.