### PR TITLE
feat(jac-client): stream npm/vite output to terminal

### DIFF
--- a/jac-client/jac_client/plugin/plugin_config.jac
+++ b/jac-client/jac_client/plugin/plugin_config.jac
@@ -239,14 +239,10 @@ def _post_create_client(project_path: Path, project_name: str) -> None {
 
         # Run npm install using NodeInstaller to handle NVM environment
         try {
-            console.print("  Installing npm packages...", style="cyan");
-            with console.status(
-                "[cyan]Installing npm packages...[/cyan]", spinner="dots"
-            ) as status {
-                NodeInstaller.run_npm_with_nvm(
-                    ['install'], cwd=client_dir, timeout=300
-                );
-            }
+            console.print("\n  ⏳ Installing npm packages...\n", style="cyan");
+            NodeInstaller.run_npm_with_nvm(
+                ['install', '--progress'], cwd=client_dir, timeout=300
+            );
 
             # Move package-lock.json to configs/ if it was created
             build_package_lock = client_dir / 'package-lock.json';

--- a/jac-client/jac_client/plugin/src/impl/package_installer.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/package_installer.impl.jac
@@ -46,15 +46,19 @@ impl PackageInstaller._regenerate_and_install(self: PackageInstaller) -> None {
     bundler._ensure_root_package_json();
     try {
         # Run npm install to actually install the packages
-        subprocess.run(
-            ['npm', 'install'],
+        print("\n  ⏳ Installing npm packages...\n", flush=True);
+        result = subprocess.run(
+            ['npm', 'install', '--progress'],
             cwd=self.project_dir,
-            check=True,
-            capture_output=True,
+            check=False,
             text=True
         );
-    } except subprocess.CalledProcessError as e {
-        raise ClientBundleError(f'Failed to install npm packages: {e.stderr}') from e ;
+        if result.returncode != 0 {
+            raise ClientBundleError(
+                'Failed to install npm packages (see output above)'
+            ) ;
+        }
+        print("\n  ✔ npm packages installed", flush=True);
     } except FileNotFoundError {
         raise ClientBundleError(
             'npm command not found. Ensure Node.js and npm are installed.'

--- a/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
@@ -400,16 +400,12 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
             }
             try {
                 # Install to .jac/client/node_modules with progress feedback
-                print(
-                    "  ⏳ Installing npm dependencies (this may take a minute)...",
-                    flush=True
-                );
+                print("\n  ⏳ Installing npm dependencies...\n", flush=True);
                 start_time = time.time();
                 result = subprocess.run(
                     ['npm', 'install', '--progress'],
                     cwd=build_dir,
                     check=False,
-                    capture_output=True,
                     text=True
                 );
                 elapsed = time.time() - start_time;
@@ -418,12 +414,9 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
                         f"\n  ✖ npm install failed after {elapsed:.1f}s",
                         file=sys.stderr
                     );
-                    raise ClientBundleError(
-                        f"Failed to install npm dependencies: {result.stderr
-                        or result.stdout}"
-                    ) ;
+                    raise ClientBundleError("Failed to install npm dependencies") ;
                 }
-                print(f"  ✔ Dependencies installed ({elapsed:.1f}s)", flush=True);
+                print(f"\n  ✔ Dependencies installed ({elapsed:.1f}s)", flush=True);
             } except FileNotFoundError {
                 raise None from ClientBundleError(
                     'npm command not found. Ensure Node.js and npm are installed.'
@@ -448,20 +441,17 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
             command = ['npm', 'run', 'build'];
         }
         # Run vite from client build directory so it can find node_modules
-        print("  ⏳ Building client bundle...", flush=True);
+        print("\n  ⏳ Building client bundle...\n", flush=True);
         start_time = time.time();
-        result = subprocess.run(
-            command, cwd=build_dir, check=False, capture_output=True, text=True
-        );
+        result = subprocess.run(command, cwd=build_dir, check=False, text=True);
         elapsed = time.time() - start_time;
         if result.returncode != 0 {
             print(f"\n  ✖ Vite build failed after {elapsed:.1f}s", file=sys.stderr);
-            error_msg = result.stderr or result.stdout or 'Unknown error';
             raise ClientBundleError(
-                f"Vite build failed:\n{error_msg}\nCommand: {' '.join(command)}"
+                f"Vite build failed (see output above)\nCommand: {' '.join(command)}"
             ) from None ;
         }
-        print(f"  ✔ Client bundle built ({elapsed:.1f}s)", flush=True);
+        print(f"\n  ✔ Client bundle built ({elapsed:.1f}s)", flush=True);
     } finally {
         # Clean up temporary package.json in client build dir
         build_package_json = build_dir / 'package.json';
@@ -658,30 +648,19 @@ impl ViteBundler.start_dev_server(self: ViteBundler, port: int = 3000) -> Any {
             shutil.copy2(generated_package_json, build_package_json);
         }
         try {
-            print(
-                "  ⏳ Installing npm dependencies (this may take a minute)...",
-                flush=True
-            );
+            print("\n  ⏳ Installing npm dependencies...\n", flush=True);
             start_time = time.time();
             result = subprocess.run(
-                ['npm', 'install', '--progress'],
-                cwd=build_dir,
-                check=False,
-                capture_output=True,
-                text=True
+                ['npm', 'install', '--progress'], cwd=build_dir, check=False, text=True
             );
             elapsed = time.time() - start_time;
             if result.returncode != 0 {
                 print(
                     f"\n  ✖ npm install failed after {elapsed:.1f}s", file=sys.stderr
                 );
-                print(f"  Error: {result.stderr or result.stdout}", file=sys.stderr);
-                raise ClientBundleError(
-                    f"Failed to install npm dependencies: {result.stderr
-                    or result.stdout}"
-                ) ;
+                raise ClientBundleError("Failed to install npm dependencies") ;
             }
-            print(f"  ✔ Dependencies installed ({elapsed:.1f}s)", flush=True);
+            print(f"\n  ✔ Dependencies installed ({elapsed:.1f}s)", flush=True);
         } finally {
             # Clean up temp package.json
             if build_package_json.exists() {

--- a/jac-client/jac_client/plugin/utils/impl/node_installer.impl.jac
+++ b/jac-client/jac_client/plugin/utils/impl/node_installer.impl.jac
@@ -224,12 +224,7 @@ impl NodeInstaller.run_npm_with_nvm(
     # First, try running npm directly (in case it's already in PATH)
     try {
         return subprocess.run(
-            ['npm'] + args,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=True
+            ['npm'] + args, cwd=cwd, text=True, timeout=timeout, check=True
         );
     } except FileNotFoundError { }
     # If npm is not in PATH, source NVM and run npm in a subprocess
@@ -239,11 +234,6 @@ impl NodeInstaller.run_npm_with_nvm(
         'export NVM_DIR="$HOME/.nvm"\n' + '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"\n' + f'npm {args_str}\n'
     );
     return subprocess.run(
-        ['bash', '-c', command],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=True
+        ['bash', '-c', command], cwd=cwd, text=True, timeout=timeout, check=True
     );
 }


### PR DESCRIPTION
## Summary
- Remove `capture_output=True` from npm/vite subprocess calls so output streams to terminal
- Add status messages before long-running operations for better user feedback
- Users can now see npm install progress, warnings, and Vite build details in real-time

## Test plan
- [x] Run `jac create testproj --use fullstack` and verify npm install output is visible
- [x] Run `jac start --dev` and verify Vite dev server output is visible
- [x] Run `jac build` and verify Vite build output (transforming, modules, chunk sizes) is visible