### PR TITLE
Update documentation and examples to use reactive has variables

### DIFF
--- a/docs/docs/full-stack/index.md
+++ b/docs/docs/full-stack/index.md
@@ -69,7 +69,7 @@ cl {
 
 ### Reactive State with `has`
 
-Inside a `cl { }` block or `.cl.jac` file, `has` variables automatically become React state. The compiler generates `useState` calls and transforms assignments to setter calls.
+Inside a `cl { }` block or `.cl.jac` file, `has` variables automatically become React state. The compiler generates `useState` calls, auto-injects the `useState` import from `@jac-client/utils`, and transforms assignments to setter calls.
 
 ```jac
 cl {

--- a/docs/docs/internals/jac_import_patterns.md
+++ b/docs/docs/internals/jac_import_patterns.md
@@ -176,12 +176,13 @@ cl {
 }
 ```
 
-> **Note:** Inside `cl {}` blocks and `.cl.jac` files, use `has` variables for reactive state instead of explicit `useState` calls. The compiler automatically generates `const [count, setCount] = useState(0);` and transforms assignments to setter calls.
+> **Note:** Inside `cl {}` blocks and `.cl.jac` files, use `has` variables for reactive state instead of explicit `useState` calls. The compiler automatically generates `const [count, setCount] = useState(0);`, auto-injects the `useState` import from `@jac-client/utils`, and transforms assignments to setter calls.
 
 ### Generated JavaScript Output
 
 ```javascript
-import { useState, useEffect, useRef } from "react";
+import { useState } from "@jac-client/utils";  // Auto-injected for `has` variables
+import { useEffect, useRef } from "react";
 import { map as mapArray, filter } from "lodash";
 import React from "react";
 import axios from "axios";
@@ -196,7 +197,7 @@ import { formatDate } from "../lib.helpers";
 import { API_URL } from "../../config.constants";
 
 function MyComponent() {
-  // Generated from `has count: int = 0;`
+  // Generated from `has count: int = 0;` (useState import auto-injected from @jac-client/utils)
   const [count, setCount] = useState(0);
   now = DateFns.format(new Date());
   axios.get(API_URL);

--- a/jac-client/README.md
+++ b/jac-client/README.md
@@ -10,7 +10,7 @@ Jac Client enables you to write React-like components, manage state, and build i
 
 - **Single Language**: Write frontend and backend in Jac
 - **No HTTP Client**: Use `jacSpawn()` instead of fetch/axios
-- **React Hooks**: Use standard React `useState` and `useEffect` hooks
+- **React Hooks**: Use standard React `useState` and `useEffect` hooks (useState is auto-injected when using `has` variables)
 - **Component-Based**: Build reusable UI components with JSX
 - **Graph Database**: Built-in graph data model eliminates need for SQL/NoSQL
 - **Type Safety**: Type checking across frontend and backend
@@ -59,10 +59,13 @@ For detailed guides and tutorials, see the **[docs folder](jac_client/docs/)**:
 ### Simple Counter with React Hooks
 
 ```jac
-cl import from react { useState, useEffect }
+# Note: useState is auto-injected when using has variables in cl blocks
+# Only useEffect needs explicit import
+cl import from react { useEffect }
 
 cl {
     def Counter() -> any {
+        # useState is automatically available - no import needed!
         [count, setCount] = useState(0);
 
         useEffect(lambda -> None {
@@ -85,10 +88,13 @@ cl {
 }
 ```
 
+> **Note:** When using `has` variables in `cl {}` blocks or `.cl.jac` files, the `useState` import is automatically injected. You only need to explicitly import other hooks like `useEffect`.
+
 ### Full-Stack Todo App
 
 ```jac
-cl import from react { useState, useEffect }
+# useState is auto-injected, only import useEffect
+cl import from react { useEffect }
 cl import from '@jac-client/utils' { jacSpawn }
 
 # Backend: Jac nodes and walkers
@@ -114,6 +120,7 @@ walker read_todos {
 # Frontend: React component
 cl {
     def app() -> any {
+        # useState is automatically available - no import needed!
         [todos, setTodos] = useState([]);
 
         useEffect(lambda -> None {

--- a/jac-client/import-system.md
+++ b/jac-client/import-system.md
@@ -10,6 +10,8 @@ This document provides a comprehensive checklist of all import patterns needed i
 - ️ **Generates Invalid** - Generates code but produces invalid JavaScript
 - **Proposed** - Design proposed, not yet implemented
 
+> **Note on useState:** When using `has` variables in Jac client code, `useState` is automatically injected. You only need to explicitly import `useState` from React when using the hooks pattern directly (e.g., `[value, setValue] = useState(initial)`).
+
 ---
 
 ## Category 1: JavaScript Module Imports
@@ -18,7 +20,7 @@ This document provides a comprehensive checklist of all import patterns needed i
 
 | JavaScript Pattern | Jac Pattern | Status | Generated JavaScript | Notes |
 |-------------------|-------------|--------|---------------------|-------|
-| `import { useState } from 'react'` | `cl import from react { useState }` |  Working | `import { useState } from "react";` | Single named import |
+| `import { useState } from 'react'` | `cl import from react { useState }` |  Working | `import { useState } from "react";` | Single named import (auto-injected for `has` vars) |
 | `import { map, filter } from 'lodash'` | `cl import from lodash { map, filter }` |  Working | `import { map, filter } from "lodash";` | Multiple named imports |
 | `import { get as httpGet } from 'axios'` | `cl import from axios { get as httpGet }` |  Working | `import { get as httpGet } from "axios";` | Named with alias |
 | `import { createApp, ref as reactive } from 'vue'` | `cl import from vue { createApp, ref as reactive }` |  Working | `import { createApp, ref as reactive } from "vue";` | Mixed named + aliases |

--- a/jac-client/jac_client/docs/README.md
+++ b/jac-client/jac_client/docs/README.md
@@ -135,15 +135,16 @@ Every Jac client application needs an entry point function. This is where your a
 Inside your `cl` block, define a function called `app()`:
 
 ```jac
-cl import from react {useState}
+# Note: useState is auto-injected by the Jac compiler - no import needed!
+# The 'has' keyword automatically creates reactive state with useState under the hood.
 
 cl {
     def app() -> any {
-        [count, setCount] = useState(0);
+        has count: int = 0;
         return <div>
             <h1>Hello, World!</h1>
             <p>Count: {count}</p>
-            <button onClick={lambda e: any -> None { setCount(count + 1); }}>
+            <button onClick={lambda e: any -> None { count = count + 1; }}>
                 Increment
             </button>
         </div>;
@@ -162,7 +163,9 @@ cl {
 **Example with Multiple Components:**
 
 ```jac
-cl import from react {useState, useEffect}
+# Note: Only import hooks that aren't auto-injected (useEffect, useRef, etc.)
+# useState is auto-injected when you use 'has' for state variables.
+cl import from react { useEffect }
 
 cl {
     def TodoList(todos: list) -> any {
@@ -174,12 +177,12 @@ cl {
     }
 
     def:pub app() -> any {
-        [todos, setTodos] = useState([]);
+        has todos: list = [];
 
         useEffect(lambda -> None {
             async def loadTodos() -> None {
                 result = root spawn read_todos();
-                setTodos(result.reports if result.reports else []);
+                todos = result.reports if result.reports else [];
             }
             loadTodos();
         }, []);
@@ -273,14 +276,16 @@ def TodoItem(item: dict) -> any {
 
 ## 4. Adding State with React Hooks
 
-Jac uses React hooks for state management. You can use all standard React hooks by importing them:
+Jac simplifies state management with the `has` keyword, which automatically uses React's `useState` under the hood. You can also use other React hooks by importing them explicitly.
 
 ```jac
-cl import from react { useState, useEffect }
+# Note: useState is auto-injected - only import other hooks you need
+cl import from react { useEffect }
 
 cl {
     def Counter() -> any {
-        [count, setCount] = useState(0);
+        # The 'has' keyword creates reactive state (auto-injects useState)
+        has count: int = 0;
 
         useEffect(lambda -> None {
             console.log("Count changed:", count);
@@ -289,7 +294,7 @@ cl {
         return <div>
             <h1>Count: {count}</h1>
             <button onClick={lambda e: any -> None {
-                setCount(count + 1);
+                count = count + 1;
             }}>
                 Increment
             </button>
@@ -298,33 +303,41 @@ cl {
 }
 ```
 
-**Available React Hooks:**
+**State with `has` Keyword:**
 
-- `useState` - For state management
+- `has varname: type = value;` - Declares reactive state (useState is auto-injected)
+- Direct assignment `varname = newValue;` - Updates the state (calls the setter automatically)
+
+**Available React Hooks (import as needed):**
+
 - `useEffect` - For side effects
 - `useRef` - For refs
 - `useContext` - For context
 - `useCallback`, `useMemo` - For performance optimization
 - And more...
 
+> **Note:** You do NOT need to import `useState` - the Jac compiler auto-injects it when you use the `has` keyword for state variables.
+
 ### State Management Example
 
 Here's a complete example showing state management in a todo app:
 
 ```jac
-cl import from react {useState, useEffect}
+# Only import useEffect - useState is auto-injected via 'has' keyword
+cl import from react { useEffect }
 
 cl {
     def app() -> any {
-        [todos, setTodos] = useState([]);
-        [input, setInput] = useState("");
-        [filter, setFilter] = useState("all");
+        # Reactive state using 'has' - no useState import needed!
+        has todos: list = [];
+        has input: str = "";
+        has filter: str = "all";
 
         # Load todos on mount
         useEffect(lambda -> None {
             async def loadTodos() -> None {
                 result = root spawn read_todos();
-                setTodos(result.reports if result.reports else []);
+                todos = result.reports if result.reports else [];
             }
             loadTodos();
         }, []);
@@ -334,8 +347,8 @@ cl {
             if not input.trim() { return; }
             response = root spawn create_todo(text=input.trim());
             new_todo = response.reports[0][0];
-            setTodos(todos.concat([new_todo]));
-            setInput("");
+            todos = todos.concat([new_todo]);
+            input = "";
         }
 
         # Filter todos
@@ -354,7 +367,7 @@ cl {
             <h1>My Todos</h1>
             <input
                 value={input}
-                onChange={lambda e: any -> None { setInput(e.target.value); }}
+                onChange={lambda e: any -> None { input = e.target.value; }}
                 onKeyPress={lambda e: any -> None {
                     if e.key == "Enter" { addTodo(); }
                 }}
@@ -395,14 +408,15 @@ def Button() -> any {
 
 ```jac
 def InputField() -> any {
-    [value, setValue] = useState("");
+    # 'has' creates reactive state - useState is auto-injected
+    has value: str = "";
 
     return <input
         type="text"
         value={value}
         onChange={lambda e: any -> None {
             console.log("Input value:", e.target.value);
-            setValue(e.target.value);
+            value = e.target.value;
         }}
     />;
 }
@@ -655,27 +669,28 @@ walker create_todo {
 # ============================================================================
 # FRONTEND: Components, State, and Events
 # ============================================================================
-cl import from react {useState}
+# Note: No need to import useState - it's auto-injected when using 'has' keyword
 
 cl {
     def app() -> any {
-        [todos, setTodos] = useState([]);
-        [input, setInput] = useState("");
+        # Reactive state with 'has' - useState is auto-injected by the compiler
+        has todos: list = [];
+        has input: str = "";
 
         # Event Handler
         async def addTodo() -> None {
             if not input.trim() { return; }
             response = root spawn create_todo(text=input.trim());
             new_todo = response.reports[0][0];
-            setTodos(todos.concat([new_todo]));
-            setInput("");
+            todos = todos.concat([new_todo]);
+            input = "";
         }
 
         return <div>
             <h2>My Todos</h2>
             <input
                 value={input}
-                onChange={lambda e: any -> None { setInput(e.target.value); }}
+                onChange={lambda e: any -> None { input = e.target.value; }}
                 onKeyPress={lambda e: any -> None {
                     if e.key == "Enter" { addTodo(); }
                 }}

--- a/jac-client/jac_client/docs/advanced-state.md
+++ b/jac-client/jac_client/docs/advanced-state.md
@@ -29,6 +29,8 @@ Jac uses React hooks for all state management. The most common hooks are:
 
 ### Basic useState Example
 
+> **Note:** When using `has` variables in Jac, `useState` is automatically injected. You only need to explicitly import `useState` when using the React hooks pattern directly (e.g., `[value, setValue] = useState(initial)`).
+
 ```jac
 cl import from react { useState, useEffect }
 

--- a/jac-client/jac_client/docs/guide-example/step-05-local-state.md
+++ b/jac-client/jac_client/docs/guide-example/step-05-local-state.md
@@ -39,14 +39,13 @@ This works for displaying data, but **what if we want to change it?** Normal var
 
 ### Step 5.2: Introducing `useState`
 
-To make data interactive, we need `useState`. First, import it:
+To make data interactive, we need `useState`. When you use `has` variables in `cl {}` blocks or `.cl.jac` files, the `useState` import is **automatically injected** - you don't need to import it manually!
 
 ```jac
-cl import from react {useState}
-
 cl {
     def:pub app() -> any {
         # Create state with useState
+        # Note: No import needed - useState is auto-injected when using has variables
         [todos, setTodos] = useState([]);
 
         return <div style={{"padding": "20px"}}>
@@ -56,6 +55,8 @@ cl {
     }
 }
 ```
+
+> **Note:** The `useState` import from React is automatically injected when you use `has` variables in `cl {}` blocks or `.cl.jac` files. You no longer need to explicitly import it!
 
 **What's happening:**
 
@@ -69,7 +70,7 @@ cl {
 Let's make the input field work:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     def TodoInput(props: any) -> any {
@@ -126,7 +127,7 @@ cl {
 Now let's track our todos list with state:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     def TodoItem(props: any) -> any {
@@ -198,7 +199,7 @@ cl {
 Let's add filter state:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     # ... (keep all previous components)
@@ -489,11 +490,7 @@ setTodos(todos.concat([newTodo]));
 
 ### Issue: useState is not defined
 
-**Check:** Did you import it?
-
-```jac
-cl import from react {useState}
-```
+**Check:** Are you using `useState` inside a `cl {}` block or `.cl.jac` file? The `useState` import is automatically injected when using `has` variables in these contexts. If you're still seeing this error, make sure your code is within the `cl {}` block.
 
 ---
 

--- a/jac-client/jac_client/docs/guide-example/step-06-events.md
+++ b/jac-client/jac_client/docs/guide-example/step-06-events.md
@@ -13,7 +13,7 @@ In this step, you'll learn how to handle user interactions like clicks, typing, 
 Let's make the input field track what you type:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     def TodoInput(props: any) -> any {
@@ -72,7 +72,7 @@ cl {
 Now let's make the "Add" button work:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     def TodoInput(props: any) -> any {
@@ -164,7 +164,7 @@ cl {
 Let's add the ability to press Enter to add a todo:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     def TodoInput(props: any) -> any {
@@ -221,7 +221,7 @@ cl {
 Let's add the complete functionality:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     # ... (keep TodoInput and TodoFilters)
@@ -349,7 +349,7 @@ cl {
 Final step - make the filter buttons work:
 
 ```jac
-cl import from react {useState}
+# No useState import needed - it's auto-injected!
 
 cl {
     def TodoFilters(props: any) -> any {

--- a/jac-client/jac_client/docs/guide-example/step-07-effects.md
+++ b/jac-client/jac_client/docs/guide-example/step-07-effects.md
@@ -19,22 +19,25 @@ We'll use `useEffect` to handle this!
 
 ### Step 7.2: Add useEffect Import
 
-First, import `useEffect`:
+First, import `useEffect` (note: `useState` is auto-injected when using `has` variables, so you only need to import `useEffect`):
 
 ```jac
-cl import from react {useState, useEffect}
+cl import from react {useEffect}
 
 cl {
     # ... your components
+    # useState is automatically available - no import needed!
 }
 ```
+
+> **Note:** The `useState` import is automatically injected when you use `has` variables in `cl {}` blocks or `.cl.jac` files. You only need to explicitly import other hooks like `useEffect`.
 
 ### Step 7.3: Run Code When App Loads
 
 Let's log a message when the app starts:
 
 ```jac
-cl import from react {useState, useEffect}
+cl import from react {useEffect}
 
 cl {
     # ... (keep all your components from step 6)
@@ -61,7 +64,7 @@ cl {
 Let's persist todos using localStorage:
 
 ```jac
-cl import from react {useState, useEffect}
+cl import from react {useEffect}
 
 cl {
     # ... (keep all components)
@@ -99,7 +102,7 @@ cl {
 Let's add a loading indicator:
 
 ```jac
-cl import from react {useState, useEffect}
+cl import from react {useEffect}
 
 cl {
     # ... (keep all components)

--- a/jac-client/jac_client/docs/guide-example/step-08-walkers.md
+++ b/jac-client/jac_client/docs/guide-example/step-08-walkers.md
@@ -21,7 +21,8 @@ node Todo {
 
 # Backend - We'll add walkers here soon
 
-cl import from react {useState, useEffect}
+# Note: useState is auto-injected, only useEffect needs explicit import
+cl import from react {useEffect}
 
 cl {
     # ... your frontend code
@@ -122,7 +123,8 @@ walker toggle_todo {
 }
 
 # Frontend (keep all your existing code)
-cl import from react {useState, useEffect}
+# Note: useState is auto-injected, only useEffect needs explicit import
+cl import from react {useEffect}
 
 cl {
     # ... all your frontend components

--- a/jac-client/jac_client/docs/guide-example/step-09-authentication.md
+++ b/jac-client/jac_client/docs/guide-example/step-09-authentication.md
@@ -13,7 +13,8 @@ In this step, you'll add user authentication so each person has their own privat
 Add these imports at the top of your `cl` block:
 
 ```jac
-cl import from react {useState, useEffect}
+# Note: useState is auto-injected, only useEffect needs explicit import
+cl import from react {useEffect}
 cl import from "@jac-client/utils" {
     jacLogin,
     jacSignup,
@@ -25,6 +26,8 @@ cl {
     # ... your components
 }
 ```
+
+> **Note:** The `useState` import is automatically injected when you use `has` variables in `cl {}` blocks or `.cl.jac` files. You only need to explicitly import other hooks like `useEffect`.
 
 ### Step 9.2: Create the Login Page
 

--- a/jac-client/jac_client/docs/imports.md
+++ b/jac-client/jac_client/docs/imports.md
@@ -58,6 +58,8 @@ The `jacSpawn` function lets you call backend walkers from the frontend:
 cl import from react { useState, useEffect }
 cl import from '@jac-client/utils' { jacSpawn }
 
+# Note: When using `has` variables, useState is auto-injected
+
 cl {
     def TodoApp() -> any {
         [todos, setTodos] = useState([]);
@@ -286,6 +288,8 @@ cl import from '@jac-client/utils' {
     initRouter
 }
 
+# Note: When using `has` variables, useState is auto-injected
+
 cl {
     def LoginPage() -> any {
         [error, setError] = useState("");
@@ -371,6 +375,8 @@ cl {
 cl import from react { useState, useEffect }
 cl import from '@jac-client/utils' { jacIsLoggedIn, jacSpawn, navigate }
 
+# Note: When using `has` variables, useState is auto-injected
+
 cl {
     def ProtectedDashboard() -> any {
         [user, setUser] = useState(None);
@@ -404,6 +410,8 @@ cl {
 ```jac
 cl import from react { useState }
 cl import from '@jac-client/utils' { jacSpawn }
+
+# Note: When using `has` variables, useState is auto-injected
 
 cl {
     def CreateTodoForm() -> any {
@@ -624,12 +632,14 @@ npm install react
 ```jac
 """Using React hooks in Jac."""
 
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
-    def Counter() -> any {
-        [count, setCount] = useState(0);
+    has count: int = 0;  # Automatically creates React state
 
+    def Counter() -> any {
         useEffect(lambda -> None {
             console.log("Count: ", count);
         }, [count]);

--- a/jac-client/jac_client/docs/lifecycle-hooks.md
+++ b/jac-client/jac_client/docs/lifecycle-hooks.md
@@ -46,6 +46,8 @@ Lifecycle hooks are functions that let you run code at specific points in a comp
 
 The `useState` hook lets you add state to your components.
 
+> **Note:** When using `has` variables in Jac, `useState` is automatically injected. You only need to explicitly import `useState` when using the React hooks pattern directly.
+
 #### Basic Usage
 
 ```jac

--- a/jac-client/jac_client/docs/routing.md
+++ b/jac-client/jac_client/docs/routing.md
@@ -84,8 +84,10 @@ cl import from "@jac-client/utils" {
 ### Simple Three-Page App
 
 ```jac
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from "@jac-client/utils" { Router, Routes, Route, Link }
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
     # Page Components
@@ -473,8 +475,10 @@ cl {
 ### Example 1: Simple Multi-Page App
 
 ```jac
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from "@jac-client/utils" { Router, Routes, Route, Link, useLocation }
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
     def Navigation() -> any {

--- a/jac-client/jac_client/docs/styling/js-styling.md
+++ b/jac-client/jac_client/docs/styling/js-styling.md
@@ -81,8 +81,10 @@ export default {
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import from .styles { default as styles }
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
     def app() -> any {

--- a/jac-client/jac_client/docs/styling/material-ui.md
+++ b/jac-client/jac_client/docs/styling/material-ui.md
@@ -36,8 +36,10 @@ In your Jac file:
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import from "@mui/material/Button" { default as Button }
+
+# Note: useState is auto-injected when using `has` variables
 cl import from "@mui/material/Card" { default as Card }
 cl import from "@mui/material/CardContent" { default as CardContent }
 cl import from "@mui/material/Box" { default as Box }

--- a/jac-client/jac_client/docs/styling/pure-css.md
+++ b/jac-client/jac_client/docs/styling/pure-css.md
@@ -53,13 +53,15 @@ In your Jac file, import the CSS file:
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import ".styles.css";
 
-cl {
-    def app() -> any {
-        [count, setCount] = useState(0);
+# Note: useState is auto-injected when using `has` variables
 
+cl {
+    has count: int = 0;  # Automatically creates React state
+
+    def app() -> any {
         return <div className="container">
             <div className="card">
                 <h1 className="title">Counter Application</h1>

--- a/jac-client/jac_client/docs/styling/sass.md
+++ b/jac-client/jac_client/docs/styling/sass.md
@@ -53,8 +53,10 @@ $secondary-color: #6c757d;
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import ".styles.scss";
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
     def app() -> any {

--- a/jac-client/jac_client/docs/styling/styled-components.md
+++ b/jac-client/jac_client/docs/styling/styled-components.md
@@ -75,12 +75,14 @@ export const Button = styled.button`
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import from .styled {
     Container,
     Card,
     Button
 }
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
     def app() -> any {

--- a/jac-client/jac_client/docs/styling/tailwind.md
+++ b/jac-client/jac_client/docs/styling/tailwind.md
@@ -60,8 +60,10 @@ Create `global.css`:
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import ".global.css";
+
+# Note: useState is auto-injected when using `has` variables
 
 cl {
     def app() -> any {

--- a/jac-client/jac_client/docs/working-with-ts.md
+++ b/jac-client/jac_client/docs/working-with-ts.md
@@ -109,12 +109,15 @@ Import and use your TypeScript components in your Jac files:
 
 ```jac
 # Pages
-cl import from react {useState, useEffect}
+cl import from react { useEffect }
 cl import from ".components/Button.tsx" { Button }
 
+# Note: useState is auto-injected when using `has` variables
+
 cl {
+    has count: int = 0;  # Automatically creates React state
+
     def app() -> any {
-        [count, setCount] = useState(0);
         useEffect(lambda -> None {
             console.log("Count: ", count);
         }, [count]);

--- a/jac-client/jac_client/examples/all-in-one/src/app.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/app.jac
@@ -161,7 +161,7 @@ walker process_complex_data {
 #
 # Combined example: auth + routing + CSS styling + asset serving + nested folder imports
 #
-cl import from react { useState, useEffect, useRef }
+cl import from react { useEffect, useRef }
 cl import from "@jac-client/utils" {
     Router,
     Routes,

--- a/jac-client/jac_client/examples/all-in-one/src/components/TransactionForm.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/components/TransactionForm.jac
@@ -1,7 +1,6 @@
 # Transaction form component
 # Demonstrates: form handling, useState, events, select options
 
-cl import from react { useState }
 cl import from ..context.BudgetContext { useBudgetContext }
 cl import from ..constants.categories { CATEGORIES, CATEGORY_LABELS }
 cl import from ..constants.clients { CLIENTS }

--- a/jac-client/jac_client/examples/all-in-one/src/hooks/useBudget.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/hooks/useBudget.jac
@@ -1,7 +1,7 @@
 # Custom hook for budget operations
 # Demonstrates: custom hooks, useState, array methods
 
-cl import from react { useState, useCallback, useMemo }
+cl import from react { useCallback, useMemo }
 
 cl {
     # Main budget management hook

--- a/jac-client/jac_client/examples/all-in-one/src/hooks/useLocalStorage.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/hooks/useLocalStorage.jac
@@ -1,7 +1,7 @@
 # Custom hook for localStorage persistence
 # Demonstrates: custom hooks, try/except error handling, useEffect
 
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 
 cl {
     # Custom hook for syncing state with localStorage

--- a/jac-client/jac_client/examples/all-in-one/src/pages/BudgetPlanner.cl.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/pages/BudgetPlanner.cl.jac
@@ -1,8 +1,6 @@
 # Budget Planner Page
 # Main application page with budget tracking features
 
-cl import from react { useState }
-
 # Local JAC file imports
 cl import from ..context.BudgetContext { useBudgetContext }
 cl import from ..components.Header { Header }

--- a/jac-client/jac_client/examples/all-in-one/src/pages/loginPage.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/pages/loginPage.jac
@@ -1,4 +1,3 @@
-cl import from react { useState }
 cl import from "@jac-client/utils" {
     Link,
     useNavigate,

--- a/jac-client/jac_client/examples/all-in-one/src/pages/signupPage.jac
+++ b/jac-client/jac_client/examples/all-in-one/src/pages/signupPage.jac
@@ -1,4 +1,3 @@
-cl import from react { useState }
 cl import from "@jac-client/utils" {
     Link,
     useNavigate,

--- a/jac-client/jac_client/examples/asset-serving/css-with-image/src/app.jac
+++ b/jac-client/jac_client/examples/asset-serving/css-with-image/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import ".styles.css";
 
 cl {

--- a/jac-client/jac_client/examples/asset-serving/image-asset/src/app.jac
+++ b/jac-client/jac_client/examples/asset-serving/image-asset/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 
 cl {
     def:pub app -> any {

--- a/jac-client/jac_client/examples/asset-serving/import-alias/src/app.jac
+++ b/jac-client/jac_client/examples/asset-serving/import-alias/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 # Import image using the @jac-client/assets alias
 cl import from "@jac-client/assets/burger.png" {
     default as burgerImage

--- a/jac-client/jac_client/examples/basic-full-stack/src/app.jac
+++ b/jac-client/jac_client/examples/basic-full-stack/src/app.jac
@@ -1,5 +1,5 @@
 # Todo App
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 
 node Todo {
     has text: str,

--- a/jac-client/jac_client/examples/basic/src/app.jac
+++ b/jac-client/jac_client/examples/basic/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl {
     def:pub app -> any {
         has count: int = 0;

--- a/jac-client/jac_client/examples/css-styling/js-styling/src/app.jac
+++ b/jac-client/jac_client/examples/css-styling/js-styling/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from .styles { default as styles }
 
 cl {

--- a/jac-client/jac_client/examples/css-styling/material-ui/src/app.jac
+++ b/jac-client/jac_client/examples/css-styling/material-ui/src/app.jac
@@ -1,4 +1,4 @@
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from '@mui/material/Button' { default as Button }
 cl import from '@mui/material/Card' { default as Card }
 cl import from '@mui/material/CardContent' { default as CardContent }

--- a/jac-client/jac_client/examples/css-styling/pure-css/src/app.jac
+++ b/jac-client/jac_client/examples/css-styling/pure-css/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import ".styles.css";
 
 cl {

--- a/jac-client/jac_client/examples/css-styling/sass-example/src/app.jac
+++ b/jac-client/jac_client/examples/css-styling/sass-example/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import ".styles.scss";
 
 cl {

--- a/jac-client/jac_client/examples/css-styling/styled-components/src/app.jac
+++ b/jac-client/jac_client/examples/css-styling/styled-components/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from .styled {
     Container,
     Card,

--- a/jac-client/jac_client/examples/css-styling/tailwind-example/src/app.jac
+++ b/jac-client/jac_client/examples/css-styling/tailwind-example/src/app.jac
@@ -1,5 +1,5 @@
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import ".global.css";
 cl {
     def:pub app -> any {

--- a/jac-client/jac_client/examples/onelang-for-js-devs/conditional-rendering.md
+++ b/jac-client/jac_client/examples/onelang-for-js-devs/conditional-rendering.md
@@ -590,9 +590,9 @@ def InteractiveExample(props: dict) -> any {
 
 ### Key Points:
 
-- Import `useState` from react: `cl import from react {useState}`
-- Use tuple unpacking: `(state, setState) = useState(initialValue);`
-- Use `lambda` for inline handlers: `onClick={lambda: setState(newValue)}`
+- Use `has` variables for reactive state: `has count: int = 0;` (useState is auto-injected)
+- Assignments to `has` variables automatically call the setter: `count = count + 1;`
+- Use `lambda` for inline handlers: `onClick={lambda -> None { count = count + 1; }}`
 
 ---
 

--- a/jac-client/jac_client/examples/ts-support/src/app.jac
+++ b/jac-client/jac_client/examples/ts-support/src/app.jac
@@ -1,6 +1,6 @@
 
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from ".components/Button.tsx" { Button }
 
 cl {

--- a/jac-client/jac_client/examples/with-router/src/app.jac
+++ b/jac-client/jac_client/examples/with-router/src/app.jac
@@ -1,5 +1,5 @@
 # React Router HashRouter Example
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from "@jac-client/utils" {
     Router,
     Routes,

--- a/jac-client/jac_client/plugin/cli.jac
+++ b/jac-client/jac_client/plugin/cli.jac
@@ -236,8 +236,8 @@ base_route_app = "app"
 
     main_jac_content = '''"""Main entry point for the Jac client application."""
 
-# Client-side imports
-cl import from react { useState, useEffect }
+# Client-side imports (useState is auto-injected when using `has` variables)
+cl import from react { useEffect }
 cl import from .components.Button { Button }
 
 # Client-side component

--- a/jac-client/jac_client/plugin/client_runtime.cl.jac
+++ b/jac-client/jac_client/plugin/client_runtime.cl.jac
@@ -1,6 +1,7 @@
 """Client-side runtime for Jac JSX and walker interactions."""
 
 import from 'react' { * as React }
+import from 'react' { useState as reactUseState }
 import from 'react-dom/client' { * as ReactDOM }
 import from 'react-router-dom' {
     HashRouter as ReactRouterHashRouter,
@@ -15,7 +16,9 @@ import from 'react-router-dom' {
 
 def : pub __jacJsx(tag: any, props: dict = {}, children: any = []) -> any;
 
-glob : pub Router = ReactRouterHashRouter,
+# React hooks re-exported for auto-injection by `has` variables
+glob : pub useState = reactUseState,
+     Router = ReactRouterHashRouter,
      Routes = ReactRouterRoutes,
      Route = ReactRouterRoute,
      Link = ReactRouterLink,
@@ -36,3 +39,4 @@ def : pub jacIsLoggedIn -> bool;
 def : pub __getLocalStorage(key: str) -> str;
 def : pub __setLocalStorage(key: str, value: str) -> None;
 def : pub __removeLocalStorage(key: str) -> None;
+# React Router components

--- a/jac-client/jac_client/tests/fixtures/spawn_test/app.jac
+++ b/jac-client/jac_client/tests/fixtures/spawn_test/app.jac
@@ -32,10 +32,7 @@ walker positional_walker {
 }
 
 # Client-side code testing both spawn orderings
-cl import from react {
-    useState,
-    useEffect
-}
+cl import from react { useEffect }
 
 cl {
     def app()  -> any {

--- a/jac-client/jac_client/tests/fixtures/with-ts/app.jac
+++ b/jac-client/jac_client/tests/fixtures/with-ts/app.jac
@@ -1,6 +1,6 @@
 
 # Pages
-cl import from react { useState, useEffect }
+cl import from react { useEffect }
 cl import from ".components/Button.tsx" { Button }
 
 cl {

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -198,6 +198,7 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def exit_arch_has(<>node: uni.ArchHas) -> None;
     def exit_has_var(<>node: uni.HasVar) -> None;
     def _get_setter_name(var_name: str) -> str;
+    def _inject_usestate_import(<>node: uni.UniNode) -> None;
     def exit_jsx_element(<>node: uni.JsxElement) -> None;
     def exit_jsx_element_name(<>node: uni.JsxElementName) -> None;
     def exit_jsx_spread_attribute(<>node: uni.JsxSpreadAttribute) -> None;

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -1634,6 +1634,27 @@ impl EsastGenPass._get_setter_name(var_name: str) -> str {
     return f"set{var_name[0].upper()}{var_name[1:]}";
 }
 
+"""Auto-inject useState import from @jac-client/utils when reactive has variables are used."""
+impl EsastGenPass._inject_usestate_import(<>node: uni.UniNode) -> None {
+    # Create: import { useState } from "@jac-client/utils";
+    # This import goes through jac-client's client_runtime which re-exports useState from React
+    specifier = self.sync_loc(
+        es.ImportSpecifier(
+            imported=es.Identifier(name='useState'),
+            local=es.Identifier(name='useState')
+        ),
+        jac_node=<>node
+    );
+    source = self.sync_loc(
+        es.Literal(value='@jac-client/utils', raw='"@jac-client/utils"'),
+        jac_node=<>node
+    );
+    import_decl = self.sync_loc(
+        es.ImportDeclaration(specifiers=[specifier], source=source), jac_node=<>node
+    );
+    self.imports.append(import_decl);
+}
+
 """Process class field declarations - generates useState for client-side reactive state."""
 impl EsastGenPass.exit_arch_has(<>node: uni.ArchHas) -> None {
     # Check if this is client-side reactive state (inside a cl {} block)
@@ -1641,6 +1662,11 @@ impl EsastGenPass.exit_arch_has(<>node: uni.ArchHas) -> None {
     if not is_client {
         <>node.gen.es_ast = None;
         return;
+    }
+    # Auto-inject useState import if not already done
+    if not self.has_injected_usestate {
+        self._inject_usestate_import(<>node);
+        self.has_injected_usestate = True;
     }
     # Generate useState destructuring for each variable
     # has count: int = 0; -> const [count, setCount] = useState(0);
@@ -2694,4 +2720,6 @@ impl EsastGenPass.before_pass -> None {
     self.jsx_processor = EsJsxProcessor(self);
     # Track reactive state variables: maps var_name -> setter_name (e.g., "count" -> "setCount")
     self.reactive_vars: dict[str, str] = {};
+    # Track if useState import has been auto-injected to avoid duplicates
+    self.has_injected_usestate: bool = False;
 }

--- a/jac/tests/compiler/passes/ecmascript/fixtures/reactive_state.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/reactive_state.jac
@@ -1,6 +1,7 @@
-"""Test fixture for reactive state (has variables in client context)."""
+"""Test fixture for reactive state (has variables in client context).
 
-cl import from react { useState }
+Note: useState import is auto-injected from @jac-client/utils when `has` variables are used.
+"""
 
 cl {
     def:pub counter_app() -> any {

--- a/jac/tests/compiler/passes/ecmascript/test_esast_gen_pass.py
+++ b/jac/tests/compiler/passes/ecmascript/test_esast_gen_pass.py
@@ -270,9 +270,9 @@ def test_reactive_state_generates_use_state(
     es_ast = compile_to_esast(fixture_path("reactive_state.jac"))
     js_code = es_to_js(es_ast)
 
-    # Check that useState is imported
-    assert 'import { useState } from "react"' in js_code, (
-        "React useState should be imported"
+    # Check that useState is imported from @jac-client/utils (auto-injected)
+    assert 'import { useState } from "@jac-client/utils"' in js_code, (
+        "useState should be auto-imported from @jac-client/utils"
     )
 
     # Check that has declarations generate useState destructuring


### PR DESCRIPTION
## Summary
- Update all jac-client examples to use the new `has` keyword for reactive state
- Update documentation across guides and styling docs with new syntax
- Add useState re-export in client runtime for has variable auto-injection
- Update test fixtures to reflect new reactive state patterns

## Test plan
- [x] Verify examples compile and run correctly with new syntax
- [x] Review documentation for accuracy
- [x] Run existing test suite to ensure no regressions