### PR TITLE
Refactor: Replace AstNode with UniNode in LSP

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,7 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.11.4 (Unreleased)
 
-- 17 small refactors/changes.
+- 19 small refactors/changes.
 - **Fix: Type Checker Validates Args Against Parameterless `init`**: The type checker now correctly reports an error when arguments are passed to a constructor whose `init` takes no parameters. Named args raise `Named argument does not match any parameter` and extra positional args raise `Too many positional arguments`. Calling with no args (`MyObj()`) remains valid.
 - **Automatic Port Fallback for `jac start`**: When starting the built-in HTTP server, if the specified port is already in use, the server now automatically finds and uses the next available port instead of crashing with "Address already in use". A warning message displays when using an alternative port. The `on_ready` callback signature updated to `Callable[[int], None]` to pass the actual bound port.
 - 9 small refactors/changes.

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -72,7 +72,7 @@ obj JacLangServer(JacProgram, LanguageServer) {
     def _do_type_check(file_uri: str) -> None;
     def get_token_at_position(
         file_path: str, position: lspt.Position
-    ) -> Optional[uni.AstNode];
+    ) -> Optional[uni.UniNode];
 
     def debug(msg: str) -> None;
     def wait_till_idle_sync(file_uri: str) -> None;
@@ -80,13 +80,13 @@ obj JacLangServer(JacProgram, LanguageServer) {
         file_uri: str, position: lspt.Position, completion_trigger: Optional[str]
     ) -> lspt.CompletionList;
 
-    def get_ast_of_file(file_path: str) -> Optional[uni.AstNode];
+    def get_ast_of_file(file_path: str) -> Optional[uni.UniNode];
     def get_node_at_position(
         file_path: str, line: int, col: int
-    ) -> Optional[uni.AstNode];
+    ) -> Optional[uni.UniNode];
 
-    def get_completion_of_node(nd: uni.AstNode) -> lspt.CompletionList;
-    def get_node_type(n: uni.AstNode) -> Optional[TypeBase];
+    def get_completion_of_node(nd: uni.UniNode) -> lspt.CompletionList;
+    def get_node_type(n: uni.UniNode) -> Optional[TypeBase];
     def get_completion_items_of(ty: TypeBase | uni.UniScopeNode) -> lspt.CompletionList;
     def rename_module(old_path: str, new_path: str) -> None;
     def close_module(uri: str) -> None;

--- a/jac/jaclang/langserve/impl/engine.impl.jac
+++ b/jac/jaclang/langserve/impl/engine.impl.jac
@@ -502,7 +502,7 @@ impl JacLangServer.get_completion_items_of(
 }
 
 """Return the type of an AST node if it has one."""
-impl JacLangServer.get_node_type(n: uni.AstNode) -> Optional[TypeBase] {
+impl JacLangServer.get_node_type(n: uni.UniNode) -> Optional[TypeBase] {
     if isinstance(n, uni.Expr) {
         typ = self.get_type_evaluator().get_type_of_expression(n);
         self.debug("found type " + str(typ) + " for expr " + str(n));
@@ -512,7 +512,7 @@ impl JacLangServer.get_node_type(n: uni.AstNode) -> Optional[TypeBase] {
     return None;
 }
 
-impl JacLangServer.get_completion_of_node(nd: uni.AstNode) -> lspt.CompletionList {
+impl JacLangServer.get_completion_of_node(nd: uni.UniNode) -> lspt.CompletionList {
     if (node_type := self.get_node_type(nd)) {
         self.debug("found type " + str(node_type));
         return self.get_completion_items_of(node_type);
@@ -526,7 +526,7 @@ impl JacLangServer.get_completion_of_node(nd: uni.AstNode) -> lspt.CompletionLis
 
 impl JacLangServer.get_node_at_position(
     file_path: str, line: int, col: int
-) -> Optional[uni.AstNode] {
+) -> Optional[uni.UniNode] {
     if (ast := self.get_ast_of_file(file_path)) {
         for ast_node in ast._in_mod_nodes {
             if not isinstance(ast_node, uni.Token) {
@@ -540,7 +540,7 @@ impl JacLangServer.get_node_at_position(
     return None;
 }
 
-impl JacLangServer.get_ast_of_file(file_path: str) -> Optional[uni.AstNode] {
+impl JacLangServer.get_ast_of_file(file_path: str) -> Optional[uni.UniNode] {
     with self._state_lock.read_lock() {
         if file_path in self.mod.hub {
             return self.mod.hub[file_path];
@@ -636,7 +636,7 @@ impl JacLangServer.debug(msg: str) -> None {
 
 impl JacLangServer.get_token_at_position(
     file_path: str, position: lspt.Position
-) -> Optional[uni.AstNode] {
+) -> Optional[uni.UniNode] {
     fs_path = uris.to_fs_path(file_path);
     with self._state_lock.read_lock() {
         if fs_path not in self.mod.hub {


### PR DESCRIPTION
`AstNode` was renamed to `UniNode` in `unitree.jac`, but the LSP layer was not updated accordingly.

This PR updates the following files to use `uni.UniNode` consistently:

- `langserve/engine.jac`
- `langserve/impl/engine.impl.jac`