### PR TITLE
fix(docs): add missing files to Docker image for MkDocs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -180,6 +180,8 @@ jobs:
           COPY jac/ ./jac/
           COPY jac-client/ ./jac-client/
           COPY scripts/ ./scripts/
+          COPY CONTRIBUTING.md ./CONTRIBUTING.md
+          COPY .pre-commit-config.yaml ./.pre-commit-config.yaml
 
           # Install Python dependencies
           RUN pip install -e ./jac


### PR DESCRIPTION
## Summary
- Fixed jac-lang-website deployment failure caused by missing files in Docker image
- Added `CONTRIBUTING.md` and `.pre-commit-config.yaml` to the Dockerfile COPY commands
- These files are referenced via `--8<--` includes in the MkDocs documentation

## Problem
The MkDocs build was failing with:
```
ERROR - Error reading page 'community/contributing.md': Document is empty
lxml.etree.ParserError: Document is empty
```

This happened because:
1. `docs/docs/community/contributing.md` uses `--8<-- "CONTRIBUTING.md"` to include content
2. `docs/docs/community/internals/contrib.md` uses `--8<-- ".pre-commit-config.yaml"`
3. These root files were not copied into the Docker container

## Test plan
- [ ] Verify the workflow runs successfully after merge
- [ ] Confirm jac-lang-website pods start without CrashLoopBackOff
- [ ] Check https://jac-lang.org loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)