### PR TITLE
Display human-readable tokens in parser errors and grammar spec

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -15,6 +15,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: JS useState scope bug**: Fixed `has` vars incorrectly triggering `setState()` in sibling functions with same variable name.
 - **Fix: Inherited field default override**: Fixed false "missing required parameter" error when a child class provides a default for a parent's required field.
 - **`parametrize()` Test Helper**: Added a `parametrize(base_name, params, test_func, id_fn=None)` runtime helper that registers one test per parameter via `JacTestCheck.add_test()`.
+- **Human-Readable Tokens in Errors and Grammar Spec**: Parser error messages and `jac grammar` output now display actual token text (`"{"`, `"if"`, `";"`) instead of internal names (`LBRACE`, `KW_IF`, `SEMI`), making syntax errors and the grammar specification much more readable.
 - 1 Minor refactors/changes.
 
 ## jaclang 0.10.2 (Latest Release)

--- a/jac/jaclang/compiler/passes/tool/grammar_extract_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/grammar_extract_pass.jac
@@ -7,6 +7,7 @@ consumption and control-flow patterns, and produces grammar rules.
 
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes { UniPass }
+import from jaclang.jac0core.parser.tokens { TokenKind }
 
 # ---------------------------------------------------------------------------
 # Grammar Expression Types

--- a/jac/jaclang/compiler/passes/tool/impl/grammar_extract_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/grammar_extract_pass.impl.jac
@@ -152,6 +152,12 @@ impl GrammarExtractPass.format_ebnf(expr: GExpr) -> str {
         return f"{inner}*";
     }
     if isinstance(expr, GTok) {
+        # Show human-readable token text: LBRACE → "{", KW_IF → "if"
+        # Category tokens (NAME, INT, STRING, etc.) stay as-is
+        kind = getattr(TokenKind, expr.name, None);
+        if kind is not None and kind.value != expr.name {
+            return f'"{kind.value}"';
+        }
         return expr.name;
     }
     if isinstance(expr, GRef) {

--- a/jac/jaclang/jac.spec
+++ b/jac/jaclang/jac.spec
@@ -1,115 +1,108 @@
-access_tag ::= (COLON (KW_PUB | KW_PRIV | KW_PROT)?)?
+access_tag ::= (":" ("pub" | "priv" | "protect")?)?
 
 module ::= STRING? element_stmt*
 
-expression ::= lambda_expr | concurrent_expr (KW_IF expression KW_ELSE expression)?
+expression ::= lambda_expr | concurrent_expr ("if" expression "else" expression)?
 
-concurrent_expr ::= (KW_FLOW | KW_WAIT) walrus_assign | walrus_assign
+concurrent_expr ::= ("flow" | "wait") walrus_assign | walrus_assign
 
-walrus_assign ::= by_expr (WALRUS_EQ by_expr)?
+walrus_assign ::= by_expr (":=" by_expr)?
 
-by_expr ::= pipe (KW_BY by_expr)?
+by_expr ::= pipe ("by" by_expr)?
 
-pipe ::= pipe_back (PIPE_FWD pipe_back)*
+pipe ::= pipe_back ("|>" pipe_back)*
 
-pipe_back ::= bitwise_or (PIPE_BKWD bitwise_or)*
+pipe_back ::= bitwise_or ("<|" bitwise_or)*
 
-bitwise_or ::= bitwise_xor (BW_OR bitwise_xor)*
+bitwise_or ::= bitwise_xor ("|" bitwise_xor)*
 
-bitwise_xor ::= bitwise_and (BW_XOR bitwise_and)*
+bitwise_xor ::= bitwise_and ("^" bitwise_and)*
 
-bitwise_and ::= shift (BW_AND shift)*
+bitwise_and ::= shift ("&" shift)*
 
-shift ::= logical_or ((LSHIFT | RSHIFT) logical_or)*
+shift ::= logical_or (("<<" | ">>") logical_or)*
 
-logical_or ::= logical_and (KW_OR logical_and)*
+logical_or ::= logical_and ("or" logical_and)*
 
-logical_and ::= logical_not (KW_AND logical_not)*
+logical_and ::= logical_not ("and" logical_not)*
 
-logical_not ::= KW_NOT logical_not | compare
+logical_not ::= "not" logical_not | compare
 
 compare ::=
     arithmetic (
-        (EE | NE | LT | GT | LTE | GTE | KW_IN | KW_IS | KW_NIN | KW_ISN)
-        ((EE | NE | LT | GT | LTE | GTE | KW_IN | KW_IS | KW_NIN | KW_ISN) arithmetic)*
+        ("==" | "!=" | "<" | ">" | "<=" | ">=" | "in" | "is" | "not in" | "is not") (
+            ("==" | "!=" | "<" | ">" | "<=" | ">=" | "in" | "is" | "not in" | "is not")
+            arithmetic
+        )*
     )?
 
-arithmetic ::= term ((PLUS | MINUS) term)*
+arithmetic ::= term (("+" | "-") term)*
 
-term ::= power ((STAR_MUL | DIV | FLOOR_DIV | MOD | DECOR_OP) power)*
+term ::= power (("*" | "/" | "//" | "%" | "@") power)*
 
-power ::= factor (STAR_POW power)?
+power ::= factor ("**" power)?
 
-factor ::= (BW_NOT | MINUS | PLUS) factor | connect
+factor ::= ("~" | "-" | "+") factor | connect
 
 connect ::= atomic_pipe (connect_op atomic_pipe)*
 
-edge_op_ref_inline ::=
-    (
-        ARROW_R
-        | ARROW_L
-        | ARROW_BI
-        | ARROW_R_P1 atom ARROW_R_P2?
-        | ARROW_L_P1 atom ARROW_L_P2?
-    )?
+edge_op_ref_inline ::= ("-->" | "<--" | "<-->" | "->:" atom ":->"? | "<-:" atom ":<-"?)?
 
 connect_op ::=
     (
-        KW_DELETE edge_op_ref_inline
-        | CARROW_R
-        | CARROW_R_P1 expression (COLON (expression (EQ expression)?)*)? CARROW_R_P2
-        | CARROW_L
-        | CARROW_L_P1 expression (COLON (expression (EQ expression)?)*)?
-          (CARROW_L_P2 | CARROW_R_P2)?
-        | CARROW_BI
+        "del" edge_op_ref_inline
+        | "++>"
+        | "+>:" expression (":" (expression ("=" expression)?)*)? ":+>"
+        | "<++"
+        | "<+:" expression (":" (expression ("=" expression)?)*)? (":<+" | ":+>")?
+        | "<++>"
     )?
 
-atomic_pipe ::= atomic_pipe_back (A_PIPE_FWD atomic_pipe_back)*
+atomic_pipe ::= atomic_pipe_back (":>" atomic_pipe_back)*
 
-atomic_pipe_back ::= spawn (A_PIPE_BKWD spawn)*
+atomic_pipe_back ::= spawn ("<:" spawn)*
 
-spawn ::= KW_SPAWN unpack | unpack (KW_SPAWN unpack)*
+spawn ::= "spawn" unpack | unpack ("spawn" unpack)*
 
-unpack ::= STAR_MUL ref | ref
+unpack ::= "*" ref | ref
 
-ref ::= BW_AND await_expr | await_expr
+ref ::= "&" await_expr | await_expr
 
-await_expr ::= KW_AWAIT pipe_call | pipe_call
+await_expr ::= "await" pipe_call | pipe_call
 
-pipe_call ::= (PIPE_FWD | A_PIPE_FWD) atomic_chain | atomic_chain
+pipe_call ::= ("|>" | ":>") atomic_chain | atomic_chain
 
 atomic_chain ::=
     atom (
-        DOT (DOT | DOT_FWD | DOT_BKWD)? (
-            KW_INIT
-            | KW_POST_INIT
-            | KW_SELF
-            | KW_PROPS
-            | KW_SUPER
-            | KW_ROOT
-            | KW_HERE
-            | KW_VISITOR
+        "." ("." | ".>" | "<.")? (
+            "init"
+            | "postinit"
+            | "self"
+            | "props"
+            | "super"
+            | "root"
+            | "here"
+            | "visitor"
         )?
-        | LPAREN (NULL_OK filter_compr_inner | EQ assign_compr_inner | call_args RPAREN)
-        | LSQUARE NULL_OK? LSQUARE expression? (
-              COLON COLON expression? (COLON expression?)?
-              (COMMA expression? COLON expression? (COLON expression?)?)* RSQUARE
-              | (COMMA expression)* RSQUARE
+        | "(" ("?" filter_compr_inner | "=" assign_compr_inner | call_args ")")
+        | "[" "?"? "[" expression? (
+              ":" ":" expression? (":" expression?)?
+              ("," expression? ":" expression? (":" expression?)?)* "]"
+              | ("," expression)* "]"
           )
     )
 
-call_args ::= call_arg (COMMA call_arg)*
+call_args ::= call_arg ("," call_arg)*
 
 call_arg ::=
-    EQ (KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)? expression
-    | STAR_POW expression
-    | STAR_MUL expression
-    | expression (KW_FOR comprehension_clauses)?
+    "=" ("self" | "props" | "super" | "root" | "here" | "visitor")? expression
+    | "**" expression
+    | "*" expression
+    | expression ("for" comprehension_clauses)?
 
-filter_compr_inner ::=
-    NULL_OK (COLON expression)? COMMA? (compare (COMMA compare)*)? RPAREN
+filter_compr_inner ::= "?" (":" expression)? ","? (compare ("," compare)*)? ")"
 
-assign_compr_inner ::= EQ (NAME EQ expression (COMMA NAME EQ expression)*)? RPAREN
+assign_compr_inner ::= "=" (NAME "=" expression ("," NAME "=" expression)*)? ")"
 
 atom_literal ::= (INT | HEX | BIN | OCT | FLOAT | BOOL | NULL | ELLIPSIS)?
 
@@ -117,35 +110,35 @@ multistring ::= (NAME | STRING | fstring) (NAME | STRING | fstring)*
 
 builtin_type ::=
     (
-        TYP_STRING
-        | TYP_INT
-        | TYP_FLOAT
-        | TYP_LIST
-        | TYP_TUPLE
-        | TYP_SET
-        | TYP_DICT
-        | TYP_BOOL
-        | TYP_BYTES
-        | TYP_ANY
-        | TYP_TYPE
+        "str"
+        | "int"
+        | "float"
+        | "list"
+        | "tuple"
+        | "set"
+        | "dict"
+        | "bool"
+        | "bytes"
+        | "any"
+        | "type"
     )?
 
 special_ref ::=
     (
-        KW_SELF
-        | KW_SUPER
-        | KW_HERE
-        | KW_ROOT
-        | KW_VISITOR
-        | KW_PROPS
-        | KW_INIT
-        | KW_POST_INIT
-        | KW_NODE
-        | KW_EDGE
-        | KW_WALKER
-        | KW_OBJECT
-        | KW_CLASS
-        | KW_ENUM
+        "self"
+        | "super"
+        | "here"
+        | "root"
+        | "visitor"
+        | "props"
+        | "init"
+        | "postinit"
+        | "node"
+        | "edge"
+        | "walker"
+        | "obj"
+        | "class"
+        | "enum"
     )?
 
 atom ::=
@@ -155,169 +148,134 @@ atom ::=
         | builtin_type
         | special_ref
         | (NAME | KWESC_NAME) NAME?
-        | STAR_MUL expression
-        | STAR_POW expression
-        | LPAREN (
-              RPAREN
-              | KW_YIELD yield_stmt RPAREN
-              | (KW_DEF | KW_CAN | KW_ASYNC) ability RPAREN
-              | expression (
-                    KW_FOR comprehension_clauses RPAREN
-                    | COMMA (expression COMMA?)* RPAREN
-                    | RPAREN
-                )
+        | "*" expression
+        | "**" expression
+        | "(" (
+              ")"
+              | "yield" yield_stmt ")"
+              | ("def" | "can" | "async") ability ")"
+              | expression
+                ("for" comprehension_clauses ")" | "," (expression ","?)* ")" | ")")
           )
-        | LSQUARE (
-              ARROW_R
-              | ARROW_L
-              | ARROW_BI
-              | ARROW_R_P1
-              | ARROW_L_P1
-              | RETURN_HINT
-              | KW_ASYNC
-              | (KW_NODE | KW_EDGE) (
-                    ARROW_R
-                    | ARROW_L
-                    | ARROW_BI
-                    | ARROW_R_P1
-                    | ARROW_L_P1
-                    | RETURN_HINT
+        | "[" (
+              "-->"
+              | "<--"
+              | "<-->"
+              | "->:"
+              | "<-:"
+              | "->"
+              | "async"
+              | ("node" | "edge") (
+                    "-->"
+                    | "<--"
+                    | "<-->"
+                    | "->:"
+                    | "<-:"
+                    | "->"
                     | NAME
-                    | KW_ROOT
-                    | KW_SELF
-                    | KW_HERE
-                    | KW_SUPER
-                    | KW_VISITOR
+                    | "root"
+                    | "self"
+                    | "here"
+                    | "super"
+                    | "visitor"
                 )?
-              | (NAME | KW_ROOT | KW_SELF | KW_HERE | KW_SUPER | KW_VISITOR) (
-                    ARROW_R
-                    | ARROW_L
-                    | ARROW_BI
-                    | ARROW_R_P1
-                    | ARROW_L_P1
-                    | RETURN_HINT
-                    | LSQUARE (LSQUARE | RSQUARE)?
-                )?
+              | (NAME | "root" | "self" | "here" | "super" | "visitor")
+                ("-->" | "<--" | "<-->" | "->:" | "<-:" | "->" | "[" ("[" | "]")?)?
           )? (edge_ref_chain | list_or_compr)
-        | LBRACE dict_or_set
+        | "{" dict_or_set
         | jsx_element
     )?
 
 fstring ::=
-    (
-        F_DQ_START
-        | F_SQ_START
-        | F_TDQ_START
-        | F_TSQ_START
-        | RF_DQ_START
-        | RF_SQ_START
-        | RF_TDQ_START
-    ) (
-        D_LBRACE
-        | D_RBRACE
-        | LBRACE expression CONV? (COLON (LBRACE expression CONV? RBRACE)?*)? RBRACE
-    )*
+    ("f"" | "f'" | "f"""" | "f'''" | "rf"" | "rf'" | "rf"""")
+    ("{{" | "}}" | "{" expression CONV? (":" ("{" expression CONV? "}")?*)? "}")*
 
 list_or_compr ::=
-    RSQUARE
-    | expression (KW_FOR comprehension_clauses RSQUARE | (COMMA expression)* RSQUARE)
+    "]" | expression ("for" comprehension_clauses "]" | ("," expression)* "]")
 
 edge_ref_chain ::=
-    KW_ASYNC? (KW_EDGE | KW_NODE)? (
-        (
-            NAME
-            | KWESC_NAME
-            | KW_ROOT
-            | KW_SELF
-            | KW_HERE
-            | KW_SUPER
-            | KW_VISITOR
-            | LSQUARE
-        ) atomic_chain
+    "async"? ("edge" | "node")? (
+        (NAME | KWESC_NAME | "root" | "self" | "here" | "super" | "visitor" | "[")
+        atomic_chain
     )? (
-        (ARROW_R | ARROW_L | ARROW_BI) (ARROW_L | ARROW_BI)?
-        | RETURN_HINT atom? (COLON (compare (COMMA compare)*)?)? ARROW_R_P2
-        | ARROW_L_P1 atom (COLON (compare (COMMA compare)*)?)? ARROW_L_P2
-        | ARROW_R_P1 atom ARROW_R_P2
+        ("-->" | "<--" | "<-->") ("<--" | "<-->")?
+        | "->" atom? (":" (compare ("," compare)*)?)? ":->"
+        | "<-:" atom (":" (compare ("," compare)*)?)? ":<-"
+        | "->:" atom ":->"
     ) (
-        LPAREN (NULL_OK filter_compr_inner | expression RPAREN)
-        | (NAME | KWESC_NAME | KW_SELF | KW_ROOT | KW_HERE | KW_SUPER) atomic_chain
-    )? RSQUARE
+        "(" ("?" filter_compr_inner | expression ")")
+        | (NAME | KWESC_NAME | "self" | "root" | "here" | "super") atomic_chain
+    )? "]"
 
 dict_or_set ::=
-    RBRACE
+    "}"
     | dict_with_spread
     | expression (
-          COLON expression (
-              KW_FOR comprehension_clauses RBRACE
-              | (COMMA (STAR_POW expression | expression COLON expression))* RBRACE
+          ":" expression (
+              "for" comprehension_clauses "}"
+              | ("," ("**" expression | expression ":" expression))* "}"
           )
-          | KW_FOR comprehension_clauses RBRACE
-          | (COMMA expression)* RBRACE
+          | "for" comprehension_clauses "}"
+          | ("," expression)* "}"
       )
 
-dict_with_spread ::= (STAR_POW expression | expression COLON expression)* RBRACE
+dict_with_spread ::= ("**" expression | expression ":" expression)* "}"
 
 comprehension_clauses ::=
-    (KW_ASYNC? KW_FOR atomic_chain KW_IN pipe_call (KW_IF walrus_assign)*)*
+    ("async"? "for" atomic_chain "in" pipe_call ("if" walrus_assign)*)*
 
 lambda_expr ::=
-    KW_LAMBDA (LPAREN func_params RPAREN | lambda_params) (RETURN_HINT expression)?
-    (COLON expression | LBRACE code_block_stmts RBRACE | expression)
+    "lambda" ("(" func_params ")" | lambda_params) ("->" expression)?
+    (":" expression | "{" code_block_stmts "}" | expression)
 
 lambda_params ::=
     (
-        STAR_MUL? DIV? (STAR_MUL | STAR_POW)? (
-            COLON (
+        "*"? "/"? ("*" | "**")? (
+            ":" (
                 (
                     NAME
-                    | TYP_STRING
-                    | TYP_INT
-                    | TYP_FLOAT
-                    | TYP_LIST
-                    | TYP_TUPLE
-                    | TYP_SET
-                    | TYP_DICT
-                    | TYP_BOOL
-                    | TYP_BYTES
-                    | TYP_ANY
-                    | TYP_TYPE
-                ) (COMMA | EQ | COLON | RETURN_HINT | LBRACE)?
+                    | "str"
+                    | "int"
+                    | "float"
+                    | "list"
+                    | "tuple"
+                    | "set"
+                    | "dict"
+                    | "bool"
+                    | "bytes"
+                    | "any"
+                    | "type"
+                ) ("," | "=" | ":" | "->" | "{")?
             )? pipe
-        )? (EQ expression)?
+        )? ("=" expression)?
     )*
 
 jsx_element ::=
-    JSX_FRAG_OPEN jsx_children JSX_FRAG_CLOSE
-    | JSX_OPEN_START JSX_NAME (DOT JSX_NAME)* jsx_attributes (
-          JSX_SELF_CLOSE
-          | JSX_TAG_END jsx_children JSX_CLOSE_START JSX_NAME (DOT JSX_NAME)*
-            JSX_TAG_END
-      )
+    "<>" jsx_children "</>"
+    | JSX_OPEN_START JSX_NAME ("." JSX_NAME)* jsx_attributes
+      ("/>" | JSX_TAG_END jsx_children "</" JSX_NAME ("." JSX_NAME)* JSX_TAG_END)
 
-jsx_opening_element ::=
-    JSX_OPEN_START JSX_NAME jsx_attributes (JSX_SELF_CLOSE | JSX_TAG_END)
+jsx_opening_element ::= JSX_OPEN_START JSX_NAME jsx_attributes ("/>" | JSX_TAG_END)
 
 jsx_attributes ::=
-    JSX_NAME (EQ (STRING | LBRACE expression RBRACE)?)?
-    | LBRACE ELLIPSIS? expression RBRACE
+    JSX_NAME ("=" (STRING | "{" expression "}")?)? | "{" ELLIPSIS? expression "}"
 
 jsx_children ::= jsx_child*
 
-jsx_child ::= (JSX_TEXT jsx_child? | LBRACE expression RBRACE | jsx_element)?
+jsx_child ::= (JSX_TEXT jsx_child? | "{" expression "}" | jsx_element)?
 
 element_stmt ::=
     (
-        SEMI
-        | KW_CLIENT (client_block | element_stmt)?
-        | KW_SERVER (server_block | element_stmt)?
-        | KW_NATIVE (native_block | element_stmt)?
+        ";"
+        | "cl" (client_block | element_stmt)?
+        | "sv" (server_block | element_stmt)?
+        | "na" (native_block | element_stmt)?
         | import_stmt
         | archetype
         | enum
         | STRING test
         | test
-        | STRING (DECOR_OP atomic_chain)* KW_ASYNC* KW_ABSTRACT?
+        | STRING ("@" atomic_chain)* "async"* "abs"?
           (archetype | enum | impl_def | ability)
         | STRING enum
         | ability
@@ -329,26 +287,24 @@ element_stmt ::=
         | PYNLINE
         | STRING module_code
         | module_code
-        | DECOR_OP (DECOR_OP atomic_chain)* KW_ASYNC*
-          (ability | enum | impl_def | archetype)
-        | KW_ASYNC KW_ASYNC* (ability | archetype)
+        | "@" ("@" atomic_chain)* "async"* (ability | enum | impl_def | archetype)
+        | "async" "async"* (ability | archetype)
     )?
 
-client_block ::= KW_CLIENT (LBRACE element_stmt* RBRACE | element_stmt)
+client_block ::= "cl" ("{" element_stmt* "}" | element_stmt)
 
-server_block ::= KW_SERVER (LBRACE element_stmt* RBRACE | element_stmt)
+server_block ::= "sv" ("{" element_stmt* "}" | element_stmt)
 
-native_block ::= KW_NATIVE (LBRACE element_stmt* RBRACE | element_stmt)
+native_block ::= "na" ("{" element_stmt* "}" | element_stmt)
 
-module_code ::=
-    KW_WITH (KW_EXIT | KW_ENTRY)? (COLON NAME)? LBRACE code_block_stmts RBRACE
+module_code ::= "with" ("exit" | "entry")? (":" NAME)? "{" code_block_stmts "}"
 
-code_block_stmts ::= (statement SEMI?)*
+code_block_stmts ::= (statement ";"?)*
 
-ctrl_stmt ::= ((KW_BREAK | KW_CONTINUE | KW_SKIP) SEMI | KW_DISENGAGE SEMI)?
+ctrl_stmt ::= (("break" | "continue" | "skip") ";" | "disengage" ";")?
 
 statement ::=
-    SEMI
+    ";"
     | import_stmt
     | if_stmt
     | while_stmt
@@ -358,7 +314,7 @@ statement ::=
     | match_stmt
     | switch_stmt
     | return_stmt
-    | KW_YIELD yield_stmt SEMI
+    | "yield" yield_stmt ";"
     | ctrl_stmt
     | raise_stmt
     | assert_stmt
@@ -373,46 +329,46 @@ statement ::=
     | impl_def
     | has_stmt
     | PYNLINE
-    | KW_ELIF
-    | KW_ELSE
-    | KW_EXCEPT
-    | KW_FINALLY
-    | KW_CASE
-    | RETURN_HINT expression LBRACE code_block_stmts RBRACE
-    | expression (assignment_with_target | SEMI?)
+    | "elif"
+    | "else"
+    | "except"
+    | "finally"
+    | "case"
+    | "->" expression "{" code_block_stmts "}"
+    | expression (assignment_with_target | ";"?)
 
-if_stmt ::= KW_IF expression LBRACE code_block_stmts RBRACE (elif_stmt | else_stmt)?
+if_stmt ::= "if" expression "{" code_block_stmts "}" (elif_stmt | else_stmt)?
 
-elif_stmt ::= KW_ELIF expression LBRACE code_block_stmts RBRACE (elif_stmt | else_stmt)?
+elif_stmt ::= "elif" expression "{" code_block_stmts "}" (elif_stmt | else_stmt)?
 
-else_stmt ::= KW_ELSE LBRACE code_block_stmts RBRACE
+else_stmt ::= "else" "{" code_block_stmts "}"
 
-while_stmt ::= KW_WHILE expression LBRACE code_block_stmts RBRACE else_stmt?
+while_stmt ::= "while" expression "{" code_block_stmts "}" else_stmt?
 
 for_stmt ::=
-    KW_ASYNC? KW_FOR atomic_chain (
-        EQ expression KW_TO pipe KW_BY atomic_chain assignment_with_target? LBRACE
-        code_block_stmts RBRACE else_stmt?
-        | KW_IN expression LBRACE code_block_stmts RBRACE else_stmt?
+    "async"? "for" atomic_chain (
+        "=" expression "to" pipe "by" atomic_chain assignment_with_target? "{"
+        code_block_stmts "}" else_stmt?
+        | "in" expression "{" code_block_stmts "}" else_stmt?
     )
 
 try_stmt ::=
-    KW_TRY LBRACE code_block_stmts RBRACE (KW_EXCEPT except_handler)* else_stmt?
-    (KW_FINALLY LBRACE code_block_stmts RBRACE)?
+    "try" "{" code_block_stmts "}" ("except" except_handler)* else_stmt?
+    ("finally" "{" code_block_stmts "}")?
 
-except_handler ::= KW_EXCEPT expression (KW_AS NAME)? LBRACE code_block_stmts RBRACE
+except_handler ::= "except" expression ("as" NAME)? "{" code_block_stmts "}"
 
 with_stmt ::=
-    KW_ASYNC? KW_WITH expression (KW_AS expression)?
-    (COMMA expression (KW_AS expression)?)* LBRACE code_block_stmts RBRACE
+    "async"? "with" expression ("as" expression)? ("," expression ("as" expression)?)*
+    "{" code_block_stmts "}"
 
-match_stmt ::= KW_MATCH expression LBRACE (KW_CASE match_case)* RBRACE
+match_stmt ::= "match" expression "{" ("case" match_case)* "}"
 
-match_case ::= KW_CASE pattern (KW_IF expression)? COLON statement*
+match_case ::= "case" pattern ("if" expression)? ":" statement*
 
-pattern ::= or_pattern (KW_AS NAME)?
+pattern ::= or_pattern ("as" NAME)?
 
-or_pattern ::= single_pattern (BW_OR single_pattern)*
+or_pattern ::= single_pattern ("|" single_pattern)*
 
 single_pattern ::=
     sequence_pattern
@@ -423,171 +379,158 @@ single_pattern ::=
     | INT
     | FLOAT
     | multistring (
-          MINUS (INT | FLOAT)?
-          | (DOT (DOT NAME)* class_pattern_args? | class_pattern_args)?
+          "-" (INT | FLOAT)?
+          | ("." ("." NAME)* class_pattern_args? | class_pattern_args)?
           | (
-                TYP_STRING
-                | TYP_INT
-                | TYP_FLOAT
-                | TYP_LIST
-                | TYP_TUPLE
-                | TYP_SET
-                | TYP_DICT
-                | TYP_BOOL
-                | TYP_BYTES
-                | TYP_ANY
-                | TYP_TYPE
+                "str"
+                | "int"
+                | "float"
+                | "list"
+                | "tuple"
+                | "set"
+                | "dict"
+                | "bool"
+                | "bytes"
+                | "any"
+                | "type"
             ) class_pattern_args?
           | expression
       )
 
-sequence_pattern ::= LSQUARE ((STAR_MUL NAME | pattern) COMMA?)* RSQUARE
+sequence_pattern ::= "[" (("*" NAME | pattern) ","?)* "]"
 
-tuple_sequence_pattern ::= LPAREN ((STAR_MUL NAME | pattern) COMMA?)* RPAREN
+tuple_sequence_pattern ::= "(" (("*" NAME | pattern) ","?)* ")"
 
-mapping_pattern ::=
-    LBRACE ((STAR_POW NAME | literal_for_mapping COLON pattern) COMMA?)* RBRACE
+mapping_pattern ::= "{" (("**" NAME | literal_for_mapping ":" pattern) ","?)* "}"
 
-literal_for_mapping ::= INT | FLOAT | multistring (MINUS (INT | FLOAT)?)?
+literal_for_mapping ::= INT | FLOAT | multistring ("-" (INT | FLOAT)?)?
 
-class_pattern_args ::= LPAREN ((EQ EQ pattern | pattern) COMMA?)* RPAREN
+class_pattern_args ::= "(" (("=" "=" pattern | pattern) ","?)* ")"
 
-return_stmt ::= KW_RETURN expression? SEMI
+return_stmt ::= "return" expression? ";"
 
-yield_stmt ::= KW_YIELD KW_FROM? expression?
+yield_stmt ::= "yield" "from"? expression?
 
-raise_stmt ::= KW_RAISE expression? (KW_FROM expression)? SEMI
+raise_stmt ::= "raise" expression? ("from" expression)? ";"
 
-assert_stmt ::= KW_ASSERT expression (COMMA expression)? SEMI
+assert_stmt ::= "assert" expression ("," expression)? ";"
 
-delete_stmt ::= KW_DELETE expression SEMI
+delete_stmt ::= "del" expression ";"
 
-global_stmt ::= KW_GLOBAL_REF NAME (COMMA NAME)* SEMI
+global_stmt ::= "global" NAME ("," NAME)* ";"
 
-nonlocal_stmt ::= KW_NONLOCAL NAME (COMMA NAME)* SEMI
+nonlocal_stmt ::= "nonlocal" NAME ("," NAME)* ";"
 
 assignment_with_target ::=
-    (COLON pipe)? (
-        EQ EQ*
+    (":" pipe)? (
+        "=" "="*
         | (
-              ADD_EQ
-              | SUB_EQ
-              | MUL_EQ
-              | DIV_EQ
-              | FLOOR_DIV_EQ
-              | MOD_EQ
-              | STAR_POW_EQ
-              | MATMUL_EQ
-              | BW_AND_EQ
-              | BW_OR_EQ
-              | BW_XOR_EQ
-              | LSHIFT_EQ
-              | RSHIFT_EQ
+              "+="
+              | "-="
+              | "*="
+              | "/="
+              | "//="
+              | "%="
+              | "**="
+              | "@="
+              | "&="
+              | "|="
+              | "^="
+              | "<<="
+              | ">>="
           )?
-    ) SEMI?
+    ) ";"?
 
 import_stmt ::=
-    (KW_INCLUDE | KW_IMPORT)
-    (KW_FROM ((DOT | ELLIPSIS) ELLIPSIS?*)? (STRING | (DOT NAME)*)?)? (
-        LBRACE ((STAR_MUL | KW_DEFAULT | NAME) (KW_AS NAME)?)* RBRACE
-        | (STRING | (DOT NAME)*)? (KW_AS NAME)?
-    ) SEMI
+    ("include" | "import")
+    ("from" (("." | ELLIPSIS) ELLIPSIS?*)? (STRING | ("." NAME)*)?)? (
+        "{" (("*" | "default" | NAME) ("as" NAME)?)* "}"
+        | (STRING | ("." NAME)*)? ("as" NAME)?
+    ) ";"
 
 archetype ::=
-    (DECOR_OP atomic_chain)* KW_ASYNC? KW_ABSTRACT? access_tag NAME
-    (LPAREN (atomic_chain (COMMA atomic_chain)*)? RPAREN)?
-    (LBRACE archetype_member* RBRACE | SEMI)
+    ("@" atomic_chain)* "async"? "abs"? access_tag NAME
+    ("(" (atomic_chain ("," atomic_chain)*)? ")")? ("{" archetype_member* "}" | ";")
 
 archetype_member ::=
-    SEMI* STRING? (
-        DECOR_OP ability
-        | KW_STATIC (KW_HAS has_stmt | ability)
-        | KW_HAS has_stmt
-        | KW_ASYNC ability
-        | (KW_DEF | KW_CAN | KW_OVERRIDE) ability
-        | (KW_OBJECT | KW_NODE | KW_EDGE | KW_WALKER | KW_CLASS) archetype
-        | KW_ENUM enum
-        | KW_IMPL impl_def
+    ";"* STRING? (
+        "@" ability
+        | "static" ("has" has_stmt | ability)
+        | "has" has_stmt
+        | "async" ability
+        | ("def" | "can" | "override") ability
+        | ("obj" | "node" | "edge" | "walker" | "class") archetype
+        | "enum" enum
+        | "impl" impl_def
         | PYNLINE
-        | KW_WITH ((KW_ENTRY | KW_EXIT) LBRACE code_block_stmts RBRACE)?
+        | "with" (("entry" | "exit") "{" code_block_stmts "}")?
         | NAME?
     )
 
-has_stmt ::= KW_STATIC? KW_HAS access_tag has_var (COMMA has_var)* SEMI
+has_stmt ::= "static"? "has" access_tag has_var ("," has_var)* ";"
 
 has_var ::=
-    NAME (KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)? COLON pipe
-    (EQ expression | (KW_BY KW_POST_INIT)?)
+    NAME ("self" | "props" | "super" | "root" | "here" | "visitor")? ":" pipe
+    ("=" expression | ("by" "postinit")?)
 
 ability ::=
-    (DECOR_OP atomic_chain)* KW_OVERRIDE? KW_STATIC? (KW_ASYNC KW_OVERRIDE? KW_STATIC?)?
-    access_tag (
-        KW_INIT
-        | KW_POST_INIT
-        | KW_ROOT
-        | KW_SUPER
-        | KW_SELF
-        | KW_PROPS
-        | KW_HERE
-        | KW_VISITOR
-    )? (KW_WITH | func_signature)
-    (LBRACE code_block_stmts RBRACE | KW_BY expression SEMI | KW_ABSTRACT? SEMI)
+    ("@" atomic_chain)* "override"? "static"? ("async" "override"? "static"?)?
+    access_tag
+    ("init" | "postinit" | "root" | "super" | "self" | "props" | "here" | "visitor")?
+    ("with" | func_signature)
+    ("{" code_block_stmts "}" | "by" expression ";" | "abs"? ";")
 
-func_signature ::= (LPAREN func_params? RPAREN)? (RETURN_HINT pipe)?
+func_signature ::= ("(" func_params? ")")? ("->" pipe)?
 
 func_params ::=
     (
-        STAR_MUL
-        | DIV
-        | (STAR_MUL | STAR_POW)?
-          (KW_SELF | (KW_SELF | KW_PROPS | KW_SUPER | KW_ROOT | KW_HERE | KW_VISITOR)?)
-          (COLON pipe)? (EQ expression)?
+        "*"
+        | "/"
+        | ("*" | "**")?
+          ("self" | ("self" | "props" | "super" | "root" | "here" | "visitor")?)
+          (":" pipe)? ("=" expression)?
     )*
 
 enum ::=
-    (DECOR_OP atomic_chain)* KW_ENUM access_tag NAME
-    (LPAREN (atomic_chain (COMMA atomic_chain)*)? RPAREN)?
-    (LBRACE (enum_member COMMA? (PYNLINE | KW_WITH module_code))* RBRACE | SEMI)
+    ("@" atomic_chain)* "enum" access_tag NAME
+    ("(" (atomic_chain ("," atomic_chain)*)? ")")?
+    ("{" (enum_member ","? (PYNLINE | "with" module_code))* "}" | ";")
 
-enum_member ::= NAME (EQ expression)?
+enum_member ::= NAME ("=" expression)?
 
-test ::= KW_TEST STRING? LBRACE code_block_stmts RBRACE
+test ::= "test" STRING? "{" code_block_stmts "}"
 
-switch_stmt ::= KW_SWITCH expression LBRACE ((KW_CASE | KW_DEFAULT) switch_case)* RBRACE
+switch_stmt ::= "switch" expression "{" (("case" | "default") switch_case)* "}"
 
-switch_case ::= (KW_DEFAULT | KW_CASE pattern) COLON statement*
+switch_case ::= ("default" | "case" pattern) ":" statement*
 
-global_var ::=
-    KW_GLOBAL access_tag global_var_assignment (COMMA global_var_assignment)* SEMI
+global_var ::= "glob" access_tag global_var_assignment ("," global_var_assignment)* ";"
 
-global_var_assignment ::= NAME (COLON pipe)? (EQ expression (EQ expression)*)?
+global_var_assignment ::= NAME (":" pipe)? ("=" expression ("=" expression)*)?
 
 impl_def ::=
-    (DECOR_OP atomic_chain)* KW_IMPL impl_target_name (DOT impl_target_name)* (
-        LPAREN (KW_SELF | RPAREN)? func_signature (atomic_chain (COMMA atomic_chain)*)?
-        RPAREN
-        | KW_WITH
+    ("@" atomic_chain)* "impl" impl_target_name ("." impl_target_name)* (
+        "(" ("self" | ")")? func_signature (atomic_chain ("," atomic_chain)*)? ")"
+        | "with"
         | func_signature
     )? (
-        LBRACE COMMA? (
-            COLON (LPAREN | LBRACE | LSQUARE | RPAREN | RBRACE | RSQUARE)? (
-                EQ (LPAREN | LBRACE | LSQUARE | RPAREN | RBRACE | RSQUARE)? COMMA?
-                | COMMA
-            )?
-        )? (EQ (LPAREN | LBRACE | LSQUARE | RPAREN | RBRACE | RSQUARE)? COMMA?)?
-        impl_enum_body code_block_stmts RBRACE
-        | KW_BY expression SEMI
-        | SEMI
+        "{" ","? (
+            ":" ("(" | "{" | "[" | ")" | "}" | "]")?
+            ("=" ("(" | "{" | "[" | ")" | "}" | "]")? ","? | ",")?
+        )? ("=" ("(" | "{" | "[" | ")" | "}" | "]")? ","?)? impl_enum_body
+        code_block_stmts "}"
+        | "by" expression ";"
+        | ";"
     )
 
 impl_target_name ::= NAME
 
-impl_enum_body ::= ((COLON pipe)? (EQ expression)? COMMA?)*
+impl_enum_body ::= ((":" pipe)? ("=" expression)? ","?)*
 
-sem_def ::= KW_SEM impl_target_name (DOT impl_target_name)* (EQ | KW_IS) STRING SEMI?
+sem_def ::= "sem" impl_target_name ("." impl_target_name)* ("=" | "is") STRING ";"?
 
-dotted_name ::= NAME (DOT NAME)*
+dotted_name ::= NAME ("." NAME)*
 
-visit_stmt ::= KW_VISIT (COLON expression COLON)? expression (else_stmt | SEMI)?
+visit_stmt ::= "visit" (":" expression ":")? expression (else_stmt | ";")?
 
-report_stmt ::= KW_REPORT expression SEMI?
+report_stmt ::= "report" expression ";"?

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -206,19 +206,17 @@ impl Parser.expect(kind: TokenKind) -> Token {
     if self.check(kind) {
         return self.advance();
     }
-    # Generate user-friendly error messages for common missing tokens
-    if kind == TokenKind.RPAREN {
-        self.error("Missing RPAREN");
-    } elif kind == TokenKind.RBRACE {
-        self.error("Missing RBRACE");
-    } elif kind == TokenKind.RSQUARE {
-        self.error("Missing RSQUARE");
-    } elif kind == TokenKind.SEMI {
-        self.error("Missing SEMI");
-    } elif kind == TokenKind.COMMA {
-        self.error("Missing COMMA");
+    # Generate user-friendly error messages for missing/unexpected tokens
+    if kind in (
+        TokenKind.RPAREN,
+        TokenKind.RBRACE,
+        TokenKind.RSQUARE,
+        TokenKind.SEMI,
+        TokenKind.COMMA
+    ) {
+        self.error(f"Missing '{kind.value}'");
     } else {
-        self.error(f"Expected {kind}, got {self.current().kind}");
+        self.error(f"Expected '{kind.value}', got '{self.current().kind.value}'");
         # Advance past the unexpected token to guarantee forward progress
         return self.advance();
     }
@@ -398,7 +396,7 @@ impl Parser.expect_name -> Token {
     if self.check_name() {
         return self.advance();
     }
-    self.error(f"Expected identifier, got {self.current().kind}");
+    self.error(f"Expected identifier, got '{self.current().kind.value}'");
     return self.current();
 }
 
@@ -1577,7 +1575,7 @@ impl Parser.parse_call_args(kid: list) -> list {
         return args;
     }
     # If current token clearly cannot start an argument, return empty
-    # so that the caller's expect(RPAREN) generates "Missing RPAREN"
+    # so that the caller's expect(RPAREN) generates "Missing ')'"
     if self.check(TokenKind.SEMI) or self.check(TokenKind.RBRACE) {
         return args;
     }
@@ -1595,7 +1593,7 @@ impl Parser.parse_call_args(kid: list) -> list {
     }
     # Check for missing comma between arguments
     if not self.check(TokenKind.RPAREN) and not self.at_end() {
-        self.error("Missing COMMA");
+        self.error("Missing ','");
         self.error("Unexpected token");
         # Skip to RPAREN or end to recover
         while not self.check(TokenKind.RPAREN) and not self.at_end() {
@@ -2182,7 +2180,7 @@ impl Parser.parse_atom -> Expr {
     if self.check(TokenKind.JSX_OPEN_START) or self.check(TokenKind.JSX_FRAG_OPEN) {
         return self.parse_jsx_element();
     }
-    self.error(f"Unexpected token in expression: {self.current().kind}");
+    self.error(f"Unexpected token in expression: '{self.current().kind.value}'");
     return self.make_name(self.advance());
 }
 

--- a/jac/tests/compiler/passes/tool/test_grammar_extract_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_grammar_extract_pass.jac
@@ -68,7 +68,7 @@ def parse_spec(text: str) -> dict[str, str] {
 
 # ── Unit tests: grammar model and formatting ─────────────────────────────
 test "gtok ebnf" {
-    assert fmt(GTok(name="KW_IF")) == "KW_IF";
+    assert fmt(GTok(name="KW_IF")) == '"if"';
 }
 
 test "gref ebnf" {
@@ -77,7 +77,7 @@ test "gref ebnf" {
 
 test "gseq ebnf" {
     seq = GSeq(items=[GTok(name="KW_IF"), GRef(name="expression")]);
-    assert fmt(seq) == "KW_IF expression";
+    assert fmt(seq) == '"if" expression';
 }
 
 test "galt ebnf" {
@@ -97,7 +97,7 @@ test "gopt alt ebnf" {
 
 test "gstar ebnf" {
     star = GStar(inner=GSeq(items=[GTok(name="BW_OR"), GRef(name="bitwise_xor")]));
-    assert fmt(star) == "(BW_OR bitwise_xor)*";
+    assert fmt(star) == '("|" bitwise_xor)*';
 }
 
 test "grammar rule ebnf" {
@@ -111,7 +111,7 @@ test "grammar rule ebnf" {
         )
     );
     ebnf = rule.to_ebnf();
-    assert ebnf == "bitwise_or ::= bitwise_xor (BW_OR bitwise_xor)*";
+    assert ebnf == 'bitwise_or ::= bitwise_xor ("|" bitwise_xor)*';
 }
 
 test "alt inside seq gets parens" {
@@ -177,7 +177,7 @@ test "bitwise or structure" {
     assert "bitwise_or" in rule_map;
     ebnf = fmt(rule_map["bitwise_or"].body);
     assert "bitwise_xor" in ebnf;
-    assert "BW_OR" in ebnf;
+    assert '"|"' in ebnf;
 }
 
 test "if stmt structure" {
@@ -188,10 +188,10 @@ test "if stmt structure" {
     rule_map = {r.name: r for r in extracted.rules};
     assert "if_stmt" in rule_map;
     ebnf = fmt(rule_map["if_stmt"].body);
-    assert "KW_IF" in ebnf;
+    assert '"if"' in ebnf;
     assert "expression" in ebnf;
-    assert "LBRACE" in ebnf;
-    assert "RBRACE" in ebnf;
+    assert '"{"' in ebnf;
+    assert '"}"' in ebnf;
 }
 
 test "while stmt structure" {
@@ -202,7 +202,7 @@ test "while stmt structure" {
     rule_map = {r.name: r for r in extracted.rules};
     assert "while_stmt" in rule_map;
     ebnf = fmt(rule_map["while_stmt"].body);
-    assert "KW_WHILE" in ebnf;
+    assert '"while"' in ebnf;
     assert "expression" in ebnf;
 }
 

--- a/jac/tests/compiler/test_parser.jac
+++ b/jac/tests/compiler/test_parser.jac
@@ -177,7 +177,7 @@ test "multiple syntax errors" {
     prog.compile(os.path.join(FIXTURES, "multiple_syntax_errors.jac"));
     sys.stdout = sys.__stdout__;
     assert len(prog.errors_had) == 3;
-    expected_substrings = ["Missing RPAREN", "Missing COMMA", "Unexpected token", ];
+    expected_substrings = ["Missing ')'", "Missing ','", "Unexpected token", ];
     for (alrt, expected) in zip(prog.errors_had, expected_substrings, strict=True) {
         pretty = alrt.pretty_print();
         assert expected in pretty;


### PR DESCRIPTION
## Summary
- Parser error messages now show actual token text (`Missing '}'`) instead of internal names (`Missing RBRACE`), and the general case shows `Expected '{', got 'if'` instead of `Expected TokenKind.LBRACE, got TokenKind.KW_IF`
- `jac grammar` EBNF output uses quoted literals for tokens (`"{"`, `"if"`, `";"`) while keeping category tokens (`NAME`, `INT`, `STRING`) as-is, producing a much more readable grammar spec
- Regenerated `jac.spec` with the new formatting

## Test plan
- [ ] Run `jac grammar` and verify output uses quoted token text for literals
- [ ] Introduce a syntax error in a `.jac` file and verify the error message shows human-readable tokens
- [ ] Run existing parser/grammar tests to ensure no regressions