### PR TITLE
feat(lsp): replace RLock with ReadWriteLock for concurrent query support

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -11,6 +11,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: `jac format` Unicode Error on Windows**: Fixed `'charmap' codec can't encode character` error when formatting files with emojis or non-ASCII text on Windows.
 - **Remove Vendored pluggy and interegular**: Replaced the vendored `pluggy` library (~1,700 lines) with a lightweight custom plugin system (`jaclang/plugin.py`, ~200 lines) that provides the same hook spec/impl/dispatch API. Removed the unused vendored `interegular` library (~2,200 lines).
 - **Enhanced jac check output**: The `jac check` command now provides a more detailed and user-friendly output format, including file progress, failure details, and timing information.
+- **LSP: ReadWriteLock for Concurrent Queries**: Replaced the single `RLock` in the language server with a writer-priority `ReadWriteLock`, allowing hover, completion, go-to-definition, and other read operations to run concurrently without blocking on type checking. Also fixed several race conditions where shared state (`mod.hub`, `sem_managers`) was accessed without any lock.
 - 2 Minor refactor
 
 ## jaclang 0.11.0 (Latest Release)

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -30,6 +30,7 @@ import from jaclang.vendor.pygls.server { LanguageServer }
 import lsprotocol.types as lspt;
 import from . { utils }
 import from .module_manager { ModuleManager }
+import from .rwlock { ReadWriteLock }
 
 obj Task {
     has file_uri: str,
@@ -50,7 +51,7 @@ obj JacLangServer(JacProgram, LanguageServer) {
         dirty_files: dict[str, bool] = {},
         last_task: Task | None = None,
         worker_future: Future | None by postinit,
-        _state_lock: threading.RLock by postinit,
+        _state_lock: ReadWriteLock by postinit,
         _work_event: threading.Event = threading.Event(),
         _idle_event: threading.Event by postinit,
         _shutdown_called: bool = False,

--- a/jac/jaclang/langserve/impl/engine.impl.jac
+++ b/jac/jaclang/langserve/impl/engine.impl.jac
@@ -11,7 +11,7 @@ impl Task.postinit -> None {
 impl JacLangServer.postinit -> None {
     LanguageServer.init(self, 'jac-lsp', 'v0.1');
     JacProgram.init(self);
-    self._state_lock = threading.RLock();
+    self._state_lock = ReadWriteLock();
     self.module_manager = ModuleManager(self, self.sem_managers);
     # Initialize idle event as set (server starts idle)
     self._idle_event = threading.Event();
@@ -24,7 +24,7 @@ impl JacLangServer.postinit -> None {
 """Debounced type check - waits for typing to pause before starting analysis."""
 impl JacLangServer.type_check(file_uri: str) -> None {
     DEBOUNCE_DELAY = 0.3;  # 300ms debounce delay
-    with self._state_lock {
+    with self._state_lock.write_lock() {
         # Cancel any pending debounce timer
         if self._debounce_timer {
             self._debounce_timer.cancel();
@@ -52,17 +52,17 @@ impl JacLangServer.type_check(file_uri: str) -> None {
 
 """Actually queue the type check task after debounce delay."""
 impl JacLangServer._do_type_check(file_uri: str) -> None {
-    with self._state_lock {
+    with self._state_lock.write_lock() {
         # Clear timer reference and pending file
         self._debounce_timer = None;
         # Clear idle event since we're about to add work
         self._idle_event.clear();
+        self.debug("Debounce triggered, starting type check for " + file_uri);
+        self.last_task = Task(file_uri);
+        self.pipe.append(self.last_task);
+        # Trigger the worker to pick up the new task.
+        self._work_event.set();
     }
-    self.debug("Debounce triggered, starting type check for " + file_uri);
-    self.last_task = Task(file_uri);
-    self.pipe.append(self.last_task);
-    # Trigger the worker to pick up the new task.
-    self._work_event.set();
 }
 
 """Rebuild a file and its dependencies (typecheck)."""
@@ -132,39 +132,44 @@ impl JacLangServer.type_check_file(
 impl JacLangServer.dispatcher -> None {
     while True {
         start_time = time.time();
-        self.debug(
-            "Dispatcher waiting for work..." + str(start_time) + str(
-                self.dirty_files.keys()
-            )
-        );
+        self.debug("Dispatcher waiting for work...");
         # Wait until there's a task to process or shutdown is called.
         self._work_event.wait();
-        if self._shutdown_called {
+        # Determine next task under write lock (pops from pipe/dirty_files).
+        task: Task | None = None;
+        should_exit = False;
+        with self._state_lock.write_lock() {
+            if self._shutdown_called {
+                should_exit = True;
+            } elif self.pipe {
+                task = self.pipe.popleft();
+            } elif self.dirty_files {
+                # Get the most recent dirty file and create a NEW task for it
+                (file_uri, _) = self.dirty_files.popitem();
+                task = Task(file_uri);
+            } else {
+                # No tasks to process, signal idle and wait for the next one.
+                self._work_event.clear();
+                self._idle_event.set();
+            }
+        }
+        if should_exit {
             self.debug("Shutting down dispatcher");
             break;
-        } elif self.pipe {
-            task = self.pipe.popleft();
-        } elif self.dirty_files {
-            # Get the most recent dirty file and create a NEW task for it
-            (file_uri, _) = self.dirty_files.popitem();
-            task = Task(file_uri);
-        } else {
-            # No tasks to process, signal idle and wait for the next one.
-            self._work_event.clear();
-            self._idle_event.set();
+        }
+        if not task {
             continue;
         }
-
+        # Lock released — type_check_file runs without holding the RWLock,
+        # allowing readers (hover, completion, etc.) to proceed concurrently.
         self.debug("Dispatching task id: " + str(task.task_id));
         try {
             self.type_check_file(task.file_uri, cancel_token=task.cancel_token);
             self.lsp.send_request(lspt.WORKSPACE_SEMANTIC_TOKENS_REFRESH);
-        } finally {
-        # self.queue.task_done();
-        }
+        } finally { }
         if task.cancel_token.is_set() {
             self.debug(
-                "Task cancled id: " + str(task.task_id) + " " + str(time.time())
+                "Task cancelled id: " + str(task.task_id) + " " + str(time.time())
             );
         } else {
             # Mark task as done so type_check won't try to "cancel" it later
@@ -177,26 +182,30 @@ impl JacLangServer.dispatcher -> None {
             );
         }
         # Check if there's more work, otherwise signal idle
-        if not self.pipe and not self.dirty_files {
+        with self._state_lock.read_lock() {
+            has_more = bool(self.pipe) or bool(self.dirty_files);
+        }
+        if not has_more {
             self._idle_event.set();
         }
     }
 }
 
 impl JacLangServer.shutdown -> None {
-    # Guard against double shutdown.
-    if self._shutdown_called {
-        return;
-    }
-    self._shutdown_called = True;
-    try {
-        # Cancel any pending debounce timer
-        with self._state_lock {
-            if self._debounce_timer {
-                self._debounce_timer.cancel();
-                self._debounce_timer = None;
-            }
+    # Guard against double shutdown under write lock.
+    with self._state_lock.write_lock() {
+        if self._shutdown_called {
+            return;
         }
+        self._shutdown_called = True;
+        # Cancel any pending debounce timer
+        if self._debounce_timer {
+            self._debounce_timer.cancel();
+            self._debounce_timer = None;
+        }
+    }
+    # Release lock before waiting on worker to avoid deadlock.
+    try {
         if self?.worker_future and not self?.worker_future.done() {
             self._work_event.set();  # Wake up the worker to let it exit gracefully.
             wait self.worker_future ;  # Wait for the worker to finish
@@ -232,15 +241,12 @@ impl JacLangServer.log_error(message: str) -> None {
 """Return semantic tokens for a file."""
 impl JacLangServer.get_semantic_tokens(file_path: str) -> lspt.SemanticTokens {
     fs_path = uris.to_fs_path(file_path);
-    self._state_lock.acquire();
-    try {
+    with self._state_lock.read_lock() {
         sem_mgr = self.sem_managers.get(fs_path);
         if not sem_mgr {
             return lspt.SemanticTokens(data=[]);
         }
         return lspt.SemanticTokens(data=list(sem_mgr.sem_tokens));
-    } finally {
-        self._state_lock.release();
     }
 }
 
@@ -350,8 +356,10 @@ impl JacLangServer.get_definition(
 """Return document symbols for a file."""
 impl JacLangServer.get_outline(file_path: str) -> list[lspt.DocumentSymbol] {
     fs_path = uris.to_fs_path(file_path);
-    if fs_path in self.mod.hub and (root_node := self.mod.hub[fs_path].sym_tab) {
-        return utils.get_symbols_for_outline(root_node);
+    with self._state_lock.read_lock() {
+        if fs_path in self.mod.hub and (root_node := self.mod.hub[fs_path].sym_tab) {
+            return utils.get_symbols_for_outline(root_node);
+        }
     }
     return [];
 }
@@ -432,28 +440,34 @@ impl JacLangServer.formatted_jac(file_path: str) -> list[lspt.TextEdit] {
 """Close module (didClose cleanup - remove sem_manager only)."""
 impl JacLangServer.close_module(uri: str) -> None {
     fs_path = uris.to_fs_path(uri);
-    if fs_path in self.sem_managers {
-        del (self.sem_managers[fs_path], );
+    with self._state_lock.write_lock() {
+        if fs_path in self.sem_managers {
+            del (self.sem_managers[fs_path], );
+        }
     }
 }
 
 """Delete module."""
 impl JacLangServer.delete_module(uri: str) -> None {
-    if uri in self.mod.hub {
-        del (self.mod.hub[uri], );
-    }
-    if uri in self.sem_managers {
-        del (self.sem_managers[uri], );
+    with self._state_lock.write_lock() {
+        if uri in self.mod.hub {
+            del (self.mod.hub[uri], );
+        }
+        if uri in self.sem_managers {
+            del (self.sem_managers[uri], );
+        }
     }
 }
 
 """Rename module."""
 impl JacLangServer.rename_module(old_path: str, new_path: str) -> None {
-    if old_path in self.mod.hub and new_path != old_path {
-        self.mod.hub[new_path] = self.mod.hub[old_path];
-        self.sem_managers[new_path] = self.sem_managers[old_path];
-        del (self.mod.hub[old_path], );
-        del (self.sem_managers[old_path], );
+    with self._state_lock.write_lock() {
+        if old_path in self.mod.hub and new_path != old_path {
+            self.mod.hub[new_path] = self.mod.hub[old_path];
+            self.sem_managers[new_path] = self.sem_managers[old_path];
+            del (self.mod.hub[old_path], );
+            del (self.sem_managers[old_path], );
+        }
     }
 }
 
@@ -516,8 +530,10 @@ impl JacLangServer.get_node_at_position(
 }
 
 impl JacLangServer.get_ast_of_file(file_path: str) -> Optional[uni.AstNode] {
-    if file_path in self.mod.hub {
-        return self.mod.hub[file_path];
+    with self._state_lock.read_lock() {
+        if file_path in self.mod.hub {
+            return self.mod.hub[file_path];
+        }
     }
     return None;
 }
@@ -526,7 +542,7 @@ impl JacLangServer.get_ast_of_file(file_path: str) -> Optional[uni.AstNode] {
 impl JacLangServer.wait_till_idle_sync(file_uri: str) -> None {
     self.debug("Waiting for server to be idle (sync)...");
     # First, flush any pending debounce timer
-    with self._state_lock {
+    with self._state_lock.write_lock() {
         if self._debounce_timer {
             self._debounce_timer.cancel();
             self._debounce_timer = None;
@@ -536,7 +552,7 @@ impl JacLangServer.wait_till_idle_sync(file_uri: str) -> None {
     # Wait for dispatcher to become idle and re-check queue state after wake to avoid races with stale work events.
     while True {
         self._idle_event.wait();
-        with self._state_lock {
+        with self._state_lock.read_lock() {
             has_pending_work = bool(
                 self.pipe or self.dirty_files or self._debounce_timer
             );
@@ -609,8 +625,7 @@ impl JacLangServer.get_token_at_position(
     file_path: str, position: lspt.Position
 ) -> Optional[uni.AstNode] {
     fs_path = uris.to_fs_path(file_path);
-    self._state_lock.acquire();
-    try {
+    with self._state_lock.read_lock() {
         if fs_path not in self.mod.hub {
             return None;
         }
@@ -628,8 +643,6 @@ impl JacLangServer.get_token_at_position(
             return sem_mgr.static_sem_tokens[token_index][3];
         }
         return None;
-    } finally {
-        self._state_lock.release();
     }
 }
 
@@ -638,51 +651,54 @@ impl JacLangServer.update_modules(
     file_path: str, build: uni.Module, need: bool = True
 ) -> None {
     self.log_py(f"'Updating modules for '{file_path}");
-    self._state_lock.acquire();
-    try {
+    with self._state_lock.write_lock() {
         self.module_manager.update(file_path, build, update_annexed=need);
-    } finally {
-        self._state_lock.release();
     }
 }
 
 """Get IR for a file path."""
 impl JacLangServer.get_ir(file_path: str) -> Optional[uni.Module] {
-    return self.mod.hub.get(file_path);
+    with self._state_lock.read_lock() {
+        return self.mod.hub.get(file_path);
+    }
 }
 
 """Remove errors and warnings for a specific file from the lists."""
 impl JacLangServer._clear_alerts_for_file(file_path: str) -> None {
-    self.module_manager.clear_alerts_for_file(file_path);
-    # Also clear from internal_program (jaclang.* modules) if it exists
-    if (self._compiler and self._compiler._internal_program) {
-        internal = self._compiler._internal_program;
-        internal.errors_had = [
-            e
-            for e in internal.errors_had
-            if e.loc.mod_path != file_path
-        ];
-        internal.warnings_had = [
-            w
-            for w in internal.warnings_had
-            if w.loc.mod_path != file_path
-        ];
+    with self._state_lock.write_lock() {
+        self.module_manager.clear_alerts_for_file(file_path);
+        # Also clear from internal_program (jaclang.* modules) if it exists
+        if (self._compiler and self._compiler._internal_program) {
+            internal = self._compiler._internal_program;
+            internal.errors_had = [
+                e
+                for e in internal.errors_had
+                if e.loc.mod_path != file_path
+            ];
+            internal.warnings_had = [
+                w
+                for w in internal.warnings_had
+                if w.loc.mod_path != file_path
+            ];
+        }
     }
 }
 
 """Return diagnostics for all files as a dict {uri: diagnostics}."""
 impl JacLangServer.diagnostics -> dict[str, list] {
-    # Aggregate errors from internal_program (jaclang.* modules) if any
-    all_errors = list(self.errors_had);
-    all_warnings = list(self.warnings_had);
-    if (self._compiler and self._compiler._internal_program) {
-        all_errors.extend(self._compiler._internal_program.errors_had);
-        all_warnings.extend(self._compiler._internal_program.warnings_had);
+    with self._state_lock.read_lock() {
+        # Aggregate errors from internal_program (jaclang.* modules) if any
+        all_errors = list(self.errors_had);
+        all_warnings = list(self.warnings_had);
+        if (self._compiler and self._compiler._internal_program) {
+            all_errors.extend(self._compiler._internal_program.errors_had);
+            all_warnings.extend(self._compiler._internal_program.warnings_had);
+        }
+        result = {};
+        for file_path in self.mod.hub {
+            uri = uris.from_fs_path(file_path);
+            result[uri] = utils.gen_diagnostics(file_path, all_errors, all_warnings);
+        }
+        return result;
     }
-    result = {};
-    for file_path in self.mod.hub {
-        uri = uris.from_fs_path(file_path);
-        result[uri] = utils.gen_diagnostics(file_path, all_errors, all_warnings);
-    }
-    return result;
 }

--- a/jac/jaclang/langserve/rwlock.jac
+++ b/jac/jaclang/langserve/rwlock.jac
@@ -1,0 +1,93 @@
+"""Read-Write Lock for concurrent reader access with exclusive writer access."""
+
+import threading;
+import from contextlib { contextmanager }
+
+"""A Read-Write Lock that allows concurrent readers but exclusive writers.
+
+Multiple threads can hold the read lock simultaneously.
+Only one thread can hold the write lock, and it excludes all readers.
+Writers have priority: once a writer is waiting, new readers block.
+NOT reentrant: a thread must not attempt to acquire the same lock twice.
+"""
+obj ReadWriteLock {
+    has _cond: threading.Condition by postinit,
+        _readers: int = 0,
+        _writer: bool = False,
+        _writers_waiting: int = 0;
+
+    def postinit -> None;
+    def acquire_read -> None;
+    def release_read -> None;
+    def acquire_write -> None;
+    def release_write -> None;
+    @contextmanager
+    def read_lock -> None;
+
+    @contextmanager
+    def write_lock -> None;
+}
+
+impl ReadWriteLock.postinit -> None {
+    self._cond = threading.Condition(threading.Lock());
+}
+
+"""Acquire the read lock. Blocks while a writer is active or waiting."""
+impl ReadWriteLock.acquire_read -> None {
+    with self._cond {
+        while self._writer or self._writers_waiting > 0 {
+            self._cond.wait();
+        }
+        self._readers += 1;
+    }
+}
+
+"""Release the read lock."""
+impl ReadWriteLock.release_read -> None {
+    with self._cond {
+        self._readers -= 1;
+        if self._readers == 0 {
+            self._cond.notify_all();
+        }
+    }
+}
+
+"""Acquire the write lock. Blocks while readers or another writer are active."""
+impl ReadWriteLock.acquire_write -> None {
+    with self._cond {
+        self._writers_waiting += 1;
+        while self._writer or self._readers > 0 {
+            self._cond.wait();
+        }
+        self._writers_waiting -= 1;
+        self._writer = True;
+    }
+}
+
+"""Release the write lock."""
+impl ReadWriteLock.release_write -> None {
+    with self._cond {
+        self._writer = False;
+        self._cond.notify_all();
+    }
+}
+
+"""Context manager for acquiring/releasing the read lock."""
+impl ReadWriteLock.read_lock -> None {
+    self.acquire_read();
+    try {
+        yield ;
+    } finally {
+        self.release_read();
+    }
+}
+
+"""Context manager for acquiring/releasing the write lock."""
+impl ReadWriteLock.write_lock -> None {
+    self.acquire_write();
+    try {
+        yield ;
+    } finally {
+        self.release_write();
+    }
+}

--- a/jac/tests/langserve/test_rwlock.jac
+++ b/jac/tests/langserve/test_rwlock.jac
@@ -1,0 +1,308 @@
+"""Tests for ReadWriteLock concurrency correctness."""
+
+import threading;
+import time;
+import os;
+import sys;
+import contextlib;
+
+import from pathlib { Path }
+
+import lsprotocol.types as lspt;
+
+import jaclang;
+import from jaclang.langserve.rwlock { ReadWriteLock }
+import from jaclang.langserve.engine { JacLangServer }
+import from jaclang.vendor.pygls { uris }
+import from jaclang.vendor.pygls.workspace { Workspace }
+
+glob JAC_ROOT = str(Path(jaclang.__file__).parent.parent),
+     FIXTURE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures"),
+     _active_servers: list = [];
+
+def _clear_jac_modules {
+    jac_modules_to_clear = [
+        k
+        for k in list(sys.modules.keys())
+        if not k.startswith(("jaclang", "test", "_"))
+        and hasattr(sys.modules.get(k), "__jac_mod__")
+    ];
+    for mod_name in jac_modules_to_clear {
+        sys.modules.pop(mod_name, None);
+    }
+}
+
+def setup_test {
+    _clear_jac_modules();
+    _active_servers.clear();
+}
+
+def teardown_test {
+    for server in _active_servers {
+        with contextlib.suppress(Exception) as _s {
+            server.shutdown();
+        }
+        server.clear_type_system(clear_hub=True);
+    }
+    _active_servers.clear();
+    _clear_jac_modules();
+}
+
+def create_server(workspace_path: str | None = None) -> JacLangServer {
+    lsp = JacLangServer();
+    workspace_root = workspace_path if workspace_path is not None else FIXTURE_DIR;
+    workspace_val = Workspace(workspace_root, lsp);
+    lsp.lsp._workspace = workspace_val;
+    _active_servers.append(lsp);
+    return lsp;
+}
+
+test "rwlock concurrent readers and exclusive writer" {
+    """Verify multiple readers run concurrently, writers get exclusive access,
+    and writer priority prevents reader starvation of writers."""
+    setup_test();
+    try {
+        lock = ReadWriteLock();
+        results: list[str] = [];
+        barrier = threading.Barrier(3);  # Sync 3 reader threads
+
+        def reader_work(reader_id: int) -> None {
+            with lock.read_lock() {
+                # All readers should be able to enter concurrently
+                barrier.wait(timeout=5);  # Would deadlock if readers blocked each other
+                results.append(f"reader_{reader_id}_in");
+                time.sleep(0.05);  # Hold lock briefly
+                results.append(f"reader_{reader_id}_out");
+            }
+        }
+
+        # Phase 1: Concurrent readers don't block each other
+        threads = [threading.Thread(target=reader_work, args=[i]) for i in range(3)];
+        for t in threads {
+            t.start();
+        }
+        for t in threads {
+            t.join(timeout=10);
+        }
+        # All 3 readers entered the lock (barrier would timeout otherwise)
+        assert len(results) == 6 , f"Expected 6 results, got {len(results)}: {results}";
+
+        # Phase 2: Writer excludes readers
+        results.clear();
+        writer_entered = threading.Event();
+        writer_done = threading.Event();
+        reader_entered = threading.Event();
+
+        def writer_work -> None {
+            with lock.write_lock() {
+                writer_entered.set();
+                results.append("writer_in");
+                time.sleep(0.15);  # Hold write lock
+                results.append("writer_out");
+            }
+            writer_done.set();
+        }
+
+        def reader_after_writer -> None {
+            # Wait until writer has started, then try to read
+            writer_entered.wait(timeout=5);
+            time.sleep(0.02);  # Small delay to ensure writer is holding lock
+            with lock.read_lock() {
+                reader_entered.set();
+                results.append("reader_after");
+            }
+        }
+
+        wt = threading.Thread(target=writer_work);
+        rt = threading.Thread(target=reader_after_writer);
+        wt.start();
+        rt.start();
+        wt.join(timeout=10);
+        rt.join(timeout=10);
+
+        # Writer must complete before reader enters
+        assert results.index("writer_out") < results.index("reader_after") , (
+            f"Writer should finish before reader enters: {results}"
+        );
+
+        # Phase 3: Writer priority — waiting writer blocks new readers
+        results.clear();
+        hold_read = threading.Event();
+        writer_waiting = threading.Event();
+
+        def holding_reader -> None {
+            with lock.read_lock() {
+                results.append("hold_reader_in");
+                hold_read.wait(timeout=5);  # Hold read lock until signaled
+                results.append("hold_reader_out");
+            }
+        }
+
+        def priority_writer -> None {
+            writer_waiting.set();
+            with lock.write_lock() {
+                results.append("priority_writer");
+            }
+        }
+
+        def late_reader -> None {
+            writer_waiting.wait(timeout=5);
+            time.sleep(0.05);  # Ensure writer is queued first
+            with lock.read_lock() {
+                results.append("late_reader");
+            }
+        }
+
+        t1 = threading.Thread(target=holding_reader);
+        t1.start();
+        time.sleep(0.05);  # Let reader acquire lock
+
+        t2 = threading.Thread(target=priority_writer);
+        t3 = threading.Thread(target=late_reader);
+        t2.start();
+        t3.start();
+        time.sleep(0.1);  # Let writer and late reader queue up
+
+        hold_read.set();  # Release the holding reader
+        t1.join(timeout=10);
+        t2.join(timeout=10);
+        t3.join(timeout=10);
+
+        # Writer should run before late reader (writer priority)
+        assert results.index("priority_writer") < results.index("late_reader") , (
+            f"Writer should have priority over late reader: {results}"
+        );
+    } finally {
+        teardown_test();
+    }
+}
+
+test "concurrent queries during type checking" {
+    """Verify that read operations (hover, outline, semantic tokens) can proceed
+    concurrently without deadlock while type checking updates the hub."""
+    setup_test();
+    try {
+        lsp = create_server();
+        circle_file = os.path.join(FIXTURE_DIR, "circle.jac");
+        circle_uri = uris.from_fs_path(circle_file);
+
+        # First, type check the file so hub is populated
+        lsp.type_check_file(circle_uri);
+
+        # Now simulate concurrent reads from multiple threads while a write happens
+        errors: list[str] = [];
+        results: dict[str, bool] = {};
+        num_iterations = 10;
+
+        def read_hover -> None {
+            try {
+                for _ in range(num_iterations) {
+                    lsp.get_hover_info(circle_uri, lspt.Position(line=5, character=4));
+                }
+                results["hover"] = True;
+            } except Exception as e {
+                errors.append(f"hover: {e}");
+            }
+        }
+
+        def read_outline -> None {
+            try {
+                for _ in range(num_iterations) {
+                    lsp.get_outline(circle_uri);
+                }
+                results["outline"] = True;
+            } except Exception as e {
+                errors.append(f"outline: {e}");
+            }
+        }
+
+        def read_semantic_tokens -> None {
+            try {
+                for _ in range(num_iterations) {
+                    lsp.get_semantic_tokens(circle_uri);
+                }
+                results["sem_tokens"] = True;
+            } except Exception as e {
+                errors.append(f"sem_tokens: {e}");
+            }
+        }
+
+        def read_definition -> None {
+            try {
+                for _ in range(num_iterations) {
+                    lsp.get_definition(circle_uri, lspt.Position(line=5, character=4));
+                }
+                results["definition"] = True;
+            } except Exception as e {
+                errors.append(f"definition: {e}");
+            }
+        }
+
+        def write_type_check -> None {
+            try {
+                for _ in range(3) {
+                    lsp.type_check_file(circle_uri);
+                }
+                results["type_check"] = True;
+            } except Exception as e {
+                errors.append(f"type_check: {e}");
+            }
+        }
+
+        # Launch readers and writer concurrently
+        threads = [
+            threading.Thread(target=read_hover),
+            threading.Thread(target=read_outline),
+            threading.Thread(target=read_semantic_tokens),
+            threading.Thread(target=read_definition),
+            threading.Thread(target=write_type_check),
+
+        ];
+        for t in threads {
+            t.start();
+        }
+        for t in threads {
+            t.join(timeout=60);
+        }
+
+        assert not errors , f"Concurrent access errors: {errors}";
+        assert len(results) == 5 , (f"Not all operations completed: {results}");
+    } finally {
+        teardown_test();
+    }
+}
+
+test "shutdown under active dispatch" {
+    """Verify shutdown completes without deadlock when the dispatcher is busy."""
+    setup_test();
+    try {
+        lsp = create_server();
+        circle_file = os.path.join(FIXTURE_DIR, "circle.jac");
+        circle_uri = uris.from_fs_path(circle_file);
+
+        # Kick off a type check via the dispatcher
+        lsp.type_check_file(circle_uri);
+
+        # Queue more work so dispatcher has something to do
+        lsp._do_type_check(circle_uri);
+
+        # Shutdown should complete without deadlock
+        shutdown_done = threading.Event();
+
+        def do_shutdown -> None {
+            lsp.shutdown();
+            shutdown_done.set();
+        }
+
+        t = threading.Thread(target=do_shutdown);
+        t.start();
+        completed = shutdown_done.wait(timeout=15);
+        assert completed , "Shutdown deadlocked — did not complete within 15s";
+        t.join(timeout=5);
+
+        # Remove from active servers since we already shut it down
+        _active_servers.remove(lsp);
+    } finally {
+        teardown_test();
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the single `threading.RLock` in the LSP engine with a writer-priority `ReadWriteLock`, allowing hover, completion, go-to-definition, and other read operations to run concurrently without blocking on type checking
- Fixes race conditions where `mod.hub`, `sem_managers`, `dirty_files`, and error/warning lists were accessed without any lock (`close_module`, `delete_module`, `rename_module`, `get_outline`, `get_ast_of_file`, `get_ir`, `diagnostics`, `_clear_alerts_for_file`)
- Adds fine-grained locking to the dispatcher: write lock only for task selection, released before `type_check_file()` runs so readers aren't blocked during compilation

## Test plan
- [x] All 44 langserve tests pass (41 existing + 3 new)
- [ ] New `test_rwlock.jac` covers:
  - Concurrent readers don't block each other (barrier-based verification)
  - Writer exclusivity and writer priority over late readers
  - Concurrent hover/outline/semantic-tokens/go-to-def during active type checking
  - Shutdown under active dispatch completes without deadlock
- [ ] Manual verification: `jac lsp` in VSCode with active editing