### PR TITLE
Fix comment preservation in auto-lint pass

### DIFF
--- a/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
@@ -177,39 +177,74 @@ impl JacAutoLintPass.exit_impl_def(<>node: uni.ImplDef) -> None {
     self._remove_empty_parens_from_sig(<>node, spec, "spec");
 }
 
-"""Process Enum to combine consecutive has statements."""
+"""Process Enum to combine consecutive has statements.
+
+This implementation avoids calling normalize() to preserve comment associations.
+We update the kid list by removing merged statements and keeping the combined ones.
+"""
 impl JacAutoLintPass.enter_enum(node: uni.Enum) -> None {
     if not self.lint_enabled {
         return;
     }
     enum_node = node;
     if enum_node.body is not None and isinstance(enum_node.body, list) {
-        new_body = self.combine_consecutive_has(list(enum_node.body));
-        if len(new_body) != len(enum_node.body) {
+        old_body = list(enum_node.body);
+        new_body = self.combine_consecutive_has(old_body);
+        if len(new_body) != len(old_body) {
             enum_node.body = new_body;
             self.recalculate_parents(enum_node);
-            enum_node.normalize(deep=False);
+            # Update kid list: remove merged-away statements, keep everything else
+            # The merged statements are those in old_body but not in new_body
+            new_body_set = set(id(s) for s in new_body);
+            new_kid: list[uni.UniNode] = [];
+            for kid in enum_node.kid {
+                # Keep kid if it's not a body item, or if it's in the new body
+                if not isinstance(kid, uni.ArchHas) or id(kid) in new_body_set {
+                    new_kid.append(kid);
+                }
+            }
+            enum_node.kid = new_kid;
         }
     }
 }
 
-"""Process Archetype to combine consecutive has statements."""
+"""Process Archetype to combine consecutive has statements.
+
+This implementation avoids calling normalize() to preserve comment associations.
+We update the kid list by removing merged statements and keeping the combined ones.
+"""
 impl JacAutoLintPass.enter_archetype(node: uni.Archetype) -> None {
     if not self.lint_enabled {
         return;
     }
     arch = node;
     if arch.body is not None and isinstance(arch.body, list) {
-        new_body = self.combine_consecutive_has(list(arch.body));
-        if len(new_body) != len(arch.body) {
+        old_body = list(arch.body);
+        new_body = self.combine_consecutive_has(old_body);
+        if len(new_body) != len(old_body) {
             arch.body = new_body;
             self.recalculate_parents(arch);
-            arch.normalize(deep=False);
+            # Update kid list: remove merged-away statements, keep everything else
+            # The merged statements are those in old_body but not in new_body
+            new_body_set = set(id(s) for s in new_body);
+            new_kid: list[uni.UniNode] = [];
+            for kid in arch.kid {
+                # Keep kid if it's not an ArchHas body item, or if it's in the new body
+                if not isinstance(kid, uni.ArchHas) or id(kid) in new_body_set {
+                    new_kid.append(kid);
+                }
+            }
+            arch.kid = new_kid;
         }
     }
 }
 
-"""Combine consecutive glob statements in a body list."""
+"""Combine consecutive glob statements in a body list.
+
+This implementation avoids calling normalize() to preserve comment associations.
+Instead of creating a new node, we modify the first statement in place and
+manually build the kid list to include assignments from merged statements.
+"""
 impl JacAutoLintPass.combine_consecutive_glob(body: list) -> list {
     if len(body) <= 1 {
         return body;
@@ -221,32 +256,57 @@ impl JacAutoLintPass.combine_consecutive_glob(body: list) -> list {
 
         if isinstance(stmt, uni.GlobalVars) {
             # Start collecting consecutive compatible glob statements
-            combined_assignments: list = list(stmt.assignments);
-            combined_doc = stmt.doc;
             base_glob = stmt;
+            merged_globs: list[uni.GlobalVars] = [base_glob];
             j = i + 1;
             while j < len(body) {
                 next_stmt = body[j];
                 if isinstance(next_stmt, uni.GlobalVars)
                 and self.can_combine_glob(base_glob, next_stmt) {
-                    # Combine the assignments
-                    combined_assignments.extend(next_stmt.assignments);
+                    merged_globs.append(next_stmt);
                     j += 1;
                 } else {
                     break;
                 }
             }
-            # If we combined multiple glob statements, create new one
-            if j > i + 1 {
-                new_glob = uni.GlobalVars(
-                    access=base_glob.access,
-                    assignments=combined_assignments,
-                    is_frozen=base_glob.is_frozen,
-                    kid=combined_assignments,
-                    doc=combined_doc
-                );
-                new_glob.normalize(deep=True);
-                new_body.append(new_glob);
+            # If we combined multiple glob statements, merge them without normalize
+            if len(merged_globs) > 1 {
+                # Collect all assignments
+                combined_assignments: list[uni.Assignment] = [];
+                for glob in merged_globs {
+                    combined_assignments.extend(glob.assignments);
+                }
+                # Build new kid list preserving tokens from base_glob
+                # Structure: [doc?] [client?] glob [access?] assign1, assign2, ...
+                new_kid: list[uni.UniNode] = [];
+                # Copy prefix tokens from base_glob (everything before first assignment)
+                for kid in base_glob.kid {
+                    if kid in base_glob.assignments {
+                        break;
+                    }
+                    new_kid.append(kid);
+                }
+                # Add all assignments with commas between them
+                # Note: Assignments from entry blocks may have trailing semicolons in their
+                # kid lists - we need to strip those before combining
+                for (idx, assign) in enumerate(combined_assignments) {
+                    if idx > 0 {
+                        new_kid.append(base_glob.gen_token(Tok.COMMA));
+                    }
+                    # Strip trailing semicolon from assignment if present
+                    if assign.kid and isinstance(assign.kid[-1], uni.Semi) {
+                        # Create a copy of kids without the trailing semicolon
+                        assign_kids = list(assign.kid[:-1]);
+                        assign.set_kids(nodes=assign_kids);
+                    }
+                    new_kid.append(assign);
+                }
+                # Add semicolon at the end (required by grammar)
+                new_kid.append(base_glob.gen_token(Tok.SEMI));
+                # Update base_glob in place (no normalize call)
+                base_glob.assignments = combined_assignments;
+                base_glob.set_kids(nodes=new_kid);
+                new_body.append(base_glob);
             } else {
                 new_body.append(stmt);
             }
@@ -259,7 +319,12 @@ impl JacAutoLintPass.combine_consecutive_glob(body: list) -> list {
     return new_body;
 }
 
-"""Combine consecutive has statements in a body list."""
+"""Combine consecutive has statements in a body list.
+
+This implementation avoids calling normalize() to preserve comment associations.
+Instead of creating a new node, we modify the first statement in place and
+manually build the kid list to include vars from merged statements.
+"""
 impl JacAutoLintPass.combine_consecutive_has(body: list) -> list {
     if len(body) <= 1 {
         return body;
@@ -271,33 +336,49 @@ impl JacAutoLintPass.combine_consecutive_has(body: list) -> list {
 
         if isinstance(stmt, uni.ArchHas) {
             # Start collecting consecutive compatible has statements
-            combined_vars: list = list(stmt.vars);
-            combined_doc = stmt.doc;
             base_has = stmt;
+            merged_has_list: list[uni.ArchHas] = [base_has];
             j = i + 1;
             while j < len(body) {
                 next_stmt = body[j];
                 if isinstance(next_stmt, uni.ArchHas)
                 and self.can_combine_has(base_has, next_stmt) {
-                    # Combine the vars
-                    combined_vars.extend(next_stmt.vars);
+                    merged_has_list.append(next_stmt);
                     j += 1;
                 } else {
                     break;
                 }
             }
-            # If we combined multiple has statements, create new one
-            if j > i + 1 {
-                new_has = uni.ArchHas(
-                    is_static=base_has.is_static,
-                    access=base_has.access,
-                    vars=combined_vars,
-                    is_frozen=base_has.is_frozen,
-                    kid=combined_vars,
-                    doc=combined_doc
-                );
-                new_has.normalize(deep=True);
-                new_body.append(new_has);
+            # If we combined multiple has statements, merge them without normalize
+            if len(merged_has_list) > 1 {
+                # Collect all vars
+                combined_vars: list[uni.HasVar] = [];
+                for has_stmt in merged_has_list {
+                    combined_vars.extend(has_stmt.vars);
+                }
+                # Build new kid list preserving tokens from base_has
+                # Structure: [doc?] [static?] has [access?] var1, var2, ... varN;
+                new_kid: list[uni.UniNode] = [];
+                # Copy prefix tokens from base_has (everything before first var)
+                for kid in base_has.kid {
+                    if kid in base_has.vars {
+                        break;
+                    }
+                    new_kid.append(kid);
+                }
+                # Add all vars with commas between them
+                for (idx, var) in enumerate(combined_vars) {
+                    if idx > 0 {
+                        new_kid.append(base_has.gen_token(Tok.COMMA));
+                    }
+                    new_kid.append(var);
+                }
+                # Add semicolon at the end
+                new_kid.append(base_has.gen_token(Tok.SEMI));
+                # Update base_has in place (no normalize call)
+                base_has.vars = combined_vars;
+                base_has.set_kids(nodes=new_kid);
+                new_body.append(base_has);
             } else {
                 new_body.append(stmt);
             }
@@ -346,15 +427,31 @@ impl JacAutoLintPass.can_combine_has(has1: uni.ArchHas, has2: uni.ArchHas) -> bo
     return True;
 }
 
-"""Create a new ModuleCode (with entry) block from a list of statements."""
+"""Create a new ModuleCode (with entry) block from a list of statements.
+
+This implementation avoids calling normalize() to preserve comment associations.
+We manually build the kid list with required tokens.
+"""
 impl JacAutoLintPass.create_entry_block(stmts: list) -> uni.ModuleCode {
     entry_block = uni.ModuleCode(name=None, body=stmts, kid=stmts, doc=None);
-    # Normalize shallowly - generates with entry tokens but preserves child loc info
-    entry_block.normalize(deep=False);
+    # Build kid list manually: with entry { stmts... }
+    new_kid: list[uni.UniNode] = [];
+    new_kid.append(entry_block.gen_token(Tok.KW_WITH));
+    new_kid.append(entry_block.gen_token(Tok.KW_ENTRY));
+    new_kid.append(entry_block.gen_token(Tok.LBRACE));
+    for stmt in stmts {
+        new_kid.append(stmt);
+    }
+    new_kid.append(entry_block.gen_token(Tok.RBRACE));
+    entry_block.set_kids(nodes=new_kid);
     return entry_block;
 }
 
-"""Create a GlobalVars node from an assignment."""
+"""Create a GlobalVars node from an assignment.
+
+This implementation avoids calling normalize() to preserve comment associations.
+We manually build the kid list with required tokens.
+"""
 impl JacAutoLintPass.create_glob_from_assignment(
     assignment: uni.Assignment
 ) -> uni.GlobalVars {
@@ -365,8 +462,11 @@ impl JacAutoLintPass.create_glob_from_assignment(
         kid=[assignment],
         doc=None
     );
-    # Normalize shallowly - generates glob keyword but preserves child loc info
-    glob_node.normalize(deep=False);
+    # Build kid list manually: glob assignment
+    new_kid: list[uni.UniNode] = [];
+    new_kid.append(glob_node.gen_token(Tok.KW_GLOBAL));
+    new_kid.append(assignment);
+    glob_node.set_kids(nodes=new_kid);
     return glob_node;
 }
 
@@ -465,7 +565,14 @@ impl JacAutoLintPass.enter_module(node: uni.Module) -> None {
     new_body = self.combine_consecutive_glob(new_body);
     module.body = new_body;
     self.recalculate_parents(module);
-    module.normalize(deep=False);
+    # Build kid list manually to avoid normalize() and preserve comment associations
+    # Module structure: [doc?] body...
+    new_kid: list[uni.UniNode] = [];
+    if module.doc {
+        new_kid.append(module.doc);
+    }
+    new_kid.extend(new_body);
+    module.set_kids(nodes=new_kid if len(new_kid) else [uni.EmptyToken()]);
 }
 
 """Remove unnecessary angle bracket escaping from names that are not actual keywords.
@@ -604,6 +711,8 @@ impl JacAutoLintPass._convert_hasattr_to_null_ok(
         is_kwesc=False
     );
     # Create the null-safe AtomTrailer (obj null-safe attr)
+    # Build kid list manually to avoid normalize() and preserve comment associations
+    # Structure: target ? . right
     null_ok_access = uni.AtomTrailer(
         target=obj_expr,
         right=attr_name_node,
@@ -611,7 +720,11 @@ impl JacAutoLintPass._convert_hasattr_to_null_ok(
         is_null_ok=True,
         kid=[obj_expr, attr_name_node]
     );
-    null_ok_access.normalize(deep=False);
+    new_kid: list[uni.UniNode] = [obj_expr];
+    new_kid.append(null_ok_access.gen_token(Tok.NULL_OK));
+    new_kid.append(null_ok_access.gen_token(Tok.DOT));
+    new_kid.append(attr_name_node);
+    null_ok_access.set_kids(nodes=new_kid);
     return null_ok_access;
 }
 
@@ -642,12 +755,26 @@ impl JacAutoLintPass._is_matching_attr_access(
 """Convert an AtomTrailer to use null-safe access.
 
 Takes an existing obj.attr AtomTrailer and converts it to use null-safe access
-by setting is_null_ok=True and re-normalizing.
+by setting is_null_ok=True. We surgically insert the NULL_OK token instead of
+calling normalize() to preserve comment associations.
 """
 impl JacAutoLintPass._make_null_ok(trailer: uni.AtomTrailer) -> None {
     if not trailer.is_null_ok {
         trailer.is_null_ok = True;
-        trailer.normalize(deep=False);
+        # Surgically insert NULL_OK token after the target
+        # Original structure: target [.] right
+        # New structure: target ? [.] right
+        new_kid: list[uni.UniNode] = [];
+        inserted_null_ok = False;
+        for kid in trailer.kid {
+            new_kid.append(kid);
+            # Insert NULL_OK token right after the target
+            if kid is trailer.target and not inserted_null_ok {
+                new_kid.append(trailer.gen_token(Tok.NULL_OK));
+                inserted_null_ok = True;
+            }
+        }
+        trailer.set_kids(nodes=new_kid);
     }
 }
 
@@ -679,6 +806,8 @@ impl JacAutoLintPass.exit_func_call(node: uni.FuncCall) -> None {
     }
     replacement.parent = parent;
     # Find and replace in parent's children
+    # We avoid calling normalize() to preserve comment associations.
+    # Instead, we update the semantic field AND directly update the kid list.
     # Handle different parent types that might contain this FuncCall
     if isinstance(parent, uni.IfElseExpr) {
         if parent.condition is node {
@@ -696,14 +825,12 @@ impl JacAutoLintPass.exit_func_call(node: uni.FuncCall) -> None {
         } elif parent.else_value is node {
             parent.else_value = replacement;
         }
-        parent.normalize(deep=False);
     } elif isinstance(parent, uni.BinaryExpr) {
         if parent.left is node {
             parent.left = replacement;
         } elif parent.right is node {
             parent.right = replacement;
         }
-        parent.normalize(deep=False);
     } elif isinstance(parent, uni.BoolExpr) {
         # BoolExpr has a values list (for 'and'/'or' expressions)
         new_values: list[uni.Expr] = [];
@@ -715,34 +842,30 @@ impl JacAutoLintPass.exit_func_call(node: uni.FuncCall) -> None {
             }
         }
         parent.values = new_values;
-        parent.normalize(deep=False);
     } elif isinstance(parent, uni.UnaryExpr) {
         if parent.operand is node {
             parent.operand = replacement;
         }
-        parent.normalize(deep=False);
     } elif isinstance(parent, uni.IfStmt) {
         if parent.condition is node {
             parent.condition = replacement;
         }
-        parent.normalize(deep=False);
     } elif isinstance(parent, uni.WhileStmt) {
         if parent.condition is node {
             parent.condition = replacement;
         }
-        parent.normalize(deep=False);
-    } else {
-        # For other parent types, update kid list manually
-        new_kids: list[uni.UniNode] = [];
-        for kid in parent.kid {
-            if kid is node {
-                new_kids.append(replacement);
-            } else {
-                new_kids.append(kid);
-            }
-        }
-        parent.kid = new_kids;
     }
+    # For all parent types, update the kid list directly to reflect the replacement
+    # This preserves comment associations since we're reusing the original kid structure
+    new_kids: list[uni.UniNode] = [];
+    for kid in parent.kid {
+        if kid is node {
+            new_kids.append(replacement);
+        } else {
+            new_kids.append(kid);
+        }
+    }
+    parent.kid = new_kids;
 }
 
 """Recursively collect all AtomTrailer nodes from a subtree."""
@@ -863,29 +986,33 @@ impl JacAutoLintPass._exprs_are_identical(expr1: uni.Expr, expr2: uni.Expr) -> b
 
 Transforms: x?.attr if x?.attr else default -> x?.attr or default
 This only applies when the value and condition are identical expressions.
+
+This implementation avoids calling normalize() to preserve comment associations.
 """
 impl JacAutoLintPass._convert_ternary_to_or(if_else_node: uni.IfElseExpr) -> bool {
     # Check if value and condition are identical
     if not self._exprs_are_identical(if_else_node.value, if_else_node.condition) {
         return False;
     }
-    # Create a BoolExpr with 'or' operator: value or else_value
-    or_expr = uni.BoolExpr(
-        op=uni.Token(
-            orig_src=if_else_node.loc.orig_src,
-            name=Tok.KW_OR,
-            value="or",
-            line=if_else_node.loc.first_line,
-            end_line=if_else_node.loc.first_line,
-            col_start=0,
-            col_end=2,
-            pos_start=0,
-            pos_end=2
-        ),
-        values=[if_else_node.value, if_else_node.else_value],
-        kid=[if_else_node.value, if_else_node.else_value]
+    # Create the 'or' token
+    or_token = uni.Token(
+        orig_src=if_else_node.loc.orig_src,
+        name=Tok.KW_OR,
+        value="or",
+        line=if_else_node.loc.first_line,
+        end_line=if_else_node.loc.first_line,
+        col_start=0,
+        col_end=2,
+        pos_start=0,
+        pos_end=2
     );
-    or_expr.normalize(deep=False);
+    # Create a BoolExpr with 'or' operator: value or else_value
+    # Build kid list manually: value1 or value2
+    or_expr = uni.BoolExpr(
+        op=or_token,
+        values=[if_else_node.value, if_else_node.else_value],
+        kid=[if_else_node.value, or_token, if_else_node.else_value]
+    );
     # Replace in parent
     parent = if_else_node.parent;
     if parent is None {
@@ -967,18 +1094,15 @@ impl JacAutoLintPass.exit_if_else_expr(if_else_node: uni.IfElseExpr) -> None {
         return;
     }
     # Convert matching non-null-safe accesses
-    changed = False;
+    # Note: _make_null_ok() already updates the kid list for each trailer,
+    # so we don't need to call normalize() on the parent node.
     for trailer in trailers {
         if isinstance(trailer, uni.AtomTrailer) and not trailer.is_null_ok {
             key = self._get_trailer_key(trailer);
             if key is not None and key in null_ok_keys {
                 self._make_null_ok(trailer);
-                changed = True;
             }
         }
-    }
-    if changed {
-        if_else_node.normalize(deep=True);
     }
 }
 
@@ -1011,18 +1135,15 @@ impl JacAutoLintPass.exit_bool_expr(bool_node: uni.BoolExpr) -> None {
         return;
     }
     # Convert matching non-null-safe accesses
-    changed = False;
+    # Note: _make_null_ok() already updates the kid list for each trailer,
+    # so we don't need to call normalize() on the parent node.
     for trailer in trailers {
         if isinstance(trailer, uni.AtomTrailer) and not trailer.is_null_ok {
             key = self._get_trailer_key(trailer);
             if key is not None and key in null_ok_keys {
                 self._make_null_ok(trailer);
-                changed = True;
             }
         }
-    }
-    if changed {
-        bool_node.normalize(deep=True);
     }
 }
 

--- a/jac/jaclang/tests/fixtures/comment_normalize_stress_test.jac
+++ b/jac/jaclang/tests/fixtures/comment_normalize_stress_test.jac
@@ -1,0 +1,264 @@
+"""Intensive test for comment preservation during auto-lint normalize operations.
+
+This file tests various scenarios where normalize() is called and comments
+might be lost or misplaced:
+1. Consecutive has statement combining
+2. Consecutive glob statement combining
+3. @staticmethod -> static conversion
+4. __init__/__post_init__ -> init/postinit conversion
+5. with entry block transformation
+6. hasattr() -> null-safe access
+7. Ternary -> or simplification
+8. Angle bracket escape removal
+"""
+
+# Comment before first glob
+glob x = 1;  # Inline comment on first glob
+# Comment between glob statements
+glob y = 2;  # Inline comment on second glob
+# Comment before third glob
+glob z = 3;  # Inline comment on third glob
+
+# Different access modifier - should not combine
+glob : priv private_var = 100;  # Inline on private glob
+
+# Comment before obj definition
+obj Calculator {
+    # Comment before first has
+    has value: int;  # Inline comment on value
+    # Comment between has statements - CRITICAL: may be lost during combine
+    has name: str;  # Inline comment on name
+    # Comment before third has
+    has count: int = 0;  # Inline comment on count
+    # Different modifier - should stay separate
+    has : priv secret: str;  # Inline on private has
+    # Static has fields with comments
+    static has instance_count: int = 0;  # Inline on static has
+    # Between static has
+    static has version: str = "1.0";  # Second static has inline
+
+    # Comment before method declaration
+    def add(a: int, b: int) -> int;  # Inline on method decl
+
+    # Comment before staticmethod
+    @staticmethod  # Comment on decorator
+    def helper -> None;  # Inline on helper decl
+
+
+    # Comment before init
+    def __init__(self: Calculator, val: int) -> None;  # Inline on init decl
+
+
+    # Nested obj with comments
+    obj InnerClass {
+        # Comment in inner obj has
+        has inner_val: int;  # Inline inner has
+        # Second inner has comment
+        has inner_name: str;  # Second inline inner has
+    }
+}
+
+# Implementation comments
+impl Calculator.add(a: int, b: int) -> int {
+    # Comment inside impl body
+    return a + b;  # Inline return comment
+
+}
+
+# Comment on staticmethod impl
+@ staticmethod  # Decorator comment on impl
+impl Calculator.helper -> None {
+    # Comment inside helper
+    print("helper");  # Inline print comment
+}
+
+# Comment on init impl
+impl Calculator.__init__(self: Calculator, val: int) -> None {
+    # Comment on self assignment
+    self.value = val;  # Inline assignment
+    # Comment after init body
+}
+
+# Enum with consecutive assignments and comments
+enum Color {
+    RED = 1,  # Inline on RED
+    # Comment before GREEN
+    GREEN = 2,  # Inline on GREEN
+    # Comment before BLUE
+    BLUE = 3,  # Inline on BLUE
+}
+
+# Test hasattr conversion with comments
+obj NullSafeTest {
+    has data: dict | None;
+    has obj: any | None;
+
+    def check_attr -> any {
+        # Comment before hasattr usage
+        if hasattr(self.obj, "value") {  # Inline on if hasattr
+
+            # Comment inside if block
+            return self.obj.value;  # Return comment
+
+        }
+        # Comment after if
+        return None;  # Inline on return None
+
+    }
+
+    def check_with_default -> any {
+        # Comment before ternary with hasattr
+        result = self.obj.attr if hasattr(self.obj, "attr") else "default";  # Inline on ternary
+        # Comment after assignment
+        return result;  # Return result comment
+
+    }
+}
+
+# Test ternary to or simplification with comments
+obj TernaryTest {
+    has val: int | None;
+
+    def get_or_default -> int {
+        # Comment before ternary that should become or
+        x = self.val if self.val else 0;  # Inline on ternary
+        # Comment after ternary
+        return x;  # Return comment
+
+    }
+
+    def nested_ternary -> int {
+        # Comment on nested ternary
+        a = self.val;  # Inline a
+        # Comment between
+        b = a if a else (self.val if self.val else 0);  # Nested ternary inline
+        # After nested
+        return b;  # Return b
+
+    }
+}
+
+# Test with entry block transformation
+with entry {
+    # Comment at start of entry
+    entry_x = 10;  # Inline on x
+    # Comment between statements
+    entry_y = 20;  # Inline on y
+
+    # Comment before print
+    print(entry_x + entry_y);  # Inline on print
+
+    # Comment before function def inside entry
+    def helper_fn {
+        # Inside helper
+        return 42;  # Return 42 comment
+
+    }
+
+    # Comment after function
+    result = helper_fn();  # Inline on result
+
+    # Assignment that should become glob
+    module_level = 100;  # This should become glob with comment
+}
+
+# Test angle bracket escaped names with comments
+obj KeywordEscapeTest {
+    # Comment before escaped name
+    has <>type_name: str;  # Inline on escaped name
+    # Comment between
+    has <>value_name: str;  # Second escaped inline
+
+    # Method with escaped param
+    def process(<>input: str) -> str {  # Inline on method with escaped param
+        # Comment inside
+        return <>input;  # Return escaped
+
+    }
+}
+
+# Test multiple has statements with type annotations and defaults
+obj ComplexHasTest {
+    # Comment block before complex has
+    # This is a multi-line comment
+    # describing the fields below
+    has field1: int = 1;  # First field inline
+    # Single comment between
+    has field2: str = "test";  # Second field inline
+    # Another comment
+    # Multi-line again
+    has field3: list[int] = [];  # Third field inline
+    # Comment before different access
+    has : priv private1: int = 0;  # Private field inline
+    # Between private fields
+    has : priv private2: str = "";  # Second private inline
+}
+
+# Test static vs non-static has - should not combine
+obj StaticVsNonStaticTest {
+    # Comment on static has
+    static has static1: int = 10;  # Inline static
+    # Between static has
+    static has static2: str = "static";  # Second static inline
+    # Regular has after static - should not combine
+    has mutable: int = 0;  # Mutable inline
+}
+
+# Test impl signature mismatch with comments
+obj SignatureTest {
+    def method1(a: int, b: str, c: float) -> bool;  # Declaration comment
+
+    def method2(x: int) -> int;  # Second decl comment
+
+}
+
+# Impl with same signature
+impl SignatureTest.method1(a: int, b: str, c: float) -> bool {
+    # Comment inside method1
+    return True;  # Return comment
+
+}
+
+impl SignatureTest.method2(x: int) -> int {
+    # Comment inside method2
+    return x * 2;  # Return double
+
+}
+
+# Test empty parens removal with comments
+obj EmptyParensTest {
+    def no_params()  -> None;  # Declaration with empty parens
+
+    def also_no_params()  -> int;  # Another empty parens
+
+    def really_no_params_no_return();  # No params no return
+
+}
+
+impl EmptyParensTest.no_params()  -> None {
+    # Inside no_params
+    print("no params");  # Print comment
+}
+
+impl EmptyParensTest.also_no_params()  -> int {
+    # Inside also_no_params
+    return 42;  # Return answer
+
+}
+
+impl EmptyParensTest.really_no_params_no_return() {
+    # Inside really_no_params_no_return
+    print("done");  # Done comment
+}
+
+# Test import inside code block
+obj ImportInsideCode {
+    def do_import -> None {
+        # Comment before import
+        import from os { path }
+        ;  # Inline on import
+        # Comment after import
+        print(path);  # Print path comment
+    }
+}
+# Final comment at end of file

--- a/jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.py
+++ b/jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.py
@@ -886,3 +886,191 @@ class TestRemoveFutureAnnotations:
         # Without linting, __future__ import should remain
         assert "__future__" in formatted
         assert "annotations" in formatted
+
+
+class TestCommentPreservation:
+    """Tests for comment preservation during auto-lint transformations.
+
+    The auto-lint pass performs various transformations (combining statements,
+    converting hasattr to null-safe access, etc.) which historically lost comments.
+    These tests verify that comments are preserved after transformations.
+
+    Uses the comprehensive stress test fixture that covers many edge cases:
+    - Consecutive glob statement combining
+    - Consecutive has statement combining
+    - @staticmethod -> static conversion
+    - __init__/__post_init__ -> init/postinit conversion
+    - hasattr() -> null-safe access
+    - Ternary -> or simplification
+    - Angle bracket escape removal
+
+    Note: When statements are merged (e.g., multiple has statements combined into one),
+    standalone comments that appeared between the merged statements will appear after
+    the combined statement. This is expected behavior since we can't interleave comments
+    within a single combined statement.
+    """
+
+    @pytest.fixture
+    def stress_test_path(self) -> str:
+        """Return the path to the comment stress test fixture."""
+        return os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "..",
+            "jaclang",
+            "tests",
+            "fixtures",
+            "comment_normalize_stress_test.jac",
+        )
+
+    def test_glob_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments around glob statements are preserved during combining."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Standalone comments around glob statements should be preserved
+        assert "# Comment before first glob" in formatted
+        assert "# Comment between glob statements" in formatted
+        assert "# Comment before third glob" in formatted
+        # Private glob comment
+        assert "# Inline on private glob" in formatted
+
+    def test_has_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments around has statements are preserved during combining."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Standalone comments in obj body should be preserved
+        assert "# Comment before first has" in formatted
+        assert "# Comment between has statements" in formatted
+        assert "# Comment before third has" in formatted
+        # Private has inline
+        assert "# Inline on private has" in formatted
+
+    def test_method_and_impl_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments on methods and impl blocks are preserved."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Method declaration comments
+        assert "# Comment before method declaration" in formatted
+        assert "# Comment before staticmethod" in formatted
+        assert "# Comment before init" in formatted
+        # Impl comments
+        assert "# Implementation comments" in formatted
+        assert "# Comment inside impl body" in formatted
+        assert "# Inline return comment" in formatted
+        assert "# Comment on staticmethod impl" in formatted
+        assert "# Comment inside helper" in formatted
+
+    def test_enum_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments in enum definitions are preserved."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Enum comments
+        assert "# Enum with consecutive assignments and comments" in formatted
+        assert "# Comment before GREEN" in formatted
+        assert "# Comment before BLUE" in formatted
+
+    def test_hasattr_conversion_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments are preserved during hasattr -> null-safe conversion."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Comments around hasattr usage
+        assert "# Test hasattr conversion with comments" in formatted
+        assert "# Comment before hasattr usage" in formatted
+        assert "# Comment inside if block" in formatted
+        assert "# Comment after if" in formatted
+
+    def test_ternary_conversion_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments are preserved during ternary -> or conversion."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Comments around ternary expressions
+        assert "# Test ternary to or simplification with comments" in formatted
+        assert "# Comment before ternary that should become or" in formatted
+        assert "# Comment after ternary" in formatted
+
+    def test_entry_block_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments are preserved during with entry block transformation."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Entry block comments
+        assert "# Test with entry block transformation" in formatted
+        assert "# Comment at start of entry" in formatted
+        assert "# Comment between statements" in formatted
+        assert "# Comment before print" in formatted
+
+    def test_escaped_name_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments are preserved when removing unnecessary escaping."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Comments around escaped names
+        assert "# Test angle bracket escaped names with comments" in formatted
+        assert "# Comment before escaped name" in formatted
+        assert "# Method with escaped param" in formatted
+
+    def test_nested_obj_comments_preserved(self, stress_test_path: str) -> None:
+        """Test that comments in nested obj definitions are preserved."""
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Nested obj comments
+        assert "# Nested obj with comments" in formatted
+        assert "# Comment in inner obj has" in formatted
+
+    def test_no_orphaned_comments_at_eof(self, stress_test_path: str) -> None:
+        """Test that critical comments aren't lost - inline comments on merged statements may become orphans.
+
+        When statements are merged (e.g., `has a: int; # inline` + `has b: str; # inline`
+        becomes `has a: int, b: str;`), the inline comments on the merged statements
+        don't have a natural place in the combined statement and may appear at the end.
+
+        This test verifies that:
+        1. Standalone comments (full-line comments) are preserved in-place
+        2. Comments in code bodies are preserved
+        3. The first statement in a merged group keeps its inline comment
+
+        The orphaned comments at the end are inline comments from merged statements -
+        this is a known limitation when combining statements.
+        """
+        prog = JacProgram.jac_file_formatter(stress_test_path, auto_lint=True)
+        formatted = prog.mod.main.gen.jac
+
+        # Critical check: standalone comments should appear BEFORE the code they precede,
+        # not at the end of the file
+        critical_standalone_comments = [
+            "# Comment before first glob",
+            "# Comment between glob statements",
+            "# Comment before first has",
+            "# Comment between has statements",
+            "# Comment before method declaration",
+            "# Comment inside impl body",
+            "# Test hasattr conversion with comments",
+            "# Comment before hasattr usage",
+        ]
+
+        for comment in critical_standalone_comments:
+            # Find the position of this comment
+            pos = formatted.find(comment)
+            assert pos != -1, f"Comment not found: {comment}"
+
+            # Check that it's NOT in the last 500 characters (orphan section)
+            assert pos < len(formatted) - 500, (
+                f"Critical standalone comment appears to be orphaned at end: {comment}"
+            )
+
+        # Also verify the final legitimate comment is near the end but not orphaned
+        final_comment_pos = formatted.find("# Final comment at end of file")
+        assert final_comment_pos != -1, "Final comment should be present"
+        # It should be in the last third of the file (normal position)
+        assert final_comment_pos > len(formatted) * 0.5, (
+            "Final comment should be near the end of file, not moved earlier"
+        )


### PR DESCRIPTION
## Summary

- Remove all `normalize()` calls from auto-lint pass that were breaking comment-to-token associations
- Replace with manual kid list construction that preserves original tokens
- Fix trailing semicolon handling when combining glob statements extracted from entry blocks
- Add comprehensive stress test fixture and test class for comment preservation

## Problem

The auto-lint pass performs various transformations (combining has/glob statements, converting hasattr to null-safe access, etc.) that were causing comments to be lost or orphaned at the end of the file. This happened because `normalize()` regenerates tokens, breaking the comment injection infrastructure's token ID associations.

## Solution

Instead of calling `normalize()` after AST modifications, manually construct the kid lists to preserve original tokens. This keeps comment associations intact.

Key changes to `jac_auto_lint_pass.impl.jac`:
- `combine_consecutive_glob()` - manual kid list with assignments + semicolon
- `combine_consecutive_has()` - manual kid list with vars + semicolon  
- `create_entry_block()` - manual `with entry { stmts }` structure
- `create_glob_from_assignment()` - manual `glob assignment` structure
- `_convert_hasattr_to_null_ok()` - manual `target ? . right` structure
- `_make_null_ok()` - surgical NULL_OK token insertion
- `enter_enum()` / `enter_archetype()` - filter kid list to remove merged statements
- `enter_module()` - manual `[doc?] body...` structure
- `_convert_ternary_to_or()` - manual `value1 or value2` structure

## Test plan

- [x] All 42 existing auto-lint tests pass
- [x] New `TestCommentPreservation` class with 10 tests verifying comments are preserved during:
  - Glob statement combining
  - Has statement combining
  - Method/impl body transformations
  - Enum transformations
  - hasattr -> null-safe conversion
  - Ternary -> or simplification
  - Entry block transformation
  - Escaped name handling
  - Nested obj definitions
- [x] Stress test fixture covers edge cases with inline and standalone comments