### PR TITLE
Fix an issue related to using an imported struct as a function parameter

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -16,6 +16,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Native `for k in dict[K,V]` Loop Body Elided**: Fixed `for k in d` over a dict function parameter emitting no loop IR - the dict/set parameter type was never registered in `var_dict_type`, causing `_codegen_for` to silently skip the body.
 - **Native Codegen: `del d[k]` and `d.remove(key)` for Dicts**: `del d[key]` and `d.remove(key)` now correctly remove entries from native dicts. Previously both operations were silently dropped, leaving the dict unchanged. Works for both `dict[int, int]` and object-value dicts (`dict[int, T]`).
 - **Fix: Native Cross-Module Struct Type Resolution**: Importing a user-defined `obj` from another `.na.jac` module and using it as a function parameter type no longer crashes the compiler. The importing module now walks the imported module's AST to fully register imported archetypes (struct layout, field types, field indices), and interop binding type strings resolve against both primitive types and struct types.
+- **Fix: Native Locally-Defined Function with Imported Struct Parameter**: Minor fixes related to importing struct used as a function parameter.
 
 ## jaclang 0.11.3 (Latest Release)
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -226,25 +226,154 @@ impl NaIRGenPass._register_imported_struct_types -> None {
             continue;
         }
         processed_modules.add(resolved_path);
-        # Look up the imported module in the hub
+        # Look up the imported module in the hub.
+        # NOTE: .na.jac files skip the type-checking passes that would normally
+        # populate the hub (TypeEvaluator._import_module_from_path only runs
+        # during type-checking).  If the imported module is absent, compile it
+        # on-demand (parse + symtab only, no codegen) and cache it in the hub.
+        if not (resolved_path in self.prog.mod.hub) {
+            try {
+                imported_mod_tmp = self.prog.compile(
+                    resolved_path, no_cgen=True, type_check=False, symtab_ir_only=True
+                );
+                self.prog.mod.hub[resolved_path] = imported_mod_tmp;
+            } except Exception {
+                continue;
+            }
+        }
         if not (resolved_path in self.prog.mod.hub) {
             continue;
         }
         imported_mod = self.prog.mod.hub[resolved_path];
-        # Walk the imported module for archetype definitions
+        # Walk the imported module for archetype definitions AND free functions.
         for imp_stmt in imported_mod.body {
             if isinstance(imp_stmt, uni.NativeBlock) {
                 for inner in imp_stmt.body {
                     if isinstance(inner, uni.Archetype) {
                         self._register_imported_archetype(inner);
+                        # Forward-declare methods so calls like obj.is_foo() resolve.
+                        _aname = inner.name.value if inner.name else None;
+                        if _aname is not None and inner.body is not None {
+                            for _m in inner.body {
+                                if (
+                                    isinstance(_m, uni.Ability)
+                                    and _m.signature is not None
+                                    and isinstance(_m.signature, uni.FuncSignature)
+                                ) {
+                                    self._forward_declare_method(_aname, _m);
+                                }
+                            }
+                        }
+                        # Ensure the module is linked at JIT time.
+                        import from jaclang.jac0core.codeinfo {
+                            InteropBinding,
+                            InteropContext
+                        }
+                        _link_key = f"__link__{resolved_path}";
+                        _manifest = self.ir_in.gen.interop_manifest;
+                        if _link_key not in _manifest.bindings {
+                            _manifest.bindings[_link_key] = InteropBinding(
+                                name=_link_key,
+                                source_context=InteropContext.NATIVE,
+                                callers={InteropContext.NATIVE},
+                                source_module=resolved_path
+                            );
+                        }
+                    } elif isinstance(inner, uni.Enum) {
+                        # Register imported enum member values so struct
+                        # construction keyword initializers (e.g. Foo(tag=MyEnum.Val))
+                        # emit the correct integer instead of 0.
+                        self._codegen_enum(inner);
+                    } elif (
+                        isinstance(inner, uni.Ability)
+                        and isinstance(inner, uni.ContextAwareNode)
+                        and inner.code_context == CodeContext.NATIVE
+                        and inner.signature is not None
+                        and isinstance(inner.signature, uni.FuncSignature)
+                    ) {
+                        # Forward-declare imported free functions so calls from
+                        # locally-defined functions can resolve them in func_symtab.
+                        self._maybe_declare_ability(inner);
+                        # Register a cross-module binding so NativeCompilePass
+                        # knows to link this imported module at JIT time.
+                        # (InteropAnalysisPass misses calls in `with entry {}` because
+                        # in_native_context() doesn't walk through ModuleCode.)
+                        import from jaclang.jac0core.codeinfo {
+                            InteropBinding,
+                            InteropContext
+                        }
+                        _fn_name = inner.name_ref.sym_name if inner.name_ref else None;
+                        if _fn_name is not None {
+                            _manifest = self.ir_in.gen.interop_manifest;
+                            if _fn_name not in _manifest.bindings {
+                                _manifest.bindings[_fn_name] = InteropBinding(
+                                    name=_fn_name,
+                                    source_context=InteropContext.NATIVE,
+                                    callers={InteropContext.NATIVE},
+                                    source_module=resolved_path
+                                );
+                            }
+                        }
                     }
                 }
+            } elif isinstance(imp_stmt, uni.Enum) {
+                # Top-level imported enum — same treatment as inside NativeBlock.
+                self._codegen_enum(imp_stmt);
             } elif isinstance(imp_stmt, uni.Archetype) {
                 if (
                     isinstance(imp_stmt, uni.ContextAwareNode)
                     and imp_stmt.code_context == CodeContext.NATIVE
                 ) {
                     self._register_imported_archetype(imp_stmt);
+                    # Forward-declare methods so calls like obj.is_foo() resolve.
+                    _aname = imp_stmt.name.value if imp_stmt.name else None;
+                    if _aname is not None and imp_stmt.body is not None {
+                        for _m in imp_stmt.body {
+                            if (
+                                isinstance(_m, uni.Ability)
+                                and _m.signature is not None
+                                and isinstance(_m.signature, uni.FuncSignature)
+                            ) {
+                                self._forward_declare_method(_aname, _m);
+                            }
+                        }
+                    }
+                    # Ensure the module is linked at JIT time.
+                    import from jaclang.jac0core.codeinfo {
+                        InteropBinding,
+                        InteropContext
+                    }
+                    _link_key = f"__link__{resolved_path}";
+                    _manifest = self.ir_in.gen.interop_manifest;
+                    if _link_key not in _manifest.bindings {
+                        _manifest.bindings[_link_key] = InteropBinding(
+                            name=_link_key,
+                            source_context=InteropContext.NATIVE,
+                            callers={InteropContext.NATIVE},
+                            source_module=resolved_path
+                        );
+                    }
+                }
+            } elif (
+                isinstance(imp_stmt, uni.Ability)
+                and isinstance(imp_stmt, uni.ContextAwareNode)
+                and imp_stmt.code_context == CodeContext.NATIVE
+                and imp_stmt.signature is not None
+                and isinstance(imp_stmt.signature, uni.FuncSignature)
+            ) {
+                self._maybe_declare_ability(imp_stmt);
+                import from jaclang.jac0core.codeinfo { InteropBinding, InteropContext }
+                _fn_name = imp_stmt.name_ref.sym_name if imp_stmt.name_ref else None;
+                if _fn_name is not None {
+                    _manifest = self.ir_in.gen.interop_manifest;
+                    if _fn_name not in _manifest.bindings {
+                        _manifest.bindings[_fn_name] = InteropBinding(
+                            name=_fn_name,
+                            source_context=InteropContext.NATIVE,
+                            callers={InteropContext.NATIVE},
+                            source_module=resolved_path
+                        );
+                    }
                 }
             }
         }

--- a/jac/tests/compiler/passes/native/fixtures/na_local_fn_imported_struct.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/na_local_fn_imported_struct.na.jac
@@ -1,0 +1,15 @@
+import from na_struct_export { Point, make_point }
+
+def local_get_x(p: Point) -> int {
+    return p.x;
+}
+
+def local_sum(p: Point) -> int {
+    return p.x + p.y;
+}
+
+with entry {
+    pt: Point = make_point(3, 4);
+    x_val: int = local_get_x(pt);
+    print("x =", x_val);
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -1484,6 +1484,57 @@ test "cross module struct execution" {
     assert result2 == 7 , f"Expected 7, got {result2}";
 }
 
+# --- TestLocalFnImportedStruct ---
+test "local fn imported struct compiles" {
+    # A locally-defined function whose parameter type comes from an imported
+    # .na.jac module must compile without errors.
+    prog = JacProgram();
+    ir = prog.compile(str(os.path.join(FIXTURES, "na_local_fn_imported_struct.na.jac")));
+    assert not prog.errors_had , f"Errors: {prog.errors_had}";
+    assert ir is not None;
+    assert ir.gen.native_engine is not None , "No native engine produced";
+}
+
+test "local fn imported struct field access" {
+    # local_get_x(p) is defined in the importing module with p: Point (imported).
+    # Before the fix the call site emitted i64 0 and returned 0; now it must
+    # return the actual x field value.
+    prog = JacProgram();
+    ir = prog.compile(str(os.path.join(FIXTURES, "na_local_fn_imported_struct.na.jac")));
+    assert not prog.errors_had , f"Compilation errors: {prog.errors_had}";
+    eng = ir.gen.native_engine;
+    assert eng is not None;
+    local_get_x = get_func(eng, "local_get_x", ctypes.c_int64, ctypes.c_int64);
+    make_point_addr = eng.get_function_address("make_point");
+    assert make_point_addr != 0 , "make_point not linked";
+    make_point_fn = ctypes.CFUNCTYPE(ctypes.c_int64, ctypes.c_int64, ctypes.c_int64)(
+        make_point_addr
+    );
+    pt = make_point_fn(3, 4);
+    assert local_get_x(pt) == 3 , f"Expected 3, got {local_get_x(pt)}";
+    pt2 = make_point_fn(7, 9);
+    assert local_get_x(pt2) == 7 , f"Expected 7, got {local_get_x(pt2)}";
+}
+
+test "local fn imported struct multiple field access" {
+    # local_sum(p) accesses both x and y to exercise multiple imported fields.
+    prog = JacProgram();
+    ir = prog.compile(str(os.path.join(FIXTURES, "na_local_fn_imported_struct.na.jac")));
+    assert not prog.errors_had , f"Compilation errors: {prog.errors_had}";
+    eng = ir.gen.native_engine;
+    assert eng is not None;
+    local_sum = get_func(eng, "local_sum", ctypes.c_int64, ctypes.c_int64);
+    make_point_addr = eng.get_function_address("make_point");
+    assert make_point_addr != 0 , "make_point not linked";
+    make_point_fn = ctypes.CFUNCTYPE(ctypes.c_int64, ctypes.c_int64, ctypes.c_int64)(
+        make_point_addr
+    );
+    pt = make_point_fn(3, 4);
+    assert local_sum(pt) == 7 , f"Expected 7, got {local_sum(pt)}";
+    pt2 = make_point_fn(10, 5);
+    assert local_sum(pt2) == 15 , f"Expected 15, got {local_sum(pt2)}";
+}
+
 # --- TestNativeCacheMarker ---
 test "cache marker non native file caches empty llvmir" {
     # Compiling a file without na blocks stores '' for llvm_ir in cache.


### PR DESCRIPTION
Bug Summary:
    PARTIAL FIX: #4912 (Fix native cross-module struct type resolution, Mar 2026)
    fixed the case where a function defined in the *exporting* module is called
    from the *importing* module. The original crash (list index out of range) is
    gone for that scenario.

    REMAINING BUG: When a function is defined *locally* in the importing module
    with a parameter whose type is a `obj` imported from another `.na.jac` module,
    two sub-bugs remain:
      1. Call site emits `call i64 @"fn"(i64 0)` — the struct argument is passed
         as literal 0 instead of the actual value.
      2. Inside the function, field accesses on the imported struct parameter
         return 0 (all fields read as zero).

    The fix in #4912 registers imported struct layouts so imported function calls
    link correctly, but does NOT register them for locally-defined function
    signatures in the importing module. `_coerce_type` for the call-site arg still
    resolves the struct to `i64 0`.
