### PR TITLE
fix(jac-scale): include redis.conf.template in package distribution

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -6,6 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - [Internal] Refactor: Extract graph visualizer HTML into a standalone template file.
 - **User storage now supports both MongoDB and SQLite**: User authentication and management automatically uses SQLite when MongoDB is not configured, maintaining full backward compatibility with existing installations.
+- [fix] Include `redis.conf.template` in package distribution so Redis deployment works with non-editable installs.
 
 ## jac-scale 0.2.4 (Latest Release)
 

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -30,7 +30,7 @@ include = ["jac_scale*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.jac", "*.impl/*.jac", "*.cl/*.jac"]
-jac_scale = ["_precompiled/**/*.jir", "_precompiled/manifest.json", "templates/*.html"]
+jac_scale = ["_precompiled/**/*.jir", "_precompiled/manifest.json", "templates/*.html", "providers/**/*.template"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
## Summary
- `redis.conf.template` was missing from non-editable `jac-scale` installs because `pyproject.toml` package-data didn't include `*.template` files
- Added `"providers/**/*.template"` to `[tool.setuptools.package-data]` so Redis deployment works correctly in CI and production

Fixes #5057

## Test plan
- [ ] Build `jac-scale` wheel and verify `redis.conf.template` is included: `pip wheel . && unzip -l jac_scale-*.whl | grep template`
- [ ] Run `jac start --scale` with a non-editable install and confirm Redis deploys without errors