### PR TITLE
Tighten RD parser strictness for Lark parity

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -19,6 +19,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **RD Parser: Yield in Assignments & Grammar Extraction Improvements**: The RD parser now correctly handles `x = yield expr` in assignments. The `jac grammar` extraction pass was improved to accurately display binary operator rules (e.g., `logical_or` now shows `logical_and (KW_OR logical_and)*` instead of the incorrect `logical_and KW_OR*`).
 - **RD Parser: Async, Impl & F-String Gap Fixes**: Fixed 6 more coverage gaps in the recursive descent parser: `async with` statements, async comprehensions (list/set/gen), `async for` token in AST kid lists, `impl` with event clause missing `with` token, `impl` by-expression extra `by` token, and nested `{expr}` inside f-string format specs (e.g., `f"{value:{width}}"`).
 - **RD Parser: Enum & Match Pattern Gap Fixes**: Fixed 3 more coverage gaps: multistring (concatenated string literals) in match literal patterns, `py_code_block` (inline Python) in enum blocks, and `free_code` (`with entry` blocks) in enum blocks.
+- **RD Parser: Strictness Parity with Lark**: Tightened the RD parser to reject constructs that the Lark grammar also rejects, closing 7 permissiveness gaps.
 
 ## jaclang 0.9.15 (Latest Release)
 

--- a/jac/jaclang/compiler/parser/impl/parser.impl.jac
+++ b/jac/jaclang/compiler/parser/impl/parser.impl.jac
@@ -336,6 +336,10 @@ impl Parser.make_name(tok: Token, is_enum_stmt: bool = False) -> Name {
     if val.startswith("<>") {
         val = val[2:];
     }
+    # Reject Python-only keywords that are not valid Jac identifiers
+    if val == "pass" {
+        self.error("'pass' keyword is not allowed in Jac");
+    }
     return Name(
         orig_src=self.get_source(),
         name=Tok.NAME.value,
@@ -3050,7 +3054,6 @@ impl Parser.parse_element_stmt{
         TokenKind.KW_OVERRIDE,
         TokenKind.KW_STATIC,
         TokenKind.KW_ASYNC,
-        TokenKind.KW_ABSTRACT,
         TokenKind.DECOR_OP
     ] {
         doc_tok = self.advance();
@@ -3144,15 +3147,25 @@ impl Parser.parse_element_stmt{
             self.advance();
             self.parse_atomic_chain();  # consume decorator expression
         }
-        # Skip async/abstract if present
-        while self.check_any(TokenKind.KW_ASYNC, TokenKind.KW_ABSTRACT) {
+        # Skip async if present
+        while self.check(TokenKind.KW_ASYNC) {
+            self.advance();
+        }
+        # Check for abs prefix - valid before archetypes, NOT before abilities
+        has_abs_prefix = self.check(TokenKind.KW_ABSTRACT);
+        if has_abs_prefix {
             self.advance();
         }
         # Now check what the decorated item is
         is_ability = self.check_any(TokenKind.KW_DEF, TokenKind.KW_CAN);
         is_enum = self.check(TokenKind.KW_ENUM);
         self.pos = save_pos;  # Restore position
-        if is_ability {
+        if has_abs_prefix and is_ability {
+            self.error(
+                "'abs' is not a valid prefix for abilities (use 'abs' before archetype keywords only)"
+            );
+        }
+        if is_ability and not has_abs_prefix {
             return self.parse_ability();
         } elif is_enum {
             return self.parse_enum();
@@ -3160,11 +3173,11 @@ impl Parser.parse_element_stmt{
             return self.parse_archetype();
         }
     }
-    # Handle abstract/async prefixes
-    if self.check_any(TokenKind.KW_ABSTRACT, TokenKind.KW_ASYNC) {
+    # Handle async prefix (abs is NOT a valid prefix per Lark grammar)
+    if self.check(TokenKind.KW_ASYNC) {
         # Look ahead to see if it's an ability (def/can) or archetype (class/obj/etc)
         save_pos = self.pos;
-        while self.check_any(TokenKind.KW_ABSTRACT, TokenKind.KW_ASYNC) {
+        while self.check(TokenKind.KW_ASYNC) {
             self.advance();
         }
         is_ability = self.check_any(TokenKind.KW_DEF, TokenKind.KW_CAN);
@@ -3174,9 +3187,9 @@ impl Parser.parse_element_stmt{
         }
         return self.parse_archetype();
     }
-    expr = self.parse_expression();
-    self.match_tok(TokenKind.SEMI);
-    return expr;
+    self.error("Unexpected token at module level");
+    self.advance();
+    return EmptyToken();
 }
 
 """Parse client block: cl { stmts } or cl stmt"""
@@ -3270,12 +3283,16 @@ impl Parser.parse_native_block -> NativeBlock {
 }
 
 impl Parser.parse_module_code -> ModuleCode {
-    # Parse 'with entry { ... }' or 'with entry:__main__ { ... }' or 'with exit { ... }'
+    # Parse 'with entry { ... }' or 'with entry:__main__ { ... }'
     # Grammar: free_code: KW_WITH KW_ENTRY (COLON NAME)? code_block
     self.expect(TokenKind.KW_WITH);
     name = None;
     target_name = None;  # For :__main__ style target
-    if self.check_any(TokenKind.KW_ENTRY, TokenKind.KW_EXIT) {
+    if self.check(TokenKind.KW_EXIT) {
+        self.error("Module-level 'with' blocks only support 'entry', not 'exit'");
+        name_tok = self.advance();
+        name = self.make_uni_token(name_tok);
+    } elif self.check(TokenKind.KW_ENTRY) {
         name_tok = self.advance();
         name = self.make_uni_token(name_tok);
     }
@@ -4967,9 +4984,9 @@ impl Parser.parse_archetype_member{
             return ModuleCode(name=None, body=body, kid=kid, doc=None);
         }
     }
-    expr = self.parse_expression();
-    self.match_tok(TokenKind.SEMI);
-    return expr;
+    self.error("Unexpected token in archetype body");
+    self.advance();
+    return EmptyToken();
 }
 
 impl Parser.parse_has_stmt -> ArchHas {
@@ -5026,14 +5043,6 @@ impl Parser.parse_has_stmt -> ArchHas {
 }
 
 impl Parser.parse_has_var -> HasVar {
-    # Check for per-variable access modifier: :pub name: type
-    # Note: HasVar doesn't have access field - access modifiers are at ArchHas level
-    if self.match_tok(TokenKind.COLON) {
-        if self.check_any(TokenKind.KW_PUB, TokenKind.KW_PRIV, TokenKind.KW_PROT) {
-            # Skip the access modifier token - it's consumed but not stored per-var
-            self.advance();
-        }
-    }
     name_tok: Token;
     if self.check_name() {
         name_tok = self.advance();
@@ -5140,6 +5149,11 @@ impl Parser.parse_ability -> Ability {
         signature = EventSignature(
             event=event_uni_tok, arch_tag_info=event_type, kid=sig_kid
         );
+    } elif is_can {
+        self.error(
+            "Expected 'with' after 'can' ability name (use 'def' for function-style declarations)"
+        );
+        signature = self.parse_func_signature();
     } else {
         signature = self.parse_func_signature();
     }
@@ -5762,6 +5776,7 @@ impl Parser.parse_impl_def -> ImplDef {
         body = self.parse_expression();
         self.expect(TokenKind.SEMI);
     } else {
+        self.error("Expected '{' or 'by' for impl body");
         self.expect(TokenKind.SEMI);
     }
     kid: list = [];


### PR DESCRIPTION
## Summary
- Close 7 permissiveness gaps where the RD parser accepted syntax that the Lark grammar rejects: `can` without event clause, per-variable access tags in `has`, `pass` keyword, module-level `with exit`, `abs` prefix on abilities, bare expressions at module/archetype level, and `impl` with bare semicolon
- Add 9 parametrized `test_rd_parser_strictness_parity` tests confirming both parsers reject these constructs
- Update release notes

## Test plan
- [x] All 437 existing validation tests pass (zero regressions)
- [x] All 9 new strictness parity tests pass
- [x] 446 total tests passed, 17 skipped
- [ ] CI passes