### PR TITLE
Fix segfault due to assign a null ptr to dict when an empty value is used

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -7,6 +7,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - 3 small refactors/changes.
 - **Type System Improvement**: Fixed type narrowing not working correctly inside while loops, for loops with break/continue, and loop else blocks.
 - **Fix: Formatter Comment Injection for `na {}` Blocks**: Fixed a bug where `jac format` would orphan comments inside `na {}` (native) blocks, dumping them at the end of the file.
+- **Fix: Native Empty Dict/List `{}` in Struct Constructor Null Pointer**: Passing an empty dict or list literal as a keyword argument in a struct constructor (e.g. `Container(d={})`) no longer stores a null pointer in the field. The compiler now falls back to `helpers["new"]()` when `_codegen_dict_val`/`_codegen_list_val` returns `None` for an empty literal, matching the existing fix for global variable initializers.
 - **Native Primitives: Set Algebra & Dict `setdefault`**: Implemented 6 new native LLVM emitters -- `set.symmetric_difference`, `set.update`, `set.intersection_update`, `set.difference_update`, `set.symmetric_difference_update`, and `dict.setdefault`. Native primitive coverage rises from 47% → 49% implemented (147/299) and 45% → 47% tested (140/299), with SetEmitter at 61% and DictEmitter at 81%.
 
 ## jaclang 0.11.3 (Latest Release)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -476,7 +476,41 @@ impl NaIRGenPass._codegen_instantiation(nd: uni.FuncCall) -> (ir.Value | None) {
             }
             val = self._codegen_expr(param.value);
             if val is None {
-                continue;
+                # Empty dict/list literal returns None from _codegen_dict_val /
+                # _codegen_list_val.  Fall back to calling helpers["new"] for
+                # the field's concrete dict or list type.
+                ftype_probe = field_types.get(key_name);
+                if ftype_probe is not None and isinstance(ftype_probe, ir.PointerType) {
+                    for (dict_key, dtype) in self.dict_types.items() {
+                        if ftype_probe == dtype.as_pointer() {
+                            helpers = self.dict_helpers.get(dict_key);
+                            if helpers is not None {
+                                val = self.builder.call(
+                                    helpers["new"], [], name=f"dict.ctor.{key_name}"
+                                );
+                            }
+                            break;
+                        }
+                    }
+                    if val is None {
+                        for (elem_key, ltype) in self.list_types.items() {
+                            if ftype_probe == ltype.as_pointer() {
+                                helpers = self.list_helpers.get(elem_key);
+                                if helpers is not None {
+                                    val = self.builder.call(
+                                        helpers["new"],
+                                        [],
+                                        name=f"list.ctor.{key_name}"
+                                    );
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+                if val is None {
+                    continue;
+                }
             }
             idx = field_indices[key_name];
             ftype = field_types[key_name];
@@ -498,6 +532,37 @@ impl NaIRGenPass._codegen_instantiation(nd: uni.FuncCall) -> (ir.Value | None) {
     for (fname, default_expr) in field_defaults.items() {
         if fname not in set_fields {
             val = self._codegen_expr(default_expr);
+            # Empty dict/list default returns None — fall back to helpers["new"].
+            if val is None {
+                ftype_probe = field_types.get(fname);
+                if ftype_probe is not None
+                and isinstance(ftype_probe, ir.PointerType) {
+                    for (dict_key, dtype) in self.dict_types.items() {
+                        if ftype_probe == dtype.as_pointer() {
+                            helpers = self.dict_helpers.get(dict_key);
+                            if helpers is not None {
+                                val = self.builder.call(
+                                    helpers["new"], [], name=f"dict.dflt.{fname}"
+                                );
+                            }
+                            break;
+                        }
+                    }
+                    if val is None {
+                        for (elem_key, ltype) in self.list_types.items() {
+                            if ftype_probe == ltype.as_pointer() {
+                                helpers = self.list_helpers.get(elem_key);
+                                if helpers is not None {
+                                    val = self.builder.call(
+                                        helpers["new"], [], name=f"list.dflt.{fname}"
+                                    );
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
             if val is not None {
                 idx = field_indices[fname];
                 ftype = field_types[fname];

--- a/jac/tests/compiler/passes/native/fixtures/objects.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/objects.na.jac
@@ -162,3 +162,18 @@ def test_init_side_effects() -> int {
     }
     return 0;
 }
+
+# ── empty dict {} passed as struct constructor keyword arg ──
+obj DictFieldHolder {
+    has entries: dict[int, int];
+}
+
+"""empty dict {} in struct ctor — field must be a live dict, not a null pointer."""
+def test_empty_dict_ctor_field() -> int {
+    # This used to segfault: entries was zero-initialised to null instead of
+    # calling __dict_new_i64_i64().
+    c: DictFieldHolder = DictFieldHolder(entries={});
+    c.entries[1] = 10;
+    c.entries[2] = 20;
+    return c.entries[1] + c.entries[2];
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -366,6 +366,13 @@ test "objects init side effects" {
     assert f() == 1;
 }
 
+test "objects empty dict in struct ctor" {
+    # Container(entries={}) used to store null → segfault on first dict access.
+    (eng, _) = compile_native("objects.na.jac");
+    f = get_func(eng, "test_empty_dict_ctor_field", ctypes.c_int64);
+    assert f() == 30;
+}
+
 # --- TestNativeInheritance ---
 test "inheritance dog speak" {
     (eng, _) = compile_native("inheritance.na.jac");


### PR DESCRIPTION
When an empty dict literal {} is passed as a keyword argument inside a struct constructor call (e.g. Container(d={})), the compiler's _codegen_instantiationzero-initialises the struct field to a null dict pointer instead of calling_dict_new(). Any subsequent access to the field (set, get, in) dereferences the null pointer and causes a segmentation fault at runtime.  A non-empty literal (e.g. {0: sentinel}) works correctly because the dict-set codepath is triggered, which implicitly calls _dict_new` before the first insert.