### PR TITLE
refactor: Replace _persistence_type string with PersistenceType enum

### DIFF
--- a/jac-scale/jac_scale/impl/memory_hierarchy.main.impl.jac
+++ b/jac-scale/jac_scale/impl/memory_hierarchy.main.impl.jac
@@ -17,7 +17,7 @@ impl ScaleTieredMemory.init(use_cache: bool = True) -> None {
     self._cache_available = redis_backend.is_available();
     if self._cache_available and use_cache {
         self.l2 = redis_backend;
-        logger.info("Redis cache backend initialized");
+        logger.debug("Redis cache backend initialized");
     } else {
         self.l2 = None;
         logger.debug("Redis not available, running without distributed cache");
@@ -26,13 +26,13 @@ impl ScaleTieredMemory.init(use_cache: bool = True) -> None {
     mongo_backend = MongoBackend();
     if mongo_backend.is_available() {
         self.l3 = mongo_backend;
-        self._persistence_type = 'mongodb';
-        logger.info("MongoDB persistence backend initialized");
+        self._persistence_type = PersistenceType.MONGODB;
+        logger.debug("MongoDB persistence backend initialized");
     } else {
         # Fall back to jaclang's SqliteMemory using configured path
         self.l3 = SqliteMemory(path=_db_config['shelf_db_path']);
-        self._persistence_type = 'sqlite';
-        logger.info("MongoDB not available, using SqliteMemory for persistence");
+        self._persistence_type = PersistenceType.SQLITE;
+        logger.debug("MongoDB not available, using SqliteMemory for persistence");
     }
 }
 

--- a/jac-scale/jac_scale/memory_hierarchy.jac
+++ b/jac-scale/jac_scale/memory_hierarchy.jac
@@ -111,6 +111,15 @@ obj MongoBackend(PersistentMemory) {
 }
 
 """
+Persistence backend type for ScaleTieredMemory.
+"""
+enum PersistenceType {
+    NONE,
+    MONGODB,
+    SQLITE
+}
+
+"""
 Scalable Tiered Memory - extends TieredMemory with distributed backends.
 
 Swaps the default implementations:
@@ -122,7 +131,7 @@ Storage configuration comes from environment variables or jac.toml.
 """
 obj ScaleTieredMemory(TieredMemory) {
     has _cache_available: bool = False,
-        _persistence_type: str = 'none';
+        _persistence_type: PersistenceType = PersistenceType.NONE;
 
     def init(use_cache: bool = True) -> None;
     def close -> None;


### PR DESCRIPTION
## Summary
- Add `PersistenceType` enum with `NONE`, `MONGODB`, and `SQLITE` values
- Replace string-based `_persistence_type` field with enum type for better type safety
- Change backend initialization log level from `info` to `debug`

## Test plan
- [ ] Verify jac-scale plugin loads correctly
- [ ] Test with MongoDB available (should use `PersistenceType.MONGODB`)
- [ ] Test with MongoDB unavailable (should fall back to `PersistenceType.SQLITE`)