### PR TITLE
feat(jac-client): prompt to install default client deps when missing

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.2.12 (Unreleased)
 
+- **Auto-Prompt for Missing Client Dependencies**: When running `jac start` on a project without npm dependencies configured (no `jac.toml` or empty `[dependencies.npm]`), the CLI now detects the missing dependencies and interactively prompts the user to install the default jac-client packages (react, vite, etc.). Accepting writes the defaults to `jac.toml` and proceeds with the build. This follows the same pattern as the existing Bun auto-install prompt and eliminates the cryptic "Cannot find package 'vite'" error that previously occurred. Additionally, stale `node_modules` directories from prior failed installs are now automatically detected and cleaned up before reinstalling.
+
 ## jac-client 0.2.11 (Latest Release)
 
 - **Bun Runtime Migration**: Replaced npm/npx with Bun for package management and JavaScript bundling. Bun provides significantly faster dependency installation and build times. When Bun is not installed, the CLI prompts users to install it automatically via the official installer script.

--- a/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
@@ -426,22 +426,29 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
     import sys;
     import time;
     import shutil;
-    import from jac_client.plugin.utils { ensure_bun_available }
+    import from jac_client.plugin.utils { ensure_bun_available, ensure_client_deps }
     # Ensure bun is available before proceeding
     if not ensure_bun_available() {
         raise ClientBundleError('Bun is required. Install manually: https://bun.sh') from None ;
     }
-    self.output_dir.mkdir(parents=True, exist_ok=True);
-    generated_package_json = self._get_client_dir() / 'configs' / 'package.json';
-    if not generated_package_json.exists() {
-        self.create_package_json();
-    } else {
-        # Ensure tsconfig.json exists even if package.json already exists
-        self.create_tsconfig();
+    # Ensure client npm deps are configured; prompt to install defaults if missing
+    if not ensure_client_deps(self.config_loader) {
+        raise ClientBundleError(
+            'Client dependencies not configured. Add [dependencies.npm] to jac.toml '
+            'or create a project with: jac create --use client'
+        ) from None ;
     }
+    self.output_dir.mkdir(parents=True, exist_ok=True);
+    # Always regenerate package.json to pick up any dependency changes
+    self.create_package_json();
     try {
         build_dir = self._get_client_dir();
         node_modules = build_dir / 'node_modules';
+        # Reinstall if node_modules is missing or stale (e.g. empty from a prior failed install)
+        vite_bin = node_modules / '.bin' / 'vite';
+        if node_modules.exists() and not vite_bin.exists() {
+            shutil.rmtree(node_modules);
+        }
         if not node_modules.exists() {
             # Temporarily copy package.json to client build dir for bun install
             build_package_json = build_dir / 'package.json';

--- a/jac-client/jac_client/plugin/utils/__init__.jac
+++ b/jac-client/jac_client/plugin/utils/__init__.jac
@@ -1,3 +1,4 @@
 """Utility modules for jac-client plugin."""
 
 import from .bun_installer { ensure_bun_available, prompt_install_bun }
+import from .client_deps { ensure_client_deps }

--- a/jac-client/jac_client/plugin/utils/client_deps.jac
+++ b/jac-client/jac_client/plugin/utils/client_deps.jac
@@ -1,0 +1,14 @@
+"""Client dependency checker utility for jac-client.
+
+Provides a function to check if required npm dependencies are configured
+and prompt the user to install defaults if missing.
+"""
+
+"""Check if client npm dependencies are configured, prompt to install if missing.
+
+Takes a JacClientConfig instance, checks if dependencies and devDependencies
+are both empty, and if so prompts the user to install default jac-client deps.
+
+Returns True if deps are configured (or were just installed), False if user declined.
+"""
+def ensure_client_deps(config_loader: object) -> bool;

--- a/jac-client/jac_client/plugin/utils/impl/client_deps.impl.jac
+++ b/jac-client/jac_client/plugin/utils/impl/client_deps.impl.jac
@@ -1,0 +1,73 @@
+"""Implementation of client dependency checker utility."""
+
+"""Check if client npm dependencies are configured, prompt to install if missing."""
+impl ensure_client_deps(config_loader: object) -> bool {
+    package_config = config_loader.get_package_config();
+    dependencies = package_config.get('dependencies', {});
+    dev_dependencies = package_config.get('devDependencies', {});
+    # If either deps or devDeps has entries, assume configured
+    if dependencies or dev_dependencies {
+        return True;
+    }
+    # No deps configured — prompt the user
+    return prompt_install_client_deps(config_loader);
+}
+
+"""Prompt user to install default jac-client npm dependencies."""
+def prompt_install_client_deps(config_loader: object) -> bool {
+    import sys;
+    print("\n  ⚠ Client dependencies are not configured.", file=sys.stderr);
+    print(
+        "  jac-client requires npm packages (react, vite, etc.) to build client pages.",
+        file=sys.stderr
+    );
+    print("  These will be added to your jac.toml file.\n", file=sys.stderr);
+    try {
+        response = input("  Install default client dependencies now? [Y/n]: ").strip().lower();
+    } except (EOFError, KeyboardInterrupt) {
+        print("", file=sys.stderr);
+        return False;
+    }
+    if response and response not in ('y', 'yes', '') {
+        print(
+            "\n  To configure manually, add [dependencies.npm] to your jac.toml.",
+            file=sys.stderr
+        );
+        print(
+            "  Or create a new project with: jac create --use client\n",
+            file=sys.stderr
+        );
+        return False;
+    }
+    # Default runtime dependencies
+    default_deps: dict[str, str] = {
+        'react': '^18.2.0',
+        'react-dom': '^18.2.0',
+        'react-router-dom': '^6.22.0',
+        'react-error-boundary': '^5.0.0'
+    };
+    # Default build infrastructure dependencies
+    default_dev_deps: dict[str, str] = {
+        'vite': '^6.4.1',
+        '@vitejs/plugin-react': '^4.2.1',
+        'typescript': '^5.3.3',
+        '@types/react': '^18.2.0',
+        '@types/react-dom': '^18.2.0'
+    };
+    print("\n  ⏳ Adding default client dependencies to jac.toml...", flush=True);
+    try {
+        for (name, version) in default_deps.items() {
+            config_loader.add_dependency(name, version, is_dev=False);
+        }
+        for (name, version) in default_dev_deps.items() {
+            config_loader.add_dependency(name, version, is_dev=True);
+        }
+        config_loader.save();
+        config_loader.invalidate();
+        print("  ✔ Default client dependencies added to jac.toml\n", flush=True);
+        return True;
+    } except Exception as e {
+        print(f"  ✖ Failed to add dependencies: {e}", file=sys.stderr);
+        return False;
+    }
+}

--- a/jac-client/jac_client/tests/test_cli.py
+++ b/jac-client/jac_client/tests/test_cli.py
@@ -1,9 +1,11 @@
 """Test create-jac-app command."""
 
+import contextlib
 import os
 import tempfile
 import tomllib
 from subprocess import PIPE, Popen, run
+from unittest.mock import patch
 
 
 def test_create_jac_app() -> None:
@@ -920,3 +922,69 @@ def test_create_cl_and_run_no_root_files() -> None:
 
         finally:
             os.chdir(original_cwd)
+
+
+def test_vite_build_prompts_for_missing_client_deps() -> None:
+    """Test that ViteBundler.build() prompts to install deps when jac.toml is missing.
+
+    Exercises the same code path as `jac start` → server.start() → ensure_bundle()
+    → ViteBundler.build(), which checks for npm deps before building.
+    """
+    import json
+    from pathlib import Path
+
+    from jac_client.plugin.src.vite_bundler import ViteBundler
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_dir = Path(temp_dir)
+        config_file = project_dir / "jac.toml"
+
+        # No jac.toml — ViteBundler.build() should prompt via ensure_client_deps
+        bundler = ViteBundler(project_dir)
+
+        # Mock input to accept, and mock bun/vite so we don't need real installs.
+        # We only care that ensure_client_deps wrote jac.toml before reaching bun.
+        with (
+            patch("builtins.input", return_value="Y"),
+            patch(
+                "jac_client.plugin.utils.bun_installer.ensure_bun_available",
+                return_value=True,
+            ),
+            patch("subprocess.run") as mock_subprocess,
+        ):
+            # bun install returns success, vite build returns failure
+            # (we don't have real vite — that's fine, we're testing the dep prompt)
+            mock_subprocess.side_effect = [
+                type("Result", (), {"returncode": 0})(),  # bun install
+                type("Result", (), {"returncode": 1})(),  # vite build
+            ]
+            with contextlib.suppress(Exception):
+                bundler.build()  # vite build failure is expected
+
+        # The key assertion: jac.toml was created with default client deps
+        assert config_file.exists(), (
+            "jac.toml should have been created after accepting the prompt"
+        )
+
+        with open(config_file, "rb") as f:
+            data = tomllib.load(f)
+
+        npm_deps = data.get("dependencies", {}).get("npm", {})
+        assert "react" in npm_deps, "react should be in dependencies.npm"
+        assert "react-dom" in npm_deps, "react-dom should be in dependencies.npm"
+
+        npm_dev = npm_deps.get("dev", {})
+        assert "vite" in npm_dev, "vite should be in dev dependencies"
+        assert "@vitejs/plugin-react" in npm_dev, (
+            "@vitejs/plugin-react should be in dev deps"
+        )
+
+        # Verify the generated package.json also picked up the deps
+        package_json = project_dir / ".jac" / "client" / "configs" / "package.json"
+        assert package_json.exists(), "package.json should have been generated"
+
+        with open(package_json) as f:
+            pkg = json.load(f)
+
+        assert pkg["dependencies"].get("react"), "package.json should have react"
+        assert pkg["devDependencies"].get("vite"), "package.json should have vite"


### PR DESCRIPTION
## Summary

- When `jac start` runs on a project without npm dependencies configured (no `jac.toml` or empty `[dependencies.npm]`), ViteBundler now detects the missing deps and interactively prompts the user to install the defaults (react, vite, typescript, etc.) into `jac.toml`
- Follows the same interactive prompt pattern as the existing `ensure_bun_available()` utility
- Also fixes stale `node_modules` detection (clears and reinstalls when vite binary is missing) and always regenerates `package.json` to pick up dependency changes

## Test plan

- [ ] Run `jac start demo.jac` on a project with no `jac.toml` -- should see the prompt asking to install default client deps
- [ ] Accept prompt (Y) -- verify `jac.toml` is created with react, vite, etc. and build proceeds
- [ ] Decline prompt (n) -- verify graceful error with guidance message
- [ ] Run again after accepting -- should not prompt again (deps already configured)
- [ ] Run `pytest jac-client/jac_client/tests/test_cli.py::test_vite_build_prompts_for_missing_client_deps`