### PR TITLE
fix(parser): Correct bitwise vs logical operator precedence

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -25,6 +25,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Quoted JSX Text Produces Invalid JS**: Fixed JSX text containing quote characters (e.g., `<p>"text"</p>`) generating invalid double-double-quoted JavaScript (`""text""`). Inner quotes are now properly escaped in the emitted JS string literals.
 - **Fix: `unittest.mock.patch` Compatibility in Jac Tests**: Fixed `unittest.mock.patch` not intercepting calls in Jac test blocks.
 - **Modern Generics: `type` Aliases & Inline Type Parameters**: Added PEP 695-style `type` alias statements (`type JsonPrimitive = str | int | float | bool | None;`) and inline generic type parameters on archetypes (`obj Result[T, E = Exception] { ... }`). Supports bounded type vars (`T: Comparable`), default type values, and recursive type aliases. Compiles to native Python 3.12 `ast.TypeAlias` and `ast.TypeVar` nodes.
+- **Fix: Operator Precedence for Bitwise vs Logical Operators**: Fixed operator precedence so bitwise operators (`|`, `^`, `&`, `<<`, `>>`) bind tighter than logical operators (`or`, `and`, `not`), matching Python's semantics. Previously `3 & 1 == 1` was parsed as `3 & (1 == 1)` instead of `(3 & 1) == 1`.
 - 2 Minor refactors/changes.
 
 ## jaclang 0.10.2 (Latest Release)

--- a/jac/jaclang/jac.spec
+++ b/jac/jaclang/jac.spec
@@ -12,7 +12,7 @@ by_expr ::= pipe ("by" by_expr)?
 
 pipe ::= pipe_back ("|>" pipe_back)*
 
-pipe_back ::= bitwise_or ("<|" bitwise_or)*
+pipe_back ::= logical_or ("<|" logical_or)*
 
 bitwise_or ::= bitwise_xor ("|" bitwise_xor)*
 
@@ -20,7 +20,7 @@ bitwise_xor ::= bitwise_and ("^" bitwise_and)*
 
 bitwise_and ::= shift ("&" shift)*
 
-shift ::= logical_or (("<<" | ">>") logical_or)*
+shift ::= arithmetic (("<<" | ">>") arithmetic)*
 
 logical_or ::= logical_and ("or" logical_and)*
 
@@ -29,10 +29,10 @@ logical_and ::= logical_not ("and" logical_not)*
 logical_not ::= "not" logical_not | compare
 
 compare ::=
-    arithmetic (
+    bitwise_or (
         ("==" | "!=" | "<" | ">" | "<=" | ">=" | "in" | "is" | "not in" | "is not") (
             ("==" | "!=" | "<" | ">" | "<=" | ">=" | "in" | "is" | "not in" | "is not")
-            arithmetic
+            bitwise_or
         )*
     )?
 

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -824,10 +824,10 @@ impl Parser.parse_pipe -> Expr {
 }
 
 impl Parser.parse_pipe_back -> Expr {
-    left = self.parse_bitwise_or();
+    left = self.parse_logical_or();
     while self.match_tok(TokenKind.PIPE_BKWD) {
         op = self.make_uni_token(self.previous());
-        right = self.parse_bitwise_or();
+        right = self.parse_logical_or();
         left = BinaryExpr(left=left, op=op, right=right, kid=[left, op, right]);
     }
     return left;
@@ -864,11 +864,11 @@ impl Parser.parse_bitwise_and -> Expr {
 }
 
 impl Parser.parse_shift -> Expr {
-    left = self.parse_logical_or();
+    left = self.parse_arithmetic();
     while self.check_any(TokenKind.LSHIFT, TokenKind.RSHIFT) {
         tok = self.advance();
         op = self.make_uni_token(tok);
-        right = self.parse_logical_or();
+        right = self.parse_arithmetic();
         left = BinaryExpr(left=left, op=op, right=right, kid=[left, op, right]);
     }
     return left;
@@ -930,7 +930,7 @@ impl Parser.parse_logical_not -> Expr {
 }
 
 impl Parser.parse_compare -> Expr {
-    left = self.parse_arithmetic();
+    left = self.parse_bitwise_or();
     if self.check_any(
         TokenKind.EE,
         TokenKind.NE,
@@ -962,7 +962,7 @@ impl Parser.parse_compare -> Expr {
             op = self.make_uni_token(op_tok);
             ops.append(op);
             kid.append(op);
-            right = self.parse_arithmetic();
+            right = self.parse_bitwise_or();
             rights.append(right);
             kid.append(right);
         }

--- a/jac/tests/language/fixtures/operator_precedence.jac
+++ b/jac/tests/language/fixtures/operator_precedence.jac
@@ -1,0 +1,55 @@
+"""Test that bitwise vs logical operator precedence matches Python.
+
+Runs each expression in Jac, then the same expressions via ::py:: inline Python,
+and asserts the outputs match.
+"""
+
+with entry {
+    jac_results: list = [];
+
+    # Bitwise AND vs comparison: should be (3 & 1) == 1, not 3 & (1 == 1)
+    jac_results.append(str(3 & 1 == 1));
+
+    # Bitwise OR vs logical or: should be (3 | 0) or 4, not 3 | (0 or 4)
+    jac_results.append(str(3 | 0 or 4));
+
+    # Bitwise XOR vs logical and: should be (3 ^ 1) and 0, not 3 ^ (1 and 0)
+    jac_results.append(str(3 ^ 1 and 0));
+
+    # Comparison vs bitwise OR: should be 2 < (3 | 1), not (2 < 3) | 1
+    jac_results.append(str(2 < 3 | 1));
+
+    # Mixed: bitwise AND, comparison, logical and
+    jac_results.append(str(7 & 3 == 3 and True));
+
+    # Logical not vs bitwise AND: should be not (0 & 1), not (not 0) & 1
+    jac_results.append(str(not 0 & 1));
+
+    # Relative bitwise precedence preserved: | < ^ < &
+    jac_results.append(str(5 | 3 ^ 1 & 2));
+
+    # Shift vs arithmetic preserved: should be 1 << (2 + 1)
+    jac_results.append(str(1 << 2 + 1));
+
+    # Get Python results via inline Python
+    py_results: list = [];
+    ::py::
+py_results = []
+py_results.append(str(3 & 1 == 1))
+py_results.append(str(3 | 0 or 4))
+py_results.append(str(3 ^ 1 and 0))
+py_results.append(str(2 < 3 | 1))
+py_results.append(str(7 & 3 == 3 and True))
+py_results.append(str(not 0 & 1))
+py_results.append(str(5 | 3 ^ 1 & 2))
+py_results.append(str(1 << 2 + 1))
+    ::py::
+
+    # Compare and report
+    for i in range(len(jac_results)) {
+        assert jac_results[i] == py_results[i], (
+            f"Mismatch at expression {i}: jac={jac_results[i]} py={py_results[i]}"
+        );
+    }
+    print("PASS");
+}

--- a/jac/tests/language/test_language.jac
+++ b/jac/tests/language/test_language.jac
@@ -671,3 +671,8 @@ test "type aliases and modern generics" {
     output = run_jac(os.path.join(FIXTURES, "type_alias_generics.jac"));
     assert output == "True\n42\nok\n";
 }
+
+test "operator precedence matches python" {
+    output = run_jac(os.path.join(FIXTURES, "operator_precedence.jac"));
+    assert "PASS" in output , f"Operator precedence test failed:\n{output}";
+}


### PR DESCRIPTION
## Summary

- Fixed operator precedence so bitwise operators (`|`, `^`, `&`, `<<`, `>>`) bind tighter than logical operators (`or`, `and`, `not`), matching Python's semantics
- Previously `3 & 1 == 1` was parsed as `3 & (1 == 1)` instead of `(3 & 1) == 1`, silently producing wrong results
- Added a test that evaluates mixed expressions in both Jac and inline `::py::` Python, asserting outputs match

## Changes

**Parser** (`parser.impl.jac`) — 3 methods, 6 line changes:
- `parse_pipe_back()`: calls `parse_logical_or()` instead of `parse_bitwise_or()`
- `parse_shift()`: calls `parse_arithmetic()` instead of `parse_logical_or()`
- `parse_compare()`: calls `parse_bitwise_or()` instead of `parse_arithmetic()`

Reorders the precedence chain from:
`pipe_back → bitwise → logical → compare → arithmetic`
to:
`pipe_back → logical → compare → bitwise → arithmetic`

**Test** — new fixture `operator_precedence.jac` with 8 mixed bitwise/logical/comparison expressions validated against inline Python via `::py::`.

**Spec** — regenerated `jac.spec` to reflect updated grammar.

## Test plan

- [x] New `operator precedence matches python` test passes
- [x] Full test suite: 3741 passed, 0 failed