### PR TITLE
Audit and update documentation for accuracy and completeness

### DIFF
--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -6,6 +6,16 @@ This page documents significant breaking changes in Jac and Jaseci that may affe
 
 MTLLM library is now deprecated and replaced by the byLLM package. In all place where `mtllm` was used before can be replaced with `byllm`.
 
+### CLI Dependency Commands Redesigned (0.10.0)
+
+The `jac add`, `jac install`, `jac remove`, and `jac update` commands were redesigned. Key behavioral changes:
+
+- `jac add` now **requires** at least one package argument (previously, calling `jac add` with no args silently fell through to install)
+- `jac add` without a version spec now queries the installed version and records `~=X.Y` (previously recorded `>=0.0.0`)
+- `jac install` now syncs all dependency types (pip, git, and plugin-provided like npm)
+- New `jac update` command for updating dependencies to latest compatible versions
+- Virtual environment is now at `.jac/venv/` instead of `.jac/packages/`
+
 ### KWESC_NAME Syntax Changed from `<>` to Backtick
 
 Keyword-escaped names now use a backtick (`` ` ``) prefix instead of the angle-bracket (`<>`) prefix. This affects any identifier that uses a Jac keyword as a variable, field, or parameter name.

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -176,8 +176,8 @@
             <!-- Right: Content Area -->
             <div class="vt-main-content" id="main-content">
                 <div class="vt-content-heading" id="content-heading">
-                    Jac is a drop-in replacement for Python and supersets Python, much like Typescript supersets
-                    Javascript or C++ supersets C. It maintains full interoperability with the Python ecosystem,
+                    Jac supersets Python and JavaScript, much like TypeScript
+                    supersets JavaScript or C++ supersets C. It maintains full interoperability with the Python ecosystem,
                     introducing new features to minimize complexity and accelerate AI application development. We also
                     provide library mode.
                 </div>
@@ -327,8 +327,8 @@
                             <div class="feature-icon">🐍</div>
                             <h3 class="feature-title">Jac supersets Python</h3>
                             <p class="feature-description">
-                                Jac is a drop-in replacement for Python and supersets Python, much like Typescript
-                                supersets Javascript or C++ supersets C.
+                                Jac supersets Python and JavaScript, much like TypeScript
+                                supersets JavaScript or C++ supersets C.
                             </p>
                         </div>
 
@@ -414,7 +414,7 @@
                     </div>
                     <div class="about-text">
                         <p class="about-description">
-                            Jac is an innovative programming language and superset of both Python and TypeScript/JavaScript,
+                            Jac is an innovative programming language that supersets Python and JavaScript,
                             providing seamless access to both the PyPI and npm ecosystems. Created by <strong><a
                                     href="https://github.com/marsninja" target="_blank"
                                     class="fancy-link">@marsninja</a></strong>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,7 @@
 
 **One Language for AI-Native Full-Stack Development**
 
-Jac is a programming language and superset of both Python and TypeScript/JavaScript, with novel constructs for AI-integrated programming. Access the entire PyPI and npm ecosystems while using features like `by llm()` to seamlessly weave AI into your code. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
+Jac is a programming language that supersets Python and JavaScript with native compilation support, adding novel constructs for AI-integrated programming. Access the entire PyPI and npm ecosystems while using features like `by llm()` to seamlessly weave AI into your code. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
 
 ---
 

--- a/docs/docs/js/landing.js
+++ b/docs/docs/js/landing.js
@@ -630,7 +630,7 @@ document.addEventListener('DOMContentLoaded', function () {
 const tabsData = [
     {
         tagline: "Jac Supersets Python",
-        summary: `Jac is a drop-in replacement for Python and supersets Python, much like Typescript supersets Javascript or C++ supersets C. It maintains full interoperability with the Python ecosystem, introducing new features to minimize complexity and accelerate AI application development. We also provide library mode.`,
+        summary: `Jac supersets Python and JavaScript, much like TypeScript supersets JavaScript or C++ supersets C. It maintains full interoperability with the Python ecosystem, introducing new features to minimize complexity and accelerate AI application development. We also provide library mode.`,
         filename: "distance_calculator.jac",
         code: `
 import math;

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -2,7 +2,7 @@
 
 **One Language for AI-Native Full-Stack Development**
 
-Jac is a programming language and superset of both Python and TypeScript/JavaScript, with novel constructs for AI-integrated programming. Access the entire PyPI and npm ecosystems while using features like `by llm()` to seamlessly weave AI into your code. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
+Jac is a programming language that supersets Python and JavaScript with native compilation support, adding novel constructs for AI-integrated programming. Access the entire PyPI and npm ecosystems while using features like `by llm()` to seamlessly weave AI into your code. Write backend logic, frontend interfaces, and AI integrations in a single unified language.
 
 ---
 
@@ -102,7 +102,7 @@ Jac is built on six key principles:
 
 2. **Full-Stack in One Language** - Write React components alongside server code. No context switching.
 
-3. **Python & JavaScript Superset** - Use `numpy`, `pandas`, `react`, `tailwind` directly. Your existing knowledge applies.
+3. **Supersets Python & JavaScript** - Use `numpy`, `pandas`, `react`, `tailwind` directly. Your existing knowledge applies.
 
 4. **Object-Spatial Programming** - Model domains as graphs. Deploy walkers to traverse and transform data.
 
@@ -126,7 +126,7 @@ Jac is designed for developers who want to build AI-powered applications without
 | **Student/Learner** | Modern language designed for clarity and simplicity |
 
 !!! note "What You Should Know"
-    Jac is a Python superset, so **Python familiarity is assumed** throughout these docs. If you plan to use the full-stack features, basic **React/JSX** knowledge helps. No graph database experience is needed -- Jac teaches you that.
+    Jac supersets Python, so **Python familiarity is assumed** throughout these docs. If you plan to use the full-stack features, basic **React/JSX** knowledge helps. No graph database experience is needed -- Jac teaches you that.
 
 ---
 

--- a/docs/docs/quick-guide/next-steps.md
+++ b/docs/docs/quick-guide/next-steps.md
@@ -63,7 +63,7 @@ cl {
 2. [Object-Spatial Programming](../tutorials/language/osp.md) - Nodes, edges, walkers
 3. [Testing](../tutorials/language/testing.md) - Write and run tests
 
-**Key concept:** Jac is a superset of Python and TypeScript/JavaScript, adding graphs as first-class citizens and walkers for graph traversal.
+**Key concept:** Jac supersets Python and JavaScript, adding graphs as first-class citizens and walkers for graph traversal.
 
 ```jac
 node Person { has name: str; }
@@ -102,7 +102,7 @@ jac start app.jac --scale
 
 ### Coming from Python
 
-You'll feel at home. Jac is a Python superset.
+You'll feel at home. Jac supersets Python.
 
 **What's different:**
 

--- a/docs/docs/quick-guide/what-makes-jac-different.md
+++ b/docs/docs/quick-guide/what-makes-jac-different.md
@@ -1,18 +1,18 @@
 # Core Concepts
 
-Most of Jac will be recognizable if you are familary with another programming language like Python -- Jac is a Python superset, so familiar constructs like functions, classes, imports, list comprehensions, and control flow all work as expected. You can explore those in depth in the [tutorials](../tutorials/index.md) and [language reference](../reference/language/index.md).
+Most of Jac will be recognizable if you are familiar with another programming language like Python -- Jac supersets Python, so familiar constructs like functions, classes, imports, list comprehensions, and control flow all work as expected. You can explore those in depth in the [tutorials](../tutorials/index.md) and [language reference](../reference/language/index.md).
 
-This page focuses on the three concepts that Jac adds beyond traditional programming languges. These are the ideas the rest of the documentation builds on, introduced briefly so you have the vocabulary for the tutorials that follow. Through these concepts three important questions can be answered:
+This page focuses on the three concepts that Jac adds beyond traditional programming languages. These are the ideas the rest of the documentation builds on, introduced briefly so you have the vocabulary for the tutorials that follow. Through these concepts three important questions can be answered:
 
 1. [How can one language target frontend, backend, and native binaries at the same time?](#1-how-can-one-language-target-frontends-backends-and-native-binaries-at-the-same-time)
 2. [How does Jac fully abstract away database organization and interactions and the complexity of multiuser persistent data?](#2-how-does-jac-fully-abstract-away-database-organization-and-interactions-and-the-complexity-of-multiuser-persistent-data)
-3. [How does Jac abstract away the laborious task of prompt/context engineering for AI and turn it into a compiler/runtime problem?](#3-how-does-jac-abstract-away-the-laborius-task-of-promptcontext-engineering-for-ai-and-turn-it-into-a-compilerruntime-problem)
+3. [How does Jac abstract away the laborious task of prompt/context engineering for AI and turn it into a compiler/runtime problem?](#3-how-does-jac-abstract-away-the-laborious-task-of-promptcontext-engineering-for-ai-and-turn-it-into-a-compilerruntime-problem)
 
 ---
 
 ## 1. How can one language target frontends, backends, and native binaries at the same time?
 
-Similar to namespaces, the Jac language introduces the conecept of **codespaces**. A Jac program can contain code that runs in different environments. You denote the codespace either with a **block prefix** inside a file or with a **file extension**:
+Similar to namespaces, the Jac language introduces the concept of **codespaces**. A Jac program can contain code that runs in different environments. You denote the codespace either with a **block prefix** inside a file or with a **file extension**:
 
 ```mermaid
 graph LR
@@ -80,7 +80,7 @@ Codespaces are similar to namespaces, but instead of organizing names, they orga
 
 ## 2. How does Jac fully abstract away database organization and interactions and the complexity of multiuser persistent data?
 
-Jac introduces graph-based Object Spatial Programming (OSP) contructs. OSP gives us two key capabilities. It provides us with a natural way to articulate solutions to problems with graph-like and hierarchical properties, and importantly, a way to organize a programs interaction with data that allows us to hide the complexity of database organization and management.
+Jac introduces graph-based Object Spatial Programming (OSP) constructs. OSP gives us two key capabilities. It provides us with a natural way to articulate solutions to problems with graph-like and hierarchical properties, and importantly, a way to organize a programs interaction with data that allows us to hide the complexity of database organization and management.
 
 Standard object-oriented programming models data as isolated objects -- you call methods to bring data to computation. OSP adds a layer on top: objects exist in a **graph** with explicit relationships. Additionally, the `walker` construct is also introduced allowing computation to **move to the data** by traversing that graph.
 
@@ -131,7 +131,7 @@ You declare `node Todo { has title: str; }`, connect instances to `root`, and th
 
 ---
 
-## 3. How does Jac abstract away the laborius task of prompt/context engineering for AI and turn it into a compiler/runtime problem?
+## 3. How does Jac abstract away the laborious task of prompt/context engineering for AI and turn it into a compiler/runtime problem?
 
 Jac introduces Compiler-Integrated AI through its `by` and `sem` keywords. These  two keywords allow integrating language models into programs at the language level rather than through library calls.
 

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -26,7 +26,8 @@ The Jac CLI provides commands for running, building, testing, and deploying Jac 
 | `jac remove` | Remove packages from project |
 | `jac update` | Update dependencies to latest compatible versions |
 | `jac jacpack` | Manage project templates (.jacpack files) |
-| `jac get_object` | Retrieve object by ID |
+| `jac grammar` | Extract and print the Jac grammar |
+| `jac script` | Run project scripts |
 | `jac py2jac` | Convert Python to Jac |
 | `jac jac2py` | Convert Jac to Python |
 | `jac tool` | Language tools (IR, AST) |
@@ -82,8 +83,8 @@ jac start [-h] [-p PORT] [-m] [--no-main] [-f] [--no-faux] [-d] [--no-dev] [-a A
 | `-m, --main` | Treat as `__main__` | `True` |
 | `-f, --faux` | Print docs only (no server) | `False` |
 | `-d, --dev` | Enable HMR (Hot Module Replacement) mode | `False` |
-| `-a, --api_port` | Separate API port for HMR mode (0=same as port) | `0` |
-| `-n, --no_client` | Skip client bundling/serving (API only) | `False` |
+| `--api_port` | Separate API port for HMR mode (0=same as port) | `0` |
+| `--no_client` | Skip client bundling/serving (API only) | `False` |
 | `--scale` | Deploy to Kubernetes (requires jac-scale) | `False` |
 | `-b, --build` | Build Docker image before deploy (with `--scale`) | `False` |
 
@@ -168,15 +169,17 @@ jac create
 Type check Jac code for errors.
 
 ```bash
-jac check [-h] [-p] [-np] [-w] [-nw] [--ignore PATTERNS] paths [paths ...]
+jac check [-h] [-e] [-w] [--ignore PATTERNS] [-p] [--nowarn] paths [paths ...]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `paths` | Files/directories to check | Required |
-| `-p, --print_errs` | Print errors | `True` |
-| `-w, --warnonly` | Warnings only (no errors) | `False` |
+| `-e, --print_errs` | Print detailed error messages | `True` |
+| `-w, --warnonly` | Treat errors as warnings | `False` |
 | `--ignore` | Comma-separated list of files/folders to ignore | None |
+| `-p, --parse_only` | Only check syntax (skip type checking) | `False` |
+| `--nowarn` | Suppress warning output | `False` |
 
 **Examples:**
 
@@ -243,13 +246,14 @@ jac test main.jac -v
 Format Jac code according to style guidelines. For auto-linting (code corrections like combining consecutive `has` statements, converting `@staticmethod` to `static`), use `jac lint --fix` instead.
 
 ```bash
-jac format [-h] [-t] paths [paths ...]
+jac format [-h] [-s] [-l] paths [paths ...]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `paths` | Files/directories to format | Required |
-| `-t, --to_screen` | Print to screen (don't write) | `False` |
+| `-s, --to_screen` | Print to stdout instead of writing | `False` |
+| `-l, --lintfix` | Also apply auto-lint fixes in the same pass | `False` |
 
 **Examples:**
 
@@ -307,29 +311,29 @@ jac lint . --ignore fixtures
 Run a specific entrypoint in a Jac file.
 
 ```bash
-jac enter [-h] -e ENTRYPOINT [-s SESSION] [-m] [-r ROOT] [-n NODE] filename [args ...]
+jac enter [-h] [-m] [-r ROOT] [-n NODE] filename entrypoint [args ...]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `filename` | Jac file | Required |
-| `-e, --entrypoint` | Entrypoint function/walker | Required |
+| `entrypoint` | Function/walker to invoke (positional) | Required |
 | `args` | Arguments to pass | None |
-| `-s, --session` | Session name | None |
-| `-r, --root` | Root node ID | None |
-| `-n, --node` | Target node ID | None |
+| `-m, --main` | Treat as `__main__` | `True` |
+| `-r, --root` | Root executor ID | None |
+| `-n, --node` | Starting node ID | None |
 
 **Examples:**
 
 ```bash
 # Run specific entrypoint
-jac enter main.jac -e my_walker
+jac enter main.jac my_walker
 
 # With arguments
-jac enter main.jac -e process_data arg1 arg2
+jac enter main.jac process_data arg1 arg2
 
-# With session
-jac enter main.jac -e my_walker -s my_session
+# With root and node
+jac enter main.jac my_walker -r root_id -n node_id
 ```
 
 ---
@@ -341,21 +345,22 @@ jac enter main.jac -e my_walker -s my_session
 Generate DOT graph visualization.
 
 ```bash
-jac dot [-h] [-s SESSION] [-i INITIAL] [-d DEPTH] [-t] [-b] [-e EDGE_LIMIT] [-n NODE_LIMIT] [-sa SAVETO] [-to] [-f FORMAT] filename [connection ...]
+jac dot [-h] [-s SESSION] [-i INITIAL] [-d DEPTH] [-t] [-b] [-e EDGE_LIMIT] [-n NODE_LIMIT] [-o SAVETO] [-p] [-f FORMAT] filename [connection ...]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `filename` | Jac file | Required |
-| `-s, --session` | Session name | None |
-| `-i, --initial` | Initial node | None |
-| `-d, --depth` | Traversal depth | `-1` (unlimited) |
-| `-t, --traverse` | Traverse connections | `False` |
+| `-s, --session` | Session identifier | None |
+| `-i, --initial` | Initial node ID | None |
+| `-d, --depth` | Max traversal depth | `-1` (unlimited) |
+| `-t, --traverse` | Enable traversal mode | `False` |
+| `-c, --connection` | Connection filters | None |
 | `-b, --bfs` | Use BFS traversal | `False` |
 | `-e, --edge_limit` | Max edges | `512` |
 | `-n, --node_limit` | Max nodes | `512` |
-| `-sa, --saveto` | Output file path | None |
-| `-to, --to_screen` | Print to screen | `False` |
+| `-o, --saveto` | Output file path | None |
+| `-p, --to_screen` | Print to stdout | `False` |
 | `-f, --format` | Output format | `dot` |
 
 **Examples:**
@@ -409,10 +414,10 @@ jac plugins [-h] [-v] [action] [names ...]
 | Action | Description |
 |--------|-------------|
 | `list` | List installed plugins (default) |
-| `install` | Install plugins |
-| `uninstall` | Remove plugins |
+| `info` | Show plugin information |
 | `enable` | Enable plugins |
 | `disable` | Disable plugins |
+| `disabled` | List disabled plugins |
 
 | Option | Description | Default |
 |--------|-------------|---------|
@@ -427,16 +432,21 @@ jac plugins
 # Explicitly list plugins
 jac plugins list
 
-# Install a plugin
-jac plugins install jac-scale
+# Show info about a plugin
+jac plugins info byllm
 
-# Install jac-super for enhanced console output
-jac plugins install jac-super
+# Disable a plugin
+jac plugins disable byllm
 
-# Uninstall
-jac plugins uninstall byllm
+# Enable a plugin
+jac plugins enable byllm
+
+# List disabled plugins
+jac plugins disabled
 ```
 
+> **Note:** To install or uninstall plugins, use `pip install` / `pip uninstall` directly. The `jac plugins` command manages enabled/disabled state for already-installed plugins.
+>
 > **💡 Popular Plugins**:
 >
 > - **jac-super**: Enhanced console output with Rich formatting, colors, and spinners (`pip install jac-super`)
@@ -452,7 +462,7 @@ jac plugins uninstall byllm
 View and modify project configuration settings in `jac.toml`.
 
 ```bash
-jac config [action] [-k KEY] [-v VALUE] [-g GROUP] [-o FORMAT]
+jac config [action] [key] [value] [-g GROUP] [-o FORMAT]
 ```
 
 | Action | Description |
@@ -461,14 +471,14 @@ jac config [action] [-k KEY] [-v VALUE] [-g GROUP] [-o FORMAT]
 | `list` | Display all settings including defaults |
 | `get` | Get a specific setting value |
 | `set` | Set a configuration value |
-| `unset` | Remove a configuration value |
+| `unset` | Remove a configuration value (revert to default) |
 | `path` | Show path to config file |
 | `groups` | List available configuration groups |
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-k, --key` | Configuration key (e.g., `project.name`) | None |
-| `-v, --value` | Value to set | None |
+| `key` | Configuration key (positional, e.g., `project.name`) | None |
+| `value` | Value to set (positional) | None |
 | `-g, --group` | Filter by configuration group | None |
 | `-o, --output` | Output format (`table`, `json`, `toml`) | `table` |
 
@@ -499,13 +509,13 @@ jac config list
 jac config show -g project
 
 # Get a specific value
-jac config get -k project.name
+jac config get project.name
 
 # Set a value
-jac config set -k project.version -v "2.0.0"
+jac config set project.version "2.0.0"
 
 # Remove a value (revert to default)
-jac config unset -k run.cache
+jac config unset run.cache
 
 # Show config file path
 jac config path
@@ -709,7 +719,7 @@ jac clean [-h] [-a] [-d] [-c] [-p] [-f]
 | `-a, --all` | Clean all `.jac` artifacts (data, cache, packages, client) | `False` |
 | `-d, --data` | Clean data directory (`.jac/data`) | `False` |
 | `-c, --cache` | Clean cache directory (`.jac/cache`) | `False` |
-| `-p, --packages` | Clean packages directory (`.jac/packages`) | `False` |
+| `-p, --packages` | Clean virtual environment (`.jac/venv`) | `False` |
 | `-f, --force` | Force clean without confirmation prompt | `False` |
 
 By default (no flags), `jac clean` removes only the data directory (`.jac/data`).
@@ -843,25 +853,58 @@ jac js app.jac
 
 ## Utility Commands
 
-### jac get_object
+### jac grammar
 
-Retrieve an object by ID from a session.
+Extract and print the Jac grammar.
 
 ```bash
-jac get_object [-h] -i ID [-s SESSION] filename
+jac grammar [-h] [--lark] [-o OUTPUT]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `filename` | Jac file | Required |
-| `-i, --id` | Object ID | Required |
-| `-s, --session` | Session name | None |
+| `--lark` | Output in Lark format instead of EBNF | `False` |
+| `-o, --output` | Write output to file instead of stdout | None |
 
 **Examples:**
 
 ```bash
-jac get_object main.jac -i "node_123" -s my_session
+# Print grammar in EBNF format
+jac grammar
+
+# Print in Lark format
+jac grammar --lark
+
+# Save to file
+jac grammar -o grammar.ebnf
 ```
+
+---
+
+### jac script
+
+Run custom scripts defined in the `[scripts]` section of `jac.toml`.
+
+```bash
+jac script [-h] [-l] [name]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `name` | Script name to run | None |
+| `-l, --list_scripts` | List available scripts | `False` |
+
+**Examples:**
+
+```bash
+# Run a script
+jac script dev
+
+# List available scripts
+jac script --list
+```
+
+See [Configuration: Scripts](../config/index.md#scripts) for defining scripts in `jac.toml`.
 
 ---
 

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -117,7 +117,7 @@ dir = ".jac"        # Build artifacts directory
 The `dir` setting controls where all build artifacts are stored:
 
 - `.jac/cache/` - Bytecode cache
-- `.jac/packages/` - Installed packages
+- `.jac/venv/` - Project virtual environment
 - `.jac/client/` - Client-side builds
 - `.jac/data/` - Runtime data
 
@@ -129,7 +129,7 @@ Defaults for `jac test`:
 
 ```toml
 [test]
-directory = "tests"     # Test directory
+directory = ""          # Test directory (empty = current directory)
 filter = ""             # Filter pattern
 verbose = false         # Verbose output
 fail_fast = false       # Stop on first failure
@@ -145,7 +145,6 @@ Defaults for `jac format`:
 ```toml
 [format]
 outfile = ""        # Output file (empty = in-place)
-fix = false         # Auto-fix issues
 ```
 
 ---
@@ -204,7 +203,7 @@ select = ["combine-has", "remove-empty-parens"]
 | `staticmethod-to-static` | Convert `@staticmethod` decorator to `static` keyword | default |
 | `init-to-can` | Convert `def __init__` / `def __post_init__` to `can init` / `can postinit` | default |
 | `remove-empty-parens` | Remove empty parentheses from declarations (`def foo()` → `def foo`) | default |
-| `remove-kwesc` | Remove unnecessary angle bracket escaping from non-keyword names | default |
+| `remove-kwesc` | Remove unnecessary backtick escaping from non-keyword names | default |
 | `hasattr-to-null-ok` | Convert `hasattr(obj, "attr")` to null-safe access (`obj?.attr`) | default |
 | `simplify-ternary` | Simplify `x if x else default` to `x or default` | default |
 | `remove-future-annotations` | Remove `import from __future__ { annotations }` (not needed in Jac) | default |
@@ -254,6 +253,7 @@ Bytecode cache settings:
 ```toml
 [cache]
 enabled = true      # Enable caching
+dir = ".jac_cache"  # Cache directory
 ```
 
 ---
@@ -320,7 +320,29 @@ jac_client = "latest"
 jac_byllm = "none"           # Use "none" to skip installation
 ```
 
-See [jac-scale Webhooks](../plugins/jac-scale.md#webhooks) and [Kubernetes Deployment](../plugins/jac-scale.md#kubernetes-deployment) for details.
+**Prometheus Metrics (jac-scale):**
+
+```toml
+[plugins.scale.metrics]
+enabled = true
+endpoint = "/metrics"
+namespace = "myapp"
+walker_metrics = true
+```
+
+See [Prometheus Metrics](../plugins/jac-scale.md#prometheus-metrics) for details.
+
+**Kubernetes Secrets (jac-scale):**
+
+```toml
+[plugins.scale.secrets]
+OPENAI_API_KEY = "${OPENAI_API_KEY}"
+DATABASE_PASSWORD = "${DB_PASS}"
+```
+
+See [Kubernetes Secrets](../plugins/jac-scale.md#kubernetes-secrets) for details.
+
+See also [jac-scale Webhooks](../plugins/jac-scale.md#webhooks) and [Kubernetes Deployment](../plugins/jac-scale.md#kubernetes-deployment) for more options.
 
 ---
 

--- a/docs/docs/reference/language/ai-integration.md
+++ b/docs/docs/reference/language/ai-integration.md
@@ -148,7 +148,7 @@ def summarize(text: str) -> str by llm(
 );
 
 def creative_story(prompt: str) -> str by llm(
-    model_name="claude-3-opus",
+    model_name="claude-3-opus-20240229",
     temperature=1.0
 );
 ```

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -404,7 +404,7 @@ Examples:
 Version: 3.1
 Last Updated: January 2026
 
-**Validation Status:** Validated against `jac/jaclang/pycore/jac.lark`
+**Validation Status:** Validated against the Jac recursive descent parser (jaclang 0.10.0)
 
 **Resources:**
 

--- a/docs/docs/reference/language/deployment.md
+++ b/docs/docs/reference/language/deployment.md
@@ -45,10 +45,8 @@ jac start --scale
 
 | Variable | Description |
 |----------|-------------|
-| `REDIS_HOST` | Redis server host |
-| `REDIS_PORT` | Redis server port |
-| `MONGO_URI` | MongoDB connection URI |
-| `MONGO_DB` | MongoDB database name |
+| `REDIS_URL` | Redis connection URL |
+| `MONGODB_URI` | MongoDB connection URI |
 | `K8S_NAMESPACE` | Kubernetes namespace |
 | `K8S_REPLICAS` | Number of replicas |
 

--- a/docs/docs/reference/language/ecosystem.md
+++ b/docs/docs/reference/language/ecosystem.md
@@ -6,7 +6,7 @@
 - [Plugin System](#plugin-system) - Installing and managing plugins
 - [Project Configuration](#project-configuration) - jac.toml settings
 - [Python Interoperability](#python-interoperability) - Using Python from Jac
-- [JavaScript/TypeScript Interoperability](#javascripttypescript-interoperability) - Using JS from Jac
+- [JavaScript/npm Interoperability](#javascriptnpm-interoperability) - Using JS from Jac
 
 ---
 
@@ -213,8 +213,8 @@ cache = false
 |----------|-------------|
 | `OPENAI_API_KEY` | OpenAI API key |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
-| `REDIS_HOST`, `REDIS_PORT` | Redis connection |
-| `MONGO_URI`, `MONGO_DB` | MongoDB connection |
+| `REDIS_URL` | Redis connection URL |
+| `MONGODB_URI` | MongoDB connection URI |
 | `JWT_SECRET` | JWT signing secret |
 
 **Client-side (Vite):**
@@ -320,7 +320,7 @@ instance = my_module.MyClass()
 
 ---
 
-## JavaScript/TypeScript Interoperability
+## JavaScript/npm Interoperability
 
 ### 1 npm Packages
 
@@ -333,14 +333,16 @@ cl {
 }
 ```
 
-### 2 TypeScript Support
+### 2 TypeScript Configuration
 
-Enable in `jac.toml`:
+TypeScript is supported through the jac-client Vite toolchain for client-side code. Configure in `jac.toml`:
 
 ```toml
 [plugins.client]
 typescript = true
 ```
+
+> **Note:** Jac does not parse TypeScript files directly. TypeScript support is provided through Vite's built-in TypeScript handling in client-side (`cl {}`) code.
 
 ### 3 Browser APIs
 

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -16,7 +16,7 @@
 
 ### 1 What is Jac?
 
-Jac is an AI-native full-stack programming language and superset of both Python and TypeScript/JavaScript. It introduces Object-Spatial Programming (OSP) and novel constructs for AI-integrated programming (such as `by llm()`), providing a unified language for backend, frontend, and AI development with full access to the PyPI and npm ecosystems.
+Jac is an AI-native full-stack programming language that supersets Python and JavaScript with native compilation support. It introduces Object-Spatial Programming (OSP) and novel constructs for AI-integrated programming (such as `by llm()`), providing a unified language for backend, frontend, and AI development with full access to the PyPI and npm ecosystems.
 
 ```jac
 with entry {
@@ -218,11 +218,11 @@ Jac keywords are reserved and cannot be used as identifiers:
 
 Valid identifiers start with a letter or underscore, followed by letters, digits, or underscores.
 
-To use a reserved keyword as an identifier, escape it with angle brackets:
+To use a reserved keyword as an identifier, escape it with a backtick prefix:
 
 ```jac
 obj Example {
-    has class_name: str;  # Field name (use <class> syntax for reserved words)
+    has `class: str;  # Backtick-escaped keyword used as identifier
 }
 ```
 

--- a/docs/docs/reference/language/graph-operations.md
+++ b/docs/docs/reference/language/graph-operations.md
@@ -187,8 +187,9 @@ with entry {
 ```jac
 can delete_if_done with Todo entry {
     if here.completed {
+        node_id = here.id;  # Capture ID before deletion
         del here;  # Remove this node from the graph
-        report {"deleted": here.id};
+        report {"deleted": node_id};
     }
 }
 ```

--- a/docs/docs/reference/language/index.md
+++ b/docs/docs/reference/language/index.md
@@ -99,7 +99,7 @@ Tools, plugins, and interoperability.
 - Plugin System
 - Project Configuration
 - Python Interoperability
-- JavaScript/TypeScript Interoperability
+- JavaScript/npm Interoperability
 - **[Python Integration](python-integration.md)** - 5 adoption patterns, transpilation details
 
 ### [Part IX: Deployment and Scaling](deployment.md)

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -6,9 +6,9 @@
 
 ---
 
-## **Jac's Native Superset of Python and TypeScript/JavaScript**
+## **Jac Supersets Python**
 
-Jac is designed as a superset of both Python and TypeScript/JavaScript, providing full compatibility with both the PyPI and npm ecosystems. Developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
+Jac supersets Python and JavaScript, providing full compatibility with both the PyPI and npm ecosystems. Developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
 
 ### **How it Works: Transpilation to Native Python**
 

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -98,7 +98,7 @@ Before starting tutorials, ensure you have:
 
 **Assumed knowledge:**
 
-- **Python familiarity required** -- Jac is a Python superset; you should be comfortable with functions, classes, and type annotations
+- **Python familiarity required** -- Jac supersets Python; you should be comfortable with functions, classes, and type annotations
 - **React/JSX familiarity helpful** -- for full-stack tutorials, basic component and hook knowledge helps
 - **Web development basics helpful** -- HTTP, REST, frontend/backend separation
 

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -10,9 +10,9 @@ Learn Jac syntax and fundamentals, especially if you're coming from Python.
 
 ---
 
-## Jac is a Superset of Python and TypeScript/JavaScript
+## Jac is a Superset of Python
 
-Jac extends both Python and TypeScript/JavaScript - concepts from both languages apply. The main syntactic differences from Python are:
+Jac supersets Python with new paradigms -- familiar Python concepts all apply. The main syntactic differences from Python are:
 
 | Python | Jac |
 |--------|-----|

--- a/docs/docs/tutorials/language/mixing-jac-python.md
+++ b/docs/docs/tutorials/language/mixing-jac-python.md
@@ -1,6 +1,6 @@
 # Mixing Jac and Python
 
-Jac is designed as a superset of Python, extending the language with additional features for modern software architecture while maintaining full compatibility with the Python ecosystem. Python developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
+Jac supersets Python with additional features for modern software architecture while maintaining full compatibility with the Python ecosystem. Python developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
 
 ## How it Works: Transpilation to Native Python
 

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -4,7 +4,7 @@ Run your Jac walkers as a production-ready HTTP API server.
 
 > **Prerequisites**
 >
-> - Completed: [Your First App](../../quick-guide/first-app.md)
+> - Completed: [Your First App](../first-app/part1-todo-app.md)
 > - Time: ~15 minutes
 
 ---


### PR DESCRIPTION
## Summary

Comprehensive audit of MkDocs documentation cross-referenced against recently merged PRs. Fixes incorrect content, adds missing documentation, and updates language positioning.

### Changes

**CLI Reference** (`reference/cli/index.md`)
- Removed ghost `jac get_object` command that doesn't exist
- Added `jac grammar` and `jac script` commands
- Fixed `jac config` from `-k`/`-v` flags to positional args (PR #4503)
- Fixed `jac plugins` actions and `jac enter` syntax
- Corrected short flags across multiple commands

**Plugin Documentation** (`reference/plugins/jac-scale.md`)
- Fixed `@restspec` options table: replaced `webhook` bool with `protocol` (APIProtocol enum) and `broadcast`
- Added Prometheus Metrics section (PR #4475)
- Added Kubernetes Secrets section (PR #4526)

**Configuration Reference** (`reference/config/index.md`)
- Fixed `[test].directory` default from `"tests"` to `""`
- Removed nonexistent `fix` field from `[format]`
- Added `dir = ".jac_cache"` to `[cache]` section
- Updated `.jac/packages/` to `.jac/venv/`
- Added metrics and secrets config examples

**Language Reference**
- Fixed env var names: `REDIS_HOST` → `REDIS_URL`, `MONGO_URI` → `MONGODB_URI`
- Updated keyword escape syntax from `<keyword>` to `` `keyword `` (PR #4504)
- Fixed model name `claude-3-opus` → `claude-3-opus-20240229`
- Fixed `del here` then `here.id` bug in graph-operations.md
- Removed obsolete Lark grammar reference from appendices
- Fixed link fragment in ecosystem.md ToC

**Language Positioning** (across 11 files)
- Updated to "supersets Python and JavaScript with native compilation support"
- Consistent messaging on landing page, quick guide, tutorials, and reference docs

**Breaking Changes** (`community/breaking-changes.md`)
- Added CLI Dependency Commands Redesigned entry (0.10.0)
- Added KWESC_NAME syntax change entry

**Other Fixes**
- Fixed dead link in `tutorials/production/local.md`
- Fixed Python version requirement in install.md
- Fixed 5 typos in what-makes-jac-different.md

## Test plan

- [ ] Verify `mkdocs serve` builds without warnings
- [ ] Spot-check CLI examples against `jac --help`
- [ ] Verify all internal links resolve correctly