### PR TITLE
Enhance JSX processing in EsJsxProcessor to correctly handle member e…

### DIFF
--- a/jac/jaclang/pycore/passes/ast_gen/jsx_processor.py
+++ b/jac/jaclang/pycore/passes/ast_gen/jsx_processor.py
@@ -168,9 +168,7 @@ class EsJsxProcessor:
                 )
             else:
                 # Single part starting with lowercase - HTML element string
-                expr = self.pass_ref.sync_loc(
-                    es.Literal(value=first), jac_node=node
-                )
+                expr = self.pass_ref.sync_loc(es.Literal(value=first), jac_node=node)
         node.gen.es_ast = expr
         return expr
 


### PR DESCRIPTION
## Fix: JSX dotted component names compiled as string literals instead of member expressions

**Problem**
JSX tags with dotted names like `<motion.section>` were being compiled as string literals (`"motion.section"`) instead of member expressions (`motion.section`), causing Framer Motion components and other imported objects with dotted property access to fail.

**Root Cause**
The JSX processor only checked the case of the first part. Dotted names starting with lowercase (e.g., `motion.section`) were incorrectly treated as HTML element strings.

**Solution**
Updated `element_name()` in `jsx_processor.py` to check for multiple parts first. If a tag has multiple parts (dotted name), it always creates a member expression chain, regardless of case.

**Impact**
- ✅ Fixes Framer Motion components (`motion.section`, `motion.div`, etc.)
- ✅ Enables any imported object with dotted property access in JSX
- ✅ Backward compatible: single-part names (`<div>`, `<MyComponent>`) unchanged

**Files Changed**
- `jaseci/jac/jaclang/pycore/passes/ast_gen/jsx_processor.py`