### PR TITLE
chore: Bump version for Jaclang(`0.9.10`), byllm, Jac Client, Jac-Scale, Jac-Super and Jaseci meta package

### DIFF
--- a/docs/docs/community/release_notes/byllm.md
+++ b/docs/docs/community/release_notes/byllm.md
@@ -2,11 +2,13 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **byLLM** (formerly MTLLM). For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## byllm 0.4.15 (Unreleased)
+## byllm 0.4.16 (Unreleased)
+
+## byllm 0.4.15 (Latest Release)
 
 - **Direct HTTP model calls:** Added support for calling custom LLM endpoints via direct HTTP (`http_client` in model config).
 
-## byllm 0.4.14 (Latest Release)
+## byllm 0.4.14
 
 - **Max Iterations for ReAct (`max_react_iterations`)**: Added a configurable limit for ReAct tool-calling loops via `by llm(max_react_iterations=3)` to prevent overly long or endless reasoning cycles. When the limit is reached, the model stops calling tools and returns a final answer based on the information gathered so far.
 

--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,9 +2,13 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.2.10 (Unreleased)
+## jac-client 0.2.11 (Unreleased)
 
-## jac-client 0.2.9 (Latest Release)
+## jac-client 0.2.10 (Latest Release)
+
+- **Desktop Target Support (Tauri)**: Added multi-target build support for creating native desktop applications. Use `jac setup desktop` for one-time setup, `jac build --client desktop` to build installers, and `jac start --client desktop --dev` for development with hot reload. Supports Windows, macOS, and Linux. [Documentation](../../../jac-client/multi-targets/intro/)
+
+## jac-client 0.2.9
 
 - **Generic Config File Generation from jac.toml**: Added support for generating JavaScript config files (e.g., `postcss.config.js`, `tailwind.config.js`) directly from `jac.toml` configuration. Define configs under `[plugins.client.configs.<name>]` and they are automatically converted to `<name>.config.js` files in `.jac/client/configs/`. This eliminates the need for standalone JavaScript config files in the project root for tools like PostCSS, Tailwind (v3), ESLint, and other npm packages that use the `*.config.js` convention.
 - **Error Handling with JacClientErrorBoundary**: Introduced  error boundary handling in Jac Client apps. The new `JacClientErrorBoundary` component allows you to wrap specific parts of your component tree to catch and display errors gracefully, without affecting the entire application.

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -2,9 +2,11 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Scale**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-scale 0.1.1 (Unreleased)
+## jac-scale 0.1.2 (Unreleased)
 
-## jac-scale 0.1.0 (Latest Release)
+## jac-scale 0.1.1 (Latest Release)
+
+## jac-scale 0.1.0
 
 ### Initial Release
 

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -2,9 +2,13 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jaclang**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jaclang 0.9.10 (Unreleased)
+## jaclang 0.9.11 (Unreleased)
 
-## jaclang 0.9.9 (Latest Release)
+## jaclang 0.9.10 (Latest Release)
+
+- **Formatter Spacing Fixes**: Fixed extra spaces before semicolons in `report` and `del` statements, and corrected semantic definition formatting to properly handle dot notation and `=` operator spacing.
+
+## jaclang 0.9.9
 
 ### Breaking Changes
 

--- a/jac-byllm/pyproject.toml
+++ b/jac-byllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "byllm"
-version = "0.4.14"
+version = "0.4.15"
 description = "byLLM Provides Easy to use APIs for different LLM Providers to be used with Jaseci's Jaclang Programming Language."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["llm", "jaclang", "jaseci", "byLLM"]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.9.9",
+    "jaclang>=0.9.10",
     "litellm>=1.75.5.post1,<1.80.0",
     "loguru>=0.7.2,<0.8.0",
     "pillow>=10.4.0,<10.5.0",

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.2.9"
+version = "0.2.10"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.9",
+    "jaclang>=0.9.10",
 ]
 
 [project.urls]

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jac-scale"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.9",
+    "jaclang>=0.9.10",
     "python-dotenv>=1.2.1,<2.0.0",
     "docker>=7.1.0,<8.0.0",
     "kubernetes>=34.1.0,<35.0.0",

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaclang"
-version = "0.9.9"
+version = "0.9.10"
 description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]

--- a/jaseci-package/pyproject.toml
+++ b/jaseci-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaseci"
-version = "2.2.7"
+version = "2.2.8"
 description = "Jaseci - A complete AI-native programming ecosystem with Jac language, LLM integration, and full-stack web apps"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -22,10 +22,10 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.9.9",
-    "byllm>=0.4.14",
-    "jac-client>=0.2.9",
-    "jac-scale>=0.1.0",
+    "jaclang>=0.9.10",
+    "byllm>=0.4.15",
+    "jac-client>=0.2.10",
+    "jac-scale>=0.1.1",
     "jac-super>=0.1.0",
 ]
 


### PR DESCRIPTION
## **Description**

This PR bumps version numbers across all packages to align with Jaclang 0.9.10.

| Package | Previous Version | New Version |
|---------|-----------------|-------------|
| **jaclang** | 0.9.9 | 0.9.10 |
| **jac-client** | 0.2.9 | 0.2.10 |
| **jac-scale** | 0.1.0 | 0.1.1 |
| **byllm** | 0.4.14 | 0.4.15 |
| **jaseci** | 2.2.7 | 2.2.8 |
| **jac-super** | 0.1.0 | 0.1.0 (no change) |


