### PR TITLE
fix(runtime): walker result.reports in CLI mode + docs QA fixes

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -9,6 +9,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Bare Impl Files Not Matched to Variant Modules**: Fixed `discover_annex_files` rejecting bare annex files (e.g., `foo.impl.jac`) when the source is a variant (e.g., `foo.cl.jac`) with no plain `foo.jac` head. Bare annex files now match any variant source unless a bare `.jac` head exists that would claim them.
 - **Fix: Bare-Dot Relative Import (`from . import x`) Not Resolved**: Fixed `import from . { x }` silently resolving to `UnknownType`. The import path is now computed directly from the current file's directory, ensuring sibling modules are correctly found and type-checked.
 - **Fix:**: update the jac-check command to print the file names of the files that failed to have clean error message.
+- **Fix: Walker `result.reports` in CLI Mode**: Fixed `report` keyword not populating `result.reports` when running walkers via `jac run` or `jac test`.
 
 ## jaclang 0.10.5 (Latest Release)
 

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -2,6 +2,8 @@
 
 This page is a **lookup reference**, not a learning guide. For hands-on learning, start with the [AI Day Planner tutorial](../tutorials/first-app/build-ai-day-planner.md) which teaches these concepts progressively.
 
+**Try it:** [Functions](../tutorials/language/basics.md#functions) | [Objects](../tutorials/language/basics.md#objects) | [Walkers & Graphs](../tutorials/language/osp.md) | [AI Integration](../tutorials/ai/quickstart.md) | [Full Reference](../reference/language/foundation.md)
+
 ```jac
 # ============================================================
 # Learn Jac in Y Minutes

--- a/docs/docs/reference/language/advanced.md
+++ b/docs/docs/reference/language/advanced.md
@@ -188,7 +188,11 @@ def example() {
 }
 ```
 
-### 2 Filter Comprehension Syntax
+### 2 Filter and Assign Comprehensions
+
+Jac extends standard comprehension syntax with **filter** (`?`) and **assign** (`=`) operators that work on collections of nodes or objects. These provide concise ways to query and modify groups of items.
+
+**Filter syntax** uses `?` to select matching elements, and **assign syntax** uses `=` to bulk-update matching elements.
 
 Filter collections with `?condition`:
 

--- a/docs/docs/reference/language/ai-integration.md
+++ b/docs/docs/reference/language/ai-integration.md
@@ -161,7 +161,7 @@ def summarize(text: str) -> str by llm(
 );
 
 def creative_story(prompt: str) -> str by llm(
-    model_name="claude-3-opus-20240229",
+    model_name="claude-sonnet-4-6",
     temperature=1.0
 );
 ```

--- a/docs/docs/reference/language/concurrency.md
+++ b/docs/docs/reference/language/concurrency.md
@@ -11,6 +11,9 @@ Jac supports Python-style `async/await` for concurrent I/O operations, plus a un
 
 ## Async/Await
 
+!!! note
+    Async functions must be `await`ed in an async context. In `with entry` blocks, use `await` directly or wrap calls in an async ability.
+
 The `async/await` syntax works like Python's -- `async` marks a function as a coroutine, and `await` suspends execution until the awaited operation completes. Walkers can also be async, enabling non-blocking graph traversal with I/O at each node.
 
 ### 1 Async Functions

--- a/docs/docs/reference/language/ecosystem.md
+++ b/docs/docs/reference/language/ecosystem.md
@@ -13,6 +13,21 @@
 
 The Jac ecosystem includes the `jac` CLI tool, a plugin system for extending functionality, and seamless interoperability with Python and JavaScript. This part covers the practical tools you'll use daily when developing with Jac.
 
+### Quick Start
+
+```bash
+# 1. Install
+pip install jaseci
+
+# 2. Scaffold a new project
+jac create myapp --use client
+
+# 3. Run
+jac start main.jac
+```
+
+---
+
 ## CLI Reference
 
 The `jac` command is your primary interface to the Jac toolchain. It handles execution, compilation, testing, formatting, and project management. Most commands work on `.jac` files directly.

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -513,6 +513,18 @@ def example() {
 }
 ```
 
+??? example "Try it: Literals and collections"
+    ```jac
+    with entry {
+        name = "Jac";
+        nums = [1, 2, 3, 4, 5];
+        info = {"language": name, "version": "0.10"};
+        evens = [x for x in nums if x % 2 == 0];
+        print(f"{name} evens: {evens}");
+        print(f"Info: {info}");
+    }
+    ```
+
 ---
 
 ## Variables and Scope
@@ -1301,6 +1313,19 @@ def example() {
 }
 ```
 
+??? example "Try it: Operators"
+    ```jac
+    with entry {
+        x = 10;
+        y = 3;
+        print(f"{x} + {y} = {x + y}");
+        print(f"{x} ** {y} = {x ** y}");
+        print(f"{x} > {y} = {x > y}");
+        print(f"not False = {not False}");
+        print(f"{x} in [1,5,10] = {x in [1, 5, 10]}");
+    }
+    ```
+
 ---
 
 ## Control Flow
@@ -1720,6 +1745,29 @@ def example() {
     squares_list = [x ** 2 for x in range(100)];
 }
 ```
+
+??? example "Try it: Control flow and generators"
+    ```jac
+    def fizzbuzz(n: int) -> str {
+        if n % 15 == 0 { return "FizzBuzz"; }
+        elif n % 3 == 0 { return "Fizz"; }
+        elif n % 5 == 0 { return "Buzz"; }
+        return str(n);
+    }
+
+    can countdown(n: int) -> Generator[int] {
+        while n > 0 {
+            yield n;
+            n -= 1;
+        }
+    }
+
+    with entry {
+        results = [fizzbuzz(i) for i in range(1, 16)];
+        print(results);
+        print([x for x in countdown(5)]);
+    }
+    ```
 
 ---
 

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -303,6 +303,27 @@ def:priv _private_func -> None { }
 def:protect _protected_func -> None { }
 ```
 
+??? example "Try it: Functions complete example"
+    ```jac
+    def greet(name: str) -> str {
+        return f"Hello, {name}!";
+    }
+
+    can add(a: int, b: int) -> int {
+        return a + b;
+    }
+
+    def apply(func: Callable[[int, int], int], x: int, y: int) -> int {
+        return func(x, y);
+    }
+
+    with entry {
+        print(greet("World"));
+        print(add(3, 4));
+        print(apply(lambda x, y: int -> x * y, 5, 6));
+    }
+    ```
+
 ---
 
 ## Object-Oriented Programming
@@ -430,6 +451,38 @@ obj Account {
     }
 }
 ```
+
+??? example "Try it: Objects and Enums complete example"
+    ```jac
+    enum Color {
+        RED = "red",
+        GREEN = "green",
+        BLUE = "blue"
+    }
+
+    obj Animal {
+        has name: str,
+            sound: str;
+
+        can speak -> str {
+            return f"{self.name} says {self.sound}!";
+        }
+    }
+
+    obj Dog(Animal) {
+        has breed: str;
+
+        can speak -> str {
+            return f"{self.name} the {self.breed} says {self.sound}!";
+        }
+    }
+
+    with entry {
+        dog = Dog(name="Rex", sound="woof", breed="Labrador");
+        print(dog.speak());
+        print(f"Favorite color: {Color.BLUE.value}");
+    }
+    ```
 
 ---
 

--- a/docs/docs/reference/language/library-mode.md
+++ b/docs/docs/reference/language/library-mode.md
@@ -91,79 +91,79 @@ with entry {
 
 Run `jac jac2py friends.jac` to generate:
 
-```python
-from __future__ import annotations
-from jaclang.lib import (
-    Edge,
-    Node,
-    OPath,
-    Root,
-    Walker,
-    build_edge,
-    connect,
-    on_entry,
-    refs,
-    root,
-    spawn,
-    visit,
-)
+??? example "Generated Python code"
+    ```python
+    from **future** import annotations
+    from jaclang.lib import (
+        Edge,
+        Node,
+        OPath,
+        Root,
+        Walker,
+        build_edge,
+        connect,
+        on_entry,
+        refs,
+        root,
+        spawn,
+        visit,
+    )
+
+    class Person(Node):
+        name: str
+
+        @on_entry
+        def announce(self, visitor: FriendFinder) -> None:
+            print(f"{visitor} is checking me out")
 
 
-class Person(Node):
-    name: str
-
-    @on_entry
-    def announce(self, visitor: FriendFinder) -> None:
-        print(f"{visitor} is checking me out")
+    class Friend(Edge):
+        pass
 
 
-class Friend(Edge):
-    pass
+    class Family(Edge):
+
+        @on_entry
+        def announce(self, visitor: FriendFinder) -> None:
+            print(f"{visitor} is traveling to family member")
 
 
-class Family(Edge):
-
-    @on_entry
-    def announce(self, visitor: FriendFinder) -> None:
-        print(f"{visitor} is traveling to family member")
-
-
-# Build the graph
-p1 = Person(name="John")
-p2 = Person(name="Susan")
-p3 = Person(name="Mike")
-p4 = Person(name="Alice")
-connect(left=root(), right=p1)
-connect(left=p1, right=p2, edge=Friend)
-connect(left=p2, right=[p1, p3], edge=Family)
-connect(left=p2, right=p3, edge=Friend)
+    # Build the graph
+    p1 = Person(name="John")
+    p2 = Person(name="Susan")
+    p3 = Person(name="Mike")
+    p4 = Person(name="Alice")
+    connect(left=root(), right=p1)
+    connect(left=p1, right=p2, edge=Friend)
+    connect(left=p2, right=[p1, p3], edge=Family)
+    connect(left=p2, right=p3, edge=Friend)
 
 
-class FriendFinder(Walker):
-    started: bool = False
+    class FriendFinder(Walker):
+        started: bool = False
 
-    @on_entry
-    def report_friend(self, here: Person) -> None:
-        if self.started:
-            print(f"{here.name} is a friend of friend, or family")
-        else:
-            self.started = True
+        @on_entry
+        def report_friend(self, here: Person) -> None:
+            if self.started:
+                print(f"{here.name} is a friend of friend, or family")
+            else:
+                self.started = True
+                visit(self, refs(OPath(here).edge_out().visit()))
+            visit(
+                self,
+                refs(
+                    OPath(here).edge_out(edge=lambda i: isinstance(i, Family)).edge().visit()
+                ),
+            )
+
+        @on_entry
+        def move_to_person(self, here: Root) -> None:
             visit(self, refs(OPath(here).edge_out().visit()))
-        visit(
-            self,
-            refs(
-                OPath(here).edge_out(edge=lambda i: isinstance(i, Family)).edge().visit()
-            ),
-        )
-
-    @on_entry
-    def move_to_person(self, here: Root) -> None:
-        visit(self, refs(OPath(here).edge_out().visit()))
 
 
-result = spawn(FriendFinder(), root())
-print(result)
-```
+    result = spawn(FriendFinder(), root())
+    print(result)
+    ```
 
 ---
 

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -829,7 +829,9 @@ walker Querier {
 
 ### 1 What are Typed Context Blocks?
 
-Handle different types with specialized code paths. The syntax uses `->Type{code}` with no space between the arrow and type name:
+Typed context blocks let you conditionally execute code based on the runtime type of the current node. Instead of writing separate abilities for each node type, you can handle multiple types within a single ability using `->Type{code}` blocks. This is especially useful when a walker visits a heterogeneous graph with different node types.
+
+The syntax uses `->Type{code}` with no space between the arrow and type name:
 
 ```jac
 walker AnimalVisitor {

--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -78,7 +78,7 @@ byLLM uses [LiteLLM](https://docs.litellm.ai/docs/providers) for model integrati
     ```jac
     import from byllm.lib { Model }
 
-    glob llm = Model(model_name="claude-3-5-sonnet-20240620");
+    glob llm = Model(model_name="claude-sonnet-4-6");
     ```
     ```bash
     export ANTHROPIC_API_KEY="sk-ant-..."

--- a/docs/docs/reference/testing.md
+++ b/docs/docs/reference/testing.md
@@ -167,6 +167,9 @@ jac test -d tests/ -m 3
 jac test main.jac -t calculator_add -v
 ```
 
+!!! tip "File naming"
+    Avoid naming `.jac` files with a `test_` prefix (e.g., `test_utils.jac`), as this can conflict with Python's module import system. Use descriptive names like `utils_tests.jac` or `my_app.jac` instead.
+
 ---
 
 ## Test Output

--- a/docs/docs/tutorials/ai/quickstart.md
+++ b/docs/docs/tutorials/ai/quickstart.md
@@ -50,7 +50,7 @@ def translate2french(text: str) -> str by llm();
 sem translate2french = "Translate the given text to French";
 
 with entry {
-    result = translate("Hello, how are you?");
+    result = translate2french("Hello, how are you?");
     print(result);
 }
 ```
@@ -79,7 +79,7 @@ def translate2french(text: str) -> str by llm();
 
 | Part | Purpose |
 |------|---------|
-| `translate_to_french` | Function name conveys the intent |
+| `translate2french` | Function name conveys the intent |
 | `(text: str)` | Input parameter with descriptive name and type |
 | `-> str` | Expected return type |
 | `by llm()` | Delegates implementation to the LLM |
@@ -128,7 +128,7 @@ byLLM uses [LiteLLM](https://docs.litellm.ai/docs/providers) under the hood, giv
 
 === "Anthropic"
     ```jac
-    glob llm = Model(model_name="claude-3-5-sonnet-20241022");
+    glob llm = Model(model_name="claude-sonnet-4-6");
     ```
     ```bash
     export ANTHROPIC_API_KEY="sk-ant-..."
@@ -157,6 +157,9 @@ byLLM uses [LiteLLM](https://docs.litellm.ai/docs/providers) under the hood, giv
     ```
 
 For model name formats, configuration options, and 100+ additional providers (Azure, AWS Bedrock, Vertex AI, Groq, etc.), see the [byLLM Reference](../../reference/plugins/byllm.md#supported-providers) and [LiteLLM documentation](https://docs.litellm.ai/docs/providers).
+
+!!! tip "Model names change"
+    AI model names are updated regularly by providers. If an example's model name returns a "not found" error, check the provider's documentation for current model names. The `by llm()` syntax works with any model supported by [LiteLLM](https://docs.litellm.ai/docs/providers).
 
 ---
 

--- a/docs/docs/tutorials/examples/emailbuddy.md
+++ b/docs/docs/tutorials/examples/emailbuddy.md
@@ -270,6 +270,30 @@ def summarize(
 
 This prevents the context window from overflowing as the walker explores more nodes.
 
+??? example "Try it: AI classification standalone"
+    ```jac
+    import from byllm.lib { Model }
+
+    glob llm = Model(model_name="gpt-4o-mini");
+
+    enum EmailCategory {
+        WORK = "work",
+        PERSONAL = "personal",
+        SPAM = "spam"
+    }
+
+    def classify_email(subject: str, body: str) -> EmailCategory by llm();
+    sem classify_email = "Classify the email based on its subject and body content";
+
+    with entry {
+        result = classify_email(
+            subject="Q3 Budget Review Meeting",
+            body="Please review the attached budget spreadsheet before Friday's meeting."
+        );
+        print(f"Category: {result}");
+    }
+    ```
+
 ---
 
 ## Running EmailBuddy

--- a/docs/docs/tutorials/examples/littlex.md
+++ b/docs/docs/tutorials/examples/littlex.md
@@ -196,6 +196,47 @@ walker load_feed {
 }
 ```
 
+??? example "Try it: Standalone graph demo (no server needed)"
+    ```jac
+    import from datetime { datetime }
+
+    node Profile {
+        has username: str;
+    }
+
+    node Tweet {
+        has content: str,
+            created_at: str = "";
+    }
+
+    edge Post {}
+    edge Follow {}
+
+    with entry {
+        # Create profiles
+        alice = Profile(username="alice");
+        bob = Profile(username="bob");
+        root ++> alice;
+        root ++> bob;
+
+        # Alice follows Bob
+        alice +>: Follow() :+> bob;
+
+        # Both post tweets
+        t1 = Tweet(content="Hello from Alice!", created_at=datetime.now().isoformat());
+        alice +>: Post() :+> t1;
+
+        t2 = Tweet(content="Bob here!", created_at=datetime.now().isoformat());
+        bob +>: Post() :+> t2;
+
+        # Query Alice's feed (own + followed)
+        feed = [alice ->:Post:->] + [p ->:Post:-> for p in [alice ->:Follow:->]];
+        for tweet in feed {
+            print(f"  {tweet.content}");
+        }
+    }
+    ```
+
 ---
 
 ## Running the App

--- a/docs/docs/tutorials/fullstack/auth.md
+++ b/docs/docs/tutorials/fullstack/auth.md
@@ -37,7 +37,7 @@ cl import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn }
 cl import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn, useNavigate }
 
 cl {
-    def:pub LoginPage() -> any {
+    def:pub LoginPage() -> JsxElement {
         has username: str = "";
         has password: str = "";
         has error: str = "";
@@ -171,7 +171,7 @@ Checks if user is currently authenticated.
 cl import from "@jac/runtime" { jacIsLoggedIn }
 
 cl {
-    def:pub NavBar() -> any {
+    def:pub NavBar() -> JsxElement {
         isLoggedIn = jacIsLoggedIn();
 
         return <nav>
@@ -204,7 +204,7 @@ cl import from "@jac/runtime" {
 
 cl {
     # === Login Page ===
-    def:pub LoginPage() -> any {
+    def:pub LoginPage() -> JsxElement {
         has username: str = "";
         has password: str = "";
         has error: str = "";
@@ -288,7 +288,7 @@ cl {
     }
 
     # === Signup Page ===
-    def:pub SignupPage() -> any {
+    def:pub SignupPage() -> JsxElement {
         has username: str = "";
         has password: str = "";
         has confirmPassword: str = "";
@@ -386,7 +386,7 @@ cl {
     }
 
     # === Protected Dashboard ===
-    def:pub Dashboard() -> any {
+    def:pub Dashboard() -> JsxElement {
         navigate = useNavigate();
 
         # Redirect if not logged in
@@ -425,7 +425,7 @@ cl {
     }
 
     # === Main App ===
-    def:pub app() -> any {
+    def:pub app() -> JsxElement {
         return <Router>
             <Routes>
                 <Route path="/" element={<Dashboard />} />
@@ -448,7 +448,7 @@ cl import from "@jac/runtime" { AuthGuard, Outlet }
 
 # pages/(auth)/layout.jac - Protects all routes in (auth) group
 cl {
-    def:pub layout() -> any {
+    def:pub layout() -> JsxElement {
         return <AuthGuard redirect="/login">
             <Outlet />
         </AuthGuard>;

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -14,6 +14,9 @@ Build multi-page applications with client-side routing.
 !!! info "Single-page vs multi-page"
     If your app is a single-page application (like the [AI Day Planner tutorial](../first-app/build-ai-day-planner.md)), you don't need routing -- a single `def:pub app -> JsxElement` entry point is sufficient. Add routing when your app needs multiple distinct pages (e.g., dashboard, settings, profile).
 
+!!! tip "Browser APIs in client code"
+    Inside `cl { }` blocks, standard JavaScript browser APIs like `URLSearchParams`, `parseInt`, `setInterval`, `clearInterval`, `localStorage`, and `JSON` are available since client code compiles to JavaScript.
+
 Jac-client supports two routing approaches:
 
 1. **File-Based Routing** (Recommended) - Convention over configuration

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -160,7 +160,7 @@ cl {
 
 ### Effect Dependencies
 
-Use list `[dep]` or tuple `(dep1, dep2)` syntax to specify dependencies:
+Use list syntax `[dep1, dep2]` to specify dependencies (similar to React's dependency arrays):
 
 ```jac
 cl {
@@ -381,7 +381,7 @@ cl {
         has submitting: bool = False;
 
         def update_field(field: str, value: str) -> None {
-            form_data[field] = value;
+            form_data = {**form_data, field: value};
         }
 
         def validate() -> bool {

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -189,6 +189,9 @@ with entry {
 
 ### Match (Pattern Matching)
 
+!!! warning "Match/case uses Python-style indentation"
+    Match case bodies use `case X:` with indentation, not braces. This is the one exception to Jac's brace-based block syntax.
+
 Match case bodies use Python-style indentation, not braces:
 
 ```jac

--- a/docs/docs/tutorials/language/coding_primer.md
+++ b/docs/docs/tutorials/language/coding_primer.md
@@ -1792,7 +1792,7 @@ node Person {
 }
 
 walker Greeter {
-    can start with `root entry {
+    can start with Root entry {
         print("Walker starting journey!");
         visit [-->];  # Visit all connected nodes
     }
@@ -1838,7 +1838,7 @@ with entry {
 ```jac
 walker MyWalker {
     # Runs when walker spawns at root
-    can start with `root entry {
+    can start with Root entry {
         # ...
     }
 
@@ -2010,7 +2010,7 @@ walker FindPerson {
     has target: str;
     has found: bool = False;
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2063,7 +2063,7 @@ edge Friendship {
 walker FriendRecommender {
     has recommendations: list = [];
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2091,7 +2091,7 @@ walker InterestMatcher {
     has target_interest: str;
     has matches: list = [];
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2208,7 +2208,7 @@ edge Friend {
 }
 
 walker FindFriends {
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2283,7 +2283,7 @@ walker FindAncestors {
     has generations: int = 0;
     has max_generations: int = 3;
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2344,7 +2344,7 @@ walker CanTake {
     has completed: list;
     has can_take: bool = True;
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2366,7 +2366,7 @@ walker FindPath {
     has path: list = [];
     has visited: set = set();
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2439,7 +2439,7 @@ walker RecommendProducts {
     has min_rating: int = 4;
     has recommendations: list = [];
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2515,7 +2515,7 @@ edge DependsOn {
 walker CheckReady {
     has ready_tasks: list = [];
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2544,7 +2544,7 @@ walker CheckReady {
 walker MarkComplete {
     has task_title: str;
 
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 
@@ -2943,7 +2943,7 @@ edge Friend {
 
 # Walker
 walker Greeter {
-    can start with `root entry {
+    can start with Root entry {
         visit [-->];
     }
 

--- a/docs/docs/tutorials/language/osp.md
+++ b/docs/docs/tutorials/language/osp.md
@@ -204,6 +204,8 @@ def query_examples(node: Person, alice: Person) {
 
 ## Walkers: Mobile Computation
 
+**Naming:** `Root` (capitalized) is the type of the root node, used in ability declarations like `can X with Root entry`. `root` (lowercase) is the built-in instance, used in expressions like `root ++> node` or `root spawn Walker()`.
+
 Walkers are objects that traverse the graph and execute abilities at each node.
 
 ```jac
@@ -240,6 +242,9 @@ with entry {
 ```
 Hello, Alice!
 ```
+
+!!! warning "Walkers need explicit traversal"
+    A walker spawned at `root` starts there but doesn't automatically visit connected nodes. You must include a `can start with Root entry { visit [-->]; }` ability to begin traversal. Without it, the walker sits at root and its node-specific abilities never fire.
 
 Wait, why only Alice? Because the walker visits root first (via `start`), then visits Alice (via `greet`), but doesn't continue to Bob. The walker needs to be told to continue traversing.
 
@@ -356,10 +361,14 @@ with entry {
 **Output:**
 
 ```
+Person(name='Alice', age=30)
+Person(name='Carol', age=25)
 Found 2 adults
   - Alice
   - Carol
 ```
+
+The `report` keyword does two things: prints the value to the console, and stores it in `result.reports` for programmatic access.
 
 ---
 
@@ -393,8 +402,15 @@ with entry {
     root ++> Person(name="Carol", age=30);
 
     result = root spawn FindFirst();
-    print(f"First adult: {result.reports[0].name}");  # Bob
+    print(f"First adult: {result.reports[0].name}");
 }
+```
+
+**Output:**
+
+```
+Person(name='Bob', age=25)
+First adult: Bob
 ```
 
 Without `disengage`, the walker would continue visiting Carol. With it, the walker stops as soon as it finds Bob. This is especially useful in search walkers where you need to find and modify a specific node (like toggling or deleting a task by ID).
@@ -496,6 +512,19 @@ with entry {
         print(f"  - {user.username}");
     }
 }
+```
+
+**Output:**
+
+```
+User(username='bob')
+User(username='carol')
+Alice's followers:
+  - bob
+  - carol
+User(username='bob')
+Alice's mutual follows:
+  - bob
 ```
 
 ---

--- a/docs/docs/tutorials/troubleshooting.md
+++ b/docs/docs/tutorials/troubleshooting.md
@@ -226,6 +226,26 @@ This clears the global bytecode cache. Works even when the cache is corrupted.
 
 ## Runtime Errors
 
+### NodeAnchor errors between runs
+
+**Error:** `NodeAnchor [...] is not a valid reference!`
+
+**Cause:** Jac persists graph state in `.jac/data/anchor_store.db`. When you run different `.jac` files with different node types in the same directory, stale references can cause errors.
+
+**Fix:**
+
+```bash
+# Clear graph state
+rm -rf .jac
+
+# Or use jac clean
+jac clean --all
+```
+
+**Tip:** When working through tutorials, either use a fresh directory for each example or clear state between runs.
+
+---
+
 ### Walker reports are empty
 
 **Cause:** Walker didn't visit any nodes or didn't call `report`.
@@ -516,7 +536,8 @@ jac check myfile.jac
 
 | Error | Quick Fix |
 |-------|-----------|
-| Cache/setup errors (`jaclang.pycore`, `NodeAnchor`, stalling) | Run `jac purge` |
+| Cache/setup errors (`jaclang.pycore`, stalling) | Run `jac purge` |
+| `NodeAnchor is not a valid reference` | Run `rm -rf .jac` or `jac clean --all` |
 | Walker doesn't run | Add `can start with Root entry { visit [-->]; }` |
 | Missing glob keyword | Use `glob var = value;` in `cl {}` blocks |
 | Enumerate unpacking | Use `for (i, x) in enumerate(...)` |

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -10,6 +10,7 @@ import from collections { OrderedDict }
 import from collections.abc { Callable, Coroutine, Iterator, Mapping, Sequence }
 import from concurrent.futures { Future, ThreadPoolExecutor }
 import from contextlib { contextmanager, suppress }
+import dataclasses;
 import from dataclasses { dataclass, field }
 import from functools { wraps }
 import from http.server { HTTPServer }
@@ -559,48 +560,65 @@ class JacWalker {
     static def spawn_call(
         `walker: WalkerAnchor, nd: (NodeAnchor | EdgeAnchor)
     ) -> WalkerArchetype {
+        import from jaclang.runtimelib.context { CallState }
         warch = `walker.archetype;
         `walker.path = [];
         current_loc = nd.archetype;
         ctx = JacRuntimeInterface.get_context();
         call_state = ctx.call_state.get(None);
-        for i in warch._jac_entry_funcs_ {
-            if not i.trigger {
-                i.func(warch, current_loc);
-            }
-            if `walker.disengaged {
-                `walker.ignores = [];
-                if call_state {
-                    warch.reports = call_state.reports;
+        owns_call_state = False;
+        if not call_state {
+            call_token = ctx.call_state.set(CallState());
+            call_state = ctx.call_state.get();
+            owns_call_state = True;
+        }
+        try {
+            for i in warch._jac_entry_funcs_ {
+                if not i.trigger {
+                    i.func(warch, current_loc);
                 }
-                return warch;
+                if `walker.disengaged {
+                    `walker.ignores = [];
+                    return warch;
+                }
+            }
+            while `walker.next {
+                next_anchor = `walker.next.pop(0);
+                if (
+                    (next_anchor not in `walker.ignores)
+                    and not JacWalker._visit_node_recursive(
+                        warch, `walker, next_anchor
+                    )
+                ) {
+                    break;
+                }
+            }
+            if `walker.path {
+                current_loc = `walker.path[-1].archetype;
+            }
+            for i in warch._jac_exit_funcs_ {
+                if not i.trigger {
+                    i.func(warch, current_loc);
+                }
+                if `walker.disengaged {
+                    break;
+                }
+            }
+            `walker.ignores = [];
+            return warch;
+        } finally {
+            if owns_call_state {
+                reports = [];
+                while not call_state.reports.empty() {
+                    item = call_state.reports.get_nowait();
+                    if item is not call_state._sentinel {
+                        reports.append(item);
+                    }
+                }
+                warch.reports = reports;
+                ctx.call_state.reset(call_token);
             }
         }
-        while `walker.next {
-            next_anchor = `walker.next.pop(0);
-            if (
-                (next_anchor not in `walker.ignores)
-                and not JacWalker._visit_node_recursive(warch, `walker, next_anchor)
-            ) {
-                break;
-            }
-        }
-        if `walker.path {
-            current_loc = `walker.path[-1].archetype;
-        }
-        for i in warch._jac_exit_funcs_ {
-            if not i.trigger {
-                i.func(warch, current_loc);
-            }
-            if `walker.disengaged {
-                break;
-            }
-        }
-        `walker.ignores = [];
-        if call_state {
-            warch.reports = call_state.reports;
-        }
-        return warch;
     }
 
     """Async version: Execute all entry abilities for current location.
@@ -760,56 +778,71 @@ class JacWalker {
     static async def async_spawn_call(
         `walker: WalkerAnchor, nd: (NodeAnchor | EdgeAnchor)
     ) -> WalkerArchetype {
+        import from jaclang.runtimelib.context { CallState }
         warch = `walker.archetype;
         `walker.path = [];
         current_loc = nd.archetype;
         ctx = JacRuntimeInterface.get_context();
         call_state = ctx.call_state.get(None);
-        for i in warch._jac_entry_funcs_ {
-            if not i.trigger {
-                result = i.func(warch, current_loc);
-                if isinstance(result, Coroutine) {
-                    await result;
+        owns_call_state = False;
+        if not call_state {
+            call_token = ctx.call_state.set(CallState());
+            call_state = ctx.call_state.get();
+            owns_call_state = True;
+        }
+        try {
+            for i in warch._jac_entry_funcs_ {
+                if not i.trigger {
+                    result = i.func(warch, current_loc);
+                    if isinstance(result, Coroutine) {
+                        await result;
+                    }
+                }
+                if `walker.disengaged {
+                    `walker.ignores = [];
+                    return warch;
                 }
             }
-            if `walker.disengaged {
-                `walker.ignores = [];
-                if call_state {
-                    warch.reports = call_state.reports;
-                }
-                return warch;
-            }
-        }
-        while `walker.next {
-            next_anchor = `walker.next.pop(0);
-            if (
-                (next_anchor not in `walker.ignores)
-                and not await JacWalker._async_visit_node_recursive(
-                    warch, `walker, next_anchor
-                )
-            ) {
-                break;
-            }
-        }
-        if `walker.path {
-            current_loc = `walker.path[-1].archetype;
-        }
-        for i in warch._jac_exit_funcs_ {
-            if not i.trigger {
-                result = i.func(warch, current_loc);
-                if isinstance(result, Coroutine) {
-                    await result;
+            while `walker.next {
+                next_anchor = `walker.next.pop(0);
+                if (
+                    (next_anchor not in `walker.ignores)
+                    and not await JacWalker._async_visit_node_recursive(
+                        warch, `walker, next_anchor
+                    )
+                ) {
+                    break;
                 }
             }
-            if `walker.disengaged {
-                break;
+            if `walker.path {
+                current_loc = `walker.path[-1].archetype;
+            }
+            for i in warch._jac_exit_funcs_ {
+                if not i.trigger {
+                    result = i.func(warch, current_loc);
+                    if isinstance(result, Coroutine) {
+                        await result;
+                    }
+                }
+                if `walker.disengaged {
+                    break;
+                }
+            }
+            `walker.ignores = [];
+            return warch;
+        } finally {
+            if owns_call_state {
+                reports = [];
+                while not call_state.reports.empty() {
+                    item = call_state.reports.get_nowait();
+                    if item is not call_state._sentinel {
+                        reports.append(item);
+                    }
+                }
+                warch.reports = reports;
+                ctx.call_state.reset(call_token);
             }
         }
-        `walker.ignores = [];
-        if call_state {
-            warch.reports = call_state.reports;
-        }
-        return warch;
     }
 
     """Jac's spawn operator feature."""
@@ -1097,6 +1130,16 @@ class JacBasics {
         }
         cls._jac_entry_funcs_ = [*entries.values()];
         cls._jac_exit_funcs_ = [*exits.values()];
+        if issubclass(cls, WalkerArchetype)
+        and 'reports' not in cls.__dict__.get('__annotations__', {}) {
+            if not hasattr(cls, '__annotations__') {
+                cls.__annotations__ = {};
+            }
+            cls.__annotations__['reports'] = list;
+            cls.reports = dataclasses.field(
+                default_factory=`list, init=False, repr=False, compare=False
+            );
+        }
         dataclass(eq=False)(cls);
         return cls;
     }


### PR DESCRIPTION
## Summary

- **Fix walker `result.reports` broken in CLI mode**: The `report` keyword was not populating `result.reports` when running walkers via `jac run` or `jac test`. `CallState` (which collects reported values) was only initialized in the HTTP server context, so CLI-mode walkers silently dropped all reports. `spawn_call` and `async_spawn_call` now create a `CallState` when one doesn't exist and drain collected reports into a proper `list`. `make_archetype` now injects `reports` as a real dataclass field on every walker subclass so `MyWalker().reports` returns `[]` instead of a `Field` descriptor.

- **25 documentation fixes from comprehensive QA review** across 22 doc files:
  - Fix quickstart.md function name mismatch (`translate` vs `translate2french`)
  - Update 3 outdated Anthropic model names to `claude-sonnet-4-6`
  - Fix 13 backtick `` `root entry `` to `Root entry` in coding_primer.md
  - Add walker traversal warning, Root vs root clarification to osp.md
  - Add NodeAnchor state cleanup section to troubleshooting.md
  - Fix immutable state mutation in fullstack state.md ContactForm example
  - Standardize component return types to `JsxElement` in auth.md
  - Add notes for async/await, browser APIs, match/case indentation, test file naming
  - Add filter comprehension intro, typed context block explanation
  - Add collapsible try-it examples to foundation, functions-objects, littlex, emailbuddy
  - Fold dense generated code in library-mode.md
  - Add expected outputs to osp.md walker examples
  - Add quick start flow to ecosystem.md, try-it links to syntax cheatsheet

## Test plan

- [x] All 3765 existing tests pass (including server/HMR tests)
- [x] `jac run` with `report` keyword populates `result.reports` as a list
- [x] `jac test` with `result.reports` assertions pass
- [x] `disengage` + `report` correctly captures partial reports
- [x] `MyWalker().reports` returns `[]` (not a `Field` descriptor)
- [x] Server-mode `report_collector` still works (no Queue drain interference)