### PR TITLE
docs: improve descriptions and normalize tone across documentation

### DIFF
--- a/docs/docs/quick-guide/faq.md
+++ b/docs/docs/quick-guide/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-Common questions and answers. If you don't see your question below and couldn't find a solution in the docs, ask your question in our [Discord Community](https://discord.gg/6j3QNdtcN6) (We try to answer within 2hrs.)
+Answers to common questions about Jac, organized by topic. Click a category to expand it, then click a specific question to see the answer. If you don't see your question below and couldn't find a solution in the docs, ask your question in our [Discord Community](https://discord.gg/6j3QNdtcN6) (we try to answer within 2hrs).
 
 ---
 

--- a/docs/docs/quick-guide/jac-vs-traditional-stack.md
+++ b/docs/docs/quick-guide/jac-vs-traditional-stack.md
@@ -1,6 +1,6 @@
 # Jac vs Traditional Stack: A Side-by-Side Comparison
 
-This document compares building the same Todo application using Jac versus a traditional Python + FastAPI + SQLite + TypeScript + React stack.
+A traditional full-stack web application requires separate projects, frameworks, and glue code -- a Python backend, a React frontend, an ORM, API route definitions, and serialization logic. In Jac, you write all of this in a single file: nodes are your data model, walkers are your API endpoints, and `cl { }` blocks are your UI components. This comparison builds the same Todo app both ways so you can see the difference.
 
 ---
 

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1,6 +1,8 @@
 # CLI Reference
 
-The Jac CLI provides commands for running, building, testing, and deploying Jac applications.
+The `jac` command is your primary interface for working with Jac projects. It handles the full development lifecycle: running programs (`jac run`), type-checking code (`jac check`), running tests (`jac test`), formatting and linting (`jac format`, `jac lint`), managing dependencies (`jac add`, `jac install`), serving APIs (`jac start`), and even compiling to native binaries (`jac nacompile`). Think of it as combining the roles of `python`, `pip`, `pytest`, `black`, and `flask` into a single unified tool.
+
+The CLI is extensible through plugins. When you install plugins like `jac-scale` or `jac-client`, they add new commands and flags automatically -- for example, `jac start --scale` for Kubernetes deployment or `jac build --client desktop` for desktop app packaging.
 
 > **💡 Enhanced Output**: For beautiful, colorful terminal output with Rich formatting, install the optional `jac-super` plugin: `pip install jac-super`. All CLI commands will automatically use enhanced output with themes, panels, and spinners.
 

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -1,6 +1,8 @@
 # Configuration Reference
 
-The `jac.toml` file is the central configuration for Jac projects. It defines project metadata, dependencies, command defaults, and plugin settings.
+The `jac.toml` file is the central configuration for Jac projects -- similar to `pyproject.toml` in Python or `package.json` in Node.js. It defines project metadata (name, version, entry point), manages dependencies (both PyPI and npm packages), sets defaults for CLI commands (test verbosity, server port, lint rules), configures plugins (LLM models, deployment targets), and supports environment-specific profiles (development vs. production).
+
+You typically don't need to edit `jac.toml` manually for basic projects. The `jac create` command generates one with sensible defaults, and commands like `jac add` and `jac config set` modify it for you. But understanding the full configuration surface is valuable when you need to customize build behavior, configure LLM providers, set up lint rules, or manage deployment settings.
 
 ## Creating a Project
 

--- a/docs/docs/reference/language/advanced.md
+++ b/docs/docs/reference/language/advanced.md
@@ -9,7 +9,12 @@
 
 ---
 
-Jac extends Python's comprehension syntax with **filter** (`?`) and **assign** (`=`) operators that work on collections of nodes or objects. These provide concise ways to query and modify groups of items.
+Jac includes Python's familiar list, dict, set, and generator comprehensions -- and extends them with two powerful operators designed for working with collections of graph nodes and objects:
+
+- **Filter comprehensions** (`?`) -- query a collection by attribute conditions or type, returning only the matching elements. This replaces verbose `for`/`if` filtering with a concise inline syntax. For example, `people(?age >= 18)` returns all people whose age is 18 or above.
+- **Assign comprehensions** (`=`) -- bulk-update attributes on every item in a collection. Instead of writing a loop to set a field on each element, `people(=verified=True)` sets `verified` to `True` on all items in one expression.
+
+These operators are especially useful during graph traversal, where you often need to filter connected nodes by type or attribute and then update them. They chain naturally: `people(?age >= 18)(=can_vote=True)` filters *then* assigns in a single expression.
 
 > **Related:**
 >
@@ -18,6 +23,8 @@ Jac extends Python's comprehension syntax with **filter** (`?`) and **assign** (
 > - [Testing](../testing.md) - Test blocks, assertions, CLI commands
 
 ## Standard Comprehensions
+
+Jac supports all four Python comprehension forms -- list, dict, set, and generator -- with identical semantics. If you know Python comprehensions, these work exactly as you'd expect, just wrapped in braces and terminated with semicolons.
 
 ```jac
 def example() {
@@ -41,7 +48,9 @@ def example() {
 
 ## Filter Comprehensions
 
-Filter collections with `?condition`:
+Filter comprehensions use the `?` operator to select elements from a collection based on attribute conditions. The syntax is `collection(?attr op value)` -- the condition references attributes directly by name, without needing a lambda or loop variable. Multiple conditions are separated by commas and are ANDed together.
+
+This is particularly powerful with graph traversals. Instead of fetching all connected nodes and then filtering in a separate loop, you can write `[-->](?status == "active")` to get only the active connections in one expression.
 
 ```jac
 node Person {
@@ -68,7 +77,7 @@ def example(people: list[Person], employees: list[Employee]) {
 
 ## Typed Filter Comprehensions
 
-Filter by type with filter syntax:
+When a graph has multiple node types connected to the same parent, typed filter comprehensions let you select by type using the `?:Type` syntax. This is the graph-aware equivalent of `isinstance` filtering -- `[-->](?:Person)` returns only `Person` nodes from all outgoing connections. You can combine type filters with attribute conditions: `[-->](?:Person, age > 21)` filters by both type and attribute in one expression.
 
 ```jac
 node Dog {
@@ -93,7 +102,7 @@ def example(animals: list) {
 
 ## Assign Comprehensions
 
-Modify all items with `=attr=value`:
+Assign comprehensions bulk-update attributes on every item in a collection using the `=attr=value` syntax. This eliminates the need for `for` loops that exist solely to set a field on each element. The real power comes from chaining with filter comprehensions: `people(?age >= 18)(=can_vote=True)` first selects adults, then sets `can_vote` on each one -- a pattern that would otherwise require a multi-line loop with a conditional.
 
 ```jac
 node Person {

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -1,5 +1,7 @@
 # Appendices
 
+Use these appendices when you need to look up a specific keyword, operator, or syntax rule. You'll also find a migration guide for Python developers and a provider configuration reference for byLLM.
+
 **In this part:**
 
 - [Appendix A: Complete Keyword Reference](#appendix-a-complete-keyword-reference) - All keywords

--- a/docs/docs/reference/language/concurrency.md
+++ b/docs/docs/reference/language/concurrency.md
@@ -7,16 +7,24 @@
 
 ---
 
-Jac supports Python-style `async/await` for concurrent I/O operations, plus a unique `flow/wait` syntax for launching and collecting parallel tasks. Use async when you need non-blocking I/O (like HTTP requests), and `flow` when you want to run multiple independent operations concurrently.
+Most real-world applications need to do multiple things at once -- fetching data from several APIs, processing independent tasks in parallel, or keeping a UI responsive while background work runs. Jac provides two distinct concurrency models to handle these scenarios:
+
+1. **`async/await`** -- cooperative concurrency on a single-threaded event loop, ideal for I/O-bound work like HTTP requests, database queries, and file operations. Tasks voluntarily yield control while waiting, allowing other tasks to progress. This is the same model used by Python's `asyncio`, JavaScript's promises, and Rust's `async` -- if you've used any of those, the concepts transfer directly.
+
+2. **`flow/wait`** -- parallel execution using a thread pool, suited for CPU-bound work and cases where you want true simultaneous execution. `flow` launches a function as a background task and immediately returns a future; `wait` blocks until the result is available. Think of it as structured, explicit parallelism -- you control exactly when work starts and when you synchronize.
+
+The key distinction: `async/await` multiplexes tasks on one thread (cooperative), while `flow/wait` runs tasks on separate threads (parallel). Choose `async` when your bottleneck is waiting for external services, and `flow` when your bottleneck is computation.
 
 ## Async/Await
 
 !!! note
     Async functions must be `await`ed in an async context. In `with entry` blocks, use `await` directly or wrap calls in an async ability.
 
-The `async/await` syntax works like Python's -- `async` marks a function as a coroutine, and `await` suspends execution until the awaited operation completes. Walkers can also be async, enabling non-blocking graph traversal with I/O at each node.
+The `async/await` syntax works like Python's -- `async` marks a function as a coroutine, and `await` suspends execution until the awaited operation completes. This enables non-blocking I/O: while one coroutine waits on a network response, others can run. Walkers can also be async, enabling non-blocking graph traversal that performs I/O at each node without stalling the event loop.
 
 ### 1 Async Functions
+
+Prefix a function definition with `async` to declare it as a coroutine. Inside an async function, use `await` to pause execution until an asynchronous operation completes. The function returns control to the event loop during the pause, allowing other coroutines to run. This makes async functions ideal for operations that involve waiting -- network requests, database queries, file reads -- because the program stays productive instead of blocking.
 
 !!! note "Conceptual Examples"
     The examples below use `http_get` as a placeholder for an async HTTP client. In practice, import an async library (e.g., `import from aiohttp { ClientSession }`) or define your own async helper.
@@ -39,6 +47,8 @@ async def process_multiple(urls: list[str]) -> list[dict] {
 
 ### 2 Async Walkers
 
+Walkers can be declared `async` to perform non-blocking I/O during graph traversal. This is particularly useful when each node in your graph requires an external call -- for example, fetching data from an API for each node, or running an LLM query at each step. Without `async`, each I/O call would block the entire traversal; with it, the walker yields during each `await` and stays responsive.
+
 ```jac
 async walker DataFetcher {
     has url: str;
@@ -50,9 +60,9 @@ async walker DataFetcher {
 }
 ```
 
-Use `async walker` for non-blocking I/O during traversal.
-
 ### 3 Async For Loops
+
+Use `async for` to iterate over async iterators -- objects that produce values asynchronously, such as streaming responses from an API, reading chunks from a file, or consuming messages from a queue. Each iteration may `await` internally, so the loop yields to the event loop between items.
 
 ```jac
 async def process_stream(stream: AsyncIterator) -> None {
@@ -66,11 +76,13 @@ async def process_stream(stream: AsyncIterator) -> None {
 
 ## Concurrent Expressions
 
-The `flow/wait` pattern provides explicit concurrency control. `flow` launches a task and immediately returns a future (without blocking), while `wait` retrieves the result (blocking if necessary). This is more explicit than async/await -- you decide exactly when to start parallel work and when to synchronize.
+The `flow/wait` pattern provides explicit concurrency control for running functions in parallel on a thread pool. Unlike `async/await` (which is cooperative and single-threaded), `flow` dispatches work to separate threads, making it suitable for CPU-bound computations that benefit from true parallelism.
+
+The mental model is simple: `flow` says "start this work now, in the background" and hands you a future (a handle to the pending result). `wait` says "I need the result now" and blocks until it's ready. Between `flow` and `wait`, you're free to do other work -- or launch more `flow` tasks -- making it easy to overlap independent operations.
 
 ### 1 flow Keyword
 
-The `flow` keyword launches a function call as a background task and returns a future immediately. Use it when you have independent operations that can run in parallel.
+The `flow` keyword launches a function call as a background task and returns a future immediately. The function runs on a separate thread, so it truly executes in parallel with your main code. Use it when you have independent operations -- such as computations, file processing, or data transformations -- that don't depend on each other's results.
 
 ```jac
 def expensive_computation -> int {
@@ -93,6 +105,8 @@ with entry {
 ```
 
 ### 2 Parallel Operations
+
+The real power of `flow/wait` emerges when you launch multiple tasks simultaneously. Each `flow` call starts a new background task immediately, so all tasks run concurrently. You then collect results with `wait` -- the total wall-clock time is roughly the duration of the slowest task, not the sum of all tasks.
 
 ```jac
 def fetch_users -> list {
@@ -129,11 +143,18 @@ with entry {
 
 ### 3 flow vs async
 
+Choosing between the two concurrency models depends on what your code spends its time doing:
+
 | Feature | async/await | flow/wait |
 |---------|-------------|-----------|
-| Model | Event loop (cooperative) | Thread pool (parallel) |
-| Best for | I/O-bound, many concurrent | CPU-bound, few concurrent |
-| Blocking | Non-blocking | Can block threads |
+| **Model** | Event loop (cooperative) | Thread pool (parallel) |
+| **Best for** | I/O-bound work (HTTP, DB, files) | CPU-bound work (computation, data processing) |
+| **Blocking** | Non-blocking -- yields to event loop | Can block threads -- each task gets its own thread |
+| **Scalability** | Thousands of concurrent tasks | Limited by thread pool size |
+| **Syntax** | `async def` / `await` | `flow` / `wait` |
+| **Use when** | Waiting on external services | Crunching numbers or processing data |
+
+In practice, many applications use both: `async/await` for the I/O layer (API calls, database queries) and `flow/wait` for compute-heavy operations that benefit from parallelism.
 
 ---
 

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -6,7 +6,7 @@
 
 ## **Jac Supersets Python**
 
-Jac supersets Python and JavaScript, providing full compatibility with both the PyPI and npm ecosystems. Developers can leverage their existing knowledge while accessing new capabilities for graph-based and object-spatial programming.
+Jac supersets Python and JavaScript, giving you full compatibility with both the PyPI and npm ecosystems. You can use your existing Python and JavaScript knowledge while accessing Jac's graph-based and object-spatial programming features.
 
 ### **How it Works: Transpilation to Native Python**
 

--- a/docs/docs/reference/language/walker-responses.md
+++ b/docs/docs/reference/language/walker-responses.md
@@ -1,6 +1,8 @@
 # Walker Response Patterns
 
-This reference explains how walker responses work and the common patterns for handling them.
+Walkers traverse a graph, visiting nodes and executing logic at each step. But how do you get data *out* of a walker after it finishes? That's what the `report` statement is for -- it's the primary mechanism for walkers to communicate results back to the code that spawned them.
+
+This reference covers the `report` mechanism and the common patterns for structuring walker responses. Choosing the right pattern matters because it affects how your client code (whether a `with entry` block, an API endpoint, or another walker) consumes the results.
 
 > **Related:**
 >
@@ -12,7 +14,7 @@ This reference explains how walker responses work and the common patterns for ha
 
 ## The `.reports` Array
 
-Every time a walker executes a `report` statement, the value is appended to a `.reports` array. When you spawn a walker, you receive this array in the response.
+Every time a walker executes a `report` statement, the value is appended to a `.reports` array on the response object. When you spawn a walker with `root spawn MyWalker()`, the returned object contains this array, giving you access to everything the walker reported during its traversal. Think of `report` as the walker's "return channel" -- except that a walker can report multiple times as it moves through the graph, accumulating results along the way.
 
 !!! note
     The `report` statement also prints each reported value to stdout as a side effect. This means you will see the reported values printed to the console in addition to them being collected in `.reports`.

--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -1,6 +1,8 @@
 # byLLM Reference
 
-Complete reference for byLLM, the AI integration framework implementing Meaning-Typed Programming (MTP).
+byLLM lets you delegate function implementations to large language models. You declare a function signature -- its name, parameter names, and types -- append `by llm`, and the LLM infers the behavior at runtime. byLLM handles prompt construction, model communication, response parsing, and type validation, so your Jac type annotations act as an enforced output schema.
+
+This approach is called **Meaning-Typed Programming (MTP)**: well-named function signatures already describe what a function should do, and byLLM makes that intent executable. This reference covers MTP concepts, configuration, structured outputs, tool calling, and provider setup.
 
 ---
 

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1,6 +1,8 @@
 # jac-client Reference
 
-Complete reference for jac-client, the full-stack web development plugin for Jac.
+jac-client adds client-side compilation to Jac so you can write React-style UI components using `cl { }` blocks or `.cl.jac` files. The compiler separates your code automatically -- server-side logic compiles to Python, while client-side components compile to JavaScript with React as the rendering engine.
+
+You also get project scaffolding (`jac create --use client`), npm dependency management, a Vite-powered dev server with HMR, and automatic HTTP bridge generation so your client components can call server walkers without manual API wiring. This reference covers installation, project structure, the module system, component authoring, and build configuration.
 
 ---
 

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -1,6 +1,8 @@
 # jac-scale Reference
 
-Complete reference for jac-scale, the cloud-native deployment and scaling plugin for Jac.
+jac-scale generates REST endpoints from your Jac walkers and functions. Running `jac start` with this plugin turns every `:pub` or `:priv` walker into an API endpoint backed by FastAPI, with automatic Swagger docs, SQLite persistence, and built-in authentication.
+
+For production, the `--scale` flag automates Docker image builds and Kubernetes deployment -- generating Dockerfiles, manifests, and service configurations from your code. This reference covers server startup options, endpoint generation, authentication, database persistence, Kubernetes deployment, and the CLI flags for each mode.
 
 ---
 

--- a/docs/docs/reference/testing.md
+++ b/docs/docs/reference/testing.md
@@ -1,6 +1,11 @@
 # Testing Reference
 
-Complete reference for writing and running tests in Jac.
+Jac has first-class support for testing built directly into the language. Instead of importing a test framework or following naming conventions, you write `test "description" { ... }` blocks right alongside your code. These blocks are ignored during normal execution (`jac run`) and only run when you invoke `jac test`.
+
+Tests in Jac use the standard `assert` statement for all checks. Each test block runs in its own isolated context, so state created in one test (including graph nodes connected to `root`) doesn't leak into another. This isolation means you can test walkers, graph operations, and node behaviors without worrying about test ordering or cleanup -- each test gets a fresh graph.
+
+!!! tip "Graph state and tests"
+    If you encounter `NodeAnchor` errors when re-running tests, clear stale persisted state with `jac clean --all` before retrying. The local storage persists graph data between runs, but test isolation resets the in-memory graph for each test block.
 
 ---
 

--- a/docs/docs/tutorials/ai/agentic.md
+++ b/docs/docs/tutorials/ai/agentic.md
@@ -1,6 +1,10 @@
 # Agentic AI
 
-Build AI agents that can use tools and reason through problems.
+The previous tutorials showed LLMs generating text and extracting structured data. But what happens when the LLM needs information it doesn't have -- like the current time, a database record, or today's weather? That's where **tool calling** comes in.
+
+byLLM lets you pass regular Jac functions as "tools" to a `by llm()` call. The LLM can then decide *when* to call these tools, *what arguments* to pass, and *how to use the results* in its response. This transforms the LLM from a passive text generator into an active agent that can interact with your application's data and services.
+
+This tutorial covers basic tool calling, multi-tool orchestration, the ReAct reasoning pattern, method-based tools on objects, combining agents with graph walkers, and building a complete agent with a knowledge base.
 
 > **Prerequisites**
 >
@@ -11,7 +15,7 @@ Build AI agents that can use tools and reason through problems.
 
 ## What is Agentic AI?
 
-Regular LLMs can only generate text. **Agentic AI** can:
+Regular LLMs can only generate text -- they have no ability to look up data, call APIs, or interact with external systems. **Agentic AI** bridges this gap by giving the LLM access to tools (functions you define) and the autonomy to use them. An agentic LLM can:
 
 - Use **tools** (functions you define)
 - **Reason** about which tools to use
@@ -127,7 +131,7 @@ with entry {
 
 ## ReAct Pattern
 
-**ReAct** (Reason + Act) lets the LLM think step-by-step:
+**ReAct** (Reason + Act) is a prompting pattern where the LLM alternates between *thinking* about what to do next and *acting* by calling tools. With multiple tools available, the LLM chains together a sequence of reasoning steps and tool calls to solve problems that require multiple pieces of information. byLLM implements this automatically when you provide multiple tools -- the LLM reasons about which tools to call, in what order, and how to combine their results:
 
 ```jac
 """Search the web for information."""
@@ -298,7 +302,7 @@ with entry {
 
 ## Context Injection
 
-Provide additional context to the LLM:
+Sometimes the LLM needs background knowledge that isn't available through tools -- company policies, product details, user preferences, or domain-specific rules. The `incl_info` parameter lets you inject this context directly into the LLM prompt alongside the function's semantic information. The LLM sees this context as authoritative background and uses it when generating responses:
 
 ```jac
 glob company_info = """

--- a/docs/docs/tutorials/ai/multimodal.md
+++ b/docs/docs/tutorials/ai/multimodal.md
@@ -1,6 +1,8 @@
 # Multimodal AI
 
-Work with images and videos in byLLM.
+Modern vision-capable LLMs (like GPT-4o and Gemini) can understand images and videos alongside text. byLLM integrates this capability through the `Image` and `Video` types -- you pass them as parameters to any `by llm()` function, and the LLM "sees" the visual content when generating its response.
+
+This enables powerful use cases: extracting structured data from photos (receipts, documents, diagrams), classifying images, describing scenes, analyzing video content, and combining visual understanding with text processing. All the structured output patterns from the previous tutorial (enums, objects, lists) work with multimodal inputs, so you can extract typed data directly from images.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/ai/quickstart.md
+++ b/docs/docs/tutorials/ai/quickstart.md
@@ -1,6 +1,10 @@
 # byLLM Quickstart
 
-Build your first AI-integrated function in Jac.
+byLLM is Jac's AI integration framework that lets you delegate function implementations to large language models. Instead of writing the logic yourself, you declare a function's signature -- its name, parameter names and types, and return type -- and end it with `by llm()`. The compiler uses these semantics to construct a prompt, calls the LLM at runtime, and validates the response against your declared return type.
+
+This is what Jac calls **Meaning-Typed Programming (MTP)**: the idea that a well-named function signature already describes what the function should do, and an LLM can infer the implementation from that meaning. It works because `translate_to_spanish(text: str) -> str` already tells the LLM everything it needs to know.
+
+In this tutorial, you'll set up byLLM, write your first AI-powered function, explore different model providers, and learn how to test AI functions with mocks.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/ai/structured-outputs.md
+++ b/docs/docs/tutorials/ai/structured-outputs.md
@@ -1,6 +1,8 @@
 # Structured Outputs
 
-Get type-safe responses from LLMs with enums, objects, and lists.
+One of the most powerful aspects of byLLM is that your `by llm()` functions aren't limited to returning strings. You can return enums, objects, lists, nested structures -- any Jac type -- and byLLM will validate that the LLM's response matches your declared type. This turns LLMs from text generators into reliable data extractors and classifiers that integrate cleanly into typed code.
+
+This tutorial covers returning enums (fixed choices), objects (structured records), lists, nested types, and optional fields from LLM calls -- all with automatic type validation.
 
 > **Prerequisites**
 >
@@ -11,7 +13,9 @@ Get type-safe responses from LLMs with enums, objects, and lists.
 
 ## Why Structured Outputs?
 
-Traditional LLM calls return strings that you must parse manually. byLLM returns proper typed objects:
+The fundamental problem with raw LLM calls is unpredictable output format. Ask an LLM "What's the sentiment?" and you might get `"positive"`, `"POSITIVE"`, `"The sentiment is positive"`, or a paragraph of explanation. Parsing these inconsistent strings into usable data requires fragile regex or string matching.
+
+byLLM solves this by using your return type annotation as a contract. When you declare `-> Sentiment`, byLLM constrains the LLM's output to valid enum values and returns a proper typed object -- no parsing required:
 
 ```
 # Traditional: Returns string, you parse it

--- a/docs/docs/tutorials/fullstack/auth.md
+++ b/docs/docs/tutorials/fullstack/auth.md
@@ -1,6 +1,8 @@
 # Authentication
 
-Add user login, signup, and protected routes to your Jac application.
+Most applications need to identify users and protect their data. Jac has authentication built into the runtime -- there's no need to integrate a third-party auth library or manage session tokens manually. The access modifier system (`:pub` vs `:priv`) directly controls which endpoints require authentication and which are open to everyone.
+
+The key concept is **per-user data isolation**: when a function or walker is marked `:priv`, each authenticated user gets their own isolated graph root. User A's data is completely invisible to User B, enforced at the runtime level. This means you don't need to write authorization checks or filter queries by user ID -- the isolation is automatic.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/fullstack/backend.md
+++ b/docs/docs/tutorials/fullstack/backend.md
@@ -1,6 +1,8 @@
 # Backend Integration
 
-Connect your frontend components to Jac walkers for data fetching and mutations.
+The real power of Jac's full-stack model is how seamlessly client components connect to server logic. Instead of manually defining REST endpoints, writing fetch calls, and parsing JSON, you simply call server-side functions or spawn walkers from your client code -- the compiler generates the HTTP layer automatically. Data goes from your graph through walkers, over the network, and into your React-style components with minimal boilerplate.
+
+This tutorial shows how to call backend functions from the frontend, use walkers for graph-based data operations, handle loading states, and structure your server-client communication.
 
 > **Prerequisites**
 >
@@ -12,7 +14,7 @@ Connect your frontend components to Jac walkers for data fetching and mutations.
 
 ## How It Works
 
-In Jac full-stack apps:
+In Jac full-stack apps, the compiler handles the client-server boundary for you. Here's the mental model:
 
 1. **Backend** = Functions or walkers that process data and return results
 2. **Frontend** = Components in `cl { }` blocks

--- a/docs/docs/tutorials/fullstack/components.md
+++ b/docs/docs/tutorials/fullstack/components.md
@@ -1,6 +1,8 @@
 # React-Style Components
 
-Build reusable UI components with JSX syntax.
+Jac's client-side code uses JSX syntax (the same HTML-in-code approach popularized by React) to build UI components. Components are functions declared inside `cl { }` blocks that return `JsxElement` values. They support props for data passing, composition for building complex UIs from simple parts, and all the familiar React patterns -- conditional rendering, list mapping, and event handling.
+
+The key difference from a standard React setup: there's no separate JavaScript project, no webpack configuration, and no build toolchain to manage. You write components in Jac syntax, the compiler generates optimized JavaScript, and the dev server bundles and serves it automatically.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -1,6 +1,6 @@
 # Routing
 
-Build multi-page applications with client-side routing.
+When your application grows beyond a single view, you need routing -- the ability to map URLs to different pages or views within your app. Jac-client supports client-side routing (the browser URL changes but the page doesn't fully reload) with two approaches: file-based routing that uses directory conventions (like Next.js) and manual routing using explicit route declarations (like React Router).
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -1,6 +1,10 @@
 # Full-Stack Project Setup
 
-Create a Jac project with frontend and backend in one codebase.
+Jac's `jac-client` plugin lets you build full-stack web applications where the frontend (React-style JSX components) and backend (walkers, functions, graph operations) live in the same codebase -- even the same file. The compiler separates client and server code automatically: code inside `cl { }` blocks compiles to JavaScript and runs in the browser, while everything else compiles to Python and runs on the server.
+
+This means no separate frontend repository, no REST API boilerplate, and no manual data serialization. When a client component calls a server function, the compiler generates the HTTP layer for you. Hot Module Replacement (HMR) is built in, so changes to both frontend and backend code reflect instantly during development.
+
+In this tutorial, you'll set up a full-stack project, understand the file structure, and get the development server running.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -1,6 +1,8 @@
 # State Management
 
-Manage reactive state with hooks and the `has` keyword.
+Interactive applications need to track and respond to changing data -- a counter incrementing, a list of items growing, a form being filled out. In Jac's client-side code, state management uses the `has` keyword inside component functions to declare reactive variables. When a `has` variable changes, the component automatically re-renders to reflect the new value, just like React's `useState` hook.
+
+This tutorial covers declaring reactive state, handling user input, sharing state between components, and managing complex state with effects and derived values.
 
 > **Prerequisites**
 >
@@ -11,7 +13,7 @@ Manage reactive state with hooks and the `has` keyword.
 
 ## Reactive State with `has`
 
-Inside `cl { }` blocks, `has` creates reactive state (like React's `useState`):
+Inside `cl { }` blocks, `has` creates reactive state (like React's `useState`). Declaring `has count: int = 0;` inside a component function creates a stateful variable that persists across re-renders and triggers a UI update whenever its value changes:
 
 ```jac
 cl {

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -1,6 +1,8 @@
 # Jac Basics
 
-Learn Jac syntax and fundamentals, especially if you're coming from Python.
+This tutorial covers the core syntax and concepts you need to start writing Jac programs. If you're coming from Python, most things will look familiar -- Jac is a superset of Python, so your existing knowledge applies directly. The key differences are syntactic (braces instead of indentation, semicolons to end statements) and conceptual (graph-native types, the `has` keyword for fields, `with entry` for entry points).
+
+By the end of this tutorial, you'll be comfortable writing functions, objects, control flow, imports, and simple graph operations in Jac.
 
 > **Prerequisites**
 >
@@ -12,7 +14,7 @@ Learn Jac syntax and fundamentals, especially if you're coming from Python.
 
 ## Jac is a Superset of Python
 
-Jac supersets Python with new paradigms -- familiar Python concepts all apply. The main syntactic differences from Python are:
+Jac supersets Python with new paradigms -- familiar Python concepts all apply. The relationship is similar to TypeScript and JavaScript: everything valid in the base language works, and the superset adds new capabilities on top. The main syntactic differences from Python are:
 
 | Python | Jac |
 |--------|-----|
@@ -25,6 +27,10 @@ Jac supersets Python with new paradigms -- familiar Python concepts all apply. T
 ---
 
 ## Variables and Types
+
+Jac supports all the same primitive types as Python (`str`, `int`, `float`, `bool`) and the same collection types (`list`, `dict`, `set`, `tuple`). Type annotations are optional but recommended -- they enable better IDE support, catch errors during `jac check`, and make your code self-documenting.
+
+The `with entry { }` block is Jac's equivalent of Python's `if __name__ == "__main__":` -- it defines the program's entry point and runs when you execute the file with `jac run`.
 
 ### Basic Variables
 
@@ -69,6 +75,8 @@ with entry {
 ---
 
 ## Functions
+
+Functions in Jac use `def` just like Python, with the body enclosed in braces instead of an indented block. Return type annotations use `-> Type` syntax. Jac also has a `can` keyword for event-triggered abilities on nodes and walkers (covered later in the [OSP tutorial](osp.md)), but for regular standalone functions and methods on objects, use `def`.
 
 ### Basic Functions
 
@@ -216,6 +224,8 @@ with entry {
 ---
 
 ## Objects (Classes)
+
+Jac uses `obj` instead of Python's `class`. Fields are declared with `has` (replacing Python's `__init__` boilerplate), and constructors are auto-generated from `has` declarations. This means you get dataclass-like convenience by default -- named fields, automatic `__init__`, and default values -- without extra decorators. Methods use `def` with implicit `self`, just like Python.
 
 ### Basic Object Definition
 
@@ -378,7 +388,7 @@ with entry {
 
 ## Global Variables
 
-Use `glob` for module-level variables:
+The `glob` keyword declares module-level variables that are accessible from any function in the file. This is Jac's equivalent of Python's module-level variables, but made explicit with a keyword so you can immediately distinguish global state from local variables when reading code.
 
 ```jac
 glob config: dict = {
@@ -424,7 +434,7 @@ You'll learn more about `can` in the [OSP tutorial](osp.md).
 
 ## Access Modifiers
 
-Jac supports access modifiers on functions:
+When you deploy a Jac application as a server (with `jac start`), access modifiers control which functions and walkers become HTTP endpoints and how authentication is handled. This is one of Jac's most distinctive features: instead of manually defining API routes with decorators (like Flask's `@app.route`), you simply annotate your functions with `:pub` or `:priv` and the framework automatically generates REST endpoints with the right authentication behavior.
 
 ```jac
 # Public endpoint -- auto-generates an HTTP API
@@ -450,7 +460,7 @@ These modifiers also apply to walkers (`walker:pub`, `walker:priv`).
 
 ## Preview: Nodes and Graphs
 
-Jac extends objects with **graph-aware types**. A quick preview before the [OSP tutorial](osp.md):
+Jac's most distinctive feature is its graph-native type system. Beyond regular objects (`obj`), Jac provides `node`, `edge`, and `walker` types that live in an in-memory graph. Nodes hold data, edges define relationships between them, and walkers traverse the graph executing logic at each step. Here's a quick preview before the full [OSP tutorial](osp.md):
 
 ```jac
 # A node is like an object that can live in a graph

--- a/docs/docs/tutorials/language/debugging.md
+++ b/docs/docs/tutorials/language/debugging.md
@@ -1,6 +1,8 @@
 # Debugging in VS Code
 
-Debug your Jac programs with breakpoints, variable inspection, and graph visualization.
+Jac integrates with VS Code's debugging infrastructure through the Jac extension, giving you the same debugging experience you'd expect from Python or JavaScript: breakpoints, step-through execution, variable inspection, call stacks, and watch expressions. The extension also includes `jacvis`, a live graph visualization tool that renders your graph structure in real time as you step through walker traversals -- so you can *see* nodes and edges appear as your code builds the graph.
+
+This tutorial walks you through setting up the debugger, using breakpoints effectively, and visualizing graph operations during debugging sessions.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -1,6 +1,8 @@
 # Kubernetes Deployment
 
-Deploy your Jac application to Kubernetes with a single command.
+Moving from a local API server to a production Kubernetes deployment typically requires writing Dockerfiles, Kubernetes manifests, configuring databases, and setting up monitoring. The `jac-scale` plugin eliminates this boilerplate: `jac start --scale` generates and applies all the necessary Kubernetes resources automatically -- your application, a MongoDB instance for graph persistence, Redis for caching, and optionally Prometheus/Grafana for monitoring.
+
+This tutorial covers deploying to a local Kubernetes cluster (minikube or Docker Desktop), but the same command works for cloud providers (EKS, GKE, AKS) with `kubectl` properly configured.
 
 > **Prerequisites**
 >

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -1,6 +1,8 @@
 # Local API Server
 
-Run your Jac walkers as a production-ready HTTP API server.
+During development, `jac run` executes your program and exits. But production applications need to stay running and respond to HTTP requests from browsers, mobile apps, or other services. The `jac start` command transforms your Jac application into a persistent API server -- every walker and function marked with `:pub` or `:priv` access modifiers automatically becomes a REST endpoint, complete with authentication, JSON serialization, and API documentation.
+
+This means you go from "Jac program that runs locally" to "HTTP API server that clients can call" with a single command change -- no Flask routes, no Express middleware, no API framework needed.
 
 > **Prerequisites**
 >
@@ -11,7 +13,7 @@ Run your Jac walkers as a production-ready HTTP API server.
 
 ## Overview
 
-The `jac start` command turns your walkers into REST API endpoints automatically:
+The `jac start` command turns your walkers and functions into REST API endpoints automatically:
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary
- Add introductory descriptions to plugin references and quick-guide pages for better context
- Improve descriptions across 20+ mkdocs pages for clearer education
- Normalize tone across doc intros with consistent voice and shorter sentences

## Test plan
- [ ] Verify mkdocs builds without errors
- [ ] Review rendered pages for readability and consistency