### PR TITLE
Bump versions of jaclang(0.9.14), jac-client(0.2.14), jac-scale(0.1.5) and Jaseci-meta package(2.2.12)

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,14 +2,16 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.2.14 (Unreleased)
+## jac-client 0.2.15 (Unreleased)
+
+## jac-client 0.2.14 (Latest Release)
 
 - **JsxElement Return Types**: Updated all JSX component return types from `any` to `JsxElement` for compile-time type safety.
 - **Updated Fullstack Template**: Modernized the `fullstack` jacpack template to use idiomatic Jac patterns -- `can with entry` lifecycle effects instead of `useEffect`, JSX comprehensions instead of `.map()`, and impl separation (`frontend.impl.jac`) for cleaner code organization. Updated template README with project structure and pattern documentation.
 - **E2E Tests**: Now use jacpack workflow for testing.
 - **File-Based Routing**: Added Next.js-style file-based routing via a `pages/` directory convention. Place `.jac` files under `pages/` and routes are generated automatically -- `pages/index.jac` maps to `/`, `pages/about.jac` to `/about`, `pages/users/[id].jac` to `/users/:id`, and `pages/[...slug].jac` to a catch-all `*` route. Organize routes with parenthesized group directories: `pages/(auth)/` marks enclosed pages as requiring authentication, while `pages/(public)/` keeps them open -- groups control auth without adding URL segments. Add `layout.jac` files at any level for shared layout wrappers rendered via React Router `<Outlet/>`. The compiler detects `pages/`, generates a route manifest (`_routes.js`) with lazy imports, and produces an `_entry.js` that wires up `BrowserRouter`, `Routes`, layout nesting, and an `AuthGuard` component that checks `jacIsLoggedIn()` and redirects unauthenticated users (configurable via `auth_redirect` in `jac.toml` routing config). Duplicate route paths and duplicate layouts at the same level raise `ClientBundleError` at compile time. Projects without a `pages/` directory continue to use explicit routing unchanged.
 
-## jac-client 0.2.13 (Latest Release)
+## jac-client 0.2.13
 
 - **Console infrastructure**: Replaced bare `print()` calls with `console` abstraction for consistent output formatting.
 - **Desktop App Auto-Start & Port Discovery**: Running `jac start` or `jac dev` for a desktop (Tauri) target now automatically launches the backend API server and connects the app to it -- no manual setup needed. The backend port is dynamically allocated and injected into the webview before any page JavaScript runs, so API calls just work out of the box. Configure a fixed backend URL via `base_url` in `jac.toml` if needed.

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -2,12 +2,14 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Scale**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-scale 0.1.5 (Unreleased)
+## jac-scale 0.1.6 (Unreleased)
+
+## jac-scale 0.1.5 (Latest Release)
 
 - **JsxElement Return Types**: Updated all JSX component return types from `any` to `JsxElement` for compile-time type safety.
 - **Client bundle error help message**: When the client bundle build fails during `jac start`, the server now prints a troubleshooting suggestion to run `jac clean --all` and a link to the Discord community for support.
 
-## jac-scale 0.1.4 (Latest Release)
+## jac-scale 0.1.4
 
 - **Console infrastructure**: Replaced bare `print()` calls with `console` abstraction for consistent output formatting.
 - **Hot fix: call state**: Normal spawn calls inside API spawn calls supported.

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jaclang**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jaclang 0.9.14 (Unreleased)
+## jaclang 0.9.15 (Unreleased)
+
+## jaclang 0.9.14 (Latest Release)
 
 - **Fix: `jac format` No Longer Deletes Files with Syntax Errors**: Fixed a bug where `jac format` would overwrite a file's contents with an empty string when the file contained syntax errors. The formatter now checks for parse errors before writing and leaves the original file untouched.
 - **`jac lint` Command**: Added a dedicated `jac lint` command that reports all lint violations as errors with file, line, and column info. Use `jac lint --fix` to auto-fix violations. Lint rules are configured via `[check.lint]` in `jac.toml`. All enabled rules are treated as errors (not warnings). The `--fix` flag has been removed from `jac format`, which is now pure formatting only.
@@ -15,7 +17,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **JsxElement Builtin Type**: Added `JsxElement` builtin type for strict type checking of JSX expressions for client-side UI components.
 - **1 Small Refactors**
 
-## jaclang 0.9.13 (Latest Release)
+## jaclang 0.9.13
 
 - **Configurable Lint Rules**: Auto-lint rules are now individually configurable via `jac.toml` `[check.lint]` section using a select/ignore model. A `LintRule` enum defines all 12 rules with kebab-case names. Use `select = ["default"]` for code-transforming rules only, `select = ["all"]` to enable every rule including warning-only rules, `ignore = ["rule-name"]` to disable specific ones, or `select = ["rule1", "rule2"]` to enable only listed rules.
 - **No-Print Lint Rule**: Added a `no-print` lint rule that errors on bare `print()` calls in `.jac` files, encouraging use of the console abstraction instead. Included in the `"all"` group; enable via `select = ["all"]` or `select = ["default", "no-print"]` in `[check.lint]`.

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.2.13"
+version = "0.2.14"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.13",
+    "jaclang>=0.9.14",
 ]
 
 [project.urls]

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jac-scale"
-version = "0.1.4"
+version = "0.1.5"
 description = ""
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.9.13",
+    "jaclang>=0.9.14",
     "python-dotenv>=1.2.1,<2.0.0",
     "docker>=7.1.0,<8.0.0",
     "kubernetes>=34.1.0,<35.0.0",

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaclang"
-version = "0.9.13"
+version = "0.9.14"
 description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]

--- a/jaseci-package/pyproject.toml
+++ b/jaseci-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaseci"
-version = "2.2.11"
+version = "2.2.12"
 description = "Jaseci - A complete AI-native programming ecosystem with Jac language, LLM integration, and full-stack web apps"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -22,10 +22,10 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.9.13",
+    "jaclang>=0.9.14",
     "byllm>=0.4.17",
-    "jac-client>=0.2.13",
-    "jac-scale>=0.1.4",
+    "jac-client>=0.2.14",
+    "jac-scale>=0.1.5",
     "jac-super>=0.1.0",
 ]
 


### PR DESCRIPTION
## **Description**

| Package | Old Version | New Version |
|---------|-------------|-------------|
| **jaclang** | 0.9.13 | 0.9.14 |
| **jac-client** | 0.2.13 | 0.2.14 |
| **jac-scale** | 0.1.4 | 0.1.5 |
| **jaseci** | 2.2.11 | 2.2.12 |
