### PR TITLE
fix: create playground directory before writing zip

### DIFF
--- a/docs/scripts/handle_jac_compile_data.py
+++ b/docs/scripts/handle_jac_compile_data.py
@@ -65,6 +65,8 @@ def create_playground_zip() -> None:
     if not os.path.exists(TARGET_FOLDER):
         raise FileNotFoundError(f"Folder not found: {TARGET_FOLDER}")
 
+    os.makedirs(EXTRACTED_FOLDER, exist_ok=True)
+
     # Files/directories to exclude for faster zipping
     exclude_patterns = {
         ".pyi",  # Type stub files (4427 files!)


### PR DESCRIPTION
## Summary
- Add `os.makedirs(EXTRACTED_FOLDER, exist_ok=True)` in `create_playground_zip()` to ensure the output directory exists before writing the zip file

## Root Cause
PR #4742 removed `docs/docs/playground/README.md` — the only file keeping that directory tracked by git. When the jac-lang-website pod checks out the code, `docs/playground/` doesn't exist, and the mkdocs pre-build hook fails with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'docs/playground/jaclang.zip'
```

This causes the pod to CrashLoopBackOff (currently at 20+ restarts).

## Test plan
- [ ] Verify `mkdocs build` succeeds with a clean checkout (no `docs/docs/playground/` directory)
- [ ] Confirm the jac-lang-website pod recovers after deployment