### PR TITLE
Fix `jac grammar` command broken after parser relocation

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.10.2 (Unreleased)
 
+- **Fix: `jac grammar` Command Broken Path**: Fixed the `jac grammar` CLI command.
 - 3 Minor refactors/changes.
 
 ## jaclang 0.10.1 (Latest Release)

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -501,7 +501,7 @@ impl grammar(lark: bool = False, output: str = "") -> int {
     import from jaclang.compiler.passes.tool.grammar_extract_pass { GrammarExtractPass }
     import jaclang;
     parser_path = str(
-        Path(jaclang.__file__).parent / "compiler" / "parser" / "parser.jac"
+        Path(jaclang.__file__).parent / "jac0core" / "parser" / "parser.jac"
     );
     prog = JacProgram();
     mod = prog.compile(parser_path, no_cgen=True);

--- a/jac/tests/language/test_cli.py
+++ b/jac/tests/language/test_cli.py
@@ -967,6 +967,33 @@ def _run_jac_check(test_dir: str, ignore_pattern: str = "") -> int:
     return int(match.group(1)) if match else 0
 
 
+def test_jac_grammar(
+    capture_stdout: Callable[[], AbstractContextManager[io.StringIO]],
+) -> None:
+    """Test that jac grammar command extracts grammar rules."""
+    with capture_stdout() as output:
+        result = analysis.grammar()
+
+    stdout_value = output.getvalue()
+    assert result == 0, "grammar command should exit with code 0"
+    # Should contain grammar rule definitions (::= for EBNF)
+    assert "::=" in stdout_value, "EBNF output should contain rule definitions"
+    # Should contain well-known rule names from the parser
+    assert "module" in stdout_value, "Grammar should contain 'module' rule"
+
+
+def test_jac_grammar_lark(
+    capture_stdout: Callable[[], AbstractContextManager[io.StringIO]],
+) -> None:
+    """Test that jac grammar --lark outputs Lark format."""
+    with capture_stdout() as output:
+        result = analysis.grammar(lark=True)
+
+    stdout_value = output.getvalue()
+    assert result == 0, "grammar --lark command should exit with code 0"
+    assert len(stdout_value) > 0, "Lark output should not be empty"
+
+
 def test_jac_cli_check_ignore_patterns(fixture_path: Callable[[str], str]) -> None:
     """Test --ignore flag with exact pattern matching (combined patterns)."""
     test_dir = fixture_path("deep")


### PR DESCRIPTION
## Summary
- Fixed the `jac grammar` CLI command which was broken after the parser moved from `compiler/parser/` to `jac0core/parser/` during the Lark parser removal (#4557). The hardcoded path was not updated, causing a `FileNotFoundError` on every invocation.
- Added CLI tests for both EBNF (`jac grammar`) and Lark (`jac grammar --lark`) output modes.

## Test plan
- [x] `test_jac_grammar` — verifies EBNF output contains rule definitions and known rules
- [x] `test_jac_grammar_lark` — verifies `--lark` flag produces non-empty output
- [x] Confirmed test fails without the fix (`FileNotFoundError` on old path)
- [x] Confirmed test passes with the fix