### PR TITLE
feat: native generic syntax in jac0 transpiler and codebase migration

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -16,6 +16,9 @@ This document provides a summary of new features, improvements, and bug fixes in
 - 4 Minor refactors/chages
 - **Native Codegen: Expanded Primitive Coverage**: Added 17 new LLVM IR emitter implementations across 6 emitters: IntEmitter (`conjugate`, `bit_length`, `bit_count`), FloatEmitter (`conjugate`, `is_integer`, `op_floordiv`), StrEmitter (`title`, `rfind`, `ljust`, `rjust`, `zfill`), SetEmitter (`clear`, `discard`, `copy`), ListEmitter (`extend`, `insert`), and BuiltinEmitter (`bool`). Fixed string comparison operators (`<`, `>`, `<=`, `>=`) via `strcmp` and added float floor division (`fdiv` + `floor`). Fixed `rfind` infinite loop on empty substring. 108/299 implemented (36%), 105/299 tested (35%).
 - **Fix: Walker `result.reports` in CLI Mode**: Fixed `report` keyword not populating `result.reports` when running walkers via `jac run` or `jac test`.
+- **`jac format` Support for Generic Syntax**: `jac format` now correctly handles native generic type parameters (`class Foo[V, C]`) and type aliases (`type Result[T, E] = T | E;`). Previously, formatting would lose type parameter names and produce broken output.
+- **Bootstrap Compiler (jac0) Native Generic Support**: Extended the jac0 bootstrap transpiler to parse and emit PEP 695 generic class syntax (`class Foo[T, V](Base)`) and type alias statements (`type Alias[T] = Expr`), enabling jac0core infrastructure files to use native Jac generics instead of Python-style `Generic[T]`/`TypeVar` patterns.
+- **Migrate jac0core and Compiler Passes to Native Generics**: Replaced `Generic[(T, V)]` inheritance and `TypeVar` declarations with native `[T, V]` syntax across `transform.jac`, `unitree.jac`, `base_ast_gen_pass.jac`, and all `Transform[(X, Y)]` subscription sites in the compiler pipeline.
 
 ## jaclang 0.10.5 (Latest Release)
 

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
@@ -32,7 +32,7 @@ with entry {
 glob T = TypeVar('T', bound=uni.UniNode);
 
 """Jac Parser."""
-obj PyastBuildPass(Transform[(uni.PythonModuleAst, uni.Module)]) {
+obj PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]) {
     has ir_in: uni.PythonModuleAst,
         prog: JacProgram,
         cancel_token: Event | None = None,

--- a/jac/jaclang/compiler/passes/main/sem_def_match_pass.jac
+++ b/jac/jaclang/compiler/passes/main/sem_def_match_pass.jac
@@ -14,7 +14,7 @@ import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.transform { Transform }
 import from jaclang.jac0core.unitree { Symbol, UniScopeNode }
 """Jac Semantic definition match pass."""
-obj SemDefMatchPass(Transform[(uni.Module, uni.Module)]) {
+obj SemDefMatchPass(Transform[uni.Module, uni.Module]) {
     def init(ir_in: uni.Module, prog: Any, cancel_token: Any = None) -> None;
     def transform(ir_in: uni.Module) -> uni.Module;
     def find_symbol_from_dotted_name(

--- a/jac/jaclang/compiler/passes/tool/comment_injection_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/comment_injection_pass.jac
@@ -62,7 +62,7 @@ Injects comments using token sequence analysis for perfect precision.
     injects them using source_token annotations with automatic duplicate
     line collapsing.
 """
-obj CommentInjectionPass(Transform[(uni.Module, uni.Module)]) {
+obj CommentInjectionPass(Transform[uni.Module, uni.Module]) {
     def init(ir_in: uni.Module, prog: Any, cancel_token: Any = None);
     def transform(ir_in: uni.Module) -> uni.Module;
     def _process(ctx: uni.UniNode, nd: doc.DocType) -> doc.DocType;

--- a/jac/jaclang/compiler/passes/tool/jac_formatter_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/jac_formatter_pass.jac
@@ -7,7 +7,7 @@ import jaclang.compiler.passes.tool.doc_ir as doc;
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes { Transform }
 """JacFormat Pass format Jac code."""
-obj JacFormatPass(Transform[(uni.Module, uni.Module)]) {
+obj JacFormatPass(Transform[uni.Module, uni.Module]) {
     def init(ir_in: uni.Module, prog: Any, cancel_token: Any = None) -> None;
     def pre_transform -> None;
     def _probe_fits(

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -35,7 +35,7 @@ with entry {
 }
 
 """Symbol table build schedule."""
-def get_symtab_ir_sched -> list[type[Transform[(uni.Module, uni.Module)]]] {
+def get_symtab_ir_sched -> list[type[Transform[uni.Module, uni.Module]]] {
     return [SymTabBuildPass, DeclImplMatchPass];
 }
 
@@ -50,7 +50,7 @@ glob _ir_sched_loading = False,
     to the basic schedule (symtab + semantic analysis only), which uses
     only jac0core passes with no lazy imports.
     """
-def get_ir_gen_sched -> list[type[Transform[(uni.Module, uni.Module)]]] {
+def get_ir_gen_sched -> list[type[Transform[uni.Module, uni.Module]]] {
     global _ir_sched_loading;
     if _ir_sched_loading {
         return [SymTabBuildPass, DeclImplMatchPass, SemanticAnalysisPass];
@@ -76,7 +76,7 @@ def get_ir_gen_sched -> list[type[Transform[(uni.Module, uni.Module)]]] {
 }
 
 """Type checking schedule."""
-def get_type_check_sched -> list[type[Transform[(uni.Module, uni.Module)]]] {
+def get_type_check_sched -> list[type[Transform[uni.Module, uni.Module]]] {
     import from jaclang.compiler.passes.main { TypeCheckPass }
     return [TypeCheckPass];
 }
@@ -86,7 +86,7 @@ def get_type_check_sched -> list[type[Transform[(uni.Module, uni.Module)]]] {
     Same re-entrancy guard as get_ir_gen_sched: when compiling the pass
     modules this depends on, falls back to bytecode-only generation.
     """
-def get_py_code_gen -> list[type[Transform[(uni.Module, uni.Module)]]] {
+def get_py_code_gen -> list[type[Transform[uni.Module, uni.Module]]] {
     global _codegen_sched_loading;
     if _codegen_sched_loading {
         return [PyastGenPass, PyBytecodeGenPass];
@@ -95,7 +95,7 @@ def get_py_code_gen -> list[type[Transform[(uni.Module, uni.Module)]]] {
     try {
         import from jaclang.compiler.passes.ecmascript { EsastGenPass }
         import from jaclang.compiler.passes.main { PyJacAstLinkPass }
-        passes: list[type[Transform[(uni.Module, uni.Module)]]] = [
+        passes: list[type[Transform[uni.Module, uni.Module]]] = [
             InteropAnalysisPass,
             EsastGenPass
         ];
@@ -116,7 +116,7 @@ def get_py_code_gen -> list[type[Transform[(uni.Module, uni.Module)]]] {
     """
 def get_format_sched(
     auto_lint: bool = False
-) -> list[type[Transform[(uni.Module, uni.Module)]]] {
+) -> list[type[Transform[uni.Module, uni.Module]]] {
     import from jaclang.compiler.passes.tool.comment_injection_pass {
         CommentInjectionPass
     }
@@ -135,7 +135,7 @@ def get_format_sched(
     Note: Annex modules are loaded by the caller (jac_file_linter) via
     parse-only to avoid cascading compilation through the import graph.
     """
-def get_lint_sched -> list[type[Transform[(uni.Module, uni.Module)]]] {
+def get_lint_sched -> list[type[Transform[uni.Module, uni.Module]]] {
     import from jaclang.compiler.passes.tool.jac_auto_lint_pass { JacAutoLintPass }
     return [JacAutoLintPass];
 }
@@ -730,7 +730,7 @@ class JacCompiler {
         self: JacCompiler,
         mod: uni.Module,
         target_program: JacProgram,
-        passes: list[type[Transform[(uni.Module, uni.Module)]]],
+        passes: list[type[Transform[uni.Module, uni.Module]]],
         cancel_token: (Event | None) = None
     ) -> None {
         for current_pass in passes {

--- a/jac/jaclang/jac0core/impl/program.impl.jac
+++ b/jac/jaclang/jac0core/impl/program.impl.jac
@@ -110,7 +110,7 @@ impl JacProgram.build(
 impl JacProgram.run_schedule(
     self: JacProgram,
     mod: uni.Module,
-    passes: list[type[Transform[(uni.Module, uni.Module)]]],
+    passes: list[type[Transform[uni.Module, uni.Module]]],
     cancel_token: (Event | None) = None
 ) -> None {
     self._get_compiler().run_schedule(mod, self, passes, cancel_token);

--- a/jac/jaclang/jac0core/passes/annex_pass.jac
+++ b/jac/jaclang/jac0core/passes/annex_pass.jac
@@ -26,7 +26,7 @@ with entry {
 }
 
 """Handles loading and attaching of annex files (.impl.jac, .test.jac)."""
-class JacAnnexPass(Transform[(uni.Module, uni.Module)]) {
+class JacAnnexPass(Transform[uni.Module, uni.Module]) {
     """Load and attach annex modules to the given module."""
     def transform(self: JacAnnexPass, ir_in: uni.Module) -> uni.Module;
 

--- a/jac/jaclang/jac0core/passes/ast_gen/base_ast_gen_pass.jac
+++ b/jac/jaclang/jac0core/passes/ast_gen/base_ast_gen_pass.jac
@@ -1,13 +1,12 @@
 """Shared helpers for AST generation passes."""
 import from collections.abc { Sequence }
-import from typing { Any, Generic, TypeVar }
+import from typing { Any, TypeVar }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.uni_pass { UniPass }
-glob T = TypeVar('T'),
-     ChildPassT = TypeVar('ChildPassT', bound='BaseAstGenPass[Any]');
+glob ChildPassT = TypeVar('ChildPassT', bound='BaseAstGenPass[Any]');
 
 """Common functionality shared across AST generation passes."""
-class BaseAstGenPass(UniPass, Generic[T]) {
+class BaseAstGenPass[T](UniPass) {
     """Return the list of body statements regardless of ImplDef wrapping."""
     def _get_body_inner(
         self: BaseAstGenPass, nd: uni.Archetype | uni.Enum | uni.Ability

--- a/jac/jaclang/jac0core/passes/def_impl_match_pass.jac
+++ b/jac/jaclang/jac0core/passes/def_impl_match_pass.jac
@@ -22,7 +22,7 @@ import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.transform { Transform }
 import from jaclang.jac0core.unitree { Symbol, UniScopeNode }
 """Decls and Def matching pass."""
-class DeclImplMatchPass(Transform[(uni.Module, uni.Module)]) {
+class DeclImplMatchPass(Transform[uni.Module, uni.Module]) {
     """Connect Decls and Defs."""
     def transform(self: DeclImplMatchPass, ir_in: uni.Module) -> uni.Module;
 

--- a/jac/jaclang/jac0core/passes/pybc_gen_pass.jac
+++ b/jac/jaclang/jac0core/passes/pybc_gen_pass.jac
@@ -20,7 +20,7 @@ import marshal;
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.transform { Transform }
 """Python and bytecode file printing pass."""
-class PyBytecodeGenPass(Transform[(uni.Module, uni.Module)]) {
+class PyBytecodeGenPass(Transform[uni.Module, uni.Module]) {
     """Transform AST into Python bytecode."""
     def transform(self: PyBytecodeGenPass, ir_in: uni.Module) -> uni.Module;
 

--- a/jac/jaclang/jac0core/passes/transform.jac
+++ b/jac/jaclang/jac0core/passes/transform.jac
@@ -2,7 +2,7 @@
 import time;
 import from abc { ABC, abstractmethod }
 import from threading { Event }
-import from typing { TYPE_CHECKING, Generic, TypeVar }
+import from typing { TYPE_CHECKING }
 import from jaclang.jac0core.codeinfo { CodeLocInfo }
 import from jaclang.jac0core.log { logging }
 import from jaclang.jac0core.unitree { UniNode }
@@ -12,11 +12,6 @@ with entry {
         import from jaclang.jac0core.program { JacProgram }
     }
 }
-
-glob T_in = TypeVar('T_in'),
-     T_out = TypeVar('T_out'),
-     T = TypeVar('T', bound=UniNode),
-     R = TypeVar('R', bound=UniNode);
 
 """Alert interface."""
 class Alert {
@@ -43,7 +38,7 @@ class Alert {
     Use this base class for transforms that don't operate on AST nodes,
     such as parser transforms that take string input and produce parse trees.
     """
-class BaseTransform(ABC, Generic[(T_in, T_out)]) {
+class BaseTransform[T_in, T_out](ABC) {
     """Initialize pass."""
     def init(
         self: BaseTransform,
@@ -77,7 +72,7 @@ class BaseTransform(ABC, Generic[(T_in, T_out)]) {
     This class extends BaseTransform with UniNode-specific functionality
     like error/warning logging with source location tracking.
     """
-class Transform(BaseTransform[(T, R)]) {
+class Transform[T: UniNode, R: UniNode](BaseTransform[T, R]) {
     """Initialize pass."""
     def init(
         self: Transform,

--- a/jac/jaclang/jac0core/passes/uni_pass.jac
+++ b/jac/jaclang/jac0core/passes/uni_pass.jac
@@ -12,7 +12,7 @@ with entry {
 
 glob T = TypeVar('T', bound=uni.UniNode);
 """Abstract class for IR passes."""
-class UniPass(Transform[(uni.Module, uni.Module)]) {
+class UniPass(Transform[uni.Module, uni.Module]) {
     """Initialize parser."""
     def init(
         self: UniPass,

--- a/jac/jaclang/jac0core/program.jac
+++ b/jac/jaclang/jac0core/program.jac
@@ -73,7 +73,7 @@ class JacProgram {
     def run_schedule(
         self: JacProgram,
         mod: uni.Module,
-        passes: list[type[Transform[(uni.Module, uni.Module)]]],
+        passes: list[type[Transform[uni.Module, uni.Module]]],
         cancel_token: (Event | None) = None
     ) -> None;
 

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -8,7 +8,7 @@ import from dataclasses { dataclass, field }
 import from enum { IntEnum }
 import from hashlib { md5 }
 import from types { EllipsisType }
-import from typing { TYPE_CHECKING, Any, Generic, TypeVar, cast }
+import from typing { TYPE_CHECKING, Any, cast }
 import from jaclang.jac0core.bccache { discover_base_file }
 import from jaclang.jac0core.codeinfo { CodeGenTarget, CodeLocInfo }
 import from jaclang.jac0core.constant {
@@ -321,7 +321,6 @@ class AstAccessNode(UniNode) {
     def public_access(self: AstAccessNode) -> bool;
 }
 
-glob T = TypeVar('T', bound=UniNode);
 """Base class for nodes that can be marked with execution context
 (client/server)."""
 class ContextAwareNode(UniNode) {
@@ -451,7 +450,7 @@ class CodeBlockStmt(UniCFGNode) {
 }
 
 """AstImplNeedingNode node type for Jac Ast."""
-class AstImplNeedingNode(AstSymbolNode, Generic[T]) {
+class AstImplNeedingNode[T](AstSymbolNode) {
     def init(self: AstImplNeedingNode, body: (T | None)) -> None;
     @property
     def needs_impl(self: AstImplNeedingNode) -> bool;
@@ -515,7 +514,7 @@ class ArchSpec(ElementStmt, CodeBlockStmt, AstSymbolNode, AstAsyncNode, AstDocNo
 class MatchPattern(UniNode) {}
 
 """SubTag node type for Jac Ast."""
-class SubTag(UniNode, Generic[T]) {
+class SubTag[T](UniNode) {
     def init(self: SubTag, tag: T, kid: Sequence[UniNode]) -> None;
 }
 


### PR DESCRIPTION
## Summary

- Extends the jac0 bootstrap transpiler to support PEP 695 generic class syntax (`class Foo[T, V](Base)`) and `type` alias statements (`type Alias[T] = Expr;`)
- Migrates all jac0core infrastructure and compiler passes from Python-style `Generic[(T, V)]`/`TypeVar` patterns to native Jac bracket syntax `[T, V]`
- Updates `Transform[(X, Y)]` subscription syntax to `Transform[X, Y]` across 16 files

## Test plan

- [x] All 3601 compiler tests pass
- [x] All 188 language tests pass
- [x] All pre-commit hooks pass (including jac-format)
- [x] `jac format` correctly handles `class Foo[V, C]` and `type Foo[T] = Expr;`
- [x] Bootstrap compilation of jac0core files works with native generic syntax