### PR TITLE
update pillow dependency to version 12.0.0 in byllm

### DIFF
--- a/jac-byllm/pyproject.toml
+++ b/jac-byllm/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "jaclang>=0.11.0",
     "litellm>=1.75.5.post1,<1.80.0",
     "loguru>=0.7.2,<0.8.0",
-    "pillow>=10.4.0,<10.5.0",
+    "pillow>=12.0.0,<13.0.0",
 ]
 
 [project.entry-points."jac"]


### PR DESCRIPTION
## Description

- Python 3.14 builds were failing during pre-compilation because pillow 10.4.x doesn't support it.

Bumped pillow from `>=10.4.0,<10.5.0` to `>=12.0.0,<13.0.0` since pillow 12 has full 3.14 support.
https://pillow.readthedocs.io/en/stable/installation/python-support.html

Tested locally - multimodal and all other byllm features work fine with pillow 12.1.1.
