### PR TITLE
feat(es-codegen): Wire operator primitive dispatch into JS code generation

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -18,6 +18,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Generic Primitive Emitter Interface**: Refactored the primitive codegen emitter contracts. Emitters are now stateless singletons with per-call context, and dispatch uses typed instance methods instead of static class-as-namespace calls.
 - **Human-Readable Tokens in Errors and Grammar Spec**: Parser error messages and `jac grammar` output now display actual token text (`"{"`, `"if"`, `";"`) instead of internal names (`LBRACE`, `KW_IF`, `SEMI`), making syntax errors and the grammar specification much more readable.
 - **Support Bare `type` Parameter Assignment**: Functions with `type` parameter annotations now correctly accept class types as arguments (e.g., `process(cls: type)` can be called with `process(MyClass)`).
+- **Operator Primitive Dispatch for ES Codegen**: Wired type-aware operator dispatch into the JavaScript code generation pass. Binary, comparison, unary, and augmented assignment operators now query the type evaluator and delegate to the appropriate primitive emitter, producing correct JS semantics for Python-style operators (e.g., `list + list` emits spread concatenation `[...a, ...b]`, `str * n` emits `.repeat(n)`, `x in list` emits `.includes(x)`).
 - 2 Minor refactors/changes.
 
 ## jaclang 0.10.2 (Latest Release)

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -84,6 +84,43 @@ glob _T = TypeVar('_T', bound=es.Node),
          Tok.RSHIFT_EQ: '>>=',
          Tok.STAR_POW_EQ: '**='
      },
+     OP_EMIT_MAP: dict[(Tok, str)] = {
+         Tok.PLUS: "emit_op_add",
+         Tok.MINUS: "emit_op_sub",
+         Tok.STAR_MUL: "emit_op_mul",
+         Tok.DIV: "emit_op_truediv",
+         Tok.FLOOR_DIV: "emit_op_floordiv",
+         Tok.MOD: "emit_op_mod",
+         Tok.STAR_POW: "emit_op_pow",
+         Tok.BW_AND: "emit_op_and",
+         Tok.BW_OR: "emit_op_or",
+         Tok.BW_XOR: "emit_op_xor",
+         Tok.LSHIFT: "emit_op_lshift",
+         Tok.RSHIFT: "emit_op_rshift"
+     },
+     CMP_EMIT_MAP: dict[(Tok, str)] = {
+         Tok.EE: "emit_op_eq",
+         Tok.NE: "emit_op_ne",
+         Tok.LT: "emit_op_lt",
+         Tok.GT: "emit_op_gt",
+         Tok.LTE: "emit_op_le",
+         Tok.GTE: "emit_op_ge",
+         Tok.KW_IN: "emit_op_contains",
+         Tok.KW_NIN: "emit_op_contains"
+     },
+     UNARY_EMIT_MAP: dict[(Tok, str)] = {
+         Tok.MINUS: "emit_op_neg",
+         Tok.PLUS: "emit_op_pos",
+         Tok.BW_NOT: "emit_op_invert"
+     },
+     AUG_EMIT_MAP: dict[(Tok, str)] = {
+         Tok.ADD_EQ: "emit_op_iadd",
+         Tok.SUB_EQ: "emit_op_isub",
+         Tok.MUL_EQ: "emit_op_imul",
+         Tok.BW_OR_EQ: "emit_op_ior",
+         Tok.BW_AND_EQ: "emit_op_iand",
+         Tok.BW_XOR_EQ: "emit_op_ixor"
+     },
      LiteralValue = str | bool | int | float | None;
 
 """Track declarations within a lexical scope."""
@@ -226,6 +263,14 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def exit_expr_stmt(nd: uni.ExprStmt) -> None;
     def exit_switch_stmt(nd: uni.SwitchStmt) -> None;
     def exit_switch_case(nd: uni.SwitchCase) -> None;
+    def _try_primitive_op(
+        expr_node: uni.UniNode,
+        emit_method: str,
+        left_es: es.Expression,
+        right_es: (es.Expression | None),
+        jac_node: uni.UniNode
+    ) -> (es.Expression | None);
+
     def exit_binary_expr(nd: uni.BinaryExpr) -> None;
     def exit_bool_expr(nd: uni.BoolExpr) -> None;
     def exit_compare_expr(nd: uni.CompareExpr) -> None;

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -1077,8 +1077,6 @@ impl EsastGenPass.exit_assignment(nd: uni.Assignment) -> None {
     if nd.aug_op {
         (left, _, _) = self._convert_assignment_target(nd.target[0]);
         aug_tok = Tok(nd.aug_op.name) if (nd.aug_op.name in Tok.__members__) else None;
-        operator = ES_AUG_ASSIGN_OPS.get(aug_tok) if aug_tok else None;
-        operator = operator or '=';
         right = cast(
             es.Expression,
             (
@@ -1089,6 +1087,22 @@ impl EsastGenPass.exit_assignment(nd: uni.Assignment) -> None {
                 )
             )
         );
+        # Type-aware augmented assignment primitive dispatch
+        _aug_emit_name = AUG_EMIT_MAP.get(aug_tok) if aug_tok else None;
+        if _aug_emit_name {
+            _prim_result = self._try_primitive_op(
+                nd.target[0], _aug_emit_name, cast(es.Expression, left), right, nd
+            );
+            if _prim_result is not None {
+                expr_stmt = self.sync_loc(
+                    es.ExpressionStatement(expression=_prim_result), jac_node=nd
+                );
+                nd.gen.es_ast = expr_stmt;
+                return;
+            }
+        }
+        operator = ES_AUG_ASSIGN_OPS.get(aug_tok) if aug_tok else None;
+        operator = operator or '=';
         assign_expr = self.sync_loc(
             es.AssignmentExpression(operator=operator, left=left, right=right),
             jac_node=nd
@@ -1296,6 +1310,81 @@ impl EsastGenPass._convert_assignment_target(
     return (left, reference, None);
 }
 
+"""Try to dispatch an operator through the primitive emitter system.
+
+Returns an es.Expression (raw Identifier wrapping emitted JS) on success, or None
+if the type evaluator doesn't know the type or the emitter doesn't handle this op.
+"""
+impl EsastGenPass._try_primitive_op(
+    expr_node: uni.UniNode,
+    emit_method: str,
+    left_es: es.Expression,
+    right_es: (es.Expression | None),
+    jac_node: uni.UniNode
+) -> (es.Expression | None) {
+    import from jaclang.compiler.type_system { types as jtypes }
+    import from jaclang.compiler.passes.ecmascript.es_unparse { JSCodeGenerator }
+    _obj_type = None;
+    try {
+        _te = self.prog.get_type_evaluator();
+        if _te {
+            _obj_type = _te.get_type_of_expression(expr_node);
+        }
+    } except Exception {
+        _obj_type = None;
+    }
+    if not (
+        isinstance(_obj_type, jtypes.ClassType)
+        and _obj_type.shared
+        and _obj_type.shared.class_name in self._primitive_type_names
+    ) {
+        return None;
+    }
+    # Lazily initialize emitter singletons on first use
+    if self._primitive_emitters is None {
+        _pes = __import__(
+            "jaclang.compiler.passes.ecmascript.primitives_es",
+            fromlist=["ESIntEmitter"]
+        );
+        self._primitive_emitters = {
+            "int": _pes.ESIntEmitter(),
+            "float": _pes.ESFloatEmitter(),
+            "complex": _pes.ESComplexEmitter(),
+            "str": _pes.ESStrEmitter(),
+            "bytes": _pes.ESBytesEmitter(),
+            "list": _pes.ESListEmitter(),
+            "dict": _pes.ESDictEmitter(),
+            "set": _pes.ESSetEmitter(),
+            "frozenset": _pes.ESFrozensetEmitter(),
+            "tuple": _pes.ESTupleEmitter(),
+            "range": _pes.ESRangeEmitter()
+        };
+        self._es_emit_ctx_class = _pes.ESEmitCtx;
+    }
+    _type_name = _obj_type.shared.class_name;
+    # bool delegates to int emitter
+    if _type_name == "bool" {
+        _type_name = "int";
+    }
+    _emitter = self._primitive_emitters.get(_type_name);
+    _emit_fn = getattr(_emitter, emit_method, None) if _emitter else None;
+    if not _emit_fn {
+        return None;
+    }
+    _unparser = JSCodeGenerator();
+    _ctx = self._es_emit_ctx_class(unparser=_unparser);
+    _target_str = _unparser.generate(left_es);
+    _args_strs: list[str] = [];
+    if right_es is not None {
+        _args_strs.append(_unparser.generate(right_es));
+    }
+    _result = _emit_fn(_ctx, _target_str, _args_strs);
+    if _result is None {
+        return None;
+    }
+    return self.sync_loc(es.Identifier(name=_result), jac_node=jac_node);
+}
+
 """Process unary expression."""
 impl EsastGenPass.exit_unary_expr(nd: uni.UnaryExpr) -> None {
     operand = cast(
@@ -1305,6 +1394,17 @@ impl EsastGenPass.exit_unary_expr(nd: uni.UnaryExpr) -> None {
         )
     );
     op_tok = Tok(nd.op.name) if (nd.op.name in Tok.__members__) else None;
+    # Type-aware unary primitive dispatch
+    _unary_emit_name = UNARY_EMIT_MAP.get(op_tok) if op_tok else None;
+    if _unary_emit_name {
+        _prim_result = self._try_primitive_op(
+            nd.operand, _unary_emit_name, operand, None, nd
+        );
+        if _prim_result is not None {
+            nd.gen.es_ast = _prim_result;
+            return;
+        }
+    }
     operator = ES_UNARY_OPS.get(op_tok) if op_tok else None;
     operator = operator or '!';
     unary_expr = self.sync_loc(
@@ -1343,6 +1443,35 @@ impl EsastGenPass.exit_compare_expr(nd: uni.CompareExpr) -> None {
             )
         );
         op_tok = Tok(op_token.name) if (op_token.name in Tok.__members__) else None;
+        # Type-aware comparison primitive dispatch
+        _cmp_emit_name = CMP_EMIT_MAP.get(op_tok) if op_tok else None;
+        if _cmp_emit_name {
+            # For in/not in: type-check the container (right), swap target/arg
+            if op_tok in (Tok.KW_IN, Tok.KW_NIN) {
+                _prim_result = self._try_primitive_op(
+                    right_node, _cmp_emit_name, right, left, nd
+                );
+            } else {
+                _prim_result = self._try_primitive_op(
+                    nd.left, _cmp_emit_name, left, right, nd
+                );
+            }
+            if _prim_result is not None {
+                if op_tok == Tok.KW_NIN {
+                    comparison = self.sync_loc(
+                        es.UnaryExpression(
+                            operator='!', prefix=True, argument=_prim_result
+                        ),
+                        jac_node=nd
+                    );
+                } else {
+                    comparison = _prim_result;
+                }
+                comparisons.append(comparison);
+                left = right;
+                continue;
+            }
+        }
         operator = ES_COMPARISON_OPS.get(op_tok) if op_tok else None;
         operator = operator or '===';
         comparison: (es.UnaryExpression | es.BinaryExpression);
@@ -1445,6 +1574,19 @@ impl EsastGenPass.exit_binary_expr(nd: uni.BinaryExpr) -> None {
         );
         nd.gen.es_ast = assign_expr;
         return;
+    }
+    # Type-aware operator primitive dispatch
+    if op_name {
+        _op_emit_name = OP_EMIT_MAP.get(op_name);
+        if _op_emit_name {
+            _prim_result = self._try_primitive_op(
+                nd.left, _op_emit_name, left, right, nd
+            );
+            if _prim_result is not None {
+                nd.gen.es_ast = _prim_result;
+                return;
+            }
+        }
     }
     logical_op = ES_LOGICAL_OPS.get(op_name) if op_name else None;
     bin_expr: (es.LogicalExpression | es.BinaryExpression);

--- a/jac/jaclang/compiler/passes/ecmascript/primitives_es.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/primitives_es.jac
@@ -1,8 +1,8 @@
 """ECMAScript backend primitive emitter implementations.
 
-Maps Jac primitive methods to their JavaScript equivalents. Where no direct
-JS equivalent exists, calls are emitted to the Jac JS runtime library
-(_jac.str.partition, _jac.list.remove, etc.).
+Maps Jac primitive methods and operators to their JavaScript equivalents.
+Where no direct JS equivalent exists, calls are emitted to the Jac JS
+runtime library (_jac.str.partition, _jac.list.remove, etc.).
 
 Each emitter is a stateless singleton; backend context is passed per-call
 via ESEmitCtx.
@@ -60,12 +60,18 @@ def _rt(ns: str, method: str, args: list[str]) -> str {
     return "_jac." + ns + "." + method + "()";
 }
 
+def _binop(left: str, op: str, right: str) -> str {
+    """Emit (left op right) with parens for safety.""";
+    return "(" + left + " " + op + " " + right + ")";
+}
+
 # =============================================================================
 #  Numeric Types
 # =============================================================================
 class ESIntEmitter(IntEmitter[
     (str, ESEmitCtx)
 ]) {
+    # --- Named methods ---
     def emit_bit_length(
         self, ctx: ESEmitCtx, target: str, args: list[str]
     ) -> (str | None) {
@@ -99,9 +105,109 @@ class ESIntEmitter(IntEmitter[
     def emit_from_bytes(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
         return _rt("int", "from_bytes", args);
     }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "+", args[0]);
+    }
+
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "-", args[0]);
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "*", args[0]);
+    }
+
+    def emit_op_truediv(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _binop(target, "/", args[0]);
+    }
+
+    def emit_op_floordiv(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return "Math.floor(" + target + " / " + args[0] + ")";
+    }
+
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        # Python modulo semantics: result has same sign as divisor
+        return _rt("int", "mod", [target, args[0]]);
+    }
+
+    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "**", args[0]);
+    }
+
+    # --- Bitwise operators ---
+    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "&", args[0]);
+    }
+
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "|", args[0]);
+    }
+
+    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "^", args[0]);
+    }
+
+    def emit_op_lshift(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _binop(target, "<<", args[0]);
+    }
+
+    def emit_op_rshift(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _binop(target, ">>", args[0]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "===", args[0]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "!==", args[0]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "<", args[0]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, ">", args[0]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "<=", args[0]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, ">=", args[0]);
+    }
+
+    # --- Unary operators ---
+    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "(-" + target + ")";
+    }
+
+    def emit_op_pos(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "(+" + target + ")";
+    }
+
+    def emit_op_invert(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return "(~" + target + ")";
+    }
 }
 
 class ESFloatEmitter(FloatEmitter[(str, ESEmitCtx)]) {
+    # --- Named methods ---
     def emit_is_integer(
         self, ctx: ESEmitCtx, target: str, args: list[str]
     ) -> (str | None) {
@@ -127,13 +233,123 @@ class ESFloatEmitter(FloatEmitter[(str, ESEmitCtx)]) {
     def emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
         return _rt("float", "fromhex", args);
     }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "+", args[0]);
+    }
+
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "-", args[0]);
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "*", args[0]);
+    }
+
+    def emit_op_truediv(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _binop(target, "/", args[0]);
+    }
+
+    def emit_op_floordiv(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return "Math.floor(" + target + " / " + args[0] + ")";
+    }
+
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        # Python modulo semantics: result has same sign as divisor
+        return _rt("float", "mod", [target, args[0]]);
+    }
+
+    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "**", args[0]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "===", args[0]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "!==", args[0]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "<", args[0]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, ">", args[0]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "<=", args[0]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, ">=", args[0]);
+    }
+
+    # --- Unary operators ---
+    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "(-" + target + ")";
+    }
+
+    def emit_op_pos(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "(+" + target + ")";
+    }
 }
 
 class ESComplexEmitter(ComplexEmitter[(str, ESEmitCtx)]) {
+    # --- Named methods ---
     def emit_conjugate(
         self, ctx: ESEmitCtx, target: str, args: list[str]
     ) -> (str | None) {
         return _rt("complex", "conjugate", [target]);
+    }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "add", [target, args[0]]);
+    }
+
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "sub", [target, args[0]]);
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "mul", [target, args[0]]);
+    }
+
+    def emit_op_truediv(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("complex", "truediv", [target, args[0]]);
+    }
+
+    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "pow", [target, args[0]]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("complex", "eq", [target, args[0]]);
+    }
+
+    # --- Unary operators ---
+    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "neg", [target]);
+    }
+
+    def emit_op_pos(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("complex", "pos", [target]);
     }
 }
 
@@ -430,6 +646,51 @@ class ESStrEmitter(StrEmitter[
     def emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
         return _rt("str", "maketrans", args);
     }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "+", args[0]);
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "repeat", [args[0]]);
+    }
+
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("str", "mod", [target, args[0]]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "===", args[0]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "!==", args[0]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "<", args[0]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, ">", args[0]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, "<=", args[0]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _binop(target, ">=", args[0]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _mcall(target, "includes", [args[0]]);
+    }
 }
 
 class ESBytesEmitter(BytesEmitter[(str, ESEmitCtx)]) {
@@ -642,6 +903,51 @@ class ESBytesEmitter(BytesEmitter[(str, ESEmitCtx)]) {
     def emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
         return _rt("bytes", "maketrans", args);
     }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "add", [target, args[0]]);
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "mul", [target, args[0]]);
+    }
+
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "mod", [target, args[0]]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("bytes", "eq", [target, args[0]]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "lt", [target, args[0]]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "gt", [target, args[0]]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "le", [target, args[0]]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("bytes", "ge", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("bytes", "contains", [target, args[0]]);
+    }
 }
 
 # =============================================================================
@@ -650,6 +956,7 @@ class ESBytesEmitter(BytesEmitter[(str, ESEmitCtx)]) {
 class ESListEmitter(ListEmitter[
     (str, ESEmitCtx)
 ]) {
+    # --- Named methods ---
     def emit_append(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _mcall(target, "push", args);
     }
@@ -704,9 +1011,65 @@ class ESListEmitter(ListEmitter[
     def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return "[..." + target + "]";
     }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "[..." + target + ", ..." + args[0] + "]";
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("list", "repeat", [target, args[0]]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("list", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("list", "eq", [target, args[0]]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("list", "lt", [target, args[0]]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("list", "gt", [target, args[0]]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("list", "le", [target, args[0]]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("list", "ge", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _mcall(target, "includes", [args[0]]);
+    }
+
+    # --- In-place operators ---
+    def emit_op_iadd(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        # list += other is extend in-place (mutates), not concat+reassign
+        return target + ".push(..." + args[0] + ")";
+    }
+
+    def emit_op_imul(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("list", "imul", [target, args[0]]);
+    }
 }
 
 class ESDictEmitter(DictEmitter[(str, ESEmitCtx)]) {
+    # --- Named methods ---
     def emit_get(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         if len(args) == 1 {
             return target + "[" + args[0] + "] ?? undefined";
@@ -757,10 +1120,36 @@ class ESDictEmitter(DictEmitter[(str, ESEmitCtx)]) {
     def emit_fromkeys(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
         return _rt("dict", "fromkeys", args);
     }
+
+    # --- Bitwise operators (dict merge) ---
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "{..." + target + ", ..." + args[0] + "}";
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("dict", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("dict", "eq", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _binop(args[0], "in", target);
+    }
+
+    # --- In-place operators ---
+    def emit_op_ior(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "Object.assign(" + target + ", " + args[0] + ")";
+    }
 }
 
 class ESSetEmitter(SetEmitter[(str, ESEmitCtx)]) {
-    # Mutation
+    # --- Named methods (mutation) ---
     def emit_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _mcall(target, "add", args);
     }
@@ -783,7 +1172,7 @@ class ESSetEmitter(SetEmitter[(str, ESEmitCtx)]) {
         return _mcall(target, "clear", []);
     }
 
-    # Set algebra
+    # --- Named methods (set algebra) ---
     def emit_union(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _mcall(target, "union", args);
     }
@@ -806,7 +1195,7 @@ class ESSetEmitter(SetEmitter[(str, ESEmitCtx)]) {
         return _mcall(target, "symmetricDifference", args);
     }
 
-    # In-place set algebra
+    # --- Named methods (in-place set algebra) ---
     def emit_update(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _rt("set", "update", [target] + args);
     }
@@ -829,7 +1218,7 @@ class ESSetEmitter(SetEmitter[(str, ESEmitCtx)]) {
         return _rt("set", "symmetric_difference_update", [target] + args);
     }
 
-    # Tests
+    # --- Named methods (tests) ---
     def emit_issubset(
         self, ctx: ESEmitCtx, target: str, args: list[str]
     ) -> (str | None) {
@@ -851,9 +1240,82 @@ class ESSetEmitter(SetEmitter[(str, ESEmitCtx)]) {
     def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return "new Set(" + target + ")";
     }
+
+    # --- Set algebra operators ---
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "union", [args[0]]);
+    }
+
+    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "intersection", [args[0]]);
+    }
+
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "difference", [args[0]]);
+    }
+
+    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "symmetricDifference", [args[0]]);
+    }
+
+    # --- Comparison operators (subset/superset) ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("set", "eq", [target, args[0]]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "isSubsetOf", [args[0]]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "is_proper_subset", [target, args[0]]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "isSupersetOf", [args[0]]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "is_proper_superset", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _mcall(target, "has", [args[0]]);
+    }
+
+    # --- In-place operators ---
+    def emit_op_ior(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "update", [target, args[0]]);
+    }
+
+    def emit_op_iand(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("set", "intersection_update", [target, args[0]]);
+    }
+
+    def emit_op_isub(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("set", "difference_update", [target, args[0]]);
+    }
+
+    def emit_op_ixor(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("set", "symmetric_difference_update", [target, args[0]]);
+    }
 }
 
 class ESFrozensetEmitter(FrozensetEmitter[(str, ESEmitCtx)]) {
+    # --- Named methods ---
     def emit_union(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _mcall(target, "union", args);
     }
@@ -897,10 +1359,59 @@ class ESFrozensetEmitter(FrozensetEmitter[(str, ESEmitCtx)]) {
     def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return "new Set(" + target + ")";
     }
+
+    # --- Set algebra operators ---
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "union", [args[0]]);
+    }
+
+    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "intersection", [args[0]]);
+    }
+
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "difference", [args[0]]);
+    }
+
+    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "symmetricDifference", [args[0]]);
+    }
+
+    # --- Comparison operators (subset/superset) ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("set", "eq", [target, args[0]]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "isSubsetOf", [args[0]]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "is_proper_subset", [target, args[0]]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _mcall(target, "isSupersetOf", [args[0]]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("set", "is_proper_superset", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _mcall(target, "has", [args[0]]);
+    }
 }
 
 class ESTupleEmitter(TupleEmitter[(str, ESEmitCtx)]) {
-    # JS arrays used as tuples
+    # --- Named methods ---
     def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _rt("tuple", "count", [target] + args);
     }
@@ -911,15 +1422,73 @@ class ESTupleEmitter(TupleEmitter[(str, ESEmitCtx)]) {
         }
         return _rt("tuple", "index", [target] + args);
     }
+
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "[..." + target + ", ..." + args[0] + "]";
+    }
+
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("tuple", "repeat", [target, args[0]]);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("tuple", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("tuple", "eq", [target, args[0]]);
+    }
+
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("tuple", "lt", [target, args[0]]);
+    }
+
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("tuple", "gt", [target, args[0]]);
+    }
+
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("tuple", "le", [target, args[0]]);
+    }
+
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("tuple", "ge", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _mcall(target, "includes", [args[0]]);
+    }
 }
 
 class ESRangeEmitter(RangeEmitter[(str, ESEmitCtx)]) {
+    # --- Named methods ---
     def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _rt("range", "count", [target] + args);
     }
 
     def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
         return _rt("range", "index", [target] + args);
+    }
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return _rt("range", "eq", [target, args[0]]);
+    }
+
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
+        return "!" + _rt("range", "eq", [target, args[0]]);
+    }
+
+    # --- Membership operators ---
+    def emit_op_contains(
+        self, ctx: ESEmitCtx, target: str, args: list[str]
+    ) -> (str | None) {
+        return _rt("range", "contains", [target, args[0]]);
     }
 }
 

--- a/jac/jaclang/compiler/primitives.jac
+++ b/jac/jaclang/compiler/primitives.jac
@@ -1,25 +1,30 @@
 """Jac Primitive Codegen Interface.
 
-Generic abstract emitter contracts for all Jac primitive type methods and
-builtin functions, parameterized on value type V and context type C.
+Generic abstract emitter contracts for all Jac primitive type methods,
+operator semantics, and builtin functions, parameterized on value type V
+and context type C.
 
 Each compilation backend (Python, ECMAScript, Native) must subclass every
 emitter class here, binding V and C to its own types:
   - ES:     V = str,      C = ESEmitCtx
   - Native: V = ir.Value,  C = NativeEmitCtx
 
-All methods receive a backend-specific context `ctx: C`, a target
+Named methods receive a backend-specific context `ctx: C`, a target
 expression `target: V` (the object the method is called on), and a list
 of argument expressions `args: list[V]`. Static methods and builtin
 functions omit the target parameter.
 
+Operator methods (emit_op_*) follow the same signature: target is the
+left-hand operand and args[0] is the right-hand operand for binary ops.
+For unary ops, target is the sole operand and args is empty. For
+membership tests (emit_op_contains), target is the container (right-hand
+side of `in`) and args[0] is the element being tested.
+
+In-place operator methods (emit_op_iadd, etc.) are provided for mutable
+types where in-place mutation differs from create-and-reassign.
+
 Returning None signals that this backend has not yet implemented the
 operation, allowing the dispatch layer to fall back gracefully.
-
-Syntactic operations (indexing, slicing, iteration, arithmetic, comparison,
-membership) are handled by each backend's expression codegen passes and
-are not covered here — only user-callable named methods and builtin
-functions are specified.
 """
 
 import from typing { TypeVar, Generic }
@@ -33,24 +38,127 @@ glob V = TypeVar('V'),
 class IntEmitter(Generic[
     (V, C)
 ]) {
+    # --- Named methods ---
     def emit_bit_length(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_bit_count(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_to_bytes(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_as_integer_ratio(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_conjugate(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_from_bytes(self, ctx: C, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +
+
+    def emit_op_sub(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *
+
+    def emit_op_truediv(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # /
+
+    def emit_op_floordiv(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # //
+
+    def emit_op_mod(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # %
+
+    def emit_op_pow(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # **
+
+    # --- Bitwise operators ---
+    def emit_op_and(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # &
+
+    def emit_op_or(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # |
+
+    def emit_op_xor(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ^
+
+    def emit_op_lshift(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <<
+
+    def emit_op_rshift(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >>
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ==
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <=
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >=
+
+    # --- Unary operators ---
+    def emit_op_neg(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -x
+
+    def emit_op_pos(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +x
+
+    def emit_op_invert(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ~x
+
 }
 
 class FloatEmitter(Generic[(V, C)]) {
+    # --- Named methods ---
     def emit_is_integer(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_as_integer_ratio(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_conjugate(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_hex(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_fromhex(self, ctx: C, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +
+
+    def emit_op_sub(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *
+
+    def emit_op_truediv(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # /
+
+    def emit_op_floordiv(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # //
+
+    def emit_op_mod(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # %
+
+    def emit_op_pow(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # **
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ==
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <=
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >=
+
+    # --- Unary operators ---
+    def emit_op_neg(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -x
+
+    def emit_op_pos(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +x
+
 }
 
 class ComplexEmitter(Generic[(V, C)]) {
+    # --- Named methods ---
     def emit_conjugate(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +
+
+    def emit_op_sub(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *
+
+    def emit_op_truediv(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # /
+
+    def emit_op_pow(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # **
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ==
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    # --- Unary operators ---
+    def emit_op_neg(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -x
+
+    def emit_op_pos(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +x
+
 }
 
 # =============================================================================
@@ -114,6 +222,29 @@ class StrEmitter(Generic[
     # Translation
     def emit_translate(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_maketrans(self, ctx: C, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +  (concatenation)
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *  (repetition)
+
+    def emit_op_mod(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # %  (printf formatting)
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ==
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <  (lexicographic)
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <=
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >=
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in (substring test)
+
 }
 
 class BytesEmitter(Generic[(V, C)]) {
@@ -167,6 +298,29 @@ class BytesEmitter(Generic[(V, C)]) {
     # Translation
     def emit_translate(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_maketrans(self, ctx: C, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +  (concatenation)
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *  (repetition)
+
+    def emit_op_mod(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # %  (printf formatting)
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ==
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <  (lexicographic)
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <=
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >=
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in (byte membership)
+
 }
 
 # =============================================================================
@@ -175,6 +329,7 @@ class BytesEmitter(Generic[(V, C)]) {
 class ListEmitter(Generic[
     (V, C)
 ]) {
+    # --- Named methods ---
     def emit_append(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_extend(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_insert(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
@@ -186,9 +341,36 @@ class ListEmitter(Generic[
     def emit_sort(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_reverse(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_copy(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +  (concatenation)
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *  (repetition)
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # == (structural)
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <  (lexicographic)
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <=
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >=
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in
+
+    # --- In-place operators ---
+    def emit_op_iadd(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # += (extend in-place)
+
+    def emit_op_imul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *= (repeat in-place)
+
 }
 
 class DictEmitter(Generic[(V, C)]) {
+    # --- Named methods ---
     def emit_get(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_keys(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_values(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
@@ -200,35 +382,84 @@ class DictEmitter(Generic[(V, C)]) {
     def emit_clear(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_copy(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_fromkeys(self, ctx: C, args: list[V]) -> (V | None) abs;
+    # --- Bitwise operators (dict merge, Python 3.9+) ---
+    def emit_op_or(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # |  (merge)
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # == (structural)
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in (key membership)
+
+    # --- In-place operators ---
+    def emit_op_ior(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # |= (update in-place)
+
 }
 
 class SetEmitter(Generic[(V, C)]) {
-    # Mutation
+    # --- Named methods (mutation) ---
     def emit_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_remove(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_discard(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_pop(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_clear(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
-    # Set algebra (return new set)
+    # --- Named methods (set algebra, return new set) ---
     def emit_union(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_intersection(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_difference(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_symmetric_difference(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
-    # In-place set algebra
+    # --- Named methods (in-place set algebra) ---
     def emit_update(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_intersection_update(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_difference_update(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_symmetric_difference_update(
         self, ctx: C, target: V, args: list[V]
     ) -> (V | None) abs;
-    # Tests
+    # --- Named methods (tests) ---
     def emit_issubset(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_issuperset(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_isdisjoint(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_copy(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
+    # --- Set algebra operators ---
+    def emit_op_or(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # |  (union)
+
+    def emit_op_and(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # &  (intersection)
+
+    def emit_op_sub(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -  (difference)
+
+    def emit_op_xor(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ^  (symmetric difference)
+
+    # --- Comparison operators (subset/superset) ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # == (set equality)
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <= (subset)
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <  (proper subset)
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >= (superset)
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >  (proper superset)
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in
+
+    # --- In-place operators ---
+    def emit_op_ior(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # |= (update)
+
+    def emit_op_iand(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # &= (intersection_update)
+
+    def emit_op_isub(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -= (difference_update)
+
+    def emit_op_ixor(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ^= (symmetric_difference_update)
+
 }
 
 class FrozensetEmitter(Generic[(V, C)]) {
+    # --- Named methods ---
     def emit_union(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_intersection(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_difference(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
@@ -237,16 +468,72 @@ class FrozensetEmitter(Generic[(V, C)]) {
     def emit_issuperset(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_isdisjoint(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_copy(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
+    # --- Set algebra operators ---
+    def emit_op_or(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # |  (union)
+
+    def emit_op_and(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # &  (intersection)
+
+    def emit_op_sub(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # -  (difference)
+
+    def emit_op_xor(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ^  (symmetric difference)
+
+    # --- Comparison operators (subset/superset) ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # == (set equality)
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <= (subset)
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <  (proper subset)
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >= (superset)
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >  (proper superset)
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in
+
 }
 
 class TupleEmitter(Generic[(V, C)]) {
+    # --- Named methods ---
     def emit_count(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_index(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
+    # --- Arithmetic operators ---
+    def emit_op_add(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # +  (concatenation)
+
+    def emit_op_mul(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # *  (repetition)
+
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # == (structural)
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    def emit_op_lt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <  (lexicographic)
+
+    def emit_op_gt(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >
+
+    def emit_op_le(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # <=
+
+    def emit_op_ge(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # >=
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in
+
 }
 
 class RangeEmitter(Generic[(V, C)]) {
+    # --- Named methods ---
     def emit_count(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
     def emit_index(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;
+    # --- Comparison operators ---
+    def emit_op_eq(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # ==
+
+    def emit_op_ne(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # !=
+
+    # --- Membership operators ---
+    def emit_op_contains(self, ctx: C, target: V, args: list[V]) -> (V | None) abs;  # in
+
 }
 
 # =============================================================================

--- a/jac/tests/compiler/passes/ecmascript/fixtures/operator_primitives.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/operator_primitives.jac
@@ -1,0 +1,17 @@
+"""Test fixture for operator primitive dispatch in JS codegen."""
+
+cl def test_list_concat() -> list {
+    a: list = [1, 2];
+    b: list = a + [3];
+    return b;
+}
+
+cl def test_str_repeat() -> str {
+    s: str = "abc";
+    return s * 3;
+}
+
+cl def test_list_contains() -> bool {
+    items: list = [1, 2, 3];
+    return 2 in items;
+}

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -383,6 +383,22 @@ test "assignment inside globvar js" {
     }
 }
 
+test "operator primitive dispatch" {
+    fixture = "operator_primitives.jac";
+    js_code = compile_fixture_to_js(fixture, FIXTURES);
+
+    # list + list should use spread, not raw +
+    assert "[...a, ...[3]]" in js_code , "list concat should use spread operator";
+
+    # str * n should use .repeat()
+    assert ".repeat(3)" in js_code , "str repeat should use .repeat()";
+
+    # x in list should use .includes()
+    assert ".includes(" in js_code , "list membership should use .includes()";
+
+    assert_balanced_syntax(js_code, fixture);
+}
+
 test "hyphenated package imports generate correct js" {
     fixture_file_path = os.path.join(FIXTURES, "hyphenated_imports.jac");
     js_code = compile_fixture_to_js(fixture_file_path);


### PR DESCRIPTION
## Summary
- Adds ~115 `emit_op_*` abstract operator methods to all primitive emitter interfaces (`primitives.jac`) covering every Python operator per type (arithmetic, comparison, bitwise, unary, in-place)
- Implements all ES backend operator emitters (`primitives_es.jac`) producing correct JavaScript for Python-semantic operators
- Wires type-aware dispatch into the four ES codegen operator methods (`exit_binary_expr`, `exit_compare_expr`, `exit_unary_expr`, `exit_assignment`) via a new `_try_primitive_op` helper that queries the type evaluator and delegates to the appropriate emitter
- Fixes incorrect JS output for operators with divergent semantics (e.g., `[1,2] + [3]` was producing `"1,23"` via string coercion, now correctly emits `[...a, ...[3]]`)

## Test plan
- [x] New test fixture `operator_primitives.jac` covering list concat, string repeat, and list membership
- [x] New test case in `test_js_generation.jac` verifying spread concat, `.repeat()`, and `.includes()` in JS output
- [x] All 25 ES codegen tests pass
- [x] Graceful fallback: when type evaluator has no info, operators fall through to existing generic JS codegen