### PR TITLE
test: add test cases for range() function

### DIFF
--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
@@ -84,9 +84,24 @@ impl TypeEvaluator.validate_call_args(
             # Only validate __new__ if it's not from object (the base class)
             # object.__new__ accepts (*args, **kwargs) which matches anything
             is_from_object = new_method.class_type.shared.class_name == "object";
+            # TODO: This bellow logic to extract overloads is also used in another place
+            # unify them and place them in a helper method.
+            method_ty = self.get_type_of_symbol(new_method.symbol);
+            overloaded_fns: list[types.FunctionType] = [method_ty];
+            for overload in new_method.overloads {
+                overload_member_ty = self.get_type_of_symbol(overload);
+                if isinstance(overload_member_ty, types.FunctionType) {
+                    overload_member_ty = overload_member_ty.specialize(caller_type);
+                    overloaded_fns.append(overload_member_ty);
+                }
+            }
+            overloaded_ty: types.OverloadedType | None = None;
+            if len(overloaded_fns) > 1 {
+                overloaded_ty = types.OverloadedType(overloaded_fns);
+            }
             if not is_from_object {
                 validated = self._validate_constructor_method(
-                    expr, self.get_type_of_symbol(new_method.symbol)
+                    expr, overloaded_ty or method_ty
                 );
             }
         }

--- a/jac/tests/compiler/passes/main/fixtures/checker_range.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker_range.jac
@@ -1,0 +1,4 @@
+with entry {
+    range(10);  # <-- Ok
+    range(1, 5);  # <-- Ok
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.py
+++ b/jac/tests/compiler/passes/main/test_checker_pass.py
@@ -1083,3 +1083,12 @@ def test_union_type_annotation(fixture_path: Callable[[str], str]) -> None:
     TypeCheckPass(ir_in=mod, prog=program)
     # Should have no errors - int | None annotation should be valid
     assert len(program.errors_had) == 0
+
+
+def test_range_function(fixture_path: Callable[[str], str]) -> None:
+    """Test that range() function works correctly with different argument counts."""
+    program = JacProgram()
+    mod = program.compile(fixture_path("checker_range.jac"))
+    TypeCheckPass(ir_in=mod, prog=program)
+    # Should have no errors - range() should work with 1 or 2 arguments
+    assert len(program.errors_had) == 0


### PR DESCRIPTION

<img width="2355" height="1658" alt="error_report" src="https://github.com/user-attachments/assets/0d6305de-7604-421b-b655-238bc6b6faa5" />


<img width="2635" height="1630" alt="error_diff_report" src="https://github.com/user-attachments/assets/195108c9-e0a3-49d8-a75b-70f6b51e7b19" />


```
📊 Diff report saved to: build/error_diff_report.png

================================================================================
TYPE CHECKER ERROR DIFF REPORT
================================================================================

Comparing: feat/range-function-test vs main

--------------------------------------------------------------------------------
SUMMARY
--------------------------------------------------------------------------------
Output file lines:
  Main branch (main):      2,159 lines
  Current branch (feat/range-function-test):  2,119 lines
  Net change:                       -40 lines

Total errors:
  Main branch (main):     770 errors
  Current branch (feat/range-function-test): 730 errors
  Net change:                    -40 errors

================================================================================
COMPLETE ERROR DIFF TABLE - All Errors from Both Branches
================================================================================

Total unique error types: 51
Total errors in main branch:     770
Total errors in current branch:  730
Net change:                      -40

    Main |  Current |     Diff | Level           | Error Message
--------------------------------------------------------------------------------
      63 |       23 |      -40 | Error           | Too many positional arguments
      83 |       83 |       +0 | Error           | Cannot assign <TYPE> to parameter 'PARAM' of type <TYPE>
      81 |       81 |       +0 | Error           | Connection right operand must be a node instance
      71 |       71 |       +0 | Error           | No matching overload found for the function call with the gi...
      67 |       67 |       +0 | Error           | Connection left operand must be a node instance
      58 |       58 |       +0 | Error           | Not all required parameters were provided in the function ca...
      49 |       49 |       +0 | Error           | Cannot assign <TYPE> to <TYPE>
      33 |       33 |       +0 | Error           | Cannot return <TYPE>, expected <TYPE>
      29 |       29 |       +0 | Error           | Connection type must be an edge instance
      26 |       26 |       +0 | Error           | No matching overload found for method "TOKEN" with the given...
      24 |       24 |       +0 | Error checking  | Could not read file <FILE>: [Errno 21] Is a directory: '<DIR...
      17 |       17 |       +0 | Error           | Cannot assign <TYPE_OBJ> to parameter 'PARAM' of type <TYPE_...
      17 |       17 |       +0 | Error           | Cannot assign <TYPE_OBJ> to parameter 'PARAM' of type <TYPE>
      16 |       16 |       +0 | Error checking  | 'PARAM' object has no attribute 'PARAM'
      16 |       16 |       +0 | Error           | Cannot return <TYPE_OBJ>, expected <TYPE>
      15 |       15 |       +0 | Error           | Not all required parameters were provided in the function ca...
      14 |       14 |       +0 | Error           | Cannot assign <TYPE> to <TYPE_OBJ>
      11 |       11 |       +0 | Error           | Cannot assign <TYPE> to parameter 'PARAM' of type <TYPE_OBJ>
      10 |       10 |       +0 | Error           | Cannot perform assignment comprehension on type "TOKEN"
       7 |        7 |       +0 | Error           | Positional only parameter 'PARAM' cannot be matched with a n...
       6 |        6 |       +0 | Error           | Named argument 'PARAM' does not match any parameter
       5 |        5 |       +0 | Error           | Invalid syntax in function parameters: '/' cannot appear aft...
       5 |        5 |       +0 | Error           | Non default attribute 'PARAM' follows default attribute
       4 |        4 |       +0 | Error checking  | name 'PARAM' is not defined
       3 |        3 |       +0 | Error           | Type "TOKEN" is not assignable to type "TOKEN"
       3 |        3 |       +0 | Error           | Cannot return <TYPE_OBJ>, expected <TYPE_OBJ>
       3 |        3 |       +0 | Error           | Invalid syntax in function parameters: '*' cannot appear aft...
       3 |        3 |       +0 | Error           | Cannot assign <TYPE_OBJ> to <TYPE>
       2 |        2 |       +0 | Error           | From the declaration of __init__.
       2 |        2 |       +0 | Error           | Member "TOKEN"
       2 |        2 |       +0 | Error           | Use `Reflect.construct(target, argumentsList)` method to cre...
       2 |        2 |       +0 | Error           | Cannot return <TYPE>, expected <TYPE_OBJ>
       2 |        2 |       +0 | Error           | Missing COMMA
       2 |        2 |       +0 | Error           | The 'PARAM' keyword is not supported in Jac
       2 |        2 |       +0 | Error           | Not all required parameters were provided in the function ca...
       2 |        2 |       +0 | Error           | Parameter 'PARAM' already matched
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.Calculator.multipl...
       1 |        1 |       +0 | Error           | Missing RPAREN
       1 |        1 |       +0 | Error           | From the declaration of reset.
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.Calculator.reset.
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.SomeObj.foo.
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.OuterClass.InnerCl...
       1 |        1 |       +0 | Error           | Missing "TOKEN" method required by un initialized attribute(...
       1 |        1 |       +0 | Error           | From the declaration of foo.
       1 |        1 |       +0 | Error           | From the declaration of baz.
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.OuterClass.Another...
       1 |        1 |       +0 | Error           | Edge type "TOKEN" has no member named "TOKEN"
       1 |        1 |       +0 | Error           | Parameter count mismatch for ability impl.SomeObj.baz.
       1 |        1 |       +0 | Error           | From the declaration of multiply.
       1 |        1 |       +0 | Error           | Type "TOKEN"
       1 |        1 |       +0 | Error           | Incomplete member access

--------------------------------------------------------------------------------
SUMMARY BREAKDOWN
--------------------------------------------------------------------------------
Errors removed (main only):           0 unique types
Errors introduced (current only):     0 unique types
Errors changed (both, diff != 0):      1 unique types
Errors unchanged (both, same):        50 unique types
```


## Summary

This PR adds test cases for the range() function to verify that type checking handles it correctly.

## Changes

- Added test_range_function: Verifies that range() works correctly with 1 or 2 arguments
- Added checker_range.jac fixture: Contains test cases with range(10) and range(1, 5)
- Updated parameter_type_check.impl.jac: Includes related changes

## Testing

- New test added to verify range() function type checking works correctly
- All existing tests should continue to pass