### PR TITLE
Fix: Remove orphaned _logged_type_to_schema declaration from byllm/schema.jac

### DIFF
--- a/jac-byllm/byllm/schema.jac
+++ b/jac-byllm/byllm/schema.jac
@@ -18,10 +18,6 @@ def _type_to_schema(
     ty: type, title: str = "", desc: str = "", info: Info = None
 ) -> dict;
 
-def _logged_type_to_schema(
-    ty: type, title: str = "", desc: str = "", info: Info = None, lineno: int = -1
-) -> dict;
-
 def _name_of_type(ty: type, info: Info) -> str;
 def _convert_dict_to_schema(ty_dict: type) -> dict;
 def _decode_dict(json_obj: dict) -> dict;


### PR DESCRIPTION
## Summary
- Removes orphaned `_logged_type_to_schema` function declaration from `jac-byllm/byllm/schema.jac`
- This declaration was introduced in PR #4053 but has no implementation and is never used
- Fixes runtime error: "Ability has no body. Perhaps an impl must be imported."

Fixes #4351

## Problem
PR #4053 "MTIR Implementation for byLLM" added a function declaration that was never implemented:

```jac
def _logged_type_to_schema(
    ty: type, title: str = "", desc: str = "", info: Info = None, lineno: int = -1
) -> dict;
```

This causes any project using byllm to fail with:
```
Error: .../jac-byllm/byllm/schema.jac, line 21, col 1: Ability has no body. Perhaps an impl must be imported.
```

## Test plan
- [x] Verified `_logged_type_to_schema` has no implementation in `schema.impl.jac`
- [x] Verified `_logged_type_to_schema` is not used anywhere in the codebase
- [x] Tested `jac start` works after removing the declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)