### PR TITLE
Fix: pin Python <3.14 in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -235,13 +235,13 @@ install_via_uv() {
     if uv tool list 2>/dev/null | grep -q "^jaclang "; then
         info "Upgrading jaclang..."
         if [[ -n "$VERSION" ]]; then
-            uv tool install "$spec" "${with_args[@]}" --python ">=3.12" --force
+            uv tool install "$spec" "${with_args[@]}" --python ">=3.12,<3.14" --force
         else
-            uv tool upgrade jaclang "${with_args[@]}" --python ">=3.12"
+            uv tool upgrade jaclang "${with_args[@]}" --python ">=3.12,<3.14"
         fi
     else
         info "Installing jaclang..."
-        uv tool install "$spec" "${with_args[@]}" --python ">=3.12"
+        uv tool install "$spec" "${with_args[@]}" --python ">=3.12,<3.14"
     fi
 
     ensure_on_path


### PR DESCRIPTION
## Summary
- Pin Python version to `>=3.12,<3.14` in the `uv tool install` calls in `scripts/install.sh`
- `llvmlite 0.46.0` fails to build on Python 3.14 due to a `distutils.spawn()` API change (`spawn() got an unexpected keyword argument 'dry_run'`)
- This affects users running the install script on systems where Python 3.14 is the default (e.g., latest Alpine containers)

## Test plan
- [ ] Run install script on Alpine container with Python 3.14 as system default — should auto-fetch Python 3.12/3.13 via uv
- [ ] Run install script on system with Python 3.12 — should work as before