### PR TITLE
Move release notes check from pre-commit to CI workflow

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -8,6 +8,12 @@ on:
       - 'docs/**/*.md'
       - 'docs/scripts/validate_docs_code.py'
       - '.github/workflows/docs-validation.yml'
+      - 'jac/**'
+      - 'jac-scale/**'
+      - 'jac-client/**'
+      - 'jac-byllm/**'
+      - 'jac-super/**'
+      - 'docs/docs/community/release_notes/**'
   push:
     branches:
       - main
@@ -67,3 +73,19 @@ jobs:
             echo "- Jac code block syntax: ✓" >> $GITHUB_STEP_SUMMARY
             echo "- Internal links: ✓" >> $GITHUB_STEP_SUMMARY
           fi
+
+  check-release-notes:
+    name: Check Release Notes Updated
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check release notes
+        env:
+          CI: "true"
+        run: bash scripts/check-release-notes.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,10 +88,3 @@ repos:
         language: pygrep
         entry: '—'
         types: [markdown]
-
-      - id: check-release-notes
-        name: Check release notes updated
-        language: script
-        entry: scripts/check-release-notes.sh
-        always_run: true
-        pass_filenames: false


### PR DESCRIPTION
## Summary
- Removed the `check-release-notes` pre-commit hook from `.pre-commit-config.yaml`
- Added a new `check-release-notes` job to the `docs-validation.yml` GitHub Actions workflow
- Expanded PR trigger paths to include code folders (`jac/`, `jac-scale/`, `jac-client/`, `jac-byllm/`, `jac-super/`) and release notes files

The new CI job checks out with full history and runs the existing `scripts/check-release-notes.sh` script, only on pull requests.

## Test plan
- [ ] Open a PR that modifies files in `jac/` without updating `docs/docs/community/release_notes/jaclang.md` — the `check-release-notes` job should fail
- [ ] Open a PR that modifies files in `jac/` and updates the corresponding release notes — the job should pass
- [ ] Verify `pre-commit run --all-files` no longer includes the release notes check