### PR TITLE
Generate Button.cl.jac instead of Button.tsx for jac create --cl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ demo.jac
 # Jaclang session files
 *.session
 mydatabase/
+demo/
 
 # session files
 *.bak

--- a/jac-client/jac_client/plugin/cli.jac
+++ b/jac-client/jac_client/plugin/cli.jac
@@ -238,7 +238,7 @@ base_route_app = "app"
 
 # Client-side imports
 cl import from react { useState, useEffect }
-cl import from ".components/Button.tsx" { Button }
+cl import from .components.Button { Button }
 
 # Client-side component
 cl {
@@ -273,64 +273,48 @@ cl {
     }
     print("Created main.jac");
 
-    button_tsx_content = '''import React from 'react';
+    button_cl_jac_content = '''"""Button component for the Jac client application."""
 
-interface ButtonProps {
-  label: string;
-  onClick?: () => void;
-  variant?: 'primary' | 'secondary';
-  disabled?: boolean;
-}
+def:pub Button(label: str, onClick: any, variant: str = "primary", disabled: bool = False) -> any {
+    base_styles = {
+        "padding": "0.75rem 1.5rem",
+        "fontSize": "1rem",
+        "fontWeight": "600",
+        "borderRadius": "0.5rem",
+        "border": "none",
+        "cursor": "not-allowed" if disabled else "pointer",
+        "transition": "all 0.2s ease"
+    };
 
-export const Button: React.FC<ButtonProps> = ({
-  label,
-  onClick,
-  variant = 'primary',
-  disabled = false
-}) => {
-  const baseStyles: React.CSSProperties = {
-    padding: '0.75rem 1.5rem',
-    fontSize: '1rem',
-    fontWeight: '600',
-    borderRadius: '0.5rem',
-    border: 'none',
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    transition: 'all 0.2s ease',
-  };
+    variant_styles = {
+        "primary": {
+            "backgroundColor": "#9ca3af" if disabled else "#3b82f6",
+            "color": "#ffffff"
+        },
+        "secondary": {
+            "backgroundColor": "#e5e7eb" if disabled else "#6b7280",
+            "color": "#ffffff"
+        }
+    };
 
-  const variantStyles: Record<string, React.CSSProperties> = {
-    primary: {
-      backgroundColor: disabled ? '#9ca3af' : '#3b82f6',
-      color: '#ffffff',
-    },
-    secondary: {
-      backgroundColor: disabled ? '#e5e7eb' : '#6b7280',
-      color: '#ffffff',
-    },
-  };
-
-  return (
-    <button
-      style={{ ...baseStyles, ...variantStyles[variant] }}
-      onClick={onClick}
-      disabled={disabled}
+    return <button
+        style={{**base_styles, **variant_styles[variant]}}
+        onClick={onClick}
+        disabled={disabled}
     >
-      {label}
-    </button>
-  );
-};
-
-export default Button;
+        {label}
+    </button>;
+}
 ''';
-    with open(components_dir / "Button.tsx", 'w') as f {
-        f.write(button_tsx_content);
+    with open(components_dir / "Button.cl.jac", 'w') as f {
+        f.write(button_cl_jac_content);
     }
-    print("Created components/Button.tsx");
+    print("Created components/Button.cl.jac");
 
     readme_content = f'''  # {project_name}
 
 
-A Jac client-side application with React and TypeScript support.
+A Jac client-side application with React support.
 
 ## Project Structure
 
@@ -339,7 +323,7 @@ A Jac client-side application with React and TypeScript support.
 ├── jac.toml              # Project configuration
 ├── main.jac              # Main application entry
 ├── components/           # Reusable components
-│   └── Button.tsx        # Example TypeScript component
+│   └── Button.cl.jac     # Example Jac component
 ├── assets/               # Static assets (images, fonts, etc.)
 └── build/                # Build output (generated)
 ```
@@ -352,12 +336,12 @@ Start the development server:
 jac serve main.jac
 ```
 
-## TypeScript Support
+## Components
 
-Create TypeScript components in `components/` and import them in your Jac files:
+Create Jac components in `components/` as `.cl.jac` files and import them:
 
 ```jac
-cl import from ".components/Button.tsx" {{ Button }}
+cl import from .components.Button {{ Button }}
 ```
 
 ## Adding Dependencies

--- a/jac-client/jac_client/plugin/src/impl/compiler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/compiler.impl.jac
@@ -166,9 +166,29 @@ impl ViteCompiler.compile_dependencies_recursively(
     combined_js = self.jac_compiler.add_runtime_imports(module_js);
     try {
         relative_path = module_path.relative_to(source_root);
-        output_path = self.compiled_dir / relative_path.with_suffix('.js');
+        # Handle compound extensions like .cl.jac, .impl.jac -> .js
+        rel_str = str(relative_path);
+        for compound_ext in ['.cl.jac', '.impl.jac', '.test.jac'] {
+            if rel_str.endswith(compound_ext) {
+                rel_str = rel_str[:-len(compound_ext)] + '.js';
+                break;
+            }
+        } else {
+            rel_str = str(relative_path.with_suffix('.js'));
+        }
+        output_path = self.compiled_dir / rel_str;
     } except ValueError {
-        output_path = self.compiled_dir / f"{module_path.stem}.js";
+        # Handle compound extensions in filename
+        name = module_path.name;
+        for compound_ext in ['.cl.jac', '.impl.jac', '.test.jac'] {
+            if name.endswith(compound_ext) {
+                name = name[:-len(compound_ext)] + '.js';
+                break;
+            }
+        } else {
+            name = module_path.stem + '.js';
+        }
+        output_path = self.compiled_dir / name;
     }
     output_path.parent.mkdir(parents=True, exist_ok=True);
     output_path.write_text(combined_js, encoding='utf-8');

--- a/jac-client/jac_client/tests/test_cli.py
+++ b/jac-client/jac_client/tests/test_cli.py
@@ -159,9 +159,9 @@ def test_create_jac_app_existing_directory() -> None:
             os.chdir(original_cwd)
 
 
-def test_create_jac_app_with_typescript() -> None:
-    """Test jac create --cl command with TypeScript support (enabled by default)."""
-    test_project_name = "test-jac-app-ts"
+def test_create_jac_app_with_button_component() -> None:
+    """Test jac create --cl command creates Button.cl.jac component."""
+    test_project_name = "test-jac-app-component"
 
     # Create a temporary directory for testing
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -170,7 +170,7 @@ def test_create_jac_app_with_typescript() -> None:
             # Change to temp directory
             os.chdir(temp_dir)
 
-            # Run jac create --cl command (TypeScript is enabled by default)
+            # Run jac create --cl command
             process = Popen(
                 ["jac", "create", "--cl", test_project_name],
                 stdin=PIPE,
@@ -203,41 +203,39 @@ def test_create_jac_app_with_typescript() -> None:
             assert "serve" in config_data
             assert config_data["serve"]["base_route_app"] == "app"
 
-            # Verify components directory and Button.tsx were created at project root
+            # Verify components directory and Button.cl.jac were created at project root
             components_dir = os.path.join(project_path, "components")
             assert os.path.exists(components_dir)
             assert os.path.isdir(components_dir)
 
-            button_tsx_path = os.path.join(components_dir, "Button.tsx")
-            assert os.path.exists(button_tsx_path)
+            button_jac_path = os.path.join(components_dir, "Button.cl.jac")
+            assert os.path.exists(button_jac_path)
 
-            with open(button_tsx_path) as f:
+            with open(button_jac_path) as f:
                 button_content = f.read()
 
-            assert "interface ButtonProps" in button_content
-            assert "export const Button" in button_content
+            assert "def:pub Button" in button_content
+            assert "base_styles" in button_content
 
-            # Verify main.jac includes TypeScript import
+            # Verify main.jac includes Jac component import
             app_jac_path = os.path.join(project_path, "main.jac")
             assert os.path.exists(app_jac_path)
 
             with open(app_jac_path) as f:
                 app_jac_content = f.read()
 
-            assert (
-                'cl import from ".components/Button.tsx" { Button }' in app_jac_content
-            )
+            assert "cl import from .components.Button { Button }" in app_jac_content
             assert "<Button" in app_jac_content
 
-            # Verify README.md includes TypeScript information
+            # Verify README.md includes component information
             readme_path = os.path.join(project_path, "README.md")
             assert os.path.exists(readme_path)
 
             with open(readme_path) as f:
                 readme_content = f.read()
 
-            assert "TypeScript Support" in readme_content
-            assert "components/Button.tsx" in readme_content
+            assert "Components" in readme_content
+            assert "Button.cl.jac" in readme_content
 
             # Verify default packages installation (package.json should be generated)
             package_json_path = os.path.join(

--- a/jac-client/jac_client/tests/test_it.py
+++ b/jac-client/jac_client/tests/test_it.py
@@ -665,8 +665,10 @@ def test_default_client_app_renders() -> None:
             )
 
             # Components are now at root level (not src/components)
-            button_tsx_path = os.path.join(project_path, "components", "Button.tsx")
-            assert os.path.isfile(button_tsx_path), "components/Button.tsx should exist"
+            button_jac_path = os.path.join(project_path, "components", "Button.cl.jac")
+            assert os.path.isfile(button_jac_path), (
+                "components/Button.cl.jac should exist"
+            )
 
             jac_toml_path = os.path.join(project_path, "jac.toml")
             assert os.path.isfile(jac_toml_path), "jac.toml should exist"


### PR DESCRIPTION
## Summary
- Change `jac create --cl` to generate native Jac component (`Button.cl.jac`) instead of TypeScript (`Button.tsx`)
- Update main.jac template and README to reference `.cl.jac` files
- Add auto lint test fixtures (implementation pending)

## Test plan
- [ ] Run `jac create --cl testapp` and verify `components/Button.cl.jac` is created
- [ ] Verify the generated Button component uses proper Jac syntax
- [ ] Run `test_create_jac_app_with_button_component` test
- [ ] Implement auto lint changes to make new tests pass
