### PR TITLE
fix(client): auto-logout on 401 unauthorized response

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,7 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.2.20 (Unreleased)
 
-- 1 minor refactor/change.
+- 2 minor refactor/change.
 
 ## jac-client 0.2.19 (Latest Release)
 

--- a/jac-client/jac_client/plugin/impl/client_runtime.impl.jac
+++ b/jac-client/jac_client/plugin/impl/client_runtime.impl.jac
@@ -67,6 +67,11 @@ impl __jacSpawn(left: str, right: str = "", fields: dict = {}) -> any {
         url, {"method": "POST", "headers": headers, "body": JSON.stringify(fields)}
     );
     if not response.ok {
+        if response.status == 401 {
+            __removeLocalStorage("jac_token");
+            window.location.reload();
+            return {};
+        }
         error_text = await response.text();
         walker_name = f"{left}/{right}" if right else left;
         raise Exception(f"Walker {walker_name} failed: {error_text}") ;


### PR DESCRIPTION
## Summary
- Automatically clear stored auth token and reload the page when a walker request returns a 401 status, redirecting the user to login instead of throwing an error
- Updated release notes count for jac-client 0.2.20

## Test plan
- [ ] Trigger a 401 response from a walker endpoint and verify the token is cleared and the page reloads to the login screen
- [ ] Verify non-401 errors still raise exceptions as before