### PR TITLE
Fix union type annotation handling for None type

### DIFF
--- a/jac/jaclang/compiler/type_system/operations.jac
+++ b/jac/jaclang/compiler/type_system/operations.jac
@@ -59,9 +59,19 @@ def get_type_of_binary_operation(
         #
         # TODO: Pyright checks if the types support '__or__' and '__ror__' before returning UnionType
         # If they support, we can treat them as binary operands, instead of Union types.
+        def is_annotation_type(ty: jtypes.TypeBase) -> bool {
+            if ty.is_instantiable() or isinstance(ty, jtypes.UnionType) {
+                return True;
+            }
+            # Althought None is not a valid class, it can be used as a class in the type annotation.
+            if isinstance(ty, jtypes.ClassType) {
+                return ty.shared == evaluator.prefetch.none_type_class.shared;
+            }
+            return False;
+        }
         if expr.op.name == Tok.BW_OR {
             # TODO: Handle None instance used
-            if left_type.is_instantiable() and right_type.is_instantiable() {
+            if is_annotation_type(left_type) and is_annotation_type(right_type) {
                 return jtypes.UnionType([left_type, right_type]);
             }
         }

--- a/jac/tests/compiler/passes/main/fixtures/checker_union_type_annotation.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker_union_type_annotation.jac
@@ -1,0 +1,3 @@
+with entry {
+    x: int | None = 21;  # <-- Ok
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.py
+++ b/jac/tests/compiler/passes/main/test_checker_pass.py
@@ -1074,3 +1074,12 @@ def test_builtin_constructors(fixture_path: Callable[[str], str]) -> None:
     TypeCheckPass(ir_in=mod, prog=program)
     # All constructors should work without errors
     assert len(program.errors_had) == 0
+
+
+def test_union_type_annotation(fixture_path: Callable[[str], str]) -> None:
+    """Test union type annotation with None (e.g., int | None)."""
+    program = JacProgram()
+    mod = program.compile(fixture_path("checker_union_type_annotation.jac"))
+    TypeCheckPass(ir_in=mod, prog=program)
+    # Should have no errors - int | None annotation should be valid
+    assert len(program.errors_had) == 0


### PR DESCRIPTION
This PR fixes the handling of union type annotations when None is used (e.g., `int | None`).

<img width="2355" height="1658" alt="error_report" src="https://github.com/user-attachments/assets/e998c285-49f8-423b-b160-23760d36f553" />


<img width="2635" height="1630" alt="error_diff_report" src="https://github.com/user-attachments/assets/4abf368c-1947-4589-b9a4-9fd86f8dacf4" />

```
 Diff report saved to: build/error_diff_report.png

================================================================================
TYPE CHECKER ERROR DIFF REPORT
================================================================================

Comparing: fix/type-annotation-union-handling vs main

--------------------------------------------------------------------------------
SUMMARY
--------------------------------------------------------------------------------
Output file lines:
  Main branch (main):      2,192 lines
  Current branch (fix/type-annotation-union-handling):  2,150 lines
  Net change:                       -42 lines

Total errors:
  Main branch (main):     804 errors
  Current branch (fix/type-annotation-union-handling): 762 errors
  Net change:                    -42 errors

================================================================================
COMPLETE ERROR DIFF TABLE - All Errors from Both Branches
================================================================================

Total unique error types: 46
Total errors in main branch:     804
Total errors in current branch:  762
Net change:                      -42

    Main |  Current |     Diff | Level           | Error Message
--------------------------------------------------------------------------------
     102 |       26 |      -76 | Error           | No matching overload found for method "TOKEN" with the given...
       1 |       17 |      +16 | Error           | Cannot assign <TYPE_OBJ> to parameter 'PARAM' of type <TYPE_...
       6 |       17 |      +11 | Error           | Cannot assign <TYPE_OBJ> to parameter 'PARAM' of type <TYPE>
       0 |        3 |       +3 | Error           | Cannot assign <TYPE_OBJ> to <TYPE>
       1 |        3 |       +2 | Error           | Cannot return <TYPE_OBJ>, expected <TYPE_OBJ>
      15 |       16 |       +1 | Error           | Cannot return <TYPE_OBJ>, expected <TYPE>
      11 |       12 |       +1 | Error           | Cannot assign <TYPE> to parameter 'PARAM' of type <TYPE_OBJ>
      83 |       83 |       +0 | Error           | Cannot assign <TYPE> to parameter 'PARAM' of type <TYPE>
      81 |       81 |       +0 | Error           | Connection right operand must be a node instance
      71 |       71 |       +0 | Error           | No matching overload found for the function call with the gi...
      67 |       67 |       +0 | Error           | Connection left operand must be a node instance
      61 |       61 |       +0 | Error           | Too many positional arguments
      58 |       58 |       +0 | Error           | Not all required parameters were provided in the function ca...
      49 |       49 |       +0 | Error           | Cannot assign <TYPE> to <TYPE>
      33 |       33 |       +0 | Error           | Cannot return <TYPE>, expected <TYPE>
      29 |       29 |       +0 | Error           | Connection type must be an edge instance
      23 |       23 |       +0 | Error checking  | Could not read file <FILE>: [Errno 21] Is a directory: '<DIR...
      16 |       16 |       +0 | Error checking  | 'PARAM' object has no attribute 'PARAM'
      15 |       15 |       +0 | Error           | Not all required parameters were provided in the function ca...
      14 |       14 |       +0 | Error           | Cannot assign <TYPE> to <TYPE_OBJ>
      10 |       10 |       +0 | Error           | Cannot perform assignment comprehension on type "TOKEN"
       7 |        7 |       +0 | Error           | Positional only parameter 'PARAM' cannot be matched with a n...
       6 |        6 |       +0 | Error           | Named argument 'PARAM' does not match any parameter
       5 |        5 |       +0 | Error           | Invalid syntax in function parameters: '/' cannot appear aft...
       5 |        5 |       +0 | Error           | Non default attribute 'PARAM' follows default attribute
       4 |        4 |       +0 | Error checking  | type object 'PARAM' has no attribute 'PARAM'
       3 |        3 |       +0 | Error           | Invalid syntax in function parameters: '*' cannot appear aft...
       3 |        3 |       +0 | Error           | Type "TOKEN" is not assignable to type "TOKEN"
       2 |        2 |       +0 | Error           | Missing COMMA
       2 |        2 |       +0 | Error           | Member "TOKEN"
       2 |        2 |       +0 | Error           | Not all required parameters were provided in the function ca...
       2 |        2 |       +0 | Error           | Parameter 'PARAM' already matched
       2 |        2 |       +0 | Error           | Cannot return <TYPE>, expected <TYPE_OBJ>
       2 |        2 |       +0 | Error           | Use `Reflect.construct(target, argumentsList)` method to cre...
       2 |        2 |       +0 | Error           | The 'PARAM' keyword is not supported in Jac
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.Calculator.multipl...
       1 |        1 |       +0 | Error           | Incomplete member access
       1 |        1 |       +0 | Error           | Edge type "TOKEN" has no member named "TOKEN"
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.SomeObj.foo.
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.SomeObj.baz.
       1 |        1 |       +0 | Error           | From the declaration of baz.
       1 |        1 |       +0 | Error           | From the declaration of foo.
       1 |        1 |       +0 | Error           | Type "TOKEN"
       1 |        1 |       +0 | Error           | Missing "TOKEN" method required by un initialized attribute(...
       1 |        1 |       +0 | Error           | Missing RPAREN
       1 |        1 |       +0 | Error           | From the declaration of multiply.

--------------------------------------------------------------------------------
SUMMARY BREAKDOWN
--------------------------------------------------------------------------------
Errors removed (main only):           0 unique types
Errors introduced (current only):     1 unique types
Errors changed (both, diff != 0):      6 unique types
Errors unchanged (both, same):        39 unique types


================================================================================
Report generation complete!
================================================================================
```

## Changes
- Add `is_annotation_type` helper function to properly detect annotation types
- Handle None type class in union type annotations
- Add test case for union type annotation with None

## Testing
- Added test case `test_union_type_annotation` that verifies `int | None` annotation works correctly
- Test passes successfully