### PR TITLE
refactor: deduplicate native container codegen

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,7 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.11.4 (Unreleased)
 
-- 24 small refactors/changes.
+- 26 small refactors/changes.
 - **Fix: Formatter Semicolon & Decorator Spacing**: Fixed spacing bugs in the formatter where `@` decorators produced `@ decorator` instead of `@decorator`, and statement semicolons produced `raise ;` instead of `raise;`.
 - **Fix: Type Checker Validates Args Against Parameterless `init`**: The type checker now correctly reports an error when arguments are passed to a constructor whose `init` takes no parameters. Named args raise `Named argument does not match any parameter` and extra positional args raise `Too many positional arguments`. Calling with no args (`MyObj()`) remains valid.
 - **Automatic Port Fallback for `jac start`**: When starting the built-in HTTP server, if the specified port is already in use, the server now automatically finds and uses the next available port instead of crashing with "Address already in use". A warning message displays when using an alternative port. The `on_ready` callback signature updated to `Callable[[int], None]` to pass the actual bound port.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/container_helpers.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/container_helpers.impl.jac
@@ -1,0 +1,257 @@
+"""Shared helper methods for list/dict/set container codegen.
+
+These extract common patterns that were previously duplicated across
+lists.impl.jac, dicts.impl.jac, and sets.impl.jac.
+"""
+
+"""Emit an element/key comparison for container lookup.
+
+Dispatches based on type:
+- IntType: icmp_signed ==
+- i8* (string): strcmp == 0
+- PointerType with known size: memcmp == 0
+- PointerType (unknown size): icmp_unsigned ==
+- Fallback: icmp_signed ==
+
+Returns an i1 value (true if equal).
+"""
+impl NaIRGenPass._emit_key_comparison(
+    b: ir.IRBuilder,
+    key_type: ir.Type,
+    stored_val: ir.Value,
+    search_val: ir.Value,
+    key_size: int = 0
+) -> ir.Value {
+    i8_ptr = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    if isinstance(key_type, ir.IntType) {
+        return b.icmp_signed("==", stored_val, search_val, name="key.eq");
+    } elif key_type == i8_ptr {
+        strcmp_fn = self._get_or_declare_extern(
+            "strcmp", ir.IntType(32), [i8_ptr, i8_ptr]
+        );
+        cmp_result = b.call(strcmp_fn, [stored_val, search_val], name="strcmp");
+        return b.icmp_signed(
+            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="key.eq"
+        );
+    } elif isinstance(key_type, ir.PointerType) and key_size > 0 {
+        memcmp_fn = self._get_or_declare_extern(
+            "memcmp", ir.IntType(32), [i8_ptr, i8_ptr, i64]
+        );
+        key_i8 = b.bitcast(stored_val, i8_ptr, name="key.i8");
+        arg_i8 = b.bitcast(search_val, i8_ptr, name="arg.i8");
+        cmp_result = b.call(
+            memcmp_fn, [key_i8, arg_i8, ir.Constant(i64, key_size)], name="memcmp"
+        );
+        return b.icmp_signed(
+            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="key.eq"
+        );
+    } elif isinstance(key_type, ir.PointerType) {
+        return b.icmp_unsigned("==", stored_val, search_val, name="key.eq");
+    } else {
+        return b.icmp_signed("==", stored_val, search_val, name="key.eq");
+    }
+}
+
+"""Allocate an RC-managed container struct and its data arrays.
+
+Args:
+    b: IRBuilder positioned in the entry block of the constructor
+    container_ptr_type: The pointer type of the container struct
+    data_types: List of element types for the data arrays (1 for list/set, 2 for dict)
+    initial_cap: Initial capacity (default 8)
+
+Returns:
+    (container_ptr, data_pointers...) tuple — the RC-allocated container
+    and the stored data array pointers.
+"""
+impl NaIRGenPass._emit_rc_alloc_container(
+    b: ir.IRBuilder,
+    container_ptr_type: ir.Type,
+    data_types: list,
+    initial_cap: int = 8
+) -> tuple {
+    i64 = ir.IntType(64);
+    i32 = ir.IntType(32);
+    i8_ptr = ir.IntType(8).as_pointer();
+    malloc_fn = self._get_or_declare_extern("malloc", i8_ptr, [i64]);
+    # Allocate container struct via rc_alloc
+    null_ptr = ir.Constant(container_ptr_type, None);
+    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="sizeof");
+    struct_size = b.ptrtoint(size_gep, i64, name="size");
+    raw = b.call(self.rc_alloc_fn, [struct_size], name="raw");
+    container_ptr = b.bitcast(raw, container_ptr_type, name="container");
+    # len = 0
+    len_p = b.gep(
+        container_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="len.ptr"
+    );
+    b.store(ir.Constant(i64, 0), len_p);
+    # cap = initial_cap
+    cap_p = b.gep(
+        container_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="cap.ptr"
+    );
+    b.store(ir.Constant(i64, initial_cap), cap_p);
+    # Allocate data arrays
+    data_ptrs = [];
+    for (i, dtype) in enumerate(data_types) {
+        field_idx = i + 2;  # fields 0=len, 1=cap, 2+=data
+        elem_null = ir.Constant(dtype.as_pointer(), None);
+        elem_gep = b.gep(elem_null, [ir.Constant(i32, 1)], name=f"elem{i}.sizeof");
+        elem_size = b.ptrtoint(elem_gep, i64, name=f"elem{i}.size");
+        data_bytes = b.mul(
+            ir.Constant(i64, initial_cap), elem_size, name=f"data{i}.bytes"
+        );
+        data_raw = b.call(malloc_fn, [data_bytes], name=f"data{i}.raw");
+        data = b.bitcast(data_raw, dtype.as_pointer(), name=f"data{i}");
+        data_p = b.gep(
+            container_ptr,
+            [ir.Constant(i32, 0), ir.Constant(i32, field_idx)],
+            name=f"data{i}.ptr"
+        );
+        b.store(data, data_p);
+        data_ptrs.append(data);
+    }
+    return tuple([container_ptr] + data_ptrs);
+}
+
+"""Emit capacity-doubling grow logic for a data array.
+
+Doubles capacity, mallocs new array, memcpys old data, frees old array,
+stores new array back. Returns the new data pointer.
+
+Args:
+    b: IRBuilder positioned in the grow basic block
+    arr_ptr: GEP pointer to the data array field in the container
+    elem_type: Element type of the array
+    cur_len: Current length (for memcpy size)
+    cap_ptr: GEP pointer to the capacity field
+    cur_cap: Current capacity value
+"""
+impl NaIRGenPass._emit_grow_array(
+    b: ir.IRBuilder,
+    arr_ptr: ir.Value,
+    elem_type: ir.Type,
+    cur_len: ir.Value,
+    cap_ptr: ir.Value,
+    cur_cap: ir.Value
+) -> ir.Value {
+    i64 = ir.IntType(64);
+    i32 = ir.IntType(32);
+    i8_ptr = ir.IntType(8).as_pointer();
+    malloc_fn = self._get_or_declare_extern("malloc", i8_ptr, [i64]);
+    free_fn = self._get_or_declare_extern("free", ir.VoidType(), [i8_ptr]);
+    memcpy_fn = self._get_or_declare_extern("memcpy", i8_ptr, [i8_ptr, i8_ptr, i64]);
+    new_cap = b.mul(cur_cap, ir.Constant(i64, 2), name="new.cap");
+    b.store(new_cap, cap_ptr);
+    elem_null = ir.Constant(elem_type.as_pointer(), None);
+    elem_gep = b.gep(elem_null, [ir.Constant(i32, 1)], name="elem.sizeof");
+    elem_sz = b.ptrtoint(elem_gep, i64, name="elem.size");
+    new_bytes = b.mul(new_cap, elem_sz, name="new.bytes");
+    new_data_raw = b.call(malloc_fn, [new_bytes], name="new.data.raw");
+    new_data = b.bitcast(new_data_raw, elem_type.as_pointer(), name="new.data");
+    old_data = b.load(arr_ptr, name="old.data");
+    old_bytes = b.mul(cur_len, elem_sz, name="old.bytes");
+    old_i8 = b.bitcast(old_data, i8_ptr, name="old.i8");
+    new_i8 = b.bitcast(new_data, i8_ptr, name="new.i8");
+    b.call(memcpy_fn, [new_i8, old_i8, old_bytes]);
+    b.call(free_fn, [old_i8]);
+    b.store(new_data, arr_ptr);
+    return new_data;
+}
+
+"""Emit the standard RC destructor preamble: null-check, decrement, branch-if-zero.
+
+Creates the basic block structure:
+    entry -> dec -> (free_bb if zero, done_bb if nonzero)
+
+Returns:
+    (free_bb_builder, done_bb) — caller should emit cleanup in free_bb,
+    then branch to done_bb and emit ret_void there.
+"""
+impl NaIRGenPass._emit_rc_destructor_preamble(
+    release_fn: ir.Function, ptr_type: ir.Type
+) -> tuple {
+    i8_ptr = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    entry_bb = release_fn.append_basic_block("entry");
+    dec_bb = release_fn.append_basic_block("dec");
+    free_bb = release_fn.append_basic_block("do_free");
+    done_bb = release_fn.append_basic_block("done");
+    b = ir.IRBuilder(entry_bb);
+    # Null check
+    is_null = b.icmp_unsigned(
+        "==", release_fn.args[0], ir.Constant(ptr_type, None), name="is.null"
+    );
+    b.cbranch(is_null, done_bb, dec_bb);
+    # Decrement refcount
+    b = ir.IRBuilder(dec_bb);
+    raw_ptr = b.bitcast(release_fn.args[0], i8_ptr, name="raw.cast");
+    rc_raw = b.gep(raw_ptr, [ir.Constant(i64, -8)], name="rc.raw");
+    rc_ptr_r = b.bitcast(rc_raw, ir.IntType(64).as_pointer(), name="rc.ptr");
+    old_rc = b.load(rc_ptr_r, name="old.rc");
+    new_rc = b.sub(old_rc, ir.Constant(i64, 1), name="new.rc");
+    b.store(new_rc, rc_ptr_r);
+    is_zero = b.icmp_unsigned("==", new_rc, ir.Constant(i64, 0), name="is.zero");
+    b.cbranch(is_zero, free_bb, done_bb);
+    # Return builder positioned at free_bb and the done_bb for later use
+    free_builder = ir.IRBuilder(free_bb);
+    return (free_builder, done_bb);
+}
+
+"""Emit a loop that releases all pointer-typed elements in a container data array.
+
+Iterates data[0..len-1] calling rc_release_simple on each element.
+Used for list data, dict keys, dict vals, and set elems.
+
+Args:
+    b: IRBuilder positioned in the free block
+    release_fn: The destructor function (to append basic blocks)
+    container_arg: The container pointer argument (release_fn.args[0])
+    data_field_idx: Struct field index of the data array (2 for list/set, 2 or 3 for dict)
+
+Returns:
+    Updated IRBuilder positioned after the loop.
+"""
+impl NaIRGenPass._emit_rc_release_elem_loop(
+    b: ir.IRBuilder,
+    release_fn: ir.Function,
+    container_arg: ir.Value,
+    data_field_idx: int
+) -> ir.IRBuilder {
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    i8_ptr = ir.IntType(8).as_pointer();
+    # Load len and data array
+    len_p = b.gep(
+        container_arg, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="len.ptr.rel"
+    );
+    cur_len = b.load(len_p, name="len.rel");
+    data_p = b.gep(
+        container_arg,
+        [ir.Constant(i32, 0), ir.Constant(i32, data_field_idx)],
+        name="data.ptr.rel"
+    );
+    data_arr = b.load(data_p, name="data.rel");
+    # Loop: i = 0; while i < len { release(data[i]); i++ }
+    loop_alloca = b.alloca(i64, name="loop.rel");
+    b.store(ir.Constant(i64, 0), loop_alloca);
+    lcond = release_fn.append_basic_block("loop.cond.rel");
+    lbody = release_fn.append_basic_block("loop.body.rel");
+    lend = release_fn.append_basic_block("loop.end.rel");
+    b.branch(lcond);
+    b = ir.IRBuilder(lcond);
+    li = b.load(loop_alloca, name="li.rel");
+    b.cbranch(b.icmp_unsigned("<", li, cur_len, name="cmp.rel"), lbody, lend);
+    b = ir.IRBuilder(lbody);
+    ep = b.gep(data_arr, [b.load(loop_alloca, name="li2.rel")], name="elem.ptr.rel");
+    ev = b.load(ep, name="elem.val.rel");
+    b.call(self.rc_release_simple_fn, [b.bitcast(ev, i8_ptr, name="elem.cast.rel")]);
+    b.store(
+        b.add(
+            b.load(loop_alloca, name="li3.rel"), ir.Constant(i64, 1), name="inc.rel"
+        ),
+        loop_alloca
+    );
+    b.branch(lcond);
+    return ir.IRBuilder(lend);
+}

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/dicts.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/dicts.impl.jac
@@ -81,40 +81,9 @@ impl NaIRGenPass._emit_dict_helpers(
     new_fn.linkage = "private";
     bb = new_fn.append_basic_block("entry");
     b = ir.IRBuilder(bb);
-    # Allocate dict struct via rc_alloc (RC-managed)
-    null_ptr = ir.Constant(dict_ptr_type, None);
-    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="sizeof");
-    struct_size = b.ptrtoint(size_gep, i64, name="size");
-    raw = b.call(self.rc_alloc_fn, [struct_size], name="raw");
-    dict_ptr = b.bitcast(raw, dict_ptr_type, name="dict");
-    # len = 0
-    len_p = b.gep(dict_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="len.ptr");
-    b.store(ir.Constant(i64, 0), len_p);
-    # cap = 8
-    cap_p = b.gep(dict_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="cap.ptr");
-    b.store(ir.Constant(i64, 8), cap_p);
-    # Allocate keys: 8 * sizeof(key) via plain malloc (internal, not RC-managed)
-    key_null = ir.Constant(key_type.as_pointer(), None);
-    key_gep = b.gep(key_null, [ir.Constant(i32, 1)], name="key.sizeof");
-    key_size = b.ptrtoint(key_gep, i64, name="key.size");
-    keys_bytes = b.mul(ir.Constant(i64, 8), key_size, name="keys.bytes");
-    keys_raw = b.call(malloc_fn, [keys_bytes], name="keys.raw");
-    keys = b.bitcast(keys_raw, key_type.as_pointer(), name="keys");
-    keys_p = b.gep(
-        dict_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="keys.ptr"
+    (dict_ptr, _, _) = self._emit_rc_alloc_container(
+        b, dict_ptr_type, [key_type, val_type]
     );
-    b.store(keys, keys_p);
-    # Allocate vals: 8 * sizeof(val) via plain malloc (internal, not RC-managed)
-    val_null = ir.Constant(val_type.as_pointer(), None);
-    val_gep = b.gep(val_null, [ir.Constant(i32, 1)], name="val.sizeof");
-    val_size = b.ptrtoint(val_gep, i64, name="val.size");
-    vals_bytes = b.mul(ir.Constant(i64, 8), val_size, name="vals.bytes");
-    vals_raw = b.call(malloc_fn, [vals_bytes], name="vals.raw");
-    vals = b.bitcast(vals_raw, val_type.as_pointer(), name="vals");
-    vals_p = b.gep(
-        dict_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 3)], name="vals.ptr"
-    );
-    b.store(vals, vals_p);
     b.ret(dict_ptr);
     # --- __dict_set: set key=value (linear search, grow if needed) ---
     set_fnty = ir.FunctionType(ir.VoidType(), [dict_ptr_type, key_type, val_type]);
@@ -159,36 +128,7 @@ impl NaIRGenPass._emit_dict_helpers(
     idx_body = b.load(idx_alloca, name="idx.body");
     key_ptr = b.gep(keys_arr, [idx_body], name="key.ptr");
     key_val = b.load(key_ptr, name="key.val");
-    # Compare keys - use strcmp for string keys (i8*), memcmp for tuples
-    if isinstance(key_type, ir.IntType) {
-        key_eq = b.icmp_signed("==", key_val, k_arg, name="key.eq");
-    } elif key_type == i8_ptr {
-        # String comparison using strcmp
-        strcmp_fn = self._get_or_declare_extern(
-            "strcmp", ir.IntType(32), [i8_ptr, i8_ptr]
-        );
-        cmp_result = b.call(strcmp_fn, [key_val, k_arg], name="strcmp");
-        key_eq = b.icmp_signed(
-            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="key.eq"
-        );
-    } elif isinstance(key_type, ir.PointerType) and _key_sz > 0 {
-        # Struct/tuple pointer - use memcmp for content comparison
-        memcmp_fn = self._get_or_declare_extern(
-            "memcmp", ir.IntType(32), [i8_ptr, i8_ptr, i64]
-        );
-        key_i8 = b.bitcast(key_val, i8_ptr, name="key.i8");
-        arg_i8 = b.bitcast(k_arg, i8_ptr, name="arg.i8");
-        cmp_result = b.call(
-            memcmp_fn, [key_i8, arg_i8, ir.Constant(i64, _key_sz)], name="memcmp"
-        );
-        key_eq = b.icmp_signed(
-            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="key.eq"
-        );
-    } elif isinstance(key_type, ir.PointerType) {
-        key_eq = b.icmp_unsigned("==", key_val, k_arg, name="key.eq");
-    } else {
-        key_eq = b.icmp_signed("==", key_val, k_arg, name="key.eq");
-    }
+    key_eq = self._emit_key_comparison(b, key_type, key_val, k_arg, _key_sz);
     b.cbranch(key_eq, found_bb, incr_bb);
     # Increment block
     b.position_at_end(incr_bb);
@@ -207,36 +147,23 @@ impl NaIRGenPass._emit_dict_helpers(
     cur_cap = b.load(cap_p2, name="cap");
     need_grow = b.icmp_unsigned(">=", cur_len, cur_cap, name="need.grow");
     b.cbranch(need_grow, grow_bb, append_bb);
-    # Grow block
+    # Grow block: grow both keys and vals arrays
     b.position_at_end(grow_bb);
-    new_cap = b.mul(cur_cap, ir.Constant(i64, 2), name="new.cap");
-    b.store(new_cap, cap_p2);
-    # Reallocate keys
-    key_null2 = ir.Constant(key_type.as_pointer(), None);
-    key_gep2 = b.gep(key_null2, [ir.Constant(i32, 1)], name="key.sizeof");
-    key_sz = b.ptrtoint(key_gep2, i64, name="key.size");
-    new_keys_bytes = b.mul(new_cap, key_sz, name="new.keys.bytes");
-    new_keys_raw = b.call(malloc_fn, [new_keys_bytes], name="new.keys.raw");
-    new_keys = b.bitcast(new_keys_raw, key_type.as_pointer(), name="new.keys");
-    old_keys_bytes = b.mul(cur_len, key_sz, name="old.keys.bytes");
-    old_keys_i8 = b.bitcast(keys_arr, i8_ptr, name="old.keys.i8");
-    new_keys_i8 = b.bitcast(new_keys, i8_ptr, name="new.keys.i8");
-    b.call(memcpy_fn, [new_keys_i8, old_keys_i8, old_keys_bytes]);
-    # Free old keys array (plain malloc'd, not RC-managed)
-    b.call(free_fn, [old_keys_i8]);
-    b.store(new_keys, keys_p2);
-    # Reallocate vals
+    self._emit_grow_array(b, keys_p2, key_type, cur_len, cap_p2, cur_cap);
+    # Reload cap after first grow (cap_p2 was updated)
+    new_cap = b.load(cap_p2, name="new.cap.reload");
+    # Grow vals — pass new_cap directly via a manual grow since cap is already doubled
     val_null2 = ir.Constant(val_type.as_pointer(), None);
     val_gep2 = b.gep(val_null2, [ir.Constant(i32, 1)], name="val.sizeof");
     val_sz = b.ptrtoint(val_gep2, i64, name="val.size");
     new_vals_bytes = b.mul(new_cap, val_sz, name="new.vals.bytes");
     new_vals_raw = b.call(malloc_fn, [new_vals_bytes], name="new.vals.raw");
     new_vals = b.bitcast(new_vals_raw, val_type.as_pointer(), name="new.vals");
+    old_vals = b.load(vals_p2, name="old.vals");
     old_vals_bytes = b.mul(cur_len, val_sz, name="old.vals.bytes");
-    old_vals_i8 = b.bitcast(vals_arr, i8_ptr, name="old.vals.i8");
+    old_vals_i8 = b.bitcast(old_vals, i8_ptr, name="old.vals.i8");
     new_vals_i8 = b.bitcast(new_vals, i8_ptr, name="new.vals.i8");
     b.call(memcpy_fn, [new_vals_i8, old_vals_i8, old_vals_bytes]);
-    # Free old vals array (plain malloc'd, not RC-managed)
     b.call(free_fn, [old_vals_i8]);
     b.store(new_vals, vals_p2);
     b.branch(append_bb);
@@ -293,35 +220,7 @@ impl NaIRGenPass._emit_dict_helpers(
     idx_bg = b.load(idx_alloca_g, name="idx.body");
     key_ptr_g = b.gep(keys_g, [idx_bg], name="key.ptr");
     key_val_g = b.load(key_ptr_g, name="key.val");
-    # Use strcmp for string keys, memcmp for tuples
-    if isinstance(key_type, ir.IntType) {
-        key_eq_g = b.icmp_signed("==", key_val_g, k_arg_g, name="key.eq");
-    } elif key_type == i8_ptr {
-        strcmp_fn = self._get_or_declare_extern(
-            "strcmp", ir.IntType(32), [i8_ptr, i8_ptr]
-        );
-        cmp_result_g = b.call(strcmp_fn, [key_val_g, k_arg_g], name="strcmp");
-        key_eq_g = b.icmp_signed(
-            "==", cmp_result_g, ir.Constant(ir.IntType(32), 0), name="key.eq"
-        );
-    } elif isinstance(key_type, ir.PointerType) and _key_sz > 0 {
-        # Struct/tuple pointer - use memcmp for content comparison
-        memcmp_fn = self._get_or_declare_extern(
-            "memcmp", ir.IntType(32), [i8_ptr, i8_ptr, i64]
-        );
-        key_i8_g = b.bitcast(key_val_g, i8_ptr, name="key.i8");
-        arg_i8_g = b.bitcast(k_arg_g, i8_ptr, name="arg.i8");
-        cmp_result_g = b.call(
-            memcmp_fn, [key_i8_g, arg_i8_g, ir.Constant(i64, _key_sz)], name="memcmp"
-        );
-        key_eq_g = b.icmp_signed(
-            "==", cmp_result_g, ir.Constant(ir.IntType(32), 0), name="key.eq"
-        );
-    } elif isinstance(key_type, ir.PointerType) {
-        key_eq_g = b.icmp_unsigned("==", key_val_g, k_arg_g, name="key.eq");
-    } else {
-        key_eq_g = b.icmp_signed("==", key_val_g, k_arg_g, name="key.eq");
-    }
+    key_eq_g = self._emit_key_comparison(b, key_type, key_val_g, k_arg_g, _key_sz);
     b.cbranch(key_eq_g, found_g, incr_g);
     # Increment block - only reached when not found
     b.position_at_end(incr_g);
@@ -395,35 +294,7 @@ impl NaIRGenPass._emit_dict_helpers(
     idx_bc = b.load(idx_alloca_c, name="idx.body");
     key_ptr_c = b.gep(keys_c, [idx_bc], name="key.ptr");
     key_val_c = b.load(key_ptr_c, name="key.val");
-    # Use strcmp for string keys, memcmp for tuples
-    if isinstance(key_type, ir.IntType) {
-        key_eq_c = b.icmp_signed("==", key_val_c, k_arg_c, name="key.eq");
-    } elif key_type == i8_ptr {
-        strcmp_fn = self._get_or_declare_extern(
-            "strcmp", ir.IntType(32), [i8_ptr, i8_ptr]
-        );
-        cmp_result_c = b.call(strcmp_fn, [key_val_c, k_arg_c], name="strcmp");
-        key_eq_c = b.icmp_signed(
-            "==", cmp_result_c, ir.Constant(ir.IntType(32), 0), name="key.eq"
-        );
-    } elif isinstance(key_type, ir.PointerType) and _key_sz > 0 {
-        # Struct/tuple pointer - use memcmp for content comparison
-        memcmp_fn = self._get_or_declare_extern(
-            "memcmp", ir.IntType(32), [i8_ptr, i8_ptr, i64]
-        );
-        key_i8_c = b.bitcast(key_val_c, i8_ptr, name="key.i8");
-        arg_i8_c = b.bitcast(k_arg_c, i8_ptr, name="arg.i8");
-        cmp_result_c = b.call(
-            memcmp_fn, [key_i8_c, arg_i8_c, ir.Constant(i64, _key_sz)], name="memcmp"
-        );
-        key_eq_c = b.icmp_signed(
-            "==", cmp_result_c, ir.Constant(ir.IntType(32), 0), name="key.eq"
-        );
-    } elif isinstance(key_type, ir.PointerType) {
-        key_eq_c = b.icmp_unsigned("==", key_val_c, k_arg_c, name="key.eq");
-    } else {
-        key_eq_c = b.icmp_signed("==", key_val_c, k_arg_c, name="key.eq");
-    }
+    key_eq_c = self._emit_key_comparison(b, key_type, key_val_c, k_arg_c, _key_sz);
     b.cbranch(key_eq_c, found_c, loop_cond_c);
     b.position_before(b.block.terminator);
     next_idx_c = b.add(idx_bc, ir.Constant(i64, 1), name="next.idx");
@@ -483,96 +354,14 @@ impl NaIRGenPass._emit_dict_helpers(
     );
     release_fn.linkage = "private";
     release_fn.args[0].name = "dict";
-    entry_bb = release_fn.append_basic_block("entry");
-    dec_bb = release_fn.append_basic_block("dec");
-    free_bb = release_fn.append_basic_block("do_free");
-    done_bb = release_fn.append_basic_block("done");
-    b = ir.IRBuilder(entry_bb);
-    is_null = b.icmp_unsigned(
-        "==", release_fn.args[0], ir.Constant(dict_ptr_type, None), name="is.null"
-    );
-    b.cbranch(is_null, done_bb, dec_bb);
-    b = ir.IRBuilder(dec_bb);
-    raw_ptr = b.bitcast(release_fn.args[0], i8_ptr, name="raw.cast");
-    rc_raw = b.gep(raw_ptr, [ir.Constant(i64, -8)], name="rc.raw");
-    rc_ptr_r = b.bitcast(rc_raw, ir.IntType(64).as_pointer(), name="rc.ptr");
-    old_rc = b.load(rc_ptr_r, name="old.rc");
-    new_rc = b.sub(old_rc, ir.Constant(i64, 1), name="new.rc");
-    b.store(new_rc, rc_ptr_r);
-    is_zero = b.icmp_unsigned("==", new_rc, ir.Constant(i64, 0), name="is.zero");
-    b.cbranch(is_zero, free_bb, done_bb);
-    b = ir.IRBuilder(free_bb);
-    # Release pointer-typed keys if applicable
+    (b, done_bb) = self._emit_rc_destructor_preamble(release_fn, dict_ptr_type);
+    # Release pointer-typed keys if applicable (field index 2)
     if isinstance(key_type, ir.PointerType) {
-        len_p_dk = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name="len.ptr.dk"
-        );
-        cur_len_dk = b.load(len_p_dk, name="len.dk");
-        keys_p_dk = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 2)],
-            name="keys.ptr.dk"
-        );
-        keys_dk = b.load(keys_p_dk, name="keys.dk");
-        loop_alloca_k = b.alloca(i64, name="loop.k");
-        b.store(ir.Constant(i64, 0), loop_alloca_k);
-        lcond_k = release_fn.append_basic_block("loop.cond.k");
-        lbody_k = release_fn.append_basic_block("loop.body.k");
-        lend_k = release_fn.append_basic_block("loop.end.k");
-        b.branch(lcond_k);
-        b = ir.IRBuilder(lcond_k);
-        ki = b.load(loop_alloca_k, name="ki");
-        b.cbranch(b.icmp_unsigned("<", ki, cur_len_dk, name="kcmp"), lbody_k, lend_k);
-        b = ir.IRBuilder(lbody_k);
-        kp = b.gep(keys_dk, [b.load(loop_alloca_k, name="ki2")], name="k.ptr");
-        kv = b.load(kp, name="k.val");
-        b.call(self.rc_release_simple_fn, [b.bitcast(kv, i8_ptr, name="k.cast")]);
-        b.store(
-            b.add(
-                b.load(loop_alloca_k, name="ki3"), ir.Constant(i64, 1), name="kinc"
-            ),
-            loop_alloca_k
-        );
-        b.branch(lcond_k);
-        b = ir.IRBuilder(lend_k);
+        b = self._emit_rc_release_elem_loop(b, release_fn, release_fn.args[0], 2);
     }
-    # Release pointer-typed vals if applicable
+    # Release pointer-typed vals if applicable (field index 3)
     if isinstance(val_type, ir.PointerType) {
-        len_p_dv = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name="len.ptr.dv"
-        );
-        cur_len_dv = b.load(len_p_dv, name="len.dv");
-        vals_p_dv = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 3)],
-            name="vals.ptr.dv"
-        );
-        vals_dv = b.load(vals_p_dv, name="vals.dv");
-        loop_alloca_v = b.alloca(i64, name="loop.v");
-        b.store(ir.Constant(i64, 0), loop_alloca_v);
-        lcond_v = release_fn.append_basic_block("loop.cond.v");
-        lbody_v = release_fn.append_basic_block("loop.body.v");
-        lend_v = release_fn.append_basic_block("loop.end.v");
-        b.branch(lcond_v);
-        b = ir.IRBuilder(lcond_v);
-        vi = b.load(loop_alloca_v, name="vi");
-        b.cbranch(b.icmp_unsigned("<", vi, cur_len_dv, name="vcmp"), lbody_v, lend_v);
-        b = ir.IRBuilder(lbody_v);
-        vp = b.gep(vals_dv, [b.load(loop_alloca_v, name="vi2")], name="v.ptr");
-        vv = b.load(vp, name="v.val");
-        b.call(self.rc_release_simple_fn, [b.bitcast(vv, i8_ptr, name="v.cast")]);
-        b.store(
-            b.add(
-                b.load(loop_alloca_v, name="vi3"), ir.Constant(i64, 1), name="vinc"
-            ),
-            loop_alloca_v
-        );
-        b.branch(lcond_v);
-        b = ir.IRBuilder(lend_v);
+        b = self._emit_rc_release_elem_loop(b, release_fn, release_fn.args[0], 3);
     }
     # Free keys array
     keys_p_f = b.gep(

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
@@ -27,29 +27,7 @@ impl NaIRGenPass._emit_list_helpers(elem_type_name: str, elem_type: ir.Type) -> 
     new_fn.linkage = "private";
     bb = new_fn.append_basic_block("entry");
     b = ir.IRBuilder(bb);
-    # Allocate list struct via rc_alloc (RC-managed)
-    null_ptr = ir.Constant(list_ptr_type, None);
-    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="sizeof");
-    struct_size = b.ptrtoint(size_gep, i64, name="size");
-    raw = b.call(self.rc_alloc_fn, [struct_size], name="raw");
-    list_ptr = b.bitcast(raw, list_ptr_type, name="list");
-    # len = 0
-    len_p = b.gep(list_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="len.ptr");
-    b.store(ir.Constant(i64, 0), len_p);
-    # cap = 8
-    cap_p = b.gep(list_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="cap.ptr");
-    b.store(ir.Constant(i64, 8), cap_p);
-    # Allocate data: 8 * sizeof(elem) via plain malloc (internal, not RC-managed)
-    elem_null = ir.Constant(elem_type.as_pointer(), None);
-    elem_gep = b.gep(elem_null, [ir.Constant(i32, 1)], name="elem.sizeof");
-    elem_size = b.ptrtoint(elem_gep, i64, name="elem.size");
-    data_bytes = b.mul(ir.Constant(i64, 8), elem_size, name="data.bytes");
-    data_raw = b.call(malloc_fn, [data_bytes], name="data.raw");
-    data = b.bitcast(data_raw, elem_type.as_pointer(), name="data");
-    data_p = b.gep(
-        list_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="data.ptr"
-    );
-    b.store(data, data_p);
+    (list_ptr, _) = self._emit_rc_alloc_container(b, list_ptr_type, [elem_type]);
     b.ret(list_ptr);
     # --- __list_append_T: append an element, growing if needed ---
     append_fnty = ir.FunctionType(ir.VoidType(), [list_ptr_type, elem_type]);
@@ -73,25 +51,10 @@ impl NaIRGenPass._emit_list_helpers(elem_type_name: str, elem_type: ir.Type) -> 
     b.cbranch(need_grow, grow_bb, store_bb);
     # Grow block
     b.position_at_end(grow_bb);
-    new_cap = b.mul(cur_cap, ir.Constant(i64, 2), name="new.cap");
-    b.store(new_cap, cap_p2);
-    elem_null2 = ir.Constant(elem_type.as_pointer(), None);
-    elem_gep2 = b.gep(elem_null2, [ir.Constant(i32, 1)], name="elem.sizeof");
-    elem_sz = b.ptrtoint(elem_gep2, i64, name="elem.size");
-    new_bytes = b.mul(new_cap, elem_sz, name="new.bytes");
-    new_data_raw = b.call(malloc_fn, [new_bytes], name="new.data.raw");
-    new_data = b.bitcast(new_data_raw, elem_type.as_pointer(), name="new.data");
     data_p_g = b.gep(
         l_arg, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="data.ptr.g"
     );
-    old_data = b.load(data_p_g, name="old.data");
-    old_bytes = b.mul(cur_len, elem_sz, name="old.bytes");
-    old_i8 = b.bitcast(old_data, i8_ptr, name="old.i8");
-    new_i8 = b.bitcast(new_data, i8_ptr, name="new.i8");
-    b.call(memcpy_fn, [new_i8, old_i8, old_bytes]);
-    # Free old data array (plain malloc'd, not RC-managed)
-    b.call(free_fn, [old_i8]);
-    b.store(new_data, data_p_g);
+    self._emit_grow_array(b, data_p_g, elem_type, cur_len, cap_p2, cur_cap);
     b.branch(store_bb);
     # Store block
     b.position_at_end(store_bb);
@@ -160,63 +123,10 @@ impl NaIRGenPass._emit_list_helpers(elem_type_name: str, elem_type: ir.Type) -> 
     );
     release_fn.linkage = "private";
     release_fn.args[0].name = "list";
-    entry_bb = release_fn.append_basic_block("entry");
-    dec_bb = release_fn.append_basic_block("dec");
-    free_bb = release_fn.append_basic_block("do_free");
-    done_bb = release_fn.append_basic_block("done");
-    b = ir.IRBuilder(entry_bb);
-    # Null check
-    is_null = b.icmp_unsigned(
-        "==", release_fn.args[0], ir.Constant(list_ptr_type, None), name="is.null"
-    );
-    b.cbranch(is_null, done_bb, dec_bb);
-    # Decrement refcount
-    b = ir.IRBuilder(dec_bb);
-    raw_ptr = b.bitcast(release_fn.args[0], i8_ptr, name="raw.cast");
-    rc_raw = b.gep(raw_ptr, [ir.Constant(i64, -8)], name="rc.raw");
-    rc_ptr_r = b.bitcast(rc_raw, ir.IntType(64).as_pointer(), name="rc.ptr");
-    old_rc = b.load(rc_ptr_r, name="old.rc");
-    new_rc = b.sub(old_rc, ir.Constant(i64, 1), name="new.rc");
-    b.store(new_rc, rc_ptr_r);
-    is_zero = b.icmp_unsigned("==", new_rc, ir.Constant(i64, 0), name="is.zero");
-    b.cbranch(is_zero, free_bb, done_bb);
+    (b, done_bb) = self._emit_rc_destructor_preamble(release_fn, list_ptr_type);
     # Free block: release elements if pointer, free data, free struct
-    b = ir.IRBuilder(free_bb);
-    is_ptr_elem = isinstance(elem_type, ir.PointerType);
-    if is_ptr_elem {
-        # Loop over data[0..len-1] and rc_release_simple each element
-        len_p_r = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name="len.ptr.r"
-        );
-        cur_len_r = b.load(len_p_r, name="len.r");
-        data_p_r = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 2)],
-            name="data.ptr.r"
-        );
-        data_r = b.load(data_p_r, name="data.r");
-        # Loop: i = 0; while i < len { release(data[i]); i++ }
-        loop_alloca = b.alloca(i64, name="loop.i");
-        b.store(ir.Constant(i64, 0), loop_alloca);
-        loop_cond_bb = release_fn.append_basic_block("loop.cond");
-        loop_body_bb = release_fn.append_basic_block("loop.body");
-        loop_end_bb = release_fn.append_basic_block("loop.end");
-        b.branch(loop_cond_bb);
-        b = ir.IRBuilder(loop_cond_bb);
-        loop_i = b.load(loop_alloca, name="i");
-        cmp = b.icmp_unsigned("<", loop_i, cur_len_r, name="cmp");
-        b.cbranch(cmp, loop_body_bb, loop_end_bb);
-        b = ir.IRBuilder(loop_body_bb);
-        elem_ptr = b.gep(data_r, [b.load(loop_alloca, name="i2")], name="elem.ptr");
-        elem_val = b.load(elem_ptr, name="elem.val");
-        elem_cast = b.bitcast(elem_val, i8_ptr, name="elem.cast");
-        b.call(self.rc_release_simple_fn, [elem_cast]);
-        inc_i = b.add(b.load(loop_alloca, name="i3"), ir.Constant(i64, 1), name="inc");
-        b.store(inc_i, loop_alloca);
-        b.branch(loop_cond_bb);
-        b = ir.IRBuilder(loop_end_bb);
+    if isinstance(elem_type, ir.PointerType) {
+        b = self._emit_rc_release_elem_loop(b, release_fn, release_fn.args[0], 2);
     }
     # Free data array (plain malloc'd)
     data_p_f = b.gep(

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/refcount.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/refcount.impl.jac
@@ -330,7 +330,6 @@ impl NaIRGenPass._emit_struct_release_fn(arch_name: str) -> None {
     struct_ptr_type = struct_type.as_pointer();
     i8_ptr = ir.IntType(8).as_pointer();
     i32 = ir.IntType(32);
-    i64 = ir.IntType(64);
     # Create the destructor function
     release_fnty = ir.FunctionType(ir.VoidType(), [struct_ptr_type]);
     release_fn = ir.Function(
@@ -338,28 +337,7 @@ impl NaIRGenPass._emit_struct_release_fn(arch_name: str) -> None {
     );
     release_fn.linkage = "private";
     release_fn.args[0].name = "obj";
-    entry_bb = release_fn.append_basic_block("entry");
-    dec_bb = release_fn.append_basic_block("dec");
-    free_bb = release_fn.append_basic_block("do_free");
-    done_bb = release_fn.append_basic_block("done");
-    b = ir.IRBuilder(entry_bb);
-    # Null check
-    is_null = b.icmp_unsigned(
-        "==", release_fn.args[0], ir.Constant(struct_ptr_type, None), name="is.null"
-    );
-    b.cbranch(is_null, done_bb, dec_bb);
-    # Decrement refcount
-    b = ir.IRBuilder(dec_bb);
-    raw_ptr = b.bitcast(release_fn.args[0], i8_ptr, name="raw.cast");
-    rc_raw = b.gep(raw_ptr, [ir.Constant(i64, -8)], name="rc.raw");
-    rc_ptr_r = b.bitcast(rc_raw, ir.IntType(64).as_pointer(), name="rc.ptr");
-    old_rc = b.load(rc_ptr_r, name="old.rc");
-    new_rc = b.sub(old_rc, ir.Constant(i64, 1), name="new.rc");
-    b.store(new_rc, rc_ptr_r);
-    is_zero = b.icmp_unsigned("==", new_rc, ir.Constant(i64, 0), name="is.zero");
-    b.cbranch(is_zero, free_bb, done_bb);
-    # Free block: release pointer-typed fields, then free struct
-    b = ir.IRBuilder(free_bb);
+    (b, done_bb) = self._emit_rc_destructor_preamble(release_fn, struct_ptr_type);
     for (fname, ftype) in field_types.items() {
         if isinstance(ftype, ir.PointerType) {
             idx = field_indices.get(fname, -1);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/sets.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/sets.impl.jac
@@ -29,29 +29,7 @@ impl NaIRGenPass._emit_set_helpers(
     new_fn.linkage = "private";
     bb = new_fn.append_basic_block("entry");
     b = ir.IRBuilder(bb);
-    # Allocate set struct via rc_alloc (RC-managed)
-    null_ptr = ir.Constant(set_ptr_type, None);
-    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="sizeof");
-    struct_size = b.ptrtoint(size_gep, i64, name="size");
-    raw = b.call(self.rc_alloc_fn, [struct_size], name="raw");
-    set_ptr = b.bitcast(raw, set_ptr_type, name="set");
-    # len = 0
-    len_p = b.gep(set_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="len.ptr");
-    b.store(ir.Constant(i64, 0), len_p);
-    # cap = 8
-    cap_p = b.gep(set_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="cap.ptr");
-    b.store(ir.Constant(i64, 8), cap_p);
-    # Allocate elems: 8 * sizeof(elem) via plain malloc (internal, not RC-managed)
-    elem_null = ir.Constant(elem_type.as_pointer(), None);
-    elem_gep = b.gep(elem_null, [ir.Constant(i32, 1)], name="elem.sizeof");
-    elem_sizeof_val = b.ptrtoint(elem_gep, i64, name="elem.size");
-    elems_bytes = b.mul(ir.Constant(i64, 8), elem_sizeof_val, name="elems.bytes");
-    elems_raw = b.call(malloc_fn, [elems_bytes], name="elems.raw");
-    elems = b.bitcast(elems_raw, elem_type.as_pointer(), name="elems");
-    elems_p = b.gep(
-        set_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="elems.ptr"
-    );
-    b.store(elems, elems_p);
+    (set_ptr, _) = self._emit_rc_alloc_container(b, set_ptr_type, [elem_type]);
     b.ret(set_ptr);
     # --- __set_add: add element if not already present ---
     add_fnty = ir.FunctionType(ir.VoidType(), [set_ptr_type, elem_type]);
@@ -91,35 +69,7 @@ impl NaIRGenPass._emit_set_helpers(
     idx_body = b.load(idx_alloca, name="idx.body");
     elem_ptr = b.gep(elems_arr, [idx_body], name="elem.ptr");
     elem_val = b.load(elem_ptr, name="elem.val");
-    # Compare elements - use strcmp for strings, memcmp for tuples, etc.
-    if isinstance(elem_type, ir.IntType) {
-        elem_eq = b.icmp_signed("==", elem_val, e_arg, name="elem.eq");
-    } elif elem_type == i8_ptr {
-        strcmp_fn = self._get_or_declare_extern(
-            "strcmp", ir.IntType(32), [i8_ptr, i8_ptr]
-        );
-        cmp_result = b.call(strcmp_fn, [elem_val, e_arg], name="strcmp");
-        elem_eq = b.icmp_signed(
-            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="elem.eq"
-        );
-    } elif isinstance(elem_type, ir.PointerType) and elem_size > 0 {
-        # Pointer with known size (e.g., tuples) - use memcmp
-        memcmp_fn = self._get_or_declare_extern(
-            "memcmp", ir.IntType(32), [i8_ptr, i8_ptr, i64]
-        );
-        elem_i8 = b.bitcast(elem_val, i8_ptr, name="elem.i8");
-        arg_i8 = b.bitcast(e_arg, i8_ptr, name="arg.i8");
-        cmp_result = b.call(
-            memcmp_fn, [elem_i8, arg_i8, ir.Constant(i64, elem_size)], name="memcmp"
-        );
-        elem_eq = b.icmp_signed(
-            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="elem.eq"
-        );
-    } elif isinstance(elem_type, ir.PointerType) {
-        elem_eq = b.icmp_unsigned("==", elem_val, e_arg, name="elem.eq");
-    } else {
-        elem_eq = b.icmp_signed("==", elem_val, e_arg, name="elem.eq");
-    }
+    elem_eq = self._emit_key_comparison(b, elem_type, elem_val, e_arg, elem_size);
     b.cbranch(elem_eq, found_bb, loop_cond_bb);
     # Increment index before next iteration
     b.position_before(b.block.terminator);
@@ -135,21 +85,7 @@ impl NaIRGenPass._emit_set_helpers(
     b.cbranch(need_grow, grow_bb, append_bb);
     # Grow block
     b.position_at_end(grow_bb);
-    new_cap = b.mul(cur_cap, ir.Constant(i64, 2), name="new.cap");
-    b.store(new_cap, cap_p2);
-    elem_null2 = ir.Constant(elem_type.as_pointer(), None);
-    elem_gep2 = b.gep(elem_null2, [ir.Constant(i32, 1)], name="elem.sizeof");
-    elem_sz = b.ptrtoint(elem_gep2, i64, name="elem.size");
-    new_elems_bytes = b.mul(new_cap, elem_sz, name="new.elems.bytes");
-    new_elems_raw = b.call(malloc_fn, [new_elems_bytes], name="new.elems.raw");
-    new_elems = b.bitcast(new_elems_raw, elem_type.as_pointer(), name="new.elems");
-    old_elems_bytes = b.mul(cur_len, elem_sz, name="old.elems.bytes");
-    old_elems_i8 = b.bitcast(elems_arr, i8_ptr, name="old.elems.i8");
-    new_elems_i8 = b.bitcast(new_elems, i8_ptr, name="new.elems.i8");
-    b.call(memcpy_fn, [new_elems_i8, old_elems_i8, old_elems_bytes]);
-    # Free old elements array (plain malloc'd, not RC-managed)
-    b.call(free_fn, [old_elems_i8]);
-    b.store(new_elems, elems_p2);
+    self._emit_grow_array(b, elems_p2, elem_type, cur_len, cap_p2, cur_cap);
     b.branch(append_bb);
     # Append block
     b.position_at_end(append_bb);
@@ -194,37 +130,7 @@ impl NaIRGenPass._emit_set_helpers(
     idx_bc = b.load(idx_alloca_c, name="idx.body");
     elem_ptr_c = b.gep(elems_c, [idx_bc], name="elem.ptr");
     elem_val_c = b.load(elem_ptr_c, name="elem.val");
-    # Use strcmp for strings, memcmp for tuples, etc.
-    if isinstance(elem_type, ir.IntType) {
-        elem_eq_c = b.icmp_signed("==", elem_val_c, e_arg_c, name="elem.eq");
-    } elif elem_type == i8_ptr {
-        strcmp_fn = self._get_or_declare_extern(
-            "strcmp", ir.IntType(32), [i8_ptr, i8_ptr]
-        );
-        cmp_result_c = b.call(strcmp_fn, [elem_val_c, e_arg_c], name="strcmp");
-        elem_eq_c = b.icmp_signed(
-            "==", cmp_result_c, ir.Constant(ir.IntType(32), 0), name="elem.eq"
-        );
-    } elif isinstance(elem_type, ir.PointerType) and elem_size > 0 {
-        # Pointer with known size (e.g., tuples) - use memcmp
-        memcmp_fn = self._get_or_declare_extern(
-            "memcmp", ir.IntType(32), [i8_ptr, i8_ptr, i64]
-        );
-        elem_i8_c = b.bitcast(elem_val_c, i8_ptr, name="elem.i8");
-        arg_i8_c = b.bitcast(e_arg_c, i8_ptr, name="arg.i8");
-        cmp_result_c = b.call(
-            memcmp_fn,
-            [elem_i8_c, arg_i8_c, ir.Constant(i64, elem_size)],
-            name="memcmp"
-        );
-        elem_eq_c = b.icmp_signed(
-            "==", cmp_result_c, ir.Constant(ir.IntType(32), 0), name="elem.eq"
-        );
-    } elif isinstance(elem_type, ir.PointerType) {
-        elem_eq_c = b.icmp_unsigned("==", elem_val_c, e_arg_c, name="elem.eq");
-    } else {
-        elem_eq_c = b.icmp_signed("==", elem_val_c, e_arg_c, name="elem.eq");
-    }
+    elem_eq_c = self._emit_key_comparison(b, elem_type, elem_val_c, e_arg_c, elem_size);
     b.cbranch(elem_eq_c, found_c, loop_cond_c);
     b.position_before(b.block.terminator);
     next_idx_c = b.add(idx_bc, ir.Constant(i64, 1), name="next.idx");
@@ -252,60 +158,9 @@ impl NaIRGenPass._emit_set_helpers(
     );
     release_fn.linkage = "private";
     release_fn.args[0].name = "set";
-    entry_bb = release_fn.append_basic_block("entry");
-    dec_bb = release_fn.append_basic_block("dec");
-    free_bb = release_fn.append_basic_block("do_free");
-    done_bb = release_fn.append_basic_block("done");
-    b = ir.IRBuilder(entry_bb);
-    is_null = b.icmp_unsigned(
-        "==", release_fn.args[0], ir.Constant(set_ptr_type, None), name="is.null"
-    );
-    b.cbranch(is_null, done_bb, dec_bb);
-    b = ir.IRBuilder(dec_bb);
-    raw_ptr = b.bitcast(release_fn.args[0], i8_ptr, name="raw.cast");
-    rc_raw = b.gep(raw_ptr, [ir.Constant(i64, -8)], name="rc.raw");
-    rc_ptr_r = b.bitcast(rc_raw, ir.IntType(64).as_pointer(), name="rc.ptr");
-    old_rc = b.load(rc_ptr_r, name="old.rc");
-    new_rc = b.sub(old_rc, ir.Constant(i64, 1), name="new.rc");
-    b.store(new_rc, rc_ptr_r);
-    is_zero = b.icmp_unsigned("==", new_rc, ir.Constant(i64, 0), name="is.zero");
-    b.cbranch(is_zero, free_bb, done_bb);
-    b = ir.IRBuilder(free_bb);
-    # Release pointer-typed elements if applicable
+    (b, done_bb) = self._emit_rc_destructor_preamble(release_fn, set_ptr_type);
     if isinstance(elem_type, ir.PointerType) {
-        len_p_r = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name="len.ptr.r"
-        );
-        cur_len_r = b.load(len_p_r, name="len.r");
-        elems_p_r = b.gep(
-            release_fn.args[0],
-            [ir.Constant(i32, 0), ir.Constant(i32, 2)],
-            name="elems.ptr.r"
-        );
-        elems_r = b.load(elems_p_r, name="elems.r");
-        loop_alloca = b.alloca(i64, name="loop.i");
-        b.store(ir.Constant(i64, 0), loop_alloca);
-        lcond = release_fn.append_basic_block("loop.cond");
-        lbody = release_fn.append_basic_block("loop.body");
-        lend = release_fn.append_basic_block("loop.end");
-        b.branch(lcond);
-        b = ir.IRBuilder(lcond);
-        li = b.load(loop_alloca, name="li");
-        b.cbranch(b.icmp_unsigned("<", li, cur_len_r, name="lcmp"), lbody, lend);
-        b = ir.IRBuilder(lbody);
-        ep = b.gep(elems_r, [b.load(loop_alloca, name="li2")], name="e.ptr");
-        ev = b.load(ep, name="e.val");
-        b.call(self.rc_release_simple_fn, [b.bitcast(ev, i8_ptr, name="e.cast")]);
-        b.store(
-            b.add(
-                b.load(loop_alloca, name="li3"), ir.Constant(i64, 1), name="linc"
-            ),
-            loop_alloca
-        );
-        b.branch(lcond);
-        b = ir.IRBuilder(lend);
+        b = self._emit_rc_release_elem_loop(b, release_fn, release_fn.args[0], 2);
     }
     # Free elems array
     elems_p_f = b.gep(

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -111,6 +111,41 @@ obj NaIRGenPass(Transform) {
     ) -> (ir.Value | None);
 
     def _codegen_field_assign(target: uni.AtomTrailer, value: ir.Value) -> None;
+    # Shared container helpers (used by lists, dicts, sets)
+    def _emit_key_comparison(
+        b: ir.IRBuilder,
+        key_type: ir.Type,
+        stored_val: ir.Value,
+        search_val: ir.Value,
+        key_size: int = 0
+    ) -> ir.Value;
+
+    def _emit_rc_alloc_container(
+        b: ir.IRBuilder,
+        container_ptr_type: ir.Type,
+        data_types: list,
+        initial_cap: int = 8
+    ) -> tuple;
+
+    def _emit_grow_array(
+        b: ir.IRBuilder,
+        arr_ptr: ir.Value,
+        elem_type: ir.Type,
+        cur_len: ir.Value,
+        cap_ptr: ir.Value,
+        cur_cap: ir.Value
+    ) -> ir.Value;
+
+    def _emit_rc_destructor_preamble(
+        release_fn: ir.Function, ptr_type: ir.Type
+    ) -> tuple;
+
+    def _emit_rc_release_elem_loop(
+        b: ir.IRBuilder,
+        release_fn: ir.Function,
+        container_arg: ir.Value,
+        data_field_idx: int
+    ) -> ir.IRBuilder;
     # Phase 4: Lists
     def _emit_list_helpers(elem_type_name: str, elem_type: ir.Type) -> None;
     def _codegen_list_val(nd: uni.ListVal) -> (ir.Value | None);


### PR DESCRIPTION
## Summary

- Extract 5 shared helper methods into `container_helpers.impl.jac`, eliminating ~350 lines of copy-pasted LLVM IR codegen across list, dict, and set container implementations
- `_emit_key_comparison`: consolidates 5 identical type-dispatched comparison blocks (IntType/string/tuple/pointer)
- `_emit_rc_alloc_container`: replaces 3 identical RC-managed struct allocation sequences
- `_emit_grow_array`: replaces 3 identical capacity-doubling realloc patterns
- `_emit_rc_destructor_preamble`: replaces 4 identical null-check/decrement/branch-if-zero destructor preambles
- `_emit_rc_release_elem_loop`: replaces 3 identical pointer-element release loops in container destructors

## Test plan

- [x] All 294 native compiler pass tests pass (`tests/compiler/passes/native/`)
- [ ] Full test suite passes