### PR TITLE
feat: Add handwritten recursive descent parser for Jac

### DIFF
--- a/jac/jaclang/compiler/rd_parser/__init__.py
+++ b/jac/jaclang/compiler/rd_parser/__init__.py
@@ -1,0 +1,143 @@
+"""Handwritten recursive descent parser for Jac, written in Jac.
+
+Provides JacRDParser as a drop-in alternative to JacParser,
+selectable via the JAC_RD_PARSER=1 environment variable.
+"""
+
+import logging
+import os
+from threading import Event
+from typing import TYPE_CHECKING
+
+import jaclang.pycore.unitree as uni
+from jaclang.pycore.constant import CodeContext
+from jaclang.pycore.passes.transform import Transform
+
+if TYPE_CHECKING:
+    from jaclang.pycore.program import JacProgram
+
+logger = logging.getLogger(__name__)
+
+
+class JacRDParser(Transform[uni.Source, uni.Module]):
+    """Drop-in alternative to JacParser using handwritten recursive descent.
+
+    This parser is written in Jac and compiled to Python. It produces the
+    same AST (uni.Module) as the Lark-based JacParser, enabling A/B
+    validation during development.
+
+    Usage:
+        Set environment variable JAC_RD_PARSER=1 to use this parser
+        instead of the default Lark-based parser.
+    """
+
+    def __init__(
+        self,
+        root_ir: uni.Source,
+        prog: "JacProgram",
+        cancel_token: Event | None = None,
+    ) -> None:
+        """Initialize the RD parser."""
+        self.mod_path: str = root_ir.loc.mod_path
+        self.node_list: list[uni.UniNode] = []
+        self._node_ids: set[int] = set()
+
+        if cancel_token and cancel_token.is_set():
+            return
+
+        Transform.__init__(self, ir_in=root_ir, prog=prog, cancel_token=cancel_token)
+
+    def transform(self, ir_in: uni.Source) -> uni.Module:
+        """Transform source into AST Module using the RD parser."""
+        try:
+            # Import the Jac-compiled parser core
+            from jaclang.compiler.rd_parser.parser import JacRDParserCore
+
+            core = JacRDParserCore(
+                source=ir_in.value,
+                orig_src=ir_in,
+                mod_path=self.mod_path,
+            )
+            mod = core.parse_module()
+
+            # Transfer comments from lexer
+            if hasattr(core, "lexer") and hasattr(core.lexer, "comments"):
+                ir_in.comments = core.lexer.comments
+
+            # Transfer node tracking
+            if hasattr(core, "node_list"):
+                self.node_list = core.node_list
+
+            # Check for parse errors
+            if not isinstance(mod, uni.Module):
+                mod = uni.Module.make_stub(inject_src=ir_in)
+                mod.has_syntax_errors = True
+                self.log_error("Parser did not produce a Module", node_override=ir_in)
+                return mod
+
+            if hasattr(core, "errors_had") and core.errors_had:
+                mod.has_syntax_errors = True
+                for err in core.errors_had:
+                    self.errors_had.append(err)
+                    self.prog.errors_had.append(err)
+
+            # Apply context coercion for .cl.jac, .sv.jac, .na.jac files
+            self._apply_context_coercion(ir_in, mod)
+
+            self.ir_out = mod
+            return mod
+
+        except Exception as e:
+            logger.error("RD parser error in %s: %s", self.mod_path, e, exc_info=True)
+            mod = uni.Module.make_stub(inject_src=ir_in)
+            mod.has_syntax_errors = True
+            self.log_error(f"Internal parser error: {e}", node_override=ir_in)
+            return mod
+
+    def _apply_context_coercion(self, ir_in: uni.Source, mod: uni.Module) -> None:
+        """Apply .cl.jac / .sv.jac / .na.jac context coercion."""
+        file_path = ir_in.loc.mod_path if ir_in.loc else ""
+
+        if file_path.endswith(".cl.jac"):
+            self._coerce_context(mod, CodeContext.CLIENT, uni.ClientBlock)
+        elif file_path.endswith(".sv.jac"):
+            self._coerce_context(mod, CodeContext.SERVER, uni.ServerBlock)
+        elif file_path.endswith(".na.jac"):
+            self._coerce_context(mod, CodeContext.NATIVE, uni.NativeBlock)
+
+    @staticmethod
+    def _coerce_context(
+        module: uni.Module,
+        default_context: CodeContext,
+        unwrap_block_type: type,
+    ) -> None:
+        """Coerce module statements to a default context.
+
+        Unwraps blocks of the given type and marks all top-level
+        statements with the default context.
+        """
+        elements: list[uni.ElementStmt] = []
+        for stmt in module.body:
+            if isinstance(stmt, unwrap_block_type) and hasattr(stmt, "body"):
+                elements.extend(stmt.body)  # type: ignore[union-attr]
+            elif isinstance(stmt, uni.ElementStmt):
+                elements.append(stmt)
+
+        for elem in elements:
+            # Skip blocks that are explicitly a different context
+            if isinstance(elem, (uni.ClientBlock, uni.ServerBlock, uni.NativeBlock)):
+                continue
+            if isinstance(elem, uni.ContextAwareNode):
+                elem.code_context = default_context.value  # type: ignore[assignment]
+                # Propagate to inner body if ModuleCode
+                if isinstance(elem, uni.ModuleCode) and elem.body:
+                    for inner in elem.body:
+                        if isinstance(inner, uni.ContextAwareNode):
+                            inner.code_context = default_context.value  # type: ignore[assignment]
+
+        module.body = elements
+
+
+def is_rd_parser_enabled() -> bool:
+    """Check if the RD parser is enabled via environment variable."""
+    return os.environ.get("JAC_RD_PARSER", "0") == "1"

--- a/jac/jaclang/compiler/rd_parser/ast_builder.jac
+++ b/jac/jaclang/compiler/rd_parser/ast_builder.jac
@@ -1,0 +1,149 @@
+"""AST construction helpers for the handwritten Jac parser.
+
+Provides:
+- KidCollector: Context-like helper for accumulating child nodes in source order.
+- Utility functions for building AST nodes with correct kid lists.
+"""
+
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    Source as UniSource,
+    EmptyToken as UniEmptyToken,
+    SpecialVarRef as UniSpecialVarRef
+}
+
+import from jaclang.pycore.constant { Tokens as Tok }
+
+import from jaclang.compiler.rd_parser.lexer {
+    SPECIAL_REF_TOKENS,
+    KEYWORD_MAP,
+    BUILTIN_TYPE_MAP,
+    EOF_NAME
+}
+
+# ── KidCollector ─────────────────────────────────────────────────────────────
+obj KidCollector {
+    """Collects all tokens and nodes consumed during a grammar production.
+
+    Usage:
+        collector = KidCollector();
+        collector.start(parser);
+        # ... parse sub-productions, each call to parser.advance() or
+        # adding a sub-node goes through the collector ...
+        nd = SomeASTNode(..., kid=collector.kids);
+        collector.stop();
+    """
+    has kids: list = [],
+        parser: any = None,
+        prev_collector: any = None;
+
+    def init {
+        self.kids = [];
+        self.parser = None;
+        self.prev_collector = None;
+    }
+
+    def start(parser: any) {
+        # Begin collecting kids. Saves the parser's current collector.
+        self.parser = parser;
+        self.prev_collector = parser.current_collector;
+        parser.current_collector = self;
+    }
+
+    def stop {
+        # Stop collecting kids. Restores the parser's previous collector.
+        if self.parser is not None {
+            self.parser.current_collector = self.prev_collector;
+        }
+    }
+
+    def add(node: any) {
+        # Add a node or token to the kid list.
+        if node is not None {
+            self.kids.append(nd);
+        }
+    }
+
+    def add_many(nodes: list) {
+        # Add multiple nodes to the kid list.
+        for node in nodes {
+            if node is not None {
+                self.kids.append(nd);
+            }
+        }
+    }
+}
+
+# ── Helper Functions ─────────────────────────────────────────────────────────
+def is_eof_token(
+    tok: UniToken
+) -> bool {
+    # Check if a token is the EOF sentinel.
+    return tok.name == EOF_NAME;
+}
+
+# Build the set of token names accepted as identifiers in named_ref context.
+# Includes NAME, KWESC_NAME, all KW_* keyword tokens (which are alphabetic words),
+# but excludes BOOL (True/False) and NULL (None) since those are literals.
+# This mirrors Lark's contextual lexer which resolves keyword-vs-name ambiguity
+# based on parser state — since parse_named_ref is only called when a name is
+# explicitly expected, any keyword token (e.g. KW_HAS for 'has') should be accepted.
+def _build_name_token_set -> set {
+    s: set = {Tok.NAME.value,Tok.KWESC_NAME.value};
+    # Add all keyword-mapped token names (except literals)
+    for (word, tok_enum) in KEYWORD_MAP.items() {
+        tok_name = tok_enum.value;
+        if tok_name not in [Tok.BOOL.value, Tok.NULL.value] {
+            s.add(tok_name);
+        }
+    }
+    # Add all builtin type token names (set, list, dict, int, etc.)
+    for (word, tok_enum) in BUILTIN_TYPE_MAP.items() {
+        s.add(tok_enum.value);
+    }
+    return s;
+}
+
+glob _NAME_TOKEN_SET: set = _build_name_token_set();
+
+def is_name_token(tok: UniToken) -> bool {
+    # Check if a token can serve as a Name in named_ref position.
+    return tok.name in _NAME_TOKEN_SET;
+}
+
+def is_special_ref_token(tok: UniToken) -> bool {
+    # Check if a token is a special variable reference.
+    return tok.name in SPECIAL_REF_TOKENS;
+}
+
+def wrap_special_ref(name_tok: UniName) -> UniSpecialVarRef {
+    # Wrap a Name token as a SpecialVarRef if it's a special reference keyword.
+    return UniSpecialVarRef(var=name_tok);
+}
+
+def make_empty_token(orig_src: UniSource) -> UniEmptyToken {
+    # Create an empty token for error recovery.
+    return UniEmptyToken(orig_src=orig_src);
+}
+
+# ── Token Type Check Helpers ─────────────────────────────────────────────────
+glob AUGMENTED_ASSIGN_OPS:
+         set = {Tok.ADD_EQ.value,Tok.SUB_EQ.value,Tok.MUL_EQ.value,Tok.STAR_POW_EQ.value,Tok.FLOOR_DIV_EQ.value,Tok.DIV_EQ.value,Tok.MOD_EQ.value,Tok.BW_AND_EQ.value,Tok.BW_OR_EQ.value,Tok.BW_XOR_EQ.value,Tok.LSHIFT_EQ.value,Tok.RSHIFT_EQ.value,Tok.MATMUL_EQ.value},
+     COMPARISON_OPS: set = {Tok.EE.value,Tok.NE.value,Tok.LT.value,Tok.GT.value,Tok.LTE.value,Tok.GTE.value,Tok.KW_IS.value,Tok.KW_ISN.value,Tok.KW_IN.value,Tok.KW_NIN.value},
+     ARCH_TYPE_TOKENS: set = {Tok.KW_OBJECT.value,Tok.KW_CLASS.value,Tok.KW_NODE.value,Tok.KW_EDGE.value,Tok.KW_WALKER.value},
+     UNARY_PREFIX_OPS: set = {Tok.MINUS.value,Tok.PLUS.value,Tok.BW_NOT.value},
+     STATEMENT_START_TOKENS: set = {Tok.KW_IF.value,Tok.KW_WHILE.value,Tok.KW_FOR.value,Tok.KW_TRY.value,Tok.KW_WITH.value,Tok.KW_MATCH.value,Tok.KW_SWITCH.value,Tok.KW_RETURN.value,Tok.KW_YIELD.value,Tok.KW_RAISE.value,Tok.KW_ASSERT.value,Tok.KW_DELETE.value,Tok.KW_REPORT.value,Tok.KW_BREAK.value,Tok.KW_CONTINUE.value,Tok.KW_SKIP.value,Tok.KW_VISIT.value,Tok.KW_DISENGAGE.value,Tok.GLOBAL_OP.value,Tok.NONLOCAL_OP.value,Tok.KW_IMPORT.value,Tok.KW_INCLUDE.value,Tok.KW_HAS.value,Tok.KW_ASYNC.value,Tok.SEMI.value,Tok.RETURN_HINT.value},
+     TOPLEVEL_SYNC_TOKENS: set = {Tok.KW_IMPORT.value,Tok.KW_INCLUDE.value,Tok.KW_OBJECT.value,Tok.KW_CLASS.value,Tok.KW_NODE.value,Tok.KW_EDGE.value,Tok.KW_WALKER.value,Tok.KW_ENUM.value,Tok.KW_DEF.value,Tok.KW_CAN.value,Tok.KW_IMPL.value,Tok.KW_SEM.value,Tok.KW_TEST.value,Tok.KW_GLOBAL.value,Tok.KW_CLIENT.value,Tok.KW_SERVER.value,Tok.KW_NATIVE.value,Tok.DECOR_OP.value,Tok.KW_WITH.value,Tok.KW_ASYNC.value},
+     STMT_SYNC_TOKENS: set = {Tok.RBRACE.value,Tok.SEMI.value,Tok.KW_IF.value,Tok.KW_FOR.value,Tok.KW_WHILE.value,Tok.KW_TRY.value,Tok.KW_WITH.value,Tok.KW_RETURN.value,Tok.KW_RAISE.value,Tok.KW_IMPORT.value},
+     EXPR_SYNC_TOKENS: set = {Tok.SEMI.value,Tok.RPAREN.value,Tok.RBRACE.value,Tok.RSQUARE.value,Tok.COMMA.value,Tok.COLON.value},
+     AUTO_INSERT_TOKENS: set = {Tok.SEMI.value,Tok.COMMA.value,Tok.COLON.value,Tok.RPAREN.value,Tok.RBRACE.value,Tok.RSQUARE.value,Tok.RETURN_HINT.value},
+     EDGE_OP_TOKENS: set = {Tok.ARROW_R.value,Tok.ARROW_L.value,Tok.ARROW_BI.value,Tok.ARROW_R_P1.value,Tok.ARROW_L_P1.value,Tok.ARROW_R_P2.value,Tok.ARROW_L_P2.value},
+     CONNECT_OP_TOKENS: set = {Tok.CARROW_R.value,Tok.CARROW_L.value,Tok.CARROW_BI.value,Tok.CARROW_R_P1.value,Tok.CARROW_L_P1.value,Tok.CARROW_R_P2.value,Tok.CARROW_L_P2.value},
+     ALL_EDGE_CONNECT_TOKENS: set = EDGE_OP_TOKENS | CONNECT_OP_TOKENS,
+     EDGE_CONNECT_START_TOKENS: set = {Tok.ARROW_R.value,Tok.ARROW_L.value,Tok.ARROW_BI.value,Tok.ARROW_R_P1.value,Tok.ARROW_L_P1.value,Tok.CARROW_R.value,Tok.CARROW_L.value,Tok.CARROW_BI.value,Tok.CARROW_R_P1.value,Tok.CARROW_L_P1.value},
+     CONNECT_OP_START_TOKENS: set = {Tok.CARROW_R.value,Tok.CARROW_L.value,Tok.CARROW_BI.value,Tok.CARROW_R_P1.value,Tok.CARROW_L_P1.value};
+# Tokens that can START an edge or connect operator (excludes P2 closing tokens)
+
+# Tokens that can START a connect operator only (excludes edge ops and P2 closing tokens)

--- a/jac/jaclang/compiler/rd_parser/lexer.jac
+++ b/jac/jaclang/compiler/rd_parser/lexer.jac
@@ -1,0 +1,1966 @@
+"""Handwritten lexer for the Jac language.
+
+Produces uni.Token (and subclasses) directly, with full source location tracking.
+Supports mode-based context-sensitive tokenization for f-strings and JSX.
+"""
+
+import re;
+
+import from jaclang.pycore.unitree {
+    Token as UniToken,
+    Name as UniName,
+    Semi as UniSemi,
+    Float as UniFloat,
+    Int as UniInt,
+    String as UniString,
+    Bool as UniBool,
+    Null as UniNull,
+    Ellipsis as UniEllipsis,
+    BuiltinType as UniBuiltinType,
+    CommentToken as UniCommentToken,
+    Source as UniSource,
+    SpecialVarRef as UniSpecialVarRef
+}
+
+import from jaclang.pycore.constant { Tokens as Tok }
+
+# ── Lexer Mode Enum ──────────────────────────────────────────────────────────
+enum LexerMode {
+    NORMAL = "normal",
+    FSTRING_DQ = "fstring_dq",
+    FSTRING_SQ = "fstring_sq",
+    FSTRING_TDQ = "fstring_tdq",
+    FSTRING_TSQ = "fstring_tsq",
+    FSTRING_EXPR = "fstring_expr",
+    FSTRING_FORMAT = "fstring_format",  # For format specs after : in f-string expressions
+    JSX_TAG = "jsx_tag",
+    JSX_CONTENT = "jsx_content"
+}
+
+# ── Keyword Map ──────────────────────────────────────────────────────────────
+glob KEYWORD_MAP:
+         dict = {
+         "abs": Tok.KW_ABSTRACT,
+         "obj": Tok.KW_OBJECT,
+         "class": Tok.KW_CLASS,
+         "enum": Tok.KW_ENUM,
+         "node": Tok.KW_NODE,
+         "edge": Tok.KW_EDGE,
+         "walker": Tok.KW_WALKER,
+         "def": Tok.KW_DEF,
+         "can": Tok.KW_CAN,
+         "static": Tok.KW_STATIC,
+         "override": Tok.KW_OVERRIDE,
+         "has": Tok.KW_HAS,
+         "if": Tok.KW_IF,
+         "elif": Tok.KW_ELIF,
+         "else": Tok.KW_ELSE,
+         "for": Tok.KW_FOR,
+         "to": Tok.KW_TO,
+         "by": Tok.KW_BY,
+         "while": Tok.KW_WHILE,
+         "continue": Tok.KW_CONTINUE,
+         "break": Tok.KW_BREAK,
+         "skip": Tok.KW_SKIP,
+         "return": Tok.KW_RETURN,
+         "yield": Tok.KW_YIELD,
+         "del": Tok.KW_DELETE,
+         "try": Tok.KW_TRY,
+         "except": Tok.KW_EXCEPT,
+         "finally": Tok.KW_FINALLY,
+         "raise": Tok.KW_RAISE,
+         "assert": Tok.KW_ASSERT,
+         "import": Tok.KW_IMPORT,
+         "include": Tok.KW_INCLUDE,
+         "from": Tok.KW_FROM,
+         "as": Tok.KW_AS,
+         "with": Tok.KW_WITH,
+         "entry": Tok.KW_ENTRY,
+         "exit": Tok.KW_EXIT,
+         "async": Tok.KW_ASYNC,
+         "await": Tok.KW_AWAIT,
+         "flow": Tok.KW_FLOW,
+         "wait": Tok.KW_WAIT,
+         "spawn": Tok.KW_SPAWN,
+         "test": Tok.KW_TEST,
+         "visit": Tok.KW_VISIT,
+         "disengage": Tok.KW_DISENGAGE,
+         "report": Tok.KW_REPORT,
+         "match": Tok.KW_MATCH,
+         "switch": Tok.KW_SWITCH,
+         "case": Tok.KW_CASE,
+         "default": Tok.KW_DEFAULT,
+         "impl": Tok.KW_IMPL,
+         "sem": Tok.KW_SEM,
+         "lambda": Tok.KW_LAMBDA,
+         "glob": Tok.KW_GLOBAL,
+         "priv": Tok.KW_PRIV,
+         "pub": Tok.KW_PUB,
+         "protect": Tok.KW_PROT,
+         "cl": Tok.KW_CLIENT,
+         "sv": Tok.KW_SERVER,
+         "na": Tok.KW_NATIVE,
+         # Logic keyword-operators
+         "and": Tok.KW_AND,
+         "or": Tok.KW_OR,
+         "not": Tok.NOT,
+         "in": Tok.KW_IN,
+         "is": Tok.KW_IS,
+         # Literals
+         "True": Tok.BOOL,
+         "False": Tok.BOOL,
+         "None": Tok.NULL,
+         # Special refs
+         "init": Tok.KW_INIT,
+         "postinit": Tok.KW_POST_INIT,
+         "self": Tok.KW_SELF,
+         "props": Tok.KW_PROPS,
+         "super": Tok.KW_SUPER,
+         "root": Tok.KW_ROOT,
+         "here": Tok.KW_HERE,
+         "visitor": Tok.KW_VISITOR,
+         # Global/nonlocal as keyword-operators
+         "global": Tok.GLOBAL_OP,
+         "nonlocal": Tok.NONLOCAL_OP
+     },
+     BUILTIN_TYPE_MAP: dict = {
+         "str": Tok.TYP_STRING,
+         "int": Tok.TYP_INT,
+         "float": Tok.TYP_FLOAT,
+         "list": Tok.TYP_LIST,
+         "tuple": Tok.TYP_TUPLE,
+         "set": Tok.TYP_SET,
+         "dict": Tok.TYP_DICT,
+         "bool": Tok.TYP_BOOL,
+         "bytes": Tok.TYP_BYTES,
+         "any": Tok.TYP_ANY,
+         "type": Tok.TYP_TYPE
+     },
+     SPECIAL_REF_TOKENS: set = {Tok.KW_INIT.value,Tok.KW_POST_INIT.value,Tok.KW_SELF.value,Tok.KW_PROPS.value,Tok.KW_SUPER.value,Tok.KW_ROOT.value,Tok.KW_HERE.value,Tok.KW_VISITOR.value},
+     NAME_TOKENS: set = {Tok.NAME.value,Tok.KWESC_NAME.value,Tok.KW_INIT.value,Tok.KW_POST_INIT.value,Tok.KW_SELF.value,Tok.KW_PROPS.value,Tok.KW_SUPER.value,Tok.KW_ROOT.value,Tok.KW_HERE.value,Tok.KW_VISITOR.value},
+     EOF_NAME: str = "__EOF__";
+
+# ── JacLexer ─────────────────────────────────────────────────────────────────
+obj JacLexer {
+    """Lexer for the Jac language with mode-based context-sensitive tokenization."""
+    has source: str,
+        orig_src: UniSource,
+        pos: int = 0,
+        line: int = 1,
+        col: int = 1,
+        mode_stack: list = [],
+        comments: list = [],
+        peeked: list = [],
+        terminals: list = [],
+        all_tokens: list = [],
+        in_jsx_close_tag: bool = False,
+        fstring_bracket_depth: int = 0;
+
+    def init(source: str, orig_src: UniSource) {
+        self.source = source;
+        self.orig_src = orig_src;
+        self.pos = 0;
+        self.line = 1;
+        self.col = 1;
+        self.mode_stack = [LexerMode.NORMAL];
+        self.comments = [];
+        self.peeked = [];
+        self.terminals = [];
+        self.all_tokens = [];
+        self.in_jsx_close_tag = False;
+        self.fstring_bracket_depth = 0;
+    }
+
+    # ── Mode management ──────────────────────────────────────────────────
+    def current_mode -> str {
+        if len(self.mode_stack) > 0 {
+            return self.mode_stack[-1];
+        }
+        return LexerMode.NORMAL;
+    }
+
+    def push_mode(mode: str) {
+        self.mode_stack.append(mode);
+    }
+
+    def pop_mode {
+        if len(self.mode_stack) > 1 {
+            self.mode_stack.pop();
+        }
+    }
+
+    # ── Position helpers ─────────────────────────────────────────────────
+    def at_end -> bool {
+        return self.pos >= len(self.source);
+    }
+
+    def char_at(offset: int = 0) -> str {
+        # Return character at current pos + offset, or empty string if out of bounds.
+        idx = self.pos + offset;
+        if idx < len(self.source) {
+            return self.source[idx];
+        }
+        return "";
+    }
+
+    def starts_with(s: str) -> bool {
+        # Check if source at current position starts with given string.
+        return self.source[self.pos:self.pos + len(s)] == s;
+    }
+
+    def advance_char -> str {
+        # Advance position by one character, updating line/col tracking.
+        ch = self.source[self.pos];
+        self.pos += 1;
+        if ch == "\n" {
+            self.line += 1;
+            self.col = 1;
+        } else {
+            self.col += 1;
+        }
+        return ch;
+    }
+
+    def advance_n(n: int) {
+        # Advance position by n characters, updating line/col tracking.
+        i = 0;
+        while i < n {
+            self.advance_char();
+            i += 1;
+        }
+    }
+
+    # ── Token creation ───────────────────────────────────────────────────
+    def make_token(
+        tok_type: str, value: str, start_pos: int, start_line: int, start_col: int
+    ) -> UniToken {
+        # Create the appropriate Token subclass based on token type.
+        end_pos = self.pos;
+        end_line = self.line;
+        end_col = self.col;
+
+        tok_name = tok_type;
+
+        # Determine correct subclass
+        if tok_name in NAME_TOKENS {
+            ret = UniName(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value[2:] if tok_name == Tok.KWESC_NAME.value else value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos,
+                is_kwesc=tok_name == Tok.KWESC_NAME.value
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name == Tok.SEMI.value {
+            ret = UniSemi(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name == Tok.NULL.value {
+            ret = UniNull(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name == Tok.ELLIPSIS.value {
+            ret = UniEllipsis(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name == Tok.FLOAT.value {
+            ret = UniFloat(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name in [Tok.INT.value, Tok.HEX.value, Tok.BIN.value, Tok.OCT.value] {
+            ret = UniInt(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name in [
+            Tok.STRING.value,
+            Tok.D_LBRACE.value,
+            Tok.D_RBRACE.value,
+            Tok.F_TEXT_DQ.value,
+            Tok.F_TEXT_SQ.value,
+            Tok.F_TEXT_TDQ.value,
+            Tok.F_TEXT_TSQ.value,
+            Tok.RF_TEXT_DQ.value,
+            Tok.RF_TEXT_SQ.value,
+            Tok.RF_TEXT_TDQ.value,
+            Tok.RF_TEXT_TSQ.value,
+            Tok.F_FORMAT_TEXT.value
+        ] {
+            actual_value = value;
+            if tok_name == Tok.D_LBRACE.value {
+                actual_value = "{";
+            } elif tok_name == Tok.D_RBRACE.value {
+                actual_value = "}";
+            }
+            ret = UniString(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=actual_value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name == Tok.BOOL.value {
+            ret = UniBool(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        } elif tok_name == Tok.PYNLINE.value {
+            ret = UniToken(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        }
+
+        # Builtin types produce BuiltinType nodes
+        if tok_name in [
+            Tok.TYP_STRING.value,
+            Tok.TYP_INT.value,
+            Tok.TYP_FLOAT.value,
+            Tok.TYP_LIST.value,
+            Tok.TYP_TUPLE.value,
+            Tok.TYP_SET.value,
+            Tok.TYP_DICT.value,
+            Tok.TYP_BOOL.value,
+            Tok.TYP_BYTES.value,
+            Tok.TYP_ANY.value,
+            Tok.TYP_TYPE.value
+        ] {
+            ret = UniBuiltinType(
+                orig_src=self.orig_src,
+                name=tok_name,
+                value=value,
+                line=start_line,
+                end_line=end_line,
+                col_start=start_col,
+                col_end=end_col,
+                pos_start=start_pos,
+                pos_end=end_pos
+            );
+            self.terminals.append(ret);
+            self.all_tokens.append(ret);
+            return ret;
+        }
+
+        # Default: plain Token
+        ret = UniToken(
+            orig_src=self.orig_src,
+            name=tok_name,
+            value=value,
+            line=start_line,
+            end_line=end_line,
+            col_start=start_col,
+            col_end=end_col,
+            pos_start=start_pos,
+            pos_end=end_pos
+        );
+        self.terminals.append(ret);
+        self.all_tokens.append(ret);
+        return ret;
+    }
+
+    def make_eof_token -> UniToken {
+        # Create an EOF sentinel token.
+        return UniToken(
+            orig_src=self.orig_src,
+            name=EOF_NAME,
+            value="",
+            line=self.line,
+            end_line=self.line,
+            col_start=self.col,
+            col_end=self.col,
+            pos_start=self.pos,
+            pos_end=self.pos
+        );
+    }
+
+    # ── Whitespace and comments ──────────────────────────────────────────
+    def skip_whitespace_and_comments {
+        # Skip whitespace and collect comments.
+        while not self.at_end() {
+            ch = self.char_at();
+
+            # Whitespace
+            if ch in " \t\r\n\f" {
+                self.advance_char();
+                continue;
+            }
+
+            # Block comment: #* ... *#
+            if ch == "#" and self.char_at(1) == "*" {
+                self._scan_block_comment();
+                continue;
+            }
+
+            # Line comment: # ...
+            if ch == "#" {
+                self._scan_line_comment();
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    def _scan_line_comment {
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+        value = "";
+        while not self.at_end() and self.char_at() != "\n" {
+            value += self.advance_char();
+        }
+        comment = UniCommentToken(
+            orig_src=self.orig_src,
+            name=Tok.COMMENT.value,
+            value=value,
+            line=start_line,
+            end_line=self.line,
+            col_start=start_col,
+            col_end=self.col,
+            pos_start=start_pos,
+            pos_end=self.pos,
+            kid=[]
+        );
+        self.comments.append(comment);
+    }
+
+    def _scan_block_comment {
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+        value = "";
+        # consume #*
+        value += self.advance_char();
+        value += self.advance_char();
+        while not self.at_end() {
+            if self.char_at() == "*" and self.char_at(1) == "#" {
+                value += self.advance_char();
+                value += self.advance_char();
+                break;
+            }
+            value += self.advance_char();
+        }
+        comment = UniCommentToken(
+            orig_src=self.orig_src,
+            name=Tok.COMMENT.value,
+            value=value,
+            line=start_line,
+            end_line=self.line,
+            col_start=start_col,
+            col_end=self.col,
+            pos_start=start_pos,
+            pos_end=self.pos,
+            kid=[]
+        );
+        self.comments.append(comment);
+    }
+
+    # ── Number scanning ──────────────────────────────────────────────────
+    def _scan_number -> UniToken {
+        # Scan a numeric literal (INT, FLOAT, HEX, BIN, OCT).
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        ch = self.char_at();
+        ch1 = self.char_at(1);
+
+        # Hex: 0x...
+        if ch == "0" and ch1 in "xX" {
+            value = self.advance_char() + self.advance_char();
+            while not self.at_end() and (self.char_at() in "0123456789abcdefABCDEF_") {
+                value += self.advance_char();
+            }
+            return self.make_token(
+                Tok.HEX.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Binary: 0b...
+        if ch == "0" and ch1 in "bB" {
+            value = self.advance_char() + self.advance_char();
+            while not self.at_end() and (self.char_at() in "01_") {
+                value += self.advance_char();
+            }
+            return self.make_token(
+                Tok.BIN.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Octal: 0o...
+        if ch == "0" and ch1 in "oO" {
+            value = self.advance_char() + self.advance_char();
+            while not self.at_end() and (self.char_at() in "01234567_") {
+                value += self.advance_char();
+            }
+            return self.make_token(
+                Tok.OCT.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Integer or float
+        value = "";
+        is_float = False;
+
+        # Integer part
+        while not self.at_end() and (self.char_at() in "0123456789_") {
+            value += self.advance_char();
+        }
+
+        # Decimal point
+        if not self.at_end() and self.char_at() == "." and self.char_at(1) != "." {
+            is_float = True;
+            value += self.advance_char();
+            while not self.at_end() and (self.char_at() in "0123456789_") {
+                value += self.advance_char();
+            }
+        }
+
+        # Exponent
+        if not self.at_end() and self.char_at() in "eE" {
+            is_float = True;
+            value += self.advance_char();
+            if not self.at_end() and self.char_at() in "+-" {
+                value += self.advance_char();
+            }
+            while not self.at_end() and (self.char_at() in "0123456789_") {
+                value += self.advance_char();
+            }
+        }
+
+        if is_float {
+            return self.make_token(
+                Tok.FLOAT.value, value, start_pos, start_line, start_col
+            );
+        }
+        return self.make_token(Tok.INT.value, value, start_pos, start_line, start_col);
+    }
+
+    def _scan_dot_number -> UniToken {
+        # Scan a number starting with dot: .5, .5e3, etc.
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+        value = self.advance_char();  # consume '.'
+        while not self.at_end() and self.char_at() in "0123456789_" {
+            value += self.advance_char();
+        }
+        # Exponent
+        if not self.at_end() and self.char_at() in "eE" {
+            value += self.advance_char();
+            if not self.at_end() and self.char_at() in "+-" {
+                value += self.advance_char();
+            }
+            while not self.at_end() and self.char_at() in "0123456789_" {
+                value += self.advance_char();
+            }
+        }
+        return self.make_token(
+            Tok.FLOAT.value, value, start_pos, start_line, start_col
+        );
+    }
+
+    # ── String scanning ──────────────────────────────────────────────────
+    def _scan_string(prefix: str = "") -> UniToken {
+        # Scan a string literal with optional prefix (r, b, rb, br).
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        # Skip prefix chars already consumed
+        value = prefix;
+
+        quote_char = self.char_at();
+        # Check for triple-quote
+        if self.char_at(1) == quote_char and self.char_at(2) == quote_char {
+            # Triple-quoted string
+            triple = quote_char * 3;
+            value += self.advance_char() + self.advance_char() + self.advance_char();
+            while not self.at_end() {
+                if self.char_at() == quote_char
+                and self.char_at(1) == quote_char
+                and self.char_at(2) == quote_char {
+                    value += self.advance_char() + self.advance_char() + self.advance_char();
+                    break;
+                }
+                if self.char_at() == "\\" {
+                    value += self.advance_char();
+                    if not self.at_end() {
+                        value += self.advance_char();
+                    }
+                } else {
+                    value += self.advance_char();
+                }
+            }
+        } else {
+            # Single-quoted string
+            value += self.advance_char();  # opening quote
+            while not self.at_end()
+            and self.char_at() != quote_char
+            and self.char_at() != "\n" {
+                if self.char_at() == "\\" {
+                    value += self.advance_char();
+                    if not self.at_end() {
+                        value += self.advance_char();
+                    }
+                } else {
+                    value += self.advance_char();
+                }
+            }
+            if not self.at_end() and self.char_at() == quote_char {
+                value += self.advance_char();  # closing quote
+            }
+        }
+
+        return self.make_token(
+            Tok.STRING.value, value, start_pos, start_line, start_col
+        );
+    }
+
+    # ── F-string scanning ────────────────────────────────────────────────
+    def _scan_fstring_start(prefix: str) -> UniToken {
+        # Scan f-string opening (e.g., f", f', f\"\"\", rf', etc.).
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        value = prefix;
+        is_raw = "r" in prefix.lower();
+
+        quote_char = self.char_at();
+        # Check for triple-quote
+        if self.char_at(1) == quote_char and self.char_at(2) == quote_char {
+            value += self.advance_char() + self.advance_char() + self.advance_char();
+            if quote_char == '"' {
+                tok_type = Tok.RF_TDQ_START.value if is_raw else Tok.F_TDQ_START.value;
+                self.push_mode(LexerMode.FSTRING_TDQ);
+            } else {
+                tok_type = Tok.RF_TSQ_START.value if is_raw else Tok.F_TSQ_START.value;
+                self.push_mode(LexerMode.FSTRING_TSQ);
+            }
+        } else {
+            value += self.advance_char();  # single quote
+            if quote_char == '"' {
+                tok_type = Tok.RF_DQ_START.value if is_raw else Tok.F_DQ_START.value;
+                self.push_mode(LexerMode.FSTRING_DQ);
+            } else {
+                tok_type = Tok.RF_SQ_START.value if is_raw else Tok.F_SQ_START.value;
+                self.push_mode(LexerMode.FSTRING_SQ);
+            }
+        }
+
+        return self.make_token(tok_type, value, start_pos, start_line, start_col);
+    }
+
+    def _scan_fstring_body -> UniToken {
+        # Scan f-string body content in the appropriate mode.
+        mode = self.current_mode();
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        is_raw = mode in [LexerMode.FSTRING_TDQ, LexerMode.FSTRING_TSQ] and False;
+        # Determine is_raw from mode name (modes with RF prefix are handled differently)
+        # Actually, we track raw-ness by the start token. For now detect from f-string mode.
+
+        # Determine quote char and triple
+        is_triple = mode in [LexerMode.FSTRING_TDQ, LexerMode.FSTRING_TSQ];
+
+        if mode in [LexerMode.FSTRING_DQ, LexerMode.FSTRING_TDQ] {
+            quote_char = '"';
+        } else {
+            quote_char = "'";
+        }
+
+        # Check for end of f-string
+        if is_triple {
+            end_str = quote_char * 3;
+            if self.starts_with(end_str) {
+                value = self.advance_char() + self.advance_char() + self.advance_char();
+                self.pop_mode();
+                tok_type = Tok.F_TDQ_END.value
+                if quote_char == '"'
+                else Tok.F_TSQ_END.value;
+                return self.make_token(
+                    tok_type, value, start_pos, start_line, start_col
+                );
+            }
+        } else {
+            if self.char_at() == quote_char {
+                value = self.advance_char();
+                self.pop_mode();
+                tok_type = Tok.F_DQ_END.value
+                if quote_char == '"'
+                else Tok.F_SQ_END.value;
+                return self.make_token(
+                    tok_type, value, start_pos, start_line, start_col
+                );
+            }
+        }
+
+        # Escaped braces {{ and }}
+        if self.char_at() == "{" and self.char_at(1) == "{" {
+            value = self.advance_char() + self.advance_char();
+            return self.make_token(
+                Tok.D_LBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+        if self.char_at() == "}" and self.char_at(1) == "}" {
+            value = self.advance_char() + self.advance_char();
+            return self.make_token(
+                Tok.D_RBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Expression start {
+        if self.char_at() == "{" {
+            value = self.advance_char();
+            self.push_mode(LexerMode.FSTRING_EXPR);
+            self.fstring_bracket_depth = 0;  # Reset bracket depth for new expression
+            return self.make_token(
+                Tok.LBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Text content
+        value = "";
+
+        # Determine text token type
+        if mode == LexerMode.FSTRING_DQ {
+            text_tok = Tok.F_TEXT_DQ.value;
+        } elif mode == LexerMode.FSTRING_SQ {
+            text_tok = Tok.F_TEXT_SQ.value;
+        } elif mode == LexerMode.FSTRING_TDQ {
+            text_tok = Tok.F_TEXT_TDQ.value;
+        } else {
+            text_tok = Tok.F_TEXT_TSQ.value;
+        }
+
+        while not self.at_end() {
+            ch = self.char_at();
+
+            # Check for end of f-string
+            if is_triple {
+                if ch == quote_char
+                and self.char_at(1) == quote_char
+                and self.char_at(2) == quote_char {
+                    break;
+                }
+            } else {
+                if ch == quote_char {
+                    break;
+                }
+                if ch == "\n" {
+                    break;
+                }
+            }
+
+            # Expression or escaped braces
+            if ch == "{" {
+                if self.char_at(1) == "{" {
+                    break;
+                }
+                break;
+            }
+            if ch == "}" {
+                if self.char_at(1) == "}" {
+                    break;
+                }
+                break;
+            }
+
+            # Escape sequence (non-raw)
+            if ch == "\\" and not is_raw {
+                value += self.advance_char();
+                if not self.at_end() {
+                    value += self.advance_char();
+                }
+            } else {
+                value += self.advance_char();
+            }
+        }
+
+        if len(value) > 0 {
+            return self.make_token(text_tok, value, start_pos, start_line, start_col);
+        }
+
+        # Shouldn't reach here, but handle gracefully
+        return self.make_token(text_tok, "", start_pos, start_line, start_col);
+    }
+
+    def _scan_fstring_format -> UniToken {
+        # Scan format spec content after : in f-string expression.
+        # Format specs are text until } or { for nested expressions.
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        if self.at_end() {
+            self.pop_mode();  # Exit format mode
+            return self.make_eof_token();
+        }
+
+        ch = self.char_at();
+        ch1 = self.char_at(1);
+
+        # Closing brace ends format spec and the expression
+        if ch == "}" {
+            value = self.advance_char();
+            self.pop_mode();  # Exit FSTRING_FORMAT mode
+            self.pop_mode();  # Exit FSTRING_EXPR mode
+            return self.make_token(
+                Tok.RBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Escaped braces {{ and }}
+        if ch == "{" and ch1 == "{" {
+            value = self.advance_char() + self.advance_char();
+            return self.make_token(
+                Tok.D_LBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+        if ch == "}" and ch1 == "}" {
+            value = self.advance_char() + self.advance_char();
+            return self.make_token(
+                Tok.D_RBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Nested expression start
+        if ch == "{" {
+            value = self.advance_char();
+            self.push_mode(LexerMode.FSTRING_EXPR);
+            self.fstring_bracket_depth = 0;  # Reset bracket depth for new expression
+            return self.make_token(
+                Tok.LBRACE.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Collect format text until we hit { or }
+        value = "";
+        while not self.at_end() {
+            ch = self.char_at();
+            ch1 = self.char_at(1);
+
+            # Stop at brace (single or double)
+            if ch == "{" or ch == "}" {
+                break;
+            }
+
+            value += self.advance_char();
+        }
+
+        if len(value) > 0 {
+            return self.make_token(
+                Tok.F_FORMAT_TEXT.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Shouldn't reach here, but handle gracefully
+        return self.make_token(
+            Tok.F_FORMAT_TEXT.value, "", start_pos, start_line, start_col
+        );
+    }
+
+    # ── Identifier / keyword scanning ────────────────────────────────────
+    def _scan_identifier_or_keyword -> UniToken {
+        # Scan an identifier, keyword, or builtin type.
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        value = "";
+        while not self.at_end() {
+            ch = self.char_at();
+            if ch.isalnum() or ch == "_" {
+                value += self.advance_char();
+            } else {
+                break;
+            }
+        }
+
+        # Multi-word token: is not
+        if value == "is" {
+            saved_pos = self.pos;
+            saved_line = self.line;
+            saved_col = self.col;
+            ws = "";
+            while not self.at_end() and self.char_at() in " \t" {
+                ws += self.advance_char();
+            }
+            if self.starts_with("not") {
+                # Check next char after "not" is not alphanumeric
+                check_pos = self.pos + 3;
+                if check_pos >= len(self.source)
+                or not (
+                    self.source[check_pos].isalnum() or self.source[check_pos] == "_"
+                ) {
+                    # Consume "not"
+                    i = 0;
+                    while i < 3 {
+                        self.advance_char();
+                        i += 1;
+                    }
+                    return self.make_token(
+                        Tok.KW_ISN.value,
+                        "is" + ws + "not",
+                        start_pos,
+                        start_line,
+                        start_col
+                    );
+                }
+            }
+            # Restore
+            self.pos = saved_pos;
+            self.line = saved_line;
+            self.col = saved_col;
+        }
+
+        # Multi-word token: not in
+        if value == "not" {
+            saved_pos = self.pos;
+            saved_line = self.line;
+            saved_col = self.col;
+            ws = "";
+            while not self.at_end() and self.char_at() in " \t" {
+                ws += self.advance_char();
+            }
+            if self.starts_with("in") {
+                check_pos = self.pos + 2;
+                if check_pos >= len(self.source)
+                or not (
+                    self.source[check_pos].isalnum() or self.source[check_pos] == "_"
+                ) {
+                    i = 0;
+                    while i < 2 {
+                        self.advance_char();
+                        i += 1;
+                    }
+                    return self.make_token(
+                        Tok.KW_NIN.value,
+                        "not" + ws + "in",
+                        start_pos,
+                        start_line,
+                        start_col
+                    );
+                }
+            }
+            # Restore
+            self.pos = saved_pos;
+            self.line = saved_line;
+            self.col = saved_col;
+        }
+
+        # Check for builtin type
+        if value in BUILTIN_TYPE_MAP {
+            tok_type = BUILTIN_TYPE_MAP[value];
+            return self.make_token(
+                tok_type.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Check for keyword
+        if value in KEYWORD_MAP {
+            tok_type = KEYWORD_MAP[value];
+            return self.make_token(
+                tok_type.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Logical operators with symbol form: &&, ||
+        # These are already handled as operators, but "and" and "or" keywords
+        # are handled here via KEYWORD_MAP above.
+
+        # Regular identifier
+        return self.make_token(Tok.NAME.value, value, start_pos, start_line, start_col);
+    }
+
+    # ── Inline python block ──────────────────────────────────────────────
+    def _scan_pynline -> UniToken {
+        # Scan ::py:: ... ::py:: inline Python block.
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        # Consume opening ::py::
+        full_value = "";
+        i = 0;
+        while i < 6 {
+            full_value += self.advance_char();
+            i += 1;
+        }
+
+        # Scan until closing ::py::
+        content = "";
+        while not self.at_end() {
+            if self.starts_with("::py::") {
+                # Consume closing ::py::
+                j = 0;
+                while j < 6 {
+                    full_value += self.advance_char();
+                    j += 1;
+                }
+                break;
+            }
+            ch = self.advance_char();
+            content += ch;
+            full_value += ch;
+        }
+
+        # Value is content between ::py:: markers (stripped)
+        return self.make_token(
+            Tok.PYNLINE.value, content, start_pos, start_line, start_col
+        );
+    }
+
+    # ── Operator / punctuation scanning ──────────────────────────────────
+    def _scan_operator -> UniToken {
+        # Scan operators and punctuation. Uses longest-match.
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+
+        ch = self.char_at();
+        ch1 = self.char_at(1);
+        ch2 = self.char_at(2);
+        ch3 = self.char_at(3);
+
+        # 4-char operators
+        four = ch + ch1 + ch2 + ch3;
+        if four == "<-->" {
+            self.advance_n(4);
+            return self.make_token(
+                Tok.ARROW_BI.value, "<-->", start_pos, start_line, start_col
+            );
+        }
+        if four == "<++>" {
+            self.advance_n(4);
+            return self.make_token(
+                Tok.CARROW_BI.value, "<++>", start_pos, start_line, start_col
+            );
+        }
+
+        # 3-char operators
+        three = ch + ch1 + ch2;
+        if three == "..." {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ELLIPSIS.value, "...", start_pos, start_line, start_col
+            );
+        }
+        if three == "**=" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.STAR_POW_EQ.value, "**=", start_pos, start_line, start_col
+            );
+        }
+        if three == "//=" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.FLOOR_DIV_EQ.value, "//=", start_pos, start_line, start_col
+            );
+        }
+        if three == "<<=" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.LSHIFT_EQ.value, "<<=", start_pos, start_line, start_col
+            );
+        }
+        if three == ">>=" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.RSHIFT_EQ.value, ">>=", start_pos, start_line, start_col
+            );
+        }
+        if three == "-->" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ARROW_R.value, "-->", start_pos, start_line, start_col
+            );
+        }
+        if three == "<--" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ARROW_L.value, "<--", start_pos, start_line, start_col
+            );
+        }
+        if three == "++>" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.CARROW_R.value, "++>", start_pos, start_line, start_col
+            );
+        }
+        if three == "<++" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.CARROW_L.value, "<++", start_pos, start_line, start_col
+            );
+        }
+        if three == "<-:" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ARROW_L_P1.value, "<-:", start_pos, start_line, start_col
+            );
+        }
+        if three == ":->" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ARROW_R_P2.value, ":->", start_pos, start_line, start_col
+            );
+        }
+        if three == ":<-" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ARROW_L_P2.value, ":<-", start_pos, start_line, start_col
+            );
+        }
+        if three == "->:" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ARROW_R_P1.value, "->:", start_pos, start_line, start_col
+            );
+        }
+        if three == "<+:" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.CARROW_L_P1.value, "<+:", start_pos, start_line, start_col
+            );
+        }
+        if three == ":+>" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.CARROW_R_P2.value, ":+>", start_pos, start_line, start_col
+            );
+        }
+        if three == ":<+" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.CARROW_L_P2.value, ":<+", start_pos, start_line, start_col
+            );
+        }
+        if three == "+>:" {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.CARROW_R_P1.value, "+>:", start_pos, start_line, start_col
+            );
+        }
+        if three == "<>/" {
+            # This is for JSX fragment close, handled elsewhere
+            # JSX fragment close handled elsewhere
+        }
+
+        # 2-char operators
+        two = ch + ch1;
+        if two == "**" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.STAR_POW.value, "**", start_pos, start_line, start_col
+            );
+        }
+        if two == "//" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.FLOOR_DIV.value, "//", start_pos, start_line, start_col
+            );
+        }
+        if two == "|>" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.PIPE_FWD.value, "|>", start_pos, start_line, start_col
+            );
+        }
+        if two == "<|" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.PIPE_BKWD.value, "<|", start_pos, start_line, start_col
+            );
+        }
+        if two == ":>" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.A_PIPE_FWD.value, ":>", start_pos, start_line, start_col
+            );
+        }
+        if two == "<:" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.A_PIPE_BKWD.value, "<:", start_pos, start_line, start_col
+            );
+        }
+        if two == ".>" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.DOT_FWD.value, ".>", start_pos, start_line, start_col
+            );
+        }
+        if two == "<." {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.DOT_BKWD.value, "<.", start_pos, start_line, start_col
+            );
+        }
+        if two == "==" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.EE.value, "==", start_pos, start_line, start_col
+            );
+        }
+        if two == "!=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.NE.value, "!=", start_pos, start_line, start_col
+            );
+        }
+        if two == "<=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.LTE.value, "<=", start_pos, start_line, start_col
+            );
+        }
+        if two == ">=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.GTE.value, ">=", start_pos, start_line, start_col
+            );
+        }
+        if two == "<<" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.LSHIFT.value, "<<", start_pos, start_line, start_col
+            );
+        }
+        if two == ">>" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.RSHIFT.value, ">>", start_pos, start_line, start_col
+            );
+        }
+        if two == "+=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.ADD_EQ.value, "+=", start_pos, start_line, start_col
+            );
+        }
+        if two == "-=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.SUB_EQ.value, "-=", start_pos, start_line, start_col
+            );
+        }
+        if two == "*=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.MUL_EQ.value, "*=", start_pos, start_line, start_col
+            );
+        }
+        if two == "/=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.DIV_EQ.value, "/=", start_pos, start_line, start_col
+            );
+        }
+        if two == "%=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.MOD_EQ.value, "%=", start_pos, start_line, start_col
+            );
+        }
+        if two == "@=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.MATMUL_EQ.value, "@=", start_pos, start_line, start_col
+            );
+        }
+        if two == "&=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.BW_AND_EQ.value, "&=", start_pos, start_line, start_col
+            );
+        }
+        if two == "|=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.BW_OR_EQ.value, "|=", start_pos, start_line, start_col
+            );
+        }
+        if two == "^=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.BW_XOR_EQ.value, "^=", start_pos, start_line, start_col
+            );
+        }
+        if two == "->" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.RETURN_HINT.value, "->", start_pos, start_line, start_col
+            );
+        }
+        if two == ":=" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.WALRUS_EQ.value, ":=", start_pos, start_line, start_col
+            );
+        }
+        if two == "&&" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.KW_AND.value, "&&", start_pos, start_line, start_col
+            );
+        }
+        if two == "||" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.KW_OR.value, "||", start_pos, start_line, start_col
+            );
+        }
+        if two == "/>" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.JSX_SELF_CLOSE.value, "/>", start_pos, start_line, start_col
+            );
+        }
+        if two == "</" {
+            self.advance_n(2);
+            self.in_jsx_close_tag = True;
+            self.push_mode(LexerMode.JSX_TAG);
+            return self.make_token(
+                Tok.JSX_CLOSE_START.value, "</", start_pos, start_line, start_col
+            );
+        }
+        # <> as fragment open
+        if two == "<>" {
+            self.advance_n(2);
+            return self.make_token(
+                Tok.JSX_FRAG_OPEN.value, "<>", start_pos, start_line, start_col
+            );
+        }
+
+        # 1-char operators
+        if ch == "+" {
+            self.advance_char();
+            return self.make_token(
+                Tok.PLUS.value, "+", start_pos, start_line, start_col
+            );
+        }
+        if ch == "-" {
+            self.advance_char();
+            return self.make_token(
+                Tok.MINUS.value, "-", start_pos, start_line, start_col
+            );
+        }
+        if ch == "*" {
+            self.advance_char();
+            return self.make_token(
+                Tok.STAR_MUL.value, "*", start_pos, start_line, start_col
+            );
+        }
+        if ch == "/" {
+            self.advance_char();
+            return self.make_token(
+                Tok.DIV.value, "/", start_pos, start_line, start_col
+            );
+        }
+        if ch == "%" {
+            self.advance_char();
+            return self.make_token(
+                Tok.MOD.value, "%", start_pos, start_line, start_col
+            );
+        }
+        if ch == "@" {
+            self.advance_char();
+            return self.make_token(
+                Tok.DECOR_OP.value, "@", start_pos, start_line, start_col
+            );
+        }
+        if ch == "&" {
+            self.advance_char();
+            return self.make_token(
+                Tok.BW_AND.value, "&", start_pos, start_line, start_col
+            );
+        }
+        if ch == "|" {
+            self.advance_char();
+            return self.make_token(
+                Tok.BW_OR.value, "|", start_pos, start_line, start_col
+            );
+        }
+        if ch == "^" {
+            self.advance_char();
+            return self.make_token(
+                Tok.BW_XOR.value, "^", start_pos, start_line, start_col
+            );
+        }
+        if ch == "~" {
+            self.advance_char();
+            return self.make_token(
+                Tok.BW_NOT.value, "~", start_pos, start_line, start_col
+            );
+        }
+        if ch == "<" {
+            # Check if this could be JSX: <identifier or <_identifier
+            next_ch = self.char_at(1);
+            if next_ch.isalpha() or next_ch == "_" {
+                # This looks like JSX start: <div, <MyComponent, etc.
+                self.advance_char();
+                self.push_mode(LexerMode.JSX_TAG);
+                return self.make_token(
+                    Tok.JSX_OPEN_START.value, "<", start_pos, start_line, start_col
+                );
+            }
+            self.advance_char();
+            return self.make_token(Tok.LT.value, "<", start_pos, start_line, start_col);
+        }
+        if ch == ">" {
+            self.advance_char();
+            return self.make_token(Tok.GT.value, ">", start_pos, start_line, start_col);
+        }
+        if ch == "=" {
+            self.advance_char();
+            return self.make_token(Tok.EQ.value, "=", start_pos, start_line, start_col);
+        }
+        if ch == "." {
+            self.advance_char();
+            return self.make_token(
+                Tok.DOT.value, ".", start_pos, start_line, start_col
+            );
+        }
+        if ch == "," {
+            self.advance_char();
+            return self.make_token(
+                Tok.COMMA.value, ",", start_pos, start_line, start_col
+            );
+        }
+        if ch == ":" {
+            self.advance_char();
+            return self.make_token(
+                Tok.COLON.value, ":", start_pos, start_line, start_col
+            );
+        }
+        if ch == ";" {
+            self.advance_char();
+            return self.make_token(
+                Tok.SEMI.value, ";", start_pos, start_line, start_col
+            );
+        }
+        if ch == "?" {
+            self.advance_char();
+            return self.make_token(
+                Tok.NULL_OK.value, "?", start_pos, start_line, start_col
+            );
+        }
+        if ch == "`" {
+            self.advance_char();
+            return self.make_token(
+                Tok.TYPE_OP.value, "`", start_pos, start_line, start_col
+            );
+        }
+        if ch == "(" {
+            self.advance_char();
+            return self.make_token(
+                Tok.LPAREN.value, "(", start_pos, start_line, start_col
+            );
+        }
+        if ch == ")" {
+            self.advance_char();
+            return self.make_token(
+                Tok.RPAREN.value, ")", start_pos, start_line, start_col
+            );
+        }
+        if ch == "[" {
+            self.advance_char();
+            return self.make_token(
+                Tok.LSQUARE.value, "[", start_pos, start_line, start_col
+            );
+        }
+        if ch == "]" {
+            self.advance_char();
+            return self.make_token(
+                Tok.RSQUARE.value, "]", start_pos, start_line, start_col
+            );
+        }
+        if ch == "{" {
+            self.advance_char();
+            return self.make_token(
+                Tok.LBRACE.value, "{", start_pos, start_line, start_col
+            );
+        }
+        if ch == "}" {
+            self.advance_char();
+            return self.make_token(
+                Tok.RBRACE.value, "}", start_pos, start_line, start_col
+            );
+        }
+
+        # Unknown character - advance and return as error token
+        value = self.advance_char();
+        return self.make_token("ERROR", value, start_pos, start_line, start_col);
+    }
+
+    # ── JSX scanning ─────────────────────────────────────────────────────
+    def _scan_jsx_tag_token -> UniToken {
+        # Scan a token inside a JSX tag: <Tag attr="val" ...>.
+        self.skip_whitespace_and_comments();
+        if self.at_end() {
+            return self.make_eof_token();
+        }
+
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+        ch = self.char_at();
+
+        # End of tag
+        if ch == ">" {
+            self.advance_char();
+            self.pop_mode();  # Exit JSX_TAG
+            # Only push JSX_CONTENT for opening tags, not closing tags
+            if not self.in_jsx_close_tag {
+                self.push_mode(LexerMode.JSX_CONTENT);
+            }
+            self.in_jsx_close_tag = False;  # Reset for next tag
+            return self.make_token(
+                Tok.JSX_TAG_END.value, ">", start_pos, start_line, start_col
+            );
+        }
+
+        # Self-closing
+        if ch == "/" and self.char_at(1) == ">" {
+            self.advance_n(2);
+            self.pop_mode();  # Exit JSX_TAG
+            return self.make_token(
+                Tok.JSX_SELF_CLOSE.value, "/>", start_pos, start_line, start_col
+            );
+        }
+
+        # Attribute expression: {expr}
+        if ch == "{" {
+            self.advance_char();
+            return self.make_token(
+                Tok.LBRACE.value, "{", start_pos, start_line, start_col
+            );
+        }
+
+        # Dot for element name chaining
+        if ch == "." {
+            self.advance_char();
+            return self.make_token(
+                Tok.DOT.value, ".", start_pos, start_line, start_col
+            );
+        }
+
+        # Equals for attribute assignment
+        if ch == "=" {
+            self.advance_char();
+            return self.make_token(Tok.EQ.value, "=", start_pos, start_line, start_col);
+        }
+
+        # Ellipsis
+        if ch == "." and self.char_at(1) == "." and self.char_at(2) == "." {
+            self.advance_n(3);
+            return self.make_token(
+                Tok.ELLIPSIS.value, "...", start_pos, start_line, start_col
+            );
+        }
+
+        # String attribute value
+        if ch in "\"'" {
+            return self._scan_string();
+        }
+
+        # JSX_NAME: [A-Za-z_][A-Za-z0-9_-]*
+        if ch.isalpha() or ch == "_" {
+            value = "";
+            while not self.at_end() {
+                c = self.char_at();
+                if c.isalnum() or c in "_-" {
+                    value += self.advance_char();
+                } else {
+                    break;
+                }
+            }
+            return self.make_token(
+                Tok.JSX_NAME.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Fallback
+        return self._scan_operator();
+    }
+
+    def _scan_jsx_content_token -> UniToken {
+        # Scan content between JSX tags.
+        if self.at_end() {
+            return self.make_eof_token();
+        }
+
+        start_pos = self.pos;
+        start_line = self.line;
+        start_col = self.col;
+        ch = self.char_at();
+
+        # Expression: {expr}
+        if ch == "{" {
+            self.advance_char();
+            return self.make_token(
+                Tok.LBRACE.value, "{", start_pos, start_line, start_col
+            );
+        }
+
+        # Closing tag: </
+        if ch == "<" and self.char_at(1) == "/" {
+            # Check for fragment close: </>
+            if self.char_at(2) == ">" {
+                self.advance_n(3);
+                self.pop_mode();  # Exit JSX_CONTENT
+                return self.make_token(
+                    Tok.JSX_FRAG_CLOSE.value, "</>", start_pos, start_line, start_col
+                );
+            }
+            self.advance_n(2);
+            self.pop_mode();  # Exit JSX_CONTENT
+            self.in_jsx_close_tag = True;
+            self.push_mode(LexerMode.JSX_TAG);
+            return self.make_token(
+                Tok.JSX_CLOSE_START.value, "</", start_pos, start_line, start_col
+            );
+        }
+
+        # Nested JSX element: <
+        if ch == "<" {
+            next_ch = self.char_at(1);
+            if next_ch.isalpha() or next_ch == "_" {
+                self.advance_char();
+                self.push_mode(LexerMode.JSX_TAG);
+                return self.make_token(
+                    Tok.JSX_OPEN_START.value, "<", start_pos, start_line, start_col
+                );
+            }
+            # Fragment: <>
+            if next_ch == ">" {
+                self.advance_n(2);
+                self.push_mode(LexerMode.JSX_CONTENT);
+                return self.make_token(
+                    Tok.JSX_FRAG_OPEN.value, "<>", start_pos, start_line, start_col
+                );
+            }
+        }
+
+        # JSX text content
+        value = "";
+        while not self.at_end() {
+            c = self.char_at();
+            if c in "<{}" {
+                break;
+            }
+            if c == "\n" {
+                break;
+            }
+            value += self.advance_char();
+        }
+
+        if len(value) > 0 {
+            return self.make_token(
+                Tok.JSX_TEXT.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # Newlines as text
+        if not self.at_end() and self.char_at() == "\n" {
+            value = self.advance_char();
+            return self.make_token(
+                Tok.JSX_TEXT.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        return self.make_eof_token();
+    }
+
+    # ── Main token dispatch ──────────────────────────────────────────────
+    def _scan_token -> UniToken {
+        # Raw scan: always reads the next token from source (ignores peeked buffer).
+        mode = self.current_mode();
+
+        # F-string body modes
+        if mode in [
+            LexerMode.FSTRING_DQ,
+            LexerMode.FSTRING_SQ,
+            LexerMode.FSTRING_TDQ,
+            LexerMode.FSTRING_TSQ
+        ] {
+            if self.at_end() {
+                return self.make_eof_token();
+            }
+            return self._scan_fstring_body();
+        }
+
+        # JSX modes
+        if mode == LexerMode.JSX_TAG {
+            return self._scan_jsx_tag_token();
+        }
+        if mode == LexerMode.JSX_CONTENT {
+            return self._scan_jsx_content_token();
+        }
+
+        # FSTRING_FORMAT mode: emit F_FORMAT_TEXT tokens until } or {
+        if mode == LexerMode.FSTRING_FORMAT {
+            return self._scan_fstring_format();
+        }
+
+        # FSTRING_EXPR mode: lex as normal but track brace depth
+        # (handled below in NORMAL + FSTRING_EXPR)
+
+        # Normal mode (and FSTRING_EXPR mode)
+        self.skip_whitespace_and_comments();
+
+        if self.at_end() {
+            return self.make_eof_token();
+        }
+
+        ch = self.char_at();
+        ch1 = self.char_at(1);
+
+        # In FSTRING_EXPR, closing brace at depth 0 exits the mode
+        if mode == LexerMode.FSTRING_EXPR and ch == "}" {
+            start_pos = self.pos;
+            start_line = self.line;
+            start_col = self.col;
+            self.advance_char();
+            self.pop_mode();
+            return self.make_token(
+                Tok.RBRACE.value, "}", start_pos, start_line, start_col
+            );
+        }
+
+        # In FSTRING_EXPR, colon starts format spec mode ONLY if not inside brackets
+        if mode == LexerMode.FSTRING_EXPR
+        and ch == ":"
+        and self.fstring_bracket_depth == 0 {
+            start_pos = self.pos;
+            start_line = self.line;
+            start_col = self.col;
+            self.advance_char();
+            self.push_mode(LexerMode.FSTRING_FORMAT);
+            return self.make_token(
+                Tok.COLON.value, ":", start_pos, start_line, start_col
+            );
+        }
+
+        # Track bracket depth in FSTRING_EXPR mode for slice support
+        if mode == LexerMode.FSTRING_EXPR and ch == "[" {
+            self.fstring_bracket_depth += 1;
+        }
+        if mode == LexerMode.FSTRING_EXPR and ch == "]" {
+            if self.fstring_bracket_depth > 0 {
+                self.fstring_bracket_depth -= 1;
+            }
+        }
+
+        # ::py:: blocks
+        if self.starts_with("::py::") {
+            return self._scan_pynline();
+        }
+
+        # Keyword-escaped name: <>identifier
+        if ch == "<" and ch1 == ">" {
+            start_pos = self.pos;
+            start_line = self.line;
+            start_col = self.col;
+            prefix = self.advance_char() + self.advance_char();  # consume <>
+            value = prefix;
+            while not self.at_end()
+            and (self.char_at().isalnum() or self.char_at() == "_") {
+                value += self.advance_char();
+            }
+            return self.make_token(
+                Tok.KWESC_NAME.value, value, start_pos, start_line, start_col
+            );
+        }
+
+        # F-string or raw-f-string start
+        if (ch in "fF" and ch1 in "\"'")
+        or (ch in "rR" and ch1 in "fF" and self.char_at(2) in "\"'")
+        or (ch in "fF" and ch1 in "rR" and self.char_at(2) in "\"'") {
+            start_pos = self.pos;
+            start_line = self.line;
+            start_col = self.col;
+            prefix = "";
+            if ch in "fF" and ch1 in "\"'" {
+                prefix = self.advance_char();  # f
+            } elif ch in "rR" and ch1 in "fF" {
+                prefix = self.advance_char() + self.advance_char();  # rf
+            } else {
+                prefix = self.advance_char() + self.advance_char();  # fr
+            }
+            return self._scan_fstring_start(prefix);
+        }
+
+        # Raw or byte strings: r"...", b"...", rb"...", br"..."
+        if ch in "rRbB" {
+            # Check for various string prefixes
+            if ch in "rR" and ch1 in "\"'" {
+                prefix = self.advance_char();
+                return self._scan_string(prefix);
+            }
+            if ch in "bB" and ch1 in "\"'" {
+                prefix = self.advance_char();
+                return self._scan_string(prefix);
+            }
+            if ch in "rR" and ch1 in "bB" and self.char_at(2) in "\"'" {
+                prefix = self.advance_char() + self.advance_char();
+                return self._scan_string(prefix);
+            }
+            if ch in "bB" and ch1 in "rR" and self.char_at(2) in "\"'" {
+                prefix = self.advance_char() + self.advance_char();
+                return self._scan_string(prefix);
+            }
+        }
+
+        # Regular strings
+        if ch in "\"'" {
+            return self._scan_string();
+        }
+
+        # Numbers
+        if ch.isdigit() {
+            return self._scan_number();
+        }
+        # Numbers starting with dot: .5, .5e3
+        if ch == "." and ch1.isdigit() {
+            return self._scan_dot_number();
+        }
+
+        # Identifiers and keywords
+        if ch.isalpha() or ch == "_" {
+            return self._scan_identifier_or_keyword();
+        }
+
+        # Operators and punctuation
+        return self._scan_operator();
+    }
+
+    def next_token -> UniToken {
+        # Get the next token. Returns from peeked buffer first, then scans source.
+        if len(self.peeked) > 0 {
+            return self.peeked.pop(0);
+        }
+        return self._scan_token();
+    }
+
+    def peek(offset: int = 0) -> UniToken {
+        # Peek at the next token without consuming it. Supports lookahead.
+        # Always scans directly from source to fill the buffer (never via next_token,
+        # which would consume from the same buffer and cause an infinite loop).
+        while len(self.peeked) <= offset {
+            self.peeked.append(self._scan_token());
+        }
+        return self.peeked[offset];
+    }
+
+    def push_back(token: UniToken) {
+        # Push a token back to be read again.
+        self.peeked.insert(0, token);
+    }
+
+    # ── JSX context helpers (called by parser) ───────────────────────────
+    def enter_jsx_tag_mode {
+        # Enter JSX tag mode (called by parser when < is detected as JSX).
+        self.push_mode(LexerMode.JSX_TAG);
+    }
+
+    def exit_jsx_mode {
+        # Exit current JSX mode.
+        if self.current_mode() in [LexerMode.JSX_TAG, LexerMode.JSX_CONTENT] {
+            self.pop_mode();
+        }
+    }
+}
+# Sentinel for EOF

--- a/jac/jaclang/compiler/rd_parser/parser.jac
+++ b/jac/jaclang/compiler/rd_parser/parser.jac
@@ -1,0 +1,696 @@
+# Handwritten recursive descent parser core for the Jac language.
+#
+# Provides JacRDParserCore with token primitives, error recovery,
+# and module/top-level parsing. Delegates to parser_exprs.jac and
+# parser_stmts.jac for expression and statement parsing.
+import os;
+
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    String as UniString,
+    Source as UniSource,
+    Module as UniModule,
+    EmptyToken as UniEmptyToken,
+    SpecialVarRef as UniSpecialVarRef,
+    Expr,
+    ElementStmt,
+    CodeBlockStmt,
+    ContextAwareNode,
+    ModuleCode as UniModuleCode,
+    ClientBlock as UniClientBlock,
+    ServerBlock as UniServerBlock,
+    NativeBlock as UniNativeBlock,
+    GlobalVars as UniGlobalVars,
+    Test as UniTest,
+    PyInlineCode as UniPyInlineCode,
+    Import as UniImport,
+    SubTag,
+    Archetype as UniArchetype,
+    Ability as UniAbility,
+    ImplDef as UniImplDef,
+    SemDef as UniSemDef
+}
+
+import from jaclang.pycore.constant { Tokens as Tok, CodeContext }
+
+import from jaclang.compiler.rd_parser.lexer {
+    JacLexer,
+    EOF_NAME,
+    KEYWORD_MAP,
+    BUILTIN_TYPE_MAP,
+    SPECIAL_REF_TOKENS
+}
+
+import from jaclang.compiler.rd_parser.ast_builder {
+    KidCollector,
+    is_eof_token,
+    is_name_token,
+    is_special_ref_token,
+    wrap_special_ref,
+    make_empty_token,
+    AUGMENTED_ASSIGN_OPS,
+    COMPARISON_OPS,
+    ARCH_TYPE_TOKENS,
+    UNARY_PREFIX_OPS,
+    STATEMENT_START_TOKENS,
+    TOPLEVEL_SYNC_TOKENS,
+    STMT_SYNC_TOKENS,
+    EXPR_SYNC_TOKENS,
+    AUTO_INSERT_TOKENS
+}
+
+import from jaclang.compiler.rd_parser.parser_exprs {
+    parse_expression as _expr_impl,
+    parse_atomic_chain as _atomic_chain_impl,
+    parse_pipe as _pipe_impl
+}
+
+import from jaclang.compiler.rd_parser.parser_stmts {
+    parse_statement as _stmt_impl,
+    parse_code_block as _code_block_impl,
+    parse_code_block_with_kids as _code_block_kids_impl,
+    parse_else_stmt as _else_stmt_impl
+}
+
+import from jaclang.compiler.rd_parser.parser_defs {
+    parse_import_stmt as _import_stmt_impl,
+    parse_archetype as _archetype_impl,
+    parse_enum_def as _enum_impl,
+    parse_ability as _ability_impl,
+    parse_global_var as _global_var_impl,
+    parse_impl_def as _impl_def_impl,
+    parse_sem_def as _sem_def_impl,
+    parse_has_stmt as _has_stmt_impl,
+    parse_func_signature as _func_sig_impl,
+    parse_event_clause as _event_clause_impl,
+    parse_access_tag as _access_tag_impl,
+    parse_type_tag as _type_tag_impl
+}
+
+import from jaclang.compiler.rd_parser.parser_edges {
+    parse_edge_ref_chain as _edge_ref_chain_impl,
+    parse_connect_op as _connect_op_impl,
+    parse_disconnect_op as _disconnect_op_impl,
+    parse_filter_compare_list as _filter_compare_list_impl
+}
+
+import from jaclang.compiler.rd_parser.parser_patterns {
+    parse_match_stmt as _match_stmt_impl,
+    parse_switch_stmt as _switch_stmt_impl
+}
+
+import from jaclang.compiler.rd_parser.parser_fstring { parse_fstring as _fstring_impl }
+
+import from jaclang.compiler.rd_parser.parser_jsx {
+    parse_jsx_element as _jsx_element_impl
+}
+
+# ── Parser Core ──────────────────────────────────────────────────────────────
+obj JacRDParserCore {
+    # Recursive descent parser for Jac.
+    # Produces uni.Module ASTs compatible with the existing compilation pipeline.
+    has source: str,
+        orig_src: UniSource,
+        mod_path: str,
+        lexer: JacLexer,
+        node_list: list = [],
+        node_ids: set = set(),
+        errors_had: list = [],
+        warnings_had: list = [],
+        current_collector: KidCollector | None = None;
+
+    def init(source: str, orig_src: UniSource, mod_path: str) {
+        self.source = source;
+        self.orig_src = orig_src;
+        self.mod_path = mod_path;
+        self.lexer = JacLexer(source=source, orig_src=orig_src);
+        self.node_list = [];
+        self.node_ids = set();
+        self.errors_had = [];
+        self.warnings_had = [];
+        self.current_collector = None;
+    }
+
+    # ── Node registration ────────────────────────────────────────────────
+    def register_node(nd: UniNode) -> UniNode {
+        # Register an AST node in the node list.
+        node_id = id(nd);
+        if node_id not in self.node_ids {
+            self.node_ids.add(node_id);
+            self.node_list.append(nd);
+        }
+        return nd;
+    }
+
+    # ── Error logging ────────────────────────────────────────────────────
+    def log_error(msg: str, tok: UniToken | None = None) {
+        self.errors_had.append({"msg": msg, "token": tok});
+    }
+
+    def log_warning(msg: str, tok: UniToken | None = None) {
+        self.warnings_had.append({"msg": msg, "token": tok});
+    }
+
+    # ── Token consumption primitives ─────────────────────────────────────
+    def peek(offset: int = 0) -> UniToken {
+        # Look at the next token without consuming it.
+        return self.lexer.peek(offset);
+    }
+
+    def advance -> UniToken {
+        # Consume and return the next token.
+        tok = self.lexer.next_token();
+        self.register_node(tok);
+        return tok;
+    }
+
+    def expect(tok_type: str) -> UniToken {
+        # Consume a token of the expected type. On mismatch, try error recovery.
+        peeked = self.peek();
+        if peeked.name == tok_type {
+            return self.advance();
+        }
+        # Auto-insert missing tokens
+        if tok_type in AUTO_INSERT_TOKENS {
+            self.log_error(f"Expected '{tok_type}', inserting missing token", peeked);
+            return self._synthesize_token(tok_type);
+        }
+        # Unexpected token
+        self.log_error(
+            f"Expected '{tok_type}', got '{peeked.name}' ('{peeked.value}')", peeked
+        );
+        return self._synthesize_token(tok_type);
+    }
+
+    def match_tok(tok_type: str) -> UniToken | None {
+        # If next token matches, consume and return it. Otherwise return None.
+        if self.peek().name == tok_type {
+            return self.advance();
+        }
+        return None;
+    }
+
+    def match_any(*tok_types: str) -> UniToken | None {
+        # If next token matches any of the types, consume and return it.
+        peeked_name = self.peek().name;
+        for tt in tok_types {
+            if peeked_name == tt {
+                return self.advance();
+            }
+        }
+        return None;
+    }
+
+    def check(tok_type: str) -> bool {
+        return self.peek().name == tok_type;
+    }
+
+    def check_any(*tok_types: str) -> bool {
+        peeked_name = self.peek().name;
+        for tt in tok_types {
+            if peeked_name == tt {
+                return True;
+            }
+        }
+        return False;
+    }
+
+    def at_end -> bool {
+        return is_eof_token(self.peek());
+    }
+
+    # ── Error recovery helpers ───────────────────────────────────────────
+    def _synthesize_token(tok_type: str) -> UniToken {
+        tok = UniToken(
+            orig_src=self.orig_src,
+            name=tok_type,
+            value="",
+            line=self.lexer.line,
+            end_line=self.lexer.line,
+            col_start=self.lexer.col,
+            col_end=self.lexer.col,
+            pos_start=self.lexer.pos,
+            pos_end=self.lexer.pos
+        );
+        self.register_node(tok);
+        return tok;
+    }
+
+    def synchronize(sync_tokens: set) {
+        while not self.at_end() {
+            if self.peek().name in sync_tokens {
+                return;
+            }
+            self.advance();
+        }
+    }
+
+    # ── Named reference parsing ──────────────────────────────────────────
+    def parse_named_ref -> UniName {
+        tok = self.peek();
+        if is_name_token(tok) {
+            name_tok = self.advance();
+            if is_special_ref_token(name_tok) {
+                ref = wrap_special_ref(name_tok);
+                self.register_node(ref);
+                return ref;
+            }
+            # If the token is a keyword being used as an identifier (e.g. 'has'
+            # tokenized as KW_HAS), convert it from UniToken to UniName so
+            # downstream AST nodes (like Ability) that require Name nodes work.
+            if not isinstance(name_tok, UniName) {
+                name_nd = UniName(
+                    orig_src=self.orig_src,
+                    name=Tok.NAME.value,
+                    value=name_tok.value,
+                    line=name_tok.loc.first_line,
+                    end_line=name_tok.loc.last_line,
+                    col_start=name_tok.loc.col_start,
+                    col_end=name_tok.loc.col_end,
+                    pos_start=name_tok.loc.pos_start,
+                    pos_end=name_tok.loc.pos_end
+                );
+                self.register_node(name_nd);
+                return name_nd;
+            }
+            return name_tok;
+        }
+        self.log_error(f"Expected identifier, got '{tok.name}'", tok);
+        return self._synthesize_name();
+    }
+
+    def _synthesize_name -> UniName {
+        nd = UniName(
+            orig_src=self.orig_src,
+            name=Tok.NAME.value,
+            value="__missing__",
+            line=self.lexer.line,
+            end_line=self.lexer.line,
+            col_start=self.lexer.col,
+            col_end=self.lexer.col,
+            pos_start=self.lexer.pos,
+            pos_end=self.lexer.pos
+        );
+        self.register_node(nd);
+        return nd;
+    }
+
+    # ── Delegated methods (expression/statement parsing) ─────────────────
+    def parse_expression -> Expr {
+        return _expr_impl(self);
+    }
+
+    def parse_atomic_chain -> Expr {
+        return _atomic_chain_impl(self);
+    }
+
+    def parse_pipe_expr -> Expr {
+        return _pipe_impl(self);
+    }
+
+    def parse_statement -> any {
+        return _stmt_impl(self);
+    }
+
+    def parse_code_block -> list {
+        return _code_block_impl(self);
+    }
+
+    def parse_code_block_with_kids -> tuple {
+        return _code_block_kids_impl(self);
+    }
+
+    # ── Module-level parsing ─────────────────────────────────────────────
+    def parse_module -> UniModule {
+        # Parse the entire module.
+        doc = None;
+        body: list = [];
+        kids: list = [];
+
+        # Check for module docstring
+        if self.check(Tok.STRING.value) {
+            peek_1 = self.peek(1);
+            if is_eof_token(peek_1)
+            or peek_1.name in TOPLEVEL_SYNC_TOKENS
+            or peek_1.name == Tok.STRING.value {
+                doc = self.advance();
+                kids.append(doc);
+            }
+        }
+
+        # Parse top-level statements
+        while not self.at_end() {
+            stmt_doc = None;
+            if self.check(Tok.STRING.value) {
+                peek_1 = self.peek(1);
+                if not is_eof_token(peek_1)
+                and (
+                    peek_1.name in TOPLEVEL_SYNC_TOKENS
+                    or peek_1.name == Tok.DECOR_OP.value
+                    or peek_1.name == Tok.KW_ASYNC.value
+                ) {
+                    stmt_doc = self.advance();
+                }
+            }
+
+            stmt = self.parse_toplevel_stmt();
+            if stmt is not None {
+                if stmt_doc is not None and stmt?.doc {
+                    stmt.doc = stmt_doc;
+                    stmt.add_kids_left([stmt_doc]);
+                }
+                if isinstance(stmt, list) {
+                    for s in stmt {
+                        body.append(s);
+                        kids.append(s);
+                    }
+                } else {
+                    body.append(stmt);
+                    kids.append(stmt);
+                }
+            } elif stmt_doc is not None {
+                body.append(stmt_doc);
+                kids.append(stmt_doc);
+            } else {
+                if not self.at_end() {
+                    self.log_error(
+                        f"Unexpected token '{self.peek().value}'", self.peek()
+                    );
+                    self.advance();
+                }
+            }
+        }
+
+        mod_name = self.mod_path.split(os.sep)[-1].removesuffix(".jac");
+
+        if len(kids) == 0 {
+            kids = [UniEmptyToken(self.orig_src)];
+        }
+
+        mod = UniModule(
+            name=mod_name,
+            source=self.orig_src,
+            doc=doc,
+            body=body,
+            terminals=self.lexer.terminals,
+            kid=kids
+        );
+        self.register_node(mod);
+        return mod;
+    }
+
+    def parse_toplevel_stmt -> ElementStmt | list | None {
+        context_tok = self.match_any(
+            Tok.KW_CLIENT.value, Tok.KW_SERVER.value, Tok.KW_NATIVE.value
+        );
+
+        if context_tok is not None {
+            if context_tok.name == Tok.KW_CLIENT.value {
+                context = CodeContext.CLIENT;
+            } elif context_tok.name == Tok.KW_SERVER.value {
+                context = CodeContext.SERVER;
+            } else {
+                context = CodeContext.NATIVE;
+            }
+            if self.check(Tok.LBRACE.value) {
+                return self._parse_context_block(context_tok, context);
+            }
+            stmt = self.parse_onelang_stmt();
+            if stmt is not None and isinstance(stmt, ContextAwareNode) {
+                stmt.code_context = context;
+                stmt.add_kids_left([context_tok]);
+            }
+            return stmt;
+        }
+
+        if self.check(Tok.PYNLINE.value) {
+            return self.parse_py_code_block();
+        }
+
+        return self.parse_onelang_stmt();
+    }
+
+    def _parse_context_block(context_tok: UniToken, context: str) -> ElementStmt {
+        lbrace = self.expect(Tok.LBRACE.value);
+        elements: list = [];
+        kids: list = [context_tok, lbrace];
+
+        while not self.at_end() and not self.check(Tok.RBRACE.value) {
+            elem = self.parse_onelang_stmt();
+            if elem is not None {
+                if isinstance(elem, ContextAwareNode) {
+                    elem.code_context = context;
+                }
+                elements.append(elem);
+                kids.append(elem);
+            } else {
+                if not self.at_end() and not self.check(Tok.RBRACE.value) {
+                    self.advance();
+                }
+            }
+        }
+
+        rbrace = self.expect(Tok.RBRACE.value);
+        kids.append(rbrace);
+
+        if context_tok.name == Tok.KW_CLIENT.value {
+            result = UniClientBlock(body=elements, kid=kids);
+        } elif context_tok.name == Tok.KW_SERVER.value {
+            result = UniServerBlock(body=elements, kid=kids);
+        } else {
+            result = UniNativeBlock(body=elements, kid=kids);
+        }
+        self.register_node(result);
+        return result;
+    }
+
+    def parse_onelang_stmt -> ElementStmt | None {
+        tok = self.peek();
+
+        if tok.name in [Tok.KW_IMPORT.value, Tok.KW_INCLUDE.value] {
+            return self.parse_import_stmt();
+        }
+        if tok.name == Tok.DECOR_OP.value {
+            return self.parse_decorated_def();
+        }
+        if tok.name == Tok.KW_ASYNC.value {
+            peek1 = self.peek(1);
+            if peek1.name in ARCH_TYPE_TOKENS {
+                return self.parse_archetype();
+            }
+            return self.parse_ability();
+        }
+        if tok.name in ARCH_TYPE_TOKENS {
+            return self.parse_archetype();
+        }
+        if tok.name == Tok.KW_ENUM.value {
+            return self.parse_enum();
+        }
+        if tok.name in [
+            Tok.KW_DEF.value,
+            Tok.KW_CAN.value,
+            Tok.KW_OVERRIDE.value,
+            Tok.KW_STATIC.value
+        ] {
+            return self.parse_ability();
+        }
+        if tok.name == Tok.KW_GLOBAL.value {
+            return self.parse_global_var();
+        }
+        if tok.name == Tok.KW_WITH.value {
+            peek1 = self.peek(1);
+            if peek1.name == Tok.KW_ENTRY.value {
+                return self.parse_free_code();
+            }
+        }
+        if tok.name == Tok.KW_TEST.value {
+            return self.parse_test();
+        }
+        if tok.name == Tok.KW_IMPL.value {
+            return self.parse_impl_def();
+        }
+        if tok.name == Tok.KW_SEM.value {
+            return self.parse_sem_def();
+        }
+        if tok.name == Tok.PYNLINE.value {
+            return self.parse_py_code_block();
+        }
+        return None;
+    }
+
+    def parse_decorated_def -> ElementStmt {
+        decorators = self.parse_decorators();
+        tok = self.peek();
+        if tok.name == Tok.KW_ASYNC.value {
+            peek1 = self.peek(1);
+            if peek1.name in ARCH_TYPE_TOKENS {
+                return self.parse_archetype(decorators=decorators);
+            }
+            return self.parse_ability(decorators=decorators);
+        }
+        if tok.name in ARCH_TYPE_TOKENS {
+            return self.parse_archetype(decorators=decorators);
+        }
+        if tok.name == Tok.KW_ENUM.value {
+            return self.parse_enum(decorators=decorators);
+        }
+        if tok.name in [
+            Tok.KW_DEF.value,
+            Tok.KW_CAN.value,
+            Tok.KW_OVERRIDE.value,
+            Tok.KW_STATIC.value
+        ] {
+            return self.parse_ability(decorators=decorators);
+        }
+        self.log_error("Expected declaration after decorator", tok);
+        return None;
+    }
+
+    def parse_decorators -> list {
+        decorators: list = [];
+        while self.check(Tok.DECOR_OP.value) {
+            self.advance();
+            expr = self.parse_atomic_chain();
+            decorators.append(expr);
+        }
+        return decorators;
+    }
+
+    # ── Concrete top-level construct parsers ─────────────────────────────
+    def parse_py_code_block -> UniPyInlineCode {
+        pyinline = self.expect(Tok.PYNLINE.value);
+        nd = UniPyInlineCode(code=pyinline, kid=[pyinline]);
+        self.register_node(nd);
+        return nd;
+    }
+
+    def parse_test -> UniTest {
+        test_tok = self.expect(Tok.KW_TEST.value);
+        name = None;
+        if is_name_token(self.peek()) {
+            name = self.advance();
+        }
+        if name is None {
+            name = test_tok;
+        }
+        block = self.parse_code_block_with_kids();
+        body = block[0];
+        kids: list = [test_tok];
+        if name is not test_tok {
+            kids.append(name);
+        }
+        kids.extend(block[1]);
+        nd = UniTest(
+            name=name,
+            body=[
+                s
+                for s in body
+                if isinstance(s, CodeBlockStmt)
+            ],
+            kid=kids
+        );
+        self.register_node(nd);
+        return nd;
+    }
+
+    def parse_free_code -> UniModuleCode {
+        with_tok = self.expect(Tok.KW_WITH.value);
+        entry_tok = self.expect(Tok.KW_ENTRY.value);
+        kids: list = [with_tok, entry_tok];
+
+        name = None;
+        if self.check(Tok.COLON.value) {
+            colon = self.advance();
+            kids.append(colon);
+            name = self.parse_named_ref();
+            kids.append(name);
+        }
+
+        block = self.parse_code_block_with_kids();
+        body = block[0];
+        kids.extend(block[1]);
+
+        nd = UniModuleCode(
+            name=name,
+            body=[
+                s
+                for s in body
+                if isinstance(s, CodeBlockStmt)
+            ],
+            kid=kids
+        );
+        self.register_node(nd);
+        return nd;
+    }
+
+    # ── Delegation methods to parser_defs.jac ────────────────────────────
+    def parse_import_stmt -> UniImport {
+        return _import_stmt_impl(self);
+    }
+
+    def parse_archetype(decorators: list = []) -> UniArchetype {
+        return _archetype_impl(self, decorators=decorators);
+    }
+
+    def parse_enum(decorators: list = []) -> any {
+        return _enum_impl(self, decorators=decorators);
+    }
+
+    def parse_ability(decorators: list = []) -> UniAbility {
+        return _ability_impl(self, decorators=decorators);
+    }
+
+    def parse_global_var -> UniGlobalVars {
+        return _global_var_impl(self);
+    }
+
+    def parse_impl_def -> UniImplDef {
+        return _impl_def_impl(self);
+    }
+
+    def parse_sem_def -> UniSemDef {
+        return _sem_def_impl(self);
+    }
+
+    def parse_has_stmt -> any {
+        return _has_stmt_impl(self);
+    }
+
+    def parse_func_signature -> any {
+        return _func_sig_impl(self);
+    }
+
+    def parse_fstring -> any {
+        return _fstring_impl(self);
+    }
+
+    def parse_jsx_element -> any {
+        return _jsx_element_impl(self);
+    }
+
+    def parse_edge_ref_chain -> any {
+        return _edge_ref_chain_impl(self);
+    }
+
+    def parse_disconnect_op -> any {
+        return _disconnect_op_impl(self);
+    }
+
+    def parse_connect_op -> any {
+        return _connect_op_impl(self);
+    }
+
+    def parse_filter_compare_list -> list {
+        return _filter_compare_list_impl(self);
+    }
+
+    def parse_match_stmt -> any {
+        return _match_stmt_impl(self);
+    }
+
+    def parse_switch_stmt -> any {
+        return _switch_stmt_impl(self);
+    }
+}

--- a/jac/jaclang/compiler/rd_parser/parser_defs.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_defs.jac
@@ -1,0 +1,1349 @@
+# Declaration parsing for the Jac recursive descent parser.
+#
+# Handles archetypes, abilities, enums, imports, impls, sem-defs,
+# global vars, has-stmts, function signatures, and event clauses.
+#
+# All functions take `p` (the parser instance) as first argument.
+# Type is `any` to avoid circular imports with parser.jac.
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    String as UniString,
+    Source as UniSource,
+    Expr,
+    NameAtom,
+    AtomExpr,
+    CodeBlockStmt,
+    ArchBlockStmt,
+    EnumBlockStmt,
+    Archetype as UniArchetype,
+    Enum as UniEnum,
+    Ability as UniAbility,
+    FuncSignature as UniFuncSignature,
+    EventSignature as UniEventSignature,
+    ParamVar as UniParamVar,
+    ParamKind,
+    ArchHas as UniArchHas,
+    HasVar as UniHasVar,
+    Import as UniImport,
+    ModulePath as UniModulePath,
+    ModuleItem as UniModuleItem,
+    ImplDef as UniImplDef,
+    SemDef as UniSemDef,
+    GlobalVars as UniGlobalVars,
+    Assignment as UniAssignment,
+    SubTag as UniSubTag,
+    ModuleCode as UniModuleCode,
+    PyInlineCode as UniPyInlineCode
+}
+
+import from jaclang.pycore.constant { Tokens as Tok, SymbolType }
+
+import from jaclang.compiler.rd_parser.lexer { EOF_NAME }
+
+import from jaclang.compiler.rd_parser.ast_builder {
+    is_eof_token,
+    is_name_token,
+    is_special_ref_token,
+    ARCH_TYPE_TOKENS
+}
+
+import from jaclang.compiler.rd_parser.parser_exprs {
+    parse_expression,
+    parse_atomic_chain,
+    parse_pipe
+}
+
+import from jaclang.compiler.rd_parser.parser_stmts {
+    parse_statement,
+    parse_code_block,
+    parse_code_block_with_kids
+}
+
+# ── Access Tag ─────────────────────────────────────────────────────────
+"""Parse access_tag: COLON ( KW_PROT | KW_PUB | KW_PRIV )."""
+def parse_access_tag(p: any) -> any {
+    if not p.check(Tok.COLON.value) {
+        return None;
+    }
+    colon = p.advance();
+    access_names: list = [Tok.KW_PUB.value, Tok.KW_PROT.value, Tok.KW_PRIV.value];
+    if p.peek().name in access_names {
+        access_tok = p.advance();
+    } else {
+        access_tok = p.expect(Tok.KW_PUB.value);
+    }
+    nd = UniSubTag(tag=access_tok, kid=[colon, access_tok]);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Type Tag ───────────────────────────────────────────────────────────
+"""Parse type_tag: COLON pipe."""
+def parse_type_tag(p: any) -> any {
+    colon = p.expect(Tok.COLON.value);
+    type_expr = parse_pipe(p);
+    nd = UniSubTag(tag=type_expr, kid=[colon, type_expr]);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Inherited Archs ───────────────────────────────────────────────────
+"""Parse inherited_archs: LPAREN (atomic_chain COMMA)* atomic_chain RPAREN.
+    Returns (bases_list, kids_list)."""
+def _parse_inherited_archs(p: any) -> tuple {
+    lparen = p.expect(Tok.LPAREN.value);
+    bases: list = [];
+    kids: list = [lparen];
+    if not p.check(Tok.RPAREN.value) {
+        base = parse_atomic_chain(p);
+        bases.append(base);
+        kids.append(base);
+        while p.check(Tok.COMMA.value) {
+            comma = p.advance();
+            kids.append(comma);
+            if p.check(Tok.RPAREN.value) {
+                break;
+            }
+            base = parse_atomic_chain(p);
+            bases.append(base);
+            kids.append(base);
+        }
+    }
+    rparen = p.expect(Tok.RPAREN.value);
+    kids.append(rparen);
+    return (bases, kids);
+}
+
+# ── Dotted Name ────────────────────────────────────────────────────────
+"""Parse dotted_name: named_ref (DOT named_ref)*.
+    Returns (names_list, kids_list)."""
+def _parse_dotted_name(p: any) -> tuple {
+    names: list = [];
+    kids: list = [];
+    name = p.parse_named_ref();
+    names.append(name);
+    kids.append(name);
+    while p.check(Tok.DOT.value) {
+        dot = p.advance();
+        kids.append(dot);
+        name = p.parse_named_ref();
+        names.append(name);
+        kids.append(name);
+    }
+    return (names, kids);
+}
+
+# ── Import Statement ──────────────────────────────────────────────────
+"""Parse import_stmt (three forms):
+    - KW_IMPORT KW_FROM from_path LBRACE import_items RBRACE
+    - KW_IMPORT import_path (COMMA import_path)* SEMI
+    - KW_INCLUDE import_path SEMI
+    """
+def parse_import_stmt(p: any) -> any {
+    # Form 3: include
+    if p.check(Tok.KW_INCLUDE.value) {
+        include_tok = p.advance();
+        path = _parse_import_path(p);
+        semi = p.expect(Tok.SEMI.value);
+        kids: list = [include_tok, path, semi];
+        nd = UniImport(from_loc=None, items=[path], is_absorb=True, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    import_tok = p.expect(Tok.KW_IMPORT.value);
+
+    # Form 1: from-import
+    if p.check(Tok.KW_FROM.value) {
+        from_tok = p.advance();
+        from_path = _parse_from_path(p);
+        lbrace = p.expect(Tok.LBRACE.value);
+        items = _parse_import_items(p);
+        rbrace = p.expect(Tok.RBRACE.value);
+        kids: list = [import_tok, from_tok, from_path, lbrace];
+        for item in items {
+            kids.append(item);
+        }
+        kids.append(rbrace);
+        nd = UniImport(from_loc=from_path, items=items, is_absorb=False, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Form 2: direct import
+    path = _parse_import_path(p);
+    paths: list = [path];
+    kids: list = [import_tok, path];
+    while p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids.append(comma);
+        path = _parse_import_path(p);
+        paths.append(path);
+        kids.append(path);
+    }
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+    nd = UniImport(from_loc=None, items=paths, is_absorb=False, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse from_path: (DOT | ELLIPSIS)* import_path | (DOT | ELLIPSIS)+."""
+def _parse_from_path(p: any) -> any {
+    level = 0;
+    kids: list = [];
+    while p.check(Tok.DOT.value) or p.check(Tok.ELLIPSIS.value) {
+        tok = p.advance();
+        kids.append(tok);
+        if tok.name == Tok.ELLIPSIS.value {
+            level = level + 3;
+        } else {
+            level = level + 1;
+        }
+    }
+    # Check if there's an actual path after the dots
+    path_names: list = [];
+    if is_name_token(p.peek()) or p.check(Tok.STRING.value) {
+        result = _parse_import_path_inner(p);
+        path_names = result[0];
+        kids.extend(result[1]);
+        alias = result[2];
+    } else {
+        alias = None;
+    }
+    nd = UniModulePath(
+        path=path_names if len(path_names) > 0 else None,
+        level=level,
+        alias=alias,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse import_path: (dotted_name | STRING) (KW_AS NAME)?."""
+def _parse_import_path(p: any) -> any {
+    result = _parse_import_path_inner(p);
+    path_names = result[0];
+    kids = result[1];
+    alias = result[2];
+    nd = UniModulePath(path=path_names, level=0, alias=alias, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Inner helper returning (path_names, kids, alias)."""
+def _parse_import_path_inner(p: any) -> tuple {
+    path_names: list = [];
+    kids: list = [];
+
+    if p.check(Tok.STRING.value) {
+        str_tok = p.advance();
+        path_names.append(str_tok);
+        kids.append(str_tok);
+    } else {
+        name = p.parse_named_ref();
+        path_names.append(name);
+        kids.append(name);
+        while p.check(Tok.DOT.value) {
+            dot = p.advance();
+            kids.append(dot);
+            name = p.parse_named_ref();
+            path_names.append(name);
+            kids.append(name);
+        }
+    }
+
+    alias = None;
+    if p.check(Tok.KW_AS.value) {
+        as_tok = p.advance();
+        kids.append(as_tok);
+        alias = p.parse_named_ref();
+        kids.append(alias);
+    }
+
+    return (path_names, kids, alias);
+}
+
+"""Parse import_items: (import_item COMMA)* import_item COMMA?."""
+def _parse_import_items(p: any) -> list {
+    items: list = [];
+    if p.check(Tok.RBRACE.value) {
+        return items;
+    }
+    item = _parse_import_item(p);
+    items.append(item);
+    while p.check(Tok.COMMA.value) {
+        p.advance();
+        if p.check(Tok.RBRACE.value) {
+            break;
+        }
+        item = _parse_import_item(p);
+        items.append(item);
+    }
+    return items;
+}
+
+"""Parse import_item: (KW_DEFAULT | STAR_MUL | named_ref) (KW_AS NAME)?."""
+def _parse_import_item(p: any) -> any {
+    kids: list = [];
+
+    if p.check(Tok.KW_DEFAULT.value) {
+        name = p.advance();
+        kids.append(name);
+    } elif p.check(Tok.STAR_MUL.value) {
+        name = p.advance();
+        kids.append(name);
+    } else {
+        name = p.parse_named_ref();
+        kids.append(name);
+    }
+
+    alias = None;
+    if p.check(Tok.KW_AS.value) {
+        as_tok = p.advance();
+        kids.append(as_tok);
+        alias = p.parse_named_ref();
+        kids.append(alias);
+    }
+
+    nd = UniModuleItem(name=name, alias=alias, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Archetype Declaration ─────────────────────────────────────────────
+"""Parse archetype: decorators? KW_ASYNC? archetype_decl."""
+def parse_archetype(p: any, decorators: list = []) -> any {
+    kids: list = [];
+    for d in decorators {
+        kids.append(d);
+    }
+
+    is_async = False;
+    if p.check(Tok.KW_ASYNC.value) {
+        async_tok = p.advance();
+        kids.append(async_tok);
+        is_async = True;
+    }
+
+    # arch_type token
+    arch_type_tok = p.advance();
+    kids.append(arch_type_tok);
+
+    # Optional access tag
+    access = None;
+    if p.check(Tok.COLON.value) {
+        access = parse_access_tag(p);
+        if access is not None {
+            kids.append(access);
+        }
+    }
+
+    # Name
+    name = p.parse_named_ref();
+    kids.append(name);
+
+    # Optional inherited_archs
+    base_classes: list = [];
+    if p.check(Tok.LPAREN.value) {
+        inh_result = _parse_inherited_archs(p);
+        base_classes = inh_result[0];
+        kids.extend(inh_result[1]);
+    }
+
+    # Body: member_block or SEMI
+    body = None;
+    if p.check(Tok.LBRACE.value) {
+        body_result = _parse_member_block(p);
+        body = body_result[0];
+        kids.extend(body_result[1]);
+    } elif p.check(Tok.SEMI.value) {
+        semi = p.advance();
+        kids.append(semi);
+        body = None;
+    } else {
+        p.log_error("Expected '{' or ';' after archetype declaration", p.peek());
+    }
+
+    nd = UniArchetype(
+        name=name,
+        arch_type=arch_type_tok,
+        access=access,
+        base_classes=base_classes,
+        body=body,
+        kid=kids,
+        decorators=decorators if len(decorators) > 0 else None
+    );
+    p.register_node(nd);
+    if is_async {
+        nd.is_async = True;
+    }
+    return nd;
+}
+
+"""Parse member_block: LBRACE member_stmt* RBRACE.
+    Returns (stmts_list, kids_list)."""
+def _parse_member_block(p: any) -> tuple {
+    lbrace = p.expect(Tok.LBRACE.value);
+    stmts: list = [];
+    kids: list = [lbrace];
+
+    while not p.at_end() and not p.check(Tok.RBRACE.value) {
+        # Optional docstring before member
+        doc = None;
+        if p.check(Tok.STRING.value) {
+            doc = p.advance();
+            kids.append(doc);
+        }
+
+        stmt = _parse_member_stmt(p);
+        if stmt is not None {
+            if doc is not None and stmt?.doc {
+                stmt.doc = doc;
+            }
+            stmts.append(stmt);
+            kids.append(stmt);
+        } else {
+            if not p.at_end() and not p.check(Tok.RBRACE.value) {
+                p.advance();
+            }
+        }
+    }
+
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+    return (stmts, kids);
+}
+
+"""Parse member_stmt: py_code_block | ability | archetype | impl_def | has_stmt | free_code."""
+def _parse_member_stmt(p: any) -> any {
+    tok = p.peek();
+
+    if tok.name == Tok.PYNLINE.value {
+        return p.parse_py_code_block();
+    }
+    if tok.name == Tok.DECOR_OP.value {
+        decorators = p.parse_decorators();
+        tok = p.peek();
+        if tok.name == Tok.KW_ASYNC.value {
+            peek1 = p.peek(1);
+            if peek1.name in ARCH_TYPE_TOKENS {
+                return parse_archetype(p, decorators=decorators);
+            }
+            return parse_ability(p, decorators=decorators);
+        }
+        if tok.name in ARCH_TYPE_TOKENS {
+            return parse_archetype(p, decorators=decorators);
+        }
+        if tok.name == Tok.KW_ENUM.value {
+            return parse_enum_def(p, decorators=decorators);
+        }
+        if tok.name == Tok.KW_STATIC.value {
+            # static with decorator is always ability (static def/can); static has doesn't take decorators
+            return parse_ability(p, decorators=decorators);
+        }
+        if tok.name in [Tok.KW_DEF.value, Tok.KW_CAN.value, Tok.KW_OVERRIDE.value] {
+            return parse_ability(p, decorators=decorators);
+        }
+        p.log_error("Expected declaration after decorator", tok);
+        return None;
+    }
+    if tok.name == Tok.KW_ASYNC.value {
+        peek1 = p.peek(1);
+        if peek1.name in ARCH_TYPE_TOKENS {
+            return parse_archetype(p);
+        }
+        return parse_ability(p);
+    }
+    if tok.name in ARCH_TYPE_TOKENS {
+        return parse_archetype(p);
+    }
+    if tok.name == Tok.KW_ENUM.value {
+        return parse_enum_def(p);
+    }
+    # static can start either ability (static def/can) or has_stmt (static has)
+    if tok.name == Tok.KW_STATIC.value {
+        peek1 = p.peek(1);
+        if peek1.name == Tok.KW_HAS.value {
+            return parse_has_stmt(p);
+        }
+        return parse_ability(p);
+    }
+    if tok.name in [Tok.KW_DEF.value, Tok.KW_CAN.value, Tok.KW_OVERRIDE.value] {
+        return parse_ability(p);
+    }
+    if tok.name == Tok.KW_IMPL.value {
+        return parse_impl_def(p);
+    }
+    if tok.name == Tok.KW_HAS.value {
+        return parse_has_stmt(p);
+    }
+    if tok.name == Tok.KW_WITH.value {
+        peek1 = p.peek(1);
+        if peek1.name == Tok.KW_ENTRY.value {
+            return p.parse_free_code();
+        }
+    }
+    return None;
+}
+
+# ── Enum Declaration ──────────────────────────────────────────────────
+"""Parse enum: decorators? enum_decl.
+    enum_decl: KW_ENUM access_tag? NAME inherited_archs? (enum_block | SEMI)."""
+def parse_enum_def(p: any, decorators: list = []) -> any {
+    kids: list = [];
+    for d in decorators {
+        kids.append(d);
+    }
+
+    enum_tok = p.expect(Tok.KW_ENUM.value);
+    kids.append(enum_tok);
+
+    # Optional access tag
+    access = None;
+    if p.check(Tok.COLON.value) {
+        access = parse_access_tag(p);
+        if access is not None {
+            kids.append(access);
+        }
+    }
+
+    # Name
+    name = p.parse_named_ref();
+    kids.append(name);
+
+    # Optional inherited_archs (with colon for enums: NAME : base1, base2)
+    base_classes: list = [];
+    if p.check(Tok.LPAREN.value) {
+        inh_result = _parse_inherited_archs(p);
+        base_classes = inh_result[0];
+        kids.extend(inh_result[1]);
+    }
+
+    # Body: enum_block or SEMI
+    body = None;
+    if p.check(Tok.LBRACE.value) {
+        body_result = _parse_enum_block(p);
+        body = body_result[0];
+        kids.extend(body_result[1]);
+    } elif p.check(Tok.SEMI.value) {
+        semi = p.advance();
+        kids.append(semi);
+        body = None;
+    } else {
+        p.log_error("Expected '{' or ';' after enum declaration", p.peek());
+    }
+
+    nd = UniEnum(
+        name=name,
+        access=access,
+        base_classes=base_classes,
+        body=body,
+        kid=kids,
+        decorators=decorators if len(decorators) > 0 else None
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse enum_block: LBRACE assignment_list (py_code_block | free_code)* RBRACE.
+    Returns (stmts_list, kids_list)."""
+def _parse_enum_block(p: any) -> tuple {
+    lbrace = p.expect(Tok.LBRACE.value);
+    stmts: list = [];
+    kids: list = [lbrace];
+
+    # Parse assignment_list
+    assignments = _parse_assignment_list(p);
+    for a in assignments {
+        if isinstance(a, UniAssignment) {
+            a.is_enum_stmt = True;
+        }
+        stmts.append(a);
+        kids.append(a);
+    }
+
+    # Optional trailing comma
+    if p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids.append(comma);
+    }
+
+    # Optional py_code_block or free_code entries
+    while not p.at_end() and not p.check(Tok.RBRACE.value) {
+        if p.check(Tok.PYNLINE.value) {
+            stmt = p.parse_py_code_block();
+            stmt.is_enum_stmt = True;
+            stmts.append(stmt);
+            kids.append(stmt);
+        } elif p.check(Tok.KW_WITH.value) {
+            stmt = p.parse_free_code();
+            stmt.is_enum_stmt = True;
+            stmts.append(stmt);
+            kids.append(stmt);
+        } else {
+            break;
+        }
+    }
+
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+    return (stmts, kids);
+}
+
+"""Parse assignment_list: (assignment | named_ref) (COMMA (assignment | named_ref))* COMMA?."""
+def _parse_assignment_list(p: any) -> list {
+    items: list = [];
+    if p.check(Tok.RBRACE.value) or p.check(Tok.SEMI.value) {
+        return items;
+    }
+    item = _parse_assignment_or_name(p);
+    items.append(item);
+    while p.check(Tok.COMMA.value) {
+        peek_after = p.peek(1);
+        # Stop if next is RBRACE or if this is trailing comma before py_code_block/free_code
+        if peek_after.name == Tok.RBRACE.value
+        or peek_after.name == Tok.PYNLINE.value
+        or peek_after.name == Tok.KW_WITH.value {
+            break;
+        }
+        p.advance();
+        item = _parse_assignment_or_name(p);
+        items.append(item);
+    }
+    return items;
+}
+
+"""Parse assignment or named_ref for global_var / enum lists.
+    Always returns an Assignment node - bare names are wrapped for enum/global_var compatibility."""
+def _parse_assignment_or_name(p: any) -> any {
+    expr = parse_expression(p);
+    if p.check(Tok.EQ.value) {
+        eq_tok = p.advance();
+        value = parse_expression(p);
+        kids: list = [expr, eq_tok, value];
+        nd = UniAssignment(target=[expr], value=value, type_tag=None, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    if p.check(Tok.COLON.value) {
+        type_tag = parse_type_tag(p);
+        value = None;
+        if p.check(Tok.EQ.value) {
+            eq_tok = p.advance();
+            value = parse_expression(p);
+            kids: list = [expr, type_tag, eq_tok, value];
+        } else {
+            kids: list = [expr, type_tag];
+        }
+        nd = UniAssignment(target=[expr], value=value, type_tag=type_tag, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    # Wrap bare name in Assignment node for enum/global_var compatibility
+    nd = UniAssignment(target=[expr], value=None, type_tag=None, kid=[expr]);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Ability / Function Declaration ────────────────────────────────────
+"""Parse ability: decorators? KW_ASYNC? (ability_decl | function_decl)."""
+def parse_ability(p: any, decorators: list = []) -> any {
+    kids: list = [];
+    for d in decorators {
+        kids.append(d);
+    }
+
+    is_async = False;
+    if p.check(Tok.KW_ASYNC.value) {
+        async_tok = p.advance();
+        kids.append(async_tok);
+        is_async = True;
+    }
+
+    # Determine if this is ability_decl (can) or function_decl (def)
+    is_override = False;
+    is_static = False;
+
+    if p.check(Tok.KW_OVERRIDE.value) {
+        override_tok = p.advance();
+        kids.append(override_tok);
+        is_override = True;
+    }
+    if p.check(Tok.KW_STATIC.value) {
+        static_tok = p.advance();
+        kids.append(static_tok);
+        is_static = True;
+    }
+
+    if p.check(Tok.KW_CAN.value) {
+        return _parse_ability_decl(
+            p, kids, is_async, is_override, is_static, decorators
+        );
+    }
+    if p.check(Tok.KW_DEF.value) {
+        return _parse_function_decl(
+            p, kids, is_async, is_override, is_static, decorators
+        );
+    }
+
+    p.log_error("Expected 'can' or 'def' in ability declaration", p.peek());
+    return None;
+}
+
+"""Parse ability_decl: KW_CAN access_tag? named_ref? event_clause (block_tail | KW_ABSTRACT? SEMI)."""
+def _parse_ability_decl(
+    p: any,
+    kids: list,
+    is_async: bool,
+    is_override: bool,
+    is_static: bool,
+    decorators: list
+) -> any {
+    can_tok = p.expect(Tok.KW_CAN.value);
+    kids.append(can_tok);
+
+    # Optional access tag
+    access = None;
+    if p.check(Tok.COLON.value) {
+        access = parse_access_tag(p);
+        if access is not None {
+            kids.append(access);
+        }
+    }
+
+    # Optional name (can be omitted for event handlers)
+    name_ref = None;
+    if is_name_token(p.peek()) {
+        name_ref = p.parse_named_ref();
+        kids.append(name_ref);
+    }
+
+    # Event clause
+    signature = parse_event_clause(p);
+    kids.append(signature);
+
+    # Block tail or abstract/semi
+    body = None;
+    is_abstract = False;
+    if p.check(Tok.LBRACE.value) {
+        block_result = parse_code_block_with_kids(p);
+        body = block_result[0];
+        kids.extend(block_result[1]);
+    } elif p.check(Tok.KW_BY.value) {
+        by_tok = p.advance();
+        kids.append(by_tok);
+        body = parse_expression(p);
+        kids.append(body);
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+    } else {
+        if p.check(Tok.KW_ABSTRACT.value) {
+            abstract_tok = p.advance();
+            kids.append(abstract_tok);
+            is_abstract = True;
+        }
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+    }
+
+    if isinstance(body, list) {
+        body_stmts = [
+            s
+            for s in body
+            if isinstance(s, CodeBlockStmt)
+        ];
+    } else {
+        body_stmts = body;
+    }
+
+    nd = UniAbility(
+        name_ref=name_ref,
+        is_async=is_async,
+        is_override=is_override,
+        is_static=is_static,
+        is_abstract=is_abstract,
+        access=access,
+        signature=signature,
+        body=body_stmts,
+        kid=kids,
+        decorators=decorators if len(decorators) > 0 else None
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse function_decl: KW_DEF access_tag? named_ref func_decl? (block_tail | KW_ABSTRACT? SEMI)."""
+def _parse_function_decl(
+    p: any,
+    kids: list,
+    is_async: bool,
+    is_override: bool,
+    is_static: bool,
+    decorators: list
+) -> any {
+    def_tok = p.expect(Tok.KW_DEF.value);
+    kids.append(def_tok);
+
+    # Optional access tag
+    access = None;
+    if p.check(Tok.COLON.value) {
+        access = parse_access_tag(p);
+        if access is not None {
+            kids.append(access);
+        }
+    }
+
+    # Name
+    name_ref = p.parse_named_ref();
+    kids.append(name_ref);
+
+    # Optional func_decl (signature)
+    signature = None;
+    if p.check(Tok.LPAREN.value) or p.check(Tok.RETURN_HINT.value) {
+        signature = parse_func_signature(p);
+        kids.append(signature);
+    }
+
+    # Block tail or abstract/semi
+    body = None;
+    is_abstract = False;
+    if p.check(Tok.LBRACE.value) {
+        block_result = parse_code_block_with_kids(p);
+        body = block_result[0];
+        kids.extend(block_result[1]);
+    } elif p.check(Tok.KW_BY.value) {
+        by_tok = p.advance();
+        kids.append(by_tok);
+        body = parse_expression(p);
+        kids.append(body);
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+    } else {
+        if p.check(Tok.KW_ABSTRACT.value) {
+            abstract_tok = p.advance();
+            kids.append(abstract_tok);
+            is_abstract = True;
+        }
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+    }
+
+    if isinstance(body, list) {
+        body_stmts = [
+            s
+            for s in body
+            if isinstance(s, CodeBlockStmt)
+        ];
+    } else {
+        body_stmts = body;
+    }
+
+    nd = UniAbility(
+        name_ref=name_ref,
+        is_async=is_async,
+        is_override=is_override,
+        is_static=is_static,
+        is_abstract=is_abstract,
+        access=access,
+        signature=signature,
+        body=body_stmts,
+        kid=kids,
+        decorators=decorators if len(decorators) > 0 else None
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Event Clause ──────────────────────────────────────────────────────
+"""Parse event_clause: KW_WITH expression? (KW_EXIT | KW_ENTRY)."""
+def parse_event_clause(p: any) -> any {
+    kids: list = [];
+    with_tok = p.expect(Tok.KW_WITH.value);
+    kids.append(with_tok);
+
+    # Optional type expression
+    arch_tag_info = None;
+    if not p.check(Tok.KW_EXIT.value) and not p.check(Tok.KW_ENTRY.value) {
+        arch_tag_info = parse_expression(p);
+        kids.append(arch_tag_info);
+    }
+
+    # Exit or Entry
+    if p.check(Tok.KW_EXIT.value) {
+        event_tok = p.advance();
+    } else {
+        event_tok = p.expect(Tok.KW_ENTRY.value);
+    }
+    kids.append(event_tok);
+
+    nd = UniEventSignature(event=event_tok, arch_tag_info=arch_tag_info, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Function Signature ────────────────────────────────────────────────
+"""Parse func_decl: (LPAREN func_decl_params? RPAREN) (RETURN_HINT pipe)?
+                      | (RETURN_HINT pipe)."""
+def parse_func_signature(p: any) -> any {
+    # Return-only form
+    if p.check(Tok.RETURN_HINT.value) {
+        return_hint = p.advance();
+        return_type = parse_pipe(p);
+        kids: list = [return_hint];
+        if return_type is not None {
+            kids.append(return_type);
+        }
+        nd = UniFuncSignature(
+            posonly_params=[],
+            params=[],
+            varargs=None,
+            kwonlyargs=[],
+            kwargs=None,
+            return_type=return_type,
+            kid=kids
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Full form
+    lparen = p.expect(Tok.LPAREN.value);
+    all_params: list = [];
+    all_kids: list = [lparen];
+
+    if not p.check(Tok.RPAREN.value) {
+        param_result = _parse_func_params(p);
+        all_params = param_result[0];
+        all_kids.extend(param_result[1]);
+    }
+
+    rparen = p.expect(Tok.RPAREN.value);
+    all_kids.append(rparen);
+
+    # Optional return type
+    return_type = None;
+    if p.check(Tok.RETURN_HINT.value) {
+        return_hint = p.advance();
+        all_kids.append(return_hint);
+        return_type = parse_pipe(p);
+        if return_type is not None {
+            all_kids.append(return_type);
+        }
+    }
+
+    # Categorize parameters
+    categories = _parse_parameter_categories(all_params);
+    posonly = categories[0];
+    params = categories[1];
+    varargs = categories[2];
+    kwonly = categories[3];
+    kwargs = categories[4];
+
+    nd = UniFuncSignature(
+        posonly_params=posonly,
+        params=params,
+        varargs=varargs,
+        kwonlyargs=kwonly,
+        kwargs=kwargs,
+        return_type=return_type,
+        kid=all_kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse func_decl_params: (param_var COMMA)* param_var COMMA?.
+    Returns (params_list, kids_list)."""
+def _parse_func_params(p: any) -> tuple {
+    params: list = [];
+    kids: list = [];
+
+    param = _parse_param_var(p);
+    params.append(param);
+    kids.append(param);
+
+    while p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids.append(comma);
+        if p.check(Tok.RPAREN.value) {
+            break;
+        }
+        param = _parse_param_var(p);
+        params.append(param);
+        kids.append(param);
+    }
+
+    return (params, kids);
+}
+
+"""Parse param_var: (STAR_POW | STAR_MUL)? named_ref type_tag (EQ expression)?
+                      | DIV
+                      | STAR_MUL (bare, as separator)."""
+def _parse_param_var(p: any) -> any {
+    # Bare DIV separator
+    if p.check(Tok.DIV.value) {
+        return p.advance();
+    }
+
+    # Bare STAR_MUL separator (no name follows)
+    if p.check(Tok.STAR_MUL.value) {
+        peek1 = p.peek(1);
+        if peek1.name == Tok.COMMA.value or peek1.name == Tok.RPAREN.value {
+            return p.advance();
+        }
+    }
+
+    # Full parameter
+    kids: list = [];
+    unpack = None;
+    if p.check(Tok.STAR_MUL.value) or p.check(Tok.STAR_POW.value) {
+        unpack = p.advance();
+        kids.append(unpack);
+    }
+
+    name = p.parse_named_ref();
+    kids.append(name);
+
+    # Type tag
+    type_tag = parse_type_tag(p);
+    kids.append(type_tag);
+
+    # Optional default value
+    value = None;
+    if p.check(Tok.EQ.value) {
+        eq = p.advance();
+        kids.append(eq);
+        value = parse_expression(p);
+        kids.append(value);
+    }
+
+    nd = UniParamVar(
+        name=name, unpack=unpack, type_tag=type_tag, value=value, kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Categorize params into posonly, regular, varargs, kwonly, kwargs.
+    Returns (posonly, params, varargs, kwonly, kwargs)."""
+def _parse_parameter_categories(all_params: list) -> tuple {
+    posonly: list = [];
+    params: list = [];
+    varargs = None;
+    kwonly: list = [];
+    kwargs = None;
+
+    # First pass: check if there's a DIV separator
+    has_div = False;
+    for param in all_params {
+        if isinstance(param, UniToken) and param.name == Tok.DIV.value {
+            has_div = True;
+            break;
+        }
+    }
+
+    cur_state = "posonly" if has_div else "positional";
+
+    for cur_nd in all_params {
+        # State transitions on separator tokens
+        if isinstance(cur_nd, UniToken) {
+            if cur_nd.name == Tok.DIV.value {
+                cur_state = "positional";
+                continue;
+            }
+            if cur_nd.name == Tok.STAR_MUL.value {
+                cur_state = "keyword_only";
+                continue;
+            }
+        }
+        if not isinstance(cur_nd, UniParamVar) {
+            continue;
+        }
+        # Assign based on state
+        if cur_state == "positional" {
+            cur_nd.param_kind = ParamKind.NORMAL;
+            params.append(cur_nd);
+        } elif cur_state == "posonly" {
+            cur_nd.param_kind = ParamKind.POSONLY;
+            posonly.append(cur_nd);
+        } elif cur_state == "keyword_only" {
+            if cur_nd.unpack is not None and cur_nd.unpack.name == Tok.STAR_POW.value {
+                cur_nd.param_kind = ParamKind.KWARG;
+                kwargs = cur_nd;
+            } else {
+                cur_nd.param_kind = ParamKind.KWONLY;
+                kwonly.append(cur_nd);
+            }
+        } else {
+            # Check for *args and **kwargs
+            if cur_nd.unpack is not None {
+                if cur_nd.unpack.name == Tok.STAR_MUL.value {
+                    cur_nd.param_kind = ParamKind.VARARG;
+                    varargs = cur_nd;
+                    cur_state = "keyword_only";
+                } elif cur_nd.unpack.name == Tok.STAR_POW.value {
+                    cur_nd.param_kind = ParamKind.KWARG;
+                    kwargs = cur_nd;
+                }
+            } else {
+                cur_nd.param_kind = ParamKind.NORMAL;
+                params.append(cur_nd);
+            }
+        }
+    }
+
+    return (posonly, params, varargs, kwonly, kwargs);
+}
+
+# ── Has Statement ─────────────────────────────────────────────────────
+"""Parse has_stmt: KW_STATIC? KW_HAS access_tag? has_assign_list SEMI."""
+def parse_has_stmt(p: any) -> any {
+    kids: list = [];
+    is_static = False;
+
+    if p.check(Tok.KW_STATIC.value) {
+        static_tok = p.advance();
+        kids.append(static_tok);
+        is_static = True;
+    }
+
+    has_tok = p.expect(Tok.KW_HAS.value);
+    kids.append(has_tok);
+
+    # Optional access tag
+    access = None;
+    if p.check(Tok.COLON.value) {
+        access = parse_access_tag(p);
+        if access is not None {
+            kids.append(access);
+        }
+    }
+
+    # has_assign_list: (has_assign_list COMMA)? typed_has_clause
+    vars_list = _parse_has_assign_list(p);
+    for v in vars_list {
+        kids.append(v);
+    }
+
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+
+    nd = UniArchHas(
+        is_static=is_static, access=access, vars=vars_list, is_frozen=False, kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse has_assign_list: (has_assign_list COMMA)? typed_has_clause."""
+def _parse_has_assign_list(p: any) -> list {
+    vars_list: list = [];
+    var = _parse_typed_has_clause(p);
+    vars_list.append(var);
+    while p.check(Tok.COMMA.value) {
+        p.advance();
+        var = _parse_typed_has_clause(p);
+        vars_list.append(var);
+    }
+    return vars_list;
+}
+
+"""Parse typed_has_clause: named_ref type_tag (EQ expression | KW_BY KW_POST_INIT)?."""
+def _parse_typed_has_clause(p: any) -> any {
+    kids: list = [];
+    name = p.parse_named_ref();
+    kids.append(name);
+
+    type_tag = parse_type_tag(p);
+    kids.append(type_tag);
+
+    value = None;
+    defer = False;
+    if p.check(Tok.EQ.value) {
+        eq = p.advance();
+        kids.append(eq);
+        value = parse_expression(p);
+        kids.append(value);
+    } elif p.check(Tok.KW_BY.value) {
+        by = p.advance();
+        kids.append(by);
+        post_init = p.expect(Tok.KW_POST_INIT.value);
+        kids.append(post_init);
+        defer = True;
+    }
+
+    nd = UniHasVar(name=name, type_tag=type_tag, value=value, defer=defer, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Global Variable ───────────────────────────────────────────────────
+"""Parse global_var: KW_GLOBAL access_tag? assignment_list SEMI."""
+def parse_global_var(p: any) -> any {
+    global_tok = p.expect(Tok.KW_GLOBAL.value);
+    kids: list = [global_tok];
+
+    # Optional access tag
+    access = None;
+    if p.check(Tok.COLON.value) {
+        access = parse_access_tag(p);
+        if access is not None {
+            kids.append(access);
+        }
+    }
+
+    # assignment_list
+    assignments = _parse_assignment_list(p);
+    for a in assignments {
+        kids.append(a);
+    }
+
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+
+    nd = UniGlobalVars(
+        access=access,
+        assignments=[
+            a
+            for a in assignments
+            if isinstance(a, UniAssignment)
+        ],
+        is_frozen=False,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Implementation Definition ─────────────────────────────────────────
+"""Parse impl_def: decorators? KW_IMPL dotted_name impl_spec? impl_tail."""
+def parse_impl_def(p: any, decorators: list = []) -> any {
+    kids: list = [];
+    for d in decorators {
+        kids.append(d);
+    }
+
+    impl_tok = p.expect(Tok.KW_IMPL.value);
+    kids.append(impl_tok);
+
+    # dotted_name -> target
+    dotted = _parse_dotted_name(p);
+    target = dotted[0];
+    kids.extend(dotted[1]);
+
+    # Optional impl_spec: inherited_archs | func_decl | event_clause
+    spec = None;
+    if p.check(Tok.LPAREN.value) {
+        # Disambiguate func_decl vs inherited_archs.
+        # func_decl: LPAREN func_decl_params? RPAREN (RETURN_HINT expr)?
+        # inherited_archs: LPAREN (expression (COMMA expression)*)? RPAREN
+        # Heuristic: if LPAREN is followed by name COLON or */** or RPAREN RETURN_HINT,
+        # it's func_decl; otherwise inherited_archs.
+        is_func_sig = False;
+        peek1 = p.peek(1);
+        if peek1.name == Tok.RPAREN.value {
+            # Empty parens — check for -> after
+            peek2 = p.peek(2);
+            if peek2.name == Tok.RETURN_HINT.value {
+                is_func_sig = True;
+            }
+        } elif peek1.name in [Tok.STAR_MUL.value, Tok.STAR_POW.value] {
+            # *args or **kwargs → func_decl
+            is_func_sig = True;
+        } elif is_name_token(peek1) {
+            peek2 = p.peek(2);
+            if peek2.name == Tok.COLON.value {
+                # name: type → func_decl parameter
+                is_func_sig = True;
+            }
+        }
+        if is_func_sig {
+            spec = parse_func_signature(p);
+            kids.append(spec);
+        } else {
+            inh_result = _parse_inherited_archs(p);
+            spec = inh_result[0];
+            kids.extend(inh_result[1]);
+        }
+    } elif p.check(Tok.RETURN_HINT.value) {
+        spec = parse_func_signature(p);
+        kids.append(spec);
+    } elif p.check(Tok.KW_WITH.value) {
+        peek1 = p.peek(1);
+        if peek1.name in [Tok.KW_ENTRY.value, Tok.KW_EXIT.value]
+        or (peek1.name != Tok.KW_ENTRY.value and peek1.name != Tok.KW_EXIT.value) {
+            spec = parse_event_clause(p);
+            kids.append(spec);
+        }
+    }
+
+    # impl_tail: enum_block | block_tail
+    body = None;
+    if p.check(Tok.LBRACE.value) {
+        # Could be enum_block or code_block - peek ahead to decide
+        # For now, try code_block (more common)
+        block_result = parse_code_block_with_kids(p);
+        body = block_result[0];
+        kids.extend(block_result[1]);
+    } elif p.check(Tok.KW_BY.value) {
+        by_tok = p.advance();
+        kids.append(by_tok);
+        body = parse_expression(p);
+        kids.append(body);
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+    }
+
+    if isinstance(body, list) {
+        body_stmts = body;
+    } else {
+        body_stmts = body;
+    }
+
+    nd = UniImplDef(
+        decorators=decorators if len(decorators) > 0 else None,
+        target=target,
+        spec=spec,
+        body=body_stmts,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Semantic Definition ───────────────────────────────────────────────
+"""Parse sem_def: KW_SEM dotted_name (EQ | KW_IS) STRING SEMI."""
+def parse_sem_def(p: any) -> any {
+    sem_tok = p.expect(Tok.KW_SEM.value);
+    kids: list = [sem_tok];
+
+    # dotted_name
+    dotted = _parse_dotted_name(p);
+    target = dotted[0];
+    kids.extend(dotted[1]);
+
+    # EQ or KW_IS
+    if p.check(Tok.KW_IS.value) {
+        is_tok = p.advance();
+        kids.append(is_tok);
+    } else {
+        eq_tok = p.expect(Tok.EQ.value);
+        kids.append(eq_tok);
+    }
+
+    # STRING value
+    value = p.expect(Tok.STRING.value);
+    kids.append(value);
+
+    # SEMI
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+
+    nd = UniSemDef(target=target, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}

--- a/jac/jaclang/compiler/rd_parser/parser_edges.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_edges.jac
@@ -1,0 +1,405 @@
+# Edge and spatial parsing for the Jac recursive descent parser.
+#
+# Handles edge_ref_chain, edge_op_ref, connect_op, disconnect_op,
+# filter_compr, assign_compr, and filter_compare_list.
+#
+# All functions take `p` (the parser instance) as first argument.
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    Expr,
+    NameAtom,
+    CompareExpr as UniCompareExpr,
+    EdgeRefTrailer as UniEdgeRefTrailer,
+    EdgeOpRef as UniEdgeOpRef,
+    ConnectOp as UniConnectOp,
+    DisconnectOp as UniDisconnectOp,
+    FilterCompr as UniFilterCompr,
+    AssignCompr as UniAssignCompr,
+    KWPair as UniKWPair
+}
+
+import from jaclang.pycore.constant { Tokens as Tok, EdgeDir }
+
+import from jaclang.compiler.rd_parser.ast_builder {
+    EDGE_OP_TOKENS,
+    CONNECT_OP_TOKENS,
+    COMPARISON_OPS
+}
+
+import from jaclang.compiler.rd_parser.parser_exprs {
+    parse_expression,
+    parse_atomic_chain
+}
+
+# ── Edge Reference Chain ──────────────────────────────────────────────
+"""Parse edge_ref_chain:
+    LSQUARE KW_ASYNC? (KW_NODE|KW_EDGE)? expression? (edge_op_ref (filter_compr|expression)?)+ RSQUARE."""
+def parse_edge_ref_chain(p: any) -> any {
+    lsquare = p.expect(Tok.LSQUARE.value);
+    kids: list = [lsquare];
+    chain: list = [];
+
+    # Optional async
+    is_async = False;
+    if p.check(Tok.KW_ASYNC.value) {
+        async_tok = p.advance();
+        kids.append(async_tok);
+        is_async = True;
+    }
+
+    # Optional node/edge qualifier
+    edges_only = False;
+    if p.check(Tok.KW_EDGE.value) {
+        edge_tok = p.advance();
+        kids.append(edge_tok);
+        edges_only = True;
+    } elif p.check(Tok.KW_NODE.value) {
+        node_tok = p.advance();
+        kids.append(node_tok);
+    }
+
+    # Optional starting expression (before first edge_op_ref)
+    if not _is_edge_op_start(p) and not p.check(Tok.RSQUARE.value) {
+        expr = parse_expression(p);
+        chain.append(expr);
+        kids.append(expr);
+    }
+
+    # One or more: edge_op_ref (filter_compr | expression)?
+    while _is_edge_op_start(p) {
+        edge_op = _parse_edge_op_ref(p);
+        chain.append(edge_op);
+        kids.append(edge_op);
+
+        # Optional filter_compr or expression after edge_op_ref
+        if not p.check(Tok.RSQUARE.value) and not _is_edge_op_start(p) {
+            if p.check(Tok.LPAREN.value) {
+                # Could be filter_compr or just a parenthesized expression
+                peek1 = p.peek(1);
+                if peek1.name == Tok.NULL_OK.value or peek1.name == Tok.TYPE_OP.value {
+                    filt = _parse_filter_compr_standalone(p);
+                    chain.append(filt);
+                    kids.append(filt);
+                } else {
+                    expr = parse_expression(p);
+                    chain.append(expr);
+                    kids.append(expr);
+                }
+            } elif not p.check(Tok.RSQUARE.value) {
+                expr = parse_expression(p);
+                chain.append(expr);
+                kids.append(expr);
+            }
+        }
+    }
+
+    rsquare = p.expect(Tok.RSQUARE.value);
+    kids.append(rsquare);
+
+    nd = UniEdgeRefTrailer(
+        chain=chain, edges_only=edges_only, is_async=is_async, kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Check if current token starts an edge_op_ref."""
+def _is_edge_op_start(p: any) -> bool {
+    tok = p.peek();
+    edge_simple: list = [
+        Tok.ARROW_R.value,
+        Tok.ARROW_L.value,
+        Tok.ARROW_BI.value,
+        Tok.ARROW_R_P1.value,
+        Tok.ARROW_L_P1.value
+    ];
+    return tok.name in edge_simple;
+}
+
+# ── Edge Op Ref ───────────────────────────────────────────────────────
+"""Parse edge_op_ref: edge_to | edge_from | edge_any."""
+def _parse_edge_op_ref(p: any) -> any {
+    tok = p.peek();
+
+    # edge_to: ARROW_R | ARROW_R_P1 typed_filter_compare_list ARROW_R_P2
+    if tok.name == Tok.ARROW_R.value {
+        arrow = p.advance();
+        nd = UniEdgeOpRef(filter_cond=None, edge_dir=EdgeDir.OUT, kid=[arrow]);
+        p.register_node(nd);
+        return nd;
+    }
+    if tok.name == Tok.ARROW_R_P1.value {
+        arrow_p1 = p.advance();
+        fcond = _parse_typed_filter_compare_list(p);
+        arrow_p2 = p.expect(Tok.ARROW_R_P2.value);
+        kids: list = [arrow_p1, fcond, arrow_p2];
+        nd = UniEdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.OUT, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # edge_from: ARROW_L | ARROW_L_P1 typed_filter_compare_list ARROW_L_P2
+    if tok.name == Tok.ARROW_L.value {
+        arrow = p.advance();
+        nd = UniEdgeOpRef(filter_cond=None, edge_dir=EdgeDir.IN, kid=[arrow]);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # edge_any: ARROW_BI | ARROW_L_P1 typed_filter_compare_list ARROW_R_P2
+    # edge_from: ARROW_L_P1 typed_filter_compare_list ARROW_L_P2
+    if tok.name == Tok.ARROW_L_P1.value {
+        arrow_p1 = p.advance();
+        fcond = _parse_typed_filter_compare_list(p);
+        # Determine direction: ARROW_L_P2 -> IN, ARROW_R_P2 -> ANY
+        if p.check(Tok.ARROW_L_P2.value) {
+            arrow_p2 = p.advance();
+            kids: list = [arrow_p1, fcond, arrow_p2];
+            nd = UniEdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.IN, kid=kids);
+        } else {
+            arrow_p2 = p.expect(Tok.ARROW_R_P2.value);
+            kids: list = [arrow_p1, fcond, arrow_p2];
+            nd = UniEdgeOpRef(filter_cond=fcond, edge_dir=EdgeDir.ANY, kid=kids);
+        }
+        p.register_node(nd);
+        return nd;
+    }
+
+    if tok.name == Tok.ARROW_BI.value {
+        arrow = p.advance();
+        nd = UniEdgeOpRef(filter_cond=None, edge_dir=EdgeDir.ANY, kid=[arrow]);
+        p.register_node(nd);
+        return nd;
+    }
+
+    p.log_error("Expected edge operator", tok);
+    return None;
+}
+
+# ── Connect Op ────────────────────────────────────────────────────────
+"""Parse connect_op: connect_to | connect_from | connect_any."""
+def parse_connect_op(p: any) -> any {
+    tok = p.peek();
+
+    # connect_to: CARROW_R | CARROW_R_P1 expression (COLON kw_expr_list)? CARROW_R_P2
+    if tok.name == Tok.CARROW_R.value {
+        arrow = p.advance();
+        nd = UniConnectOp(
+            conn_type=None, conn_assign=None, edge_dir=EdgeDir.OUT, kid=[arrow]
+        );
+        p.register_node(nd);
+        return nd;
+    }
+    if tok.name == Tok.CARROW_R_P1.value {
+        return _parse_connect_detailed(
+            p, Tok.CARROW_R_P1.value, Tok.CARROW_R_P2.value, EdgeDir.OUT
+        );
+    }
+
+    # connect_from: CARROW_L | CARROW_L_P1 expression (COLON kw_expr_list)? CARROW_L_P2
+    if tok.name == Tok.CARROW_L.value {
+        arrow = p.advance();
+        nd = UniConnectOp(
+            conn_type=None, conn_assign=None, edge_dir=EdgeDir.IN, kid=[arrow]
+        );
+        p.register_node(nd);
+        return nd;
+    }
+    if tok.name == Tok.CARROW_L_P1.value {
+        # Could be connect_from or connect_any
+        arrow_p1 = p.advance();
+        conn_type = parse_expression(p);
+        conn_assign = None;
+        if p.check(Tok.COLON.value) {
+            colon = p.advance();
+            kw_pairs = _parse_kw_expr_list(p);
+            conn_assign = UniAssignCompr(assigns=kw_pairs, kid=kw_pairs);
+            p.register_node(conn_assign);
+        }
+        # Determine direction: CARROW_L_P2 -> IN, CARROW_R_P2 -> ANY
+        if p.check(Tok.CARROW_L_P2.value) {
+            arrow_p2 = p.advance();
+            edge_dir = EdgeDir.IN;
+        } else {
+            arrow_p2 = p.expect(Tok.CARROW_R_P2.value);
+            edge_dir = EdgeDir.ANY;
+        }
+        kids: list = [arrow_p1, conn_type];
+        if conn_assign is not None {
+            kids.append(conn_assign);
+        }
+        kids.append(arrow_p2);
+        nd = UniConnectOp(
+            conn_type=conn_type, conn_assign=conn_assign, edge_dir=edge_dir, kid=kids
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # connect_any: CARROW_BI
+    if tok.name == Tok.CARROW_BI.value {
+        arrow = p.advance();
+        nd = UniConnectOp(
+            conn_type=None, conn_assign=None, edge_dir=EdgeDir.ANY, kid=[arrow]
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    p.log_error("Expected connect operator", tok);
+    return None;
+}
+
+"""Parse detailed connect op: P1 expression (COLON kw_expr_list)? P2."""
+def _parse_connect_detailed(p: any, p1_tok: str, p2_tok: str, direction: any) -> any {
+    arrow_p1 = p.advance();
+    conn_type = parse_expression(p);
+    conn_assign = None;
+    if p.check(Tok.COLON.value) {
+        colon = p.advance();
+        kw_pairs = _parse_kw_expr_list(p);
+        conn_assign = UniAssignCompr(assigns=kw_pairs, kid=kw_pairs);
+        p.register_node(conn_assign);
+    }
+    arrow_p2 = p.expect(p2_tok);
+    kids: list = [arrow_p1, conn_type];
+    if conn_assign is not None {
+        kids.append(conn_assign);
+    }
+    kids.append(arrow_p2);
+    nd = UniConnectOp(
+        conn_type=conn_type, conn_assign=conn_assign, edge_dir=direction, kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Disconnect Op ─────────────────────────────────────────────────────
+"""Parse disconnect_op: KW_DELETE edge_op_ref."""
+def parse_disconnect_op(p: any) -> any {
+    del_tok = p.expect(Tok.KW_DELETE.value);
+    edge_spec = _parse_edge_op_ref(p);
+    kids: list = [del_tok, edge_spec];
+    nd = UniDisconnectOp(edge_spec=edge_spec, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Filter Compr ──────────────────────────────────────────────────────
+"""Parse filter_compr: LPAREN NULL_OK filter_compare_list RPAREN
+                         | LPAREN TYPE_OP NULL_OK typed_filter_compare_list RPAREN."""
+def _parse_filter_compr_standalone(p: any) -> any {
+    lparen = p.expect(Tok.LPAREN.value);
+    kids: list = [lparen];
+
+    if p.check(Tok.TYPE_OP.value) {
+        type_op = p.advance();
+        kids.append(type_op);
+        null_ok = p.expect(Tok.NULL_OK.value);
+        kids.append(null_ok);
+        filt = _parse_typed_filter_compare_list(p);
+        kids.append(filt);
+        rparen = p.expect(Tok.RPAREN.value);
+        kids.append(rparen);
+        # Return the typed filter with adjusted kids
+        return filt;
+    }
+
+    null_ok = p.expect(Tok.NULL_OK.value);
+    kids.append(null_ok);
+    compares = parse_filter_compare_list(p);
+    for c in compares {
+        kids.append(c);
+    }
+    rparen = p.expect(Tok.RPAREN.value);
+    kids.append(rparen);
+
+    nd = UniFilterCompr(f_type=None, compares=compares, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Typed Filter Compare List ─────────────────────────────────────────
+"""Parse typed_filter_compare_list: expression (COLON filter_compare_list)?."""
+def _parse_typed_filter_compare_list(p: any) -> any {
+    type_expr = parse_expression(p);
+    kids: list = [type_expr];
+    compares: list = [];
+    if p.check(Tok.COLON.value) {
+        colon = p.advance();
+        kids.append(colon);
+        compares = parse_filter_compare_list(p);
+        for c in compares {
+            kids.append(c);
+        }
+    }
+    nd = UniFilterCompr(f_type=type_expr, compares=compares, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Filter Compare List ───────────────────────────────────────────────
+"""Parse filter_compare_list: (filter_compare_list COMMA)? filter_compare_item."""
+def parse_filter_compare_list(p: any) -> list {
+    items: list = [];
+    item = _parse_filter_compare_item(p);
+    items.append(item);
+    while p.check(Tok.COMMA.value) {
+        p.advance();
+        item = _parse_filter_compare_item(p);
+        items.append(item);
+    }
+    return items;
+}
+
+"""Parse filter_compare_item: named_ref cmp_op expression."""
+def _parse_filter_compare_item(p: any) -> any {
+    name_ref = p.parse_named_ref();
+    cmp_op = p.advance();
+    expr = parse_expression(p);
+    kids: list = [name_ref, cmp_op, expr];
+    nd = UniCompareExpr(left=name_ref, ops=[cmp_op], rights=[expr], kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── KW Expr List ──────────────────────────────────────────────────────
+"""Parse kw_expr_list: kw_expr (COMMA kw_expr)*."""
+def _parse_kw_expr_list(p: any) -> list {
+    pairs: list = [];
+    pair = _parse_kw_expr(p);
+    pairs.append(pair);
+    while p.check(Tok.COMMA.value) {
+        p.advance();
+        pair = _parse_kw_expr(p);
+        pairs.append(pair);
+    }
+    return pairs;
+}
+
+"""Parse kw_expr: named_ref EQ expression | STAR_POW expression."""
+def _parse_kw_expr(p: any) -> any {
+    kids: list = [];
+
+    if p.check(Tok.STAR_POW.value) {
+        star = p.advance();
+        kids.append(star);
+        value = parse_expression(p);
+        kids.append(value);
+        nd = UniKWPair(key=None, value=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    key = p.parse_named_ref();
+    kids.append(key);
+    eq = p.expect(Tok.EQ.value);
+    kids.append(eq);
+    value = parse_expression(p);
+    kids.append(value);
+    nd = UniKWPair(key=key, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}

--- a/jac/jaclang/compiler/rd_parser/parser_exprs.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_exprs.jac
@@ -1,0 +1,1555 @@
+# Expression parsing for the Jac recursive descent parser.
+#
+# All functions take `p` (the parser instance) as first argument.
+# Type is `any` to avoid circular imports with parser.jac.
+# Functions build kid lists manually (no KidCollector).
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    String as UniString,
+    Source as UniSource,
+    Expr,
+    AtomExpr,
+    NameAtom,
+    CodeBlockStmt,
+    BinaryExpr as UniBinaryExpr,
+    CompareExpr as UniCompareExpr,
+    BoolExpr as UniBoolExpr,
+    UnaryExpr as UniUnaryExpr,
+    IfElseExpr as UniIfElseExpr,
+    ConcurrentExpr as UniConcurrentExpr,
+    AwaitExpr as UniAwaitExpr,
+    YieldExpr as UniYieldExpr,
+    LambdaExpr as UniLambdaExpr,
+    AtomTrailer as UniAtomTrailer,
+    FuncCall as UniFuncCall,
+    AtomUnit as UniAtomUnit,
+    IndexSlice as UniIndexSlice,
+    TypeRef as UniTypeRef,
+    ListVal as UniListVal,
+    SetVal as UniSetVal,
+    TupleVal as UniTupleVal,
+    DictVal as UniDictVal,
+    KVPair as UniKVPair,
+    KWPair as UniKWPair,
+    ListCompr as UniListCompr,
+    GenCompr as UniGenCompr,
+    SetCompr as UniSetCompr,
+    DictCompr as UniDictCompr,
+    InnerCompr as UniInnerCompr,
+    MultiString as UniMultiString,
+    FString as UniFString,
+    FormattedValue as UniFormattedValue,
+    Assignment as UniAssignment,
+    SubTag as UniSubTag,
+    FuncSignature as UniFuncSignature,
+    ParamVar as UniParamVar,
+    BuiltinType as UniBuiltinType,
+    SpecialVarRef as UniSpecialVarRef,
+    FilterCompr as UniFilterCompr,
+    AssignCompr as UniAssignCompr
+}
+
+import from jaclang.pycore.constant { Tokens as Tok, EdgeDir }
+
+import from jaclang.compiler.rd_parser.lexer {
+    KEYWORD_MAP,
+    BUILTIN_TYPE_MAP,
+    SPECIAL_REF_TOKENS,
+    EOF_NAME
+}
+
+import from jaclang.compiler.rd_parser.ast_builder {
+    is_eof_token,
+    is_name_token,
+    is_special_ref_token,
+    wrap_special_ref,
+    AUGMENTED_ASSIGN_OPS,
+    COMPARISON_OPS,
+    UNARY_PREFIX_OPS,
+    EDGE_OP_TOKENS,
+    CONNECT_OP_TOKENS,
+    ALL_EDGE_CONNECT_TOKENS,
+    EDGE_CONNECT_START_TOKENS,
+    CONNECT_OP_START_TOKENS,
+    EXPR_SYNC_TOKENS
+}
+
+# ── Expression (lowest precedence) ──────────────────────────────────────
+def parse_expression(
+    p: any
+) -> any {
+    # expression: concurrent_expr (KW_IF expression KW_ELSE expression)?
+    #           | lambda_expr
+    if p.check(Tok.KW_LAMBDA.value) {
+        return parse_lambda(p);
+    }
+
+    value = parse_concurrent(p);
+
+    if p.check(Tok.KW_IF.value) {
+        if_tok = p.advance();
+        condition = parse_expression(p);
+        else_tok = p.expect(Tok.KW_ELSE.value);
+        else_value = parse_expression(p);
+        kids: list = [value, if_tok, condition, else_tok, else_value];
+        nd = UniIfElseExpr(
+            condition=condition, value=value, else_value=else_value, kid=kids
+        );
+        p.register_node(nd);
+        return nd;
+    }
+    return value;
+}
+
+# ── Concurrent ──────────────────────────────────────────────────────────
+def parse_concurrent(
+    p: any
+) -> any {
+    # concurrent_expr: (KW_FLOW | KW_WAIT)? walrus_assign
+    tok = p.match_any(Tok.KW_FLOW.value, Tok.KW_WAIT.value);
+    value = parse_walrus(p);
+    if tok is not None {
+        kids: list = [tok, value];
+        nd = UniConcurrentExpr(tok=tok, target=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return value;
+}
+
+# ── Walrus assignment ───────────────────────────────────────────────────
+def parse_walrus(
+    p: any
+) -> any {
+    # walrus_assign: (named_ref WALRUS_EQ)? by_expr
+    if is_name_token(p.peek()) and p.peek(1).name == Tok.WALRUS_EQ.value {
+        name = p.parse_named_ref();
+        op = p.advance();
+        value = parse_by_expr(p);
+        kids: list = [name, op, value];
+        nd = UniBinaryExpr(left=name, op=op, right=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_by_expr(p);
+}
+
+# ── By expression ──────────────────────────────────────────────────────
+def parse_by_expr(
+    p: any
+) -> any {
+    # by_expr: pipe | pipe KW_BY by_expr  (right-associative)
+    left = parse_pipe(p);
+    if p.check(Tok.KW_BY.value) {
+        op = p.advance();
+        right = parse_by_expr(p);
+        kids: list = [left, op, right];
+        nd = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return left;
+}
+
+# ── Lambda ──────────────────────────────────────────────────────────────
+def parse_lambda(
+    p: any
+) -> any {
+    # lambda_expr: KW_LAMBDA func_decl_params (RETURN_HINT expression)?
+    #              (COLON expression | code_block)
+    #            | KW_LAMBDA func_decl? (COLON expression | code_block)
+    lambda_tok = p.expect(Tok.KW_LAMBDA.value);
+    kids: list = [lambda_tok];
+
+    # Parse optional signature
+    sig = None;
+    if not p.check(Tok.COLON.value)
+    and not p.check(Tok.LBRACE.value)
+    and not p.check(Tok.RETURN_HINT.value) {
+        sig = p.parse_func_signature();
+        if sig is not None {
+            kids.append(sig);
+        }
+    }
+
+    # Optional return hint
+    ret_type = None;
+    if p.check(Tok.RETURN_HINT.value) {
+        hint_tok = p.advance();
+        kids.append(hint_tok);
+        ret_type = parse_expression(p);
+        kids.append(ret_type);
+        if sig is not None {
+            sig.return_type = ret_type;
+        }
+    }
+
+    # Body: COLON expression or code_block
+    if p.check(Tok.COLON.value) {
+        colon = p.advance();
+        kids.append(colon);
+        body_expr = parse_expression(p);
+        kids.append(body_expr);
+        nd = UniLambdaExpr(body=body_expr, kid=kids, signature=sig);
+    } else {
+        body_stmts = p.parse_code_block();
+        for s in body_stmts {
+            kids.append(s);
+        }
+        nd = UniLambdaExpr(body=body_stmts, kid=kids, signature=sig);
+    }
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Pipe forward ────────────────────────────────────────────────────────
+def parse_pipe(
+    p: any
+) -> any {
+    # pipe: (pipe PIPE_FWD)? pipe_back  (left-associative)
+    left = parse_pipe_back(p);
+    while p.check(Tok.PIPE_FWD.value) {
+        op = p.advance();
+        right = parse_pipe_back(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Pipe backward ──────────────────────────────────────────────────────
+def parse_pipe_back(
+    p: any
+) -> any {
+    # pipe_back: (pipe_back PIPE_BKWD)? bitwise_or
+    left = parse_bitwise_or(p);
+    while p.check(Tok.PIPE_BKWD.value) {
+        op = p.advance();
+        right = parse_bitwise_or(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Bitwise OR ──────────────────────────────────────────────────────────
+def parse_bitwise_or(
+    p: any
+) -> any {
+    # bitwise_or: (bitwise_or BW_OR)? bitwise_xor
+    left = parse_bitwise_xor(p);
+    while p.check(Tok.BW_OR.value) {
+        op = p.advance();
+        right = parse_bitwise_xor(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Bitwise XOR ─────────────────────────────────────────────────────────
+def parse_bitwise_xor(
+    p: any
+) -> any {
+    # bitwise_xor: (bitwise_xor BW_XOR)? bitwise_and
+    left = parse_bitwise_and(p);
+    while p.check(Tok.BW_XOR.value) {
+        op = p.advance();
+        right = parse_bitwise_and(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Bitwise AND ─────────────────────────────────────────────────────────
+def parse_bitwise_and(
+    p: any
+) -> any {
+    # bitwise_and: (bitwise_and BW_AND)? shift
+    left = parse_shift(p);
+    while p.check(Tok.BW_AND.value) {
+        op = p.advance();
+        right = parse_shift(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Shift ───────────────────────────────────────────────────────────────
+def parse_shift(
+    p: any
+) -> any {
+    # shift: (shift (RSHIFT | LSHIFT))? logical_or
+    left = parse_logical_or(p);
+    while p.check_any(Tok.RSHIFT.value, Tok.LSHIFT.value) {
+        op = p.advance();
+        right = parse_logical_or(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Logical OR ──────────────────────────────────────────────────────────
+def parse_logical_or(
+    p: any
+) -> any {
+    # logical_or: logical_and (KW_OR logical_and)*
+    first = parse_logical_and(p);
+    if not p.check(Tok.KW_OR.value) {
+        return first;
+    }
+    values: list = [first];
+    kids: list = [first];
+    op = None;
+    while p.check(Tok.KW_OR.value) {
+        op_tok = p.advance();
+        if op is None {
+            op = op_tok;
+        }
+        next_val = parse_logical_and(p);
+        values.append(next_val);
+        kids.append(op_tok);
+        kids.append(next_val);
+    }
+    nd = UniBoolExpr(op=op, values=values, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Logical AND ─────────────────────────────────────────────────────────
+def parse_logical_and(
+    p: any
+) -> any {
+    # logical_and: logical_not (KW_AND logical_not)*
+    first = parse_logical_not(p);
+    if not p.check(Tok.KW_AND.value) {
+        return first;
+    }
+    values: list = [first];
+    kids: list = [first];
+    op = None;
+    while p.check(Tok.KW_AND.value) {
+        op_tok = p.advance();
+        if op is None {
+            op = op_tok;
+        }
+        next_val = parse_logical_not(p);
+        values.append(next_val);
+        kids.append(op_tok);
+        kids.append(next_val);
+    }
+    nd = UniBoolExpr(op=op, values=values, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Logical NOT ─────────────────────────────────────────────────────────
+def parse_logical_not(
+    p: any
+) -> any {
+    # logical_not: NOT logical_not | compare
+    if p.check(Tok.NOT.value) {
+        op = p.advance();
+        operand = parse_logical_not(p);
+        kids: list = [op, operand];
+        nd = UniUnaryExpr(operand=operand, op=op, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_compare(p);
+}
+
+# ── Compare ─────────────────────────────────────────────────────────────
+def parse_compare(
+    p: any
+) -> any {
+    # compare: (arithmetic cmp_op)* arithmetic
+    left = parse_arithmetic(p);
+    if p.peek().name not in COMPARISON_OPS {
+        return left;
+    }
+    ops: list = [];
+    rights: list = [];
+    kids: list = [left];
+    while p.peek().name in COMPARISON_OPS {
+        op = p.advance();
+        right = parse_arithmetic(p);
+        ops.append(op);
+        rights.append(right);
+        kids.append(op);
+        kids.append(right);
+    }
+    nd = UniCompareExpr(left=left, rights=rights, ops=ops, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Arithmetic (+, -) ──────────────────────────────────────────────────
+def parse_arithmetic(
+    p: any
+) -> any {
+    # arithmetic: (arithmetic (MINUS | PLUS))? term
+    left = parse_term(p);
+    while p.check_any(Tok.PLUS.value, Tok.MINUS.value) {
+        op = p.advance();
+        right = parse_term(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Term (*, /, //, %, @) ──────────────────────────────────────────────
+def parse_term(
+    p: any
+) -> any {
+    # term: (term (MOD | DIV | FLOOR_DIV | STAR_MUL | DECOR_OP))? power
+    left = parse_power(p);
+    while p.check_any(
+        Tok.MOD.value,
+        Tok.DIV.value,
+        Tok.FLOOR_DIV.value,
+        Tok.STAR_MUL.value,
+        Tok.DECOR_OP.value
+    ) {
+        op = p.advance();
+        right = parse_power(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Power (**) ──────────────────────────────────────────────────────────
+def parse_power(
+    p: any
+) -> any {
+    # power: (power STAR_POW)? factor  -- right-associative
+    left = parse_factor(p);
+    if p.check(Tok.STAR_POW.value) {
+        op = p.advance();
+        right = parse_power(p);
+        kids: list = [left, op, right];
+        nd = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return left;
+}
+
+# ── Factor (unary -, +, ~) ─────────────────────────────────────────────
+def parse_factor(
+    p: any
+) -> any {
+    # factor: (BW_NOT | MINUS | PLUS) factor | connect
+    if p.peek().name in UNARY_PREFIX_OPS {
+        op = p.advance();
+        operand = parse_factor(p);
+        kids: list = [op, operand];
+        nd = UniUnaryExpr(operand=operand, op=op, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_connect(p);
+}
+
+# ── Connect expressions ────────────────────────────────────────────────
+def parse_connect(
+    p: any
+) -> any {
+    # connect: (connect (connect_op | disconnect_op))? atomic_pipe
+    left = parse_atomic_pipe(p);
+    while p.peek().name in CONNECT_OP_START_TOKENS
+    or (p.check(Tok.KW_DELETE.value) and p.peek(1).name in EDGE_OP_TOKENS) {
+        if p.check(Tok.KW_DELETE.value) {
+            # disconnect_op: KW_DELETE edge_op_ref
+            op = p.parse_disconnect_op();
+        } else {
+            op = p.parse_connect_op();
+        }
+        right = parse_atomic_pipe(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Atomic pipe forward (:>) ───────────────────────────────────────────
+def parse_atomic_pipe(
+    p: any
+) -> any {
+    # atomic_pipe: (atomic_pipe A_PIPE_FWD)? atomic_pipe_back
+    left = parse_atomic_pipe_back(p);
+    while p.check(Tok.A_PIPE_FWD.value) {
+        op = p.advance();
+        right = parse_atomic_pipe_back(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Atomic pipe backward (<:) ──────────────────────────────────────────
+def parse_atomic_pipe_back(
+    p: any
+) -> any {
+    # atomic_pipe_back: (atomic_pipe_back A_PIPE_BKWD)? os_spawn
+    left = parse_spawn(p);
+    while p.check(Tok.A_PIPE_BKWD.value) {
+        op = p.advance();
+        right = parse_spawn(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Spawn ───────────────────────────────────────────────────────────────
+def parse_spawn(
+    p: any
+) -> any {
+    # os_spawn: (os_spawn KW_SPAWN)? unpack
+    left = parse_unpack(p);
+    while p.check(Tok.KW_SPAWN.value) {
+        op = p.advance();
+        right = parse_unpack(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}
+
+# ── Unpack (*) ──────────────────────────────────────────────────────────
+def parse_unpack(
+    p: any
+) -> any {
+    # unpack: STAR_MUL? ref
+    if p.check(Tok.STAR_MUL.value) {
+        op = p.advance();
+        operand = parse_ref(p);
+        kids: list = [op, operand];
+        nd = UniUnaryExpr(operand=operand, op=op, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_ref(p);
+}
+
+# ── Reference (&) ──────────────────────────────────────────────────────
+def parse_ref(
+    p: any
+) -> any {
+    # ref: BW_AND? await_expr
+    if p.check(Tok.BW_AND.value) {
+        # Make sure this is a reference, not bitwise and
+        # Reference & is a prefix unary op, bitwise & is infix
+        op = p.advance();
+        operand = parse_await(p);
+        kids: list = [op, operand];
+        nd = UniUnaryExpr(operand=operand, op=op, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_await(p);
+}
+
+# ── Await ───────────────────────────────────────────────────────────────
+def parse_await(
+    p: any
+) -> any {
+    # await_expr: KW_AWAIT? pipe_call
+    if p.check(Tok.KW_AWAIT.value) {
+        await_tok = p.advance();
+        target = parse_pipe_call(p);
+        kids: list = [await_tok, target];
+        nd = UniAwaitExpr(target=target, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_pipe_call(p);
+}
+
+# ── Pipe call (prefix |>, :>, spawn) ───────────────────────────────────
+def parse_pipe_call(
+    p: any
+) -> any {
+    # pipe_call: (PIPE_FWD | A_PIPE_FWD | KW_SPAWN)? atomic_chain
+    if p.check_any(Tok.PIPE_FWD.value, Tok.A_PIPE_FWD.value, Tok.KW_SPAWN.value) {
+        op = p.advance();
+        operand = parse_atomic_chain(p);
+        kids: list = [op, operand];
+        nd = UniUnaryExpr(operand=operand, op=op, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return parse_atomic_chain(p);
+}
+
+# ── Atomic chain (., [], (), ?) ────────────────────────────────────────
+def parse_atomic_chain(
+    p: any
+) -> any {
+    # atomic_chain: atomic_chain NULL_OK? (filter_compr|assign_compr|index_slice)
+    #             | atomic_chain NULL_OK? (DOT_BKWD|DOT_FWD|DOT) named_ref
+    #             | (atomic_call | atom | edge_ref_chain)
+    left = parse_atom_or_edge(p);
+
+    while not p.at_end() {
+        # Check for null-safe chaining: ?
+        null_ok_tok = None;
+        is_null = False;
+
+        if p.check(Tok.NULL_OK.value) {
+            peek1_name = p.peek(1).name;
+            if peek1_name in [
+                Tok.DOT.value,
+                Tok.DOT_FWD.value,
+                Tok.DOT_BKWD.value,
+                Tok.LSQUARE.value,
+                Tok.LPAREN.value
+            ] {
+                null_ok_tok = p.advance();
+                is_null = True;
+            } else {
+                break;
+            }
+        }
+
+        # Dot access
+        if p.check_any(Tok.DOT.value, Tok.DOT_FWD.value, Tok.DOT_BKWD.value) {
+            dot = p.advance();
+            right = p.parse_named_ref();
+            kids: list = [left];
+            if null_ok_tok is not None {
+                kids.append(null_ok_tok);
+            }
+            kids.append(dot);
+            kids.append(right);
+            left = UniAtomTrailer(
+                target=left, right=right, is_attr=True, is_null_ok=is_null, kid=kids
+            );
+            p.register_node(left);
+            continue;
+        }
+
+        # Function call
+        if p.check(Tok.LPAREN.value) {
+            left = _parse_call_or_gencompr(p, left, null_ok_tok);
+            continue;
+        }
+
+        # Index/slice
+        if p.check(Tok.LSQUARE.value) {
+            idx = parse_index_slice(p);
+            kids: list = [left];
+            if null_ok_tok is not None {
+                kids.append(null_ok_tok);
+            }
+            kids.append(idx);
+            left = UniAtomTrailer(
+                target=left, right=idx, is_attr=False, is_null_ok=is_null, kid=kids
+            );
+            p.register_node(left);
+            continue;
+        }
+
+        # Nothing matched after null_ok - shouldn't happen (we checked peek above)
+        break;
+    }
+    return left;
+}
+
+def parse_atom_or_edge(p: any) -> any {
+    # Dispatch between atom and edge_ref_chain
+    # edge_ref_chain starts with LSQUARE followed by edge keywords/operators
+    if p.check(Tok.LSQUARE.value) {
+        # Could be list_val, index_slice, or edge_ref_chain
+        # Edge ref chain: [ async? (node|edge)? expr? edge_op_ref ... ]
+        # List val: [ expr, expr, ... ]
+        # Disambiguate by looking ahead
+        peek1 = p.peek(1);
+        peek2 = p.peek(2);
+        edge_start_names = [Tok.KW_ASYNC.value, Tok.KW_NODE.value, Tok.KW_EDGE.value];
+        if (peek1.name in edge_start_names or peek1.name in EDGE_OP_TOKENS) {
+            return p.parse_edge_ref_chain();
+        }
+        # Also check for [name edge_op ...] pattern (e.g., [self-->])
+        if is_name_token(peek1) and peek2.name in EDGE_OP_TOKENS {
+            return p.parse_edge_ref_chain();
+        }
+    }
+    return parse_atom(p);
+}
+
+# ── Function call ──────────────────────────────────────────────────────
+def _parse_call_or_gencompr(
+    p: any, target: any, null_ok: any
+) -> any {
+    # atomic_call: atomic_chain (gen_compr | LPAREN param_list? RPAREN)
+    # Also handles filter_compr and assign_compr after null_ok
+    lparen = p.advance();
+
+    # Empty call
+    if p.check(Tok.RPAREN.value) {
+        rparen = p.advance();
+        kids: list = [target];
+        if null_ok is not None {
+            kids.append(null_ok);
+        }
+        kids.extend([lparen, rparen]);
+        nd = UniFuncCall(target=target, params=None, genai_call=None, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for filter_compr: (? filter_compare_list)
+    if p.check(Tok.NULL_OK.value) {
+        return _parse_filter_compr(p, target, null_ok, lparen);
+    }
+
+    # Check for assign_compr: (= kw_expr_list)
+    if p.check(Tok.EQ.value) {
+        return _parse_assign_compr(p, target, null_ok, lparen);
+    }
+
+    # Check for type filter: (:> ? typed_filter_compare_list)
+    if p.check(Tok.TYPE_OP.value) {
+        return _parse_type_filter_compr(p, target, null_ok, lparen);
+    }
+
+    # Parse first parameter (may be keyword arg like name=value)
+    first = _parse_param_item(p);
+
+    # Check for generator comprehension: expression KW_FOR ...
+    # Only valid if first is a plain expression, not a KWPair
+    if not isinstance(first, UniKWPair)
+    and (p.check(Tok.KW_FOR.value) or p.check(Tok.KW_ASYNC.value)) {
+        comprs = _parse_inner_comprs(p);
+        rparen = p.expect(Tok.RPAREN.value);
+        gen_kids: list = [lparen, first];
+        gen_kids.extend(comprs);
+        gen_kids.append(rparen);
+        gen = UniGenCompr(out_expr=first, compr=comprs, kid=gen_kids);
+        p.register_node(gen);
+        # Wrap as FuncCall with genai param
+        kids: list = [target];
+        if null_ok is not None {
+            kids.append(null_ok);
+        }
+        kids.append(gen);
+        nd = UniFuncCall(target=target, params=None, genai_call=None, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Regular param list
+    params: list = [first];
+    kids_inner: list = [first];
+    while p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids_inner.append(comma);
+        if p.check(Tok.RPAREN.value) {
+            break;
+        }  # trailing comma
+        param = _parse_param_item(p);
+        params.append(param);
+        kids_inner.append(param);
+    }
+    rparen = p.expect(Tok.RPAREN.value);
+
+    kids: list = [target];
+    if null_ok is not None {
+        kids.append(null_ok);
+    }
+    kids.append(lparen);
+    kids.extend(kids_inner);
+    kids.append(rparen);
+    nd = UniFuncCall(target=target, params=params, genai_call=None, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def _parse_param_item(p: any) -> any {
+    # Parse a single parameter in a function call
+    # kw_expr: named_ref EQ expression | STAR_POW expression
+    # Or just expression
+
+    # **kwargs
+    if p.check(Tok.STAR_POW.value) {
+        stars = p.advance();
+        value = parse_expression(p);
+        kids: list = [stars, value];
+        nd = UniKWPair(key=None, value=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for keyword argument: name = value
+    if is_name_token(p.peek()) and p.peek(1).name == Tok.EQ.value {
+        name = p.parse_named_ref();
+        eq = p.advance();
+        value = parse_expression(p);
+        kids: list = [name, eq, value];
+        nd = UniKWPair(key=name, value=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    return parse_expression(p);
+}
+
+def _parse_filter_compr(p: any, target: any, null_ok: any, lparen: any) -> any {
+    # filter_compr: LPAREN NULL_OK filter_compare_list RPAREN
+    filter_null = p.advance();  # NULL_OK (?)
+    compares = p.parse_filter_compare_list();
+    rparen = p.expect(Tok.RPAREN.value);
+    kids: list = [lparen, filter_null];
+    kids.extend(compares);
+    kids.append(rparen);
+    filt = UniFilterCompr(f_type=None, compares=compares, kid=kids);
+    p.register_node(filt);
+    # Wrap as AtomTrailer
+    outer_kids: list = [target];
+    if null_ok is not None {
+        outer_kids.append(null_ok);
+    }
+    outer_kids.append(filt);
+    nd = UniAtomTrailer(
+        target=target,
+        right=filt,
+        is_attr=False,
+        is_null_ok=(null_ok is not None),
+        kid=outer_kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+def _parse_assign_compr(p: any, target: any, null_ok: any, lparen: any) -> any {
+    # assign_compr: LPAREN EQ kw_expr_list RPAREN
+    eq = p.advance();
+    assigns = _parse_kw_expr_list(p);
+    rparen = p.expect(Tok.RPAREN.value);
+    kids: list = [lparen, eq];
+    kids.extend(assigns);
+    kids.append(rparen);
+    acompr = UniAssignCompr(assigns=assigns, kid=kids);
+    p.register_node(acompr);
+    outer_kids: list = [target];
+    if null_ok is not None {
+        outer_kids.append(null_ok);
+    }
+    outer_kids.append(acompr);
+    nd = UniAtomTrailer(
+        target=target,
+        right=acompr,
+        is_attr=False,
+        is_null_ok=(null_ok is not None),
+        kid=outer_kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+def _parse_type_filter_compr(p: any, target: any, null_ok: any, lparen: any) -> any {
+    # filter_compr: LPAREN TYPE_OP NULL_OK typed_filter_compare_list RPAREN
+    type_op = p.advance();  # TYPE_OP
+    filter_null = p.expect(Tok.NULL_OK.value);
+    type_expr = parse_expression(p);
+    compares: list = [];
+    if p.check(Tok.COLON.value) {
+        p.advance();
+        compares = p.parse_filter_compare_list();
+    }
+    rparen = p.expect(Tok.RPAREN.value);
+    kids: list = [lparen, type_op, filter_null, type_expr];
+    kids.extend(compares);
+    kids.append(rparen);
+    filt = UniFilterCompr(f_type=type_expr, compares=compares, kid=kids);
+    p.register_node(filt);
+    outer_kids: list = [target];
+    if null_ok is not None {
+        outer_kids.append(null_ok);
+    }
+    outer_kids.append(filt);
+    nd = UniAtomTrailer(
+        target=target,
+        right=filt,
+        is_attr=False,
+        is_null_ok=(null_ok is not None),
+        kid=outer_kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Index/Slice ────────────────────────────────────────────────────────
+def parse_index_slice(
+    p: any
+) -> any {
+    # index_slice: LSQUARE expression? COLON expression? (COLON expression?)?
+    #              (COMMA expression? COLON ...)* RSQUARE
+    #            | list_val
+    lsquare = p.advance();  # LSQUARE
+    kids: list = [lsquare];
+
+    # Check for empty slice or simple index
+    if p.check(Tok.RSQUARE.value) {
+        rsquare = p.advance();
+        kids.append(rsquare);
+        nd = UniListVal(values=[], kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Parse first element
+    slices: list = [];
+    is_range = False;
+
+    # Check if this is a slice (has COLON) or simple index
+    start = None;
+    if not p.check(Tok.COLON.value) {
+        start = parse_expression(p);
+        kids.append(start);
+    }
+
+    if p.check(Tok.COLON.value) {
+        # This is a slice
+        is_range = True;
+        colon1 = p.advance();
+        kids.append(colon1);
+        stop = None;
+        step = None;
+        if not p.check_any(Tok.COLON.value, Tok.RSQUARE.value, Tok.COMMA.value) {
+            stop = parse_expression(p);
+            kids.append(stop);
+        }
+        if p.check(Tok.COLON.value) {
+            colon2 = p.advance();
+            kids.append(colon2);
+            if not p.check_any(Tok.RSQUARE.value, Tok.COMMA.value) {
+                step = parse_expression(p);
+                kids.append(step);
+            }
+        }
+        slices.append(UniIndexSlice.Slice(start=start, stop=stop, step=step));
+        # Additional slices
+        while p.check(Tok.COMMA.value) {
+            comma = p.advance();
+            kids.append(comma);
+            if p.check(Tok.RSQUARE.value) {
+                break;
+            }
+            s_start = None;
+            if not p.check(Tok.COLON.value) {
+                s_start = parse_expression(p);
+                kids.append(s_start);
+            }
+            s_colon = p.expect(Tok.COLON.value);
+            kids.append(s_colon);
+            s_stop = None;
+            s_step = None;
+            if not p.check_any(Tok.COLON.value, Tok.RSQUARE.value, Tok.COMMA.value) {
+                s_stop = parse_expression(p);
+                kids.append(s_stop);
+            }
+            if p.check(Tok.COLON.value) {
+                s_colon2 = p.advance();
+                kids.append(s_colon2);
+                if not p.check_any(Tok.RSQUARE.value, Tok.COMMA.value) {
+                    s_step = parse_expression(p);
+                    kids.append(s_step);
+                }
+            }
+            slices.append(UniIndexSlice.Slice(start=s_start, stop=s_stop, step=s_step));
+        }
+    } else {
+        # Simple index or multi-value subscript (generic type params).
+        # e.g. x[0], Generator[int, None, None], Callable[[int], bool]
+        if p.check(Tok.COMMA.value) {
+            # Multiple comma-separated expressions → wrap in TupleVal.
+            # The TupleVal must be in the IndexSlice kid list so the pass
+            # traverses it and populates its gen.py_ast.
+            values: list = [start];
+            tuple_kids: list = [start];
+            while p.check(Tok.COMMA.value) {
+                comma = p.advance();
+                tuple_kids.append(comma);
+                if p.check(Tok.RSQUARE.value) {
+                    break;
+                }
+                val = parse_expression(p);
+                tuple_kids.append(val);
+                values.append(val);
+            }
+            if len(values) > 1 {
+                tuple_nd = UniTupleVal(values=values, kid=tuple_kids);
+                p.register_node(tuple_nd);
+                # Remove individual values/commas from IndexSlice kids
+                # and add the TupleVal instead so the pass traverses it.
+                # kids currently has [lsquare, start, ...]; remove start
+                # and replace with the TupleVal.
+                kids_clean: list = [lsquare, tuple_nd];
+                kids = kids_clean;
+                slices.append(
+                    UniIndexSlice.Slice(start=tuple_nd, stop=None, step=None)
+                );
+            } else {
+                slices.append(UniIndexSlice.Slice(start=start, stop=None, step=None));
+            }
+        } else {
+            slices.append(UniIndexSlice.Slice(start=start, stop=None, step=None));
+        }
+    }
+
+    rsquare = p.expect(Tok.RSQUARE.value);
+    kids.append(rsquare);
+
+    nd = UniIndexSlice(slices=slices, is_range=is_range, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Atom ────────────────────────────────────────────────────────────────
+def parse_atom(
+    p: any
+) -> any {
+    # atom: named_ref | LPAREN expr RPAREN | atom_collection
+    #     | atom_literal | type_ref | jsx_element
+    tok = p.peek();
+
+    # Parenthesized expression or tuple
+    if tok.name == Tok.LPAREN.value {
+        return _parse_paren_expr(p);
+    }
+
+    # List literal or comprehension
+    if tok.name == Tok.LSQUARE.value {
+        return _parse_list_or_compr(p);
+    }
+
+    # Dict/set literal or comprehension
+    if tok.name == Tok.LBRACE.value {
+        return _parse_brace_collection(p);
+    }
+
+    # Type reference: :> name
+    if tok.name == Tok.TYPE_OP.value {
+        return _parse_type_ref(p);
+    }
+
+    # String / multistring / fstring
+    if tok.name == Tok.STRING.value or _is_fstring_start(tok) {
+        return _parse_multistring(p);
+    }
+
+    # Numeric literals
+    if tok.name == Tok.INT.value {
+        return p.advance();
+    }
+    if tok.name == Tok.FLOAT.value {
+        return p.advance();
+    }
+    if tok.name == Tok.HEX.value {
+        return p.advance();
+    }
+    if tok.name == Tok.BIN.value {
+        return p.advance();
+    }
+    if tok.name == Tok.OCT.value {
+        return p.advance();
+    }
+
+    # Boolean literal
+    if tok.name == Tok.BOOL.value {
+        return p.advance();
+    }
+
+    # Null literal
+    if tok.name == Tok.NULL.value {
+        return p.advance();
+    }
+
+    # Ellipsis literal
+    if tok.name == Tok.ELLIPSIS.value {
+        return p.advance();
+    }
+
+    # Builtin type name (str, int, float, etc.)
+    builtin_type_toks: set = {Tok.TYP_STRING.value,Tok.TYP_INT.value,Tok.TYP_FLOAT.value,Tok.TYP_LIST.value,Tok.TYP_TUPLE.value,Tok.TYP_SET.value,Tok.TYP_DICT.value,Tok.TYP_BOOL.value,Tok.TYP_BYTES.value,Tok.TYP_TYPE.value,Tok.TYP_ANY.value};
+    if tok.name in builtin_type_toks {
+        return p.advance();
+    }
+
+    # JSX element
+    if tok.name == Tok.JSX_OPEN_START.value or tok.name == Tok.JSX_FRAG_OPEN.value {
+        return p.parse_jsx_element();
+    }
+
+    # Named reference (identifier, keyword-escaped, special ref)
+    if is_name_token(tok) {
+        return p.parse_named_ref();
+    }
+
+    # Yield expression (when used as atom)
+    if tok.name == Tok.KW_YIELD.value {
+        return parse_yield_expr(p);
+    }
+
+    # Error - unexpected token
+    p.log_error(f"Unexpected token '{tok.value}' in expression", tok);
+    p.synchronize(EXPR_SYNC_TOKENS);
+    return p._synthesize_token(Tok.NAME.value);
+}
+
+# ── Yield expression ───────────────────────────────────────────────────
+def parse_yield_expr(
+    p: any
+) -> any {
+    # yield_expr: KW_YIELD KW_FROM? expression
+    yield_tok = p.advance();
+    with_from = False;
+    from_tok = None;
+    if p.check(Tok.KW_FROM.value) {
+        from_tok = p.advance();
+        with_from = True;
+    }
+    expr = None;
+    if not p.check(Tok.SEMI.value) and not p.check(Tok.RBRACE.value) and not p.at_end() {
+        expr = parse_expression(p);
+    }
+    kids: list = [yield_tok];
+    if from_tok is not None {
+        kids.append(from_tok);
+    }
+    if expr is not None {
+        kids.append(expr);
+    }
+    nd = UniYieldExpr(expr=expr, with_from=with_from, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Parenthesized expression / tuple ───────────────────────────────────
+def _parse_paren_expr(
+    p: any
+) -> any {
+    # atom: LPAREN (expression | yield_expr | function_decl) RPAREN
+    # tuple_val: LPAREN tuple_list? RPAREN
+    lparen = p.advance();
+
+    if p.check(Tok.RPAREN.value) {
+        # Empty tuple
+        rparen = p.advance();
+        kids: list = [lparen, rparen];
+        nd = UniTupleVal(values=[], kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for yield
+    if p.check(Tok.KW_YIELD.value) {
+        inner = parse_yield_expr(p);
+        rparen = p.expect(Tok.RPAREN.value);
+        kids: list = [lparen, inner, rparen];
+        nd = UniAtomUnit(value=inner, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Parse first expression
+    first = parse_expression(p);
+
+    # Check for generator comprehension inside parens
+    if p.check(Tok.KW_FOR.value) or p.check(Tok.KW_ASYNC.value) {
+        comprs = _parse_inner_comprs(p);
+        rparen = p.expect(Tok.RPAREN.value);
+        kids: list = [lparen, first];
+        kids.extend(comprs);
+        kids.append(rparen);
+        nd = UniGenCompr(out_expr=first, compr=comprs, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for tuple (comma after first expr)
+    if p.check(Tok.COMMA.value) {
+        values: list = [first];
+        kids: list = [lparen, first];
+        while p.check(Tok.COMMA.value) {
+            comma = p.advance();
+            kids.append(comma);
+            if p.check(Tok.RPAREN.value) {
+                break;
+            }
+            item = _parse_param_item(p);
+            values.append(item);
+            kids.append(item);
+        }
+        rparen = p.expect(Tok.RPAREN.value);
+        kids.append(rparen);
+        nd = UniTupleVal(values=values, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Single parenthesized expression
+    rparen = p.expect(Tok.RPAREN.value);
+    kids: list = [lparen, first, rparen];
+    nd = UniAtomUnit(value=first, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── List literal / comprehension ───────────────────────────────────────
+def _parse_list_or_compr(
+    p: any
+) -> any {
+    lsquare = p.advance();
+
+    if p.check(Tok.RSQUARE.value) {
+        rsquare = p.advance();
+        kids: list = [lsquare, rsquare];
+        nd = UniListVal(values=[], kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    first = parse_expression(p);
+
+    # List comprehension
+    if p.check(Tok.KW_FOR.value) or p.check(Tok.KW_ASYNC.value) {
+        comprs = _parse_inner_comprs(p);
+        rsquare = p.expect(Tok.RSQUARE.value);
+        kids: list = [lsquare, first];
+        kids.extend(comprs);
+        kids.append(rsquare);
+        nd = UniListCompr(out_expr=first, compr=comprs, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Regular list
+    values: list = [first];
+    kids: list = [lsquare, first];
+    while p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids.append(comma);
+        if p.check(Tok.RSQUARE.value) {
+            break;
+        }
+        val = parse_expression(p);
+        values.append(val);
+        kids.append(val);
+    }
+    rsquare = p.expect(Tok.RSQUARE.value);
+    kids.append(rsquare);
+    nd = UniListVal(values=values, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Dict/Set literal or comprehension ──────────────────────────────────
+def _parse_brace_collection(
+    p: any
+) -> any {
+    # Could be: dict_val, set_val, dict_compr, set_compr
+    lbrace = p.advance();
+
+    # Empty dict
+    if p.check(Tok.RBRACE.value) {
+        rbrace = p.advance();
+        kids: list = [lbrace, rbrace];
+        nd = UniDictVal(kv_pairs=[], kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for **expr (dict unpack)
+    if p.check(Tok.STAR_POW.value) {
+        return _finish_dict_val(p, lbrace);
+    }
+
+    # Parse first expression
+    first = parse_expression(p);
+
+    # Dict: first COLON value
+    if p.check(Tok.COLON.value) {
+        colon = p.advance();
+        value = parse_expression(p);
+        pair_kids: list = [first, colon, value];
+        pair = UniKVPair(key=first, value=value, kid=pair_kids);
+        p.register_node(pair);
+        # Dict comprehension
+        if p.check(Tok.KW_FOR.value) or p.check(Tok.KW_ASYNC.value) {
+            comprs = _parse_inner_comprs(p);
+            rbrace = p.expect(Tok.RBRACE.value);
+            kids: list = [lbrace, pair];
+            kids.extend(comprs);
+            kids.append(rbrace);
+            nd = UniDictCompr(kv_pair=pair, compr=comprs, kid=kids);
+            p.register_node(nd);
+            return nd;
+        }
+        # Regular dict
+        pairs: list = [pair];
+        kids: list = [lbrace, pair];
+        while p.check(Tok.COMMA.value) {
+            comma = p.advance();
+            kids.append(comma);
+            if p.check(Tok.RBRACE.value) {
+                break;
+            }
+            kv = _parse_kv_pair(p);
+            pairs.append(kv);
+            kids.append(kv);
+        }
+        rbrace = p.expect(Tok.RBRACE.value);
+        kids.append(rbrace);
+        nd = UniDictVal(kv_pairs=pairs, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Set comprehension
+    if p.check(Tok.KW_FOR.value) or p.check(Tok.KW_ASYNC.value) {
+        comprs = _parse_inner_comprs(p);
+        rbrace = p.expect(Tok.RBRACE.value);
+        kids: list = [lbrace, first];
+        kids.extend(comprs);
+        kids.append(rbrace);
+        nd = UniSetCompr(out_expr=first, compr=comprs, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Set literal
+    values: list = [first];
+    kids: list = [lbrace, first];
+    while p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids.append(comma);
+        if p.check(Tok.RBRACE.value) {
+            break;
+        }
+        val = parse_expression(p);
+        values.append(val);
+        kids.append(val);
+    }
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+    nd = UniSetVal(values=values, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def _finish_dict_val(p: any, lbrace: any) -> any {
+    # Finish parsing dict_val starting with **expr
+    pairs: list = [];
+    kids: list = [lbrace];
+    while True {
+        kv = _parse_kv_pair(p);
+        pairs.append(kv);
+        kids.append(kv);
+        if not p.check(Tok.COMMA.value) {
+            break;
+        }
+        comma = p.advance();
+        kids.append(comma);
+        if p.check(Tok.RBRACE.value) {
+            break;
+        }
+    }
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+    nd = UniDictVal(kv_pairs=pairs, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def _parse_kv_pair(p: any) -> any {
+    # kv_pair: expression COLON expression | STAR_POW expression
+    if p.check(Tok.STAR_POW.value) {
+        stars = p.advance();
+        value = parse_expression(p);
+        kids: list = [stars, value];
+        nd = UniKVPair(key=None, value=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    key = parse_expression(p);
+    colon = p.expect(Tok.COLON.value);
+    value = parse_expression(p);
+    kids: list = [key, colon, value];
+    nd = UniKVPair(key=key, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Comprehension helpers ──────────────────────────────────────────────
+def _parse_inner_comprs(
+    p: any
+) -> list {
+    # inner_compr: KW_ASYNC? KW_FOR atomic_chain KW_IN pipe_call (KW_IF walrus_assign)*
+    comprs: list = [];
+    while p.check(Tok.KW_FOR.value) or p.check(Tok.KW_ASYNC.value) {
+        kids: list = [];
+        is_async = False;
+        if p.check(Tok.KW_ASYNC.value) {
+            async_tok = p.advance();
+            is_async = True;
+            kids.append(async_tok);
+        }
+        for_tok = p.expect(Tok.KW_FOR.value);
+        kids.append(for_tok);
+        target = parse_atomic_chain(p);
+        kids.append(target);
+        in_tok = p.expect(Tok.KW_IN.value);
+        kids.append(in_tok);
+        collection = parse_pipe_call(p);
+        kids.append(collection);
+        conditionals: list = [];
+        while p.check(Tok.KW_IF.value) {
+            if_tok = p.advance();
+            kids.append(if_tok);
+            cond = parse_walrus(p);
+            conditionals.append(cond);
+            kids.append(cond);
+        }
+        compr = UniInnerCompr(
+            is_async=is_async,
+            target=target,
+            collection=collection,
+            conditional=conditionals if len(conditionals) > 0 else None,
+            kid=kids
+        );
+        p.register_node(compr);
+        comprs.append(compr);
+    }
+    return comprs;
+}
+
+# ── KW expression list ─────────────────────────────────────────────────
+def _parse_kw_expr_list(
+    p: any
+) -> list {
+    # kw_expr_list: (kw_expr_list COMMA)? kw_expr
+    items: list = [];
+    while True {
+        item = _parse_kw_expr(p);
+        items.append(item);
+        if not p.check(Tok.COMMA.value) {
+            break;
+        }
+        p.advance();
+        if p.check(Tok.RPAREN.value) or p.check(Tok.RBRACE.value) {
+            break;
+        }
+    }
+    return items;
+}
+
+def _parse_kw_expr(p: any) -> any {
+    # kw_expr: named_ref EQ expression | STAR_POW expression
+    if p.check(Tok.STAR_POW.value) {
+        stars = p.advance();
+        value = parse_expression(p);
+        kids: list = [stars, value];
+        nd = UniKWPair(key=None, value=value, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    name = p.parse_named_ref();
+    eq = p.expect(Tok.EQ.value);
+    value = parse_expression(p);
+    kids: list = [name, eq, value];
+    nd = UniKWPair(key=name, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Type reference ─────────────────────────────────────────────────────
+def _parse_type_ref(
+    p: any
+) -> any {
+    # type_ref: TYPE_OP (named_ref | builtin_type)
+    type_op = p.advance();
+    target = p.parse_named_ref();
+    kids: list = [type_op, target];
+    nd = UniTypeRef(target=target, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Multistring / fstring ──────────────────────────────────────────────
+def _is_fstring_start(
+    tok: any
+) -> bool {
+    # Check if token is the start of an f-string
+    return tok.name in [
+        Tok.F_DQ_START.value,
+        Tok.F_SQ_START.value,
+        Tok.F_TDQ_START.value,
+        Tok.F_TSQ_START.value,
+        Tok.RF_DQ_START.value,
+        Tok.RF_SQ_START.value,
+        Tok.RF_TDQ_START.value,
+        Tok.RF_TSQ_START.value
+    ];
+}
+
+def _parse_multistring(p: any) -> any {
+    # multistring: (fstring | STRING)+
+    strings: list = [];
+    kids: list = [];
+    while p.check(Tok.STRING.value) or _is_fstring_start(p.peek()) {
+        if p.check(Tok.STRING.value) {
+            s = p.advance();
+            strings.append(s);
+            kids.append(s);
+        } else {
+            fs = p.parse_fstring();
+            strings.append(fs);
+            kids.append(fs);
+        }
+    }
+    if len(strings) == 1 {
+        return strings[0];
+    }
+    nd = UniMultiString(strings=strings, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Pipe expression (used from type_tag and other contexts) ────────────
+def parse_pipe(
+    p: any
+) -> any {
+    # pipe: (pipe PIPE_FWD)? pipe_back  (left-associative)
+    left = parse_pipe_back(p);
+    while p.check(Tok.PIPE_FWD.value) {
+        op = p.advance();
+        right = parse_pipe_back(p);
+        kids: list = [left, op, right];
+        left = UniBinaryExpr(left=left, op=op, right=right, kid=kids);
+        p.register_node(left);
+    }
+    return left;
+}

--- a/jac/jaclang/compiler/rd_parser/parser_fstring.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_fstring.jac
@@ -1,0 +1,225 @@
+# F-string and multistring parsing for the Jac recursive descent parser.
+#
+# Handles fstring, multistring, and formatted value parts.
+#
+# All functions take `p` (the parser instance) as first argument.
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    String as UniString,
+    Expr,
+    FString as UniFString,
+    MultiString as UniMultiString,
+    FormattedValue as UniFormattedValue
+}
+
+import from jaclang.pycore.constant { Tokens as Tok }
+
+import from jaclang.compiler.rd_parser.parser_exprs { parse_expression }
+
+# ── F-string start token sets ─────────────────────────────────────────
+glob FSTRING_START_TOKENS:
+         set = {Tok.F_DQ_START.value,Tok.F_SQ_START.value,Tok.F_TDQ_START.value,Tok.F_TSQ_START.value,Tok.RF_DQ_START.value,Tok.RF_SQ_START.value,Tok.RF_TDQ_START.value,Tok.RF_TSQ_START.value},
+     FSTRING_TEXT_TOKENS: set = {Tok.F_TEXT_DQ.value,Tok.F_TEXT_SQ.value,Tok.F_TEXT_TDQ.value,Tok.F_TEXT_TSQ.value,Tok.RF_TEXT_DQ.value,Tok.RF_TEXT_SQ.value,Tok.RF_TEXT_TDQ.value,Tok.RF_TEXT_TSQ.value};
+
+# ── Multistring ───────────────────────────────────────────────────────
+"""Parse multistring: (fstring | STRING)+."""
+def parse_multistring(p: any) -> any {
+    strings: list = [];
+    kids: list = [];
+
+    first = _parse_string_or_fstring(p);
+    strings.append(first);
+    kids.append(first);
+
+    while p.check(Tok.STRING.value) or p.peek().name in FSTRING_START_TOKENS {
+        nd = _parse_string_or_fstring(p);
+        strings.append(nd);
+        kids.append(nd);
+    }
+
+    if len(strings) == 1 and isinstance(strings[0], UniString) {
+        return strings[0];
+    }
+
+    nd = UniMultiString(strings=strings, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse either a regular string or an f-string."""
+def _parse_string_or_fstring(p: any) -> any {
+    if p.peek().name in FSTRING_START_TOKENS {
+        return parse_fstring(p);
+    }
+    return p.advance();
+}
+
+# ── F-string ──────────────────────────────────────────────────────────
+"""Parse fstring: F_*_START fstr_*_part* F_*_END."""
+def parse_fstring(p: any) -> any {
+    start_tok = p.advance();
+    kids: list = [start_tok];
+    parts: list = [];
+
+    # Determine the end token and text token based on start
+    end_tok_name = _get_fstring_end_token(start_tok.name);
+    text_tok_name = _get_fstring_text_token(start_tok.name);
+
+    # Parse parts until end token
+    while not p.at_end() and not p.check(end_tok_name) {
+        part = _parse_fstr_part(p, text_tok_name);
+        if part is not None {
+            parts.append(part);
+            kids.append(part);
+        }
+    }
+
+    end_tok = p.expect(end_tok_name);
+    kids.append(end_tok);
+
+    nd = UniFString(start=start_tok, parts=parts, end=end_tok, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Get the matching end token name for a given f-string start token."""
+def _get_fstring_end_token(start_name: str) -> str {
+    if start_name == Tok.F_DQ_START.value or start_name == Tok.RF_DQ_START.value {
+        return Tok.F_DQ_END.value;
+    }
+    if start_name == Tok.F_SQ_START.value or start_name == Tok.RF_SQ_START.value {
+        return Tok.F_SQ_END.value;
+    }
+    if start_name == Tok.F_TDQ_START.value or start_name == Tok.RF_TDQ_START.value {
+        return Tok.F_TDQ_END.value;
+    }
+    if start_name == Tok.F_TSQ_START.value or start_name == Tok.RF_TSQ_START.value {
+        return Tok.F_TSQ_END.value;
+    }
+    return Tok.F_DQ_END.value;
+}
+
+"""Get the matching text token name for a given f-string start token."""
+def _get_fstring_text_token(start_name: str) -> str {
+    if start_name == Tok.F_DQ_START.value {
+        return Tok.F_TEXT_DQ.value;
+    }
+    if start_name == Tok.F_SQ_START.value {
+        return Tok.F_TEXT_SQ.value;
+    }
+    if start_name == Tok.F_TDQ_START.value {
+        return Tok.F_TEXT_TDQ.value;
+    }
+    if start_name == Tok.F_TSQ_START.value {
+        return Tok.F_TEXT_TSQ.value;
+    }
+    if start_name == Tok.RF_DQ_START.value {
+        return Tok.RF_TEXT_DQ.value;
+    }
+    if start_name == Tok.RF_SQ_START.value {
+        return Tok.RF_TEXT_SQ.value;
+    }
+    if start_name == Tok.RF_TDQ_START.value {
+        return Tok.RF_TEXT_TDQ.value;
+    }
+    if start_name == Tok.RF_TSQ_START.value {
+        return Tok.RF_TEXT_TSQ.value;
+    }
+    return Tok.F_TEXT_DQ.value;
+}
+
+"""Parse a single f-string part: text | {{ | }} | {expression CONV? (:fformat*)?}."""
+def _parse_fstr_part(p: any, text_tok_name: str) -> any {
+    tok = p.peek();
+
+    # Plain text - lexer already creates String nodes for these
+    if tok.name == text_tok_name or tok.name in FSTRING_TEXT_TOKENS {
+        return p.advance();  # Already a String node from lexer
+
+    }
+
+    # Double brace escapes {{ or }} - lexer already creates String nodes with correct values
+    if tok.name == Tok.D_LBRACE.value or tok.name == Tok.D_RBRACE.value {
+        return p.advance();  # Already a String node from lexer
+
+    }
+
+    # Formatted expression: { expression CONV? (COLON fformat*)? }
+    if tok.name == Tok.LBRACE.value {
+        return _parse_formatted_value(p);
+    }
+
+    # Unknown token in fstring context - skip
+    return p.advance();
+}
+
+"""Parse { expression CONV? (COLON fformat*)? }."""
+def _parse_formatted_value(p: any) -> any {
+    lbrace = p.expect(Tok.LBRACE.value);
+    expr = parse_expression(p);
+    kids: list = [lbrace, expr];
+
+    # Optional conversion: !r, !s, !a
+    conversion = -1;
+    if p.check(Tok.CONV.value) {
+        conv_tok = p.advance();
+        kids.append(conv_tok);
+        conv_char = conv_tok.value;
+        if len(conv_char) > 1 {
+            conversion = ord(conv_char[1]);
+        }
+    }
+
+    # Optional format spec: COLON fformat*
+    format_spec = None;
+    if p.check(Tok.COLON.value) {
+        colon = p.advance();
+        kids.append(colon);
+        format_parts: list = [];
+        while not p.at_end() and not p.check(Tok.RBRACE.value) {
+            part = _parse_fformat(p);
+            if part is not None {
+                format_parts.append(part);
+                kids.append(part);
+            } else {
+                break;
+            }
+        }
+        if len(format_parts) == 1 and isinstance(format_parts[0], UniString) {
+            format_spec = format_parts[0];
+        } elif len(format_parts) > 0 {
+            format_spec = UniFString(
+                start=None, parts=format_parts, end=None, kid=format_parts
+            );
+            p.register_node(format_spec);
+        }
+    }
+
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+
+    nd = UniFormattedValue(
+        format_part=expr, conversion=conversion, format_spec=format_spec, kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse fformat: F_FORMAT_TEXT | D_LBRACE | D_RBRACE | {expression CONV? (:fformat*)?}."""
+def _parse_fformat(p: any) -> any {
+    tok = p.peek();
+
+    # Lexer already creates String nodes for these tokens
+    if tok.name == Tok.F_FORMAT_TEXT.value {
+        return p.advance();
+    }
+    if tok.name == Tok.D_LBRACE.value or tok.name == Tok.D_RBRACE.value {
+        return p.advance();
+    }
+    if tok.name == Tok.LBRACE.value {
+        return _parse_formatted_value(p);
+    }
+    return None;
+}

--- a/jac/jaclang/compiler/rd_parser/parser_jsx.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_jsx.jac
@@ -1,0 +1,289 @@
+# JSX element parsing for the Jac recursive descent parser.
+#
+# Handles JSX elements, fragments, attributes, and children.
+#
+# All functions take `p` (the parser instance) as first argument.
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    String as UniString,
+    Expr,
+    JsxElement as UniJsxElement,
+    JsxElementName as UniJsxElementName,
+    JsxAttribute as UniJsxAttribute,
+    JsxSpreadAttribute as UniJsxSpreadAttribute,
+    JsxNormalAttribute as UniJsxNormalAttribute,
+    JsxChild as UniJsxChild,
+    JsxText as UniJsxText,
+    JsxExpression as UniJsxExpression
+}
+
+import from jaclang.pycore.constant { Tokens as Tok }
+
+import from jaclang.compiler.rd_parser.parser_exprs { parse_expression }
+
+# ── JSX Element ───────────────────────────────────────────────────────
+"""Parse jsx_element: jsx_self_closing | jsx_fragment | jsx_opening_closing."""
+def parse_jsx_element(p: any) -> any {
+    tok = p.peek();
+
+    # Fragment: <>
+    if tok.name == Tok.JSX_FRAG_OPEN.value {
+        return _parse_jsx_fragment(p);
+    }
+
+    # Opening tag: <Name
+    if tok.name == Tok.JSX_OPEN_START.value {
+        return _parse_jsx_tag(p);
+    }
+
+    p.log_error("Expected JSX element", tok);
+    return None;
+}
+
+"""Parse JSX self-closing or opening/closing tag."""
+def _parse_jsx_tag(p: any) -> any {
+    open_start = p.expect(Tok.JSX_OPEN_START.value);
+    name = _parse_jsx_element_name(p);
+    kids: list = [open_start, name];
+
+    # Parse optional attributes
+    attrs: list = [];
+    while not p.at_end()
+    and not p.check(Tok.JSX_SELF_CLOSE.value)
+    and not p.check(Tok.JSX_TAG_END.value) {
+        attr = _parse_jsx_attribute(p);
+        if attr is not None {
+            attrs.append(attr);
+            kids.append(attr);
+        } else {
+            break;
+        }
+    }
+
+    # Self-closing: />
+    if p.check(Tok.JSX_SELF_CLOSE.value) {
+        self_close = p.advance();
+        kids.append(self_close);
+        nd = UniJsxElement(
+            name=name,
+            attributes=attrs,
+            children=None,
+            is_self_closing=True,
+            is_fragment=False,
+            kid=kids
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Opening tag: >
+    tag_end = p.expect(Tok.JSX_TAG_END.value);
+    kids.append(tag_end);
+
+    # Parse children
+    children: list = [];
+    while not p.at_end() and not p.check(Tok.JSX_CLOSE_START.value) {
+        child = _parse_jsx_child(p);
+        if child is not None {
+            children.append(child);
+            kids.append(child);
+        } else {
+            break;
+        }
+    }
+
+    # Closing tag: </Name>
+    close_start = p.expect(Tok.JSX_CLOSE_START.value);
+    kids.append(close_start);
+    close_name = _parse_jsx_element_name(p);
+    kids.append(close_name);
+    close_end = p.expect(Tok.JSX_TAG_END.value);
+    kids.append(close_end);
+
+    nd = UniJsxElement(
+        name=name,
+        attributes=attrs,
+        children=children if len(children) > 0 else None,
+        is_self_closing=False,
+        is_fragment=False,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse jsx_fragment: JSX_FRAG_OPEN jsx_children? JSX_FRAG_CLOSE."""
+def _parse_jsx_fragment(p: any) -> any {
+    frag_open = p.expect(Tok.JSX_FRAG_OPEN.value);
+    kids: list = [frag_open];
+    children: list = [];
+
+    while not p.at_end() and not p.check(Tok.JSX_FRAG_CLOSE.value) {
+        child = _parse_jsx_child(p);
+        if child is not None {
+            children.append(child);
+            kids.append(child);
+        } else {
+            break;
+        }
+    }
+
+    frag_close = p.expect(Tok.JSX_FRAG_CLOSE.value);
+    kids.append(frag_close);
+
+    nd = UniJsxElement(
+        name=None,
+        attributes=None,
+        children=children if len(children) > 0 else None,
+        is_self_closing=False,
+        is_fragment=True,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── JSX Element Name ──────────────────────────────────────────────────
+"""Parse jsx_element_name: JSX_NAME (DOT JSX_NAME)*."""
+def _parse_jsx_element_name(p: any) -> any {
+    parts: list = [];
+    kids: list = [];
+
+    first = p.expect(Tok.JSX_NAME.value);
+    parts.append(first);
+    kids.append(first);
+
+    while p.check(Tok.DOT.value) {
+        dot = p.advance();
+        kids.append(dot);
+        part = p.expect(Tok.JSX_NAME.value);
+        parts.append(part);
+        kids.append(part);
+    }
+
+    nd = UniJsxElementName(parts=parts, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── JSX Attributes ────────────────────────────────────────────────────
+"""Parse jsx_attribute: jsx_spread_attribute | jsx_normal_attribute."""
+def _parse_jsx_attribute(p: any) -> any {
+    # Spread: { ...expr }
+    if p.check(Tok.LBRACE.value) {
+        return _parse_jsx_spread_attribute(p);
+    }
+
+    # Normal: JSX_NAME (= value)?
+    if p.check(Tok.JSX_NAME.value) {
+        return _parse_jsx_normal_attribute(p);
+    }
+
+    return None;
+}
+
+"""Parse jsx_spread_attribute: LBRACE ELLIPSIS expression RBRACE."""
+def _parse_jsx_spread_attribute(p: any) -> any {
+    lbrace = p.expect(Tok.LBRACE.value);
+    ellipsis = p.expect(Tok.ELLIPSIS.value);
+    expr = parse_expression(p);
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids: list = [lbrace, ellipsis, expr, rbrace];
+    nd = UniJsxSpreadAttribute(expr=expr, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse jsx_normal_attribute: JSX_NAME (EQ jsx_attr_value)?."""
+def _parse_jsx_normal_attribute(p: any) -> any {
+    name = p.expect(Tok.JSX_NAME.value);
+    kids: list = [name];
+    value = None;
+
+    if p.check(Tok.EQ.value) {
+        eq = p.advance();
+        kids.append(eq);
+        value = _parse_jsx_attr_value(p);
+        kids.append(value);
+    }
+
+    nd = UniJsxNormalAttribute(name=name, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse jsx_attr_value: STRING | LBRACE expression RBRACE."""
+def _parse_jsx_attr_value(p: any) -> any {
+    if p.check(Tok.STRING.value) {
+        return p.advance();
+    }
+    lbrace = p.expect(Tok.LBRACE.value);
+    expr = parse_expression(p);
+    rbrace = p.expect(Tok.RBRACE.value);
+    return expr;
+}
+
+# ── JSX Children ──────────────────────────────────────────────────────
+"""Parse jsx_child: jsx_element | jsx_expression | jsx_text."""
+def _parse_jsx_child(p: any) -> any {
+    tok = p.peek();
+
+    # Nested JSX element
+    if tok.name == Tok.JSX_OPEN_START.value or tok.name == Tok.JSX_FRAG_OPEN.value {
+        return parse_jsx_element(p);
+    }
+
+    # JSX expression: { expression }
+    if tok.name == Tok.LBRACE.value {
+        return _parse_jsx_expression(p);
+    }
+
+    # JSX text
+    if tok.name == Tok.JSX_TEXT.value {
+        return _parse_jsx_text(p);
+    }
+
+    # Keywords as text in JSX context
+    if _is_jsx_text_keyword(tok) {
+        return _parse_jsx_text_keyword(p);
+    }
+
+    return None;
+}
+
+"""Parse jsx_expression: LBRACE expression RBRACE."""
+def _parse_jsx_expression(p: any) -> any {
+    lbrace = p.expect(Tok.LBRACE.value);
+    expr = parse_expression(p);
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids: list = [lbrace, expr, rbrace];
+    nd = UniJsxExpression(expr=expr, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse jsx_text: JSX_TEXT."""
+def _parse_jsx_text(p: any) -> any {
+    text_tok = p.advance();
+    escaped = text_tok.value;
+    nd = UniJsxText(value=escaped, kid=[text_tok]);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse keyword used as text in JSX content."""
+def _parse_jsx_text_keyword(p: any) -> any {
+    kw_tok = p.advance();
+    nd = UniJsxText(value=kw_tok, kid=[kw_tok]);
+    p.register_node(nd);
+    return nd;
+}
+
+glob JSX_TEXT_KEYWORD_TOKENS: set = {Tok.KW_TO.value,Tok.KW_AS.value,Tok.KW_FROM.value,Tok.KW_WITH.value,Tok.KW_IF.value,Tok.KW_FOR.value,Tok.KW_BY.value,Tok.KW_IN.value,Tok.KW_IS.value,Tok.KW_HAS.value,Tok.KW_CAN.value,Tok.KW_TRY.value,Tok.KW_MATCH.value,Tok.KW_CASE.value,Tok.KW_TEST.value,Tok.KW_ELSE.value,Tok.KW_RETURN.value,Tok.KW_BREAK.value,Tok.KW_CLASS.value,Tok.KW_NODE.value,Tok.KW_EDGE.value,Tok.KW_VISIT.value,Tok.KW_ENTRY.value,Tok.KW_EXIT.value,Tok.KW_WAIT.value,Tok.KW_FLOW.value,Tok.KW_SKIP.value,Tok.KW_CONTINUE.value,Tok.KW_REPORT.value,Tok.KW_RAISE.value,Tok.KW_DEFAULT.value,Tok.KW_YIELD.value,Tok.KW_EXCEPT.value,Tok.KW_FINALLY.value,Tok.KW_ASSERT.value,Tok.KW_WHILE.value,Tok.KW_STATIC.value,Tok.KW_OVERRIDE.value,Tok.KW_SWITCH.value,Tok.KW_HERE.value,Tok.KW_SELF.value,Tok.KW_PROPS.value,Tok.KW_SUPER.value,Tok.KW_ROOT.value,Tok.NOT.value,Tok.KW_DELETE.value,Tok.KW_IMPORT.value,Tok.KW_INCLUDE.value,Tok.KW_ASYNC.value,Tok.KW_AWAIT.value,Tok.KW_SPAWN.value,Tok.KW_LAMBDA.value,Tok.KW_ENUM.value,Tok.KW_OBJECT.value,Tok.KW_ABSTRACT.value,Tok.KW_WALKER.value,Tok.KW_IMPL.value,Tok.KW_SEM.value,Tok.KW_ELIF.value,Tok.KW_DISENGAGE.value,Tok.KW_PRIV.value,Tok.KW_PUB.value,Tok.KW_PROT.value,Tok.KW_GLOBAL.value,Tok.KW_DEF.value,Tok.KW_CLIENT.value,Tok.KW_INIT.value,Tok.KW_POST_INIT.value,Tok.KW_VISITOR.value,Tok.KW_AND.value,Tok.KW_OR.value};
+
+"""Check if a token is a keyword that can appear as text in JSX."""
+def _is_jsx_text_keyword(tok: any) -> bool {
+    return tok.name in JSX_TEXT_KEYWORD_TOKENS;
+}

--- a/jac/jaclang/compiler/rd_parser/parser_patterns.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_patterns.jac
@@ -1,0 +1,517 @@
+# Match/switch pattern parsing for the Jac recursive descent parser.
+#
+# Handles match_stmt, switch_stmt, and all pattern types.
+#
+# All functions take `p` (the parser instance) as first argument.
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    Expr,
+    NameAtom,
+    AtomExpr,
+    CodeBlockStmt,
+    MatchPattern,
+    MatchStmt as UniMatchStmt,
+    MatchCase as UniMatchCase,
+    SwitchStmt as UniSwitchStmt,
+    SwitchCase as UniSwitchCase,
+    MatchOr as UniMatchOr,
+    MatchAs as UniMatchAs,
+    MatchWild as UniMatchWild,
+    MatchValue as UniMatchValue,
+    MatchSingleton as UniMatchSingleton,
+    MatchSequence as UniMatchSequence,
+    MatchMapping as UniMatchMapping,
+    MatchKVPair as UniMatchKVPair,
+    MatchStar as UniMatchStar,
+    MatchArch as UniMatchArch,
+    AtomTrailer as UniAtomTrailer
+}
+
+import from jaclang.pycore.constant { Tokens as Tok }
+
+import from jaclang.compiler.rd_parser.ast_builder { is_name_token }
+
+import from jaclang.compiler.rd_parser.parser_exprs { parse_expression }
+
+import from jaclang.compiler.rd_parser.parser_stmts { parse_statement }
+
+# ── Match Statement ───────────────────────────────────────────────────
+"""Parse match_stmt: KW_MATCH expression LBRACE match_case_block+ RBRACE."""
+def parse_match_stmt(p: any) -> any {
+    match_tok = p.expect(Tok.KW_MATCH.value);
+    target = parse_expression(p);
+    lbrace = p.expect(Tok.LBRACE.value);
+    kids: list = [match_tok, target, lbrace];
+    cases: list = [];
+
+    while p.check(Tok.KW_CASE.value) {
+        case_nd = _parse_match_case_block(p);
+        cases.append(case_nd);
+        kids.append(case_nd);
+    }
+
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+
+    nd = UniMatchStmt(target=target, cases=cases, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse match_case_block: KW_CASE pattern_seq (KW_IF expression)? COLON statement+."""
+def _parse_match_case_block(p: any) -> any {
+    case_tok = p.expect(Tok.KW_CASE.value);
+    pattern = _parse_pattern_seq(p);
+    kids: list = [case_tok, pattern];
+
+    # Optional guard
+    guard = None;
+    if p.check(Tok.KW_IF.value) {
+        if_tok = p.advance();
+        guard = parse_expression(p);
+        kids.append(if_tok);
+        kids.append(guard);
+    }
+
+    colon = p.expect(Tok.COLON.value);
+    kids.append(colon);
+
+    # One or more statements
+    stmts: list = [];
+    while (
+        not p.at_end()
+        and not p.check(Tok.KW_CASE.value)
+        and not p.check(Tok.RBRACE.value)
+        and not p.check(Tok.KW_DEFAULT.value)
+    ) {
+        stmt = parse_statement(p);
+        if stmt is not None {
+            stmts.append(stmt);
+            kids.append(stmt);
+        } else {
+            break;
+        }
+    }
+
+    nd = UniMatchCase(pattern=pattern, guard=guard, body=stmts, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Switch Statement ──────────────────────────────────────────────────
+"""Parse switch_stmt: KW_SWITCH expression LBRACE switch_case_block+ RBRACE."""
+def parse_switch_stmt(p: any) -> any {
+    switch_tok = p.expect(Tok.KW_SWITCH.value);
+    target = parse_expression(p);
+    lbrace = p.expect(Tok.LBRACE.value);
+    kids: list = [switch_tok, target, lbrace];
+    cases: list = [];
+
+    while p.check(Tok.KW_CASE.value) or p.check(Tok.KW_DEFAULT.value) {
+        case_nd = _parse_switch_case_block(p);
+        cases.append(case_nd);
+        kids.append(case_nd);
+    }
+
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+
+    nd = UniSwitchStmt(target=target, cases=cases, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse switch_case_block: (KW_CASE pattern_seq | KW_DEFAULT) COLON statement*."""
+def _parse_switch_case_block(p: any) -> any {
+    kids: list = [];
+    pattern = None;
+
+    if p.check(Tok.KW_CASE.value) {
+        case_tok = p.advance();
+        kids.append(case_tok);
+        pattern = _parse_pattern_seq(p);
+        kids.append(pattern);
+    } else {
+        default_tok = p.expect(Tok.KW_DEFAULT.value);
+        kids.append(default_tok);
+    }
+
+    colon = p.expect(Tok.COLON.value);
+    kids.append(colon);
+
+    # Zero or more statements
+    stmts: list = [];
+    while (
+        not p.at_end()
+        and not p.check(Tok.KW_CASE.value)
+        and not p.check(Tok.RBRACE.value)
+        and not p.check(Tok.KW_DEFAULT.value)
+    ) {
+        stmt = parse_statement(p);
+        if stmt is not None {
+            stmts.append(stmt);
+            kids.append(stmt);
+        } else {
+            break;
+        }
+    }
+
+    nd = UniSwitchCase(pattern=pattern, body=stmts, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Pattern Sequence ──────────────────────────────────────────────────
+"""Parse pattern_seq: or_pattern | as_pattern."""
+def _parse_pattern_seq(p: any) -> any {
+    pattern = _parse_or_pattern(p);
+
+    # Check for as_pattern: or_pattern KW_AS NAME
+    if p.check(Tok.KW_AS.value) {
+        as_tok = p.advance();
+        name = p.parse_named_ref();
+        kids: list = [pattern, as_tok, name];
+        nd = UniMatchAs(name=name, pattern=pattern, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    return pattern;
+}
+
+"""Parse or_pattern: (pattern BW_OR)* pattern."""
+def _parse_or_pattern(p: any) -> any {
+    pattern = _parse_pattern(p);
+    patterns: list = [pattern];
+    kids: list = [pattern];
+
+    while p.check(Tok.BW_OR.value) {
+        or_tok = p.advance();
+        kids.append(or_tok);
+        next_pattern = _parse_pattern(p);
+        patterns.append(next_pattern);
+        kids.append(next_pattern);
+    }
+
+    if len(patterns) == 1 {
+        return patterns[0];
+    }
+
+    nd = UniMatchOr(patterns=patterns, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Pattern Dispatch ──────────────────────────────────────────────────
+"""Parse pattern: literal | singleton | capture | sequence | mapping | attr | class."""
+def _parse_pattern(p: any) -> any {
+    tok = p.peek();
+
+    # Singleton patterns: True, False, None
+    if tok.name == Tok.NULL.value {
+        val = p.advance();
+        nd = UniMatchSingleton(value=val, kid=[val]);
+        p.register_node(nd);
+        return nd;
+    }
+    if tok.name == Tok.BOOL.value {
+        val = p.advance();
+        nd = UniMatchSingleton(value=val, kid=[val]);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Literal patterns: INT, FLOAT, STRING, negative numbers
+    if tok.name == Tok.INT.value or tok.name == Tok.FLOAT.value {
+        val = p.advance();
+        nd = UniMatchValue(value=val, kid=[val]);
+        p.register_node(nd);
+        return nd;
+    }
+    if tok.name == Tok.STRING.value {
+        val = p.advance();
+        nd = UniMatchValue(value=val, kid=[val]);
+        p.register_node(nd);
+        return nd;
+    }
+    if tok.name == Tok.MINUS.value {
+        minus = p.advance();
+        num = p.advance();
+        kids: list = [minus, num];
+        nd = UniMatchValue(value=num, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Sequence pattern: [...]
+    if tok.name == Tok.LSQUARE.value {
+        return _parse_sequence_pattern(p, Tok.LSQUARE.value, Tok.RSQUARE.value);
+    }
+
+    # Sequence pattern with parens: (...)
+    if tok.name == Tok.LPAREN.value {
+        return _parse_sequence_pattern(p, Tok.LPAREN.value, Tok.RPAREN.value);
+    }
+
+    # Mapping pattern: {...}
+    if tok.name == Tok.LBRACE.value {
+        return _parse_mapping_pattern(p);
+    }
+
+    # Star patterns in list context: *name
+    if tok.name == Tok.STAR_MUL.value {
+        star = p.advance();
+        name = p.parse_named_ref();
+        kids: list = [star, name];
+        nd = UniMatchStar(name=name, is_list=True, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Capture, attr, or class pattern: starts with NAME
+    if is_name_token(tok) {
+        return _parse_name_pattern(p);
+    }
+
+    p.log_error("Expected pattern", tok);
+    return None;
+}
+
+"""Parse NAME-based patterns: capture, attr, or class."""
+def _parse_name_pattern(p: any) -> any {
+    # Parse the first name
+    name = p.parse_named_ref();
+
+    # Check for dotted name: NAME (DOT NAME)+
+    if p.check(Tok.DOT.value) {
+        # attr_pattern or class_pattern
+        trailer = name;
+        kids: list = [name];
+        while p.check(Tok.DOT.value) {
+            dot = p.advance();
+            kids.append(dot);
+            right = p.parse_named_ref();
+            kids.append(right);
+            trailer = UniAtomTrailer(
+                target=trailer,
+                right=right,
+                is_attr=True,
+                is_null_ok=False,
+                kid=[trailer, dot, right]
+            );
+            p.register_node(trailer);
+        }
+        # Check for class pattern with LPAREN
+        if p.check(Tok.LPAREN.value) {
+            return _parse_class_pattern_args(p, trailer);
+        }
+        # Attr pattern
+        nd = UniMatchValue(value=trailer, kid=[trailer]);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for class pattern: NAME LPAREN
+    if p.check(Tok.LPAREN.value) {
+        return _parse_class_pattern_args(p, name);
+    }
+
+    # Wildcard: _
+    if name.value == "_" {
+        nd = UniMatchWild(kid=[name]);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Capture pattern: NAME
+    nd = UniMatchAs(name=name, pattern=None, kid=[name]);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse class pattern arguments: LPAREN (pattern_list | kw_pattern_list | both)? RPAREN."""
+def _parse_class_pattern_args(p: any, name: any) -> any {
+    lparen = p.expect(Tok.LPAREN.value);
+    kids: list = [name, lparen];
+    arg_patterns: list = [];
+    kw_patterns: list = [];
+
+    if not p.check(Tok.RPAREN.value) {
+        # Try parsing patterns
+        first = _parse_pattern_or_kw(p);
+        if isinstance(first, UniMatchKVPair) {
+            kw_patterns.append(first);
+            kids.append(first);
+            while p.check(Tok.COMMA.value) {
+                comma = p.advance();
+                kids.append(comma);
+                if p.check(Tok.RPAREN.value) {
+                    break;
+                }
+                kw = _parse_kw_pattern(p);
+                kw_patterns.append(kw);
+                kids.append(kw);
+            }
+        } else {
+            arg_patterns.append(first);
+            kids.append(first);
+            while p.check(Tok.COMMA.value) {
+                comma = p.advance();
+                kids.append(comma);
+                if p.check(Tok.RPAREN.value) {
+                    break;
+                }
+                next_item = _parse_pattern_or_kw(p);
+                if isinstance(next_item, UniMatchKVPair) {
+                    kw_patterns.append(next_item);
+                    kids.append(next_item);
+                    while p.check(Tok.COMMA.value) {
+                        comma2 = p.advance();
+                        kids.append(comma2);
+                        if p.check(Tok.RPAREN.value) {
+                            break;
+                        }
+                        kw = _parse_kw_pattern(p);
+                        kw_patterns.append(kw);
+                        kids.append(kw);
+                    }
+                    break;
+                }
+                arg_patterns.append(next_item);
+                kids.append(next_item);
+            }
+        }
+    }
+
+    rparen = p.expect(Tok.RPAREN.value);
+    kids.append(rparen);
+
+    nd = UniMatchArch(
+        name=name,
+        arg_patterns=arg_patterns if len(arg_patterns) > 0 else None,
+        kw_patterns=kw_patterns if len(kw_patterns) > 0 else None,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse either a positional pattern or a keyword pattern.
+    Keyword pattern: named_ref EQ pattern_seq."""
+def _parse_pattern_or_kw(p: any) -> any {
+    # If we see NAME EQ, it's a keyword pattern
+    if is_name_token(p.peek()) {
+        peek1 = p.peek(1);
+        if peek1.name == Tok.EQ.value {
+            return _parse_kw_pattern(p);
+        }
+    }
+    return _parse_pattern_seq(p);
+}
+
+"""Parse kw_pattern: named_ref EQ pattern_seq."""
+def _parse_kw_pattern(p: any) -> any {
+    name = p.parse_named_ref();
+    eq = p.expect(Tok.EQ.value);
+    value = _parse_pattern_seq(p);
+    kids: list = [name, eq, value];
+    nd = UniMatchKVPair(key=name, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Sequence Pattern ──────────────────────────────────────────────────
+"""Parse sequence_pattern: LSQUARE/LPAREN list_inner_pattern (COMMA list_inner_pattern)* RSQUARE/RPAREN."""
+def _parse_sequence_pattern(p: any, open_tok: str, close_tok: str) -> any {
+    opener = p.expect(open_tok);
+    kids: list = [opener];
+    patterns: list = [];
+
+    if not p.check(close_tok) {
+        inner = _parse_list_inner_pattern(p);
+        patterns.append(inner);
+        kids.append(inner);
+        while p.check(Tok.COMMA.value) {
+            comma = p.advance();
+            kids.append(comma);
+            if p.check(close_tok) {
+                break;
+            }
+            inner = _parse_list_inner_pattern(p);
+            patterns.append(inner);
+            kids.append(inner);
+        }
+    }
+
+    closer = p.expect(close_tok);
+    kids.append(closer);
+
+    nd = UniMatchSequence(values=patterns, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse list_inner_pattern: pattern_seq | STAR_MUL NAME."""
+def _parse_list_inner_pattern(p: any) -> any {
+    if p.check(Tok.STAR_MUL.value) {
+        star = p.advance();
+        name = p.parse_named_ref();
+        kids: list = [star, name];
+        nd = UniMatchStar(name=name, is_list=True, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    return _parse_pattern_seq(p);
+}
+
+# ── Mapping Pattern ───────────────────────────────────────────────────
+"""Parse mapping_pattern: LBRACE (dict_inner_pattern (COMMA dict_inner_pattern)*)? RBRACE."""
+def _parse_mapping_pattern(p: any) -> any {
+    lbrace = p.expect(Tok.LBRACE.value);
+    kids: list = [lbrace];
+    patterns: list = [];
+
+    if not p.check(Tok.RBRACE.value) {
+        inner = _parse_dict_inner_pattern(p);
+        patterns.append(inner);
+        kids.append(inner);
+        while p.check(Tok.COMMA.value) {
+            comma = p.advance();
+            kids.append(comma);
+            if p.check(Tok.RBRACE.value) {
+                break;
+            }
+            inner = _parse_dict_inner_pattern(p);
+            patterns.append(inner);
+            kids.append(inner);
+        }
+    }
+
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+
+    nd = UniMatchMapping(values=patterns, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+"""Parse dict_inner_pattern: literal_pattern COLON pattern_seq | STAR_POW NAME."""
+def _parse_dict_inner_pattern(p: any) -> any {
+    if p.check(Tok.STAR_POW.value) {
+        star = p.advance();
+        name = p.parse_named_ref();
+        kids: list = [star, name];
+        nd = UniMatchStar(name=name, is_list=False, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+    key = _parse_pattern(p);
+    colon = p.expect(Tok.COLON.value);
+    value = _parse_pattern_seq(p);
+    kids: list = [key, colon, value];
+    nd = UniMatchKVPair(key=key, value=value, kid=kids);
+    p.register_node(nd);
+    return nd;
+}

--- a/jac/jaclang/compiler/rd_parser/parser_stmts.jac
+++ b/jac/jaclang/compiler/rd_parser/parser_stmts.jac
@@ -1,0 +1,1015 @@
+# Statement parsing for the Jac recursive descent parser.
+#
+# All functions take `p` (the parser instance) as first argument.
+# Type is `any` to avoid circular imports with parser.jac.
+import from jaclang.pycore.unitree {
+    UniNode,
+    Token as UniToken,
+    Name as UniName,
+    String as UniString,
+    Source as UniSource,
+    Expr,
+    AtomExpr,
+    NameAtom,
+    CodeBlockStmt,
+    ContextAwareNode,
+    IfStmt as UniIfStmt,
+    ElseIf as UniElseIf,
+    ElseStmt as UniElseStmt,
+    WhileStmt as UniWhileStmt,
+    IterForStmt as UniIterForStmt,
+    InForStmt as UniInForStmt,
+    TryStmt as UniTryStmt,
+    Except as UniExcept,
+    FinallyStmt as UniFinallyStmt,
+    WithStmt as UniWithStmt,
+    ExprAsItem as UniExprAsItem,
+    ReturnStmt as UniReturnStmt,
+    YieldExpr as UniYieldExpr,
+    RaiseStmt as UniRaiseStmt,
+    AssertStmt as UniAssertStmt,
+    DeleteStmt as UniDeleteStmt,
+    ReportStmt as UniReportStmt,
+    CtrlStmt as UniCtrlStmt,
+    VisitStmt as UniVisitStmt,
+    DisengageStmt as UniDisengageStmt,
+    Assignment as UniAssignment,
+    GlobalStmt as UniGlobalStmt,
+    NonLocalStmt as UniNonLocalStmt,
+    TypedCtxBlock as UniTypedCtxBlock,
+    ExprStmt as UniExprStmt,
+    SubTag as UniSubTag,
+    Semi as UniSemi,
+    Import as UniImport,
+    PyInlineCode as UniPyInlineCode
+}
+
+import from jaclang.pycore.constant { Tokens as Tok }
+
+import from jaclang.compiler.rd_parser.ast_builder {
+    is_eof_token,
+    is_name_token,
+    is_special_ref_token,
+    AUGMENTED_ASSIGN_OPS,
+    STATEMENT_START_TOKENS,
+    STMT_SYNC_TOKENS,
+    ARCH_TYPE_TOKENS
+}
+
+import from jaclang.compiler.rd_parser.parser_exprs {
+    parse_expression,
+    parse_atomic_chain,
+    parse_arithmetic,
+    parse_pipe,
+    parse_yield_expr
+}
+
+# ── Code block ──────────────────────────────────────────────────────────
+def parse_code_block(
+    p: any
+) -> list {
+    # code_block: LBRACE statement* RBRACE
+    # Returns list of CodeBlockStmt
+    p.expect(Tok.LBRACE.value);
+    stmts: list = [];
+    while not p.at_end() and not p.check(Tok.RBRACE.value) {
+        stmt = parse_statement(p);
+        if stmt is not None {
+            stmts.append(stmt);
+        } else {
+            if not p.at_end() and not p.check(Tok.RBRACE.value) {
+                p.advance();
+            }
+        }
+    }
+    p.expect(Tok.RBRACE.value);
+    return stmts;
+}
+
+def parse_code_block_with_kids(p: any) -> tuple {
+    # Returns (stmts_list, kids_list) where kids includes LBRACE, stmts, RBRACE
+    lbrace = p.expect(Tok.LBRACE.value);
+    stmts: list = [];
+    kids: list = [lbrace];
+    while not p.at_end() and not p.check(Tok.RBRACE.value) {
+        stmt = parse_statement(p);
+        if stmt is not None {
+            stmts.append(stmt);
+            kids.append(stmt);
+        } else {
+            if not p.at_end() and not p.check(Tok.RBRACE.value) {
+                p.advance();
+            }
+        }
+    }
+    rbrace = p.expect(Tok.RBRACE.value);
+    kids.append(rbrace);
+    return (stmts, kids);
+}
+
+# ── Statement dispatch ──────────────────────────────────────────────────
+def parse_statement(
+    p: any
+) -> any {
+    # statement: import_stmt | ability | has_stmt | archetype | impl_def
+    #          | if_stmt | while_stmt | for_stmt | try_stmt | match_stmt
+    #          | switch_stmt | with_stmt | global_ref SEMI | nonlocal_ref SEMI
+    #          | typed_ctx_block | return_stmt SEMI | yield_expr SEMI
+    #          | raise_stmt SEMI | assert_stmt SEMI | assignment SEMI
+    #          | delete_stmt SEMI | report_stmt SEMI | expression SEMI
+    #          | ctrl_stmt SEMI | py_code_block | spatial_stmt | SEMI
+    tok = p.peek();
+
+    # Empty statement
+    if tok.name == Tok.SEMI.value {
+        semi = p.advance();
+        return semi;
+    }
+
+    # Import statement
+    if tok.name in [Tok.KW_IMPORT.value, Tok.KW_INCLUDE.value] {
+        return p.parse_import_stmt();
+    }
+
+    # Ability (def/can)
+    if tok.name in [
+        Tok.KW_DEF.value,
+        Tok.KW_CAN.value,
+        Tok.KW_OVERRIDE.value,
+        Tok.KW_STATIC.value
+    ] {
+        return p.parse_ability();
+    }
+
+    # Has statement
+    if tok.name == Tok.KW_HAS.value {
+        return p.parse_has_stmt();
+    }
+
+    # Archetype
+    if tok.name in ARCH_TYPE_TOKENS {
+        return p.parse_archetype();
+    }
+
+    # Enum
+    if tok.name == Tok.KW_ENUM.value {
+        return p.parse_enum();
+    }
+
+    # Decorator (for nested archetype/ability)
+    if tok.name == Tok.DECOR_OP.value {
+        return p.parse_decorated_def();
+    }
+
+    # Impl definition
+    if tok.name == Tok.KW_IMPL.value {
+        return p.parse_impl_def();
+    }
+
+    # If statement
+    if tok.name == Tok.KW_IF.value {
+        return parse_if_stmt(p);
+    }
+
+    # While statement
+    if tok.name == Tok.KW_WHILE.value {
+        return parse_while_stmt(p);
+    }
+
+    # For statement
+    if tok.name == Tok.KW_FOR.value {
+        return parse_for_stmt(p);
+    }
+
+    # Async for / async with
+    if tok.name == Tok.KW_ASYNC.value {
+        peek1 = p.peek(1);
+        if peek1.name == Tok.KW_FOR.value {
+            return parse_for_stmt(p);
+        }
+        if peek1.name == Tok.KW_WITH.value {
+            return parse_with_stmt(p);
+        }
+        # Async ability or archetype
+        if peek1.name in ARCH_TYPE_TOKENS {
+            return p.parse_archetype();
+        }
+        return p.parse_ability();
+    }
+
+    # Try statement
+    if tok.name == Tok.KW_TRY.value {
+        return parse_try_stmt(p);
+    }
+
+    # Match statement
+    if tok.name == Tok.KW_MATCH.value {
+        return p.parse_match_stmt();
+    }
+
+    # Switch statement
+    if tok.name == Tok.KW_SWITCH.value {
+        return p.parse_switch_stmt();
+    }
+
+    # With statement
+    if tok.name == Tok.KW_WITH.value {
+        return parse_with_stmt(p);
+    }
+
+    # Global reference
+    if tok.name == Tok.GLOBAL_OP.value {
+        return parse_global_ref(p);
+    }
+
+    # Nonlocal reference
+    if tok.name == Tok.NONLOCAL_OP.value {
+        return parse_nonlocal_ref(p);
+    }
+
+    # Typed context block
+    if tok.name == Tok.RETURN_HINT.value {
+        return parse_typed_ctx_block(p);
+    }
+
+    # Return statement
+    if tok.name == Tok.KW_RETURN.value {
+        return parse_return_stmt(p);
+    }
+
+    # Yield expression - must be wrapped in ExprStmt at statement level
+    if tok.name == Tok.KW_YIELD.value {
+        yield_expr = parse_yield_expr(p);
+        semi = p.expect(Tok.SEMI.value);
+        kids: list = [yield_expr, semi];
+        nd = UniExprStmt(expr=yield_expr, in_fstring=False, kid=kids);
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Raise statement
+    if tok.name == Tok.KW_RAISE.value {
+        return parse_raise_stmt(p);
+    }
+
+    # Assert statement
+    if tok.name == Tok.KW_ASSERT.value {
+        return parse_assert_stmt(p);
+    }
+
+    # Delete statement
+    if tok.name == Tok.KW_DELETE.value {
+        # Could also be disconnect_op (del edge_op), handle that case
+        peek1 = p.peek(1);
+        if peek1.name in [
+            Tok.ARROW_R.value,
+            Tok.ARROW_L.value,
+            Tok.ARROW_BI.value,
+            Tok.ARROW_R_P1.value,
+            Tok.ARROW_L_P1.value
+        ] {
+            # This is probably part of an expression (disconnect)
+            return _parse_expr_or_assignment(p);
+        }
+        return parse_delete_stmt(p);
+    }
+
+    # Report statement
+    if tok.name == Tok.KW_REPORT.value {
+        return parse_report_stmt(p);
+    }
+
+    # Control statements
+    if tok.name in [Tok.KW_BREAK.value, Tok.KW_CONTINUE.value, Tok.KW_SKIP.value] {
+        return parse_ctrl_stmt(p);
+    }
+
+    # Visit statement
+    if tok.name == Tok.KW_VISIT.value {
+        return parse_visit_stmt(p);
+    }
+
+    # Disengage statement
+    if tok.name == Tok.KW_DISENGAGE.value {
+        return parse_disengage_stmt(p);
+    }
+
+    # Inline Python
+    if tok.name == Tok.PYNLINE.value {
+        return p.parse_py_code_block();
+    }
+
+    # Expression or assignment
+    return _parse_expr_or_assignment(p);
+}
+
+# ── Expression or Assignment ───────────────────────────────────────────
+def _parse_expr_or_assignment(
+    p: any
+) -> any {
+    # Parse expression, then check for assignment operators
+    # assignment: (atomic_chain EQ)+ (yield_expr | expression)
+    #           | atomic_chain type_tag (EQ (yield_expr | expression))?
+    #           | atomic_chain aug_op (yield_expr | expression)
+    expr = parse_expression(p);
+
+    # Check for assignment: EQ
+    if p.check(Tok.EQ.value) {
+        targets: list = [expr];
+        kids: list = [expr];
+        while p.check(Tok.EQ.value) {
+            eq = p.advance();
+            kids.append(eq);
+            # Parse value (could be another target if followed by EQ)
+            if p.check(Tok.KW_YIELD.value) {
+                value = parse_yield_expr(p);
+            } else {
+                value = parse_expression(p);
+            }
+            kids.append(value);
+            if p.check(Tok.EQ.value) {
+                targets.append(value);
+            }
+        }
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+        nd = UniAssignment(
+            target=targets,
+            value=value,
+            type_tag=None,
+            kid=kids,
+            mutable=True,
+            aug_op=None
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for typed assignment: COLON type (= value)?
+    if p.check(Tok.COLON.value) {
+        colon = p.advance();
+        type_expr = parse_pipe(p);
+        tag_kids: list = [colon, type_expr];
+        type_tag = UniSubTag(tag=type_expr, kid=tag_kids);
+        p.register_node(type_tag);
+        value = None;
+        kids: list = [expr, type_tag];
+        if p.check(Tok.EQ.value) {
+            eq = p.advance();
+            kids.append(eq);
+            if p.check(Tok.KW_YIELD.value) {
+                value = parse_yield_expr(p);
+            } else {
+                value = parse_expression(p);
+            }
+            kids.append(value);
+        }
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+        nd = UniAssignment(
+            target=[expr],
+            value=value,
+            type_tag=type_tag,
+            kid=kids,
+            mutable=True,
+            aug_op=None
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Check for augmented assignment: +=, -=, etc.
+    if p.peek().name in AUGMENTED_ASSIGN_OPS {
+        aug = p.advance();
+        if p.check(Tok.KW_YIELD.value) {
+            value = parse_yield_expr(p);
+        } else {
+            value = parse_expression(p);
+        }
+        semi = p.expect(Tok.SEMI.value);
+        kids: list = [expr, aug, value, semi];
+        nd = UniAssignment(
+            target=[expr],
+            value=value,
+            type_tag=None,
+            kid=kids,
+            mutable=True,
+            aug_op=aug
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # Just an expression statement
+    semi = p.expect(Tok.SEMI.value);
+    kids: list = [expr, semi];
+    nd = UniExprStmt(expr=expr, in_fstring=False, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── If statement ───────────────────────────────────────────────────────
+def parse_if_stmt(
+    p: any
+) -> any {
+    # if_stmt: KW_IF expression code_block (elif_stmt | else_stmt)?
+    if_tok = p.expect(Tok.KW_IF.value);
+    condition = parse_expression(p);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    block_kids = block[1];
+
+    else_body = None;
+    if p.check(Tok.KW_ELIF.value) {
+        else_body = parse_elif_stmt(p);
+    } elif p.check(Tok.KW_ELSE.value) {
+        else_body = parse_else_stmt(p);
+    }
+
+    kids: list = [if_tok, condition];
+    kids.extend(block_kids);
+    if else_body is not None {
+        kids.append(else_body);
+    }
+
+    nd = UniIfStmt(condition=condition, body=body, else_body=else_body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def parse_elif_stmt(p: any) -> any {
+    # elif_stmt: KW_ELIF expression code_block (elif_stmt | else_stmt)?
+    elif_tok = p.expect(Tok.KW_ELIF.value);
+    condition = parse_expression(p);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    block_kids = block[1];
+
+    else_body = None;
+    if p.check(Tok.KW_ELIF.value) {
+        else_body = parse_elif_stmt(p);
+    } elif p.check(Tok.KW_ELSE.value) {
+        else_body = parse_else_stmt(p);
+    }
+
+    kids: list = [elif_tok, condition];
+    kids.extend(block_kids);
+    if else_body is not None {
+        kids.append(else_body);
+    }
+
+    nd = UniElseIf(condition=condition, body=body, else_body=else_body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def parse_else_stmt(p: any) -> any {
+    # else_stmt: KW_ELSE code_block
+    else_tok = p.expect(Tok.KW_ELSE.value);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    block_kids = block[1];
+
+    kids: list = [else_tok];
+    kids.extend(block_kids);
+
+    nd = UniElseStmt(body=body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── While statement ────────────────────────────────────────────────────
+def parse_while_stmt(
+    p: any
+) -> any {
+    # while_stmt: KW_WHILE expression code_block else_stmt?
+    while_tok = p.expect(Tok.KW_WHILE.value);
+    condition = parse_expression(p);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    block_kids = block[1];
+
+    else_body = None;
+    if p.check(Tok.KW_ELSE.value) {
+        else_body = parse_else_stmt(p);
+    }
+
+    kids: list = [while_tok, condition];
+    kids.extend(block_kids);
+    if else_body is not None {
+        kids.append(else_body);
+    }
+
+    nd = UniWhileStmt(condition=condition, body=body, else_body=else_body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── For statement ──────────────────────────────────────────────────────
+def parse_for_stmt(
+    p: any
+) -> any {
+    # for_stmt: KW_ASYNC? KW_FOR assignment KW_TO expression KW_BY assignment code_block else_stmt?
+    #         | KW_ASYNC? KW_FOR atomic_chain KW_IN expression code_block else_stmt?
+    kids: list = [];
+    is_async = False;
+
+    if p.check(Tok.KW_ASYNC.value) {
+        async_tok = p.advance();
+        is_async = True;
+        kids.append(async_tok);
+    }
+
+    for_tok = p.expect(Tok.KW_FOR.value);
+    kids.append(for_tok);
+
+    # Parse the target/assignment part.
+    # Use parse_arithmetic (stops before comparison operators like `in`, `is`)
+    # so that `for x in collection` doesn't consume `in` as a compare op.
+    target_expr = parse_arithmetic(p);
+
+    # For iter-for loops (C-style), the first part may be an assignment: `for i = 0 to ...`
+    # Check if we have an `=` and parse it as an assignment
+    if p.check(Tok.EQ.value) {
+        eq_tok = p.advance();
+        value = parse_arithmetic(p);
+        assign_kids: list = [target_expr, eq_tok, value];
+        target_expr = UniAssignment(
+            target=[target_expr],
+            value=value,
+            type_tag=None,
+            kid=assign_kids,
+            mutable=True,
+            aug_op=None
+        );
+        p.register_node(target_expr);
+    }
+
+    # Check which form: KW_TO (iter-for) or KW_IN (in-for)
+    if p.check(Tok.KW_TO.value) {
+        # IterForStmt: for assignment KW_TO expression KW_BY assignment code_block
+        # target_expr should be the iter assignment (parsed as expression)
+        # Need to check if it was an assignment (had EQ)
+        iter_assign = _expr_to_assignment(p, target_expr);
+        to_tok = p.advance();
+        kids.extend([target_expr, to_tok]);
+        condition = parse_pipe(p);
+        kids.append(condition);
+        by_tok = p.expect(Tok.KW_BY.value);
+        kids.append(by_tok);
+        # count_by can be: expression, assignment (i = i + 1), or augmented assignment (i += 1)
+        count_by_expr = parse_arithmetic(p);
+        # Check for augmented assignment: +=, -=, etc.
+        if p.peek().name in AUGMENTED_ASSIGN_OPS {
+            aug_op = p.advance();
+            aug_value = parse_arithmetic(p);
+            assign_kids: list = [count_by_expr, aug_op, aug_value];
+            count_by = UniAssignment(
+                target=[count_by_expr],
+                value=aug_value,
+                type_tag=None,
+                kid=assign_kids,
+                mutable=True,
+                aug_op=aug_op
+            );
+            p.register_node(count_by);
+            kids.append(count_by);
+        } elif p.check(Tok.EQ.value) {
+            # Regular assignment: i = i + 1
+            eq_tok = p.advance();
+            eq_value = parse_arithmetic(p);
+            assign_kids: list = [count_by_expr, eq_tok, eq_value];
+            count_by = UniAssignment(
+                target=[count_by_expr],
+                value=eq_value,
+                type_tag=None,
+                kid=assign_kids,
+                mutable=True,
+                aug_op=None
+            );
+            p.register_node(count_by);
+            kids.append(count_by);
+        } else {
+            # Simple expression (wrapped in Assignment for compatibility)
+            count_by = _expr_to_assignment(p, count_by_expr);
+            kids.append(count_by_expr);
+        }
+        block = parse_code_block_with_kids(p);
+        body = block[0];
+        kids.extend(block[1]);
+        else_body = None;
+        if p.check(Tok.KW_ELSE.value) {
+            else_body = parse_else_stmt(p);
+            kids.append(else_body);
+        }
+        nd = UniIterForStmt(
+            iter=iter_assign,
+            is_async=is_async,
+            condition=condition,
+            count_by=count_by,
+            body=body,
+            else_body=else_body,
+            kid=kids
+        );
+        p.register_node(nd);
+        return nd;
+    }
+
+    # InForStmt: for atomic_chain KW_IN expression code_block
+    in_tok = p.expect(Tok.KW_IN.value);
+    kids.extend([target_expr, in_tok]);
+    collection = parse_expression(p);
+    kids.append(collection);
+
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    kids.extend(block[1]);
+
+    else_body = None;
+    if p.check(Tok.KW_ELSE.value) {
+        else_body = parse_else_stmt(p);
+        kids.append(else_body);
+    }
+
+    nd = UniInForStmt(
+        target=target_expr,
+        is_async=is_async,
+        collection=collection,
+        body=body,
+        else_body=else_body,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+def _expr_to_assignment(p: any, expr: any) -> any {
+    # Wrap an expression as an Assignment if needed
+    if isinstance(expr, UniAssignment) {
+        return expr;
+    }
+    # Create a simple assignment: target = target (identity)
+    nd = UniAssignment(
+        target=[expr], value=None, type_tag=None, kid=[expr], mutable=True, aug_op=None
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Try statement ──────────────────────────────────────────────────────
+def parse_try_stmt(
+    p: any
+) -> any {
+    # try_stmt: KW_TRY code_block except_list? else_stmt? finally_stmt?
+    try_tok = p.expect(Tok.KW_TRY.value);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    kids: list = [try_tok];
+    kids.extend(block[1]);
+
+    excepts: list = [];
+    while p.check(Tok.KW_EXCEPT.value) {
+        exc = parse_except_def(p);
+        excepts.append(exc);
+        kids.append(exc);
+    }
+
+    else_body = None;
+    if p.check(Tok.KW_ELSE.value) {
+        else_body = parse_else_stmt(p);
+        kids.append(else_body);
+    }
+
+    finally_body = None;
+    if p.check(Tok.KW_FINALLY.value) {
+        finally_body = parse_finally_stmt(p);
+        kids.append(finally_body);
+    }
+
+    nd = UniTryStmt(
+        body=body,
+        excepts=excepts,
+        else_body=else_body,
+        finally_body=finally_body,
+        kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+def parse_except_def(p: any) -> any {
+    # except_def: KW_EXCEPT expression (KW_AS NAME)? code_block
+    except_tok = p.expect(Tok.KW_EXCEPT.value);
+    ex_type = parse_expression(p);
+    kids: list = [except_tok, ex_type];
+
+    name = None;
+    if p.check(Tok.KW_AS.value) {
+        as_tok = p.advance();
+        kids.append(as_tok);
+        name = p.parse_named_ref();
+        kids.append(name);
+    }
+
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    kids.extend(block[1]);
+
+    nd = UniExcept(ex_type=ex_type, name=name, body=body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def parse_finally_stmt(p: any) -> any {
+    # finally_stmt: KW_FINALLY code_block
+    finally_tok = p.expect(Tok.KW_FINALLY.value);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    kids: list = [finally_tok];
+    kids.extend(block[1]);
+
+    nd = UniFinallyStmt(body=body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── With statement ─────────────────────────────────────────────────────
+def parse_with_stmt(
+    p: any
+) -> any {
+    # with_stmt: KW_ASYNC? KW_WITH expr_as_list code_block
+    kids: list = [];
+    is_async = False;
+
+    if p.check(Tok.KW_ASYNC.value) {
+        async_tok = p.advance();
+        is_async = True;
+        kids.append(async_tok);
+    }
+
+    with_tok = p.expect(Tok.KW_WITH.value);
+    kids.append(with_tok);
+
+    # Parse expr_as list
+    exprs: list = [];
+    while True {
+        item = _parse_expr_as(p);
+        exprs.append(item);
+        kids.append(item);
+        if not p.check(Tok.COMMA.value) {
+            break;
+        }
+        comma = p.advance();
+        kids.append(comma);
+    }
+
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    kids.extend(block[1]);
+
+    nd = UniWithStmt(is_async=is_async, exprs=exprs, body=body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+def _parse_expr_as(p: any) -> any {
+    # expr_as: expression (KW_AS expression)?
+    expr = parse_expression(p);
+    alias = None;
+    kids: list = [expr];
+    if p.check(Tok.KW_AS.value) {
+        as_tok = p.advance();
+        kids.append(as_tok);
+        alias = parse_expression(p);
+        kids.append(alias);
+    }
+    nd = UniExprAsItem(expr=expr, alias=alias, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Return statement ───────────────────────────────────────────────────
+def parse_return_stmt(
+    p: any
+) -> any {
+    # return_stmt: KW_RETURN expression?
+    return_tok = p.expect(Tok.KW_RETURN.value);
+    expr = None;
+    kids: list = [return_tok];
+    if not p.check(Tok.SEMI.value) and not p.check(Tok.RBRACE.value) and not p.at_end() {
+        expr = parse_expression(p);
+        kids.append(expr);
+    }
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+    nd = UniReturnStmt(expr=expr, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Raise statement ────────────────────────────────────────────────────
+def parse_raise_stmt(
+    p: any
+) -> any {
+    # raise_stmt: KW_RAISE (expression (KW_FROM expression)?)?
+    raise_tok = p.expect(Tok.KW_RAISE.value);
+    cause = None;
+    from_target = None;
+    kids: list = [raise_tok];
+
+    if not p.check(Tok.SEMI.value) and not p.at_end() {
+        cause = parse_expression(p);
+        kids.append(cause);
+        if p.check(Tok.KW_FROM.value) {
+            from_tok = p.advance();
+            kids.append(from_tok);
+            from_target = parse_expression(p);
+            kids.append(from_target);
+        }
+    }
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+    nd = UniRaiseStmt(cause=cause, from_target=from_target, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Assert statement ───────────────────────────────────────────────────
+def parse_assert_stmt(
+    p: any
+) -> any {
+    # assert_stmt: KW_ASSERT expression (COMMA expression)?
+    assert_tok = p.expect(Tok.KW_ASSERT.value);
+    condition = parse_expression(p);
+    error_msg = None;
+    kids: list = [assert_tok, condition];
+
+    if p.check(Tok.COMMA.value) {
+        comma = p.advance();
+        kids.append(comma);
+        error_msg = parse_expression(p);
+        kids.append(error_msg);
+    }
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+    nd = UniAssertStmt(condition=condition, error_msg=error_msg, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Delete statement ───────────────────────────────────────────────────
+def parse_delete_stmt(
+    p: any
+) -> any {
+    # delete_stmt: KW_DELETE expression
+    del_tok = p.expect(Tok.KW_DELETE.value);
+    target = parse_expression(p);
+    semi = p.expect(Tok.SEMI.value);
+    kids: list = [del_tok, target, semi];
+    nd = UniDeleteStmt(target=target, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Report statement ───────────────────────────────────────────────────
+def parse_report_stmt(
+    p: any
+) -> any {
+    # report_stmt: KW_REPORT expression
+    report_tok = p.expect(Tok.KW_REPORT.value);
+    expr = parse_expression(p);
+    semi = p.expect(Tok.SEMI.value);
+    kids: list = [report_tok, expr, semi];
+    nd = UniReportStmt(expr=expr, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Control statements ─────────────────────────────────────────────────
+def parse_ctrl_stmt(
+    p: any
+) -> any {
+    # ctrl_stmt: KW_SKIP | KW_BREAK | KW_CONTINUE
+    ctrl = p.advance();
+    semi = p.expect(Tok.SEMI.value);
+    kids: list = [ctrl, semi];
+    nd = UniCtrlStmt(ctrl=ctrl, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Visit statement ────────────────────────────────────────────────────
+def parse_visit_stmt(
+    p: any
+) -> any {
+    # visit_stmt: KW_VISIT (COLON expression COLON)? expression (else_stmt | SEMI)
+    visit_tok = p.expect(Tok.KW_VISIT.value);
+    kids: list = [visit_tok];
+
+    insert_loc = None;
+    if p.check(Tok.COLON.value) {
+        colon1 = p.advance();
+        kids.append(colon1);
+        insert_loc = parse_expression(p);
+        kids.append(insert_loc);
+        colon2 = p.expect(Tok.COLON.value);
+        kids.append(colon2);
+    }
+
+    target = parse_expression(p);
+    kids.append(target);
+
+    else_body = None;
+    if p.check(Tok.KW_ELSE.value) {
+        else_body = parse_else_stmt(p);
+        kids.append(else_body);
+    } else {
+        semi = p.expect(Tok.SEMI.value);
+        kids.append(semi);
+    }
+
+    nd = UniVisitStmt(
+        insert_loc=insert_loc, target=target, else_body=else_body, kid=kids
+    );
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Disengage statement ────────────────────────────────────────────────
+def parse_disengage_stmt(
+    p: any
+) -> any {
+    # disenage_stmt: KW_DISENGAGE SEMI
+    dis_tok = p.expect(Tok.KW_DISENGAGE.value);
+    semi = p.expect(Tok.SEMI.value);
+    kids: list = [dis_tok, semi];
+    nd = UniDisengageStmt(kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Global reference ───────────────────────────────────────────────────
+def parse_global_ref(
+    p: any
+) -> any {
+    # global_ref: GLOBAL_OP name_list
+    global_tok = p.advance();
+    names: list = [];
+    kids: list = [global_tok];
+    while True {
+        name = p.parse_named_ref();
+        names.append(name);
+        kids.append(name);
+        if not p.check(Tok.COMMA.value) {
+            break;
+        }
+        comma = p.advance();
+        kids.append(comma);
+    }
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+    nd = UniGlobalStmt(target=names, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Nonlocal reference ─────────────────────────────────────────────────
+def parse_nonlocal_ref(
+    p: any
+) -> any {
+    # nonlocal_ref: NONLOCAL_OP name_list
+    nonlocal_tok = p.advance();
+    names: list = [];
+    kids: list = [nonlocal_tok];
+    while True {
+        name = p.parse_named_ref();
+        names.append(name);
+        kids.append(name);
+        if not p.check(Tok.COMMA.value) {
+            break;
+        }
+        comma = p.advance();
+        kids.append(comma);
+    }
+    semi = p.expect(Tok.SEMI.value);
+    kids.append(semi);
+    nd = UniNonLocalStmt(target=names, kid=kids);
+    p.register_node(nd);
+    return nd;
+}
+
+# ── Typed context block ────────────────────────────────────────────────
+def parse_typed_ctx_block(
+    p: any
+) -> any {
+    # typed_ctx_block: RETURN_HINT expression code_block
+    hint_tok = p.expect(Tok.RETURN_HINT.value);
+    type_ctx = parse_expression(p);
+    block = parse_code_block_with_kids(p);
+    body = block[0];
+    kids: list = [hint_tok, type_ctx];
+    kids.extend(block[1]);
+    nd = UniTypedCtxBlock(type_ctx=type_ctx, body=body, kid=kids);
+    p.register_node(nd);
+    return nd;
+}

--- a/jac/jaclang/meta_importer.py
+++ b/jac/jaclang/meta_importer.py
@@ -38,6 +38,15 @@ def _discover_minimal_compile_modules() -> frozenset[str]:
             module_path = jac_file.relative_to(jaclang_dir).with_suffix("")
             modules.add(f"jaclang.{module_path.as_posix().replace('/', '.')}")
 
+    # Also include rd_parser modules to avoid circular imports and llvmlite dependency
+    rd_parser_dir = jaclang_dir / "compiler" / "rd_parser"
+    if rd_parser_dir.exists():
+        for jac_file in rd_parser_dir.rglob("*.jac"):
+            if jac_file.name.endswith(".impl.jac"):
+                continue
+            module_path = jac_file.relative_to(jaclang_dir).with_suffix("")
+            modules.add(f"jaclang.{module_path.as_posix().replace('/', '.')}")
+
     return frozenset(modules)
 
 


### PR DESCRIPTION
## Summary

- Add a complete handwritten recursive descent parser written in Jac as an alternative to the Lark-based parser
- Lexer with mode stack for context-sensitive tokenization (NORMAL, FSTRING_EXPR, FSTRING_FORMAT, JSX_TAG, JSX_CONTENT)
- Expression parsing with 27 precedence levels
- Statement parsing including C-style and Python-style for loops
- Declaration parsing for archetypes, abilities, enums, and impls
- F-string parsing with bracket depth tracking for slice support
- JSX parsing with proper close tag handling
- Pattern matching support for match/switch statements
- Edge reference and spatial operator parsing
- Update meta_importer.py to include rd_parser modules in minimal compile modules

## Usage

Set environment variable `JAC_RD_PARSER=1` to use the new parser instead of the default Lark-based parser.

## Test plan

- [ ] Run `JAC_RD_PARSER=1 pytest` to verify parser correctness
- [ ] Compare AST output between Lark and RD parser
- [ ] Verify f-string parsing with slices works correctly
- [ ] Verify JSX parsing handles close tags properly
- [ ] Verify C-style for loops parse correctly