### PR TITLE
Bump version of jaclang(0.10.2), byllm(0.4.20), jac-client(0.2.18), jac-scale(0.1.9), jac-super(0.1.9) and jaseci(2.2.16)

### DIFF
--- a/docs/docs/community/release_notes/byllm.md
+++ b/docs/docs/community/release_notes/byllm.md
@@ -2,11 +2,13 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **byLLM** (formerly MTLLM). For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## byllm 0.4.20 (Unreleased)
+## byllm 0.4.21 (Unreleased)
+
+## byllm 0.4.20 (Latest Release)
 
 - Minor internal refactors
 
-## byllm 0.4.19 (Latest Release)
+## byllm 0.4.19
 
 - Various refactors
 - **Fix: `api_key` parameter no longer silently ignored**: The `api_key` passed via constructor, instance config, or global config (`jac.toml`) was being overwritten with `None` before every LLM call. The key is now properly resolved with a clear priority chain (constructor > instance config > global config > environment variables) and passed to LiteLLM, OpenAI client, and HTTP calls. API keys are also masked in verbose logs, showing only the last 4 characters.

--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,12 +2,14 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.2.18 (Unreleased)
+## jac-client 0.2.19 (Unreleased)
+
+## jac-client 0.2.18 (Latest Release)
 
 - 2 Minor internal refactors
 - **Standardize Jac idioms in examples and runtime**: Replaced JS-style method calls with Jac-idiomatic equivalents across all examples, test fixtures, and the client runtime plugin (`.trim()` → `.strip()`, `.push()` → `.append()`, `.length` → `len()`, `.toUpperCase()/.toLowerCase()` → `.upper()/.lower()`, `console.log()` → `print()`, etc.). These are now translated to the correct JS equivalents at compile time via the primitive emitter infrastructure.
 
-## jac-client 0.2.17 (Latest Release)
+## jac-client 0.2.17
 
 - **Structured Build Error Diagnostics**: Build errors now display formatted diagnostic output with error codes (JAC_CLIENT_XXX), source code snippets pointing to the error location, actionable hints, and quick fix commands. The diagnostic engine maps Vite/npm errors back to original `.jac` files, hiding internal JavaScript paths from developers. Detectors identify common issues: missing npm dependencies (JAC_CLIENT_001), syntax errors (JAC_CLIENT_003), and unresolved imports (JAC_CLIENT_004). Enable `debug = true` under `[plugins.client]` in `jac.toml` or set `JAC_DEBUG=1` to see raw error output alongside formatted diagnostics.
 

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -2,11 +2,13 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Scale**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-scale 0.1.9 (Unreleased)
+## jac-scale 0.1.10 (Unreleased)
+
+## jac-scale 0.1.9 (Latest Release)
 
 - 1 Minor refactors/changes.
 
-## jac-scale 0.1.8 (Latest Release)
+## jac-scale 0.1.8
 
 - Internal: K8s integration tests now install jac plugins from fork PRs instead of always using main
 - **.jac folder is excluded when creating the zip folder that is uploaded into jaseci deployment pods.Fasten up deployment**

--- a/docs/docs/community/release_notes/jac-super.md
+++ b/docs/docs/community/release_notes/jac-super.md
@@ -2,9 +2,11 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Super**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-super 0.1.3 (Unreleased)
+## jac-super 0.1.4 (Unreleased)
 
-## jac-super 0.1.2 (Latest Release)
+## jac-super 0.1.3 (Latest Release)
+
+## jac-super 0.1.2
 
 - Various refactors
 

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jaclang**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jaclang 0.10.2 (Unreleased)
+## jaclang 0.10.3 (Unreleased)
+
+## jaclang 0.10.2 (Latest Release)
 
 - **Unified Primitive Codegen Interface**: Added abstract emitter contracts (`primitives.jac`) for all Jac primitive type methods and builtin functions. Each compilation backend (Python, ECMAScript, Native) must implement these interfaces, ensuring consistent primitive support across all code generation pathways. Python, JS, and Native backend implementations provided.
 - **Pytest Plugin for Native Jac Tests**: Added a `pytest11` entry-point plugin (`jaclang.pytest_plugin`) that discovers and runs `test` blocks in `.jac` files alongside Python tests with zero configuration. Migrated ~79 language integration tests and 8 compilation tests from Python to native Jac `test` keyword.
@@ -14,7 +16,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Black-style Grammar Formatting**: Replaced alignment-based `jac grammar` formatting with Black-style fixed 4-space indentation, blank lines between rules, and 88-char line width. Uses a recursive tree-based formatter instead of the previous string-based wrapping.
 - 4 Minor refactors/changes.
 
-## jaclang 0.10.1 (Latest Release)
+## jaclang 0.10.1
 
 - **`jac purge` Command**: Added `jac purge` to clear the bytecode cache. Works even when the cache is corrupted.
 - **`format_build_error` Plugin Hook**: Added `format_build_error(error_output, project_dir, config)` hook to `JacMachineInterface`, allowing plugins to provide custom error formatting for client bundle build failures. The default implementation returns raw error output; plugins like `jac-client` can override to display structured diagnostics.

--- a/jac-byllm/pyproject.toml
+++ b/jac-byllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "byllm"
-version = "0.4.19"
+version = "0.4.20"
 description = "byLLM Provides Easy to use APIs for different LLM Providers to be used with Jaseci's Jaclang Programming Language."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["llm", "jaclang", "jaseci", "byLLM"]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.10.1",
+    "jaclang>=0.10.2",
     "litellm>=1.75.5.post1,<1.80.0",
     "loguru>=0.7.2,<0.8.0",
     "pillow>=10.4.0,<10.5.0",

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.2.17"
+version = "0.2.18"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.10.1",
+    "jaclang>=0.10.2",
 ]
 
 [project.urls]

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jac-scale"
-version = "0.1.8"
+version = "0.1.9"
 description = ""
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.10.1",
+    "jaclang>=0.10.2",
     "python-dotenv>=1.2.1,<2.0.0",
     "docker>=7.1.0,<8.0.0",
     "kubernetes>=34.1.0,<35.0.0",

--- a/jac-super/pyproject.toml
+++ b/jac-super/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-super"
-version = "0.1.2"
+version = "0.1.3"
 description = "Enhanced console output for Jac CLI with Rich formatting"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.10.1",
+    "jaclang>=0.10.2",
     "rich>=13.0.0",
 ]
 

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaclang"
-version = "0.10.1"
+version = "0.10.2"
 description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]

--- a/jaseci-package/pyproject.toml
+++ b/jaseci-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaseci"
-version = "2.2.15"
+version = "2.2.16"
 description = "Jaseci - A complete AI-native programming ecosystem with Jac language, LLM integration, and full-stack web apps"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -22,11 +22,11 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.10.1",
-    "byllm>=0.4.19",
-    "jac-client>=0.2.17",
-    "jac-scale>=0.1.8",
-    "jac-super>=0.1.2",
+    "jaclang>=0.10.2",
+    "byllm>=0.4.20",
+    "jac-client>=0.2.18",
+    "jac-scale>=0.1.9",
+    "jac-super>=0.1.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
## **Description**

## **Description**

| Package      | Previous Version | New Version |
|--------------|------------------|-------------|
| jaclang      | 0.10.1           | 0.10.2      |
| jac-byllm    | 0.4.19           | 0.4.20      |
| jac-client   | 0.2.17           | 0.2.18      |
| jac-scale    | 0.1.8            | 0.1.9       |
| jac-super    | 0.1.2            | 0.1.3       |
| jaseci       | 2.2.15           | 2.2.16      |
