### PR TITLE
fix: Preserve file content when formatting files with syntax errors

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -11,6 +11,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Native Compiler Buildout**: Major expansion of the native binary compilation pipeline for `.na.jac` files. The native backend now supports enums, boolean short-circuit evaluation, break/continue, for loops, ternary expressions, string literals and f-strings, objects with fields/methods/postinit, GC-managed lists, single inheritance with vtable-based virtual dispatch, complex access chains, indexed field assignment, string methods (strip, split, indexing), builtins (ord, int, input), augmented assignment operators (`+=`, `-=`, `*=`, `//=`, `%=`), and `with entry { ... }` blocks. All heap allocations use Boehm GC. Validated end-to-end with a fully native chess game.
 - **`jac run` for `.na.jac` Files**: Running `jac run file.na.jac` now compiles the file to native machine code and executes the `jac_entry` function directly, bypassing the Python import machinery entirely. Native execution runs as pure machine code with zero Python interpreter overhead at runtime.
 - **LSP Semantic Token Manager Refactor**: Refactored the language server's `SemTokManager` for production robustness. Deduplicated ~170 lines of shared symbol resolution logic.
+- **Fix: `jac format` no longer wipes files with syntax errors**: Files with parse errors are now left untouched instead of being overwritten with empty output.
 - **1 Small Refactors**
 
 ## jaclang 0.9.13 (Latest Release)

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -319,6 +319,12 @@ impl format(paths: list, to_screen: bool = False, lintfix: bool = False) -> int 
         }
         try {
             prog = JacProgram.jac_file_formatter(str(path_obj), auto_lint=lintfix);
+            if prog.errors_had {
+                for error in prog.errors_had {
+                    console.error(f"{error}");
+                }
+                return (False, False, 0);
+            }
             try {
                 formatted_code = prog.mod.main.gen.jac;
                 original_code = prog.mod.main.source.code;

--- a/jac/tests/language/test_cli.py
+++ b/jac/tests/language/test_cli.py
@@ -698,6 +698,39 @@ def test_format_tracks_changed_files(
         assert "(1 changed)" in combined_output
 
 
+def test_format_preserves_file_on_syntax_error(
+    fixture_path: Callable[[str], str],
+) -> None:
+    """Test that format command preserves file content when there are syntax errors."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Copy err2.jac (which has syntax errors) to a temp location
+        src = fixture_path("err2.jac")
+        dest = os.path.join(tmpdir, "err2.jac")
+        with open(src) as f:
+            original_content = f.read()
+        with open(dest, "w") as f:
+            f.write(original_content)
+
+        # Run format on the file with syntax errors
+        captured_stderr = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = captured_stderr
+
+        try:
+            result = analysis.format([dest])
+        finally:
+            sys.stderr = old_stderr
+
+        # Read file content after formatting
+        with open(dest) as f:
+            after_content = f.read()
+
+        # File content must be preserved (not wiped)
+        assert after_content == original_content
+        # Format should report failure
+        assert result == 0  # 0 changed files, but failure is silent in exit code
+
+
 def test_jac_create_and_run_no_root_files(
     cli_test_dir: Path,
     capture_stdout: Callable[[], AbstractContextManager[io.StringIO]],


### PR DESCRIPTION
## **Description**

Previously, `jac format` on a file with syntax errors would silently overwrite the file with empty/partial output. Now checks for parse errors before writing and bails out, keeping the original file intact.


