### PR TITLE
Store runtime files in .jac/data/ instead of project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ media
 migrations
 venv
 __jac_gen__/
-.jaccache/
+.jac/
 *.jir
 *.jbc
 

--- a/jac-scale/jac_scale/impl/config_loader.impl.jac
+++ b/jac-scale/jac_scale/impl/config_loader.impl.jac
@@ -26,7 +26,7 @@ impl JacScaleConfig.get_default_config(self: JacScaleConfig) -> dict[str, Any] {
         'database': {
             'mongodb_uri': None,
             'redis_url': None,
-            'shelf_db_path': 'anchor_store.db'
+            'shelf_db_path': '.jac/data/anchor_store.db'
         },
         'kubernetes': {
             'app_name': 'jaseci',
@@ -86,7 +86,7 @@ impl JacScaleConfig.get_database_config(self: JacScaleConfig) -> dict[str, Any] 
     return {
         'mongodb_uri': os.environ.get('MONGODB_URI') or db_config.get('mongodb_uri'),
         'redis_url': os.environ.get('REDIS_URL') or db_config.get('redis_url'),
-        'shelf_db_path': db_config.get('shelf_db_path', 'anchor_store.db')
+        'shelf_db_path': db_config.get('shelf_db_path', '.jac/data/anchor_store.db')
     };
 }
 

--- a/jac/jaclang/cli/impl/cli.impl.jac
+++ b/jac/jaclang/cli/impl/cli.impl.jac
@@ -121,7 +121,7 @@ Users must create an account and authenticate to access the API.
 
 Args:
 filename: Path to the .jac file to serve
-session: Session identifier for persistent state (default: auto-generated)
+session: Session identifier for persistent state (default: .jac/data/{module}.session)
 port: Port to run the server on (default: 8000)
 main: Treat the module as __main__ (default: True)
 faux: Perform introspection and print endpoint docs without starting server (default: False)
@@ -150,7 +150,10 @@ impl serve(
     } elif filename.endswith('.py') {
         mod = mod[:-3];
     }
-    session_path = session or os.path.join(base, f"{mod}.session");
+    # Use .jac/data/ directory for session files (runtime artifacts)
+    data_dir = os.path.join(base, ".jac", "data");
+    os.makedirs(data_dir, exist_ok=True);
+    session_path = session or os.path.join(data_dir, f"{mod}.session");
     # Now call proc_file_sess with the computed session_path
     (base, mod, mach) = proc_file_sess(filename, session_path);
     lng = filename.split('.')[-1];

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -4,6 +4,7 @@ Implementations for VolatileMemory, LocalCacheMemory, ShelfMemory, and TieredMem
 """
 
 import logging;
+import os;
 import shelve;
 import from collections.abc { Callable, Generator, Iterable }
 import from pickle { dumps }
@@ -157,6 +158,11 @@ impl ShelfMemory.init(path: str) -> None {
     self.path = path;
     self.__mem__ = {};
     self.__gc__ = set();
+    # Ensure parent directory exists for shelf files
+    parent_dir = os.path.dirname(path);
+    if parent_dir {
+        os.makedirs(parent_dir, exist_ok=True);
+    }
     self.__shelf__ = shelve.open(path);
 }
 


### PR DESCRIPTION
## Summary
- Move session files from project root to `.jac/data/{module}.session`
- Move user database files to `.jac/data/{module}.session.users.json`
- Update anchor_store.db default path to `.jac/data/anchor_store.db`
- ShelfMemory now creates parent directories automatically

## Test plan
- [x] Added `test_jac_create_and_run_no_root_files` test in jac/tests/language/test_cli.py
- [x] Added `test_create_cl_and_run_no_root_files` test in jac-client/jac_client/tests/test_cli.py
- [ ] Manual testing: Run `jac create myapp && cd myapp && jac run main.jac` and verify no files created in root
- [ ] Manual testing: Run `jac serve main.jac` and verify session files go to `.jac/data/`