### PR TITLE
chore: minor formatting fixes in byllm

### DIFF
--- a/docs/docs/community/release_notes/byllm.md
+++ b/docs/docs/community/release_notes/byllm.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## byllm 0.5.5 (Unreleased)
 
+- Small refactors/formatting fixes.
+
 ## byllm 0.5.4 (Latest Release)
 
 - 2 small refactors/changes.

--- a/jac-byllm/byllm/llm.impl/basellm.impl.jac
+++ b/jac-byllm/byllm/llm.impl/basellm.impl.jac
@@ -66,7 +66,7 @@ impl BaseLLM.invoke(mt_run: MTRuntime) -> object {
             # gpt-4o returned plain text that can't be parsed — attempt recovery.
             recovery_resp = self._attempt_recovery(mt_run);
             if recovery_resp is None {
-                raise ;
+                raise;
             }
             if recovery_resp.tool_calls {
                 for tool_call in recovery_resp.tool_calls {
@@ -441,7 +441,7 @@ impl BaseLLM._invoke_streaming(
                 # gpt-4o returned plain text that can't be parsed — attempt recovery.
                 recovery_resp = self._attempt_recovery(mt_run);
                 if recovery_resp is None {
-                    raise ;
+                    raise;
                 }
                 yield from self._yield_recovery_result(
                     recovery_resp, iter_count, mt_run


### PR DESCRIPTION
## Summary
- Remove extra whitespace before semicolons in bare `raise` statements in `basellm.impl.jac`
- Update release notes for byllm 0.5.5

## Test plan
- [x] Pre-commit hooks pass
- Formatting-only change, no behavioral impact