### PR TITLE
Bump versions of jaclang(`0.9.11`) , jac-client(`0.2.11`), jac-scale(`0.1.2`) and Jaseci-meta package(`2.2.9`)

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.2.11 (Unreleased)
+## jac-client 0.2.12 (Unreleased)
+
+## jac-client 0.2.11 (Latest Release)
 
 - **Bun Runtime Migration**: Replaced npm/npx with Bun for package management and JavaScript bundling. Bun provides significantly faster dependency installation and build times. When Bun is not installed, the CLI prompts users to install it automatically via the official installer script.
 
@@ -11,7 +13,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **`@jac/runtime` Canonical Import Path**: Migrated the client runtime import path from `@jac-client/utils` to `@jac/runtime`, aligning with the new `@jac/` scoped package syntax in Jac source code. The jac-client Vite plugin now maps `@jac/runtime` to its own compiled runtime via a resolve alias. Compiled modules include ES module `export` statements so Vite can resolve named imports between modules. All examples, docs, and templates have been updated.
 - **Various Refactors**: Inluding supporting new useEffect primitives, example updates, etc
 
-## jac-client 0.2.10 (Latest Release)
+## jac-client 0.2.10
 
 ## jac-client 0.2.9
 

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,7 +4,9 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.1.2 (Unreleased)
 
-## jac-scale 0.1.1 (Latest Release)
+## jac-scale 0.1.2 (Latest Release)
+
+## jac-scale 0.1.1
 
 ## jac-scale 0.1.0
 

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jaclang**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jaclang 0.9.11 (Unreleased)
+## jaclang 0.9.12 (Unreleased)
+
+## jaclang 0.9.11 (Latest Release)
 
 - **Reactive Effects with `can with entry/exit`**: The `can with entry` and `can with exit` syntax now automatically generates React `useEffect` hooks in client-side code. When used inside a `cl` codespace, `async can with entry { items = await fetch(); }` generates `useEffect(() => { (async () => { setItems(await fetch()); })(); }, []);`. Supports dependency arrays using list or tuple syntax: `can with (userId, count) entry { ... }` generates effects that re-run when dependencies change. The `can with exit` variant generates cleanup functions via `return () => { ... }` inside the effect. This provides a declarative, Jac-native way to handle component lifecycle without manual `useEffect` boilerplate.
 
@@ -11,7 +13,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - **Permissive Type Check for Node Collections in Connections**: The type checker now accepts collections (list, tuple, set, frozenset) on the right side of connection operators (`++>`, `<++>`, etc.). Previously, code like `root ++> [Node1(), Node2(), Node3()];` was incorrectly rejected. This is a temporary workaround until element type inference for list literals is fully implemented.
 
-## jaclang 0.9.10 (Latest Release)
+## jaclang 0.9.10
 
 - **Formatter Spacing Fixes**: Fixed extra spaces before semicolons in `report` and `del` statements, and corrected semantic definition formatting to properly handle dot notation and `=` operator spacing.
 

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.2.10"
+version = "0.2.11"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.10",
+    "jaclang>=0.9.11",
 ]
 
 [project.urls]

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jac-scale"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.10",
+    "jaclang>=0.9.11",
     "python-dotenv>=1.2.1,<2.0.0",
     "docker>=7.1.0,<8.0.0",
     "kubernetes>=34.1.0,<35.0.0",

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaclang"
-version = "0.9.10"
+version = "0.9.11"
 description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]

--- a/jaseci-package/pyproject.toml
+++ b/jaseci-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaseci"
-version = "2.2.8"
+version = "2.2.9"
 description = "Jaseci - A complete AI-native programming ecosystem with Jac language, LLM integration, and full-stack web apps"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -22,10 +22,10 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.9.10",
+    "jaclang>=0.9.11",
     "byllm>=0.4.15",
-    "jac-client>=0.2.10",
-    "jac-scale>=0.1.1",
+    "jac-client>=0.2.11",
+    "jac-scale>=0.1.2",
     "jac-super>=0.1.0",
 ]
 


### PR DESCRIPTION
## **Description**


| Package | Old Version | New Version |
|---------|-------------|-------------|
| **jaclang** | 0.9.10 | 0.9.11 |
| **jac-client** | 0.2.10 | 0.2.11 |
| **jac-scale** | 0.1.1 | 0.1.2 |
| **jaseci** | 2.2.8 | 2.2.9 |