### PR TITLE
Add integration test for default jac create --cl app

### DIFF
--- a/jac-client/jac_client/tests/test_it.py
+++ b/jac-client/jac_client/tests/test_it.py
@@ -792,8 +792,7 @@ def test_default_client_app_renders() -> None:
                     # The page should include the bundled JavaScript
                     # that will render "Hello, World!" client-side
                     assert (
-                        "<script" in page_body.lower()
-                        or "src=" in page_body.lower()
+                        "<script" in page_body.lower() or "src=" in page_body.lower()
                     ), "Response should include script tags for React app"
 
                 except (URLError, HTTPError, TimeoutError) as exc:


### PR DESCRIPTION
## Summary
- Add `test_default_client_app_renders()` integration test to validate the out-of-the-box experience for `jac create --cl`
- Test creates a default client app, starts the server, and validates that endpoints return expected responses
- Ensures the default template renders correctly with proper HTML structure and script tags

## Test plan
- [ ] Run `pytest jac-client/jac_client/tests/test_it.py::test_default_client_app_renders -v` to validate the new test
- [ ] Verify test passes in CI environment with npm available
- [ ] Confirm test properly cleans up server process and temp directories