### PR TITLE
Use Unicode chess piece symbols in chess example

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,7 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.11.4 (Unreleased)
 
-- 2 small refactors/changes.
+- 3 small refactors/changes.
 - **Type System Improvement**: Fixed type narrowing not working correctly inside while loops, for loops with break/continue, and loop else blocks.
 
 ## jaclang 0.11.3 (Latest Release)

--- a/jac/examples/chess/chess.jac
+++ b/jac/examples/chess/chess.jac
@@ -36,21 +36,21 @@ glob CENTER_MASK: int = 0b00111100;
 
 # Piece display symbols per side
 glob WHITE_SYMBOLS: dict[PieceKind, str] = {
-         PieceKind.PAWN: "P",
-         PieceKind.KNIGHT: "N",
-         PieceKind.BISHOP: "B",
-         PieceKind.ROOK: "R",
-         PieceKind.QUEEN: "Q",
-         PieceKind.KING: "K"
+         PieceKind.PAWN: "♙",
+         PieceKind.KNIGHT: "♘",
+         PieceKind.BISHOP: "♗",
+         PieceKind.ROOK: "♖",
+         PieceKind.QUEEN: "♕",
+         PieceKind.KING: "♔"
      };
 
 glob BLACK_SYMBOLS: dict[PieceKind, str] = {
-         PieceKind.PAWN: "p",
-         PieceKind.KNIGHT: "n",
-         PieceKind.BISHOP: "b",
-         PieceKind.ROOK: "r",
-         PieceKind.QUEEN: "q",
-         PieceKind.KING: "k"
+         PieceKind.PAWN: "♟",
+         PieceKind.KNIGHT: "♞",
+         PieceKind.BISHOP: "♝",
+         PieceKind.ROOK: "♜",
+         PieceKind.QUEEN: "♛",
+         PieceKind.KING: "♚"
      };
 
 glob COL_NAMES: str = "abcdefgh";


### PR DESCRIPTION
## Summary
- Replace ASCII letter piece symbols (P/N/B/R/Q/K and p/n/b/r/q/k) with standard Unicode chess characters (♔♕♖♗♘♙ / ♚♛♜♝♞♟) for a nicer board display
- Bump minor changes count in release notes

## Test plan
- [ ] Run `jac run jac/examples/chess/chess.jac` and verify Unicode pieces render correctly in terminal