### PR TITLE
docs: fix install command from jaclang[all] to jaseci

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Jac is an innovative programming language that extends both Python and TypeScrip
 Get the complete, stable toolkit from PyPI:
 
 ```bash
-pip install jaclang[all]
+pip install jaseci
 ```
 
-This is the fastest way to get started with building applications.
+The `jaseci` package is a meta-package that bundles `jaclang`, `byllm`, `jac-client`, `jac-scale`, and `jac-super` together for convenience. This is the fastest way to get started with building applications.
 
 </details>
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -28,7 +28,9 @@ Jac is a programming language that extends Python with powerful capabilities for
 ## Quick Install
 
 ```bash
-pip install jaclang[all]
+pip install jaseci
 ```
+
+This meta-package bundles the Jac language with all plugins (`byllm`, `jac-client`, `jac-scale`, `jac-super`).
 
 [Get started now](quick-guide/index.md){ .md-button .md-button--primary }

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -23,7 +23,7 @@ Jac is a programming language that extends Python with powerful capabilities for
 ### Step 1: Install
 
 ```bash
-pip install jaclang[all]
+pip install jaseci
 ```
 
 ### Step 2: Create Your First Program

--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -14,10 +14,10 @@ Get Jac installed and ready to use in under 2 minutes.
 ## Quick Install
 
 ```bash
-pip install jaclang[all]
+pip install jaseci
 ```
 
-This installs:
+The `jaseci` package is a meta-package that bundles all Jac ecosystem packages together. This installs:
 
 - `jaclang` - The Jac language and compiler
 - `byllm` - AI/LLM integration
@@ -71,7 +71,7 @@ source jac-env/bin/activate   # Linux/Mac
 jac-env\Scripts\activate      # Windows
 
 # Install Jac
-pip install jaclang[all]
+pip install jaseci
 ```
 
 ---
@@ -166,7 +166,7 @@ export PATH="$PATH:$(python -c 'import site; print(site.USER_BASE)')/bin"
 Use `--user` flag:
 
 ```bash
-pip install --user jaclang[all]
+pip install --user jaseci
 ```
 
 ### Conflicting Packages

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -85,7 +85,7 @@ obj Person {
 
 ```bash
 # Full installation with all plugins
-pip install jaclang[all]
+pip install jaseci
 
 # Minimal installation
 pip install jaclang

--- a/docs/docs/reference/plugins/index.md
+++ b/docs/docs/reference/plugins/index.md
@@ -16,13 +16,13 @@ Jac extends its capabilities through a plugin ecosystem. These plugins provide A
 
 ## Quick Installation
 
-Install all plugins:
+Install all plugins via the `jaseci` meta-package:
 
 ```bash
-pip install jaclang[all]
+pip install jaseci
 ```
 
-Or individually:
+This bundles `jaclang` with all official plugins. Or install individually:
 
 ```bash
 pip install byllm        # AI integration

--- a/docs/docs/tutorials/ai/quickstart.md
+++ b/docs/docs/tutorials/ai/quickstart.md
@@ -8,7 +8,7 @@ Build your first AI-integrated function in Jac.
 
 ## Prerequisites
 
-- Jac installed with `pip install jaclang[all]`
+- Jac installed with `pip install jaseci`
 - An API key from OpenAI, Anthropic, or Google
 
 ---

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -9,7 +9,7 @@ Create a Jac project with frontend and backend in one codebase.
 ## Prerequisites
 
 ```bash
-pip install jaclang[all]  # Includes jac-client
+pip install jaseci  # Includes jac-client
 ```
 
 ---

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -77,7 +77,7 @@ Complete applications to study and learn from.
 
 Before starting tutorials, ensure you have:
 
-- [x] Jac installed (`pip install jaclang[all]`)
+- [x] Jac installed (`pip install jaseci`)
 - [x] Completed the [Quick Guide](../quick-guide/index.md)
 - [x] A code editor (VS Code with Jac extension recommended)
 


### PR DESCRIPTION
## Summary

- Replace all instances of `pip install jaclang[all]` with `pip install jaseci` since `jaclang[all]` is not a valid installation option (no `[all]` extra is defined in jaclang's pyproject.toml)
- Add clarifying notes explaining that `jaseci` is a meta-package bundling `jaclang`, `byllm`, `jac-client`, `jac-scale`, and `jac-super`

## Files Changed

- README.md
- docs/docs/index.md
- docs/docs/quick-guide/index.md
- docs/docs/quick-guide/install.md
- docs/docs/reference/language/foundation.md
- docs/docs/reference/plugins/index.md
- docs/docs/tutorials/ai/quickstart.md
- docs/docs/tutorials/fullstack/setup.md
- docs/docs/tutorials/index.md

## Test plan

- [x] Verify no remaining instances of `jaclang[all]` in docs
- [ ] Review documentation renders correctly