### PR TITLE
docs: update README to reflect Jac's evolved capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 
   <h1>Jaseci</h1>
-  <h3>The AI-Native Stack for Python Developers</h3>
+  <h3>One Language for AI-Native Full-Stack Development</h3>
 
   <p>
     <a href="https://pypi.org/project/jaclang/">
@@ -34,28 +34,32 @@
 
 Welcome to the Jaseci project. This repository houses the core libraries and tooling for building next-generation applications with the Jac programming language.
 
-Jaseci serves as the implementation stack for the Jac programming language, and is packaged as a simple Python library. This runtime stack enables Jac code to execute with its enhanced features while maintaining the seamless Python interoperability that makes the language particularly accessible to Python developers.
+Jaseci serves as the implementation stack for the Jac programming language. As a superset of both Python and TypeScript/JavaScript, Jac provides seamless access to the entire PyPI and npm ecosystems, enabling developers to build complete applications, from backend logic to frontend interfaces, in a single unified language.
 
 The project brings together a set of components that work seamlessly together:
 
-- **[`jaclang`](jac/):** The Jac programming language, a drop‑in replacement for and superset of Python.
-- **[`byllm`](jac-byllm/):** Plugin for Jac enabling easy integration of large language models into your applications.
-- **[`jac-client`](jac-client/):** Plugin for Jac to build full-stack web applications with React-like components, all in one language.
+- **[`jaclang`](jac/):** The Jac programming language, a drop‑in replacement for and superset of both Python and Typescript/Javascript.
+- **[`byllm`](jac-byllm/):** Plugin for Jac enabling easy integration of large language models into your applications through the innovative [Meaning Typed Programming](https://arxiv.org/pdf/2405.08965) concept.
+- **[`jac-client`](jac-client/):** Plugin for Jac to bundle full-stack web applications with full access to the entire npm/node package ecosystem.
+- **[`jac-scale`](jac-scale/):** Plugin for Jac enabling fully abstracted and automated deployment and scaling with FastAPI, Redis, MongoDB, and Kubernetes integration.
+- **[`jac-super`](jac-super/):** Plugin for Jac providing enhanced console output with Rich formatting.
 - **[`jac VSCE`](https://github.com/jaseci-labs/jac-vscode/blob/main/README.md):** The official VS Code extension for Jac.
 
 ---
 
 ## Core Concepts
 
-Jac is an innovative programming language that extends Python's semantics while maintaining full interoperability with the Python ecosystem. It introduces cutting-edge programming models and abstractions specifically designed to hide complexity, embrace AI-forward development, and automate categories of common software systems that typically require manual implementation. Despite being relatively new, Jac has already proven its production-grade capabilities, currently powering several real-world applications across various use cases. Jaseci's power is rooted in four key principles.
+Jac is an innovative programming language that extends both Python and TypeScript/JavaScript while maintaining full interoperability with both ecosystems. It introduces cutting-edge programming models and abstractions specifically designed to hide complexity, embrace AI-forward development, and automate categories of common software systems that typically require manual implementation. Despite being relatively new, Jac has already proven its production-grade capabilities, currently powering several real-world applications across various use cases. Jaseci's power is rooted in five key principles.
 
-- **AI-Native:** Treat AI models as a native type. Weave them into your logic as effortlessly as calling a function with first-class AI abstractions.
+- **AI-Native:** Treat AI models as a native type through [Meaning Typed Programming](https://arxiv.org/pdf/2405.08965). Weave LLMs into your logic as effortlessly as calling a function, no prompt engineering required.
 
-- **Agentic Object-Spatial Programming Model:** Model your domain as a graph of objects and deploy agentic **walker** objects to travel through your object graph performing operations in-situ. Intuitively model AI state, the problem domain, and data.
+- **Full-Stack in One Language:** Build complete applications, backend logic and frontend interfaces, in a single language. Write React-like components alongside your server code with seamless data flow between them.
 
-- **Python Superset:** Use the entire Python ecosystem (`pip`, `numpy`, `pandas`, etc.) without friction. All valid Python code is also valid Jac code, ensuring a gentle learning curve.
+- **Python & JavaScript Superset:** Access the entire PyPI ecosystem (`numpy`, `pandas`, `torch`, etc.) and npm ecosystem (`react`, `vite`, `tailwind`, etc.) without friction. All valid Python and JavaScript code can be expressed in Jac code.
 
-- **Cloud-Native:** Deploy your application as a production-ready API server with a single `jac start` command, scaling from local prototype development to a distributed cloud environment with zero code changes.
+- **Agentic Object Spatial Programming Model:** The next evolution beyond objects and types, is representing them in a graph. Model your domain as a first-class graph of objects and deploy agentic **walker** objects to travel through your object graph performing operations in-situ. Intuitively model AI state, the problem domain, and data.
+
+- **Cloud-Native:** Deploy your application as a production-ready API server with a single `jac start` command. Scale automatically to Kubernetes with `jac start --scale`, zero code changes required.
 
 ---
 
@@ -99,8 +103,10 @@ The `jac` CLI is your primary interface for interacting with the Jaseci ecosyste
 | Command | Description |
 | :--- | :--- |
 | **`jac run <file.jac>`** | Executes a Jac file, much like `python3`. |
-| **`jac build <file.jac>`** | Builds a self-contained Jac application from a source file. |
 | **`jac start <file.jac>`** | Starts a REST API server for a Jac program. |
+| **`jac start <file.jac> --scale`** | Deploys to Kubernetes with Redis and MongoDB auto-provisioning. |
+| **`jac create --cl <name>`** | Creates a new full-stack Jac project with frontend support. |
+| **`jac plugins`** | Manages Jac plugins (enable/disable jac-scale, jac-client, etc.). |
 
 ---
 
@@ -110,13 +116,10 @@ Explore these impressive projects built with Jaseci! These innovative applicatio
 
 | Project | Description | Link |
 |---------|-------------|------|
-| **Jivas** | An Agentic Framework for rapidly prototyping and deploying graph-based, AI solutions | [GitHub](https://github.com/TrueSelph/jivas) |
 | **Tobu** | Your AI-powered memory keeper that captures the stories behind your photos and videos | [Website](https://tobu.life/) |
 | **TrueSelph** | A Platform Built on Jivas for building Production-grade Scalable Agentic Conversational AI solutions | [Website](https://trueselph.com/) |
 | **Myca** | An AI-powered productivity tool designed for high-performing individuals | [Website](https://www.myca.ai/) |
 | **Pocketnest Birdy AI** | A Commercial Financial AI Empowered by Your Own Financial Journey | [Website](https://www.pocketnest.com/) |
-| **LittleX** | A lightweight social media application inspired by X, developed using the Jaseci Stack | [GitHub](https://github.com/Jaseci-Labs/littleX) |
-| **Visit_Zoo** | An interactive zoo simulation with clickable sections, images, and videos | [GitHub](https://github.com/Thamirawaran/Visit_Zoo) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates tagline to "One Language for AI-Native Full-Stack Development"
- Revises intro paragraph to highlight Python & TypeScript/JavaScript superset with access to both PyPI and npm ecosystems
- Adds jac-scale and jac-super to component list
- Updates Core Concepts from 4 to 5 key principles:
  - AI-Native (now links to Meaning Typed Programming paper)
  - Full-Stack in One Language (new)
  - Python & JavaScript Superset (updated from Python-only)
  - Agentic Object Spatial Programming Model
  - Cloud-Native (now mentions `jac start --scale`)
- Expands CLI table with new commands (`--scale`, `create --cl`, `plugins`)
- Updates jac-client description to emphasize npm ecosystem access

## Test plan

- [ ] Verify all links work correctly
- [ ] Confirm README renders properly on GitHub