### PR TITLE
docs: update Jac messaging and simplify run commands

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -414,8 +414,8 @@
                     </div>
                     <div class="about-text">
                         <p class="about-description">
-                            Jac is an innovative programming language that extends Python's semantics while maintaining
-                            full interoperability with the Python ecosystem. Created by <strong><a
+                            Jac is an innovative programming language and superset of both Python and TypeScript/JavaScript,
+                            providing seamless access to both the PyPI and npm ecosystems. Created by <strong><a
                                     href="https://github.com/marsninja" target="_blank"
                                     class="fancy-link">@marsninja</a></strong>
                             with contributors of <strong><a href="/communityhub/top_contributors/" target="_blank"

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,7 @@
 
 **One Language for AI-Native Full-Stack Development**
 
-Jac is a programming language that extends Python with powerful capabilities for building modern AI-powered applications. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
+Jac is a programming language and superset of both Python and TypeScript/JavaScript, with novel constructs for AI-integrated programming. Access the entire PyPI and npm ecosystems while using features like `by llm()` to seamlessly weave AI into your code. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
 
 ---
 

--- a/docs/docs/quick-guide/first-app.md
+++ b/docs/docs/quick-guide/first-app.md
@@ -109,7 +109,7 @@ with entry {
 Run it:
 
 ```bash
-jac run todo.jac
+jac todo.jac
 ```
 
 Output:

--- a/docs/docs/quick-guide/hello-world.md
+++ b/docs/docs/quick-guide/hello-world.md
@@ -17,7 +17,7 @@ with entry {
 Run it:
 
 ```bash
-jac run hello.jac
+jac hello.jac
 ```
 
 Output:

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -2,7 +2,7 @@
 
 **One Language for AI-Native Full-Stack Development**
 
-Jac is a programming language that extends Python with powerful capabilities for building modern AI-powered applications. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
+Jac is a programming language and superset of both Python and TypeScript/JavaScript, with novel constructs for AI-integrated programming. Access the entire PyPI and npm ecosystems while using features like `by llm()` to seamlessly weave AI into your code. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
 
 ---
 
@@ -15,6 +15,7 @@ Jac is a programming language that extends Python with powerful capabilities for
 | **Use existing libraries** | Full access to PyPI and npm ecosystems |
 | **Deploy without DevOps** | `jac start --scale` deploys to Kubernetes automatically |
 | **Model complex domains** | Graph-based Object-Spatial Programming for connected data |
+| **Code with AI assistance** | Clean syntax designed for both humans and AI models to read and write |
 
 ---
 
@@ -25,6 +26,16 @@ Jac is a programming language that extends Python with powerful capabilities for
 ```bash
 pip install jaclang[all]
 ```
+
+This installs the complete Jac ecosystem: `jaclang` (compiler), `byllm` (AI integration), `jac-client` (frontend), `jac-scale` (deployment), and `jac-super` (enhanced console).
+
+Verify your installation:
+
+```bash
+jac --version
+```
+
+This also warms the cache, making subsequent commands faster.
 
 ### Step 2: Create Your First Program
 
@@ -39,8 +50,10 @@ with entry {
 ### Step 3: Run It
 
 ```bash
-jac run hello.jac
+jac hello.jac
 ```
+
+Note: `jac` is shorthand for `jac run` - both work identically.
 
 **That's it!** You just ran your first Jac program.
 

--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -6,8 +6,7 @@ Get Jac installed and ready to use in under 2 minutes.
 
 ## Requirements
 
-- **Python 3.10+** (check with `python --version`)
-- **pip** (comes with Python)
+- **Python 3.12+** (check with `python --version`)
 
 ---
 
@@ -23,12 +22,15 @@ This installs:
 - `byllm` - AI/LLM integration
 - `jac-client` - Full-stack web development
 - `jac-scale` - Production deployment
+- `jac-super` - Enhanced console output
 
 Verify the installation:
 
 ```bash
 jac --version
 ```
+
+This also warms the cache, making subsequent commands faster.
 
 ---
 
@@ -130,7 +132,7 @@ with entry {
 Run it:
 
 ```bash
-jac run test.jac
+jac test.jac
 ```
 
 Expected output:

--- a/docs/docs/quick-guide/next-steps.md
+++ b/docs/docs/quick-guide/next-steps.md
@@ -59,7 +59,7 @@ cl {
 2. [Object-Spatial Programming](../tutorials/language/osp.md) - Nodes, edges, walkers
 3. [Testing](../tutorials/language/testing.md) - Write and run tests
 
-**Key concept:** Jac extends Python with graphs as first-class citizens and walkers for graph traversal.
+**Key concept:** Jac is a superset of Python and TypeScript/JavaScript, adding graphs as first-class citizens and walkers for graph traversal.
 
 ```jac
 node Person { has name: str; }

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -40,6 +40,8 @@ The Jac CLI provides commands for running, building, testing, and deploying Jac 
 
 Execute a Jac file.
 
+**Note:** `jac <file>` is shorthand for `jac run <file>` - both work identically.
+
 ```bash
 jac run [-h] [-m] [--no-main] [-c] [--no-cache] [filename]
 ```

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -16,7 +16,7 @@
 
 ### 1 What is Jac?
 
-Jac is an AI-native full-stack programming language that extends Python with Object-Spatial Programming (OSP). It provides a unified language for backend, frontend, and AI development.
+Jac is an AI-native full-stack programming language and superset of both Python and TypeScript/JavaScript. It introduces Object-Spatial Programming (OSP) and novel constructs for AI-integrated programming (such as `by llm()`), providing a unified language for backend, frontend, and AI development with full access to the PyPI and npm ecosystems.
 
 ```jac
 with entry {
@@ -113,8 +113,10 @@ with entry {
 Run it:
 
 ```bash
-jac run hello.jac
+jac hello.jac
 ```
+
+Note: `jac` is shorthand for `jac run`.
 
 ### 3 Project Structure
 

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -1,6 +1,6 @@
-## **Jac's Native Superset of Python**
+## **Jac's Native Superset of Python and TypeScript/JavaScript**
 
-Jac is designed as a superset of Python, extending the language with additional features for modern software architecture while maintaining full compatibility with the Python ecosystem. Python developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
+Jac is designed as a superset of both Python and TypeScript/JavaScript, providing full compatibility with both the PyPI and npm ecosystems. Developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
 
 ### **How it Works: Transpilation to Native Python**
 

--- a/docs/docs/tutorials/ai/quickstart.md
+++ b/docs/docs/tutorials/ai/quickstart.md
@@ -60,7 +60,7 @@ with entry {
 Run it:
 
 ```bash
-jac run hello_ai.jac
+jac hello_ai.jac
 ```
 
 **Output:**

--- a/docs/docs/tutorials/examples/index.md
+++ b/docs/docs/tutorials/examples/index.md
@@ -90,7 +90,7 @@ git clone https://github.com/Jaseci-Labs/jaseci.git
 cd jaseci/examples
 
 # Run an example
-jac run example_name/main.jac
+jac example_name/main.jac
 ```
 
 ### As API Server

--- a/docs/docs/tutorials/examples/rag-chatbot.md
+++ b/docs/docs/tutorials/examples/rag-chatbot.md
@@ -243,7 +243,7 @@ export SERPER_API_KEY=your-key  # Free at serper.dev
 Terminal 1 - Tool server:
 
 ```bash
-jac run mcp_server.jac
+jac mcp_server.jac
 ```
 
 Terminal 2 - Main application:

--- a/docs/docs/tutorials/examples/rpg.md
+++ b/docs/docs/tutorials/examples/rpg.md
@@ -240,7 +240,7 @@ with entry {
 Run it:
 
 ```bash
-jac run test_generator.jac
+jac test_generator.jac
 ```
 
 ---

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -6,9 +6,9 @@ Learn Jac syntax and fundamentals, especially if you're coming from Python.
 
 ---
 
-## Jac is a Python Superset
+## Jac is a Superset of Python and TypeScript/JavaScript
 
-Jac extends Python - all Python concepts apply. The main differences are syntactic:
+Jac extends both Python and TypeScript/JavaScript - concepts from both languages apply. The main syntactic differences from Python are:
 
 | Python | Jac |
 |--------|-----|

--- a/jac/README.md
+++ b/jac/README.md
@@ -23,7 +23,7 @@ This is the main source code repository for the [Jac] programming language. It c
 
 ## What and Why is Jac?
 
-- **Native Superset of Python** - Jac is a native superset of python, meaning the entire python ecosystem is directly interoperable with Jac without any trickery (no interop interface needed). Like Typescript is to Javascript, or C++ is to C, Jac is to Python. (every Jac program can be ejected to pure python, and every python program can be transpiled to a Jac program)
+- **Native Superset of Python and TypeScript/JavaScript** - Jac is a native superset of both Python and TypeScript/JavaScript, meaning both ecosystems (PyPI and npm) are directly interoperable with Jac without any trickery (no interop interface needed). Every Jac program can be ejected to pure Python, and Python programs can be transpiled to Jac.
 
 - **AI as a Programming Language Constructs** - Jac includes a novel (neurosymbolic) language construct that allows replacing code with generative AI models themselves. Jac's philosophy abstracts away prompt engineering. (Imagine taking a function body and swapping it out with a model.)
 

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jaclang"
 version = "0.9.9"
-description = "Jac is a unique and powerful programming language that extends Python, offering an unprecedented level of awesomenss."
+description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Update language description from "extends Python" to "superset of both Python and TypeScript/JavaScript" throughout documentation
- Add mention of novel AI constructs (`by llm()`) in key intro sections
- Clarify that `jaseci` is a meta-package bundling all ecosystem packages
- Add `jac-super` to package lists where missing
- Add `jac --version` verification step with cache warming note
- Add "Code with AI assistance" row to Why Jac table
- Simplify `jac run` to just `jac` (since run is default)
- Add note that `jac` is shorthand for `jac run`
- Update pyproject.toml description

## Files Changed

- README.md (via previous PR)
- jac/README.md
- jac/pyproject.toml
- docs/docs/index.md
- docs/docs/index.html
- docs/docs/quick-guide/index.md
- docs/docs/quick-guide/install.md
- docs/docs/quick-guide/hello-world.md
- docs/docs/quick-guide/first-app.md
- docs/docs/quick-guide/next-steps.md
- docs/docs/reference/cli/index.md
- docs/docs/reference/language/foundation.md
- docs/docs/reference/language/python-integration.md
- docs/docs/tutorials/ai/quickstart.md
- docs/docs/tutorials/language/basics.md
- docs/docs/tutorials/examples/index.md
- docs/docs/tutorials/examples/rpg.md
- docs/docs/tutorials/examples/rag-chatbot.md

## Test plan

- [ ] Review documentation renders correctly
- [ ] Verify messaging is consistent across all pages