### PR TITLE
Fix formatter orphaning comments inside na {} blocks

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -6,6 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - 2 small refactors/changes.
 - **Type System Improvement**: Fixed type narrowing not working correctly inside while loops, for loops with break/continue, and loop else blocks.
+- **Fix: Formatter Comment Injection for `na {}` Blocks**: Fixed a bug where `jac format` would orphan comments inside `na {}` (native) blocks, dumping them at the end of the file.
 - **Native Primitives: Set Algebra & Dict `setdefault`**: Implemented 6 new native LLVM emitters -- `set.symmetric_difference`, `set.update`, `set.intersection_update`, `set.difference_update`, `set.symmetric_difference_update`, and `dict.setdefault`. Native primitive coverage rises from 47% → 49% implemented (147/299) and 45% → 47% tested (140/299), with SetEmitter at 61% and DictEmitter at 81%.
 
 ## jaclang 0.11.3 (Latest Release)

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.jac
@@ -124,6 +124,7 @@ obj DocIRGenPass(UniPass) {
     def exit_global_vars(nd: uni.GlobalVars) -> None;
     def exit_client_block(nd: uni.ClientBlock) -> None;
     def exit_server_block(nd: uni.ServerBlock) -> None;
+    def exit_native_block(nd: uni.NativeBlock) -> None;
     def exit_module_code(nd: uni.ModuleCode) -> None;
     def exit_global_stmt(nd: uni.GlobalStmt) -> None;
     def exit_non_local_stmt(nd: uni.NonLocalStmt) -> None;

--- a/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
@@ -890,6 +890,42 @@ impl DocIRGenPass.exit_server_block(nd: uni.ServerBlock) -> None {
     nd.gen.doc_ir = self.group(self.concat(parts, ast_node=nd), ast_node=nd);
 }
 
+"""Generate DocIR for native blocks (na { ... })."""
+impl DocIRGenPass.exit_native_block(nd: uni.NativeBlock) -> None {
+    parts: list[doc.DocType] = [];
+    body_parts: list[doc.DocType] = [];
+    in_body = False;
+    prev_body_item: (uni.UniNode | None) = None;
+    for i in nd.kid {
+        if (isinstance(i, uni.Token) and (i.name == Tok.KW_NATIVE)) {
+            parts.append(i.gen.doc_ir);
+            parts.append(self.space());
+        } elif (isinstance(i, uni.Token) and (i.name == Tok.LBRACE)) {
+            parts.append(i.gen.doc_ir);
+            body_parts.append(self.hard_line());
+            in_body = True;
+        } elif (isinstance(i, uni.Token) and (i.name == Tok.RBRACE)) {
+            in_body = False;
+            self.trim_trailing_line(body_parts);
+            parts.append(self.indent(self.concat(body_parts), ast_node=nd));
+            if len(body_parts) {
+                parts.append(self.hard_line());
+            } else {
+                parts.append(self.line());
+            }
+            parts.append(i.gen.doc_ir);
+            parts.append(self.space());
+        } elif in_body {
+            self.add_body_stmt_with_spacing(body_parts, i, prev_body_item);
+            prev_body_item = i;
+        } else {
+            parts.append(i.gen.doc_ir);
+            parts.append(self.space());
+        }
+    }
+    nd.gen.doc_ir = self.group(self.concat(parts, ast_node=nd), ast_node=nd);
+}
+
 """Generate DocIR for global variables."""
 impl DocIRGenPass.exit_global_vars(nd: uni.GlobalVars) -> None {
     prefix_parts: list[doc.DocType] = [];

--- a/jac/tests/compiler/passes/tool/fixtures/native_block_comment.jac
+++ b/jac/tests/compiler/passes/tool/fixtures/native_block_comment.jac
@@ -1,0 +1,13 @@
+"""Test fixture: comments inside na {} blocks must be preserved in place."""
+
+na {
+    # Comment inside native block
+    def add(a: int, b: int) -> int {
+        return a + b;
+    }
+
+    # Another comment
+    def mul(a: int, b: int) -> int {
+        return a * b;
+    }
+}

--- a/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
@@ -240,6 +240,52 @@ test "unicode encoding write roundtrip" {
     }
 }
 
+test "native block comments stay in place" {
+    path = os.path.join(FIXTURES, "native_block_comment.jac");
+    prog = JacProgram.jac_file_formatter(path);
+    formatted = prog.mod.main.gen.jac;
+    lines = formatted.splitlines();
+
+    # Comments must appear between "na {" and its closing "}", not at end of file
+    na_start = next(
+        (
+            i
+            for (i, ln) in enumerate(lines)
+            if ln.strip().startswith("na {")
+        ),
+        None
+    );
+    assert na_start is not None , "na { not found in formatted output";
+    # Find the matching closing brace at the same or lesser indentation
+    na_indent = len(lines[na_start]) - len(lines[na_start].lstrip());
+    na_end: int | None = None;
+    for i in range(len(lines) - 1, na_start, -1) {
+        if lines[i].strip() == "}"
+        and (len(lines[i]) - len(lines[i].lstrip())) <= na_indent {
+            na_end = i;
+            break;
+        }
+    }
+    assert na_end is not None , "closing } for na block not found in formatted output";
+    comment_lines = [
+        i
+        for (i, ln) in enumerate(lines)
+        if "# Comment inside native block" in ln or "# Another comment" in ln
+    ];
+    assert len(comment_lines) == 2 , f"Expected 2 comments, found {len(comment_lines)}";
+    for cl in comment_lines {
+        assert na_start < cl < na_end , (
+            f"Comment at line {cl + 1} is outside the na block "
+            f"(na: {na_start + 1}-{na_end + 1}):\n" + formatted
+        );
+    }
+
+    # Idempotency
+    prog2 = JacProgram.jac_file_formatter(path);
+    formatted2 = prog2.mod.main.gen.jac;
+    assert formatted == formatted2 , "Formatting of na {} block is not idempotent";
+}
+
 """Regression: jac_str_formatter must populate errors_had on syntax error
 so that the LSP returns the original source instead of an empty string."""
 test "syntax error preserves original source" {


### PR DESCRIPTION
## Summary

- Fixed a bug where `jac format` would orphan comments inside `na {}` (native) blocks, dumping them at the end of the formatted file
- Root cause: `DocIRGenPass` was missing an `exit_native_block` handler, so native blocks had no DocIR representation and the comment injection pass treated their comments as unattached leftovers
- Added `exit_native_block` to `DocIRGenPass` following the same pattern as `exit_server_block` / `exit_client_block`

## Test plan

- [x] Added regression test `"native block comments stay in place"` that verifies comments remain inside the `na {}` block after formatting and checks idempotency
- [x] All 443 formatter tests pass