### PR TITLE
add observability system for tracing LLM calls

### DIFF
--- a/jac-byllm/byllm/config_loader.jac
+++ b/jac-byllm/byllm/config_loader.jac
@@ -21,6 +21,7 @@ class JacByllmConfig(PluginConfigBase) {
     def get_call_params_config(self: JacByllmConfig) -> dict[str, Any];
     def get_litellm_config(self: JacByllmConfig) -> dict[str, Any];
     def get_system_prompt(self: JacByllmConfig) -> str;
+    def get_observability_config(self: JacByllmConfig) -> dict[str, Any];
 }
 
 glob _byllm_config_instance: JacByllmConfig | None = None;

--- a/jac-byllm/byllm/impl/config_loader.impl.jac
+++ b/jac-byllm/byllm/impl/config_loader.impl.jac
@@ -26,7 +26,21 @@ impl JacByllmConfig.get_default_config(self: JacByllmConfig) -> dict[str, Any] {
         },
         'call_params': {'temperature': 0.7, 'max_tokens': 0},
         'litellm': {'local_cost_map': True, 'drop_params': True},
-        'system_prompt': ''
+        'system_prompt': '',
+        'observability': {
+            'enabled': False,
+            'console': {
+                'enabled': True,
+                'level': 'INFO',
+                'show_args': True,
+                'show_results': True,
+                'colorize': True
+            },
+            'file': {
+                'enabled': False,
+                'path': 'byllm_events.jsonl'
+            }
+        }
     };
 }
 
@@ -88,6 +102,12 @@ impl get_byllm_config(project_dir: Path | None = None) -> JacByllmConfig {
 impl JacByllmConfig.get_system_prompt(self: JacByllmConfig) -> str {
     config = self.load();
     return config.get('system_prompt', '');
+}
+
+"""Get observability configuration from jac.toml."""
+impl JacByllmConfig.get_observability_config(self: JacByllmConfig) -> dict[str, Any] {
+    # load() already deep-merges get_default_config() with user config
+    return self.load().get('observability', {});
 }
 
 """Reset the global config instance (useful for testing)."""

--- a/jac-byllm/byllm/impl/mtir.impl.jac
+++ b/jac-byllm/byllm/impl/mtir.impl.jac
@@ -167,6 +167,15 @@ impl MTRuntime.factory(mtir: MTIR) -> MTRuntime {
         finish_tool = Tool.make_finish_tool(return_type or str);
         tools.append(finish_tool);
     }
+
+    import from byllm.observability { get_observer, EventType }
+    get_observer().emit_event(EventType.MTIR_FACTORY,
+        caller_name=getattr(caller, "__name__", "?"),
+        num_args=len(args),
+        num_tools=len([t for t in tools if not t.is_finish_tool()]),
+        return_type_name=getattr(return_type, "__name__", "None") if return_type else "None",
+        is_streaming=is_streaming);
+
     return MTRuntime(
         messages=messages,
         tools=tools,

--- a/jac-byllm/byllm/impl/observability.impl.jac
+++ b/jac-byllm/byllm/impl/observability.impl.jac
@@ -1,0 +1,260 @@
+"""Implementation of the byllm observability system."""
+import json;
+import time;
+import uuid;
+import from typing { Any, Callable }
+import from loguru { logger }
+
+#-------------------------------------------------------------------------------
+# ByllmEvent Implementation
+#-------------------------------------------------------------------------------
+"""Serialize the event to a JSON-compatible dict."""
+impl ByllmEvent.to_dict -> dict[str, Any] {
+    return {
+        "event_type": self.event_type.value,
+        "trace_id": self.trace_id,
+        "timestamp": self.timestamp,
+        "model_name": self.model_name,
+        "metadata": self.metadata,
+    };
+}
+
+#-------------------------------------------------------------------------------
+# EventHandler Implementation
+#-------------------------------------------------------------------------------
+"""Base handle method. Subclasses must override."""
+impl EventHandler.handle(event: ByllmEvent) -> None {
+    raise NotImplementedError("Subclasses must implement handle()");
+}
+
+#-------------------------------------------------------------------------------
+# ConsoleHandler Implementation
+#-------------------------------------------------------------------------------
+"""Log events to console with colored, human-readable formatting."""
+impl ConsoleHandler.handle(event: ByllmEvent) -> None {
+    m = event.metadata;
+    c = self._colors();
+
+    prefix = f"[{c['C']}byllm{c['R']}][{c['D']}{event.trace_id}{c['R']}]";
+    detail = self._format_detail(event.event_type, m, c);
+    print(f"{prefix} {detail}");
+}
+
+"""Return color codes dict (empty strings when colorize=False)."""
+impl ConsoleHandler._colors -> dict[str, str] {
+    if self.colorize {
+        return {"C": "\033[96m", "G": "\033[92m", "Y": "\033[93m",
+                "E": "\033[91m", "B": "\033[1m", "D": "\033[2m", "R": "\033[0m"};
+    }
+    return {"C": "", "G": "", "Y": "", "E": "", "B": "", "D": "", "R": ""};
+}
+
+"""Format event detail string by type."""
+impl ConsoleHandler._format_detail(et: EventType, m: dict, c: dict) -> str {
+    B = c["B"];
+    G = c["G"];
+    Y = c["Y"];
+    E = c["E"];
+    D = c["D"];
+    R = c["R"];
+
+    if et == EventType.INVOKE_START {
+        return (f"{B}invoke_start{R} caller={m.get('caller_name', '?')} "
+                f"tools=[{', '.join(m.get('tool_names', []))}] "
+                f"streaming={m.get('is_streaming', False)}");
+    } elif et == EventType.INVOKE_END {
+        return (f"{B}invoke_end{R} iterations={m.get('total_iterations', 0)} "
+                f"finish={m.get('finish_reason', '?')} ({m.get('duration_ms', 0):.0f}ms)");
+    } elif et == EventType.REACT_ITERATION_START {
+        return f"{D}react_iter {m.get('iteration', 0)} start{R}";
+    } elif et == EventType.REACT_ITERATION_END {
+        return (f"{D}react_iter {m.get('iteration', 0)} end{R} "
+                f"({m.get('duration_ms', 0):.0f}ms) tool_calls={m.get('num_tool_calls', 0)}");
+    } elif et == EventType.LLM_REQUEST {
+        return f"{B}llm_request{R} messages={m.get('num_messages', 0)} tools={m.get('has_tools', False)}";
+    } elif et == EventType.LLM_RESPONSE {
+        tc = m.get("tool_call_names", []);
+        tc_str = f" [{', '.join(tc)}]" if tc else "";
+        line = (f"{G}llm_response{R} ({m.get('duration_ms', 0):.0f}ms) "
+                f"tool_calls={m.get('num_tool_calls', 0)}{tc_str} output_len={m.get('output_length', 0)}");
+        reasoning = m.get("reasoning_preview", "");
+        if reasoning {
+            line += f"\n  {D}[reasoning] {reasoning[:200]}{R}";
+        }
+        output = m.get("output_preview", "");
+        if output {
+            line += f"\n  {D}[content] {output[:200]}{R}";
+        }
+        return line;
+    } elif et == EventType.LLM_ERROR {
+        return f"{E}llm_error{R} {m.get('error_type', '?')}: {m.get('error_message', '?')}";
+    } elif et == EventType.TOOL_CALL_START {
+        args_str = json.dumps(m.get("args", {})) if self.show_args else "...";
+        return f"{Y}tool_call{R} {m.get('tool_name', '?')}({args_str})";
+    } elif et == EventType.TOOL_CALL_END {
+        result_str = m.get("result_preview", "") if self.show_results else "...";
+        return f"{G}tool_done{R} {m.get('tool_name', '?')} ({m.get('duration_ms', 0):.0f}ms) -> {result_str}";
+    } elif et == EventType.TOOL_CALL_ERROR {
+        return f"{E}tool_error{R} {m.get('tool_name', '?')}: {m.get('error_type', '?')}: {m.get('error_message', '?')}";
+    } elif et == EventType.FINISH_TOOL_CALLED {
+        return f"{G}finish_tool{R} output_type={m.get('output_type', '?')}";
+    } elif et == EventType.MTIR_FACTORY {
+        return (f"{D}mtir_factory{R} caller={m.get('caller_name', '?')} "
+                f"tools={m.get('num_tools', 0)} return_type={m.get('return_type_name', '?')}");
+    }
+    return f"{et.value} {json.dumps(m)}";
+}
+
+#-------------------------------------------------------------------------------
+# FileHandler Implementation
+#-------------------------------------------------------------------------------
+"""Write one JSON line per event to the file (JSONL format)."""
+impl FileHandler.handle(event: ByllmEvent) -> None {
+    line = json.dumps(event.to_dict()) + "\n";
+    with open(self.file_path, "a") as f {
+        f.write(line);
+    }
+}
+
+"""Close is a no-op since we open/close per write for safety."""
+impl FileHandler.close -> None {}
+
+#-------------------------------------------------------------------------------
+# CallbackHandler Implementation
+#-------------------------------------------------------------------------------
+"""Pass the event dict to the user-supplied callback, with optional filtering."""
+impl CallbackHandler.handle(event: ByllmEvent) -> None {
+    if self.callback is None {
+        return;
+    }
+    if self.event_filter is not None and event.event_type not in self.event_filter {
+        return;
+    }
+    self.callback(event.to_dict());
+}
+
+#-------------------------------------------------------------------------------
+# ByllmObserver Implementation
+#-------------------------------------------------------------------------------
+"""Dispatch an event to all enabled handlers. No-op when disabled."""
+impl ByllmObserver.emit(event: ByllmEvent) -> None {
+    if not self.enabled {
+        return;
+    }
+    for handler in self.handlers {
+        if handler.enabled {
+            try {
+                handler.handle(event);
+            } except Exception as e {
+                # Never let observer errors propagate to business logic
+                logger.warning(f"Observer handler error: {e}");
+            }
+        }
+    }
+}
+
+"""Emit a structured event. No-op when disabled (zero cost)."""
+impl ByllmObserver.emit_event(event_type: EventType, model_name: str = "", **metadata: Any) -> None {
+    if not self.enabled {
+        return;
+    }
+    self.emit(ByllmEvent(
+        event_type=event_type,
+        trace_id=self._current_trace_id,
+        timestamp=time.time(),
+        model_name=model_name,
+        metadata=metadata,
+    ));
+}
+
+"""Generate a new trace ID for a by llm() invocation."""
+impl ByllmObserver.start_trace -> str {
+    self._current_trace_id = str(uuid.uuid4())[:8];
+    return self._current_trace_id;
+}
+
+"""Add a handler to the observer."""
+impl ByllmObserver.add_handler(handler: EventHandler) -> None {
+    self.handlers.append(handler);
+}
+
+"""Remove a handler from the observer."""
+impl ByllmObserver.remove_handler(handler: EventHandler) -> None {
+    if handler in self.handlers {
+        self.handlers.remove(handler);
+    }
+}
+
+"""Remove all handlers."""
+impl ByllmObserver.clear_handlers -> None {
+    self.handlers = [];
+}
+
+#-------------------------------------------------------------------------------
+# ObserveScope Implementation
+#-------------------------------------------------------------------------------
+"""Enter the scope: enable observer and attach a callback handler."""
+impl ObserveScope.__enter__ -> ObserveScope {
+    observer = get_observer();
+    self._prev_enabled = observer.enabled;
+    observer.enabled = True;
+    self._handler = CallbackHandler(
+        callback=self.callback,
+        event_filter=self.event_filter,
+    );
+    observer.add_handler(self._handler);
+    return self;
+}
+
+"""Exit the scope: remove the handler and restore previous enabled state."""
+impl ObserveScope.__exit__(exc_type: type, exc_val: object, exc_tb: object) -> None {
+    observer = get_observer();
+    if self._handler is not None {
+        observer.remove_handler(self._handler);
+    }
+    observer.enabled = self._prev_enabled;
+}
+
+#-------------------------------------------------------------------------------
+# Module-Level Functions
+#-------------------------------------------------------------------------------
+"""Get the global ByllmObserver singleton."""
+impl get_observer -> ByllmObserver {
+    global _observer_instance;
+    if _observer_instance is None {
+        _observer_instance = ByllmObserver();
+    }
+    return _observer_instance;
+}
+
+"""Configure the observer from jac.toml [plugins.byllm.observability] settings."""
+impl configure_observer_from_config -> None {
+    import from byllm.config_loader { get_byllm_config }
+    obs_config = get_byllm_config().get_observability_config();
+
+    observer = get_observer();
+    observer.clear_handlers();
+    observer.enabled = bool(obs_config.get("enabled", False));
+
+    if not observer.enabled {
+        return;
+    }
+
+    console_config = obs_config.get("console", {});
+    if bool(console_config.get("enabled", True)) {
+        observer.add_handler(ConsoleHandler(
+            level=console_config.get("level", "INFO"),
+            show_args=bool(console_config.get("show_args", True)),
+            show_results=bool(console_config.get("show_results", True)),
+            colorize=bool(console_config.get("colorize", True)),
+        ));
+    }
+
+    file_config = obs_config.get("file", {});
+    if bool(file_config.get("enabled", False)) {
+        observer.add_handler(FileHandler(
+            file_path=file_config.get("path", "byllm_events.jsonl"),
+        ));
+    }
+}
+

--- a/jac-byllm/byllm/lib.jac
+++ b/jac-byllm/byllm/lib.jac
@@ -3,15 +3,27 @@ import from byllm.llm { MockLLM, Model }
 import from byllm.mtir { MTIR, MTRuntime }
 import from byllm.plugin { JacRuntime }
 import from byllm.types { Image, MockToolCall, Video }
+import from byllm.observability {
+    ByllmObserver,
+    CallbackHandler,
+    ObserveScope,
+    EventType,
+    get_observer
+}
 
 glob by = JacRuntime.by ,
      __all__ = [
          'by',
+         'ByllmObserver',
+         'CallbackHandler',
+         'EventType',
+         'get_observer',
          'Image',
          'MockLLM',
          'MockToolCall',
          'Model',
          'MTIR',
          'MTRuntime',
+         'ObserveScope',
          'Video'
      ];

--- a/jac-byllm/byllm/llm.impl/basellm.impl.jac
+++ b/jac-byllm/byllm/llm.impl/basellm.impl.jac
@@ -13,21 +13,41 @@ Handles both streaming and non-streaming modes. For tool-enabled requests,
 implements a ReAct loop that continues until finish_tool is called.
 """
 impl BaseLLM.invoke(mt_run: MTRuntime) -> object {
-    # If streaming without tools, stream immediately
-    if mt_run.stream and len(mt_run.tools) == 0 {
-        return self.dispatch_streaming(mt_run);
-    }
+    import from byllm.observability { get_observer, EventType }
+    observer = get_observer();
+    observer.start_trace();
+    invoke_start = time.monotonic();
+
     max_iters = (
         mt_run.call_params.get("max_react_iterations")
         or self.call_params.get("max_react_iterations")
         or _call_params_config.get("max_react_iterations")
         or 0
     );
+    tool_names = [t.get_name() for t in mt_run.tools if not t.is_finish_tool()];
+    observer.emit_event(EventType.INVOKE_START, self.model_name,
+        caller_name=getattr(mt_run.mtir.caller, "__name__", "?"),
+        has_tools=len(mt_run.tools) > 0, tool_names=tool_names,
+        is_streaming=mt_run.stream, max_react_iterations=int(max_iters));
+
+    # If streaming without tools, stream immediately.
+    # No INVOKE_END here — timing is meaningless before the generator runs.
+    # The consumer will see LLM_REQUEST/LLM_RESPONSE from dispatch_streaming.
+    if mt_run.stream and len(mt_run.tools) == 0 {
+        return self.dispatch_streaming(mt_run);
+    }
+
     iter_count = 0;
     # Invoke the LLM and handle tool calls (ReAct loop).
     while True {
         iter_count += 1;
+        iter_start = time.monotonic();
+        observer.emit_event(EventType.REACT_ITERATION_START, self.model_name, iteration=iter_count);
+
         if int(max_iters) > 0 and iter_count > int(max_iters) {
+            observer.emit_event(EventType.INVOKE_END, self.model_name,
+                total_iterations=iter_count - 1, duration_ms=(time.monotonic() - invoke_start) * 1000,
+                finish_reason="max_iterations", has_output=True);
             # If streaming, reuse the existing streaming final-answer path
             if mt_run.stream {
                 return self._stream_final_answer(mt_run);
@@ -49,23 +69,38 @@ impl BaseLLM.invoke(mt_run: MTRuntime) -> object {
         }
         resp = self.dispatch_no_streaming(mt_run);
         if resp.tool_calls {
+            observer.emit_event(EventType.REACT_ITERATION_END, self.model_name,
+                iteration=iter_count, duration_ms=(time.monotonic() - iter_start) * 1000,
+                num_tool_calls=len(resp.tool_calls),
+                has_finish_tool=any(tc.is_finish_call() for tc in resp.tool_calls));
             for tool_call in resp.tool_calls {
                 if tool_call.is_finish_call() {
-                    # If streaming is enabled, make a new streaming call
                     mt_run.add_message(tool_call());
-                    # to generate the final answer based on all context
+                    output = tool_call.get_output();
+                    observer.emit_event(EventType.FINISH_TOOL_CALLED, self.model_name,
+                        call_id=tool_call.call_id, output_type=type(output).__name__,
+                        output_preview=str(output)[:200]);
+                    observer.emit_event(EventType.INVOKE_END, self.model_name,
+                        total_iterations=iter_count, duration_ms=(time.monotonic() - invoke_start) * 1000,
+                        finish_reason="finish_tool", has_output=True);
                     if mt_run.stream {
                         return self._stream_final_answer(mt_run);
                     }
-                    return tool_call.get_output();
+                    return output;
                 } else {
                     mt_run.add_message(tool_call());
                 }
             }
         } else {
+            observer.emit_event(EventType.REACT_ITERATION_END, self.model_name,
+                iteration=iter_count, duration_ms=(time.monotonic() - iter_start) * 1000,
+                num_tool_calls=0, has_finish_tool=False);
             break;
         }
     }
+    observer.emit_event(EventType.INVOKE_END, self.model_name,
+        total_iterations=iter_count, duration_ms=(time.monotonic() - invoke_start) * 1000,
+        finish_reason="no_tool_calls", has_output=resp.output is not None);
     return resp.output;
 }
 
@@ -92,8 +127,20 @@ impl BaseLLM.make_model_params(mt_run: MTRuntime) -> dict {
         "api_key": self.api_key or None,
         "temperature": self.call_params.get("temperature", default_temp),
         "max_tokens": self.call_params.get("max_tokens", default_max_tokens),
-
     };
+
+    # Forward reasoning/thinking params to LiteLLM when present
+    # Anthropic extended thinking: thinking={"type": "enabled", "budget_tokens": N}
+    thinking = self.call_params.get("thinking") or mt_run.call_params.get("thinking");
+    if thinking {
+        params["thinking"] = thinking;
+    }
+    # OpenAI o-series / DeepSeek / others: reasoning_effort="low"|"medium"|"high"
+    reasoning_effort = self.call_params.get("reasoning_effort") or mt_run.call_params.get("reasoning_effort");
+    if reasoning_effort {
+        params["reasoning_effort"] = reasoning_effort;
+    }
+
     return params;
 }
 
@@ -152,23 +199,48 @@ Makes a synchronous API call and processes the response, including
 parsing any tool calls returned by the model.
 """
 impl BaseLLM.dispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
-    # Construct the parameters for the LLM call
+    import from byllm.observability { get_observer, EventType }
+    observer = get_observer();
+
     params = self.make_model_params(mt_run);
-    # Call the LiteLLM API
     log_params = self.format_prompt(params);
     self.log_info(f"Calling LLM: {self.model_name} with params: {log_params}");
+
+    observer.emit_event(EventType.LLM_REQUEST, self.model_name,
+        num_messages=len(params.get("messages", [])),
+        has_tools=params.get("tools") is not None,
+        temperature=params.get("temperature", 0));
+
     self.api_base = params.pop("api_base", DEFAULT_BASE_URL);
     params.pop("api_key", None);
-    response = self.model_call_no_stream(params);
-    # Output format:
-    # https://docs.litellm.ai/docs/#response-format-openai-format
-    #
-    # TODO: Handle stream output (type ignoring stream response)
+    llm_start = time.monotonic();
+    try {
+        response = self.model_call_no_stream(params);
+    } except Exception as e {
+        observer.emit_event(EventType.LLM_ERROR, self.model_name,
+            error_type=type(e).__name__, error_message=str(e)[:500],
+            duration_ms=(time.monotonic() - llm_start) * 1000);
+        raise;
+    }
+    llm_duration_ms = (time.monotonic() - llm_start) * 1000;
+
     message: LiteLLMMessage = response.get("choices", [])[0].get("message");  # type: ignore
     mt_run.add_message(message);
     output_content: str = message.get("content") or "";  # type: ignore
     self.log_info(f"LLM call completed with response: {output_content}");
     output_value = mt_run.parse_response(output_content);
+
+    # Extract reasoning/thinking content (model-specific)
+    reasoning = (message or {}).get("reasoning_content") or "";
+    if not reasoning {
+        # Anthropic extended thinking: extract from thinking_blocks
+        for block in ((message or {}).get("thinking_blocks") or []) {
+            if block.get("type") == "thinking" {
+                reasoning += block.get("thinking", "");
+            }
+        }
+    }
+
     tool_calls: list[ToolCall] = [];
     tool_calls_list = (message or {}).get("tool_calls") or [];
     for tool_call in tool_calls_list {
@@ -182,27 +254,54 @@ impl BaseLLM.dispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
             ) ;
         }
     }
+
+    observer.emit_event(EventType.LLM_RESPONSE, self.model_name,
+        duration_ms=llm_duration_ms, output_length=len(output_content),
+        output_preview=output_content[:500],
+        reasoning_preview=reasoning[:500],
+        num_tool_calls=len(tool_calls_list),
+        tool_call_names=[tc.function.name for tc in tool_calls_list]);
+
     return CompletionResult(output=output_value, tool_calls=tool_calls,);
 }
 
 """Dispatch the LLM call with streaming.
 
 Makes a streaming API call and yields content chunks as they arrive.
+Events fire lazily as the generator is consumed — LLM_REQUEST on first
+iteration, LLM_RESPONSE after the last chunk.
 """
 impl BaseLLM.dispatch_streaming(mt_run: MTRuntime) -> Generator[str, None, None] {
-    # Construct the parameters for the LLM call
+    import from byllm.observability { get_observer, EventType }
+    observer = get_observer();
+
     params = self.make_model_params(mt_run);
-    # Call the LiteLLM API
     log_params = self.format_prompt(params);
     self.log_info(f"Calling LLM: {self.model_name} with params:\n{log_params}");
+
+    observer.emit_event(EventType.LLM_REQUEST, self.model_name,
+        num_messages=len(params.get("messages", [])),
+        has_tools=params.get("tools") is not None,
+        temperature=params.get("temperature", 0), streaming=True);
+
     self.api_base = params.pop("api_base", DEFAULT_BASE_URL);
     params.pop("api_key", None);
-    response = self.model_call_with_stream(params);
-    for chunk in response {
-        if chunk?.choices and chunk?.choices?[0]?.delta {
-            delta = chunk.choices[0].delta;
-            yield delta.content or "";
+    llm_start = time.monotonic();
+    try {
+        response = self.model_call_with_stream(params);
+        for chunk in response {
+            if chunk?.choices and chunk?.choices?[0]?.delta {
+                delta = chunk.choices[0].delta;
+                yield delta.content or "";
+            }
         }
+        observer.emit_event(EventType.LLM_RESPONSE, self.model_name,
+            duration_ms=(time.monotonic() - llm_start) * 1000, streaming=True);
+    } except Exception as e {
+        observer.emit_event(EventType.LLM_ERROR, self.model_name,
+            error_type=type(e).__name__, error_message=str(e)[:500],
+            duration_ms=(time.monotonic() - llm_start) * 1000);
+        raise;
     }
 }
 

--- a/jac-byllm/byllm/llm.jac
+++ b/jac-byllm/byllm/llm.jac
@@ -38,6 +38,9 @@ with entry {
     if _litellm_config['local_cost_map'] {
         os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True";
     }
+    # Initialize observability from jac.toml config
+    import from byllm.observability { configure_observer_from_config }
+    configure_observer_from_config();
 }
 
 glob DEFAULT_BASE_URL = "http://localhost:4000",

--- a/jac-byllm/byllm/observability.jac
+++ b/jac-byllm/byllm/observability.jac
@@ -1,0 +1,104 @@
+"""Observability system for byllm.
+
+Provides structured event emission at key execution points
+(LLM calls, tool execution, ReAct iterations) for debugging,
+monitoring, and UI integration.
+"""
+import json;
+import time;
+import uuid;
+import from enum { StrEnum }
+import from typing { Any, Callable }
+
+"""Discriminator for all observability events."""
+enum EventType ( StrEnum ) {
+    INVOKE_START = "invoke_start",
+    INVOKE_END = "invoke_end",
+    REACT_ITERATION_START = "react_iteration_start",
+    REACT_ITERATION_END = "react_iteration_end",
+    LLM_REQUEST = "llm_request",
+    LLM_RESPONSE = "llm_response",
+    LLM_ERROR = "llm_error",
+    TOOL_CALL_START = "tool_call_start",
+    TOOL_CALL_END = "tool_call_end",
+    TOOL_CALL_ERROR = "tool_call_error",
+    FINISH_TOOL_CALLED = "finish_tool_called",
+    MTIR_FACTORY = "mtir_factory"
+}
+
+"""Structured observability event. JSON-serializable via to_dict()."""
+obj ByllmEvent {
+    has event_type: EventType,
+        trace_id: str,
+        timestamp: float,
+        model_name: str = "",
+        metadata: dict[str, Any] = {};
+
+    def to_dict -> dict[str, Any];
+}
+
+"""Abstract handler interface. Concrete handlers implement handle()."""
+obj EventHandler {
+    has enabled: bool = True;
+
+    def handle(event: ByllmEvent) -> None;
+}
+
+"""Console handler that logs events with colored output."""
+obj ConsoleHandler(EventHandler) {
+    has level: str = "INFO",
+        show_args: bool = True,
+        show_results: bool = True,
+        colorize: bool = True;
+
+    override def handle(event: ByllmEvent) -> None;
+    def _colors -> dict[str, str];
+    def _format_detail(et: EventType, m: dict, c: dict) -> str;
+}
+
+"""File handler that writes JSON events in JSONL format."""
+obj FileHandler(EventHandler) {
+    has file_path: str = "byllm_events.jsonl";
+
+    override def handle(event: ByllmEvent) -> None;
+    def close -> None;
+}
+
+"""Callback handler for UI integration and programmatic access."""
+obj CallbackHandler(EventHandler) {
+    has callback: Callable[[dict[str, Any]], None] | None = None,
+        event_filter: list[EventType] | None = None;
+
+    override def handle(event: ByllmEvent) -> None;
+}
+
+"""Central observer singleton. Receives events and dispatches to handlers."""
+obj ByllmObserver {
+    has handlers: list[EventHandler] = [],
+        enabled: bool = False,
+        _current_trace_id: str = "";
+
+    def emit(event: ByllmEvent) -> None;
+    def emit_event(event_type: EventType, model_name: str = "", **metadata: Any) -> None;
+    def start_trace -> str;
+    def add_handler(handler: EventHandler) -> None;
+    def remove_handler(handler: EventHandler) -> None;
+    def clear_handlers -> None;
+}
+
+"""Context manager for scoped observation. Attaches a callback handler
+on enter and removes it on exit."""
+obj ObserveScope {
+    has callback: Callable[[dict[str, Any]], None],
+        event_filter: list[EventType] | None = None,
+        _handler: CallbackHandler | None = None,
+        _prev_enabled: bool = False;
+
+    def __enter__ -> ObserveScope;
+    def __exit__(exc_type: type, exc_val: object, exc_tb: object) -> None;
+}
+
+glob _observer_instance: ByllmObserver | None = None;
+
+def get_observer -> ByllmObserver;
+def configure_observer_from_config -> None;

--- a/jac-byllm/byllm/plugin_config.jac
+++ b/jac-byllm/byllm/plugin_config.jac
@@ -97,6 +97,67 @@ class JacByllmPluginConfig {
                     "type": "string",
                     "default": "",
                     "description": "Override the default system prompt for LLM interactions. Leave empty to use built-in default."
+                },
+                "observability": {
+                    "type": "dict",
+                    "default": {},
+                    "description": "Structured observability/logging for LLM calls, tool execution, and ReAct iterations",
+                    "nested": {
+                        "enabled": {
+                            "type": "bool",
+                            "default": False,
+                            "description": "Enable structured event logging"
+                        },
+                        "console": {
+                            "type": "dict",
+                            "default": {},
+                            "description": "Console output handler configuration",
+                            "nested": {
+                                "enabled": {
+                                    "type": "bool",
+                                    "default": True,
+                                    "description": "Enable console event output"
+                                },
+                                "level": {
+                                    "type": "string",
+                                    "default": "INFO",
+                                    "description": "Log level for console output"
+                                },
+                                "show_args": {
+                                    "type": "bool",
+                                    "default": True,
+                                    "description": "Show tool call arguments"
+                                },
+                                "show_results": {
+                                    "type": "bool",
+                                    "default": True,
+                                    "description": "Show tool call results"
+                                },
+                                "colorize": {
+                                    "type": "bool",
+                                    "default": True,
+                                    "description": "Enable ANSI color codes"
+                                }
+                            }
+                        },
+                        "file": {
+                            "type": "dict",
+                            "default": {},
+                            "description": "JSONL file output handler configuration",
+                            "nested": {
+                                "enabled": {
+                                    "type": "bool",
+                                    "default": False,
+                                    "description": "Enable file event output"
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "default": "byllm_events.jsonl",
+                                    "description": "Output file path for JSONL events"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         };

--- a/jac-byllm/byllm/types.impl/tool.impl.jac
+++ b/jac-byllm/byllm/types.impl/tool.impl.jac
@@ -23,8 +23,11 @@ impl Tool.__call__(*args: list, **kwargs: dict) -> object {
         # TODO: Should I json serialize or this is fine?
         return self.func(*args, **kwargs);
     } except Exception as e {
-        # For the LLM if the tool failed, it'll see the error message
-        logger.exception("Tool execution failed");  # To prevent sensitive info leakage(generic message)
+        import from byllm.observability { get_observer, EventType }
+        get_observer().emit_event(EventType.TOOL_CALL_ERROR,
+            tool_name=self.get_name(),
+            error_type=type(e).__name__, error_message=str(e)[:500]);
+        logger.exception("Tool execution failed");
         return "Tool error";
     }
 }

--- a/jac-byllm/byllm/types.impl/toolcall.impl.jac
+++ b/jac-byllm/byllm/types.impl/toolcall.impl.jac
@@ -3,11 +3,28 @@
 #-------------------------------------------------------------------------------
 """Execute the tool call and return a result message."""
 impl ToolCall.__call__ -> ToolCallResultMsg {
+    import from byllm.observability { get_observer, EventType }
+    import time;
+    observer = get_observer();
+
+    observer.emit_event(EventType.TOOL_CALL_START,
+        call_id=self.call_id, tool_name=self.tool.get_name(),
+        args={k: str(v)[:500] for (k, v) in (self.args or {}).items()},
+        is_finish_tool=self.tool.is_finish_tool());
+
+    tool_start = time.monotonic();
     if self.args is not None {
         result = self.tool(**self.args);
     } else {
         raise ValueError("args is None, Expected a dictionary") ;
     }
+
+    result_str = str(result);
+    observer.emit_event(EventType.TOOL_CALL_END,
+        call_id=self.call_id, tool_name=self.tool.get_name(),
+        duration_ms=(time.monotonic() - tool_start) * 1000,
+        result_length=len(result_str), result_preview=result_str[:200]);
+
     return ToolCallResultMsg(
         content=str(result), tool_call_id=self.call_id, name=self.tool.get_name(),
     );

--- a/jac-byllm/tests/fixtures/jac.toml
+++ b/jac-byllm/tests/fixtures/jac.toml
@@ -1,0 +1,24 @@
+[project]
+name = "todo"
+version = "1.0.0"
+description = "Jac client application: todo"
+entry-point = "main.jac"
+
+[dependencies]
+
+[dependencies.npm]
+jac-client-node = "1.0.4"
+
+[dependencies.npm.dev]
+"@jac-client/dev-deps" = "1.0.0"
+
+[dev-dependencies]
+watchdog = ">=3.0.0"
+
+[serve]
+base_route_app = "app"
+
+[plugins.client]
+
+[plugins.byllm.observability]
+enabled = true


### PR DESCRIPTION
Add event-based observability with console, file (JSONL), and callback handlers. Supports 12 event types covering invoke, ReAct iterations, LLM requests/responses, and tool calls. Zero cost when disabled.

