### PR TITLE
feat: add curl|bash installer and standalone binary builds

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -1,0 +1,144 @@
+name: Build Standalone Binaries
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (must exist on PyPI, e.g. 2.3.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # --- jaclang (slim, core only) ---
+          - package: jaclang
+            asset-prefix: jac
+            os: ubuntu-latest
+            platform: linux-x86_64
+          - package: jaclang
+            asset-prefix: jac
+            os: macos-13
+            platform: macos-x86_64
+          - package: jaclang
+            asset-prefix: jac
+            os: macos-latest
+            platform: macos-aarch64
+
+          # --- jaseci (full, all plugins) ---
+          - package: jaseci
+            asset-prefix: jaseci
+            os: ubuntu-latest
+            platform: linux-x86_64
+          - package: jaseci
+            asset-prefix: jaseci
+            os: macos-13
+            platform: macos-x86_64
+          - package: jaseci
+            asset-prefix: jaseci
+            os: macos-latest
+            platform: macos-aarch64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pex
+        run: pip install pex
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building version: $VERSION"
+
+      - name: Build standalone binary
+        run: |
+          ASSET="${{ matrix.asset-prefix }}-${{ steps.version.outputs.version }}-${{ matrix.platform }}"
+          echo "Building ${ASSET}..."
+
+          pex \
+            "${{ matrix.package }}==${{ steps.version.outputs.version }}" \
+            --console-script jac \
+            --scie eager \
+            --python-version 3.12 \
+            -o "$ASSET"
+
+          echo "asset_name=${ASSET}" >> "$GITHUB_ENV"
+
+      - name: Verify binary
+        run: |
+          chmod +x "${{ env.asset_name }}"
+          echo "Running --version check..."
+          ./${{ env.asset_name }} --version || true
+
+      - name: Generate checksum
+        run: |
+          if command -v sha256sum &>/dev/null; then
+            sha256sum "${{ env.asset_name }}" > "${{ env.asset_name }}.sha256"
+          else
+            shasum -a 256 "${{ env.asset_name }}" > "${{ env.asset_name }}.sha256"
+          fi
+          echo "Checksum:"
+          cat "${{ env.asset_name }}.sha256"
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ env.asset_name }}" \
+            "${{ env.asset_name }}.sha256" \
+            --clobber
+
+      - name: Upload as artifact (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.asset_name }}
+          path: |
+            ${{ env.asset_name }}
+            ${{ env.asset_name }}.sha256
+
+  summary:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Build summary
+        run: |
+          echo "## Standalone Binary Build Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Package | Platform | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| jaclang (slim) | linux-x86_64 | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| jaclang (slim) | macos-x86_64 | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| jaclang (slim) | macos-aarch64 | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| jaseci (full) | linux-x86_64 | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| jaseci (full) | macos-x86_64 | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| jaseci (full) | macos-aarch64 | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Note:** linux-aarch64 builds can be added when ARM runners are available." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,32 +1,74 @@
-name: Create Releases from Specific Subdirectories
+name: Create GitHub Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (reads from jaseci pyproject.toml if empty)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
-  create-github-releases:
+  create-release:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v5
-      with:
-        submodules: true
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-    - name: Create Releases for Specific Subdirectories
-      run: |
-        # List of subdirectories for which releases need to be created
-        subdirs=("jac" "jac-byllm")
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-        for dir in "${subdirs[@]}"; do
-          # Extract the directory name as the release name
-          release_name=$(basename "$dir")
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(python3 -c "
+          import tomllib
+          with open('jaseci-package/pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
 
-          # Get the latest commit hash for this subdirectory
-          release_version=$(git log -n 1 --format=%h -- "$dir")
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release v${{ steps.version.outputs.version }} already exists."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
-          # Create a release for the subdirectory with the release version (commit hash)
-          gh release create "$release_name-$release_version" "$dir/*" --title "$release_name" --notes "Release for $release_name version $release_version"
-        done
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "Jaseci v${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            --latest
+          echo "Created release v${{ steps.version.outputs.version }}"
+
+      - name: Summary
+        run: |
+          echo "## Release v${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.check.outputs.exists }}" = "true" ]; then
+            echo "Release already existed — no action taken." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "GitHub Release created. Standalone binary build will be triggered automatically." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release-jaseci.yml
+++ b/.github/workflows/release-jaseci.yml
@@ -3,12 +3,18 @@ name: Release jaseci to PYPI
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release-jaseci:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: jaseci-package
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -17,9 +23,19 @@ jobs:
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION=$(python3 -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install build tools
         run: |
@@ -31,3 +47,42 @@ jobs:
       - name: Publish package to PyPI
         run: |
           twine upload dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN }}
+
+  create-github-release:
+    needs: release-jaseci
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Wait for PyPI availability
+        run: |
+          VERSION="${{ needs.release-jaseci.outputs.version }}"
+          echo "Waiting for jaseci==$VERSION to be available on PyPI..."
+          for i in $(seq 1 30); do
+            if pip index versions jaseci 2>/dev/null | grep -q "$VERSION"; then
+              echo "jaseci==$VERSION is available on PyPI."
+              exit 0
+            fi
+            echo "  Attempt $i/30 — not yet available, waiting 10s..."
+            sleep 10
+          done
+          echo "Warning: jaseci==$VERSION not found on PyPI after 5 minutes."
+          echo "Proceeding with GitHub Release creation anyway."
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.release-jaseci.outputs.version }}"
+          if gh release view "v$VERSION" &>/dev/null; then
+            echo "Release v$VERSION already exists, skipping."
+          else
+            gh release create "v$VERSION" \
+              --title "Jaseci v$VERSION" \
+              --generate-notes \
+              --latest
+            echo "Created release v$VERSION"
+            echo "Standalone binary build will be triggered automatically."
+          fi

--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -4,13 +4,50 @@ Get Jac installed and ready to use in under 2 minutes.
 
 ---
 
-## Requirements
+## One-Line Install (Recommended)
 
-- **Python 3.12+** (check with `python --version`)
+Install Jac with a single command -- no Python setup required:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+```
+
+This automatically installs [uv](https://docs.astral.sh/uv/) (if needed), a Python 3.12+ runtime, and the full Jac ecosystem including all plugins.
+
+### Installer Options
+
+Pass flags after `--` to customize the install:
+
+```bash
+# Core language only (no plugins)
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --core
+
+# Specific version
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --version 2.3.1
+
+# Standalone binary (self-contained, no Python/uv needed at runtime)
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --standalone
+
+# Uninstall
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --uninstall
+```
+
+| Flag | Description |
+|------|-------------|
+| `--core` | Install only the Jac language compiler, no plugins |
+| `--standalone` | Download a pre-built binary from GitHub Releases |
+| `--version V` | Install a specific version |
+| `--uninstall` | Remove Jac |
+
+### Upgrading
+
+Re-run the install command to upgrade to the latest version. The installer detects existing installations and upgrades in place.
 
 ---
 
-## Quick Install
+## Install via pip
+
+If you already have Python 3.12+ and prefer pip:
 
 ```bash
 pip install jaseci
@@ -201,6 +238,14 @@ jac create my-app --use https://raw.githubusercontent.com/jaseci-labs/jacpacks/m
 ---
 
 ## Upgrading Jac
+
+If you installed via the one-line installer, re-run it to upgrade:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+```
+
+If you installed via pip:
 
 ```bash
 # Upgrade everything at once

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# Jac Programming Language Installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+#
+# Options:
+#   --core        Install only jaclang (no plugins)
+#   --standalone  Download a pre-built standalone binary from GitHub Releases
+#   --version V   Install a specific version
+#   --uninstall   Remove Jac
+#   --help        Print usage
+#
+# Examples:
+#   curl -fsSL ... | bash                          # Full ecosystem via uv
+#   curl -fsSL ... | bash -s -- --core             # Core language only
+#   curl -fsSL ... | bash -s -- --standalone       # Standalone binary (all plugins)
+#   curl -fsSL ... | bash -s -- --standalone --core  # Standalone binary (core only)
+#   curl -fsSL ... | bash -s -- --version 2.3.1    # Specific version
+
+set -euo pipefail
+
+REPO="jaseci-labs/jaseci"
+GITHUB_API="https://api.github.com/repos/${REPO}"
+UV_INSTALL_URL="https://astral.sh/uv/install.sh"
+INSTALL_DIR="${HOME}/.local/bin"
+
+# --- Defaults ---
+CORE_ONLY=false
+STANDALONE=false
+VERSION=""
+UNINSTALL=false
+
+# --- Colors and output helpers ---
+
+info() {
+    printf "\033[0;34m[jac]\033[0m %s\n" "$*"
+}
+
+warn() {
+    printf "\033[0;33m[jac]\033[0m %s\n" "$*" >&2
+}
+
+err() {
+    printf "\033[0;31m[jac]\033[0m %s\n" "$*" >&2
+}
+
+has_cmd() {
+    command -v "$1" &>/dev/null
+}
+
+need_cmd() {
+    if ! has_cmd "$1"; then
+        err "Required command not found: $1"
+        err "Please install '$1' and try again."
+        exit 1
+    fi
+}
+
+# --- Usage ---
+
+usage() {
+    cat <<EOF
+Jac Programming Language Installer
+
+USAGE:
+    curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+    curl -fsSL ... | bash -s -- [OPTIONS]
+
+OPTIONS:
+    --core        Install only jaclang (no plugins)
+    --standalone  Download a pre-built standalone binary from GitHub Releases
+    --version V   Install a specific version (e.g., 2.3.1)
+    --uninstall   Remove Jac installation
+    --help        Print this help message
+
+EXAMPLES:
+    # Full ecosystem (all plugins) via uv
+    curl -fsSL ... | bash
+
+    # Core language only via uv
+    curl -fsSL ... | bash -s -- --core
+
+    # Standalone binary with all plugins
+    curl -fsSL ... | bash -s -- --standalone
+
+    # Standalone binary, core only
+    curl -fsSL ... | bash -s -- --standalone --core
+
+    # Specific version
+    curl -fsSL ... | bash -s -- --version 2.3.1
+EOF
+}
+
+# --- Platform detection ---
+
+detect_platform() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Linux*)  OS="linux" ;;
+        Darwin*) OS="macos" ;;
+        MINGW* | MSYS* | CYGWIN*)
+            err "Windows detected. Windows support via PowerShell is coming soon."
+            err "For now, please use WSL2 or install manually: pip install jaseci"
+            exit 1
+            ;;
+        *)
+            err "Unsupported operating system: $os"
+            exit 1
+            ;;
+    esac
+
+    case "$arch" in
+        x86_64 | amd64)  ARCH="x86_64" ;;
+        aarch64 | arm64)  ARCH="aarch64" ;;
+        *)
+            err "Unsupported architecture: $arch"
+            exit 1
+            ;;
+    esac
+}
+
+# --- Argument parsing ---
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --core)
+                CORE_ONLY=true
+                shift
+                ;;
+            --standalone)
+                STANDALONE=true
+                shift
+                ;;
+            --version)
+                if [[ $# -lt 2 ]]; then
+                    err "--version requires a version argument (e.g., --version 2.3.1)"
+                    exit 1
+                fi
+                VERSION="$2"
+                shift 2
+                ;;
+            --uninstall)
+                UNINSTALL=true
+                shift
+                ;;
+            --help | -h)
+                usage
+                exit 0
+                ;;
+            *)
+                err "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# --- PATH helpers ---
+
+ensure_on_path() {
+    if ! echo "$PATH" | tr ':' '\n' | grep -q "^${INSTALL_DIR}$"; then
+        export PATH="${INSTALL_DIR}:${PATH}"
+    fi
+
+    # Check if the install dir is in the user's shell profile
+    local shell_name
+    shell_name="$(basename "${SHELL:-/bin/bash}")"
+    local profile=""
+
+    case "$shell_name" in
+        zsh)  profile="$HOME/.zshrc" ;;
+        bash)
+            if [[ -f "$HOME/.bashrc" ]]; then
+                profile="$HOME/.bashrc"
+            elif [[ -f "$HOME/.bash_profile" ]]; then
+                profile="$HOME/.bash_profile"
+            fi
+            ;;
+        fish) profile="$HOME/.config/fish/config.fish" ;;
+    esac
+
+    if [[ -n "$profile" ]] && ! grep -q "${INSTALL_DIR}" "$profile" 2>/dev/null; then
+        warn ""
+        warn "Add ${INSTALL_DIR} to your PATH by running:"
+        if [[ "$shell_name" == "fish" ]]; then
+            warn "  fish_add_path ${INSTALL_DIR}"
+        else
+            warn "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> $profile"
+        fi
+        warn ""
+        warn "Then restart your shell or run: source $profile"
+    fi
+}
+
+# --- uv installation path ---
+
+install_via_uv() {
+    need_cmd "curl"
+
+    # Ensure uv is installed
+    if ! has_cmd uv; then
+        info "Installing uv (Python package manager)..."
+        curl -LsSf "$UV_INSTALL_URL" | sh
+        export PATH="${INSTALL_DIR}:${PATH}"
+
+        if ! has_cmd uv; then
+            err "Failed to install uv. Please install it manually:"
+            err "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+            exit 1
+        fi
+        info "uv installed successfully."
+    else
+        info "uv is already installed."
+    fi
+
+    # Determine package
+    local pkg
+    if $CORE_ONLY; then
+        pkg="jaclang"
+    else
+        pkg="jaseci"
+    fi
+
+    # Build version spec
+    local spec="$pkg"
+    if [[ -n "$VERSION" ]]; then
+        spec="${pkg}==${VERSION}"
+    fi
+
+    # Check if already installed and upgrade vs fresh install
+    if uv tool list 2>/dev/null | grep -q "^${pkg} "; then
+        info "Upgrading ${pkg}..."
+        if [[ -n "$VERSION" ]]; then
+            # For pinned version, reinstall
+            uv tool install "$spec" --python ">=3.12" --force
+        else
+            uv tool upgrade "$pkg" --python ">=3.12"
+        fi
+    else
+        info "Installing ${pkg}..."
+        uv tool install "$spec" --python ">=3.12"
+    fi
+
+    ensure_on_path
+
+    # Verify
+    if has_cmd jac; then
+        info ""
+        info "Jac installed successfully!"
+        jac --version 2>/dev/null || true
+        info ""
+        info "Get started:"
+        info "  jac --help"
+        info ""
+    else
+        warn "Installation completed but 'jac' is not on PATH."
+        warn "Try restarting your shell or adding ~/.local/bin to PATH."
+    fi
+}
+
+# --- Standalone binary installation path ---
+
+get_latest_version() {
+    local response
+    response=$(curl -fsSL "${GITHUB_API}/releases/latest" 2>/dev/null) || {
+        err "Failed to query GitHub API for latest release."
+        err "Check your internet connection or specify a version with --version."
+        exit 1
+    }
+
+    # Extract tag_name, strip leading 'v'
+    local tag
+    tag=$(echo "$response" | grep -o '"tag_name":[[:space:]]*"[^"]*"' | head -1 | grep -o '"v[^"]*"' | tr -d '"' | sed 's/^v//')
+
+    if [[ -z "$tag" ]]; then
+        err "Could not determine latest version from GitHub Releases."
+        err "Please specify a version with --version."
+        exit 1
+    fi
+
+    echo "$tag"
+}
+
+install_standalone() {
+    need_cmd "curl"
+
+    # Resolve version
+    if [[ -z "$VERSION" ]]; then
+        info "Fetching latest version..."
+        VERSION=$(get_latest_version)
+        info "Latest version: ${VERSION}"
+    fi
+
+    # Determine asset name
+    local asset_prefix
+    if $CORE_ONLY; then
+        asset_prefix="jac"
+    else
+        asset_prefix="jaseci"
+    fi
+
+    local asset="${asset_prefix}-${VERSION}-${OS}-${ARCH}"
+    local download_url="https://github.com/${REPO}/releases/download/v${VERSION}/${asset}"
+    local checksum_url="${download_url}.sha256"
+
+    # Create install directory
+    mkdir -p "$INSTALL_DIR"
+
+    # Download to temp location
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    info "Downloading ${asset}..."
+    if ! curl -fsSL -o "${tmpdir}/${asset}" "$download_url"; then
+        err "Failed to download: ${download_url}"
+        err ""
+        err "This could mean:"
+        err "  - The version '${VERSION}' does not exist"
+        err "  - Standalone binaries are not available for ${OS}-${ARCH}"
+        err "  - Network issue"
+        err ""
+        err "Try installing via uv instead (remove --standalone flag)."
+        exit 1
+    fi
+
+    # Verify checksum if available
+    if curl -fsSL -o "${tmpdir}/${asset}.sha256" "$checksum_url" 2>/dev/null; then
+        info "Verifying checksum..."
+        local expected actual
+        expected=$(awk '{print $1}' "${tmpdir}/${asset}.sha256")
+
+        if has_cmd sha256sum; then
+            actual=$(sha256sum "${tmpdir}/${asset}" | awk '{print $1}')
+        elif has_cmd shasum; then
+            actual=$(shasum -a 256 "${tmpdir}/${asset}" | awk '{print $1}')
+        else
+            warn "Neither sha256sum nor shasum found, skipping checksum verification."
+            actual="$expected"
+        fi
+
+        if [[ "$expected" != "$actual" ]]; then
+            err "Checksum verification failed!"
+            err "  Expected: ${expected}"
+            err "  Got:      ${actual}"
+            exit 1
+        fi
+        info "Checksum verified."
+    else
+        warn "Checksum file not available, skipping verification."
+    fi
+
+    # Install binary
+    mv "${tmpdir}/${asset}" "${INSTALL_DIR}/jac"
+    chmod +x "${INSTALL_DIR}/jac"
+
+    ensure_on_path
+
+    # Verify
+    if has_cmd jac; then
+        info ""
+        info "Jac installed successfully! (standalone binary)"
+        jac --version 2>/dev/null || true
+        info ""
+        info "Get started:"
+        info "  jac --help"
+        info ""
+    else
+        warn "Binary installed to ${INSTALL_DIR}/jac but 'jac' is not on PATH."
+        warn "Try restarting your shell or adding ~/.local/bin to PATH."
+    fi
+}
+
+# --- Uninstall ---
+
+do_uninstall() {
+    local removed=false
+
+    # Remove uv-managed installations
+    if has_cmd uv; then
+        if uv tool list 2>/dev/null | grep -q "^jaseci "; then
+            info "Removing jaseci (uv tool)..."
+            uv tool uninstall jaseci
+            removed=true
+        fi
+        if uv tool list 2>/dev/null | grep -q "^jaclang "; then
+            info "Removing jaclang (uv tool)..."
+            uv tool uninstall jaclang
+            removed=true
+        fi
+    fi
+
+    # Remove standalone binary
+    if [[ -f "${INSTALL_DIR}/jac" ]]; then
+        info "Removing ${INSTALL_DIR}/jac..."
+        rm -f "${INSTALL_DIR}/jac"
+        removed=true
+    fi
+
+    if $removed; then
+        info "Jac has been uninstalled."
+    else
+        warn "No Jac installation found."
+    fi
+}
+
+# --- Main ---
+
+main() {
+    parse_args "$@"
+
+    if $UNINSTALL; then
+        do_uninstall
+        exit 0
+    fi
+
+    detect_platform
+
+    info "Detected platform: ${OS}-${ARCH}"
+
+    if $STANDALONE; then
+        install_standalone
+    else
+        install_via_uv
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds a `curl | bash` one-line installer (`scripts/install.sh`) for Jac, similar to how bun/uv distribute
- Two install channels: **uv-based** (default, manages Python automatically) and **standalone binary** (pex-scie, self-contained with bundled Python)
- Standalone binaries are built automatically after each jaseci PyPI release via a new GitHub Actions workflow

## Changes

**New files:**
- `scripts/install.sh` -- Installer script with `--core`, `--standalone`, `--version`, `--uninstall` flags
- `.github/workflows/build-standalone.yml` -- Builds pex-scie binaries for 6 targets (jaclang + jaseci x linux-x64/macos-x64/macos-arm64), uploads as GitHub Release assets

**Modified files:**
- `.github/workflows/release-jaseci.yml` -- Now auto-creates a GitHub Release after PyPI publish, which triggers standalone binary builds
- `.github/workflows/release-github.yml` -- Rewritten from stub to proper versioned release creation
- `docs/docs/quick-guide/install.md` -- Added one-line install documentation at the top

## Install usage

```bash
# Full ecosystem (all plugins)
curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash

# Core only
curl -fsSL ... | bash -s -- --core

# Standalone binary
curl -fsSL ... | bash -s -- --standalone

# Specific version
curl -fsSL ... | bash -s -- --version 2.3.1
```

## Release flow (post-merge)

```
release-*.yml (PyPI) → release-jaseci.yml (PyPI + GitHub Release) → build-standalone.yml (auto)
```

## Test plan

- [ ] Run `shellcheck scripts/install.sh` (passes locally)
- [ ] Test uv install path in clean Docker container (`ubuntu:22.04`)
- [ ] Test `--core` flag installs only jaclang
- [ ] Test `--uninstall` removes installation
- [ ] Validate workflow YAML syntax (passes locally)
- [ ] Trigger `build-standalone.yml` via workflow_dispatch after next PyPI release
- [ ] Verify standalone binary runs `jac --version` on each platform