### PR TITLE
lint: enforce console abstraction over print statements

### DIFF
--- a/jac/jaclang/pycore/runtime.py
+++ b/jac/jaclang/pycore/runtime.py
@@ -1367,7 +1367,7 @@ class JacBasics:
                 )
                 ret_count = JacTestCheck.failcount
             else:
-                print("Not a .jac file.")
+                JacConsole.get_console().error("Not a .jac file.")
         else:
             directory = directory if directory else os.getcwd()
 
@@ -1387,7 +1387,9 @@ class JacBasics:
                 for file in files:
                     if file.endswith(".jac"):
                         test_file = True
-                        print(f"\n\n\t\t* Inside {root_dir}" + "/" + f"{file} *")
+                        JacConsole.get_console().info(
+                            f"\n\n\t\t* Inside {root_dir}/{file} *"
+                        )
                         JacTestCheck.reset()
                         JacRuntimeInterface.jac_import(
                             target=file[:-4], base_path=root_dir
@@ -1403,7 +1405,8 @@ class JacBasics:
             JacTestCheck.breaker = False
             ret_count += JacTestCheck.failcount
             JacTestCheck.failcount = 0
-            print("No test files found.") if not test_file else None
+            if not test_file:
+                JacConsole.get_console().warning("No test files found.")
 
         return ret_count
 
@@ -1421,7 +1424,7 @@ class JacBasics:
         if custom:
             ctx.custom = expr
         else:
-            print(expr)
+            JacConsole.get_console().print(expr)
             ctx.reports.append(expr)
 
     @staticmethod

--- a/ruff.toml
+++ b/ruff.toml
@@ -24,6 +24,7 @@ select = [
     "ANN",    # flake8-annotations
     "SIM",    # flake8-simplify
     "UP",     # pyupgrade
+    "T201",   # print statements - use console abstraction instead
 ]
 
 # TODO: Make strict: Ignore E501 (line too long) - let formatter handle code, accept long strings/comments
@@ -37,3 +38,13 @@ known-first-party = ["jaclang", "jac_client", "jac_scale", "byllm"]
 
 [lint.flake8-annotations]
 suppress-none-returning = true
+
+[lint.per-file-ignores]
+# Allow print in tests (for debugging output), scripts, and test fixtures
+"**/tests/**/*.py" = ["T201"]
+"**/fixtures/**/*.py" = ["T201"]
+"scripts/**/*.py" = ["T201"]
+"docs/scripts/**/*.py" = ["T201"]
+# Bootstrap/low-level files that run before console is available
+"jac/jaclang/compiler/__init__.py" = ["T201"]
+"jac/jaclang/pycore/tsparser.py" = ["T201"]


### PR DESCRIPTION
## Summary
- Add ruff `T201` rule to flag `print()` usage in source code
- Encourages use of the `JacConsole` abstraction for consistent output handling
- Add per-file ignores for tests, fixtures, scripts, and bootstrap files where print is acceptable
- Update `runtime.py` to use `JacConsole.get_console()` methods (`.error()`, `.info()`, `.warning()`, `.print()`)

## Test plan
- [x] Pre-commit hooks pass
- [ ] Verify `ruff check --select=T201 .` flags new print statements in source files
- [ ] Verify excluded files (tests, fixtures, scripts) are not flagged