### PR TITLE
Improve grammar extraction accuracy and add spec snapshot test

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -8,6 +8,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Perf: Cache `len()` in Lexer/Parser Hot Paths**: Cached source and token list lengths in the jac0 bootstrap transpiler and the RD parser/lexer, eliminating ~1.8M redundant `len()` calls per startup.
 - 3 Minor refactors/changes.
 - **Fix: `jac grammar` Command Broken Path**: Fixed the `jac grammar` CLI command.
+- **Grammar Extraction Pass Improvements & Spec Snapshot Test**: Improved `jac grammar` extraction accuracy for negated-check loops, optional dispatch branches, `while True` parse-and-break patterns, and standalone `match_tok` calls. Added a golden-file snapshot test (`jac.spec`) that validates extracted grammar rules against a checked-in spec, catching unintended grammar drift on every CI run.
 - 4 Minor refactors/changes.
 
 ## jaclang 0.10.1 (Latest Release)

--- a/jac/jaclang/compiler/passes/tool/grammar_extract_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/grammar_extract_pass.jac
@@ -106,10 +106,14 @@ obj GrammarExtractPass(UniPass) {
     def analyze_if_stmt(stmt: uni.IfStmt) -> GExpr | None;
     def analyze_while_stmt(stmt: uni.WhileStmt) -> GExpr | None;
     def find_break_match_tok(stmts: list) -> tuple | None;
+    def find_break_none_check(stmts: list) -> tuple | None;
     def analyze_condition(cond: uni.Expr) -> tuple | None;
     def collect_elif_chain(stmt: uni.IfStmt) -> list;
     def has_early_return(stmts: list) -> bool;
+    def is_negated_check_condition(cond: uni.Expr) -> bool;
+    def expr_contains_tok(expr: GExpr, tok_name: str) -> bool;
     # AST helpers
+    def extract_token_kind(expr: uni.Expr) -> str | None;
     def get_self_method(nd: uni.Expr) -> str | None;
     def get_token_args(call: uni.FuncCall) -> list;
     def get_call_from_expr(expr: uni.Expr) -> uni.FuncCall | None;

--- a/jac/jaclang/compiler/passes/tool/impl/grammar_extract_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/grammar_extract_pass.impl.jac
@@ -324,37 +324,73 @@ impl GrammarExtractPass.extract_from_stmts(stmts: list) -> GExpr | None {
                 i += 1;
                 continue;
             }
+            # Local-variable dispatch: condition not recognizable but branch
+            # returns early (e.g., if is_ability { return parse_ability(); })
+            if cond_info is None
+            and self.has_early_return(list(stmt.body))
+            and stmt.else_body is None {
+                body_expr = self.extract_from_stmts(list(stmt.body));
+                if body_expr is not None {
+                    alt_branches.append(body_expr);
+                }
+                i += 1;
+                continue;
+            }
         }
 
         # If we hit a return after dispatch branches, it's the fallback
         if isinstance(stmt, uni.ReturnStmt) and len(alt_branches) > 0 {
+            has_fallback = False;
             if stmt.expr is not None {
                 call = self.get_call_from_expr(stmt.expr);
                 if call is not None {
                     fallback = self.analyze_func_call(call);
                     if fallback is not None {
                         alt_branches.append(fallback);
+                        has_fallback = True;
                     }
                 }
             }
+            branch_expr: GExpr;
             if len(alt_branches) == 1 {
-                parts.append(alt_branches[0]);
-            } elif len(alt_branches) > 1 {
-                parts.append(GAlt(choices=alt_branches));
+                branch_expr = alt_branches[0];
+            } else {
+                branch_expr = GAlt(choices=alt_branches);
+            }
+            # If the return doesn't produce a grammar element (e.g. return local var
+            # or return None), the dispatch branches are optional
+            if has_fallback {
+                parts.append(branch_expr);
+            } else {
+                parts.append(GOpt(inner=branch_expr));
             }
             alt_branches = [];
             i += 1;
             continue;
         }
 
-        # Flush any pending alternatives
+        # Flush any pending dispatch alternatives
+        # Since dispatch branches return early, remaining code only runs
+        # when no dispatch matched → remaining is an alternative
         if len(alt_branches) > 0 {
-            if len(alt_branches) == 1 {
-                parts.append(GOpt(inner=alt_branches[0]));
+            remaining = stmts[i:];
+            remaining_expr = self.extract_from_stmts(remaining);
+            if remaining_expr is not None {
+                alt_branches.append(remaining_expr);
+                if len(alt_branches) == 1 {
+                    parts.append(alt_branches[0]);
+                } else {
+                    parts.append(GAlt(choices=alt_branches));
+                }
             } else {
-                parts.append(GOpt(inner=GAlt(choices=alt_branches)));
+                if len(alt_branches) == 1 {
+                    parts.append(GOpt(inner=alt_branches[0]));
+                } else {
+                    parts.append(GOpt(inner=GAlt(choices=alt_branches)));
+                }
             }
             alt_branches = [];
+            break;
         }
 
         # Normal statement
@@ -381,12 +417,104 @@ impl GrammarExtractPass.extract_from_stmts(stmts: list) -> GExpr | None {
     return GSeq(items=parts);
 }
 
-"""Check if a statement list contains a return statement."""
+"""Check if a statement list contains a return statement (searches nested ifs)."""
 impl GrammarExtractPass.has_early_return(stmts: list) -> bool {
     for stmt in stmts {
         if isinstance(stmt, uni.ReturnStmt) {
             return True;
         }
+        # Check nested if/elif/else bodies for returns
+        if isinstance(stmt, (uni.IfStmt, uni.ElseIf)) {
+            if self.has_early_return(list(stmt.body)) {
+                return True;
+            }
+            if stmt.else_body is not None {
+                if isinstance(stmt.else_body, uni.ElseStmt) {
+                    if self.has_early_return(list(stmt.else_body.body)) {
+                        return True;
+                    }
+                } elif isinstance(stmt.else_body, (uni.ElseIf, uni.IfStmt)) {
+                    if self.has_early_return([stmt.else_body]) {
+                        return True;
+                    }
+                }
+            }
+        }
+    }
+    return False;
+}
+
+"""Check if condition is a negated check pattern (e.g. not check(X), not check(X) and not at_end())."""
+impl GrammarExtractPass.is_negated_check_condition(cond: uni.Expr) -> bool {
+    # Single negation: not self.check(X) or not self.at_end()
+    if isinstance(cond, uni.UnaryExpr) {
+        if cond.op is not None and cond.op?.value and cond.op.value == "not" {
+            if isinstance(cond.operand, uni.FuncCall) {
+                method = self.get_self_method(cond.operand.target);
+                if method in (
+                    "check",
+                    "check_any",
+                    "check_peek",
+                    "check_peek_any",
+                    "at_end"
+                ) {
+                    return True;
+                }
+            }
+        }
+        return False;
+    }
+    # BoolExpr AND of negations: not check(X) and not check(Y)
+    if isinstance(cond, uni.BoolExpr) {
+        if not (cond.op and cond.op?.value and cond.op.value == "and") {
+            return False;
+        }
+        if not cond.values or len(cond.values) == 0 {
+            return False;
+        }
+        for val in cond.values {
+            if not self.is_negated_check_condition(val) {
+                return False;
+            }
+        }
+        return True;
+    }
+    # BinaryExpr AND of negations
+    if isinstance(cond, uni.BinaryExpr) {
+        if cond.op and cond.op?.value and cond.op.value in ("and", "&&") {
+            return (
+                self.is_negated_check_condition(cond.left)
+                and self.is_negated_check_condition(cond.right)
+            );
+        }
+    }
+    return False;
+}
+
+"""Check if a grammar expression contains a specific token name."""
+impl GrammarExtractPass.expr_contains_tok(expr: GExpr, tok_name: str) -> bool {
+    if isinstance(expr, GTok) {
+        return expr.name == tok_name;
+    }
+    if isinstance(expr, GSeq) {
+        for item in expr.items {
+            if self.expr_contains_tok(item, tok_name) {
+                return True;
+            }
+        }
+    }
+    if isinstance(expr, GAlt) {
+        for c in expr.choices {
+            if self.expr_contains_tok(c, tok_name) {
+                return True;
+            }
+        }
+    }
+    if isinstance(expr, GOpt) {
+        return self.expr_contains_tok(expr.inner, tok_name);
+    }
+    if isinstance(expr, GStar) {
+        return self.expr_contains_tok(expr.inner, tok_name);
     }
     return False;
 }
@@ -408,6 +536,18 @@ impl GrammarExtractPass.extract_from_stmt(stmt: uni.UniNode) -> GExpr | None {
             call = self.get_call_from_expr(stmt.value);
             if call is not None {
                 return self.analyze_func_call(call);
+            }
+            # Handle list initialization: x = [self.parse_X()]
+            if isinstance(stmt.value, uni.ListVal) and hasattr(stmt.value, 'values') {
+                for elem in stmt.value.values {
+                    inner_call = self.get_call_from_expr(elem);
+                    if inner_call is not None {
+                        result = self.analyze_func_call(inner_call);
+                        if result is not None {
+                            return result;
+                        }
+                    }
+                }
             }
         }
         return None;
@@ -450,6 +590,12 @@ impl GrammarExtractPass.analyze_func_call(call: uni.FuncCall) -> GExpr | None {
         if method == "expect_name" {
             return GTok(name="NAME");
         }
+        if method == "match_tok" {
+            tokens = self.get_token_args(call);
+            if len(tokens) > 0 {
+                return GOpt(inner=GTok(name=tokens[0]));
+            }
+        }
         return None;
     }
     # Not a self.method call — scan arguments for grammar-relevant calls.
@@ -473,7 +619,57 @@ impl GrammarExtractPass.analyze_func_call(call: uni.FuncCall) -> GExpr | None {
 impl GrammarExtractPass.analyze_if_stmt(stmt: uni.IfStmt) -> GExpr | None {
     cond_info = self.analyze_condition(stmt.condition);
     if cond_info is None {
+        # Negated guard: if not check(SEMI) and not check(RBRACE) { body } → GOpt(body)
+        if self.is_negated_check_condition(stmt.condition) and stmt.else_body is None {
+            opt_body = self.extract_from_stmts(list(stmt.body));
+            if opt_body is not None {
+                return GOpt(inner=opt_body);
+            }
+            return None;
+        }
         body_expr = self.extract_from_stmts(list(stmt.body));
+        # If the if-body returns early and there are elif/else branches,
+        # branches are alternatives (local-variable dispatch pattern)
+        if self.has_early_return(list(stmt.body)) and stmt.else_body is not None {
+            alt_list: list = [];
+            if body_expr is not None {
+                alt_list.append(body_expr);
+            }
+            cur_alt = stmt.else_body;
+            while cur_alt is not None {
+                if isinstance(cur_alt, (uni.ElseIf, uni.IfStmt)) {
+                    eb = self.extract_from_stmts(list(cur_alt.body));
+                    if eb is not None {
+                        alt_list.append(eb);
+                    }
+                    cur_alt = cur_alt?.else_body;
+                } elif isinstance(cur_alt, uni.ElseStmt) {
+                    eb = self.extract_from_stmts(list(cur_alt.body));
+                    if eb is not None {
+                        alt_list.append(eb);
+                    }
+                    cur_alt = None;
+                } else {
+                    cur_alt = None;
+                }
+            }
+            # Deduplicate alternatives
+            unique_alts: list = [];
+            seen_reprs: set = set();
+            for a in alt_list {
+                r = repr(a);
+                if r not in seen_reprs {
+                    unique_alts.append(a);
+                    seen_reprs.add(r);
+                }
+            }
+            if len(unique_alts) > 1 {
+                return GAlt(choices=unique_alts);
+            } elif len(unique_alts) == 1 {
+                return unique_alts[0];
+            }
+            return body_expr;
+        }
         else_expr: GExpr | None = None;
         if stmt.else_body is not None {
             if isinstance(stmt.else_body, (uni.ElseIf, uni.IfStmt)) {
@@ -523,7 +719,7 @@ impl GrammarExtractPass.analyze_if_stmt(stmt: uni.IfStmt) -> GExpr | None {
         return GOpt(inner=inner);
     }
     # if self.check(X) / check_any(X,Y) { body } [elif ...] -> optional/alt
-    if method in ("check", "check_any") {
+    if method in ("check", "check_any", "check_peek", "check_peek_any") {
         branches = self.collect_elif_chain(stmt);
         if len(branches) == 0 {
             return None;
@@ -570,7 +766,7 @@ impl GrammarExtractPass.collect_elif_chain(stmt: uni.IfStmt) -> list {
         if cond_info is not None {
             method = cond_info[0];
             tokens: list = cond_info[1];
-            if method in ("check", "check_any") {
+            if method in ("check", "check_any", "check_peek", "check_peek_any") {
                 tok_expr: GExpr | None = None;
                 if len(tokens) > 1 {
                     tok_expr = GAlt(choices=[GTok(name=t) for t in tokens]);
@@ -580,7 +776,23 @@ impl GrammarExtractPass.collect_elif_chain(stmt: uni.IfStmt) -> list {
                 if tok_expr is not None and branch_body is not None {
                     branches.append(GSeq(items=[tok_expr, branch_body]));
                 } elif tok_expr is not None {
-                    branches.append(tok_expr);
+                    # check/check_any doesn't consume token - only include
+                    # the bare token if the body does something non-trivial
+                    # (skip guard clauses like: if check(RBRACE) { return None; })
+                    is_guard = True;
+                    for s in list(cur.body) {
+                        if not isinstance(s, uni.ReturnStmt)
+                        and not (
+                            isinstance(s, uni.CtrlStmt)
+                            and s.ctrl is not None
+                            and s.ctrl.value == "break"
+                        ) {
+                            is_guard = False;
+                        }
+                    }
+                    if not is_guard {
+                        branches.append(tok_expr);
+                    }
                 } elif branch_body is not None {
                     branches.append(branch_body);
                 }
@@ -657,6 +869,29 @@ impl GrammarExtractPass.analyze_while_stmt(stmt: uni.WhileStmt) -> GExpr | None 
                 else inner_parts[0];
                 return GStar(inner=inner);
             }
+            # Handle: while True { x = parse_X(); if x is None { break; } body }
+            none_check_info = self.find_break_none_check(list(stmt.body));
+            if none_check_info is not None {
+                ref_name: str = none_check_info[0];
+                remaining_stmts: list = none_check_info[1];
+                remaining_expr = self.extract_from_stmts(remaining_stmts);
+                inner_parts2: list = [GRef(name=ref_name)];
+                if remaining_expr is not None {
+                    inner_parts2.append(remaining_expr);
+                }
+                inner2: GExpr = GSeq(items=inner_parts2)
+                if len(inner_parts2) > 1
+                else inner_parts2[0];
+                return GStar(inner=inner2);
+            }
+        }
+        # Handle: while not self.check(X) { body } → body*
+        if self.is_negated_check_condition(stmt.condition) {
+            body_expr = self.extract_from_stmts(list(stmt.body));
+            if body_expr is not None {
+                return GStar(inner=body_expr);
+            }
+            return None;
         }
         return self.extract_from_stmts(list(stmt.body));
     }
@@ -673,8 +908,27 @@ impl GrammarExtractPass.analyze_while_stmt(stmt: uni.WhileStmt) -> GExpr | None 
         else inner_parts[0];
         return GStar(inner=inner);
     }
-    if method in ("check", "check_any") and len(tokens) > 0 {
+    if method in ("check", "check_any", "check_peek", "check_peek_any")
+    and len(tokens) > 0 {
         body_expr = self.extract_from_stmts(list(stmt.body));
+        # If body already contains condition tokens (via consume_uni/expect),
+        # skip adding them to avoid duplication. Otherwise include them
+        # (body uses advance() which isn't grammar-recognized).
+        body_has_cond_tok = False;
+        if body_expr is not None {
+            for t in tokens {
+                if self.expr_contains_tok(body_expr, t) {
+                    body_has_cond_tok = True;
+                    break;
+                }
+            }
+        }
+        if body_has_cond_tok {
+            if body_expr is not None {
+                return GStar(inner=body_expr);
+            }
+            return None;
+        }
         tok_expr: GExpr | None = None;
         if len(tokens) > 1 {
             tok_expr = GAlt(choices=[GTok(name=t) for t in tokens]);
@@ -741,26 +995,167 @@ impl GrammarExtractPass.find_break_match_tok(stmts: list) -> tuple | None {
 }
 
 # -------------------------------------------------------------------------
+# Find break-none-check in while True bodies
+# -------------------------------------------------------------------------
+"""Find `x = self.parse_X(); if x is None { break; }` at start of while True body.
+
+Returns (rule_name, remaining_body_stmts) or None."""
+impl GrammarExtractPass.find_break_none_check(stmts: list) -> tuple | None {
+    if len(stmts) < 2 {
+        return None;
+    }
+    # First stmt: x = self.parse_X()
+    first = stmts[0];
+    if not isinstance(first, uni.Assignment) {
+        return None;
+    }
+    if first.value is None {
+        return None;
+    }
+    call = self.get_call_from_expr(first.value);
+    if call is None {
+        return None;
+    }
+    method = self.get_self_method(call.target);
+    if method is None or not method.startswith("parse_") {
+        return None;
+    }
+    rule_name = method[6:];
+    # Second stmt: if x is None { break; }
+    second = stmts[1];
+    if not isinstance(second, uni.IfStmt) {
+        return None;
+    }
+    # Check condition is `x is None` (CompareExpr with 'is' and Null)
+    cond = second.condition;
+    if not isinstance(cond, uni.CompareExpr) {
+        return None;
+    }
+    is_none_check = False;
+    if cond.ops is not None and len(cond.ops) > 0 {
+        for op in cond.ops {
+            if op.value == "is" {
+                is_none_check = True;
+            }
+        }
+    }
+    if not is_none_check {
+        return None;
+    }
+    # Check body contains break
+    has_break = False;
+    for s in second.body {
+        if isinstance(s, uni.CtrlStmt) {
+            if s.ctrl is not None and s.ctrl.value == "break" {
+                has_break = True;
+            }
+        }
+    }
+    if not has_break {
+        return None;
+    }
+    remaining = stmts[2:];
+    return (rule_name, remaining);
+}
+
+# -------------------------------------------------------------------------
 # Condition analysis
 # -------------------------------------------------------------------------
 """Analyze condition. Returns (method_name, [token_names]) or None."""
 impl GrammarExtractPass.analyze_condition(cond: uni.Expr) -> tuple | None {
     if isinstance(cond, uni.FuncCall) {
         method = self.get_self_method(cond.target);
-        if method in ("check", "check_any", "match_tok") {
+        if method in (
+            "check",
+            "check_any",
+            "check_peek",
+            "check_peek_any",
+            "match_tok"
+        ) {
             tokens = self.get_token_args(cond);
             return (method, tokens);
         }
     }
-    # Boolean AND: self.check(X) and something_else
+    # Handle peek().kind == TokenKind.X or peek().kind in [...] comparisons
+    if isinstance(cond, uni.CompareExpr) {
+        if cond.ops is not None
+        and len(cond.ops) > 0
+        and cond.rights is not None
+        and len(cond.rights) > 0 {
+            op_val = "";
+            if hasattr(cond.ops[0], 'value') {
+                op_val = cond.ops[0].value;
+            }
+            if op_val == "==" {
+                right = cond.rights[0];
+                tok_name = self.extract_token_kind(right);
+                if tok_name is not None {
+                    return ("check", [tok_name]);
+                }
+            } elif op_val == "in" {
+                right = cond.rights[0];
+                if isinstance(right, uni.ListVal) {
+                    tok_names: list = [];
+                    for item in right.values {
+                        tn = self.extract_token_kind(item);
+                        if tn is not None {
+                            tok_names.append(tn);
+                        }
+                    }
+                    if len(tok_names) > 0 {
+                        return ("check", tok_names);
+                    }
+                }
+            }
+        }
+    }
+    # Boolean expressions: BoolExpr for and/or
     if isinstance(cond, uni.BoolExpr) {
+        is_or = cond?.op and cond.op?.value and cond.op.value == "or";
+        if is_or {
+            # For OR: collect all check/match_tok tokens from all values
+            all_toks: list = [];
+            found_method: str | None = None;
+            if cond?.values {
+                for val in cond.values {
+                    if isinstance(val, uni.FuncCall) {
+                        m = self.get_self_method(val.target);
+                        if m in (
+                            "check",
+                            "check_any",
+                            "check_peek",
+                            "check_peek_any",
+                            "match_tok"
+                        ) {
+                            tks = self.get_token_args(val);
+                            all_toks.extend(tks);
+                            if found_method is None {
+                                found_method = m;
+                            }
+                        }
+                    }
+                }
+            }
+            if found_method is not None and len(all_toks) > 0 {
+                return (found_method, all_toks);
+            }
+            return None;
+        }
+        # For AND: find the first check/match_tok call in any position
         if cond?.values and len(cond.values) > 0 {
-            first = cond.values[0];
-            if isinstance(first, uni.FuncCall) {
-                method = self.get_self_method(first.target);
-                if method in ("check", "check_any", "match_tok") {
-                    tokens = self.get_token_args(first);
-                    return (method, tokens);
+            for val in cond.values {
+                if isinstance(val, uni.FuncCall) {
+                    method = self.get_self_method(val.target);
+                    if method in (
+                        "check",
+                        "check_any",
+                        "check_peek",
+                        "check_peek_any",
+                        "match_tok"
+                    ) {
+                        tokens = self.get_token_args(val);
+                        return (method, tokens);
+                    }
                 }
             }
         }
@@ -771,7 +1166,13 @@ impl GrammarExtractPass.analyze_condition(cond: uni.Expr) -> tuple | None {
                 left = cond.left;
                 if isinstance(left, uni.FuncCall) {
                     method = self.get_self_method(left.target);
-                    if method in ("check", "check_any", "match_tok") {
+                    if method in (
+                        "check",
+                        "check_any",
+                        "check_peek",
+                        "check_peek_any",
+                        "match_tok"
+                    ) {
                         tokens = self.get_token_args(left);
                         return (method, tokens);
                     }
@@ -785,6 +1186,18 @@ impl GrammarExtractPass.analyze_condition(cond: uni.Expr) -> tuple | None {
 # -------------------------------------------------------------------------
 # AST helpers
 # -------------------------------------------------------------------------
+"""Extract token name from a TokenKind.X expression, or None."""
+impl GrammarExtractPass.extract_token_kind(expr: uni.Expr) -> str | None {
+    if isinstance(expr, uni.AtomTrailer) and expr.is_attr {
+        if isinstance(expr.target, uni.Name) and expr.target.value == "TokenKind" {
+            if isinstance(expr.right, uni.Name) {
+                return expr.right.value;
+            }
+        }
+    }
+    return None;
+}
+
 """Extract method name from self.method access."""
 impl GrammarExtractPass.get_self_method(nd: uni.Expr) -> str | None {
     if isinstance(nd, uni.AtomTrailer) and nd.is_attr {

--- a/jac/jaclang/jac.spec
+++ b/jac/jaclang/jac.spec
@@ -1,0 +1,144 @@
+access_tag ::= (COLON (KW_PUB | KW_PRIV | KW_PROT)?)?
+module ::= STRING? element_stmt*
+expression ::= KW_LAMBDA lambda_expr | concurrent_expr (KW_IF expression KW_ELSE expression)?
+concurrent_expr ::= (KW_FLOW | KW_WAIT) walrus_assign | walrus_assign
+walrus_assign ::= by_expr (WALRUS_EQ by_expr)?
+by_expr ::= pipe (KW_BY by_expr)?
+pipe ::= pipe_back (PIPE_FWD pipe_back)*
+pipe_back ::= bitwise_or (PIPE_BKWD bitwise_or)*
+bitwise_or ::= bitwise_xor (BW_OR bitwise_xor)*
+bitwise_xor ::= bitwise_and (BW_XOR bitwise_and)*
+bitwise_and ::= shift (BW_AND shift)*
+shift ::= logical_or ((LSHIFT | RSHIFT) logical_or)*
+logical_or ::= logical_and (KW_OR logical_and)*
+logical_and ::= logical_not (KW_AND logical_not)*
+logical_not ::= KW_NOT logical_not | compare
+compare ::= arithmetic ((EE | NE | LT | GT | LTE | GTE | KW_IN | KW_IS | KW_NIN | KW_ISN) ((EE | NE | LT | GT | LTE | GTE | KW_IN | KW_IS | KW_NIN | KW_ISN) arithmetic)*)?
+arithmetic ::= term ((PLUS | MINUS) term)*
+term ::= power ((STAR_MUL | DIV | FLOOR_DIV | MOD | DECOR_OP) power)*
+power ::= factor (STAR_POW power)?
+factor ::= (BW_NOT | MINUS | PLUS) factor | connect
+connect ::= atomic_pipe (connect_op atomic_pipe)*
+edge_op_ref_inline ::= (ARROW_R | ARROW_L | ARROW_BI | ARROW_R_P1 atom ARROW_R_P2? | ARROW_L_P1 atom ARROW_L_P2?)?
+connect_op ::= (KW_DELETE edge_op_ref_inline | CARROW_R | CARROW_R_P1 expression (COLON (expression (EQ expression)?)*)? CARROW_R_P2 | CARROW_L | CARROW_L_P1 expression (COLON
+(expression (EQ expression)?)*)? (CARROW_L_P2 | CARROW_R_P2)? | CARROW_BI)?
+atomic_pipe ::= atomic_pipe_back (A_PIPE_FWD atomic_pipe_back)*
+atomic_pipe_back ::= spawn (A_PIPE_BKWD spawn)*
+spawn ::= KW_SPAWN unpack | unpack (KW_SPAWN unpack)*
+unpack ::= STAR_MUL ref | ref
+ref ::= BW_AND await_expr | await_expr
+await_expr ::= KW_AWAIT pipe_call | pipe_call
+pipe_call ::= (PIPE_FWD | A_PIPE_FWD) atomic_chain | atomic_chain
+atomic_chain ::= atom (DOT (DOT | DOT_FWD | DOT_BKWD)? (KW_INIT | KW_POST_INIT | KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)? | LPAREN (NULL_OK
+filter_compr_inner | EQ assign_compr_inner | call_args RPAREN) | LSQUARE NULL_OK? LSQUARE expression? (COLON COLON expression? (COLON expression?)? (COMMA expression? COLON
+expression? (COLON expression?)?)* RSQUARE | (COMMA expression)* RSQUARE))
+call_args ::= call_arg (COMMA call_arg)*
+call_arg ::= EQ (KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)? expression | STAR_POW expression | STAR_MUL expression | expression (KW_FOR
+comprehension_clauses)?
+filter_compr_inner ::= NULL_OK (COLON expression)? COMMA? (compare (COMMA compare)*)? RPAREN
+assign_compr_inner ::= EQ (NAME EQ expression (COMMA NAME EQ expression)*)? RPAREN
+atom ::= (INT | HEX | BIN | OCT | FLOAT | STRING (NAME | STRING | fstring)* | BOOL | NULL | ELLIPSIS | TYP_STRING | TYP_INT | TYP_FLOAT | TYP_LIST | TYP_TUPLE | TYP_SET |
+TYP_DICT | TYP_BOOL | TYP_BYTES | TYP_ANY | TYP_TYPE | KW_SELF | KW_SUPER | KW_HERE | KW_ROOT | KW_VISITOR | KW_PROPS | KW_INIT | KW_POST_INIT | KW_NODE | KW_EDGE | KW_WALKER |
+KW_OBJECT | KW_CLASS | KW_ENUM | NAME (NAME | STRING | fstring)* | (NAME | KWESC_NAME) NAME? | STAR_MUL expression | STAR_POW expression | LPAREN (RPAREN | KW_YIELD yield_stmt
+RPAREN | (KW_DEF | KW_CAN | KW_ASYNC) ability RPAREN | expression (KW_FOR comprehension_clauses RPAREN | COMMA (expression COMMA?)* RPAREN | RPAREN)) | LSQUARE (ARROW_R |
+ARROW_L | ARROW_BI | ARROW_R_P1 | ARROW_L_P1 | RETURN_HINT | KW_ASYNC | (KW_NODE | KW_EDGE) (ARROW_R | ARROW_L | ARROW_BI | ARROW_R_P1 | ARROW_L_P1 | RETURN_HINT | NAME |
+KW_ROOT | KW_SELF | KW_HERE | KW_SUPER | KW_VISITOR)? | (NAME | KW_ROOT | KW_SELF | KW_HERE | KW_SUPER | KW_VISITOR) (ARROW_R | ARROW_L | ARROW_BI | ARROW_R_P1 | ARROW_L_P1 |
+RETURN_HINT | LSQUARE (LSQUARE | RSQUARE)?)?)? (edge_ref_chain | list_or_compr) | LBRACE dict_or_set | (F_DQ_START | F_SQ_START | F_TDQ_START | F_TSQ_START | RF_DQ_START |
+RF_SQ_START | RF_TDQ_START | RF_TSQ_START) fstring (STRING | fstring)* | (JSX_OPEN_START | JSX_FRAG_OPEN) jsx_element)?
+fstring ::= (F_DQ_START | F_SQ_START | F_TDQ_START | F_TSQ_START | RF_DQ_START | RF_SQ_START | RF_TDQ_START) (D_LBRACE | D_RBRACE | LBRACE expression CONV? (COLON (LBRACE
+expression CONV? RBRACE)?*)? RBRACE)*
+list_or_compr ::= RSQUARE | expression (KW_FOR comprehension_clauses RSQUARE | (COMMA expression)* RSQUARE)
+edge_ref_chain ::= KW_ASYNC? (KW_EDGE | KW_NODE)? ((NAME | KWESC_NAME | KW_ROOT | KW_SELF | KW_HERE | KW_SUPER | KW_VISITOR | LSQUARE) atomic_chain)? ((ARROW_R | ARROW_L |
+ARROW_BI) (ARROW_L | ARROW_BI)? | RETURN_HINT ((TYP_STRING | TYP_INT | TYP_FLOAT | TYP_LIST | TYP_TUPLE | TYP_SET | TYP_DICT | TYP_BOOL | TYP_BYTES | TYP_ANY | TYP_TYPE) atom)?
+(COLON (compare (COMMA compare)*)?)? ARROW_R_P2 | ARROW_L_P1 atom (COLON (compare (COMMA compare)*)?)? ARROW_L_P2 | ARROW_R_P1 atom ARROW_R_P2) (LPAREN (NULL_OK
+filter_compr_inner | expression RPAREN) | (NAME | KWESC_NAME | KW_SELF | KW_ROOT | KW_HERE | KW_SUPER) atomic_chain)? RSQUARE
+dict_or_set ::= RBRACE | STAR_POW dict_with_spread | expression (COLON expression (KW_FOR comprehension_clauses RBRACE | (COMMA (STAR_POW expression | expression COLON
+expression))* RBRACE) | KW_FOR comprehension_clauses RBRACE | (COMMA expression)* RBRACE)
+dict_with_spread ::= (STAR_POW expression | expression COLON expression)* RBRACE
+comprehension_clauses ::= (KW_ASYNC? KW_FOR atomic_chain KW_IN pipe_call (KW_IF walrus_assign)*)*
+lambda_expr ::= KW_LAMBDA (LPAREN func_params RPAREN | lambda_params) (RETURN_HINT expression)? (COLON expression | LBRACE code_block_stmts RBRACE | expression)
+lambda_params ::= (STAR_MUL? DIV? (STAR_MUL | STAR_POW)? (COLON ((NAME | TYP_STRING | TYP_INT | TYP_FLOAT | TYP_LIST | TYP_TUPLE | TYP_SET | TYP_DICT | TYP_BOOL | TYP_BYTES |
+TYP_ANY | TYP_TYPE) (COMMA | EQ | COLON | RETURN_HINT | LBRACE)?)? pipe)? (EQ expression)?)*
+jsx_element ::= JSX_FRAG_OPEN jsx_children JSX_FRAG_CLOSE | JSX_OPEN_START JSX_NAME (DOT JSX_NAME)* jsx_attributes (JSX_SELF_CLOSE | JSX_TAG_END jsx_children JSX_CLOSE_START
+JSX_NAME (DOT JSX_NAME)* JSX_TAG_END)
+jsx_opening_element ::= JSX_OPEN_START JSX_NAME jsx_attributes (JSX_SELF_CLOSE | JSX_TAG_END)
+jsx_attributes ::= JSX_NAME (EQ (STRING | LBRACE expression RBRACE)?)? | LBRACE ELLIPSIS? expression RBRACE
+jsx_children ::= jsx_child*
+jsx_child ::= (JSX_TEXT jsx_child? | LBRACE expression RBRACE | (JSX_OPEN_START | JSX_FRAG_OPEN) jsx_element)?
+element_stmt ::= SEMI* (KW_CLIENT (LBRACE client_block | element_stmt)? | KW_SERVER (LBRACE server_block | element_stmt)? | KW_NATIVE (LBRACE native_block | element_stmt)? |
+(KW_IMPORT | KW_INCLUDE) import_stmt | (KW_OBJECT | KW_NODE | KW_EDGE | KW_WALKER | KW_CLASS) archetype | KW_ENUM enum | STRING test | KW_TEST test | STRING (DECOR_OP
+atomic_chain)* KW_ASYNC* KW_ABSTRACT? (archetype | enum | impl_def | ability) | STRING enum | (KW_DEF | KW_CAN) ability | STRING global_var | KW_GLOBAL global_var | STRING
+impl_def | KW_IMPL impl_def | KW_SEM sem_def | PYNLINE | STRING module_code | KW_WITH module_code | DECOR_OP (DECOR_OP atomic_chain)* KW_ASYNC* (ability | enum | impl_def |
+archetype) | KW_ASYNC KW_ASYNC* (ability | archetype))?
+client_block ::= KW_CLIENT (LBRACE element_stmt* RBRACE | element_stmt)
+server_block ::= KW_SERVER (LBRACE element_stmt* RBRACE | element_stmt)
+native_block ::= KW_NATIVE (LBRACE element_stmt* RBRACE | element_stmt)
+module_code ::= KW_WITH (KW_EXIT | KW_ENTRY)? (COLON NAME)? LBRACE code_block_stmts RBRACE
+code_block_stmts ::= (statement SEMI?)*
+statement ::= SEMI | (KW_IMPORT | KW_INCLUDE) import_stmt | KW_IF if_stmt | KW_WHILE while_stmt | KW_ASYNC for_stmt | KW_ASYNC with_stmt | KW_FOR for_stmt | KW_TRY try_stmt |
+KW_WITH with_stmt | KW_MATCH match_stmt | KW_SWITCH switch_stmt | KW_RETURN return_stmt | KW_YIELD yield_stmt SEMI? | KW_BREAK SEMI? | KW_CONTINUE SEMI? | KW_SKIP SEMI? |
+KW_RAISE raise_stmt | KW_ASSERT assert_stmt | KW_DELETE delete_stmt | KW_GLOBAL_REF global_stmt | KW_NONLOCAL nonlocal_stmt | KW_VISIT visit_stmt | KW_DISENGAGE SEMI? |
+KW_REPORT report_stmt | (KW_DEF | KW_CAN | KW_ASYNC) ability | DECOR_OP ability | (KW_OBJECT | KW_NODE | KW_EDGE | KW_WALKER | KW_CLASS) archetype | KW_ENUM enum | KW_IMPL
+impl_def | KW_HAS has_stmt | PYNLINE | RETURN_HINT expression LBRACE code_block_stmts RBRACE | expression ((EQ | COLON | ADD_EQ | SUB_EQ | MUL_EQ | DIV_EQ | FLOOR_DIV_EQ |
+MOD_EQ | STAR_POW_EQ | MATMUL_EQ | BW_AND_EQ | BW_OR_EQ | BW_XOR_EQ | LSHIFT_EQ | RSHIFT_EQ) assignment_with_target | SEMI?)
+if_stmt ::= KW_IF expression LBRACE code_block_stmts RBRACE (KW_ELIF elif_stmt | KW_ELSE else_stmt)?
+elif_stmt ::= KW_ELIF expression LBRACE code_block_stmts RBRACE (KW_ELIF elif_stmt | KW_ELSE else_stmt)?
+else_stmt ::= KW_ELSE LBRACE code_block_stmts RBRACE
+while_stmt ::= KW_WHILE expression LBRACE code_block_stmts RBRACE (KW_ELSE else_stmt)?
+for_stmt ::= KW_ASYNC? KW_FOR atomic_chain (EQ expression KW_TO pipe KW_BY atomic_chain ((ADD_EQ | SUB_EQ | MUL_EQ | DIV_EQ | FLOOR_DIV_EQ | MOD_EQ | STAR_POW_EQ | MATMUL_EQ)
+assignment_with_target)? LBRACE code_block_stmts RBRACE (KW_ELSE else_stmt)? | KW_IN expression LBRACE code_block_stmts RBRACE (KW_ELSE else_stmt)?)
+try_stmt ::= KW_TRY LBRACE code_block_stmts RBRACE (KW_EXCEPT except_handler)* (KW_ELSE else_stmt)? (KW_FINALLY LBRACE code_block_stmts RBRACE)?
+except_handler ::= KW_EXCEPT expression (KW_AS NAME)? LBRACE code_block_stmts RBRACE
+with_stmt ::= KW_ASYNC? KW_WITH expression (KW_AS expression)? (COMMA expression (KW_AS expression)?)* LBRACE code_block_stmts RBRACE
+match_stmt ::= KW_MATCH expression LBRACE (KW_CASE match_case)* RBRACE
+match_case ::= KW_CASE pattern (KW_IF expression)? COLON statement*
+pattern ::= or_pattern (KW_AS NAME)?
+or_pattern ::= single_pattern (BW_OR single_pattern)*
+single_pattern ::= LSQUARE sequence_pattern | LPAREN tuple_sequence_pattern | LBRACE mapping_pattern | BOOL | NULL | INT | FLOAT | (STRING | F_DQ_START | F_SQ_START |
+F_TDQ_START | F_TSQ_START | RF_DQ_START | RF_SQ_START | RF_TDQ_START | RF_TSQ_START) (STRING | fstring) (STRING | fstring)* | MINUS (INT | FLOAT)? | (DOT (DOT NAME)* (LPAREN
+class_pattern_args)? | LPAREN class_pattern_args)? | (TYP_STRING | TYP_INT | TYP_FLOAT | TYP_LIST | TYP_TUPLE | TYP_SET | TYP_DICT | TYP_BOOL | TYP_BYTES | TYP_ANY | TYP_TYPE)
+(LPAREN class_pattern_args)? | expression
+sequence_pattern ::= LSQUARE ((STAR_MUL NAME | pattern) COMMA?)* RSQUARE
+tuple_sequence_pattern ::= LPAREN ((STAR_MUL NAME | pattern) COMMA?)* RPAREN
+mapping_pattern ::= LBRACE ((STAR_POW NAME | literal_for_mapping COLON pattern) COMMA?)* RBRACE
+literal_for_mapping ::= (INT | FLOAT | (STRING | F_DQ_START | F_SQ_START | F_TDQ_START | F_TSQ_START | RF_DQ_START | RF_SQ_START | RF_TDQ_START | RF_TSQ_START) (STRING |
+fstring) (STRING | fstring)* | MINUS (INT | FLOAT)?)?
+class_pattern_args ::= LPAREN ((EQ EQ pattern | pattern) COMMA?)* RPAREN
+return_stmt ::= KW_RETURN expression? SEMI?
+yield_stmt ::= KW_YIELD KW_FROM? expression?
+raise_stmt ::= KW_RAISE expression? (KW_FROM expression)? SEMI?
+assert_stmt ::= KW_ASSERT expression (COMMA expression)? SEMI?
+delete_stmt ::= KW_DELETE expression SEMI?
+global_stmt ::= KW_GLOBAL_REF NAME (COMMA NAME)* SEMI?
+nonlocal_stmt ::= KW_NONLOCAL NAME (COMMA NAME)* SEMI?
+assignment_with_target ::= (COLON pipe)? (EQ EQ* | (ADD_EQ | SUB_EQ | MUL_EQ | DIV_EQ | FLOOR_DIV_EQ | MOD_EQ | STAR_POW_EQ | MATMUL_EQ | BW_AND_EQ | BW_OR_EQ | BW_XOR_EQ |
+LSHIFT_EQ | RSHIFT_EQ)?) SEMI?
+import_stmt ::= (KW_FROM ((DOT | ELLIPSIS) ELLIPSIS?*)? (STRING | (DOT NAME)*)?)? (LBRACE ((STAR_MUL | KW_DEFAULT | NAME) (KW_AS NAME)?)* RBRACE | (STRING | (DOT NAME)*)? (KW_AS
+NAME)?) SEMI?
+archetype ::= (DECOR_OP atomic_chain)* KW_ASYNC? KW_ABSTRACT? access_tag NAME (LPAREN (atomic_chain (COMMA atomic_chain)*)? RPAREN)? (LBRACE archetype_member* RBRACE | SEMI?)
+archetype_member ::= SEMI* STRING? (DECOR_OP ability | KW_STATIC (KW_HAS has_stmt | ability) | KW_HAS has_stmt | KW_ASYNC ability | (KW_DEF | KW_CAN | KW_OVERRIDE) ability |
+(KW_OBJECT | KW_NODE | KW_EDGE | KW_WALKER | KW_CLASS) archetype | KW_ENUM enum | KW_IMPL impl_def | PYNLINE | KW_WITH ((KW_ENTRY | KW_EXIT) LBRACE code_block_stmts RBRACE)? |
+NAME?)
+has_stmt ::= KW_STATIC? KW_HAS access_tag has_var (COMMA has_var)* SEMI
+has_var ::= NAME (KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)? COLON pipe (EQ expression | (KW_BY KW_POST_INIT)?)
+ability ::= (DECOR_OP atomic_chain)* KW_OVERRIDE? KW_STATIC? (KW_ASYNC KW_OVERRIDE? KW_STATIC?)? access_tag (KW_INIT | KW_POST_INIT | KW_ROOT | KW_SUPER | KW_SELF | KW_PROPS |
+KW_HERE | KW_VISITOR)? (KW_WITH | func_signature) (LBRACE code_block_stmts RBRACE | KW_BY expression SEMI | KW_ABSTRACT? SEMI)
+func_signature ::= (LPAREN func_params? RPAREN)? (RETURN_HINT pipe)?
+func_params ::= (STAR_MUL | DIV | (STAR_MUL | STAR_POW)? (KW_SELF | (KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)?) (COLON pipe)? (EQ expression)?)*
+enum ::= (DECOR_OP atomic_chain)* KW_ENUM access_tag NAME (LPAREN (atomic_chain (COMMA atomic_chain)*)? RPAREN)? (LBRACE (enum_member COMMA? (PYNLINE | KW_WITH module_code))*
+RBRACE | SEMI)
+enum_member ::= NAME (EQ expression)?
+test ::= KW_TEST NAME? LBRACE code_block_stmts RBRACE
+switch_stmt ::= KW_SWITCH expression LBRACE ((KW_CASE | KW_DEFAULT) switch_case)* RBRACE
+switch_case ::= (KW_DEFAULT | KW_CASE pattern) COLON statement*
+global_var ::= KW_GLOBAL access_tag global_var_assignment (COMMA global_var_assignment)* SEMI
+global_var_assignment ::= NAME (COLON pipe)? (EQ expression (EQ expression)*)?
+impl_def ::= (DECOR_OP atomic_chain)* KW_IMPL impl_target_name (DOT impl_target_name)* (LPAREN (KW_SELF | RPAREN)? func_signature (atomic_chain (COMMA atomic_chain)*)? RPAREN |
+KW_WITH | RETURN_HINT func_signature)? (LBRACE COMMA? (COLON (LPAREN | LBRACE | LSQUARE | RPAREN | RBRACE | RSQUARE)? (EQ (LPAREN | LBRACE | LSQUARE | RPAREN | RBRACE |
+RSQUARE)? COMMA? | COMMA)?)? (EQ (LPAREN | LBRACE | LSQUARE | RPAREN | RBRACE | RSQUARE)? COMMA?)? impl_enum_body code_block_stmts RBRACE | KW_BY expression SEMI | SEMI)
+impl_target_name ::= NAME
+impl_enum_body ::= ((COLON pipe)? (EQ expression)? COMMA?)*
+sem_def ::= KW_SEM impl_target_name (DOT impl_target_name)* (EQ | KW_IS) STRING SEMI?
+dotted_name ::= NAME (DOT NAME)*
+visit_stmt ::= KW_VISIT (COLON expression COLON)? expression (KW_ELSE else_stmt | SEMI)?
+report_stmt ::= KW_REPORT expression SEMI?

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -176,6 +176,14 @@ impl Parser.check_any(*kinds: TokenKind) -> bool {
     return self.current().kind in kinds;
 }
 
+impl Parser.check_peek(kind: TokenKind) -> bool {
+    return self.peek().kind == kind;
+}
+
+impl Parser.check_peek_any(*kinds: TokenKind) -> bool {
+    return self.peek().kind in kinds;
+}
+
 impl Parser.get_source -> Source {
     # Return the cached source (set in parse_module) or create new one
     # Note: self.source is guaranteed to be set in parse_module before any token creation
@@ -1033,13 +1041,13 @@ impl Parser.parse_edge_op_ref_inline -> EdgeOpRef | None {
 impl Parser.parse_connect_op -> ConnectOp | DisconnectOp | None {
     # Check for disconnect: del followed by edge_op_ref (-->, <--, <-->, or typed variants)
     if self.check(TokenKind.KW_DELETE)
-    and self.peek().kind in [
+    and self.check_peek_any(
         TokenKind.ARROW_R,
         TokenKind.ARROW_L,
         TokenKind.ARROW_BI,
         TokenKind.ARROW_R_P1,
         TokenKind.ARROW_L_P1
-    ] {
+    ) {
         del_tok = self.advance();
         # Parse the edge op ref directly (not in brackets)
         edge_op = self.parse_edge_op_ref_inline();
@@ -1254,7 +1262,7 @@ impl Parser.parse_atomic_chain -> Expr {
         if self.match_tok(TokenKind.DOT)
         or (
             self.check(TokenKind.NULL_OK)
-            and self.peek().kind != TokenKind.LSQUARE
+            and not self.check_peek(TokenKind.LSQUARE)
             and self.match_tok(TokenKind.NULL_OK)
         )
         or self.match_tok(TokenKind.DOT_FWD)
@@ -1336,7 +1344,7 @@ impl Parser.parse_atomic_chain -> Expr {
             );
         } elif self.check(TokenKind.LPAREN) {
             # Check if this is filter_compr: (?...) or (?:Type, ...)
-            if self.peek().kind == TokenKind.NULL_OK {
+            if self.check_peek(TokenKind.NULL_OK) {
                 # Parse filter comprehension: (?val==10) or (?:Type, val==10)
                 self.advance();  # consume LPAREN
                 filter_expr = self.parse_filter_compr_inner();
@@ -1349,7 +1357,7 @@ impl Parser.parse_atomic_chain -> Expr {
                     is_null_ok=False,
                     kid=kid
                 );
-            } elif self.peek().kind == TokenKind.EQ {
+            } elif self.check_peek(TokenKind.EQ) {
                 # Parse assign_compr: (=a=5, b=6)
                 self.advance();  # consume LPAREN
                 assign_expr = self.parse_assign_compr_inner();
@@ -1388,9 +1396,7 @@ impl Parser.parse_atomic_chain -> Expr {
                 }
                 expr = FuncCall(target=expr, params=args, genai_call=None, kid=kid);
             }
-        } elif (
-            self.check(TokenKind.NULL_OK) and self.peek().kind == TokenKind.LSQUARE
-        )
+        } elif (self.check(TokenKind.NULL_OK) and self.check_peek(TokenKind.LSQUARE))
         or self.check(TokenKind.LSQUARE) {
             # Parse index or slice: a[x], a?[x], a[x,y], a[1:2], a[::3], etc.
             is_null_ok_index = False;
@@ -1560,8 +1566,7 @@ impl Parser.parse_call_args(kid: list) -> list {
 
 impl Parser.parse_call_arg -> Expr | KWPair {
     # Check for keyword argument: NAME = expr (also KWESC_NAME like `type)
-    if (self.check_name() or self.is_keyword_token())
-    and self.peek().kind == TokenKind.EQ {
+    if (self.check_name() or self.is_keyword_token()) and self.check_peek(TokenKind.EQ) {
         name_tok = self.advance();
         name: Name;
         if name_tok.kind == TokenKind.NAME or name_tok.kind == TokenKind.KWESC_NAME {
@@ -1602,7 +1607,7 @@ impl Parser.parse_call_arg -> Expr | KWPair {
     expr = self.parse_expression();
     # If followed by 'for' or 'async for', it's a generator expression: all(x > 0 for x in items)
     if self.check(TokenKind.KW_FOR)
-    or (self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR) {
+    or (self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR)) {
         comprs = self.parse_comprehension_clauses();
         kid: list = [expr];
         kid.extend(comprs);
@@ -1734,9 +1739,9 @@ impl Parser.parse_atom -> Expr {
                 "BR",
                 "RB"
             ]
-            and self.peek().kind == TokenKind.STRING
+            and self.check_peek(TokenKind.STRING)
         ) {
-            if self.check(TokenKind.NAME) and self.peek().kind == TokenKind.STRING {
+            if self.check(TokenKind.NAME) and self.check_peek(TokenKind.STRING) {
                 ptok = self.advance();
                 stok = self.advance();
                 s = self.make_string(stok);
@@ -1834,7 +1839,7 @@ impl Parser.parse_atom -> Expr {
         "BR",
         "RB"
     ]
-    and self.peek().kind == TokenKind.STRING {
+    and self.check_peek(TokenKind.STRING) {
         prefix_tok = self.advance();
         str_tok = self.advance();
         combined = self.make_string(str_tok);
@@ -1867,9 +1872,9 @@ impl Parser.parse_atom -> Expr {
                 "BR",
                 "RB"
             ]
-            and self.peek().kind == TokenKind.STRING
+            and self.check_peek(TokenKind.STRING)
         ) {
-            if self.check(TokenKind.NAME) and self.peek().kind == TokenKind.STRING {
+            if self.check(TokenKind.NAME) and self.check_peek(TokenKind.STRING) {
                 ptok = self.advance();
                 stok = self.advance();
                 s = self.make_string(stok);
@@ -1889,7 +1894,7 @@ impl Parser.parse_atom -> Expr {
         # Allow 'new' as a regular variable name (e.g., new = out(), new.cnt)
         if self.check(TokenKind.NAME)
         and self.current().value == "new"
-        and self.peek().kind in [TokenKind.NAME, TokenKind.KWESC_NAME] {
+        and self.check_peek_any(TokenKind.NAME, TokenKind.KWESC_NAME) {
             self.error("The 'new' keyword is not supported in Jac");
             self.error(
                 "Use `Reflect.construct(target, argumentsList)` method to create new instances"
@@ -1939,7 +1944,7 @@ impl Parser.parse_atom -> Expr {
         expr = self.parse_expression();
         # Standalone generator expression: (expr for x in items) or (expr async for x in items)
         if self.check(TokenKind.KW_FOR)
-        or (self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR) {
+        or (self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR)) {
             comprs = self.parse_comprehension_clauses();
             gc_kid: list = [lp_uni, expr];
             gc_kid.extend(comprs);
@@ -1997,7 +2002,7 @@ impl Parser.parse_atom -> Expr {
             is_edge_ref = True;
         } elif self.check_any(TokenKind.KW_NODE, TokenKind.KW_EDGE) {
             # [node ...] or [edge ...] is only an edge ref if followed by an arrow
-            if self.peek().kind in [
+            if self.check_peek_any(
                 TokenKind.ARROW_R,
                 TokenKind.ARROW_L,
                 TokenKind.ARROW_BI,
@@ -2010,7 +2015,7 @@ impl Parser.parse_atom -> Expr {
                 TokenKind.KW_HERE,
                 TokenKind.KW_SUPER,
                 TokenKind.KW_VISITOR
-            ] {
+            ) {
                 is_edge_ref = True;
             }
         } elif self.check_any(
@@ -2021,16 +2026,16 @@ impl Parser.parse_atom -> Expr {
             TokenKind.KW_SUPER,
             TokenKind.KW_VISITOR
         ) {
-            if self.peek().kind in [
+            if self.check_peek_any(
                 TokenKind.ARROW_R,
                 TokenKind.ARROW_L,
                 TokenKind.ARROW_BI,
                 TokenKind.ARROW_R_P1,  # For typed edges like [self->:Type:->]
                 TokenKind.ARROW_L_P1,  # For typed edges like [self<-:Type:<-]
                 TokenKind.RETURN_HINT  # For [root->:a:->]
-            ] {
+            ) {
                 is_edge_ref = True;
-            } elif self.peek().kind == TokenKind.LSQUARE {
+            } elif self.check_peek(TokenKind.LSQUARE) {
                 # Check for NAME[subscript]->... pattern (e.g., [parent[0]->:Edge:->])
                 save_pos = self.pos;
                 self.advance();  # skip NAME
@@ -2254,7 +2259,7 @@ impl Parser.parse_list_or_compr -> Expr {
     }
     first = self.parse_expression();
     if self.check(TokenKind.KW_FOR)
-    or (self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR) {
+    or (self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR)) {
         comprs = self.parse_comprehension_clauses();
         kid: list = [lsquare_uni, first];
         kid.extend(comprs);
@@ -2346,7 +2351,7 @@ impl Parser.continue_edge_ref_chain(start_expr: Expr, lsquare_uni: UniToken) -> 
         }
         # Check for filter expressions after edge operator: -->(?val==5) or -->(?:A)
         if self.check(TokenKind.LPAREN) {
-            if self.peek().kind == TokenKind.NULL_OK {
+            if self.check_peek(TokenKind.NULL_OK) {
                 self.advance();
                 filter_expr = self.parse_filter_compr_inner();
                 chain.append(filter_expr);
@@ -2417,7 +2422,7 @@ impl Parser.parse_edge_ref_chain -> Expr {
             edge_op_ref = EdgeOpRef(filter_cond=None, edge_dir=dir, kid=[edge_uni]);
         }
         # Typed edge out: ->:type:-> (as RETURN_HINT + COLON ... ARROW_R_P2)
-        elif self.check(TokenKind.RETURN_HINT) and self.peek().kind == TokenKind.COLON {
+        elif self.check(TokenKind.RETURN_HINT) and self.check_peek(TokenKind.COLON) {
             self.advance();  # ->
             arrow_r_tok = self.previous();
             self.advance();  # :
@@ -2529,7 +2534,7 @@ impl Parser.parse_edge_ref_chain -> Expr {
         }
         # Check for filter expressions after edge operator: -->(?val==5) or -->(?:A)
         if self.check(TokenKind.LPAREN) {
-            if self.peek().kind == TokenKind.NULL_OK {
+            if self.check_peek(TokenKind.NULL_OK) {
                 self.advance();
                 filter_expr = self.parse_filter_compr_inner();
                 chain.append(filter_expr);
@@ -2581,7 +2586,7 @@ impl Parser.parse_dict_or_set -> Expr {
         colon_uni = self.make_uni_token(self.previous());
         value = self.parse_expression();
         if self.check(TokenKind.KW_FOR)
-        or (self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR) {
+        or (self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR)) {
             comprs = self.parse_comprehension_clauses();
             kv = KVPair(key=first, value=value, kid=[first, colon_uni, value]);
             kid: list = [lbrace_uni, kv];
@@ -2617,7 +2622,7 @@ impl Parser.parse_dict_or_set -> Expr {
         return DictVal(kv_pairs=pairs, kid=kid);
     }
     if self.check(TokenKind.KW_FOR)
-    or (self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR) {
+    or (self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR)) {
         comprs = self.parse_comprehension_clauses();
         kid = [lbrace_uni, first];
         kid.extend(comprs);
@@ -2669,7 +2674,7 @@ impl Parser.parse_dict_with_spread(lbrace_uni: UniToken) -> DictVal {
 impl Parser.parse_comprehension_clauses -> list {
     comprs: list = [];
     while self.check(TokenKind.KW_FOR)
-    or (self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR) {
+    or (self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR)) {
         is_async = False;
         async_uni: UniToken | None = None;
         if self.match_tok(TokenKind.KW_ASYNC) {
@@ -2794,10 +2799,10 @@ impl Parser.parse_lambda_params(sig_kid: list) -> list {
         # Handle bare * (keyword-only separator)
         if self.check(TokenKind.STAR_MUL)
         and (
-            self.peek().kind == TokenKind.COMMA
-            or self.peek().kind == TokenKind.COLON
-            or self.peek().kind == TokenKind.RETURN_HINT
-            or self.peek().kind == TokenKind.LBRACE
+            self.check_peek(TokenKind.COMMA)
+            or self.check_peek(TokenKind.COLON)
+            or self.check_peek(TokenKind.RETURN_HINT)
+            or self.check_peek(TokenKind.LBRACE)
         ) {
             star_tok = self.advance();
             star_uni = self.make_uni_token(star_tok);
@@ -2811,10 +2816,10 @@ impl Parser.parse_lambda_params(sig_kid: list) -> list {
         # Handle / (positional-only separator)
         if self.check(TokenKind.DIV)
         and (
-            self.peek().kind == TokenKind.COMMA
-            or self.peek().kind == TokenKind.COLON
-            or self.peek().kind == TokenKind.RETURN_HINT
-            or self.peek().kind == TokenKind.LBRACE
+            self.check_peek(TokenKind.COMMA)
+            or self.check_peek(TokenKind.COLON)
+            or self.check_peek(TokenKind.RETURN_HINT)
+            or self.check_peek(TokenKind.LBRACE)
         ) {
             div_tok = self.advance();
             div_uni = self.make_uni_token(div_tok);
@@ -3131,7 +3136,7 @@ impl Parser.parse_element_stmt{
     }
     # Handle client/server/native context blocks: cl { ... } or cl stmt
     if self.check(TokenKind.KW_CLIENT) {
-        if self.peek().kind == TokenKind.LBRACE {
+        if self.check_peek(TokenKind.LBRACE) {
             return self.parse_client_block();
         } else {
             # Single statement: cl def ..., cl import ..., etc.
@@ -3148,7 +3153,7 @@ impl Parser.parse_element_stmt{
         }
     }
     if self.check(TokenKind.KW_SERVER) {
-        if self.peek().kind == TokenKind.LBRACE {
+        if self.check_peek(TokenKind.LBRACE) {
             return self.parse_server_block();
         } else {
             self.advance();  # consume sv
@@ -3164,7 +3169,7 @@ impl Parser.parse_element_stmt{
         }
     }
     if self.check(TokenKind.KW_NATIVE) {
-        if self.peek().kind == TokenKind.LBRACE {
+        if self.check_peek(TokenKind.LBRACE) {
             return self.parse_native_block();
         } else {
             self.advance();  # consume na
@@ -3191,20 +3196,20 @@ impl Parser.parse_element_stmt{
     )
     or (
         self.check(TokenKind.KW_ABSTRACT)
-        and self.peek().kind in [
+        and self.check_peek_any(
             TokenKind.KW_OBJECT,
             TokenKind.KW_NODE,
             TokenKind.KW_EDGE,
             TokenKind.KW_WALKER,
             TokenKind.KW_CLASS
-        ]
+        )
     ) {
         return self.parse_archetype();
     }
     if self.check(TokenKind.KW_ENUM) {
         return self.parse_enum();
     }
-    if self.check(TokenKind.STRING) and self.peek().kind == TokenKind.KW_TEST {
+    if self.check(TokenKind.STRING) and self.check_peek(TokenKind.KW_TEST) {
         doc_tok = self.advance();
         elem_doc = self.make_string(doc_tok);
         test = self.parse_test();
@@ -3216,7 +3221,7 @@ impl Parser.parse_element_stmt{
         return self.parse_test();
     }
     if self.check(TokenKind.STRING)
-    and self.peek().kind in [
+    and self.check_peek_any(
         TokenKind.KW_DEF,
         TokenKind.KW_CAN,
         TokenKind.KW_OVERRIDE,
@@ -3230,7 +3235,7 @@ impl Parser.parse_element_stmt{
         TokenKind.KW_CLASS,
         TokenKind.KW_ABSTRACT,
         TokenKind.KW_IMPL
-    ] {
+    ) {
         # Need to look ahead past decorators/async/abs to determine if ability, archetype, enum, or impl
         save_pos = self.pos;
         self.advance();  # skip STRING
@@ -3279,7 +3284,7 @@ impl Parser.parse_element_stmt{
             return ability;
         }
     }
-    if self.check(TokenKind.STRING) and self.peek().kind == TokenKind.KW_ENUM {
+    if self.check(TokenKind.STRING) and self.check_peek(TokenKind.KW_ENUM) {
         doc_tok = self.advance();
         elem_doc = self.make_string(doc_tok);
         en = self.parse_enum();
@@ -3291,7 +3296,7 @@ impl Parser.parse_element_stmt{
         return self.parse_ability();
     }
     # Handle docstring before glob: "docstring" glob ...
-    if self.check(TokenKind.STRING) and self.peek().kind == TokenKind.KW_GLOBAL {
+    if self.check(TokenKind.STRING) and self.check_peek(TokenKind.KW_GLOBAL) {
         doc_tok = self.advance();
         elem_doc = self.make_string(doc_tok);
         gv = self.parse_global_var();
@@ -3304,7 +3309,7 @@ impl Parser.parse_element_stmt{
         return self.parse_global_var();
     }
     # Handle docstring before impl
-    if self.check(TokenKind.STRING) and self.peek().kind == TokenKind.KW_IMPL {
+    if self.check(TokenKind.STRING) and self.check_peek(TokenKind.KW_IMPL) {
         doc_tok = self.advance();
         elem_doc = self.make_string(doc_tok);
         impl_def = self.parse_impl_def();
@@ -3327,7 +3332,7 @@ impl Parser.parse_element_stmt{
         return PyInlineCode(code=py_code, kid=[py_code]);
     }
     # Handle docstring before 'with entry { ... }' module code
-    if self.check(TokenKind.STRING) and self.peek().kind == TokenKind.KW_WITH {
+    if self.check(TokenKind.STRING) and self.check_peek(TokenKind.KW_WITH) {
         doc_tok = self.advance();
         elem_doc = self.make_string(doc_tok);
         mc = self.parse_module_code();
@@ -3577,10 +3582,10 @@ impl Parser.parse_statement{
         return self.parse_while_stmt();
     }
     # Handle async for/with statements
-    if self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_FOR {
+    if self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_FOR) {
         return self.parse_for_stmt();
     }
-    if self.check(TokenKind.KW_ASYNC) and self.peek().kind == TokenKind.KW_WITH {
+    if self.check(TokenKind.KW_ASYNC) and self.check_peek(TokenKind.KW_WITH) {
         return self.parse_with_stmt();
     }
     if self.check(TokenKind.KW_FOR) {
@@ -3705,7 +3710,7 @@ impl Parser.parse_statement{
     }
     # Handle has statements (in impl bodies and archetype bodies)
     if self.check(TokenKind.KW_HAS)
-    or (self.check(TokenKind.KW_STATIC) and self.peek().kind == TokenKind.KW_HAS) {
+    or (self.check(TokenKind.KW_STATIC) and self.check_peek(TokenKind.KW_HAS)) {
         return self.parse_has_stmt();
     }
     # Handle inline Python: ::py:: ... ::py::
@@ -3715,7 +3720,7 @@ impl Parser.parse_statement{
         return PyInlineCode(code=py_code, kid=[py_code]);
     }
     # Handle typed context block: -> Type { ... }
-    if self.check(TokenKind.RETURN_HINT) and self.peek().kind != TokenKind.SEMI {
+    if self.check(TokenKind.RETURN_HINT) and not self.check_peek(TokenKind.SEMI) {
         self.advance();  # consume ->
         arrow_uni = self.make_uni_token(self.previous());
         type_ctx = self.parse_expression();
@@ -4544,7 +4549,7 @@ impl Parser.parse_class_pattern_args(names: list, dot_unis: list | None = None) 
     # Parse patterns
     while not self.check(TokenKind.RPAREN) and not self.at_end() {
         # Check if it's a keyword pattern (NAME EQ)
-        if self.check_name() and self.peek().kind == TokenKind.EQ {
+        if self.check_name() and self.check_peek(TokenKind.EQ) {
             # Keyword pattern
             name_tok = self.advance();
             eq_uni = self.consume_uni(TokenKind.EQ);
@@ -5104,7 +5109,7 @@ impl Parser.parse_archetype_member{
     # Handle static has or static def/can
     if self.check(TokenKind.KW_STATIC) {
         # Look ahead to see if it's static has or static def/can
-        if self.peek().kind == TokenKind.KW_HAS {
+        if self.check_peek(TokenKind.KW_HAS) {
             has_stmt = self.parse_has_stmt();
             if doc {
                 has_stmt.doc = doc;
@@ -5154,13 +5159,13 @@ impl Parser.parse_archetype_member{
     )
     or (
         self.check(TokenKind.KW_ABSTRACT)
-        and self.peek().kind in [
+        and self.check_peek_any(
             TokenKind.KW_OBJECT,
             TokenKind.KW_NODE,
             TokenKind.KW_EDGE,
             TokenKind.KW_WALKER,
             TokenKind.KW_CLASS
-        ]
+        )
     ) {
         archetype = self.parse_archetype();
         if doc {
@@ -5622,9 +5627,7 @@ impl Parser.parse_func_params(kid: list) -> list {
     while not self.check(TokenKind.RPAREN) {
         # Handle bare * (keyword-only separator) or / (positional-only separator)
         if self.check(TokenKind.STAR_MUL)
-        and (
-            self.peek().kind == TokenKind.COMMA or self.peek().kind == TokenKind.RPAREN
-        ) {
+        and (self.check_peek(TokenKind.COMMA) or self.check_peek(TokenKind.RPAREN)) {
             star_tok = self.advance();
             star_uni = self.make_uni_token(star_tok);
             kid.append(star_uni);
@@ -5633,9 +5636,7 @@ impl Parser.parse_func_params(kid: list) -> list {
             }
             kid.append(self.make_uni_token(self.previous()));
         } elif self.check(TokenKind.DIV)
-        and (
-            self.peek().kind == TokenKind.COMMA or self.peek().kind == TokenKind.RPAREN
-        ) {
+        and (self.check_peek(TokenKind.COMMA) or self.check_peek(TokenKind.RPAREN)) {
             div_tok = self.advance();
             div_uni = self.make_uni_token(div_tok);
             kid.append(div_uni);
@@ -6126,13 +6127,11 @@ impl Parser.parse_impl_def -> ImplDef {
         # Key distinction: enum-style uses commas, regular uses semicolons
         is_enum_style = False;
         # Bare name followed by comma is enum-style: impl Enum { Bar, Baz }
-        if self.check_name() and self.peek().kind == TokenKind.COMMA {
+        if self.check_name() and self.check_peek(TokenKind.COMMA) {
             is_enum_style = True;
         }
         # NAME: type = value followed by comma is enum-style
-        if not is_enum_style
-        and self.check_name()
-        and self.peek().kind == TokenKind.COLON {
+        if not is_enum_style and self.check_name() and self.check_peek(TokenKind.COLON) {
             save_pos = self.pos;
             self.advance();  # consume NAME
             self.advance();  # consume COLON
@@ -6195,7 +6194,7 @@ impl Parser.parse_impl_def -> ImplDef {
             self.pos = save_pos;
         }
         # NAME = value followed by comma is enum-style
-        if not is_enum_style and self.check_name() and self.peek().kind == TokenKind.EQ {
+        if not is_enum_style and self.check_name() and self.check_peek(TokenKind.EQ) {
             # Look further ahead to find COMMA or SEMI after the value
             save_pos = self.pos;
             self.advance();  # consume NAME

--- a/jac/jaclang/jac0core/parser/parser.jac
+++ b/jac/jaclang/jac0core/parser/parser.jac
@@ -369,6 +369,8 @@ obj Parser {
     def at_end -> bool;
     def check(kind: TokenKind) -> bool;
     def check_any(*kinds: TokenKind) -> bool;
+    def check_peek(kind: TokenKind) -> bool;
+    def check_peek_any(*kinds: TokenKind) -> bool;
     def check_name -> bool;
     def is_keyword_token -> bool;
     def get_source -> Source;


### PR DESCRIPTION
## Summary
- Enhanced `GrammarExtractPass` to correctly handle negated-check while loops, optional dispatch branches, `while True` parse-and-break patterns, standalone `match_tok` calls, and smart token dedup for binary operators
- Added `check_peek`/`check_peek_any` helpers to the RD parser for non-consuming lookahead
- Introduced a `jac.spec` golden file with a snapshot test that validates extracted grammar rules against the checked-in spec on every CI run

## Test plan
- [x] All 24 grammar extraction tests pass (`pytest jac/tests/compiler/passes/tool/test_grammar_extract_pass.py -v`)
- [x] New `TestGrammarSpec` class validates extracted grammar matches `jac.spec` rule-by-rule
- [x] Pre-commit hooks (ruff, mypy, jac-format) all pass
- [ ] CI pipeline passes