### PR TITLE
chore: remove obsolete __jac_gen__ references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ db.sqlite3
 media
 migrations
 venv
-__jac_gen__/
 .jac/
 *.jir
 *.jbc

--- a/jac-byllm/.flake8
+++ b/jac-byllm/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = __jac_gen__, build, dist
+exclude = build, dist
 plugins = flake8_import_order, flake8_docstrings, flake8_comprehensions, flake8_bugbear, flake8_annotations, pep8_naming, flake8_simplify
 max-line-length = 120
 ignore = E203, W503, ANN101, ANN102, D401

--- a/jac-byllm/.gitignore
+++ b/jac-byllm/.gitignore
@@ -1,5 +1,4 @@
 # Jaclang
-__jac_gen__/
 temp*
 
 # Byte-compiled / optimized / DLL files

--- a/jac/.gitignore
+++ b/jac/.gitignore
@@ -7,7 +7,6 @@ db.sqlite3
 media
 migrations
 venv
-__jac_gen__/
 .jaccache/
 *.jbc
 

--- a/jac/jaclang/pycore/helpers.py
+++ b/jac/jaclang/pycore/helpers.py
@@ -71,19 +71,7 @@ def dump_traceback(e: Exception) -> str:
     # Utility function to check if a file is a compiled Jac file and get the original .jac source
     def get_jac_source_info(py_filename: str) -> tuple[str | None, str | None]:
         """Return (jac_filename, jac_source) if available, else (None, None)."""
-        # Check if this is a generated Python file from Jac compilation
-        # Generated Python files are stored in __jac_gen__ directory
-        if "__jac_gen__" in py_filename and py_filename.endswith(".py"):
-            # Try to find the corresponding .jac file
-            # The generated .py file typically mirrors the original .jac structure
-            jac_filename = py_filename.replace("__jac_gen__", "").replace(".py", ".jac")
-            if os.path.exists(jac_filename):
-                try:
-                    with open(jac_filename) as f:
-                        jac_source = f.read()
-                    return jac_filename, jac_source
-                except Exception:
-                    pass
+        # Currently no mapping from Python to Jac source files is available
         return None, None
 
     tb = TracebackException(type(e), e, e.__traceback__, limit=None, compact=True)

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -432,20 +432,8 @@ impl ModuleIntrospector._extract_access_levels -> None {
                 self._walker_access[name] = True;
                 continue;
             }
-            # Convert Python file path to Jac file path if needed
-            # Generated Python files are in __jac_gen__ directory
-            jac_source_file = source_file;
-            if "__jac_gen__" in source_file and source_file.endswith(".py") {
-                jac_source_file = source_file.replace("__jac_gen__", "").replace(
-                    ".py", ".jac"
-                );
-            }
             # Try to get the AST from the source module
-            source_ast = get_module_ast(jac_source_file);
-            if not source_ast {
-                # Try the original path as fallback
-                source_ast = get_module_ast(source_file);
-            }
+            source_ast = get_module_ast(source_file);
             if source_ast {
                 access_level = find_walker_access_in_ast(source_ast, name);
                 if access_level is not None {

--- a/jac/tests/langserve/test_server.py
+++ b/jac/tests/langserve/test_server.py
@@ -19,11 +19,8 @@ def _clear_jac_modules() -> None:
     jac_modules_to_clear = [
         k
         for k in list(sys.modules.keys())
-        if k.startswith("__jac_gen__")
-        or (
-            not k.startswith(("jaclang", "test", "_"))
-            and hasattr(sys.modules.get(k), "__jac_mod__")
-        )
+        if not k.startswith(("jaclang", "test", "_"))
+        and hasattr(sys.modules.get(k), "__jac_mod__")
     ]
     for mod in jac_modules_to_clear:
         sys.modules.pop(mod, None)


### PR DESCRIPTION
## Summary
- Removed `__jac_gen__/` entries from `.gitignore` files (root, jac/, jac-byllm/)
- Removed `__jac_gen__` from flake8 exclusions in jac-byllm/.flake8
- Simplified `get_jac_source_info()` in helpers.py (removed dead code path)
- Simplified walker source file lookup in server.impl.jac (removed dead code path)
- Simplified `_clear_jac_modules()` in test_server.py (removed obsolete check)

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, jac-format, jac-check)
- [ ] CI tests pass