### PR TITLE
docs: Replace ASCII art diagrams with Mermaid equivalents

### DIFF
--- a/docs/docs/reference/language/deployment.md
+++ b/docs/docs/reference/language/deployment.md
@@ -106,16 +106,11 @@ Built-in endpoints:
 
 ### 1 Multi-Layer Memory
 
-```
-┌─────────────────┐
-│   Application   │
-├─────────────────┤
-│  L1: Volatile   │  (in-memory)
-├─────────────────┤
-│  L2: Redis      │  (cache)
-├─────────────────┤
-│  L3: MongoDB    │  (persistent)
-└─────────────────┘
+```mermaid
+graph TD
+    App["Application"] --- L1["L1: Volatile (in-memory)"]
+    L1 --- L2["L2: Redis (cache)"]
+    L2 --- L3["L3: MongoDB (persistent)"]
 ```
 
 ### 2 FastAPI Integration

--- a/docs/docs/tutorials/examples/rag-chatbot.md
+++ b/docs/docs/tutorials/examples/rag-chatbot.md
@@ -34,23 +34,13 @@ This example demonstrates advanced Jac concepts:
 
 ## Architecture Overview
 
-```
-┌─────────────┐     ┌──────────────┐     ┌─────────────┐
-│   Client    │ ──→ │    Router    │ ──→ │  Chat Node  │
-│  Streamlit  │     │   (AI-based) │     │  (Handler)  │
-└─────────────┘     └──────────────┘     └─────────────┘
-                           ↓
-                    ┌──────────────┐
-                    │  MCP Server  │
-                    │  (Tools)     │
-                    └──────────────┘
-                           ↓
-              ┌────────────┴────────────┐
-              ↓                         ↓
-       ┌────────────┐            ┌────────────┐
-       │  ChromaDB  │            │ Web Search │
-       │  (Docs)    │            │  (Serper)  │
-       └────────────┘            └────────────┘
+```mermaid
+graph TD
+    Client["Client<br/>Streamlit"] --> Router["Router<br/>(AI-based)"]
+    Router --> Chat["Chat Node<br/>(Handler)"]
+    Router --> MCP["MCP Server<br/>(Tools)"]
+    MCP --> Chroma["ChromaDB<br/>(Docs)"]
+    MCP --> Web["Web Search<br/>(Serper)"]
 ```
 
 ---

--- a/docs/docs/tutorials/fullstack/backend.md
+++ b/docs/docs/tutorials/fullstack/backend.md
@@ -18,11 +18,9 @@ In Jac full-stack apps:
 2. **Frontend** = Components in `cl { }` blocks
 3. **Connection** = `useWalker` hook fetches walker results
 
-```
-┌─────────────┐     HTTP/WS      ┌─────────────┐
-│  Frontend   │ ←───────────────→ │   Walker    │
-│  Component  │    useWalker()    │   API       │
-└─────────────┘                   └─────────────┘
+```mermaid
+graph LR
+    Frontend["Frontend<br/>Component"] <-- "HTTP/WS<br/>useWalker()" --> Backend["Walker<br/>API"]
 ```
 
 ---

--- a/docs/docs/tutorials/language/osp.md
+++ b/docs/docs/tutorials/language/osp.md
@@ -16,17 +16,16 @@ Traditional OOP: Objects exist in isolation. You call methods to bring data to c
 
 **Object-Spatial Programming (OSP):** Objects exist in a graph with explicit relationships. You send computation (walkers) to data.
 
-```
-Traditional OOP:           OSP:
-┌─────────┐               ┌─────────┐
-│ Object  │               │  Node   │◄──── Walker visits
-│ .method │               │         │      and operates
-└─────────┘               └────┬────┘
-                               │ Edge
-                          ┌────▼────┐
-                          │  Node   │◄──── Walker moves
-                          │         │      to connected nodes
-                          └─────────┘
+```mermaid
+graph TD
+    subgraph oop["Traditional OOP"]
+        Obj["Object<br/>.method()"]
+    end
+    subgraph osp["Object-Spatial Programming"]
+        N1["Node"] -->|Edge| N2["Node"]
+        W1(["Walker visits<br/>and operates"]) -.-> N1
+        W2(["Walker moves<br/>to connected nodes"]) -.-> N2
+    end
 ```
 
 ---
@@ -100,12 +99,11 @@ with entry {
 
 This creates a graph:
 
-```
-    root
-    /  \
- alice  bob
-   |
- carol
+```mermaid
+graph TD
+    root --> alice
+    root --> bob
+    alice --> carol
 ```
 
 ---

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -14,20 +14,14 @@ Scale your Jac application with jac-scale on Kubernetes.
 
 jac-scale provides cloud-native deployment for Jac applications:
 
-```
-┌─────────────────────────────────────────────┐
-│            Kubernetes Cluster               │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  │
-│  │  Pod 1   │  │  Pod 2   │  │  Pod 3   │  │
-│  │ jac-app  │  │ jac-app  │  │ jac-app  │  │
-│  └──────────┘  └──────────┘  └──────────┘  │
-│         ↑           ↑           ↑          │
-│         └───────────┼───────────┘          │
-│                     ↓                      │
-│              ┌──────────────┐              │
-│              │ Load Balancer│              │
-│              └──────────────┘              │
-└─────────────────────────────────────────────┘
+```mermaid
+graph TD
+    subgraph cluster["Kubernetes Cluster"]
+        LB["Load Balancer"]
+        LB --> P1["Pod 1<br/>jac-app"]
+        LB --> P2["Pod 2<br/>jac-app"]
+        LB --> P3["Pod 3<br/>jac-app"]
+    end
 ```
 
 ---

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -13,12 +13,10 @@ Run your Jac walkers as a production-ready HTTP API server.
 
 The `jac start` command turns your walkers into REST API endpoints automatically:
 
-```
-┌─────────────┐     HTTP      ┌─────────────┐
-│   Client    │ ─────────────→ │  jac start  │
-│  (Browser,  │               │   Server    │
-│   Mobile)   │ ←───────────── │             │
-└─────────────┘    JSON       └─────────────┘
+```mermaid
+graph LR
+    Client["Client<br/>(Browser, Mobile)"] -- "HTTP" --> Server["jac start<br/>Server"]
+    Server -- "JSON" --> Client
 ```
 
 ---

--- a/docs/internal/Transport_layer.md
+++ b/docs/internal/Transport_layer.md
@@ -129,30 +129,12 @@ obj HTTPTransport(BaseTransport) {
 
 ### Connection Lifecycle
 
-```
-┌─────────────────────────────────────┐
-│  Client initiates request           │
-└────────────────┬────────────────────┘
-                 │
-         ┌───────▼────────┐
-         │   connect()    │
-         │ (if stateful)  │
-         └───────┬────────┘
-                 │
-      ┌──────────▼──────────┐
-      │ Process request &   │
-      │ generate response   │
-      └──────────┬──────────┘
-                 │
-         ┌───────▼────────┐
-         │   send(data)   │
-         │ (encode data)  │
-         └───────┬────────┘
-                 │
-         ┌───────▼────────┐
-         │  close()       │
-         │ (if stateful)  │
-         └───────────────┘
+```mermaid
+graph TD
+    A["Client initiates request"] --> B["connect()<br/>(if stateful)"]
+    B --> C["Process request &<br/>generate response"]
+    C --> D["send(data)<br/>(encode data)"]
+    D --> E["close()<br/>(if stateful)"]
 ```
 
 ## Adding New Transport Types


### PR DESCRIPTION
## Summary

- Replaced 8 ASCII art box-drawing diagrams with Mermaid syntax across 7 documentation files
- Mermaid was already enabled in `mkdocs.yml` via `pymdownx.superfences` custom fences -- no config changes needed
- Directory tree listings (e.g. `├── file.jac`) intentionally left as-is since they are standard convention

### Files changed

| File | Diagram |
|------|---------|
| `docs/reference/language/deployment.md` | Multi-layer memory architecture stack |
| `docs/tutorials/language/osp.md` | OOP vs OSP comparison, graph tree structure |
| `docs/tutorials/production/kubernetes.md` | Kubernetes cluster architecture |
| `docs/tutorials/production/local.md` | Client-server HTTP/JSON communication |
| `docs/tutorials/fullstack/backend.md` | Frontend-backend useWalker integration |
| `docs/tutorials/examples/rag-chatbot.md` | RAG chatbot architecture overview |
| `internal/Transport_layer.md` | Connection lifecycle flow |

## Test plan

- [ ] Verify Mermaid diagrams render correctly with `mkdocs serve`
- [ ] Check each diagram visually matches the intent of the original ASCII art
- [ ] Confirm no regressions in surrounding content