### PR TITLE
install graphviz for documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -166,6 +166,7 @@ jobs:
           RUN apt-get update && apt-get install -y \
               curl \
               git \
+              graphviz \
               && rm -rf /var/lib/apt/lists/*
 
           # Set working directory


### PR DESCRIPTION
provides the `dot` executable

## **Description**

otherwise [this page](https://docs.jaseci.org/testing-debugging/) appears broken