### PR TITLE
feat(jac-mcp): bundle documentation resources for PyPI installs

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -53,6 +53,14 @@ jobs:
           path: jac-mcp/jac_mcp/_precompiled/
           pattern: precompiled-mcp-*
           merge-multiple: true
+      - name: Bundle documentation
+        run: |
+          mkdir -p jac_mcp/content/docs
+          cp ../docs/docs/reference/language/*.md jac_mcp/content/docs/
+          cp ../docs/docs/quick-guide/syntax-cheatsheet.md jac_mcp/content/docs/
+          cp ../docs/docs/reference/plugins/*.md jac_mcp/content/docs/
+          cp ../jac/jaclang/jac.spec jac_mcp/content/docs/jac-grammar.spec
+          cp ../jac/jaclang/jac0core/parser/tokens.jac jac_mcp/content/docs/tokens.jac
       - name: Install build tools
         run: |
           pip install build twine

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv
 *.jir
 *.jbc
 _precompiled/
+content/docs/
 _planning/
 
 # Distribution / packaging

--- a/jac-mcp/jac_mcp/impl/resources.impl.jac
+++ b/jac-mcp/jac_mcp/impl/resources.impl.jac
@@ -28,14 +28,75 @@ impl find_repo_root -> str | None {
     return None;
 }
 
+"""Mapping from URI to (relative doc path, bundled filename, description)."""
+glob DOC_MAPPINGS: dict[str, tuple] = {
+         "jac://docs/foundation": (
+             "reference/language/foundation.md",
+             "foundation.md",
+             "Foundation - Core language concepts"
+         ),
+         "jac://docs/primitives": (
+             "reference/language/primitives.md",
+             "primitives.md",
+             "Primitives & Codespace Semantics"
+         ),
+         "jac://docs/functions-objects": (
+             "reference/language/functions-objects.md",
+             "functions-objects.md",
+             "Functions & Objects - Archetypes, abilities, has"
+         ),
+         "jac://docs/osp": (
+             "reference/language/osp.md",
+             "osp.md",
+             "Object-Spatial Programming - Nodes, edges, walkers"
+         ),
+         "jac://docs/concurrency": (
+             "reference/language/concurrency.md",
+             "concurrency.md",
+             "Concurrency - flow, wait, async"
+         ),
+         "jac://docs/advanced": (
+             "reference/language/advanced.md",
+             "advanced.md",
+             "Comprehensions & Filters"
+         ),
+         "jac://docs/cheatsheet": (
+             "quick-guide/syntax-cheatsheet.md",
+             "syntax-cheatsheet.md",
+             "Syntax Cheatsheet - Quick reference"
+         ),
+         "jac://docs/python-integration": (
+             "reference/language/python-integration.md",
+             "python-integration.md",
+             "Python Integration - Interop with Python"
+         ),
+         "jac://docs/byllm": (
+             "reference/plugins/byllm.md",
+             "byllm.md",
+             "byLLM - LLM integration reference"
+         ),
+         "jac://docs/jac-client": (
+             "reference/plugins/jac-client.md",
+             "jac-client.md",
+             "jac-client - Full-stack web reference"
+         ),
+         "jac://docs/jac-scale": (
+             "reference/plugins/jac-scale.md",
+             "jac-scale.md",
+             "jac-scale - Deployment/scaling reference"
+         ),
+
+     };
+
 """Scan paths and build URI to filepath mapping."""
 impl ResourceProvider.index_resources -> None {
     self._package_dir = str(Path(__file__).parent);
     self._repo_root = find_repo_root();
     self._resources = {};
     if self._repo_root is None {
-        # PyPI install — only bundled content
+        # PyPI install — bundled content + bundled docs
         self._index_bundled();
+        self._index_bundled_docs();
         return;
     }
     repo_root = Path(self._repo_root);
@@ -60,56 +121,9 @@ impl ResourceProvider.index_resources -> None {
             "path": str(tokens_path)
         };
     }
-    # Documentation resources
-    doc_mappings: dict[str, tuple] = {
-        "jac://docs/foundation": (
-            "reference/language/foundation.md",
-            "Foundation - Core language concepts"
-        ),
-        "jac://docs/primitives": (
-            "reference/language/primitives.md",
-            "Primitives & Codespace Semantics"
-        ),
-        "jac://docs/functions-objects": (
-            "reference/language/functions-objects.md",
-            "Functions & Objects - Archetypes, abilities, has"
-        ),
-        "jac://docs/osp": (
-            "reference/language/osp.md",
-            "Object-Spatial Programming - Nodes, edges, walkers"
-        ),
-        "jac://docs/concurrency": (
-            "reference/language/concurrency.md",
-            "Concurrency - flow, wait, async"
-        ),
-        "jac://docs/advanced": (
-            "reference/language/advanced.md",
-            "Comprehensions & Filters"
-        ),
-        "jac://docs/cheatsheet": (
-            "quick-guide/syntax-cheatsheet.md",
-            "Syntax Cheatsheet - Quick reference"
-        ),
-        "jac://docs/python-integration": (
-            "reference/language/python-integration.md",
-            "Python Integration - Interop with Python"
-        ),
-        "jac://docs/byllm": (
-            "reference/plugins/byllm.md",
-            "byLLM - LLM integration reference"
-        ),
-        "jac://docs/jac-client": (
-            "reference/plugins/jac-client.md",
-            "jac-client - Full-stack web reference"
-        ),
-        "jac://docs/jac-scale": (
-            "reference/plugins/jac-scale.md",
-            "jac-scale - Deployment/scaling reference"
-        ),
-
-    };
-    for (uri, mapping) in doc_mappings.items() {
-        (rel_path, desc) = mapping;
+    # Documentation resources (from repo docs/)
+    for (uri, mapping) in DOC_MAPPINGS.items() {
+        (rel_path, _, desc) = mapping;
         full_path = repo_root / "docs" / "docs" / rel_path;
         if full_path.exists() {
             name = desc.split(" - ")[0] if " - " in desc else desc;
@@ -176,6 +190,51 @@ impl ResourceProvider._index_bundled -> None {
             "mimeType": "text/markdown",
             "path": str(patterns_path)
         };
+    }
+}
+
+"""Index bundled docs copied at release time."""
+impl ResourceProvider._index_bundled_docs -> None {
+    docs_dir = Path(self._package_dir) / "content" / "docs";
+    if not docs_dir.exists() {
+        return;
+    }
+    # Grammar spec
+    spec_path = docs_dir / "jac-grammar.spec";
+    if spec_path.exists() {
+        self._resources["jac://grammar/spec"] = {
+            "uri": "jac://grammar/spec",
+            "name": "Jac Grammar Specification",
+            "description": "Full EBNF grammar for the Jac language",
+            "mimeType": "text/plain",
+            "path": str(spec_path)
+        };
+    }
+    # Token definitions
+    tokens_path = docs_dir / "tokens.jac";
+    if tokens_path.exists() {
+        self._resources["jac://grammar/tokens"] = {
+            "uri": "jac://grammar/tokens",
+            "name": "Jac Token Definitions",
+            "description": "Token definitions and keywords for the Jac language",
+            "mimeType": "text/plain",
+            "path": str(tokens_path)
+        };
+    }
+    # Documentation markdown files
+    for (uri, mapping) in DOC_MAPPINGS.items() {
+        (_, bundled_name, desc) = mapping;
+        full_path = docs_dir / bundled_name;
+        if full_path.exists() {
+            name = desc.split(" - ")[0] if " - " in desc else desc;
+            self._resources[uri] = {
+                "uri": uri,
+                "name": name,
+                "description": desc,
+                "mimeType": "text/markdown",
+                "path": str(full_path)
+            };
+        }
     }
 }
 

--- a/jac-mcp/jac_mcp/resources.jac
+++ b/jac-mcp/jac_mcp/resources.jac
@@ -21,6 +21,9 @@ obj ResourceProvider {
     """Index bundled content (pitfalls, patterns)."""
     def _index_bundled -> None;
 
+    """Index bundled docs copied at release time."""
+    def _index_bundled_docs -> None;
+
     """Return list of available resources."""
     def list_resources -> list[dict[str, str]];
 

--- a/jac-mcp/pyproject.toml
+++ b/jac-mcp/pyproject.toml
@@ -29,7 +29,7 @@ include = ["jac_mcp*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.jac", "*.impl/*.jac", "*.cl/*.jac"]
-jac_mcp = ["content/*.md", "_precompiled/**/*.jbc", "_precompiled/manifest.json"]
+jac_mcp = ["content/*.md", "content/docs/*.md", "content/docs/*.spec", "content/docs/*.jac", "_precompiled/**/*.jbc", "_precompiled/manifest.json"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
## Summary
- Move doc URI mappings to a module-level `DOC_MAPPINGS` global for reuse across repo and bundled indexing paths
- Add `_index_bundled_docs` method to serve grammar specs, token definitions, and language/plugin docs from bundled content when running outside a repo checkout
- Update release workflow to copy docs into `content/docs/` at build time
- Update `pyproject.toml` to include the new bundled doc file patterns

## Test plan
- [ ] Verify MCP server starts and lists all documentation resources when running from a repo checkout
- [ ] Verify bundled docs are served correctly in a PyPI-installed environment
- [ ] Confirm release workflow bundles the expected markdown, spec, and jac files