### PR TITLE
jac-mcp: complete docs coverage and import:py pitfall

### DIFF
--- a/jac-mcp/jac_mcp/content/pitfalls.md
+++ b/jac-mcp/jac_mcp/content/pitfalls.md
@@ -39,11 +39,18 @@ if x > 5 {
 
 ### 3. Import syntax is different
 
-WRONG:
+WRONG (Python style):
 
 ```
 from os import path
 from typing import Any
+```
+
+WRONG (deprecated Jac v1 syntax -- do NOT use):
+
+```
+import:py from os { path }
+import:py typing;
 ```
 
 RIGHT:
@@ -52,6 +59,8 @@ RIGHT:
 import from os { path }
 import from typing { Any }
 ```
+
+The `import:py` prefix is **removed** from modern Jac. All imports use plain `import` -- Python modules are imported the same way as Jac modules. Never generate `import:py`, `include:jac`, or any colon-tagged import variant.
 
 ### 4. Prefer `obj` over Python-style `class`
 

--- a/jac-mcp/jac_mcp/impl/resources.impl.jac
+++ b/jac-mcp/jac_mcp/impl/resources.impl.jac
@@ -118,6 +118,17 @@ glob DOC_MAPPINGS: dict[str, tuple] = {
              "tutorial-osp.md",
              "Graphs & Walkers - OSP tutorial"
          ),
+         # --- Native Compilation ---
+         "jac://docs/native-pathway": (
+             "reference/language/native-pathway.md",
+             "native-pathway.md",
+             "Native Compilation - Native pathway reference"
+         ),
+         "jac://docs/tutorial-native-chess": (
+             "tutorials/native/chess.md",
+             "native-chess.md",
+             "Build a Chess Engine - Native compilation tutorial"
+         ),
          # --- AI Integration ---
          "jac://docs/byllm": (
              "reference/plugins/byllm.md",


### PR DESCRIPTION
## Summary
- Add native compilation docs (`native-pathway.md`, `chess.md` tutorial) to `DOC_MAPPINGS` — these were the only two mkdocs nav entries missing from the MCP resource catalog
- Update pitfalls guide to explicitly warn against deprecated `import:py` syntax that models frequently generate from stale training data

## Test plan
- [ ] Run `jac mcp --inspect` and verify `jac://docs/native-pathway` and `jac://docs/tutorial-native-chess` appear in resource list
- [ ] Verify pitfalls guide renders correctly via `jac://guide/pitfalls` resource