### PR TITLE
docs: backfill reference docs with undocumented features from release notes

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -39,6 +39,31 @@ The Jac CLI provides commands for running, building, testing, and deploying Jac 
 
 ---
 
+## Version Info
+
+```bash
+jac --version
+```
+
+Displays the Jac version, Python version, platform, and all detected plugins with their versions:
+
+```
+ _
+(_) __ _  ___     Jac Language
+| |/ _` |/ __|
+| | (_| | (__     Version:  0.10.2
+_/ |\__,_|\___|    Python 3.12.3
+|__/                Platform: Linux x86_64
+
+🔌 Plugins Detected:
+   byllm==0.4.17
+   jac-client==0.2.13
+   jac-scale==0.1.4
+   jac-super==0.1.0
+```
+
+---
+
 ## Core Commands
 
 ### jac run
@@ -294,7 +319,7 @@ jac test main.jac -v
 Format Jac code according to style guidelines. For auto-linting (code corrections like combining consecutive `has` statements, converting `@staticmethod` to `static`), use `jac lint --fix` instead.
 
 ```bash
-jac format [-h] [-s] [-l] paths [paths ...]
+jac format [-h] [-s] [-l] [-c] paths [paths ...]
 ```
 
 | Option | Description | Default |
@@ -302,6 +327,7 @@ jac format [-h] [-s] [-l] paths [paths ...]
 | `paths` | Files/directories to format | Required |
 | `-s, --to_screen` | Print to stdout instead of writing | `False` |
 | `-l, --lintfix` | Also apply auto-lint fixes in the same pass | `False` |
+| `-c, --check` | Check if files are formatted without modifying them (exit 1 if unformatted) | `False` |
 
 **Examples:**
 
@@ -314,6 +340,9 @@ jac format main.jac
 
 # Format entire directory
 jac format .
+
+# Check formatting without modifying (useful in CI)
+jac format . --check
 ```
 
 > **Note**: For auto-linting (code corrections), use `jac lint --fix` instead. See [`jac lint`](#jac-lint) below.

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -379,6 +379,27 @@ _authToken = "${NODE_AUTH_TOKEN}"
 
 This generates an `.npmrc` file during dependency installation for private/scoped npm packages. See [jac-client NPM Registry Configuration](../plugins/jac-client.md#npm-registry-configuration) for details.
 
+**Build-Time Constants (jac-client):**
+
+Define global variables that are replaced at compile time in client code via the `[plugins.client.vite.define]` section:
+
+```toml
+[plugins.client.vite.define]
+"globalThis.API_URL" = "\"https://api.example.com\""
+"globalThis.FEATURE_ENABLED" = true
+"globalThis.BUILD_VERSION" = "\"1.2.3\""
+```
+
+These values are inlined by Vite during bundling. String values must be double-quoted (JSON-encoded). In client code, access them directly:
+
+```jac
+cl {
+    def:pub Footer() -> JsxElement {
+        return <p>Version: {globalThis.BUILD_VERSION}</p>;
+    }
+}
+```
+
 ---
 
 ### [scripts]

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -349,21 +349,30 @@ walker Visitor {
 }
 ```
 
-**Indexed Visit:**
+**Queue Insertion Index:**
+
+The `visit : index : [-->]` syntax controls *where* in the walker's traversal queue new destinations are inserted. This enables DFS, BFS, and custom traversal strategies:
 
 ```jac
 node Item {}
 
 walker Visitor {
-    can indexed with Item entry {
-        visit : 0 : [-->];              # Visit first outgoing node only
-        visit : -1 : [-->];             # Visit last outgoing node only
-        visit : 2 : [-->];              # Visit third node (0-indexed)
+    can traverse with Item entry {
+        visit : 0 : [-->];              # Insert at FRONT of queue (DFS behavior)
+        visit : -1 : [-->];             # Insert at END of queue (BFS behavior)
+        visit : 2 : [-->];              # Insert at position 2 in queue
     }
 }
 ```
 
-Out-of-bounds indices result in no visit.
+| Syntax | Queue Position | Effect |
+|--------|---------------|--------|
+| `visit [-->]` | End (default) | BFS-like -- standard breadth-first traversal |
+| `visit : 0 : [-->]` | Front | DFS-like -- depth-first by inserting at front |
+| `visit : -1 : [-->]` | End | Explicit BFS -- same as default |
+| `visit : N : [-->]` | Position N | Custom insertion point |
+
+Out-of-bounds indices fall back to appending at the end.
 
 ### 4 The `report` Statement
 
@@ -743,6 +752,36 @@ walker BFSWalker {
     }
 }
 ```
+
+### Traversal Semantics: Deferred Exits
+
+Walker traversal uses recursive post-order exit execution. Entry abilities execute immediately when entering a node, while **exit abilities are deferred** until all descendants are visited. This means exits execute in LIFO order (last visited node exits first), similar to function call stack unwinding.
+
+```jac
+node Step { has label: str; }
+
+walker Logger {
+    can enter with Step entry {
+        print(f"ENTER: {here.label}");
+        visit [-->];
+    }
+
+    can leave with Step exit {
+        print(f"EXIT: {here.label}");
+    }
+}
+
+# For a chain: A → B → C
+# Output:
+#   ENTER: A
+#   ENTER: B
+#   ENTER: C
+#   EXIT: C    ← innermost exits first
+#   EXIT: B
+#   EXIT: A    ← outermost exits last
+```
+
+This is useful for aggregation patterns where you need to collect results from children before processing the parent (e.g., calculating subtree totals, building trees bottom-up).
 
 ### 2 Filtered Traversal
 

--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -355,6 +355,22 @@ enum Sentiment {
 def analyze_sentiment(text: str) -> Sentiment by llm();
 ```
 
+Enum member semstrings are included in the LLM's schema, helping the model understand what each value means:
+
+```jac
+enum Personality {
+    INTROVERT,
+    EXTROVERT,
+    AMBIVERT
+}
+
+sem Personality.INTROVERT = "Prefers solitude and small groups, energized by alone time";
+sem Personality.EXTROVERT = "Thrives in social settings, energized by interaction";
+sem Personality.AMBIVERT = "Comfortable in both social and solitary settings";
+
+def classify_personality(bio: str) -> Personality by llm();
+```
+
 ### Object Types
 
 ```jac
@@ -390,10 +406,13 @@ Parameters passed to `by llm()` at call time:
 |-----------|------|-------------|
 | `temperature` | float | Controls randomness (0.0 = deterministic, 2.0 = creative). Default: 0.7 |
 | `max_tokens` | int | Maximum tokens in response |
-| `tools` | list | Tool functions for agentic behavior (enables ReAct loop) |
+| `tools` | list | Tool functions for agentic behavior (automatically enables ReAct loop) |
 | `incl_info` | dict | Additional context key-value pairs injected into the prompt |
 | `stream` | bool | Enable streaming output (only supports `str` return type) |
 | `max_react_iterations` | int | Maximum ReAct iterations before forcing final answer |
+
+!!! warning "Deprecated: `method` parameter"
+    The `method` parameter (`"ReAct"`, `"Reason"`, `"Chain-of-Thoughts"`) is deprecated and was never functional. The ReAct tool-calling loop is automatically enabled when `tools=[...]` is provided. Simply pass `tools` directly instead of `method="ReAct"`.
 
 ### Chained Transformations
 

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1351,7 +1351,80 @@ description = "My awesome Jac app"
 
 ---
 
+## Automatic Endpoint Caching
+
+The client runtime automatically caches responses from reader endpoints and invalidates caches when writer endpoints are called. This uses compiler-provided `endpoint_effects` metadata -- no manual cache annotations or `jacInvalidate()` calls needed.
+
+**How it works:**
+
+1. The compiler classifies each walker/function endpoint as a **reader** (no side effects) or **writer** (modifies state)
+2. Reader responses are stored in an LRU cache (500 entries, 60-second TTL)
+3. Concurrent identical requests are deduplicated (only one network call)
+4. When a writer endpoint is called, all cached reader responses are automatically invalidated
+5. Auth state changes (login/logout) clear the entire cache
+
+This means spawning the same walker twice in quick succession only makes one API call, and creating/updating data automatically refreshes any cached reads.
+
+---
+
+## BrowserRouter (Clean URLs)
+
+jac-client uses `BrowserRouter` for client-side routing, producing clean URLs like `/about` and `/users/123` instead of hash-based URLs like `#/about`.
+
+For this to work in production, your server must return the SPA HTML for all non-API routes. When using `jac start`, this is handled automatically -- the server's catch-all route serves the SPA HTML for extensionless paths, excluding API prefixes (`cl/`, `walker/`, `function/`, `user/`, `static/`).
+
+The Vite dev server is configured with `appType: 'spa'` for history API fallback during development.
+
+---
+
+## Build Error Diagnostics
+
+When client builds fail, jac-client displays structured error diagnostics instead of raw Vite/Rollup output. Errors include:
+
+- **Error codes** (`JAC_CLIENT_001`, `JAC_CLIENT_003`, etc.)
+- **Source snippets** pointing to the original `.jac` file location
+- **Actionable hints** and quick fix commands
+
+| Code | Issue | Example Fix |
+|------|-------|-------------|
+| `JAC_CLIENT_001` | Missing npm dependency | `jac add --npm <package>` |
+| `JAC_CLIENT_003` | Syntax error in client code | Check source snippet |
+| `JAC_CLIENT_004` | Unresolved import | Verify import path |
+
+To see raw error output alongside formatted diagnostics, set `debug = true` under `[plugins.client]` in `jac.toml` or set the `JAC_DEBUG=1` environment variable.
+
+> **Note:** Debug mode is enabled by default for a better development experience. For production deployments, set `debug = false` in `jac.toml`.
+
+---
+
+## Build-Time Constants
+
+Define global variables that are replaced at compile time using the `[plugins.client.vite.define]` section in `jac.toml`:
+
+```toml
+[plugins.client.vite.define]
+"globalThis.API_URL" = "\"https://api.example.com\""
+"globalThis.FEATURE_ENABLED" = true
+"globalThis.BUILD_VERSION" = "\"1.2.3\""
+```
+
+These values are inlined by Vite during bundling. String values must be double-quoted (JSON-encoded). Access them in client code:
+
+```jac
+cl {
+    def:pub Footer() -> JsxElement {
+        return <p>Version: {globalThis.BUILD_VERSION}</p>;
+    }
+}
+```
+
+---
+
 ## Development Server
+
+### Prerequisites
+
+jac-client uses [Bun](https://bun.sh/) for package management and JavaScript bundling. If Bun is not installed, the CLI prompts you to install it automatically.
 
 ### Start Server
 

--- a/docs/docs/reference/testing.md
+++ b/docs/docs/reference/testing.md
@@ -560,6 +560,77 @@ def test_hmr(tmp_path):
 
 ---
 
+## Parameterized Tests
+
+The `parametrize()` helper registers one test per parameter, similar to `pytest.mark.parametrize`. It creates individual test cases from a list of inputs, so each case runs and reports independently.
+
+### Import
+
+```jac
+import from jaclang.runtimelib.test { parametrize }
+```
+
+### Signature
+
+```
+parametrize(base_name: str, params: Iterable, test_func: Callable, id_fn: Callable | None = None)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `base_name` | `str` | Base name for the generated tests |
+| `params` | `Iterable` | List of parameter values, each passed to the test function |
+| `test_func` | `Callable` | Test function to invoke with each parameter |
+| `id_fn` | `Callable \| None` | Optional function to generate test IDs from each parameter |
+
+### Usage
+
+Define a test function that takes a single parameter, then call `parametrize()` in a `with entry` block:
+
+```jac
+import from jaclang.runtimelib.test { parametrize }
+
+def _test_square(pair: tuple) {
+    input_val = pair[0];
+    expected = pair[1];
+    result = input_val ** 2;
+    assert result == expected, f"Expected {expected}, got {result}";
+}
+
+with entry {
+    parametrize(
+        "square",
+        [(2, 4), (3, 9), (0, 0), (-1, 1)],
+        _test_square
+    );
+}
+```
+
+This registers four tests: `square_0`, `square_1`, `square_2`, `square_3`.
+
+### Custom Test IDs
+
+Use `id_fn` to generate descriptive test names:
+
+```jac
+import from jaclang.runtimelib.test { parametrize }
+
+def _test_parse(raw: str) {
+    # test logic
+}
+
+with entry {
+    parametrize(
+        "parse values",
+        ["500m", "2", "250"],
+        _test_parse,
+        id_fn=lambda p: str -> str { return f"input_{p}"; }
+    );
+}
+```
+
+---
+
 ## Best Practices
 
 ### 1. Descriptive Names


### PR DESCRIPTION
## Summary

Audited release notes across jaclang, jac-client, jac-scale, and byLLM plugins and backfilled missing user-facing features into the reference documentation.

### Changes by section

- **CLI** (`cli/index.md`): Added `--version` banner output and `format --check` dry-run flag
- **Testing** (`testing.md`): Added `parametrize()` helper documentation with signature, usage examples, and custom test IDs
- **Config** (`config/index.md`): Added build-time constants via `[plugins.client.vite.define]`
- **Foundation** (`language/foundation.md`): Enhanced `?[]` null-safe subscript docs (out-of-bounds, missing keys); added native compilation section (`.na.jac`, C library imports, struct coercion)
- **OSP** (`language/osp.md`): Fixed incorrect "indexed visit" docs — corrected to queue insertion index semantics (DFS vs BFS); added deferred exit traversal semantics
- **byLLM** (`plugins/byllm.md`): Added deprecated `method` parameter warning; added enum member semstrings example
- **jac-client** (`plugins/jac-client.md`): Added endpoint caching, BrowserRouter, build error diagnostics (JAC_CLIENT_XXX codes), build-time constants, Bun runtime prerequisite
- **jac-scale** (`plugins/jac-scale.md`): Added secure-by-default endpoints, SSO frontend callback redirect, horizontal pod autoscaling, persistent webhook API keys

## Test plan

- [ ] Verify `mkdocs serve` renders all new sections correctly
- [ ] Confirm code examples are syntactically valid
- [ ] Review that new content integrates naturally with existing documentation flow