### PR TITLE
Bump versions of jaclang(0.9.12), jac-client(0.2.12) and jac-scale(0.1.3)

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,12 +2,14 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.2.12 (Unreleased)
+## jac-client 0.2.13 (Unreleased)
+
+## jac-client 0.2.12 (Latest Release)
 
 - **Improved client bundling error handling and reliability:** Captures Vite/Bun output and displays concise, formatted errors after the API endpoint list; fixed the Bun install invocation to improve build reliability.
 - **Auto-Prompt for Missing Client Dependencies**: When running `jac start` on a project without npm dependencies configured (no `jac.toml` or empty `[dependencies.npm]`), the CLI now detects the missing dependencies and interactively prompts the user to install the default jac-client packages (react, vite, etc.). Accepting writes the defaults to `jac.toml` and proceeds with the build. This follows the same pattern as the existing Bun auto-install prompt and eliminates the cryptic "Cannot find package 'vite'" error that previously occurred. Additionally, stale `node_modules` directories from prior failed installs are now automatically detected and cleaned up before reinstalling.
 
-## jac-client 0.2.11 (Latest Release)
+## jac-client 0.2.11
 
 - **Bun Runtime Migration**: Replaced npm/npx with Bun for package management and JavaScript bundling. Bun provides significantly faster dependency installation and build times. When Bun is not installed, the CLI prompts users to install it automatically via the official installer script.
 

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Scale**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-scale 0.1.3 (Unreleased)
+## jac-scale 0.1.4 (Unreleased)
+
+## jac-scale 0.1.3 (Latest Release)
 
 - **Streaming Response Support**: Streaming responses are supported with walker spawn calls and function calls.
 
@@ -57,7 +59,7 @@ The `@restspec` decorator now supports custom HTTP methods and custom endpoint p
 - **Custom Methods**: Use `method=HTTPMethod.GET`, `method=HTTPMethod.PUT`, etc.
 - **Custom Paths**: Use `path="/my/custom/path"` to override the default routing.
 
-## jac-scale 0.1.1 (Latest Release)
+## jac-scale 0.1.1
 
 ## jac-scale 0.1.0
 

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jaclang**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jaclang 0.9.12 (Unreleased)
+## jaclang 0.9.13 (Unreleased)
+
+## jaclang 0.9.12 (Latest Release)
 
 - **Native Binary Compilation via `na {}` Blocks and `.na.jac` Files**: Added a third compilation target to Jac using `na {}` context blocks and `.na.jac` file conventions. Code within the `na` context compiles to native LLVM IR via llvmlite and is JIT-compiled to machine code at runtime. Functions defined in `na {}` blocks are callable via ctypes function pointers. Supports integer, float, and boolean types, arithmetic and comparison operators, if/else and while control flow, recursive function calls, local variables with type inference, and `print()` mapped to native `printf`. Native code is fully isolated from Python (`sv`) and JavaScript (`cl`) codegen -- `na` functions are excluded from both `py_ast` and `es_ast` output, and vice versa. The `llvmlite` package is now a core dependency.
 - **Startup error handling improvements:** Aggregates initialization errors and displays concise, formatted Vite/Bun bundling failures after the API endpoint list.
@@ -21,7 +23,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Support Go to Definition for Nested Unpacking Assignments**: Fixed symbol table generation to support recursive nested unpacking (e.g., `[a, [b, c]] = val`) ensuring all inner variables are registered.
 - **Fix: Module Name Truncation in MTIR Scope Resolution**: Fixed a bug where module names ending with 'j', 'a', or 'c' were incorrectly truncated due to using `.rstrip(".jac")` instead of `.removesuffix(".jac")`. This caused MTIR lookup failures and degraded functionality when the runtime tried to fetch metadata with the correct module name but found truncated keys (e.g., `test_schema` → `test_schem`).
 
-## jaclang 0.9.11 (Latest Release)
+## jaclang 0.9.11
 
 - **MTIR Generation Pass**: Added `MTIRGenPass` compiler pass that extracts semantic type information from GenAI `by` call sites at compile time. The pass captures parameter types, return types, semstrings, tool schemas, and class structures into `Info` dataclasses (`FunctionInfo`, `MethodInfo`, `ClassInfo`, `ParamInfo`, `FieldInfo`). MTIR is stored in `JacProgram.mtir_map` keyed by scope path.
 

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.2.11"
+version = "0.2.12"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.11",
+    "jaclang>=0.9.12",
 ]
 
 [project.urls]

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jac-scale"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.11",
+    "jaclang>=0.9.12",
     "python-dotenv>=1.2.1,<2.0.0",
     "docker>=7.1.0,<8.0.0",
     "kubernetes>=34.1.0,<35.0.0",

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaclang"
-version = "0.9.11"
+version = "0.9.12"
 description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]


### PR DESCRIPTION
## **Description**

## Description

| Package | Old Version | New Version |
|---------|-------------|-------------|
| **jaclang** | 0.9.11 | 0.9.12 |
| **jac-client** | 0.2.11 | 0.2.12 |
| **jac-scale** | 0.1.2 | 0.1.3 |
