### PR TITLE
jac-gpt testing workflow added back

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -195,7 +195,7 @@ jobs:
     - name: Run admin API tests
       run: |
         pytest -x jac-scale/jac_scale/tests/test_admin.jac
-    
+
     - name: Run MongoDB user manager tests
       run: |
         pytest -x jac-scale/jac_scale/tests/test_mongo_user_manager.jac


### PR DESCRIPTION
With the PR https://github.com/jaseci-labs/jaseci/pull/5043 the jac-gpt tests were mistakenly removed. So they've added back with this PR