### PR TITLE
Fix(type-checker): Tuple unpacking in for loops now infers correct types

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.12.1 (Unreleased)
 
+- **Fix: Tuple Unpacking in For Loops**: `for (a, b, c) in list[tuple[A, B, C]]` now correctly infers types for unpacked variables instead of `UnknownType`.
 - **Refactor: `GUEST` Constant for Guest Username**: Added a `GUEST = '__guest__'` constant to `Constants` enum and replaced hardcoded `'__guest__'` strings in the stdlib HTTP server with `Con.GUEST.value` for improved maintainability and consistency.
 - **Fix: Native Cross-Module Global Variable Access**: Module-level globals declared in one `.na.jac` file are now correctly accessible from importing modules. Previously, accessing such a global caused a segfault at runtime.
 - 4 small refactors/changes.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -1177,6 +1177,64 @@ impl TypeEvaluator._get_type_of_symbol(symbol: uni.Symbol) -> TypeBase {
                         }
                     }
                 }
+                # ---- Handle tuple unpacking in for loops: for (a, b, c) in <expr> ----
+                # Similar to Pyright's evaluateTypesForForStatement + assignTypeToTupleOrListNode
+                elif isinstance(unpack_assignment, (uni.InForStmt, uni.InnerCompr)) {
+                    collection_type = self.get_type_of_expression(
+                        unpack_assignment.collection
+                    );
+                    # Get the iterator's element type (similar to Pyright's getTypeOfIterator)
+                    iter_type = self.get_type_of_magic_method_call(
+                        collection_type, "__iter__", [], unpack_assignment
+                    );
+                    elem_type: types.TypeBase | None = None;
+                    if isinstance(iter_type, types.ClassType)
+                    and len(iter_type.private.type_args) == 1 {
+                        elem_type = iter_type.private.type_args[0];
+                        # If element type is a TypeVar, specialize it using collection's type_args
+                        if isinstance(elem_type, types.TypeVarType)
+                        and isinstance(collection_type, types.ClassType)
+                        and collection_type.private.type_args {
+                            specialized = iter_type.specialize_generics(
+                                collection_type.private.type_args
+                            );
+                            if len(specialized.private.type_args) == 1 {
+                                elem_type = specialized.private.type_args[0];
+                            }
+                        }
+                    }
+                    # Now extract the tuple element at the correct index
+                    if isinstance(elem_type, types.ClassType) {
+                        idx = -1;
+                        for (vi, v) in enumerate(unpack_container.values) {
+                            if v is node_ {
+                                idx = vi;
+                                break;
+                            }
+                        }
+                        if idx >= 0 {
+                            # NamedTuple: get field types from has vars
+                            if elem_type.is_namedtuple() {
+                                has_vars = elem_type.shared.symbol_table.get_has_vars();
+                                if idx < len(has_vars) {
+                                    field = has_vars[idx];
+                                    if field.type_tag {
+                                        field_type = self.get_type_of_expression(
+                                            field.type_tag.tag
+                                        );
+                                        return self._convert_to_instance(field_type);
+                                    }
+                                }
+                                # Regular tuple with type_args
+                            } elif elem_type.private.type_args
+                            and idx < len(elem_type.private.type_args) {
+                                return self._convert_to_instance(
+                                    elem_type.private.type_args[idx]
+                                );
+                            }
+                        }
+                    }
+                }
             }
 
             # ---- Handle simple assignment: var = <expr> ----

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_tuple_unpack_for_loop.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_tuple_unpack_for_loop.jac
@@ -1,0 +1,43 @@
+"""Fixture for Bug #22: Tuple unpacking in for loops returns UnknownType.
+
+When iterating over list[tuple[A, B, C]] with destructuring like:
+    for (a, b, c) in items { ... }
+
+The type checker failed to infer types for a, b, c because it only
+handled tuple unpacking for Assignment, not for InForStmt/InnerCompr.
+"""
+
+class Foo {
+    has name: str = "test";
+}
+
+with entry {
+    # Test 1: Basic tuple unpacking in for loop
+    items: list[tuple[str, int, Foo]] = [("a", 1, Foo()), ("b", 2, Foo())];
+
+    for (s, n, f) in items {
+        # These should all be correctly typed now
+        x: str = s;      # s should be str
+        y: int = n;      # n should be int
+        z: Foo = f;      # f should be Foo
+        print(f.name);   # Should work - f is Foo
+
+        # These should produce type errors
+        bad1: int = s;   # Error: str not assignable to int
+        bad2: str = n;   # Error: int not assignable to str
+        bad3: str = f;   # Error: Foo not assignable to str
+    }
+
+    # Test 2: Tuple unpacking in list comprehension
+    names = [name for (name, _, _) in items];
+    check_name: str = names[0];  # Should work
+    bad_name: int = names[0];    # Error: str not assignable to int
+
+    # Test 3: Nested tuple unpacking (2-element tuple)
+    pairs: list[tuple[int, str]] = [(1, "a"), (2, "b")];
+    for (num, text) in pairs {
+        a: int = num;    # Should work
+        b: str = text;   # Should work
+        c: str = num;    # Error: int not assignable to str
+    }
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -14,6 +14,7 @@ Bug index:
   #13 - IfExpr (ternary) has no handler (returns UnknownType)
   #15 - No generic type argument checking (list[int] -> list[str])
   #21 - _get_method_with_overloads doesn't specialize the base method
+  #22 - Tuple unpacking in for loops returns UnknownType
 """
 
 import os;
@@ -240,4 +241,34 @@ test "bug_15_no_generic_variance_check" {
     assert len(program.errors_had) >= 1 , f"Bug #15: No generic type argument checking. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
     f"list[int] should NOT be assignable to list[str].";
+}
+
+# =========================================================================
+# Bug #22: Tuple unpacking in for loops returns UnknownType
+#
+# When iterating with destructuring like `for (a, b, c) in items`, the
+# type checker only handled tuple unpacking for Assignment targets, not
+# for InForStmt/InnerCompr targets.
+#
+# In type_evaluator.impl.jac, the Name case checked if the grandparent
+# was Assignment but not InForStmt, so unpacked variables got UnknownType.
+#
+# Impact: `for (x, y) in list[tuple[A, B]]` types x and y as Unknown,
+#         missing all type errors involving these variables.
+# =========================================================================
+test "bug_22_tuple_unpack_for_loop_unknown" {
+    program = compile_and_check("checker_bug_tuple_unpack_for_loop.jac");
+
+    # Expected errors:
+    #   - bad1: int = s (str -> int)
+    #   - bad2: str = n (int -> str)
+    #   - bad3: str = f (Foo -> str)
+    #   - bad_name: int = names[0] (str -> int)
+    #   - c: str = num (int -> str)
+    # Total: 5 errors
+    #
+    # With the bug: 0 errors (all unpacked vars are UnknownType)
+    assert len(program.errors_had) == 5 , f"Bug #22: Tuple unpacking in for loops returns UnknownType. "
+    f"Expected 5 type errors but got {len(program.errors_had)}. "
+    f"for (a, b) in list[tuple[A, B]] should type a as A and b as B.";
 }


### PR DESCRIPTION
## Summary
- Fixed type inference for tuple unpacking in for loops (`for (a, b, c) in items`)
- Previously, unpacked variables were typed as `UnknownType`
- Now correctly infers types from `list[tuple[A, B, C]]` element types

## Problem
When iterating with destructuring like:
```jac
items: list[tuple[str, int, Foo]] = [...];
for (s, n, f) in items {
    print(f.name);  // Error: Type is Unknown, cannot access attribute "name"
}
```
The type checker only handled tuple unpacking for `Assignment` targets, not for `InForStmt`/`InnerCompr` targets.

## Solution
Added handling for `InForStmt` and `InnerCompr` in the Name type evaluation logic (similar to Pyright's `evaluateTypesForForStatement` + `assignTypeToTupleOrListNode`):
1. Get the collection type from the for loop
2. Call `__iter__` to get the iterator element type (the tuple)
3. Extract the specific tuple element based on the variable's index