### PR TITLE
Document class def syntax and Self type

### DIFF
--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -280,6 +280,16 @@ obj Dog {
     def bark() {
         print(f"{self.name} says Woof!");
     }
+
+    # Class method -- Self refers to the class
+    class def create(name: str) -> Self {
+        return Self(name=name);
+    }
+
+    # Static method -- no self or Self
+    static def species() -> str {
+        return "Canis familiaris";
+    }
 }
 
 # `class` follows standard Python class behavior
@@ -392,6 +402,12 @@ type Json = JsonPrimitive | list[Json] | dict[str, Json];
 # Generic type alias
 type NumberList = list[int | float];
 
+# Self type -- refers to the enclosing archetype
+obj TreeNode {
+    has value: int = 0,
+        next: Self | None = None;  # Self = TreeNode here
+}
+
 
 # ============================================================
 # Global Variables (glob)
@@ -480,6 +496,8 @@ with entry {
 # Decorators
 # ============================================================
 
+# Prefer `class def` for classmethods in obj (see Objects section above)
+# @classmethod decorator is supported for Python `class` compatibility
 @classmethod
 def my_class_method(cls: type) -> str {
     return cls.__name__;

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -75,6 +75,7 @@ Use these appendices when you need to look up a specific keyword, operator, or s
 | `return` | Statement | Return value |
 | `root` | OSP | Root node reference |
 | `self` | Reference | Current instance |
+| `Self` | Type | Enclosing archetype type (used in `class def` and type annotations) |
 | `sem` | Declaration | Semantic string |
 | `skip` | Control | Skip (nested context) |
 | `spawn` | OSP | Spawn walker |
@@ -97,7 +98,7 @@ Use these appendices when you need to look up a specific keyword, operator, or s
 - The abstract keyword is `abs`, not `abstract`
 - Logical operators have both word and symbol forms: `and`/`&&`, `or`/`||`
 - `cl`, `sv`, and `na` are block keywords for client/server/native code separation
-- **Special variable references** (`self`, `super`, `root`, `here`, `visitor`, `init`, `postinit`) are used directly without backtick escaping -- they are built-in references, not identifiers. Only use backtick escaping when repurposing other keywords as regular identifiers (e.g., `` `type `` as a field name).
+- **Special variable references** (`self`, `Self`, `super`, `root`, `here`, `visitor`, `init`, `postinit`) are used directly without backtick escaping -- they are built-in references, not identifiers. `self` refers to the current instance; `Self` refers to the enclosing type (see [Class Methods](../language/functions-objects.md#6-static-methods-and-class-methods)). Only use backtick escaping when repurposing other keywords as regular identifiers (e.g., `` `type `` as a field name).
 
 ---
 

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -209,7 +209,7 @@ Jac keywords are reserved and cannot be used as identifiers:
 |----------|----------|
 | **Archetypes** | `obj`, `node`, `edge`, `walker`, `class`, `enum` |
 | **Abilities** | `can`, `def`, `init`, `postinit` |
-| **Access** | `pub`, `priv`, `protect`, `static`, `override`, `abs` |
+| **Access** | `pub`, `priv`, `protect`, `static`, `override`, `abs`, `Self` |
 | **Control** | `if`, `elif`, `else`, `while`, `for`, `match`, `case`, `switch`, `default` |
 | **Loop** | `break`, `continue` |
 | **Return** | `return`, `yield`, `report`, `skip` |
@@ -237,7 +237,7 @@ obj Example {
     Backtick-escaped keywords in `has` declarations **do not work** -- they cause a `SyntaxError` in Python's dataclass machinery at runtime. Choose a non-keyword identifier instead (e.g., `has cls: str;` or `has kind: str;`).
 
 !!! note "Special variable references don't need backtick escaping"
-    The following are **built-in references**, not regular identifiers. Use them directly without backticks: `self`, `super`, `root`, `here`, `visitor`, `init`, `postinit`. For example, write `self.name`, `root ++> node`, and `def init()` -- never `` `self ``, `` `root ``, or `` `init ``.
+    The following are **built-in references**, not regular identifiers. Use them directly without backticks: `self`, `Self`, `super`, `root`, `here`, `visitor`, `init`, `postinit`. `self` is the current instance; `Self` is the enclosing type. For example, write `self.name`, `root ++> node`, and `def init()` -- never `` `self ``, `` `root ``, or `` `init ``.
 
 ### 7 Entry Point Variants
 
@@ -334,7 +334,29 @@ obj Container {
 }
 ```
 
-### 4 Union Types
+### 4 The `Self` Type
+
+`Self` (capital S) is a special type that refers to the enclosing archetype. It is distinct from `self` (lowercase), which refers to the current instance.
+
+```jac
+obj Node {
+    has value: int = 0,
+        next: Self | None = None;  # Self = Node in type annotations
+
+    class def create(v: int) -> Self {  # Self = cls in class methods
+        return Self(value=v);
+    }
+
+    def set_next(n: Self) -> Self {  # Self as parameter and return type
+        self.next = n;
+        return self;
+    }
+}
+```
+
+`Self` is polymorphic -- in a subclass, it resolves to the subclass type, not the parent. See [Class Methods and Self](functions-objects.md#6-static-methods-and-class-methods) for usage details.
+
+### 5 Union Types
 
 ```jac
 obj Example {
@@ -346,7 +368,7 @@ def process(data: list[int] | dict[str, int]) -> None {
 }
 ```
 
-### 5 Type References
+### 6 Type References
 
 Type references are used in OSP operations like filtering graph traversals by node type. The `Root` keyword refers to the root node type in entry/exit clauses, and the `(?:TypeName)` syntax filters collections or traversals by type.
 
@@ -357,7 +379,7 @@ def example() {
 }
 ```
 
-### 6 Literals
+### 7 Literals
 
 **Numbers:**
 
@@ -392,7 +414,7 @@ def example() {
 }
 ```
 
-### 7 F-String Format Specifications
+### 8 F-String Format Specifications
 
 F-strings support powerful formatting with the syntax `{expression:format_spec}`.
 

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -210,23 +210,99 @@ obj Calculator {
 }
 ```
 
-### 6 Static Methods
+### 6 Static Methods and Class Methods
+
+Jac provides three method modifiers: `def` (instance method, receives `self`), `static def` (no receiver), and `class def` (class method, receives `Self`).
 
 ```jac
 obj Counter {
     static has count: int = 0;
 
-    # Static method
+    # Static method -- no self or cls, pure utility
     static def get_count() -> int {
         return Counter.count;
     }
 
-    # Instance method
+    # Class method -- Self refers to the class itself
+    class def create() -> Self {
+        return Self();
+    }
+
+    # Instance method -- self is the instance
     def increment() -> None {
         Counter.count += 1;
     }
 }
 ```
+
+| Modifier | Receiver | Use case |
+|----------|----------|----------|
+| `def` | `self` (implicit) | Instance behavior |
+| `static def` | none | Utility functions |
+| `class def` | `Self` (implicit) | Factory methods, alternative constructors |
+
+#### Class Methods and `Self`
+
+`class def` declares a class method. Inside it, `Self` (capital S) refers to the class itself -- equivalent to Python's `cls` parameter, but auto-injected.
+
+```jac
+obj Animal {
+    has name: str,
+        sound: str = "...";
+
+    class def create(name: str) -> Self {
+        return Self(name=name);
+    }
+
+    def speak() -> str {
+        return f"{self.name} says {self.sound}";
+    }
+}
+
+obj Dog(Animal) {
+    has sound: str = "woof";
+}
+
+with entry {
+    # Self resolves to Dog, not Animal -- polymorphic!
+    d = Dog.create("Rex");
+    print(d.speak());         # Rex says woof
+    print(type(d).__name__);  # Dog
+}
+```
+
+`Self` is polymorphic: when a subclass inherits a `class def`, `Self` resolves to the subclass. This makes factory methods work correctly across inheritance hierarchies without overriding.
+
+#### `Self` as a Type Annotation
+
+`Self` also works as a type annotation in instance methods, enabling fluent/builder patterns:
+
+```jac
+obj QueryBuilder {
+    has table: str = "",
+        limit_val: int = -1;
+
+    def from_table(table: str) -> Self {
+        self.table = table;
+        return self;
+    }
+
+    def limit(n: int) -> Self {
+        self.limit_val = n;
+        return self;
+    }
+}
+
+with entry {
+    q = QueryBuilder().from_table("users").limit(10);
+}
+```
+
+| Context | `Self` resolves to |
+|---------|-------------------|
+| `class def` body | the class (`cls` in Python) |
+| `def` body | `type(self)` -- the runtime class |
+| Type annotation | the enclosing class name |
 
 ### 7 Lambda Expressions
 
@@ -337,7 +413,7 @@ Objects are Jac's basic unit of data and behavior. Use `obj` for general-purpose
 !!! note "When to use `obj` vs `class`"
     Jac's `obj` enforces stricter semantics than Python's `class` -- fields are declared upfront with `has`, constructors are auto-generated, and the structure is designed to be portable across codespaces (server, client, native). This strictness is intentional: it enables the compiler to target multiple execution environments from the same source code.
 
-    If you need Python-specific class machinery like metaclasses, `@classmethod`, or `@property` decorators, use a Python `class` instead. Jac provides the `static` keyword for static methods and fields, covering the most common use case for `@classmethod` and `@staticmethod`.
+    If you need Python-specific class machinery like metaclasses or `@property` decorators, use a Python `class` instead. Jac provides `static def` for static methods, `class def` for class methods (with `Self`), and `static has` for class-level fields.
 
 ```jac
 obj Person {


### PR DESCRIPTION
## Summary
- Document `class def` classmethod modifier and `Self` type across the language reference
- Update functions-objects.md with class method section, examples, and comparison tables
- Add Self type to foundation.md type system section
- Add quick examples to syntax-cheatsheet.md
- Add Self to keyword reference in appendices.md

## Files changed
- **functions-objects.md**: Expanded Section 6 to "Static Methods and Class Methods" with `class def`, `Self`, factory patterns, fluent builders, and polymorphic inheritance examples
- **foundation.md**: New Section 4 "The Self Type" in Types and Values, added Self to keywords table and special references
- **syntax-cheatsheet.md**: Added `class def`/`static def` to Dog example, Self type in Type Aliases, decorator note
- **appendices.md**: Added Self to keyword reference table and special variable references note

## Test plan
- [ ] Verify mkdocs builds without errors
- [ ] Review examples for accuracy against implementation