### PR TITLE
feat(jac-mcp): expand DOC_MAPPINGS to full mkdocs coverage

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -53,14 +53,12 @@ jobs:
           path: jac-mcp/jac_mcp/_precompiled/
           pattern: precompiled-mcp-*
           merge-multiple: true
-      - name: Bundle documentation
+      - name: Install jaclang and jac-mcp
         run: |
-          mkdir -p jac_mcp/content/docs
-          cp ../docs/docs/reference/language/*.md jac_mcp/content/docs/
-          cp ../docs/docs/quick-guide/syntax-cheatsheet.md jac_mcp/content/docs/
-          cp ../docs/docs/reference/plugins/*.md jac_mcp/content/docs/
-          cp ../jac/jaclang/jac.spec jac_mcp/content/docs/jac-grammar.spec
-          cp ../jac/jaclang/jac0core/parser/tokens.jac jac_mcp/content/docs/tokens.jac
+          pip install -e ../jac
+          pip install -e .
+      - name: Bundle documentation
+        run: jac run scripts/bundle_docs.jac
       - name: Install build tools
         run: |
           pip install build twine

--- a/docs/docs/community/release_notes/jac-mcp.md
+++ b/docs/docs/community/release_notes/jac-mcp.md
@@ -2,6 +2,9 @@
 
 ## jac-mcp 0.1.1 (Unreleased)
 
+- **Expanded documentation resources**: DOC_MAPPINGS now covers all 42 mkdocs pages (up from 12), including tutorials, developer workflow, and quick-start guides
+- **Auto-generated doc bundling**: New `scripts/bundle_docs.jac` script replaces hardcoded CI copy commands, using DOC_MAPPINGS as the single source of truth for PyPI release bundling
+
 ## jac-mcp 0.1.0
 
 Initial release of jac-mcp, the MCP (Model Context Protocol) server plugin for Jac.

--- a/jac-mcp/jac_mcp/impl/resources.impl.jac
+++ b/jac-mcp/jac_mcp/impl/resources.impl.jac
@@ -30,6 +30,48 @@ impl find_repo_root -> str | None {
 
 """Mapping from URI to (relative doc path, bundled filename, description)."""
 glob DOC_MAPPINGS: dict[str, tuple] = {
+         # --- Get Started ---
+         "jac://docs/welcome": (
+             "quick-guide/index.md",
+             "quick-guide-index.md",
+             "Welcome - Getting started with Jac"
+         ),
+         "jac://docs/install": (
+             "quick-guide/install.md",
+             "install.md",
+             "Installation - Setting up Jac"
+         ),
+         "jac://docs/core-concepts": (
+             "quick-guide/what-makes-jac-different.md",
+             "what-makes-jac-different.md",
+             "Core Concepts - What makes Jac different"
+         ),
+         "jac://docs/first-app": (
+             "tutorials/first-app/build-ai-day-planner.md",
+             "build-ai-day-planner.md",
+             "Build to Learn - AI Day Planner tutorial"
+         ),
+         "jac://docs/cheatsheet": (
+             "quick-guide/syntax-cheatsheet.md",
+             "syntax-cheatsheet.md",
+             "Syntax Cheatsheet - Quick reference"
+         ),
+         "jac://docs/jac-vs-traditional": (
+             "quick-guide/jac-vs-traditional-stack.md",
+             "jac-vs-traditional-stack.md",
+             "Jac vs Traditional Stack - Architecture comparison"
+         ),
+         "jac://docs/faq": (
+             "quick-guide/faq.md",
+             "faq.md",
+             "FAQ - Frequently asked questions"
+         ),
+         # --- Language Specification ---
+         "jac://docs/reference-overview": (
+             "reference/index.md",
+             "reference-index.md",
+             "Reference Overview - Full reference index"
+         ),
          "jac://docs/foundation": (
              "reference/language/foundation.md",
              "foundation.md",
@@ -60,30 +102,152 @@ glob DOC_MAPPINGS: dict[str, tuple] = {
              "advanced.md",
              "Comprehensions & Filters"
          ),
-         "jac://docs/cheatsheet": (
-             "quick-guide/syntax-cheatsheet.md",
-             "syntax-cheatsheet.md",
-             "Syntax Cheatsheet - Quick reference"
+         # --- Learn by Doing: Language ---
+         "jac://docs/tutorial-coding-primer": (
+             "tutorials/language/coding_primer.md",
+             "coding_primer.md",
+             "New to Programming? - Coding primer for beginners"
          ),
-         "jac://docs/python-integration": (
-             "reference/language/python-integration.md",
-             "python-integration.md",
-             "Python Integration - Interop with Python"
+         "jac://docs/tutorial-basics": (
+             "tutorials/language/basics.md",
+             "basics.md",
+             "Jac Fundamentals - Language basics tutorial"
          ),
+         "jac://docs/tutorial-osp": (
+             "tutorials/language/osp.md",
+             "tutorial-osp.md",
+             "Graphs & Walkers - OSP tutorial"
+         ),
+         # --- AI Integration ---
          "jac://docs/byllm": (
              "reference/plugins/byllm.md",
              "byllm.md",
              "byLLM - LLM integration reference"
          ),
+         "jac://docs/tutorial-ai-quickstart": (
+             "tutorials/ai/quickstart.md",
+             "ai-quickstart.md",
+             "Your First AI Function - AI quickstart tutorial"
+         ),
+         "jac://docs/tutorial-ai-structured": (
+             "tutorials/ai/structured-outputs.md",
+             "ai-structured-outputs.md",
+             "Structured Outputs - AI structured output tutorial"
+         ),
+         "jac://docs/tutorial-ai-agentic": (
+             "tutorials/ai/agentic.md",
+             "ai-agentic.md",
+             "Agentic AI - Building AI agents tutorial"
+         ),
+         "jac://docs/tutorial-ai-multimodal": (
+             "tutorials/ai/multimodal.md",
+             "ai-multimodal.md",
+             "Multimodal - Multimodal AI tutorial"
+         ),
+         # --- Full-Stack Development ---
          "jac://docs/jac-client": (
              "reference/plugins/jac-client.md",
              "jac-client.md",
              "jac-client - Full-stack web reference"
          ),
+         "jac://docs/tutorial-fullstack-setup": (
+             "tutorials/fullstack/setup.md",
+             "fullstack-setup.md",
+             "Project Setup - Full-stack setup tutorial"
+         ),
+         "jac://docs/tutorial-fullstack-components": (
+             "tutorials/fullstack/components.md",
+             "fullstack-components.md",
+             "Components - Full-stack components tutorial"
+         ),
+         "jac://docs/tutorial-fullstack-state": (
+             "tutorials/fullstack/state.md",
+             "fullstack-state.md",
+             "State Management - Full-stack state tutorial"
+         ),
+         "jac://docs/tutorial-fullstack-backend": (
+             "tutorials/fullstack/backend.md",
+             "fullstack-backend.md",
+             "Backend Integration - Full-stack backend tutorial"
+         ),
+         "jac://docs/tutorial-fullstack-auth": (
+             "tutorials/fullstack/auth.md",
+             "fullstack-auth.md",
+             "Authentication - Full-stack auth tutorial"
+         ),
+         "jac://docs/tutorial-fullstack-routing": (
+             "tutorials/fullstack/routing.md",
+             "fullstack-routing.md",
+             "Routing - Full-stack routing tutorial"
+         ),
+         # --- Deployment & Scaling ---
          "jac://docs/jac-scale": (
              "reference/plugins/jac-scale.md",
              "jac-scale.md",
              "jac-scale - Deployment/scaling reference"
+         ),
+         "jac://docs/tutorial-production-local": (
+             "tutorials/production/local.md",
+             "production-local.md",
+             "Local API Server - Local deployment tutorial"
+         ),
+         "jac://docs/tutorial-production-k8s": (
+             "tutorials/production/kubernetes.md",
+             "production-kubernetes.md",
+             "Kubernetes - Kubernetes deployment tutorial"
+         ),
+         # --- Developer Workflow ---
+         "jac://docs/cli": (
+             "reference/cli/index.md",
+             "cli-index.md",
+             "CLI Commands - Command line interface reference"
+         ),
+         "jac://docs/config": (
+             "reference/config/index.md",
+             "config-index.md",
+             "Configuration - Project configuration reference"
+         ),
+         "jac://docs/code-organization": (
+             "reference/code-organization.md",
+             "code-organization.md",
+             "Code Organization - Project structure guide"
+         ),
+         "jac://docs/mcp": (
+             "reference/tools/mcp.md",
+             "mcp.md",
+             "MCP Server - Model Context Protocol reference"
+         ),
+         "jac://docs/testing": (
+             "reference/testing.md",
+             "testing.md",
+             "Testing - Test framework reference"
+         ),
+         "jac://docs/debugging": (
+             "tutorials/language/debugging.md",
+             "debugging.md",
+             "Debugging - Debugging techniques tutorial"
+         ),
+         # --- Python Integration ---
+         "jac://docs/python-integration": (
+             "reference/language/python-integration.md",
+             "python-integration.md",
+             "Python Integration - Interop with Python"
+         ),
+         "jac://docs/library-mode": (
+             "reference/language/library-mode.md",
+             "library-mode.md",
+             "Library Mode - Using Jac as a library"
+         ),
+         # --- Quick Reference ---
+         "jac://docs/walker-responses": (
+             "reference/language/walker-responses.md",
+             "walker-responses.md",
+             "Walker Patterns - Walker response patterns"
+         ),
+         "jac://docs/appendices": (
+             "reference/language/appendices.md",
+             "appendices.md",
+             "Appendices - Additional language reference"
          ),
 
      };

--- a/jac-mcp/scripts/bundle_docs.jac
+++ b/jac-mcp/scripts/bundle_docs.jac
@@ -1,0 +1,93 @@
+"""Bundle documentation for PyPI release.
+
+Reads DOC_MAPPINGS directly from the resources module (single source of truth)
+and copies each referenced doc file into jac_mcp/content/docs/ with its
+bundled filename. Also copies grammar files (jac.spec, tokens.jac).
+
+Usage (from jac-mcp/ directory):
+    jac run scripts/bundle_docs.jac
+"""
+
+import shutil;
+import sys;
+
+import from pathlib { Path }
+import from jac_mcp.resources { find_repo_root, DOC_MAPPINGS }
+
+"""Grammar files to copy (source relative to repo root, destination filename)."""
+glob GRAMMAR_FILES: list[tuple] = [
+         ("jac/jaclang/jac.spec", "jac-grammar.spec"),
+         ("jac/jaclang/jac0core/parser/tokens.jac", "tokens.jac"),
+
+     ],
+     w = sys.stdout.write;
+
+"""Run the bundling pipeline."""
+def main -> int {
+    repo_root = find_repo_root();
+    if repo_root is None {
+        w("ERROR: Could not find repo root (jaclang not installed?)\n");
+        return 1;
+    }
+    repo = Path(repo_root);
+    docs_src = repo / "docs" / "docs";
+    bundle_dst = repo / "jac-mcp" / "jac_mcp" / "content" / "docs";
+
+    w(f"Repo root: {repo}\n");
+    w(f"DOC_MAPPINGS: {len(DOC_MAPPINGS)} entries\n\n");
+
+    # Create output directory
+    bundle_dst.mkdir(parents=True, exist_ok=True);
+
+    copied = 0;
+    missing: list[tuple] = [];
+
+    # Copy documentation files
+    for (uri, mapping) in DOC_MAPPINGS.items() {
+        (rel_path, bundled_name, desc) = mapping;
+        src = docs_src / rel_path;
+        dst = bundle_dst / bundled_name;
+
+        if src.exists() {
+            shutil.copy2(str(src), str(dst));
+            copied += 1;
+            w(f"  OK   {rel_path} -> {bundled_name}\n");
+        } else {
+            missing.append((rel_path, bundled_name));
+            w(f"  MISS {rel_path}\n");
+        }
+    }
+
+    # Copy grammar files
+    w("\n");
+    for (src_rel, dst_name) in GRAMMAR_FILES {
+        src = repo / src_rel;
+        dst = bundle_dst / dst_name;
+
+        if src.exists() {
+            shutil.copy2(str(src), str(dst));
+            copied += 1;
+            w(f"  OK   {src_rel} -> {dst_name}\n");
+        } else {
+            missing.append((src_rel, dst_name));
+            w(f"  MISS {src_rel}\n");
+        }
+    }
+
+    # Summary
+    w(f"\nBundled: {copied} files -> {bundle_dst}\n");
+    if missing {
+        w(f"Missing: {len(missing)} files:\n");
+        for (rel, name) in missing {
+            w(f"  - {rel} (expected as {name})\n");
+        }
+        return 1;
+    }
+
+    w("All files bundled successfully.\n");
+    return 0;
+}
+
+with entry {
+    sys.exit(main());
+}

--- a/jac-mcp/tests/test_mcp.jac
+++ b/jac-mcp/tests/test_mcp.jac
@@ -347,3 +347,63 @@ test "unknown prompt returns error" {
     result = pp.get_prompt("nonexistent", {});
     assert "Unknown" in result.get("description", "") or "messages" in result;
 }
+
+# ── Bundle Script Tests ──
+test "all doc mapping source files exist" {
+    """Verify every DOC_MAPPINGS entry points to a real file in docs/."""
+    import from jac_mcp.resources { find_repo_root, DOC_MAPPINGS }
+    import from pathlib { Path }
+
+    repo_root = find_repo_root();
+    if repo_root is None {
+        # Skip in non-repo (PyPI) environments
+        return;
+    }
+    docs_dir = Path(repo_root) / "docs" / "docs";
+    missing: list[str] = [];
+    for (uri, mapping) in DOC_MAPPINGS.items() {
+        (rel_path, bundled_name, desc) = mapping;
+        full_path = docs_dir / rel_path;
+        if not full_path.exists() {
+            missing.append(f"{uri} -> {rel_path}");
+        }
+    }
+    assert len(missing) == 0 , f"Missing doc files: {missing}";
+}
+
+test "bundle script runs successfully" {
+    """Verify the bundle_docs.jac script exits 0."""
+    import subprocess;
+    import from pathlib { Path }
+    import from jac_mcp.resources { find_repo_root }
+
+    repo_root = find_repo_root();
+    if repo_root is None {
+        return;
+    }
+    script = Path(repo_root) / "jac-mcp" / "scripts" / "bundle_docs.jac";
+    if not script.exists() {
+        return;
+    }
+    result = subprocess.run(
+        ["jac", "run", str(script)], capture_output=True, text=True, timeout=60
+    );
+    assert result.returncode == 0 , f"bundle_docs.jac failed:\n{result.stdout}\n{result.stderr}";
+}
+
+test "doc mappings have unique bundled names" {
+    """Verify no two DOC_MAPPINGS entries share the same bundled filename."""
+    import from jac_mcp.resources { DOC_MAPPINGS }
+
+    seen: dict[str, str] = {};
+    dupes: list[str] = [];
+    for (uri, mapping) in DOC_MAPPINGS.items() {
+        bundled_name = mapping[1];
+        if bundled_name in seen {
+            dupes.append(f"{bundled_name}: {seen[bundled_name]} vs {uri}");
+        } else {
+            seen[bundled_name] = uri;
+        }
+    }
+    assert len(dupes) == 0 , f"Duplicate bundled names: {dupes}";
+}


### PR DESCRIPTION
## Summary

- Expand MCP resource DOC_MAPPINGS from 12 to 42 entries covering the full mkdocs navigation (get-started, tutorials, AI integration, full-stack, deployment, developer workflow, quick reference)
- Add `scripts/bundle_docs.jac` that imports DOC_MAPPINGS directly as the single source of truth, replacing hardcoded `cp` commands in the CI release workflow
- Update `release-mcp.yml` to use `jac run scripts/bundle_docs.jac` for doc bundling
- Add 3 tests: source file existence, bundle script execution, and unique bundled name validation
- Add release notes for 0.1.1

## Test plan

- [x] `jac run scripts/bundle_docs.jac` bundles all 44 files (42 docs + 2 grammar) successfully
- [x] `jac test tests/test_mcp.jac` — all 42 tests pass
- [ ] Verify CI release workflow runs `bundle_docs.jac` correctly on next release