### PR TITLE
add publish-release workflow with OIDC authentication

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,377 @@
+name: Publish Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  # ============================================================================
+  # Parse release info from merged PR
+  # ============================================================================
+  parse-release:
+    if: |
+      github.repository == 'Jaseci-Labs/jaseci' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      has_releases: ${{ steps.parse.outputs.has_releases }}
+      matrix: ${{ steps.parse.outputs.matrix }}
+      release_summary: ${{ steps.parse.outputs.release_summary }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Parse release info
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          python scripts/parse_release.py --pr-title "$PR_TITLE"
+
+  # ============================================================================
+  # Approval gate - ONE click to approve all publishing
+  # ============================================================================
+  approve-release:
+    needs: parse-release
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    timeout-minutes: 60
+    steps:
+      - name: Approval granted
+        env:
+          SUMMARY: ${{ needs.parse-release.outputs.release_summary }}
+        run: |
+          echo "Release approved: $SUMMARY"
+          echo "Proceeding with publish..."
+
+  # ============================================================================
+  # Build packages (all tiers in parallel, publish enforces order)
+  # ============================================================================
+  build:
+    needs: [parse-release, approve-release]
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parse-release.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: ${{ matrix.submodules }}
+
+      - name: Build package
+        uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.13.0
+        with:
+          path: ${{ matrix.dir }}
+          attest-build-provenance-github: "true"
+          upload-name-suffix: -${{ matrix.pypi }}
+
+  # ============================================================================
+  # Publish Tier 1: jaclang (base package)
+  # ============================================================================
+  publish-tier1:
+    needs: [parse-release, build]
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parse-release.outputs.matrix) }}
+    steps:
+      - name: Check if tier 1
+        id: check
+        run: |
+          if [[ "${{ matrix.tier }}" != "1" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download package
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: Packages-${{ matrix.pypi }}
+          path: dist
+
+      - name: Publish to PyPI
+        if: steps.check.outputs.skip != 'true'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.15.0
+        with:
+          attestations: true
+
+  wait-tier1:
+    needs: [parse-release, publish-tier1]
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Wait for tier 1 on PyPI
+        env:
+          MATRIX: ${{ needs.parse-release.outputs.matrix }}
+        run: python scripts/wait_for_pypi.py --matrix "$MATRIX" --tier 1
+
+  # ============================================================================
+  # Publish Tier 2: packages depending on jaclang
+  # ============================================================================
+  publish-tier2:
+    needs: [parse-release, build, wait-tier1]
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parse-release.outputs.matrix) }}
+    steps:
+      - name: Check if tier 2
+        id: check
+        run: |
+          if [[ "${{ matrix.tier }}" != "2" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download package
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: Packages-${{ matrix.pypi }}
+          path: dist
+
+      - name: Publish to PyPI
+        if: steps.check.outputs.skip != 'true'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.15.0
+        with:
+          attestations: true
+
+  wait-tier2:
+    needs: [parse-release, publish-tier2]
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Wait for tier 2 on PyPI
+        env:
+          MATRIX: ${{ needs.parse-release.outputs.matrix }}
+        run: python scripts/wait_for_pypi.py --matrix "$MATRIX" --tier 2
+
+  # ============================================================================
+  # Publish Tier 3: jaseci meta-package
+  # ============================================================================
+  publish-tier3:
+    needs: [parse-release, build, wait-tier2]
+    if: needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.parse-release.outputs.matrix) }}
+    steps:
+      - name: Check if tier 3
+        id: check
+        run: |
+          if [[ "${{ matrix.tier }}" != "3" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download package
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: Packages-${{ matrix.pypi }}
+          path: dist
+
+      - name: Publish to PyPI
+        if: steps.check.outputs.skip != 'true'
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.15.0
+        with:
+          attestations: true
+
+  # ============================================================================
+  # Push tags after successful publish
+  # ============================================================================
+  push-tags:
+    needs: [parse-release, publish-tier1, publish-tier2, publish-tier3]
+    if: |
+      always() &&
+      needs.parse-release.outputs.has_releases == 'true' &&
+      (needs.publish-tier1.result == 'success' || needs.publish-tier2.result == 'success' || needs.publish-tier3.result == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Push tags
+        env:
+          MATRIX: ${{ needs.parse-release.outputs.matrix }}
+          TIER1_RESULT: ${{ needs.publish-tier1.result }}
+          TIER2_RESULT: ${{ needs.publish-tier2.result }}
+          TIER3_RESULT: ${{ needs.publish-tier3.result }}
+        run: |
+          echo "$MATRIX" | jq -c '.include[]' | while read -r pkg; do
+            pypi_name=$(echo "$pkg" | jq -r '.pypi')
+            version=$(echo "$pkg" | jq -r '.version')
+            tier=$(echo "$pkg" | jq -r '.tier')
+
+            case "$tier" in
+              1) result="$TIER1_RESULT" ;;
+              2) result="$TIER2_RESULT" ;;
+              3) result="$TIER3_RESULT" ;;
+            esac
+
+            if [[ "$result" == "success" ]]; then
+              tag="${pypi_name}-v${version}"
+              echo "Creating tag: $tag"
+              git tag --annotate --message="Release ${pypi_name} ${version}" "$tag" "$GITHUB_SHA"
+              git push origin "$tag"
+            else
+              echo "Skipping tag for $pypi_name (tier $tier result: $result)"
+            fi
+          done
+
+  # ============================================================================
+  # Create GitHub Release
+  # ============================================================================
+  create-github-release:
+    needs: [parse-release, push-tags]
+    if: always() && needs.push-tags.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download all packages
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: dist
+          pattern: Packages-*
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          MATRIX: ${{ needs.parse-release.outputs.matrix }}
+          RELEASE_SUMMARY: ${{ needs.parse-release.outputs.release_summary }}
+        run: |
+          # Get primary tag (first package)
+          PRIMARY_TAG=$(echo "$MATRIX" | jq -r '.include[0] | "\(.pypi)-v\(.version)"')
+
+          # Build release notes
+          {
+            echo "## Packages Released"
+            echo ""
+            while read -r pkg; do
+              pypi_name=$(echo "$pkg" | jq -r '.pypi')
+              version=$(echo "$pkg" | jq -r '.version')
+              echo "- **${pypi_name}** ${version} ([PyPI](https://pypi.org/project/${pypi_name}/${version}/))"
+            done < <(echo "$MATRIX" | jq -c '.include[]')
+          } > release_notes.md
+
+          # Create release
+          gh release create "$PRIMARY_TAG" \
+            --verify-tag \
+            --title "Release: $RELEASE_SUMMARY" \
+            --notes-file release_notes.md \
+            dist/*
+
+  # ============================================================================
+  # Summary
+  # ============================================================================
+  summary:
+    needs: [parse-release, build, publish-tier1, publish-tier2, publish-tier3, push-tags, create-github-release]
+    if: always() && needs.parse-release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Release Summary
+        env:
+          SUMMARY: ${{ needs.parse-release.outputs.release_summary }}
+          BUILD: ${{ needs.build.result }}
+          TIER1: ${{ needs.publish-tier1.result }}
+          TIER2: ${{ needs.publish-tier2.result }}
+          TIER3: ${{ needs.publish-tier3.result }}
+          TAGS: ${{ needs.push-tags.result }}
+          RELEASE: ${{ needs.create-github-release.result }}
+        run: |
+          {
+            echo "## Release Summary: $SUMMARY"
+            echo ""
+            echo "| Step | Status |"
+            echo "|------|--------|"
+            echo "| Build | $BUILD |"
+            echo "| Publish Tier 1 (jaclang) | $TIER1 |"
+            echo "| Publish Tier 2 (plugins) | $TIER2 |"
+            echo "| Publish Tier 3 (jaseci) | $TIER3 |"
+            echo "| Push Tags | $TAGS |"
+            echo "| GitHub Release | $RELEASE |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$TIER1" == "failure" || "$TIER2" == "failure" || "$TIER3" == "failure" ]]; then
+            echo "::error::Some packages failed to publish"
+            exit 1
+          fi
+
+          echo "All packages published successfully!" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/parse_release.py
+++ b/scripts/parse_release.py
@@ -1,0 +1,73 @@
+"""Parse release info from PR title for the publish workflow.
+
+Extracts package names and versions from merged release PR titles and outputs
+a GitHub Actions matrix for tiered publishing.
+
+Example PR title: "release: jaclang 1.2.3, jac-byllm 2.0.0"
+
+The output matrix includes tier information for dependency-aware publishing:
+  - Tier 1: jaclang (base package, no internal dependencies)
+  - Tier 2: jac-byllm, jac-client, etc. (depend on jaclang)
+  - Tier 3: jaseci meta-package (depends on all)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+from release_utils import PACKAGES, set_output
+
+
+def parse_from_title(pr_title: str) -> list[dict]:
+    """Match patterns like 'jaclang 1.2.3' or 'jac-client 2.0.0'."""
+    releases = []
+    for pkg_name, version in re.findall(r"([\w-]+)\s+(\d+\.\d+\.\d+)", pr_title):
+        pkg_name_lower = pkg_name.lower()
+        if pkg_name_lower in PACKAGES:
+            pkg_info = PACKAGES[pkg_name_lower]
+            releases.append(
+                {
+                    "name": pkg_name_lower,
+                    "dir": pkg_info.dir,
+                    "pypi": pkg_info.pypi,
+                    "tier": pkg_info.tier,
+                    "version": version,
+                    "submodules": pkg_info.submodules,
+                }
+            )
+    return releases
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pr-title", required=True)
+    args = parser.parse_args()
+
+    releases = parse_from_title(args.pr_title)
+
+    if not releases:
+        print("No packages found to release")
+        set_output("has_releases", "false")
+        set_output("matrix", json.dumps({"include": []}))
+        set_output("release_summary", "none")
+        return 1
+
+    # Sort by tier for dependency ordering
+    releases.sort(key=lambda x: x["tier"])
+
+    print("Packages to release:")
+    for r in releases:
+        print(f"  - {r['pypi']} {r['version']} (tier {r['tier']})")
+
+    summary = ", ".join(f"{r['pypi']} {r['version']}" for r in releases)
+    set_output("has_releases", "true")
+    set_output("matrix", json.dumps({"include": releases}))
+    set_output("release_summary", summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wait_for_pypi.py
+++ b/scripts/wait_for_pypi.py
@@ -1,0 +1,84 @@
+"""Wait for packages to appear on PyPI before publishing dependent packages.
+
+PyPI has propagation delay after upload. This script polls until packages
+are available, ensuring dependent packages (e.g., byllm requiring jaclang>=1.2.4)
+can be installed during their own publish step.
+
+Used between tier publishes in the release workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+from release_utils import check_pypi
+
+DEFAULT_TIMEOUT = 600  # 10 minutes
+DEFAULT_INTERVAL = 30  # 30 seconds
+
+
+def wait_for_packages(
+    packages: list[dict],
+    tier: int,
+    timeout: int = DEFAULT_TIMEOUT,
+    interval: int = DEFAULT_INTERVAL,
+) -> bool:
+    """Wait for all packages of a given tier to appear on PyPI."""
+    tier_packages = [p for p in packages if p["tier"] == tier]
+
+    if not tier_packages:
+        print(f"No tier {tier} packages to wait for")
+        return True
+
+    print(f"Waiting for tier {tier} packages on PyPI:")
+    for p in tier_packages:
+        print(f"  - {p['pypi']} {p['version']}")
+
+    start = time.time()
+    pending = {p["pypi"]: p["version"] for p in tier_packages}
+
+    while pending and (time.time() - start) < timeout:
+        for pypi_name, version in list(pending.items()):
+            if check_pypi(pypi_name, version):
+                print(f"  Found: {pypi_name} {version}")
+                del pending[pypi_name]
+
+        if pending:
+            elapsed = int(time.time() - start)
+            print(f"  Waiting... ({elapsed}s elapsed, {len(pending)} remaining)")
+            time.sleep(interval)
+
+    if pending:
+        print("\nTimeout waiting for packages:")
+        for pypi_name, version in pending.items():
+            print(f"  - {pypi_name} {version}")
+        return False
+
+    print(f"\nAll tier {tier} packages available on PyPI")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--matrix", required=True, help="JSON matrix from parse_release"
+    )
+    parser.add_argument("--tier", type=int, required=True, help="Tier to wait for")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--interval", type=int, default=DEFAULT_INTERVAL)
+    args = parser.parse_args()
+
+    matrix = json.loads(args.matrix)
+    packages = matrix.get("include", [])
+
+    if not wait_for_packages(packages, args.tier, args.timeout, args.interval):
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `publish-release.yml` workflow triggered when release PRs merge
- Tiered publishing: tier 1 (`jaclang`) -> tier 2 (`plugins[byllm, jac-scale..]`) -> tier 3 (`jaseci Metapackages`)
- OIDC authentication
- Automatic git tags and GitHub releases with artifacts

-----------------------------------

### Trigger Conditions
workflow runs only when ALL conditions are met:
- PR is merged to `main`  and branch starts with `release/` prefix
- repo is `Jaseci-Labs/jaseci`


### Workflow Flow
1. **parse-release** - Extract packages/versions from PR title
2. **approve-release** - Manual one-time approval via pypi environment
3. **build** - Build all packages in parallel with attestations
4. **publish-tier1** -> wait-tier1 - Publish jaclang, wait for PyPI
5. **publish-tier2** -> wait-tier2 - Publish plugins, wait for PyPI
6. **publish-tier3** - Publish jaseci meta-package
7. **push-tags** - Create git tags for successful publishes
8. **create-github-release** - Create GitHub release with artifacts


## Failure Handling

- **Tier dependency**: If tier 1 (jaclang) fails, tier 2 and 3 are skipped (they depend on jaclang)
- **Within-tier isolation**: `fail-fast: false` means failures within a tier don't block siblings (e.g., jac-byllm failing doesn't block jac-client)
- **Tags**: Only created for packages that successfully published
- **GitHub release**: Only created if at least one package published


### Security

- Uses OIDC (no stored API tokens)
- Minimal permissions per job