### PR TITLE
fix(ci): remove macos-x86_64 standalone builds

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -64,8 +64,6 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux-x86_64
-          - os: macos-13
-            platform: macos-x86_64
           - os: macos-latest
             platform: macos-aarch64
 
@@ -142,8 +140,6 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux-x86_64
-          - os: macos-13
-            platform: macos-x86_64
           - os: macos-latest
             platform: macos-aarch64
 
@@ -226,10 +222,8 @@ jobs:
           echo "| Package | Platform | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---------|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| jaclang (slim) | linux-x86_64 | ${{ needs.build-jaclang.result }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| jaclang (slim) | macos-x86_64 | ${{ needs.build-jaclang.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| jaclang (slim) | macos-aarch64 | ${{ needs.build-jaclang.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| jaseci (full) | linux-x86_64 | ${{ needs.build-jaseci.result }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| jaseci (full) | macos-x86_64 | ${{ needs.build-jaseci.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| jaseci (full) | macos-aarch64 | ${{ needs.build-jaseci.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Note:** linux-aarch64 builds can be added when ARM runners are available." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Remove macos-x86_64 (macos-13) build targets from `build-standalone.yml` for both jaclang and jaseci
- Remove corresponding rows from the build summary table
- macos-13 runners are being deprecated; only linux-x86_64 and macos-aarch64 are needed

## Test plan
- [ ] Trigger `build-standalone.yml` via workflow_dispatch and verify only linux-x86_64 and macos-aarch64 jobs run
- [ ] Confirm build summary table shows the correct two platforms per package