### PR TITLE
feat(jac-scale): add post-init hook system for JacAPIServer

### DIFF
--- a/jac-scale/jac_scale/impl/serve.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.impl.jac
@@ -1255,6 +1255,10 @@ impl JacAPIServer.postinit -> None {
         );
         logger.info(f"Prometheus metrics enabled at {metrics_endpoint}");
     }
+    # Run registered post-init hooks
+    for hook in _post_init_hooks {
+        hook(self);
+    }
 }
 
 impl JacAPIServer.register_sso_endpoints -> None {

--- a/jac-scale/jac_scale/serve.jac
+++ b/jac-scale/jac_scale/serve.jac
@@ -43,7 +43,13 @@ glob _jwt_config = get_scale_config().get_jwt_config(),
      JWT_ALGORITHM = _jwt_config['algorithm'],
      JWT_EXP_DELTA_DAYS = _jwt_config['exp_delta_days'],
      SSO_HOST = _sso_config['host'],
-     logger = logging.getLogger(__name__);
+     logger = logging.getLogger(__name__),
+     _post_init_hooks: list = [];
+
+"""Register a callback to run after JacAPIServer.postinit completes."""
+def register_post_init_hook(hook: Callable) -> None {
+    _post_init_hooks.append(hook);
+}
 
 enum Platforms ( StrEnum ) { GOOGLE = 'google' }
 


### PR DESCRIPTION
## Summary
- Adds `register_post_init_hook(hook)` to `jac_scale.serve`, allowing users to register callbacks that run after `JacAPIServer.postinit` completes
- Hooks receive the server instance, enabling clean app mounting (e.g. MCP servers, custom middleware) without monkey-patching `postinit`
- All built-in setup (CORS, metrics, API keys) runs first, then hooks execute in registration order

## Usage
```jac
import from jac_scale.serve {register_post_init_hook}

def _setup_mcp(server: any) -> None {
    # mount custom apps, add middleware, etc.
    server.server.app.mount("/ai", my_app);
}

with entry {
    register_post_init_hook(_setup_mcp);
}
```

## Motivation
Previously, extending `JacAPIServer.postinit` required runtime monkey-patching (save original, replace with wrapper). Jac's `impl` blocks fully replace methods with no `super()` equivalent, so they can't be used to extend external class behavior. This hook system provides a clean, idiomatic way to extend server initialization.

## Test plan
- [ ] Verify `jac start` still works with no hooks registered (backward compatible)
- [ ] Verify registered hooks run after postinit and receive the server instance
- [ ] Verify multiple hooks run in registration order