### PR TITLE
docs: fix incorrect imports in quick-guide tutorials

### DIFF
--- a/docs/docs/quick-guide/first-fullstack-ai-app.md
+++ b/docs/docs/quick-guide/first-fullstack-ai-app.md
@@ -180,7 +180,7 @@ Update `main.jac` - just add the AI parts:
 
 ```jac
 import from uuid { uuid4 }
-import from byllm { Model }
+import from byllm.lib { Model }
 
 glob llm = Model(model_name="claude-sonnet-4-20250514");
 
@@ -308,7 +308,7 @@ Update `main.jac`:
 
 ```jac
 import from uuid { uuid4 }
-import from byllm { Model }
+import from byllm.lib { Model }
 
 glob llm = Model(model_name="claude-sonnet-4-20250514");
 
@@ -369,7 +369,7 @@ walker:priv DeleteTodo {
 
 cl {
     import from react { useEffect }
-    import from "@jac-client/utils" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
+    import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
     import "./styles.css";
 
     def:pub app -> any {

--- a/docs/docs/quick-guide/jac-vs-traditional-stack.md
+++ b/docs/docs/quick-guide/jac-vs-traditional-stack.md
@@ -4,7 +4,7 @@ This document compares building the same Todo application using Jac versus a tra
 
 ---
 
-## Jac Implementation (1 file, 37 lines)
+## Jac Implementation
 
 ```jac
 # This single jac program is a fullstack application
@@ -14,6 +14,11 @@ node Todo {
 }
 
 def:pub get_todos -> list {
+    root ++> [
+        Todo("build startup", False),
+        Todo("raise funding", False),
+        Todo("change the world", False)
+    ];
     return [{"title": t.title, "done": t.done} for t in [root-->](`?Todo)];
 }
 
@@ -34,11 +39,7 @@ cl def:pub app() -> any {
 }
 
 with entry {
-    root ++> [
-        Todo("build startup", False),
-        Todo("raise funding", False),
-        Todo("change the world", False)
-    ];
+
 }
 ```
 
@@ -54,7 +55,7 @@ with entry {
 
 ---
 
-## Traditional Stack Implementation (10 files, ~200 lines)
+## Traditional Stack Implementation
 
 The equivalent functionality using Python, FastAPI, SQLite, TypeScript, and React.
 


### PR DESCRIPTION
## Summary
- Fix `import from byllm { Model }` to `import from byllm.lib { Model }` in Phase 2 and Phase 3 code examples (`Model` is not exported from the top-level `byllm` package)
- Fix deprecated `@jac-client/utils` import to `@jac/runtime` in Phase 3 code example (migrated in jac-client v0.2.11)
- Fix `jac-vs-traditional-stack.md` example to seed data inside `get_todos` and remove line count claims from headings

## Test plan
- [x] Verified Phase 2 code builds and runs with `jac start`
- [x] Verified AI categorization works (e.g. "Buy groceries" -> shopping, "Finish quarterly report" -> work)
- [x] Verified Phase 3 code builds and runs with `jac start`
- [x] Verified user signup/login, walker endpoints, and per-user data isolation