### PR TITLE
Fix: recognize enum types as layout-compatible in layout pass field validation

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,8 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.12.1 (Unreleased)
 
+- 3 small refactors/changes.
 - **Compiler Warns on `@classmethod`/`@staticmethod` in `obj` Definitions**: Using `@classmethod` or `@staticmethod` inside `obj`, `node`, `edge`, or `walker` now emits a warning. Use the `static` keyword instead, or switch to `class` for Python-specific decorator features. Compilation warnings are now also surfaced during `jac run`.
-- 2 small refactors/changes.
 - **Fix: Union Type Member Access Errors**: `x.attr` on a union type now errors when the attribute is missing from any variant (previously silently returned `UnknownType`). Reports which variant(s) lack the attribute.
 - **Fix: Module-Level Overload Resolution**: `math.floor()`, `math.ceil()` and other module-level overloaded functions now correctly resolve all `@overload` signatures instead of only the first.
 - **Stdlib Protocol Detection**: Added Pyright-style `ModuleSourceFlags` for production-grade stdlib type detection. Protocol types like `_SupportsFloor` and `_SupportsTrunc` are now properly recognized, enabling `math.floor(3.7)` and `math.trunc(4.9)` to type-check correctly.

--- a/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
@@ -10,6 +10,13 @@ impl LayoutPass.init(ir_in: uni.Module, prog: Any, cancel_token: Any = None) -> 
 
 impl LayoutPass.before_pass -> None {
     module = self.ir_in;
+    # Step 0: Collect all enum names (layout-compatible as i64 ordinals)
+    for nd in self.get_all_sub_nodes(module, uni.Enum, brute_force=True) {
+        ename = nd.name.value if nd.name else None;
+        if ename is not None {
+            self.registry.enum_names.add(ename);
+        }
+    }
     # Step 1: Collect all archetypes
     arch_map = self._collect_archetypes(module);
     if not arch_map {
@@ -500,7 +507,9 @@ impl LayoutPass._is_layout_compatible_type(
             return True;
         }
         # Enum types are layout-compatible (stored as i64)
-        # Check if the name resolves to an Enum in the module
+        if tname in self.registry.enum_names {
+            return True;
+        }
         if tname in self.registry.layouts {
             return True;
         }
@@ -556,6 +565,9 @@ impl LayoutPass._is_layout_compatible_type(
             return True;
         }
         if tname in arch_map {
+            return True;
+        }
+        if tname in self.registry.enum_names {
             return True;
         }
         if tname in self.registry.layouts {

--- a/jac/jaclang/compiler/passes/main/layout_pass.jac
+++ b/jac/jaclang/compiler/passes/main/layout_pass.jac
@@ -73,7 +73,8 @@ obj LayoutRegistry {
     has layouts: dict[str, ArchetypeLayout] = {},
         class_parents: dict[str, list[str]] = {},
         mro_order: dict[str, list[str]] = {},
-        topo_order: list[str] = [];
+        topo_order: list[str] = [],
+        enum_names: set[str] = set();
 
     def get_layout(name: str) -> (ArchetypeLayout | None);
     def get_mro(name: str) -> list[str];


### PR DESCRIPTION
## Problem

PR #4983 added `_validate_obj_fields` to enforce that `obj` fields use layout-compatible types. It correctly documented that enums should be allowed (stored as `i64` ordinals), but the implementation never actually checked `uni.Enum` nodes — it only checked `registry.layouts`, which only contains `Archetype` entries. So any `obj` field typed as an enum triggered a false-positive warning.

Example (`circle_clean.jac`):

    enum ShapeType;  # <- uni.Enum node, never in registry.layouts

    obj Shape {
        has shape_type: ShapeType;  # <- false-positive warning fired here
    }

Warning emitted (incorrectly):

    ⚠ obj 'Shape' field 'shape_type' has type 'ShapeType' which is not layout-compatible.

This was silent until PR #5025 started printing `warnings_had` to stdout during `jac run`, which caused `test_man_code.jac::clean circle jac` to fail.

## Fix

Collect all `uni.Enum` names into `registry.enum_names` at the start of `before_pass`, then check against that set in `_is_layout_compatible_type`.

## Changes

- `layout_pass.jac` — add `enum_names: set[str]` field to `LayoutRegistry`
- `layout_pass.impl.jac` — populate `enum_names` from `uni.Enum` nodes before validation; check it in the type compatibility check
