### PR TITLE
Fix release notes pre-commit hook for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,4 +107,4 @@ repos:
         language: script
         entry: scripts/check-release-notes.sh
         always_run: true
-        pass_filenames: true
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- Fixes the `check-release-notes` pre-commit hook that was failing on pre-commit.ci (#4345)
- **Root cause**: `pass_filenames: true` + `always_run: true` causes pre-commit.ci (which runs `--all-files`) to pass every file in the repo to the script, triggering false positives for all monitored folders
- **Fix**: Set `pass_filenames: false` and have the script detect changed files via `git diff`:
  - **Local commits**: `git diff --cached --name-only` (staged files)
  - **CI** (`PRE_COMMIT_FROM_REF`/`PRE_COMMIT_TO_REF` set): `git diff` between those refs
  - **CI fallback** (`CI` env var set): `git diff` against `origin/main`

## Test plan
- [ ] Verify pre-commit.ci passes on this PR
- [x] Tested locally: no staged files → passes
- [x] Tested with `CI=true`: compares against origin/main → passes when release notes included