### PR TITLE
Fix CSS not rendering by standardizing output filename to styles.css

### DIFF
--- a/jac-client/jac_client/plugin/impl/client.impl.jac
+++ b/jac-client/jac_client/plugin/impl/client.impl.jac
@@ -125,10 +125,10 @@ impl JacClientModuleIntrospector.render_page(
         dist_dir = base_path / '.jac' / 'client' / 'dist';
     }
     css_link = '';
-    css_file = dist_dir / 'main.css';
+    css_file = dist_dir / 'styles.css';
     if css_file.exists() {
         css_hash = hashlib.sha256(css_file.read_bytes()).hexdigest()[:8];
-        css_link = f'<link rel="stylesheet" href="/static/main.css?hash={css_hash}"/>';
+        css_link = f'<link rel="stylesheet" href="/static/styles.css?hash={css_hash}"/>';
     }
     # Get meta data from config
     client_cfg = config.get_plugin_config("client") if config else None;

--- a/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
@@ -322,7 +322,7 @@ export default defineConfig({{
       input: path.resolve(buildDir, "{entry_relative}"), // your compiled entry file
       output: {{
         entryFileNames: "client.[hash].js", // name of the final js file
-        assetFileNames: "[name].[ext]",
+        assetFileNames: (assetInfo) => assetInfo.name?.endsWith('.css') ? 'styles.css' : '[name].[ext]',
       }},
     }},
     outDir: path.resolve(buildDir, "{output_relative}"), // final bundled output
@@ -363,14 +363,8 @@ impl ViteBundler.read_bundle(self: ViteBundler) -> tuple[str, str] {
 
 """Find the generated Vite CSS file."""
 impl ViteBundler.find_css(self: ViteBundler) -> Optional[Path] {
-    css_file = self.output_dir / 'main.css';
-    if css_file.exists() {
-        return css_file;
-    }
-    for file in self.output_dir.glob('*.css') {
-        return file;
-    }
-    return None;
+    css_file = self.output_dir / 'styles.css';
+    return css_file if css_file.exists() else None;
 }
 
 """Find the generated Vite bundle file."""


### PR DESCRIPTION
## Summary

- Fixes CSS styling not rendering when running `jac serve`
- Standardizes CSS output filename to `styles.css` instead of relying on entry file name
- The issue occurred because entry file was renamed from `main.js` to `_entry.js`, causing Vite to output `_entry.css` while the code expected `main.css`

## Changes

- **vite_bundler.impl.jac**: Use function for `assetFileNames` to explicitly name CSS as `styles.css`
- **client.impl.jac**: Look for `styles.css` and serve `/static/styles.css`
- **ViteBundler.find_css()**: Simplified to check for `styles.css`

## Test plan

- [x] Run `jac serve src/app.jac` on demo app
- [x] Verify HTML includes `<link rel="stylesheet" href="/static/styles.css">`
- [x] Verify `/static/styles.css` endpoint returns CSS content
- [x] Verify styling renders correctly in browser