### PR TITLE
Fix false "required parameter" error when child overrides field with default

### DIFF
--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -1,7 +1,8 @@
 impl TypeEvaluator._create_dataclass_init_method(
     class_type: types.ClassType
 ) -> types.FunctionType {
-    parameters: list[types.Parameter] = [];
+    # Use a dictionary to track parameters by name to allow child classes to override parent parameters
+    param_dict: dict[str, types.Parameter] = {};
     for cls in class_type.shared.mro[::-1] {
         # Iterate over the has vars and create parameters.
         for has_var in cls.shared.symbol_table.get_has_vars() {
@@ -13,19 +14,17 @@ impl TypeEvaluator._create_dataclass_init_method(
                 param_type = self._convert_to_instance(type_cls);
             }
 
-            # Create parameter.
-            parameters.append(
-                types.Parameter(
-                    name=has_var.name.value,
-                    category=types.ParameterCategory.Positional,
-                    param_type=param_type,
-                    default_value=has_var.value,
-                    is_self=False,
-                    param_kind=types.ParamKind.NORMAL,
-                )
+            param_dict[has_var.name.value] = types.Parameter(
+                name=has_var.name.value,
+                category=types.ParameterCategory.Positional,
+                param_type=param_type,
+                default_value=has_var.value,
+                is_self=False,
+                param_kind=types.ParamKind.NORMAL,
             );
         }
     }
+    parameters: list[types.Parameter] = list(param_dict.values());
     # Create and return the __init__ method type.
     return types.FunctionType(
         func_name="__init__", return_type=types.UnknownType(), parameters=parameters,

--- a/jac/tests/compiler/passes/main/fixtures/checker_inherit_init_params.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker_inherit_init_params.jac
@@ -12,3 +12,16 @@ with entry {
     c2 = Child("Bob");  # <-- Error: missing age
     c3 = Child(age=25);  # <-- Error: missing name
 }
+
+obj Foo {
+    has val: int;
+}
+
+obj Bar(Foo) {
+    has val: int = 1;
+}
+
+with entry {
+    b1 = Bar();
+    b2 = Bar(val=10);
+}


### PR DESCRIPTION
## **Description**

 Addresses type checker incorrectly reporting missing `required parameters` when a child class provides a default value for a parent's required field. 

### Before
<img width="1804" height="902" alt="image" src="https://github.com/user-attachments/assets/03f7343f-8785-4207-b3da-b76182bab055" />
