### PR TITLE
add PyPI version validation before release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -99,11 +99,20 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tomlkit==0.14.0
+        run: pip install tomlkit==0.14.0
 
-      - name: Run release script
+      - name: Validate versions against PyPI
+        run: |
+          python scripts/validate_release.py \
+            --jaclang "${{ inputs.jaclang }}" \
+            --jac-byllm "${{ inputs.jac-byllm }}" \
+            --jac-client "${{ inputs.jac-client }}" \
+            --jac-scale "${{ inputs.jac-scale }}" \
+            --jac-super "${{ inputs.jac-super }}" \
+            --jac-mcp "${{ inputs.jac-mcp }}" \
+            --jaseci "${{ inputs.jaseci }}"
+
+      - name: Bump versions
         id: release
         run: |
           python scripts/release.py \

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -1,0 +1,78 @@
+"""Pre-release validation to catch version conflicts early.
+
+Runs during the create-release-pr workflow BEFORE bumping versions.
+Computes what the new versions would be and checks PyPI to ensure
+they don't already exist. Fails fast to prevent wasted PR creation
+if a version was already published.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import tomlkit
+from release_utils import PACKAGES, bump_version, check_pypi
+
+
+def get_current_version(repo_root: Path, pkg_dir: str) -> str:
+    """Read the current version from a package's pyproject.toml."""
+    pyproject = repo_root / pkg_dir / "pyproject.toml"
+    data = tomlkit.loads(pyproject.read_text())
+    return str(data["project"]["version"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    for pkg_name in PACKAGES:
+        parser.add_argument(
+            f"--{pkg_name}", choices=["skip", "patch", "minor", "major"], default="skip"
+        )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    releases: list[dict[str, str]] = []
+    errors: list[str] = []
+
+    for pkg_name, pkg_info in PACKAGES.items():
+        bump_type = getattr(args, pkg_name.replace("-", "_"))
+        if bump_type == "skip":
+            continue
+
+        current = get_current_version(repo_root, pkg_info.dir)
+        new_version = bump_version(current, bump_type)
+
+        print(f"Checking {pkg_info.pypi} {new_version}...")
+        if check_pypi(pkg_info.pypi, new_version):
+            errors.append(f"{pkg_info.pypi} {new_version} already exists on PyPI")
+        else:
+            releases.append(
+                {
+                    "name": pkg_name,
+                    "pypi": pkg_info.pypi,
+                    "current": current,
+                    "new": new_version,
+                    "bump": bump_type,
+                }
+            )
+
+    if errors:
+        print("\nValidation failed:")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    if not releases:
+        print("No packages selected for release")
+        return 1
+
+    print("\nValidation passed:")
+    for r in releases:
+        print(f"  - {r['pypi']}: {r['current']} -> {r['new']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `validate_release.py` script to check if versions already exist on PyPI
- Run validation BEFORE bumping versions in the workflow
- Fails fast with clear error if a version conflict is detected
