### PR TITLE
feat: nacompile accepts .jac files, chess benchmark mode

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -16,6 +16,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Structured GitHub Issue Forms**: Replaced blank markdown issue templates with guided YAML forms, making it easier to submit well-structured bug reports, feature requests, and docs issues.
 - **Native Codegen: Split-File Chess Engine & Major IR Gen Fixes**: Enabled complex multi-file native applications (declaration `.na.jac` + implementation `.impl.jac`) by fixing 10+ IR generation bugs.
 - **Native Auto-Promotion (`--autonative`)**: Regular `.jac` modules can now be automatically promoted to native (LLVM JIT) execution without requiring the `.na.jac` extension.
+- **`jac nacompile` accepts `.jac` files**: `jac nacompile` now auto-promotes compatible `.jac` files to native compilation, with a clear error message when a file uses unsupported constructs.
 
 ## jaclang 0.11.2 (Latest Release)
 

--- a/jac/examples/chess/chess.impl.jac
+++ b/jac/examples/chess/chess.impl.jac
@@ -639,6 +639,68 @@ impl Game.move_summary -> str {
     return f"Move {full_moves + 1}" + ("..." if half == 1 else "");
 }
 
+impl Game.play_auto -> str {
+    """Play one full game with random moves. Returns 'White', 'Black', or 'Draw'."""
+    max_moves = 500;
+    while not self.is_over and self.move_count < max_moves {
+        all_legal: list[Move] = self.legal_moves(self.current_turn);
+        if len(all_legal) == 0 {
+            if self.in_check(self.current_turn) {
+                winner = "White" if self.current_turn == Color.BLACK else "Black";
+                return winner;
+            } else {
+                return "Draw";
+            }
+        }
+        idx = random_int(len(all_legal));
+        chosen = all_legal[idx];
+        self.board.make_move(chosen);
+        self.move_count += 1;
+        self.current_turn = opposite_color(self.current_turn);
+
+        if self.is_checkmate(self.current_turn) {
+            winner = "White" if self.current_turn == Color.BLACK else "Black";
+            return winner;
+        } elif self.is_stalemate(self.current_turn) {
+            return "Draw";
+        }
+    }
+    return "Draw";
+}
+
+impl Game.benchmark(num_games: int) -> None {
+    """Run num_games automated random games and print results."""
+    white_wins = 0;
+    black_wins = 0;
+    draws = 0;
+
+    print(f"Running {num_games} games...\n");
+
+    for i in range(num_games) {
+        g = Game();
+        seed_random(i * 7919 + 42);
+        result = g.play_auto();
+
+        if result == "White" {
+            white_wins += 1;
+        } elif result == "Black" {
+            black_wins += 1;
+        } else {
+            draws += 1;
+        }
+        print(
+            f"Game {i + 1}: {result} wins"
+                if result != "Draw"
+                else f"Game {i + 1}: Draw"
+        );
+    }
+
+    print(f"\n--- Results ({num_games} games) ---");
+    print(f"White wins: {white_wins}");
+    print(f"Black wins: {black_wins}");
+    print(f"Draws:      {draws}");
+}
+
 impl Game.play -> None {
     while not self.is_over {
         self.board.display();

--- a/jac/examples/chess/chess.jac
+++ b/jac/examples/chess/chess.jac
@@ -197,11 +197,19 @@ obj Game {
     def parse_input(text: str) -> tuple[int, int, int, int] | None;
     def move_summary -> str;
     def play -> None;
+    def play_auto -> str;
+    def benchmark(num_games: int) -> None;
 }
 
 # ────────────────────── Entry ──────────────────────
-glob game = Game();
+# Set _benchmark_mode > 0 to run that many automated games.
+glob _benchmark_mode: int = 0,
+     game = Game();
 
 with entry {
-    game.play();
+    if _benchmark_mode > 0 {
+        game.benchmark(_benchmark_mode);
+    } else {
+        game.play();
+    }
 }

--- a/jac/jaclang/cli/commands/impl/nacompile.impl.jac
+++ b/jac/jaclang/cli/commands/impl/nacompile.impl.jac
@@ -45,8 +45,8 @@ def _inject_entry_macho(llvm_ir_str: str) -> str {
 """Compile a .na.jac file to a standalone native binary."""
 impl nacompile(filename: str, output: str = "") -> int {
     # Validate input
-    if not filename.endswith(".na.jac") {
-        console.error("Input must be a .na.jac file.");
+    if not filename.endswith(".na.jac") and not filename.endswith(".jac") {
+        console.error("Input must be a .jac or .na.jac file.");
         return 1;
     }
     if not os.path.exists(filename) {
@@ -54,15 +54,18 @@ impl nacompile(filename: str, output: str = "") -> int {
         return 1;
     }
 
+    auto_promote = filename.endswith(".jac") and not filename.endswith(".na.jac");
+
     # Detect platform
     is_macos = sys.platform == "darwin";
 
     # Determine output path
     if not output {
         output = os.path.basename(filename);
-        # Strip .na.jac extension
         if output.endswith(".na.jac") {
             output = output[:-7];
+        } elif output.endswith(".jac") {
+            output = output[:-4];
         }
     }
 
@@ -74,6 +77,10 @@ impl nacompile(filename: str, output: str = "") -> int {
 
     try {
         prog = JacProgram();
+        if auto_promote {
+            prog._auto_promote_native = True;
+            prog._auto_promote_target = os.path.abspath(filename);
+        }
         options = CompileOptions(skip_native_engine=True);
         ir_module = prog.compile(file_path=os.path.abspath(filename), options=options);
     } except Exception as e {
@@ -84,13 +91,29 @@ impl nacompile(filename: str, output: str = "") -> int {
     }
 
     if ir_module is None or ir_module.gen.llvm_ir is None {
-        console.error("Native compilation produced no LLVM IR.");
+        if auto_promote
+        and not getattr(
+            ir_module.gen if ir_module else None, '_auto_promoted_native', False
+        ) {
+            console.error(
+                "This .jac file is not compatible with native compilation.\n"
+                "  It may use walkers, nodes, edges, async, lambdas, or other\n"
+                "  constructs not supported by the native backend.\n"
+                "  Use a .na.jac file or remove incompatible constructs."
+            );
+        } else {
+            console.error("Native compilation produced no LLVM IR.");
+        }
         if prog.errors_had {
             for err in prog.errors_had {
                 console.error(f"  {err}");
             }
         }
         return 1;
+    }
+
+    if auto_promote {
+        console.print("  Auto-promoted to native compilation.");
     }
 
     # Step 2: Check for Python/server interop (can't compile standalone)

--- a/jac/jaclang/cli/commands/nacompile.jac
+++ b/jac/jaclang/cli/commands/nacompile.jac
@@ -11,12 +11,14 @@ import from jaclang.cli.registry { get_registry }
 
 glob registry = get_registry();
 
-"""Compile a .na.jac file to a standalone native binary."""
+"""Compile a .jac or .na.jac file to a standalone native binary."""
 @registry.command(
     name="nacompile",
-    help="Compile a .na.jac file to a standalone native binary",
+    help="Compile a Jac file to a standalone native binary",
     args=[
-        Arg.create("filename", kind=ArgKind.POSITIONAL, help="Path to .na.jac file"),
+        Arg.create(
+            "filename", kind=ArgKind.POSITIONAL, help="Path to .jac or .na.jac file"
+        ),
         Arg.create(
             "output",
             kind=ArgKind.OPTION,
@@ -28,6 +30,7 @@ glob registry = get_registry();
     ],
     examples=[
         ("jac nacompile program.na.jac", "Compile to ./program"),
+        ("jac nacompile program.jac", "Auto-promote and compile to ./program"),
         ("jac nacompile program.na.jac -o mybin", "Compile to ./mybin"),
 
     ],


### PR DESCRIPTION
## Summary
- `jac nacompile` now accepts regular `.jac` files in addition to `.na.jac`, auto-promoting native-compatible modules. Incompatible files get a clear error message explaining why they can't be compiled natively.
- Chess example gains a benchmark mode (`play_auto`, `benchmark(n)`) that runs N automated random games and prints win/draw statistics. Works in both Python and native execution paths via a `_benchmark_mode` global.

## Test plan
- [x] `jac nacompile examples/chess/chess.jac` produces a working native binary
- [x] `jac nacompile` on a walker-based `.jac` file gives a clear incompatibility error
- [x] `jac run examples/chess/chess.jac` with `_benchmark_mode > 0` runs automated games
- [ ] Existing native tests still pass