### PR TITLE
feat(jac-client): add bun package manager support

### DIFF
--- a/jac-client/README.md
+++ b/jac-client/README.md
@@ -146,8 +146,10 @@ cl {
 ## Requirements
 
 - Python: 3.12+
-- Node.js: For npm and Vite
+- Node.js and package manager: bun (recommended) or npm for Vite bundling
 - Jac Language: `jaclang` (installed automatically)
+
+> **Note**: jac-client automatically detects and uses bun if available, otherwise falls back to npm. Set `JAC_CLIENT_PACKAGE_MANAGER=npm` or `JAC_CLIENT_PACKAGE_MANAGER=bun` to override.
 
 ---
 

--- a/jac-client/jac_client/docs/advance/package-management.md
+++ b/jac-client/jac_client/docs/advance/package-management.md
@@ -10,6 +10,26 @@ Jac Client integrates with the core Jac package management system:
 - Uses `[dependencies.npm]` and `[dependencies.npm.dev]` sections
 - Automatically generates `package.json` from your configuration
 - Integrates seamlessly with the build system
+- **Supports both bun and npm** - automatically detects and uses bun if available, falls back to npm
+
+## Package Manager Selection
+
+Jac Client automatically detects your preferred package manager:
+
+1. **bun** (recommended) - Used if installed, faster installs
+2. **npm** - Fallback if bun is not available
+
+### Override Package Manager
+
+Set the `JAC_CLIENT_PACKAGE_MANAGER` environment variable:
+
+```bash
+# Force npm even if bun is installed
+JAC_CLIENT_PACKAGE_MANAGER=npm jac add --npm lodash
+
+# Force bun (will error if not installed)
+JAC_CLIENT_PACKAGE_MANAGER=bun jac add --npm lodash
+```
 
 ## Quick Start
 
@@ -124,7 +144,7 @@ JacClientConfig reads from jac.toml
     ↓
 ViteBundler generates package.json
     ↓
-npm install installs packages
+bun/npm install installs packages
 ```
 
 ### Generated Files
@@ -325,15 +345,17 @@ sass = "^1.77.8"
 - Check npm registry is accessible
 - Ensure you have internet connection
 
-### npm Command Not Found
+### Package Manager Not Found
 
-**Problem**: `npm command not found` error.
+**Problem**: `bun command not found` or `npm command not found` error.
 
 **Solution**:
 
-- Ensure Node.js and npm are installed
-- Verify npm is in your PATH
+- Install bun: `curl -fsSL https://bun.sh/install | bash` (recommended)
+- Or ensure Node.js and npm are installed
+- Verify the package manager is in your PATH: `bun --version` or `npm --version`
 - Check Node.js version: `node --version`
+- Override with: `JAC_CLIENT_PACKAGE_MANAGER=npm jac add --npm`
 
 ### Config Not Applied
 

--- a/jac-client/jac_client/plugin/src/babel_processor.jac
+++ b/jac-client/jac_client/plugin/src/babel_processor.jac
@@ -4,6 +4,7 @@ import from pathlib { Path }
 import from jaclang.runtimelib.client_bundle { ClientBundleError }
 import from .asset_processor { AssetProcessor }
 import from .vite_bundler { ViteBundler }
+import from ..utils.package_manager { PackageManager }
 
 """Handles Babel compilation of JavaScript files."""
 class BabelProcessor {

--- a/jac-client/jac_client/plugin/src/impl/babel_processor.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/babel_processor.impl.jac
@@ -10,17 +10,18 @@ impl BabelProcessor.copy_assets_after_compile(
     asset_processor.copy_typescript_files(compiled_dir, build_dir);
 }
 
-"""Run Babel compilation (npm run compile)."""
+"""Run Babel compilation."""
 impl BabelProcessor.compile(self: BabelProcessor) -> None {
     bundler = ViteBundler(self.project_dir);
-    # Ensure root package.json exists temporarily for npm commands
+    # Ensure root package.json exists temporarily for package manager commands
     bundler._ensure_root_package_json();
     try {
         # Ensure dependencies are installed (check if node_modules exists)
         client_dir = bundler._get_client_dir();
         node_modules = client_dir / 'node_modules';
+        pm = PackageManager.get_preferred();
         if not node_modules.exists() {
-            # Temporarily copy package.json to .jac/client/ for npm install
+            # Temporarily copy package.json to .jac/client/ for install
             build_package_json = client_dir / 'package.json';
             configs_package_json = client_dir / 'configs' / 'package.json';
             if configs_package_json.exists() and not build_package_json.exists() {
@@ -30,36 +31,34 @@ impl BabelProcessor.compile(self: BabelProcessor) -> None {
             try {
                 # Install to .jac/client/node_modules
                 subprocess.run(
-                    ['npm', 'install'],
+                    PackageManager.get_install_cmd(),
                     cwd=client_dir,
                     check=True,
                     capture_output=True,
                     text=True
                 );
             } except subprocess.CalledProcessError as e {
-                raise ClientBundleError(
-                    f'Failed to install npm dependencies: {e.stderr}'
-                ) from e ;
+                raise ClientBundleError(f'Failed to install dependencies: {e.stderr}') from e ;
             } except FileNotFoundError {
                 raise ClientBundleError(
-                    'npm command not found. Ensure Node.js and npm are installed.'
+                    f'{pm} command not found. Ensure Node.js and {pm} are installed.'
                 ) from None ;
             }
         }
 
-        # Temporarily copy package.json to .jac/client/ for npm run compile
+        # Temporarily copy package.json to .jac/client/ for compile
         build_package_json = client_dir / 'package.json';
         configs_package_json = client_dir / 'configs' / 'package.json';
         if configs_package_json.exists() and not build_package_json.exists() {
             import shutil;
             shutil.copy2(configs_package_json, build_package_json);
         }
-        command = ['npm', 'run', 'compile'];
+        command = PackageManager.get_run_cmd('compile');
         result = subprocess.run(
             command, cwd=client_dir, capture_output=True, text=True
         );
         if result.returncode != 0 {
-            # Show the actual error from npm/babel
+            # Show the actual error from package manager/babel
             error_output = result.stderr or result.stdout or "Unknown error";
             raise RuntimeError(f"Client bundle compilation failed:\n{error_output}") ;
         }

--- a/jac-client/jac_client/plugin/src/impl/package_installer.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/package_installer.impl.jac
@@ -33,39 +33,41 @@ impl PackageInstaller.uninstall_package(
     }
     # Save the updated config
     self.config_loader.save();
-    # Regenerate package.json and run npm install to actually remove the package
+    # Regenerate package.json and run install to actually remove the package
     self._regenerate_and_install();
 }
 
-"""Regenerate package.json from jac.toml and run npm install."""
+"""Regenerate package.json from jac.toml and run package install."""
 impl PackageInstaller._regenerate_and_install(self: PackageInstaller) -> None {
     # Regenerate package.json from updated jac.toml
     bundler = ViteBundler(self.project_dir);
     bundler.create_package_json();
-    # Ensure root package.json exists temporarily for npm commands
+    # Ensure root package.json exists temporarily for package manager commands
     bundler._ensure_root_package_json();
     try {
-        # Run npm install to actually install the packages
+        # Run install using preferred package manager (bun or npm)
+        pm = PackageManager.get_preferred();
         subprocess.run(
-            ['npm', 'install'],
+            PackageManager.get_install_cmd(),
             cwd=self.project_dir,
             check=True,
             capture_output=True,
             text=True
         );
     } except subprocess.CalledProcessError as e {
-        raise ClientBundleError(f'Failed to install npm packages: {e.stderr}') from e ;
+        raise ClientBundleError(f'Failed to install packages: {e.stderr}') from e ;
     } except FileNotFoundError {
+        pm = PackageManager.get_preferred();
         raise ClientBundleError(
-            'npm command not found. Ensure Node.js and npm are installed.'
+            f'{pm} command not found. Ensure Node.js and {pm} are installed.'
         ) from None ;
     } finally {
-        # Always clean up root package.json and move package-lock.json
+        # Always clean up root package.json and move lock file
         bundler._cleanup_root_package_files();
     }
 }
 
-"""Install all packages from jac.toml (regenerate package.json and run npm install)."""
+"""Install all packages from jac.toml (regenerate package.json and run install)."""
 impl PackageInstaller.install_all(self: PackageInstaller) -> None {
     if not self.config_file.exists() {
         raise ClientBundleError(
@@ -93,7 +95,7 @@ impl PackageInstaller.install_package(
     self.config_loader.add_dependency(package_name, package_version, is_dev);
     # Save the updated config
     self.config_loader.save();
-    # Regenerate package.json and install the package via npm
+    # Regenerate package.json and install the package
     self._regenerate_and_install();
 }
 

--- a/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
@@ -44,8 +44,10 @@ impl ViteBundler.create_package_json(
     }
     dependencies = package_config.get('dependencies', {});
     dev_dependencies = package_config.get('devDependencies', {});
+    # Use detected package manager for build script
+    pm = PackageManager.get_preferred();
     scripts = {
-        'build': 'npm run compile && vite build --config .jac/client/configs/vite.config.js',
+        'build': f'{pm} run compile && vite build --config .jac/client/configs/vite.config.js',
         'dev': 'vite dev --config .jac/client/configs/vite.config.js',
         'preview': 'vite preview --config .jac/client/configs/vite.config.js',
         'compile': 'babel compiled --out-dir build --extensions ".jsx,.js" --out-file-extension .js'
@@ -154,7 +156,7 @@ impl ViteBundler._cleanup_root_package_files(self: ViteBundler) -> None {
 }
 
 """
-Ensure root package.json exists temporarily for npm commands.
+Ensure root package.json exists temporarily for package manager commands.
 
         Create root package.json temporarily if it doesn't exist.
 """
@@ -391,7 +393,7 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
         build_dir = self._get_client_dir();
         node_modules = build_dir / 'node_modules';
         if not node_modules.exists() {
-            # Temporarily copy package.json to client build dir for npm install
+            # Temporarily copy package.json to client build dir for install
             build_package_json = build_dir / 'package.json';
             configs_package_json = build_dir / 'configs' / 'package.json';
             if configs_package_json.exists() and not build_package_json.exists() {
@@ -400,13 +402,19 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
             }
             try {
                 # Install to .jac/client/node_modules with progress feedback
+                pm = PackageManager.get_preferred();
                 print(
-                    "  ⏳ Installing npm dependencies (this may take a minute)...",
+                    f"  ⏳ Installing dependencies with {pm} (this may take a minute)...",
                     flush=True
                 );
                 start_time = time.time();
+                # bun doesn't need --progress flag
+                install_cmd = PackageManager.get_install_cmd();
+                if pm == 'npm' {
+                    install_cmd.append('--progress');
+                }
                 result = subprocess.run(
-                    ['npm', 'install', '--progress'],
+                    install_cmd,
                     cwd=build_dir,
                     check=False,
                     capture_output=True,
@@ -415,37 +423,45 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
                 elapsed = time.time() - start_time;
                 if result.returncode != 0 {
                     print(
-                        f"\n  ✖ npm install failed after {elapsed:.1f}s",
+                        f"\n  ✖ {pm} install failed after {elapsed:.1f}s",
                         file=sys.stderr
                     );
                     raise ClientBundleError(
-                        f"Failed to install npm dependencies: {result.stderr
+                        f"Failed to install dependencies: {result.stderr
                         or result.stdout}"
                     ) ;
                 }
                 print(f"  ✔ Dependencies installed ({elapsed:.1f}s)", flush=True);
             } except FileNotFoundError {
+                pm = PackageManager.get_preferred();
                 raise None from ClientBundleError(
-                    'npm command not found. Ensure Node.js and npm are installed.'
+                    f'{pm} command not found. Ensure Node.js and {pm} are installed.'
                 ) ;
             }
         }
+        exec_cmd = PackageManager.get_exec_cmd();
         if self.config_path {
             # Make config path relative to build_dir (where vite runs from)
             try {
                 config_rel = self.config_path.relative_to(build_dir);
-                command = ['npx', 'vite', 'build', '--config', str(config_rel)];
+                command = [exec_cmd, 'vite', 'build', '--config', str(config_rel)];
             } except ValueError {
                 # Config is outside client build dir, use absolute path
-                command = ['npx', 'vite', 'build', '--config', str(self.config_path)];
+                command = [
+                    exec_cmd,
+                    'vite',
+                    'build',
+                    '--config',
+                    str(self.config_path)
+                ];
             }
         } elif entry_file {
             generated_config = self.create_vite_config(entry_file);
             # Config is in configs/, make it relative to build_dir
             config_rel = generated_config.relative_to(build_dir);
-            command = ['npx', 'vite', 'build', '--config', str(config_rel)];
+            command = [exec_cmd, 'vite', 'build', '--config', str(config_rel)];
         } else {
-            command = ['npm', 'run', 'build'];
+            command = PackageManager.get_run_cmd('build');
         }
         # Run vite from client build directory so it can find node_modules
         print("  ⏳ Building client bundle...", flush=True);
@@ -652,33 +668,34 @@ impl ViteBundler.start_dev_server(self: ViteBundler, port: int = 3000) -> Any {
         if not generated_package_json.exists() {
             self.create_package_json();
         }
-        # Temporarily copy package.json for npm install
+        # Temporarily copy package.json for install
         build_package_json = build_dir / 'package.json';
         if not build_package_json.exists() {
             shutil.copy2(generated_package_json, build_package_json);
         }
         try {
+            pm = PackageManager.get_preferred();
             print(
-                "  ⏳ Installing npm dependencies (this may take a minute)...",
+                f"  ⏳ Installing dependencies with {pm} (this may take a minute)...",
                 flush=True
             );
             start_time = time.time();
+            # bun doesn't need --progress flag
+            install_cmd = PackageManager.get_install_cmd();
+            if pm == 'npm' {
+                install_cmd.append('--progress');
+            }
             result = subprocess.run(
-                ['npm', 'install', '--progress'],
-                cwd=build_dir,
-                check=False,
-                capture_output=True,
-                text=True
+                install_cmd, cwd=build_dir, check=False, capture_output=True, text=True
             );
             elapsed = time.time() - start_time;
             if result.returncode != 0 {
                 print(
-                    f"\n  ✖ npm install failed after {elapsed:.1f}s", file=sys.stderr
+                    f"\n  ✖ {pm} install failed after {elapsed:.1f}s", file=sys.stderr
                 );
                 print(f"  Error: {result.stderr or result.stdout}", file=sys.stderr);
                 raise ClientBundleError(
-                    f"Failed to install npm dependencies: {result.stderr
-                    or result.stdout}"
+                    f"Failed to install dependencies: {result.stderr or result.stdout}"
                 ) ;
             }
             print(f"  ✔ Dependencies installed ({elapsed:.1f}s)", flush=True);
@@ -699,8 +716,9 @@ impl ViteBundler.start_dev_server(self: ViteBundler, port: int = 3000) -> Any {
     config_rel = dev_config.relative_to(build_dir);
     logger.debug(f"Starting Vite dev server on port {port}");
     # Start Vite in dev mode (let output go to terminal for HMR visibility)
+    exec_cmd = PackageManager.get_exec_cmd();
     process = subprocess.Popen(
-        ['npx', 'vite', '--config', str(config_rel), '--port', str(port)],
+        [exec_cmd, 'vite', '--config', str(config_rel), '--port', str(port)],
         cwd=build_dir
     );
     return process;

--- a/jac-client/jac_client/plugin/src/package_installer.jac
+++ b/jac-client/jac_client/plugin/src/package_installer.jac
@@ -6,6 +6,7 @@ import from pathlib { Path }
 import from jaclang.runtimelib.client_bundle { ClientBundleError }
 import from .config_loader { JacClientConfig }
 import from .vite_bundler { ViteBundler }
+import from ..utils.package_manager { PackageManager }
 
 class PackageInstaller {
     def init(self: PackageInstaller, project_dir: Path);

--- a/jac-client/jac_client/plugin/src/targets/desktop_target.jac
+++ b/jac-client/jac_client/plugin/src/targets/desktop_target.jac
@@ -5,6 +5,7 @@ This target will be implemented in Phase 2.
 import from pathlib { Path }
 import from typing { Optional }
 import from jac_client.plugin.src.targets.registry { ClientTarget }
+import from jac_client.plugin.utils.package_manager { PackageManager }
 
 """Desktop build target (placeholder for Phase 2)."""
 class DesktopTarget(ClientTarget) {

--- a/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
+++ b/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
@@ -1297,17 +1297,18 @@ def _check_and_install_tauri_cli -> None {
         }
     } except Exception { }
 
-    # Check if npm tauri CLI is available
-    npm_tauri_ok = False;
+    # Check if package manager (bun/npm) tauri CLI is available
+    pm = PackageManager.get_preferred();
+    pm_tauri_ok = False;
     try {
         result = subprocess.run(
-            ["npm", "list", "-g", "@tauri-apps/cli"],
+            PackageManager.get_global_list_cmd() + ["@tauri-apps/cli"],
             capture_output=True,
             text=True,
             timeout=5
         );
         if result.returncode == 0 {
-            console.print("  ✔ Tauri CLI found (npm)", style="success");
+            console.print(f"  ✔ Tauri CLI found ({pm})", style="success");
             return;
         }
     } except Exception { }
@@ -1327,23 +1328,17 @@ def _check_and_install_tauri_cli -> None {
         cargo_available = True;
     } except Exception { }
 
-    # Check if npm is available
-    npm_available = False;
-    try {
-        subprocess.run(
-            ["npm", "--version"], capture_output=True, check=True, timeout=5
-        );
-        npm_available = True;
-    } except Exception { }
+    # Check if package manager (bun/npm) is available
+    pm_available = PackageManager.is_bun_installed()
+    or PackageManager.is_npm_installed();
 
-    if not cargo_available and not npm_available {
+    if not cargo_available and not pm_available {
         console.print(
-            "  Neither cargo nor npm is available. Cannot install Tauri CLI automatically.",
+            "  Neither cargo nor bun/npm is available. Cannot install Tauri CLI automatically.",
             style="muted"
         );
         console.print(
-            "  Please install Rust (for cargo) or Node.js (for npm) first.",
-            style="muted"
+            "  Please install Rust (for cargo) or Node.js/bun first.", style="muted"
         );
         return;
     }
@@ -1365,17 +1360,17 @@ def _check_and_install_tauri_cli -> None {
                     console.print("  ✔ Tauri CLI installed", style="success");
                     return;
                 } else {
-                    console.warning("  Failed to install via cargo. Trying npm...");
+                    console.warning(f"  Failed to install via cargo. Trying {pm}...");
                 }
             } except Exception as e {
                 console.warning(f"  Error installing via cargo: {e}");
             }
         }
-        if npm_available {
-            console.print("  Installing Tauri CLI via npm...", style="muted");
+        if pm_available {
+            console.print(f"  Installing Tauri CLI via {pm}...", style="muted");
             try {
                 result = subprocess.run(
-                    ["npm", "install", "-g", "@tauri-apps/cli"],
+                    PackageManager.get_global_add_cmd("@tauri-apps/cli"),
                     check=False,
                     timeout=300,
                     capture_output=False  # Show output
@@ -1384,18 +1379,22 @@ def _check_and_install_tauri_cli -> None {
                     console.print("  ✔ Tauri CLI installed", style="success");
                     return;
                 } else {
-                    console.warning("  Failed to install via npm");
+                    console.warning(f"  Failed to install via {pm}");
                 }
             } except Exception as e {
-                console.warning(f"  Error installing via npm: {e}");
+                console.warning(f"  Error installing via {pm}: {e}");
             }
         }
         console.print("  Please install manually:", style="muted");
         if cargo_available {
             console.print("    cargo install tauri-cli", style="muted");
         }
-        if npm_available {
-            console.print("    npm install -g @tauri-apps/cli", style="muted");
+        if pm_available {
+            if pm == 'bun' {
+                console.print("    bun add -g @tauri-apps/cli", style="muted");
+            } else {
+                console.print("    npm install -g @tauri-apps/cli", style="muted");
+            }
         }
     } else {
         console.print("  Skipping Tauri CLI installation.", style="muted");
@@ -1405,8 +1404,12 @@ def _check_and_install_tauri_cli -> None {
         if cargo_available {
             console.print("    cargo install tauri-cli", style="muted");
         }
-        if npm_available {
-            console.print("    npm install -g @tauri-apps/cli", style="muted");
+        if pm_available {
+            if pm == 'bun' {
+                console.print("    bun add -g @tauri-apps/cli", style="muted");
+            } else {
+                console.print("    npm install -g @tauri-apps/cli", style="muted");
+            }
         }
     }
 }
@@ -1846,22 +1849,23 @@ def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
         target = "x86_64-unknown-linux-gnu";
     }
 
-    # Build command
-    build_cmd = ["npm", "run", "tauri", "build"];
+    # Build command using preferred package manager
+    pm = PackageManager.get_preferred();
+    build_cmd = PackageManager.get_run_cmd("tauri") + ["build"];
     if target {
         build_cmd.extend(["--", "--client", target]);
     }
 
     # Check if package.json has tauri scripts, if not, use cargo directly
     package_json = tauri_dir.parent / "package.json";
-    use_npm = False;
+    use_pm = False;
     if package_json.exists() {
         try {
             with open(package_json, "r") as f {
                 package_data = json.load(f);
                 scripts = package_data.get("scripts", {});
                 if "tauri" in scripts or "tauri:build" in scripts {
-                    use_npm = True;
+                    use_pm = True;
                 }
             }
         } except Exception {
@@ -1869,7 +1873,7 @@ def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
         }
     }
 
-    if not use_npm {
+    if not use_pm {
         # Use cargo tauri build directly
         build_cmd = ["cargo", "tauri", "build"];
         if target {
@@ -2199,6 +2203,7 @@ def _run_tauri_dev(tauri_dir: Path) -> subprocess.Popen {
     }
 
     # Check if tauri CLI is available via cargo
+    pm = PackageManager.get_preferred();
     try {
         subprocess.run(
             ["cargo", "tauri", "--version"], capture_output=True, check=True, timeout=5
@@ -2210,32 +2215,41 @@ def _run_tauri_dev(tauri_dir: Path) -> subprocess.Popen {
     ) {
         console.warning("Tauri CLI not found.");
         console.print("  Install manually: cargo install tauri-cli", style="muted");
-        console.print("  Or use npm: npm install -D @tauri-apps/cli", style="muted");
+        if pm == 'bun' {
+            console.print("  Or use bun: bun add -D @tauri-apps/cli", style="muted");
+        } else {
+            console.print(
+                "  Or use npm: npm install -D @tauri-apps/cli", style="muted"
+            );
+        }
+        install_hint = "bun add -D @tauri-apps/cli"
+        if pm == 'bun'
+        else "npm install -D @tauri-apps/cli";
         raise RuntimeError(
-            "Tauri CLI not installed. Install it first:\n"
-            "  cargo install tauri-cli\n"
-            "  Or: npm install -D @tauri-apps/cli"
+            f"Tauri CLI not installed. Install it first:\n"
+            f"  cargo install tauri-cli\n"
+            f"  Or: {install_hint}"
         ) ;
     }
 
     # Check if package.json has tauri scripts
     package_json = tauri_dir.parent / "package.json";
-    use_npm = False;
+    use_pm = False;
     if package_json.exists() {
         try {
             with open(package_json, "r") as f {
                 package_data = json.load(f);
                 scripts = package_data.get("scripts", {});
                 if "tauri" in scripts or "tauri:dev" in scripts {
-                    use_npm = True;
+                    use_pm = True;
                 }
             }
         } except Exception { }
     }
 
-    if use_npm {
-        # Use npm run tauri dev
-        dev_cmd = ["npm", "run", "tauri", "dev"];
+    if use_pm {
+        # Use package manager to run tauri dev
+        dev_cmd = PackageManager.get_run_cmd("tauri") + ["dev"];
     } else {
         # Use cargo tauri dev directly
         dev_cmd = ["cargo", "tauri", "dev"];

--- a/jac-client/jac_client/plugin/src/vite_bundler.jac
+++ b/jac-client/jac_client/plugin/src/vite_bundler.jac
@@ -8,6 +8,7 @@ import from pathlib { Path }
 import from typing { Any, Optional }
 import from jaclang.runtimelib.client_bundle { ClientBundleError }
 import from .config_loader { JacClientConfig }
+import from ..utils.package_manager { PackageManager }
 
 glob logger = logging.getLogger(__name__);
 """Handles Vite bundling operations."""

--- a/jac-client/jac_client/plugin/utils/impl/node_installer.impl.jac
+++ b/jac-client/jac_client/plugin/utils/impl/node_installer.impl.jac
@@ -1,4 +1,4 @@
-"""Implementation of Node.js installer methods."""
+"""Implementation of Node.js and bun installer methods."""
 
 """Check if Node.js is installed and accessible."""
 impl NodeInstaller.is_node_installed -> bool {
@@ -24,6 +24,33 @@ impl NodeInstaller.is_npm_installed -> bool {
     }
 }
 
+"""Check if bun is installed and accessible."""
+impl NodeInstaller.is_bun_installed -> bool {
+    try {
+        result = subprocess.run(
+            ['bun', '--version'], capture_output=True, text=True, timeout=5
+        );
+        return result.returncode == 0;
+    } except (FileNotFoundError, subprocess.TimeoutExpired) {
+        # Also check common bun install location
+        bun_path = Path.home() / '.bun' / 'bin' / 'bun';
+        if bun_path.exists() {
+            try {
+                result = subprocess.run(
+                    [str(bun_path), '--version'],
+                    capture_output=True,
+                    text=True,
+                    timeout=5
+                );
+                return result.returncode == 0;
+            } except (FileNotFoundError, subprocess.TimeoutExpired) {
+                return False;
+            }
+        }
+        return False;
+    }
+}
+
 """Check if NVM is installed."""
 impl NodeInstaller.is_nvm_installed -> bool {
     nvm_dir = Path.home() / '.nvm';
@@ -40,6 +67,35 @@ impl NodeInstaller.get_node_version -> (str | None) {
             return result.stdout.strip();
         }
     } except (FileNotFoundError, subprocess.TimeoutExpired) { }
+    return None;
+}
+
+"""Get the currently installed bun version."""
+impl NodeInstaller.get_bun_version -> (str | None) {
+    try {
+        result = subprocess.run(
+            ['bun', '--version'], capture_output=True, text=True, timeout=5
+        );
+        if result.returncode == 0 {
+            return result.stdout.strip();
+        }
+    } except (FileNotFoundError, subprocess.TimeoutExpired) {
+        # Also check common bun install location
+        bun_path = Path.home() / '.bun' / 'bin' / 'bun';
+        if bun_path.exists() {
+            try {
+                result = subprocess.run(
+                    [str(bun_path), '--version'],
+                    capture_output=True,
+                    text=True,
+                    timeout=5
+                );
+                if result.returncode == 0 {
+                    return result.stdout.strip();
+                }
+            } except (FileNotFoundError, subprocess.TimeoutExpired) { }
+        }
+    }
     return None;
 }
 
@@ -98,6 +154,65 @@ impl NodeInstaller.install_nvm -> tuple[bool, str] {
         return (False, f'Required command not found: {e}');
     } except Exception as e {
         return (False, f'Unexpected error during NVM installation: {e}');
+    }
+}
+
+"""Install bun using the official install script."""
+impl NodeInstaller.install_bun -> tuple[bool, str] {
+    system = platform.system();
+    if system == 'Windows' {
+        return (
+            False,
+            'Windows detected. Please install bun manually:\n' + '  Run in PowerShell: irm bun.sh/install.ps1 | iex\n' + '  Or download from: https://bun.sh/\n' + '  After installation, run your command again.'
+        );
+    }
+    print('Installing bun...');
+    try {
+        # Download and run bun installation script
+        # The bun install script: curl -fsSL https://bun.sh/install | bash
+        install_script = subprocess.run(
+            ['curl', '-fsSL', NodeInstaller.BUN_INSTALL_URL],
+            capture_output=True,
+            text=True,
+            timeout=30
+        );
+
+        if install_script.returncode != 0 {
+            return (
+                False,
+                f'Failed to download bun installer: {install_script.stderr}'
+            );
+        }
+
+        # Execute the installation script
+        result = subprocess.run(
+            ['bash', '-c', install_script.stdout],
+            capture_output=True,
+            text=True,
+            timeout=120
+        );
+
+        if result.returncode != 0 {
+            return (False, f'bun installation failed: {result.stderr}');
+        }
+
+        print('bun installed successfully!');
+        return (True, 'bun installed successfully');
+    } except subprocess.TimeoutExpired {
+        return (
+            False,
+            'bun installation timed out. Please check your internet connection.'
+        );
+    } except FileNotFoundError as e {
+        if 'curl' in str(e) {
+            return (
+                False,
+                'curl command not found. Please install curl first:\n' + '  Ubuntu/Debian: sudo apt-get install curl\n' + '  macOS: curl is pre-installed\n' + '  Fedora/RHEL: sudo dnf install curl'
+            );
+        }
+        return (False, f'Required command not found: {e}');
+    } except Exception as e {
+        return (False, f'Unexpected error during bun installation: {e}');
     }
 }
 
@@ -245,5 +360,164 @@ impl NodeInstaller.run_npm_with_nvm(
         text=True,
         timeout=timeout,
         check=True
+    );
+}
+
+"""Run bun command with proper PATH (handles ~/.bun/bin).
+
+This method adds the bun bin directory to PATH, so bun commands work
+immediately after installation without requiring the user to reload their shell.
+"""
+impl NodeInstaller.run_bun_with_path(
+    args: list, cwd: Path, timeout: int = 300
+) -> object {
+    # First, try running bun directly (in case it's already in PATH)
+    try {
+        return subprocess.run(
+            ['bun'] + args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True
+        );
+    } except FileNotFoundError { }
+    # If bun is not in PATH, check common install location
+    bun_bin = Path.home() / '.bun' / 'bin';
+    bun_path = bun_bin / 'bun';
+    if bun_path.exists() {
+        return subprocess.run(
+            [str(bun_path)] + args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True
+        );
+    }
+    # Fall back to running via bash with PATH set
+    args_str = ' '.join(args);
+    command = f'export PATH="$HOME/.bun/bin:$PATH"\n' + f'bun {args_str}\n';
+    return subprocess.run(
+        ['bash', '-c', command],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True
+    );
+}
+
+"""Ensure bun is installed, installing automatically if needed.
+
+Returns tuple of (success: bool, message: str, was_just_installed: bool)
+"""
+impl NodeInstaller.ensure_bun_installed(
+    interactive: bool = True
+) -> tuple[bool, str, bool] {
+    # Common fallback message for manual installation
+    manual_install_msg = (
+        'Please install bun manually:\n' + '  • Run: curl -fsSL https://bun.sh/install | bash\n' + '  • Or visit: https://bun.sh/\n' + '  After installation, run your command again.'
+    );
+    # Check if bun is already available
+    if NodeInstaller.is_bun_installed() {
+        version = NodeInstaller.get_bun_version();
+        return (True, f'bun {version} is already installed', False);
+    }
+    print('\nbun is not installed or not found in PATH.');
+    # Check for interactive mode
+    if interactive {
+        print('\nbun is a fast JavaScript runtime and package manager.');
+        print('Would you like to automatically install bun?');
+        response = input('Install bun? [Y/n]: ').strip().lower();
+        if response and response not in ('y', 'yes') {
+            return (False, f'bun installation cancelled. {manual_install_msg}', False);
+        }
+    }
+    # Wrap entire installation process in error handling
+    try {
+        success_bun = NodeInstaller.install_bun();
+        if not success_bun[0] {
+            return (
+                False,
+                f'Unable to automatically install bun.\n\nError: {success_bun[1]}\n\n{manual_install_msg}',
+                False
+            );
+        }
+
+        # bun is now available
+        print('\n' + '=' * 70);
+        print('bun has been installed successfully!');
+        print('Continuing with package installation...');
+        print('=' * 70 + '\n');
+
+        return (True, 'bun installed successfully', True);
+    } except Exception as e {
+        # Catch any unexpected errors during installation
+        return (
+            False,
+            f'Unable to automatically install bun.\n\nUnexpected error: {str(e)}\n\n{manual_install_msg}',
+            False
+        );
+    }
+}
+
+"""Ensure a package manager (bun or npm) is available.
+
+Prefers bun, falls back to npm/Node.js if bun installation fails.
+Returns tuple of (success: bool, message: str, package_manager: str)
+"""
+impl NodeInstaller.ensure_package_manager_installed(
+    interactive: bool = True
+) -> tuple[bool, str, str] {
+    # Check if bun is available (preferred)
+    if NodeInstaller.is_bun_installed() {
+        version = NodeInstaller.get_bun_version();
+        return (True, f'bun {version} is available', 'bun');
+    }
+    # Check if npm is available (fallback)
+    if NodeInstaller.is_npm_installed() {
+        version = NodeInstaller.get_node_version();
+        return (True, f'npm (Node.js {version}) is available', 'npm');
+    }
+    # Neither is installed, try to install bun first (faster, simpler)
+    print('\nNo package manager found. Attempting to install bun (recommended)...');
+    if interactive {
+        print(
+            '\nJac client requires a package manager (bun or npm) to build client applications.'
+        );
+        print('bun is recommended for faster installs.');
+        print('\nOptions:');
+        print('  1. Install bun (recommended, faster)');
+        print('  2. Install Node.js/npm');
+        print('  3. Cancel');
+        response = input('\nChoose [1/2/3] (default: 1): ').strip();
+        if response == '3' {
+            return (False, 'Package manager installation cancelled.', '');
+        }
+        if response == '2' {
+            # Install Node.js/npm
+            result = NodeInstaller.ensure_node_installed(interactive=False);
+            if result[0] {
+                return (True, result[1], 'npm');
+            }
+            return (False, result[1], '');
+        }
+    }
+    # Default: Try to install bun
+    result = NodeInstaller.ensure_bun_installed(interactive=False);
+    if result[0] {
+        return (True, result[1], 'bun');
+    }
+    # bun failed, try npm as fallback
+    print('\nbun installation failed. Falling back to Node.js/npm...');
+    result = NodeInstaller.ensure_node_installed(interactive=False);
+    if result[0] {
+        return (True, result[1], 'npm');
+    }
+    return (
+        False,
+        'Failed to install any package manager. Please install bun or Node.js manually:\n' + '  • bun: curl -fsSL https://bun.sh/install | bash\n' + '  • Node.js: https://nodejs.org/',
+        ''
     );
 }

--- a/jac-client/jac_client/plugin/utils/impl/package_manager.impl.jac
+++ b/jac-client/jac_client/plugin/utils/impl/package_manager.impl.jac
@@ -1,0 +1,177 @@
+"""Implementation of package manager abstraction methods."""
+
+"""Check if bun is installed and accessible."""
+impl PackageManager.is_bun_installed -> bool {
+    try {
+        result = subprocess.run(
+            ['bun', '--version'], capture_output=True, text=True, timeout=5
+        );
+        return result.returncode == 0;
+    } except (FileNotFoundError, subprocess.TimeoutExpired) {
+        return False;
+    }
+}
+
+"""Check if npm is installed and accessible."""
+impl PackageManager.is_npm_installed -> bool {
+    try {
+        result = subprocess.run(
+            ['npm', '--version'], capture_output=True, text=True, timeout=5
+        );
+        return result.returncode == 0;
+    } except (FileNotFoundError, subprocess.TimeoutExpired) {
+        return False;
+    }
+}
+
+"""Get the currently installed bun version."""
+impl PackageManager.get_bun_version -> (str | None) {
+    try {
+        result = subprocess.run(
+            ['bun', '--version'], capture_output=True, text=True, timeout=5
+        );
+        if result.returncode == 0 {
+            return result.stdout.strip();
+        }
+    } except (FileNotFoundError, subprocess.TimeoutExpired) { }
+    return None;
+}
+
+"""Get the currently installed npm version."""
+impl PackageManager.get_npm_version -> (str | None) {
+    try {
+        result = subprocess.run(
+            ['npm', '--version'], capture_output=True, text=True, timeout=5
+        );
+        if result.returncode == 0 {
+            return result.stdout.strip();
+        }
+    } except (FileNotFoundError, subprocess.TimeoutExpired) { }
+    return None;
+}
+
+"""Get the preferred package manager."""
+impl PackageManager.get_preferred -> str {
+    # Check environment variable override first
+    env_override = os.environ.get(PackageManager.ENV_VAR, '').lower();
+    if env_override in ('bun', 'npm') {
+        return env_override;
+    }
+    # Auto-detect: prefer bun if available
+    if PackageManager.is_bun_installed() {
+        return 'bun';
+    }
+    # Fallback to npm
+    return 'npm';
+}
+
+"""Get the install command for the preferred package manager."""
+impl PackageManager.get_install_cmd -> list[str] {
+    pm = PackageManager.get_preferred();
+    return [pm, 'install'];
+}
+
+"""Get the run command for a script."""
+impl PackageManager.get_run_cmd(script: str) -> list[str] {
+    pm = PackageManager.get_preferred();
+    return [pm, 'run', script];
+}
+
+"""Get the exec command (npx/bunx)."""
+impl PackageManager.get_exec_cmd -> str {
+    pm = PackageManager.get_preferred();
+    if pm == 'bun' {
+        return 'bunx';
+    }
+    return 'npx';
+}
+
+"""Get the global add command for a package."""
+impl PackageManager.get_global_add_cmd(pkg: str) -> list[str] {
+    pm = PackageManager.get_preferred();
+    if pm == 'bun' {
+        return ['bun', 'add', '-g', pkg];
+    }
+    return ['npm', 'install', '-g', pkg];
+}
+
+"""Get the global list command."""
+impl PackageManager.get_global_list_cmd -> list[str] {
+    pm = PackageManager.get_preferred();
+    if pm == 'bun' {
+        return ['bun', 'pm', 'ls', '-g'];
+    }
+    return ['npm', 'list', '-g'];
+}
+
+"""Get the version check command."""
+impl PackageManager.get_version_cmd -> list[str] {
+    pm = PackageManager.get_preferred();
+    return [pm, '--version'];
+}
+
+"""Run a package manager command with proper environment."""
+impl PackageManager.run_cmd(
+    args: list,
+    cwd: Path,
+    timeout: int = 300,
+    check: bool = True,
+    capture_output: bool = True
+) -> object {
+    pm = PackageManager.get_preferred();
+    cmd = [pm] + args;
+    # First, try running directly (if pm is in PATH)
+    try {
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=capture_output,
+            text=True,
+            timeout=timeout,
+            check=check
+        );
+    } except FileNotFoundError { }
+    # For npm: If not in PATH, try sourcing NVM
+    if pm == 'npm' {
+        args_str = ' '.join(args);
+        command = (
+            'export NVM_DIR="$HOME/.nvm"\n' + '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"\n' + f'npm {args_str}\n'
+        );
+        return subprocess.run(
+            ['bash', '-c', command],
+            cwd=cwd,
+            capture_output=capture_output,
+            text=True,
+            timeout=timeout,
+            check=check
+        );
+    }
+    # For bun: check common install locations
+    if pm == 'bun' {
+        bun_paths = [
+            Path.home() / '.bun' / 'bin' / 'bun',
+            Path('/usr/local/bin/bun'),
+
+        ];
+        for bun_path in bun_paths {
+            if bun_path.exists() {
+                return subprocess.run(
+                    [str(bun_path)] + args,
+                    cwd=cwd,
+                    capture_output=capture_output,
+                    text=True,
+                    timeout=timeout,
+                    check=check
+                );
+            }
+        }
+    }
+    # Re-raise the FileNotFoundError if we couldn't find the command
+    raise FileNotFoundError(f'{pm} command not found') ;
+}
+
+"""Get the build script content for package.json."""
+impl PackageManager.get_build_script(config_path: str) -> str {
+    pm = PackageManager.get_preferred();
+    return f'{pm} run compile && vite build --config {config_path}';
+}

--- a/jac-client/jac_client/plugin/utils/node_installer.jac
+++ b/jac-client/jac_client/plugin/utils/node_installer.jac
@@ -1,14 +1,15 @@
-"""Automatic Node.js installation utility using NVM."""
+"""Automatic Node.js and bun installation utilities."""
 
 import os;
 import platform;
 import subprocess;
 import from pathlib { Path }
 
-"""Handles Node.js installation and detection."""
+"""Handles Node.js and bun installation and detection."""
 obj NodeInstaller {
     static has DEFAULT_NODE_VERSION: str = "20",
-        NVM_INSTALL_URL: str = "https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh";
+        NVM_INSTALL_URL: str = "https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh",
+        BUN_INSTALL_URL: str = "https://bun.sh/install";
 
     """Check if Node.js is installed and accessible."""
     static def is_node_installed -> bool;
@@ -16,14 +17,23 @@ obj NodeInstaller {
     """Check if npm is installed and accessible."""
     static def is_npm_installed -> bool;
 
+    """Check if bun is installed and accessible."""
+    static def is_bun_installed -> bool;
+
     """Check if NVM is installed."""
     static def is_nvm_installed -> bool;
 
     """Get the currently installed Node.js version."""
     static def get_node_version -> (str | None);
 
+    """Get the currently installed bun version."""
+    static def get_bun_version -> (str | None);
+
     """Install NVM (Node Version Manager)."""
     static def install_nvm -> tuple[bool, str];
+
+    """Install bun using the official install script."""
+    static def install_bun -> tuple[bool, str];
 
     """Install Node.js using NVM."""
     static def install_node_via_nvm(version: str = "20") -> tuple[bool, str];
@@ -36,6 +46,24 @@ obj NodeInstaller {
         interactive: bool = True
     ) -> tuple[bool, str, bool];
 
+    """Ensure bun is installed, installing automatically if needed.
+
+    Returns tuple of (success: bool, message: str, was_just_installed: bool)
+    """
+    static def ensure_bun_installed(interactive: bool = True) -> tuple[bool, str, bool];
+
+    """Ensure a package manager (bun or npm) is available.
+
+    Prefers bun, falls back to npm/Node.js if bun installation fails.
+    Returns tuple of (success: bool, message: str, package_manager: str)
+    """
+    static def ensure_package_manager_installed(
+        interactive: bool = True
+    ) -> tuple[bool, str, str];
+
     """Run npm command with NVM environment properly sourced."""
     static def run_npm_with_nvm(args: list, cwd: Path, timeout: int = 300) -> object;
+
+    """Run bun command with proper PATH (handles ~/.bun/bin)."""
+    static def run_bun_with_path(args: list, cwd: Path, timeout: int = 300) -> object;
 }

--- a/jac-client/jac_client/plugin/utils/package_manager.jac
+++ b/jac-client/jac_client/plugin/utils/package_manager.jac
@@ -1,0 +1,91 @@
+"""Package manager abstraction for npm/bun support."""
+
+import os;
+import subprocess;
+import from pathlib { Path }
+
+"""Handles package manager detection and command abstraction.
+
+Supports both npm and bun with automatic detection and fallback.
+Can be overridden via JAC_CLIENT_PACKAGE_MANAGER environment variable.
+"""
+obj PackageManager {
+    static has ENV_VAR: str = "JAC_CLIENT_PACKAGE_MANAGER";
+
+    """Check if bun is installed and accessible."""
+    static def is_bun_installed -> bool;
+
+    """Check if npm is installed and accessible."""
+    static def is_npm_installed -> bool;
+
+    """Get the currently installed bun version."""
+    static def get_bun_version -> (str | None);
+
+    """Get the currently installed npm version."""
+    static def get_npm_version -> (str | None);
+
+    """Get the preferred package manager.
+
+    Priority:
+    1. JAC_CLIENT_PACKAGE_MANAGER env var if set
+    2. bun if installed
+    3. npm as fallback
+
+    Returns "bun" or "npm".
+    """
+    static def get_preferred -> str;
+
+    """Get the install command for the preferred package manager.
+
+    Returns ["bun", "install"] or ["npm", "install"].
+    """
+    static def get_install_cmd -> list[str];
+
+    """Get the run command for a script.
+
+    Returns ["bun", "run", script] or ["npm", "run", script].
+    """
+    static def get_run_cmd(script: str) -> list[str];
+
+    """Get the exec command (npx/bunx).
+
+    Returns "bunx" or "npx".
+    """
+    static def get_exec_cmd -> str;
+
+    """Get the global add command for a package.
+
+    Returns ["bun", "add", "-g", pkg] or ["npm", "install", "-g", pkg].
+    """
+    static def get_global_add_cmd(pkg: str) -> list[str];
+
+    """Get the global list command.
+
+    Returns appropriate command to list global packages.
+    """
+    static def get_global_list_cmd -> list[str];
+
+    """Get the version check command.
+
+    Returns ["bun", "--version"] or ["npm", "--version"].
+    """
+    static def get_version_cmd -> list[str];
+
+    """Run a package manager command with proper environment.
+
+    Handles NVM sourcing for npm if needed.
+    """
+    static def run_cmd(
+        args: list,
+        cwd: Path,
+        timeout: int = 300,
+        check: bool = True,
+        capture_output: bool = True
+    ) -> object;
+
+    """Get the build script content for package.json.
+
+    Returns the appropriate build script based on package manager.
+    """
+    static def get_build_script(config_path: str) -> str;
+}


### PR DESCRIPTION
## Summary

- Add bun as the preferred package manager with automatic npm fallback
- Create `PackageManager` abstraction for unified npm/bun command handling  
- Add bun detection, installation, and runtime support to `NodeInstaller`
- Update all npm command usages to use the new `PackageManager` abstraction
- Add `JAC_CLIENT_PACKAGE_MANAGER` environment variable for manual override

## Changes

### New Files
- `jac_client/plugin/utils/package_manager.jac` - Core package manager abstraction
- `jac_client/plugin/utils/impl/package_manager.impl.jac` - Implementation

### Modified Files  
- `node_installer.jac/.impl.jac` - Added bun detection/installation methods
- `package_installer.impl.jac` - Use PackageManager for installs
- `vite_bundler.impl.jac` - Use PackageManager for build commands
- `babel_processor.impl.jac` - Use PackageManager for compile
- `desktop_target.impl.jac` - Use PackageManager for Tauri CLI
- `conftest.py` / `test_helpers.py` - Updated test infrastructure
- `README.md` / `package-management.md` - Documentation updates

## Behavior

1. Auto-detects bun if available (faster installs)
2. Falls back to npm if bun is not installed
3. Can be overridden with `JAC_CLIENT_PACKAGE_MANAGER=npm` or `=bun`

## Test plan

- [ ] Run existing jac-client tests with npm
- [ ] Install bun and verify auto-detection works
- [ ] Test `jac create --use client` with bun
- [ ] Test `jac add --npm` package installation with bun
- [ ] Test `jac build` with bun
- [ ] Verify npm fallback when bun unavailable