### PR TITLE
fix: chain standalone binary build from release workflows

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -4,6 +4,17 @@ on:
   release:
     types: [published]
 
+  workflow_call:
+    inputs:
+      jaseci_version:
+        description: "jaseci version to build (must exist on PyPI)"
+        required: true
+        type: string
+      release_tag:
+        description: "GitHub Release tag to upload assets to (e.g. v2.3.3)"
+        required: true
+        type: string
+
   workflow_dispatch:
     inputs:
       jaseci_version:
@@ -112,7 +123,7 @@ jobs:
           echo "Checksum:"
           cat "${{ env.asset_name }}.sha256"
 
-      - name: Upload to GitHub Release
+      - name: Upload to GitHub Release (release event)
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -122,8 +133,18 @@ jobs:
             "${{ env.asset_name }}.sha256" \
             --clobber
 
-      - name: Upload as artifact (manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload to GitHub Release (called from another workflow)
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "${{ env.asset_name }}" \
+            "${{ env.asset_name }}.sha256" \
+            --clobber
+
+      - name: Upload as artifact (manual dispatch without release_tag)
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag == ''
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.asset_name }}
@@ -188,7 +209,7 @@ jobs:
           echo "Checksum:"
           cat "${{ env.asset_name }}.sha256"
 
-      - name: Upload to GitHub Release
+      - name: Upload to GitHub Release (release event)
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -198,8 +219,18 @@ jobs:
             "${{ env.asset_name }}.sha256" \
             --clobber
 
-      - name: Upload as artifact (manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload to GitHub Release (called from another workflow)
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "${{ env.asset_name }}" \
+            "${{ env.asset_name }}.sha256" \
+            --clobber
+
+      - name: Upload as artifact (manual dispatch without release_tag)
+        if: github.event_name == 'workflow_dispatch' && inputs.release_tag == ''
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.asset_name }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -70,5 +70,19 @@ jobs:
           if [ "${{ steps.check.outputs.exists }}" = "true" ]; then
             echo "Release already existed — no action taken." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "GitHub Release created. Standalone binary build will be triggered automatically." >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub Release created. Standalone binary build chained." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_created: ${{ steps.check.outputs.exists == 'false' }}
+
+  build-standalone-binaries:
+    needs: create-release
+    if: needs.create-release.outputs.release_created == 'true'
+    uses: ./.github/workflows/build-standalone.yml
+    with:
+      jaseci_version: ${{ needs.create-release.outputs.version }}
+      release_tag: v${{ needs.create-release.outputs.version }}
+    permissions:
+      contents: write

--- a/.github/workflows/release-jaseci.yml
+++ b/.github/workflows/release-jaseci.yml
@@ -84,5 +84,13 @@ jobs:
               --generate-notes \
               --latest
             echo "Created release v$VERSION"
-            echo "Standalone binary build will be triggered automatically."
           fi
+
+  build-standalone-binaries:
+    needs: [release-jaseci, create-github-release]
+    uses: ./.github/workflows/build-standalone.yml
+    with:
+      jaseci_version: ${{ needs.release-jaseci.outputs.version }}
+      release_tag: v${{ needs.release-jaseci.outputs.version }}
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary
- The `build-standalone.yml` workflow was not being triggered by the `release: published` event because GitHub Actions events created by `GITHUB_TOKEN` don't trigger other workflows — this caused v2.3.3 to ship without binaries attached
- Added `workflow_call` trigger to `build-standalone.yml` so it can be called directly by other workflows
- Chained `build-standalone.yml` from both `release-jaseci.yml` and `release-github.yml` after the GitHub Release is created, eliminating the dependency on the `release: published` event

## Test plan
- [ ] Trigger `release-github.yml` manually and verify `build-standalone-binaries` job runs and uploads to the release
- [ ] Trigger `build-standalone.yml` via `workflow_dispatch` (without `release_tag`) and verify artifacts are uploaded as CI artifacts (not to a release)
- [ ] Verify next full release via `release-jaseci.yml` includes binaries on the GitHub Release