### PR TITLE
Add bootstrap bytecode cache for jac0core modules

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,7 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.10.2 (Unreleased)
 
-- **Perf: Cache `len()` in Lexer/Parser Hot Paths**: Cached source and token list lengths in the jac0 bootstrap transpiler and the RD parser/lexer, eliminating ~1.8M redundant `len()` calls per startup and reducing bootstrap overhead by ~18%.
+- **Perf: Bootstrap Bytecode Cache**: Cache the jac0-transpiled bytecode for jac0core modules on disk, eliminating ~200ms of repeated transpilation on every invocation. `jac purge -f` clears both caches.
+- **Perf: Cache `len()` in Lexer/Parser Hot Paths**: Cached source and token list lengths in the jac0 bootstrap transpiler and the RD parser/lexer, eliminating ~1.8M redundant `len()` calls per startup.
 - 3 Minor refactors/changes.
 - **Fix: `jac grammar` Command Broken Path**: Fixed the `jac grammar` CLI command.
 - 4 Minor refactors/changes.

--- a/jac/jaclang/jac0core/cli_boot.jac
+++ b/jac/jaclang/jac0core/cli_boot.jac
@@ -34,31 +34,42 @@ def _handle_purge -> None {
     }
 
     cache_dir = _get_cache_dir();
-    if not cache_dir.exists() {
+    bootstrap_dir = cache_dir.parent / "bootstrap";
+
+    total_files = 0;
+    total_size = 0;
+    removed_dirs: list[str] = [];
+    for d in [cache_dir, bootstrap_dir] {
+        if d.exists() {
+            total_files += sum(
+                1
+                for f in d.iterdir()
+                if f.is_file()
+            );
+            total_size += sum(
+                f.stat().st_size
+                for f in d.iterdir()
+                if f.is_file()
+            );
+            try {
+                shutil.rmtree(d);
+                removed_dirs.append(str(d));
+            } except OSError as e {
+                print(f"Error purging {d}: {e}", file=sys.stderr);
+            }
+        }
+    }
+
+    if not removed_dirs {
         print(f"Cache directory does not exist: {cache_dir}");
         sys.exit(0);
     }
 
-    file_count = sum(
-        1
-        for f in cache_dir.iterdir()
-        if f.is_file()
-    );
-    total_size = sum(
-        f.stat().st_size
-        for f in cache_dir.iterdir()
-        if f.is_file()
-    );
-
-    try {
-        shutil.rmtree(cache_dir);
-        print(f"Purged {file_count} cached files ({total_size / 1024:.1f} KB)");
-        print(f"Removed: {cache_dir}");
-        sys.exit(0);
-    } except OSError as e {
-        print(f"Error purging cache: {e}", file=sys.stderr);
-        sys.exit(1);
+    print(f"Purged {total_files} cached files ({total_size / 1024:.1f} KB)");
+    for rd in removed_dirs {
+        print(f"Removed: {rd}");
     }
+    sys.exit(0);
 }
 
 """Start the Jac CLI."""

--- a/jac/jaclang/meta_importer.py
+++ b/jac/jaclang/meta_importer.py
@@ -7,10 +7,12 @@ integrate Jac modules into Python's import system.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.abc
 import importlib.machinery
 import importlib.util
 import logging
+import marshal
 import os
 import shutil
 import sys
@@ -48,32 +50,108 @@ def _handle_early_purge() -> None:
             return base / "jac" / "bytecode"
 
     cache_dir = _get_cache_dir()
-    if not cache_dir.exists():
+    # Bootstrap cache is a sibling directory
+    bootstrap_dir = cache_dir.parent / "bootstrap"
+
+    total_files = 0
+    total_size = 0
+    removed_dirs: list[str] = []
+    for d in [cache_dir, bootstrap_dir]:
+        if d.exists():
+            total_files += sum(1 for f in d.iterdir() if f.is_file())
+            total_size += sum(f.stat().st_size for f in d.iterdir() if f.is_file())
+            try:
+                shutil.rmtree(d)
+                removed_dirs.append(str(d))
+            except OSError as e:
+                print(f"Error purging {d}: {e}", file=sys.stderr)  # noqa: T201
+
+    if not removed_dirs:
         print(f"Cache directory does not exist: {cache_dir}")  # noqa: T201
         sys.stdout.flush()
         os._exit(0)
 
-    file_count = sum(1 for f in cache_dir.iterdir() if f.is_file())
-    total_size = sum(f.stat().st_size for f in cache_dir.iterdir() if f.is_file())
-
-    try:
-        shutil.rmtree(cache_dir)
-        print(f"Purged {file_count} cached files ({total_size / 1024:.1f} KB)")  # noqa: T201
-        print(f"Removed: {cache_dir}")  # noqa: T201
-        sys.stdout.flush()
-        os._exit(0)
-    except OSError as e:
-        print(f"Error purging cache: {e}", file=sys.stderr)  # noqa: T201
-        sys.stderr.flush()
-        os._exit(1)
+    print(f"Purged {total_files} cached files ({total_size / 1024:.1f} KB)")  # noqa: T201
+    for rd in removed_dirs:
+        print(f"Removed: {rd}")  # noqa: T201
+    sys.stdout.flush()
+    os._exit(0)
 
 
 _handle_early_purge()
 
 from jaclang.jac0 import compile_jac as _jac0_compile  # noqa: E402
+from jaclang.jac0 import discover_impl_files as _jac0_discover_impls  # noqa: E402
 
 # Inline logging config (previously in jaclang.jac0core.log)
 logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap bytecode cache
+#
+# jac0core .jac files are transpiled by jac0 on every invocation.  Caching
+# the resulting bytecode avoids ~200 ms of repeated work when the sources
+# haven't changed.  The cache lives next to the regular bytecode cache
+# (e.g. ~/.cache/jac/bootstrap/) and is keyed on a SHA-256 digest of all
+# source inputs plus the Python version.
+# ---------------------------------------------------------------------------
+
+
+def _get_bootstrap_cache_dir() -> Path:
+    """Return the platform-appropriate bootstrap cache directory."""
+    if sys.platform == "win32":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / "jac" / "cache" / "bootstrap"
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "jac" / "bootstrap"
+    else:
+        xdg = os.environ.get("XDG_CACHE_HOME")
+        base = Path(xdg) if xdg else (Path.home() / ".cache")
+        return base / "jac" / "bootstrap"
+
+
+def _bootstrap_compile(
+    file_path: str,
+    jac_source: str,
+    impl_sources: list[tuple[str, str]] | None = None,
+) -> types.CodeType:
+    """Compile a bootstrap .jac file, using a disk cache when possible."""
+    # Build the hash key from all source inputs + Python version
+    h = hashlib.sha256()
+    h.update(sys.version.encode())
+    h.update(jac_source.encode())
+    if impl_sources:
+        for src, path in impl_sources:
+            h.update(path.encode())
+            h.update(src.encode())
+    digest = h.hexdigest()[:16]
+
+    # Derive a human-readable cache filename
+    base_name = os.path.splitext(os.path.basename(file_path))[0]
+    cache_file = _get_bootstrap_cache_dir() / f"{base_name}.{digest}.bc"
+
+    # Try loading from cache
+    if cache_file.is_file():
+        try:
+            data = cache_file.read_bytes()
+            return marshal.loads(data)  # noqa: S302
+        except Exception:
+            cache_file.unlink(missing_ok=True)
+
+    # Cache miss — transpile with jac0 and compile
+    py_source = _jac0_compile(jac_source, file_path, impl_sources=impl_sources)
+    code = compile(py_source, file_path, "exec")
+
+    # Write to cache (best-effort)
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_bytes(marshal.dumps(code))
+    except OSError:
+        pass
+
+    return code
+
 
 # Bootstrap modresolver.jac with jac0 before JacMetaImporter is registered.
 # This module must be available for find_spec()/get_code(), but normal
@@ -81,11 +159,11 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 _jac0core_dir = os.path.join(os.path.dirname(__file__), "jac0core")
 _modresolver_jac = os.path.join(_jac0core_dir, "modresolver.jac")
 with open(_modresolver_jac, encoding="utf-8") as _f:
-    _py_src = _jac0_compile(_f.read(), _modresolver_jac)
+    _modresolver_code = _bootstrap_compile(_modresolver_jac, _f.read())
 _modresolver = types.ModuleType("jaclang.jac0core.modresolver")
 _modresolver.__file__ = _modresolver_jac
 _modresolver.__package__ = "jaclang.jac0core"
-exec(compile(_py_src, _modresolver_jac, "exec"), _modresolver.__dict__)  # noqa: S102
+exec(_modresolver_code, _modresolver.__dict__)  # noqa: S102
 sys.modules["jaclang.jac0core.modresolver"] = _modresolver
 get_jac_search_paths = _modresolver.get_jac_search_paths
 
@@ -186,24 +264,21 @@ class JacMetaImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         return None  # use default machinery
 
     def _exec_bootstrap(self, module: ModuleType, file_path: str) -> None:
-        """Execute a bootstrap .jac module using jac0 (in-memory, no disk I/O).
+        """Execute a bootstrap .jac module using jac0 with bytecode caching.
 
         Bootstrap modules are part of the jaclang compiler infrastructure.
         They are compiled with the lightweight jac0 transpiler rather than
         the full Jac compiler, which depends on them.
         """
-        from jaclang.jac0 import compile_jac, discover_impl_files
-
         with open(file_path, encoding="utf-8") as f:
             jac_source = f.read()
 
         impl_sources: list[tuple[str, str]] = []
-        for impl_path in discover_impl_files(file_path):
+        for impl_path in _jac0_discover_impls(file_path):
             with open(impl_path, encoding="utf-8") as f:
                 impl_sources.append((f.read(), impl_path))
 
-        py_source = compile_jac(jac_source, file_path, impl_sources=impl_sources)
-        code = compile(py_source, file_path, "exec")
+        code = _bootstrap_compile(file_path, jac_source, impl_sources or None)
         exec(code, module.__dict__)
 
     def exec_module(self, module: ModuleType) -> None:


### PR DESCRIPTION
## Summary
- Cache jac0-transpiled bytecode for jac0core bootstrap modules on disk (`~/.cache/jac/bootstrap/`), eliminating ~200ms of repeated transpilation on every `jac` invocation
- Cache key is a SHA-256 digest of all source inputs (main `.jac` + impl files) plus the Python version, so cache invalidates automatically when sources change
- Update both `jac purge` and `jac purge -f` to clean both the bytecode and bootstrap cache directories

## Performance
Warm startup goes from ~470ms to ~170ms (~64% faster) with the bootstrap cache populated.

## Test plan
- [x] Verified cold start (no cache) compiles and caches correctly
- [x] Verified warm start loads from cache and skips transpilation
- [x] Verified `jac purge` removes both `bytecode/` and `bootstrap/` directories
- [x] Verified `jac purge -f` removes both directories
- [x] Verified cache auto-invalidates when source files change
- [x] mypy passes with no new errors