### PR TITLE
fix: preserve sv import token during unparse in .cl.jac files

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -17,6 +17,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Native Compiler: File I/O**: The `open()` builtin now compiles to native code, returning a `File` struct backed by C `fopen`. File methods `read()`, `write()`, `readline()`, `close()`, and `flush()` are all supported. NULL handle checks are generated for failed opens.
 - **Native Compiler: Context Managers**: `with` statements compile to native LLVM IR. `__enter__` is called on entry, `__exit__` on exit (including when exceptions occur). The `as` binding form (`with open(path) as f`) is supported. File objects implement the context manager protocol for automatic resource cleanup.
 - **Native Compiler: Runtime Error Checks**: The native backend now generates runtime safety checks that raise structured exceptions: `ZeroDivisionError` for integer and float division/modulo by zero, `IndexError` for list index out of bounds, `KeyError` for missing dictionary keys, `OverflowError` for integer arithmetic overflow, `AttributeError` for null pointer dereference, `ValueError` for invalid `int()` parsing, and `AssertionError` for failed assertions.
+- **Fix:** `sv import` Lost During Unparse in `.cl.jac` Files
 
 ## jaclang 0.9.14 (Latest Release)
 

--- a/jac/jaclang/pycore/unitree.py
+++ b/jac/jaclang/pycore/unitree.py
@@ -1537,11 +1537,15 @@ class Import(ContextAwareNode, ElementStmt, CodeBlockStmt):
         new_kid: list[UniNode] = []
         if self.doc:
             new_kid.append(self.doc)
-        client_tok = self._source_context_token()
+        ctx_tok = self._source_context_token()
         if self.code_context == CodeContext.CLIENT and (
-            client_tok is not None or not self.in_client_context()
+            ctx_tok is not None or not self.in_client_context()
         ):
-            new_kid.append(client_tok if client_tok else self.gen_token(Tok.KW_CLIENT))
+            new_kid.append(ctx_tok if ctx_tok else self.gen_token(Tok.KW_CLIENT))
+        elif self.code_context == CodeContext.SERVER and (
+            ctx_tok is not None or self.in_client_context()
+        ):
+            new_kid.append(ctx_tok if ctx_tok else self.gen_token(Tok.KW_SERVER))
         if self.is_absorb:
             new_kid.append(self.gen_token(Tok.KW_INCLUDE))
         else:

--- a/jac/tests/fixtures_list.py
+++ b/jac/tests/fixtures_list.py
@@ -273,6 +273,7 @@ MICRO_JAC_FILES: list[str] = [
     "tests/compiler/passes/ecmascript/fixtures/mixed_explicit.jac",
     "tests/compiler/passes/ecmascript/fixtures/mixed_sv_default.sv.jac",
     "tests/compiler/passes/ecmascript/fixtures/root_render.jac",
+    "tests/compiler/passes/ecmascript/fixtures/separated_client.cl.jac",
     "tests/compiler/passes/ecmascript/fixtures/side_effect_imports.jac",
     "tests/compiler/passes/main/fixtures/M1.jac",
     "tests/compiler/passes/main/fixtures/access_checker.jac",


### PR DESCRIPTION
## Summary
- Fixed a bug where `sv import` statements in `.cl.jac` files were silently dropped during the unparse-recompile cycle
- `Import.normalize()` now emits the `sv` (KW_SERVER) token for SERVER-context imports when inside a client context, mirroring the existing `cl` token handling
- Added `separated_client.cl.jac` to the fixtures list for unparse validation testing

## Test plan
- [x] `test_micro_suite[..separated_client.cl.jac]` now passes
- [x] All 482 unparse validation tests pass