### PR TITLE
docs: Fix tutorial QA issues in Build Your First App (Parts 1-3)

### DIFF
--- a/docs/docs/tutorials/first-app/part1-todo-app.md
+++ b/docs/docs/tutorials/first-app/part1-todo-app.md
@@ -13,7 +13,9 @@ jac create my-todo --use client --skip
 cd my-todo
 ```
 
-Create `styles.css` in your project root:
+`--skip` skips the interactive prompts after creation. You don't need to run `jac install` separately -- `jac start` handles dependency installation automatically.
+
+Now replace `main.jac` with the code below and create `styles.css` in your project root:
 
 ```css
 .container { max-width: 500px; margin: 40px auto; font-family: system-ui; padding: 20px; }
@@ -27,7 +29,7 @@ Create `styles.css` in your project root:
 .count { text-align: center; color: #888; margin-top: 16px; font-size: 0.9rem; }
 ```
 
-Now replace `main.jac` with the code below. We'll walk through each piece.
+We'll walk through each piece of `main.jac` below.
 
 ---
 
@@ -314,8 +316,10 @@ The rest is JSX-like syntax: `{[... for t in items]}` renders a list, `lambda` h
 jac start main.jac
 ```
 
+This starts on port 8000 by default. Use `jac start main.jac --port 3000` to pick a different port.
+
 !!! warning "Common issue"
-    If you see "Address already in use", another process is on port 8000. See [Troubleshooting: Server won't start](../troubleshooting.md#server-wont-start-address-already-in-use).
+    If you see "Address already in use", another process is on port 8000. Use `--port` to pick a different port, or see [Troubleshooting: Server won't start](../troubleshooting.md#server-wont-start-address-already-in-use).
 
 Open [http://localhost:8000](http://localhost:8000). You should see a clean todo app with an input field and an "Add" button. Try it:
 

--- a/docs/docs/tutorials/first-app/part2-ai-features.md
+++ b/docs/docs/tutorials/first-app/part2-ai-features.md
@@ -4,6 +4,9 @@ Your todo app works, but it's not very smart. Let's fix that -- you'll add AI-po
 
 **Prerequisites:** Complete [Part 1](part1-todo-app.md) first.
 
+!!! tip "Starting fresh"
+    If you have leftover data from Part 1, delete the `.jac/data/` directory before running Part 2. The schema changes in this part (adding `category`) may conflict with old Todo nodes.
+
 ---
 
 ## Set Up Your API Key
@@ -15,7 +18,7 @@ export ANTHROPIC_API_KEY="your-key-here"
 ```
 
 !!! warning "Common issue"
-    If you get "API key not found" errors, make sure the environment variable is set in the same terminal where you run `jac`. See [Troubleshooting: API key issues](../troubleshooting.md#openai-api-key-not-found).
+    If you get "API key not found" errors, make sure the environment variable is set in the same terminal where you run `jac`. If adding a todo silently fails (nothing happens), check the terminal running `jac start` for error messages -- a missing or invalid API key causes a server error. See [Troubleshooting: API key issues](../troubleshooting.md#api-key-not-found).
 
 ---
 
@@ -313,6 +316,9 @@ Add one line to `styles.css`:
 export ANTHROPIC_API_KEY="your-key"
 jac start main.jac
 ```
+
+!!! warning "Common issue"
+    If you see "Address already in use", use `--port` to pick a different port: `jac start main.jac --port 3000`.
 
 Open [http://localhost:8000](http://localhost:8000). The app looks the same as before, but now when you add a todo it takes a moment longer -- the LLM is categorizing it behind the scenes. Try it:
 

--- a/docs/docs/tutorials/first-app/part3-multi-user.md
+++ b/docs/docs/tutorials/first-app/part3-multi-user.md
@@ -45,12 +45,14 @@ The core keywords:
 
 Walkers live on the server, but the frontend needs to spawn them. Jac handles this with `sv import` -- server imports that the client uses to call walkers. This naturally leads to splitting your code into separate files.
 
-Create a new project:
+Create a new project (this gives you a clean slate with no leftover data from Parts 1-2):
 
 ```bash
 jac create my-todo-app --use client --skip
 cd my-todo-app
 ```
+
+You can delete the scaffolded `main.jac` and `components/Button.cl.jac` -- you'll replace them with the files below.
 
 You'll create these files:
 
@@ -98,7 +100,7 @@ The `cl { }` block is client-side code embedded in a server file. It imports the
 
 ### Data Models
 
-You already know `Todo` from Parts 1 and 2. Now add `MealIngredient` -- a node that persists generated ingredients to the graph (unlike Part 2 where they only existed in browser memory):
+You already know `Todo` from Parts 1 and 2. Note the field rename from `done` to `completed` -- this aligns with the walker convention used throughout Part 3. Now add `MealIngredient` -- a node that persists generated ingredients to the graph (unlike Part 2 where they only existed in browser memory):
 
 ```jac
 node Todo {
@@ -1539,6 +1541,9 @@ All the complete files are in the collapsible sections below. Create each file i
 export ANTHROPIC_API_KEY="your-key"
 jac start main.jac
 ```
+
+!!! warning "Common issue"
+    If you see "Address already in use", use `--port` to pick a different port: `jac start main.jac --port 3000`.
 
 Open [http://localhost:8000](http://localhost:8000). You should see a login screen -- that's the auth working.
 

--- a/docs/docs/tutorials/troubleshooting.md
+++ b/docs/docs/tutorials/troubleshooting.md
@@ -385,7 +385,7 @@ See [Walker Responses](../reference/language/walker-responses.md) for details on
 
 ## AI Integration Issues
 
-### OpenAI API key not found
+### API key not found
 
 **Error:**
 
@@ -395,13 +395,17 @@ AuthenticationError: No API key provided
 
 **Solution:**
 
+Set the environment variable for your LLM provider in the same terminal where you run `jac`:
+
 ```bash
-# Set environment variable
+# Anthropic (used in the tutorials)
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# OpenAI
 export OPENAI_API_KEY="sk-..."
 
-# Or in .env file
-echo "OPENAI_API_KEY=sk-..." > .env
-source .env
+# Google
+export GOOGLE_API_KEY="..."
 ```
 
 ### Rate limit exceeded
@@ -497,4 +501,4 @@ jac check myfile.jac
 | Empty reports | Check node connections and `report` calls |
 | 401 Unauthorized | Add `:pub` modifier to walker or include auth token |
 | CORS error | Configure `[plugins.scale.cors]` in jac.toml |
-| API key missing | Set `OPENAI_API_KEY` environment variable |
+| API key missing | Set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` environment variable |


### PR DESCRIPTION
## Summary
- **Part 1:** Clarify `--skip` flag, note that `jac install` is handled by `jac start`, add `--port` usage, improve port conflict admonition
- **Part 2:** Add data cleanup tip for Part 1 → Part 2 transition (schema change), improve API key error guidance (silent failure symptom), fix troubleshooting link anchor, add port conflict admonition
- **Part 3:** Note `done` → `completed` field rename, mention deleting scaffold files (`Button.cl.jac`), add port conflict admonition
- **Troubleshooting:** Rename "OpenAI API key not found" → "API key not found" with Anthropic/OpenAI/Google examples, update quick reference table

## Context
Found during a hands-on walkthrough of the full tutorial series (Parts 1-3) using `jac 0.9.8`. Key pain points were silent failures when API keys are missing, schema migration between parts, and small mismatches between `jac create` scaffold output and tutorial instructions.

## Test plan
- [ ] Verify docs site renders all admonitions (`!!! tip`, `!!! warning`) correctly
- [ ] Confirm troubleshooting anchor `#api-key-not-found` resolves from Part 2 link
- [ ] Walk through Part 1 → Part 2 → Part 3 flow and verify new guidance is helpful