### PR TITLE
Chore: Remove redundant path filters from pull_request trigger in docs-validation workflow

### DIFF
--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -4,17 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'docs/**/*.md'
-      - 'docs/scripts/validate_docs_code.jac'
-      - '.github/workflows/docs-validation.yml'
-      - 'jac/jaclang/**'
-      - 'jac-scale/jac_scale/**'
-      - 'jac-client/jac_client/**'
-      - 'jac-byllm/byllm/**'
-      - 'jac-super/jac_super/**'
-      - 'docs/docs/community/release_notes/**'
-      - '!**/tests/**'
   push:
     branches:
       - main


### PR DESCRIPTION
#### Removed the paths filter from the pull_request trigger. The filter was redundant since check-release-notes.sh already handles its own diff logic internally. Now the workflow runs on all PRs to main.