### PR TITLE
Fix Jac syntax error in StorageFactory docs code block

### DIFF
--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -594,13 +594,11 @@ For advanced use cases, you can use `StorageFactory` directly instead of the `st
 import from jac_scale.factories.storage_factory { StorageFactory }
 
 # Create with explicit type and config
-storage = StorageFactory.create("local", {
-    "base_path": "./my-files",
-    "create_dirs": True
-});
+glob config = {"base_path": "./my-files", "create_dirs": True};
+glob storage = StorageFactory.create("local", config);
 
 # Create using jac.toml / env var / defaults
-storage = StorageFactory.get_default();
+glob default_storage = StorageFactory.get_default();
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Fix invalid Jac syntax in the StorageFactory (Advanced) code example in `jac-scale.md`
- Use `glob` keyword for module-level variable declarations (bare assignments are not valid at module level in Jac)
- Extract inline dict literal into a separate variable for valid parsing

Found by running `python docs/scripts/validate_docs_code.py --docs-dir docs/docs` (1 failure out of 556 code blocks, now 0).

## Test plan

- [x] Run `python docs/scripts/validate_docs_code.py --docs-dir docs/docs` -- all 556 code blocks pass