### PR TITLE
Add native set algebra and dict.setdefault primitives

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -6,6 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - 2 small refactors/changes.
 - **Type System Improvement**: Fixed type narrowing not working correctly inside while loops, for loops with break/continue, and loop else blocks.
+- **Native Primitives: Set Algebra & Dict `setdefault`**: Implemented 6 new native LLVM emitters -- `set.symmetric_difference`, `set.update`, `set.intersection_update`, `set.difference_update`, `set.symmetric_difference_update`, and `dict.setdefault`. Native primitive coverage rises from 47% → 49% implemented (147/299) and 45% → 47% tested (140/299), with SetEmitter at 61% and DictEmitter at 81%.
 
 ## jaclang 0.11.3 (Latest Release)
 

--- a/jac/jaclang/compiler/passes/native/primitives_native.jac
+++ b/jac/jaclang/compiler/passes/native/primitives_native.jac
@@ -2994,7 +2994,41 @@ class NativeDictEmitter(DictEmitter[(ir.Value, NativeEmitCtx)]) {
     def emit_setdefault(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
     ) -> (ir.Value | None) {
-        return None;
+        # setdefault(key, default=None): if key not in dict, set it to default; return value
+        if not args {
+            return None;
+        }
+        p = ctx.pass_ref;
+        helpers = p.dict_helpers.get(ctx.type_key);
+        if helpers is None {
+            return None;
+        }
+        b = p.builder;
+        i64 = ir.IntType(64);
+        key = args[0];
+        val_type = helpers["val_type"];
+        default_val = args[1] if len(args) >= 2 else ir.Constant(val_type, 0);
+        # Check if key exists
+        found = b.call(helpers["contains"], [target, key], name="sdef.found");
+        func = b.basic_block.function;
+        found_bb = func.append_basic_block(name="sdef.yes");
+        notfound_bb = func.append_basic_block(name="sdef.no");
+        done_bb = func.append_basic_block(name="sdef.done");
+        b.cbranch(found, found_bb, notfound_bb);
+        # Found: just get the value
+        b.position_at_start(found_bb);
+        existing = b.call(helpers["get"], [target, key], name="sdef.existing");
+        b.branch(done_bb);
+        # Not found: set default and return it
+        b.position_at_start(notfound_bb);
+        b.call(helpers["set"], [target, key, default_val]);
+        b.branch(done_bb);
+        # Merge
+        b.position_at_start(done_bb);
+        result = b.phi(val_type, name="sdef.result");
+        result.add_incoming(existing, found_bb);
+        result.add_incoming(default_val, notfound_bb);
+        return result;
     }
 
     def emit_update(
@@ -3556,32 +3590,341 @@ class NativeSetEmitter(SetEmitter[(ir.Value, NativeEmitCtx)]) {
     def emit_symmetric_difference(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
     ) -> (ir.Value | None) {
-        return None;
+        # symmetric_difference(other): elements in either set but not both
+        if not args {
+            return None;
+        }
+        p = ctx.pass_ref;
+        helpers = p.set_helpers.get(ctx.type_key);
+        if helpers is None {
+            return None;
+        }
+        b = p.builder;
+        i32 = ir.IntType(32);
+        i64 = ir.IntType(64);
+        new_set = b.call(helpers["new"], [], name="ssymd.new");
+        other = args[0];
+        # Pass 1: add elements from self that are NOT in other
+        len1_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssymd.l1.ptr"
+        );
+        e1_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssymd.e1.ptr"
+        );
+        len1 = b.load(len1_ptr, name="ssymd.len1");
+        elems1 = b.load(e1_ptr, name="ssymd.elems1");
+        func = b.basic_block.function;
+        entry1 = b.basic_block;
+        loop1 = func.append_basic_block(name="ssymd.loop1");
+        body1 = func.append_basic_block(name="ssymd.body1");
+        add1 = func.append_basic_block(name="ssymd.add1");
+        skip1 = func.append_basic_block(name="ssymd.skip1");
+        mid_bb = func.append_basic_block(name="ssymd.mid");
+        b.branch(loop1);
+        b.position_at_start(loop1);
+        i1 = b.phi(i64, name="ssymd.i1");
+        i1.add_incoming(ir.Constant(i64, 0), entry1);
+        end1 = b.icmp_unsigned(">=", i1, len1, name="ssymd.end1");
+        b.cbranch(end1, mid_bb, body1);
+        b.position_at_start(body1);
+        ep1 = b.gep(elems1, [i1], name="ssymd.ep1");
+        ev1 = b.load(ep1, name="ssymd.ev1");
+        in_other1 = b.call(helpers["contains"], [other, ev1], name="ssymd.inother1");
+        not_in1 = b.icmp_unsigned(
+            "==", in_other1, ir.Constant(ir.IntType(1), 0), name="ssymd.notin1"
+        );
+        b.cbranch(not_in1, add1, skip1);
+        b.position_at_start(add1);
+        b.call(helpers["add"], [new_set, ev1]);
+        b.branch(skip1);
+        b.position_at_start(skip1);
+        n1 = b.add(i1, ir.Constant(i64, 1), name="ssymd.n1");
+        i1.add_incoming(n1, skip1);
+        b.branch(loop1);
+        # Pass 2: add elements from other that are NOT in self
+        b.position_at_start(mid_bb);
+        len2_ptr = b.gep(
+            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssymd.l2.ptr"
+        );
+        e2_ptr = b.gep(
+            other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssymd.e2.ptr"
+        );
+        len2 = b.load(len2_ptr, name="ssymd.len2");
+        elems2 = b.load(e2_ptr, name="ssymd.elems2");
+        loop2 = func.append_basic_block(name="ssymd.loop2");
+        body2 = func.append_basic_block(name="ssymd.body2");
+        add2 = func.append_basic_block(name="ssymd.add2");
+        skip2 = func.append_basic_block(name="ssymd.skip2");
+        done_bb = func.append_basic_block(name="ssymd.done");
+        b.branch(loop2);
+        b.position_at_start(loop2);
+        i2 = b.phi(i64, name="ssymd.i2");
+        i2.add_incoming(ir.Constant(i64, 0), mid_bb);
+        end2 = b.icmp_unsigned(">=", i2, len2, name="ssymd.end2");
+        b.cbranch(end2, done_bb, body2);
+        b.position_at_start(body2);
+        ep2 = b.gep(elems2, [i2], name="ssymd.ep2");
+        ev2 = b.load(ep2, name="ssymd.ev2");
+        in_self = b.call(helpers["contains"], [target, ev2], name="ssymd.inself");
+        not_in2 = b.icmp_unsigned(
+            "==", in_self, ir.Constant(ir.IntType(1), 0), name="ssymd.notin2"
+        );
+        b.cbranch(not_in2, add2, skip2);
+        b.position_at_start(add2);
+        b.call(helpers["add"], [new_set, ev2]);
+        b.branch(skip2);
+        b.position_at_start(skip2);
+        n2 = b.add(i2, ir.Constant(i64, 1), name="ssymd.n2");
+        i2.add_incoming(n2, skip2);
+        b.branch(loop2);
+        b.position_at_start(done_bb);
+        return new_set;
     }
 
     # In-place set algebra
     def emit_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
     ) -> (ir.Value | None) {
-        return None;
+        # update(other): add all elements from other to self
+        if not args {
+            return None;
+        }
+        p = ctx.pass_ref;
+        helpers = p.set_helpers.get(ctx.type_key);
+        if helpers is None {
+            return None;
+        }
+        b = p.builder;
+        i32 = ir.IntType(32);
+        i64 = ir.IntType(64);
+        other = args[0];
+        len_ptr = b.gep(
+            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="supd.len.ptr"
+        );
+        other_len = b.load(len_ptr, name="supd.len");
+        elems_ptr = b.gep(
+            other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="supd.elems.ptr"
+        );
+        elems_arr = b.load(elems_ptr, name="supd.elems");
+        func = b.basic_block.function;
+        entry_bb = b.basic_block;
+        loop_bb = func.append_basic_block(name="supd.loop");
+        body_bb = func.append_basic_block(name="supd.body");
+        done_bb = func.append_basic_block(name="supd.done");
+        b.branch(loop_bb);
+        b.position_at_start(loop_bb);
+        idx = b.phi(i64, name="supd.idx");
+        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        at_end = b.icmp_unsigned(">=", idx, other_len, name="supd.atend");
+        b.cbranch(at_end, done_bb, body_bb);
+        b.position_at_start(body_bb);
+        ep = b.gep(elems_arr, [idx], name="supd.ep");
+        ev = b.load(ep, name="supd.ev");
+        b.call(helpers["add"], [target, ev]);
+        next_idx = b.add(idx, ir.Constant(i64, 1), name="supd.next");
+        idx.add_incoming(next_idx, body_bb);
+        b.branch(loop_bb);
+        b.position_at_start(done_bb);
+        return ir.Constant(i64, 0);
     }
 
     def emit_intersection_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
     ) -> (ir.Value | None) {
-        return None;
+        # intersection_update(other): keep only elements found in other
+        if not args {
+            return None;
+        }
+        p = ctx.pass_ref;
+        helpers = p.set_helpers.get(ctx.type_key);
+        if helpers is None {
+            return None;
+        }
+        b = p.builder;
+        i32 = ir.IntType(32);
+        i64 = ir.IntType(64);
+        elem_type = helpers["elem_type"];
+        # Build a list of elements to remove (those NOT in other)
+        len_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="siupd.len.ptr"
+        );
+        elems_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="siupd.elems.ptr"
+        );
+        other = args[0];
+        # We'll do a two-pass approach: first collect elements to keep, then rebuild
+        # Actually simpler: iterate backwards, discard elements not in other
+        set_len = b.load(len_ptr, name="siupd.len");
+        elems_arr = b.load(elems_ptr, name="siupd.elems");
+        func = b.basic_block.function;
+        # Iterate forward; compact in place
+        entry_bb = b.basic_block;
+        loop_bb = func.append_basic_block(name="siupd.loop");
+        body_bb = func.append_basic_block(name="siupd.body");
+        keep_bb = func.append_basic_block(name="siupd.keep");
+        skip_bb = func.append_basic_block(name="siupd.skip");
+        done_bb = func.append_basic_block(name="siupd.done");
+        b.branch(loop_bb);
+        b.position_at_start(loop_bb);
+        read_idx = b.phi(i64, name="siupd.ridx");
+        write_idx = b.phi(i64, name="siupd.widx");
+        read_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        write_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        at_end = b.icmp_unsigned(">=", read_idx, set_len, name="siupd.atend");
+        b.cbranch(at_end, done_bb, body_bb);
+        b.position_at_start(body_bb);
+        ep = b.gep(elems_arr, [read_idx], name="siupd.ep");
+        ev = b.load(ep, name="siupd.ev");
+        in_other = b.call(helpers["contains"], [other, ev], name="siupd.inother");
+        b.cbranch(in_other, keep_bb, skip_bb);
+        # Keep: copy element to write position
+        b.position_at_start(keep_bb);
+        wp = b.gep(elems_arr, [write_idx], name="siupd.wp");
+        b.store(ev, wp);
+        new_widx = b.add(write_idx, ir.Constant(i64, 1), name="siupd.nwidx");
+        next_ridx_k = b.add(read_idx, ir.Constant(i64, 1), name="siupd.nridx.k");
+        b.branch(loop_bb);
+        # Skip: advance read only
+        b.position_at_start(skip_bb);
+        next_ridx_s = b.add(read_idx, ir.Constant(i64, 1), name="siupd.nridx.s");
+        b.branch(loop_bb);
+        # Wire phi nodes
+        read_idx.add_incoming(next_ridx_k, keep_bb);
+        read_idx.add_incoming(next_ridx_s, skip_bb);
+        write_idx.add_incoming(new_widx, keep_bb);
+        write_idx.add_incoming(write_idx, skip_bb);
+        # Done: update length (write_idx in loop_bb has the correct final count)
+        b.position_at_start(done_bb);
+        b.store(write_idx, len_ptr);
+        return ir.Constant(i64, 0);
     }
 
     def emit_difference_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
     ) -> (ir.Value | None) {
-        return None;
+        # difference_update(other): remove all elements found in other
+        if not args {
+            return None;
+        }
+        p = ctx.pass_ref;
+        helpers = p.set_helpers.get(ctx.type_key);
+        if helpers is None {
+            return None;
+        }
+        b = p.builder;
+        i32 = ir.IntType(32);
+        i64 = ir.IntType(64);
+        len_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sdupd.len.ptr"
+        );
+        elems_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sdupd.elems.ptr"
+        );
+        other = args[0];
+        set_len = b.load(len_ptr, name="sdupd.len");
+        elems_arr = b.load(elems_ptr, name="sdupd.elems");
+        func = b.basic_block.function;
+        # Compact in place: keep elements NOT in other
+        entry_bb = b.basic_block;
+        loop_bb = func.append_basic_block(name="sdupd.loop");
+        body_bb = func.append_basic_block(name="sdupd.body");
+        keep_bb = func.append_basic_block(name="sdupd.keep");
+        skip_bb = func.append_basic_block(name="sdupd.skip");
+        done_bb = func.append_basic_block(name="sdupd.done");
+        b.branch(loop_bb);
+        b.position_at_start(loop_bb);
+        read_idx = b.phi(i64, name="sdupd.ridx");
+        write_idx = b.phi(i64, name="sdupd.widx");
+        read_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        write_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        at_end = b.icmp_unsigned(">=", read_idx, set_len, name="sdupd.atend");
+        b.cbranch(at_end, done_bb, body_bb);
+        b.position_at_start(body_bb);
+        ep = b.gep(elems_arr, [read_idx], name="sdupd.ep");
+        ev = b.load(ep, name="sdupd.ev");
+        in_other = b.call(helpers["contains"], [other, ev], name="sdupd.inother");
+        # Keep if NOT in other
+        not_in = b.icmp_unsigned(
+            "==", in_other, ir.Constant(ir.IntType(1), 0), name="sdupd.notin"
+        );
+        b.cbranch(not_in, keep_bb, skip_bb);
+        b.position_at_start(keep_bb);
+        wp = b.gep(elems_arr, [write_idx], name="sdupd.wp");
+        b.store(ev, wp);
+        new_widx = b.add(write_idx, ir.Constant(i64, 1), name="sdupd.nwidx");
+        next_ridx_k = b.add(read_idx, ir.Constant(i64, 1), name="sdupd.nridx.k");
+        b.branch(loop_bb);
+        b.position_at_start(skip_bb);
+        next_ridx_s = b.add(read_idx, ir.Constant(i64, 1), name="sdupd.nridx.s");
+        b.branch(loop_bb);
+        read_idx.add_incoming(next_ridx_k, keep_bb);
+        read_idx.add_incoming(next_ridx_s, skip_bb);
+        write_idx.add_incoming(new_widx, keep_bb);
+        write_idx.add_incoming(write_idx, skip_bb);
+        # Done: update length (write_idx in loop_bb has the correct final count)
+        b.position_at_start(done_bb);
+        b.store(write_idx, len_ptr);
+        return ir.Constant(i64, 0);
     }
 
     def emit_symmetric_difference_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
     ) -> (ir.Value | None) {
-        return None;
+        # symmetric_difference_update(other): keep only elements in either but not both
+        # Strategy: compute symmetric_difference, then replace target contents
+        if not args {
+            return None;
+        }
+        p = ctx.pass_ref;
+        helpers = p.set_helpers.get(ctx.type_key);
+        if helpers is None {
+            return None;
+        }
+        b = p.builder;
+        i32 = ir.IntType(32);
+        i64 = ir.IntType(64);
+        other = args[0];
+        # Step 1: build the symmetric difference as a new set
+        result = self.emit_symmetric_difference(ctx, target, [other]);
+        if result is None {
+            return None;
+        }
+        # Step 2: clear target
+        len_ptr = b.gep(
+            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssdupd.len.ptr"
+        );
+        b.store(ir.Constant(i64, 0), len_ptr);
+        # Step 3: add all elements from result to target
+        res_len_ptr = b.gep(
+            result, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssdupd.rlen.ptr"
+        );
+        res_elems_ptr = b.gep(
+            result,
+            [ir.Constant(i32, 0), ir.Constant(i32, 2)],
+            name="ssdupd.relems.ptr"
+        );
+        res_len = b.load(res_len_ptr, name="ssdupd.rlen");
+        res_elems = b.load(res_elems_ptr, name="ssdupd.relems");
+        func = b.basic_block.function;
+        entry_bb = b.basic_block;
+        loop_bb = func.append_basic_block(name="ssdupd.loop");
+        body_bb = func.append_basic_block(name="ssdupd.body");
+        done_bb = func.append_basic_block(name="ssdupd.done");
+        b.branch(loop_bb);
+        b.position_at_start(loop_bb);
+        idx = b.phi(i64, name="ssdupd.idx");
+        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        at_end = b.icmp_unsigned(">=", idx, res_len, name="ssdupd.atend");
+        b.cbranch(at_end, done_bb, body_bb);
+        b.position_at_start(body_bb);
+        ep = b.gep(res_elems, [idx], name="ssdupd.ep");
+        ev = b.load(ep, name="ssdupd.ev");
+        b.call(helpers["add"], [target, ev]);
+        next_idx = b.add(idx, ir.Constant(i64, 1), name="ssdupd.next");
+        idx.add_incoming(next_idx, body_bb);
+        b.branch(loop_bb);
+        b.position_at_start(done_bb);
+        return ir.Constant(i64, 0);
     }
 
     # Tests

--- a/jac/tests/compiler/passes/native/fixtures/prim_dict_setdefault.jac
+++ b/jac/tests/compiler/passes/native/fixtures/prim_dict_setdefault.jac
@@ -1,0 +1,76 @@
+"""Dict setdefault primitive.
+
+Cross-backend equivalence fixture -- Python reference + native implementation.
+"""
+
+def dict_setdefault_py() -> dict {
+    # setdefault with missing key
+    d1: dict[str, int] = {"a": 1, "b": 2};
+    sd_missing: int = d1.setdefault("c", 99);
+    sd_missing_len: int = len(d1);
+    sd_missing_c: int = d1["c"];
+
+    # setdefault with existing key
+    d2: dict[str, int] = {"x": 10, "y": 20};
+    sd_existing: int = d2.setdefault("x", 999);
+    sd_existing_len: int = len(d2);
+    sd_existing_x: int = d2["x"];
+
+    # setdefault adding multiple keys
+    d3: dict[str, int] = {};
+    d3.setdefault("a", 1);
+    d3.setdefault("b", 2);
+    d3.setdefault("a", 100);  # should not overwrite
+    sd_multi_len: int = len(d3);
+    sd_multi_a: int = d3["a"];
+    sd_multi_b: int = d3["b"];
+
+    return {
+        "sd_missing": sd_missing,
+        "sd_missing_len": sd_missing_len,
+        "sd_missing_c": sd_missing_c,
+        "sd_existing": sd_existing,
+        "sd_existing_len": sd_existing_len,
+        "sd_existing_x": sd_existing_x,
+        "sd_multi_len": sd_multi_len,
+        "sd_multi_a": sd_multi_a,
+        "sd_multi_b": sd_multi_b
+    };
+}
+
+na {
+    def dict_setdefault_na() -> dict[str, any] {
+        # setdefault with missing key
+        d1: dict[str, int] = {"a": 1, "b": 2};
+        sd_missing: int = d1.setdefault("c", 99);
+        sd_missing_len: int = len(d1);
+        sd_missing_c: int = d1["c"];
+
+        # setdefault with existing key
+        d2: dict[str, int] = {"x": 10, "y": 20};
+        sd_existing: int = d2.setdefault("x", 999);
+        sd_existing_len: int = len(d2);
+        sd_existing_x: int = d2["x"];
+
+        # setdefault adding multiple keys
+        d3: dict[str, int] = {};
+        d3.setdefault("a", 1);
+        d3.setdefault("b", 2);
+        d3.setdefault("a", 100);  # should not overwrite
+        sd_multi_len: int = len(d3);
+        sd_multi_a: int = d3["a"];
+        sd_multi_b: int = d3["b"];
+
+        return {
+            "sd_missing": sd_missing,
+            "sd_missing_len": sd_missing_len,
+            "sd_missing_c": sd_missing_c,
+            "sd_existing": sd_existing,
+            "sd_existing_len": sd_existing_len,
+            "sd_existing_x": sd_existing_x,
+            "sd_multi_len": sd_multi_len,
+            "sd_multi_a": sd_multi_a,
+            "sd_multi_b": sd_multi_b
+        };
+    }
+}

--- a/jac/tests/compiler/passes/native/fixtures/prim_set_advanced.jac
+++ b/jac/tests/compiler/passes/native/fixtures/prim_set_advanced.jac
@@ -1,0 +1,155 @@
+"""Set advanced operations: symmetric_difference, update, intersection_update,
+difference_update, symmetric_difference_update.
+
+Cross-backend equivalence fixture -- Python reference + native implementation.
+"""
+
+def set_advanced_py() -> dict {
+    # symmetric_difference
+    a: set[int] = {1, 2, 3, 4};
+    b: set[int] = {3, 4, 5, 6};
+    sd: set[int] = a.symmetric_difference(b);
+    sd_len: int = len(sd);
+    sd_has_1: int = 1 if 1 in sd else 0;
+    sd_has_3: int = 1 if 3 in sd else 0;
+    sd_has_5: int = 1 if 5 in sd else 0;
+    sd_has_6: int = 1 if 6 in sd else 0;
+
+    # update
+    c: set[int] = {10, 20};
+    d: set[int] = {20, 30, 40};
+    c.update(d);
+    upd_len: int = len(c);
+    upd_has_10: int = 1 if 10 in c else 0;
+    upd_has_30: int = 1 if 30 in c else 0;
+    upd_has_40: int = 1 if 40 in c else 0;
+
+    # intersection_update
+    e: set[int] = {1, 2, 3, 4, 5};
+    f: set[int] = {2, 4, 6};
+    e.intersection_update(f);
+    iupd_len: int = len(e);
+    iupd_has_2: int = 1 if 2 in e else 0;
+    iupd_has_4: int = 1 if 4 in e else 0;
+    iupd_has_1: int = 1 if 1 in e else 0;
+
+    # difference_update
+    g: set[int] = {1, 2, 3, 4, 5};
+    h: set[int] = {2, 4};
+    g.difference_update(h);
+    dupd_len: int = len(g);
+    dupd_has_1: int = 1 if 1 in g else 0;
+    dupd_has_2: int = 1 if 2 in g else 0;
+    dupd_has_3: int = 1 if 3 in g else 0;
+    dupd_has_5: int = 1 if 5 in g else 0;
+
+    # symmetric_difference_update
+    j: set[int] = {1, 2, 3};
+    k: set[int] = {2, 3, 4};
+    j.symmetric_difference_update(k);
+    sdupd_len: int = len(j);
+    sdupd_has_1: int = 1 if 1 in j else 0;
+    sdupd_has_2: int = 1 if 2 in j else 0;
+    sdupd_has_4: int = 1 if 4 in j else 0;
+
+    return {
+        "sd_len": sd_len,
+        "sd_has_1": sd_has_1,
+        "sd_has_3": sd_has_3,
+        "sd_has_5": sd_has_5,
+        "sd_has_6": sd_has_6,
+        "upd_len": upd_len,
+        "upd_has_10": upd_has_10,
+        "upd_has_30": upd_has_30,
+        "upd_has_40": upd_has_40,
+        "iupd_len": iupd_len,
+        "iupd_has_2": iupd_has_2,
+        "iupd_has_4": iupd_has_4,
+        "iupd_has_1": iupd_has_1,
+        "dupd_len": dupd_len,
+        "dupd_has_1": dupd_has_1,
+        "dupd_has_2": dupd_has_2,
+        "dupd_has_3": dupd_has_3,
+        "dupd_has_5": dupd_has_5,
+        "sdupd_len": sdupd_len,
+        "sdupd_has_1": sdupd_has_1,
+        "sdupd_has_2": sdupd_has_2,
+        "sdupd_has_4": sdupd_has_4
+    };
+}
+
+na {
+    def set_advanced_na() -> dict[str, any] {
+        # symmetric_difference
+        a: set[int] = {1, 2, 3, 4};
+        b: set[int] = {3, 4, 5, 6};
+        sd: set[int] = a.symmetric_difference(b);
+        sd_len: int = len(sd);
+        sd_has_1: int = 1 if 1 in sd else 0;
+        sd_has_3: int = 1 if 3 in sd else 0;
+        sd_has_5: int = 1 if 5 in sd else 0;
+        sd_has_6: int = 1 if 6 in sd else 0;
+
+        # update
+        c: set[int] = {10, 20};
+        d: set[int] = {20, 30, 40};
+        c.update(d);
+        upd_len: int = len(c);
+        upd_has_10: int = 1 if 10 in c else 0;
+        upd_has_30: int = 1 if 30 in c else 0;
+        upd_has_40: int = 1 if 40 in c else 0;
+
+        # intersection_update
+        e: set[int] = {1, 2, 3, 4, 5};
+        f: set[int] = {2, 4, 6};
+        e.intersection_update(f);
+        iupd_len: int = len(e);
+        iupd_has_2: int = 1 if 2 in e else 0;
+        iupd_has_4: int = 1 if 4 in e else 0;
+        iupd_has_1: int = 1 if 1 in e else 0;
+
+        # difference_update
+        g: set[int] = {1, 2, 3, 4, 5};
+        h: set[int] = {2, 4};
+        g.difference_update(h);
+        dupd_len: int = len(g);
+        dupd_has_1: int = 1 if 1 in g else 0;
+        dupd_has_2: int = 1 if 2 in g else 0;
+        dupd_has_3: int = 1 if 3 in g else 0;
+        dupd_has_5: int = 1 if 5 in g else 0;
+
+        # symmetric_difference_update
+        j: set[int] = {1, 2, 3};
+        k: set[int] = {2, 3, 4};
+        j.symmetric_difference_update(k);
+        sdupd_len: int = len(j);
+        sdupd_has_1: int = 1 if 1 in j else 0;
+        sdupd_has_2: int = 1 if 2 in j else 0;
+        sdupd_has_4: int = 1 if 4 in j else 0;
+
+        return {
+            "sd_len": sd_len,
+            "sd_has_1": sd_has_1,
+            "sd_has_3": sd_has_3,
+            "sd_has_5": sd_has_5,
+            "sd_has_6": sd_has_6,
+            "upd_len": upd_len,
+            "upd_has_10": upd_has_10,
+            "upd_has_30": upd_has_30,
+            "upd_has_40": upd_has_40,
+            "iupd_len": iupd_len,
+            "iupd_has_2": iupd_has_2,
+            "iupd_has_4": iupd_has_4,
+            "iupd_has_1": iupd_has_1,
+            "dupd_len": dupd_len,
+            "dupd_has_1": dupd_has_1,
+            "dupd_has_2": dupd_has_2,
+            "dupd_has_3": dupd_has_3,
+            "dupd_has_5": dupd_has_5,
+            "sdupd_len": sdupd_len,
+            "sdupd_has_1": sdupd_has_1,
+            "sdupd_has_2": sdupd_has_2,
+            "sdupd_has_4": sdupd_has_4
+        };
+    }
+}

--- a/jac/tests/compiler/passes/native/test_prim_equivalence.jac
+++ b/jac/tests/compiler/passes/native/test_prim_equivalence.jac
@@ -440,3 +440,18 @@ test "runtime: error with finally block" {
     f = get_func(eng, "test_runtime_finally_na", ctypes.c_int64);
     assert f() == 11;
 }
+
+# --- New primitive equivalence tests ---
+test "set advanced operations match across backends" {
+    py_result = run_py_fixture("prim_set_advanced", "set_advanced_py");
+    (eng, _) = compile_native("prim_set_advanced.jac");
+    na_result = run_native_function(eng, "set_advanced_na");
+    compare_results(py_result, na_result, "set_advanced");
+}
+
+test "dict setdefault matches across backends" {
+    py_result = run_py_fixture("prim_dict_setdefault", "dict_setdefault_py");
+    (eng, _) = compile_native("prim_dict_setdefault.jac");
+    na_result = run_native_function(eng, "dict_setdefault_na");
+    compare_results(py_result, na_result, "dict_setdefault");
+}


### PR DESCRIPTION
## Summary
- Implement 6 new LLVM emitters for native codegen: `set.symmetric_difference`, `set.update`, `set.intersection_update`, `set.difference_update`, `set.symmetric_difference_update`, and `dict.setdefault`
- Add cross-backend equivalence test fixtures (`prim_set_advanced.jac`, `prim_dict_setdefault.jac`) and tests
- Native primitive coverage: SetEmitter 45%→61%, DictEmitter 75%→81%, overall 47%→49% impl / 45%→47% tested

## Test plan
- [x] All 48 prim equivalence tests pass (`test_prim_equivalence.jac`)
- [x] All 222 native gen pass tests pass (`test_native_gen_pass.jac`)
- [ ] CI passes