### PR TITLE
Fix flaky hub size assertion in test_deep_imports_interp_mode

### DIFF
--- a/jac/tests/language/test_py_infra.py
+++ b/jac/tests/language/test_py_infra.py
@@ -332,7 +332,9 @@ def test_deep_imports_interp_mode(
     with capture_stdout() as captured_output:
         Jac.jac_import("deep_import_interp", base_path=fixture_path("./"))
     stdout_value = captured_output.getvalue()
-    assert len(Jac.get_program().mod.hub.keys()) == 1
+    # Main module must be registered in the hub; transitive imports may also
+    # appear when their bytecode isn't cached yet, so only assert presence.
+    assert fixture_path("deep_import_interp.jac") in Jac.get_program().mod.hub
     assert "one level deeperslHello World!" in stdout_value
 
     Jac.set_base_path(fixture_path("./"))


### PR DESCRIPTION
## Summary
- Fix `test_deep_imports_interp_mode` which fails when transitive dependencies (`one_lev.jac`, `snd_lev.jac`) aren't already cached in `sys.modules` or on disk
- The test asserted exactly 1 entry in `program.mod.hub` after `jac_import`, but uncached transitive imports get compiled through `parse_str` which adds them to the hub
- Changed the assertion from an exact count to a presence check for the main module

## Test plan
- [x] `pytest jac/tests/language/test_py_infra.py::test_deep_imports_interp_mode -xvs` passes