### PR TITLE
Fix `jac format --check` to fail on lint errors

### DIFF
--- a/jac.toml
+++ b/jac.toml
@@ -8,5 +8,4 @@ exclude = [
     "*/examples/*",
     "*/tests/*",
     "console.impl.jac",
-    "cli_boot.jac"
 ]

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -428,6 +428,10 @@ impl format(
             );
             has_errors = True;
         }
+        if total_errors > 0 {
+            console.error(f"\n{total_errors} lint error(s) found (see errors above).");
+            has_errors = True;
+        }
         if has_errors {
             return 1;
         }


### PR DESCRIPTION
## **Description**
