### PR TITLE
fix(jac-scale): update --cl flag to --npm in kubernetes deployment

### DIFF
--- a/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
@@ -227,7 +227,7 @@ class KubernetesTarget(DeploymentTarget) {
         commands.append('jac add');
 
         # Install Node requirements
-        commands.append('jac add --cl');
+        commands.append('jac add --npm');
 
         # Start the application
         commands.append(f"jac start {app_config.file_name}");


### PR DESCRIPTION
## Summary
- Updates the kubernetes deployment target to use `--npm` flag instead of the deprecated `--cl` flag
- The `--cl` flag was renamed to `--npm` when moved from core to jac-client plugin in #4203
- Fixes CI failure in `test_deploy_all_in_one` test

## Test plan
- [ ] CI passes for `jac-scale/jac_scale/tests/test_deploy_k8s.py::test_deploy_all_in_one`