### PR TITLE
Refactor: separate impl from declarations across 11 jac modules

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -6,7 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - **Refactor: `GUEST` Constant for Guest Username**: Added a `GUEST = '__guest__'` constant to `Constants` enum and replaced hardcoded `'__guest__'` strings in the stdlib HTTP server with `Con.GUEST.value` for improved maintainability and consistency.
 - **Fix: Native Cross-Module Global Variable Access**: Module-level globals declared in one `.na.jac` file are now correctly accessible from importing modules. Previously, accessing such a global caused a segfault at runtime.
-- 4 small refactors/changes.
+- 15 small refactors/changes.
 - **Fix: HMR Recursive recompilation**: Fixed client-side code recursive recompilation process, preventing cyclic recompilation, and ensuring that all dependencies are up to date.
 - **Fix: HTTP Server Authentication for Imported `:pub` Functions**: Fixed server incorrectly requiring authentication (401) for imported `:pub` functions. The server now inspects source file ASTs to determine access levels for imported function endpoints, matching the existing behavior for imported walkers.
 - **Fix: Python Package Imports**: Fixed two import bugs. (1) `import from mypkg { MyClass }` now works when `mypkg/__init__.py` re-exports via `from .mymod import *` - previously the type checker couldn't find `MyClass`. (2) `import from mypkg { subpkg }` now correctly types `subpkg` as a module - previously it failed when `subpkg` is a sub-package inside `mypkg`.

--- a/jac/jaclang/compiler/passes/ecmascript/impl/primitives_es.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/primitives_es.impl.jac
@@ -1,0 +1,2069 @@
+"""Implementation of ECMAScript primitive emitters."""
+
+# --- Named methods ---
+impl ESIntEmitter.emit_bit_length(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("int", "bit_length", [target]);
+}
+
+impl ESIntEmitter.emit_bit_count(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("int", "bit_count", [target]);
+}
+
+impl ESIntEmitter.emit_to_bytes(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("int", "to_bytes", [target] + args);
+}
+
+impl ESIntEmitter.emit_as_integer_ratio(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "[" + target + ", 1]";
+}
+
+impl ESIntEmitter.emit_conjugate(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return target;
+}
+
+impl ESIntEmitter.emit_from_bytes(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("int", "from_bytes", args);
+}
+
+# --- Arithmetic operators ---
+impl ESIntEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "+", args[0]);
+}
+
+impl ESIntEmitter.emit_op_sub(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "-", args[0]);
+}
+
+impl ESIntEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "*", args[0]);
+}
+
+impl ESIntEmitter.emit_op_truediv(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "/", args[0]);
+}
+
+impl ESIntEmitter.emit_op_floordiv(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Math.floor(" + target + " / " + args[0] + ")";
+}
+
+impl ESIntEmitter.emit_op_mod(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    # Python modulo semantics: result has same sign as divisor
+    return _rt("int", "mod", [target, args[0]]);
+}
+
+impl ESIntEmitter.emit_op_pow(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "**", args[0]);
+}
+
+# --- Bitwise operators ---
+impl ESIntEmitter.emit_op_and(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "&", args[0]);
+}
+
+impl ESIntEmitter.emit_op_or(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "|", args[0]);
+}
+
+impl ESIntEmitter.emit_op_xor(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "^", args[0]);
+}
+
+impl ESIntEmitter.emit_op_lshift(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<<", args[0]);
+}
+
+impl ESIntEmitter.emit_op_rshift(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">>", args[0]);
+}
+
+# --- Comparison operators ---
+impl ESIntEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "===", args[0]);
+}
+
+impl ESIntEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "!==", args[0]);
+}
+
+impl ESIntEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<", args[0]);
+}
+
+impl ESIntEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">", args[0]);
+}
+
+impl ESIntEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<=", args[0]);
+}
+
+impl ESIntEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">=", args[0]);
+}
+
+# --- Unary operators ---
+impl ESIntEmitter.emit_op_neg(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(-" + target + ")";
+}
+
+impl ESIntEmitter.emit_op_pos(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(+" + target + ")";
+}
+
+impl ESIntEmitter.emit_op_invert(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(~" + target + ")";
+}
+
+# --- Named methods ---
+impl ESFloatEmitter.emit_is_integer(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Number.isInteger(" + target + ")";
+}
+
+impl ESFloatEmitter.emit_as_integer_ratio(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("float", "as_integer_ratio", [target]);
+}
+
+impl ESFloatEmitter.emit_conjugate(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return target;
+}
+
+impl ESFloatEmitter.emit_hex(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("float", "hex", [target]);
+}
+
+impl ESFloatEmitter.emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("float", "fromhex", args);
+}
+
+# --- Arithmetic operators ---
+impl ESFloatEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "+", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_sub(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "-", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "*", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_truediv(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "/", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_floordiv(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Math.floor(" + target + " / " + args[0] + ")";
+}
+
+impl ESFloatEmitter.emit_op_mod(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    # Python modulo semantics: result has same sign as divisor
+    return _rt("float", "mod", [target, args[0]]);
+}
+
+impl ESFloatEmitter.emit_op_pow(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "**", args[0]);
+}
+
+# --- Comparison operators ---
+impl ESFloatEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "===", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "!==", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<=", args[0]);
+}
+
+impl ESFloatEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">=", args[0]);
+}
+
+# --- Unary operators ---
+impl ESFloatEmitter.emit_op_neg(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(-" + target + ")";
+}
+
+impl ESFloatEmitter.emit_op_pos(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(+" + target + ")";
+}
+
+# --- Named methods ---
+impl ESComplexEmitter.emit_conjugate(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "conjugate", [target]);
+}
+
+# --- Arithmetic operators ---
+impl ESComplexEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "add", [target, args[0]]);
+}
+
+impl ESComplexEmitter.emit_op_sub(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "sub", [target, args[0]]);
+}
+
+impl ESComplexEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "mul", [target, args[0]]);
+}
+
+impl ESComplexEmitter.emit_op_truediv(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "truediv", [target, args[0]]);
+}
+
+impl ESComplexEmitter.emit_op_pow(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "pow", [target, args[0]]);
+}
+
+# --- Comparison operators ---
+impl ESComplexEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "eq", [target, args[0]]);
+}
+
+impl ESComplexEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("complex", "eq", [target, args[0]]);
+}
+
+# --- Unary operators ---
+impl ESComplexEmitter.emit_op_neg(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "neg", [target]);
+}
+
+impl ESComplexEmitter.emit_op_pos(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("complex", "pos", [target]);
+}
+
+# Override bitwise ops to return boolean
+impl ESBoolEmitter.emit_op_and(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Boolean(" + _binop(target, "&", args[0]) + ")";
+}
+
+impl ESBoolEmitter.emit_op_or(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Boolean(" + _binop(target, "|", args[0]) + ")";
+}
+
+impl ESBoolEmitter.emit_op_xor(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Boolean(" + _binop(target, "^", args[0]) + ")";
+}
+
+# Case conversion
+impl ESStrEmitter.emit_capitalize(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "capitalize", [target]);
+}
+
+impl ESStrEmitter.emit_casefold(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "toLowerCase", []);
+}
+
+impl ESStrEmitter.emit_lower(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "toLowerCase", []);
+}
+
+impl ESStrEmitter.emit_upper(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "toUpperCase", []);
+}
+
+impl ESStrEmitter.emit_title(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "title", [target]);
+}
+
+impl ESStrEmitter.emit_swapcase(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "swapcase", [target]);
+}
+
+# Search
+impl ESStrEmitter.emit_count(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "count", [target] + args);
+}
+
+impl ESStrEmitter.emit_find(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) > 1 {
+        return _rt("str", "find", [target] + args);
+    }
+    return _mcall(target, "indexOf", args);
+}
+
+impl ESStrEmitter.emit_rfind(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) > 1 {
+        return _rt("str", "rfind", [target] + args);
+    }
+    return _mcall(target, "lastIndexOf", args);
+}
+
+impl ESStrEmitter.emit_index(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "index", [target] + args);
+}
+
+impl ESStrEmitter.emit_rindex(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "rindex", [target] + args);
+}
+
+impl ESStrEmitter.emit_startswith(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 1 {
+        return _mcall(target, "startsWith", args);
+    }
+    return _rt("str", "startswith", [target] + args);
+}
+
+impl ESStrEmitter.emit_endswith(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 1 {
+        return _mcall(target, "endsWith", args);
+    }
+    return _rt("str", "endswith", [target] + args);
+}
+
+# Modification
+impl ESStrEmitter.emit_replace(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 2 {
+        return _mcall(target, "replaceAll", args);
+    }
+    return _rt("str", "replace", [target] + args);
+}
+
+impl ESStrEmitter.emit_strip(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _mcall(target, "trim", []);
+    }
+    return _rt("str", "strip", [target] + args);
+}
+
+impl ESStrEmitter.emit_lstrip(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _mcall(target, "trimStart", []);
+    }
+    return _rt("str", "lstrip", [target] + args);
+}
+
+impl ESStrEmitter.emit_rstrip(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _mcall(target, "trimEnd", []);
+    }
+    return _rt("str", "rstrip", [target] + args);
+}
+
+impl ESStrEmitter.emit_removeprefix(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "removeprefix", [target] + args);
+}
+
+impl ESStrEmitter.emit_removesuffix(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "removesuffix", [target] + args);
+}
+
+# Split and join
+impl ESStrEmitter.emit_split(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _rt("str", "split", [target]);
+    }
+    if len(args) == 1 {
+        return _mcall(target, "split", args);
+    }
+    return _rt("str", "split", [target] + args);
+}
+
+impl ESStrEmitter.emit_rsplit(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "rsplit", [target] + args);
+}
+
+impl ESStrEmitter.emit_splitlines(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _mcall(target, "split", ["/\\r?\\n/"]);
+    }
+    return _rt("str", "splitlines", [target] + args);
+}
+
+impl ESStrEmitter.emit_join(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    # Python: separator.join(iterable) → JS: array.join(separator)
+    return _mcall(args[0], "join", [target]);
+}
+
+impl ESStrEmitter.emit_partition(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "partition", [target] + args);
+}
+
+impl ESStrEmitter.emit_rpartition(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "rpartition", [target] + args);
+}
+
+# Formatting and alignment
+impl ESStrEmitter.emit_format(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "format", [target] + args);
+}
+
+impl ESStrEmitter.emit_format_map(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "format_map", [target] + args);
+}
+
+impl ESStrEmitter.emit_center(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "center", [target] + args);
+}
+
+impl ESStrEmitter.emit_ljust(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 1 {
+        return _mcall(target, "padEnd", args);
+    }
+    return _mcall(target, "padEnd", args);
+}
+
+impl ESStrEmitter.emit_rjust(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 1 {
+        return _mcall(target, "padStart", args);
+    }
+    return _mcall(target, "padStart", args);
+}
+
+impl ESStrEmitter.emit_zfill(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "zfill", [target] + args);
+}
+
+impl ESStrEmitter.emit_expandtabs(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "expandtabs", [target] + args);
+}
+
+# Character tests
+impl ESStrEmitter.emit_isalnum(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[a-zA-Z0-9]+$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_isalpha(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[a-zA-Z]+$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_isascii(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[\\x00-\\x7F]*$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_isdecimal(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[0-9]+$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_isdigit(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[0-9]+$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_isidentifier(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_islower(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(" + target + " === " + target + ".toLowerCase() && " + target + " !== " + target + ".toUpperCase())";
+}
+
+impl ESStrEmitter.emit_isnumeric(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "isnumeric", [target]);
+}
+
+impl ESStrEmitter.emit_isprintable(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^[\\x20-\\x7E]*$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_isspace(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "/^\\s+$/.test(" + target + ")";
+}
+
+impl ESStrEmitter.emit_istitle(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "istitle", [target]);
+}
+
+impl ESStrEmitter.emit_isupper(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "(" + target + " === " + target + ".toUpperCase() && " + target + " !== " + target + ".toLowerCase())";
+}
+
+# Encoding
+impl ESStrEmitter.emit_encode(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "new TextEncoder().encode(" + target + ")";
+}
+
+# Translation
+impl ESStrEmitter.emit_translate(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "translate", [target] + args);
+}
+
+impl ESStrEmitter.emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("str", "maketrans", args);
+}
+
+# --- Arithmetic operators ---
+impl ESStrEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "+", args[0]);
+}
+
+impl ESStrEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "repeat", [args[0]]);
+}
+
+impl ESStrEmitter.emit_op_mod(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("str", "mod", [target, args[0]]);
+}
+
+# --- Comparison operators ---
+impl ESStrEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "===", args[0]);
+}
+
+impl ESStrEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "!==", args[0]);
+}
+
+impl ESStrEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<", args[0]);
+}
+
+impl ESStrEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">", args[0]);
+}
+
+impl ESStrEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, "<=", args[0]);
+}
+
+impl ESStrEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(target, ">=", args[0]);
+}
+
+# --- Membership operators ---
+impl ESStrEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "includes", [args[0]]);
+}
+
+# Decoding
+impl ESBytesEmitter.emit_decode(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "new TextDecoder(" + (args[0] if len(args) > 0 else "") + ").decode(" + target + ")";
+}
+
+impl ESBytesEmitter.emit_hex(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "hex", [target] + args);
+}
+
+impl ESBytesEmitter.emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("bytes", "fromhex", args);
+}
+
+# Search
+impl ESBytesEmitter.emit_count(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "count", [target] + args);
+}
+
+impl ESBytesEmitter.emit_find(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "find", [target] + args);
+}
+
+impl ESBytesEmitter.emit_rfind(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "rfind", [target] + args);
+}
+
+impl ESBytesEmitter.emit_index(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "index", [target] + args);
+}
+
+impl ESBytesEmitter.emit_rindex(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "rindex", [target] + args);
+}
+
+impl ESBytesEmitter.emit_startswith(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "startswith", [target] + args);
+}
+
+impl ESBytesEmitter.emit_endswith(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "endswith", [target] + args);
+}
+
+# Modification
+impl ESBytesEmitter.emit_replace(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "replace", [target] + args);
+}
+
+impl ESBytesEmitter.emit_strip(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "strip", [target] + args);
+}
+
+impl ESBytesEmitter.emit_lstrip(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "lstrip", [target] + args);
+}
+
+impl ESBytesEmitter.emit_rstrip(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "rstrip", [target] + args);
+}
+
+impl ESBytesEmitter.emit_removeprefix(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "removeprefix", [target] + args);
+}
+
+impl ESBytesEmitter.emit_removesuffix(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "removesuffix", [target] + args);
+}
+
+# Split and join
+impl ESBytesEmitter.emit_split(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "split", [target] + args);
+}
+
+impl ESBytesEmitter.emit_rsplit(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "rsplit", [target] + args);
+}
+
+impl ESBytesEmitter.emit_splitlines(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "splitlines", [target] + args);
+}
+
+impl ESBytesEmitter.emit_join(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "join", [target] + args);
+}
+
+impl ESBytesEmitter.emit_partition(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "partition", [target] + args);
+}
+
+impl ESBytesEmitter.emit_rpartition(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "rpartition", [target] + args);
+}
+
+# Case (ASCII only)
+impl ESBytesEmitter.emit_capitalize(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "capitalize", [target]);
+}
+
+impl ESBytesEmitter.emit_lower(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "lower", [target]);
+}
+
+impl ESBytesEmitter.emit_upper(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "upper", [target]);
+}
+
+impl ESBytesEmitter.emit_title(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "title", [target]);
+}
+
+impl ESBytesEmitter.emit_swapcase(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "swapcase", [target]);
+}
+
+# Character tests (ASCII only)
+impl ESBytesEmitter.emit_isalnum(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "isalnum", [target]);
+}
+
+impl ESBytesEmitter.emit_isalpha(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "isalpha", [target]);
+}
+
+impl ESBytesEmitter.emit_isascii(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "isascii", [target]);
+}
+
+impl ESBytesEmitter.emit_isdigit(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "isdigit", [target]);
+}
+
+impl ESBytesEmitter.emit_islower(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "islower", [target]);
+}
+
+impl ESBytesEmitter.emit_isspace(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "isspace", [target]);
+}
+
+impl ESBytesEmitter.emit_istitle(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "istitle", [target]);
+}
+
+impl ESBytesEmitter.emit_isupper(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "isupper", [target]);
+}
+
+# Alignment
+impl ESBytesEmitter.emit_center(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "center", [target] + args);
+}
+
+impl ESBytesEmitter.emit_ljust(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "ljust", [target] + args);
+}
+
+impl ESBytesEmitter.emit_rjust(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "rjust", [target] + args);
+}
+
+impl ESBytesEmitter.emit_zfill(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "zfill", [target] + args);
+}
+
+impl ESBytesEmitter.emit_expandtabs(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "expandtabs", [target] + args);
+}
+
+# Translation
+impl ESBytesEmitter.emit_translate(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "translate", [target] + args);
+}
+
+impl ESBytesEmitter.emit_maketrans(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "maketrans", args);
+}
+
+# --- Arithmetic operators ---
+impl ESBytesEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "add", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "mul", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_mod(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "mod", [target, args[0]]);
+}
+
+# --- Comparison operators ---
+impl ESBytesEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "eq", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("bytes", "eq", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "lt", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "gt", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "le", [target, args[0]]);
+}
+
+impl ESBytesEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "ge", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESBytesEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("bytes", "contains", [target, args[0]]);
+}
+
+# --- Named methods ---
+impl ESListEmitter.emit_append(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "push", args);
+}
+
+impl ESListEmitter.emit_extend(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return target + ".push(..." + args[0] + ")";
+}
+
+impl ESListEmitter.emit_insert(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "splice", [args[0], "0", args[1]]);
+}
+
+impl ESListEmitter.emit_remove(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "remove", [target] + args);
+}
+
+impl ESListEmitter.emit_pop(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _mcall(target, "pop", []);
+    }
+    return _mcall(target, "splice", [args[0], "1"]) + "[0]";
+}
+
+impl ESListEmitter.emit_clear(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return target + ".length = 0";
+}
+
+impl ESListEmitter.emit_index(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "index", [target] + args);
+}
+
+impl ESListEmitter.emit_count(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "count", [target] + args);
+}
+
+impl ESListEmitter.emit_sort(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return _mcall(target, "sort", []);
+    }
+    return _rt("list", "sort", [target] + args);
+}
+
+impl ESListEmitter.emit_reverse(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "reverse", []);
+}
+
+impl ESListEmitter.emit_copy(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "[..." + target + "]";
+}
+
+# --- Arithmetic operators ---
+impl ESListEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "[..." + target + ", ..." + args[0] + "]";
+}
+
+impl ESListEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "repeat", [target, args[0]]);
+}
+
+# --- Comparison operators ---
+impl ESListEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "eq", [target, args[0]]);
+}
+
+impl ESListEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("list", "eq", [target, args[0]]);
+}
+
+impl ESListEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "lt", [target, args[0]]);
+}
+
+impl ESListEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "gt", [target, args[0]]);
+}
+
+impl ESListEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "le", [target, args[0]]);
+}
+
+impl ESListEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "ge", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESListEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "includes", [args[0]]);
+}
+
+# --- In-place operators ---
+impl ESListEmitter.emit_op_iadd(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    # list += other is extend in-place (mutates), not concat+reassign
+    return target + ".push(..." + args[0] + ")";
+}
+
+impl ESListEmitter.emit_op_imul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("list", "imul", [target, args[0]]);
+}
+
+# --- Named methods ---
+impl ESDictEmitter.emit_get(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    if len(args) == 1 {
+        return target + "[" + args[0] + "] ?? undefined";
+    }
+    return target + "[" + args[0] + "] ?? " + args[1];
+}
+
+impl ESDictEmitter.emit_keys(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Object.keys(" + target + ")";
+}
+
+impl ESDictEmitter.emit_values(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Object.values(" + target + ")";
+}
+
+impl ESDictEmitter.emit_items(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Object.entries(" + target + ")";
+}
+
+impl ESDictEmitter.emit_pop(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("dict", "pop", [target] + args);
+}
+
+impl ESDictEmitter.emit_popitem(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("dict", "popitem", [target]);
+}
+
+impl ESDictEmitter.emit_setdefault(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("dict", "setdefault", [target] + args);
+}
+
+impl ESDictEmitter.emit_update(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Object.assign(" + target + ", " + args[0] + ")";
+}
+
+impl ESDictEmitter.emit_clear(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("dict", "clear", [target]);
+}
+
+impl ESDictEmitter.emit_copy(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "{..." + target + "}";
+}
+
+impl ESDictEmitter.emit_fromkeys(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("dict", "fromkeys", args);
+}
+
+# --- Bitwise operators (dict merge) ---
+impl ESDictEmitter.emit_op_or(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "{..." + target + ", ..." + args[0] + "}";
+}
+
+# --- Comparison operators ---
+impl ESDictEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("dict", "eq", [target, args[0]]);
+}
+
+impl ESDictEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("dict", "eq", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESDictEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _binop(args[0], "in", target);
+}
+
+# --- In-place operators ---
+impl ESDictEmitter.emit_op_ior(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "Object.assign(" + target + ", " + args[0] + ")";
+}
+
+# --- Named methods (mutation) ---
+impl ESSetEmitter.emit_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "add", args);
+}
+
+impl ESSetEmitter.emit_remove(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "remove", [target] + args);
+}
+
+impl ESSetEmitter.emit_discard(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "delete", args);
+}
+
+impl ESSetEmitter.emit_pop(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "pop", [target]);
+}
+
+impl ESSetEmitter.emit_clear(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "clear", []);
+}
+
+# --- Named methods (set algebra) ---
+impl ESSetEmitter.emit_union(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "union", [target] + args);
+}
+
+impl ESSetEmitter.emit_intersection(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "intersection", [target] + args);
+}
+
+impl ESSetEmitter.emit_difference(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "difference", [target] + args);
+}
+
+impl ESSetEmitter.emit_symmetric_difference(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "symmetricDifference", [target] + args);
+}
+
+# --- Named methods (in-place set algebra) ---
+impl ESSetEmitter.emit_update(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "update", [target] + args);
+}
+
+impl ESSetEmitter.emit_intersection_update(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "intersection_update", [target] + args);
+}
+
+impl ESSetEmitter.emit_difference_update(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "difference_update", [target] + args);
+}
+
+impl ESSetEmitter.emit_symmetric_difference_update(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "symmetric_difference_update", [target] + args);
+}
+
+# --- Named methods (tests) ---
+impl ESSetEmitter.emit_issubset(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSubsetOf", [target] + args);
+}
+
+impl ESSetEmitter.emit_issuperset(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSupersetOf", [target] + args);
+}
+
+impl ESSetEmitter.emit_isdisjoint(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isDisjointFrom", [target] + args);
+}
+
+impl ESSetEmitter.emit_copy(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "new Set(" + target + ")";
+}
+
+# --- Set algebra operators ---
+impl ESSetEmitter.emit_op_or(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "union", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_and(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "intersection", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_sub(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "difference", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_xor(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "symmetricDifference", [target, args[0]]);
+}
+
+# --- Comparison operators (subset/superset) ---
+impl ESSetEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "eq", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("set", "eq", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSubsetOf", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "is_proper_subset", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSupersetOf", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "is_proper_superset", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESSetEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "has", [args[0]]);
+}
+
+# --- In-place operators ---
+impl ESSetEmitter.emit_op_ior(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "update", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_iand(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "intersection_update", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_isub(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "difference_update", [target, args[0]]);
+}
+
+impl ESSetEmitter.emit_op_ixor(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "symmetric_difference_update", [target, args[0]]);
+}
+
+# --- Named methods ---
+impl ESFrozensetEmitter.emit_union(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "union", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_intersection(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "intersection", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_difference(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "difference", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_symmetric_difference(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "symmetricDifference", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_issubset(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSubsetOf", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_issuperset(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSupersetOf", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_isdisjoint(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isDisjointFrom", [target] + args);
+}
+
+impl ESFrozensetEmitter.emit_copy(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "new Set(" + target + ")";
+}
+
+# --- Set algebra operators ---
+impl ESFrozensetEmitter.emit_op_or(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "union", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_and(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "intersection", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_sub(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "difference", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_xor(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "symmetricDifference", [target, args[0]]);
+}
+
+# --- Comparison operators (subset/superset) ---
+impl ESFrozensetEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "eq", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("set", "eq", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSubsetOf", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "is_proper_subset", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "isSupersetOf", [target, args[0]]);
+}
+
+impl ESFrozensetEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("set", "is_proper_superset", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESFrozensetEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "has", [args[0]]);
+}
+
+# --- Named methods ---
+impl ESTupleEmitter.emit_count(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "count", [target] + args);
+}
+
+impl ESTupleEmitter.emit_index(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "index", [target] + args);
+}
+
+# --- Arithmetic operators ---
+impl ESTupleEmitter.emit_op_add(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "[..." + target + ", ..." + args[0] + "]";
+}
+
+impl ESTupleEmitter.emit_op_mul(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "repeat", [target, args[0]]);
+}
+
+# --- Comparison operators ---
+impl ESTupleEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "eq", [target, args[0]]);
+}
+
+impl ESTupleEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("tuple", "eq", [target, args[0]]);
+}
+
+impl ESTupleEmitter.emit_op_lt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "lt", [target, args[0]]);
+}
+
+impl ESTupleEmitter.emit_op_gt(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "gt", [target, args[0]]);
+}
+
+impl ESTupleEmitter.emit_op_le(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "le", [target, args[0]]);
+}
+
+impl ESTupleEmitter.emit_op_ge(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("tuple", "ge", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESTupleEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _mcall(target, "includes", [args[0]]);
+}
+
+# --- Named methods ---
+impl ESRangeEmitter.emit_count(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("range", "count", [target] + args);
+}
+
+impl ESRangeEmitter.emit_index(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("range", "index", [target] + args);
+}
+
+# --- Comparison operators ---
+impl ESRangeEmitter.emit_op_eq(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("range", "eq", [target, args[0]]);
+}
+
+impl ESRangeEmitter.emit_op_ne(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return "!" + _rt("range", "eq", [target, args[0]]);
+}
+
+# --- Membership operators ---
+impl ESRangeEmitter.emit_op_contains(
+    self, ctx: ESEmitCtx, target: str, args: list[str]
+) -> (str | None) {
+    return _rt("range", "contains", [target, args[0]]);
+}
+
+impl ESBuiltinEmitter.emit_print(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _fcall("console.log", args);
+}
+
+impl ESBuiltinEmitter.emit_input(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _fcall("prompt", args);
+}
+
+impl ESBuiltinEmitter.emit_len(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return args[0] + ".length";
+}
+
+impl ESBuiltinEmitter.emit_abs(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return "Math.abs(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_round(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 1 {
+        return "Math.round(" + args[0] + ")";
+    }
+    return _rt("builtin", "round", args);
+}
+
+impl ESBuiltinEmitter.emit_min(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _fcall("Math.min", args);
+}
+
+impl ESBuiltinEmitter.emit_max(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _fcall("Math.max", args);
+}
+
+impl ESBuiltinEmitter.emit_sum(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "sum", args);
+}
+
+impl ESBuiltinEmitter.emit_sorted(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("builtin", "sorted", args);
+}
+
+impl ESBuiltinEmitter.emit_reversed(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return "[..." + args[0] + "].reverse()";
+}
+
+impl ESBuiltinEmitter.emit_enumerate(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("builtin", "enumerate", args);
+}
+
+impl ESBuiltinEmitter.emit_zip(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "zip", args);
+}
+
+impl ESBuiltinEmitter.emit_map(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 2 {
+        return _mcall(args[1], "map", [args[0]]);
+    }
+    return _rt("builtin", "map", args);
+}
+
+impl ESBuiltinEmitter.emit_filter(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    if len(args) == 2 {
+        return _mcall(args[1], "filter", [args[0]]);
+    }
+    return _rt("builtin", "filter", args);
+}
+
+impl ESBuiltinEmitter.emit_any(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _mcall(args[0], "some", ["Boolean"]);
+}
+
+impl ESBuiltinEmitter.emit_all(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _mcall(args[0], "every", ["Boolean"]);
+}
+
+impl ESBuiltinEmitter.emit_isinstance(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return args[0] + " instanceof " + args[1];
+}
+
+impl ESBuiltinEmitter.emit_issubclass(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("builtin", "issubclass", args);
+}
+
+impl ESBuiltinEmitter.emit_type(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return "typeof " + args[0];
+}
+
+impl ESBuiltinEmitter.emit_id(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "id", args);
+}
+
+impl ESBuiltinEmitter.emit_hash(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "hash", args);
+}
+
+impl ESBuiltinEmitter.emit_repr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "repr", args);
+}
+
+impl ESBuiltinEmitter.emit_chr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return "String.fromCodePoint(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_ord(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return args[0] + ".codePointAt(0)";
+}
+
+impl ESBuiltinEmitter.emit_hex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return "'0x' + (" + args[0] + ").toString(16)";
+}
+
+impl ESBuiltinEmitter.emit_oct(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return "'0o' + (" + args[0] + ").toString(8)";
+}
+
+impl ESBuiltinEmitter.emit_bin(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return "'0b' + (" + args[0] + ").toString(2)";
+}
+
+impl ESBuiltinEmitter.emit_pow(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 2 {
+        return args[0] + " ** " + args[1];
+    }
+    return _rt("builtin", "pow", args);
+}
+
+impl ESBuiltinEmitter.emit_divmod(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return "[Math.floor(" + args[0] + " / " + args[1] + "), " + args[0] + " % " + args[
+        1
+    ] + "]";
+}
+
+impl ESBuiltinEmitter.emit_iter(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return args[0] + "[Symbol.iterator]()";
+}
+
+impl ESBuiltinEmitter.emit_next(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "next", args);
+}
+
+impl ESBuiltinEmitter.emit_callable(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return "typeof " + args[0] + " === 'function'";
+}
+
+impl ESBuiltinEmitter.emit_getattr(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    if len(args) == 2 {
+        return args[0] + "[" + args[1] + "]";
+    }
+    return args[0] + "[" + args[1] + "] ?? " + args[2];
+}
+
+impl ESBuiltinEmitter.emit_setattr(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return args[0] + "[" + args[1] + "] = " + args[2];
+}
+
+impl ESBuiltinEmitter.emit_hasattr(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return args[1] + " in " + args[0];
+}
+
+impl ESBuiltinEmitter.emit_delattr(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return "delete " + args[0] + "[" + args[1] + "]";
+}
+
+impl ESBuiltinEmitter.emit_vars(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "vars", args);
+}
+
+impl ESBuiltinEmitter.emit_dir(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return _rt("builtin", "dir", []);
+    }
+    return "Object.getOwnPropertyNames(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_open(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "open", args);
+}
+
+impl ESBuiltinEmitter.emit_format(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("builtin", "format", args);
+}
+
+impl ESBuiltinEmitter.emit_ascii(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "ascii", args);
+}
+
+# Type conversion builtins
+impl ESBuiltinEmitter.emit_str(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return '""';
+    }
+    return "String(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_int(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "0";
+    }
+    if len(args) == 1 {
+        # Use Math.trunc(Number(x)) instead of parseInt(x) to correctly
+        # handle booleans (parseInt(false) → NaN, Number(false) → 0)
+        # and floats (int(3.14) → 3).
+        return "Math.trunc(Number(" + args[0] + "))";
+    }
+    return "parseInt(" + args[0] + ", " + args[1] + ")";
+}
+
+impl ESBuiltinEmitter.emit_float(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "0.0";
+    }
+    return "parseFloat(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_bool(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "false";
+    }
+    # Use runtime helper for Python truthiness semantics:
+    # Python: bool([]) → False, bool({}) → False, bool(set()) → False
+    # JS:     Boolean([]) → true,  Boolean({}) → true
+    return _rt("builtin", "bool", args);
+}
+
+impl ESBuiltinEmitter.emit_list(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "[]";
+    }
+    return "Array.from(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_dict(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "{}";
+    }
+    return "Object.fromEntries(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_set(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "new Set()";
+    }
+    return "new Set(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_tuple(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "Object.freeze([])";
+    }
+    return "Object.freeze(Array.from(" + args[0] + "))";
+}
+
+impl ESBuiltinEmitter.emit_frozenset(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return "Object.freeze(new Set())";
+    }
+    return "Object.freeze(new Set(" + args[0] + "))";
+}
+
+impl ESBuiltinEmitter.emit_bytes(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    if len(args) == 0 {
+        return "new Uint8Array()";
+    }
+    return "new Uint8Array(" + args[0] + ")";
+}
+
+impl ESBuiltinEmitter.emit_complex(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    return _rt("builtin", "complex", args);
+}
+
+impl ESBuiltinEmitter.emit_range(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "range", args);
+}
+
+impl ESBuiltinEmitter.emit_slice(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
+    return _rt("builtin", "slice", args);
+}
+
+impl ESBuiltinEmitter.emit_bytearray(
+    self, ctx: ESEmitCtx, args: list[str]
+) -> (str | None) {
+    if len(args) == 0 {
+        return "new Uint8Array()";
+    }
+    return "new Uint8Array(" + args[0] + ")";
+}

--- a/jac/jaclang/compiler/passes/ecmascript/primitives_es.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/primitives_es.jac
@@ -59,6 +59,7 @@ def _binop(left: str, op: str, right: str) -> str {
     return "(" + left + " " + op + " " + right + ")";
 }
 
+
 # =============================================================================
 #  Numeric Types
 # =============================================================================
@@ -66,287 +67,133 @@ class ESIntEmitter(IntEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
     def emit_bit_length(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("int", "bit_length", [target]);
-    }
+    ) -> (str | None);
 
     def emit_bit_count(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("int", "bit_count", [target]);
-    }
+    ) -> (str | None);
 
     def emit_to_bytes(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("int", "to_bytes", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_as_integer_ratio(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "[" + target + ", 1]";
-    }
+    ) -> (str | None);
 
     def emit_conjugate(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return target;
-    }
+    ) -> (str | None);
 
-    def emit_from_bytes(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("int", "from_bytes", args);
-    }
-
+    def emit_from_bytes(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "+", args[0]);
-    }
-
-    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "-", args[0]);
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "*", args[0]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_truediv(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _binop(target, "/", args[0]);
-    }
+    ) -> (str | None);
 
     def emit_op_floordiv(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "Math.floor(" + target + " / " + args[0] + ")";
-    }
+    ) -> (str | None);
 
-    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        # Python modulo semantics: result has same sign as divisor
-        return _rt("int", "mod", [target, args[0]]);
-    }
-
-    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "**", args[0]);
-    }
-
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Bitwise operators ---
-    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "&", args[0]);
-    }
-
-    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "|", args[0]);
-    }
-
-    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "^", args[0]);
-    }
-
+    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_lshift(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _binop(target, "<<", args[0]);
-    }
+    ) -> (str | None);
 
     def emit_op_rshift(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _binop(target, ">>", args[0]);
-    }
+    ) -> (str | None);
 
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "===", args[0]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "!==", args[0]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "<", args[0]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, ">", args[0]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "<=", args[0]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, ">=", args[0]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Unary operators ---
-    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "(-" + target + ")";
-    }
-
-    def emit_op_pos(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "(+" + target + ")";
-    }
-
+    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_pos(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_invert(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "(~" + target + ")";
-    }
+    ) -> (str | None);
 }
 
 class ESFloatEmitter(FloatEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
     def emit_is_integer(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "Number.isInteger(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_as_integer_ratio(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("float", "as_integer_ratio", [target]);
-    }
+    ) -> (str | None);
 
     def emit_conjugate(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return target;
-    }
+    ) -> (str | None);
 
-    def emit_hex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("float", "hex", [target]);
-    }
-
-    def emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("float", "fromhex", args);
-    }
-
+    def emit_hex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "+", args[0]);
-    }
-
-    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "-", args[0]);
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "*", args[0]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_truediv(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _binop(target, "/", args[0]);
-    }
+    ) -> (str | None);
 
     def emit_op_floordiv(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "Math.floor(" + target + " / " + args[0] + ")";
-    }
+    ) -> (str | None);
 
-    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        # Python modulo semantics: result has same sign as divisor
-        return _rt("float", "mod", [target, args[0]]);
-    }
-
-    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "**", args[0]);
-    }
-
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "===", args[0]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "!==", args[0]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "<", args[0]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, ">", args[0]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "<=", args[0]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, ">=", args[0]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Unary operators ---
-    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "(-" + target + ")";
-    }
-
+    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_pos(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "(+" + target + ")";
-    }
+    ) -> (str | None);
 }
 
 class ESComplexEmitter(ComplexEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
     def emit_conjugate(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("complex", "conjugate", [target]);
-    }
+    ) -> (str | None);
 
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("complex", "add", [target, args[0]]);
-    }
-
-    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("complex", "sub", [target, args[0]]);
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("complex", "mul", [target, args[0]]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_truediv(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("complex", "truediv", [target, args[0]]);
-    }
+    ) -> (str | None);
 
-    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("complex", "pow", [target, args[0]]);
-    }
-
+    def emit_op_pow(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("complex", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("complex", "eq", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Unary operators ---
-    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("complex", "neg", [target]);
-    }
-
+    def emit_op_neg(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_pos(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("complex", "pos", [target]);
-    }
+    ) -> (str | None);
 }
 
 class ESBoolEmitter(ESIntEmitter) {
@@ -359,19 +206,12 @@ class ESBoolEmitter(ESIntEmitter) {
     # Override bitwise ops to return boolean
     def emit_op_and(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "Boolean(" + _binop(target, "&", args[0]) + ")";
-    }
+    ) -> (str | None);
 
-    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "Boolean(" + _binop(target, "|", args[0]) + ")";
-    }
-
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_xor(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "Boolean(" + _binop(target, "^", args[0]) + ")";
-    }
+    ) -> (str | None);
 }
 
 # =============================================================================
@@ -381,592 +221,279 @@ class ESStrEmitter(StrEmitter[(str, ESEmitCtx)]) {
     # Case conversion
     def emit_capitalize(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "capitalize", [target]);
-    }
+    ) -> (str | None);
 
     def emit_casefold(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "toLowerCase", []);
-    }
+    ) -> (str | None);
 
-    def emit_lower(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "toLowerCase", []);
-    }
-
-    def emit_upper(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "toUpperCase", []);
-    }
-
-    def emit_title(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "title", [target]);
-    }
-
+    def emit_lower(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_upper(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_title(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_swapcase(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "swapcase", [target]);
-    }
+    ) -> (str | None);
 
     # Search
-    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "count", [target] + args);
-    }
-
-    def emit_find(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) > 1 {
-            return _rt("str", "find", [target] + args);
-        }
-        return _mcall(target, "indexOf", args);
-    }
-
-    def emit_rfind(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) > 1 {
-            return _rt("str", "rfind", [target] + args);
-        }
-        return _mcall(target, "lastIndexOf", args);
-    }
-
-    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "index", [target] + args);
-    }
-
-    def emit_rindex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "rindex", [target] + args);
-    }
-
+    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_find(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rfind(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rindex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_startswith(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        if len(args) == 1 {
-            return _mcall(target, "startsWith", args);
-        }
-        return _rt("str", "startswith", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_endswith(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        if len(args) == 1 {
-            return _mcall(target, "endsWith", args);
-        }
-        return _rt("str", "endswith", [target] + args);
-    }
+    ) -> (str | None);
 
     # Modification
     def emit_replace(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        if len(args) == 2 {
-            return _mcall(target, "replaceAll", args);
-        }
-        return _rt("str", "replace", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_strip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _mcall(target, "trim", []);
-        }
-        return _rt("str", "strip", [target] + args);
-    }
-
-    def emit_lstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _mcall(target, "trimStart", []);
-        }
-        return _rt("str", "lstrip", [target] + args);
-    }
-
-    def emit_rstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _mcall(target, "trimEnd", []);
-        }
-        return _rt("str", "rstrip", [target] + args);
-    }
-
+    def emit_strip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_lstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_removeprefix(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "removeprefix", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_removesuffix(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "removesuffix", [target] + args);
-    }
+    ) -> (str | None);
 
     # Split and join
-    def emit_split(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _rt("str", "split", [target]);
-        }
-        if len(args) == 1 {
-            return _mcall(target, "split", args);
-        }
-        return _rt("str", "split", [target] + args);
-    }
-
-    def emit_rsplit(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "rsplit", [target] + args);
-    }
-
+    def emit_split(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rsplit(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_splitlines(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        if len(args) == 0 {
-            return _mcall(target, "split", ["/\\r?\\n/"]);
-        }
-        return _rt("str", "splitlines", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_join(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        # Python: separator.join(iterable) → JS: array.join(separator)
-        return _mcall(args[0], "join", [target]);
-    }
-
+    def emit_join(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_partition(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "partition", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_rpartition(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "rpartition", [target] + args);
-    }
+    ) -> (str | None);
 
     # Formatting and alignment
-    def emit_format(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "format", [target] + args);
-    }
-
+    def emit_format(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_format_map(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "format_map", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_center(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "center", [target] + args);
-    }
-
-    def emit_ljust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 1 {
-            return _mcall(target, "padEnd", args);
-        }
-        return _mcall(target, "padEnd", args);
-    }
-
-    def emit_rjust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 1 {
-            return _mcall(target, "padStart", args);
-        }
-        return _mcall(target, "padStart", args);
-    }
-
-    def emit_zfill(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "zfill", [target] + args);
-    }
-
+    def emit_center(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_ljust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rjust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_zfill(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_expandtabs(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "expandtabs", [target] + args);
-    }
+    ) -> (str | None);
 
     # Character tests
     def emit_isalnum(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[a-zA-Z0-9]+$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_isalpha(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[a-zA-Z]+$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_isascii(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[\\x00-\\x7F]*$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_isdecimal(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[0-9]+$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_isdigit(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[0-9]+$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_isidentifier(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_islower(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "(" + target + " === " + target + ".toLowerCase() && " + target + " !== " + target + ".toUpperCase())";
-    }
+    ) -> (str | None);
 
     def emit_isnumeric(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "isnumeric", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isprintable(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^[\\x20-\\x7E]*$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_isspace(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "/^\\s+$/.test(" + target + ")";
-    }
+    ) -> (str | None);
 
     def emit_istitle(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "istitle", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isupper(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "(" + target + " === " + target + ".toUpperCase() && " + target + " !== " + target + ".toLowerCase())";
-    }
+    ) -> (str | None);
 
     # Encoding
-    def emit_encode(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "new TextEncoder().encode(" + target + ")";
-    }
-
+    def emit_encode(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # Translation
     def emit_translate(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("str", "translate", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("str", "maketrans", args);
-    }
-
+    def emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "+", args[0]);
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "repeat", [args[0]]);
-    }
-
-    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("str", "mod", [target, args[0]]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "===", args[0]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "!==", args[0]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "<", args[0]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, ">", args[0]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, "<=", args[0]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _binop(target, ">=", args[0]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "includes", [args[0]]);
-    }
+    ) -> (str | None);
 }
 
 class ESBytesEmitter(BytesEmitter[(str, ESEmitCtx)]) {
     # Decoding
-    def emit_decode(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "new TextDecoder(" + (args[0] if len(args) > 0 else "") + ").decode(" + target + ")";
-    }
-
-    def emit_hex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "hex", [target] + args);
-    }
-
-    def emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("bytes", "fromhex", args);
-    }
-
+    def emit_decode(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_hex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_fromhex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # Search
-    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "count", [target] + args);
-    }
-
-    def emit_find(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "find", [target] + args);
-    }
-
-    def emit_rfind(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "rfind", [target] + args);
-    }
-
-    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "index", [target] + args);
-    }
-
-    def emit_rindex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "rindex", [target] + args);
-    }
-
+    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_find(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rfind(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rindex(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_startswith(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "startswith", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_endswith(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "endswith", [target] + args);
-    }
+    ) -> (str | None);
+
     # Modification
     def emit_replace(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "replace", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_strip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "strip", [target] + args);
-    }
-
-    def emit_lstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "lstrip", [target] + args);
-    }
-
-    def emit_rstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "rstrip", [target] + args);
-    }
-
+    def emit_strip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_lstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rstrip(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_removeprefix(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "removeprefix", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_removesuffix(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "removesuffix", [target] + args);
-    }
+    ) -> (str | None);
+
     # Split and join
-    def emit_split(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "split", [target] + args);
-    }
-
-    def emit_rsplit(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "rsplit", [target] + args);
-    }
-
+    def emit_split(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rsplit(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_splitlines(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "splitlines", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_join(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "join", [target] + args);
-    }
-
+    def emit_join(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_partition(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "partition", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_rpartition(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "rpartition", [target] + args);
-    }
+    ) -> (str | None);
+
     # Case (ASCII only)
     def emit_capitalize(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "capitalize", [target]);
-    }
+    ) -> (str | None);
 
-    def emit_lower(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "lower", [target]);
-    }
-
-    def emit_upper(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "upper", [target]);
-    }
-
-    def emit_title(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "title", [target]);
-    }
-
+    def emit_lower(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_upper(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_title(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_swapcase(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "swapcase", [target]);
-    }
+    ) -> (str | None);
+
     # Character tests (ASCII only)
     def emit_isalnum(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "isalnum", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isalpha(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "isalpha", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isascii(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "isascii", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isdigit(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "isdigit", [target]);
-    }
+    ) -> (str | None);
 
     def emit_islower(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "islower", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isspace(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "isspace", [target]);
-    }
+    ) -> (str | None);
 
     def emit_istitle(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "istitle", [target]);
-    }
+    ) -> (str | None);
 
     def emit_isupper(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "isupper", [target]);
-    }
+    ) -> (str | None);
+
     # Alignment
-    def emit_center(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "center", [target] + args);
-    }
-
-    def emit_ljust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "ljust", [target] + args);
-    }
-
-    def emit_rjust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "rjust", [target] + args);
-    }
-
-    def emit_zfill(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "zfill", [target] + args);
-    }
-
+    def emit_center(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_ljust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_rjust(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_zfill(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_expandtabs(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "expandtabs", [target] + args);
-    }
+    ) -> (str | None);
+
     # Translation
     def emit_translate(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "translate", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("bytes", "maketrans", args);
-    }
-
+    def emit_maketrans(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "add", [target, args[0]]);
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "mul", [target, args[0]]);
-    }
-
-    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "mod", [target, args[0]]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mod(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("bytes", "eq", [target, args[0]]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "lt", [target, args[0]]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "gt", [target, args[0]]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "le", [target, args[0]]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("bytes", "ge", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("bytes", "contains", [target, args[0]]);
-    }
+    ) -> (str | None);
 }
 
 # =============================================================================
@@ -974,821 +501,301 @@ class ESBytesEmitter(BytesEmitter[(str, ESEmitCtx)]) {
 # =============================================================================
 class ESListEmitter(ListEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
-    def emit_append(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "push", args);
-    }
-
-    def emit_extend(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return target + ".push(..." + args[0] + ")";
-    }
-
-    def emit_insert(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "splice", [args[0], "0", args[1]]);
-    }
-
-    def emit_remove(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "remove", [target] + args);
-    }
-
-    def emit_pop(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _mcall(target, "pop", []);
-        }
-        return _mcall(target, "splice", [args[0], "1"]) + "[0]";
-    }
-
-    def emit_clear(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return target + ".length = 0";
-    }
-
-    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "index", [target] + args);
-    }
-
-    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "count", [target] + args);
-    }
-
-    def emit_sort(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _mcall(target, "sort", []);
-        }
-        return _rt("list", "sort", [target] + args);
-    }
-
+    def emit_append(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_extend(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_insert(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_remove(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_pop(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_clear(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_sort(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_reverse(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "reverse", []);
-    }
+    ) -> (str | None);
 
-    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "[..." + target + "]";
-    }
-
+    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "[..." + target + ", ..." + args[0] + "]";
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "repeat", [target, args[0]]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("list", "eq", [target, args[0]]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "lt", [target, args[0]]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "gt", [target, args[0]]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "le", [target, args[0]]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("list", "ge", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "includes", [args[0]]);
-    }
+    ) -> (str | None);
 
     # --- In-place operators ---
     def emit_op_iadd(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        # list += other is extend in-place (mutates), not concat+reassign
-        return target + ".push(..." + args[0] + ")";
-    }
+    ) -> (str | None);
 
     def emit_op_imul(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("list", "imul", [target, args[0]]);
-    }
+    ) -> (str | None);
 }
 
 class ESDictEmitter(DictEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
-    def emit_get(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        if len(args) == 1 {
-            return target + "[" + args[0] + "] ?? undefined";
-        }
-        return target + "[" + args[0] + "] ?? " + args[1];
-    }
-
-    def emit_keys(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "Object.keys(" + target + ")";
-    }
-
-    def emit_values(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "Object.values(" + target + ")";
-    }
-
-    def emit_items(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "Object.entries(" + target + ")";
-    }
-
-    def emit_pop(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("dict", "pop", [target] + args);
-    }
-
+    def emit_get(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_keys(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_values(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_items(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_pop(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_popitem(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("dict", "popitem", [target]);
-    }
+    ) -> (str | None);
 
     def emit_setdefault(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("dict", "setdefault", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_update(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "Object.assign(" + target + ", " + args[0] + ")";
-    }
-
-    def emit_clear(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("dict", "clear", [target]);
-    }
-
-    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "{..." + target + "}";
-    }
-
-    def emit_fromkeys(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("dict", "fromkeys", args);
-    }
-
+    def emit_update(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_clear(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_fromkeys(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # --- Bitwise operators (dict merge) ---
-    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "{..." + target + ", ..." + args[0] + "}";
-    }
-
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("dict", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("dict", "eq", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _binop(args[0], "in", target);
-    }
+    ) -> (str | None);
 
     # --- In-place operators ---
     def emit_op_ior(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return "Object.assign(" + target + ", " + args[0] + ")";
-    }
+    ) -> (str | None);
 }
 
 class ESSetEmitter(SetEmitter[(str, ESEmitCtx)]) {
     # --- Named methods (mutation) ---
-    def emit_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "add", args);
-    }
-
-    def emit_remove(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "remove", [target] + args);
-    }
-
+    def emit_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_remove(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_discard(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "delete", args);
-    }
+    ) -> (str | None);
 
-    def emit_pop(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "pop", [target]);
-    }
-
-    def emit_clear(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _mcall(target, "clear", []);
-    }
-
+    def emit_pop(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_clear(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Named methods (set algebra) ---
-    def emit_union(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "union", [target] + args);
-    }
-
+    def emit_union(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_intersection(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "intersection", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_difference(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "difference", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_symmetric_difference(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "symmetricDifference", [target] + args);
-    }
+    ) -> (str | None);
 
     # --- Named methods (in-place set algebra) ---
-    def emit_update(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "update", [target] + args);
-    }
-
+    def emit_update(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_intersection_update(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "intersection_update", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_difference_update(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "difference_update", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_symmetric_difference_update(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "symmetric_difference_update", [target] + args);
-    }
+    ) -> (str | None);
 
     # --- Named methods (tests) ---
     def emit_issubset(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "isSubsetOf", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_issuperset(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "isSupersetOf", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_isdisjoint(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "isDisjointFrom", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "new Set(" + target + ")";
-    }
-
+    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Set algebra operators ---
-    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "union", [target, args[0]]);
-    }
-
-    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "intersection", [target, args[0]]);
-    }
-
-    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "difference", [target, args[0]]);
-    }
-
-    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "symmetricDifference", [target, args[0]]);
-    }
-
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators (subset/superset) ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("set", "eq", [target, args[0]]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "isSubsetOf", [target, args[0]]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "is_proper_subset", [target, args[0]]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "isSupersetOf", [target, args[0]]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "is_proper_superset", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "has", [args[0]]);
-    }
+    ) -> (str | None);
 
     # --- In-place operators ---
-    def emit_op_ior(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "update", [target, args[0]]);
-    }
-
+    def emit_op_ior(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_op_iand(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "intersection_update", [target, args[0]]);
-    }
+    ) -> (str | None);
 
     def emit_op_isub(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "difference_update", [target, args[0]]);
-    }
+    ) -> (str | None);
 
     def emit_op_ixor(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "symmetric_difference_update", [target, args[0]]);
-    }
+    ) -> (str | None);
 }
 
 class ESFrozensetEmitter(FrozensetEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
-    def emit_union(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "union", [target] + args);
-    }
-
+    def emit_union(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     def emit_intersection(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "intersection", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_difference(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "difference", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_symmetric_difference(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "symmetricDifference", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_issubset(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "isSubsetOf", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_issuperset(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "isSupersetOf", [target] + args);
-    }
+    ) -> (str | None);
 
     def emit_isdisjoint(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("set", "isDisjointFrom", [target] + args);
-    }
+    ) -> (str | None);
 
-    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "new Set(" + target + ")";
-    }
-
+    def emit_copy(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Set algebra operators ---
-    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "union", [target, args[0]]);
-    }
-
-    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "intersection", [target, args[0]]);
-    }
-
-    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "difference", [target, args[0]]);
-    }
-
-    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "symmetricDifference", [target, args[0]]);
-    }
-
+    def emit_op_or(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_and(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_sub(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_xor(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators (subset/superset) ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("set", "eq", [target, args[0]]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "isSubsetOf", [target, args[0]]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "is_proper_subset", [target, args[0]]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "isSupersetOf", [target, args[0]]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("set", "is_proper_superset", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "has", [args[0]]);
-    }
+    ) -> (str | None);
 }
 
 class ESTupleEmitter(TupleEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
-    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "count", [target] + args);
-    }
-
-    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "index", [target] + args);
-    }
-
+    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Arithmetic operators ---
-    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "[..." + target + ", ..." + args[0] + "]";
-    }
-
-    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "repeat", [target, args[0]]);
-    }
-
+    def emit_op_add(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_mul(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("tuple", "eq", [target, args[0]]);
-    }
-
-    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "lt", [target, args[0]]);
-    }
-
-    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "gt", [target, args[0]]);
-    }
-
-    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "le", [target, args[0]]);
-    }
-
-    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("tuple", "ge", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_lt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_gt(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_le(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ge(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _mcall(target, "includes", [args[0]]);
-    }
+    ) -> (str | None);
 }
 
 class ESRangeEmitter(RangeEmitter[(str, ESEmitCtx)]) {
     # --- Named methods ---
-    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("range", "count", [target] + args);
-    }
-
-    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("range", "index", [target] + args);
-    }
-
+    def emit_count(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_index(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Comparison operators ---
-    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return _rt("range", "eq", [target, args[0]]);
-    }
-
-    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None) {
-        return "!" + _rt("range", "eq", [target, args[0]]);
-    }
-
+    def emit_op_eq(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
+    def emit_op_ne(self, ctx: ESEmitCtx, target: str, args: list[str]) -> (str | None);
     # --- Membership operators ---
     def emit_op_contains(
         self, ctx: ESEmitCtx, target: str, args: list[str]
-    ) -> (str | None) {
-        return _rt("range", "contains", [target, args[0]]);
-    }
+    ) -> (str | None);
 }
 
 # =============================================================================
 #  Builtin Functions
 # =============================================================================
 class ESBuiltinEmitter(BuiltinEmitter[(str, ESEmitCtx)]) {
-    def emit_print(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _fcall("console.log", args);
-    }
-
-    def emit_input(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _fcall("prompt", args);
-    }
-
-    def emit_len(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return args[0] + ".length";
-    }
-
-    def emit_abs(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "Math.abs(" + args[0] + ")";
-    }
-
-    def emit_round(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 1 {
-            return "Math.round(" + args[0] + ")";
-        }
-        return _rt("builtin", "round", args);
-    }
-
-    def emit_min(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _fcall("Math.min", args);
-    }
-
-    def emit_max(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _fcall("Math.max", args);
-    }
-
-    def emit_sum(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "sum", args);
-    }
-
-    def emit_sorted(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "sorted", args);
-    }
-
-    def emit_reversed(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "[..." + args[0] + "].reverse()";
-    }
-
-    def emit_enumerate(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "enumerate", args);
-    }
-
-    def emit_zip(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "zip", args);
-    }
-
-    def emit_map(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 2 {
-            return _mcall(args[1], "map", [args[0]]);
-        }
-        return _rt("builtin", "map", args);
-    }
-
-    def emit_filter(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 2 {
-            return _mcall(args[1], "filter", [args[0]]);
-        }
-        return _rt("builtin", "filter", args);
-    }
-
-    def emit_any(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _mcall(args[0], "some", ["Boolean"]);
-    }
-
-    def emit_all(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _mcall(args[0], "every", ["Boolean"]);
-    }
-
-    def emit_isinstance(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return args[0] + " instanceof " + args[1];
-    }
-
-    def emit_issubclass(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "issubclass", args);
-    }
-
-    def emit_type(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "typeof " + args[0];
-    }
-
-    def emit_id(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "id", args);
-    }
-
-    def emit_hash(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "hash", args);
-    }
-
-    def emit_repr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "repr", args);
-    }
-
-    def emit_chr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "String.fromCodePoint(" + args[0] + ")";
-    }
-
-    def emit_ord(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return args[0] + ".codePointAt(0)";
-    }
-
-    def emit_hex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "'0x' + (" + args[0] + ").toString(16)";
-    }
-
-    def emit_oct(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "'0o' + (" + args[0] + ").toString(8)";
-    }
-
-    def emit_bin(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "'0b' + (" + args[0] + ").toString(2)";
-    }
-
-    def emit_pow(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 2 {
-            return args[0] + " ** " + args[1];
-        }
-        return _rt("builtin", "pow", args);
-    }
-
-    def emit_divmod(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "[Math.floor(" + args[0] + " / " + args[1] + "), " + args[0] + " % " + args[
-            1
-        ] + "]";
-    }
-
-    def emit_iter(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return args[0] + "[Symbol.iterator]()";
-    }
-
-    def emit_next(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "next", args);
-    }
-
-    def emit_callable(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "typeof " + args[0] + " === 'function'";
-    }
-
-    def emit_getattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 2 {
-            return args[0] + "[" + args[1] + "]";
-        }
-        return args[0] + "[" + args[1] + "] ?? " + args[2];
-    }
-
-    def emit_setattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return args[0] + "[" + args[1] + "] = " + args[2];
-    }
-
-    def emit_hasattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return args[1] + " in " + args[0];
-    }
-
-    def emit_delattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return "delete " + args[0] + "[" + args[1] + "]";
-    }
-
-    def emit_vars(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "vars", args);
-    }
-
-    def emit_dir(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return _rt("builtin", "dir", []);
-        }
-        return "Object.getOwnPropertyNames(" + args[0] + ")";
-    }
-
-    def emit_open(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "open", args);
-    }
-
-    def emit_format(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "format", args);
-    }
-
-    def emit_ascii(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "ascii", args);
-    }
-
+    def emit_print(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_input(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_len(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_abs(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_round(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_min(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_max(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_sum(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_sorted(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_reversed(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_enumerate(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_zip(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_map(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_filter(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_any(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_all(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_isinstance(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_issubclass(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_type(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_id(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_hash(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_repr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_chr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_ord(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_hex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_oct(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_bin(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_pow(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_divmod(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_iter(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_next(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_callable(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_getattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_setattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_hasattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_delattr(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_vars(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_dir(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_open(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_format(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_ascii(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
     # Type conversion builtins
-    def emit_str(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return '""';
-        }
-        return "String(" + args[0] + ")";
-    }
-
-    def emit_int(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "0";
-        }
-        if len(args) == 1 {
-            # Use Math.trunc(Number(x)) instead of parseInt(x) to correctly
-            # handle booleans (parseInt(false) → NaN, Number(false) → 0)
-            # and floats (int(3.14) → 3).
-            return "Math.trunc(Number(" + args[0] + "))";
-        }
-        return "parseInt(" + args[0] + ", " + args[1] + ")";
-    }
-
-    def emit_float(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "0.0";
-        }
-        return "parseFloat(" + args[0] + ")";
-    }
-
-    def emit_bool(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "false";
-        }
-        # Use runtime helper for Python truthiness semantics:
-        # Python: bool([]) → False, bool({}) → False, bool(set()) → False
-        # JS:     Boolean([]) → true,  Boolean({}) → true
-        return _rt("builtin", "bool", args);
-    }
-
-    def emit_list(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "[]";
-        }
-        return "Array.from(" + args[0] + ")";
-    }
-
-    def emit_dict(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "{}";
-        }
-        return "Object.fromEntries(" + args[0] + ")";
-    }
-
-    def emit_set(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "new Set()";
-        }
-        return "new Set(" + args[0] + ")";
-    }
-
-    def emit_tuple(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "Object.freeze([])";
-        }
-        return "Object.freeze(Array.from(" + args[0] + "))";
-    }
-
-    def emit_frozenset(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "Object.freeze(new Set())";
-        }
-        return "Object.freeze(new Set(" + args[0] + "))";
-    }
-
-    def emit_bytes(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "new Uint8Array()";
-        }
-        return "new Uint8Array(" + args[0] + ")";
-    }
-
-    def emit_complex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "complex", args);
-    }
-
-    def emit_range(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "range", args);
-    }
-
-    def emit_slice(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        return _rt("builtin", "slice", args);
-    }
-
-    def emit_bytearray(self, ctx: ESEmitCtx, args: list[str]) -> (str | None) {
-        if len(args) == 0 {
-            return "new Uint8Array()";
-        }
-        return "new Uint8Array(" + args[0] + ")";
-    }
+    def emit_str(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_int(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_float(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_bool(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_list(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_dict(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_set(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_tuple(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_frozenset(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_bytes(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_complex(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_range(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_slice(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
+    def emit_bytearray(self, ctx: ESEmitCtx, args: list[str]) -> (str | None);
 }

--- a/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
@@ -1,0 +1,6395 @@
+"""Implementation file for native (LLVM) backend primitive emitters."""
+
+import from llvmlite { ir }
+
+impl NativeIntEmitter.emit_bit_length(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeIntEmitter.emit_bit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeIntEmitter.emit_to_bytes(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # to_bytes(length, byteorder): convert int to bytes
+    if len(args) < 2 {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    zero64 = ir.Constant(i64, 0);
+    one64 = ir.Constant(i64, 1);
+    eight64 = ir.Constant(i64, 8);
+    mask_ff = ir.Constant(i64, 0xFF);
+    length = args[0];  # i64
+    byteorder = args[1];  # i8* "big" or "little"
+    # Allocate length+1 bytes (null-terminated)
+    alloc_sz = b.add(length, one64, name="tb.alloc.sz");
+    buf = b.call(p.rc_alloc_fn, [alloc_sz], name="tb.buf");
+    # Null-terminate
+    end_ptr = b.gep(buf, [length], name="tb.end");
+    b.store(ir.Constant(i8, 0), end_ptr);
+    # Determine if big-endian: strcmp(byteorder, "big") == 0
+    big_str = p._make_global_string("big");
+    strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
+    cmp_res = b.call(strcmp_fn, [byteorder, big_str], name="tb.cmp");
+    is_big = b.icmp_signed("==", cmp_res, ir.Constant(i32, 0), name="tb.isbig");
+    # Loop: for i in range(length)
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="tb.loop");
+    body_bb = func.append_basic_block(name="tb.body");
+    done_bb = func.append_basic_block(name="tb.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="tb.idx");
+    idx.add_incoming(zero64, entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, length, name="tb.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    # Extract byte: (target >> (i * 8)) & 0xFF
+    shift_amt = b.mul(idx, eight64, name="tb.shift");
+    shifted = b.lshr(target, shift_amt, name="tb.shifted");
+    byte_val = b.and_(shifted, mask_ff, name="tb.byte");
+    byte_i8 = b.trunc(byte_val, i8, name="tb.i8");
+    # Store position: big-endian = length-1-i, little-endian = i
+    big_pos = b.sub(b.sub(length, one64, name="tb.lm1"), idx, name="tb.bigpos");
+    store_pos = b.select(is_big, big_pos, idx, name="tb.pos");
+    byte_ptr = b.gep(buf, [store_pos], name="tb.ptr");
+    b.store(byte_i8, byte_ptr);
+    next_idx = b.add(idx, one64, name="tb.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return buf;
+}
+
+impl NativeIntEmitter.emit_as_integer_ratio(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # as_integer_ratio for int: returns (n, 1) as a 2-element tuple
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    one = ir.Constant(i64, 1);
+    tuple_type = ir.LiteralStructType([i64, i64]);
+    null_ptr = ir.Constant(tuple_type.as_pointer(), None);
+    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="iair.sizeof.gep");
+    size = b.ptrtoint(size_gep, i64, name="iair.sizeof");
+    raw_ptr = b.call(p.rc_alloc_fn, [size], name="iair.alloc");
+    tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="iair.ptr");
+    n_ptr = b.gep(
+        tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="iair.n.ptr"
+    );
+    d_ptr = b.gep(
+        tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="iair.d.ptr"
+    );
+    b.store(target, n_ptr);
+    b.store(one, d_ptr);
+    tkey = "i64.i64";
+    if tkey not in p.tuple_types {
+        p.tuple_types[tkey] = tuple_type;
+    }
+    return tuple_ptr;
+}
+
+impl NativeIntEmitter.emit_bit_length(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # bit_length: number of bits needed to represent abs(target), excluding sign and leading zeros
+    # 0.bit_length() == 0, 1.bit_length() == 1, 255.bit_length() == 8
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    zero = ir.Constant(i64, 0);
+    one = ir.Constant(i64, 1);
+    # abs(target)
+    is_neg = b.icmp_signed("<", target, zero, name="bitlen.neg");
+    neg_val = b.sub(zero, target, name="bitlen.abs");
+    abs_val = b.select(is_neg, neg_val, target, name="bitlen.absv");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="bitlen.loop");
+    body_bb = func.append_basic_block(name="bitlen.body");
+    done_bb = func.append_basic_block(name="bitlen.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    val = b.phi(i64, name="bitlen.val");
+    count = b.phi(i64, name="bitlen.count");
+    val.add_incoming(abs_val, entry_bb);
+    count.add_incoming(zero, entry_bb);
+    is_zero = b.icmp_unsigned("==", val, zero, name="bitlen.iszero");
+    b.cbranch(is_zero, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    new_val = b.lshr(val, one, name="bitlen.shr");
+    new_count = b.add(count, one, name="bitlen.inc");
+    val.add_incoming(new_val, body_bb);
+    count.add_incoming(new_count, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return count;
+}
+
+impl NativeIntEmitter.emit_bit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # bit_count: number of ones in the binary representation (popcount)
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    zero = ir.Constant(i64, 0);
+    one = ir.Constant(i64, 1);
+    # Use abs value for negative numbers (Python counts bits of magnitude)
+    is_neg = b.icmp_signed("<", target, zero, name="bitcnt.neg");
+    neg_val = b.sub(zero, target, name="bitcnt.abs");
+    abs_val = b.select(is_neg, neg_val, target, name="bitcnt.absv");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="bitcnt.loop");
+    body_bb = func.append_basic_block(name="bitcnt.body");
+    done_bb = func.append_basic_block(name="bitcnt.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    val = b.phi(i64, name="bitcnt.val");
+    count = b.phi(i64, name="bitcnt.count");
+    val.add_incoming(abs_val, entry_bb);
+    count.add_incoming(zero, entry_bb);
+    is_zero = b.icmp_unsigned("==", val, zero, name="bitcnt.iszero");
+    b.cbranch(is_zero, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    bit = b.and_(val, one, name="bitcnt.bit");
+    new_count = b.add(count, bit, name="bitcnt.inc");
+    new_val = b.lshr(val, one, name="bitcnt.shr");
+    val.add_incoming(new_val, body_bb);
+    count.add_incoming(new_count, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return count;
+}
+
+impl NativeIntEmitter.emit_conjugate(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # conjugate of an integer is itself
+    return target;
+}
+
+impl NativeIntEmitter.emit_from_bytes(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # int.from_bytes(bytes_str, byteorder): reconstruct int from bytes (i8*)
+    if len(args) < 2 {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    zero64 = ir.Constant(i64, 0);
+    one64 = ir.Constant(i64, 1);
+    eight64 = ir.Constant(i64, 8);
+    bytes_ptr = args[0];  # i8*
+    byteorder = args[1];  # i8* "big" or "little"
+    # Get length of bytes string
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    length = b.call(strlen_fn, [bytes_ptr], name="fb.len");
+    # Determine if big-endian
+    big_str = p._make_global_string("big");
+    strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
+    cmp_res = b.call(strcmp_fn, [byteorder, big_str], name="fb.cmp");
+    is_big = b.icmp_signed("==", cmp_res, ir.Constant(i32, 0), name="fb.isbig");
+    # Loop: accumulate bytes into result i64
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="fb.loop");
+    body_bb = func.append_basic_block(name="fb.body");
+    done_bb = func.append_basic_block(name="fb.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="fb.idx");
+    result = b.phi(i64, name="fb.result");
+    idx.add_incoming(zero64, entry_bb);
+    result.add_incoming(zero64, entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, length, name="fb.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    # Load byte at idx
+    byte_ptr = b.gep(bytes_ptr, [idx], name="fb.bptr");
+    byte_val = b.load(byte_ptr, name="fb.byte");
+    byte_i64 = b.zext(byte_val, i64, name="fb.ext");
+    # For big-endian: shift_amt = (length - 1 - i) * 8
+    # For little-endian: shift_amt = i * 8
+    big_shift_idx = b.sub(b.sub(length, one64, name="fb.lm1"), idx, name="fb.bidx");
+    shift_idx = b.select(is_big, big_shift_idx, idx, name="fb.sidx");
+    shift_amt = b.mul(shift_idx, eight64, name="fb.shift");
+    shifted = b.shl(byte_i64, shift_amt, name="fb.shifted");
+    new_result = b.or_(result, shifted, name="fb.accum");
+    next_idx = b.add(idx, one64, name="fb.next");
+    idx.add_incoming(next_idx, body_bb);
+    result.add_incoming(new_result, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return result;
+}
+
+impl NativeFloatEmitter.emit_is_integer(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # is_integer: True if float has no fractional part
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    # Convert to int and back, compare
+    truncated = b.fptosi(target, i64, name="isint.trunc");
+    roundtripped = b.sitofp(truncated, ir.DoubleType(), name="isint.rt");
+    is_eq = b.fcmp_ordered("==", target, roundtripped, name="isint.eq");
+    return b.zext(is_eq, i64, name="isint.result");
+}
+
+impl NativeFloatEmitter.emit_as_integer_ratio(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # as_integer_ratio for float: returns (numerator, denominator) as tuple
+    # Algorithm: multiply by 2 until integer, track denominator
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    f64 = ir.DoubleType();
+    func = b.basic_block.function;
+    # Get floor function
+    floor_fn = p._get_or_declare_extern("floor", f64, [f64]);
+    # Loop: while floor(num) != num, num *= 2, den *= 2
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="fair.loop");
+    body_bb = func.append_basic_block(name="fair.body");
+    done_bb = func.append_basic_block(name="fair.done");
+    two = ir.Constant(f64, 2.0);
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    num_phi = b.phi(f64, name="fair.num");
+    den_phi = b.phi(i64, name="fair.den");
+    num_phi.add_incoming(target, entry_bb);
+    den_phi.add_incoming(ir.Constant(i64, 1), entry_bb);
+    floored = b.call(floor_fn, [num_phi], name="fair.floor");
+    is_int = b.fcmp_ordered("==", num_phi, floored, name="fair.isint");
+    b.cbranch(is_int, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    new_num = b.fmul(num_phi, two, name="fair.num2");
+    new_den = b.mul(den_phi, ir.Constant(i64, 2), name="fair.den2");
+    num_phi.add_incoming(new_num, body_bb);
+    den_phi.add_incoming(new_den, body_bb);
+    b.branch(loop_bb);
+    # Build result tuple
+    b.position_at_start(done_bb);
+    numer = b.fptosi(num_phi, i64, name="fair.numer");
+    tuple_type = ir.LiteralStructType([i64, i64]);
+    null_ptr = ir.Constant(tuple_type.as_pointer(), None);
+    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="fair.sizeof.gep");
+    size = b.ptrtoint(size_gep, i64, name="fair.sizeof");
+    raw_ptr = b.call(p.rc_alloc_fn, [size], name="fair.alloc");
+    tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="fair.ptr");
+    n_ptr = b.gep(
+        tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="fair.n.ptr"
+    );
+    d_ptr = b.gep(
+        tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="fair.d.ptr"
+    );
+    b.store(numer, n_ptr);
+    b.store(den_phi, d_ptr);
+    tkey = "i64.i64";
+    if tkey not in p.tuple_types {
+        p.tuple_types[tkey] = tuple_type;
+    }
+    return tuple_ptr;
+}
+
+impl NativeFloatEmitter.emit_conjugate(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # conjugate of a float is itself
+    return target;
+}
+
+impl NativeFloatEmitter.emit_hex(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # float.hex(): return hex representation using C %a format
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    i32 = ir.IntType(32);
+    buf_size = ir.Constant(i64, 64);
+    buf = b.call(p.rc_alloc_fn, [buf_size], name="fhex.buf");
+    fmt = p._make_global_string("%a");
+    snprintf = p._get_or_declare_extern("snprintf", i32, [i8p, i64, i8p], var_arg=True);
+    b.call(snprintf, [buf, buf_size, fmt, target], name="fhex.len");
+    return buf;
+}
+
+impl NativeFloatEmitter.emit_fromhex(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # float.fromhex(s): parse hex float string (C strtod supports hex)
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    f64 = ir.DoubleType();
+    i8p = ir.IntType(8).as_pointer();
+    strtod_fn = p._get_or_declare_extern("strtod", f64, [i8p, i8p.as_pointer()]);
+    null_ptr = ir.Constant(i8p.as_pointer(), None);
+    result = b.call(strtod_fn, [args[0], null_ptr], name="fhex.result");
+    return result;
+}
+
+"""Bool-specific emitter.
+
+Inherits all int operations but overrides bitwise operators so that
+True & False yields False (bool i1) rather than 0 (i64), matching
+Python semantics where bool & bool -> bool.
+"""
+impl NativeBoolEmitter.emit_op_and(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i1 = ir.IntType(1);
+    lhs = p._coerce_type(target, i1) if target.type != i1 else target;
+    rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
+    return b.and_(lhs, rhs, name="bool.and");
+}
+
+impl NativeBoolEmitter.emit_op_or(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i1 = ir.IntType(1);
+    lhs = p._coerce_type(target, i1) if target.type != i1 else target;
+    rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
+    return b.or_(lhs, rhs, name="bool.or");
+}
+
+impl NativeBoolEmitter.emit_op_xor(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i1 = ir.IntType(1);
+    lhs = p._coerce_type(target, i1) if target.type != i1 else target;
+    rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
+    return b.xor(lhs, rhs, name="bool.xor");
+}
+
+"""Bool-specific emitter.
+
+Inherits all int operations but overrides bitwise operators so that
+True & False yields False (bool i1) rather than 0 (i64), matching
+Python semantics where bool & bool -> bool.
+"""
+impl NativeBoolEmitter.emit_op_and(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i1 = ir.IntType(1);
+    lhs = p._coerce_type(target, i1) if target.type != i1 else target;
+    rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
+    return b.and_(lhs, rhs, name="bool.and");
+}
+
+impl NativeBoolEmitter.emit_op_or(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i1 = ir.IntType(1);
+    lhs = p._coerce_type(target, i1) if target.type != i1 else target;
+    rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
+    return b.or_(lhs, rhs, name="bool.or");
+}
+
+impl NativeBoolEmitter.emit_op_xor(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i1 = ir.IntType(1);
+    lhs = p._coerce_type(target, i1) if target.type != i1 else target;
+    rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
+    return b.xor(lhs, rhs, name="bool.xor");
+}
+
+"""Helper: load real and imag from a JacComplex pointer."""
+impl NativeComplexEmitter._load_parts(
+    self, ctx: NativeEmitCtx, val: ir.Value
+) -> (tuple | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    z0 = ir.Constant(i32, 0);
+    z1 = ir.Constant(i32, 1);
+    r = b.load(b.gep(val, [z0, z0], name="cx.rp"), name="cx.r");
+    im = b.load(b.gep(val, [z0, z1], name="cx.ip"), name="cx.i");
+    return (r, im);
+}
+
+"""Helper: create a new JacComplex from real and imag f64 values."""
+impl NativeComplexEmitter._make_complex(
+    self, ctx: NativeEmitCtx, real: ir.Value, imag: ir.Value
+) -> ir.Value {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    z0 = ir.Constant(i32, 0);
+    z1 = ir.Constant(i32, 1);
+    ctype = p.complex_struct_type;
+    raw = b.call(p.rc_alloc_fn, [ir.Constant(i64, 16)], name="cx.raw");
+    ptr = b.bitcast(raw, ctype.as_pointer(), name="cx.ptr");
+    b.store(real, b.gep(ptr, [z0, z0], name="cx.srp"));
+    b.store(imag, b.gep(ptr, [z0, z1], name="cx.sip"));
+    return ptr;
+}
+
+impl NativeComplexEmitter.emit_conjugate(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    parts = self._load_parts(ctx, target);
+    if parts is None {
+        return None;
+    }
+    (r, im) = parts;
+    ni = ctx.pass_ref.builder.fneg(im, name="conj.ni");
+    return self._make_complex(ctx, r, ni);
+}
+
+impl NativeComplexEmitter.emit_op_add(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_sub(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_mul(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_truediv(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_pow(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_eq(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_ne(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_neg(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeComplexEmitter.emit_op_pos(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Case conversion
+impl NativeStrEmitter.emit_capitalize(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # Capitalize: uppercase first char, lowercase the rest
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    toupper_fn = p._get_or_declare_extern("toupper", i32, [i32]);
+    tolower_fn = p._get_or_declare_extern("tolower", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="cap.len");
+    alloc_size = b.add(slen, ir.Constant(i64, 1), name="cap.alloc.sz");
+    result = b.call(rc_alloc_fn, [alloc_size], name="cap.buf");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="cap.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    first_bb = func.append_basic_block(name="cap.first");
+    loop_bb = func.append_basic_block(name="cap.loop");
+    body_bb = func.append_basic_block(name="cap.body");
+    done_bb = func.append_basic_block(name="cap.done");
+    b.cbranch(is_empty, done_bb, first_bb);
+    # Uppercase the first character
+    b.position_at_start(first_bb);
+    first_ch = b.load(target, name="cap.first.ch");
+    first_i32 = b.zext(first_ch, i32, name="cap.first.i32");
+    upper_ch = b.call(toupper_fn, [first_i32], name="cap.first.upper");
+    upper_i8 = b.trunc(upper_ch, i8, name="cap.first.i8");
+    b.store(upper_i8, result);
+    b.branch(loop_bb);
+    # Lowercase remaining characters
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="cap.idx");
+    idx.add_incoming(ir.Constant(i64, 1), first_bb);
+    cond = b.icmp_unsigned("<", idx, slen, name="cap.cond");
+    b.cbranch(cond, body_bb, done_bb);
+    b.position_at_start(body_bb);
+    src_ptr = b.gep(target, [idx], name="cap.src.ptr");
+    ch = b.load(src_ptr, name="cap.ch");
+    ch_i32 = b.zext(ch, i32, name="cap.ch.i32");
+    lower_ch = b.call(tolower_fn, [ch_i32], name="cap.lower");
+    lower_i8 = b.trunc(lower_ch, i8, name="cap.lower.i8");
+    dst_ptr = b.gep(result, [idx], name="cap.dst.ptr");
+    b.store(lower_i8, dst_ptr);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="cap.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    null_ptr = b.gep(result, [slen], name="cap.null.ptr");
+    b.store(ir.Constant(i8, 0), null_ptr);
+    return result;
+}
+
+impl NativeStrEmitter.emit_casefold(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # casefold is equivalent to lower for ASCII
+    return self._emit_case_transform(ctx, target, "tolower");
+}
+
+impl NativeStrEmitter.emit_lower(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_case_transform(ctx, target, "tolower");
+}
+
+impl NativeStrEmitter.emit_upper(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_case_transform(ctx, target, "toupper");
+}
+
+impl NativeStrEmitter._emit_case_transform(
+    self, ctx: NativeEmitCtx, target: ir.Value, cfunc_name: str
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    slen = b.call(strlen_fn, [target], name="case.len");
+    rc_alloc_fn = p.rc_alloc_fn;
+    alloc_size = b.add(slen, ir.Constant(i64, 1), name="case.alloc.sz");
+    result = b.call(rc_alloc_fn, [alloc_size], name="case.buf");
+    transform_fn = p._get_or_declare_extern(cfunc_name, i32, [i32]);
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="case.loop");
+    body_bb = func.append_basic_block(name="case.body");
+    done_bb = func.append_basic_block(name="case.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="case.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    cond = b.icmp_unsigned("<", idx, slen, name="case.cond");
+    b.cbranch(cond, body_bb, done_bb);
+    b.position_at_start(body_bb);
+    src_ptr = b.gep(target, [idx], name="case.src.ptr");
+    ch = b.load(src_ptr, name="case.ch");
+    ch_i32 = b.zext(ch, i32, name="case.ch.i32");
+    transformed = b.call(transform_fn, [ch_i32], name="case.transformed");
+    ch_out = b.trunc(transformed, i8, name="case.ch.out");
+    dst_ptr = b.gep(result, [idx], name="case.dst.ptr");
+    b.store(ch_out, dst_ptr);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="case.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    null_ptr = b.gep(result, [slen], name="case.null.ptr");
+    b.store(ir.Constant(i8, 0), null_ptr);
+    return result;
+}
+
+impl NativeStrEmitter.emit_title(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # title: uppercase first char of each word, lowercase rest
+    # Word boundary = after non-alpha character
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    toupper_fn = p._get_or_declare_extern("toupper", i32, [i32]);
+    tolower_fn = p._get_or_declare_extern("tolower", i32, [i32]);
+    isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="title.len");
+    alloc_size = b.add(slen, ir.Constant(i64, 1), name="title.alloc");
+    result = b.call(rc_alloc_fn, [alloc_size], name="title.buf");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="title.loop");
+    body_bb = func.append_basic_block(name="title.body");
+    done_bb = func.append_basic_block(name="title.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="title.idx");
+    at_boundary = b.phi(i64, name="title.boundary");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_boundary.add_incoming(ir.Constant(i64, 1), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="title.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    src_ptr = b.gep(target, [idx], name="title.src.ptr");
+    ch = b.load(src_ptr, name="title.ch");
+    ch_i32 = b.zext(ch, i32, name="title.ch.i32");
+    is_alpha = b.call(isalpha_fn, [ch_i32], name="title.isalpha");
+    is_alpha_bool = b.icmp_signed(
+        "!=", is_alpha, ir.Constant(i32, 0), name="title.isalp"
+    );
+    is_boundary = b.icmp_unsigned(
+        "!=", at_boundary, ir.Constant(i64, 0), name="title.isbnd"
+    );
+    upper_ch = b.call(toupper_fn, [ch_i32], name="title.upper");
+    lower_ch = b.call(tolower_fn, [ch_i32], name="title.lower");
+    should_upper = b.and_(is_boundary, is_alpha_bool, name="title.shup");
+    pick1 = b.select(should_upper, upper_ch, ch_i32, name="title.pick1");
+    should_lower = b.and_(
+        b.not_(is_boundary, name="title.notbnd"), is_alpha_bool, name="title.shlo"
+    );
+    pick2 = b.select(should_lower, lower_ch, pick1, name="title.pick2");
+    out_i8 = b.trunc(pick2, i8, name="title.out");
+    dst_ptr = b.gep(result, [idx], name="title.dst.ptr");
+    b.store(out_i8, dst_ptr);
+    new_boundary = b.select(
+        is_alpha_bool, ir.Constant(i64, 0), ir.Constant(i64, 1), name="title.newbnd"
+    );
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="title.next");
+    idx.add_incoming(next_idx, body_bb);
+    at_boundary.add_incoming(new_boundary, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    null_ptr = b.gep(result, [slen], name="title.null.ptr");
+    b.store(ir.Constant(i8, 0), null_ptr);
+    return result;
+}
+
+impl NativeStrEmitter.emit_swapcase(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # Swapcase: toupper if lower, tolower if upper
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    toupper_fn = p._get_or_declare_extern("toupper", i32, [i32]);
+    tolower_fn = p._get_or_declare_extern("tolower", i32, [i32]);
+    islower_fn = p._get_or_declare_extern("islower", i32, [i32]);
+    isupper_fn = p._get_or_declare_extern("isupper", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="swap.len");
+    alloc_size = b.add(slen, ir.Constant(i64, 1), name="swap.alloc.sz");
+    result = b.call(rc_alloc_fn, [alloc_size], name="swap.buf");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="swap.loop");
+    body_bb = func.append_basic_block(name="swap.body");
+    done_bb = func.append_basic_block(name="swap.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="swap.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    cond = b.icmp_unsigned("<", idx, slen, name="swap.cond");
+    b.cbranch(cond, body_bb, done_bb);
+    b.position_at_start(body_bb);
+    src_ptr = b.gep(target, [idx], name="swap.src.ptr");
+    ch = b.load(src_ptr, name="swap.ch");
+    ch_i32 = b.zext(ch, i32, name="swap.ch.i32");
+    is_low = b.call(islower_fn, [ch_i32], name="swap.islow");
+    is_low_bool = b.icmp_signed("!=", is_low, ir.Constant(i32, 0), name="swap.islo");
+    upper_ch = b.call(toupper_fn, [ch_i32], name="swap.upper");
+    is_up = b.call(isupper_fn, [ch_i32], name="swap.isup");
+    is_up_bool = b.icmp_signed("!=", is_up, ir.Constant(i32, 0), name="swap.isup.b");
+    lower_ch = b.call(tolower_fn, [ch_i32], name="swap.lower");
+    # If lower -> use upper, elif upper -> use lower, else keep original
+    pick1 = b.select(is_up_bool, lower_ch, ch_i32, name="swap.pick1");
+    pick2 = b.select(is_low_bool, upper_ch, pick1, name="swap.pick2");
+    out_i8 = b.trunc(pick2, i8, name="swap.out");
+    dst_ptr = b.gep(result, [idx], name="swap.dst.ptr");
+    b.store(out_i8, dst_ptr);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="swap.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    null_ptr = b.gep(result, [slen], name="swap.null.ptr");
+    b.store(ir.Constant(i8, 0), null_ptr);
+    return result;
+}
+
+# Search
+impl NativeStrEmitter.emit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # Count non-overlapping occurrences of substring using strstr loop
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    sub_len = b.call(strlen_fn, [args[0]], name="cnt.sub.len");
+    null_ptr = ir.Constant(i8p, None);
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="cnt.loop");
+    found_bb = func.append_basic_block(name="cnt.found");
+    done_bb = func.append_basic_block(name="cnt.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    cur_ptr = b.phi(i8p, name="cnt.cur");
+    count = b.phi(i64, name="cnt.count");
+    cur_ptr.add_incoming(target, entry_bb);
+    count.add_incoming(ir.Constant(i64, 0), entry_bb);
+    found = b.call(strstr_fn, [cur_ptr, args[0]], name="cnt.found.ptr");
+    is_null = b.icmp_unsigned("==", found, null_ptr, name="cnt.null");
+    b.cbranch(is_null, done_bb, found_bb);
+    b.position_at_start(found_bb);
+    new_count = b.add(count, ir.Constant(i64, 1), name="cnt.inc");
+    found_int = b.ptrtoint(found, i64, name="cnt.fnd.int");
+    next_int = b.add(found_int, sub_len, name="cnt.next.int");
+    next_ptr = b.inttoptr(next_int, i8p, name="cnt.next.ptr");
+    cur_ptr.add_incoming(next_ptr, found_bb);
+    count.add_incoming(new_count, found_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return count;
+}
+
+impl NativeStrEmitter.emit_find(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    found = b.call(strstr_fn, [target, args[0]], name="find.ptr");
+    null_ptr = ir.Constant(i8p, None);
+    is_null = b.icmp_unsigned("==", found, null_ptr, name="find.null");
+    target_int = b.ptrtoint(target, i64, name="find.tgt.int");
+    found_int = b.ptrtoint(found, i64, name="find.fnd.int");
+    diff = b.sub(found_int, target_int, name="find.diff");
+    return b.select(is_null, ir.Constant(i64, -1), diff, name="find.result");
+}
+
+impl NativeStrEmitter.emit_rfind(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # rfind: find last occurrence of substring, return index or -1
+    # Empty substring returns len(target) matching Python semantics
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    slen = b.call(strlen_fn, [target], name="rfind.slen");
+    sub_len = b.call(strlen_fn, [args[0]], name="rfind.sub.len");
+    null_ptr = ir.Constant(i8p, None);
+    target_int = b.ptrtoint(target, i64, name="rfind.tgt.int");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    # Handle empty substring: return len(target)
+    empty_bb = func.append_basic_block(name="rfind.empty");
+    search_bb = func.append_basic_block(name="rfind.search");
+    loop_bb = func.append_basic_block(name="rfind.loop");
+    found_bb = func.append_basic_block(name="rfind.found");
+    done_bb = func.append_basic_block(name="rfind.done");
+    is_empty = b.icmp_unsigned("==", sub_len, ir.Constant(i64, 0), name="rfind.isempty");
+    b.cbranch(is_empty, empty_bb, search_bb);
+    b.position_at_start(empty_bb);
+    b.branch(done_bb);
+    b.position_at_start(search_bb);
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    cur_ptr = b.phi(i8p, name="rfind.cur");
+    last_pos = b.phi(i64, name="rfind.last");
+    cur_ptr.add_incoming(target, search_bb);
+    last_pos.add_incoming(ir.Constant(i64, -1), search_bb);
+    found = b.call(strstr_fn, [cur_ptr, args[0]], name="rfind.found.ptr");
+    is_null = b.icmp_unsigned("==", found, null_ptr, name="rfind.null");
+    b.cbranch(is_null, done_bb, found_bb);
+    b.position_at_start(found_bb);
+    found_int = b.ptrtoint(found, i64, name="rfind.fnd.int");
+    new_pos = b.sub(found_int, target_int, name="rfind.pos");
+    next_int = b.add(found_int, sub_len, name="rfind.next.int");
+    next_ptr = b.inttoptr(next_int, i8p, name="rfind.next.ptr");
+    cur_ptr.add_incoming(next_ptr, found_bb);
+    last_pos.add_incoming(new_pos, found_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="rfind.result");
+    result.add_incoming(slen, empty_bb);
+    result.add_incoming(last_pos, loop_bb);
+    return result;
+}
+
+impl NativeStrEmitter.emit_index(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # index: like find but raises ValueError if not found
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    found = b.call(strstr_fn, [target, args[0]], name="index.ptr");
+    null_ptr = ir.Constant(i8p, None);
+    is_null = b.icmp_unsigned("==", found, null_ptr, name="index.null");
+    p._emit_runtime_raise(is_null, "ValueError", "substring not found");
+    target_int = b.ptrtoint(target, i64, name="index.tgt.int");
+    found_int = b.ptrtoint(found, i64, name="index.fnd.int");
+    return b.sub(found_int, target_int, name="index.result");
+}
+
+impl NativeStrEmitter.emit_rindex(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # rindex: like rfind but raises ValueError if not found
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    # Reuse rfind logic
+    rfind_result = self.emit_rfind(ctx, target, args);
+    if rfind_result is None {
+        return None;
+    }
+    is_neg = b.icmp_signed("<", rfind_result, ir.Constant(i64, 0), name="rindex.neg");
+    p._emit_runtime_raise(is_neg, "ValueError", "substring not found");
+    return rfind_result;
+}
+
+impl NativeStrEmitter.emit_startswith(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strncmp_fn = p._get_or_declare_extern("strncmp", i32, [i8p, i8p, i64]);
+    prefix_len = b.call(strlen_fn, [args[0]], name="sw.pfx.len");
+    cmp = b.call(strncmp_fn, [target, args[0], prefix_len], name="sw.cmp");
+    is_zero = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="sw.eq");
+    return b.zext(is_zero, i64, name="sw.result");
+}
+
+impl NativeStrEmitter.emit_endswith(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
+    target_len = b.call(strlen_fn, [target], name="ew.tgt.len");
+    suffix_len = b.call(strlen_fn, [args[0]], name="ew.sfx.len");
+    too_long = b.icmp_unsigned(">", suffix_len, target_len, name="ew.toolong");
+    offset = b.sub(target_len, suffix_len, name="ew.offset");
+    end_ptr = b.gep(target, [offset], name="ew.end.ptr");
+    cmp = b.call(strcmp_fn, [end_ptr, args[0]], name="ew.cmp");
+    is_match = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="ew.match");
+    match_i64 = b.zext(is_match, i64, name="ew.match.i64");
+    return b.select(too_long, ir.Constant(i64, 0), match_i64, name="ew.result");
+}
+
+# Modification
+impl NativeStrEmitter.emit_replace(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # replace(old, new[, count])
+    # count < 0 or omitted means replace all occurrences.
+    # count == 0 means replace nothing.
+    # count > 0 means replace at most that many occurrences.
+    if len(args) < 2 {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    old_str = args[0];
+    new_str = args[1];
+    # count_val: use the third arg if provided, else -1 (unlimited sentinel).
+    # The loop checks remaining == 0 to stop; -1 decrements to -2, -3, ...
+    # and never reaches 0, so unlimited behaviour is preserved.
+    count_val: ir.Value = ir.Constant(i64, -1) if len(args) < 3 else args[2];
+    target_len = b.call(strlen_fn, [target], name="repl.tgt.len");
+    old_len = b.call(strlen_fn, [old_str], name="repl.old.len");
+    new_len = b.call(strlen_fn, [new_str], name="repl.new.len");
+    # Worst-case allocation: every char replaced
+    generous_factor = b.add(new_len, ir.Constant(i64, 1), name="repl.factor");
+    generous_size = b.mul(target_len, generous_factor, name="repl.generous");
+    alloc_size = b.add(generous_size, ir.Constant(i64, 1), name="repl.alloc");
+    result = b.call(rc_alloc_fn, [alloc_size], name="repl.buf");
+    null_ptr = ir.Constant(i8p, None);
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="repl.loop");
+    found_bb = func.append_basic_block(name="repl.found");
+    notfound_bb = func.append_basic_block(name="repl.notfound");
+    done_bb = func.append_basic_block(name="repl.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    src = b.phi(i8p, name="repl.src");
+    dst_off = b.phi(i64, name="repl.dst.off");
+    remaining = b.phi(i64, name="repl.remaining");
+    src.add_incoming(target, entry_bb);
+    dst_off.add_incoming(ir.Constant(i64, 0), entry_bb);
+    remaining.add_incoming(count_val, entry_bb);
+    # Stop replacing when count is exhausted (remaining == 0).
+    count_exhausted = b.icmp_signed(
+        "==", remaining, ir.Constant(i64, 0), name="repl.exhausted"
+    );
+    found = b.call(strstr_fn, [src, old_str], name="repl.found.ptr");
+    is_null = b.icmp_unsigned("==", found, null_ptr, name="repl.null");
+    no_replace = b.or_(count_exhausted, is_null, name="repl.no.repl");
+    b.cbranch(no_replace, notfound_bb, found_bb);
+    b.position_at_start(found_bb);
+    src_int = b.ptrtoint(src, i64, name="repl.src.int");
+    found_int = b.ptrtoint(found, i64, name="repl.fnd.int");
+    prefix_len = b.sub(found_int, src_int, name="repl.pfx.len");
+    dst_ptr = b.gep(result, [dst_off], name="repl.dst.ptr");
+    b.call(memcpy_fn, [dst_ptr, src, prefix_len]);
+    dst_off2 = b.add(dst_off, prefix_len, name="repl.off2");
+    dst_ptr2 = b.gep(result, [dst_off2], name="repl.dst.ptr2");
+    b.call(memcpy_fn, [dst_ptr2, new_str, new_len]);
+    dst_off3 = b.add(dst_off2, new_len, name="repl.off3");
+    next_src_int = b.add(found_int, old_len, name="repl.next.int");
+    next_src = b.inttoptr(next_src_int, i8p, name="repl.next.src");
+    # Decrement remaining; -1 wraps to -2, -3, ... (never hits 0 → unlimited).
+    next_remaining = b.sub(remaining, ir.Constant(i64, 1), name="repl.next.rem");
+    src.add_incoming(next_src, found_bb);
+    dst_off.add_incoming(dst_off3, found_bb);
+    remaining.add_incoming(next_remaining, found_bb);
+    b.branch(loop_bb);
+    b.position_at_start(notfound_bb);
+    remain_len = b.call(strlen_fn, [src], name="repl.remain.len");
+    dst_ptr3 = b.gep(result, [dst_off], name="repl.dst.ptr3");
+    b.call(memcpy_fn, [dst_ptr3, src, remain_len]);
+    final_len = b.add(dst_off, remain_len, name="repl.final.len");
+    null_term = b.gep(result, [final_len], name="repl.null.term");
+    b.store(ir.Constant(i8, 0), null_term);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    return result;
+}
+
+impl NativeStrEmitter.emit_strip(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return ctx.pass_ref._codegen_str_strip(target);
+}
+
+impl NativeStrEmitter.emit_lstrip(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # lstrip: skip leading whitespace, return new string
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    isspace_fn = p._get_or_declare_extern("isspace", i32, [i32]);
+    strcpy_fn = p._get_or_declare_extern("strcpy", i8p, [i8p, i8p]);
+    slen = b.call(strlen_fn, [target], name="lstrip.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="lstrip.loop");
+    body_bb = func.append_basic_block(name="lstrip.body");
+    done_bb = func.append_basic_block(name="lstrip.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="lstrip.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="lstrip.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name="lstrip.ch.ptr");
+    ch = b.load(ch_ptr, name="lstrip.ch");
+    ch_i32 = b.zext(ch, i32, name="lstrip.ch.i32");
+    is_sp = b.call(isspace_fn, [ch_i32], name="lstrip.issp");
+    is_sp_bool = b.icmp_signed("!=", is_sp, ir.Constant(i32, 0), name="lstrip.issp.b");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="lstrip.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(is_sp_bool, loop_bb, done_bb);
+    b.position_at_start(done_bb);
+    start = b.phi(i64, name="lstrip.start");
+    start.add_incoming(idx, loop_bb);
+    start.add_incoming(idx, body_bb);
+    new_len = b.sub(slen, start, name="lstrip.newlen");
+    alloc_size = b.add(new_len, ir.Constant(i64, 1), name="lstrip.alloc");
+    result = b.call(rc_alloc_fn, [alloc_size], name="lstrip.buf");
+    start_ptr = b.gep(target, [start], name="lstrip.start.ptr");
+    b.call(strcpy_fn, [result, start_ptr]);
+    return result;
+}
+
+impl NativeStrEmitter.emit_rstrip(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # rstrip: remove trailing whitespace
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    isspace_fn = p._get_or_declare_extern("isspace", i32, [i32]);
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    slen = b.call(strlen_fn, [target], name="rstrip.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="rstrip.loop");
+    body_bb = func.append_basic_block(name="rstrip.body");
+    done_bb = func.append_basic_block(name="rstrip.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    end = b.phi(i64, name="rstrip.end");
+    end.add_incoming(slen, entry_bb);
+    is_zero = b.icmp_unsigned("==", end, ir.Constant(i64, 0), name="rstrip.iszero");
+    b.cbranch(is_zero, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    prev = b.sub(end, ir.Constant(i64, 1), name="rstrip.prev");
+    ch_ptr = b.gep(target, [prev], name="rstrip.ch.ptr");
+    ch = b.load(ch_ptr, name="rstrip.ch");
+    ch_i32 = b.zext(ch, i32, name="rstrip.ch.i32");
+    is_sp = b.call(isspace_fn, [ch_i32], name="rstrip.issp");
+    is_sp_bool = b.icmp_signed("!=", is_sp, ir.Constant(i32, 0), name="rstrip.issp.b");
+    end.add_incoming(prev, body_bb);
+    b.cbranch(is_sp_bool, loop_bb, done_bb);
+    b.position_at_start(done_bb);
+    final_end = b.phi(i64, name="rstrip.final.end");
+    final_end.add_incoming(end, loop_bb);
+    final_end.add_incoming(end, body_bb);
+    alloc_size = b.add(final_end, ir.Constant(i64, 1), name="rstrip.alloc");
+    result = b.call(rc_alloc_fn, [alloc_size], name="rstrip.buf");
+    b.call(memcpy_fn, [result, target, final_end]);
+    null_ptr = b.gep(result, [final_end], name="rstrip.null.ptr");
+    b.store(ir.Constant(i8, 0), null_ptr);
+    return result;
+}
+
+impl NativeStrEmitter.emit_removeprefix(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strncmp_fn = p._get_or_declare_extern("strncmp", i32, [i8p, i8p, i64]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    strcpy_fn = p._get_or_declare_extern("strcpy", i8p, [i8p, i8p]);
+    prefix_len = b.call(strlen_fn, [args[0]], name="rmpfx.pfx.len");
+    target_len = b.call(strlen_fn, [target], name="rmpfx.tgt.len");
+    too_long = b.icmp_unsigned(">", prefix_len, target_len, name="rmpfx.toolong");
+    func = b.basic_block.function;
+    check_bb = func.append_basic_block(name="rmpfx.check");
+    match_bb = func.append_basic_block(name="rmpfx.match");
+    nomatch_bb = func.append_basic_block(name="rmpfx.nomatch");
+    done_bb = func.append_basic_block(name="rmpfx.done");
+    b.cbranch(too_long, nomatch_bb, check_bb);
+    b.position_at_start(check_bb);
+    cmp = b.call(strncmp_fn, [target, args[0], prefix_len], name="rmpfx.cmp");
+    is_match = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="rmpfx.eq");
+    b.cbranch(is_match, match_bb, nomatch_bb);
+    # Matched: return target + prefix_len
+    b.position_at_start(match_bb);
+    rest_len = b.sub(target_len, prefix_len, name="rmpfx.rest.len");
+    alloc_m = b.add(rest_len, ir.Constant(i64, 1), name="rmpfx.alloc.m");
+    result_m = b.call(rc_alloc_fn, [alloc_m], name="rmpfx.buf.m");
+    rest_ptr = b.gep(target, [prefix_len], name="rmpfx.rest.ptr");
+    b.call(strcpy_fn, [result_m, rest_ptr]);
+    b.branch(done_bb);
+    # Not matched: return copy of original
+    b.position_at_start(nomatch_bb);
+    alloc_n = b.add(target_len, ir.Constant(i64, 1), name="rmpfx.alloc.n");
+    result_n = b.call(rc_alloc_fn, [alloc_n], name="rmpfx.buf.n");
+    b.call(strcpy_fn, [result_n, target]);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i8p, name="rmpfx.result");
+    result_phi.add_incoming(result_m, match_bb);
+    result_phi.add_incoming(result_n, nomatch_bb);
+    return result_phi;
+}
+
+impl NativeStrEmitter.emit_removesuffix(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    suffix_len = b.call(strlen_fn, [args[0]], name="rmsfx.sfx.len");
+    target_len = b.call(strlen_fn, [target], name="rmsfx.tgt.len");
+    too_long = b.icmp_unsigned(">", suffix_len, target_len, name="rmsfx.toolong");
+    func = b.basic_block.function;
+    check_bb = func.append_basic_block(name="rmsfx.check");
+    match_bb = func.append_basic_block(name="rmsfx.match");
+    nomatch_bb = func.append_basic_block(name="rmsfx.nomatch");
+    done_bb = func.append_basic_block(name="rmsfx.done");
+    b.cbranch(too_long, nomatch_bb, check_bb);
+    b.position_at_start(check_bb);
+    offset = b.sub(target_len, suffix_len, name="rmsfx.offset");
+    end_ptr = b.gep(target, [offset], name="rmsfx.end.ptr");
+    cmp = b.call(strcmp_fn, [end_ptr, args[0]], name="rmsfx.cmp");
+    is_match = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="rmsfx.eq");
+    b.cbranch(is_match, match_bb, nomatch_bb);
+    # Matched: copy without suffix
+    b.position_at_start(match_bb);
+    new_len = b.sub(target_len, suffix_len, name="rmsfx.newlen");
+    alloc_m = b.add(new_len, ir.Constant(i64, 1), name="rmsfx.alloc.m");
+    result_m = b.call(rc_alloc_fn, [alloc_m], name="rmsfx.buf.m");
+    b.call(memcpy_fn, [result_m, target, new_len]);
+    null_ptr_m = b.gep(result_m, [new_len], name="rmsfx.null.m");
+    b.store(ir.Constant(i8, 0), null_ptr_m);
+    b.branch(done_bb);
+    # Not matched: copy original
+    b.position_at_start(nomatch_bb);
+    alloc_n = b.add(target_len, ir.Constant(i64, 1), name="rmsfx.alloc.n");
+    result_n = b.call(rc_alloc_fn, [alloc_n], name="rmsfx.buf.n");
+    b.call(memcpy_fn, [result_n, target, target_len]);
+    null_ptr_n = b.gep(result_n, [target_len], name="rmsfx.null.n");
+    b.store(ir.Constant(i8, 0), null_ptr_n);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i8p, name="rmsfx.result");
+    result_phi.add_incoming(result_m, match_bb);
+    result_phi.add_incoming(result_n, nomatch_bb);
+    return result_phi;
+}
+
+# Split and join
+impl NativeStrEmitter.emit_split(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if args {
+        return ctx.pass_ref._codegen_str_split(target, args[0]);
+    }
+    return None;
+}
+
+impl NativeStrEmitter.emit_rsplit(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # rsplit(sep) without maxsplit: same result as split(sep)
+    if args {
+        return ctx.pass_ref._codegen_str_split(target, args[0]);
+    }
+    return None;
+}
+
+impl NativeStrEmitter.emit_splitlines(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # splitlines(): split on "\n" separator
+    p = ctx.pass_ref;
+    nl_sep = p._make_global_string("\n", name_prefix=".nl.sep");
+    return p._codegen_str_split(target, nl_sep);
+}
+
+impl NativeStrEmitter.emit_join(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # join(list): concatenate list elements with separator (target)
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    zero = ir.Constant(i64, 0);
+    one = ir.Constant(i64, 1);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    # Ensure list helpers for "ptr" (string list)
+    p._emit_list_helpers("ptr", i8p);
+    lhelpers = p.list_helpers.get("ptr");
+    if lhelpers is None {
+        return None;
+    }
+    the_list = args[0];
+    sep_len = b.call(strlen_fn, [target], name="jn.seplen");
+    list_len = b.call(lhelpers["len"], [the_list], name="jn.listlen");
+    func = b.basic_block.function;
+    # Check if list is empty
+    is_empty = b.icmp_unsigned("==", list_len, zero, name="jn.isempty");
+    empty_bb = func.append_basic_block(name="jn.empty");
+    pass1_bb = func.append_basic_block(name="jn.pass1");
+    done_bb = func.append_basic_block(name="jn.done");
+    b.cbranch(is_empty, empty_bb, pass1_bb);
+    # Empty list: return empty string
+    b.position_at_start(empty_bb);
+    empty_buf = b.call(rc_alloc_fn, [one], name="jn.empty.buf");
+    b.store(ir.Constant(i8, 0), empty_buf);
+    b.branch(done_bb);
+    # Pass 1: compute total length
+    b.position_at_start(pass1_bb);
+    entry_p1 = b.basic_block;
+    loop1_bb = func.append_basic_block(name="jn.len.loop");
+    body1_bb = func.append_basic_block(name="jn.len.body");
+    pass2_start = func.append_basic_block(name="jn.p2start");
+    b.branch(loop1_bb);
+    b.position_at_start(loop1_bb);
+    p1_idx = b.phi(i64, name="jn.p1.idx");
+    p1_total = b.phi(i64, name="jn.p1.total");
+    p1_idx.add_incoming(zero, entry_p1);
+    p1_total.add_incoming(zero, entry_p1);
+    p1_end = b.icmp_unsigned(">=", p1_idx, list_len, name="jn.p1.end");
+    b.cbranch(p1_end, pass2_start, body1_bb);
+    b.position_at_start(body1_bb);
+    elem = b.call(lhelpers["get"], [the_list, p1_idx], name="jn.p1.elem");
+    elen = b.call(strlen_fn, [elem], name="jn.p1.elen");
+    new_total = b.add(p1_total, elen, name="jn.p1.ntot");
+    next_p1 = b.add(p1_idx, one, name="jn.p1.next");
+    p1_idx.add_incoming(next_p1, body1_bb);
+    p1_total.add_incoming(new_total, body1_bb);
+    b.branch(loop1_bb);
+    # Calculate total with separators
+    b.position_at_start(pass2_start);
+    total_phi = b.phi(i64, name="jn.total");
+    total_phi.add_incoming(p1_total, loop1_bb);
+    sep_count = b.sub(list_len, one, name="jn.sepcount");
+    sep_total = b.mul(sep_len, sep_count, name="jn.septotal");
+    grand_total = b.add(total_phi, sep_total, name="jn.grand");
+    alloc_sz = b.add(grand_total, one, name="jn.alloc");
+    buf = b.call(rc_alloc_fn, [alloc_sz], name="jn.buf");
+    # Pass 2: copy elements with separator
+    entry_p2 = b.basic_block;
+    loop2_bb = func.append_basic_block(name="jn.cp.loop");
+    body2_bb = func.append_basic_block(name="jn.cp.body");
+    sep_check = func.append_basic_block(name="jn.cp.sep");
+    sep_copy = func.append_basic_block(name="jn.cp.sepcopy");
+    next_iter = func.append_basic_block(name="jn.cp.next");
+    copy_done = func.append_basic_block(name="jn.cp.done");
+    b.branch(loop2_bb);
+    b.position_at_start(loop2_bb);
+    p2_idx = b.phi(i64, name="jn.p2.idx");
+    p2_off = b.phi(i64, name="jn.p2.off");
+    p2_idx.add_incoming(zero, entry_p2);
+    p2_off.add_incoming(zero, entry_p2);
+    p2_end = b.icmp_unsigned(">=", p2_idx, list_len, name="jn.p2.end");
+    b.cbranch(p2_end, copy_done, body2_bb);
+    b.position_at_start(body2_bb);
+    elem2 = b.call(lhelpers["get"], [the_list, p2_idx], name="jn.p2.elem");
+    elen2 = b.call(strlen_fn, [elem2], name="jn.p2.elen");
+    dst2 = b.gep(buf, [p2_off], name="jn.p2.dst");
+    b.call(memcpy_fn, [dst2, elem2, elen2]);
+    off_after_elem = b.add(p2_off, elen2, name="jn.p2.off2");
+    b.branch(sep_check);
+    # Check if need separator
+    b.position_at_start(sep_check);
+    next_p2 = b.add(p2_idx, one, name="jn.p2.next");
+    is_last = b.icmp_unsigned(">=", next_p2, list_len, name="jn.p2.islast");
+    b.cbranch(is_last, next_iter, sep_copy);
+    b.position_at_start(sep_copy);
+    sep_dst = b.gep(buf, [off_after_elem], name="jn.p2.sepdst");
+    b.call(memcpy_fn, [sep_dst, target, sep_len]);
+    off_after_sep = b.add(off_after_elem, sep_len, name="jn.p2.off3");
+    b.branch(next_iter);
+    # Merge offset
+    b.position_at_start(next_iter);
+    merged_off = b.phi(i64, name="jn.p2.moff");
+    merged_off.add_incoming(off_after_elem, sep_check);
+    merged_off.add_incoming(off_after_sep, sep_copy);
+    p2_idx.add_incoming(next_p2, next_iter);
+    p2_off.add_incoming(merged_off, next_iter);
+    b.branch(loop2_bb);
+    # Null-terminate
+    b.position_at_start(copy_done);
+    final_off = b.phi(i64, name="jn.final.off");
+    final_off.add_incoming(p2_off, loop2_bb);
+    null_p = b.gep(buf, [final_off], name="jn.null");
+    b.store(ir.Constant(i8, 0), null_p);
+    b.branch(done_bb);
+    # Done
+    b.position_at_start(done_bb);
+    result = b.phi(i8p, name="jn.result");
+    result.add_incoming(empty_buf, empty_bb);
+    result.add_incoming(buf, copy_done);
+    return result;
+}
+
+impl NativeStrEmitter.emit_partition(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # partition(sep) -> list[str] of [before, sep_or_empty, after_or_empty]
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    i32 = ir.IntType(32);
+    sep_val = args[0];
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    p._emit_list_helpers("ptr", i8p);
+    lh = p.list_helpers.get("ptr");
+    if lh is None {
+        return None;
+    }
+    result_list = b.call(lh["new"], [], name="part.list");
+    sep_len = b.call(strlen_fn, [sep_val], name="part.seplen");
+    str_len = b.call(strlen_fn, [target], name="part.strlen");
+    found_ptr = b.call(strstr_fn, [target, sep_val], name="part.found");
+    null_i8p = ir.Constant(i8p, None);
+    is_found = b.icmp_unsigned("!=", found_ptr, null_i8p, name="part.isfound");
+    func = b.basic_block.function;
+    found_bb = func.append_basic_block(name="part.yes");
+    notfound_bb = func.append_basic_block(name="part.no");
+    merge_bb = func.append_basic_block(name="part.merge");
+    b.cbranch(is_found, found_bb, notfound_bb);
+    # Found: before = [0, offset), sep = args[0], after = offset+sep_len..end
+    b.position_at_start(found_bb);
+    base_int = b.ptrtoint(target, i64, name="part.base");
+    found_int = b.ptrtoint(found_ptr, i64, name="part.fint");
+    before_len = b.sub(found_int, base_int, name="part.blen");
+    before_alloc = b.add(before_len, ir.Constant(i64, 1), name="part.balloc");
+    before_ptr = b.call(p.rc_alloc_fn, [before_alloc], name="part.before");
+    b.call(memcpy_fn, [before_ptr, target, before_len]);
+    before_null = b.gep(before_ptr, [before_len], name="part.bnull");
+    b.store(ir.Constant(i8, 0), before_null);
+    after_off = b.add(before_len, sep_len, name="part.aoff");
+    after_len = b.sub(str_len, after_off, name="part.alen");
+    after_alloc = b.add(after_len, ir.Constant(i64, 1), name="part.aalloc");
+    after_ptr = b.call(p.rc_alloc_fn, [after_alloc], name="part.after");
+    after_src = b.gep(target, [after_off], name="part.asrc");
+    b.call(memcpy_fn, [after_ptr, after_src, after_len]);
+    after_null = b.gep(after_ptr, [after_len], name="part.anull");
+    b.store(ir.Constant(i8, 0), after_null);
+    b.call(lh["append"], [result_list, before_ptr]);
+    b.call(lh["append"], [result_list, sep_val]);
+    b.call(lh["append"], [result_list, after_ptr]);
+    b.branch(merge_bb);
+    # Not found: [target, "", ""]
+    b.position_at_start(notfound_bb);
+    empty1 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="part.e1");
+    b.store(ir.Constant(i8, 0), empty1);
+    empty2 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="part.e2");
+    b.store(ir.Constant(i8, 0), empty2);
+    b.call(lh["append"], [result_list, target]);
+    b.call(lh["append"], [result_list, empty1]);
+    b.call(lh["append"], [result_list, empty2]);
+    b.branch(merge_bb);
+    b.position_at_start(merge_bb);
+    return result_list;
+}
+
+impl NativeStrEmitter.emit_rpartition(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # rpartition(sep) -> list[str] of [before_or_empty, sep_or_empty, after_or_target]
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    sep_val = args[0];
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    p._emit_list_helpers("ptr", i8p);
+    lh = p.list_helpers.get("ptr");
+    if lh is None {
+        return None;
+    }
+    result_list = b.call(lh["new"], [], name="rpart.list");
+    sep_len = b.call(strlen_fn, [sep_val], name="rpart.seplen");
+    str_len = b.call(strlen_fn, [target], name="rpart.strlen");
+    # Find last occurrence: scan forward keeping the latest match
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="rpart.loop");
+    body_bb = func.append_basic_block(name="rpart.body");
+    done_bb = func.append_basic_block(name="rpart.done");
+    found_bb = func.append_basic_block(name="rpart.yes");
+    notfound_bb = func.append_basic_block(name="rpart.no");
+    merge_bb = func.append_basic_block(name="rpart.merge");
+    # Allocate last_match on stack (pointer, null = not found)
+    last_match_alloca = b.alloca(i8p, name="rpart.last");
+    b.store(ir.Constant(i8p, None), last_match_alloca);
+    cur_alloca = b.alloca(i8p, name="rpart.cur");
+    b.store(target, cur_alloca);
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    cur_ptr = b.load(cur_alloca, name="rpart.curp");
+    found_ptr = b.call(strstr_fn, [cur_ptr, sep_val], name="rpart.found");
+    null_i8p = ir.Constant(i8p, None);
+    is_found = b.icmp_unsigned("!=", found_ptr, null_i8p, name="rpart.isf");
+    b.cbranch(is_found, body_bb, done_bb);
+    b.position_at_start(body_bb);
+    b.store(found_ptr, last_match_alloca);
+    next_ptr = b.gep(found_ptr, [ir.Constant(i64, 1)], name="rpart.next");
+    b.store(next_ptr, cur_alloca);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    last_match = b.load(last_match_alloca, name="rpart.last.v");
+    is_any = b.icmp_unsigned("!=", last_match, null_i8p, name="rpart.isany");
+    b.cbranch(is_any, found_bb, notfound_bb);
+    # Found: before = [0, offset), sep = args[0], after = offset+sep_len..end
+    b.position_at_start(found_bb);
+    base_int = b.ptrtoint(target, i64, name="rpart.base");
+    last_int = b.ptrtoint(last_match, i64, name="rpart.lint");
+    before_len = b.sub(last_int, base_int, name="rpart.blen");
+    before_alloc = b.add(before_len, ir.Constant(i64, 1), name="rpart.balloc");
+    before_ptr = b.call(p.rc_alloc_fn, [before_alloc], name="rpart.before");
+    b.call(memcpy_fn, [before_ptr, target, before_len]);
+    before_null = b.gep(before_ptr, [before_len], name="rpart.bnull");
+    b.store(ir.Constant(i8, 0), before_null);
+    after_off = b.add(before_len, sep_len, name="rpart.aoff");
+    after_len = b.sub(str_len, after_off, name="rpart.alen");
+    after_alloc = b.add(after_len, ir.Constant(i64, 1), name="rpart.aalloc");
+    after_ptr = b.call(p.rc_alloc_fn, [after_alloc], name="rpart.after");
+    after_src = b.gep(target, [after_off], name="rpart.asrc");
+    b.call(memcpy_fn, [after_ptr, after_src, after_len]);
+    after_null = b.gep(after_ptr, [after_len], name="rpart.anull");
+    b.store(ir.Constant(i8, 0), after_null);
+    b.call(lh["append"], [result_list, before_ptr]);
+    b.call(lh["append"], [result_list, sep_val]);
+    b.call(lh["append"], [result_list, after_ptr]);
+    b.branch(merge_bb);
+    # Not found: ["", "", target]
+    b.position_at_start(notfound_bb);
+    empty1 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="rpart.e1");
+    b.store(ir.Constant(i8, 0), empty1);
+    empty2 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="rpart.e2");
+    b.store(ir.Constant(i8, 0), empty2);
+    b.call(lh["append"], [result_list, empty1]);
+    b.call(lh["append"], [result_list, empty2]);
+    b.call(lh["append"], [result_list, target]);
+    b.branch(merge_bb);
+    b.position_at_start(merge_bb);
+    return result_list;
+}
+
+# Formatting and alignment
+impl NativeStrEmitter.emit_format(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # str.format(*args): replace {} placeholders with string args
+    # Implements by chaining single-replace operations for each arg
+    if not args {
+        return target;  # No args, return template unchanged
+
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    snprintf_fn = p._get_or_declare_extern(
+        "snprintf", i32, [i8p, i64, i8p], var_arg=True
+    );
+    rc_alloc_fn = p.rc_alloc_fn;
+    placeholder = p._make_global_string("{}");
+    ph_len = ir.Constant(i64, 2);  # strlen("{}")
+    null_ptr = ir.Constant(i8p, None);
+    # Convert each arg to i8* string
+    str_args: list[ir.Value] = [];
+    for arg in args {
+        if isinstance(arg.type, ir.IntType) and arg.type.width > 1 {
+            # Integer: snprintf("%ld", val)
+            buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="fmt.ibuf");
+            fmt_s = p._make_global_string("%ld");
+            b.call(snprintf_fn, [buf, ir.Constant(i64, 32), fmt_s, arg]);
+            str_args.append(buf);
+        } elif isinstance(arg.type, ir.DoubleType) {
+            # Float: snprintf("%g", val)
+            buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="fmt.fbuf");
+            fmt_s = p._make_global_string("%g");
+            b.call(snprintf_fn, [buf, ir.Constant(i64, 32), fmt_s, arg]);
+            str_args.append(buf);
+        } else {
+            # Already i8* (string or pointer)
+            str_args.append(arg);
+        }
+    }
+    # Chain single-replace operations: for each arg, replace first {} with arg_str
+    current = target;
+    for i in range(len(str_args)) {
+        arg_str = str_args[i];
+        arg_len = b.call(strlen_fn, [arg_str], name=f"fmt.a{i}.len");
+        cur_len = b.call(strlen_fn, [current], name=f"fmt.c{i}.len");
+        # Generous allocation: cur_len - 2 + arg_len + 1
+        alloc_sz = b.add(
+            b.sub(cur_len, ph_len, name=f"fmt.sub{i}"),
+            b.add(arg_len, ir.Constant(i64, 1), name=f"fmt.aln{i}"),
+            name=f"fmt.alloc{i}"
+        );
+        result = b.call(rc_alloc_fn, [alloc_sz], name=f"fmt.res{i}");
+        # Find first {} in current
+        found = b.call(strstr_fn, [current, placeholder], name=f"fmt.fnd{i}");
+        is_null = b.icmp_unsigned("==", found, null_ptr, name=f"fmt.null{i}");
+        func = b.basic_block.function;
+        replace_bb = func.append_basic_block(name=f"fmt.repl{i}");
+        skip_bb = func.append_basic_block(name=f"fmt.skip{i}");
+        merge_bb = func.append_basic_block(name=f"fmt.merge{i}");
+        b.cbranch(is_null, skip_bb, replace_bb);
+        # Replace path: copy prefix + arg_str + suffix
+        b.position_at_start(replace_bb);
+        cur_int = b.ptrtoint(current, i64, name=f"fmt.ci{i}");
+        fnd_int = b.ptrtoint(found, i64, name=f"fmt.fi{i}");
+        pfx_len = b.sub(fnd_int, cur_int, name=f"fmt.pfx{i}");
+        b.call(memcpy_fn, [result, current, pfx_len]);
+        dst2 = b.gep(result, [pfx_len], name=f"fmt.d2.{i}");
+        b.call(memcpy_fn, [dst2, arg_str, arg_len]);
+        dst3_off = b.add(pfx_len, arg_len, name=f"fmt.d3o{i}");
+        dst3 = b.gep(result, [dst3_off], name=f"fmt.d3.{i}");
+        sfx_start_int = b.add(fnd_int, ph_len, name=f"fmt.sfxi{i}");
+        sfx_start = b.inttoptr(sfx_start_int, i8p, name=f"fmt.sfx{i}");
+        sfx_len = b.call(strlen_fn, [sfx_start], name=f"fmt.slen{i}");
+        b.call(memcpy_fn, [dst3, sfx_start, sfx_len]);
+        total_len = b.add(dst3_off, sfx_len, name=f"fmt.tlen{i}");
+        null_term = b.gep(result, [total_len], name=f"fmt.nt{i}");
+        b.store(ir.Constant(i8, 0), null_term);
+        b.branch(merge_bb);
+        # Skip path: no {} found, return current unchanged
+        b.position_at_start(skip_bb);
+        # Copy current string to result
+        b.call(memcpy_fn, [result, current, cur_len]);
+        null_term2 = b.gep(result, [cur_len], name=f"fmt.nt2.{i}");
+        b.store(ir.Constant(i8, 0), null_term2);
+        b.branch(merge_bb);
+        b.position_at_start(merge_bb);
+        current = result;
+    }
+    return current;
+}
+
+impl NativeStrEmitter.emit_format_map(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # format_map(mapping): replace {key} placeholders with dict values
+    # Complex: requires runtime dict lookup for each placeholder key
+    # Deferring for now - returns None to fall through
+    return None;
+}
+
+impl NativeStrEmitter.emit_center(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # center(width): center string, pad with spaces on both sides
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
+    slen = b.call(strlen_fn, [target], name="center.len");
+    width = args[0];
+    needs_pad = b.icmp_unsigned("<", slen, width, name="center.needspad");
+    func = b.basic_block.function;
+    pad_bb = func.append_basic_block(name="center.pad");
+    nopad_bb = func.append_basic_block(name="center.nopad");
+    done_bb = func.append_basic_block(name="center.done");
+    b.cbranch(needs_pad, pad_bb, nopad_bb);
+    # Pad case: match CPython formula: left = marg//2 + (marg & width & 1)
+    b.position_at_start(pad_bb);
+    total_pad = b.sub(width, slen, name="center.totalpad");
+    half = b.udiv(total_pad, ir.Constant(i64, 2), name="center.half");
+    tp_and_w = b.and_(total_pad, width, name="center.tpw");
+    adj = b.and_(tp_and_w, ir.Constant(i64, 1), name="center.adj");
+    left_pad = b.add(half, adj, name="center.lpad");
+    right_pad = b.sub(total_pad, left_pad, name="center.rpad");
+    alloc_pad = b.add(width, ir.Constant(i64, 1), name="center.alloc");
+    buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="center.buf");
+    # Fill left padding with spaces
+    b.call(memset_fn, [buf_pad, ir.Constant(ir.IntType(32), 32), left_pad]);
+    # Copy string after left padding
+    str_ptr = b.gep(buf_pad, [left_pad], name="center.str.ptr");
+    b.call(memcpy_fn, [str_ptr, target, slen]);
+    # Fill right padding with spaces
+    right_ptr = b.gep(str_ptr, [slen], name="center.rpad.ptr");
+    b.call(memset_fn, [right_ptr, ir.Constant(ir.IntType(32), 32), right_pad]);
+    # Null terminate
+    null_pad = b.gep(buf_pad, [width], name="center.null");
+    b.store(ir.Constant(i8, 0), null_pad);
+    b.branch(done_bb);
+    # No pad: return copy
+    b.position_at_start(nopad_bb);
+    alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="center.alloc.np");
+    buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="center.buf.np");
+    b.call(memcpy_fn, [buf_nopad, target, slen]);
+    null_nopad = b.gep(buf_nopad, [slen], name="center.null.np");
+    b.store(ir.Constant(i8, 0), null_nopad);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i8p, name="center.result");
+    result.add_incoming(buf_pad, pad_bb);
+    result.add_incoming(buf_nopad, nopad_bb);
+    return result;
+}
+
+impl NativeStrEmitter.emit_ljust(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # ljust(width): left-justify, pad with spaces on right
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
+    slen = b.call(strlen_fn, [target], name="ljust.len");
+    width = args[0];
+    needs_pad = b.icmp_unsigned("<", slen, width, name="ljust.needspad");
+    func = b.basic_block.function;
+    pad_bb = func.append_basic_block(name="ljust.pad");
+    nopad_bb = func.append_basic_block(name="ljust.nopad");
+    done_bb = func.append_basic_block(name="ljust.done");
+    b.cbranch(needs_pad, pad_bb, nopad_bb);
+    # Pad case: copy string + fill spaces
+    b.position_at_start(pad_bb);
+    alloc_pad = b.add(width, ir.Constant(i64, 1), name="ljust.alloc");
+    buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="ljust.buf");
+    b.call(memcpy_fn, [buf_pad, target, slen]);
+    pad_ptr = b.gep(buf_pad, [slen], name="ljust.pad.ptr");
+    pad_len = b.sub(width, slen, name="ljust.pad.len");
+    b.call(memset_fn, [pad_ptr, ir.Constant(ir.IntType(32), 32), pad_len]);
+    null_pad = b.gep(buf_pad, [width], name="ljust.null");
+    b.store(ir.Constant(i8, 0), null_pad);
+    b.branch(done_bb);
+    # No pad: return copy
+    b.position_at_start(nopad_bb);
+    alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="ljust.alloc.np");
+    buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="ljust.buf.np");
+    b.call(memcpy_fn, [buf_nopad, target, slen]);
+    null_nopad = b.gep(buf_nopad, [slen], name="ljust.null.np");
+    b.store(ir.Constant(i8, 0), null_nopad);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i8p, name="ljust.result");
+    result.add_incoming(buf_pad, pad_bb);
+    result.add_incoming(buf_nopad, nopad_bb);
+    return result;
+}
+
+impl NativeStrEmitter.emit_rjust(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # rjust(width): right-justify, pad with spaces on left
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
+    slen = b.call(strlen_fn, [target], name="rjust.len");
+    width = args[0];
+    needs_pad = b.icmp_unsigned("<", slen, width, name="rjust.needspad");
+    func = b.basic_block.function;
+    pad_bb = func.append_basic_block(name="rjust.pad");
+    nopad_bb = func.append_basic_block(name="rjust.nopad");
+    done_bb = func.append_basic_block(name="rjust.done");
+    b.cbranch(needs_pad, pad_bb, nopad_bb);
+    b.position_at_start(pad_bb);
+    alloc_pad = b.add(width, ir.Constant(i64, 1), name="rjust.alloc");
+    buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="rjust.buf");
+    pad_len = b.sub(width, slen, name="rjust.pad.len");
+    b.call(memset_fn, [buf_pad, ir.Constant(ir.IntType(32), 32), pad_len]);
+    str_dst = b.gep(buf_pad, [pad_len], name="rjust.str.dst");
+    b.call(memcpy_fn, [str_dst, target, slen]);
+    null_pad = b.gep(buf_pad, [width], name="rjust.null");
+    b.store(ir.Constant(i8, 0), null_pad);
+    b.branch(done_bb);
+    b.position_at_start(nopad_bb);
+    alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="rjust.alloc.np");
+    buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="rjust.buf.np");
+    b.call(memcpy_fn, [buf_nopad, target, slen]);
+    null_nopad = b.gep(buf_nopad, [slen], name="rjust.null.np");
+    b.store(ir.Constant(i8, 0), null_nopad);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i8p, name="rjust.result");
+    result.add_incoming(buf_pad, pad_bb);
+    result.add_incoming(buf_nopad, nopad_bb);
+    return result;
+}
+
+impl NativeStrEmitter.emit_zfill(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # zfill(width): pad with '0' on left, keeping sign char
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
+    slen = b.call(strlen_fn, [target], name="zfill.len");
+    width = args[0];
+    needs_pad = b.icmp_unsigned("<", slen, width, name="zfill.needspad");
+    func = b.basic_block.function;
+    pad_bb = func.append_basic_block(name="zfill.pad");
+    nopad_bb = func.append_basic_block(name="zfill.nopad");
+    done_bb = func.append_basic_block(name="zfill.done");
+    b.cbranch(needs_pad, pad_bb, nopad_bb);
+    # Pad case: check for sign char
+    b.position_at_start(pad_bb);
+    alloc_pad = b.add(width, ir.Constant(i64, 1), name="zfill.alloc");
+    buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="zfill.buf");
+    first_ch = b.load(target, name="zfill.first");
+    is_plus = b.icmp_unsigned("==", first_ch, ir.Constant(i8, 43), name="zfill.plus");
+    is_minus = b.icmp_unsigned("==", first_ch, ir.Constant(i8, 45), name="zfill.minus");
+    has_sign = b.or_(is_plus, is_minus, name="zfill.hassign");
+    pad_len = b.sub(width, slen, name="zfill.pad.len");
+    # If sign: write sign char first, then zeros, then rest of string
+    sign_off = b.select(
+        has_sign, ir.Constant(i64, 1), ir.Constant(i64, 0), name="zfill.soff"
+    );
+    # Store sign char at position 0 if present
+    sign_bb = func.append_basic_block(name="zfill.sign");
+    nosign_bb = func.append_basic_block(name="zfill.nosign");
+    merge_bb = func.append_basic_block(name="zfill.merge");
+    b.cbranch(has_sign, sign_bb, nosign_bb);
+    b.position_at_start(sign_bb);
+    b.store(first_ch, buf_pad);
+    b.call(
+        memset_fn,
+        [
+            b.gep(buf_pad, [ir.Constant(i64, 1)], name="zfill.z1"),
+            ir.Constant(ir.IntType(32), 48),
+            pad_len
+        ]
+    );
+    src_rest = b.gep(target, [ir.Constant(i64, 1)], name="zfill.src.rest");
+    rest_len = b.sub(slen, ir.Constant(i64, 1), name="zfill.rest.len");
+    dst_rest = b.gep(
+        buf_pad,
+        [b.add(pad_len, ir.Constant(i64, 1), name="zfill.doff")],
+        name="zfill.dst.rest"
+    );
+    b.call(memcpy_fn, [dst_rest, src_rest, rest_len]);
+    b.branch(merge_bb);
+    b.position_at_start(nosign_bb);
+    b.call(memset_fn, [buf_pad, ir.Constant(ir.IntType(32), 48), pad_len]);
+    dst_nosign = b.gep(buf_pad, [pad_len], name="zfill.dst.ns");
+    b.call(memcpy_fn, [dst_nosign, target, slen]);
+    b.branch(merge_bb);
+    b.position_at_start(merge_bb);
+    null_pad = b.gep(buf_pad, [width], name="zfill.null");
+    b.store(ir.Constant(i8, 0), null_pad);
+    b.branch(done_bb);
+    # No pad: return copy
+    b.position_at_start(nopad_bb);
+    alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="zfill.alloc.np");
+    buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="zfill.buf.np");
+    b.call(memcpy_fn, [buf_nopad, target, slen]);
+    null_nopad = b.gep(buf_nopad, [slen], name="zfill.null.np");
+    b.store(ir.Constant(i8, 0), null_nopad);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i8p, name="zfill.result");
+    result.add_incoming(buf_pad, merge_bb);
+    result.add_incoming(buf_nopad, nopad_bb);
+    return result;
+}
+
+impl NativeStrEmitter.emit_expandtabs(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # expandtabs(tabsize=8): replace tabs with spaces to next tab stop
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    zero = ir.Constant(i64, 0);
+    one = ir.Constant(i64, 1);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    rc_alloc_fn = p.rc_alloc_fn;
+    slen = b.call(strlen_fn, [target], name="et.len");
+    # tabsize: default 8 if no args
+    if args {
+        tabsize = args[0];
+    } else {
+        tabsize = ir.Constant(i64, 8);
+    }
+    # Worst case allocation: every char is a tab → slen * max(tabsize, 1) + 1
+    ts_or_one = b.select(
+        b.icmp_unsigned("==", tabsize, zero), one, tabsize, name="et.ts1"
+    );
+    worst = b.mul(slen, ts_or_one, name="et.worst");
+    alloc_sz = b.add(worst, one, name="et.alloc");
+    buf = b.call(rc_alloc_fn, [alloc_sz], name="et.buf");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="et.loop");
+    check_tab = func.append_basic_block(name="et.check.tab");
+    do_tab = func.append_basic_block(name="et.do.tab");
+    tab_loop = func.append_basic_block(name="et.tab.loop");
+    tab_write = func.append_basic_block(name="et.tab.write");
+    tab_done = func.append_basic_block(name="et.tab.done");
+    check_nl = func.append_basic_block(name="et.check.nl");
+    do_nl = func.append_basic_block(name="et.do.nl");
+    do_char = func.append_basic_block(name="et.do.char");
+    next_bb = func.append_basic_block(name="et.next");
+    done_bb = func.append_basic_block(name="et.done");
+    b.branch(loop_bb);
+    # Main loop header with phi nodes
+    b.position_at_start(loop_bb);
+    si = b.phi(i64, name="et.si");
+    di = b.phi(i64, name="et.di");
+    col = b.phi(i64, name="et.col");
+    si.add_incoming(zero, entry_bb);
+    di.add_incoming(zero, entry_bb);
+    col.add_incoming(zero, entry_bb);
+    # Load current char
+    cp = b.gep(target, [si], name="et.cp");
+    ch = b.load(cp, name="et.ch");
+    is_end = b.icmp_unsigned("==", ch, ir.Constant(i8, 0), name="et.end");
+    b.cbranch(is_end, done_bb, check_tab);
+    # Check if tab char (0x09)
+    b.position_at_start(check_tab);
+    is_tab = b.icmp_unsigned("==", ch, ir.Constant(i8, 9), name="et.istab");
+    b.cbranch(is_tab, do_tab, check_nl);
+    # Tab: calculate spaces = tabsize - (col % tabsize), min 1
+    b.position_at_start(do_tab);
+    is_ts_zero = b.icmp_unsigned("==", tabsize, zero, name="et.ts0");
+    # If tabsize==0, spaces=0; else spaces = tabsize - (col % tabsize)
+    col_mod = b.urem(col, ts_or_one, name="et.colmod");
+    spaces_calc = b.sub(tabsize, col_mod, name="et.spcalc");
+    spaces = b.select(is_ts_zero, zero, spaces_calc, name="et.spaces");
+    b.branch(tab_loop);
+    # Tab fill loop
+    b.position_at_start(tab_loop);
+    ti = b.phi(i64, name="et.ti");
+    di_t = b.phi(i64, name="et.di.t");
+    ti.add_incoming(zero, do_tab);
+    di_t.add_incoming(di, do_tab);
+    ti_done = b.icmp_unsigned(">=", ti, spaces, name="et.tidone");
+    b.cbranch(ti_done, tab_done, tab_write);
+    # Write one space
+    b.position_at_start(tab_write);
+    dp = b.gep(buf, [di_t], name="et.dp.tw");
+    b.store(ir.Constant(i8, 32), dp);
+    next_ti = b.add(ti, one, name="et.nti");
+    next_di_t = b.add(di_t, one, name="et.ndi.t");
+    ti.add_incoming(next_ti, tab_write);
+    di_t.add_incoming(next_di_t, tab_write);
+    b.branch(tab_loop);
+    # After tab fill
+    b.position_at_start(tab_done);
+    new_col_tab = b.add(col, spaces, name="et.col.tab");
+    next_si_tab = b.add(si, one, name="et.si.tab");
+    b.branch(next_bb);
+    # Check newline/carriage return
+    b.position_at_start(check_nl);
+    is_nl = b.icmp_unsigned("==", ch, ir.Constant(i8, 10), name="et.isnl");
+    is_cr = b.icmp_unsigned("==", ch, ir.Constant(i8, 13), name="et.iscr");
+    is_line_end = b.or_(is_nl, is_cr, name="et.isle");
+    b.cbranch(is_line_end, do_nl, do_char);
+    # Newline: copy char, reset column to 0
+    b.position_at_start(do_nl);
+    dp_nl = b.gep(buf, [di], name="et.dp.nl");
+    b.store(ch, dp_nl);
+    next_di_nl = b.add(di, one, name="et.ndi.nl");
+    next_si_nl = b.add(si, one, name="et.si.nl");
+    b.branch(next_bb);
+    # Normal char: copy and increment column
+    b.position_at_start(do_char);
+    dp_ch = b.gep(buf, [di], name="et.dp.ch");
+    b.store(ch, dp_ch);
+    next_di_ch = b.add(di, one, name="et.ndi.ch");
+    next_col_ch = b.add(col, one, name="et.col.ch");
+    next_si_ch = b.add(si, one, name="et.si.ch");
+    b.branch(next_bb);
+    # Merge block for next iteration
+    b.position_at_start(next_bb);
+    new_si = b.phi(i64, name="et.new.si");
+    new_di = b.phi(i64, name="et.new.di");
+    new_col = b.phi(i64, name="et.new.col");
+    new_si.add_incoming(next_si_tab, tab_done);
+    new_si.add_incoming(next_si_nl, do_nl);
+    new_si.add_incoming(next_si_ch, do_char);
+    new_di.add_incoming(di_t, tab_done);
+    new_di.add_incoming(next_di_nl, do_nl);
+    new_di.add_incoming(next_di_ch, do_char);
+    new_col.add_incoming(new_col_tab, tab_done);
+    new_col.add_incoming(zero, do_nl);
+    new_col.add_incoming(next_col_ch, do_char);
+    b.branch(loop_bb);
+    si.add_incoming(new_si, next_bb);
+    di.add_incoming(new_di, next_bb);
+    col.add_incoming(new_col, next_bb);
+    # Done: null-terminate
+    b.position_at_start(done_bb);
+    done_di = b.phi(i64, name="et.done.di");
+    done_di.add_incoming(di, loop_bb);
+    null_p = b.gep(buf, [done_di], name="et.null");
+    b.store(ir.Constant(i8, 0), null_p);
+    return buf;
+}
+
+# Character tests
+"""Helper: loop over chars, call C ctype function, return 1 if all pass."""
+impl NativeStrEmitter._emit_char_test(
+    self,
+    ctx: NativeEmitCtx,
+    target: ir.Value,
+    cfunc_name: str,
+    prefix: str,
+    empty_is_true: bool = False
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    test_fn = p._get_or_declare_extern(cfunc_name, i32, [i32]);
+    slen = b.call(strlen_fn, [target], name=f"{prefix}.len");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name=f"{prefix}.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name=f"{prefix}.loop");
+    body_bb = func.append_basic_block(name=f"{prefix}.body");
+    fail_bb = func.append_basic_block(name=f"{prefix}.fail");
+    pass_bb = func.append_basic_block(name=f"{prefix}.pass");
+    done_bb = func.append_basic_block(name=f"{prefix}.done");
+    if empty_is_true {
+        b.cbranch(is_empty, pass_bb, loop_bb);
+    } else {
+        b.cbranch(is_empty, fail_bb, loop_bb);
+    }
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name=f"{prefix}.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name=f"{prefix}.atend");
+    b.cbranch(at_end, pass_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name=f"{prefix}.ch.ptr");
+    ch = b.load(ch_ptr, name=f"{prefix}.ch");
+    ch_i32 = b.zext(ch, i32, name=f"{prefix}.ch.i32");
+    result = b.call(test_fn, [ch_i32], name=f"{prefix}.test");
+    is_ok = b.icmp_signed("!=", result, ir.Constant(i32, 0), name=f"{prefix}.ok");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name=f"{prefix}.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(is_ok, loop_bb, fail_bb);
+    b.position_at_start(fail_bb);
+    b.branch(done_bb);
+    b.position_at_start(pass_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i64, name=f"{prefix}.final");
+    result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
+    result_phi.add_incoming(ir.Constant(i64, 1), pass_bb);
+    return result_phi;
+}
+
+impl NativeStrEmitter.emit_isalnum(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(ctx, target, "isalnum", "isalnum");
+}
+
+impl NativeStrEmitter.emit_isalpha(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(ctx, target, "isalpha", "isalpha");
+}
+
+impl NativeStrEmitter.emit_isascii(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # isascii: empty string returns True, check each char < 128
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    slen = b.call(strlen_fn, [target], name="isascii.len");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="isascii.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="isascii.loop");
+    body_bb = func.append_basic_block(name="isascii.body");
+    fail_bb = func.append_basic_block(name="isascii.fail");
+    pass_bb = func.append_basic_block(name="isascii.pass");
+    done_bb = func.append_basic_block(name="isascii.done");
+    b.cbranch(is_empty, pass_bb, loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="isascii.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="isascii.atend");
+    b.cbranch(at_end, pass_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name="isascii.ch.ptr");
+    ch = b.load(ch_ptr, name="isascii.ch");
+    ch_ext = b.zext(ch, i64, name="isascii.ch.ext");
+    is_ok = b.icmp_unsigned("<", ch_ext, ir.Constant(i64, 128), name="isascii.ok");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="isascii.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(is_ok, loop_bb, fail_bb);
+    b.position_at_start(fail_bb);
+    b.branch(done_bb);
+    b.position_at_start(pass_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i64, name="isascii.final");
+    result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
+    result_phi.add_incoming(ir.Constant(i64, 1), pass_bb);
+    return result_phi;
+}
+
+impl NativeStrEmitter.emit_isdecimal(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(ctx, target, "isdigit", "isdecimal");
+}
+
+impl NativeStrEmitter.emit_isdigit(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(ctx, target, "isdigit", "isdigit");
+}
+
+impl NativeStrEmitter.emit_isidentifier(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # isidentifier: non-empty, first char is alpha/underscore, rest are alnum/underscore
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
+    isalnum_fn = p._get_or_declare_extern("isalnum", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="isid.len");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="isid.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    first_bb = func.append_basic_block(name="isid.first");
+    loop_bb = func.append_basic_block(name="isid.loop");
+    body_bb = func.append_basic_block(name="isid.body");
+    fail_bb = func.append_basic_block(name="isid.fail");
+    pass_bb = func.append_basic_block(name="isid.pass");
+    done_bb = func.append_basic_block(name="isid.done");
+    b.cbranch(is_empty, fail_bb, first_bb);
+    # Check first char: must be alpha or underscore
+    b.position_at_start(first_bb);
+    first_ch = b.load(target, name="isid.first.ch");
+    first_i32 = b.zext(first_ch, i32, name="isid.first.i32");
+    is_alpha = b.call(isalpha_fn, [first_i32], name="isid.first.alpha");
+    is_alpha_ok = b.icmp_signed(
+        "!=", is_alpha, ir.Constant(i32, 0), name="isid.first.aok"
+    );
+    is_underscore = b.icmp_unsigned(
+        "==", first_ch, ir.Constant(i8, 95), name="isid.first.under"
+    );
+    first_ok = b.or_(is_alpha_ok, is_underscore, name="isid.first.ok");
+    b.cbranch(first_ok, loop_bb, fail_bb);
+    # Loop remaining chars
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="isid.idx");
+    idx.add_incoming(ir.Constant(i64, 1), first_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="isid.atend");
+    b.cbranch(at_end, pass_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name="isid.ch.ptr");
+    ch = b.load(ch_ptr, name="isid.ch");
+    ch_i32 = b.zext(ch, i32, name="isid.ch.i32");
+    is_an = b.call(isalnum_fn, [ch_i32], name="isid.isalnum");
+    is_an_ok = b.icmp_signed("!=", is_an, ir.Constant(i32, 0), name="isid.an.ok");
+    is_under = b.icmp_unsigned("==", ch, ir.Constant(i8, 95), name="isid.under");
+    ch_ok = b.or_(is_an_ok, is_under, name="isid.ch.ok");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="isid.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(ch_ok, loop_bb, fail_bb);
+    b.position_at_start(fail_bb);
+    b.branch(done_bb);
+    b.position_at_start(pass_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i64, name="isid.final");
+    result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
+    result_phi.add_incoming(ir.Constant(i64, 1), pass_bb);
+    return result_phi;
+}
+
+impl NativeStrEmitter.emit_islower(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # islower: at least one cased char, all cased chars are lowercase
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    isupper_fn = p._get_or_declare_extern("isupper", i32, [i32]);
+    isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="islower.len");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="islower.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="islower.loop");
+    body_bb = func.append_basic_block(name="islower.body");
+    fail_bb = func.append_basic_block(name="islower.fail");
+    check_bb = func.append_basic_block(name="islower.check");
+    done_bb = func.append_basic_block(name="islower.done");
+    b.cbranch(is_empty, fail_bb, loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="islower.idx");
+    has_cased = b.phi(i64, name="islower.hascased");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    has_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="islower.atend");
+    b.cbranch(at_end, check_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name="islower.ch.ptr");
+    ch = b.load(ch_ptr, name="islower.ch");
+    ch_i32 = b.zext(ch, i32, name="islower.ch.i32");
+    is_upper = b.call(isupper_fn, [ch_i32], name="islower.isupper");
+    is_upper_bool = b.icmp_signed(
+        "!=", is_upper, ir.Constant(i32, 0), name="islower.isup"
+    );
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="islower.next");
+    is_alpha = b.call(isalpha_fn, [ch_i32], name="islower.isalpha");
+    is_alpha_bool = b.icmp_signed(
+        "!=", is_alpha, ir.Constant(i32, 0), name="islower.isalp"
+    );
+    new_cased = b.select(
+        is_alpha_bool, ir.Constant(i64, 1), has_cased, name="islower.newcased"
+    );
+    idx.add_incoming(next_idx, body_bb);
+    has_cased.add_incoming(new_cased, body_bb);
+    b.cbranch(is_upper_bool, fail_bb, loop_bb);
+    b.position_at_start(check_bb);
+    has_any = b.icmp_unsigned(
+        "!=", has_cased, ir.Constant(i64, 0), name="islower.hasany"
+    );
+    b.cbranch(has_any, done_bb, fail_bb);
+    b.position_at_start(fail_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i64, name="islower.final");
+    result_phi.add_incoming(ir.Constant(i64, 1), check_bb);
+    result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
+    return result_phi;
+}
+
+impl NativeStrEmitter.emit_isnumeric(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(ctx, target, "isdigit", "isnumeric");
+}
+
+impl NativeStrEmitter.emit_isprintable(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(
+        ctx, target, "isprint", "isprintable", empty_is_true=True
+    );
+}
+
+impl NativeStrEmitter.emit_isspace(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return self._emit_char_test(ctx, target, "isspace", "isspace");
+}
+
+impl NativeStrEmitter.emit_istitle(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # istitle: uppercase chars follow non-cased, lowercase follow cased
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    isupper_fn = p._get_or_declare_extern("isupper", i32, [i32]);
+    islower_fn = p._get_or_declare_extern("islower", i32, [i32]);
+    isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="istitle.len");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="istitle.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="istitle.loop");
+    body_bb = func.append_basic_block(name="istitle.body");
+    fail_bb = func.append_basic_block(name="istitle.fail");
+    check_bb = func.append_basic_block(name="istitle.check");
+    done_bb = func.append_basic_block(name="istitle.done");
+    b.cbranch(is_empty, fail_bb, loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="istitle.idx");
+    prev_cased = b.phi(i64, name="istitle.prevcased");
+    has_cased = b.phi(i64, name="istitle.hascased");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    prev_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
+    has_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="istitle.atend");
+    b.cbranch(at_end, check_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name="istitle.ch.ptr");
+    ch = b.load(ch_ptr, name="istitle.ch");
+    ch_i32 = b.zext(ch, i32, name="istitle.ch.i32");
+    is_up = b.call(isupper_fn, [ch_i32], name="istitle.isup");
+    is_up_bool = b.icmp_signed("!=", is_up, ir.Constant(i32, 0), name="istitle.upbool");
+    is_lo = b.call(islower_fn, [ch_i32], name="istitle.islo");
+    is_lo_bool = b.icmp_signed("!=", is_lo, ir.Constant(i32, 0), name="istitle.lobool");
+    is_al = b.call(isalpha_fn, [ch_i32], name="istitle.isal");
+    is_al_bool = b.icmp_signed("!=", is_al, ir.Constant(i32, 0), name="istitle.albool");
+    prev_was_cased = b.icmp_unsigned(
+        "!=", prev_cased, ir.Constant(i64, 0), name="istitle.pwc"
+    );
+    upper_after_cased = b.and_(is_up_bool, prev_was_cased, name="istitle.uac");
+    not_prev_cased = b.not_(prev_was_cased, name="istitle.npc");
+    lower_after_noncased = b.and_(is_lo_bool, not_prev_cased, name="istitle.lanc");
+    bad = b.or_(upper_after_cased, lower_after_noncased, name="istitle.bad");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="istitle.next");
+    new_prev = b.select(
+        is_al_bool, ir.Constant(i64, 1), ir.Constant(i64, 0), name="istitle.newprev"
+    );
+    new_has = b.select(
+        is_al_bool, ir.Constant(i64, 1), has_cased, name="istitle.newhas"
+    );
+    idx.add_incoming(next_idx, body_bb);
+    prev_cased.add_incoming(new_prev, body_bb);
+    has_cased.add_incoming(new_has, body_bb);
+    b.cbranch(bad, fail_bb, loop_bb);
+    b.position_at_start(check_bb);
+    has_any = b.icmp_unsigned(
+        "!=", has_cased, ir.Constant(i64, 0), name="istitle.hasany"
+    );
+    b.cbranch(has_any, done_bb, fail_bb);
+    b.position_at_start(fail_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i64, name="istitle.final");
+    result_phi.add_incoming(ir.Constant(i64, 1), check_bb);
+    result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
+    return result_phi;
+}
+
+impl NativeStrEmitter.emit_isupper(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # isupper: at least one cased char, all cased chars are uppercase
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    islower_fn = p._get_or_declare_extern("islower", i32, [i32]);
+    isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
+    slen = b.call(strlen_fn, [target], name="isupper.len");
+    is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="isupper.empty");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="isupper.loop");
+    body_bb = func.append_basic_block(name="isupper.body");
+    fail_bb = func.append_basic_block(name="isupper.fail");
+    check_bb = func.append_basic_block(name="isupper.check");
+    done_bb = func.append_basic_block(name="isupper.done");
+    b.cbranch(is_empty, fail_bb, loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="isupper.idx");
+    has_cased = b.phi(i64, name="isupper.hascased");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    has_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, slen, name="isupper.atend");
+    b.cbranch(at_end, check_bb, body_bb);
+    b.position_at_start(body_bb);
+    ch_ptr = b.gep(target, [idx], name="isupper.ch.ptr");
+    ch = b.load(ch_ptr, name="isupper.ch");
+    ch_i32 = b.zext(ch, i32, name="isupper.ch.i32");
+    is_low = b.call(islower_fn, [ch_i32], name="isupper.islow");
+    is_low_bool = b.icmp_signed("!=", is_low, ir.Constant(i32, 0), name="isupper.islo");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="isupper.next");
+    is_alpha = b.call(isalpha_fn, [ch_i32], name="isupper.isalpha");
+    is_alpha_bool = b.icmp_signed(
+        "!=", is_alpha, ir.Constant(i32, 0), name="isupper.isalp"
+    );
+    new_cased = b.select(
+        is_alpha_bool, ir.Constant(i64, 1), has_cased, name="isupper.newcased"
+    );
+    idx.add_incoming(next_idx, body_bb);
+    has_cased.add_incoming(new_cased, body_bb);
+    b.cbranch(is_low_bool, fail_bb, loop_bb);
+    b.position_at_start(check_bb);
+    has_any = b.icmp_unsigned(
+        "!=", has_cased, ir.Constant(i64, 0), name="isupper.hasany"
+    );
+    b.cbranch(has_any, done_bb, fail_bb);
+    b.position_at_start(fail_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result_phi = b.phi(i64, name="isupper.final");
+    result_phi.add_incoming(ir.Constant(i64, 1), check_bb);
+    result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
+    return result_phi;
+}
+
+# Encoding
+impl NativeStrEmitter.emit_encode(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # encode(): in native, strings are already UTF-8 i8* — return as-is
+    return target;
+}
+
+# Translation
+impl NativeStrEmitter.emit_translate(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeStrEmitter.emit_maketrans(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Decoding
+impl NativeBytesEmitter.emit_decode(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_hex(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_fromhex(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Search
+impl NativeBytesEmitter.emit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_find(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_rfind(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_index(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_rindex(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_startswith(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_endswith(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Modification
+impl NativeBytesEmitter.emit_replace(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_strip(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_lstrip(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_rstrip(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_removeprefix(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_removesuffix(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Split and join
+impl NativeBytesEmitter.emit_split(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_rsplit(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_splitlines(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_join(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_partition(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_rpartition(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Case (ASCII only)
+impl NativeBytesEmitter.emit_capitalize(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_lower(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_upper(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_title(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_swapcase(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Character tests (ASCII only)
+impl NativeBytesEmitter.emit_isalnum(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_isalpha(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_isascii(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_isdigit(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_islower(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_isspace(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_istitle(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_isupper(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Alignment
+impl NativeBytesEmitter.emit_center(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_ljust(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_rjust(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_zfill(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_expandtabs(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Translation
+impl NativeBytesEmitter.emit_translate(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBytesEmitter.emit_maketrans(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeListEmitter.emit_append(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None or not args {
+        return None;
+    }
+    val = p._box_value_tuple(args[0]);
+    val = p._coerce_type(val, helpers["elem_type"]);
+    p.builder.call(helpers["append"], [target, val]);
+    return ir.Constant(ir.IntType(64), 0);
+}
+
+impl NativeListEmitter.emit_extend(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # extend: iterate source list, append each element
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    src = args[0];
+    src_len_ptr = b.gep(
+        src, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ext.src.len.ptr"
+    );
+    src_len = b.load(src_len_ptr, name="ext.src.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="ext.loop");
+    body_bb = func.append_basic_block(name="ext.body");
+    done_bb = func.append_basic_block(name="ext.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="ext.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, src_len, name="ext.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    elem = b.call(helpers["get"], [src, idx], name="ext.elem");
+    b.call(helpers["append"], [target, elem]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="ext.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeListEmitter.emit_insert(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # insert(index, value): shift elements right, set at index
+    if len(args) < 2 {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    insert_idx = args[0];
+    insert_val = p._coerce_type(args[1], helpers["elem_type"]);
+    # First append a dummy to grow the list
+    b.call(helpers["append"], [target, insert_val]);
+    # Get the new length
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ins.len.ptr"
+    );
+    new_len = b.load(len_ptr, name="ins.newlen");
+    last_idx = b.sub(new_len, ir.Constant(i64, 1), name="ins.last");
+    # Shift elements right from end to insert_idx
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="ins.loop");
+    body_bb = func.append_basic_block(name="ins.body");
+    done_bb = func.append_basic_block(name="ins.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    si = b.phi(i64, name="ins.si");
+    si.add_incoming(last_idx, entry_bb);
+    at_pos = b.icmp_signed("<=", si, insert_idx, name="ins.atpos");
+    b.cbranch(at_pos, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    prev = b.sub(si, ir.Constant(i64, 1), name="ins.prev");
+    prev_val = b.call(helpers["get"], [target, prev], name="ins.pval");
+    b.call(helpers["set"], [target, si, prev_val]);
+    si.add_incoming(prev, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    # Set the value at insert_idx
+    b.call(helpers["set"], [target, insert_idx, insert_val]);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeListEmitter.emit_remove(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # remove(value): find first occurrence, shift left, decrease length
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    search_val = p._coerce_type(args[0], helpers["elem_type"]);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="rem.len.ptr"
+    );
+    list_len = b.load(len_ptr, name="rem.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    find_bb = func.append_basic_block(name="rem.find");
+    find_body = func.append_basic_block(name="rem.find.body");
+    found_bb = func.append_basic_block(name="rem.found");
+    shift_bb = func.append_basic_block(name="rem.shift");
+    shift_body = func.append_basic_block(name="rem.shift.body");
+    done_bb = func.append_basic_block(name="rem.done");
+    b.branch(find_bb);
+    # Find loop: search for first occurrence
+    b.position_at_start(find_bb);
+    fi = b.phi(i64, name="rem.fi");
+    fi.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", fi, list_len, name="rem.atend");
+    b.cbranch(at_end, done_bb, find_body);
+    b.position_at_start(find_body);
+    elem = b.call(helpers["get"], [target, fi], name="rem.elem");
+    eq = b.icmp_signed("==", elem, search_val, name="rem.eq");
+    next_fi = b.add(fi, ir.Constant(i64, 1), name="rem.nextfi");
+    fi.add_incoming(next_fi, find_body);
+    b.cbranch(eq, found_bb, find_bb);
+    # Found: shift elements left from found_idx+1
+    b.position_at_start(found_bb);
+    shift_start = b.add(fi, ir.Constant(i64, 1), name="rem.shstart");
+    b.branch(shift_bb);
+    b.position_at_start(shift_bb);
+    si = b.phi(i64, name="rem.si");
+    si.add_incoming(shift_start, found_bb);
+    shift_end = b.icmp_unsigned(">=", si, list_len, name="rem.shend");
+    b.cbranch(shift_end, done_bb, shift_body);
+    b.position_at_start(shift_body);
+    val = b.call(helpers["get"], [target, si], name="rem.val");
+    prev = b.sub(si, ir.Constant(i64, 1), name="rem.prev");
+    b.call(helpers["set"], [target, prev, val]);
+    next_si = b.add(si, ir.Constant(i64, 1), name="rem.nextsi");
+    si.add_incoming(next_si, shift_body);
+    b.branch(shift_bb);
+    # Done: decrease length (only if found)
+    b.position_at_start(done_bb);
+    # PHI must be at top of block
+    found_phi = b.phi(i64, name="rem.found");
+    found_phi.add_incoming(ir.Constant(i64, 0), find_bb);
+    found_phi.add_incoming(ir.Constant(i64, 1), shift_bb);
+    was_found = b.icmp_unsigned(
+        "!=", found_phi, ir.Constant(i64, 0), name="rem.wasfound"
+    );
+    new_len = b.sub(list_len, ir.Constant(i64, 1), name="rem.newlen");
+    final_len = b.select(was_found, new_len, list_len, name="rem.finallen");
+    b.store(final_len, len_ptr);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeListEmitter.emit_pop(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="pop.len.ptr"
+    );
+    cur_len = b.load(len_ptr, name="pop.len");
+    new_len = b.sub(cur_len, ir.Constant(i64, 1), name="pop.newlen");
+    last_val = b.call(helpers["get"], [target, new_len], name="pop.val");
+    b.store(new_len, len_ptr);
+    return last_val;
+}
+
+impl NativeListEmitter.emit_clear(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="clear.len.ptr"
+    );
+    b.store(ir.Constant(i64, 0), len_ptr);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeListEmitter.emit_index(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i64 = ir.IntType(64);
+    i32 = ir.IntType(32);
+    search_val = p._coerce_type(args[0], helpers["elem_type"]);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="idx.len.ptr"
+    );
+    list_len = b.load(len_ptr, name="idx.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="idx.loop");
+    check_bb = func.append_basic_block(name="idx.check");
+    found_bb = func.append_basic_block(name="idx.found");
+    done_bb = func.append_basic_block(name="idx.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="idx.i");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, list_len, name="idx.atend");
+    b.cbranch(at_end, done_bb, check_bb);
+    b.position_at_start(check_bb);
+    elem = b.call(helpers["get"], [target, idx], name="idx.elem");
+    eq = b.icmp_signed("==", elem, search_val, name="idx.eq");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="idx.next");
+    b.cbranch(eq, found_bb, loop_bb);
+    idx.add_incoming(next_idx, check_bb);
+    b.position_at_start(found_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="idx.result");
+    result.add_incoming(ir.Constant(i64, -1), loop_bb);
+    result.add_incoming(idx, found_bb);
+    return result;
+}
+
+impl NativeListEmitter.emit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i64 = ir.IntType(64);
+    i32 = ir.IntType(32);
+    search_val = p._coerce_type(args[0], helpers["elem_type"]);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="cnt.len.ptr"
+    );
+    list_len = b.load(len_ptr, name="cnt.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="cnt.loop");
+    body_bb = func.append_basic_block(name="cnt.body");
+    inc_bb = func.append_basic_block(name="cnt.inc");
+    done_bb = func.append_basic_block(name="cnt.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="cnt.idx");
+    count = b.phi(i64, name="cnt.count");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    count.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, list_len, name="cnt.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    elem = b.call(helpers["get"], [target, idx], name="cnt.elem");
+    eq = b.icmp_signed("==", elem, search_val, name="cnt.eq");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="cnt.next");
+    b.cbranch(eq, inc_bb, loop_bb);
+    idx.add_incoming(next_idx, body_bb);
+    count.add_incoming(count, body_bb);
+    b.position_at_start(inc_bb);
+    new_count = b.add(count, ir.Constant(i64, 1), name="cnt.inc");
+    next_idx2 = b.add(idx, ir.Constant(i64, 1), name="cnt.next2");
+    idx.add_incoming(next_idx2, inc_bb);
+    count.add_incoming(new_count, inc_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return count;
+}
+
+impl NativeListEmitter.emit_sort(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # sort(): in-place bubble sort
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    zero = ir.Constant(i64, 0);
+    one = ir.Constant(i64, 1);
+    elem_type = helpers["elem_type"];
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sort.len.ptr"
+    );
+    list_len = b.load(len_ptr, name="sort.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    # Outer loop: i from 0 to len-1
+    outer_bb = func.append_basic_block(name="sort.outer");
+    inner_start = func.append_basic_block(name="sort.inner.start");
+    inner_bb = func.append_basic_block(name="sort.inner");
+    inner_body = func.append_basic_block(name="sort.inner.body");
+    swap_bb = func.append_basic_block(name="sort.swap");
+    no_swap = func.append_basic_block(name="sort.noswap");
+    inner_next = func.append_basic_block(name="sort.inner.next");
+    outer_next = func.append_basic_block(name="sort.outer.next");
+    done_bb = func.append_basic_block(name="sort.done");
+    len_m1 = b.sub(list_len, one, name="sort.lenm1");
+    b.branch(outer_bb);
+    # Outer loop header
+    b.position_at_start(outer_bb);
+    oi = b.phi(i64, name="sort.oi");
+    oi.add_incoming(zero, entry_bb);
+    outer_end = b.icmp_unsigned(">=", oi, len_m1, name="sort.oend");
+    b.cbranch(outer_end, done_bb, inner_start);
+    # Compute inner limit: len - i - 1
+    b.position_at_start(inner_start);
+    inner_limit = b.sub(len_m1, oi, name="sort.ilimit");
+    b.branch(inner_bb);
+    # Inner loop header
+    b.position_at_start(inner_bb);
+    ji = b.phi(i64, name="sort.ji");
+    ji.add_incoming(zero, inner_start);
+    inner_end = b.icmp_unsigned(">=", ji, inner_limit, name="sort.iend");
+    b.cbranch(inner_end, outer_next, inner_body);
+    # Inner body: compare adjacent elements
+    b.position_at_start(inner_body);
+    j1 = b.add(ji, one, name="sort.j1");
+    ej = b.call(helpers["get"], [target, ji], name="sort.ej");
+    ej1 = b.call(helpers["get"], [target, j1], name="sort.ej1");
+    # Compare based on element type
+    if isinstance(elem_type, ir.DoubleType) {
+        needs_swap = b.fcmp_ordered(">", ej, ej1, name="sort.gt");
+    } elif isinstance(elem_type, ir.PointerType) {
+        strcmp_fn = p._get_or_declare_extern(
+            "strcmp", ir.IntType(32), [elem_type, elem_type]
+        );
+        cmp_result = b.call(strcmp_fn, [ej, ej1], name="sort.cmp");
+        needs_swap = b.icmp_signed(
+            ">", cmp_result, ir.Constant(ir.IntType(32), 0), name="sort.gt"
+        );
+    } else {
+        needs_swap = b.icmp_signed(">", ej, ej1, name="sort.gt");
+    }
+    b.cbranch(needs_swap, swap_bb, no_swap);
+    # Swap
+    b.position_at_start(swap_bb);
+    b.call(helpers["set"], [target, ji, ej1]);
+    b.call(helpers["set"], [target, j1, ej]);
+    b.branch(inner_next);
+    b.position_at_start(no_swap);
+    b.branch(inner_next);
+    # Inner next
+    b.position_at_start(inner_next);
+    next_ji = b.add(ji, one, name="sort.nji");
+    ji.add_incoming(next_ji, inner_next);
+    b.branch(inner_bb);
+    # Outer next
+    b.position_at_start(outer_next);
+    next_oi = b.add(oi, one, name="sort.noi");
+    oi.add_incoming(next_oi, outer_next);
+    b.branch(outer_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeListEmitter.emit_reverse(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="rev.len.ptr"
+    );
+    list_len = b.load(len_ptr, name="rev.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="rev.loop");
+    body_bb = func.append_basic_block(name="rev.body");
+    done_bb = func.append_basic_block(name="rev.done");
+    j_init = b.sub(list_len, ir.Constant(i64, 1), name="rev.j.init");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    i_phi = b.phi(i64, name="rev.i");
+    j_phi = b.phi(i64, name="rev.j");
+    i_phi.add_incoming(ir.Constant(i64, 0), entry_bb);
+    j_phi.add_incoming(j_init, entry_bb);
+    cond = b.icmp_signed("<", i_phi, j_phi, name="rev.cond");
+    b.cbranch(cond, body_bb, done_bb);
+    b.position_at_start(body_bb);
+    val_i = b.call(helpers["get"], [target, i_phi], name="rev.val.i");
+    val_j = b.call(helpers["get"], [target, j_phi], name="rev.val.j");
+    b.call(helpers["set"], [target, i_phi, val_j]);
+    b.call(helpers["set"], [target, j_phi, val_i]);
+    next_i = b.add(i_phi, ir.Constant(i64, 1), name="rev.next.i");
+    next_j = b.sub(j_phi, ir.Constant(i64, 1), name="rev.next.j");
+    i_phi.add_incoming(next_i, body_bb);
+    j_phi.add_incoming(next_j, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeListEmitter.emit_copy(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    helpers = p.list_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_list = b.call(helpers["new"], [], name="copy.new");
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="copy.len.ptr"
+    );
+    src_len = b.load(len_ptr, name="copy.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="copy.loop");
+    body_bb = func.append_basic_block(name="copy.body");
+    done_bb = func.append_basic_block(name="copy.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="copy.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, src_len, name="copy.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    elem = b.call(helpers["get"], [target, idx], name="copy.elem");
+    b.call(helpers["append"], [new_list, elem]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="copy.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_list;
+}
+
+impl NativeDictEmitter.emit_get(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # get(key, default=None): return value for key, or default if missing
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i64 = ir.IntType(64);
+    key = args[0];
+    found_i1 = b.call(helpers["contains"], [target, key], name="dget.found");
+    func = b.basic_block.function;
+    found_bb = func.append_basic_block(name="dget.yes");
+    notfound_bb = func.append_basic_block(name="dget.no");
+    done_bb = func.append_basic_block(name="dget.done");
+    b.cbranch(found_i1, found_bb, notfound_bb);
+    # Found: get the value
+    b.position_at_start(found_bb);
+    val = b.call(helpers["get"], [target, key], name="dget.val");
+    b.branch(done_bb);
+    # Not found: use default or zero
+    b.position_at_start(notfound_bb);
+    val_type = helpers["val_type"];
+    if len(args) >= 2 {
+        default_val = p._coerce_type(args[1], val_type);
+    } elif isinstance(val_type, ir.PointerType) {
+        default_val = ir.Constant(val_type, None);
+    } else {
+        default_val = ir.Constant(val_type, 0);
+    }
+    b.branch(done_bb);
+    # Merge
+    b.position_at_start(done_bb);
+    result = b.phi(val_type, name="dget.result");
+    result.add_incoming(val, found_bb);
+    result.add_incoming(default_val, notfound_bb);
+    return result;
+}
+
+impl NativeDictEmitter.emit_keys(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # keys(): return list of all keys
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    # Determine key type name from type_key ("key_type:val_type")
+    key_type = helpers["key_type"];
+    if isinstance(key_type, ir.PointerType) {
+        kt_name = "ptr";
+    } elif isinstance(key_type, ir.DoubleType) {
+        kt_name = "f64";
+    } else {
+        kt_name = "i64";
+    }
+    p._emit_list_helpers(kt_name, key_type);
+    lhelpers = p.list_helpers.get(kt_name);
+    if lhelpers is None {
+        return None;
+    }
+    new_list = b.call(lhelpers["new"], [], name="dkeys.list");
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dkeys.len.ptr"
+    );
+    dict_len = b.load(len_ptr, name="dkeys.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="dkeys.loop");
+    body_bb = func.append_basic_block(name="dkeys.body");
+    done_bb = func.append_basic_block(name="dkeys.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="dkeys.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, dict_len, name="dkeys.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    key = b.call(helpers["get_key"], [target, idx], name="dkeys.key");
+    b.call(lhelpers["append"], [new_list, key]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="dkeys.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_list;
+}
+
+impl NativeDictEmitter.emit_values(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # values(): return list of all values
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    # Determine val type name
+    val_type = helpers["val_type"];
+    if isinstance(val_type, ir.PointerType) {
+        vt_name = "ptr";
+    } elif isinstance(val_type, ir.DoubleType) {
+        vt_name = "f64";
+    } else {
+        vt_name = "i64";
+    }
+    p._emit_list_helpers(vt_name, val_type);
+    lhelpers = p.list_helpers.get(vt_name);
+    if lhelpers is None {
+        return None;
+    }
+    new_list = b.call(lhelpers["new"], [], name="dvals.list");
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dvals.len.ptr"
+    );
+    dict_len = b.load(len_ptr, name="dvals.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="dvals.loop");
+    body_bb = func.append_basic_block(name="dvals.body");
+    done_bb = func.append_basic_block(name="dvals.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="dvals.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, dict_len, name="dvals.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    key = b.call(helpers["get_key"], [target, idx], name="dvals.key");
+    val = b.call(helpers["get"], [target, key], name="dvals.val");
+    b.call(lhelpers["append"], [new_list, val]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="dvals.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_list;
+}
+
+impl NativeDictEmitter.emit_items(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # items(): return list of (key, value) 2-tuples
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    i8p = ir.IntType(8).as_pointer();
+    key_type = helpers["key_type"];
+    val_type = helpers["val_type"];
+    # Build 2-tuple struct type
+    tuple_type = ir.LiteralStructType([key_type, val_type]);
+    # Register tuple type
+    kt_str = "i8p"
+        if isinstance(key_type, ir.PointerType)
+        else ("f64" if isinstance(key_type, ir.DoubleType) else "i64");
+    vt_str = "i8p"
+        if isinstance(val_type, ir.PointerType)
+        else ("f64" if isinstance(val_type, ir.DoubleType) else "i64");
+    tkey = f"{kt_str}.{vt_str}";
+    if tkey not in p.tuple_types {
+        p.tuple_types[tkey] = tuple_type;
+    }
+    # Create result list of pointers (each element is a tuple pointer)
+    p._emit_list_helpers("ptr", i8p);
+    lhelpers = p.list_helpers.get("ptr");
+    if lhelpers is None {
+        return None;
+    }
+    new_list = b.call(lhelpers["new"], [], name="ditems.list");
+    # Get dict length
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ditems.len.ptr"
+    );
+    dict_len = b.load(len_ptr, name="ditems.len");
+    # Compute tuple size once
+    null_ptr = ir.Constant(tuple_type.as_pointer(), None);
+    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="ditems.sizeof.gep");
+    tup_size = b.ptrtoint(size_gep, i64, name="ditems.sizeof");
+    # Loop over dict entries
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="ditems.loop");
+    body_bb = func.append_basic_block(name="ditems.body");
+    done_bb = func.append_basic_block(name="ditems.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="ditems.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, dict_len, name="ditems.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    # Get key and value at this index
+    key = b.call(helpers["get_key"], [target, idx], name="ditems.key");
+    val = b.call(helpers["get"], [target, key], name="ditems.val");
+    # Allocate 2-tuple
+    raw = b.call(p.rc_alloc_fn, [tup_size], name="ditems.alloc");
+    tup_ptr = b.bitcast(raw, tuple_type.as_pointer(), name="ditems.tup");
+    k_ptr = b.gep(
+        tup_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ditems.k.ptr"
+    );
+    v_ptr = b.gep(
+        tup_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="ditems.v.ptr"
+    );
+    b.store(key, k_ptr);
+    b.store(val, v_ptr);
+    # Append tuple pointer (as i8*) to list
+    tup_i8p = b.bitcast(tup_ptr, i8p, name="ditems.i8p");
+    b.call(lhelpers["append"], [new_list, tup_i8p]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="ditems.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_list;
+}
+
+impl NativeDictEmitter.emit_pop(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # pop(key, default=None): remove key and return value, or default/KeyError
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    key = args[0];
+    val_type = helpers["val_type"];
+    key_type = helpers["key_type"];
+    has_default = len(args) >= 2;
+    # Check if key exists
+    found_i1 = b.call(helpers["contains"], [target, key], name="dpop.found");
+    func = b.basic_block.function;
+    found_bb = func.append_basic_block(name="dpop.yes");
+    notfound_bb = func.append_basic_block(name="dpop.no");
+    done_bb = func.append_basic_block(name="dpop.done");
+    b.cbranch(found_i1, found_bb, notfound_bb);
+    # Found: get value, then find index and shift arrays
+    b.position_at_start(found_bb);
+    saved_val = b.call(helpers["get"], [target, key], name="dpop.val");
+    # Find the index of the key via linear search
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dpop.len.ptr"
+    );
+    keys_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="dpop.keys.ptr"
+    );
+    vals_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 3)], name="dpop.vals.ptr"
+    );
+    dict_len = b.load(len_ptr, name="dpop.len");
+    keys_arr = b.load(keys_ptr, name="dpop.keys");
+    vals_arr = b.load(vals_ptr, name="dpop.vals");
+    new_len = b.sub(dict_len, ir.Constant(i64, 1), name="dpop.newlen");
+    # Search for key index
+    search_bb = func.append_basic_block(name="dpop.search");
+    search_body = func.append_basic_block(name="dpop.search.body");
+    search_found = func.append_basic_block(name="dpop.search.found");
+    b.branch(search_bb);
+    b.position_at_start(search_bb);
+    si = b.phi(i64, name="dpop.si");
+    si.add_incoming(ir.Constant(i64, 0), found_bb);
+    si_end = b.icmp_unsigned(">=", si, dict_len, name="dpop.si.end");
+    b.cbranch(si_end, search_found, search_body);
+    b.position_at_start(search_body);
+    kp = b.gep(keys_arr, [si], name="dpop.kp");
+    kv = b.load(kp, name="dpop.kv");
+    i8p = ir.IntType(8).as_pointer();
+    if isinstance(key_type, ir.IntType) {
+        keq = b.icmp_signed("==", kv, key, name="dpop.keq");
+    } elif key_type == i8p {
+        strcmp_fn = p._get_or_declare_extern("strcmp", ir.IntType(32), [i8p, i8p]);
+        cmp_result = b.call(strcmp_fn, [kv, key], name="dpop.strcmp");
+        keq = b.icmp_signed(
+            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="dpop.keq"
+        );
+    } else {
+        keq = b.icmp_unsigned("==", kv, key, name="dpop.keq");
+    }
+    next_si = b.add(si, ir.Constant(i64, 1), name="dpop.nsi");
+    si.add_incoming(next_si, search_body);
+    b.cbranch(keq, search_found, search_bb);
+    # Found index: shift elements left from si to end
+    b.position_at_start(search_found);
+    found_idx = b.phi(i64, name="dpop.fidx");
+    found_idx.add_incoming(si, search_body);
+    found_idx.add_incoming(dict_len, search_bb);
+    shift_bb = func.append_basic_block(name="dpop.shift");
+    shift_body_bb = func.append_basic_block(name="dpop.shift.body");
+    shift_done = func.append_basic_block(name="dpop.shift.done");
+    b.branch(shift_bb);
+    b.position_at_start(shift_bb);
+    ji = b.phi(i64, name="dpop.ji");
+    ji.add_incoming(found_idx, search_found);
+    ji_end = b.icmp_unsigned(">=", ji, new_len, name="dpop.ji.end");
+    b.cbranch(ji_end, shift_done, shift_body_bb);
+    b.position_at_start(shift_body_bb);
+    next_ji = b.add(ji, ir.Constant(i64, 1), name="dpop.nji");
+    # Shift key
+    src_kp = b.gep(keys_arr, [next_ji], name="dpop.src.kp");
+    skv = b.load(src_kp, name="dpop.skv");
+    dst_kp = b.gep(keys_arr, [ji], name="dpop.dst.kp");
+    b.store(skv, dst_kp);
+    # Shift val
+    src_vp = b.gep(vals_arr, [next_ji], name="dpop.src.vp");
+    svv = b.load(src_vp, name="dpop.svv");
+    dst_vp = b.gep(vals_arr, [ji], name="dpop.dst.vp");
+    b.store(svv, dst_vp);
+    ji.add_incoming(next_ji, shift_body_bb);
+    b.branch(shift_bb);
+    b.position_at_start(shift_done);
+    b.store(new_len, len_ptr);
+    b.branch(done_bb);
+    # Not found
+    b.position_at_start(notfound_bb);
+    if has_default {
+        default_val = p._coerce_type(args[1], val_type);
+    } else {
+        p._emit_runtime_raise(
+            ir.Constant(ir.IntType(1), 1), "KeyError", "key not found"
+        );
+        if isinstance(val_type, ir.PointerType) {
+            default_val = ir.Constant(val_type, None);
+        } else {
+            default_val = ir.Constant(val_type, 0);
+        }
+    }
+    b.branch(done_bb);
+    # Merge
+    b.position_at_start(done_bb);
+    result = b.phi(val_type, name="dpop.result");
+    result.add_incoming(saved_val, shift_done);
+    result.add_incoming(default_val, notfound_bb);
+    return result;
+}
+
+impl NativeDictEmitter.emit_remove(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # d.remove(key) / del d[key]: remove key, raise KeyError if missing.
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    i8p = ir.IntType(8).as_pointer();
+    key = args[0];
+    key_type = helpers["key_type"];
+    func = b.basic_block.function;
+    found_bb = func.append_basic_block(name="drem.found");
+    nokey_bb = func.append_basic_block(name="drem.nokey");
+    search_bb = func.append_basic_block(name="drem.search");
+    search_body = func.append_basic_block(name="drem.search.body");
+    sfound_bb = func.append_basic_block(name="drem.sfound");
+    shift_bb = func.append_basic_block(name="drem.shift");
+    shift_body = func.append_basic_block(name="drem.shift.body");
+    store_bb = func.append_basic_block(name="drem.store");
+    done_bb = func.append_basic_block(name="drem.done");
+    # Contains check → branch to found or not-found
+    found_i1 = b.call(helpers["contains"], [target, key], name="drem.has");
+    b.cbranch(found_i1, found_bb, nokey_bb);
+    # Not found → KeyError, then fall to done
+    b.position_at_start(nokey_bb);
+    p._emit_runtime_raise(ir.Constant(ir.IntType(1), 1), "KeyError", "key not found");
+    b.branch(done_bb);
+    # Found: load struct fields
+    b.position_at_start(found_bb);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="drem.len.p"
+    );
+    keys_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="drem.keys.p"
+    );
+    vals_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 3)], name="drem.vals.p"
+    );
+    dict_len = b.load(len_ptr, name="drem.len");
+    keys_arr = b.load(keys_ptr, name="drem.keys");
+    vals_arr = b.load(vals_ptr, name="drem.vals");
+    new_len = b.sub(dict_len, ir.Constant(i64, 1), name="drem.newlen");
+    b.branch(search_bb);
+    # Linear search for the index of key
+    b.position_at_start(search_bb);
+    si = b.phi(i64, name="drem.si");
+    si.add_incoming(ir.Constant(i64, 0), found_bb);
+    si_end = b.icmp_unsigned(">=", si, dict_len, name="drem.si.end");
+    b.cbranch(si_end, sfound_bb, search_body);
+    b.position_at_start(search_body);
+    kp = b.gep(keys_arr, [si], name="drem.kp");
+    kv = b.load(kp, name="drem.kv");
+    if isinstance(key_type, ir.IntType) {
+        keq = b.icmp_signed("==", kv, key, name="drem.keq");
+    } elif key_type == i8p {
+        strcmp_fn = p._get_or_declare_extern("strcmp", ir.IntType(32), [i8p, i8p]);
+        cmp_result = b.call(strcmp_fn, [kv, key], name="drem.strcmp");
+        keq = b.icmp_signed(
+            "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="drem.keq"
+        );
+    } else {
+        keq = b.icmp_unsigned("==", kv, key, name="drem.keq");
+    }
+    next_si = b.add(si, ir.Constant(i64, 1), name="drem.nsi");
+    si.add_incoming(next_si, search_body);
+    b.cbranch(keq, sfound_bb, search_bb);
+    # Have found index: set up shift loop
+    b.position_at_start(sfound_bb);
+    found_idx = b.phi(i64, name="drem.fidx");
+    found_idx.add_incoming(si, search_body);
+    found_idx.add_incoming(dict_len, search_bb);
+    b.branch(shift_bb);
+    b.position_at_start(shift_bb);
+    ji = b.phi(i64, name="drem.ji");
+    ji.add_incoming(found_idx, sfound_bb);
+    ji_end = b.icmp_unsigned(">=", ji, new_len, name="drem.ji.end");
+    b.cbranch(ji_end, store_bb, shift_body);
+    b.position_at_start(shift_body);
+    next_ji = b.add(ji, ir.Constant(i64, 1), name="drem.nji");
+    b.store(
+        b.load(b.gep(keys_arr, [next_ji], name="drem.src.kp"), name="drem.skv"),
+        b.gep(keys_arr, [ji], name="drem.dst.kp")
+    );
+    b.store(
+        b.load(b.gep(vals_arr, [next_ji], name="drem.src.vp"), name="drem.svv"),
+        b.gep(vals_arr, [ji], name="drem.dst.vp")
+    );
+    ji.add_incoming(next_ji, shift_body);
+    b.branch(shift_bb);
+    # Store the new length (only reachable from the found path, so
+    # new_len and len_ptr are in scope / dominate this block).
+    b.position_at_start(store_bb);
+    b.store(new_len, len_ptr);
+    b.branch(done_bb);
+    # Done: builder left positioned here for subsequent statements.
+    b.position_at_start(done_bb);
+    return None;
+}
+
+impl NativeDictEmitter.emit_popitem(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # popitem(): remove and return last (key, value) pair as 2-tuple
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    key_type = helpers["key_type"];
+    val_type = helpers["val_type"];
+    # Load dict length
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dpi.len.ptr"
+    );
+    dict_len = b.load(len_ptr, name="dpi.len");
+    # Raise KeyError if empty
+    is_empty = b.icmp_signed("==", dict_len, ir.Constant(i64, 0), name="dpi.empty");
+    p._emit_runtime_raise(is_empty, "KeyError", "popitem(): dictionary is empty");
+    # Get last key/value
+    last_idx = b.sub(dict_len, ir.Constant(i64, 1), name="dpi.last");
+    last_key = b.call(helpers["get_key"], [target, last_idx], name="dpi.key");
+    last_val = b.call(helpers["get"], [target, last_key], name="dpi.val");
+    # Decrement length
+    b.store(last_idx, len_ptr);
+    # Build 2-tuple with actual key/value types
+    tuple_type = ir.LiteralStructType([key_type, val_type]);
+    null_ptr = ir.Constant(tuple_type.as_pointer(), None);
+    size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="dpi.sizeof.gep");
+    size = b.ptrtoint(size_gep, i64, name="dpi.sizeof");
+    raw_ptr = b.call(p.rc_alloc_fn, [size], name="dpi.alloc");
+    tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="dpi.ptr");
+    k_ptr = b.gep(
+        tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dpi.k.ptr"
+    );
+    v_ptr = b.gep(
+        tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="dpi.v.ptr"
+    );
+    b.store(last_key, k_ptr);
+    b.store(last_val, v_ptr);
+    # Register tuple type
+    kt_str = "i8p"
+        if isinstance(key_type, ir.PointerType)
+        else ("f64" if isinstance(key_type, ir.DoubleType) else "i64");
+    vt_str = "i8p"
+        if isinstance(val_type, ir.PointerType)
+        else ("f64" if isinstance(val_type, ir.DoubleType) else "i64");
+    tkey = f"{kt_str}.{vt_str}";
+    if tkey not in p.tuple_types {
+        p.tuple_types[tkey] = tuple_type;
+    }
+    return tuple_ptr;
+}
+
+impl NativeDictEmitter.emit_setdefault(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # setdefault(key, default=None): if key not in dict, set it to default; return value
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i64 = ir.IntType(64);
+    key = args[0];
+    val_type = helpers["val_type"];
+    default_val = args[1] if len(args) >= 2 else ir.Constant(val_type, 0);
+    # Check if key exists
+    found = b.call(helpers["contains"], [target, key], name="sdef.found");
+    func = b.basic_block.function;
+    found_bb = func.append_basic_block(name="sdef.yes");
+    notfound_bb = func.append_basic_block(name="sdef.no");
+    done_bb = func.append_basic_block(name="sdef.done");
+    b.cbranch(found, found_bb, notfound_bb);
+    # Found: just get the value
+    b.position_at_start(found_bb);
+    existing = b.call(helpers["get"], [target, key], name="sdef.existing");
+    b.branch(done_bb);
+    # Not found: set default and return it
+    b.position_at_start(notfound_bb);
+    b.call(helpers["set"], [target, key, default_val]);
+    b.branch(done_bb);
+    # Merge
+    b.position_at_start(done_bb);
+    result = b.phi(val_type, name="sdef.result");
+    result.add_incoming(existing, found_bb);
+    result.add_incoming(default_val, notfound_bb);
+    return result;
+}
+
+impl NativeDictEmitter.emit_update(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # update(other): merge all key-value pairs from other into target
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    other = args[0];
+    len_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dupd.len.ptr"
+    );
+    other_len = b.load(len_ptr, name="dupd.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="dupd.loop");
+    body_bb = func.append_basic_block(name="dupd.body");
+    done_bb = func.append_basic_block(name="dupd.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="dupd.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, other_len, name="dupd.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    key = b.call(helpers["get_key"], [other, idx], name="dupd.key");
+    val = b.call(helpers["get"], [other, key], name="dupd.val");
+    b.call(helpers["set"], [target, key, val]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="dupd.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeDictEmitter.emit_clear(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # clear: set length to 0
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dclear.len.ptr"
+    );
+    b.store(ir.Constant(i64, 0), len_ptr);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeDictEmitter.emit_copy(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # copy: create new dict, copy all key-value pairs
+    p = ctx.pass_ref;
+    helpers = p.dict_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_dict = b.call(helpers["new"], [], name="dcopy.new");
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dcopy.len.ptr"
+    );
+    dict_len = b.load(len_ptr, name="dcopy.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="dcopy.loop");
+    body_bb = func.append_basic_block(name="dcopy.body");
+    done_bb = func.append_basic_block(name="dcopy.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="dcopy.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, dict_len, name="dcopy.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    key = b.call(helpers["get_key"], [target, idx], name="dcopy.key");
+    val = b.call(helpers["get"], [target, key], name="dcopy.val");
+    b.call(helpers["set"], [new_dict, key, val]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="dcopy.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_dict;
+}
+
+impl NativeDictEmitter.emit_fromkeys(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+# Mutation
+impl NativeSetEmitter.emit_add(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None or not args {
+        return None;
+    }
+    val = p._coerce_type(args[0], helpers["elem_type"]);
+    p.builder.call(helpers["add"], [target, val]);
+    return ir.Constant(ir.IntType(64), 0);
+}
+
+impl NativeSetEmitter.emit_remove(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # remove: like discard but raises KeyError if element not found
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    elem_type = helpers["elem_type"];
+    search_val = p._coerce_type(args[0], elem_type);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="srem.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="srem.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="srem.len");
+    elems_arr = b.load(elems_ptr, name="srem.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="srem.loop");
+    check_bb = func.append_basic_block(name="srem.check");
+    notfound_bb = func.append_basic_block(name="srem.notfound");
+    found_bb = func.append_basic_block(name="srem.found");
+    shift_bb = func.append_basic_block(name="srem.shift");
+    shift_body = func.append_basic_block(name="srem.shift.body");
+    shift_done = func.append_basic_block(name="srem.shift.done");
+    done_bb = func.append_basic_block(name="srem.done");
+    b.branch(loop_bb);
+    # Search loop
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="srem.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="srem.atend");
+    b.cbranch(at_end, notfound_bb, check_bb);
+    b.position_at_start(check_bb);
+    ep = b.gep(elems_arr, [idx], name="srem.ep");
+    ev = b.load(ep, name="srem.ev");
+    if isinstance(elem_type, ir.IntType) {
+        eq = b.icmp_signed("==", ev, search_val, name="srem.eq");
+    } else {
+        eq = b.icmp_unsigned("==", ev, search_val, name="srem.eq");
+    }
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="srem.next");
+    b.cbranch(eq, found_bb, loop_bb);
+    idx.add_incoming(next_idx, check_bb);
+    # Not found: raise KeyError
+    b.position_at_start(notfound_bb);
+    p._emit_runtime_raise(
+        ir.Constant(ir.IntType(1), 1), "KeyError", "element not in set"
+    );
+    b.branch(done_bb);
+    # Found: shift remaining elements left
+    b.position_at_start(found_bb);
+    new_len = b.sub(set_len, ir.Constant(i64, 1), name="srem.newlen");
+    b.store(new_len, len_ptr);
+    b.branch(shift_bb);
+    b.position_at_start(shift_bb);
+    si = b.phi(i64, name="srem.si");
+    si.add_incoming(idx, found_bb);
+    si_end = b.icmp_unsigned(">=", si, new_len, name="srem.siend");
+    b.cbranch(si_end, shift_done, shift_body);
+    b.position_at_start(shift_body);
+    next_si = b.add(si, ir.Constant(i64, 1), name="srem.nsi");
+    src_p = b.gep(elems_arr, [next_si], name="srem.srcp");
+    sv = b.load(src_p, name="srem.sv");
+    dst_p = b.gep(elems_arr, [si], name="srem.dstp");
+    b.store(sv, dst_p);
+    si.add_incoming(next_si, shift_body);
+    b.branch(shift_bb);
+    b.position_at_start(shift_done);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeSetEmitter.emit_discard(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # discard: remove element if present (no error if absent)
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    elem_type = helpers["elem_type"];
+    search_val = p._coerce_type(args[0], elem_type);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="disc.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="disc.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="disc.len");
+    elems_arr = b.load(elems_ptr, name="disc.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="disc.loop");
+    check_bb = func.append_basic_block(name="disc.check");
+    found_bb = func.append_basic_block(name="disc.found");
+    shift_bb = func.append_basic_block(name="disc.shift");
+    shift_body = func.append_basic_block(name="disc.shift.body");
+    shift_done = func.append_basic_block(name="disc.shift.done");
+    done_bb = func.append_basic_block(name="disc.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="disc.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="disc.atend");
+    b.cbranch(at_end, done_bb, check_bb);
+    b.position_at_start(check_bb);
+    ep = b.gep(elems_arr, [idx], name="disc.ep");
+    ev = b.load(ep, name="disc.ev");
+    if isinstance(elem_type, ir.IntType) {
+        eq = b.icmp_signed("==", ev, search_val, name="disc.eq");
+    } else {
+        eq = b.icmp_unsigned("==", ev, search_val, name="disc.eq");
+    }
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="disc.next");
+    b.cbranch(eq, found_bb, loop_bb);
+    idx.add_incoming(next_idx, check_bb);
+    # Found: shift remaining elements left
+    b.position_at_start(found_bb);
+    new_len = b.sub(set_len, ir.Constant(i64, 1), name="disc.newlen");
+    b.store(new_len, len_ptr);
+    b.branch(shift_bb);
+    b.position_at_start(shift_bb);
+    si = b.phi(i64, name="disc.si");
+    si.add_incoming(idx, found_bb);
+    si_end = b.icmp_unsigned(">=", si, new_len, name="disc.siend");
+    b.cbranch(si_end, shift_done, shift_body);
+    b.position_at_start(shift_body);
+    next_si = b.add(si, ir.Constant(i64, 1), name="disc.nsi");
+    src_p = b.gep(elems_arr, [next_si], name="disc.srcp");
+    sv = b.load(src_p, name="disc.sv");
+    dst_p = b.gep(elems_arr, [si], name="disc.dstp");
+    b.store(sv, dst_p);
+    si.add_incoming(next_si, shift_body);
+    b.branch(shift_bb);
+    b.position_at_start(shift_done);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeSetEmitter.emit_pop(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # pop: remove and return an arbitrary element, raise KeyError if empty
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="spop.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="spop.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="spop.len");
+    # Raise KeyError if empty
+    is_empty = b.icmp_unsigned("==", set_len, ir.Constant(i64, 0), name="spop.empty");
+    p._emit_runtime_raise(is_empty, "KeyError", "pop from an empty set");
+    # Pop last element (arbitrary choice, O(1))
+    new_len = b.sub(set_len, ir.Constant(i64, 1), name="spop.newlen");
+    elems_arr = b.load(elems_ptr, name="spop.elems");
+    last_ep = b.gep(elems_arr, [new_len], name="spop.last.ptr");
+    last_val = b.load(last_ep, name="spop.last.val");
+    b.store(new_len, len_ptr);
+    return last_val;
+}
+
+impl NativeSetEmitter.emit_clear(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # clear: set length to 0
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="set.clear.len.ptr"
+    );
+    b.store(ir.Constant(i64, 0), len_ptr);
+    return ir.Constant(i64, 0);
+}
+
+# Set algebra
+impl NativeSetEmitter._emit_set_iterate(
+    self, ctx: NativeEmitCtx, source: ir.Value, prefix: str
+) -> tuple {
+    # Helper: set up iteration over a set, returns (helpers, b, i32, i64, set_len, elems_arr, entry_bb, loop_bb, body_bb, done_bb, idx, elem)
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        source, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name=f"{prefix}.len.ptr"
+    );
+    elems_ptr = b.gep(
+        source, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name=f"{prefix}.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name=f"{prefix}.len");
+    elems_arr = b.load(elems_ptr, name=f"{prefix}.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name=f"{prefix}.loop");
+    body_bb = func.append_basic_block(name=f"{prefix}.body");
+    done_bb = func.append_basic_block(name=f"{prefix}.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name=f"{prefix}.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name=f"{prefix}.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name=f"{prefix}.ep");
+    ev = b.load(ep, name=f"{prefix}.ev");
+    return (helpers, b, i64, idx, ev, entry_bb, loop_bb, body_bb, done_bb);
+}
+
+impl NativeSetEmitter.emit_union(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # union(other): new set with all elements from both
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_set = b.call(helpers["new"], [], name="sunion.new");
+    # Copy all from self
+    len1_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="su.l1.ptr"
+    );
+    e1_ptr = b.gep(target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="su.e1.ptr");
+    len1 = b.load(len1_ptr, name="su.len1");
+    elems1 = b.load(e1_ptr, name="su.elems1");
+    func = b.basic_block.function;
+    entry1 = b.basic_block;
+    loop1 = func.append_basic_block(name="su.loop1");
+    body1 = func.append_basic_block(name="su.body1");
+    mid_bb = func.append_basic_block(name="su.mid");
+    b.branch(loop1);
+    b.position_at_start(loop1);
+    i1 = b.phi(i64, name="su.i1");
+    i1.add_incoming(ir.Constant(i64, 0), entry1);
+    end1 = b.icmp_unsigned(">=", i1, len1, name="su.end1");
+    b.cbranch(end1, mid_bb, body1);
+    b.position_at_start(body1);
+    ep1 = b.gep(elems1, [i1], name="su.ep1");
+    ev1 = b.load(ep1, name="su.ev1");
+    b.call(helpers["add"], [new_set, ev1]);
+    n1 = b.add(i1, ir.Constant(i64, 1), name="su.n1");
+    i1.add_incoming(n1, body1);
+    b.branch(loop1);
+    # Copy all from other
+    b.position_at_start(mid_bb);
+    other = args[0];
+    len2_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="su.l2.ptr"
+    );
+    e2_ptr = b.gep(other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="su.e2.ptr");
+    len2 = b.load(len2_ptr, name="su.len2");
+    elems2 = b.load(e2_ptr, name="su.elems2");
+    loop2 = func.append_basic_block(name="su.loop2");
+    body2 = func.append_basic_block(name="su.body2");
+    done_bb = func.append_basic_block(name="su.done");
+    b.branch(loop2);
+    b.position_at_start(loop2);
+    i2 = b.phi(i64, name="su.i2");
+    i2.add_incoming(ir.Constant(i64, 0), mid_bb);
+    end2 = b.icmp_unsigned(">=", i2, len2, name="su.end2");
+    b.cbranch(end2, done_bb, body2);
+    b.position_at_start(body2);
+    ep2 = b.gep(elems2, [i2], name="su.ep2");
+    ev2 = b.load(ep2, name="su.ev2");
+    b.call(helpers["add"], [new_set, ev2]);
+    n2 = b.add(i2, ir.Constant(i64, 1), name="su.n2");
+    i2.add_incoming(n2, body2);
+    b.branch(loop2);
+    b.position_at_start(done_bb);
+    return new_set;
+}
+
+impl NativeSetEmitter.emit_intersection(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # intersection(other): new set with elements in both self and other
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_set = b.call(helpers["new"], [], name="sinter.new");
+    other = args[0];
+    # Iterate self
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="si.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="si.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="si.len");
+    elems_arr = b.load(elems_ptr, name="si.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="si.loop");
+    body_bb = func.append_basic_block(name="si.body");
+    add_bb = func.append_basic_block(name="si.add");
+    skip_bb = func.append_basic_block(name="si.skip");
+    done_bb = func.append_basic_block(name="si.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="si.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="si.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="si.ep");
+    ev = b.load(ep, name="si.ev");
+    in_other = b.call(helpers["contains"], [other, ev], name="si.inother");
+    b.cbranch(in_other, add_bb, skip_bb);
+    b.position_at_start(add_bb);
+    b.call(helpers["add"], [new_set, ev]);
+    b.branch(skip_bb);
+    b.position_at_start(skip_bb);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="si.next");
+    idx.add_incoming(next_idx, skip_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_set;
+}
+
+impl NativeSetEmitter.emit_difference(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # difference(other): new set with elements in self but not in other
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_set = b.call(helpers["new"], [], name="sdiff.new");
+    other = args[0];
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sd.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sd.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="sd.len");
+    elems_arr = b.load(elems_ptr, name="sd.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="sd.loop");
+    body_bb = func.append_basic_block(name="sd.body");
+    add_bb = func.append_basic_block(name="sd.add");
+    skip_bb = func.append_basic_block(name="sd.skip");
+    done_bb = func.append_basic_block(name="sd.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="sd.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="sd.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="sd.ep");
+    ev = b.load(ep, name="sd.ev");
+    in_other = b.call(helpers["contains"], [other, ev], name="sd.inother");
+    # Add if NOT in other
+    not_in = b.icmp_unsigned(
+        "==", in_other, ir.Constant(ir.IntType(1), 0), name="sd.notin"
+    );
+    b.cbranch(not_in, add_bb, skip_bb);
+    b.position_at_start(add_bb);
+    b.call(helpers["add"], [new_set, ev]);
+    b.branch(skip_bb);
+    b.position_at_start(skip_bb);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="sd.next");
+    idx.add_incoming(next_idx, skip_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_set;
+}
+
+impl NativeSetEmitter.emit_symmetric_difference(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # symmetric_difference(other): elements in either set but not both
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_set = b.call(helpers["new"], [], name="ssymd.new");
+    other = args[0];
+    # Pass 1: add elements from self that are NOT in other
+    len1_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssymd.l1.ptr"
+    );
+    e1_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssymd.e1.ptr"
+    );
+    len1 = b.load(len1_ptr, name="ssymd.len1");
+    elems1 = b.load(e1_ptr, name="ssymd.elems1");
+    func = b.basic_block.function;
+    entry1 = b.basic_block;
+    loop1 = func.append_basic_block(name="ssymd.loop1");
+    body1 = func.append_basic_block(name="ssymd.body1");
+    add1 = func.append_basic_block(name="ssymd.add1");
+    skip1 = func.append_basic_block(name="ssymd.skip1");
+    mid_bb = func.append_basic_block(name="ssymd.mid");
+    b.branch(loop1);
+    b.position_at_start(loop1);
+    i1 = b.phi(i64, name="ssymd.i1");
+    i1.add_incoming(ir.Constant(i64, 0), entry1);
+    end1 = b.icmp_unsigned(">=", i1, len1, name="ssymd.end1");
+    b.cbranch(end1, mid_bb, body1);
+    b.position_at_start(body1);
+    ep1 = b.gep(elems1, [i1], name="ssymd.ep1");
+    ev1 = b.load(ep1, name="ssymd.ev1");
+    in_other1 = b.call(helpers["contains"], [other, ev1], name="ssymd.inother1");
+    not_in1 = b.icmp_unsigned(
+        "==", in_other1, ir.Constant(ir.IntType(1), 0), name="ssymd.notin1"
+    );
+    b.cbranch(not_in1, add1, skip1);
+    b.position_at_start(add1);
+    b.call(helpers["add"], [new_set, ev1]);
+    b.branch(skip1);
+    b.position_at_start(skip1);
+    n1 = b.add(i1, ir.Constant(i64, 1), name="ssymd.n1");
+    i1.add_incoming(n1, skip1);
+    b.branch(loop1);
+    # Pass 2: add elements from other that are NOT in self
+    b.position_at_start(mid_bb);
+    len2_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssymd.l2.ptr"
+    );
+    e2_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssymd.e2.ptr"
+    );
+    len2 = b.load(len2_ptr, name="ssymd.len2");
+    elems2 = b.load(e2_ptr, name="ssymd.elems2");
+    loop2 = func.append_basic_block(name="ssymd.loop2");
+    body2 = func.append_basic_block(name="ssymd.body2");
+    add2 = func.append_basic_block(name="ssymd.add2");
+    skip2 = func.append_basic_block(name="ssymd.skip2");
+    done_bb = func.append_basic_block(name="ssymd.done");
+    b.branch(loop2);
+    b.position_at_start(loop2);
+    i2 = b.phi(i64, name="ssymd.i2");
+    i2.add_incoming(ir.Constant(i64, 0), mid_bb);
+    end2 = b.icmp_unsigned(">=", i2, len2, name="ssymd.end2");
+    b.cbranch(end2, done_bb, body2);
+    b.position_at_start(body2);
+    ep2 = b.gep(elems2, [i2], name="ssymd.ep2");
+    ev2 = b.load(ep2, name="ssymd.ev2");
+    in_self = b.call(helpers["contains"], [target, ev2], name="ssymd.inself");
+    not_in2 = b.icmp_unsigned(
+        "==", in_self, ir.Constant(ir.IntType(1), 0), name="ssymd.notin2"
+    );
+    b.cbranch(not_in2, add2, skip2);
+    b.position_at_start(add2);
+    b.call(helpers["add"], [new_set, ev2]);
+    b.branch(skip2);
+    b.position_at_start(skip2);
+    n2 = b.add(i2, ir.Constant(i64, 1), name="ssymd.n2");
+    i2.add_incoming(n2, skip2);
+    b.branch(loop2);
+    b.position_at_start(done_bb);
+    return new_set;
+}
+
+# In-place set algebra
+impl NativeSetEmitter.emit_update(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # update(other): add all elements from other to self
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    other = args[0];
+    len_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="supd.len.ptr"
+    );
+    other_len = b.load(len_ptr, name="supd.len");
+    elems_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="supd.elems.ptr"
+    );
+    elems_arr = b.load(elems_ptr, name="supd.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="supd.loop");
+    body_bb = func.append_basic_block(name="supd.body");
+    done_bb = func.append_basic_block(name="supd.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="supd.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, other_len, name="supd.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="supd.ep");
+    ev = b.load(ep, name="supd.ev");
+    b.call(helpers["add"], [target, ev]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="supd.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeSetEmitter.emit_intersection_update(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # intersection_update(other): keep only elements found in other
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    elem_type = helpers["elem_type"];
+    # Build a list of elements to remove (those NOT in other)
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="siupd.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="siupd.elems.ptr"
+    );
+    other = args[0];
+    # We'll do a two-pass approach: first collect elements to keep, then rebuild
+    # Actually simpler: iterate backwards, discard elements not in other
+    set_len = b.load(len_ptr, name="siupd.len");
+    elems_arr = b.load(elems_ptr, name="siupd.elems");
+    func = b.basic_block.function;
+    # Iterate forward; compact in place
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="siupd.loop");
+    body_bb = func.append_basic_block(name="siupd.body");
+    keep_bb = func.append_basic_block(name="siupd.keep");
+    skip_bb = func.append_basic_block(name="siupd.skip");
+    done_bb = func.append_basic_block(name="siupd.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    read_idx = b.phi(i64, name="siupd.ridx");
+    write_idx = b.phi(i64, name="siupd.widx");
+    read_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    write_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", read_idx, set_len, name="siupd.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [read_idx], name="siupd.ep");
+    ev = b.load(ep, name="siupd.ev");
+    in_other = b.call(helpers["contains"], [other, ev], name="siupd.inother");
+    b.cbranch(in_other, keep_bb, skip_bb);
+    # Keep: copy element to write position
+    b.position_at_start(keep_bb);
+    wp = b.gep(elems_arr, [write_idx], name="siupd.wp");
+    b.store(ev, wp);
+    new_widx = b.add(write_idx, ir.Constant(i64, 1), name="siupd.nwidx");
+    next_ridx_k = b.add(read_idx, ir.Constant(i64, 1), name="siupd.nridx.k");
+    b.branch(loop_bb);
+    # Skip: advance read only
+    b.position_at_start(skip_bb);
+    next_ridx_s = b.add(read_idx, ir.Constant(i64, 1), name="siupd.nridx.s");
+    b.branch(loop_bb);
+    # Wire phi nodes
+    read_idx.add_incoming(next_ridx_k, keep_bb);
+    read_idx.add_incoming(next_ridx_s, skip_bb);
+    write_idx.add_incoming(new_widx, keep_bb);
+    write_idx.add_incoming(write_idx, skip_bb);
+    # Done: update length (write_idx in loop_bb has the correct final count)
+    b.position_at_start(done_bb);
+    b.store(write_idx, len_ptr);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeSetEmitter.emit_difference_update(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # difference_update(other): remove all elements found in other
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sdupd.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sdupd.elems.ptr"
+    );
+    other = args[0];
+    set_len = b.load(len_ptr, name="sdupd.len");
+    elems_arr = b.load(elems_ptr, name="sdupd.elems");
+    func = b.basic_block.function;
+    # Compact in place: keep elements NOT in other
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="sdupd.loop");
+    body_bb = func.append_basic_block(name="sdupd.body");
+    keep_bb = func.append_basic_block(name="sdupd.keep");
+    skip_bb = func.append_basic_block(name="sdupd.skip");
+    done_bb = func.append_basic_block(name="sdupd.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    read_idx = b.phi(i64, name="sdupd.ridx");
+    write_idx = b.phi(i64, name="sdupd.widx");
+    read_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    write_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", read_idx, set_len, name="sdupd.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [read_idx], name="sdupd.ep");
+    ev = b.load(ep, name="sdupd.ev");
+    in_other = b.call(helpers["contains"], [other, ev], name="sdupd.inother");
+    # Keep if NOT in other
+    not_in = b.icmp_unsigned(
+        "==", in_other, ir.Constant(ir.IntType(1), 0), name="sdupd.notin"
+    );
+    b.cbranch(not_in, keep_bb, skip_bb);
+    b.position_at_start(keep_bb);
+    wp = b.gep(elems_arr, [write_idx], name="sdupd.wp");
+    b.store(ev, wp);
+    new_widx = b.add(write_idx, ir.Constant(i64, 1), name="sdupd.nwidx");
+    next_ridx_k = b.add(read_idx, ir.Constant(i64, 1), name="sdupd.nridx.k");
+    b.branch(loop_bb);
+    b.position_at_start(skip_bb);
+    next_ridx_s = b.add(read_idx, ir.Constant(i64, 1), name="sdupd.nridx.s");
+    b.branch(loop_bb);
+    read_idx.add_incoming(next_ridx_k, keep_bb);
+    read_idx.add_incoming(next_ridx_s, skip_bb);
+    write_idx.add_incoming(new_widx, keep_bb);
+    write_idx.add_incoming(write_idx, skip_bb);
+    # Done: update length (write_idx in loop_bb has the correct final count)
+    b.position_at_start(done_bb);
+    b.store(write_idx, len_ptr);
+    return ir.Constant(i64, 0);
+}
+
+impl NativeSetEmitter.emit_symmetric_difference_update(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # symmetric_difference_update(other): keep only elements in either but not both
+    # Strategy: compute symmetric_difference, then replace target contents
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    other = args[0];
+    # Step 1: build the symmetric difference as a new set
+    result = self.emit_symmetric_difference(ctx, target, [other]);
+    if result is None {
+        return None;
+    }
+    # Step 2: clear target
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssdupd.len.ptr"
+    );
+    b.store(ir.Constant(i64, 0), len_ptr);
+    # Step 3: add all elements from result to target
+    res_len_ptr = b.gep(
+        result, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssdupd.rlen.ptr"
+    );
+    res_elems_ptr = b.gep(
+        result, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssdupd.relems.ptr"
+    );
+    res_len = b.load(res_len_ptr, name="ssdupd.rlen");
+    res_elems = b.load(res_elems_ptr, name="ssdupd.relems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="ssdupd.loop");
+    body_bb = func.append_basic_block(name="ssdupd.body");
+    done_bb = func.append_basic_block(name="ssdupd.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="ssdupd.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, res_len, name="ssdupd.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(res_elems, [idx], name="ssdupd.ep");
+    ev = b.load(ep, name="ssdupd.ev");
+    b.call(helpers["add"], [target, ev]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="ssdupd.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return ir.Constant(i64, 0);
+}
+
+# Tests
+impl NativeSetEmitter.emit_issubset(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # issubset(other): return 1 if all elements of self are in other
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    other = args[0];
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssub.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssub.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="ssub.len");
+    elems_arr = b.load(elems_ptr, name="ssub.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="ssub.loop");
+    body_bb = func.append_basic_block(name="ssub.body");
+    false_bb = func.append_basic_block(name="ssub.false");
+    done_bb = func.append_basic_block(name="ssub.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="ssub.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="ssub.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="ssub.ep");
+    ev = b.load(ep, name="ssub.ev");
+    in_other = b.call(helpers["contains"], [other, ev], name="ssub.inother");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="ssub.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(in_other, loop_bb, false_bb);
+    b.position_at_start(false_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="ssub.result");
+    result.add_incoming(ir.Constant(i64, 1), loop_bb);
+    result.add_incoming(ir.Constant(i64, 0), false_bb);
+    return result;
+}
+
+impl NativeSetEmitter.emit_issuperset(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # issuperset(other): return 1 if all elements of other are in self
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    other = args[0];
+    # Iterate OTHER, check each in SELF
+    len_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssup.len.ptr"
+    );
+    elems_ptr = b.gep(
+        other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssup.elems.ptr"
+    );
+    other_len = b.load(len_ptr, name="ssup.len");
+    elems_arr = b.load(elems_ptr, name="ssup.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="ssup.loop");
+    body_bb = func.append_basic_block(name="ssup.body");
+    false_bb = func.append_basic_block(name="ssup.false");
+    done_bb = func.append_basic_block(name="ssup.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="ssup.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, other_len, name="ssup.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="ssup.ep");
+    ev = b.load(ep, name="ssup.ev");
+    in_self = b.call(helpers["contains"], [target, ev], name="ssup.inself");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="ssup.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(in_self, loop_bb, false_bb);
+    b.position_at_start(false_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="ssup.result");
+    result.add_incoming(ir.Constant(i64, 1), loop_bb);
+    result.add_incoming(ir.Constant(i64, 0), false_bb);
+    return result;
+}
+
+impl NativeSetEmitter.emit_isdisjoint(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # isdisjoint(other): return 1 if no elements in common
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    other = args[0];
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sdisj.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sdisj.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="sdisj.len");
+    elems_arr = b.load(elems_ptr, name="sdisj.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="sdisj.loop");
+    body_bb = func.append_basic_block(name="sdisj.body");
+    found_bb = func.append_basic_block(name="sdisj.found");
+    done_bb = func.append_basic_block(name="sdisj.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="sdisj.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="sdisj.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="sdisj.ep");
+    ev = b.load(ep, name="sdisj.ev");
+    in_other = b.call(helpers["contains"], [other, ev], name="sdisj.inother");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="sdisj.next");
+    idx.add_incoming(next_idx, body_bb);
+    # If found in other, not disjoint
+    b.cbranch(in_other, found_bb, loop_bb);
+    b.position_at_start(found_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="sdisj.result");
+    result.add_incoming(ir.Constant(i64, 1), loop_bb);
+    result.add_incoming(ir.Constant(i64, 0), found_bb);
+    return result;
+}
+
+impl NativeSetEmitter.emit_copy(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # copy: create new set and add all elements
+    p = ctx.pass_ref;
+    helpers = p.set_helpers.get(ctx.type_key);
+    if helpers is None {
+        return None;
+    }
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    new_set = b.call(helpers["new"], [], name="scopy.new");
+    len_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="scopy.len.ptr"
+    );
+    elems_ptr = b.gep(
+        target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="scopy.elems.ptr"
+    );
+    set_len = b.load(len_ptr, name="scopy.len");
+    elems_arr = b.load(elems_ptr, name="scopy.elems");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="scopy.loop");
+    body_bb = func.append_basic_block(name="scopy.body");
+    done_bb = func.append_basic_block(name="scopy.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="scopy.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, set_len, name="scopy.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    ep = b.gep(elems_arr, [idx], name="scopy.ep");
+    ev = b.load(ep, name="scopy.ev");
+    b.call(helpers["add"], [new_set, ev]);
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="scopy.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return new_set;
+}
+
+"""Frozenset emitter — delegates to set emitter since frozenset uses same LLVM type."""
+impl NativeFrozensetEmitter._get_set_emitter(
+    self, ctx: NativeEmitCtx
+) -> (object | None) {
+    return ctx.pass_ref._native_emitters.get("set");
+}
+
+impl NativeFrozensetEmitter.emit_union(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_union(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_intersection(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_intersection(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_difference(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_difference(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_symmetric_difference(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_symmetric_difference(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_issubset(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_issubset(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_issuperset(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_issuperset(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_isdisjoint(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_isdisjoint(ctx, target, args) if se is not None else None;
+}
+
+impl NativeFrozensetEmitter.emit_copy(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    se = self._get_set_emitter(ctx);
+    return se.emit_copy(ctx, target, args) if se is not None else None;
+}
+
+"""Helper: get struct type and element count from context."""
+impl NativeTupleEmitter._get_struct_info(
+    self, ctx: NativeEmitCtx, target: ir.Value
+) -> (object | None) {
+    if isinstance(target.type, ir.PointerType)
+    and isinstance(target.type.pointee, ir.LiteralStructType) {
+        return target.type.pointee;
+    }
+    # Fallback: look up from tuple_types using type_key
+    p = ctx.pass_ref;
+    st = p.tuple_types.get(ctx.type_key);
+    return st;
+}
+
+impl NativeTupleEmitter.emit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    st = self._get_struct_info(ctx, target);
+    if st is None or not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    n = len(st.elements);
+    count = ir.Constant(i64, 0);
+    val = args[0];
+    for i in range(n) {
+        ep = b.gep(
+            target,
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), i)],
+            name=f"tc.{i}.ptr"
+        );
+        elem = b.load(ep, name=f"tc.{i}");
+        val_c = p._coerce_type(val, elem.type);
+        if isinstance(elem.type, ir.IntType) {
+            eq = b.icmp_signed("==", val_c, elem, name=f"tc.{i}.eq");
+        } elif isinstance(elem.type, ir.DoubleType) {
+            eq = b.fcmp_ordered("==", val_c, elem, name=f"tc.{i}.eq");
+        } else {
+            return None;
+        }
+        inc = b.zext(eq, i64, name=f"tc.{i}.inc");
+        count = b.add(count, inc, name=f"tc.{i}.cnt");
+    }
+    return count;
+}
+
+impl NativeTupleEmitter.emit_index(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    st = self._get_struct_info(ctx, target);
+    if st is None or not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    n = len(st.elements);
+    val = args[0];
+    # Use select chain: start with -1 (not found), update on match
+    result = ir.Constant(i64, -1);
+    for i in range(n - 1, -1, -1) {
+        ep = b.gep(
+            target,
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), i)],
+            name=f"ti.{i}.ptr"
+        );
+        elem = b.load(ep, name=f"ti.{i}");
+        val_c = p._coerce_type(val, elem.type);
+        if isinstance(elem.type, ir.IntType) {
+            eq = b.icmp_signed("==", val_c, elem, name=f"ti.{i}.eq");
+        } elif isinstance(elem.type, ir.DoubleType) {
+            eq = b.fcmp_ordered("==", val_c, elem, name=f"ti.{i}.eq");
+        } else {
+            return None;
+        }
+        result = b.select(eq, ir.Constant(i64, i), result, name=f"ti.{i}.sel");
+    }
+    return result;
+}
+
+impl NativeTupleEmitter.emit_op_add(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_mul(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_eq(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_ne(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_lt(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_gt(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_le(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_ge(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeTupleEmitter.emit_op_contains(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+"""Helper: load start, stop, step from JacRange pointer."""
+impl NativeRangeEmitter._load_range(
+    self, ctx: NativeEmitCtx, target: ir.Value
+) -> (tuple | None) {
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    z0 = ir.Constant(i32, 0);
+    start = b.load(
+        b.gep(target, [z0, ir.Constant(i32, 0)], name="rng.sp"), name="rng.start"
+    );
+    stop = b.load(
+        b.gep(target, [z0, ir.Constant(i32, 1)], name="rng.ep"), name="rng.stop"
+    );
+    step = b.load(
+        b.gep(target, [z0, ir.Constant(i32, 2)], name="rng.tp"), name="rng.step"
+    );
+    return (start, stop, step);
+}
+
+"""Helper: check if val is in range(start, stop, step)."""
+impl NativeRangeEmitter._in_range(
+    self,
+    ctx: NativeEmitCtx,
+    val: ir.Value,
+    start: ir.Value,
+    stop: ir.Value,
+    step: ir.Value
+) -> ir.Value {
+    b = ctx.pass_ref.builder;
+    i64 = ir.IntType(64);
+    i1 = ir.IntType(1);
+    diff = b.sub(val, start, name="rin.diff");
+    rem = b.srem(diff, step, name="rin.rem");
+    rem_zero = b.icmp_signed("==", rem, ir.Constant(i64, 0), name="rin.remz");
+    step_pos = b.icmp_signed(">", step, ir.Constant(i64, 0), name="rin.spos");
+    ge_start = b.icmp_signed(">=", val, start, name="rin.ges");
+    lt_stop = b.icmp_signed("<", val, stop, name="rin.lts");
+    pos_ok = b.and_(ge_start, lt_stop, name="rin.pok");
+    le_start = b.icmp_signed("<=", val, start, name="rin.les");
+    gt_stop = b.icmp_signed(">", val, stop, name="rin.gts");
+    neg_ok = b.and_(le_start, gt_stop, name="rin.nok");
+    bounds = b.select(step_pos, pos_ok, neg_ok, name="rin.bounds");
+    return b.and_(rem_zero, bounds, name="rin.found");
+}
+
+impl NativeRangeEmitter.emit_count(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    parts = self._load_range(ctx, target);
+    if parts is None or not args {
+        return None;
+    }
+    (start, stop, step) = parts;
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    val = p._coerce_type(args[0], i64);
+    found = self._in_range(ctx, val, start, stop, step);
+    return b.zext(found, i64, name="rng.count");
+}
+
+impl NativeRangeEmitter.emit_index(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    parts = self._load_range(ctx, target);
+    if parts is None or not args {
+        return None;
+    }
+    (start, stop, step) = parts;
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    val = p._coerce_type(args[0], i64);
+    diff = b.sub(val, start, name="ri.diff");
+    idx = b.sdiv(diff, step, name="ri.idx");
+    return idx;
+}
+
+impl NativeRangeEmitter.emit_op_eq(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeRangeEmitter.emit_op_ne(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeRangeEmitter.emit_op_contains(
+    self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_print(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_input(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_len(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_abs(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    b = ctx.pass_ref.builder;
+    i64 = ir.IntType(64);
+    if isinstance(arg_val.type, ir.IntType) {
+        zero = ir.Constant(i64, 0);
+        is_neg = b.icmp_signed("<", arg_val, zero, name="abs.neg");
+        negated = b.sub(zero, arg_val, name="abs.negate");
+        return b.select(is_neg, negated, arg_val, name="abs.result");
+    }
+    if isinstance(arg_val.type, ir.DoubleType) {
+        fabs_fn = ctx.pass_ref._get_or_declare_extern(
+            "fabs", ir.DoubleType(), [ir.DoubleType()]
+        );
+        return b.call(fabs_fn, [arg_val], name="abs.fresult");
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_round(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    if isinstance(arg_val.type, ir.DoubleType) {
+        round_fn = p._get_or_declare_extern("round", ir.DoubleType(), [ir.DoubleType()]);
+        rounded = b.call(round_fn, [arg_val], name="round.f");
+        return b.fptosi(rounded, i64, name="round.result");
+    }
+    # int rounds to itself
+    if isinstance(arg_val.type, ir.IntType) {
+        return arg_val;
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_min(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if len(args) < 2 {
+        return None;
+    }
+    b = ctx.pass_ref.builder;
+    a = args[0];
+    v = args[1];
+    if isinstance(a.type, ir.IntType) and isinstance(v.type, ir.IntType) {
+        cmp = b.icmp_signed("<", a, v, name="min.cmp");
+        return b.select(cmp, a, v, name="min.result");
+    }
+    if isinstance(a.type, ir.DoubleType) and isinstance(v.type, ir.DoubleType) {
+        cmp = b.fcmp_ordered("<", a, v, name="min.fcmp");
+        return b.select(cmp, a, v, name="min.fresult");
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_max(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if len(args) < 2 {
+        return None;
+    }
+    b = ctx.pass_ref.builder;
+    a = args[0];
+    v = args[1];
+    if isinstance(a.type, ir.IntType) and isinstance(v.type, ir.IntType) {
+        cmp = b.icmp_signed(">", a, v, name="max.cmp");
+        return b.select(cmp, a, v, name="max.result");
+    }
+    if isinstance(a.type, ir.DoubleType) and isinstance(v.type, ir.DoubleType) {
+        cmp = b.fcmp_ordered(">", a, v, name="max.fcmp");
+        return b.select(cmp, a, v, name="max.fresult");
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_sum(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # sum(list) -> int: iterate list elements and accumulate
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    list_val = args[0];
+    # Find matching list helpers
+    helpers: (dict | None) = None;
+    elem_key: (str | None) = None;
+    for (lk, lt) in p.list_types.items() {
+        if list_val.type == lt.as_pointer() {
+            helpers = p.list_helpers.get(lk);
+            elem_key = lk;
+            break;
+        }
+    }
+    if helpers is None {
+        return None;
+    }
+    list_len = b.call(helpers["len"], [list_val], name="sum.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="sum.loop");
+    body_bb = func.append_basic_block(name="sum.body");
+    done_bb = func.append_basic_block(name="sum.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="sum.idx");
+    acc = b.phi(i64, name="sum.acc");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    acc.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, list_len, name="sum.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    elem = b.call(helpers["get"], [list_val, idx], name="sum.elem");
+    new_acc = b.add(acc, elem, name="sum.add");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="sum.next");
+    idx.add_incoming(next_idx, body_bb);
+    acc.add_incoming(new_acc, body_bb);
+    b.branch(loop_bb);
+    b.position_at_start(done_bb);
+    return acc;
+}
+
+impl NativeBuiltinEmitter.emit_sorted(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # sorted(list) -> new sorted copy
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    list_val = args[0];
+    # Find matching list helpers from the argument type
+    helpers: (dict | None) = None;
+    elem_key: (str | None) = None;
+    for (lk, lt) in p.list_types.items() {
+        if list_val.type == lt.as_pointer() {
+            helpers = p.list_helpers.get(lk);
+            elem_key = lk;
+            break;
+        }
+    }
+    if helpers is None {
+        return None;
+    }
+    _le = p._native_emitters.get("list") if p?._native_emitters else None;
+    if _le is None {
+        return None;
+    }
+    _ctx2 = ctx.__class__(pass_ref=p, type_key=elem_key or "");
+    # Copy the list then sort the copy
+    sorted_copy = _le.emit_copy(_ctx2, list_val, []);
+    if sorted_copy is None {
+        return None;
+    }
+    _le.emit_sort(_ctx2, sorted_copy, []);
+    return sorted_copy;
+}
+
+impl NativeBuiltinEmitter.emit_reversed(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # reversed(list) -> new reversed copy
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    list_val = args[0];
+    # Find matching list helpers from the argument type
+    helpers: (dict | None) = None;
+    elem_key: (str | None) = None;
+    for (lk, lt) in p.list_types.items() {
+        if list_val.type == lt.as_pointer() {
+            helpers = p.list_helpers.get(lk);
+            elem_key = lk;
+            break;
+        }
+    }
+    if helpers is None {
+        return None;
+    }
+    _le = p._native_emitters.get("list") if p?._native_emitters else None;
+    if _le is None {
+        return None;
+    }
+    _ctx2 = ctx.__class__(pass_ref=p, type_key=elem_key or "");
+    # Copy the list then reverse the copy
+    rev_copy = _le.emit_copy(_ctx2, list_val, []);
+    if rev_copy is None {
+        return None;
+    }
+    _le.emit_reverse(_ctx2, rev_copy, []);
+    return rev_copy;
+}
+
+impl NativeBuiltinEmitter.emit_enumerate(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_zip(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_map(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_filter(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_any(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # any(list) -> int: return 1 if any element is truthy
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    list_val = args[0];
+    helpers: (dict | None) = None;
+    for (lk, lt) in p.list_types.items() {
+        if list_val.type == lt.as_pointer() {
+            helpers = p.list_helpers.get(lk);
+            break;
+        }
+    }
+    if helpers is None {
+        return None;
+    }
+    list_len = b.call(helpers["len"], [list_val], name="any.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="any.loop");
+    body_bb = func.append_basic_block(name="any.body");
+    found_bb = func.append_basic_block(name="any.found");
+    done_bb = func.append_basic_block(name="any.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="any.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, list_len, name="any.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    elem = b.call(helpers["get"], [list_val, idx], name="any.elem");
+    is_true = b.icmp_signed("!=", elem, ir.Constant(i64, 0), name="any.true");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="any.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(is_true, found_bb, loop_bb);
+    b.position_at_start(found_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="any.result");
+    result.add_incoming(ir.Constant(i64, 0), loop_bb);
+    result.add_incoming(ir.Constant(i64, 1), found_bb);
+    return result;
+}
+
+impl NativeBuiltinEmitter.emit_all(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # all(list) -> int: return 1 if all elements are truthy (or list is empty)
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    list_val = args[0];
+    helpers: (dict | None) = None;
+    for (lk, lt) in p.list_types.items() {
+        if list_val.type == lt.as_pointer() {
+            helpers = p.list_helpers.get(lk);
+            break;
+        }
+    }
+    if helpers is None {
+        return None;
+    }
+    list_len = b.call(helpers["len"], [list_val], name="all.len");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    loop_bb = func.append_basic_block(name="all.loop");
+    body_bb = func.append_basic_block(name="all.body");
+    false_bb = func.append_basic_block(name="all.false");
+    done_bb = func.append_basic_block(name="all.done");
+    b.branch(loop_bb);
+    b.position_at_start(loop_bb);
+    idx = b.phi(i64, name="all.idx");
+    idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+    at_end = b.icmp_unsigned(">=", idx, list_len, name="all.atend");
+    b.cbranch(at_end, done_bb, body_bb);
+    b.position_at_start(body_bb);
+    elem = b.call(helpers["get"], [list_val, idx], name="all.elem");
+    is_false = b.icmp_signed("==", elem, ir.Constant(i64, 0), name="all.false");
+    next_idx = b.add(idx, ir.Constant(i64, 1), name="all.next");
+    idx.add_incoming(next_idx, body_bb);
+    b.cbranch(is_false, false_bb, loop_bb);
+    b.position_at_start(false_bb);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    result = b.phi(i64, name="all.result");
+    result.add_incoming(ir.Constant(i64, 1), loop_bb);
+    result.add_incoming(ir.Constant(i64, 0), false_bb);
+    return result;
+}
+
+impl NativeBuiltinEmitter.emit_isinstance(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_issubclass(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_type(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_id(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    if isinstance(arg_val.type, ir.PointerType) {
+        return b.ptrtoint(arg_val, i64, name="id.ptr");
+    }
+    if isinstance(arg_val.type, ir.IntType) {
+        return p._coerce_type(arg_val, i64);
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_hash(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    # int hash = identity
+    if isinstance(arg_val.type, ir.IntType) {
+        return p._coerce_type(arg_val, i64);
+    }
+    # string hash = djb2
+    i8p = ir.IntType(8).as_pointer();
+    if isinstance(arg_val.type, ir.PointerType) and arg_val.type == i8p {
+        i8 = ir.IntType(8);
+        func = b.basic_block.function;
+        entry_bb = b.basic_block;
+        loop_bb = func.append_basic_block(name="hash.loop");
+        body_bb = func.append_basic_block(name="hash.body");
+        done_bb = func.append_basic_block(name="hash.done");
+        b.branch(loop_bb);
+        b.position_at_start(loop_bb);
+        h = b.phi(i64, name="hash.h");
+        h.add_incoming(ir.Constant(i64, 5381), entry_bb);
+        idx = b.phi(i64, name="hash.idx");
+        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+        cp = b.gep(arg_val, [idx], name="hash.cp");
+        ch = b.load(cp, name="hash.ch");
+        is_zero = b.icmp_unsigned("==", ch, ir.Constant(i8, 0), name="hash.end");
+        b.cbranch(is_zero, done_bb, body_bb);
+        b.position_at_start(body_bb);
+        ch_ext = b.zext(ch, i64, name="hash.chext");
+        h_shl5 = b.shl(h, ir.Constant(i64, 5), name="hash.shl5");
+        h_plus_h = b.add(h_shl5, h, name="hash.mul33");
+        h_next = b.add(h_plus_h, ch_ext, name="hash.next");
+        next_idx = b.add(idx, ir.Constant(i64, 1), name="hash.nextidx");
+        h.add_incoming(h_next, body_bb);
+        idx.add_incoming(next_idx, body_bb);
+        b.branch(loop_bb);
+        b.position_at_start(done_bb);
+        return h;
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_repr(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    rc_alloc_fn = p.rc_alloc_fn;
+    buf_ptr = b.call(rc_alloc_fn, [ir.Constant(i64, 64)], name="repr.buf");
+    snprintf = p._get_or_declare_extern(
+        "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
+    );
+    if isinstance(arg_val.type, ir.IntType) {
+        fmt = p._get_snprintf_fmt("%ld");
+        fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
+        coerced = p._coerce_type(arg_val, i64);
+        b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, coerced]);
+        return buf_ptr;
+    }
+    if isinstance(arg_val.type, ir.DoubleType) {
+        fmt = p._get_snprintf_fmt("%g");
+        fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
+        b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, arg_val]);
+        return buf_ptr;
+    }
+    if isinstance(arg_val.type, ir.PointerType) and arg_val.type == i8p {
+        fmt = p._get_snprintf_fmt("'%s'");
+        fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
+        b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, arg_val]);
+        return buf_ptr;
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_chr(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    rc_alloc_fn = p.rc_alloc_fn;
+    str_ptr = b.call(rc_alloc_fn, [ir.Constant(ir.IntType(64), 2)], name="chr.buf");
+    byte_val = b.trunc(arg_val, ir.IntType(8), name="chr.byte");
+    b.store(byte_val, str_ptr);
+    idx1_ptr = b.gep(str_ptr, [ir.Constant(ir.IntType(64), 1)], name="chr.null.ptr");
+    b.store(ir.Constant(ir.IntType(8), 0), idx1_ptr);
+    return str_ptr;
+}
+
+impl NativeBuiltinEmitter.emit_ord(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    b = ctx.pass_ref.builder;
+    byte_val = b.load(arg_val, name="ord.byte");
+    return b.zext(byte_val, ir.IntType(64), name="ord.val");
+}
+
+impl NativeBuiltinEmitter.emit_hex(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    rc_alloc_fn = p.rc_alloc_fn;
+    snprintf = p._get_or_declare_extern(
+        "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
+    );
+    buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="hex.buf");
+    # Check if negative
+    arg_val = args[0];
+    zero = ir.Constant(i64, 0);
+    is_neg = b.icmp_signed("<", arg_val, zero, name="hex.neg");
+    abs_val = b.sub(zero, arg_val, name="hex.abs");
+    pos_val = b.select(is_neg, abs_val, arg_val, name="hex.pos");
+    fmt_pos = p._get_snprintf_fmt("0x%lx");
+    fmt_neg = p._get_snprintf_fmt("-0x%lx");
+    fmt_pos_ptr = b.bitcast(fmt_pos, i8p, name="hex.fmt.pos");
+    fmt_neg_ptr = b.bitcast(fmt_neg, i8p, name="hex.fmt.neg");
+    fmt = b.select(is_neg, fmt_neg_ptr, fmt_pos_ptr, name="hex.fmt");
+    b.call(snprintf, [buf, ir.Constant(i64, 32), fmt, pos_val], name="hex.snprintf");
+    return buf;
+}
+
+impl NativeBuiltinEmitter.emit_oct(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    rc_alloc_fn = p.rc_alloc_fn;
+    snprintf = p._get_or_declare_extern(
+        "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
+    );
+    buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="oct.buf");
+    arg_val = args[0];
+    zero = ir.Constant(i64, 0);
+    is_neg = b.icmp_signed("<", arg_val, zero, name="oct.neg");
+    abs_val = b.sub(zero, arg_val, name="oct.abs");
+    pos_val = b.select(is_neg, abs_val, arg_val, name="oct.pos");
+    fmt_pos = p._get_snprintf_fmt("0o%lo");
+    fmt_neg = p._get_snprintf_fmt("-0o%lo");
+    fmt_pos_ptr = b.bitcast(fmt_pos, i8p, name="oct.fmt.pos");
+    fmt_neg_ptr = b.bitcast(fmt_neg, i8p, name="oct.fmt.neg");
+    fmt = b.select(is_neg, fmt_neg_ptr, fmt_pos_ptr, name="oct.fmt");
+    b.call(snprintf, [buf, ir.Constant(i64, 32), fmt, pos_val], name="oct.snprintf");
+    return buf;
+}
+
+impl NativeBuiltinEmitter.emit_bin(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    rc_alloc_fn = p.rc_alloc_fn;
+    snprintf = p._get_or_declare_extern(
+        "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
+    );
+    # Allocate buffer: "0b" + up to 64 digits + sign + null = 68
+    buf = b.call(rc_alloc_fn, [ir.Constant(i64, 68)], name="bin.buf");
+    arg_val = args[0];
+    zero = ir.Constant(i64, 0);
+    is_neg = b.icmp_signed("<", arg_val, zero, name="bin.neg");
+    abs_val = b.sub(zero, arg_val, name="bin.abs");
+    pos_val = b.select(is_neg, abs_val, arg_val, name="bin.pos");
+    is_zero = b.icmp_signed("==", arg_val, zero, name="bin.iszero");
+    func = b.basic_block.function;
+    entry_bb = b.basic_block;
+    zero_bb = func.append_basic_block(name="bin.zero");
+    prefix_bb = func.append_basic_block(name="bin.prefix");
+    loop_bb = func.append_basic_block(name="bin.loop");
+    body_bb = func.append_basic_block(name="bin.body");
+    reverse_bb = func.append_basic_block(name="bin.reverse");
+    done_bb = func.append_basic_block(name="bin.done");
+    b.cbranch(is_zero, zero_bb, prefix_bb);
+    # Zero case: "0b0"
+    b.position_at_start(zero_bb);
+    fmt_zero = p._get_snprintf_fmt("0b0");
+    fmt_zero_ptr = b.bitcast(fmt_zero, i8p, name="bin.fmt.zero");
+    b.call(snprintf, [buf, ir.Constant(i64, 68), fmt_zero_ptr], name="bin.zero.snp");
+    b.branch(done_bb);
+    # Write prefix: "-0b" or "0b"
+    b.position_at_start(prefix_bb);
+    neg_ch = ir.Constant(i8, 45);  # '-'
+    zero_ch = ir.Constant(i8, 48);  # '0'
+    b_ch = ir.Constant(i8, 98);  # 'b'
+    # Write sign if negative
+    start_off_val = b.select(
+        is_neg, ir.Constant(i64, 1), ir.Constant(i64, 0), name="bin.start"
+    );
+    neg_ptr = b.gep(buf, [ir.Constant(i64, 0)], name="bin.neg.ptr");
+    b.store(b.select(is_neg, neg_ch, zero_ch, name="bin.first.ch"), neg_ptr);
+    zero_ptr = b.gep(buf, [start_off_val], name="bin.zero.ptr");
+    b.store(zero_ch, zero_ptr);
+    b_off = b.add(start_off_val, ir.Constant(i64, 1), name="bin.b.off");
+    b_ptr = b.gep(buf, [b_off], name="bin.b.ptr");
+    b.store(b_ch, b_ptr);
+    digit_start = b.add(b_off, ir.Constant(i64, 1), name="bin.digit.start");
+    b.branch(loop_bb);
+    # Extract digits (reverse order)
+    b.position_at_start(loop_bb);
+    val = b.phi(i64, name="bin.val");
+    off = b.phi(i64, name="bin.off");
+    val.add_incoming(pos_val, prefix_bb);
+    off.add_incoming(digit_start, prefix_bb);
+    is_done = b.icmp_unsigned("==", val, ir.Constant(i64, 0), name="bin.done.chk");
+    b.cbranch(is_done, reverse_bb, body_bb);
+    b.position_at_start(body_bb);
+    bit = b.and_(val, ir.Constant(i64, 1), name="bin.bit");
+    digit = b.trunc(
+        b.add(bit, ir.Constant(i64, 48), name="bin.digit.val"), i8, name="bin.digit"
+    );
+    digit_ptr = b.gep(buf, [off], name="bin.digit.ptr");
+    b.store(digit, digit_ptr);
+    new_val = b.lshr(val, ir.Constant(i64, 1), name="bin.new.val");
+    new_off = b.add(off, ir.Constant(i64, 1), name="bin.new.off");
+    val.add_incoming(new_val, body_bb);
+    off.add_incoming(new_off, body_bb);
+    b.branch(loop_bb);
+    # Reverse the digit portion and null-terminate
+    b.position_at_start(reverse_bb);
+    null_ptr = b.gep(buf, [off], name="bin.null.ptr");
+    b.store(ir.Constant(i8, 0), null_ptr);
+    # Reverse digits between digit_start and off-1
+    rev_entry = b.basic_block;
+    rev_loop = func.append_basic_block(name="bin.rev.loop");
+    rev_body = func.append_basic_block(name="bin.rev.body");
+    rev_done = func.append_basic_block(name="bin.rev.done");
+    end_idx = b.sub(off, ir.Constant(i64, 1), name="bin.end.idx");
+    b.branch(rev_loop);
+    b.position_at_start(rev_loop);
+    lo = b.phi(i64, name="bin.rev.lo");
+    hi = b.phi(i64, name="bin.rev.hi");
+    lo.add_incoming(digit_start, rev_entry);
+    hi.add_incoming(end_idx, rev_entry);
+    need_swap = b.icmp_signed("<", lo, hi, name="bin.rev.need");
+    b.cbranch(need_swap, rev_body, rev_done);
+    b.position_at_start(rev_body);
+    lo_ptr = b.gep(buf, [lo], name="bin.rev.lo.ptr");
+    hi_ptr = b.gep(buf, [hi], name="bin.rev.hi.ptr");
+    lo_ch = b.load(lo_ptr, name="bin.rev.lo.ch");
+    hi_ch = b.load(hi_ptr, name="bin.rev.hi.ch");
+    b.store(hi_ch, lo_ptr);
+    b.store(lo_ch, hi_ptr);
+    next_lo = b.add(lo, ir.Constant(i64, 1), name="bin.rev.next.lo");
+    next_hi = b.sub(hi, ir.Constant(i64, 1), name="bin.rev.next.hi");
+    lo.add_incoming(next_lo, rev_body);
+    hi.add_incoming(next_hi, rev_body);
+    b.branch(rev_loop);
+    b.position_at_start(rev_done);
+    b.branch(done_bb);
+    b.position_at_start(done_bb);
+    return buf;
+}
+
+impl NativeBuiltinEmitter.emit_pow(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if len(args) < 2 {
+        return None;
+    }
+    p = ctx.pass_ref;
+    base = args[0];
+    exp = args[1];
+    if isinstance(base.type, ir.IntType) and isinstance(exp.type, ir.IntType) {
+        return p._codegen_int_pow(base, exp);
+    }
+    if isinstance(base.type, ir.DoubleType) and isinstance(exp.type, ir.DoubleType) {
+        pow_fn = p._get_or_declare_extern(
+            "pow", ir.DoubleType(), [ir.DoubleType(), ir.DoubleType()]
+        );
+        return p.builder.call(pow_fn, [base, exp], name="pow.result");
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_divmod(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # divmod(a, b) -> tuple of (a // b, a % b)
+    if len(args) < 2 {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    a = args[0];
+    v = args[1];
+    if isinstance(a.type, ir.IntType) and isinstance(v.type, ir.IntType) {
+        # ZeroDivisionError check
+        izero = ir.Constant(i64, 0);
+        is_zero = b.icmp_signed("==", v, izero, name="divmod.zero.chk");
+        p._emit_runtime_raise(
+            is_zero, "ZeroDivisionError", "integer division or modulo by zero"
+        );
+        quot = b.sdiv(a, v, name="divmod.quot");
+        rem = b.srem(a, v, name="divmod.rem");
+        # Build a 2-element tuple (struct {i64, i64})
+        tuple_type = ir.LiteralStructType([i64, i64]);
+        null_ptr = ir.Constant(tuple_type.as_pointer(), None);
+        size_gep = b.gep(
+            null_ptr, [ir.Constant(ir.IntType(32), 1)], name="divmod.sizeof.gep"
+        );
+        size = b.ptrtoint(size_gep, i64, name="divmod.sizeof");
+        raw_ptr = b.call(p.rc_alloc_fn, [size], name="divmod.alloc");
+        tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="divmod.ptr");
+        # Store quotient and remainder
+        q_ptr = b.gep(
+            tuple_ptr,
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0)],
+            name="divmod.q.ptr"
+        );
+        r_ptr = b.gep(
+            tuple_ptr,
+            [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 1)],
+            name="divmod.r.ptr"
+        );
+        b.store(quot, q_ptr);
+        b.store(rem, r_ptr);
+        # Register the tuple type
+        tkey = f"Tuple.2.i64.i64";
+        if tkey not in p.tuple_types {
+            p.tuple_types[tkey] = tuple_type;
+        }
+        return tuple_ptr;
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_iter(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_next(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_callable(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_getattr(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_setattr(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_hasattr(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_delattr(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_vars(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_dir(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_open(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_format(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # format(value, spec) - format value according to format spec
+    if len(args) < 2 {
+        return None;
+    }
+    arg_val = args[0];
+    spec_val = args[1];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i64 = ir.IntType(64);
+    rc_alloc_fn = p.rc_alloc_fn;
+    buf_ptr = b.call(rc_alloc_fn, [ir.Constant(i64, 64)], name="fmt.buf");
+    snprintf = p._get_or_declare_extern(
+        "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
+    );
+    # Build format string: "%" + spec
+    strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+    memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+    spec_len = b.call(strlen_fn, [spec_val], name="fmt.speclen");
+    # Allocate fmt string: "%" + spec + null = spec_len + 2
+    fmt_size = b.add(spec_len, ir.Constant(i64, 2), name="fmt.fmtsz");
+    fmt_buf = b.call(rc_alloc_fn, [fmt_size], name="fmt.fmtbuf");
+    # Store '%' at position 0
+    b.store(ir.Constant(ir.IntType(8), 37), fmt_buf);
+    # Copy spec after '%'
+    fmt_rest = b.gep(fmt_buf, [ir.Constant(i64, 1)], name="fmt.rest");
+    copy_len = b.add(spec_len, ir.Constant(i64, 1), name="fmt.copylen");
+    b.call(memcpy_fn, [fmt_rest, spec_val, copy_len]);
+    # Call snprintf with the constructed format
+    b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_buf, arg_val]);
+    return buf_ptr;
+}
+
+impl NativeBuiltinEmitter.emit_ascii(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # ascii(s) - for strings, return repr-like with non-ASCII escaped
+    # Simplified: just return repr() for now (handles basic cases)
+    return self.emit_repr(ctx, args);
+}
+
+# Type conversion builtins
+impl NativeBuiltinEmitter.emit_str(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    rc_alloc_fn = p.rc_alloc_fn;
+    buf_ptr = b.call(rc_alloc_fn, [ir.Constant(ir.IntType(64), 32)], name="str.buf");
+    snprintf = p._get_or_declare_extern(
+        "snprintf", ir.IntType(32), [i8p, ir.IntType(64), i8p], var_arg=True
+    );
+    if isinstance(arg_val.type, ir.IntType) {
+        fmt = p._get_snprintf_fmt("%ld");
+    } elif isinstance(arg_val.type, ir.DoubleType) {
+        fmt = p._get_snprintf_fmt("%g");
+    } else {
+        fmt = p._get_snprintf_fmt("%ld");
+    }
+    fmt_ptr = b.bitcast(fmt, i8p, name="str.fmt.ptr");
+    b.call(
+        snprintf,
+        [buf_ptr, ir.Constant(ir.IntType(64), 32), fmt_ptr, arg_val],
+        name="str.snprintf"
+    );
+    return buf_ptr;
+}
+
+impl NativeBuiltinEmitter.emit_int(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    # int(bool) / int(int): zero-extend narrower integers to i64, return i64 directly
+    if isinstance(arg_val.type, ir.IntType) {
+        if arg_val.type.width == 64 {
+            return arg_val;
+        }
+        return b.zext(arg_val, i64, name="int.from.int");
+    }
+    # int(float): truncate double to i64 (same as Python int(3.7) == 3)
+    if isinstance(arg_val.type, ir.DoubleType) {
+        return b.fptosi(arg_val, i64, name="int.from.float");
+    }
+    # int(str): parse via strtol
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    strtol_fn = p._get_or_declare_extern("strtol", i64, [i8p, i8p.as_pointer(), i32]);
+    endptr_alloca = b.alloca(i8p, name="endptr");
+    result_val = b.call(
+        strtol_fn, [arg_val, endptr_alloca, ir.Constant(i32, 10)], name="strtol.result"
+    );
+    endptr_val = b.load(endptr_alloca, name="endptr.val");
+    no_parse = b.icmp_unsigned("==", endptr_val, arg_val, name="int.noparse");
+    p._emit_runtime_raise(no_parse, "ValueError", "invalid literal for int()");
+    end_char = b.load(endptr_val, name="end.char");
+    has_trail = b.icmp_unsigned(
+        "!=", end_char, ir.Constant(ir.IntType(8), 0), name="int.trail"
+    );
+    p._emit_runtime_raise(has_trail, "ValueError", "invalid literal for int()");
+    return result_val;
+}
+
+impl NativeBuiltinEmitter.emit_float(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    # String to float via strtod
+    if isinstance(arg_val.type, ir.PointerType) {
+        strtod_fn = p._get_or_declare_extern(
+            "strtod", ir.DoubleType(), [i8p, i8p.as_pointer()]
+        );
+        endptr_alloca = b.alloca(i8p, name="float.endptr");
+        result = b.call(strtod_fn, [arg_val, endptr_alloca], name="float.result");
+        endptr_val = b.load(endptr_alloca, name="float.endptr.val");
+        no_parse = b.icmp_unsigned("==", endptr_val, arg_val, name="float.noparse");
+        p._emit_runtime_raise(
+            no_parse, "ValueError", "could not convert string to float"
+        );
+        return result;
+    }
+    # Int to float
+    if isinstance(arg_val.type, ir.IntType) {
+        return b.sitofp(arg_val, ir.DoubleType(), name="float.from.int");
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_bool(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    if not args {
+        return None;
+    }
+    arg_val = args[0];
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    if isinstance(arg_val.type, ir.IntType) {
+        # bool(int): nonzero is truthy
+        is_nonzero = b.icmp_signed("!=", arg_val, ir.Constant(i64, 0), name="bool.nz");
+        return b.zext(is_nonzero, i64, name="bool.result");
+    }
+    if isinstance(arg_val.type, ir.DoubleType) {
+        # bool(float): non-zero is truthy
+        is_nonzero = b.fcmp_ordered(
+            "!=", arg_val, ir.Constant(ir.DoubleType(), 0.0), name="bool.fnz"
+        );
+        return b.zext(is_nonzero, i64, name="bool.fresult");
+    }
+    if isinstance(arg_val.type, ir.PointerType) {
+        # bool(str): non-empty is truthy
+        i8p = ir.IntType(8).as_pointer();
+        if arg_val.type == i8p {
+            strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
+            slen = b.call(strlen_fn, [arg_val], name="bool.slen");
+            is_nonempty = b.icmp_unsigned(
+                "!=", slen, ir.Constant(i64, 0), name="bool.nonempty"
+            );
+            return b.zext(is_nonempty, i64, name="bool.sresult");
+        }
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_list(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # list(set) -> new list with all set elements; list(list) -> copy
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    val = args[0];
+    # Convert set to list: set struct = {i64 len, i64 cap, elem* elems}
+    for (sk, shelpers) in p.set_helpers.items() {
+        stype = p.set_types.get(sk);
+        if stype is not None and val.type == stype.as_pointer() {
+            p._emit_list_helpers(sk, shelpers["elem_type"]);
+            lhelpers = p.list_helpers.get(sk);
+            if lhelpers is None {
+                return None;
+            }
+            new_list = b.call(lhelpers["new"], [], name="l2l.new");
+            set_len = b.call(shelpers["len"], [val], name="l2l.slen");
+            elems_ptr = b.gep(
+                val, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="l2l.elems.ptr"
+            );
+            elems_arr = b.load(elems_ptr, name="l2l.elems");
+            func = b.basic_block.function;
+            entry_bb = b.basic_block;
+            loop_bb = func.append_basic_block(name="l2l.loop");
+            body_bb = func.append_basic_block(name="l2l.body");
+            done_bb = func.append_basic_block(name="l2l.done");
+            b.branch(loop_bb);
+            b.position_at_start(loop_bb);
+            idx = b.phi(i64, name="l2l.idx");
+            idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+            at_end = b.icmp_unsigned(">=", idx, set_len, name="l2l.end");
+            b.cbranch(at_end, done_bb, body_bb);
+            b.position_at_start(body_bb);
+            ep = b.gep(elems_arr, [idx], name="l2l.ep");
+            elem = b.load(ep, name="l2l.elem");
+            b.call(lhelpers["append"], [new_list, elem]);
+            nidx = b.add(idx, ir.Constant(i64, 1), name="l2l.nidx");
+            idx.add_incoming(nidx, body_bb);
+            b.branch(loop_bb);
+            b.position_at_start(done_bb);
+            return new_list;
+        }
+    }
+    # Pass-through: if already a list, copy it
+    for (lk, lhelpers) in p.list_helpers.items() {
+        ltype = p.list_types.get(lk);
+        if ltype is not None and val.type == ltype.as_pointer() {
+            _le = p?._native_emitters?.get("list");
+            if _le is None {
+                return None;
+            }
+            _ctx2 = ctx.__class__(pass_ref=p, type_key=lk);
+            return _le.emit_copy(_ctx2, val, []);
+        }
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_dict(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # dict() with no args -> empty dict; dict(other_dict) -> copy
+    p = ctx.pass_ref;
+    b = p.builder;
+    if not args {
+        # Empty dict: create a new dict[str, int] as default
+        p._emit_dict_helpers(
+            "ptr", "i64", ir.IntType(8).as_pointer(), ir.IntType(64), 0
+        );
+        helpers = p.dict_helpers.get("ptr:i64");
+        if helpers is None {
+            return None;
+        }
+        return b.call(helpers["new"], [], name="dctor.new");
+    }
+    # dict(other_dict) -> copy
+    val = args[0];
+    for (dk, dhelpers) in p.dict_helpers.items() {
+        dtype = p.dict_types.get(dk);
+        if dtype is not None and val.type == dtype.as_pointer() {
+            _de = p?._native_emitters?.get("dict");
+            if _de is None {
+                return None;
+            }
+            _ctx2 = ctx.__class__(pass_ref=p, type_key=dk);
+            return _de.emit_copy(_ctx2, val, []);
+        }
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_set(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # set(list) -> new set with all list elements; set(set) -> copy
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i64 = ir.IntType(64);
+    val = args[0];
+    # Convert list to set
+    for (lk, lhelpers) in p.list_helpers.items() {
+        ltype = p.list_types.get(lk);
+        if ltype is not None and val.type == ltype.as_pointer() {
+            p._emit_set_helpers(lk, lhelpers["elem_type"]);
+            shelpers = p.set_helpers.get(lk);
+            if shelpers is None {
+                return None;
+            }
+            new_set = b.call(shelpers["new"], [], name="l2s.new");
+            list_len = b.call(lhelpers["len"], [val], name="l2s.llen");
+            func = b.basic_block.function;
+            entry_bb = b.basic_block;
+            loop_bb = func.append_basic_block(name="l2s.loop");
+            body_bb = func.append_basic_block(name="l2s.body");
+            done_bb = func.append_basic_block(name="l2s.done");
+            b.branch(loop_bb);
+            b.position_at_start(loop_bb);
+            idx = b.phi(i64, name="l2s.idx");
+            idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+            at_end = b.icmp_unsigned(">=", idx, list_len, name="l2s.end");
+            b.cbranch(at_end, done_bb, body_bb);
+            b.position_at_start(body_bb);
+            elem = b.call(lhelpers["get"], [val, idx], name="l2s.elem");
+            b.call(shelpers["add"], [new_set, elem]);
+            nidx = b.add(idx, ir.Constant(i64, 1), name="l2s.nidx");
+            idx.add_incoming(nidx, body_bb);
+            b.branch(loop_bb);
+            b.position_at_start(done_bb);
+            return new_set;
+        }
+    }
+    # Pass-through: if already a set, copy it
+    for (sk, shelpers) in p.set_helpers.items() {
+        stype = p.set_types.get(sk);
+        if stype is not None and val.type == stype.as_pointer() {
+            _se = p?._native_emitters?.get("set");
+            if _se is None {
+                return None;
+            }
+            _ctx2 = ctx.__class__(pass_ref=p, type_key=sk);
+            return _se.emit_copy(_ctx2, val, []);
+        }
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_tuple(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_frozenset(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # frozenset(x) -> same as set(x) since they share LLVM type
+    return self.emit_set(ctx, args);
+}
+
+impl NativeBuiltinEmitter.emit_bytes(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # bytes(list_of_ints) -> i8* string from list elements
+    if not args {
+        return None;
+    }
+    p = ctx.pass_ref;
+    b = p.builder;
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    val = args[0];
+    # bytes(list[int]) -> convert each int element to a byte
+    for (lk, lhelpers) in p.list_helpers.items() {
+        ltype = p.list_types.get(lk);
+        if ltype is not None and val.type == ltype.as_pointer() {
+            list_len = b.call(lhelpers["len"], [val], name="bytes.len");
+            alloc_sz = b.add(list_len, ir.Constant(i64, 1), name="bytes.alloc");
+            buf = b.call(p.rc_alloc_fn, [alloc_sz], name="bytes.buf");
+            func = b.basic_block.function;
+            entry_bb = b.basic_block;
+            loop_bb = func.append_basic_block(name="bytes.loop");
+            body_bb = func.append_basic_block(name="bytes.body");
+            done_bb = func.append_basic_block(name="bytes.done");
+            b.branch(loop_bb);
+            b.position_at_start(loop_bb);
+            idx = b.phi(i64, name="bytes.idx");
+            idx.add_incoming(ir.Constant(i64, 0), entry_bb);
+            at_end = b.icmp_unsigned(">=", idx, list_len, name="bytes.end");
+            b.cbranch(at_end, done_bb, body_bb);
+            b.position_at_start(body_bb);
+            elem = b.call(lhelpers["get"], [val, idx], name="bytes.elem");
+            byte_val = b.trunc(elem, i8, name="bytes.trunc");
+            bp = b.gep(buf, [idx], name="bytes.bp");
+            b.store(byte_val, bp);
+            nidx = b.add(idx, ir.Constant(i64, 1), name="bytes.nidx");
+            idx.add_incoming(nidx, body_bb);
+            b.branch(loop_bb);
+            b.position_at_start(done_bb);
+            # Null-terminate
+            end_ptr = b.gep(buf, [list_len], name="bytes.endptr");
+            b.store(ir.Constant(i8, 0), end_ptr);
+            return buf;
+        }
+    }
+    return None;
+}
+
+impl NativeBuiltinEmitter.emit_bytearray(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    # bytearray(list_of_ints) -> same as bytes: i8* string
+    return self.emit_bytes(ctx, args);
+}
+
+impl NativeBuiltinEmitter.emit_complex(
+    self, ctx: NativeEmitCtx, args: list[ir.Value]
+) -> (ir.Value | None) {
+    return None;
+}

--- a/jac/jaclang/compiler/passes/native/primitives_native.jac
+++ b/jac/jaclang/compiler/passes/native/primitives_native.jac
@@ -35,371 +35,67 @@ obj NativeEmitCtx {
         type_key: str = "";
 }
 
+
 # =============================================================================
 #  Numeric Types
 # =============================================================================
 class NativeIntEmitter(IntEmitter[(ir.Value, NativeEmitCtx)]) {
     def emit_bit_length(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_bit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_to_bytes(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # to_bytes(length, byteorder): convert int to bytes
-        if len(args) < 2 {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        zero64 = ir.Constant(i64, 0);
-        one64 = ir.Constant(i64, 1);
-        eight64 = ir.Constant(i64, 8);
-        mask_ff = ir.Constant(i64, 0xFF);
-        length = args[0];  # i64
-        byteorder = args[1];  # i8* "big" or "little"
-        # Allocate length+1 bytes (null-terminated)
-        alloc_sz = b.add(length, one64, name="tb.alloc.sz");
-        buf = b.call(p.rc_alloc_fn, [alloc_sz], name="tb.buf");
-        # Null-terminate
-        end_ptr = b.gep(buf, [length], name="tb.end");
-        b.store(ir.Constant(i8, 0), end_ptr);
-        # Determine if big-endian: strcmp(byteorder, "big") == 0
-        big_str = p._make_global_string("big");
-        strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
-        cmp_res = b.call(strcmp_fn, [byteorder, big_str], name="tb.cmp");
-        is_big = b.icmp_signed("==", cmp_res, ir.Constant(i32, 0), name="tb.isbig");
-        # Loop: for i in range(length)
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="tb.loop");
-        body_bb = func.append_basic_block(name="tb.body");
-        done_bb = func.append_basic_block(name="tb.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="tb.idx");
-        idx.add_incoming(zero64, entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, length, name="tb.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        # Extract byte: (target >> (i * 8)) & 0xFF
-        shift_amt = b.mul(idx, eight64, name="tb.shift");
-        shifted = b.lshr(target, shift_amt, name="tb.shifted");
-        byte_val = b.and_(shifted, mask_ff, name="tb.byte");
-        byte_i8 = b.trunc(byte_val, i8, name="tb.i8");
-        # Store position: big-endian = length-1-i, little-endian = i
-        big_pos = b.sub(b.sub(length, one64, name="tb.lm1"), idx, name="tb.bigpos");
-        store_pos = b.select(is_big, big_pos, idx, name="tb.pos");
-        byte_ptr = b.gep(buf, [store_pos], name="tb.ptr");
-        b.store(byte_i8, byte_ptr);
-        next_idx = b.add(idx, one64, name="tb.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return buf;
-    }
+    ) -> (ir.Value | None);
 
     def emit_as_integer_ratio(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # as_integer_ratio for int: returns (n, 1) as a 2-element tuple
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        one = ir.Constant(i64, 1);
-        tuple_type = ir.LiteralStructType([i64, i64]);
-        null_ptr = ir.Constant(tuple_type.as_pointer(), None);
-        size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="iair.sizeof.gep");
-        size = b.ptrtoint(size_gep, i64, name="iair.sizeof");
-        raw_ptr = b.call(p.rc_alloc_fn, [size], name="iair.alloc");
-        tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="iair.ptr");
-        n_ptr = b.gep(
-            tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="iair.n.ptr"
-        );
-        d_ptr = b.gep(
-            tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="iair.d.ptr"
-        );
-        b.store(target, n_ptr);
-        b.store(one, d_ptr);
-        tkey = "i64.i64";
-        if tkey not in p.tuple_types {
-            p.tuple_types[tkey] = tuple_type;
-        }
-        return tuple_ptr;
-    }
+    ) -> (ir.Value | None);
 
     def emit_bit_length(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # bit_length: number of bits needed to represent abs(target), excluding sign and leading zeros
-        # 0.bit_length() == 0, 1.bit_length() == 1, 255.bit_length() == 8
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        zero = ir.Constant(i64, 0);
-        one = ir.Constant(i64, 1);
-        # abs(target)
-        is_neg = b.icmp_signed("<", target, zero, name="bitlen.neg");
-        neg_val = b.sub(zero, target, name="bitlen.abs");
-        abs_val = b.select(is_neg, neg_val, target, name="bitlen.absv");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="bitlen.loop");
-        body_bb = func.append_basic_block(name="bitlen.body");
-        done_bb = func.append_basic_block(name="bitlen.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        val = b.phi(i64, name="bitlen.val");
-        count = b.phi(i64, name="bitlen.count");
-        val.add_incoming(abs_val, entry_bb);
-        count.add_incoming(zero, entry_bb);
-        is_zero = b.icmp_unsigned("==", val, zero, name="bitlen.iszero");
-        b.cbranch(is_zero, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        new_val = b.lshr(val, one, name="bitlen.shr");
-        new_count = b.add(count, one, name="bitlen.inc");
-        val.add_incoming(new_val, body_bb);
-        count.add_incoming(new_count, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return count;
-    }
+    ) -> (ir.Value | None);
 
     def emit_bit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # bit_count: number of ones in the binary representation (popcount)
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        zero = ir.Constant(i64, 0);
-        one = ir.Constant(i64, 1);
-        # Use abs value for negative numbers (Python counts bits of magnitude)
-        is_neg = b.icmp_signed("<", target, zero, name="bitcnt.neg");
-        neg_val = b.sub(zero, target, name="bitcnt.abs");
-        abs_val = b.select(is_neg, neg_val, target, name="bitcnt.absv");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="bitcnt.loop");
-        body_bb = func.append_basic_block(name="bitcnt.body");
-        done_bb = func.append_basic_block(name="bitcnt.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        val = b.phi(i64, name="bitcnt.val");
-        count = b.phi(i64, name="bitcnt.count");
-        val.add_incoming(abs_val, entry_bb);
-        count.add_incoming(zero, entry_bb);
-        is_zero = b.icmp_unsigned("==", val, zero, name="bitcnt.iszero");
-        b.cbranch(is_zero, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        bit = b.and_(val, one, name="bitcnt.bit");
-        new_count = b.add(count, bit, name="bitcnt.inc");
-        new_val = b.lshr(val, one, name="bitcnt.shr");
-        val.add_incoming(new_val, body_bb);
-        count.add_incoming(new_count, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return count;
-    }
+    ) -> (ir.Value | None);
 
     def emit_conjugate(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # conjugate of an integer is itself
-        return target;
-    }
+    ) -> (ir.Value | None);
 
     def emit_from_bytes(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # int.from_bytes(bytes_str, byteorder): reconstruct int from bytes (i8*)
-        if len(args) < 2 {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        zero64 = ir.Constant(i64, 0);
-        one64 = ir.Constant(i64, 1);
-        eight64 = ir.Constant(i64, 8);
-        bytes_ptr = args[0];  # i8*
-        byteorder = args[1];  # i8* "big" or "little"
-        # Get length of bytes string
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        length = b.call(strlen_fn, [bytes_ptr], name="fb.len");
-        # Determine if big-endian
-        big_str = p._make_global_string("big");
-        strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
-        cmp_res = b.call(strcmp_fn, [byteorder, big_str], name="fb.cmp");
-        is_big = b.icmp_signed("==", cmp_res, ir.Constant(i32, 0), name="fb.isbig");
-        # Loop: accumulate bytes into result i64
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="fb.loop");
-        body_bb = func.append_basic_block(name="fb.body");
-        done_bb = func.append_basic_block(name="fb.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="fb.idx");
-        result = b.phi(i64, name="fb.result");
-        idx.add_incoming(zero64, entry_bb);
-        result.add_incoming(zero64, entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, length, name="fb.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        # Load byte at idx
-        byte_ptr = b.gep(bytes_ptr, [idx], name="fb.bptr");
-        byte_val = b.load(byte_ptr, name="fb.byte");
-        byte_i64 = b.zext(byte_val, i64, name="fb.ext");
-        # For big-endian: shift_amt = (length - 1 - i) * 8
-        # For little-endian: shift_amt = i * 8
-        big_shift_idx = b.sub(b.sub(length, one64, name="fb.lm1"), idx, name="fb.bidx");
-        shift_idx = b.select(is_big, big_shift_idx, idx, name="fb.sidx");
-        shift_amt = b.mul(shift_idx, eight64, name="fb.shift");
-        shifted = b.shl(byte_i64, shift_amt, name="fb.shifted");
-        new_result = b.or_(result, shifted, name="fb.accum");
-        next_idx = b.add(idx, one64, name="fb.next");
-        idx.add_incoming(next_idx, body_bb);
-        result.add_incoming(new_result, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeFloatEmitter(FloatEmitter[(ir.Value, NativeEmitCtx)]) {
     def emit_is_integer(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # is_integer: True if float has no fractional part
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        # Convert to int and back, compare
-        truncated = b.fptosi(target, i64, name="isint.trunc");
-        roundtripped = b.sitofp(truncated, ir.DoubleType(), name="isint.rt");
-        is_eq = b.fcmp_ordered("==", target, roundtripped, name="isint.eq");
-        return b.zext(is_eq, i64, name="isint.result");
-    }
+    ) -> (ir.Value | None);
 
     def emit_as_integer_ratio(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # as_integer_ratio for float: returns (numerator, denominator) as tuple
-        # Algorithm: multiply by 2 until integer, track denominator
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        f64 = ir.DoubleType();
-        func = b.basic_block.function;
-        # Get floor function
-        floor_fn = p._get_or_declare_extern("floor", f64, [f64]);
-        # Loop: while floor(num) != num, num *= 2, den *= 2
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="fair.loop");
-        body_bb = func.append_basic_block(name="fair.body");
-        done_bb = func.append_basic_block(name="fair.done");
-        two = ir.Constant(f64, 2.0);
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        num_phi = b.phi(f64, name="fair.num");
-        den_phi = b.phi(i64, name="fair.den");
-        num_phi.add_incoming(target, entry_bb);
-        den_phi.add_incoming(ir.Constant(i64, 1), entry_bb);
-        floored = b.call(floor_fn, [num_phi], name="fair.floor");
-        is_int = b.fcmp_ordered("==", num_phi, floored, name="fair.isint");
-        b.cbranch(is_int, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        new_num = b.fmul(num_phi, two, name="fair.num2");
-        new_den = b.mul(den_phi, ir.Constant(i64, 2), name="fair.den2");
-        num_phi.add_incoming(new_num, body_bb);
-        den_phi.add_incoming(new_den, body_bb);
-        b.branch(loop_bb);
-        # Build result tuple
-        b.position_at_start(done_bb);
-        numer = b.fptosi(num_phi, i64, name="fair.numer");
-        tuple_type = ir.LiteralStructType([i64, i64]);
-        null_ptr = ir.Constant(tuple_type.as_pointer(), None);
-        size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="fair.sizeof.gep");
-        size = b.ptrtoint(size_gep, i64, name="fair.sizeof");
-        raw_ptr = b.call(p.rc_alloc_fn, [size], name="fair.alloc");
-        tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="fair.ptr");
-        n_ptr = b.gep(
-            tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="fair.n.ptr"
-        );
-        d_ptr = b.gep(
-            tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="fair.d.ptr"
-        );
-        b.store(numer, n_ptr);
-        b.store(den_phi, d_ptr);
-        tkey = "i64.i64";
-        if tkey not in p.tuple_types {
-            p.tuple_types[tkey] = tuple_type;
-        }
-        return tuple_ptr;
-    }
+    ) -> (ir.Value | None);
 
     def emit_conjugate(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # conjugate of a float is itself
-        return target;
-    }
+    ) -> (ir.Value | None);
 
     def emit_hex(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # float.hex(): return hex representation using C %a format
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        i32 = ir.IntType(32);
-        buf_size = ir.Constant(i64, 64);
-        buf = b.call(p.rc_alloc_fn, [buf_size], name="fhex.buf");
-        fmt = p._make_global_string("%a");
-        snprintf = p._get_or_declare_extern(
-            "snprintf", i32, [i8p, i64, i8p], var_arg=True
-        );
-        b.call(snprintf, [buf, buf_size, fmt, target], name="fhex.len");
-        return buf;
-    }
+    ) -> (ir.Value | None);
 
     def emit_fromhex(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # float.fromhex(s): parse hex float string (C strtod supports hex)
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        f64 = ir.DoubleType();
-        i8p = ir.IntType(8).as_pointer();
-        strtod_fn = p._get_or_declare_extern("strtod", f64, [i8p, i8p.as_pointer()]);
-        null_ptr = ir.Constant(i8p.as_pointer(), None);
-        result = b.call(strtod_fn, [args[0], null_ptr], name="fhex.result");
-        return result;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeBoolEmitter(NativeIntEmitter) {
     """Bool-specific emitter.
@@ -410,37 +106,17 @@ class NativeBoolEmitter(NativeIntEmitter) {
     """
     def emit_op_and(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i1 = ir.IntType(1);
-        lhs = p._coerce_type(target, i1) if target.type != i1 else target;
-        rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
-        return b.and_(lhs, rhs, name="bool.and");
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_or(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i1 = ir.IntType(1);
-        lhs = p._coerce_type(target, i1) if target.type != i1 else target;
-        rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
-        return b.or_(lhs, rhs, name="bool.or");
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_xor(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i1 = ir.IntType(1);
-        lhs = p._coerce_type(target, i1) if target.type != i1 else target;
-        rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
-        return b.xor(lhs, rhs, name="bool.xor");
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeBoolEmitter(NativeIntEmitter) {
     """Bool-specific emitter.
@@ -451,135 +127,68 @@ class NativeBoolEmitter(NativeIntEmitter) {
     """
     def emit_op_and(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i1 = ir.IntType(1);
-        lhs = p._coerce_type(target, i1) if target.type != i1 else target;
-        rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
-        return b.and_(lhs, rhs, name="bool.and");
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_or(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i1 = ir.IntType(1);
-        lhs = p._coerce_type(target, i1) if target.type != i1 else target;
-        rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
-        return b.or_(lhs, rhs, name="bool.or");
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_xor(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i1 = ir.IntType(1);
-        lhs = p._coerce_type(target, i1) if target.type != i1 else target;
-        rhs = p._coerce_type(args[0], i1) if args[0].type != i1 else args[0];
-        return b.xor(lhs, rhs, name="bool.xor");
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeComplexEmitter(ComplexEmitter[(ir.Value, NativeEmitCtx)]) {
     """Helper: load real and imag from a JacComplex pointer."""
-    def _load_parts(self, ctx: NativeEmitCtx, val: ir.Value) -> (tuple | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        z0 = ir.Constant(i32, 0);
-        z1 = ir.Constant(i32, 1);
-        r = b.load(b.gep(val, [z0, z0], name="cx.rp"), name="cx.r");
-        im = b.load(b.gep(val, [z0, z1], name="cx.ip"), name="cx.i");
-        return (r, im);
-    }
+    def _load_parts(self, ctx: NativeEmitCtx, val: ir.Value) -> (tuple | None);
 
     """Helper: create a new JacComplex from real and imag f64 values."""
     def _make_complex(
         self, ctx: NativeEmitCtx, real: ir.Value, imag: ir.Value
-    ) -> ir.Value {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        z0 = ir.Constant(i32, 0);
-        z1 = ir.Constant(i32, 1);
-        ctype = p.complex_struct_type;
-        raw = b.call(p.rc_alloc_fn, [ir.Constant(i64, 16)], name="cx.raw");
-        ptr = b.bitcast(raw, ctype.as_pointer(), name="cx.ptr");
-        b.store(real, b.gep(ptr, [z0, z0], name="cx.srp"));
-        b.store(imag, b.gep(ptr, [z0, z1], name="cx.sip"));
-        return ptr;
-    }
+    ) -> ir.Value;
 
     def emit_conjugate(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        parts = self._load_parts(ctx, target);
-        if parts is None {
-            return None;
-        }
-        (r, im) = parts;
-        ni = ctx.pass_ref.builder.fneg(im, name="conj.ni");
-        return self._make_complex(ctx, r, ni);
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_add(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_sub(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_mul(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_truediv(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_pow(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_eq(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_ne(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_neg(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_pos(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 # =============================================================================
 #  String Types
@@ -588,1551 +197,139 @@ class NativeStrEmitter(StrEmitter[(ir.Value, NativeEmitCtx)]) {
     # Case conversion
     def emit_capitalize(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # Capitalize: uppercase first char, lowercase the rest
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        toupper_fn = p._get_or_declare_extern("toupper", i32, [i32]);
-        tolower_fn = p._get_or_declare_extern("tolower", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="cap.len");
-        alloc_size = b.add(slen, ir.Constant(i64, 1), name="cap.alloc.sz");
-        result = b.call(rc_alloc_fn, [alloc_size], name="cap.buf");
-        is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="cap.empty");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        first_bb = func.append_basic_block(name="cap.first");
-        loop_bb = func.append_basic_block(name="cap.loop");
-        body_bb = func.append_basic_block(name="cap.body");
-        done_bb = func.append_basic_block(name="cap.done");
-        b.cbranch(is_empty, done_bb, first_bb);
-        # Uppercase the first character
-        b.position_at_start(first_bb);
-        first_ch = b.load(target, name="cap.first.ch");
-        first_i32 = b.zext(first_ch, i32, name="cap.first.i32");
-        upper_ch = b.call(toupper_fn, [first_i32], name="cap.first.upper");
-        upper_i8 = b.trunc(upper_ch, i8, name="cap.first.i8");
-        b.store(upper_i8, result);
-        b.branch(loop_bb);
-        # Lowercase remaining characters
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="cap.idx");
-        idx.add_incoming(ir.Constant(i64, 1), first_bb);
-        cond = b.icmp_unsigned("<", idx, slen, name="cap.cond");
-        b.cbranch(cond, body_bb, done_bb);
-        b.position_at_start(body_bb);
-        src_ptr = b.gep(target, [idx], name="cap.src.ptr");
-        ch = b.load(src_ptr, name="cap.ch");
-        ch_i32 = b.zext(ch, i32, name="cap.ch.i32");
-        lower_ch = b.call(tolower_fn, [ch_i32], name="cap.lower");
-        lower_i8 = b.trunc(lower_ch, i8, name="cap.lower.i8");
-        dst_ptr = b.gep(result, [idx], name="cap.dst.ptr");
-        b.store(lower_i8, dst_ptr);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="cap.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        null_ptr = b.gep(result, [slen], name="cap.null.ptr");
-        b.store(ir.Constant(i8, 0), null_ptr);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_casefold(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # casefold is equivalent to lower for ASCII
-        return self._emit_case_transform(ctx, target, "tolower");
-    }
+    ) -> (ir.Value | None);
 
     def emit_lower(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_case_transform(ctx, target, "tolower");
-    }
+    ) -> (ir.Value | None);
 
     def emit_upper(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_case_transform(ctx, target, "toupper");
-    }
+    ) -> (ir.Value | None);
 
     def _emit_case_transform(
         self, ctx: NativeEmitCtx, target: ir.Value, cfunc_name: str
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        slen = b.call(strlen_fn, [target], name="case.len");
-        rc_alloc_fn = p.rc_alloc_fn;
-        alloc_size = b.add(slen, ir.Constant(i64, 1), name="case.alloc.sz");
-        result = b.call(rc_alloc_fn, [alloc_size], name="case.buf");
-        transform_fn = p._get_or_declare_extern(cfunc_name, i32, [i32]);
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="case.loop");
-        body_bb = func.append_basic_block(name="case.body");
-        done_bb = func.append_basic_block(name="case.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="case.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        cond = b.icmp_unsigned("<", idx, slen, name="case.cond");
-        b.cbranch(cond, body_bb, done_bb);
-        b.position_at_start(body_bb);
-        src_ptr = b.gep(target, [idx], name="case.src.ptr");
-        ch = b.load(src_ptr, name="case.ch");
-        ch_i32 = b.zext(ch, i32, name="case.ch.i32");
-        transformed = b.call(transform_fn, [ch_i32], name="case.transformed");
-        ch_out = b.trunc(transformed, i8, name="case.ch.out");
-        dst_ptr = b.gep(result, [idx], name="case.dst.ptr");
-        b.store(ch_out, dst_ptr);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="case.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        null_ptr = b.gep(result, [slen], name="case.null.ptr");
-        b.store(ir.Constant(i8, 0), null_ptr);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_title(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # title: uppercase first char of each word, lowercase rest
-        # Word boundary = after non-alpha character
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        toupper_fn = p._get_or_declare_extern("toupper", i32, [i32]);
-        tolower_fn = p._get_or_declare_extern("tolower", i32, [i32]);
-        isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="title.len");
-        alloc_size = b.add(slen, ir.Constant(i64, 1), name="title.alloc");
-        result = b.call(rc_alloc_fn, [alloc_size], name="title.buf");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="title.loop");
-        body_bb = func.append_basic_block(name="title.body");
-        done_bb = func.append_basic_block(name="title.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="title.idx");
-        at_boundary = b.phi(i64, name="title.boundary");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_boundary.add_incoming(ir.Constant(i64, 1), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="title.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        src_ptr = b.gep(target, [idx], name="title.src.ptr");
-        ch = b.load(src_ptr, name="title.ch");
-        ch_i32 = b.zext(ch, i32, name="title.ch.i32");
-        is_alpha = b.call(isalpha_fn, [ch_i32], name="title.isalpha");
-        is_alpha_bool = b.icmp_signed(
-            "!=", is_alpha, ir.Constant(i32, 0), name="title.isalp"
-        );
-        is_boundary = b.icmp_unsigned(
-            "!=", at_boundary, ir.Constant(i64, 0), name="title.isbnd"
-        );
-        upper_ch = b.call(toupper_fn, [ch_i32], name="title.upper");
-        lower_ch = b.call(tolower_fn, [ch_i32], name="title.lower");
-        should_upper = b.and_(is_boundary, is_alpha_bool, name="title.shup");
-        pick1 = b.select(should_upper, upper_ch, ch_i32, name="title.pick1");
-        should_lower = b.and_(
-            b.not_(is_boundary, name="title.notbnd"), is_alpha_bool, name="title.shlo"
-        );
-        pick2 = b.select(should_lower, lower_ch, pick1, name="title.pick2");
-        out_i8 = b.trunc(pick2, i8, name="title.out");
-        dst_ptr = b.gep(result, [idx], name="title.dst.ptr");
-        b.store(out_i8, dst_ptr);
-        new_boundary = b.select(
-            is_alpha_bool,
-            ir.Constant(i64, 0),
-            ir.Constant(i64, 1),
-            name="title.newbnd"
-        );
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="title.next");
-        idx.add_incoming(next_idx, body_bb);
-        at_boundary.add_incoming(new_boundary, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        null_ptr = b.gep(result, [slen], name="title.null.ptr");
-        b.store(ir.Constant(i8, 0), null_ptr);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_swapcase(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # Swapcase: toupper if lower, tolower if upper
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        toupper_fn = p._get_or_declare_extern("toupper", i32, [i32]);
-        tolower_fn = p._get_or_declare_extern("tolower", i32, [i32]);
-        islower_fn = p._get_or_declare_extern("islower", i32, [i32]);
-        isupper_fn = p._get_or_declare_extern("isupper", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="swap.len");
-        alloc_size = b.add(slen, ir.Constant(i64, 1), name="swap.alloc.sz");
-        result = b.call(rc_alloc_fn, [alloc_size], name="swap.buf");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="swap.loop");
-        body_bb = func.append_basic_block(name="swap.body");
-        done_bb = func.append_basic_block(name="swap.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="swap.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        cond = b.icmp_unsigned("<", idx, slen, name="swap.cond");
-        b.cbranch(cond, body_bb, done_bb);
-        b.position_at_start(body_bb);
-        src_ptr = b.gep(target, [idx], name="swap.src.ptr");
-        ch = b.load(src_ptr, name="swap.ch");
-        ch_i32 = b.zext(ch, i32, name="swap.ch.i32");
-        is_low = b.call(islower_fn, [ch_i32], name="swap.islow");
-        is_low_bool = b.icmp_signed("!=", is_low, ir.Constant(i32, 0), name="swap.islo");
-        upper_ch = b.call(toupper_fn, [ch_i32], name="swap.upper");
-        is_up = b.call(isupper_fn, [ch_i32], name="swap.isup");
-        is_up_bool = b.icmp_signed("!=", is_up, ir.Constant(i32, 0), name="swap.isup.b");
-        lower_ch = b.call(tolower_fn, [ch_i32], name="swap.lower");
-        # If lower -> use upper, elif upper -> use lower, else keep original
-        pick1 = b.select(is_up_bool, lower_ch, ch_i32, name="swap.pick1");
-        pick2 = b.select(is_low_bool, upper_ch, pick1, name="swap.pick2");
-        out_i8 = b.trunc(pick2, i8, name="swap.out");
-        dst_ptr = b.gep(result, [idx], name="swap.dst.ptr");
-        b.store(out_i8, dst_ptr);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="swap.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        null_ptr = b.gep(result, [slen], name="swap.null.ptr");
-        b.store(ir.Constant(i8, 0), null_ptr);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     # Search
     def emit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # Count non-overlapping occurrences of substring using strstr loop
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        sub_len = b.call(strlen_fn, [args[0]], name="cnt.sub.len");
-        null_ptr = ir.Constant(i8p, None);
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="cnt.loop");
-        found_bb = func.append_basic_block(name="cnt.found");
-        done_bb = func.append_basic_block(name="cnt.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        cur_ptr = b.phi(i8p, name="cnt.cur");
-        count = b.phi(i64, name="cnt.count");
-        cur_ptr.add_incoming(target, entry_bb);
-        count.add_incoming(ir.Constant(i64, 0), entry_bb);
-        found = b.call(strstr_fn, [cur_ptr, args[0]], name="cnt.found.ptr");
-        is_null = b.icmp_unsigned("==", found, null_ptr, name="cnt.null");
-        b.cbranch(is_null, done_bb, found_bb);
-        b.position_at_start(found_bb);
-        new_count = b.add(count, ir.Constant(i64, 1), name="cnt.inc");
-        found_int = b.ptrtoint(found, i64, name="cnt.fnd.int");
-        next_int = b.add(found_int, sub_len, name="cnt.next.int");
-        next_ptr = b.inttoptr(next_int, i8p, name="cnt.next.ptr");
-        cur_ptr.add_incoming(next_ptr, found_bb);
-        count.add_incoming(new_count, found_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return count;
-    }
+    ) -> (ir.Value | None);
 
     def emit_find(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        found = b.call(strstr_fn, [target, args[0]], name="find.ptr");
-        null_ptr = ir.Constant(i8p, None);
-        is_null = b.icmp_unsigned("==", found, null_ptr, name="find.null");
-        target_int = b.ptrtoint(target, i64, name="find.tgt.int");
-        found_int = b.ptrtoint(found, i64, name="find.fnd.int");
-        diff = b.sub(found_int, target_int, name="find.diff");
-        return b.select(is_null, ir.Constant(i64, -1), diff, name="find.result");
-    }
+    ) -> (ir.Value | None);
 
     def emit_rfind(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # rfind: find last occurrence of substring, return index or -1
-        # Empty substring returns len(target) matching Python semantics
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        slen = b.call(strlen_fn, [target], name="rfind.slen");
-        sub_len = b.call(strlen_fn, [args[0]], name="rfind.sub.len");
-        null_ptr = ir.Constant(i8p, None);
-        target_int = b.ptrtoint(target, i64, name="rfind.tgt.int");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        # Handle empty substring: return len(target)
-        empty_bb = func.append_basic_block(name="rfind.empty");
-        search_bb = func.append_basic_block(name="rfind.search");
-        loop_bb = func.append_basic_block(name="rfind.loop");
-        found_bb = func.append_basic_block(name="rfind.found");
-        done_bb = func.append_basic_block(name="rfind.done");
-        is_empty = b.icmp_unsigned(
-            "==", sub_len, ir.Constant(i64, 0), name="rfind.isempty"
-        );
-        b.cbranch(is_empty, empty_bb, search_bb);
-        b.position_at_start(empty_bb);
-        b.branch(done_bb);
-        b.position_at_start(search_bb);
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        cur_ptr = b.phi(i8p, name="rfind.cur");
-        last_pos = b.phi(i64, name="rfind.last");
-        cur_ptr.add_incoming(target, search_bb);
-        last_pos.add_incoming(ir.Constant(i64, -1), search_bb);
-        found = b.call(strstr_fn, [cur_ptr, args[0]], name="rfind.found.ptr");
-        is_null = b.icmp_unsigned("==", found, null_ptr, name="rfind.null");
-        b.cbranch(is_null, done_bb, found_bb);
-        b.position_at_start(found_bb);
-        found_int = b.ptrtoint(found, i64, name="rfind.fnd.int");
-        new_pos = b.sub(found_int, target_int, name="rfind.pos");
-        next_int = b.add(found_int, sub_len, name="rfind.next.int");
-        next_ptr = b.inttoptr(next_int, i8p, name="rfind.next.ptr");
-        cur_ptr.add_incoming(next_ptr, found_bb);
-        last_pos.add_incoming(new_pos, found_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="rfind.result");
-        result.add_incoming(slen, empty_bb);
-        result.add_incoming(last_pos, loop_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_index(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # index: like find but raises ValueError if not found
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        found = b.call(strstr_fn, [target, args[0]], name="index.ptr");
-        null_ptr = ir.Constant(i8p, None);
-        is_null = b.icmp_unsigned("==", found, null_ptr, name="index.null");
-        p._emit_runtime_raise(is_null, "ValueError", "substring not found");
-        target_int = b.ptrtoint(target, i64, name="index.tgt.int");
-        found_int = b.ptrtoint(found, i64, name="index.fnd.int");
-        return b.sub(found_int, target_int, name="index.result");
-    }
+    ) -> (ir.Value | None);
 
     def emit_rindex(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # rindex: like rfind but raises ValueError if not found
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        # Reuse rfind logic
-        rfind_result = self.emit_rfind(ctx, target, args);
-        if rfind_result is None {
-            return None;
-        }
-        is_neg = b.icmp_signed(
-            "<", rfind_result, ir.Constant(i64, 0), name="rindex.neg"
-        );
-        p._emit_runtime_raise(is_neg, "ValueError", "substring not found");
-        return rfind_result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_startswith(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strncmp_fn = p._get_or_declare_extern("strncmp", i32, [i8p, i8p, i64]);
-        prefix_len = b.call(strlen_fn, [args[0]], name="sw.pfx.len");
-        cmp = b.call(strncmp_fn, [target, args[0], prefix_len], name="sw.cmp");
-        is_zero = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="sw.eq");
-        return b.zext(is_zero, i64, name="sw.result");
-    }
+    ) -> (ir.Value | None);
 
     def emit_endswith(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
-        target_len = b.call(strlen_fn, [target], name="ew.tgt.len");
-        suffix_len = b.call(strlen_fn, [args[0]], name="ew.sfx.len");
-        too_long = b.icmp_unsigned(">", suffix_len, target_len, name="ew.toolong");
-        offset = b.sub(target_len, suffix_len, name="ew.offset");
-        end_ptr = b.gep(target, [offset], name="ew.end.ptr");
-        cmp = b.call(strcmp_fn, [end_ptr, args[0]], name="ew.cmp");
-        is_match = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="ew.match");
-        match_i64 = b.zext(is_match, i64, name="ew.match.i64");
-        return b.select(too_long, ir.Constant(i64, 0), match_i64, name="ew.result");
-    }
+    ) -> (ir.Value | None);
 
     # Modification
     def emit_replace(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # replace(old, new[, count])
-        # count < 0 or omitted means replace all occurrences.
-        # count == 0 means replace nothing.
-        # count > 0 means replace at most that many occurrences.
-        if len(args) < 2 {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        old_str = args[0];
-        new_str = args[1];
-        # count_val: use the third arg if provided, else -1 (unlimited sentinel).
-        # The loop checks remaining == 0 to stop; -1 decrements to -2, -3, ...
-        # and never reaches 0, so unlimited behaviour is preserved.
-        count_val: ir.Value = ir.Constant(i64, -1) if len(args) < 3 else args[2];
-        target_len = b.call(strlen_fn, [target], name="repl.tgt.len");
-        old_len = b.call(strlen_fn, [old_str], name="repl.old.len");
-        new_len = b.call(strlen_fn, [new_str], name="repl.new.len");
-        # Worst-case allocation: every char replaced
-        generous_factor = b.add(new_len, ir.Constant(i64, 1), name="repl.factor");
-        generous_size = b.mul(target_len, generous_factor, name="repl.generous");
-        alloc_size = b.add(generous_size, ir.Constant(i64, 1), name="repl.alloc");
-        result = b.call(rc_alloc_fn, [alloc_size], name="repl.buf");
-        null_ptr = ir.Constant(i8p, None);
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="repl.loop");
-        found_bb = func.append_basic_block(name="repl.found");
-        notfound_bb = func.append_basic_block(name="repl.notfound");
-        done_bb = func.append_basic_block(name="repl.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        src = b.phi(i8p, name="repl.src");
-        dst_off = b.phi(i64, name="repl.dst.off");
-        remaining = b.phi(i64, name="repl.remaining");
-        src.add_incoming(target, entry_bb);
-        dst_off.add_incoming(ir.Constant(i64, 0), entry_bb);
-        remaining.add_incoming(count_val, entry_bb);
-        # Stop replacing when count is exhausted (remaining == 0).
-        count_exhausted = b.icmp_signed(
-            "==", remaining, ir.Constant(i64, 0), name="repl.exhausted"
-        );
-        found = b.call(strstr_fn, [src, old_str], name="repl.found.ptr");
-        is_null = b.icmp_unsigned("==", found, null_ptr, name="repl.null");
-        no_replace = b.or_(count_exhausted, is_null, name="repl.no.repl");
-        b.cbranch(no_replace, notfound_bb, found_bb);
-        b.position_at_start(found_bb);
-        src_int = b.ptrtoint(src, i64, name="repl.src.int");
-        found_int = b.ptrtoint(found, i64, name="repl.fnd.int");
-        prefix_len = b.sub(found_int, src_int, name="repl.pfx.len");
-        dst_ptr = b.gep(result, [dst_off], name="repl.dst.ptr");
-        b.call(memcpy_fn, [dst_ptr, src, prefix_len]);
-        dst_off2 = b.add(dst_off, prefix_len, name="repl.off2");
-        dst_ptr2 = b.gep(result, [dst_off2], name="repl.dst.ptr2");
-        b.call(memcpy_fn, [dst_ptr2, new_str, new_len]);
-        dst_off3 = b.add(dst_off2, new_len, name="repl.off3");
-        next_src_int = b.add(found_int, old_len, name="repl.next.int");
-        next_src = b.inttoptr(next_src_int, i8p, name="repl.next.src");
-        # Decrement remaining; -1 wraps to -2, -3, ... (never hits 0 → unlimited).
-        next_remaining = b.sub(remaining, ir.Constant(i64, 1), name="repl.next.rem");
-        src.add_incoming(next_src, found_bb);
-        dst_off.add_incoming(dst_off3, found_bb);
-        remaining.add_incoming(next_remaining, found_bb);
-        b.branch(loop_bb);
-        b.position_at_start(notfound_bb);
-        remain_len = b.call(strlen_fn, [src], name="repl.remain.len");
-        dst_ptr3 = b.gep(result, [dst_off], name="repl.dst.ptr3");
-        b.call(memcpy_fn, [dst_ptr3, src, remain_len]);
-        final_len = b.add(dst_off, remain_len, name="repl.final.len");
-        null_term = b.gep(result, [final_len], name="repl.null.term");
-        b.store(ir.Constant(i8, 0), null_term);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_strip(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return ctx.pass_ref._codegen_str_strip(target);
-    }
+    ) -> (ir.Value | None);
 
     def emit_lstrip(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # lstrip: skip leading whitespace, return new string
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        isspace_fn = p._get_or_declare_extern("isspace", i32, [i32]);
-        strcpy_fn = p._get_or_declare_extern("strcpy", i8p, [i8p, i8p]);
-        slen = b.call(strlen_fn, [target], name="lstrip.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="lstrip.loop");
-        body_bb = func.append_basic_block(name="lstrip.body");
-        done_bb = func.append_basic_block(name="lstrip.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="lstrip.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="lstrip.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name="lstrip.ch.ptr");
-        ch = b.load(ch_ptr, name="lstrip.ch");
-        ch_i32 = b.zext(ch, i32, name="lstrip.ch.i32");
-        is_sp = b.call(isspace_fn, [ch_i32], name="lstrip.issp");
-        is_sp_bool = b.icmp_signed(
-            "!=", is_sp, ir.Constant(i32, 0), name="lstrip.issp.b"
-        );
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="lstrip.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(is_sp_bool, loop_bb, done_bb);
-        b.position_at_start(done_bb);
-        start = b.phi(i64, name="lstrip.start");
-        start.add_incoming(idx, loop_bb);
-        start.add_incoming(idx, body_bb);
-        new_len = b.sub(slen, start, name="lstrip.newlen");
-        alloc_size = b.add(new_len, ir.Constant(i64, 1), name="lstrip.alloc");
-        result = b.call(rc_alloc_fn, [alloc_size], name="lstrip.buf");
-        start_ptr = b.gep(target, [start], name="lstrip.start.ptr");
-        b.call(strcpy_fn, [result, start_ptr]);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rstrip(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # rstrip: remove trailing whitespace
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        isspace_fn = p._get_or_declare_extern("isspace", i32, [i32]);
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        slen = b.call(strlen_fn, [target], name="rstrip.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="rstrip.loop");
-        body_bb = func.append_basic_block(name="rstrip.body");
-        done_bb = func.append_basic_block(name="rstrip.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        end = b.phi(i64, name="rstrip.end");
-        end.add_incoming(slen, entry_bb);
-        is_zero = b.icmp_unsigned("==", end, ir.Constant(i64, 0), name="rstrip.iszero");
-        b.cbranch(is_zero, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        prev = b.sub(end, ir.Constant(i64, 1), name="rstrip.prev");
-        ch_ptr = b.gep(target, [prev], name="rstrip.ch.ptr");
-        ch = b.load(ch_ptr, name="rstrip.ch");
-        ch_i32 = b.zext(ch, i32, name="rstrip.ch.i32");
-        is_sp = b.call(isspace_fn, [ch_i32], name="rstrip.issp");
-        is_sp_bool = b.icmp_signed(
-            "!=", is_sp, ir.Constant(i32, 0), name="rstrip.issp.b"
-        );
-        end.add_incoming(prev, body_bb);
-        b.cbranch(is_sp_bool, loop_bb, done_bb);
-        b.position_at_start(done_bb);
-        final_end = b.phi(i64, name="rstrip.final.end");
-        final_end.add_incoming(end, loop_bb);
-        final_end.add_incoming(end, body_bb);
-        alloc_size = b.add(final_end, ir.Constant(i64, 1), name="rstrip.alloc");
-        result = b.call(rc_alloc_fn, [alloc_size], name="rstrip.buf");
-        b.call(memcpy_fn, [result, target, final_end]);
-        null_ptr = b.gep(result, [final_end], name="rstrip.null.ptr");
-        b.store(ir.Constant(i8, 0), null_ptr);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_removeprefix(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strncmp_fn = p._get_or_declare_extern("strncmp", i32, [i8p, i8p, i64]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        strcpy_fn = p._get_or_declare_extern("strcpy", i8p, [i8p, i8p]);
-        prefix_len = b.call(strlen_fn, [args[0]], name="rmpfx.pfx.len");
-        target_len = b.call(strlen_fn, [target], name="rmpfx.tgt.len");
-        too_long = b.icmp_unsigned(">", prefix_len, target_len, name="rmpfx.toolong");
-        func = b.basic_block.function;
-        check_bb = func.append_basic_block(name="rmpfx.check");
-        match_bb = func.append_basic_block(name="rmpfx.match");
-        nomatch_bb = func.append_basic_block(name="rmpfx.nomatch");
-        done_bb = func.append_basic_block(name="rmpfx.done");
-        b.cbranch(too_long, nomatch_bb, check_bb);
-        b.position_at_start(check_bb);
-        cmp = b.call(strncmp_fn, [target, args[0], prefix_len], name="rmpfx.cmp");
-        is_match = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="rmpfx.eq");
-        b.cbranch(is_match, match_bb, nomatch_bb);
-        # Matched: return target + prefix_len
-        b.position_at_start(match_bb);
-        rest_len = b.sub(target_len, prefix_len, name="rmpfx.rest.len");
-        alloc_m = b.add(rest_len, ir.Constant(i64, 1), name="rmpfx.alloc.m");
-        result_m = b.call(rc_alloc_fn, [alloc_m], name="rmpfx.buf.m");
-        rest_ptr = b.gep(target, [prefix_len], name="rmpfx.rest.ptr");
-        b.call(strcpy_fn, [result_m, rest_ptr]);
-        b.branch(done_bb);
-        # Not matched: return copy of original
-        b.position_at_start(nomatch_bb);
-        alloc_n = b.add(target_len, ir.Constant(i64, 1), name="rmpfx.alloc.n");
-        result_n = b.call(rc_alloc_fn, [alloc_n], name="rmpfx.buf.n");
-        b.call(strcpy_fn, [result_n, target]);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i8p, name="rmpfx.result");
-        result_phi.add_incoming(result_m, match_bb);
-        result_phi.add_incoming(result_n, nomatch_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     def emit_removesuffix(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strcmp_fn = p._get_or_declare_extern("strcmp", i32, [i8p, i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        suffix_len = b.call(strlen_fn, [args[0]], name="rmsfx.sfx.len");
-        target_len = b.call(strlen_fn, [target], name="rmsfx.tgt.len");
-        too_long = b.icmp_unsigned(">", suffix_len, target_len, name="rmsfx.toolong");
-        func = b.basic_block.function;
-        check_bb = func.append_basic_block(name="rmsfx.check");
-        match_bb = func.append_basic_block(name="rmsfx.match");
-        nomatch_bb = func.append_basic_block(name="rmsfx.nomatch");
-        done_bb = func.append_basic_block(name="rmsfx.done");
-        b.cbranch(too_long, nomatch_bb, check_bb);
-        b.position_at_start(check_bb);
-        offset = b.sub(target_len, suffix_len, name="rmsfx.offset");
-        end_ptr = b.gep(target, [offset], name="rmsfx.end.ptr");
-        cmp = b.call(strcmp_fn, [end_ptr, args[0]], name="rmsfx.cmp");
-        is_match = b.icmp_signed("==", cmp, ir.Constant(i32, 0), name="rmsfx.eq");
-        b.cbranch(is_match, match_bb, nomatch_bb);
-        # Matched: copy without suffix
-        b.position_at_start(match_bb);
-        new_len = b.sub(target_len, suffix_len, name="rmsfx.newlen");
-        alloc_m = b.add(new_len, ir.Constant(i64, 1), name="rmsfx.alloc.m");
-        result_m = b.call(rc_alloc_fn, [alloc_m], name="rmsfx.buf.m");
-        b.call(memcpy_fn, [result_m, target, new_len]);
-        null_ptr_m = b.gep(result_m, [new_len], name="rmsfx.null.m");
-        b.store(ir.Constant(i8, 0), null_ptr_m);
-        b.branch(done_bb);
-        # Not matched: copy original
-        b.position_at_start(nomatch_bb);
-        alloc_n = b.add(target_len, ir.Constant(i64, 1), name="rmsfx.alloc.n");
-        result_n = b.call(rc_alloc_fn, [alloc_n], name="rmsfx.buf.n");
-        b.call(memcpy_fn, [result_n, target, target_len]);
-        null_ptr_n = b.gep(result_n, [target_len], name="rmsfx.null.n");
-        b.store(ir.Constant(i8, 0), null_ptr_n);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i8p, name="rmsfx.result");
-        result_phi.add_incoming(result_m, match_bb);
-        result_phi.add_incoming(result_n, nomatch_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     # Split and join
     def emit_split(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if args {
-            return ctx.pass_ref._codegen_str_split(target, args[0]);
-        }
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rsplit(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # rsplit(sep) without maxsplit: same result as split(sep)
-        if args {
-            return ctx.pass_ref._codegen_str_split(target, args[0]);
-        }
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_splitlines(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # splitlines(): split on "\n" separator
-        p = ctx.pass_ref;
-        nl_sep = p._make_global_string("\n", name_prefix=".nl.sep");
-        return p._codegen_str_split(target, nl_sep);
-    }
+    ) -> (ir.Value | None);
 
     def emit_join(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # join(list): concatenate list elements with separator (target)
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        zero = ir.Constant(i64, 0);
-        one = ir.Constant(i64, 1);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        # Ensure list helpers for "ptr" (string list)
-        p._emit_list_helpers("ptr", i8p);
-        lhelpers = p.list_helpers.get("ptr");
-        if lhelpers is None {
-            return None;
-        }
-        the_list = args[0];
-        sep_len = b.call(strlen_fn, [target], name="jn.seplen");
-        list_len = b.call(lhelpers["len"], [the_list], name="jn.listlen");
-        func = b.basic_block.function;
-        # Check if list is empty
-        is_empty = b.icmp_unsigned("==", list_len, zero, name="jn.isempty");
-        empty_bb = func.append_basic_block(name="jn.empty");
-        pass1_bb = func.append_basic_block(name="jn.pass1");
-        done_bb = func.append_basic_block(name="jn.done");
-        b.cbranch(is_empty, empty_bb, pass1_bb);
-        # Empty list: return empty string
-        b.position_at_start(empty_bb);
-        empty_buf = b.call(rc_alloc_fn, [one], name="jn.empty.buf");
-        b.store(ir.Constant(i8, 0), empty_buf);
-        b.branch(done_bb);
-        # Pass 1: compute total length
-        b.position_at_start(pass1_bb);
-        entry_p1 = b.basic_block;
-        loop1_bb = func.append_basic_block(name="jn.len.loop");
-        body1_bb = func.append_basic_block(name="jn.len.body");
-        pass2_start = func.append_basic_block(name="jn.p2start");
-        b.branch(loop1_bb);
-        b.position_at_start(loop1_bb);
-        p1_idx = b.phi(i64, name="jn.p1.idx");
-        p1_total = b.phi(i64, name="jn.p1.total");
-        p1_idx.add_incoming(zero, entry_p1);
-        p1_total.add_incoming(zero, entry_p1);
-        p1_end = b.icmp_unsigned(">=", p1_idx, list_len, name="jn.p1.end");
-        b.cbranch(p1_end, pass2_start, body1_bb);
-        b.position_at_start(body1_bb);
-        elem = b.call(lhelpers["get"], [the_list, p1_idx], name="jn.p1.elem");
-        elen = b.call(strlen_fn, [elem], name="jn.p1.elen");
-        new_total = b.add(p1_total, elen, name="jn.p1.ntot");
-        next_p1 = b.add(p1_idx, one, name="jn.p1.next");
-        p1_idx.add_incoming(next_p1, body1_bb);
-        p1_total.add_incoming(new_total, body1_bb);
-        b.branch(loop1_bb);
-        # Calculate total with separators
-        b.position_at_start(pass2_start);
-        total_phi = b.phi(i64, name="jn.total");
-        total_phi.add_incoming(p1_total, loop1_bb);
-        sep_count = b.sub(list_len, one, name="jn.sepcount");
-        sep_total = b.mul(sep_len, sep_count, name="jn.septotal");
-        grand_total = b.add(total_phi, sep_total, name="jn.grand");
-        alloc_sz = b.add(grand_total, one, name="jn.alloc");
-        buf = b.call(rc_alloc_fn, [alloc_sz], name="jn.buf");
-        # Pass 2: copy elements with separator
-        entry_p2 = b.basic_block;
-        loop2_bb = func.append_basic_block(name="jn.cp.loop");
-        body2_bb = func.append_basic_block(name="jn.cp.body");
-        sep_check = func.append_basic_block(name="jn.cp.sep");
-        sep_copy = func.append_basic_block(name="jn.cp.sepcopy");
-        next_iter = func.append_basic_block(name="jn.cp.next");
-        copy_done = func.append_basic_block(name="jn.cp.done");
-        b.branch(loop2_bb);
-        b.position_at_start(loop2_bb);
-        p2_idx = b.phi(i64, name="jn.p2.idx");
-        p2_off = b.phi(i64, name="jn.p2.off");
-        p2_idx.add_incoming(zero, entry_p2);
-        p2_off.add_incoming(zero, entry_p2);
-        p2_end = b.icmp_unsigned(">=", p2_idx, list_len, name="jn.p2.end");
-        b.cbranch(p2_end, copy_done, body2_bb);
-        b.position_at_start(body2_bb);
-        elem2 = b.call(lhelpers["get"], [the_list, p2_idx], name="jn.p2.elem");
-        elen2 = b.call(strlen_fn, [elem2], name="jn.p2.elen");
-        dst2 = b.gep(buf, [p2_off], name="jn.p2.dst");
-        b.call(memcpy_fn, [dst2, elem2, elen2]);
-        off_after_elem = b.add(p2_off, elen2, name="jn.p2.off2");
-        b.branch(sep_check);
-        # Check if need separator
-        b.position_at_start(sep_check);
-        next_p2 = b.add(p2_idx, one, name="jn.p2.next");
-        is_last = b.icmp_unsigned(">=", next_p2, list_len, name="jn.p2.islast");
-        b.cbranch(is_last, next_iter, sep_copy);
-        b.position_at_start(sep_copy);
-        sep_dst = b.gep(buf, [off_after_elem], name="jn.p2.sepdst");
-        b.call(memcpy_fn, [sep_dst, target, sep_len]);
-        off_after_sep = b.add(off_after_elem, sep_len, name="jn.p2.off3");
-        b.branch(next_iter);
-        # Merge offset
-        b.position_at_start(next_iter);
-        merged_off = b.phi(i64, name="jn.p2.moff");
-        merged_off.add_incoming(off_after_elem, sep_check);
-        merged_off.add_incoming(off_after_sep, sep_copy);
-        p2_idx.add_incoming(next_p2, next_iter);
-        p2_off.add_incoming(merged_off, next_iter);
-        b.branch(loop2_bb);
-        # Null-terminate
-        b.position_at_start(copy_done);
-        final_off = b.phi(i64, name="jn.final.off");
-        final_off.add_incoming(p2_off, loop2_bb);
-        null_p = b.gep(buf, [final_off], name="jn.null");
-        b.store(ir.Constant(i8, 0), null_p);
-        b.branch(done_bb);
-        # Done
-        b.position_at_start(done_bb);
-        result = b.phi(i8p, name="jn.result");
-        result.add_incoming(empty_buf, empty_bb);
-        result.add_incoming(buf, copy_done);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_partition(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # partition(sep) -> list[str] of [before, sep_or_empty, after_or_empty]
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        i32 = ir.IntType(32);
-        sep_val = args[0];
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        p._emit_list_helpers("ptr", i8p);
-        lh = p.list_helpers.get("ptr");
-        if lh is None {
-            return None;
-        }
-        result_list = b.call(lh["new"], [], name="part.list");
-        sep_len = b.call(strlen_fn, [sep_val], name="part.seplen");
-        str_len = b.call(strlen_fn, [target], name="part.strlen");
-        found_ptr = b.call(strstr_fn, [target, sep_val], name="part.found");
-        null_i8p = ir.Constant(i8p, None);
-        is_found = b.icmp_unsigned("!=", found_ptr, null_i8p, name="part.isfound");
-        func = b.basic_block.function;
-        found_bb = func.append_basic_block(name="part.yes");
-        notfound_bb = func.append_basic_block(name="part.no");
-        merge_bb = func.append_basic_block(name="part.merge");
-        b.cbranch(is_found, found_bb, notfound_bb);
-        # Found: before = [0, offset), sep = args[0], after = offset+sep_len..end
-        b.position_at_start(found_bb);
-        base_int = b.ptrtoint(target, i64, name="part.base");
-        found_int = b.ptrtoint(found_ptr, i64, name="part.fint");
-        before_len = b.sub(found_int, base_int, name="part.blen");
-        before_alloc = b.add(before_len, ir.Constant(i64, 1), name="part.balloc");
-        before_ptr = b.call(p.rc_alloc_fn, [before_alloc], name="part.before");
-        b.call(memcpy_fn, [before_ptr, target, before_len]);
-        before_null = b.gep(before_ptr, [before_len], name="part.bnull");
-        b.store(ir.Constant(i8, 0), before_null);
-        after_off = b.add(before_len, sep_len, name="part.aoff");
-        after_len = b.sub(str_len, after_off, name="part.alen");
-        after_alloc = b.add(after_len, ir.Constant(i64, 1), name="part.aalloc");
-        after_ptr = b.call(p.rc_alloc_fn, [after_alloc], name="part.after");
-        after_src = b.gep(target, [after_off], name="part.asrc");
-        b.call(memcpy_fn, [after_ptr, after_src, after_len]);
-        after_null = b.gep(after_ptr, [after_len], name="part.anull");
-        b.store(ir.Constant(i8, 0), after_null);
-        b.call(lh["append"], [result_list, before_ptr]);
-        b.call(lh["append"], [result_list, sep_val]);
-        b.call(lh["append"], [result_list, after_ptr]);
-        b.branch(merge_bb);
-        # Not found: [target, "", ""]
-        b.position_at_start(notfound_bb);
-        empty1 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="part.e1");
-        b.store(ir.Constant(i8, 0), empty1);
-        empty2 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="part.e2");
-        b.store(ir.Constant(i8, 0), empty2);
-        b.call(lh["append"], [result_list, target]);
-        b.call(lh["append"], [result_list, empty1]);
-        b.call(lh["append"], [result_list, empty2]);
-        b.branch(merge_bb);
-        b.position_at_start(merge_bb);
-        return result_list;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rpartition(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # rpartition(sep) -> list[str] of [before_or_empty, sep_or_empty, after_or_target]
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        sep_val = args[0];
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        p._emit_list_helpers("ptr", i8p);
-        lh = p.list_helpers.get("ptr");
-        if lh is None {
-            return None;
-        }
-        result_list = b.call(lh["new"], [], name="rpart.list");
-        sep_len = b.call(strlen_fn, [sep_val], name="rpart.seplen");
-        str_len = b.call(strlen_fn, [target], name="rpart.strlen");
-        # Find last occurrence: scan forward keeping the latest match
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="rpart.loop");
-        body_bb = func.append_basic_block(name="rpart.body");
-        done_bb = func.append_basic_block(name="rpart.done");
-        found_bb = func.append_basic_block(name="rpart.yes");
-        notfound_bb = func.append_basic_block(name="rpart.no");
-        merge_bb = func.append_basic_block(name="rpart.merge");
-        # Allocate last_match on stack (pointer, null = not found)
-        last_match_alloca = b.alloca(i8p, name="rpart.last");
-        b.store(ir.Constant(i8p, None), last_match_alloca);
-        cur_alloca = b.alloca(i8p, name="rpart.cur");
-        b.store(target, cur_alloca);
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        cur_ptr = b.load(cur_alloca, name="rpart.curp");
-        found_ptr = b.call(strstr_fn, [cur_ptr, sep_val], name="rpart.found");
-        null_i8p = ir.Constant(i8p, None);
-        is_found = b.icmp_unsigned("!=", found_ptr, null_i8p, name="rpart.isf");
-        b.cbranch(is_found, body_bb, done_bb);
-        b.position_at_start(body_bb);
-        b.store(found_ptr, last_match_alloca);
-        next_ptr = b.gep(found_ptr, [ir.Constant(i64, 1)], name="rpart.next");
-        b.store(next_ptr, cur_alloca);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        last_match = b.load(last_match_alloca, name="rpart.last.v");
-        is_any = b.icmp_unsigned("!=", last_match, null_i8p, name="rpart.isany");
-        b.cbranch(is_any, found_bb, notfound_bb);
-        # Found: before = [0, offset), sep = args[0], after = offset+sep_len..end
-        b.position_at_start(found_bb);
-        base_int = b.ptrtoint(target, i64, name="rpart.base");
-        last_int = b.ptrtoint(last_match, i64, name="rpart.lint");
-        before_len = b.sub(last_int, base_int, name="rpart.blen");
-        before_alloc = b.add(before_len, ir.Constant(i64, 1), name="rpart.balloc");
-        before_ptr = b.call(p.rc_alloc_fn, [before_alloc], name="rpart.before");
-        b.call(memcpy_fn, [before_ptr, target, before_len]);
-        before_null = b.gep(before_ptr, [before_len], name="rpart.bnull");
-        b.store(ir.Constant(i8, 0), before_null);
-        after_off = b.add(before_len, sep_len, name="rpart.aoff");
-        after_len = b.sub(str_len, after_off, name="rpart.alen");
-        after_alloc = b.add(after_len, ir.Constant(i64, 1), name="rpart.aalloc");
-        after_ptr = b.call(p.rc_alloc_fn, [after_alloc], name="rpart.after");
-        after_src = b.gep(target, [after_off], name="rpart.asrc");
-        b.call(memcpy_fn, [after_ptr, after_src, after_len]);
-        after_null = b.gep(after_ptr, [after_len], name="rpart.anull");
-        b.store(ir.Constant(i8, 0), after_null);
-        b.call(lh["append"], [result_list, before_ptr]);
-        b.call(lh["append"], [result_list, sep_val]);
-        b.call(lh["append"], [result_list, after_ptr]);
-        b.branch(merge_bb);
-        # Not found: ["", "", target]
-        b.position_at_start(notfound_bb);
-        empty1 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="rpart.e1");
-        b.store(ir.Constant(i8, 0), empty1);
-        empty2 = b.call(p.rc_alloc_fn, [ir.Constant(i64, 1)], name="rpart.e2");
-        b.store(ir.Constant(i8, 0), empty2);
-        b.call(lh["append"], [result_list, empty1]);
-        b.call(lh["append"], [result_list, empty2]);
-        b.call(lh["append"], [result_list, target]);
-        b.branch(merge_bb);
-        b.position_at_start(merge_bb);
-        return result_list;
-    }
+    ) -> (ir.Value | None);
 
     # Formatting and alignment
     def emit_format(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # str.format(*args): replace {} placeholders with string args
-        # Implements by chaining single-replace operations for each arg
-        if not args {
-            return target;  # No args, return template unchanged
-
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        strstr_fn = p._get_or_declare_extern("strstr", i8p, [i8p, i8p]);
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        snprintf_fn = p._get_or_declare_extern(
-            "snprintf", i32, [i8p, i64, i8p], var_arg=True
-        );
-        rc_alloc_fn = p.rc_alloc_fn;
-        placeholder = p._make_global_string("{}");
-        ph_len = ir.Constant(i64, 2);  # strlen("{}")
-        null_ptr = ir.Constant(i8p, None);
-        # Convert each arg to i8* string
-        str_args: list[ir.Value] = [];
-        for arg in args {
-            if isinstance(arg.type, ir.IntType) and arg.type.width > 1 {
-                # Integer: snprintf("%ld", val)
-                buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="fmt.ibuf");
-                fmt_s = p._make_global_string("%ld");
-                b.call(snprintf_fn, [buf, ir.Constant(i64, 32), fmt_s, arg]);
-                str_args.append(buf);
-            } elif isinstance(arg.type, ir.DoubleType) {
-                # Float: snprintf("%g", val)
-                buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="fmt.fbuf");
-                fmt_s = p._make_global_string("%g");
-                b.call(snprintf_fn, [buf, ir.Constant(i64, 32), fmt_s, arg]);
-                str_args.append(buf);
-            } else {
-                # Already i8* (string or pointer)
-                str_args.append(arg);
-            }
-        }
-        # Chain single-replace operations: for each arg, replace first {} with arg_str
-        current = target;
-        for i in range(len(str_args)) {
-            arg_str = str_args[i];
-            arg_len = b.call(strlen_fn, [arg_str], name=f"fmt.a{i}.len");
-            cur_len = b.call(strlen_fn, [current], name=f"fmt.c{i}.len");
-            # Generous allocation: cur_len - 2 + arg_len + 1
-            alloc_sz = b.add(
-                b.sub(cur_len, ph_len, name=f"fmt.sub{i}"),
-                b.add(arg_len, ir.Constant(i64, 1), name=f"fmt.aln{i}"),
-                name=f"fmt.alloc{i}"
-            );
-            result = b.call(rc_alloc_fn, [alloc_sz], name=f"fmt.res{i}");
-            # Find first {} in current
-            found = b.call(strstr_fn, [current, placeholder], name=f"fmt.fnd{i}");
-            is_null = b.icmp_unsigned("==", found, null_ptr, name=f"fmt.null{i}");
-            func = b.basic_block.function;
-            replace_bb = func.append_basic_block(name=f"fmt.repl{i}");
-            skip_bb = func.append_basic_block(name=f"fmt.skip{i}");
-            merge_bb = func.append_basic_block(name=f"fmt.merge{i}");
-            b.cbranch(is_null, skip_bb, replace_bb);
-            # Replace path: copy prefix + arg_str + suffix
-            b.position_at_start(replace_bb);
-            cur_int = b.ptrtoint(current, i64, name=f"fmt.ci{i}");
-            fnd_int = b.ptrtoint(found, i64, name=f"fmt.fi{i}");
-            pfx_len = b.sub(fnd_int, cur_int, name=f"fmt.pfx{i}");
-            b.call(memcpy_fn, [result, current, pfx_len]);
-            dst2 = b.gep(result, [pfx_len], name=f"fmt.d2.{i}");
-            b.call(memcpy_fn, [dst2, arg_str, arg_len]);
-            dst3_off = b.add(pfx_len, arg_len, name=f"fmt.d3o{i}");
-            dst3 = b.gep(result, [dst3_off], name=f"fmt.d3.{i}");
-            sfx_start_int = b.add(fnd_int, ph_len, name=f"fmt.sfxi{i}");
-            sfx_start = b.inttoptr(sfx_start_int, i8p, name=f"fmt.sfx{i}");
-            sfx_len = b.call(strlen_fn, [sfx_start], name=f"fmt.slen{i}");
-            b.call(memcpy_fn, [dst3, sfx_start, sfx_len]);
-            total_len = b.add(dst3_off, sfx_len, name=f"fmt.tlen{i}");
-            null_term = b.gep(result, [total_len], name=f"fmt.nt{i}");
-            b.store(ir.Constant(i8, 0), null_term);
-            b.branch(merge_bb);
-            # Skip path: no {} found, return current unchanged
-            b.position_at_start(skip_bb);
-            # Copy current string to result
-            b.call(memcpy_fn, [result, current, cur_len]);
-            null_term2 = b.gep(result, [cur_len], name=f"fmt.nt2.{i}");
-            b.store(ir.Constant(i8, 0), null_term2);
-            b.branch(merge_bb);
-            b.position_at_start(merge_bb);
-            current = result;
-        }
-        return current;
-    }
+    ) -> (ir.Value | None);
 
     def emit_format_map(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # format_map(mapping): replace {key} placeholders with dict values
-        # Complex: requires runtime dict lookup for each placeholder key
-        # Deferring for now - returns None to fall through
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_center(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # center(width): center string, pad with spaces on both sides
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
-        slen = b.call(strlen_fn, [target], name="center.len");
-        width = args[0];
-        needs_pad = b.icmp_unsigned("<", slen, width, name="center.needspad");
-        func = b.basic_block.function;
-        pad_bb = func.append_basic_block(name="center.pad");
-        nopad_bb = func.append_basic_block(name="center.nopad");
-        done_bb = func.append_basic_block(name="center.done");
-        b.cbranch(needs_pad, pad_bb, nopad_bb);
-        # Pad case: match CPython formula: left = marg//2 + (marg & width & 1)
-        b.position_at_start(pad_bb);
-        total_pad = b.sub(width, slen, name="center.totalpad");
-        half = b.udiv(total_pad, ir.Constant(i64, 2), name="center.half");
-        tp_and_w = b.and_(total_pad, width, name="center.tpw");
-        adj = b.and_(tp_and_w, ir.Constant(i64, 1), name="center.adj");
-        left_pad = b.add(half, adj, name="center.lpad");
-        right_pad = b.sub(total_pad, left_pad, name="center.rpad");
-        alloc_pad = b.add(width, ir.Constant(i64, 1), name="center.alloc");
-        buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="center.buf");
-        # Fill left padding with spaces
-        b.call(memset_fn, [buf_pad, ir.Constant(ir.IntType(32), 32), left_pad]);
-        # Copy string after left padding
-        str_ptr = b.gep(buf_pad, [left_pad], name="center.str.ptr");
-        b.call(memcpy_fn, [str_ptr, target, slen]);
-        # Fill right padding with spaces
-        right_ptr = b.gep(str_ptr, [slen], name="center.rpad.ptr");
-        b.call(memset_fn, [right_ptr, ir.Constant(ir.IntType(32), 32), right_pad]);
-        # Null terminate
-        null_pad = b.gep(buf_pad, [width], name="center.null");
-        b.store(ir.Constant(i8, 0), null_pad);
-        b.branch(done_bb);
-        # No pad: return copy
-        b.position_at_start(nopad_bb);
-        alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="center.alloc.np");
-        buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="center.buf.np");
-        b.call(memcpy_fn, [buf_nopad, target, slen]);
-        null_nopad = b.gep(buf_nopad, [slen], name="center.null.np");
-        b.store(ir.Constant(i8, 0), null_nopad);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i8p, name="center.result");
-        result.add_incoming(buf_pad, pad_bb);
-        result.add_incoming(buf_nopad, nopad_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_ljust(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # ljust(width): left-justify, pad with spaces on right
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
-        slen = b.call(strlen_fn, [target], name="ljust.len");
-        width = args[0];
-        needs_pad = b.icmp_unsigned("<", slen, width, name="ljust.needspad");
-        func = b.basic_block.function;
-        pad_bb = func.append_basic_block(name="ljust.pad");
-        nopad_bb = func.append_basic_block(name="ljust.nopad");
-        done_bb = func.append_basic_block(name="ljust.done");
-        b.cbranch(needs_pad, pad_bb, nopad_bb);
-        # Pad case: copy string + fill spaces
-        b.position_at_start(pad_bb);
-        alloc_pad = b.add(width, ir.Constant(i64, 1), name="ljust.alloc");
-        buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="ljust.buf");
-        b.call(memcpy_fn, [buf_pad, target, slen]);
-        pad_ptr = b.gep(buf_pad, [slen], name="ljust.pad.ptr");
-        pad_len = b.sub(width, slen, name="ljust.pad.len");
-        b.call(memset_fn, [pad_ptr, ir.Constant(ir.IntType(32), 32), pad_len]);
-        null_pad = b.gep(buf_pad, [width], name="ljust.null");
-        b.store(ir.Constant(i8, 0), null_pad);
-        b.branch(done_bb);
-        # No pad: return copy
-        b.position_at_start(nopad_bb);
-        alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="ljust.alloc.np");
-        buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="ljust.buf.np");
-        b.call(memcpy_fn, [buf_nopad, target, slen]);
-        null_nopad = b.gep(buf_nopad, [slen], name="ljust.null.np");
-        b.store(ir.Constant(i8, 0), null_nopad);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i8p, name="ljust.result");
-        result.add_incoming(buf_pad, pad_bb);
-        result.add_incoming(buf_nopad, nopad_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rjust(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # rjust(width): right-justify, pad with spaces on left
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
-        slen = b.call(strlen_fn, [target], name="rjust.len");
-        width = args[0];
-        needs_pad = b.icmp_unsigned("<", slen, width, name="rjust.needspad");
-        func = b.basic_block.function;
-        pad_bb = func.append_basic_block(name="rjust.pad");
-        nopad_bb = func.append_basic_block(name="rjust.nopad");
-        done_bb = func.append_basic_block(name="rjust.done");
-        b.cbranch(needs_pad, pad_bb, nopad_bb);
-        b.position_at_start(pad_bb);
-        alloc_pad = b.add(width, ir.Constant(i64, 1), name="rjust.alloc");
-        buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="rjust.buf");
-        pad_len = b.sub(width, slen, name="rjust.pad.len");
-        b.call(memset_fn, [buf_pad, ir.Constant(ir.IntType(32), 32), pad_len]);
-        str_dst = b.gep(buf_pad, [pad_len], name="rjust.str.dst");
-        b.call(memcpy_fn, [str_dst, target, slen]);
-        null_pad = b.gep(buf_pad, [width], name="rjust.null");
-        b.store(ir.Constant(i8, 0), null_pad);
-        b.branch(done_bb);
-        b.position_at_start(nopad_bb);
-        alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="rjust.alloc.np");
-        buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="rjust.buf.np");
-        b.call(memcpy_fn, [buf_nopad, target, slen]);
-        null_nopad = b.gep(buf_nopad, [slen], name="rjust.null.np");
-        b.store(ir.Constant(i8, 0), null_nopad);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i8p, name="rjust.result");
-        result.add_incoming(buf_pad, pad_bb);
-        result.add_incoming(buf_nopad, nopad_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_zfill(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # zfill(width): pad with '0' on left, keeping sign char
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        memset_fn = p._get_or_declare_extern("memset", i8p, [i8p, ir.IntType(32), i64]);
-        slen = b.call(strlen_fn, [target], name="zfill.len");
-        width = args[0];
-        needs_pad = b.icmp_unsigned("<", slen, width, name="zfill.needspad");
-        func = b.basic_block.function;
-        pad_bb = func.append_basic_block(name="zfill.pad");
-        nopad_bb = func.append_basic_block(name="zfill.nopad");
-        done_bb = func.append_basic_block(name="zfill.done");
-        b.cbranch(needs_pad, pad_bb, nopad_bb);
-        # Pad case: check for sign char
-        b.position_at_start(pad_bb);
-        alloc_pad = b.add(width, ir.Constant(i64, 1), name="zfill.alloc");
-        buf_pad = b.call(rc_alloc_fn, [alloc_pad], name="zfill.buf");
-        first_ch = b.load(target, name="zfill.first");
-        is_plus = b.icmp_unsigned(
-            "==", first_ch, ir.Constant(i8, 43), name="zfill.plus"
-        );
-        is_minus = b.icmp_unsigned(
-            "==", first_ch, ir.Constant(i8, 45), name="zfill.minus"
-        );
-        has_sign = b.or_(is_plus, is_minus, name="zfill.hassign");
-        pad_len = b.sub(width, slen, name="zfill.pad.len");
-        # If sign: write sign char first, then zeros, then rest of string
-        sign_off = b.select(
-            has_sign, ir.Constant(i64, 1), ir.Constant(i64, 0), name="zfill.soff"
-        );
-        # Store sign char at position 0 if present
-        sign_bb = func.append_basic_block(name="zfill.sign");
-        nosign_bb = func.append_basic_block(name="zfill.nosign");
-        merge_bb = func.append_basic_block(name="zfill.merge");
-        b.cbranch(has_sign, sign_bb, nosign_bb);
-        b.position_at_start(sign_bb);
-        b.store(first_ch, buf_pad);
-        b.call(
-            memset_fn,
-            [
-                b.gep(buf_pad, [ir.Constant(i64, 1)], name="zfill.z1"),
-                ir.Constant(ir.IntType(32), 48),
-                pad_len
-            ]
-        );
-        src_rest = b.gep(target, [ir.Constant(i64, 1)], name="zfill.src.rest");
-        rest_len = b.sub(slen, ir.Constant(i64, 1), name="zfill.rest.len");
-        dst_rest = b.gep(
-            buf_pad,
-            [b.add(pad_len, ir.Constant(i64, 1), name="zfill.doff")],
-            name="zfill.dst.rest"
-        );
-        b.call(memcpy_fn, [dst_rest, src_rest, rest_len]);
-        b.branch(merge_bb);
-        b.position_at_start(nosign_bb);
-        b.call(memset_fn, [buf_pad, ir.Constant(ir.IntType(32), 48), pad_len]);
-        dst_nosign = b.gep(buf_pad, [pad_len], name="zfill.dst.ns");
-        b.call(memcpy_fn, [dst_nosign, target, slen]);
-        b.branch(merge_bb);
-        b.position_at_start(merge_bb);
-        null_pad = b.gep(buf_pad, [width], name="zfill.null");
-        b.store(ir.Constant(i8, 0), null_pad);
-        b.branch(done_bb);
-        # No pad: return copy
-        b.position_at_start(nopad_bb);
-        alloc_nopad = b.add(slen, ir.Constant(i64, 1), name="zfill.alloc.np");
-        buf_nopad = b.call(rc_alloc_fn, [alloc_nopad], name="zfill.buf.np");
-        b.call(memcpy_fn, [buf_nopad, target, slen]);
-        null_nopad = b.gep(buf_nopad, [slen], name="zfill.null.np");
-        b.store(ir.Constant(i8, 0), null_nopad);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i8p, name="zfill.result");
-        result.add_incoming(buf_pad, merge_bb);
-        result.add_incoming(buf_nopad, nopad_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_expandtabs(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # expandtabs(tabsize=8): replace tabs with spaces to next tab stop
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        zero = ir.Constant(i64, 0);
-        one = ir.Constant(i64, 1);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        rc_alloc_fn = p.rc_alloc_fn;
-        slen = b.call(strlen_fn, [target], name="et.len");
-        # tabsize: default 8 if no args
-        if args {
-            tabsize = args[0];
-        } else {
-            tabsize = ir.Constant(i64, 8);
-        }
-        # Worst case allocation: every char is a tab → slen * max(tabsize, 1) + 1
-        ts_or_one = b.select(
-            b.icmp_unsigned("==", tabsize, zero), one, tabsize, name="et.ts1"
-        );
-        worst = b.mul(slen, ts_or_one, name="et.worst");
-        alloc_sz = b.add(worst, one, name="et.alloc");
-        buf = b.call(rc_alloc_fn, [alloc_sz], name="et.buf");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="et.loop");
-        check_tab = func.append_basic_block(name="et.check.tab");
-        do_tab = func.append_basic_block(name="et.do.tab");
-        tab_loop = func.append_basic_block(name="et.tab.loop");
-        tab_write = func.append_basic_block(name="et.tab.write");
-        tab_done = func.append_basic_block(name="et.tab.done");
-        check_nl = func.append_basic_block(name="et.check.nl");
-        do_nl = func.append_basic_block(name="et.do.nl");
-        do_char = func.append_basic_block(name="et.do.char");
-        next_bb = func.append_basic_block(name="et.next");
-        done_bb = func.append_basic_block(name="et.done");
-        b.branch(loop_bb);
-        # Main loop header with phi nodes
-        b.position_at_start(loop_bb);
-        si = b.phi(i64, name="et.si");
-        di = b.phi(i64, name="et.di");
-        col = b.phi(i64, name="et.col");
-        si.add_incoming(zero, entry_bb);
-        di.add_incoming(zero, entry_bb);
-        col.add_incoming(zero, entry_bb);
-        # Load current char
-        cp = b.gep(target, [si], name="et.cp");
-        ch = b.load(cp, name="et.ch");
-        is_end = b.icmp_unsigned("==", ch, ir.Constant(i8, 0), name="et.end");
-        b.cbranch(is_end, done_bb, check_tab);
-        # Check if tab char (0x09)
-        b.position_at_start(check_tab);
-        is_tab = b.icmp_unsigned("==", ch, ir.Constant(i8, 9), name="et.istab");
-        b.cbranch(is_tab, do_tab, check_nl);
-        # Tab: calculate spaces = tabsize - (col % tabsize), min 1
-        b.position_at_start(do_tab);
-        is_ts_zero = b.icmp_unsigned("==", tabsize, zero, name="et.ts0");
-        # If tabsize==0, spaces=0; else spaces = tabsize - (col % tabsize)
-        col_mod = b.urem(col, ts_or_one, name="et.colmod");
-        spaces_calc = b.sub(tabsize, col_mod, name="et.spcalc");
-        spaces = b.select(is_ts_zero, zero, spaces_calc, name="et.spaces");
-        b.branch(tab_loop);
-        # Tab fill loop
-        b.position_at_start(tab_loop);
-        ti = b.phi(i64, name="et.ti");
-        di_t = b.phi(i64, name="et.di.t");
-        ti.add_incoming(zero, do_tab);
-        di_t.add_incoming(di, do_tab);
-        ti_done = b.icmp_unsigned(">=", ti, spaces, name="et.tidone");
-        b.cbranch(ti_done, tab_done, tab_write);
-        # Write one space
-        b.position_at_start(tab_write);
-        dp = b.gep(buf, [di_t], name="et.dp.tw");
-        b.store(ir.Constant(i8, 32), dp);
-        next_ti = b.add(ti, one, name="et.nti");
-        next_di_t = b.add(di_t, one, name="et.ndi.t");
-        ti.add_incoming(next_ti, tab_write);
-        di_t.add_incoming(next_di_t, tab_write);
-        b.branch(tab_loop);
-        # After tab fill
-        b.position_at_start(tab_done);
-        new_col_tab = b.add(col, spaces, name="et.col.tab");
-        next_si_tab = b.add(si, one, name="et.si.tab");
-        b.branch(next_bb);
-        # Check newline/carriage return
-        b.position_at_start(check_nl);
-        is_nl = b.icmp_unsigned("==", ch, ir.Constant(i8, 10), name="et.isnl");
-        is_cr = b.icmp_unsigned("==", ch, ir.Constant(i8, 13), name="et.iscr");
-        is_line_end = b.or_(is_nl, is_cr, name="et.isle");
-        b.cbranch(is_line_end, do_nl, do_char);
-        # Newline: copy char, reset column to 0
-        b.position_at_start(do_nl);
-        dp_nl = b.gep(buf, [di], name="et.dp.nl");
-        b.store(ch, dp_nl);
-        next_di_nl = b.add(di, one, name="et.ndi.nl");
-        next_si_nl = b.add(si, one, name="et.si.nl");
-        b.branch(next_bb);
-        # Normal char: copy and increment column
-        b.position_at_start(do_char);
-        dp_ch = b.gep(buf, [di], name="et.dp.ch");
-        b.store(ch, dp_ch);
-        next_di_ch = b.add(di, one, name="et.ndi.ch");
-        next_col_ch = b.add(col, one, name="et.col.ch");
-        next_si_ch = b.add(si, one, name="et.si.ch");
-        b.branch(next_bb);
-        # Merge block for next iteration
-        b.position_at_start(next_bb);
-        new_si = b.phi(i64, name="et.new.si");
-        new_di = b.phi(i64, name="et.new.di");
-        new_col = b.phi(i64, name="et.new.col");
-        new_si.add_incoming(next_si_tab, tab_done);
-        new_si.add_incoming(next_si_nl, do_nl);
-        new_si.add_incoming(next_si_ch, do_char);
-        new_di.add_incoming(di_t, tab_done);
-        new_di.add_incoming(next_di_nl, do_nl);
-        new_di.add_incoming(next_di_ch, do_char);
-        new_col.add_incoming(new_col_tab, tab_done);
-        new_col.add_incoming(zero, do_nl);
-        new_col.add_incoming(next_col_ch, do_char);
-        b.branch(loop_bb);
-        si.add_incoming(new_si, next_bb);
-        di.add_incoming(new_di, next_bb);
-        col.add_incoming(new_col, next_bb);
-        # Done: null-terminate
-        b.position_at_start(done_bb);
-        done_di = b.phi(i64, name="et.done.di");
-        done_di.add_incoming(di, loop_bb);
-        null_p = b.gep(buf, [done_di], name="et.null");
-        b.store(ir.Constant(i8, 0), null_p);
-        return buf;
-    }
+    ) -> (ir.Value | None);
 
     # Character tests
     """Helper: loop over chars, call C ctype function, return 1 if all pass."""
@@ -2143,710 +340,250 @@ class NativeStrEmitter(StrEmitter[(ir.Value, NativeEmitCtx)]) {
         cfunc_name: str,
         prefix: str,
         empty_is_true: bool = False
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        test_fn = p._get_or_declare_extern(cfunc_name, i32, [i32]);
-        slen = b.call(strlen_fn, [target], name=f"{prefix}.len");
-        is_empty = b.icmp_unsigned(
-            "==", slen, ir.Constant(i64, 0), name=f"{prefix}.empty"
-        );
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name=f"{prefix}.loop");
-        body_bb = func.append_basic_block(name=f"{prefix}.body");
-        fail_bb = func.append_basic_block(name=f"{prefix}.fail");
-        pass_bb = func.append_basic_block(name=f"{prefix}.pass");
-        done_bb = func.append_basic_block(name=f"{prefix}.done");
-        if empty_is_true {
-            b.cbranch(is_empty, pass_bb, loop_bb);
-        } else {
-            b.cbranch(is_empty, fail_bb, loop_bb);
-        }
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name=f"{prefix}.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name=f"{prefix}.atend");
-        b.cbranch(at_end, pass_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name=f"{prefix}.ch.ptr");
-        ch = b.load(ch_ptr, name=f"{prefix}.ch");
-        ch_i32 = b.zext(ch, i32, name=f"{prefix}.ch.i32");
-        result = b.call(test_fn, [ch_i32], name=f"{prefix}.test");
-        is_ok = b.icmp_signed("!=", result, ir.Constant(i32, 0), name=f"{prefix}.ok");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name=f"{prefix}.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(is_ok, loop_bb, fail_bb);
-        b.position_at_start(fail_bb);
-        b.branch(done_bb);
-        b.position_at_start(pass_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i64, name=f"{prefix}.final");
-        result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
-        result_phi.add_incoming(ir.Constant(i64, 1), pass_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isalnum(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(ctx, target, "isalnum", "isalnum");
-    }
+    ) -> (ir.Value | None);
 
     def emit_isalpha(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(ctx, target, "isalpha", "isalpha");
-    }
+    ) -> (ir.Value | None);
 
     def emit_isascii(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # isascii: empty string returns True, check each char < 128
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        slen = b.call(strlen_fn, [target], name="isascii.len");
-        is_empty = b.icmp_unsigned(
-            "==", slen, ir.Constant(i64, 0), name="isascii.empty"
-        );
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="isascii.loop");
-        body_bb = func.append_basic_block(name="isascii.body");
-        fail_bb = func.append_basic_block(name="isascii.fail");
-        pass_bb = func.append_basic_block(name="isascii.pass");
-        done_bb = func.append_basic_block(name="isascii.done");
-        b.cbranch(is_empty, pass_bb, loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="isascii.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="isascii.atend");
-        b.cbranch(at_end, pass_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name="isascii.ch.ptr");
-        ch = b.load(ch_ptr, name="isascii.ch");
-        ch_ext = b.zext(ch, i64, name="isascii.ch.ext");
-        is_ok = b.icmp_unsigned("<", ch_ext, ir.Constant(i64, 128), name="isascii.ok");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="isascii.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(is_ok, loop_bb, fail_bb);
-        b.position_at_start(fail_bb);
-        b.branch(done_bb);
-        b.position_at_start(pass_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i64, name="isascii.final");
-        result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
-        result_phi.add_incoming(ir.Constant(i64, 1), pass_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isdecimal(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(ctx, target, "isdigit", "isdecimal");
-    }
+    ) -> (ir.Value | None);
 
     def emit_isdigit(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(ctx, target, "isdigit", "isdigit");
-    }
+    ) -> (ir.Value | None);
 
     def emit_isidentifier(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # isidentifier: non-empty, first char is alpha/underscore, rest are alnum/underscore
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
-        isalnum_fn = p._get_or_declare_extern("isalnum", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="isid.len");
-        is_empty = b.icmp_unsigned("==", slen, ir.Constant(i64, 0), name="isid.empty");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        first_bb = func.append_basic_block(name="isid.first");
-        loop_bb = func.append_basic_block(name="isid.loop");
-        body_bb = func.append_basic_block(name="isid.body");
-        fail_bb = func.append_basic_block(name="isid.fail");
-        pass_bb = func.append_basic_block(name="isid.pass");
-        done_bb = func.append_basic_block(name="isid.done");
-        b.cbranch(is_empty, fail_bb, first_bb);
-        # Check first char: must be alpha or underscore
-        b.position_at_start(first_bb);
-        first_ch = b.load(target, name="isid.first.ch");
-        first_i32 = b.zext(first_ch, i32, name="isid.first.i32");
-        is_alpha = b.call(isalpha_fn, [first_i32], name="isid.first.alpha");
-        is_alpha_ok = b.icmp_signed(
-            "!=", is_alpha, ir.Constant(i32, 0), name="isid.first.aok"
-        );
-        is_underscore = b.icmp_unsigned(
-            "==", first_ch, ir.Constant(i8, 95), name="isid.first.under"
-        );
-        first_ok = b.or_(is_alpha_ok, is_underscore, name="isid.first.ok");
-        b.cbranch(first_ok, loop_bb, fail_bb);
-        # Loop remaining chars
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="isid.idx");
-        idx.add_incoming(ir.Constant(i64, 1), first_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="isid.atend");
-        b.cbranch(at_end, pass_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name="isid.ch.ptr");
-        ch = b.load(ch_ptr, name="isid.ch");
-        ch_i32 = b.zext(ch, i32, name="isid.ch.i32");
-        is_an = b.call(isalnum_fn, [ch_i32], name="isid.isalnum");
-        is_an_ok = b.icmp_signed("!=", is_an, ir.Constant(i32, 0), name="isid.an.ok");
-        is_under = b.icmp_unsigned("==", ch, ir.Constant(i8, 95), name="isid.under");
-        ch_ok = b.or_(is_an_ok, is_under, name="isid.ch.ok");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="isid.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(ch_ok, loop_bb, fail_bb);
-        b.position_at_start(fail_bb);
-        b.branch(done_bb);
-        b.position_at_start(pass_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i64, name="isid.final");
-        result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
-        result_phi.add_incoming(ir.Constant(i64, 1), pass_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     def emit_islower(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # islower: at least one cased char, all cased chars are lowercase
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        isupper_fn = p._get_or_declare_extern("isupper", i32, [i32]);
-        isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="islower.len");
-        is_empty = b.icmp_unsigned(
-            "==", slen, ir.Constant(i64, 0), name="islower.empty"
-        );
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="islower.loop");
-        body_bb = func.append_basic_block(name="islower.body");
-        fail_bb = func.append_basic_block(name="islower.fail");
-        check_bb = func.append_basic_block(name="islower.check");
-        done_bb = func.append_basic_block(name="islower.done");
-        b.cbranch(is_empty, fail_bb, loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="islower.idx");
-        has_cased = b.phi(i64, name="islower.hascased");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        has_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="islower.atend");
-        b.cbranch(at_end, check_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name="islower.ch.ptr");
-        ch = b.load(ch_ptr, name="islower.ch");
-        ch_i32 = b.zext(ch, i32, name="islower.ch.i32");
-        is_upper = b.call(isupper_fn, [ch_i32], name="islower.isupper");
-        is_upper_bool = b.icmp_signed(
-            "!=", is_upper, ir.Constant(i32, 0), name="islower.isup"
-        );
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="islower.next");
-        is_alpha = b.call(isalpha_fn, [ch_i32], name="islower.isalpha");
-        is_alpha_bool = b.icmp_signed(
-            "!=", is_alpha, ir.Constant(i32, 0), name="islower.isalp"
-        );
-        new_cased = b.select(
-            is_alpha_bool, ir.Constant(i64, 1), has_cased, name="islower.newcased"
-        );
-        idx.add_incoming(next_idx, body_bb);
-        has_cased.add_incoming(new_cased, body_bb);
-        b.cbranch(is_upper_bool, fail_bb, loop_bb);
-        b.position_at_start(check_bb);
-        has_any = b.icmp_unsigned(
-            "!=", has_cased, ir.Constant(i64, 0), name="islower.hasany"
-        );
-        b.cbranch(has_any, done_bb, fail_bb);
-        b.position_at_start(fail_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i64, name="islower.final");
-        result_phi.add_incoming(ir.Constant(i64, 1), check_bb);
-        result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isnumeric(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(ctx, target, "isdigit", "isnumeric");
-    }
+    ) -> (ir.Value | None);
 
     def emit_isprintable(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(
-            ctx, target, "isprint", "isprintable", empty_is_true=True
-        );
-    }
+    ) -> (ir.Value | None);
 
     def emit_isspace(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return self._emit_char_test(ctx, target, "isspace", "isspace");
-    }
+    ) -> (ir.Value | None);
 
     def emit_istitle(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # istitle: uppercase chars follow non-cased, lowercase follow cased
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        isupper_fn = p._get_or_declare_extern("isupper", i32, [i32]);
-        islower_fn = p._get_or_declare_extern("islower", i32, [i32]);
-        isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="istitle.len");
-        is_empty = b.icmp_unsigned(
-            "==", slen, ir.Constant(i64, 0), name="istitle.empty"
-        );
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="istitle.loop");
-        body_bb = func.append_basic_block(name="istitle.body");
-        fail_bb = func.append_basic_block(name="istitle.fail");
-        check_bb = func.append_basic_block(name="istitle.check");
-        done_bb = func.append_basic_block(name="istitle.done");
-        b.cbranch(is_empty, fail_bb, loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="istitle.idx");
-        prev_cased = b.phi(i64, name="istitle.prevcased");
-        has_cased = b.phi(i64, name="istitle.hascased");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        prev_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
-        has_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="istitle.atend");
-        b.cbranch(at_end, check_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name="istitle.ch.ptr");
-        ch = b.load(ch_ptr, name="istitle.ch");
-        ch_i32 = b.zext(ch, i32, name="istitle.ch.i32");
-        is_up = b.call(isupper_fn, [ch_i32], name="istitle.isup");
-        is_up_bool = b.icmp_signed(
-            "!=", is_up, ir.Constant(i32, 0), name="istitle.upbool"
-        );
-        is_lo = b.call(islower_fn, [ch_i32], name="istitle.islo");
-        is_lo_bool = b.icmp_signed(
-            "!=", is_lo, ir.Constant(i32, 0), name="istitle.lobool"
-        );
-        is_al = b.call(isalpha_fn, [ch_i32], name="istitle.isal");
-        is_al_bool = b.icmp_signed(
-            "!=", is_al, ir.Constant(i32, 0), name="istitle.albool"
-        );
-        prev_was_cased = b.icmp_unsigned(
-            "!=", prev_cased, ir.Constant(i64, 0), name="istitle.pwc"
-        );
-        upper_after_cased = b.and_(is_up_bool, prev_was_cased, name="istitle.uac");
-        not_prev_cased = b.not_(prev_was_cased, name="istitle.npc");
-        lower_after_noncased = b.and_(is_lo_bool, not_prev_cased, name="istitle.lanc");
-        bad = b.or_(upper_after_cased, lower_after_noncased, name="istitle.bad");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="istitle.next");
-        new_prev = b.select(
-            is_al_bool,
-            ir.Constant(i64, 1),
-            ir.Constant(i64, 0),
-            name="istitle.newprev"
-        );
-        new_has = b.select(
-            is_al_bool, ir.Constant(i64, 1), has_cased, name="istitle.newhas"
-        );
-        idx.add_incoming(next_idx, body_bb);
-        prev_cased.add_incoming(new_prev, body_bb);
-        has_cased.add_incoming(new_has, body_bb);
-        b.cbranch(bad, fail_bb, loop_bb);
-        b.position_at_start(check_bb);
-        has_any = b.icmp_unsigned(
-            "!=", has_cased, ir.Constant(i64, 0), name="istitle.hasany"
-        );
-        b.cbranch(has_any, done_bb, fail_bb);
-        b.position_at_start(fail_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i64, name="istitle.final");
-        result_phi.add_incoming(ir.Constant(i64, 1), check_bb);
-        result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isupper(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # isupper: at least one cased char, all cased chars are uppercase
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        islower_fn = p._get_or_declare_extern("islower", i32, [i32]);
-        isalpha_fn = p._get_or_declare_extern("isalpha", i32, [i32]);
-        slen = b.call(strlen_fn, [target], name="isupper.len");
-        is_empty = b.icmp_unsigned(
-            "==", slen, ir.Constant(i64, 0), name="isupper.empty"
-        );
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="isupper.loop");
-        body_bb = func.append_basic_block(name="isupper.body");
-        fail_bb = func.append_basic_block(name="isupper.fail");
-        check_bb = func.append_basic_block(name="isupper.check");
-        done_bb = func.append_basic_block(name="isupper.done");
-        b.cbranch(is_empty, fail_bb, loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="isupper.idx");
-        has_cased = b.phi(i64, name="isupper.hascased");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        has_cased.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, slen, name="isupper.atend");
-        b.cbranch(at_end, check_bb, body_bb);
-        b.position_at_start(body_bb);
-        ch_ptr = b.gep(target, [idx], name="isupper.ch.ptr");
-        ch = b.load(ch_ptr, name="isupper.ch");
-        ch_i32 = b.zext(ch, i32, name="isupper.ch.i32");
-        is_low = b.call(islower_fn, [ch_i32], name="isupper.islow");
-        is_low_bool = b.icmp_signed(
-            "!=", is_low, ir.Constant(i32, 0), name="isupper.islo"
-        );
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="isupper.next");
-        is_alpha = b.call(isalpha_fn, [ch_i32], name="isupper.isalpha");
-        is_alpha_bool = b.icmp_signed(
-            "!=", is_alpha, ir.Constant(i32, 0), name="isupper.isalp"
-        );
-        new_cased = b.select(
-            is_alpha_bool, ir.Constant(i64, 1), has_cased, name="isupper.newcased"
-        );
-        idx.add_incoming(next_idx, body_bb);
-        has_cased.add_incoming(new_cased, body_bb);
-        b.cbranch(is_low_bool, fail_bb, loop_bb);
-        b.position_at_start(check_bb);
-        has_any = b.icmp_unsigned(
-            "!=", has_cased, ir.Constant(i64, 0), name="isupper.hasany"
-        );
-        b.cbranch(has_any, done_bb, fail_bb);
-        b.position_at_start(fail_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result_phi = b.phi(i64, name="isupper.final");
-        result_phi.add_incoming(ir.Constant(i64, 1), check_bb);
-        result_phi.add_incoming(ir.Constant(i64, 0), fail_bb);
-        return result_phi;
-    }
+    ) -> (ir.Value | None);
 
     # Encoding
     def emit_encode(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # encode(): in native, strings are already UTF-8 i8* — return as-is
-        return target;
-    }
+    ) -> (ir.Value | None);
 
     # Translation
     def emit_translate(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_maketrans(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeBytesEmitter(BytesEmitter[(ir.Value, NativeEmitCtx)]) {
     # Decoding
     def emit_decode(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_hex(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_fromhex(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Search
     def emit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_find(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rfind(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_index(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rindex(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_startswith(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_endswith(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Modification
     def emit_replace(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_strip(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_lstrip(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rstrip(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_removeprefix(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_removesuffix(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Split and join
     def emit_split(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rsplit(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_splitlines(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_join(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_partition(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rpartition(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Case (ASCII only)
     def emit_capitalize(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_lower(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_upper(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_title(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_swapcase(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Character tests (ASCII only)
     def emit_isalnum(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isalpha(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isascii(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isdigit(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_islower(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isspace(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_istitle(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isupper(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Alignment
     def emit_center(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_ljust(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_rjust(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_zfill(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_expandtabs(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     # Translation
     def emit_translate(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_maketrans(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 # =============================================================================
 #  Collection Types
@@ -2854,2364 +591,273 @@ class NativeBytesEmitter(BytesEmitter[(ir.Value, NativeEmitCtx)]) {
 class NativeListEmitter(ListEmitter[(ir.Value, NativeEmitCtx)]) {
     def emit_append(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None or not args {
-            return None;
-        }
-        val = p._box_value_tuple(args[0]);
-        val = p._coerce_type(val, helpers["elem_type"]);
-        p.builder.call(helpers["append"], [target, val]);
-        return ir.Constant(ir.IntType(64), 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_extend(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # extend: iterate source list, append each element
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        src = args[0];
-        src_len_ptr = b.gep(
-            src, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ext.src.len.ptr"
-        );
-        src_len = b.load(src_len_ptr, name="ext.src.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="ext.loop");
-        body_bb = func.append_basic_block(name="ext.body");
-        done_bb = func.append_basic_block(name="ext.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="ext.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, src_len, name="ext.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        elem = b.call(helpers["get"], [src, idx], name="ext.elem");
-        b.call(helpers["append"], [target, elem]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="ext.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_insert(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # insert(index, value): shift elements right, set at index
-        if len(args) < 2 {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        insert_idx = args[0];
-        insert_val = p._coerce_type(args[1], helpers["elem_type"]);
-        # First append a dummy to grow the list
-        b.call(helpers["append"], [target, insert_val]);
-        # Get the new length
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ins.len.ptr"
-        );
-        new_len = b.load(len_ptr, name="ins.newlen");
-        last_idx = b.sub(new_len, ir.Constant(i64, 1), name="ins.last");
-        # Shift elements right from end to insert_idx
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="ins.loop");
-        body_bb = func.append_basic_block(name="ins.body");
-        done_bb = func.append_basic_block(name="ins.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        si = b.phi(i64, name="ins.si");
-        si.add_incoming(last_idx, entry_bb);
-        at_pos = b.icmp_signed("<=", si, insert_idx, name="ins.atpos");
-        b.cbranch(at_pos, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        prev = b.sub(si, ir.Constant(i64, 1), name="ins.prev");
-        prev_val = b.call(helpers["get"], [target, prev], name="ins.pval");
-        b.call(helpers["set"], [target, si, prev_val]);
-        si.add_incoming(prev, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        # Set the value at insert_idx
-        b.call(helpers["set"], [target, insert_idx, insert_val]);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_remove(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # remove(value): find first occurrence, shift left, decrease length
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        search_val = p._coerce_type(args[0], helpers["elem_type"]);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="rem.len.ptr"
-        );
-        list_len = b.load(len_ptr, name="rem.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        find_bb = func.append_basic_block(name="rem.find");
-        find_body = func.append_basic_block(name="rem.find.body");
-        found_bb = func.append_basic_block(name="rem.found");
-        shift_bb = func.append_basic_block(name="rem.shift");
-        shift_body = func.append_basic_block(name="rem.shift.body");
-        done_bb = func.append_basic_block(name="rem.done");
-        b.branch(find_bb);
-        # Find loop: search for first occurrence
-        b.position_at_start(find_bb);
-        fi = b.phi(i64, name="rem.fi");
-        fi.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", fi, list_len, name="rem.atend");
-        b.cbranch(at_end, done_bb, find_body);
-        b.position_at_start(find_body);
-        elem = b.call(helpers["get"], [target, fi], name="rem.elem");
-        eq = b.icmp_signed("==", elem, search_val, name="rem.eq");
-        next_fi = b.add(fi, ir.Constant(i64, 1), name="rem.nextfi");
-        fi.add_incoming(next_fi, find_body);
-        b.cbranch(eq, found_bb, find_bb);
-        # Found: shift elements left from found_idx+1
-        b.position_at_start(found_bb);
-        shift_start = b.add(fi, ir.Constant(i64, 1), name="rem.shstart");
-        b.branch(shift_bb);
-        b.position_at_start(shift_bb);
-        si = b.phi(i64, name="rem.si");
-        si.add_incoming(shift_start, found_bb);
-        shift_end = b.icmp_unsigned(">=", si, list_len, name="rem.shend");
-        b.cbranch(shift_end, done_bb, shift_body);
-        b.position_at_start(shift_body);
-        val = b.call(helpers["get"], [target, si], name="rem.val");
-        prev = b.sub(si, ir.Constant(i64, 1), name="rem.prev");
-        b.call(helpers["set"], [target, prev, val]);
-        next_si = b.add(si, ir.Constant(i64, 1), name="rem.nextsi");
-        si.add_incoming(next_si, shift_body);
-        b.branch(shift_bb);
-        # Done: decrease length (only if found)
-        b.position_at_start(done_bb);
-        # PHI must be at top of block
-        found_phi = b.phi(i64, name="rem.found");
-        found_phi.add_incoming(ir.Constant(i64, 0), find_bb);
-        found_phi.add_incoming(ir.Constant(i64, 1), shift_bb);
-        was_found = b.icmp_unsigned(
-            "!=", found_phi, ir.Constant(i64, 0), name="rem.wasfound"
-        );
-        new_len = b.sub(list_len, ir.Constant(i64, 1), name="rem.newlen");
-        final_len = b.select(was_found, new_len, list_len, name="rem.finallen");
-        b.store(final_len, len_ptr);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_pop(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="pop.len.ptr"
-        );
-        cur_len = b.load(len_ptr, name="pop.len");
-        new_len = b.sub(cur_len, ir.Constant(i64, 1), name="pop.newlen");
-        last_val = b.call(helpers["get"], [target, new_len], name="pop.val");
-        b.store(new_len, len_ptr);
-        return last_val;
-    }
+    ) -> (ir.Value | None);
 
     def emit_clear(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="clear.len.ptr"
-        );
-        b.store(ir.Constant(i64, 0), len_ptr);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_index(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i64 = ir.IntType(64);
-        i32 = ir.IntType(32);
-        search_val = p._coerce_type(args[0], helpers["elem_type"]);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="idx.len.ptr"
-        );
-        list_len = b.load(len_ptr, name="idx.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="idx.loop");
-        check_bb = func.append_basic_block(name="idx.check");
-        found_bb = func.append_basic_block(name="idx.found");
-        done_bb = func.append_basic_block(name="idx.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="idx.i");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, list_len, name="idx.atend");
-        b.cbranch(at_end, done_bb, check_bb);
-        b.position_at_start(check_bb);
-        elem = b.call(helpers["get"], [target, idx], name="idx.elem");
-        eq = b.icmp_signed("==", elem, search_val, name="idx.eq");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="idx.next");
-        b.cbranch(eq, found_bb, loop_bb);
-        idx.add_incoming(next_idx, check_bb);
-        b.position_at_start(found_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="idx.result");
-        result.add_incoming(ir.Constant(i64, -1), loop_bb);
-        result.add_incoming(idx, found_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i64 = ir.IntType(64);
-        i32 = ir.IntType(32);
-        search_val = p._coerce_type(args[0], helpers["elem_type"]);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="cnt.len.ptr"
-        );
-        list_len = b.load(len_ptr, name="cnt.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="cnt.loop");
-        body_bb = func.append_basic_block(name="cnt.body");
-        inc_bb = func.append_basic_block(name="cnt.inc");
-        done_bb = func.append_basic_block(name="cnt.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="cnt.idx");
-        count = b.phi(i64, name="cnt.count");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        count.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, list_len, name="cnt.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        elem = b.call(helpers["get"], [target, idx], name="cnt.elem");
-        eq = b.icmp_signed("==", elem, search_val, name="cnt.eq");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="cnt.next");
-        b.cbranch(eq, inc_bb, loop_bb);
-        idx.add_incoming(next_idx, body_bb);
-        count.add_incoming(count, body_bb);
-        b.position_at_start(inc_bb);
-        new_count = b.add(count, ir.Constant(i64, 1), name="cnt.inc");
-        next_idx2 = b.add(idx, ir.Constant(i64, 1), name="cnt.next2");
-        idx.add_incoming(next_idx2, inc_bb);
-        count.add_incoming(new_count, inc_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return count;
-    }
+    ) -> (ir.Value | None);
 
     def emit_sort(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # sort(): in-place bubble sort
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        zero = ir.Constant(i64, 0);
-        one = ir.Constant(i64, 1);
-        elem_type = helpers["elem_type"];
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sort.len.ptr"
-        );
-        list_len = b.load(len_ptr, name="sort.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        # Outer loop: i from 0 to len-1
-        outer_bb = func.append_basic_block(name="sort.outer");
-        inner_start = func.append_basic_block(name="sort.inner.start");
-        inner_bb = func.append_basic_block(name="sort.inner");
-        inner_body = func.append_basic_block(name="sort.inner.body");
-        swap_bb = func.append_basic_block(name="sort.swap");
-        no_swap = func.append_basic_block(name="sort.noswap");
-        inner_next = func.append_basic_block(name="sort.inner.next");
-        outer_next = func.append_basic_block(name="sort.outer.next");
-        done_bb = func.append_basic_block(name="sort.done");
-        len_m1 = b.sub(list_len, one, name="sort.lenm1");
-        b.branch(outer_bb);
-        # Outer loop header
-        b.position_at_start(outer_bb);
-        oi = b.phi(i64, name="sort.oi");
-        oi.add_incoming(zero, entry_bb);
-        outer_end = b.icmp_unsigned(">=", oi, len_m1, name="sort.oend");
-        b.cbranch(outer_end, done_bb, inner_start);
-        # Compute inner limit: len - i - 1
-        b.position_at_start(inner_start);
-        inner_limit = b.sub(len_m1, oi, name="sort.ilimit");
-        b.branch(inner_bb);
-        # Inner loop header
-        b.position_at_start(inner_bb);
-        ji = b.phi(i64, name="sort.ji");
-        ji.add_incoming(zero, inner_start);
-        inner_end = b.icmp_unsigned(">=", ji, inner_limit, name="sort.iend");
-        b.cbranch(inner_end, outer_next, inner_body);
-        # Inner body: compare adjacent elements
-        b.position_at_start(inner_body);
-        j1 = b.add(ji, one, name="sort.j1");
-        ej = b.call(helpers["get"], [target, ji], name="sort.ej");
-        ej1 = b.call(helpers["get"], [target, j1], name="sort.ej1");
-        # Compare based on element type
-        if isinstance(elem_type, ir.DoubleType) {
-            needs_swap = b.fcmp_ordered(">", ej, ej1, name="sort.gt");
-        } elif isinstance(elem_type, ir.PointerType) {
-            strcmp_fn = p._get_or_declare_extern(
-                "strcmp", ir.IntType(32), [elem_type, elem_type]
-            );
-            cmp_result = b.call(strcmp_fn, [ej, ej1], name="sort.cmp");
-            needs_swap = b.icmp_signed(
-                ">", cmp_result, ir.Constant(ir.IntType(32), 0), name="sort.gt"
-            );
-        } else {
-            needs_swap = b.icmp_signed(">", ej, ej1, name="sort.gt");
-        }
-        b.cbranch(needs_swap, swap_bb, no_swap);
-        # Swap
-        b.position_at_start(swap_bb);
-        b.call(helpers["set"], [target, ji, ej1]);
-        b.call(helpers["set"], [target, j1, ej]);
-        b.branch(inner_next);
-        b.position_at_start(no_swap);
-        b.branch(inner_next);
-        # Inner next
-        b.position_at_start(inner_next);
-        next_ji = b.add(ji, one, name="sort.nji");
-        ji.add_incoming(next_ji, inner_next);
-        b.branch(inner_bb);
-        # Outer next
-        b.position_at_start(outer_next);
-        next_oi = b.add(oi, one, name="sort.noi");
-        oi.add_incoming(next_oi, outer_next);
-        b.branch(outer_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_reverse(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="rev.len.ptr"
-        );
-        list_len = b.load(len_ptr, name="rev.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="rev.loop");
-        body_bb = func.append_basic_block(name="rev.body");
-        done_bb = func.append_basic_block(name="rev.done");
-        j_init = b.sub(list_len, ir.Constant(i64, 1), name="rev.j.init");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        i_phi = b.phi(i64, name="rev.i");
-        j_phi = b.phi(i64, name="rev.j");
-        i_phi.add_incoming(ir.Constant(i64, 0), entry_bb);
-        j_phi.add_incoming(j_init, entry_bb);
-        cond = b.icmp_signed("<", i_phi, j_phi, name="rev.cond");
-        b.cbranch(cond, body_bb, done_bb);
-        b.position_at_start(body_bb);
-        val_i = b.call(helpers["get"], [target, i_phi], name="rev.val.i");
-        val_j = b.call(helpers["get"], [target, j_phi], name="rev.val.j");
-        b.call(helpers["set"], [target, i_phi, val_j]);
-        b.call(helpers["set"], [target, j_phi, val_i]);
-        next_i = b.add(i_phi, ir.Constant(i64, 1), name="rev.next.i");
-        next_j = b.sub(j_phi, ir.Constant(i64, 1), name="rev.next.j");
-        i_phi.add_incoming(next_i, body_bb);
-        j_phi.add_incoming(next_j, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_copy(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        helpers = p.list_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_list = b.call(helpers["new"], [], name="copy.new");
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="copy.len.ptr"
-        );
-        src_len = b.load(len_ptr, name="copy.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="copy.loop");
-        body_bb = func.append_basic_block(name="copy.body");
-        done_bb = func.append_basic_block(name="copy.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="copy.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, src_len, name="copy.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        elem = b.call(helpers["get"], [target, idx], name="copy.elem");
-        b.call(helpers["append"], [new_list, elem]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="copy.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_list;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeDictEmitter(DictEmitter[(ir.Value, NativeEmitCtx)]) {
     def emit_get(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # get(key, default=None): return value for key, or default if missing
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i64 = ir.IntType(64);
-        key = args[0];
-        found_i1 = b.call(helpers["contains"], [target, key], name="dget.found");
-        func = b.basic_block.function;
-        found_bb = func.append_basic_block(name="dget.yes");
-        notfound_bb = func.append_basic_block(name="dget.no");
-        done_bb = func.append_basic_block(name="dget.done");
-        b.cbranch(found_i1, found_bb, notfound_bb);
-        # Found: get the value
-        b.position_at_start(found_bb);
-        val = b.call(helpers["get"], [target, key], name="dget.val");
-        b.branch(done_bb);
-        # Not found: use default or zero
-        b.position_at_start(notfound_bb);
-        val_type = helpers["val_type"];
-        if len(args) >= 2 {
-            default_val = p._coerce_type(args[1], val_type);
-        } elif isinstance(val_type, ir.PointerType) {
-            default_val = ir.Constant(val_type, None);
-        } else {
-            default_val = ir.Constant(val_type, 0);
-        }
-        b.branch(done_bb);
-        # Merge
-        b.position_at_start(done_bb);
-        result = b.phi(val_type, name="dget.result");
-        result.add_incoming(val, found_bb);
-        result.add_incoming(default_val, notfound_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_keys(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # keys(): return list of all keys
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        # Determine key type name from type_key ("key_type:val_type")
-        key_type = helpers["key_type"];
-        if isinstance(key_type, ir.PointerType) {
-            kt_name = "ptr";
-        } elif isinstance(key_type, ir.DoubleType) {
-            kt_name = "f64";
-        } else {
-            kt_name = "i64";
-        }
-        p._emit_list_helpers(kt_name, key_type);
-        lhelpers = p.list_helpers.get(kt_name);
-        if lhelpers is None {
-            return None;
-        }
-        new_list = b.call(lhelpers["new"], [], name="dkeys.list");
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dkeys.len.ptr"
-        );
-        dict_len = b.load(len_ptr, name="dkeys.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="dkeys.loop");
-        body_bb = func.append_basic_block(name="dkeys.body");
-        done_bb = func.append_basic_block(name="dkeys.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="dkeys.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, dict_len, name="dkeys.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        key = b.call(helpers["get_key"], [target, idx], name="dkeys.key");
-        b.call(lhelpers["append"], [new_list, key]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="dkeys.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_list;
-    }
+    ) -> (ir.Value | None);
 
     def emit_values(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # values(): return list of all values
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        # Determine val type name
-        val_type = helpers["val_type"];
-        if isinstance(val_type, ir.PointerType) {
-            vt_name = "ptr";
-        } elif isinstance(val_type, ir.DoubleType) {
-            vt_name = "f64";
-        } else {
-            vt_name = "i64";
-        }
-        p._emit_list_helpers(vt_name, val_type);
-        lhelpers = p.list_helpers.get(vt_name);
-        if lhelpers is None {
-            return None;
-        }
-        new_list = b.call(lhelpers["new"], [], name="dvals.list");
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dvals.len.ptr"
-        );
-        dict_len = b.load(len_ptr, name="dvals.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="dvals.loop");
-        body_bb = func.append_basic_block(name="dvals.body");
-        done_bb = func.append_basic_block(name="dvals.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="dvals.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, dict_len, name="dvals.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        key = b.call(helpers["get_key"], [target, idx], name="dvals.key");
-        val = b.call(helpers["get"], [target, key], name="dvals.val");
-        b.call(lhelpers["append"], [new_list, val]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="dvals.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_list;
-    }
+    ) -> (ir.Value | None);
 
     def emit_items(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # items(): return list of (key, value) 2-tuples
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        i8p = ir.IntType(8).as_pointer();
-        key_type = helpers["key_type"];
-        val_type = helpers["val_type"];
-        # Build 2-tuple struct type
-        tuple_type = ir.LiteralStructType([key_type, val_type]);
-        # Register tuple type
-        kt_str = "i8p"
-            if isinstance(key_type, ir.PointerType)
-            else ("f64" if isinstance(key_type, ir.DoubleType) else "i64");
-        vt_str = "i8p"
-            if isinstance(val_type, ir.PointerType)
-            else ("f64" if isinstance(val_type, ir.DoubleType) else "i64");
-        tkey = f"{kt_str}.{vt_str}";
-        if tkey not in p.tuple_types {
-            p.tuple_types[tkey] = tuple_type;
-        }
-        # Create result list of pointers (each element is a tuple pointer)
-        p._emit_list_helpers("ptr", i8p);
-        lhelpers = p.list_helpers.get("ptr");
-        if lhelpers is None {
-            return None;
-        }
-        new_list = b.call(lhelpers["new"], [], name="ditems.list");
-        # Get dict length
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ditems.len.ptr"
-        );
-        dict_len = b.load(len_ptr, name="ditems.len");
-        # Compute tuple size once
-        null_ptr = ir.Constant(tuple_type.as_pointer(), None);
-        size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="ditems.sizeof.gep");
-        tup_size = b.ptrtoint(size_gep, i64, name="ditems.sizeof");
-        # Loop over dict entries
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="ditems.loop");
-        body_bb = func.append_basic_block(name="ditems.body");
-        done_bb = func.append_basic_block(name="ditems.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="ditems.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, dict_len, name="ditems.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        # Get key and value at this index
-        key = b.call(helpers["get_key"], [target, idx], name="ditems.key");
-        val = b.call(helpers["get"], [target, key], name="ditems.val");
-        # Allocate 2-tuple
-        raw = b.call(p.rc_alloc_fn, [tup_size], name="ditems.alloc");
-        tup_ptr = b.bitcast(raw, tuple_type.as_pointer(), name="ditems.tup");
-        k_ptr = b.gep(
-            tup_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ditems.k.ptr"
-        );
-        v_ptr = b.gep(
-            tup_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="ditems.v.ptr"
-        );
-        b.store(key, k_ptr);
-        b.store(val, v_ptr);
-        # Append tuple pointer (as i8*) to list
-        tup_i8p = b.bitcast(tup_ptr, i8p, name="ditems.i8p");
-        b.call(lhelpers["append"], [new_list, tup_i8p]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="ditems.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_list;
-    }
+    ) -> (ir.Value | None);
 
     def emit_pop(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # pop(key, default=None): remove key and return value, or default/KeyError
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        key = args[0];
-        val_type = helpers["val_type"];
-        key_type = helpers["key_type"];
-        has_default = len(args) >= 2;
-        # Check if key exists
-        found_i1 = b.call(helpers["contains"], [target, key], name="dpop.found");
-        func = b.basic_block.function;
-        found_bb = func.append_basic_block(name="dpop.yes");
-        notfound_bb = func.append_basic_block(name="dpop.no");
-        done_bb = func.append_basic_block(name="dpop.done");
-        b.cbranch(found_i1, found_bb, notfound_bb);
-        # Found: get value, then find index and shift arrays
-        b.position_at_start(found_bb);
-        saved_val = b.call(helpers["get"], [target, key], name="dpop.val");
-        # Find the index of the key via linear search
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dpop.len.ptr"
-        );
-        keys_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="dpop.keys.ptr"
-        );
-        vals_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 3)], name="dpop.vals.ptr"
-        );
-        dict_len = b.load(len_ptr, name="dpop.len");
-        keys_arr = b.load(keys_ptr, name="dpop.keys");
-        vals_arr = b.load(vals_ptr, name="dpop.vals");
-        new_len = b.sub(dict_len, ir.Constant(i64, 1), name="dpop.newlen");
-        # Search for key index
-        search_bb = func.append_basic_block(name="dpop.search");
-        search_body = func.append_basic_block(name="dpop.search.body");
-        search_found = func.append_basic_block(name="dpop.search.found");
-        b.branch(search_bb);
-        b.position_at_start(search_bb);
-        si = b.phi(i64, name="dpop.si");
-        si.add_incoming(ir.Constant(i64, 0), found_bb);
-        si_end = b.icmp_unsigned(">=", si, dict_len, name="dpop.si.end");
-        b.cbranch(si_end, search_found, search_body);
-        b.position_at_start(search_body);
-        kp = b.gep(keys_arr, [si], name="dpop.kp");
-        kv = b.load(kp, name="dpop.kv");
-        i8p = ir.IntType(8).as_pointer();
-        if isinstance(key_type, ir.IntType) {
-            keq = b.icmp_signed("==", kv, key, name="dpop.keq");
-        } elif key_type == i8p {
-            strcmp_fn = p._get_or_declare_extern("strcmp", ir.IntType(32), [i8p, i8p]);
-            cmp_result = b.call(strcmp_fn, [kv, key], name="dpop.strcmp");
-            keq = b.icmp_signed(
-                "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="dpop.keq"
-            );
-        } else {
-            keq = b.icmp_unsigned("==", kv, key, name="dpop.keq");
-        }
-        next_si = b.add(si, ir.Constant(i64, 1), name="dpop.nsi");
-        si.add_incoming(next_si, search_body);
-        b.cbranch(keq, search_found, search_bb);
-        # Found index: shift elements left from si to end
-        b.position_at_start(search_found);
-        found_idx = b.phi(i64, name="dpop.fidx");
-        found_idx.add_incoming(si, search_body);
-        found_idx.add_incoming(dict_len, search_bb);
-        shift_bb = func.append_basic_block(name="dpop.shift");
-        shift_body_bb = func.append_basic_block(name="dpop.shift.body");
-        shift_done = func.append_basic_block(name="dpop.shift.done");
-        b.branch(shift_bb);
-        b.position_at_start(shift_bb);
-        ji = b.phi(i64, name="dpop.ji");
-        ji.add_incoming(found_idx, search_found);
-        ji_end = b.icmp_unsigned(">=", ji, new_len, name="dpop.ji.end");
-        b.cbranch(ji_end, shift_done, shift_body_bb);
-        b.position_at_start(shift_body_bb);
-        next_ji = b.add(ji, ir.Constant(i64, 1), name="dpop.nji");
-        # Shift key
-        src_kp = b.gep(keys_arr, [next_ji], name="dpop.src.kp");
-        skv = b.load(src_kp, name="dpop.skv");
-        dst_kp = b.gep(keys_arr, [ji], name="dpop.dst.kp");
-        b.store(skv, dst_kp);
-        # Shift val
-        src_vp = b.gep(vals_arr, [next_ji], name="dpop.src.vp");
-        svv = b.load(src_vp, name="dpop.svv");
-        dst_vp = b.gep(vals_arr, [ji], name="dpop.dst.vp");
-        b.store(svv, dst_vp);
-        ji.add_incoming(next_ji, shift_body_bb);
-        b.branch(shift_bb);
-        b.position_at_start(shift_done);
-        b.store(new_len, len_ptr);
-        b.branch(done_bb);
-        # Not found
-        b.position_at_start(notfound_bb);
-        if has_default {
-            default_val = p._coerce_type(args[1], val_type);
-        } else {
-            p._emit_runtime_raise(
-                ir.Constant(ir.IntType(1), 1), "KeyError", "key not found"
-            );
-            if isinstance(val_type, ir.PointerType) {
-                default_val = ir.Constant(val_type, None);
-            } else {
-                default_val = ir.Constant(val_type, 0);
-            }
-        }
-        b.branch(done_bb);
-        # Merge
-        b.position_at_start(done_bb);
-        result = b.phi(val_type, name="dpop.result");
-        result.add_incoming(saved_val, shift_done);
-        result.add_incoming(default_val, notfound_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_remove(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # d.remove(key) / del d[key]: remove key, raise KeyError if missing.
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        i8p = ir.IntType(8).as_pointer();
-        key = args[0];
-        key_type = helpers["key_type"];
-        func = b.basic_block.function;
-        found_bb = func.append_basic_block(name="drem.found");
-        nokey_bb = func.append_basic_block(name="drem.nokey");
-        search_bb = func.append_basic_block(name="drem.search");
-        search_body = func.append_basic_block(name="drem.search.body");
-        sfound_bb = func.append_basic_block(name="drem.sfound");
-        shift_bb = func.append_basic_block(name="drem.shift");
-        shift_body = func.append_basic_block(name="drem.shift.body");
-        store_bb = func.append_basic_block(name="drem.store");
-        done_bb = func.append_basic_block(name="drem.done");
-        # Contains check → branch to found or not-found
-        found_i1 = b.call(helpers["contains"], [target, key], name="drem.has");
-        b.cbranch(found_i1, found_bb, nokey_bb);
-        # Not found → KeyError, then fall to done
-        b.position_at_start(nokey_bb);
-        p._emit_runtime_raise(
-            ir.Constant(ir.IntType(1), 1), "KeyError", "key not found"
-        );
-        b.branch(done_bb);
-        # Found: load struct fields
-        b.position_at_start(found_bb);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="drem.len.p"
-        );
-        keys_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="drem.keys.p"
-        );
-        vals_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 3)], name="drem.vals.p"
-        );
-        dict_len = b.load(len_ptr, name="drem.len");
-        keys_arr = b.load(keys_ptr, name="drem.keys");
-        vals_arr = b.load(vals_ptr, name="drem.vals");
-        new_len = b.sub(dict_len, ir.Constant(i64, 1), name="drem.newlen");
-        b.branch(search_bb);
-        # Linear search for the index of key
-        b.position_at_start(search_bb);
-        si = b.phi(i64, name="drem.si");
-        si.add_incoming(ir.Constant(i64, 0), found_bb);
-        si_end = b.icmp_unsigned(">=", si, dict_len, name="drem.si.end");
-        b.cbranch(si_end, sfound_bb, search_body);
-        b.position_at_start(search_body);
-        kp = b.gep(keys_arr, [si], name="drem.kp");
-        kv = b.load(kp, name="drem.kv");
-        if isinstance(key_type, ir.IntType) {
-            keq = b.icmp_signed("==", kv, key, name="drem.keq");
-        } elif key_type == i8p {
-            strcmp_fn = p._get_or_declare_extern("strcmp", ir.IntType(32), [i8p, i8p]);
-            cmp_result = b.call(strcmp_fn, [kv, key], name="drem.strcmp");
-            keq = b.icmp_signed(
-                "==", cmp_result, ir.Constant(ir.IntType(32), 0), name="drem.keq"
-            );
-        } else {
-            keq = b.icmp_unsigned("==", kv, key, name="drem.keq");
-        }
-        next_si = b.add(si, ir.Constant(i64, 1), name="drem.nsi");
-        si.add_incoming(next_si, search_body);
-        b.cbranch(keq, sfound_bb, search_bb);
-        # Have found index: set up shift loop
-        b.position_at_start(sfound_bb);
-        found_idx = b.phi(i64, name="drem.fidx");
-        found_idx.add_incoming(si, search_body);
-        found_idx.add_incoming(dict_len, search_bb);
-        b.branch(shift_bb);
-        b.position_at_start(shift_bb);
-        ji = b.phi(i64, name="drem.ji");
-        ji.add_incoming(found_idx, sfound_bb);
-        ji_end = b.icmp_unsigned(">=", ji, new_len, name="drem.ji.end");
-        b.cbranch(ji_end, store_bb, shift_body);
-        b.position_at_start(shift_body);
-        next_ji = b.add(ji, ir.Constant(i64, 1), name="drem.nji");
-        b.store(
-            b.load(b.gep(keys_arr, [next_ji], name="drem.src.kp"), name="drem.skv"),
-            b.gep(keys_arr, [ji], name="drem.dst.kp")
-        );
-        b.store(
-            b.load(b.gep(vals_arr, [next_ji], name="drem.src.vp"), name="drem.svv"),
-            b.gep(vals_arr, [ji], name="drem.dst.vp")
-        );
-        ji.add_incoming(next_ji, shift_body);
-        b.branch(shift_bb);
-        # Store the new length (only reachable from the found path, so
-        # new_len and len_ptr are in scope / dominate this block).
-        b.position_at_start(store_bb);
-        b.store(new_len, len_ptr);
-        b.branch(done_bb);
-        # Done: builder left positioned here for subsequent statements.
-        b.position_at_start(done_bb);
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_popitem(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # popitem(): remove and return last (key, value) pair as 2-tuple
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        key_type = helpers["key_type"];
-        val_type = helpers["val_type"];
-        # Load dict length
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dpi.len.ptr"
-        );
-        dict_len = b.load(len_ptr, name="dpi.len");
-        # Raise KeyError if empty
-        is_empty = b.icmp_signed("==", dict_len, ir.Constant(i64, 0), name="dpi.empty");
-        p._emit_runtime_raise(is_empty, "KeyError", "popitem(): dictionary is empty");
-        # Get last key/value
-        last_idx = b.sub(dict_len, ir.Constant(i64, 1), name="dpi.last");
-        last_key = b.call(helpers["get_key"], [target, last_idx], name="dpi.key");
-        last_val = b.call(helpers["get"], [target, last_key], name="dpi.val");
-        # Decrement length
-        b.store(last_idx, len_ptr);
-        # Build 2-tuple with actual key/value types
-        tuple_type = ir.LiteralStructType([key_type, val_type]);
-        null_ptr = ir.Constant(tuple_type.as_pointer(), None);
-        size_gep = b.gep(null_ptr, [ir.Constant(i32, 1)], name="dpi.sizeof.gep");
-        size = b.ptrtoint(size_gep, i64, name="dpi.sizeof");
-        raw_ptr = b.call(p.rc_alloc_fn, [size], name="dpi.alloc");
-        tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="dpi.ptr");
-        k_ptr = b.gep(
-            tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dpi.k.ptr"
-        );
-        v_ptr = b.gep(
-            tuple_ptr, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="dpi.v.ptr"
-        );
-        b.store(last_key, k_ptr);
-        b.store(last_val, v_ptr);
-        # Register tuple type
-        kt_str = "i8p"
-            if isinstance(key_type, ir.PointerType)
-            else ("f64" if isinstance(key_type, ir.DoubleType) else "i64");
-        vt_str = "i8p"
-            if isinstance(val_type, ir.PointerType)
-            else ("f64" if isinstance(val_type, ir.DoubleType) else "i64");
-        tkey = f"{kt_str}.{vt_str}";
-        if tkey not in p.tuple_types {
-            p.tuple_types[tkey] = tuple_type;
-        }
-        return tuple_ptr;
-    }
+    ) -> (ir.Value | None);
 
     def emit_setdefault(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # setdefault(key, default=None): if key not in dict, set it to default; return value
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i64 = ir.IntType(64);
-        key = args[0];
-        val_type = helpers["val_type"];
-        default_val = args[1] if len(args) >= 2 else ir.Constant(val_type, 0);
-        # Check if key exists
-        found = b.call(helpers["contains"], [target, key], name="sdef.found");
-        func = b.basic_block.function;
-        found_bb = func.append_basic_block(name="sdef.yes");
-        notfound_bb = func.append_basic_block(name="sdef.no");
-        done_bb = func.append_basic_block(name="sdef.done");
-        b.cbranch(found, found_bb, notfound_bb);
-        # Found: just get the value
-        b.position_at_start(found_bb);
-        existing = b.call(helpers["get"], [target, key], name="sdef.existing");
-        b.branch(done_bb);
-        # Not found: set default and return it
-        b.position_at_start(notfound_bb);
-        b.call(helpers["set"], [target, key, default_val]);
-        b.branch(done_bb);
-        # Merge
-        b.position_at_start(done_bb);
-        result = b.phi(val_type, name="sdef.result");
-        result.add_incoming(existing, found_bb);
-        result.add_incoming(default_val, notfound_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # update(other): merge all key-value pairs from other into target
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        other = args[0];
-        len_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dupd.len.ptr"
-        );
-        other_len = b.load(len_ptr, name="dupd.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="dupd.loop");
-        body_bb = func.append_basic_block(name="dupd.body");
-        done_bb = func.append_basic_block(name="dupd.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="dupd.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, other_len, name="dupd.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        key = b.call(helpers["get_key"], [other, idx], name="dupd.key");
-        val = b.call(helpers["get"], [other, key], name="dupd.val");
-        b.call(helpers["set"], [target, key, val]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="dupd.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_clear(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # clear: set length to 0
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dclear.len.ptr"
-        );
-        b.store(ir.Constant(i64, 0), len_ptr);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_copy(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # copy: create new dict, copy all key-value pairs
-        p = ctx.pass_ref;
-        helpers = p.dict_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_dict = b.call(helpers["new"], [], name="dcopy.new");
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="dcopy.len.ptr"
-        );
-        dict_len = b.load(len_ptr, name="dcopy.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="dcopy.loop");
-        body_bb = func.append_basic_block(name="dcopy.body");
-        done_bb = func.append_basic_block(name="dcopy.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="dcopy.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, dict_len, name="dcopy.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        key = b.call(helpers["get_key"], [target, idx], name="dcopy.key");
-        val = b.call(helpers["get"], [target, key], name="dcopy.val");
-        b.call(helpers["set"], [new_dict, key, val]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="dcopy.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_dict;
-    }
+    ) -> (ir.Value | None);
 
     def emit_fromkeys(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeSetEmitter(SetEmitter[(ir.Value, NativeEmitCtx)]) {
     # Mutation
     def emit_add(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None or not args {
-            return None;
-        }
-        val = p._coerce_type(args[0], helpers["elem_type"]);
-        p.builder.call(helpers["add"], [target, val]);
-        return ir.Constant(ir.IntType(64), 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_remove(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # remove: like discard but raises KeyError if element not found
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        elem_type = helpers["elem_type"];
-        search_val = p._coerce_type(args[0], elem_type);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="srem.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="srem.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="srem.len");
-        elems_arr = b.load(elems_ptr, name="srem.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="srem.loop");
-        check_bb = func.append_basic_block(name="srem.check");
-        notfound_bb = func.append_basic_block(name="srem.notfound");
-        found_bb = func.append_basic_block(name="srem.found");
-        shift_bb = func.append_basic_block(name="srem.shift");
-        shift_body = func.append_basic_block(name="srem.shift.body");
-        shift_done = func.append_basic_block(name="srem.shift.done");
-        done_bb = func.append_basic_block(name="srem.done");
-        b.branch(loop_bb);
-        # Search loop
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="srem.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="srem.atend");
-        b.cbranch(at_end, notfound_bb, check_bb);
-        b.position_at_start(check_bb);
-        ep = b.gep(elems_arr, [idx], name="srem.ep");
-        ev = b.load(ep, name="srem.ev");
-        if isinstance(elem_type, ir.IntType) {
-            eq = b.icmp_signed("==", ev, search_val, name="srem.eq");
-        } else {
-            eq = b.icmp_unsigned("==", ev, search_val, name="srem.eq");
-        }
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="srem.next");
-        b.cbranch(eq, found_bb, loop_bb);
-        idx.add_incoming(next_idx, check_bb);
-        # Not found: raise KeyError
-        b.position_at_start(notfound_bb);
-        p._emit_runtime_raise(
-            ir.Constant(ir.IntType(1), 1), "KeyError", "element not in set"
-        );
-        b.branch(done_bb);
-        # Found: shift remaining elements left
-        b.position_at_start(found_bb);
-        new_len = b.sub(set_len, ir.Constant(i64, 1), name="srem.newlen");
-        b.store(new_len, len_ptr);
-        b.branch(shift_bb);
-        b.position_at_start(shift_bb);
-        si = b.phi(i64, name="srem.si");
-        si.add_incoming(idx, found_bb);
-        si_end = b.icmp_unsigned(">=", si, new_len, name="srem.siend");
-        b.cbranch(si_end, shift_done, shift_body);
-        b.position_at_start(shift_body);
-        next_si = b.add(si, ir.Constant(i64, 1), name="srem.nsi");
-        src_p = b.gep(elems_arr, [next_si], name="srem.srcp");
-        sv = b.load(src_p, name="srem.sv");
-        dst_p = b.gep(elems_arr, [si], name="srem.dstp");
-        b.store(sv, dst_p);
-        si.add_incoming(next_si, shift_body);
-        b.branch(shift_bb);
-        b.position_at_start(shift_done);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_discard(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # discard: remove element if present (no error if absent)
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        elem_type = helpers["elem_type"];
-        search_val = p._coerce_type(args[0], elem_type);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="disc.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="disc.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="disc.len");
-        elems_arr = b.load(elems_ptr, name="disc.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="disc.loop");
-        check_bb = func.append_basic_block(name="disc.check");
-        found_bb = func.append_basic_block(name="disc.found");
-        shift_bb = func.append_basic_block(name="disc.shift");
-        shift_body = func.append_basic_block(name="disc.shift.body");
-        shift_done = func.append_basic_block(name="disc.shift.done");
-        done_bb = func.append_basic_block(name="disc.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="disc.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="disc.atend");
-        b.cbranch(at_end, done_bb, check_bb);
-        b.position_at_start(check_bb);
-        ep = b.gep(elems_arr, [idx], name="disc.ep");
-        ev = b.load(ep, name="disc.ev");
-        if isinstance(elem_type, ir.IntType) {
-            eq = b.icmp_signed("==", ev, search_val, name="disc.eq");
-        } else {
-            eq = b.icmp_unsigned("==", ev, search_val, name="disc.eq");
-        }
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="disc.next");
-        b.cbranch(eq, found_bb, loop_bb);
-        idx.add_incoming(next_idx, check_bb);
-        # Found: shift remaining elements left
-        b.position_at_start(found_bb);
-        new_len = b.sub(set_len, ir.Constant(i64, 1), name="disc.newlen");
-        b.store(new_len, len_ptr);
-        b.branch(shift_bb);
-        b.position_at_start(shift_bb);
-        si = b.phi(i64, name="disc.si");
-        si.add_incoming(idx, found_bb);
-        si_end = b.icmp_unsigned(">=", si, new_len, name="disc.siend");
-        b.cbranch(si_end, shift_done, shift_body);
-        b.position_at_start(shift_body);
-        next_si = b.add(si, ir.Constant(i64, 1), name="disc.nsi");
-        src_p = b.gep(elems_arr, [next_si], name="disc.srcp");
-        sv = b.load(src_p, name="disc.sv");
-        dst_p = b.gep(elems_arr, [si], name="disc.dstp");
-        b.store(sv, dst_p);
-        si.add_incoming(next_si, shift_body);
-        b.branch(shift_bb);
-        b.position_at_start(shift_done);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_pop(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # pop: remove and return an arbitrary element, raise KeyError if empty
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="spop.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="spop.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="spop.len");
-        # Raise KeyError if empty
-        is_empty = b.icmp_unsigned(
-            "==", set_len, ir.Constant(i64, 0), name="spop.empty"
-        );
-        p._emit_runtime_raise(is_empty, "KeyError", "pop from an empty set");
-        # Pop last element (arbitrary choice, O(1))
-        new_len = b.sub(set_len, ir.Constant(i64, 1), name="spop.newlen");
-        elems_arr = b.load(elems_ptr, name="spop.elems");
-        last_ep = b.gep(elems_arr, [new_len], name="spop.last.ptr");
-        last_val = b.load(last_ep, name="spop.last.val");
-        b.store(new_len, len_ptr);
-        return last_val;
-    }
+    ) -> (ir.Value | None);
 
     def emit_clear(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # clear: set length to 0
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target,
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name="set.clear.len.ptr"
-        );
-        b.store(ir.Constant(i64, 0), len_ptr);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     # Set algebra
     def _emit_set_iterate(
         self, ctx: NativeEmitCtx, source: ir.Value, prefix: str
-    ) -> tuple {
-        # Helper: set up iteration over a set, returns (helpers, b, i32, i64, set_len, elems_arr, entry_bb, loop_bb, body_bb, done_bb, idx, elem)
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            source,
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name=f"{prefix}.len.ptr"
-        );
-        elems_ptr = b.gep(
-            source,
-            [ir.Constant(i32, 0), ir.Constant(i32, 2)],
-            name=f"{prefix}.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name=f"{prefix}.len");
-        elems_arr = b.load(elems_ptr, name=f"{prefix}.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name=f"{prefix}.loop");
-        body_bb = func.append_basic_block(name=f"{prefix}.body");
-        done_bb = func.append_basic_block(name=f"{prefix}.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name=f"{prefix}.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name=f"{prefix}.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name=f"{prefix}.ep");
-        ev = b.load(ep, name=f"{prefix}.ev");
-        return (helpers, b, i64, idx, ev, entry_bb, loop_bb, body_bb, done_bb);
-    }
+    ) -> tuple;
 
     def emit_union(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # union(other): new set with all elements from both
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_set = b.call(helpers["new"], [], name="sunion.new");
-        # Copy all from self
-        len1_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="su.l1.ptr"
-        );
-        e1_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="su.e1.ptr"
-        );
-        len1 = b.load(len1_ptr, name="su.len1");
-        elems1 = b.load(e1_ptr, name="su.elems1");
-        func = b.basic_block.function;
-        entry1 = b.basic_block;
-        loop1 = func.append_basic_block(name="su.loop1");
-        body1 = func.append_basic_block(name="su.body1");
-        mid_bb = func.append_basic_block(name="su.mid");
-        b.branch(loop1);
-        b.position_at_start(loop1);
-        i1 = b.phi(i64, name="su.i1");
-        i1.add_incoming(ir.Constant(i64, 0), entry1);
-        end1 = b.icmp_unsigned(">=", i1, len1, name="su.end1");
-        b.cbranch(end1, mid_bb, body1);
-        b.position_at_start(body1);
-        ep1 = b.gep(elems1, [i1], name="su.ep1");
-        ev1 = b.load(ep1, name="su.ev1");
-        b.call(helpers["add"], [new_set, ev1]);
-        n1 = b.add(i1, ir.Constant(i64, 1), name="su.n1");
-        i1.add_incoming(n1, body1);
-        b.branch(loop1);
-        # Copy all from other
-        b.position_at_start(mid_bb);
-        other = args[0];
-        len2_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="su.l2.ptr"
-        );
-        e2_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="su.e2.ptr"
-        );
-        len2 = b.load(len2_ptr, name="su.len2");
-        elems2 = b.load(e2_ptr, name="su.elems2");
-        loop2 = func.append_basic_block(name="su.loop2");
-        body2 = func.append_basic_block(name="su.body2");
-        done_bb = func.append_basic_block(name="su.done");
-        b.branch(loop2);
-        b.position_at_start(loop2);
-        i2 = b.phi(i64, name="su.i2");
-        i2.add_incoming(ir.Constant(i64, 0), mid_bb);
-        end2 = b.icmp_unsigned(">=", i2, len2, name="su.end2");
-        b.cbranch(end2, done_bb, body2);
-        b.position_at_start(body2);
-        ep2 = b.gep(elems2, [i2], name="su.ep2");
-        ev2 = b.load(ep2, name="su.ev2");
-        b.call(helpers["add"], [new_set, ev2]);
-        n2 = b.add(i2, ir.Constant(i64, 1), name="su.n2");
-        i2.add_incoming(n2, body2);
-        b.branch(loop2);
-        b.position_at_start(done_bb);
-        return new_set;
-    }
+    ) -> (ir.Value | None);
 
     def emit_intersection(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # intersection(other): new set with elements in both self and other
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_set = b.call(helpers["new"], [], name="sinter.new");
-        other = args[0];
-        # Iterate self
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="si.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="si.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="si.len");
-        elems_arr = b.load(elems_ptr, name="si.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="si.loop");
-        body_bb = func.append_basic_block(name="si.body");
-        add_bb = func.append_basic_block(name="si.add");
-        skip_bb = func.append_basic_block(name="si.skip");
-        done_bb = func.append_basic_block(name="si.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="si.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="si.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="si.ep");
-        ev = b.load(ep, name="si.ev");
-        in_other = b.call(helpers["contains"], [other, ev], name="si.inother");
-        b.cbranch(in_other, add_bb, skip_bb);
-        b.position_at_start(add_bb);
-        b.call(helpers["add"], [new_set, ev]);
-        b.branch(skip_bb);
-        b.position_at_start(skip_bb);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="si.next");
-        idx.add_incoming(next_idx, skip_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_set;
-    }
+    ) -> (ir.Value | None);
 
     def emit_difference(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # difference(other): new set with elements in self but not in other
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_set = b.call(helpers["new"], [], name="sdiff.new");
-        other = args[0];
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sd.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sd.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="sd.len");
-        elems_arr = b.load(elems_ptr, name="sd.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="sd.loop");
-        body_bb = func.append_basic_block(name="sd.body");
-        add_bb = func.append_basic_block(name="sd.add");
-        skip_bb = func.append_basic_block(name="sd.skip");
-        done_bb = func.append_basic_block(name="sd.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="sd.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="sd.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="sd.ep");
-        ev = b.load(ep, name="sd.ev");
-        in_other = b.call(helpers["contains"], [other, ev], name="sd.inother");
-        # Add if NOT in other
-        not_in = b.icmp_unsigned(
-            "==", in_other, ir.Constant(ir.IntType(1), 0), name="sd.notin"
-        );
-        b.cbranch(not_in, add_bb, skip_bb);
-        b.position_at_start(add_bb);
-        b.call(helpers["add"], [new_set, ev]);
-        b.branch(skip_bb);
-        b.position_at_start(skip_bb);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="sd.next");
-        idx.add_incoming(next_idx, skip_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_set;
-    }
+    ) -> (ir.Value | None);
 
     def emit_symmetric_difference(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # symmetric_difference(other): elements in either set but not both
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_set = b.call(helpers["new"], [], name="ssymd.new");
-        other = args[0];
-        # Pass 1: add elements from self that are NOT in other
-        len1_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssymd.l1.ptr"
-        );
-        e1_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssymd.e1.ptr"
-        );
-        len1 = b.load(len1_ptr, name="ssymd.len1");
-        elems1 = b.load(e1_ptr, name="ssymd.elems1");
-        func = b.basic_block.function;
-        entry1 = b.basic_block;
-        loop1 = func.append_basic_block(name="ssymd.loop1");
-        body1 = func.append_basic_block(name="ssymd.body1");
-        add1 = func.append_basic_block(name="ssymd.add1");
-        skip1 = func.append_basic_block(name="ssymd.skip1");
-        mid_bb = func.append_basic_block(name="ssymd.mid");
-        b.branch(loop1);
-        b.position_at_start(loop1);
-        i1 = b.phi(i64, name="ssymd.i1");
-        i1.add_incoming(ir.Constant(i64, 0), entry1);
-        end1 = b.icmp_unsigned(">=", i1, len1, name="ssymd.end1");
-        b.cbranch(end1, mid_bb, body1);
-        b.position_at_start(body1);
-        ep1 = b.gep(elems1, [i1], name="ssymd.ep1");
-        ev1 = b.load(ep1, name="ssymd.ev1");
-        in_other1 = b.call(helpers["contains"], [other, ev1], name="ssymd.inother1");
-        not_in1 = b.icmp_unsigned(
-            "==", in_other1, ir.Constant(ir.IntType(1), 0), name="ssymd.notin1"
-        );
-        b.cbranch(not_in1, add1, skip1);
-        b.position_at_start(add1);
-        b.call(helpers["add"], [new_set, ev1]);
-        b.branch(skip1);
-        b.position_at_start(skip1);
-        n1 = b.add(i1, ir.Constant(i64, 1), name="ssymd.n1");
-        i1.add_incoming(n1, skip1);
-        b.branch(loop1);
-        # Pass 2: add elements from other that are NOT in self
-        b.position_at_start(mid_bb);
-        len2_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssymd.l2.ptr"
-        );
-        e2_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssymd.e2.ptr"
-        );
-        len2 = b.load(len2_ptr, name="ssymd.len2");
-        elems2 = b.load(e2_ptr, name="ssymd.elems2");
-        loop2 = func.append_basic_block(name="ssymd.loop2");
-        body2 = func.append_basic_block(name="ssymd.body2");
-        add2 = func.append_basic_block(name="ssymd.add2");
-        skip2 = func.append_basic_block(name="ssymd.skip2");
-        done_bb = func.append_basic_block(name="ssymd.done");
-        b.branch(loop2);
-        b.position_at_start(loop2);
-        i2 = b.phi(i64, name="ssymd.i2");
-        i2.add_incoming(ir.Constant(i64, 0), mid_bb);
-        end2 = b.icmp_unsigned(">=", i2, len2, name="ssymd.end2");
-        b.cbranch(end2, done_bb, body2);
-        b.position_at_start(body2);
-        ep2 = b.gep(elems2, [i2], name="ssymd.ep2");
-        ev2 = b.load(ep2, name="ssymd.ev2");
-        in_self = b.call(helpers["contains"], [target, ev2], name="ssymd.inself");
-        not_in2 = b.icmp_unsigned(
-            "==", in_self, ir.Constant(ir.IntType(1), 0), name="ssymd.notin2"
-        );
-        b.cbranch(not_in2, add2, skip2);
-        b.position_at_start(add2);
-        b.call(helpers["add"], [new_set, ev2]);
-        b.branch(skip2);
-        b.position_at_start(skip2);
-        n2 = b.add(i2, ir.Constant(i64, 1), name="ssymd.n2");
-        i2.add_incoming(n2, skip2);
-        b.branch(loop2);
-        b.position_at_start(done_bb);
-        return new_set;
-    }
+    ) -> (ir.Value | None);
 
     # In-place set algebra
     def emit_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # update(other): add all elements from other to self
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        other = args[0];
-        len_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="supd.len.ptr"
-        );
-        other_len = b.load(len_ptr, name="supd.len");
-        elems_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="supd.elems.ptr"
-        );
-        elems_arr = b.load(elems_ptr, name="supd.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="supd.loop");
-        body_bb = func.append_basic_block(name="supd.body");
-        done_bb = func.append_basic_block(name="supd.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="supd.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, other_len, name="supd.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="supd.ep");
-        ev = b.load(ep, name="supd.ev");
-        b.call(helpers["add"], [target, ev]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="supd.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_intersection_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # intersection_update(other): keep only elements found in other
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        elem_type = helpers["elem_type"];
-        # Build a list of elements to remove (those NOT in other)
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="siupd.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="siupd.elems.ptr"
-        );
-        other = args[0];
-        # We'll do a two-pass approach: first collect elements to keep, then rebuild
-        # Actually simpler: iterate backwards, discard elements not in other
-        set_len = b.load(len_ptr, name="siupd.len");
-        elems_arr = b.load(elems_ptr, name="siupd.elems");
-        func = b.basic_block.function;
-        # Iterate forward; compact in place
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="siupd.loop");
-        body_bb = func.append_basic_block(name="siupd.body");
-        keep_bb = func.append_basic_block(name="siupd.keep");
-        skip_bb = func.append_basic_block(name="siupd.skip");
-        done_bb = func.append_basic_block(name="siupd.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        read_idx = b.phi(i64, name="siupd.ridx");
-        write_idx = b.phi(i64, name="siupd.widx");
-        read_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        write_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", read_idx, set_len, name="siupd.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [read_idx], name="siupd.ep");
-        ev = b.load(ep, name="siupd.ev");
-        in_other = b.call(helpers["contains"], [other, ev], name="siupd.inother");
-        b.cbranch(in_other, keep_bb, skip_bb);
-        # Keep: copy element to write position
-        b.position_at_start(keep_bb);
-        wp = b.gep(elems_arr, [write_idx], name="siupd.wp");
-        b.store(ev, wp);
-        new_widx = b.add(write_idx, ir.Constant(i64, 1), name="siupd.nwidx");
-        next_ridx_k = b.add(read_idx, ir.Constant(i64, 1), name="siupd.nridx.k");
-        b.branch(loop_bb);
-        # Skip: advance read only
-        b.position_at_start(skip_bb);
-        next_ridx_s = b.add(read_idx, ir.Constant(i64, 1), name="siupd.nridx.s");
-        b.branch(loop_bb);
-        # Wire phi nodes
-        read_idx.add_incoming(next_ridx_k, keep_bb);
-        read_idx.add_incoming(next_ridx_s, skip_bb);
-        write_idx.add_incoming(new_widx, keep_bb);
-        write_idx.add_incoming(write_idx, skip_bb);
-        # Done: update length (write_idx in loop_bb has the correct final count)
-        b.position_at_start(done_bb);
-        b.store(write_idx, len_ptr);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_difference_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # difference_update(other): remove all elements found in other
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sdupd.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sdupd.elems.ptr"
-        );
-        other = args[0];
-        set_len = b.load(len_ptr, name="sdupd.len");
-        elems_arr = b.load(elems_ptr, name="sdupd.elems");
-        func = b.basic_block.function;
-        # Compact in place: keep elements NOT in other
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="sdupd.loop");
-        body_bb = func.append_basic_block(name="sdupd.body");
-        keep_bb = func.append_basic_block(name="sdupd.keep");
-        skip_bb = func.append_basic_block(name="sdupd.skip");
-        done_bb = func.append_basic_block(name="sdupd.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        read_idx = b.phi(i64, name="sdupd.ridx");
-        write_idx = b.phi(i64, name="sdupd.widx");
-        read_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        write_idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", read_idx, set_len, name="sdupd.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [read_idx], name="sdupd.ep");
-        ev = b.load(ep, name="sdupd.ev");
-        in_other = b.call(helpers["contains"], [other, ev], name="sdupd.inother");
-        # Keep if NOT in other
-        not_in = b.icmp_unsigned(
-            "==", in_other, ir.Constant(ir.IntType(1), 0), name="sdupd.notin"
-        );
-        b.cbranch(not_in, keep_bb, skip_bb);
-        b.position_at_start(keep_bb);
-        wp = b.gep(elems_arr, [write_idx], name="sdupd.wp");
-        b.store(ev, wp);
-        new_widx = b.add(write_idx, ir.Constant(i64, 1), name="sdupd.nwidx");
-        next_ridx_k = b.add(read_idx, ir.Constant(i64, 1), name="sdupd.nridx.k");
-        b.branch(loop_bb);
-        b.position_at_start(skip_bb);
-        next_ridx_s = b.add(read_idx, ir.Constant(i64, 1), name="sdupd.nridx.s");
-        b.branch(loop_bb);
-        read_idx.add_incoming(next_ridx_k, keep_bb);
-        read_idx.add_incoming(next_ridx_s, skip_bb);
-        write_idx.add_incoming(new_widx, keep_bb);
-        write_idx.add_incoming(write_idx, skip_bb);
-        # Done: update length (write_idx in loop_bb has the correct final count)
-        b.position_at_start(done_bb);
-        b.store(write_idx, len_ptr);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     def emit_symmetric_difference_update(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # symmetric_difference_update(other): keep only elements in either but not both
-        # Strategy: compute symmetric_difference, then replace target contents
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        other = args[0];
-        # Step 1: build the symmetric difference as a new set
-        result = self.emit_symmetric_difference(ctx, target, [other]);
-        if result is None {
-            return None;
-        }
-        # Step 2: clear target
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssdupd.len.ptr"
-        );
-        b.store(ir.Constant(i64, 0), len_ptr);
-        # Step 3: add all elements from result to target
-        res_len_ptr = b.gep(
-            result, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssdupd.rlen.ptr"
-        );
-        res_elems_ptr = b.gep(
-            result,
-            [ir.Constant(i32, 0), ir.Constant(i32, 2)],
-            name="ssdupd.relems.ptr"
-        );
-        res_len = b.load(res_len_ptr, name="ssdupd.rlen");
-        res_elems = b.load(res_elems_ptr, name="ssdupd.relems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="ssdupd.loop");
-        body_bb = func.append_basic_block(name="ssdupd.body");
-        done_bb = func.append_basic_block(name="ssdupd.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="ssdupd.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, res_len, name="ssdupd.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(res_elems, [idx], name="ssdupd.ep");
-        ev = b.load(ep, name="ssdupd.ev");
-        b.call(helpers["add"], [target, ev]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="ssdupd.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return ir.Constant(i64, 0);
-    }
+    ) -> (ir.Value | None);
 
     # Tests
     def emit_issubset(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # issubset(other): return 1 if all elements of self are in other
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        other = args[0];
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssub.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssub.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="ssub.len");
-        elems_arr = b.load(elems_ptr, name="ssub.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="ssub.loop");
-        body_bb = func.append_basic_block(name="ssub.body");
-        false_bb = func.append_basic_block(name="ssub.false");
-        done_bb = func.append_basic_block(name="ssub.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="ssub.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="ssub.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="ssub.ep");
-        ev = b.load(ep, name="ssub.ev");
-        in_other = b.call(helpers["contains"], [other, ev], name="ssub.inother");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="ssub.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(in_other, loop_bb, false_bb);
-        b.position_at_start(false_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="ssub.result");
-        result.add_incoming(ir.Constant(i64, 1), loop_bb);
-        result.add_incoming(ir.Constant(i64, 0), false_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_issuperset(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # issuperset(other): return 1 if all elements of other are in self
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        other = args[0];
-        # Iterate OTHER, check each in SELF
-        len_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="ssup.len.ptr"
-        );
-        elems_ptr = b.gep(
-            other, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="ssup.elems.ptr"
-        );
-        other_len = b.load(len_ptr, name="ssup.len");
-        elems_arr = b.load(elems_ptr, name="ssup.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="ssup.loop");
-        body_bb = func.append_basic_block(name="ssup.body");
-        false_bb = func.append_basic_block(name="ssup.false");
-        done_bb = func.append_basic_block(name="ssup.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="ssup.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, other_len, name="ssup.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="ssup.ep");
-        ev = b.load(ep, name="ssup.ev");
-        in_self = b.call(helpers["contains"], [target, ev], name="ssup.inself");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="ssup.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(in_self, loop_bb, false_bb);
-        b.position_at_start(false_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="ssup.result");
-        result.add_incoming(ir.Constant(i64, 1), loop_bb);
-        result.add_incoming(ir.Constant(i64, 0), false_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isdisjoint(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # isdisjoint(other): return 1 if no elements in common
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        other = args[0];
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="sdisj.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="sdisj.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="sdisj.len");
-        elems_arr = b.load(elems_ptr, name="sdisj.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="sdisj.loop");
-        body_bb = func.append_basic_block(name="sdisj.body");
-        found_bb = func.append_basic_block(name="sdisj.found");
-        done_bb = func.append_basic_block(name="sdisj.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="sdisj.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="sdisj.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="sdisj.ep");
-        ev = b.load(ep, name="sdisj.ev");
-        in_other = b.call(helpers["contains"], [other, ev], name="sdisj.inother");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="sdisj.next");
-        idx.add_incoming(next_idx, body_bb);
-        # If found in other, not disjoint
-        b.cbranch(in_other, found_bb, loop_bb);
-        b.position_at_start(found_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="sdisj.result");
-        result.add_incoming(ir.Constant(i64, 1), loop_bb);
-        result.add_incoming(ir.Constant(i64, 0), found_bb);
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_copy(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # copy: create new set and add all elements
-        p = ctx.pass_ref;
-        helpers = p.set_helpers.get(ctx.type_key);
-        if helpers is None {
-            return None;
-        }
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        new_set = b.call(helpers["new"], [], name="scopy.new");
-        len_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="scopy.len.ptr"
-        );
-        elems_ptr = b.gep(
-            target, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="scopy.elems.ptr"
-        );
-        set_len = b.load(len_ptr, name="scopy.len");
-        elems_arr = b.load(elems_ptr, name="scopy.elems");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="scopy.loop");
-        body_bb = func.append_basic_block(name="scopy.body");
-        done_bb = func.append_basic_block(name="scopy.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="scopy.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, set_len, name="scopy.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        ep = b.gep(elems_arr, [idx], name="scopy.ep");
-        ev = b.load(ep, name="scopy.ev");
-        b.call(helpers["add"], [new_set, ev]);
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="scopy.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return new_set;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeFrozensetEmitter(FrozensetEmitter[(ir.Value, NativeEmitCtx)]) {
     """Frozenset emitter — delegates to set emitter since frozenset uses same LLVM type."""
-    def _get_set_emitter(self, ctx: NativeEmitCtx) -> (object | None) {
-        return ctx.pass_ref._native_emitters.get("set");
-    }
+    def _get_set_emitter(self, ctx: NativeEmitCtx) -> (object | None);
 
     def emit_union(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_union(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_intersection(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_intersection(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_difference(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_difference(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_symmetric_difference(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_symmetric_difference(ctx, target, args)
-            if se is not None
-            else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_issubset(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_issubset(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_issuperset(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_issuperset(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_isdisjoint(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_isdisjoint(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_copy(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        se = self._get_set_emitter(ctx);
-        return se.emit_copy(ctx, target, args) if se is not None else None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeTupleEmitter(TupleEmitter[(ir.Value, NativeEmitCtx)]) {
     """Helper: get struct type and element count from context."""
     def _get_struct_info(
         self, ctx: NativeEmitCtx, target: ir.Value
-    ) -> (object | None) {
-        if isinstance(target.type, ir.PointerType)
-        and isinstance(target.type.pointee, ir.LiteralStructType) {
-            return target.type.pointee;
-        }
-        # Fallback: look up from tuple_types using type_key
-        p = ctx.pass_ref;
-        st = p.tuple_types.get(ctx.type_key);
-        return st;
-    }
+    ) -> (object | None);
 
     def emit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        st = self._get_struct_info(ctx, target);
-        if st is None or not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        n = len(st.elements);
-        count = ir.Constant(i64, 0);
-        val = args[0];
-        for i in range(n) {
-            ep = b.gep(
-                target,
-                [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), i)],
-                name=f"tc.{i}.ptr"
-            );
-            elem = b.load(ep, name=f"tc.{i}");
-            val_c = p._coerce_type(val, elem.type);
-            if isinstance(elem.type, ir.IntType) {
-                eq = b.icmp_signed("==", val_c, elem, name=f"tc.{i}.eq");
-            } elif isinstance(elem.type, ir.DoubleType) {
-                eq = b.fcmp_ordered("==", val_c, elem, name=f"tc.{i}.eq");
-            } else {
-                return None;
-            }
-            inc = b.zext(eq, i64, name=f"tc.{i}.inc");
-            count = b.add(count, inc, name=f"tc.{i}.cnt");
-        }
-        return count;
-    }
+    ) -> (ir.Value | None);
 
     def emit_index(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        st = self._get_struct_info(ctx, target);
-        if st is None or not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        n = len(st.elements);
-        val = args[0];
-        # Use select chain: start with -1 (not found), update on match
-        result = ir.Constant(i64, -1);
-        for i in range(n - 1, -1, -1) {
-            ep = b.gep(
-                target,
-                [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), i)],
-                name=f"ti.{i}.ptr"
-            );
-            elem = b.load(ep, name=f"ti.{i}");
-            val_c = p._coerce_type(val, elem.type);
-            if isinstance(elem.type, ir.IntType) {
-                eq = b.icmp_signed("==", val_c, elem, name=f"ti.{i}.eq");
-            } elif isinstance(elem.type, ir.DoubleType) {
-                eq = b.fcmp_ordered("==", val_c, elem, name=f"ti.{i}.eq");
-            } else {
-                return None;
-            }
-            result = b.select(eq, ir.Constant(i64, i), result, name=f"ti.{i}.sel");
-        }
-        return result;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_add(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_mul(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_eq(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_ne(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_lt(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_gt(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_le(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_ge(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_contains(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 class NativeRangeEmitter(RangeEmitter[(ir.Value, NativeEmitCtx)]) {
     """Helper: load start, stop, step from JacRange pointer."""
-    def _load_range(self, ctx: NativeEmitCtx, target: ir.Value) -> (tuple | None) {
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        z0 = ir.Constant(i32, 0);
-        start = b.load(
-            b.gep(target, [z0, ir.Constant(i32, 0)], name="rng.sp"), name="rng.start"
-        );
-        stop = b.load(
-            b.gep(target, [z0, ir.Constant(i32, 1)], name="rng.ep"), name="rng.stop"
-        );
-        step = b.load(
-            b.gep(target, [z0, ir.Constant(i32, 2)], name="rng.tp"), name="rng.step"
-        );
-        return (start, stop, step);
-    }
+    def _load_range(self, ctx: NativeEmitCtx, target: ir.Value) -> (tuple | None);
 
     """Helper: check if val is in range(start, stop, step)."""
     def _in_range(
@@ -5221,1237 +867,133 @@ class NativeRangeEmitter(RangeEmitter[(ir.Value, NativeEmitCtx)]) {
         start: ir.Value,
         stop: ir.Value,
         step: ir.Value
-    ) -> ir.Value {
-        b = ctx.pass_ref.builder;
-        i64 = ir.IntType(64);
-        i1 = ir.IntType(1);
-        diff = b.sub(val, start, name="rin.diff");
-        rem = b.srem(diff, step, name="rin.rem");
-        rem_zero = b.icmp_signed("==", rem, ir.Constant(i64, 0), name="rin.remz");
-        step_pos = b.icmp_signed(">", step, ir.Constant(i64, 0), name="rin.spos");
-        ge_start = b.icmp_signed(">=", val, start, name="rin.ges");
-        lt_stop = b.icmp_signed("<", val, stop, name="rin.lts");
-        pos_ok = b.and_(ge_start, lt_stop, name="rin.pok");
-        le_start = b.icmp_signed("<=", val, start, name="rin.les");
-        gt_stop = b.icmp_signed(">", val, stop, name="rin.gts");
-        neg_ok = b.and_(le_start, gt_stop, name="rin.nok");
-        bounds = b.select(step_pos, pos_ok, neg_ok, name="rin.bounds");
-        return b.and_(rem_zero, bounds, name="rin.found");
-    }
+    ) -> ir.Value;
 
     def emit_count(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        parts = self._load_range(ctx, target);
-        if parts is None or not args {
-            return None;
-        }
-        (start, stop, step) = parts;
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        val = p._coerce_type(args[0], i64);
-        found = self._in_range(ctx, val, start, stop, step);
-        return b.zext(found, i64, name="rng.count");
-    }
+    ) -> (ir.Value | None);
 
     def emit_index(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        parts = self._load_range(ctx, target);
-        if parts is None or not args {
-            return None;
-        }
-        (start, stop, step) = parts;
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        val = p._coerce_type(args[0], i64);
-        diff = b.sub(val, start, name="ri.diff");
-        idx = b.sdiv(diff, step, name="ri.idx");
-        return idx;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_eq(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_ne(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_op_contains(
         self, ctx: NativeEmitCtx, target: ir.Value, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }
+
 
 # =============================================================================
 #  Builtin Functions
 # =============================================================================
 class NativeBuiltinEmitter(BuiltinEmitter[(ir.Value, NativeEmitCtx)]) {
-    def emit_print(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_input(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_len(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_abs(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        b = ctx.pass_ref.builder;
-        i64 = ir.IntType(64);
-        if isinstance(arg_val.type, ir.IntType) {
-            zero = ir.Constant(i64, 0);
-            is_neg = b.icmp_signed("<", arg_val, zero, name="abs.neg");
-            negated = b.sub(zero, arg_val, name="abs.negate");
-            return b.select(is_neg, negated, arg_val, name="abs.result");
-        }
-        if isinstance(arg_val.type, ir.DoubleType) {
-            fabs_fn = ctx.pass_ref._get_or_declare_extern(
-                "fabs", ir.DoubleType(), [ir.DoubleType()]
-            );
-            return b.call(fabs_fn, [arg_val], name="abs.fresult");
-        }
-        return None;
-    }
-
-    def emit_round(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        if isinstance(arg_val.type, ir.DoubleType) {
-            round_fn = p._get_or_declare_extern(
-                "round", ir.DoubleType(), [ir.DoubleType()]
-            );
-            rounded = b.call(round_fn, [arg_val], name="round.f");
-            return b.fptosi(rounded, i64, name="round.result");
-        }
-        # int rounds to itself
-        if isinstance(arg_val.type, ir.IntType) {
-            return arg_val;
-        }
-        return None;
-    }
-
-    def emit_min(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if len(args) < 2 {
-            return None;
-        }
-        b = ctx.pass_ref.builder;
-        a = args[0];
-        v = args[1];
-        if isinstance(a.type, ir.IntType) and isinstance(v.type, ir.IntType) {
-            cmp = b.icmp_signed("<", a, v, name="min.cmp");
-            return b.select(cmp, a, v, name="min.result");
-        }
-        if isinstance(a.type, ir.DoubleType) and isinstance(v.type, ir.DoubleType) {
-            cmp = b.fcmp_ordered("<", a, v, name="min.fcmp");
-            return b.select(cmp, a, v, name="min.fresult");
-        }
-        return None;
-    }
-
-    def emit_max(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if len(args) < 2 {
-            return None;
-        }
-        b = ctx.pass_ref.builder;
-        a = args[0];
-        v = args[1];
-        if isinstance(a.type, ir.IntType) and isinstance(v.type, ir.IntType) {
-            cmp = b.icmp_signed(">", a, v, name="max.cmp");
-            return b.select(cmp, a, v, name="max.result");
-        }
-        if isinstance(a.type, ir.DoubleType) and isinstance(v.type, ir.DoubleType) {
-            cmp = b.fcmp_ordered(">", a, v, name="max.fcmp");
-            return b.select(cmp, a, v, name="max.fresult");
-        }
-        return None;
-    }
-
-    def emit_sum(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # sum(list) -> int: iterate list elements and accumulate
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        list_val = args[0];
-        # Find matching list helpers
-        helpers: (dict | None) = None;
-        elem_key: (str | None) = None;
-        for (lk, lt) in p.list_types.items() {
-            if list_val.type == lt.as_pointer() {
-                helpers = p.list_helpers.get(lk);
-                elem_key = lk;
-                break;
-            }
-        }
-        if helpers is None {
-            return None;
-        }
-        list_len = b.call(helpers["len"], [list_val], name="sum.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="sum.loop");
-        body_bb = func.append_basic_block(name="sum.body");
-        done_bb = func.append_basic_block(name="sum.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="sum.idx");
-        acc = b.phi(i64, name="sum.acc");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        acc.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, list_len, name="sum.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        elem = b.call(helpers["get"], [list_val, idx], name="sum.elem");
-        new_acc = b.add(acc, elem, name="sum.add");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="sum.next");
-        idx.add_incoming(next_idx, body_bb);
-        acc.add_incoming(new_acc, body_bb);
-        b.branch(loop_bb);
-        b.position_at_start(done_bb);
-        return acc;
-    }
-
+    def emit_print(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_input(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_len(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_abs(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_round(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_min(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_max(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_sum(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_sorted(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # sorted(list) -> new sorted copy
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        list_val = args[0];
-        # Find matching list helpers from the argument type
-        helpers: (dict | None) = None;
-        elem_key: (str | None) = None;
-        for (lk, lt) in p.list_types.items() {
-            if list_val.type == lt.as_pointer() {
-                helpers = p.list_helpers.get(lk);
-                elem_key = lk;
-                break;
-            }
-        }
-        if helpers is None {
-            return None;
-        }
-        _le = p._native_emitters.get("list") if p?._native_emitters else None;
-        if _le is None {
-            return None;
-        }
-        _ctx2 = ctx.__class__(pass_ref=p, type_key=elem_key or "");
-        # Copy the list then sort the copy
-        sorted_copy = _le.emit_copy(_ctx2, list_val, []);
-        if sorted_copy is None {
-            return None;
-        }
-        _le.emit_sort(_ctx2, sorted_copy, []);
-        return sorted_copy;
-    }
+    ) -> (ir.Value | None);
 
     def emit_reversed(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # reversed(list) -> new reversed copy
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        list_val = args[0];
-        # Find matching list helpers from the argument type
-        helpers: (dict | None) = None;
-        elem_key: (str | None) = None;
-        for (lk, lt) in p.list_types.items() {
-            if list_val.type == lt.as_pointer() {
-                helpers = p.list_helpers.get(lk);
-                elem_key = lk;
-                break;
-            }
-        }
-        if helpers is None {
-            return None;
-        }
-        _le = p._native_emitters.get("list") if p?._native_emitters else None;
-        if _le is None {
-            return None;
-        }
-        _ctx2 = ctx.__class__(pass_ref=p, type_key=elem_key or "");
-        # Copy the list then reverse the copy
-        rev_copy = _le.emit_copy(_ctx2, list_val, []);
-        if rev_copy is None {
-            return None;
-        }
-        _le.emit_reverse(_ctx2, rev_copy, []);
-        return rev_copy;
-    }
+    ) -> (ir.Value | None);
 
     def emit_enumerate(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
-    def emit_zip(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_map(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
+    def emit_zip(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_map(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_filter(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
-    def emit_any(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # any(list) -> int: return 1 if any element is truthy
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        list_val = args[0];
-        helpers: (dict | None) = None;
-        for (lk, lt) in p.list_types.items() {
-            if list_val.type == lt.as_pointer() {
-                helpers = p.list_helpers.get(lk);
-                break;
-            }
-        }
-        if helpers is None {
-            return None;
-        }
-        list_len = b.call(helpers["len"], [list_val], name="any.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="any.loop");
-        body_bb = func.append_basic_block(name="any.body");
-        found_bb = func.append_basic_block(name="any.found");
-        done_bb = func.append_basic_block(name="any.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="any.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, list_len, name="any.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        elem = b.call(helpers["get"], [list_val, idx], name="any.elem");
-        is_true = b.icmp_signed("!=", elem, ir.Constant(i64, 0), name="any.true");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="any.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(is_true, found_bb, loop_bb);
-        b.position_at_start(found_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="any.result");
-        result.add_incoming(ir.Constant(i64, 0), loop_bb);
-        result.add_incoming(ir.Constant(i64, 1), found_bb);
-        return result;
-    }
-
-    def emit_all(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # all(list) -> int: return 1 if all elements are truthy (or list is empty)
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        list_val = args[0];
-        helpers: (dict | None) = None;
-        for (lk, lt) in p.list_types.items() {
-            if list_val.type == lt.as_pointer() {
-                helpers = p.list_helpers.get(lk);
-                break;
-            }
-        }
-        if helpers is None {
-            return None;
-        }
-        list_len = b.call(helpers["len"], [list_val], name="all.len");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        loop_bb = func.append_basic_block(name="all.loop");
-        body_bb = func.append_basic_block(name="all.body");
-        false_bb = func.append_basic_block(name="all.false");
-        done_bb = func.append_basic_block(name="all.done");
-        b.branch(loop_bb);
-        b.position_at_start(loop_bb);
-        idx = b.phi(i64, name="all.idx");
-        idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-        at_end = b.icmp_unsigned(">=", idx, list_len, name="all.atend");
-        b.cbranch(at_end, done_bb, body_bb);
-        b.position_at_start(body_bb);
-        elem = b.call(helpers["get"], [list_val, idx], name="all.elem");
-        is_false = b.icmp_signed("==", elem, ir.Constant(i64, 0), name="all.false");
-        next_idx = b.add(idx, ir.Constant(i64, 1), name="all.next");
-        idx.add_incoming(next_idx, body_bb);
-        b.cbranch(is_false, false_bb, loop_bb);
-        b.position_at_start(false_bb);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        result = b.phi(i64, name="all.result");
-        result.add_incoming(ir.Constant(i64, 1), loop_bb);
-        result.add_incoming(ir.Constant(i64, 0), false_bb);
-        return result;
-    }
-
+    def emit_any(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_all(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_isinstance(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_issubclass(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
-    def emit_type(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_id(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        if isinstance(arg_val.type, ir.PointerType) {
-            return b.ptrtoint(arg_val, i64, name="id.ptr");
-        }
-        if isinstance(arg_val.type, ir.IntType) {
-            return p._coerce_type(arg_val, i64);
-        }
-        return None;
-    }
-
-    def emit_hash(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        # int hash = identity
-        if isinstance(arg_val.type, ir.IntType) {
-            return p._coerce_type(arg_val, i64);
-        }
-        # string hash = djb2
-        i8p = ir.IntType(8).as_pointer();
-        if isinstance(arg_val.type, ir.PointerType) and arg_val.type == i8p {
-            i8 = ir.IntType(8);
-            func = b.basic_block.function;
-            entry_bb = b.basic_block;
-            loop_bb = func.append_basic_block(name="hash.loop");
-            body_bb = func.append_basic_block(name="hash.body");
-            done_bb = func.append_basic_block(name="hash.done");
-            b.branch(loop_bb);
-            b.position_at_start(loop_bb);
-            h = b.phi(i64, name="hash.h");
-            h.add_incoming(ir.Constant(i64, 5381), entry_bb);
-            idx = b.phi(i64, name="hash.idx");
-            idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-            cp = b.gep(arg_val, [idx], name="hash.cp");
-            ch = b.load(cp, name="hash.ch");
-            is_zero = b.icmp_unsigned("==", ch, ir.Constant(i8, 0), name="hash.end");
-            b.cbranch(is_zero, done_bb, body_bb);
-            b.position_at_start(body_bb);
-            ch_ext = b.zext(ch, i64, name="hash.chext");
-            h_shl5 = b.shl(h, ir.Constant(i64, 5), name="hash.shl5");
-            h_plus_h = b.add(h_shl5, h, name="hash.mul33");
-            h_next = b.add(h_plus_h, ch_ext, name="hash.next");
-            next_idx = b.add(idx, ir.Constant(i64, 1), name="hash.nextidx");
-            h.add_incoming(h_next, body_bb);
-            idx.add_incoming(next_idx, body_bb);
-            b.branch(loop_bb);
-            b.position_at_start(done_bb);
-            return h;
-        }
-        return None;
-    }
-
-    def emit_repr(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        rc_alloc_fn = p.rc_alloc_fn;
-        buf_ptr = b.call(rc_alloc_fn, [ir.Constant(i64, 64)], name="repr.buf");
-        snprintf = p._get_or_declare_extern(
-            "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
-        );
-        if isinstance(arg_val.type, ir.IntType) {
-            fmt = p._get_snprintf_fmt("%ld");
-            fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
-            coerced = p._coerce_type(arg_val, i64);
-            b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, coerced]);
-            return buf_ptr;
-        }
-        if isinstance(arg_val.type, ir.DoubleType) {
-            fmt = p._get_snprintf_fmt("%g");
-            fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
-            b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, arg_val]);
-            return buf_ptr;
-        }
-        if isinstance(arg_val.type, ir.PointerType) and arg_val.type == i8p {
-            fmt = p._get_snprintf_fmt("'%s'");
-            fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
-            b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, arg_val]);
-            return buf_ptr;
-        }
-        return None;
-    }
-
-    def emit_chr(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        rc_alloc_fn = p.rc_alloc_fn;
-        str_ptr = b.call(rc_alloc_fn, [ir.Constant(ir.IntType(64), 2)], name="chr.buf");
-        byte_val = b.trunc(arg_val, ir.IntType(8), name="chr.byte");
-        b.store(byte_val, str_ptr);
-        idx1_ptr = b.gep(str_ptr, [ir.Constant(ir.IntType(64), 1)], name="chr.null.ptr");
-        b.store(ir.Constant(ir.IntType(8), 0), idx1_ptr);
-        return str_ptr;
-    }
-
-    def emit_ord(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        b = ctx.pass_ref.builder;
-        byte_val = b.load(arg_val, name="ord.byte");
-        return b.zext(byte_val, ir.IntType(64), name="ord.val");
-    }
-
-    def emit_hex(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        rc_alloc_fn = p.rc_alloc_fn;
-        snprintf = p._get_or_declare_extern(
-            "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
-        );
-        buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="hex.buf");
-        # Check if negative
-        arg_val = args[0];
-        zero = ir.Constant(i64, 0);
-        is_neg = b.icmp_signed("<", arg_val, zero, name="hex.neg");
-        abs_val = b.sub(zero, arg_val, name="hex.abs");
-        pos_val = b.select(is_neg, abs_val, arg_val, name="hex.pos");
-        fmt_pos = p._get_snprintf_fmt("0x%lx");
-        fmt_neg = p._get_snprintf_fmt("-0x%lx");
-        fmt_pos_ptr = b.bitcast(fmt_pos, i8p, name="hex.fmt.pos");
-        fmt_neg_ptr = b.bitcast(fmt_neg, i8p, name="hex.fmt.neg");
-        fmt = b.select(is_neg, fmt_neg_ptr, fmt_pos_ptr, name="hex.fmt");
-        b.call(snprintf, [buf, ir.Constant(i64, 32), fmt, pos_val], name="hex.snprintf");
-        return buf;
-    }
-
-    def emit_oct(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        rc_alloc_fn = p.rc_alloc_fn;
-        snprintf = p._get_or_declare_extern(
-            "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
-        );
-        buf = b.call(rc_alloc_fn, [ir.Constant(i64, 32)], name="oct.buf");
-        arg_val = args[0];
-        zero = ir.Constant(i64, 0);
-        is_neg = b.icmp_signed("<", arg_val, zero, name="oct.neg");
-        abs_val = b.sub(zero, arg_val, name="oct.abs");
-        pos_val = b.select(is_neg, abs_val, arg_val, name="oct.pos");
-        fmt_pos = p._get_snprintf_fmt("0o%lo");
-        fmt_neg = p._get_snprintf_fmt("-0o%lo");
-        fmt_pos_ptr = b.bitcast(fmt_pos, i8p, name="oct.fmt.pos");
-        fmt_neg_ptr = b.bitcast(fmt_neg, i8p, name="oct.fmt.neg");
-        fmt = b.select(is_neg, fmt_neg_ptr, fmt_pos_ptr, name="oct.fmt");
-        b.call(snprintf, [buf, ir.Constant(i64, 32), fmt, pos_val], name="oct.snprintf");
-        return buf;
-    }
-
-    def emit_bin(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        rc_alloc_fn = p.rc_alloc_fn;
-        snprintf = p._get_or_declare_extern(
-            "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
-        );
-        # Allocate buffer: "0b" + up to 64 digits + sign + null = 68
-        buf = b.call(rc_alloc_fn, [ir.Constant(i64, 68)], name="bin.buf");
-        arg_val = args[0];
-        zero = ir.Constant(i64, 0);
-        is_neg = b.icmp_signed("<", arg_val, zero, name="bin.neg");
-        abs_val = b.sub(zero, arg_val, name="bin.abs");
-        pos_val = b.select(is_neg, abs_val, arg_val, name="bin.pos");
-        is_zero = b.icmp_signed("==", arg_val, zero, name="bin.iszero");
-        func = b.basic_block.function;
-        entry_bb = b.basic_block;
-        zero_bb = func.append_basic_block(name="bin.zero");
-        prefix_bb = func.append_basic_block(name="bin.prefix");
-        loop_bb = func.append_basic_block(name="bin.loop");
-        body_bb = func.append_basic_block(name="bin.body");
-        reverse_bb = func.append_basic_block(name="bin.reverse");
-        done_bb = func.append_basic_block(name="bin.done");
-        b.cbranch(is_zero, zero_bb, prefix_bb);
-        # Zero case: "0b0"
-        b.position_at_start(zero_bb);
-        fmt_zero = p._get_snprintf_fmt("0b0");
-        fmt_zero_ptr = b.bitcast(fmt_zero, i8p, name="bin.fmt.zero");
-        b.call(snprintf, [buf, ir.Constant(i64, 68), fmt_zero_ptr], name="bin.zero.snp");
-        b.branch(done_bb);
-        # Write prefix: "-0b" or "0b"
-        b.position_at_start(prefix_bb);
-        neg_ch = ir.Constant(i8, 45);  # '-'
-        zero_ch = ir.Constant(i8, 48);  # '0'
-        b_ch = ir.Constant(i8, 98);  # 'b'
-        # Write sign if negative
-        start_off_val = b.select(
-            is_neg, ir.Constant(i64, 1), ir.Constant(i64, 0), name="bin.start"
-        );
-        neg_ptr = b.gep(buf, [ir.Constant(i64, 0)], name="bin.neg.ptr");
-        b.store(b.select(is_neg, neg_ch, zero_ch, name="bin.first.ch"), neg_ptr);
-        zero_ptr = b.gep(buf, [start_off_val], name="bin.zero.ptr");
-        b.store(zero_ch, zero_ptr);
-        b_off = b.add(start_off_val, ir.Constant(i64, 1), name="bin.b.off");
-        b_ptr = b.gep(buf, [b_off], name="bin.b.ptr");
-        b.store(b_ch, b_ptr);
-        digit_start = b.add(b_off, ir.Constant(i64, 1), name="bin.digit.start");
-        b.branch(loop_bb);
-        # Extract digits (reverse order)
-        b.position_at_start(loop_bb);
-        val = b.phi(i64, name="bin.val");
-        off = b.phi(i64, name="bin.off");
-        val.add_incoming(pos_val, prefix_bb);
-        off.add_incoming(digit_start, prefix_bb);
-        is_done = b.icmp_unsigned("==", val, ir.Constant(i64, 0), name="bin.done.chk");
-        b.cbranch(is_done, reverse_bb, body_bb);
-        b.position_at_start(body_bb);
-        bit = b.and_(val, ir.Constant(i64, 1), name="bin.bit");
-        digit = b.trunc(
-            b.add(bit, ir.Constant(i64, 48), name="bin.digit.val"),
-            i8,
-            name="bin.digit"
-        );
-        digit_ptr = b.gep(buf, [off], name="bin.digit.ptr");
-        b.store(digit, digit_ptr);
-        new_val = b.lshr(val, ir.Constant(i64, 1), name="bin.new.val");
-        new_off = b.add(off, ir.Constant(i64, 1), name="bin.new.off");
-        val.add_incoming(new_val, body_bb);
-        off.add_incoming(new_off, body_bb);
-        b.branch(loop_bb);
-        # Reverse the digit portion and null-terminate
-        b.position_at_start(reverse_bb);
-        null_ptr = b.gep(buf, [off], name="bin.null.ptr");
-        b.store(ir.Constant(i8, 0), null_ptr);
-        # Reverse digits between digit_start and off-1
-        rev_entry = b.basic_block;
-        rev_loop = func.append_basic_block(name="bin.rev.loop");
-        rev_body = func.append_basic_block(name="bin.rev.body");
-        rev_done = func.append_basic_block(name="bin.rev.done");
-        end_idx = b.sub(off, ir.Constant(i64, 1), name="bin.end.idx");
-        b.branch(rev_loop);
-        b.position_at_start(rev_loop);
-        lo = b.phi(i64, name="bin.rev.lo");
-        hi = b.phi(i64, name="bin.rev.hi");
-        lo.add_incoming(digit_start, rev_entry);
-        hi.add_incoming(end_idx, rev_entry);
-        need_swap = b.icmp_signed("<", lo, hi, name="bin.rev.need");
-        b.cbranch(need_swap, rev_body, rev_done);
-        b.position_at_start(rev_body);
-        lo_ptr = b.gep(buf, [lo], name="bin.rev.lo.ptr");
-        hi_ptr = b.gep(buf, [hi], name="bin.rev.hi.ptr");
-        lo_ch = b.load(lo_ptr, name="bin.rev.lo.ch");
-        hi_ch = b.load(hi_ptr, name="bin.rev.hi.ch");
-        b.store(hi_ch, lo_ptr);
-        b.store(lo_ch, hi_ptr);
-        next_lo = b.add(lo, ir.Constant(i64, 1), name="bin.rev.next.lo");
-        next_hi = b.sub(hi, ir.Constant(i64, 1), name="bin.rev.next.hi");
-        lo.add_incoming(next_lo, rev_body);
-        hi.add_incoming(next_hi, rev_body);
-        b.branch(rev_loop);
-        b.position_at_start(rev_done);
-        b.branch(done_bb);
-        b.position_at_start(done_bb);
-        return buf;
-    }
-
-    def emit_pow(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if len(args) < 2 {
-            return None;
-        }
-        p = ctx.pass_ref;
-        base = args[0];
-        exp = args[1];
-        if isinstance(base.type, ir.IntType) and isinstance(exp.type, ir.IntType) {
-            return p._codegen_int_pow(base, exp);
-        }
-        if isinstance(base.type, ir.DoubleType)
-        and isinstance(exp.type, ir.DoubleType) {
-            pow_fn = p._get_or_declare_extern(
-                "pow", ir.DoubleType(), [ir.DoubleType(), ir.DoubleType()]
-            );
-            return p.builder.call(pow_fn, [base, exp], name="pow.result");
-        }
-        return None;
-    }
-
+    def emit_type(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_id(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_hash(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_repr(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_chr(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_ord(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_hex(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_oct(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_bin(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_pow(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_divmod(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # divmod(a, b) -> tuple of (a // b, a % b)
-        if len(args) < 2 {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        a = args[0];
-        v = args[1];
-        if isinstance(a.type, ir.IntType) and isinstance(v.type, ir.IntType) {
-            # ZeroDivisionError check
-            izero = ir.Constant(i64, 0);
-            is_zero = b.icmp_signed("==", v, izero, name="divmod.zero.chk");
-            p._emit_runtime_raise(
-                is_zero, "ZeroDivisionError", "integer division or modulo by zero"
-            );
-            quot = b.sdiv(a, v, name="divmod.quot");
-            rem = b.srem(a, v, name="divmod.rem");
-            # Build a 2-element tuple (struct {i64, i64})
-            tuple_type = ir.LiteralStructType([i64, i64]);
-            null_ptr = ir.Constant(tuple_type.as_pointer(), None);
-            size_gep = b.gep(
-                null_ptr, [ir.Constant(ir.IntType(32), 1)], name="divmod.sizeof.gep"
-            );
-            size = b.ptrtoint(size_gep, i64, name="divmod.sizeof");
-            raw_ptr = b.call(p.rc_alloc_fn, [size], name="divmod.alloc");
-            tuple_ptr = b.bitcast(raw_ptr, tuple_type.as_pointer(), name="divmod.ptr");
-            # Store quotient and remainder
-            q_ptr = b.gep(
-                tuple_ptr,
-                [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 0)],
-                name="divmod.q.ptr"
-            );
-            r_ptr = b.gep(
-                tuple_ptr,
-                [ir.Constant(ir.IntType(32), 0), ir.Constant(ir.IntType(32), 1)],
-                name="divmod.r.ptr"
-            );
-            b.store(quot, q_ptr);
-            b.store(rem, r_ptr);
-            # Register the tuple type
-            tkey = f"Tuple.2.i64.i64";
-            if tkey not in p.tuple_types {
-                p.tuple_types[tkey] = tuple_type;
-            }
-            return tuple_ptr;
-        }
-        return None;
-    }
+    ) -> (ir.Value | None);
 
-    def emit_iter(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_next(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
+    def emit_iter(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_next(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_callable(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_getattr(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_setattr(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_hasattr(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
     def emit_delattr(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 
-    def emit_vars(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_dir(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
-    def emit_open(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
+    def emit_vars(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_dir(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_open(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_format(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # format(value, spec) - format value according to format spec
-        if len(args) < 2 {
-            return None;
-        }
-        arg_val = args[0];
-        spec_val = args[1];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i64 = ir.IntType(64);
-        rc_alloc_fn = p.rc_alloc_fn;
-        buf_ptr = b.call(rc_alloc_fn, [ir.Constant(i64, 64)], name="fmt.buf");
-        snprintf = p._get_or_declare_extern(
-            "snprintf", ir.IntType(32), [i8p, i64, i8p], var_arg=True
-        );
-        # Build format string: "%" + spec
-        strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-        memcpy_fn = p._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
-        spec_len = b.call(strlen_fn, [spec_val], name="fmt.speclen");
-        # Allocate fmt string: "%" + spec + null = spec_len + 2
-        fmt_size = b.add(spec_len, ir.Constant(i64, 2), name="fmt.fmtsz");
-        fmt_buf = b.call(rc_alloc_fn, [fmt_size], name="fmt.fmtbuf");
-        # Store '%' at position 0
-        b.store(ir.Constant(ir.IntType(8), 37), fmt_buf);
-        # Copy spec after '%'
-        fmt_rest = b.gep(fmt_buf, [ir.Constant(i64, 1)], name="fmt.rest");
-        copy_len = b.add(spec_len, ir.Constant(i64, 1), name="fmt.copylen");
-        b.call(memcpy_fn, [fmt_rest, spec_val, copy_len]);
-        # Call snprintf with the constructed format
-        b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_buf, arg_val]);
-        return buf_ptr;
-    }
+    ) -> (ir.Value | None);
 
-    def emit_ascii(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # ascii(s) - for strings, return repr-like with non-ASCII escaped
-        # Simplified: just return repr() for now (handles basic cases)
-        return self.emit_repr(ctx, args);
-    }
-
+    def emit_ascii(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     # Type conversion builtins
-    def emit_str(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        rc_alloc_fn = p.rc_alloc_fn;
-        buf_ptr = b.call(rc_alloc_fn, [ir.Constant(ir.IntType(64), 32)], name="str.buf");
-        snprintf = p._get_or_declare_extern(
-            "snprintf", ir.IntType(32), [i8p, ir.IntType(64), i8p], var_arg=True
-        );
-        if isinstance(arg_val.type, ir.IntType) {
-            fmt = p._get_snprintf_fmt("%ld");
-        } elif isinstance(arg_val.type, ir.DoubleType) {
-            fmt = p._get_snprintf_fmt("%g");
-        } else {
-            fmt = p._get_snprintf_fmt("%ld");
-        }
-        fmt_ptr = b.bitcast(fmt, i8p, name="str.fmt.ptr");
-        b.call(
-            snprintf,
-            [buf_ptr, ir.Constant(ir.IntType(64), 32), fmt_ptr, arg_val],
-            name="str.snprintf"
-        );
-        return buf_ptr;
-    }
-
-    def emit_int(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        # int(bool) / int(int): zero-extend narrower integers to i64, return i64 directly
-        if isinstance(arg_val.type, ir.IntType) {
-            if arg_val.type.width == 64 {
-                return arg_val;
-            }
-            return b.zext(arg_val, i64, name="int.from.int");
-        }
-        # int(float): truncate double to i64 (same as Python int(3.7) == 3)
-        if isinstance(arg_val.type, ir.DoubleType) {
-            return b.fptosi(arg_val, i64, name="int.from.float");
-        }
-        # int(str): parse via strtol
-        i8p = ir.IntType(8).as_pointer();
-        i32 = ir.IntType(32);
-        strtol_fn = p._get_or_declare_extern(
-            "strtol", i64, [i8p, i8p.as_pointer(), i32]
-        );
-        endptr_alloca = b.alloca(i8p, name="endptr");
-        result_val = b.call(
-            strtol_fn,
-            [arg_val, endptr_alloca, ir.Constant(i32, 10)],
-            name="strtol.result"
-        );
-        endptr_val = b.load(endptr_alloca, name="endptr.val");
-        no_parse = b.icmp_unsigned("==", endptr_val, arg_val, name="int.noparse");
-        p._emit_runtime_raise(no_parse, "ValueError", "invalid literal for int()");
-        end_char = b.load(endptr_val, name="end.char");
-        has_trail = b.icmp_unsigned(
-            "!=", end_char, ir.Constant(ir.IntType(8), 0), name="int.trail"
-        );
-        p._emit_runtime_raise(has_trail, "ValueError", "invalid literal for int()");
-        return result_val;
-    }
-
-    def emit_float(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8p = ir.IntType(8).as_pointer();
-        i32 = ir.IntType(32);
-        # String to float via strtod
-        if isinstance(arg_val.type, ir.PointerType) {
-            strtod_fn = p._get_or_declare_extern(
-                "strtod", ir.DoubleType(), [i8p, i8p.as_pointer()]
-            );
-            endptr_alloca = b.alloca(i8p, name="float.endptr");
-            result = b.call(strtod_fn, [arg_val, endptr_alloca], name="float.result");
-            endptr_val = b.load(endptr_alloca, name="float.endptr.val");
-            no_parse = b.icmp_unsigned("==", endptr_val, arg_val, name="float.noparse");
-            p._emit_runtime_raise(
-                no_parse, "ValueError", "could not convert string to float"
-            );
-            return result;
-        }
-        # Int to float
-        if isinstance(arg_val.type, ir.IntType) {
-            return b.sitofp(arg_val, ir.DoubleType(), name="float.from.int");
-        }
-        return None;
-    }
-
-    def emit_bool(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        if not args {
-            return None;
-        }
-        arg_val = args[0];
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        if isinstance(arg_val.type, ir.IntType) {
-            # bool(int): nonzero is truthy
-            is_nonzero = b.icmp_signed(
-                "!=", arg_val, ir.Constant(i64, 0), name="bool.nz"
-            );
-            return b.zext(is_nonzero, i64, name="bool.result");
-        }
-        if isinstance(arg_val.type, ir.DoubleType) {
-            # bool(float): non-zero is truthy
-            is_nonzero = b.fcmp_ordered(
-                "!=", arg_val, ir.Constant(ir.DoubleType(), 0.0), name="bool.fnz"
-            );
-            return b.zext(is_nonzero, i64, name="bool.fresult");
-        }
-        if isinstance(arg_val.type, ir.PointerType) {
-            # bool(str): non-empty is truthy
-            i8p = ir.IntType(8).as_pointer();
-            if arg_val.type == i8p {
-                strlen_fn = p._get_or_declare_extern("strlen", i64, [i8p]);
-                slen = b.call(strlen_fn, [arg_val], name="bool.slen");
-                is_nonempty = b.icmp_unsigned(
-                    "!=", slen, ir.Constant(i64, 0), name="bool.nonempty"
-                );
-                return b.zext(is_nonempty, i64, name="bool.sresult");
-            }
-        }
-        return None;
-    }
-
-    def emit_list(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # list(set) -> new list with all set elements; list(list) -> copy
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i32 = ir.IntType(32);
-        i64 = ir.IntType(64);
-        val = args[0];
-        # Convert set to list: set struct = {i64 len, i64 cap, elem* elems}
-        for (sk, shelpers) in p.set_helpers.items() {
-            stype = p.set_types.get(sk);
-            if stype is not None and val.type == stype.as_pointer() {
-                p._emit_list_helpers(sk, shelpers["elem_type"]);
-                lhelpers = p.list_helpers.get(sk);
-                if lhelpers is None {
-                    return None;
-                }
-                new_list = b.call(lhelpers["new"], [], name="l2l.new");
-                set_len = b.call(shelpers["len"], [val], name="l2l.slen");
-                elems_ptr = b.gep(
-                    val,
-                    [ir.Constant(i32, 0), ir.Constant(i32, 2)],
-                    name="l2l.elems.ptr"
-                );
-                elems_arr = b.load(elems_ptr, name="l2l.elems");
-                func = b.basic_block.function;
-                entry_bb = b.basic_block;
-                loop_bb = func.append_basic_block(name="l2l.loop");
-                body_bb = func.append_basic_block(name="l2l.body");
-                done_bb = func.append_basic_block(name="l2l.done");
-                b.branch(loop_bb);
-                b.position_at_start(loop_bb);
-                idx = b.phi(i64, name="l2l.idx");
-                idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-                at_end = b.icmp_unsigned(">=", idx, set_len, name="l2l.end");
-                b.cbranch(at_end, done_bb, body_bb);
-                b.position_at_start(body_bb);
-                ep = b.gep(elems_arr, [idx], name="l2l.ep");
-                elem = b.load(ep, name="l2l.elem");
-                b.call(lhelpers["append"], [new_list, elem]);
-                nidx = b.add(idx, ir.Constant(i64, 1), name="l2l.nidx");
-                idx.add_incoming(nidx, body_bb);
-                b.branch(loop_bb);
-                b.position_at_start(done_bb);
-                return new_list;
-            }
-        }
-        # Pass-through: if already a list, copy it
-        for (lk, lhelpers) in p.list_helpers.items() {
-            ltype = p.list_types.get(lk);
-            if ltype is not None and val.type == ltype.as_pointer() {
-                _le = p?._native_emitters?.get("list");
-                if _le is None {
-                    return None;
-                }
-                _ctx2 = ctx.__class__(pass_ref=p, type_key=lk);
-                return _le.emit_copy(_ctx2, val, []);
-            }
-        }
-        return None;
-    }
-
-    def emit_dict(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # dict() with no args -> empty dict; dict(other_dict) -> copy
-        p = ctx.pass_ref;
-        b = p.builder;
-        if not args {
-            # Empty dict: create a new dict[str, int] as default
-            p._emit_dict_helpers(
-                "ptr", "i64", ir.IntType(8).as_pointer(), ir.IntType(64), 0
-            );
-            helpers = p.dict_helpers.get("ptr:i64");
-            if helpers is None {
-                return None;
-            }
-            return b.call(helpers["new"], [], name="dctor.new");
-        }
-        # dict(other_dict) -> copy
-        val = args[0];
-        for (dk, dhelpers) in p.dict_helpers.items() {
-            dtype = p.dict_types.get(dk);
-            if dtype is not None and val.type == dtype.as_pointer() {
-                _de = p?._native_emitters?.get("dict");
-                if _de is None {
-                    return None;
-                }
-                _ctx2 = ctx.__class__(pass_ref=p, type_key=dk);
-                return _de.emit_copy(_ctx2, val, []);
-            }
-        }
-        return None;
-    }
-
-    def emit_set(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # set(list) -> new set with all list elements; set(set) -> copy
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i64 = ir.IntType(64);
-        val = args[0];
-        # Convert list to set
-        for (lk, lhelpers) in p.list_helpers.items() {
-            ltype = p.list_types.get(lk);
-            if ltype is not None and val.type == ltype.as_pointer() {
-                p._emit_set_helpers(lk, lhelpers["elem_type"]);
-                shelpers = p.set_helpers.get(lk);
-                if shelpers is None {
-                    return None;
-                }
-                new_set = b.call(shelpers["new"], [], name="l2s.new");
-                list_len = b.call(lhelpers["len"], [val], name="l2s.llen");
-                func = b.basic_block.function;
-                entry_bb = b.basic_block;
-                loop_bb = func.append_basic_block(name="l2s.loop");
-                body_bb = func.append_basic_block(name="l2s.body");
-                done_bb = func.append_basic_block(name="l2s.done");
-                b.branch(loop_bb);
-                b.position_at_start(loop_bb);
-                idx = b.phi(i64, name="l2s.idx");
-                idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-                at_end = b.icmp_unsigned(">=", idx, list_len, name="l2s.end");
-                b.cbranch(at_end, done_bb, body_bb);
-                b.position_at_start(body_bb);
-                elem = b.call(lhelpers["get"], [val, idx], name="l2s.elem");
-                b.call(shelpers["add"], [new_set, elem]);
-                nidx = b.add(idx, ir.Constant(i64, 1), name="l2s.nidx");
-                idx.add_incoming(nidx, body_bb);
-                b.branch(loop_bb);
-                b.position_at_start(done_bb);
-                return new_set;
-            }
-        }
-        # Pass-through: if already a set, copy it
-        for (sk, shelpers) in p.set_helpers.items() {
-            stype = p.set_types.get(sk);
-            if stype is not None and val.type == stype.as_pointer() {
-                _se = p?._native_emitters?.get("set");
-                if _se is None {
-                    return None;
-                }
-                _ctx2 = ctx.__class__(pass_ref=p, type_key=sk);
-                return _se.emit_copy(_ctx2, val, []);
-            }
-        }
-        return None;
-    }
-
-    def emit_tuple(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        return None;
-    }
-
+    def emit_str(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_int(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_float(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_bool(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_list(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_dict(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_set(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
+    def emit_tuple(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_frozenset(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # frozenset(x) -> same as set(x) since they share LLVM type
-        return self.emit_set(ctx, args);
-    }
+    ) -> (ir.Value | None);
 
-    def emit_bytes(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None) {
-        # bytes(list_of_ints) -> i8* string from list elements
-        if not args {
-            return None;
-        }
-        p = ctx.pass_ref;
-        b = p.builder;
-        i8 = ir.IntType(8);
-        i8p = i8.as_pointer();
-        i64 = ir.IntType(64);
-        val = args[0];
-        # bytes(list[int]) -> convert each int element to a byte
-        for (lk, lhelpers) in p.list_helpers.items() {
-            ltype = p.list_types.get(lk);
-            if ltype is not None and val.type == ltype.as_pointer() {
-                list_len = b.call(lhelpers["len"], [val], name="bytes.len");
-                alloc_sz = b.add(list_len, ir.Constant(i64, 1), name="bytes.alloc");
-                buf = b.call(p.rc_alloc_fn, [alloc_sz], name="bytes.buf");
-                func = b.basic_block.function;
-                entry_bb = b.basic_block;
-                loop_bb = func.append_basic_block(name="bytes.loop");
-                body_bb = func.append_basic_block(name="bytes.body");
-                done_bb = func.append_basic_block(name="bytes.done");
-                b.branch(loop_bb);
-                b.position_at_start(loop_bb);
-                idx = b.phi(i64, name="bytes.idx");
-                idx.add_incoming(ir.Constant(i64, 0), entry_bb);
-                at_end = b.icmp_unsigned(">=", idx, list_len, name="bytes.end");
-                b.cbranch(at_end, done_bb, body_bb);
-                b.position_at_start(body_bb);
-                elem = b.call(lhelpers["get"], [val, idx], name="bytes.elem");
-                byte_val = b.trunc(elem, i8, name="bytes.trunc");
-                bp = b.gep(buf, [idx], name="bytes.bp");
-                b.store(byte_val, bp);
-                nidx = b.add(idx, ir.Constant(i64, 1), name="bytes.nidx");
-                idx.add_incoming(nidx, body_bb);
-                b.branch(loop_bb);
-                b.position_at_start(done_bb);
-                # Null-terminate
-                end_ptr = b.gep(buf, [list_len], name="bytes.endptr");
-                b.store(ir.Constant(i8, 0), end_ptr);
-                return buf;
-            }
-        }
-        return None;
-    }
-
+    def emit_bytes(self, ctx: NativeEmitCtx, args: list[ir.Value]) -> (ir.Value | None);
     def emit_bytearray(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        # bytearray(list_of_ints) -> same as bytes: i8* string
-        return self.emit_bytes(ctx, args);
-    }
+    ) -> (ir.Value | None);
 
     def emit_complex(
         self, ctx: NativeEmitCtx, args: list[ir.Value]
-    ) -> (ir.Value | None) {
-        return None;
-    }
+    ) -> (ir.Value | None);
 }

--- a/jac/jaclang/compiler/primitives.jac
+++ b/jac/jaclang/compiler/primitives.jac
@@ -4,8 +4,8 @@ Generic abstract emitter contracts for all Jac primitive type methods,
 operator semantics, and builtin functions, parameterized on value type V
 and context type C.
 
-Each compilation backend (Python, ECMAScript, Native) must subclass every
-emitter class here, binding V and C to its own types:
+Each compilation backend (Python, ECMAScript, Native) must subobjevery
+emitter objhere, binding V and C to its own types:
   - ES:     V = str,      C = ESEmitCtx
   - Native: V = ir.Value,  C = NativeEmitCtx
 
@@ -794,7 +794,7 @@ class BuiltinEmitter[V, C] {
 # Backend implementation notes:
 #   - NA (Native/LLVM): Extend the flat type-ID registry with a parent-ID
 #     table. emit_match walks up the parent chain instead of a single ==.
-#   - CL (Client/ES): Generate JS class hierarchy (class ValueError extends
+#   - CL (Client/ES): Generate JS objhierarchy (objValueError extends
 #     Error {}). Multi-handler dispatch becomes instanceof chains inside a
 #     single catch block.
 #   - SV (Server/Python): Maps directly to Python's built-in exception
@@ -804,7 +804,7 @@ class BuiltinEmitter[V, C] {
 class ExceptionEmitter[V, C] {
     # --- Instance creation ---
     # Create an exception instance of the given type. type_name identifies
-    # the exception class (e.g. "ValueError"). args holds constructor
+    # the exception obj(e.g. "ValueError"). args holds constructor
     # arguments (typically a single message string). Backends must map
     # type_name to their internal representation (Python class, LLVM type
     # ID, JS Error subclass).

--- a/jac/jaclang/jac0.py
+++ b/jac/jaclang/jac0.py
@@ -1443,7 +1443,6 @@ class Parser:
     def _parse_impl(self, decorators: list[str]) -> ImplDef:
         self._expect(TT.NAME, "impl")
         is_static = False
-        is_async = False
         target = self._collect_dotted()
         params: list[Param] = []
         if self._at(TT.LPAREN):
@@ -1463,7 +1462,6 @@ class Parser:
             body=body,
             decorators=decorators,
             is_static=is_static,
-            is_async=is_async,
         )
 
     # ── With Entry ────────────────────────────────────────────────────────
@@ -1901,14 +1899,37 @@ class CodeGen:
         body = node.body
         # Stitch impls
         impls = self.impl_registry.get(node.name, [])
+        # Build lookup of stub FuncDefs (;-terminated) for decorator merging
+        _dunder_names = {"init": "__init__", "postinit": "__post_init__"}
+        stub_lookup: dict[str, FuncDef] = {}
+        if impls:
+            for n in body:
+                if isinstance(n, FuncDef):
+                    stub_name = _dunder_names.get(n.name, n.name)
+                    is_stub = len(n.body) == 1 and isinstance(n.body[0], PassStmt)
+                    if is_stub:
+                        stub_lookup[stub_name] = n
+        # Determine which stubs to skip (have matching impl)
+        impl_method_names: set[str] = set()
+        for impl in impls:
+            parts = impl.target.split(".")
+            mname = parts[-1] if len(parts) > 1 else parts[0]
+            mname = _dunder_names.get(mname, mname)
+            impl_method_names.add(mname)
         if not body and not impls:
             self._line("pass")
         else:
             prev_in_class = self._in_class
             self._in_class = True
-            self._emit_body(body)
+            # Emit body but skip stubs that have matching impls
+            for bnode in body:
+                if isinstance(bnode, FuncDef):
+                    fname = _dunder_names.get(bnode.name, bnode.name)
+                    if fname in impl_method_names and fname in stub_lookup:
+                        continue  # Skip stub; impl will provide the method
+                self._emit(bnode)
             for impl in impls:
-                self._emit_impl_as_method(impl)
+                self._emit_impl_as_method(impl, stub_lookup)
             self._in_class = prev_in_class
         self.indent -= 1
         self._line()
@@ -2024,23 +2045,51 @@ class CodeGen:
 
     # ── Impl as Method ────────────────────────────────────────────────────
 
-    def _emit_impl_as_method(self, impl: ImplDef) -> None:
+    def _emit_impl_as_method(
+        self, impl: ImplDef, stub_lookup: dict[str, FuncDef] | None = None
+    ) -> None:
         parts = impl.target.split(".")
         method_name = parts[-1] if len(parts) > 1 else parts[0]
         _dunder_names = {"init": "__init__", "postinit": "__post_init__"}
         method_name = _dunder_names.get(method_name, method_name)
-        for dec in impl.decorators:
+        # Merge decorator/flag info from the matching stub declaration
+        is_static = impl.is_static
+        is_classmethod = False
+        is_async = impl.is_async
+        decorators = list(impl.decorators)
+        stub = stub_lookup.get(method_name) if stub_lookup else None
+        if stub:
+            # Inherit decorators from declaration that aren't already on impl
+            for dec in stub.decorators:
+                if dec not in decorators:
+                    decorators.append(dec)
+            if stub.is_static:
+                is_static = True
+            if stub.is_classmethod:
+                is_classmethod = True
+            if stub.is_async:
+                is_async = True
+        for dec in decorators:
             self._line(f"@{dec}")
-        if impl.is_static:
+        if is_classmethod:
+            self._line("@classmethod")
+        if is_static:
             self._line("@staticmethod")
         func_params = list(impl.params)
-        # Auto-add self for instance methods
-        if not impl.is_static and (
+        # Auto-add cls for classmethods
+        if is_classmethod and (
             not func_params or func_params[0].name not in ("self", "cls")
+        ):
+            func_params.insert(0, Param(name="cls"))
+        # Auto-add self for instance methods
+        elif (
+            not is_static
+            and not is_classmethod
+            and (not func_params or func_params[0].name not in ("self", "cls"))
         ):
             func_params.insert(0, Param(name="self"))
         params = self._format_params(func_params)
-        ap = "async " if impl.is_async else ""
+        ap = "async " if is_async else ""
         ret = f" -> {impl.return_type}" if impl.return_type else ""
         self._line(f"{ap}def {method_name}({params}){ret}:")
         self.indent += 1

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -189,57 +189,17 @@ obj _SetupProgress {
         _seen_files: set[str] by postinit,
         _jaclang_root: (str | None) = None;
 
-    def postinit -> None {
-        self._seen_files = `set();
-    }
-
-    def _get_jaclang_root -> str {
-        if (self._jaclang_root is None) {
-            self._jaclang_root = os.path.dirname(os.path.dirname(__file__));
-        }
-        return self._jaclang_root;
-    }
-
+    def postinit -> None;
+    def _get_jaclang_root -> str;
     """Print the completion summary when the process exits."""
-    def _atexit_handler -> None {
-        if (self._banner_shown and (self._compile_count > 0)) {
-            sys.stderr.write(
-                f"Jac setup complete! ({self._compile_count} modules compiled and cached)\n"
-            );
-            sys.stderr.flush();
-        }
-    }
+    def _atexit_handler -> None;
 
     """Called when an internal jaclang module needs compilation (cache miss)."""
-    def on_internal_compile(file_path: str) -> None {
-        normalized = os.path.normpath(file_path);
-        if (normalized in self._seen_files) {
-            return;
-        }
-        self._seen_files.add(normalized);
-        if not self._banner_shown {
-            self._banner_shown = True;
-            atexit.register(self._atexit_handler);
-            sys.stderr.write(
-                '\nSetting up Jac for first use (compiling and caching compiler)...\n'
-            );
-            sys.stderr.flush();
-        }
-        jaclang_root = self._get_jaclang_root();
-        rel_path = file_path;
-        if normalized.startswith((jaclang_root + os.sep)) {
-            rel_path = os.path.relpath(normalized, os.path.dirname(jaclang_root));
-        }
-        self._compile_count += 1;
-        sys.stderr.write(f"  Compiling {rel_path}...\n");
-        sys.stderr.flush();
-    }
+    def on_internal_compile(file_path: str) -> None;
 
     """Whether we're currently in a first-run setup."""
     @property
-    def is_active -> bool {
-        return self._banner_shown;
-    }
+    def is_active -> bool;
 }
 
 glob setup_progress = _SetupProgress();
@@ -350,32 +310,14 @@ obj JacCompiler {
 
     """Module hub for jaclang.* modules (lazily initialized)."""
     @property
-    def internal_program -> JacProgram {
-        if (self._internal_program is None) {
-            import from jaclang.jac0core.program { JacProgram }
-            self._internal_program = JacProgram();
-        }
-        return self._internal_program;
-    }
+    def internal_program -> JacProgram;
 
     """Get the jaclang package root path."""
     @classmethod
-    def _get_jaclang_root(cls: Any) -> str {
-        if (cls._jaclang_root is None) {
-            cls._jaclang_root = os.path.dirname(os.path.dirname(__file__));
-        }
-        return cls._jaclang_root;
-    }
+    def _get_jaclang_root(cls: Any) -> str;
 
     """Route jaclang.* files to internal_program, others to target_program."""
-    def _resolve_program(file_path: str, target_program: JacProgram) -> JacProgram {
-        normalized_path = os.path.normpath(file_path);
-        jaclang_root = self._get_jaclang_root();
-        if normalized_path.startswith((jaclang_root + os.sep)) {
-            return self.internal_program;
-        }
-        return target_program;
-    }
+    def _resolve_program(file_path: str, target_program: JacProgram) -> JacProgram;
 
     """Get native interop setup for a module.
 
@@ -387,36 +329,12 @@ obj JacCompiler {
         """
     def get_native_interop_setup(
         full_target: str, target_program: JacProgram
-    ) -> tuple[((object | None), (dict[(str, object)] | None))] {
-        actual_program = self._resolve_program(full_target, target_program);
-        if (full_target in actual_program._native_cache) {
-            gen = actual_program._native_cache[full_target];
-            return (gen.native_engine, gen.interop_py_funcs);
-        }
-        if (full_target in actual_program.mod.hub) {
-            mod = actual_program.mod.hub[full_target];
-            native_engine = mod.gen.native_engine;
-            interop_py_funcs = mod.gen.interop_py_funcs;
-            return (native_engine, interop_py_funcs);
-        }
-        return (None, None);
-    }
+    ) -> tuple[((object | None), (dict[(str, object)] | None))];
 
     """Get native module layout metadata for auto-marshalling."""
     def get_native_layout(
         full_target: str, target_program: JacProgram
-    ) -> (object | None) {
-        actual_program = self._resolve_program(full_target, target_program);
-        if (full_target in actual_program._native_cache) {
-            gen = actual_program._native_cache[full_target];
-            return getattr(gen, 'native_layout', None);
-        }
-        if (full_target in actual_program.mod.hub) {
-            mod = actual_program.mod.hub[full_target];
-            return getattr(mod.gen, 'native_layout', None);
-        }
-        return None;
-    }
+    ) -> (object | None);
 
     """Get bytecode using 2-tier cache: in-memory -> JIR -> compile.
 
@@ -427,186 +345,20 @@ obj JacCompiler {
         """
     def get_bytecode(
         full_target: str, target_program: JacProgram
-    ) -> (types.CodeType | None) {
-        actual_program = self._resolve_program(full_target, target_program);
-
-        # Tier 1: in-memory hub
-        if (
-            (full_target in actual_program.mod.hub)
-            and actual_program.mod.hub[full_target].gen.py_bytecode
-        ) {
-            codeobj = actual_program.mod.hub[full_target].gen.py_bytecode;
-            return marshal.loads(codeobj) if isinstance(codeobj, `bytes) else None;
-        }
-
-        # Tier 2: JIR cache fast path
-        cache_path = get_module_cache_path(full_target);
-        if is_module_cache_valid(full_target, cache_path) {
-            try {
-                jir_data = cache_path.read_bytes();
-                bc = read_bytecode_only(jir_data);
-                if bc is not None {
-                    magic_bytes: Any = SECTIONS_MAGIC;
-                    sec_pos = jir_data.find(magic_bytes, HEADER_SIZE);
-                    if sec_pos >= 0 {
-                        secs = read_sections(jir_data, sec_pos + len(magic_bytes));
-                        self._restore_sections(full_target, actual_program, secs);
-                    }
-                    return marshal.loads(bc);
-                }
-            } except Exception {
-                ;
-            }
-        }
-
-        # Tier 2.5: precompiled JIR bundle shipped with the package
-        precompiled_bc = self._get_precompiled_jir_bytecode(full_target);
-        if precompiled_bc is not None {
-            try {
-                import from jaclang.jac0core.jir {
-                    write_precompiled_jir,
-                    FLAG_PRECOMPILED
-                }
-                jir_bytes = write_precompiled_jir(precompiled_bc, 0, FLAG_PRECOMPILED);
-                cache_path.parent.mkdir(parents=True, exist_ok=True);
-                tmp_path = cache_path.with_suffix('.tmp');
-                tmp_path.write_bytes(jir_bytes);
-                tmp_path.rename(cache_path);
-            } except Exception {
-                ;
-            }
-            return marshal.loads(precompiled_bc);
-        }
-
-        # Tier 3: full compile + JIR write
-        is_internal = actual_program is self._internal_program;
-        if is_internal {
-            setup_progress.on_internal_compile(full_target);
-        }
-        options = CompileOptions();
-        result = self.compile(
-            file_path=full_target, target_program=actual_program, options=options
-        );
-        if result.gen.py_bytecode {
-            try {
-                import from jaclang.jac0core.jir_passes { JirWriter }
-                import pickle;
-                import json;
-                import zlib;
-                sections: dict[int, bytes] = {};
-                sections[SEC_BYTECODE] = result.gen.py_bytecode;
-                if actual_program.mtir_map {
-                    sections[SEC_MTIR] = pickle.dumps(
-                        actual_program.mtir_map, int(pickle.HIGHEST_PROTOCOL)
-                    );
-                }
-                # Prefer post-optimization bitcode (SEC_NATIVE_OBJ) over
-                # text IR (SEC_LLVM_IR). Bitcode is faster to parse and
-                # preserves optimization work done by NativeCompilePass.
-                native_bc = result.gen.native_bitcode;
-                if native_bc is not None {
-                    import struct as _struct;
-                    import llvmlite.binding as _llvm;
-                    triple = _llvm.get_default_triple().encode('utf-8');
-                    hdr = _struct.pack('<H', len(triple)) + triple;
-                    sections[SEC_NATIVE_OBJ] = hdr + native_bc;
-                } else {
-                    llvm_ir = result.gen.llvm_ir;
-                    if llvm_ir is not None {
-                        sections[SEC_LLVM_IR] = zlib.compress(
-                            str(llvm_ir).encode('utf-8'), 6
-                        );
-                    }
-                }
-                interop_dict = self._build_interop_dict(result);
-                if interop_dict {
-                    sections[SEC_INTEROP] = json.dumps(interop_dict).encode('utf-8');
-                }
-                writer = JirWriter();
-                jir_bytes = writer.write_module(result, sections=sections);
-                cache_path.parent.mkdir(parents=True, exist_ok=True);
-                tmp_path = cache_path.with_suffix('.tmp');
-                tmp_path.write_bytes(jir_bytes);
-                tmp_path.rename(cache_path);
-            } except Exception {
-                ;
-            }
-            return marshal.loads(result.gen.py_bytecode);
-        }
-        return None;
-    }
+    ) -> (types.CodeType | None);
 
     """Load native module from cached LLVM IR.
 
         Creates a fresh MCJIT engine from the cached IR string and sets up
         interop callbacks. This is much faster than full recompilation since
-        we skip the JacâASTâLLVM IR pipeline.
+        we skip the Jac-AST-LLVM IR pipeline.
         """
     def _load_native_from_cache(
         full_target: str,
         target_program: JacProgram,
         cached_ir: str,
         cached_interop: (dict | None)
-    ) -> None {
-        try {
-            import llvmlite.binding as llvm;
-            llvm.initialize_native_target();
-            llvm.initialize_native_asmprinter();
-            import ctypes;
-            import ctypes.util;
-            libc_name = ctypes.util.find_library('c');
-            if libc_name {
-                llvm.load_library_permanently(libc_name);
-            }
-            libgc_name = ctypes.util.find_library('gc');
-            if libgc_name {
-                llvm.load_library_permanently(libgc_name);
-            } else {
-                libc = ctypes.CDLL(libc_name);
-                malloc_addr = ctypes.cast(libc.malloc, ctypes.c_void_p).value;
-                llvm.add_symbol('GC_malloc', malloc_addr);
-            }
-            llvm_mod = llvm.parse_assembly(cached_ir);
-            llvm_mod.verify();
-            target = llvm.Target.from_default_triple();
-            target_machine = target.create_target_machine();
-            engine = llvm.create_mcjit_compiler(llvm_mod, target_machine);
-            import from jaclang.jac0core.codeinfo { CodeGenTarget, InteropManifest }
-            gen = CodeGenTarget();
-            gen.native_engine = engine;
-            py_func_table: dict = {};
-            callbacks_list: list = [];
-            gen.interop_py_funcs = py_func_table;
-            gen._interop_callbacks = callbacks_list;
-            if cached_interop {
-                import from jaclang.jac0core.codeinfo { InteropBinding, InteropContext }
-                import from jaclang.jac0core.interop_bridge { register_py_callbacks }
-                manifest = InteropManifest();
-                for (name, data) in cached_interop.get('bindings', {}).items() {
-                    binding = InteropBinding(
-                        name=name,
-                        source_context=InteropContext(data['source_context']),
-                        callers={InteropContext(c) for c in data.get('callers', [])},
-                        ret_type=data.get('ret_type', 'int'),
-                        param_types=data.get('param_types', []),
-                        param_names=data.get('param_names', []),
-                        source_module=data.get('source_module')
-                    );
-                    manifest.bindings[name] = binding;
-                }
-                gen.interop_manifest = manifest;
-                if manifest.native_imports {
-                    register_py_callbacks(manifest, py_func_table, callbacks_list);
-                }
-            }
-            target_program._native_cache[full_target] = gen;
-        } except Exception as e {
-            import logging;
-            logging.getLogger(__name__).debug(
-                f"Failed to load native module from cache: {e}"
-            );
-        }
-    }
+    ) -> None;
 
     """Load native module from cached post-optimization bitcode.
 
@@ -619,216 +371,18 @@ obj JacCompiler {
         target_program: JacProgram,
         section_data: bytes,
         cached_interop: (dict | None)
-    ) -> None {
-        import struct as _struct;
-        import llvmlite.binding as llvm;
-        llvm.initialize_native_target();
-        llvm.initialize_native_asmprinter();
-        # Parse platform header: [triple_len: 2 LE] [triple: UTF-8] [bitcode ...]
-        if len(section_data) < 2 {
-            raise ValueError("SEC_NATIVE_OBJ section too short");
-        }
-        (triple_len, ) = _struct.unpack_from('<H', section_data, 0);
-        if len(section_data) < 2 + triple_len {
-            raise ValueError("SEC_NATIVE_OBJ triple truncated");
-        }
-        cached_triple = section_data[2:2 + triple_len].decode('utf-8');
-        current_triple = llvm.get_default_triple();
-        if cached_triple != current_triple {
-            raise ValueError(
-                f"Platform mismatch: cached={cached_triple}, current={current_triple}"
-            );
-        }
-        bitcode = section_data[2 + triple_len:];
-        # Load shared libraries for symbol resolution
-        import ctypes;
-        import ctypes.util;
-        libc_name = ctypes.util.find_library('c');
-        if libc_name {
-            llvm.load_library_permanently(libc_name);
-        }
-        # Parse bitcode and create engine (no optimization needed — already done)
-        llvm_mod = llvm.parse_bitcode(bitcode);
-        target = llvm.Target.from_default_triple();
-        target_machine = target.create_target_machine();
-        engine = llvm.create_mcjit_compiler(llvm_mod, target_machine);
-        import from jaclang.jac0core.codeinfo { CodeGenTarget, InteropManifest }
-        gen = CodeGenTarget();
-        gen.native_engine = engine;
-        py_func_table: dict = {};
-        callbacks_list: list = [];
-        gen.interop_py_funcs = py_func_table;
-        gen._interop_callbacks = callbacks_list;
-        if cached_interop {
-            import from jaclang.jac0core.codeinfo { InteropBinding, InteropContext }
-            import from jaclang.jac0core.interop_bridge { register_py_callbacks }
-            manifest = InteropManifest();
-            for (name, data) in cached_interop.get('bindings', {}).items() {
-                binding = InteropBinding(
-                    name=name,
-                    source_context=InteropContext(data['source_context']),
-                    callers={InteropContext(c) for c in data.get('callers', [])},
-                    ret_type=data.get('ret_type', 'int'),
-                    param_types=data.get('param_types', []),
-                    param_names=data.get('param_names', []),
-                    source_module=data.get('source_module')
-                );
-                manifest.bindings[name] = binding;
-            }
-            gen.interop_manifest = manifest;
-            if manifest.native_imports {
-                register_py_callbacks(manifest, py_func_table, callbacks_list);
-            }
-        }
-        target_program._native_cache[full_target] = gen;
-    }
+    ) -> None;
 
     """Restore side-effects (MTIR, native) from decoded JIR sections."""
     def _restore_sections(
         full_target: str, actual_program: JacProgram, secs: dict[int, bytes]
-    ) -> None {
-        import pickle;
-        mtir_bytes = secs.get(SEC_MTIR);
-        if mtir_bytes is not None {
-            try {
-                mtir_map = pickle.loads(mtir_bytes);
-                actual_program.mtir_map.update(mtir_map);
-            } except Exception {
-                ;
-            }
-        }
-        # Try fast path: post-optimization bitcode (SEC_NATIVE_OBJ)
-        native_obj_bytes = secs.get(SEC_NATIVE_OBJ);
-        if native_obj_bytes is not None {
-            try {
-                import json;
-                cached_interop: (dict | None) = None;
-                interop_bytes = secs.get(SEC_INTEROP);
-                if interop_bytes is not None {
-                    cached_interop = json.loads(interop_bytes.decode('utf-8'));
-                }
-                self._load_native_from_bitcode(
-                    full_target, actual_program, native_obj_bytes, cached_interop
-                );
-                return;
-            } except Exception {
-                ;
-            }
-        }
-        # Fallback: text IR (SEC_LLVM_IR)
-        llvm_bytes = secs.get(SEC_LLVM_IR);
-        if llvm_bytes is not None {
-            try {
-                import zlib;
-                import json;
-                cached_ir = zlib.decompress(llvm_bytes).decode('utf-8');
-                cached_interop2: (dict | None) = None;
-                interop_bytes2 = secs.get(SEC_INTEROP);
-                if interop_bytes2 is not None {
-                    cached_interop2 = json.loads(interop_bytes2.decode('utf-8'));
-                }
-                self._load_native_from_cache(
-                    full_target, actual_program, cached_ir, cached_interop2
-                );
-            } except Exception {
-                ;
-            }
-        }
-    }
+    ) -> None;
 
     """Walk up from a .jac file looking for a _precompiled/ JIR bundle."""
-    def _get_precompiled_jir_bytecode(full_target: str) -> (bytes | None) {
-        import hashlib;
-        import json;
-        import from pathlib { Path as _Path }
-        norm_file = os.path.normpath(os.path.abspath(full_target));
-        d = os.path.dirname(norm_file);
-        pyver = f"cpython-{sys.version_info.major}{sys.version_info.minor}";
-        while True {
-            manifest_path = os.path.join(d, '_precompiled', 'manifest.json');
-            if os.path.isfile(manifest_path) {
-                try {
-                    with open(manifest_path, encoding='utf-8') as f {
-                        manifest = json.load(f);
-                    }
-                    norm_root = os.path.normpath(d);
-                    if not norm_file.startswith(norm_root + os.sep) {
-                        break;
-                    }
-                    rel_path = norm_file[len(norm_root) + 1:];
-                    rel_key = rel_path.replace(os.sep, '/');
-                    entries = manifest.get('entries', {});
-                    entry = entries.get(rel_key);
-                    if not isinstance(entry, dict) {
-                        break;
-                    }
-                    expected = entry.get('source_hash');
-                    if expected {
-                        with open(norm_file, 'rb') as f2 {
-                            actual = hashlib.sha256(f2.read()).hexdigest();
-                        }
-                        if actual != expected {
-                            break;
-                        }
-                    }
-                    sentinel = manifest.get('filename_sentinel', '__PKG_ROOT__');
-                    # Try .jir bundle first
-                    jir_rel = os.path.splitext(rel_path)[0] + '.jir';
-                    jir_path = os.path.join(d, '_precompiled', pyver, jir_rel);
-                    if os.path.isfile(jir_path) {
-                        jir_data = _Path(jir_path).read_bytes();
-                        if len(jir_data) >= 32 {
-                            import struct;
-                            (flags_val, ) = struct.unpack_from('<I', jir_data, 28);
-                            if flags_val & FLAG_PRECOMPILED {
-                                bc = read_bytecode_only(jir_data);
-                                if bc is not None {
-                                    return patch_co_filenames_bytes(bc, sentinel, d);
-                                }
-                            }
-                        }
-                    }
-                    # Fallback: legacy .jbc bundle
-                    jbc_rel = os.path.splitext(rel_path)[0] + '.jbc';
-                    jbc_path = os.path.join(d, '_precompiled', pyver, jbc_rel);
-                    if os.path.isfile(jbc_path) {
-                        return patch_co_filenames_bytes(
-                            _Path(jbc_path).read_bytes(), sentinel, d
-                        );
-                    }
-                } except Exception {
-                    ;
-                }
-                break;
-            }
-            parent = os.path.dirname(d);
-            if parent == d {
-                break;
-            }
-            d = parent;
-        }
-        return None;
-    }
+    def _get_precompiled_jir_bytecode(full_target: str) -> (bytes | None);
 
     """Build a JSON-serializable interop dict from a compiled module."""
-    def _build_interop_dict(result: uni.Module) -> dict {
-        manifest = result.gen.interop_manifest;
-        if manifest is None {
-            return {};
-        }
-        interop_data: dict = {'bindings': {}};
-        for (name, binding) in manifest.bindings.items() {
-            interop_data['bindings'][name] = {
-                'source_context': binding.source_context.value,
-                'callers': [c.value for c in binding.callers],
-                'ret_type': binding.ret_type,
-                'param_types': binding.param_types,
-                'param_names': binding.param_names,
-                'source_module': binding.source_module
-            };
-        }
-        return interop_data;
-    }
+    def _build_interop_dict(result: uni.Module) -> dict;
 
     """Parse source string into AST module."""
     def parse_str(
@@ -836,45 +390,7 @@ obj JacCompiler {
         file_path: str,
         target_program: JacProgram,
         cancel_token: (Event | None) = None
-    ) -> uni.Module {
-        had_error = False;
-        if (file_path.endswith('.py') or file_path.endswith('.pyi')) {
-            import from jaclang.compiler.passes.main.pyast_load_pass { PyastBuildPass }
-            parsed_ast = py_ast.parse(source_str);
-            py_ast_ret = PyastBuildPass(
-                ir_in=uni.PythonModuleAst(
-                    parsed_ast, orig_src=uni.Source(source_str, mod_path=file_path)
-                ),
-                prog=target_program,
-                cancel_token=cancel_token
-            );
-            had_error = len(py_ast_ret.errors_had) > 0;
-            mod = py_ast_ret.ir_out;
-        } else {
-            import from jaclang.jac0core.parser { parse as rd_parse }
-            (mod, parse_errors, lex_errors) = rd_parse(
-                source_str, file_path, prog=target_program
-            );
-            _recalculate_parents(mod);
-            had_error = len(parse_errors) > 0 or len(lex_errors) > 0;
-            if file_path.endswith('.cl.jac') {
-                _coerce_client_module(mod);
-            } elif file_path.endswith('.sv.jac') {
-                _coerce_server_module(mod);
-            } elif file_path.endswith('.na.jac') {
-                _coerce_native_module(mod);
-            }
-        }
-        if had_error {
-            return mod;
-        }
-        if target_program.mod.main.stub_only {
-            target_program.mod = uni.ProgramModule(main_mod=mod);
-        }
-        target_program.mod.hub[mod.loc.mod_path] = mod;
-        JacAnnexPass(ir_in=mod, prog=target_program);
-        return mod;
-    }
+    ) -> uni.Module;
 
     """Compile a Jac file into module AST.
 
@@ -889,69 +405,7 @@ obj JacCompiler {
         target_program: JacProgram,
         use_str: (str | None) = None,
         options: (CompileOptions | None) = None
-    ) -> uni.Module {
-        if (options is None) {
-            options = CompileOptions();
-        }
-        # For impl/test annex files compiled standalone, redirect to compile the
-        # parent module instead. The parent's JacAnnexPass discovers and attaches
-        # the impl, and DeclImplMatchPass connects them with full scope context.
-        # Only applies when resolve_annex_parent is set to avoid affecting
-        # AST-only compilation (e.g., micro suite tests).
-        if (
-            use_str is None
-            and options.resolve_annex_parent
-            and (file_path.endswith('.impl.jac') or file_path.endswith('.test.jac'))
-        ) {
-            import from jaclang.jac0core.bccache { discover_base_file }
-            base_path = discover_base_file(file_path);
-            if (base_path and base_path not in target_program.mod.hub) {
-                return self.compile(
-                    file_path=base_path, target_program=target_program, options=options
-                );
-            }
-        }
-        actual_program = self._resolve_program(file_path, target_program);
-        actual_program._compile_options = options;
-        keep_str = use_str or read_file_with_encoding(file_path);
-        had_parse_errors = len(actual_program.errors_had);
-        mod_targ = self.parse_str(
-            keep_str, file_path, actual_program, cancel_token=options.cancel_token
-        );
-        had_parse_errors = len(actual_program.errors_had) > had_parse_errors;
-        if options.symtab_ir_only {
-            self.run_schedule(
-                mod=mod_targ,
-                target_program=actual_program,
-                passes=get_symtab_ir_sched(),
-                cancel_token=options.cancel_token
-            );
-        } else {
-            self.run_schedule(
-                mod=mod_targ,
-                target_program=actual_program,
-                passes=get_ir_gen_sched(),
-                cancel_token=options.cancel_token
-            );
-        }
-        if options.type_check {
-            self.run_schedule(
-                mod=mod_targ,
-                target_program=actual_program,
-                passes=get_type_check_sched(),
-                cancel_token=options.cancel_token
-            );
-        }
-        if (not had_parse_errors and not options.no_cgen) {
-            self.run_schedule(
-                mod=mod_targ,
-                target_program=actual_program,
-                passes=get_py_code_gen(),
-                cancel_token=options.cancel_token
-            );
-        }
-        return mod_targ;
-    }
+    ) -> uni.Module;
 
     """Build a Jac file with import dependency resolution."""
     def build(
@@ -959,13 +413,7 @@ obj JacCompiler {
         target_program: JacProgram,
         use_str: (str | None) = None,
         type_check: bool = False
-    ) -> uni.Module {
-        actual_program = self._resolve_program(file_path, target_program);
-        options = CompileOptions(type_check=type_check);
-        mod_targ = self.compile(file_path, actual_program, use_str, options=options);
-        SemanticAnalysisPass(ir_in=mod_targ, prog=actual_program);
-        return mod_targ;
-    }
+    ) -> uni.Module;
 
     """Run a list of passes on a module."""
     def run_schedule(
@@ -973,14 +421,7 @@ obj JacCompiler {
         target_program: JacProgram,
         passes: list[type[Transform[uni.Module, uni.Module]]],
         cancel_token: (Event | None) = None
-    ) -> None {
-        for current_pass in passes {
-            if (cancel_token and cancel_token.is_set()) {
-                break;
-            }
-            current_pass(ir_in=mod, prog=target_program, cancel_token=cancel_token);
-        }
-    }
+    ) -> None;
 
     """Parse a Jac file/string and optionally load annexes for tooling passes.
 
@@ -992,101 +433,18 @@ obj JacCompiler {
         file_path: str,
         load_impl_annexes: bool = False,
         load_test_annexes: bool = False
-    ) -> tuple[JacProgram, (uni.Module | None)] {
-        import from jaclang.jac0core.program { JacProgram }
-        import from jaclang.jac0core.parser { parse as rd_parse }
-        prog = JacProgram();
-        (current_mod, parse_errors, lex_errors) = rd_parse(source_str, file_path);
-        _recalculate_parents(current_mod);
-        if len(parse_errors) > 0 or len(lex_errors) > 0 {
-            prog.errors_had.extend(parse_errors);
-            prog.errors_had.extend(lex_errors);
-            prog.mod = uni.ProgramModule(main_mod=current_mod);
-            return (prog, None);
-        }
-        # Parse-only annex loading: just parse .impl.jac/.test.jac files
-        # without running SymTabBuildPass or any compilation passes.
-        # This avoids cascading import resolution that would compile the
-        # entire dependency graph for each formatted file.
-        if load_impl_annexes or load_test_annexes {
-            import from jaclang.jac0core.bccache { discover_annex_files }
-            if load_impl_annexes {
-                for annex_path in discover_annex_files(file_path, '.impl.jac') {
-                    try {
-                        annex_src = read_file_with_encoding(annex_path);
-                        (annex_mod, _, _) = rd_parse(annex_src, annex_path);
-                        _recalculate_parents(annex_mod);
-                        current_mod.impl_mod.append(annex_mod);
-                    } except Exception {
-                        ;
-                    }
-                }
-            }
-            if load_test_annexes {
-                for annex_path in discover_annex_files(file_path, '.test.jac') {
-                    try {
-                        annex_src = read_file_with_encoding(annex_path);
-                        (annex_mod, _, _) = rd_parse(annex_src, annex_path);
-                        _recalculate_parents(annex_mod);
-                        current_mod.test_mod.append(annex_mod);
-                    } except Exception {
-                        ;
-                    }
-                }
-            }
-        }
-        return (prog, current_mod);
-    }
+    ) -> tuple[JacProgram, (uni.Module | None)];
 
     """Format a Jac file."""
     static def jac_file_formatter(
         file_path: str, auto_lint: bool = False
-    ) -> JacProgram {
-        source_str = read_file_with_encoding(file_path);
-        (prog, current_mod) = JacCompiler._prepare_tool_program(
-            source_str,
-            file_path,
-            load_impl_annexes=auto_lint,
-            load_test_annexes=auto_lint
-        );
-        if current_mod is None {
-            return prog;
-        }
-        for pass_cls in get_format_sched(auto_lint=auto_lint) {
-            current_mod = pass_cls(ir_in=current_mod, prog=prog).ir_out;
-        }
-        prog.mod = uni.ProgramModule(main_mod=current_mod);
-        return prog;
-    }
+    ) -> JacProgram;
 
     """Format a Jac source string."""
     static def jac_str_formatter(
         source_str: str, file_path: str, auto_lint: bool = False
-    ) -> JacProgram {
-        (prog, current_mod) = JacCompiler._prepare_tool_program(source_str, file_path);
-        if current_mod is None {
-            return prog;
-        }
-        for pass_cls in get_format_sched(auto_lint=auto_lint) {
-            current_mod = pass_cls(ir_in=current_mod, prog=prog).ir_out;
-        }
-        prog.mod = uni.ProgramModule(main_mod=current_mod);
-        return prog;
-    }
+    ) -> JacProgram;
 
     """Lint a Jac file (report only, no formatting or output generation)."""
-    static def jac_file_linter(file_path: str) -> JacProgram {
-        source_str = read_file_with_encoding(file_path);
-        (prog, current_mod) = JacCompiler._prepare_tool_program(
-            source_str, file_path, load_impl_annexes=True
-        );
-        if current_mod is None {
-            return prog;
-        }
-        for pass_cls in get_lint_sched() {
-            current_mod = pass_cls(ir_in=current_mod, prog=prog).ir_out;
-        }
-        prog.mod = uni.ProgramModule(main_mod=current_mod);
-        return prog;
-    }
+    static def jac_file_linter(file_path: str) -> JacProgram;
 }

--- a/jac/jaclang/jac0core/constant.jac
+++ b/jac/jaclang/jac0core/constant.jac
@@ -61,13 +61,8 @@ class JacSemTokenType(IntEnum) {
         OPERATOR = 21;
     }
 
-    static def as_str_list -> list {
-        return [
-            i.name.lower()
-            for i in JacSemTokenType
-            if i.name
-        ];
-    }
+    """Return the string list of token types."""
+    static def as_str_list -> list;
 }
 
 """LSP Token modifiers for Jac."""
@@ -85,14 +80,8 @@ class JacSemTokenModifier(IntFlag) {
         DEFAULT_LIBRARY = 1 << 9;
     }
 
-    """Return the string representation of the token."""
-    static def as_str_list -> list {
-        return [
-            i.name.lower()
-            for i in JacSemTokenModifier
-            if i.name
-        ];
-    }
+    """Return the string list of token modifiers."""
+    static def as_str_list -> list;
 }
 
 """Token constants for Jac."""
@@ -107,9 +96,7 @@ class Constants(StrEnum) {
     }
 
     """Return the string representation of the token."""
-    def __str__(self: Constants) -> str {
-        return self.value;
-    }
+    def __str__(self: Constants) -> str;
 }
 
 """Code execution context for client/server/native separation."""

--- a/jac/jaclang/jac0core/helpers.jac
+++ b/jac/jaclang/jac0core/helpers.jac
@@ -249,22 +249,10 @@ def pretty_print_source_location(
 """Jac debugger."""
 class Jdb(pdb.Pdb) {
     """Initialize the Jac debugger."""
-    def init(self: Jdb, *args: Any, **kwargs: Any) -> None {
-        super.init(*args, **kwargs);
-        self.prompt = 'Jdb > ';
-    }
+    def init(self: Jdb, *args: Any, **kwargs: Any) -> None;
 
     """Check for breakpoint."""
-    def has_breakpoint(self: Jdb, bytecode: bytes) -> bool {
-        code = marshal.loads(bytecode);
-        instructions = dis.get_instructions(code);
-        return `any(
-            (
-                (instruction.opname in ('LOAD_GLOBAL', 'LOAD_NAME', 'LOAD_FAST'))
-                and (instruction.argval == 'breakpoint')
-            ) for instruction in instructions
-        );
-    }
+    def has_breakpoint(self: Jdb, bytecode: bytes) -> bool;
 }
 
 glob debugger = Jdb();
@@ -384,15 +372,11 @@ obj DistFacade {
 
     """Get the distribution/package name."""
     @property
-    def project_name(self: DistFacade) -> str {
-        return self._dist.name if (self._dist and self._dist?.name) else 'unknown';
-    }
+    def project_name(self: DistFacade) -> str;
 
     """Get the distribution version."""
     @property
-    def version(self: DistFacade) -> str {
-        return self._dist.version if (self._dist and self._dist?.version) else '0.0.0';
-    }
+    def version(self: DistFacade) -> str;
 }
 
 """Get list of disabled plugins from JAC_DISABLED_PLUGINS env var or jac.toml.

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -1,0 +1,788 @@
+"""Implementation for compiler.jac obj methods."""
+
+impl _SetupProgress.postinit -> None {
+    self._seen_files = `set();
+}
+
+impl _SetupProgress._get_jaclang_root -> str {
+    if (self._jaclang_root is None) {
+        self._jaclang_root = os.path.dirname(os.path.dirname(__file__));
+    }
+    return self._jaclang_root;
+}
+
+"""Print the completion summary when the process exits."""
+impl _SetupProgress._atexit_handler -> None {
+    if (self._banner_shown and (self._compile_count > 0)) {
+        sys.stderr.write(
+            f"Jac setup complete! ({self._compile_count} modules compiled and cached)\n"
+        );
+        sys.stderr.flush();
+    }
+}
+
+"""Called when an internal jaclang module needs compilation (cache miss)."""
+impl _SetupProgress.on_internal_compile(file_path: str) -> None {
+    normalized = os.path.normpath(file_path);
+    if (normalized in self._seen_files) {
+        return;
+    }
+    self._seen_files.add(normalized);
+    if not self._banner_shown {
+        self._banner_shown = True;
+        atexit.register(self._atexit_handler);
+        sys.stderr.write(
+            '\nSetting up Jac for first use (compiling and caching compiler)...\n'
+        );
+        sys.stderr.flush();
+    }
+    jaclang_root = self._get_jaclang_root();
+    rel_path = file_path;
+    if normalized.startswith((jaclang_root + os.sep)) {
+        rel_path = os.path.relpath(normalized, os.path.dirname(jaclang_root));
+    }
+    self._compile_count += 1;
+    sys.stderr.write(f"  Compiling {rel_path}...\n");
+    sys.stderr.flush();
+}
+
+"""Whether we're currently in a first-run setup."""
+impl _SetupProgress.is_active -> bool {
+    return self._banner_shown;
+}
+
+"""Module hub for jaclang.* modules (lazily initialized)."""
+impl JacCompiler.internal_program -> JacProgram {
+    if (self._internal_program is None) {
+        import from jaclang.jac0core.program { JacProgram }
+        self._internal_program = JacProgram();
+    }
+    return self._internal_program;
+}
+
+"""Get the jaclang package root path."""
+impl JacCompiler._get_jaclang_root(cls: Any) -> str {
+    if (cls._jaclang_root is None) {
+        cls._jaclang_root = os.path.dirname(os.path.dirname(__file__));
+    }
+    return cls._jaclang_root;
+}
+
+"""Route jaclang.* files to internal_program, others to target_program."""
+impl JacCompiler._resolve_program(
+    file_path: str, target_program: JacProgram
+) -> JacProgram {
+    normalized_path = os.path.normpath(file_path);
+    jaclang_root = self._get_jaclang_root();
+    if normalized_path.startswith((jaclang_root + os.sep)) {
+        return self.internal_program;
+    }
+    return target_program;
+}
+
+"""Get native interop setup for a module.
+
+    Returns:
+        Tuple of (native_engine, interop_py_funcs_dict).
+        native_engine is None if no native code.
+        interop_py_funcs_dict is None if module not found in hub
+        (caller should not inject into module dict in this case).
+    """
+impl JacCompiler.get_native_interop_setup(
+    full_target: str, target_program: JacProgram
+) -> tuple[((object | None), (dict[(str, object)] | None))] {
+    actual_program = self._resolve_program(full_target, target_program);
+    if (full_target in actual_program._native_cache) {
+        gen = actual_program._native_cache[full_target];
+        return (gen.native_engine, gen.interop_py_funcs);
+    }
+    if (full_target in actual_program.mod.hub) {
+        mod = actual_program.mod.hub[full_target];
+        native_engine = mod.gen.native_engine;
+        interop_py_funcs = mod.gen.interop_py_funcs;
+        return (native_engine, interop_py_funcs);
+    }
+    return (None, None);
+}
+
+"""Get native module layout metadata for auto-marshalling."""
+impl JacCompiler.get_native_layout(
+    full_target: str, target_program: JacProgram
+) -> (object | None) {
+    actual_program = self._resolve_program(full_target, target_program);
+    if (full_target in actual_program._native_cache) {
+        gen = actual_program._native_cache[full_target];
+        return getattr(gen, 'native_layout', None);
+    }
+    if (full_target in actual_program.mod.hub) {
+        mod = actual_program.mod.hub[full_target];
+        return getattr(mod.gen, 'native_layout', None);
+    }
+    return None;
+}
+
+"""Get bytecode using 2-tier cache: in-memory -> JIR -> compile.
+
+    Tier 1: in-memory hub (py_bytecode already set).
+    Tier 2: JIR cache fast-path (read_bytecode_only, no AST deserialize).
+    Tier 2.5: precompiled JIR bundle shipped with the package.
+    Tier 3: full compile + atomic JIR write.
+    """
+impl JacCompiler.get_bytecode(
+    full_target: str, target_program: JacProgram
+) -> (types.CodeType | None) {
+    actual_program = self._resolve_program(full_target, target_program);
+
+    # Tier 1: in-memory hub
+    if (
+        (full_target in actual_program.mod.hub)
+        and actual_program.mod.hub[full_target].gen.py_bytecode
+    ) {
+        codeobj = actual_program.mod.hub[full_target].gen.py_bytecode;
+        return marshal.loads(codeobj) if isinstance(codeobj, `bytes) else None;
+    }
+
+    # Tier 2: JIR cache fast path
+    cache_path = get_module_cache_path(full_target);
+    if is_module_cache_valid(full_target, cache_path) {
+        try {
+            jir_data = cache_path.read_bytes();
+            bc = read_bytecode_only(jir_data);
+            if bc is not None {
+                magic_bytes: Any = SECTIONS_MAGIC;
+                sec_pos = jir_data.find(magic_bytes, HEADER_SIZE);
+                if sec_pos >= 0 {
+                    secs = read_sections(jir_data, sec_pos + len(magic_bytes));
+                    self._restore_sections(full_target, actual_program, secs);
+                }
+                return marshal.loads(bc);
+            }
+        } except Exception {
+            ;
+        }
+    }
+
+    # Tier 2.5: precompiled JIR bundle shipped with the package
+    precompiled_bc = self._get_precompiled_jir_bytecode(full_target);
+    if precompiled_bc is not None {
+        try {
+            import from jaclang.jac0core.jir { write_precompiled_jir, FLAG_PRECOMPILED }
+            jir_bytes = write_precompiled_jir(precompiled_bc, 0, FLAG_PRECOMPILED);
+            cache_path.parent.mkdir(parents=True, exist_ok=True);
+            tmp_path = cache_path.with_suffix('.tmp');
+            tmp_path.write_bytes(jir_bytes);
+            tmp_path.rename(cache_path);
+        } except Exception {
+            ;
+        }
+        return marshal.loads(precompiled_bc);
+    }
+
+    # Tier 3: full compile + JIR write
+    is_internal = actual_program is self._internal_program;
+    if is_internal {
+        setup_progress.on_internal_compile(full_target);
+    }
+    options = CompileOptions();
+    result = self.compile(
+        file_path=full_target, target_program=actual_program, options=options
+    );
+    if result.gen.py_bytecode {
+        try {
+            import from jaclang.jac0core.jir_passes { JirWriter }
+            import pickle;
+            import json;
+            import zlib;
+            sections: dict[int, bytes] = {};
+            sections[SEC_BYTECODE] = result.gen.py_bytecode;
+            if actual_program.mtir_map {
+                sections[SEC_MTIR] = pickle.dumps(
+                    actual_program.mtir_map, int(pickle.HIGHEST_PROTOCOL)
+                );
+            }
+            # Prefer post-optimization bitcode (SEC_NATIVE_OBJ) over
+            # text IR (SEC_LLVM_IR). Bitcode is faster to parse and
+            # preserves optimization work done by NativeCompilePass.
+            native_bc = result.gen.native_bitcode;
+            if native_bc is not None {
+                import struct as _struct;
+                import llvmlite.binding as _llvm;
+                triple = _llvm.get_default_triple().encode('utf-8');
+                hdr = _struct.pack('<H', len(triple)) + triple;
+                sections[SEC_NATIVE_OBJ] = hdr + native_bc;
+            } else {
+                llvm_ir = result.gen.llvm_ir;
+                if llvm_ir is not None {
+                    sections[SEC_LLVM_IR] = zlib.compress(
+                        str(llvm_ir).encode('utf-8'), 6
+                    );
+                }
+            }
+            interop_dict = self._build_interop_dict(result);
+            if interop_dict {
+                sections[SEC_INTEROP] = json.dumps(interop_dict).encode('utf-8');
+            }
+            writer = JirWriter();
+            jir_bytes = writer.write_module(result, sections=sections);
+            cache_path.parent.mkdir(parents=True, exist_ok=True);
+            tmp_path = cache_path.with_suffix('.tmp');
+            tmp_path.write_bytes(jir_bytes);
+            tmp_path.rename(cache_path);
+        } except Exception {
+            ;
+        }
+        return marshal.loads(result.gen.py_bytecode);
+    }
+    return None;
+}
+
+"""Load native module from cached LLVM IR.
+
+    Creates a fresh MCJIT engine from the cached IR string and sets up
+    interop callbacks. This is much faster than full recompilation since
+    we skip the Jac-AST-LLVM IR pipeline.
+    """
+impl JacCompiler._load_native_from_cache(
+    full_target: str,
+    target_program: JacProgram,
+    cached_ir: str,
+    cached_interop: (dict | None)
+) -> None {
+    try {
+        import llvmlite.binding as llvm;
+        llvm.initialize_native_target();
+        llvm.initialize_native_asmprinter();
+        import ctypes;
+        import ctypes.util;
+        libc_name = ctypes.util.find_library('c');
+        if libc_name {
+            llvm.load_library_permanently(libc_name);
+        }
+        libgc_name = ctypes.util.find_library('gc');
+        if libgc_name {
+            llvm.load_library_permanently(libgc_name);
+        } else {
+            libc = ctypes.CDLL(libc_name);
+            malloc_addr = ctypes.cast(libc.malloc, ctypes.c_void_p).value;
+            llvm.add_symbol('GC_malloc', malloc_addr);
+        }
+        llvm_mod = llvm.parse_assembly(cached_ir);
+        llvm_mod.verify();
+        target = llvm.Target.from_default_triple();
+        target_machine = target.create_target_machine();
+        engine = llvm.create_mcjit_compiler(llvm_mod, target_machine);
+        import from jaclang.jac0core.codeinfo { CodeGenTarget, InteropManifest }
+        gen = CodeGenTarget();
+        gen.native_engine = engine;
+        py_func_table: dict = {};
+        callbacks_list: list = [];
+        gen.interop_py_funcs = py_func_table;
+        gen._interop_callbacks = callbacks_list;
+        if cached_interop {
+            import from jaclang.jac0core.codeinfo { InteropBinding, InteropContext }
+            import from jaclang.jac0core.interop_bridge { register_py_callbacks }
+            manifest = InteropManifest();
+            for (name, data) in cached_interop.get('bindings', {}).items() {
+                binding = InteropBinding(
+                    name=name,
+                    source_context=InteropContext(data['source_context']),
+                    callers={InteropContext(c) for c in data.get('callers', [])},
+                    ret_type=data.get('ret_type', 'int'),
+                    param_types=data.get('param_types', []),
+                    param_names=data.get('param_names', []),
+                    source_module=data.get('source_module')
+                );
+                manifest.bindings[name] = binding;
+            }
+            gen.interop_manifest = manifest;
+            if manifest.native_imports {
+                register_py_callbacks(manifest, py_func_table, callbacks_list);
+            }
+        }
+        target_program._native_cache[full_target] = gen;
+    } except Exception as e {
+        import logging;
+        logging.getLogger(__name__).debug(
+            f"Failed to load native module from cache: {e}"
+        );
+    }
+}
+
+"""Load native module from cached post-optimization bitcode.
+
+    Parses the SEC_NATIVE_OBJ section which contains a platform header
+    followed by LLVM bitcode. Bitcode parsing is faster than text IR
+    parsing and the bitcode is already optimized.
+    """
+impl JacCompiler._load_native_from_bitcode(
+    full_target: str,
+    target_program: JacProgram,
+    section_data: bytes,
+    cached_interop: (dict | None)
+) -> None {
+    import struct as _struct;
+    import llvmlite.binding as llvm;
+    llvm.initialize_native_target();
+    llvm.initialize_native_asmprinter();
+    # Parse platform header: [triple_len: 2 LE] [triple: UTF-8] [bitcode ...]
+    if len(section_data) < 2 {
+        raise ValueError("SEC_NATIVE_OBJ section too short");
+    }
+    (triple_len, ) = _struct.unpack_from('<H', section_data, 0);
+    if len(section_data) < 2 + triple_len {
+        raise ValueError("SEC_NATIVE_OBJ triple truncated");
+    }
+    cached_triple = section_data[2:2 + triple_len].decode('utf-8');
+    current_triple = llvm.get_default_triple();
+    if cached_triple != current_triple {
+        raise ValueError(
+            f"Platform mismatch: cached={cached_triple}, current={current_triple}"
+        );
+    }
+    bitcode = section_data[2 + triple_len:];
+    # Load shared libraries for symbol resolution
+    import ctypes;
+    import ctypes.util;
+    libc_name = ctypes.util.find_library('c');
+    if libc_name {
+        llvm.load_library_permanently(libc_name);
+    }
+    # Parse bitcode and create engine (no optimization needed — already done)
+    llvm_mod = llvm.parse_bitcode(bitcode);
+    target = llvm.Target.from_default_triple();
+    target_machine = target.create_target_machine();
+    engine = llvm.create_mcjit_compiler(llvm_mod, target_machine);
+    import from jaclang.jac0core.codeinfo { CodeGenTarget, InteropManifest }
+    gen = CodeGenTarget();
+    gen.native_engine = engine;
+    py_func_table: dict = {};
+    callbacks_list: list = [];
+    gen.interop_py_funcs = py_func_table;
+    gen._interop_callbacks = callbacks_list;
+    if cached_interop {
+        import from jaclang.jac0core.codeinfo { InteropBinding, InteropContext }
+        import from jaclang.jac0core.interop_bridge { register_py_callbacks }
+        manifest = InteropManifest();
+        for (name, data) in cached_interop.get('bindings', {}).items() {
+            binding = InteropBinding(
+                name=name,
+                source_context=InteropContext(data['source_context']),
+                callers={InteropContext(c) for c in data.get('callers', [])},
+                ret_type=data.get('ret_type', 'int'),
+                param_types=data.get('param_types', []),
+                param_names=data.get('param_names', []),
+                source_module=data.get('source_module')
+            );
+            manifest.bindings[name] = binding;
+        }
+        gen.interop_manifest = manifest;
+        if manifest.native_imports {
+            register_py_callbacks(manifest, py_func_table, callbacks_list);
+        }
+    }
+    target_program._native_cache[full_target] = gen;
+}
+
+"""Restore side-effects (MTIR, native) from decoded JIR sections."""
+impl JacCompiler._restore_sections(
+    full_target: str, actual_program: JacProgram, secs: dict[int, bytes]
+) -> None {
+    import pickle;
+    mtir_bytes = secs.get(SEC_MTIR);
+    if mtir_bytes is not None {
+        try {
+            mtir_map = pickle.loads(mtir_bytes);
+            actual_program.mtir_map.update(mtir_map);
+        } except Exception {
+            ;
+        }
+    }
+    # Try fast path: post-optimization bitcode (SEC_NATIVE_OBJ)
+    native_obj_bytes = secs.get(SEC_NATIVE_OBJ);
+    if native_obj_bytes is not None {
+        try {
+            import json;
+            cached_interop: (dict | None) = None;
+            interop_bytes = secs.get(SEC_INTEROP);
+            if interop_bytes is not None {
+                cached_interop = json.loads(interop_bytes.decode('utf-8'));
+            }
+            self._load_native_from_bitcode(
+                full_target, actual_program, native_obj_bytes, cached_interop
+            );
+            return;
+        } except Exception {
+            ;
+        }
+    }
+    # Fallback: text IR (SEC_LLVM_IR)
+    llvm_bytes = secs.get(SEC_LLVM_IR);
+    if llvm_bytes is not None {
+        try {
+            import zlib;
+            import json;
+            cached_ir = zlib.decompress(llvm_bytes).decode('utf-8');
+            cached_interop2: (dict | None) = None;
+            interop_bytes2 = secs.get(SEC_INTEROP);
+            if interop_bytes2 is not None {
+                cached_interop2 = json.loads(interop_bytes2.decode('utf-8'));
+            }
+            self._load_native_from_cache(
+                full_target, actual_program, cached_ir, cached_interop2
+            );
+        } except Exception {
+            ;
+        }
+    }
+}
+
+"""Walk up from a .jac file looking for a _precompiled/ JIR bundle."""
+impl JacCompiler._get_precompiled_jir_bytecode(full_target: str) -> (bytes | None) {
+    import hashlib;
+    import json;
+    import from pathlib { Path as _Path }
+    norm_file = os.path.normpath(os.path.abspath(full_target));
+    d = os.path.dirname(norm_file);
+    pyver = f"cpython-{sys.version_info.major}{sys.version_info.minor}";
+    while True {
+        manifest_path = os.path.join(d, '_precompiled', 'manifest.json');
+        if os.path.isfile(manifest_path) {
+            try {
+                with open(manifest_path, encoding='utf-8') as f {
+                    manifest = json.load(f);
+                }
+                norm_root = os.path.normpath(d);
+                if not norm_file.startswith(norm_root + os.sep) {
+                    break;
+                }
+                rel_path = norm_file[len(norm_root) + 1:];
+                rel_key = rel_path.replace(os.sep, '/');
+                entries = manifest.get('entries', {});
+                entry = entries.get(rel_key);
+                if not isinstance(entry, dict) {
+                    break;
+                }
+                expected = entry.get('source_hash');
+                if expected {
+                    with open(norm_file, 'rb') as f2 {
+                        actual = hashlib.sha256(f2.read()).hexdigest();
+                    }
+                    if actual != expected {
+                        break;
+                    }
+                }
+                sentinel = manifest.get('filename_sentinel', '__PKG_ROOT__');
+                # Try .jir bundle first
+                jir_rel = os.path.splitext(rel_path)[0] + '.jir';
+                jir_path = os.path.join(d, '_precompiled', pyver, jir_rel);
+                if os.path.isfile(jir_path) {
+                    jir_data = _Path(jir_path).read_bytes();
+                    if len(jir_data) >= 32 {
+                        import struct;
+                        (flags_val, ) = struct.unpack_from('<I', jir_data, 28);
+                        if flags_val & FLAG_PRECOMPILED {
+                            bc = read_bytecode_only(jir_data);
+                            if bc is not None {
+                                return patch_co_filenames_bytes(bc, sentinel, d);
+                            }
+                        }
+                    }
+                }
+                # Fallback: legacy .jbc bundle
+                jbc_rel = os.path.splitext(rel_path)[0] + '.jbc';
+                jbc_path = os.path.join(d, '_precompiled', pyver, jbc_rel);
+                if os.path.isfile(jbc_path) {
+                    return patch_co_filenames_bytes(
+                        _Path(jbc_path).read_bytes(), sentinel, d
+                    );
+                }
+            } except Exception {
+                ;
+            }
+            break;
+        }
+        parent = os.path.dirname(d);
+        if parent == d {
+            break;
+        }
+        d = parent;
+    }
+    return None;
+}
+
+"""Build a JSON-serializable interop dict from a compiled module."""
+impl JacCompiler._build_interop_dict(result: uni.Module) -> dict {
+    manifest = result.gen.interop_manifest;
+    if manifest is None {
+        return {};
+    }
+    interop_data: dict = {'bindings': {}};
+    for (name, binding) in manifest.bindings.items() {
+        interop_data['bindings'][name] = {
+            'source_context': binding.source_context.value,
+            'callers': [c.value for c in binding.callers],
+            'ret_type': binding.ret_type,
+            'param_types': binding.param_types,
+            'param_names': binding.param_names,
+            'source_module': binding.source_module
+        };
+    }
+    return interop_data;
+}
+
+"""Parse source string into AST module."""
+impl JacCompiler.parse_str(
+    source_str: str,
+    file_path: str,
+    target_program: JacProgram,
+    cancel_token: (Event | None) = None
+) -> uni.Module {
+    had_error = False;
+    if (file_path.endswith('.py') or file_path.endswith('.pyi')) {
+        import from jaclang.compiler.passes.main.pyast_load_pass { PyastBuildPass }
+        parsed_ast = py_ast.parse(source_str);
+        py_ast_ret = PyastBuildPass(
+            ir_in=uni.PythonModuleAst(
+                parsed_ast, orig_src=uni.Source(source_str, mod_path=file_path)
+            ),
+            prog=target_program,
+            cancel_token=cancel_token
+        );
+        had_error = len(py_ast_ret.errors_had) > 0;
+        mod = py_ast_ret.ir_out;
+    } else {
+        import from jaclang.jac0core.parser { parse as rd_parse }
+        (mod, parse_errors, lex_errors) = rd_parse(
+            source_str, file_path, prog=target_program
+        );
+        _recalculate_parents(mod);
+        had_error = len(parse_errors) > 0 or len(lex_errors) > 0;
+        if file_path.endswith('.cl.jac') {
+            _coerce_client_module(mod);
+        } elif file_path.endswith('.sv.jac') {
+            _coerce_server_module(mod);
+        } elif file_path.endswith('.na.jac') {
+            _coerce_native_module(mod);
+        }
+    }
+    if had_error {
+        return mod;
+    }
+    if target_program.mod.main.stub_only {
+        target_program.mod = uni.ProgramModule(main_mod=mod);
+    }
+    target_program.mod.hub[mod.loc.mod_path] = mod;
+    JacAnnexPass(ir_in=mod, prog=target_program);
+    return mod;
+}
+
+"""Compile a Jac file into module AST.
+
+    Args:
+        file_path: Path to the Jac file to compile.
+        target_program: JacProgram to store compiled module in.
+        use_str: Optional source string instead of reading from file.
+        options: CompileOptions controlling compilation behavior.
+    """
+impl JacCompiler.compile(
+    file_path: str,
+    target_program: JacProgram,
+    use_str: (str | None) = None,
+    options: (CompileOptions | None) = None
+) -> uni.Module {
+    if (options is None) {
+        options = CompileOptions();
+    }
+    # For impl/test annex files compiled standalone, redirect to compile the
+    # parent module instead. The parent's JacAnnexPass discovers and attaches
+    # the impl, and DeclImplMatchPass connects them with full scope context.
+    # Only applies when resolve_annex_parent is set to avoid affecting
+    # AST-only compilation (e.g., micro suite tests).
+    if (
+        use_str is None
+        and options.resolve_annex_parent
+        and (file_path.endswith('.impl.jac') or file_path.endswith('.test.jac'))
+    ) {
+        import from jaclang.jac0core.bccache { discover_base_file }
+        base_path = discover_base_file(file_path);
+        if (base_path and base_path not in target_program.mod.hub) {
+            return self.compile(
+                file_path=base_path, target_program=target_program, options=options
+            );
+        }
+    }
+    actual_program = self._resolve_program(file_path, target_program);
+    actual_program._compile_options = options;
+    keep_str = use_str or read_file_with_encoding(file_path);
+    had_parse_errors = len(actual_program.errors_had);
+    mod_targ = self.parse_str(
+        keep_str, file_path, actual_program, cancel_token=options.cancel_token
+    );
+    had_parse_errors = len(actual_program.errors_had) > had_parse_errors;
+    if options.symtab_ir_only {
+        self.run_schedule(
+            mod=mod_targ,
+            target_program=actual_program,
+            passes=get_symtab_ir_sched(),
+            cancel_token=options.cancel_token
+        );
+    } else {
+        self.run_schedule(
+            mod=mod_targ,
+            target_program=actual_program,
+            passes=get_ir_gen_sched(),
+            cancel_token=options.cancel_token
+        );
+    }
+    if options.type_check {
+        self.run_schedule(
+            mod=mod_targ,
+            target_program=actual_program,
+            passes=get_type_check_sched(),
+            cancel_token=options.cancel_token
+        );
+    }
+    if (not had_parse_errors and not options.no_cgen) {
+        self.run_schedule(
+            mod=mod_targ,
+            target_program=actual_program,
+            passes=get_py_code_gen(),
+            cancel_token=options.cancel_token
+        );
+    }
+    return mod_targ;
+}
+
+"""Build a Jac file with import dependency resolution."""
+impl JacCompiler.build(
+    file_path: str,
+    target_program: JacProgram,
+    use_str: (str | None) = None,
+    type_check: bool = False
+) -> uni.Module {
+    actual_program = self._resolve_program(file_path, target_program);
+    options = CompileOptions(type_check=type_check);
+    mod_targ = self.compile(file_path, actual_program, use_str, options=options);
+    SemanticAnalysisPass(ir_in=mod_targ, prog=actual_program);
+    return mod_targ;
+}
+
+"""Run a list of passes on a module."""
+impl JacCompiler.run_schedule(
+    mod: uni.Module,
+    target_program: JacProgram,
+    passes: list[type[Transform[uni.Module, uni.Module]]],
+    cancel_token: (Event | None) = None
+) -> None {
+    for current_pass in passes {
+        if (cancel_token and cancel_token.is_set()) {
+            break;
+        }
+        current_pass(ir_in=mod, prog=target_program, cancel_token=cancel_token);
+    }
+}
+
+"""Parse a Jac file/string and optionally load annexes for tooling passes.
+
+Shared scaffold for jac_file_formatter, jac_str_formatter, and jac_file_linter.
+Returns (prog, current_mod) or (prog, None) if parse errors occurred.
+"""
+impl JacCompiler._prepare_tool_program(
+    source_str: str,
+    file_path: str,
+    load_impl_annexes: bool = False,
+    load_test_annexes: bool = False
+) -> tuple[JacProgram, (uni.Module | None)] {
+    import from jaclang.jac0core.program { JacProgram }
+    import from jaclang.jac0core.parser { parse as rd_parse }
+    prog = JacProgram();
+    (current_mod, parse_errors, lex_errors) = rd_parse(source_str, file_path);
+    _recalculate_parents(current_mod);
+    if len(parse_errors) > 0 or len(lex_errors) > 0 {
+        prog.errors_had.extend(parse_errors);
+        prog.errors_had.extend(lex_errors);
+        prog.mod = uni.ProgramModule(main_mod=current_mod);
+        return (prog, None);
+    }
+    # Parse-only annex loading: just parse .impl.jac/.test.jac files
+    # without running SymTabBuildPass or any compilation passes.
+    # This avoids cascading import resolution that would compile the
+    # entire dependency graph for each formatted file.
+    if load_impl_annexes or load_test_annexes {
+        import from jaclang.jac0core.bccache { discover_annex_files }
+        if load_impl_annexes {
+            for annex_path in discover_annex_files(file_path, '.impl.jac') {
+                try {
+                    annex_src = read_file_with_encoding(annex_path);
+                    (annex_mod, _, _) = rd_parse(annex_src, annex_path);
+                    _recalculate_parents(annex_mod);
+                    current_mod.impl_mod.append(annex_mod);
+                } except Exception {
+                    ;
+                }
+            }
+        }
+        if load_test_annexes {
+            for annex_path in discover_annex_files(file_path, '.test.jac') {
+                try {
+                    annex_src = read_file_with_encoding(annex_path);
+                    (annex_mod, _, _) = rd_parse(annex_src, annex_path);
+                    _recalculate_parents(annex_mod);
+                    current_mod.test_mod.append(annex_mod);
+                } except Exception {
+                    ;
+                }
+            }
+        }
+    }
+    return (prog, current_mod);
+}
+
+"""Format a Jac file."""
+impl JacCompiler.jac_file_formatter(
+    file_path: str, auto_lint: bool = False
+) -> JacProgram {
+    source_str = read_file_with_encoding(file_path);
+    (prog, current_mod) = JacCompiler._prepare_tool_program(
+        source_str, file_path, load_impl_annexes=auto_lint, load_test_annexes=auto_lint
+    );
+    if current_mod is None {
+        return prog;
+    }
+    for pass_cls in get_format_sched(auto_lint=auto_lint) {
+        current_mod = pass_cls(ir_in=current_mod, prog=prog).ir_out;
+    }
+    prog.mod = uni.ProgramModule(main_mod=current_mod);
+    return prog;
+}
+
+"""Format a Jac source string."""
+impl JacCompiler.jac_str_formatter(
+    source_str: str, file_path: str, auto_lint: bool = False
+) -> JacProgram {
+    (prog, current_mod) = JacCompiler._prepare_tool_program(source_str, file_path);
+    if current_mod is None {
+        return prog;
+    }
+    for pass_cls in get_format_sched(auto_lint=auto_lint) {
+        current_mod = pass_cls(ir_in=current_mod, prog=prog).ir_out;
+    }
+    prog.mod = uni.ProgramModule(main_mod=current_mod);
+    return prog;
+}
+
+"""Lint a Jac file (report only, no formatting or output generation)."""
+impl JacCompiler.jac_file_linter(file_path: str) -> JacProgram {
+    source_str = read_file_with_encoding(file_path);
+    (prog, current_mod) = JacCompiler._prepare_tool_program(
+        source_str, file_path, load_impl_annexes=True
+    );
+    if current_mod is None {
+        return prog;
+    }
+    for pass_cls in get_lint_sched() {
+        current_mod = pass_cls(ir_in=current_mod, prog=prog).ir_out;
+    }
+    prog.mod = uni.ProgramModule(main_mod=current_mod);
+    return prog;
+}

--- a/jac/jaclang/jac0core/impl/constant.impl.jac
+++ b/jac/jaclang/jac0core/impl/constant.impl.jac
@@ -1,0 +1,24 @@
+"""Implementation for constant types."""
+
+"""Return the string representation of the token."""
+impl Constants.__str__(self: Constants) -> str {
+    return self.value;
+}
+
+"""Return the string list of token types."""
+impl JacSemTokenType.as_str_list -> list {
+    return [
+        i.name.lower()
+        for i in JacSemTokenType
+        if i.name
+    ];
+}
+
+"""Return the string list of token modifiers."""
+impl JacSemTokenModifier.as_str_list -> list {
+    return [
+        i.name.lower()
+        for i in JacSemTokenModifier
+        if i.name
+    ];
+}

--- a/jac/jaclang/jac0core/impl/helpers.impl.jac
+++ b/jac/jaclang/jac0core/impl/helpers.impl.jac
@@ -1,0 +1,29 @@
+"""Implementation for helpers."""
+
+"""Initialize the Jac debugger."""
+impl Jdb.init(self: Jdb, *args: Any, **kwargs: Any) -> None {
+    super.init(*args, **kwargs);
+    self.prompt = 'Jdb > ';
+}
+
+"""Check for breakpoint."""
+impl Jdb.has_breakpoint(self: Jdb, bytecode: bytes) -> bool {
+    code = marshal.loads(bytecode);
+    instructions = dis.get_instructions(code);
+    return `any(
+        (
+            (instruction.opname in ('LOAD_GLOBAL', 'LOAD_NAME', 'LOAD_FAST'))
+            and (instruction.argval == 'breakpoint')
+        ) for instruction in instructions
+    );
+}
+
+"""Get the distribution/package name."""
+impl DistFacade.project_name(self: DistFacade) -> str {
+    return self._dist.name if (self._dist and self._dist?.name) else 'unknown';
+}
+
+"""Get the distribution version."""
+impl DistFacade.version(self: DistFacade) -> str {
+    return self._dist.version if (self._dist and self._dist?.version) else '0.0.0';
+}

--- a/jac/jaclang/jac0core/impl/native_marshal.impl.jac
+++ b/jac/jaclang/jac0core/impl/native_marshal.impl.jac
@@ -1,0 +1,193 @@
+"""Implementation for NativeStructView and NativeListView."""
+
+import ctypes;
+import from typing { Any }
+
+impl NativeStructView.postinit -> None {
+    # from_address: NO copy -- creates view over C memory
+    self._native = self.ct_cls.from_address(self.addr);
+    # Build field metadata lookup (name -> NativeFieldInfo)
+    if (self.layout and hasattr(self.layout, "structs")) {
+        sl = self.layout.structs.get(self.struct_name);
+        if sl {
+            for f in sl.fields {
+                self._field_meta[f.name] = f;
+            }
+        }
+    }
+}
+
+impl NativeStructView.__getattr__(self: NativeStructView, name: str) -> Any {
+    native = self._native;
+    try {
+        raw = getattr(native, name);
+    } except AttributeError {
+        raise AttributeError(f"'{self.struct_name}' has no field '{name}'");
+    }
+    return self._resolve(name, raw);
+}
+
+impl NativeStructView._resolve(self: NativeStructView, name: str, raw: Any) -> Any {
+    finfo = self._field_meta.get(name);
+    if finfo is None {
+        return raw;
+    }
+    lt = finfo.llvm_type;
+    # Function pointer: wrap raw address as callable ctypes function
+    if finfo.is_func_ptr {
+        if (raw is None or raw == 0) {
+            return None;
+        }
+        fn_type = _build_cfunctype(finfo);
+        return fn_type(raw);
+    }
+    # String: decode from raw pointer on demand
+    if lt == "i8*" {
+        if (raw is None or raw == 0) {
+            return "";
+        }
+        return ctypes.string_at(raw).decode("utf-8", errors="replace");
+    }
+    # Enum field: ordinal -> enum value
+    if (lt in ("i64", "i32") and finfo.enum_type) {
+        val = int(raw);
+        emap = self.enum_maps.get(finfo.enum_type);
+        if (emap and 0 <= val < len(emap) and emap[val] is not None) {
+            return emap[val];
+        }
+        return val;
+    }
+    # Nested struct pointer
+    if (lt.endswith("*") and not lt.startswith("List.") and lt != "i8*") {
+        sname = lt[:-1];
+        if (raw and raw != 0) {
+            ct_cls = self.ctypes_classes.get(sname);
+            if ct_cls {
+                return NativeStructView(
+                    raw,
+                    ct_cls,
+                    sname,
+                    self.layout,
+                    self.ctypes_classes,
+                    self.enum_maps
+                );
+            }
+        }
+        return None;
+    }
+    # List pointer
+    if (lt.startswith("List.") and lt.endswith("*")) {
+        if (raw and raw != 0) {
+            elem_key = lt[5:-1];
+            return NativeListView(
+                raw, elem_key, self.ctypes_classes, self.enum_maps, self.layout
+            );
+        }
+        return NativeListView.empty();
+    }
+    return raw;
+}
+
+impl NativeStructView.__getitem__(self: NativeStructView, key: str) -> Any {
+    return getattr(self, key);
+}
+
+impl NativeStructView.__contains__(self: NativeStructView, key: str) -> bool {
+    return key in self._field_meta;
+}
+
+impl NativeStructView.keys(self: NativeStructView) -> Any {
+    return self._field_meta.keys();
+}
+
+impl NativeStructView.items(self: NativeStructView) -> Any {
+    return ((k, self[k]) for k in self.keys());
+}
+
+impl NativeStructView.__repr__(self: NativeStructView) -> str {
+    return f"<NativeStructView {self.struct_name}>";
+}
+
+impl NativeListView.postinit -> None {
+    if (self.list_ptr == 0) {
+        self._count = 0;
+        self._arr = None;
+        self._ct_cls = None;
+        self._struct_name = None;
+        return;
+    }
+    nl = NativeList.from_address(self.list_ptr);
+    self._count = nl.len if (nl.len > 0 and nl.data) else 0;
+
+    # Resolve struct class for ptr elements
+    self._struct_name = self.struct_hint;
+    if (self.elem_key == "ptr" and self._struct_name) {
+        self._ct_cls = self.ctypes_classes.get(self._struct_name);
+    }
+
+    # Create array view over data -- zero-copy via from_address
+    if self._count > 0 {
+        if self.elem_key == "i64" {
+            self._arr = (ctypes.c_int64 * self._count).from_address(nl.data);
+        } elif self.elem_key == "f64" {
+            self._arr = (ctypes.c_double * self._count).from_address(nl.data);
+        } else {
+            # 'ptr' and others
+            self._arr = (ctypes.c_void_p * self._count).from_address(nl.data);
+        }
+    }
+}
+
+impl NativeListView.__len__(self: NativeListView) -> int {
+    return self._count;
+}
+
+impl NativeListView.__getitem__(self: NativeListView, index: Any) -> Any {
+    if isinstance(index, slice) {
+        return [self[i] for i in range(*index.indices(self._count))];
+    }
+    if index < 0 {
+        index += self._count;
+    }
+    if (index < 0 or index >= self._count) {
+        raise IndexError(f"list index {index} out of range");
+    }
+    raw = self._arr[index];
+    if self.elem_key == "i64" {
+        return int(raw);
+    }
+    if self.elem_key == "f64" {
+        return float(raw);
+    }
+    # Struct pointer element
+    if (self._ct_cls and raw and raw != 0) {
+        return NativeStructView(
+            raw,
+            self._ct_cls,
+            self._struct_name,
+            self.layout,
+            self.ctypes_classes,
+            self.enum_maps
+        );
+    }
+    return raw;
+}
+
+impl NativeListView.__iter__(self: NativeListView) -> Any {
+    for i in range(len(self)) {
+        yield self[i];
+    }
+}
+
+impl NativeListView.__eq__(self: NativeListView, other: Any) -> Any {
+    if isinstance(other, list) {
+        return (
+            len(self) == len(other) and all(a == b for (a, b) in zip(self, other))
+        );
+    }
+    return NotImplemented;
+}
+
+impl NativeListView.__repr__(self: NativeListView) -> str {
+    return f"<NativeListView len={len(self)}>";
+}

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -1,0 +1,2310 @@
+"""Implementation for runtime."""
+
+"""Resolve the live anchor for an archetype from runtime memory."""
+impl JacAccessValidation._resolve_anchor(archetype: Archetype) -> tuple {
+    anchor = archetype.__jac__;
+    jctx = JacRuntimeInterface.get_context();
+    mem_anchor = jctx.mem.get(anchor.id);
+    if (mem_anchor and (mem_anchor is not anchor)) {
+        anchor = mem_anchor;
+    }
+    return (anchor, jctx);
+}
+
+"""Check if current root has at least min_level access to target anchor."""
+impl JacAccessValidation._check_access(
+    `to: Anchor, min_level: AccessLevel, operation: str
+) -> bool {
+    access_level = JacRuntimeInterface.check_access_level(`to) > min_level;
+    if not access_level {
+        logger.info(
+            "Current root doesn't have " + operation + " access to " + `to.__class__.__name__ + " " + `to.archetype.__class__.__name__ + "[" + str(
+                `to.id
+            ) + "]"
+        );
+    }
+    return access_level;
+}
+
+"""Allow all access from target root graph to current Archetype."""
+impl JacAccessValidation.allow_root(
+    archetype: Archetype, root_id: UUID, level: (AccessLevel | int | str | None) = None
+) -> None {
+    if (level is None) {
+        level = AccessLevel.READ;
+    }
+    level = AccessLevel.cast(level);
+    (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
+    access = anchor.access.roots;
+    _root_id = str(root_id);
+    if (level != access.anchors.get(_root_id, AccessLevel.NO_ACCESS)) {
+        access.anchors[_root_id] = level;
+        jctx.mem.put(anchor);
+    }
+}
+
+"""Disallow all access from target root graph to current Archetype."""
+impl JacAccessValidation.disallow_root(
+    archetype: Archetype, root_id: UUID, level: (AccessLevel | int | str | None) = None
+) -> None {
+    if (level is None) {
+        level = AccessLevel.READ;
+    }
+    level = AccessLevel.cast(level);
+    (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
+    access = anchor.access.roots;
+    access.anchors.pop(str(root_id), None);
+    jctx.mem.put(anchor);
+}
+
+"""Allow everyone to access current Archetype."""
+impl JacAccessValidation.perm_grant(
+    archetype: Archetype, level: (AccessLevel | int | str | None) = None
+) -> None {
+    if (level is None) {
+        level = AccessLevel.READ;
+    }
+    level = AccessLevel.cast(level);
+    (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
+    if (level != anchor.access.all) {
+        anchor.access.all = level;
+        jctx.mem.put(anchor);
+    }
+}
+
+"""Disallow others to access current Archetype."""
+impl JacAccessValidation.perm_revoke(archetype: Archetype) -> None {
+    (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
+    if (anchor.access.all > AccessLevel.NO_ACCESS) {
+        anchor.access.all = AccessLevel.NO_ACCESS;
+        jctx.mem.put(anchor);
+    }
+}
+
+"""Read Access Validation."""
+impl JacAccessValidation.check_read_access(`to: Anchor) -> bool {
+    return JacAccessValidation._check_access(`to, AccessLevel.NO_ACCESS, "read");
+}
+
+"""Connect Access Validation."""
+impl JacAccessValidation.check_connect_access(`to: Anchor) -> bool {
+    return JacAccessValidation._check_access(`to, AccessLevel.READ, "connect");
+}
+
+"""Write Access Validation."""
+impl JacAccessValidation.check_write_access(`to: Anchor) -> bool {
+    return JacAccessValidation._check_access(`to, AccessLevel.CONNECT, "write");
+}
+
+"""Access validation."""
+impl JacAccessValidation.check_access_level(
+    `to: Anchor, no_custom: bool = False
+) -> AccessLevel {
+    if (not `to.persistent or (`to.hash == 0)) {
+        return AccessLevel.WRITE;
+    }
+    jctx = JacRuntimeInterface.get_context();
+    jroot = jctx.user_root;
+    if ((jroot == jctx.system_root) or (jroot.id == `to.root) or (jroot == `to)) {
+        return AccessLevel.WRITE;
+    }
+    if (
+        not no_custom
+        and ((custom_level := `to.archetype.__jac_access__()) is not None)
+    ) {
+        return AccessLevel.cast(custom_level);
+    }
+    access_level = AccessLevel.NO_ACCESS;
+    if ((to_access := `to.access).all > AccessLevel.NO_ACCESS) {
+        access_level = to_access.all;
+    }
+    if (`to.root and isinstance((to_root := jctx.mem.get(`to.root)), Anchor)) {
+        if (to_root.access.all > access_level) {
+            access_level = to_root.access.all;
+        }
+        if ((level := to_root.access.roots.check(str(jroot.id))) is not None) {
+            access_level = level;
+        }
+    }
+    if ((level := to_access.roots.check(str(jroot.id))) is not None) {
+        access_level = level;
+    }
+    return access_level;
+}
+
+"""Get edges connected to this node."""
+impl JacNode.get_edges(
+    origin: list[NodeArchetype], destination: ObjectSpatialDestination
+) -> list[EdgeArchetype] {
+    edges: OrderedDict[(EdgeAnchor, EdgeArchetype)] = OrderedDict();
+    for nd in origin {
+        nanch = nd.__jac__;
+        for anchor in nanch.edges {
+            if (
+                (source := anchor.source)
+                and (target := anchor.target)
+                and destination.edge_filter(anchor.archetype)
+                and source.archetype
+                and target.archetype
+            ) {
+                if (
+                    (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
+                    and (nanch == source)
+                    and destination.node_filter(target.archetype)
+                    and JacRuntimeInterface.check_read_access(target)
+                ) {
+                    edges[anchor] = anchor.archetype;
+                }
+                if (
+                    (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
+                    and (nanch == target)
+                    and destination.node_filter(source.archetype)
+                    and JacRuntimeInterface.check_read_access(source)
+                ) {
+                    edges[anchor] = anchor.archetype;
+                }
+            }
+        }
+    }
+    return `list(edges.values());
+}
+
+"""Get edges connected to this node and the node."""
+impl JacNode.get_edges_with_node(
+    origin: list[NodeArchetype],
+    destination: ObjectSpatialDestination,
+    from_visit: bool = False
+) -> list[(EdgeArchetype | NodeArchetype)] {
+    loc: OrderedDict[((NodeAnchor | EdgeAnchor), (NodeArchetype | EdgeArchetype))] = OrderedDict();
+    for nd in origin {
+        nanch = nd.__jac__;
+        for anchor in nanch.edges {
+            if (
+                (source := anchor.source)
+                and (target := anchor.target)
+                and destination.edge_filter(anchor.archetype)
+                and source.archetype
+                and target.archetype
+            ) {
+                if (
+                    (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
+                    and (nanch == source)
+                    and destination.node_filter(target.archetype)
+                    and JacRuntimeInterface.check_read_access(target)
+                ) {
+                    loc[anchor] = anchor.archetype;
+                    loc[target] = target.archetype;
+                }
+                if (
+                    (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
+                    and (nanch == target)
+                    and destination.node_filter(source.archetype)
+                    and JacRuntimeInterface.check_read_access(source)
+                ) {
+                    loc[anchor] = anchor.archetype;
+                    loc[source] = source.archetype;
+                }
+            }
+        }
+    }
+    return `list(loc.values());
+}
+
+"""Get set of nodes connected to this node."""
+impl JacNode.edges_to_nodes(
+    origin: list[NodeArchetype], destination: ObjectSpatialDestination
+) -> list[NodeArchetype] {
+    nodes: OrderedDict[(NodeAnchor, NodeArchetype)] = OrderedDict();
+    for nd in origin {
+        nanch = nd.__jac__;
+        for anchor in nanch.edges {
+            if (
+                (source := anchor.source)
+                and (target := anchor.target)
+                and destination.edge_filter(anchor.archetype)
+                and source.archetype
+                and target.archetype
+            ) {
+                if (
+                    (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
+                    and (nanch == source)
+                    and destination.node_filter(target.archetype)
+                    and JacRuntimeInterface.check_read_access(target)
+                ) {
+                    nodes[target] = target.archetype;
+                }
+                if (
+                    (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
+                    and (nanch == target)
+                    and destination.node_filter(source.archetype)
+                    and JacRuntimeInterface.check_read_access(source)
+                ) {
+                    nodes[source] = source.archetype;
+                }
+            }
+        }
+    }
+    return `list(nodes.values());
+}
+
+"""Remove reference without checking sync status."""
+impl JacNode.remove_edge(nd: NodeAnchor, `edge: EdgeAnchor) -> None {
+    for (idx, ed) in enumerate(nd.edges) {
+        if (ed.id == `edge.id) {
+            nd.edges.pop(idx);
+            break;
+        }
+    }
+}
+
+"""Detach edge from nodes."""
+impl JacEdge.detach(`edge: EdgeAnchor) -> None {
+    JacRuntimeInterface.remove_edge(nd=`edge.source, `edge=`edge);
+    JacRuntimeInterface.remove_edge(nd=`edge.target, `edge=`edge);
+}
+
+"""Jac's visit stmt feature."""
+impl JacWalker.`visit(
+    `walker: WalkerArchetype,
+    expr:
+        (
+            list[
+                (NodeArchetype | EdgeArchetype)
+            ] | list[NodeArchetype] | list[EdgeArchetype] | NodeArchetype | EdgeArchetype | ObjectSpatialPath
+        ),
+    insert_loc: int = -1
+) -> bool {
+    if isinstance(expr, ObjectSpatialPath) {
+        expr.from_visit = True;
+        expr = JacRuntimeInterface.refs(expr);
+    }
+    if isinstance(`walker, WalkerArchetype) {
+        'Walker visits node.';
+        wanch = `walker.__jac__;
+        before_len = len(wanch.next);
+        next = [];
+        for anchor in (i.__jac__ for i in expr)
+            if isinstance(expr, `list)
+            else [expr.__jac__] {
+            if (anchor not in wanch.ignores) {
+                if isinstance(anchor, (NodeAnchor, EdgeAnchor)) {
+                    next.append(anchor);
+                } else {
+                    raise ValueError('Anchor should be NodeAnchor or EdgeAnchor.');
+                }
+            }
+        }
+        if (insert_loc < -len(wanch.next)) {
+            insert_loc = 0;
+        } elif (insert_loc < 0) {
+            insert_loc += len(wanch.next) + 1;
+        }
+        wanch.next = wanch.next[:insert_loc] + next + wanch.next[insert_loc:];
+        return (len(wanch.next) > before_len);
+    } else {
+        raise TypeError('Invalid walker object');
+    }
+}
+
+"""Execute all entry abilities for current location.
+
+    Returns True if walker should continue, False if disengaged.
+    """
+impl JacWalker._execute_entries(
+    warch: WalkerArchetype,
+    `walker: WalkerAnchor,
+    current_loc: (NodeArchetype | EdgeArchetype)
+) -> bool {
+    import from jaclang.runtimelib.utils { all_issubclass }
+    for i in warch._jac_entry_funcs_ {
+        if (
+            i.trigger
+            and (
+                all_issubclass(i.trigger, NodeArchetype)
+                or all_issubclass(i.trigger, EdgeArchetype)
+            )
+            and isinstance(current_loc, i.trigger)
+        ) {
+            i.func(warch, current_loc);
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in current_loc._jac_entry_funcs_ {
+        if not i.trigger {
+            i.func(current_loc, warch);
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in current_loc._jac_entry_funcs_ {
+        if (
+            i.trigger
+            and all_issubclass(i.trigger, WalkerArchetype)
+            and isinstance(warch, i.trigger)
+        ) {
+            i.func(current_loc, warch);
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    return True;
+}
+
+"""Execute all exit abilities for current location.
+
+    Returns True if walker should continue, False if disengaged.
+    """
+impl JacWalker._execute_exits(
+    warch: WalkerArchetype,
+    `walker: WalkerAnchor,
+    current_loc: (NodeArchetype | EdgeArchetype)
+) -> bool {
+    import from jaclang.runtimelib.utils { all_issubclass }
+    for i in current_loc._jac_exit_funcs_ {
+        if (
+            i.trigger
+            and all_issubclass(i.trigger, WalkerArchetype)
+            and isinstance(warch, i.trigger)
+        ) {
+            i.func(current_loc, warch);
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in current_loc._jac_exit_funcs_ {
+        if not i.trigger {
+            i.func(current_loc, warch);
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in warch._jac_exit_funcs_ {
+        if (
+            i.trigger
+            and (
+                all_issubclass(i.trigger, NodeArchetype)
+                or all_issubclass(i.trigger, EdgeArchetype)
+            )
+            and isinstance(current_loc, i.trigger)
+        ) {
+            i.func(warch, current_loc);
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    return True;
+}
+
+"""Recursively visit a node with DFS semantics.
+
+    1. Execute entries for this node
+    2. Recursively visit all children added during entry
+    3. Execute exits for this node (post-order)
+
+    Returns True if walker should continue, False if disengaged.
+    """
+impl JacWalker._visit_node_recursive(
+    warch: WalkerArchetype, `walker: WalkerAnchor, anchor: (NodeAnchor | EdgeAnchor)
+) -> bool {
+    current_loc = anchor.archetype;
+    if not current_loc {
+        return True;
+    }
+    `walker.path.append(anchor);
+    if not JacWalker._execute_entries(warch, `walker, current_loc) {
+        return False;
+    }
+    while `walker.next {
+        child_anchor = `walker.next.pop(0);
+        if (
+            (child_anchor not in `walker.ignores)
+            and not JacWalker._visit_node_recursive(warch, `walker, child_anchor)
+        ) {
+            return False;
+        }
+    }
+    return JacWalker._execute_exits(warch, `walker, current_loc);
+}
+
+"""Jac's spawn operator feature with recursive DFS semantics.
+
+    Entry abilities execute when entering a node, exit abilities execute
+    after all descendants are visited (post-order/LIFO).
+    """
+impl JacWalker.spawn_call(
+    `walker: WalkerAnchor, nd: (NodeAnchor | EdgeAnchor)
+) -> WalkerArchetype {
+    import from jaclang.runtimelib.context { CallState }
+    warch = `walker.archetype;
+    `walker.path = [];
+    current_loc = nd.archetype;
+    ctx = JacRuntimeInterface.get_context();
+    call_state = ctx.call_state.get(None);
+    owns_call_state = False;
+    if not call_state {
+        call_token = ctx.call_state.set(CallState());
+        call_state = ctx.call_state.get();
+        owns_call_state = True;
+    }
+    try {
+        for i in warch._jac_entry_funcs_ {
+            if not i.trigger {
+                i.func(warch, current_loc);
+            }
+            if `walker.disengaged {
+                `walker.ignores = [];
+                return warch;
+            }
+        }
+        while `walker.next {
+            next_anchor = `walker.next.pop(0);
+            if (
+                (next_anchor not in `walker.ignores)
+                and not JacWalker._visit_node_recursive(warch, `walker, next_anchor)
+            ) {
+                break;
+            }
+        }
+        if `walker.path {
+            current_loc = `walker.path[-1].archetype;
+        }
+        for i in warch._jac_exit_funcs_ {
+            if not i.trigger {
+                i.func(warch, current_loc);
+            }
+            if `walker.disengaged {
+                break;
+            }
+        }
+        `walker.ignores = [];
+        return warch;
+    } finally {
+        if owns_call_state {
+            reports = [];
+            while not call_state.reports.empty() {
+                item = call_state.reports.get_nowait();
+                if item is not call_state._sentinel {
+                    reports.append(item);
+                }
+            }
+            warch.reports = reports;
+            ctx.call_state.reset(call_token);
+        }
+    }
+}
+
+"""Async version: Execute all entry abilities for current location.
+
+    Returns True if walker should continue, False if disengaged.
+    """
+impl JacWalker._async_execute_entries(
+    warch: WalkerArchetype,
+    `walker: WalkerAnchor,
+    current_loc: (NodeArchetype | EdgeArchetype)
+) -> bool {
+    import from jaclang.runtimelib.utils { all_issubclass }
+    for i in warch._jac_entry_funcs_ {
+        if (
+            i.trigger
+            and (
+                all_issubclass(i.trigger, NodeArchetype)
+                or all_issubclass(i.trigger, EdgeArchetype)
+            )
+            and isinstance(current_loc, i.trigger)
+        ) {
+            result = i.func(warch, current_loc);
+            if isinstance(result, Coroutine) {
+                await result;
+            }
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in current_loc._jac_entry_funcs_ {
+        if not i.trigger {
+            result = i.func(current_loc, warch);
+            if isinstance(result, Coroutine) {
+                await result;
+            }
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in current_loc._jac_entry_funcs_ {
+        if (
+            i.trigger
+            and all_issubclass(i.trigger, WalkerArchetype)
+            and isinstance(warch, i.trigger)
+        ) {
+            result = i.func(current_loc, warch);
+            if isinstance(result, Coroutine) {
+                await result;
+            }
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    return True;
+}
+
+"""Async version: Execute all exit abilities for current location.
+
+    Returns True if walker should continue, False if disengaged.
+    """
+impl JacWalker._async_execute_exits(
+    warch: WalkerArchetype,
+    `walker: WalkerAnchor,
+    current_loc: (NodeArchetype | EdgeArchetype)
+) -> bool {
+    import from jaclang.runtimelib.utils { all_issubclass }
+    for i in current_loc._jac_exit_funcs_ {
+        if (
+            i.trigger
+            and all_issubclass(i.trigger, WalkerArchetype)
+            and isinstance(warch, i.trigger)
+        ) {
+            result = i.func(current_loc, warch);
+            if isinstance(result, Coroutine) {
+                await result;
+            }
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in current_loc._jac_exit_funcs_ {
+        if not i.trigger {
+            result = i.func(current_loc, warch);
+            if isinstance(result, Coroutine) {
+                await result;
+            }
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    for i in warch._jac_exit_funcs_ {
+        if (
+            i.trigger
+            and (
+                all_issubclass(i.trigger, NodeArchetype)
+                or all_issubclass(i.trigger, EdgeArchetype)
+            )
+            and isinstance(current_loc, i.trigger)
+        ) {
+            result = i.func(warch, current_loc);
+            if isinstance(result, Coroutine) {
+                await result;
+            }
+        }
+        if `walker.disengaged {
+            return False;
+        }
+    }
+    return True;
+}
+
+"""Async version: Recursively visit a node with DFS semantics.
+
+    1. Execute entries for this node
+    2. Recursively visit all children added during entry
+    3. Execute exits for this node (post-order)
+
+    Returns True if walker should continue, False if disengaged.
+    """
+impl JacWalker._async_visit_node_recursive(
+    warch: WalkerArchetype, `walker: WalkerAnchor, anchor: (NodeAnchor | EdgeAnchor)
+) -> bool {
+    current_loc = anchor.archetype;
+    if not current_loc {
+        return True;
+    }
+    `walker.path.append(anchor);
+    if not await JacWalker._async_execute_entries(warch, `walker, current_loc) {
+        return False;
+    }
+    while `walker.next {
+        child_anchor = `walker.next.pop(0);
+        if (
+            (child_anchor not in `walker.ignores)
+            and not await JacWalker._async_visit_node_recursive(
+                warch, `walker, child_anchor
+            )
+        ) {
+            return False;
+        }
+    }
+    return await JacWalker._async_execute_exits(warch, `walker, current_loc);
+}
+
+"""Jac's async spawn operator feature with recursive DFS semantics.
+
+    Entry abilities execute when entering a node, exit abilities execute
+    after all descendants are visited (post-order/LIFO).
+    """
+impl JacWalker.async_spawn_call(
+    `walker: WalkerAnchor, nd: (NodeAnchor | EdgeAnchor)
+) -> WalkerArchetype {
+    import from jaclang.runtimelib.context { CallState }
+    warch = `walker.archetype;
+    `walker.path = [];
+    current_loc = nd.archetype;
+    ctx = JacRuntimeInterface.get_context();
+    call_state = ctx.call_state.get(None);
+    owns_call_state = False;
+    if not call_state {
+        call_token = ctx.call_state.set(CallState());
+        call_state = ctx.call_state.get();
+        owns_call_state = True;
+    }
+    try {
+        for i in warch._jac_entry_funcs_ {
+            if not i.trigger {
+                result = i.func(warch, current_loc);
+                if isinstance(result, Coroutine) {
+                    await result;
+                }
+            }
+            if `walker.disengaged {
+                `walker.ignores = [];
+                return warch;
+            }
+        }
+        while `walker.next {
+            next_anchor = `walker.next.pop(0);
+            if (
+                (next_anchor not in `walker.ignores)
+                and not await JacWalker._async_visit_node_recursive(
+                    warch, `walker, next_anchor
+                )
+            ) {
+                break;
+            }
+        }
+        if `walker.path {
+            current_loc = `walker.path[-1].archetype;
+        }
+        for i in warch._jac_exit_funcs_ {
+            if not i.trigger {
+                result = i.func(warch, current_loc);
+                if isinstance(result, Coroutine) {
+                    await result;
+                }
+            }
+            if `walker.disengaged {
+                break;
+            }
+        }
+        `walker.ignores = [];
+        return warch;
+    } finally {
+        if owns_call_state {
+            reports = [];
+            while not call_state.reports.empty() {
+                item = call_state.reports.get_nowait();
+                if item is not call_state._sentinel {
+                    reports.append(item);
+                }
+            }
+            warch.reports = reports;
+            ctx.call_state.reset(call_token);
+        }
+    }
+}
+
+impl JacWalker.`spawn(
+    op1: (Archetype | list[Archetype]), op2: (Archetype | list[Archetype])
+) -> (WalkerArchetype | Coroutine) {
+    def collect_targets(
+        `walker: WalkerAnchor, items: list[Archetype]
+    ) -> (NodeAnchor | EdgeAnchor) {
+        for i in items {
+            a = i.__jac__;
+            `walker.next.append(a) if isinstance(a, (NodeAnchor, EdgeAnchor)) else None;
+            if (isinstance(a, EdgeAnchor) and a.target) {
+                `walker.next.append(a.target);
+            }
+        }
+        return `walker.next[0];
+    }
+    def assign(
+        `walker: WalkerAnchor, t: (Archetype | list[Archetype])
+    ) -> (NodeAnchor | EdgeAnchor) {
+        if isinstance(t, NodeArchetype) {
+            nd = t.__jac__;
+            `walker.next = [nd];
+            return nd;
+        } elif isinstance(t, EdgeArchetype) {
+            `edge = t.__jac__;
+            `walker.next = [`edge, `edge.target];
+            return `edge;
+        } elif (
+            isinstance(t, `list)
+            and all(isinstance(i, (NodeArchetype, EdgeArchetype)) for i in t)
+        ) {
+            return collect_targets(`walker, t);
+        } else {
+            raise TypeError('Invalid target object');
+        }
+    }
+    if isinstance(op1, WalkerArchetype) {
+        (warch, targ) = (op1, op2);
+    } elif isinstance(op2, WalkerArchetype) {
+        (warch, targ) = (op2, op1);
+    } else {
+        raise TypeError('Invalid walker object');
+    }
+    `walker: WalkerAnchor = warch.__jac__;
+    loc: (NodeAnchor | EdgeAnchor) = assign(`walker, targ);
+    if warch.__jac_async__ {
+        return JacRuntimeInterface.async_spawn_call(`walker=`walker, nd=loc);
+    }
+    return JacRuntimeInterface.spawn_call(`walker=`walker, nd=loc);
+}
+
+"""Jac's disengage stmt feature."""
+impl JacWalker.`disengage(`walker: WalkerArchetype) -> bool {
+    `walker.__jac__.disengaged = True;
+    return True;
+}
+
+"""Generate graph for visualizing nodes and edges."""
+impl JacBuiltin.printgraph(
+    nd: NodeArchetype,
+    depth: int,
+    traverse: bool,
+    edge_type: (list[str] | None),
+    bfs: bool,
+    edge_limit: int,
+    node_limit: int,
+    file: (str | None),
+    format: str
+) -> str {
+    import from jaclang.runtimelib.utils { traverse_graph }
+    edge_type = edge_type or [];
+    visited_nodes: list[NodeArchetype] = [];
+    node_depths: dict[(NodeArchetype, int)] = {nd: 0};
+    queue: list = [[nd, 0]];
+    connections: list[tuple[(NodeArchetype, NodeArchetype, EdgeArchetype)]] = [];
+    """Depth first search.""";
+    def dfs(nd: NodeArchetype, cur_depth: int) -> None {
+        if (nd not in visited_nodes) {
+            visited_nodes.append(nd);
+            traverse_graph(
+                nd,
+                cur_depth,
+                depth,
+                edge_type,
+                traverse,
+                connections,
+                node_depths,
+                visited_nodes,
+                queue,
+                bfs,
+                dfs,
+                node_limit,
+                edge_limit
+            );
+        }
+    }
+    if bfs {
+        cur_depth = 0;
+        while queue {
+            (current_node, cur_depth) = queue.pop(0);
+            if (current_node not in visited_nodes) {
+                visited_nodes.append(current_node);
+                traverse_graph(
+                    current_node,
+                    cur_depth,
+                    depth,
+                    edge_type,
+                    traverse,
+                    connections,
+                    node_depths,
+                    visited_nodes,
+                    queue,
+                    bfs,
+                    dfs,
+                    node_limit,
+                    edge_limit
+                );
+            }
+        }
+    } else {
+        dfs(nd, cur_depth=0);
+    }
+    dot_content = 'digraph {\nnode [style="filled", shape="ellipse", fillcolor="invis", fontcolor="black"];\n';
+    mermaid_content = 'flowchart LR\n';
+    for (source, target, `edge) in connections {
+        edge_label = html.escape(str(`edge.__jac__.archetype));
+        dot_content += (
+            f"{visited_nodes.index(source)} -> {visited_nodes.index(target)} " + f' [label="{edge_label
+                if "GenericEdge" not in edge_label
+                else ""}"];\n'
+        );
+        if (('GenericEdge' in edge_label) or not edge_label.strip()) {
+            mermaid_content += (
+                f"{visited_nodes.index(source)} -->{visited_nodes.index(target)}\n"
+            );
+        } else {
+            mermaid_content += (
+                f'{visited_nodes.index(source)} -->|"{edge_label}"| {visited_nodes.index(
+                    target
+                )}\n'
+            );
+        }
+    }
+    for node_ in visited_nodes {
+        color = colors[node_depths[node_]] if (node_depths[node_] < 25) else colors[24];
+        label = html.escape(str(node_.__jac__.archetype));
+        dot_content += (
+            f'{visited_nodes.index(node_)} [label="{label}"fillcolor="{color}"];\n'
+        );
+        mermaid_content += f'{visited_nodes.index(node_)}["{label}"]\n';
+    }
+    output = (dot_content + '}') if (format == 'dot') else mermaid_content;
+    if file {
+        with open(file, 'w') as f {
+            f.write(output);
+        }
+    }
+    return output;
+}
+
+"""Create Jac CLI cmds."""
+impl JacCmd.create_cmd -> None { }
+
+"""Set Class References."""
+impl JacBasics.setup -> None { }
+
+"""Get current execution context."""
+impl JacBasics.get_context -> ExecutionContext {
+    if (JacRuntime.exec_ctx is None) {
+        JacRuntime.exec_ctx = JacRuntimeInterface.create_j_context(user_root=None);
+    }
+    return JacRuntime.exec_ctx;
+}
+
+"""Commit all data from memory to datasource."""
+impl JacBasics.commit(anchor: Anchor | Archetype | None = None) -> None {
+    if isinstance(anchor, Archetype) {
+        anchor = anchor.__jac__;
+    }
+    ctx = JacRuntimeInterface.get_context();
+    ctx.mem.commit(anchor);
+}
+
+"""Purge current or target graph."""
+impl JacBasics.reset_graph(`root: (Root | None) = None) -> int {
+    import pickle;
+    import sqlite3;
+    ctx = JacRuntimeInterface.get_context();
+    mem = ctx.mem;
+    ranchor = `root.__jac__ if `root else ctx.user_root;
+    deleted_count = 0;
+    deleted_ids: set[UUID] = `set();
+    persistence = mem.l3;
+    conn = getattr(persistence, '__conn__', None) if persistence else None;
+    if (conn and isinstance(conn, sqlite3.Connection)) {
+        cursor = conn.execute('SELECT data FROM anchors');
+        anchors = [pickle.loads(row[0]) for row in cursor.fetchall()];
+    } else {
+        anchors = `list(mem.get_mem().values());
+    }
+    for anchor in anchors {
+        if ((anchor == ranchor) or (anchor.root != ranchor.id)) {
+            continue;
+        }
+        deleted_ids.add(anchor.id);
+        mem.delete(anchor.id);
+        deleted_count += 1;
+    }
+    ranchor.edges = [
+        e
+        for e in ranchor.edges
+        if (e.id not in deleted_ids)
+    ];
+    mem.commit(ranchor);
+    return deleted_count;
+}
+
+"""Get object given id."""
+impl JacBasics.get_object(id: str) -> (Archetype | None) {
+    if (id == 'root') {
+        return JacRuntimeInterface.get_context().user_root.archetype;
+    } elif (`obj := JacRuntimeInterface.get_context().mem.get(UUID(id))) {
+        return `obj.archetype;
+    }
+    return None;
+}
+
+"""Get object reference id."""
+impl JacBasics.object_ref(`obj: Archetype) -> str {
+    return `obj.__jac__.id.hex;
+}
+
+"""Create a obj archetype."""
+impl JacBasics.make_archetype(cls: type[Archetype]) -> type[Archetype] {
+    entries: OrderedDict[(str, ObjectSpatialFunction)] = OrderedDict(
+        (fn.name, fn) for fn in cls._jac_entry_funcs_
+    );
+    exits: OrderedDict[(str, ObjectSpatialFunction)] = OrderedDict(
+        (fn.name, fn) for fn in cls._jac_exit_funcs_
+    );
+    for func in cls.__dict__.values() {
+        if callable(func) {
+            if func?.__jac_entry {
+                entries[func.__name__] = JacRuntimeInterface.DSFunc(
+                    func.__name__, func
+                );
+            }
+            if func?.__jac_exit {
+                exits[func.__name__] = JacRuntimeInterface.DSFunc(func.__name__, func);
+            }
+        }
+    }
+    cls._jac_entry_funcs_ = [*entries.values()];
+    cls._jac_exit_funcs_ = [*exits.values()];
+    if issubclass(cls, WalkerArchetype)
+    and 'reports' not in cls.__dict__.get('__annotations__', {}) {
+        if not hasattr(cls, '__annotations__') {
+            cls.__annotations__ = {};
+        }
+        cls.__annotations__['reports'] = list;
+        cls.reports = dataclasses.field(
+            default_factory=`list, init=False, repr=False, compare=False
+        );
+    }
+    dataclass(eq=False)(cls);
+    return cls;
+}
+
+"""Update impl file location."""
+impl JacBasics.impl_patch_filename(
+    file_loc: str
+) -> Callable[([Callable[(P, T)]], Callable[(P, T)])] {
+    def decorator(func: Callable[(P, T)]) -> Callable[(P, T)] {
+        try {
+            code = func.__code__;
+            new_code = types.CodeType(
+                code.co_argcount,
+                code.co_posonlyargcount,
+                code.co_kwonlyargcount,
+                code.co_nlocals,
+                code.co_stacksize,
+                code.co_flags,
+                code.co_code,
+                code.co_consts,
+                code.co_names,
+                code.co_varnames,
+                file_loc,
+                code.co_name,
+                code.co_qualname,
+                code.co_firstlineno,
+                code.co_linetable,
+                code.co_exceptiontable,
+                code.co_freevars,
+                code.co_cellvars
+            );
+            func.__code__ = new_code;
+        } except AttributeError {
+            ;
+        }
+        return func;
+    }
+    return decorator;
+}
+
+"""Import a Jac or Python module using Python's standard import machinery.
+
+    This function bridges Jac's import semantics with Python's import
+system,
+    leveraging importlib.import_module() which automatically invokes our
+    JacMetaImporter (registered in sys.meta_path).
+
+    Args:
+        target: Module name to import (e.g., "foo.bar" or ".relative")
+        base_path: Base directory for resolving the module
+        absorb: If True with items, return module instead of items
+        override_name: Special handling for "__main__" execution context
+        items: Specific items to import from module (like "from X import Y")
+        reload_module: Force reload even if already in sys.modules
+        lng: Language hint ("jac", "py", etc.) - auto-detected if None
+
+    Returns:
+        Tuple of imported module(s) or item(s)
+
+    Examples:
+        # Import entire module
+        (mod,) = jac_import("mymod", "/path/to/base")
+
+        # Import specific items
+        (func, cls) = jac_import("mymod", "/path", items={"myfunc": None,
+"MyClass": None})
+
+        # Run as __main__
+        jac_import("mymod", "/path", override_name="__main__")
+    """
+impl JacBasics.jac_import(
+    target: str,
+    base_path: str,
+    absorb: bool = False,
+    override_name: (str | None) = None,
+    items: (dict[(str, str | str | None)] | None) = None,
+    reload_module: (bool | None) = False,
+    lng: (str | None) = None
+) -> tuple[(types.ModuleType, ...)] {
+    import importlib;
+    import importlib.util;
+    if (lng is None) {
+        lng = infer_language(target, base_path);
+    }
+    _ = JacRuntime.get_program();
+    if target.startswith('.') {
+        caller_dir = base_path
+            if os.path.isdir(base_path)
+            else os.path.dirname(base_path);
+        chomp_target = target;
+        while chomp_target.startswith('.') {
+            if ((len(chomp_target) > 1) and (chomp_target[1] == '.')) {
+                caller_dir = os.path.dirname(caller_dir);
+                chomp_target = chomp_target[1:];
+            } else {
+                chomp_target = chomp_target[1:];
+                break;
+            }
+        }
+        module_name = chomp_target;
+    } else {
+        module_name = target;
+    }
+    caller_dir = base_path if os.path.isdir(base_path) else os.path.dirname(base_path);
+    original_path = None;
+    if (caller_dir and (caller_dir not in sys.path)) {
+        original_path = sys.path.copy();
+        sys.path.insert(0, caller_dir);
+    }
+    try {
+        if (override_name == '__main__') {
+            import from jaclang.meta_importer { JacMetaImporter }
+            finder = JacMetaImporter();
+            spec = finder.find_spec(module_name, None);
+            if (spec and spec.origin and spec.origin.endswith('.jac') and (lng == 'py')) {
+                spec = None;
+            }
+            if ((not spec or not spec.origin) and (lng == 'py')) {
+                file_path = os.path.join(caller_dir, f"{module_name}.py");
+                if os.path.isfile(file_path) {
+                    spec_name = '__main__'
+                        if (override_name == '__main__')
+                        else module_name;
+                    spec = importlib.util.spec_from_file_location(spec_name, file_path);
+                }
+            }
+            if (not spec or not spec.origin) {
+                raise ImportError(f"Cannot find module {module_name}");
+            }
+            if (('__main__' in sys.modules) and not reload_module) {
+                module = sys.modules['__main__'];
+                to_keep = {
+                    k: v
+                    for (k, v) in module.__dict__.items()
+                    if k.startswith('__')
+                };
+                module.__dict__.update(to_keep);
+            } else {
+                module = types.ModuleType('__main__');
+                sys.modules['__main__'] = module;
+            }
+            module.__file__ = spec.origin;
+            module.__name__ = '__main__';
+            module.__spec__ = spec;
+            if spec.submodule_search_locations {
+                module.__path__ = spec.submodule_search_locations;
+            }
+            JacRuntimeInterface.load_module('__main__', module);
+            if spec.loader {
+                spec.loader.exec_module(module);
+            }
+        } elif (reload_module and (module_name in sys.modules)) {
+            module = importlib.reload(sys.modules[module_name]);
+            JacRuntimeInterface.load_module(module_name, module, force=True);
+        } else {
+            module = importlib.import_module(module_name);
+            if reload_module {
+                JacRuntimeInterface.load_module(module_name, module, force=True);
+            }
+        }
+        if items {
+            imported_items = [];
+            for (item_name, _) in items.items() {
+                if hasattr(module, item_name) {
+                    item = getattr(module, item_name);
+                    imported_items.append(item);
+                } else {
+                    raise ImportError(
+                        f"Cannot import name '{item_name}' from '{module_name}'"
+                    );
+                }
+            }
+            return `tuple(imported_items) if not absorb else (module, );
+        }
+        return (module, );
+    } finally {
+        if (original_path is not None) {
+            sys.path[:] = original_path;
+        }
+    }
+}
+
+"""Create a test."""
+impl JacBasics.jac_test(description: str = "") -> Callable {
+    import from jaclang.runtimelib.test { JacTestCheck }
+    def decorator(test_fun: Callable) -> Callable {
+        file_path = getfile(test_fun);
+        func_name = test_fun.__name__;
+        def test_deco -> None {
+            test_fun(JacTestCheck());
+        }
+        test_deco.__name__ = test_fun.__name__;
+        JacTestCheck.add_test(file_path, func_name, test_deco, display_name=description);
+        return test_deco;
+    }
+    return decorator;
+}
+
+"""JSX interface for creating elements.
+
+    Args:
+        tag: Element tag (string for HTML elements, callable for components)
+        attributes: Element attributes/props
+        children: Child elements
+
+    Returns:
+        JSX element representation.
+    """
+impl JacBasics.jsx(
+    tag: object,
+    attributes: (Mapping[(str, object)] | None) = None,
+    children: (Sequence[object] | None) = None
+) -> JsxElement {
+    `props: dict[(str, object)] = `dict(attributes) if attributes else {};
+    child_list = `list(children) if children else [];
+    return JsxElement(tag=tag, `props=`props, children=child_list);
+}
+
+"""Run the test suite in the specified .jac file."""
+impl JacBasics.run_test(
+    filepath: str,
+    func_name: (str | None) = None,
+    filter: (str | None) = None,
+    xit: bool = False,
+    maxfail: (int | None) = None,
+    directory: (str | None) = None,
+    verbose: bool = False
+) -> int {
+    import from jaclang.runtimelib.test { JacTestCheck }
+    test_file = False;
+    ret_count = 0;
+    if filepath {
+        if filepath.endswith('.jac') {
+            (base, mod_name) = os.path.split(filepath);
+            base = base or './';
+            mod_name = mod_name[:-4];
+            if mod_name.endswith('.test') {
+                mod_name = mod_name[:-5];
+            }
+            JacTestCheck.reset();
+            JacRuntimeInterface.jac_import(target=mod_name, base_path=base);
+            JacTestCheck.run_test(
+                xit, maxfail, verbose, os.path.abspath(filepath), func_name
+            );
+            ret_count = JacTestCheck.failcount;
+        } else {
+            JacConsole.get_console().error('Not a .jac file.');
+        }
+    } else {
+        directory = directory or os.getcwd();
+    }
+    if (filter or directory) {
+        current_dir = directory or os.getcwd();
+        for (root_dir, _, files) in os.walk(current_dir, topdown=True) {
+            files = [
+                file
+                for file in files
+                if fnmatch.fnmatch(file, filter)
+            ]
+                if filter
+                else files;
+            files = [
+                file
+                for file in files
+                if not file.endswith(('.test.jac', '.impl.jac'))
+            ];
+            for file in files {
+                if file.endswith('.jac') {
+                    test_file = True;
+                    JacConsole.get_console().info(
+                        f"\n\n\t\t* Inside {root_dir}/{file} *"
+                    );
+                    JacTestCheck.reset();
+                    JacRuntimeInterface.jac_import(target=file[:-4], base_path=root_dir);
+                    JacTestCheck.run_test(
+                        xit, maxfail, verbose, os.path.abspath(file), func_name
+                    );
+                }
+                if (JacTestCheck.breaker and (xit or maxfail)) {
+                    break;
+                }
+            }
+            if (JacTestCheck.breaker and (xit or maxfail)) {
+                break;
+            }
+        }
+        JacTestCheck.breaker = False;
+        ret_count += JacTestCheck.failcount;
+        JacTestCheck.failcount = 0;
+        if not test_file {
+            JacConsole.get_console().warning('No test files found.');
+        }
+    }
+    return ret_count;
+}
+
+"""Jac's field handler."""
+impl JacBasics.field(
+    factory: (Callable[([], T)] | None) = None, `init: bool = True
+) -> T {
+    if factory {
+        return field(default_factory=factory);
+    }
+    return field(`init=`init);
+}
+
+"""Jac's report stmt feature."""
+impl JacBasics.log_report(expr: Any, custom: bool = False) -> None {
+    ctx = JacRuntimeInterface.get_context();
+    if custom {
+        ctx.custom = expr;
+    } else {
+        JacConsole.get_console().print(expr);
+        call_state = ctx.call_state.get(None);
+        if call_state {
+            call_state.reports.put_nowait(expr);
+        }
+    }
+}
+
+"""Jac's apply_dir stmt feature."""
+impl JacBasics.refs(
+    path: ObjectSpatialPath | NodeArchetype | list[NodeArchetype]
+) -> list[NodeArchetype] | list[EdgeArchetype] | list[(NodeArchetype | EdgeArchetype)] {
+    if not isinstance(path, ObjectSpatialPath) {
+        path = ObjectSpatialPath(path, [ObjectSpatialDestination(EdgeDir.OUT)]);
+    }
+    origin = path.origin;
+    destinations = path.destinations[:-1] if path.edge_only else path.destinations;
+    while destinations {
+        dest = path.destinations.pop(0);
+        origin = JacRuntimeInterface.edges_to_nodes(origin, dest);
+    }
+    if path.edge_only {
+        if path.from_visit {
+            return JacRuntimeInterface.get_edges_with_node(
+                origin, path.destinations[-1]
+            );
+        }
+        return JacRuntimeInterface.get_edges(origin, path.destinations[-1]);
+    }
+    return origin;
+}
+
+"""Jac's apply_dir stmt feature."""
+impl JacBasics.arefs(
+    path: ObjectSpatialPath | NodeArchetype | list[NodeArchetype]
+) -> None {
+    ;
+}
+
+
+impl JacBasics.filter_on(
+    items: list[Archetype], func: Callable[([Archetype], bool)]
+) -> list[Archetype] {
+    return [
+        item
+        for item in items
+        if func(item)
+    ];
+}
+
+"""Jac's connect operator feature."""
+impl JacBasics.connect(
+    left: (NodeArchetype | list[NodeArchetype]),
+    right: (NodeArchetype | list[NodeArchetype]),
+    `edge: type[EdgeArchetype] | EdgeArchetype | None = None,
+    undir: bool = False,
+    conn_assign: (tuple[(tuple, tuple)] | None) = None,
+    edges_only: bool = False
+) -> (list[NodeArchetype] | list[EdgeArchetype]) {
+    left = [left] if isinstance(left, NodeArchetype) else left;
+    right = [right] if isinstance(right, NodeArchetype) else right;
+    edges = [];
+    for i in left {
+        _left = i.__jac__;
+        if JacRuntimeInterface.check_connect_access(_left) {
+            for j in right {
+                _right = j.__jac__;
+                if JacRuntimeInterface.check_connect_access(_right) {
+                    edges.append(
+                        JacRuntimeInterface.build_edge(
+                            is_undirected=undir,
+                            conn_type=`edge,
+                            conn_assign=conn_assign
+                        )(
+                            _left, _right
+                        )
+                    );
+                }
+            }
+        }
+    }
+    return right if not edges_only else edges;
+}
+
+"""Jac's disconnect operator feature."""
+impl JacBasics.disconnect(
+    left: (NodeArchetype | list[NodeArchetype]),
+    right: (NodeArchetype | list[NodeArchetype]),
+    dir: EdgeDir = EdgeDir.OUT,
+    filter: (Callable[([EdgeArchetype], bool)] | None) = None
+) -> bool {
+    disconnect_occurred = False;
+    left = [left] if isinstance(left, NodeArchetype) else left;
+    right = [right] if isinstance(right, NodeArchetype) else right;
+    for i in left {
+        nd = i.__jac__;
+        for anchor in `set(nd.edges) {
+            if (
+                (source := anchor.source)
+                and (target := anchor.target)
+                and (not filter or filter(anchor.archetype))
+                and source.archetype
+                and target.archetype
+            ) {
+                if (
+                    (dir in [EdgeDir.OUT, EdgeDir.ANY])
+                    and (nd == source)
+                    and (target.archetype in right)
+                    and JacRuntimeInterface.check_connect_access(target)
+                ) {
+                    JacRuntimeInterface.destroy([anchor])
+                        if anchor.persistent
+                        else JacRuntimeInterface.detach(anchor);
+                    disconnect_occurred = True;
+                }
+                if (
+                    (dir in [EdgeDir.IN, EdgeDir.ANY])
+                    and (nd == target)
+                    and (source.archetype in right)
+                    and JacRuntimeInterface.check_connect_access(source)
+                ) {
+                    JacRuntimeInterface.destroy([anchor])
+                        if anchor.persistent
+                        else JacRuntimeInterface.detach(anchor);
+                    disconnect_occurred = True;
+                }
+            }
+        }
+    }
+    return disconnect_occurred;
+}
+
+"""Jac's assign comprehension feature."""
+impl JacBasics.assign_all(
+    target: list[T], attr_val: tuple[(tuple[str], tuple[Any])]
+) -> list[T] {
+    for `obj in target {
+        (attrs, values) = attr_val;
+        for (attr, value) in zip(attrs, values, strict=False) {
+            setattr(`obj, attr, value);
+        }
+    }
+    return target;
+}
+
+"""Jac's safe subscript feature."""
+impl JacBasics.safe_subscript(`obj: Any, key: Any) -> Any {
+    try {
+        return `obj[key];
+    } except (KeyError, IndexError, TypeError) {
+        return None;
+    }
+}
+
+"""Jac's root getter."""
+impl JacBasics.`root -> Root {
+    return JacRuntime.get_context().get_root();
+}
+
+"""Get all the roots."""
+impl JacBasics.get_all_root -> list[Root] {
+    jmem = JacRuntimeInterface.get_context().mem;
+    return `list(jmem.get_roots());
+}
+
+"""Jac's root getter."""
+impl JacBasics.build_edge(
+    is_undirected: bool,
+    conn_type: type[EdgeArchetype] | EdgeArchetype | None,
+    conn_assign: (tuple[(tuple, tuple)] | None)
+) -> Callable[([NodeAnchor, NodeAnchor], EdgeArchetype)] {
+    ct = conn_type or GenericEdge;
+    def builder(source: NodeAnchor, target: NodeAnchor) -> EdgeArchetype {
+        `edge = ct() if isinstance(ct, `type) else ct;
+        eanch = `edge.__jac__=EdgeAnchor(
+            archetype=`edge, source=source, target=target, is_undirected=is_undirected
+        );
+        source.edges.append(eanch);
+        target.edges.append(eanch);
+        if conn_assign {
+            for (fld, val) in zip(conn_assign[0], conn_assign[1], strict=False) {
+                if hasattr(`edge, fld) {
+                    setattr(`edge, fld, val);
+                } else {
+                    raise ValueError(f"Invalid attribute: {fld}");
+                }
+            }
+        }
+        if (source.persistent or target.persistent) {
+            JacRuntimeInterface.save(eanch);
+        }
+        return `edge;
+    }
+    return builder;
+}
+
+"""Destroy object."""
+impl JacBasics.save(`obj: (Archetype | Anchor)) -> None {
+    anchor = `obj.__jac__ if isinstance(`obj, Archetype) else `obj;
+    jctx = JacRuntimeInterface.get_context();
+    if (not anchor.persistent and not anchor.root) {
+        anchor.persistent = True;
+        anchor.root = jctx.user_root.id;
+    }
+    jctx.mem.put(anchor);
+    match anchor {
+        case NodeAnchor():
+            for ed in anchor.edges {
+                if (ed.is_populated() and not ed.persistent) {
+                    JacRuntimeInterface.save(ed);
+                }
+            }
+
+        case EdgeAnchor():
+            if ((src := anchor.source) and src.is_populated() and not src.persistent) {
+                JacRuntimeInterface.save(src);
+            }
+            if ((trg := anchor.target) and trg.is_populated() and not trg.persistent) {
+                JacRuntimeInterface.save(trg);
+            }
+
+        case _:
+            ;
+
+    }
+}
+
+"""Destroy multiple objects passed in a tuple or list."""
+impl JacBasics.destroy(objs: Archetype | Anchor | list[(Archetype | Anchor)]) -> None {
+    obj_list = objs if isinstance(objs, `list) else [objs];
+    for `obj in obj_list {
+        if not isinstance(`obj, (Archetype, Anchor)) {
+            return;
+        }
+        anchor = `obj.__jac__ if isinstance(`obj, Archetype) else `obj;
+        if JacRuntimeInterface.check_write_access(anchor) {
+            match anchor {
+                case NodeAnchor():
+                    for `edge in anchor.edges[:] {
+                        JacRuntimeInterface.destroy([`edge]);
+                    }
+
+                case EdgeAnchor():
+                    JacRuntimeInterface.detach(anchor);
+
+                case _:
+                    ;
+
+            }
+            JacRuntimeInterface.get_context().mem.delete(anchor.id);
+        }
+    }
+}
+
+"""Mark a method as jac entry with this decorator."""
+impl JacBasics.on_entry(func: Callable) -> Callable {
+    setattr(func, '__jac_entry', True);
+    return func;
+}
+
+"""Mark a method as jac exit with this decorator."""
+impl JacBasics.on_exit(func: Callable) -> Callable {
+    setattr(func, '__jac_exit', True);
+    return func;
+}
+
+"""Get the client bundle builder instance."""
+impl JacClientBundle.get_client_bundle_builder -> ClientBundleBuilder {
+    import from jaclang.runtimelib.client_bundle { ClientBundleBuilder }
+    return ClientBundleBuilder();
+}
+
+"""Build a client bundle for the supplied module."""
+impl JacClientBundle.build_client_bundle(
+    module: types.ModuleType, force: bool = False
+) -> ClientBundle {
+    builder = JacRuntimeInterface.get_client_bundle_builder();
+    return builder.build(module, force=force);
+}
+
+"""Format a build error for display.
+
+    Plugins can override this hook to provide rich error formatting.
+    Default implementation returns the raw error output.
+    """
+impl JacClientBundle.format_build_error(
+    error_output: str, project_dir: Path, config: object = None
+) -> str {
+    return error_output;
+}
+
+"""Get the console instance to use for CLI output.
+
+    Plugins can override this hook to provide their own console
+implementation.
+    The returned instance should be compatible with the JacConsole
+interface.
+    """
+impl JacConsole.get_console -> ConsoleImpl {
+    import from jaclang.cli.console { JacConsole }
+    return JacConsole();
+}
+
+"""Get the JacAPIServer class to use for serve command.
+
+    Plugins can override this hook to provide their own server class.
+    The returned class should be compatible with the JacAPIServer interface.
+    """
+impl JacAPIServer.get_api_server_class -> type {
+    import from jaclang.runtimelib.server { JacAPIServer }
+    return JacAPIServer;
+}
+
+"""Create the API server instance.
+
+If the specified port is in use, tries subsequent ports up to max_retries times.
+Updates jac_server.port with the actual bound port if different from requested.
+"""
+impl JacAPIServer.create_server(
+    jac_server: JacServer, host: str, port: int, max_retries: int = 10
+) -> HTTPServer {
+    handler_class = jac_server.create_handler();
+    current_port = port;
+    for _ in range(max_retries) {
+        try {
+            server = HTTPServer((host, current_port), handler_class);
+            if current_port != port {
+                import from jaclang.cli.console { console }
+                console.print(
+                    f"  Port {port} is in use, using port {current_port} instead",
+                    style="warning"
+                );
+                jac_server.port = current_port;  # Update the server's port
+            }
+            return server;
+        } except OSError as e {
+            # errno 98 = EADDRINUSE (Linux), errno 10048 = WSAEADDRINUSE (Windows)
+            if e.errno in (98, 10048) or "Address already in use" in str(e) {
+                current_port += 1;
+            } else {
+                raise;
+            }
+        }
+    }
+    raise OSError(
+        f"Could not find an available port after trying {port}-{current_port}"
+    );
+}
+
+"""Render HTML page for client function."""
+impl JacAPIServer.render_page(
+    introspector: ModuleIntrospector,
+    function_name: str,
+    args: dict[(str, Any)],
+    username: str
+) -> dict[(str, Any)] {
+    import from jaclang.runtimelib.serializer { Serializer }
+    introspector.load();
+    available_exports = (
+        `set(introspector._client_manifest.get('exports', []))
+        or `set(introspector.get_client_functions().keys())
+    );
+    if (function_name not in available_exports) {
+        raise ValueError(f"Client function '{function_name}' not found");
+    }
+    bundle_hash = introspector.ensure_bundle();
+    arg_order = `list(
+        introspector._client_manifest.get('params', {}).get(function_name, [])
+    );
+    globals_payload = {
+        name: Serializer.serialize(value, api_mode=True)
+        for (name, value) in introspector._collect_client_globals().items()
+    };
+    initial_state = {
+        'module': introspector._module.__name__
+            if introspector._module
+            else introspector.module_name,
+        'function': function_name,
+        'args': {
+            key: Serializer.serialize(value, api_mode=True)
+            for (key, value) in args.items()
+        },
+        'globals': globals_payload,
+        'argOrder': arg_order,
+        'endpointEffects': introspector._client_manifest.get('endpoint_effects', {})
+    };
+    safe_initial_json = json.dumps(initial_state).replace('</', '<\\/');
+    page = f'<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>{html.escape(
+        function_name
+    )}</title></head><body><div id="__jac_root"></div><script id="__jac_init__" type="application/json">{safe_initial_json}</script><script type="module" src="/static/client.js?hash={bundle_hash}"></script></body></html>';
+    return {
+        'html': page,
+        'bundle_hash': bundle_hash,
+        'bundle_code': introspector._bundle.code
+    };
+}
+
+"""Get the client JavaScript bundle code.
+
+    Plugins can override this hook to provide custom bundle serving logic
+    (e.g., serving Vite-built PWA bundles).
+"""
+impl JacAPIServer.get_client_js(introspector: ModuleIntrospector) -> str {
+    introspector.load();
+    introspector.ensure_bundle();
+    return introspector._bundle.code;
+}
+
+"""Send JSON response."""
+impl JacResponseBuilder.send_json(
+    handler: BaseHTTPRequestHandler, status: StatusCode, data: dict[(str, JsonValue)]
+) -> None {
+    import from jaclang.runtimelib.server { ResponseBuilder }
+    ResponseBuilder.send_json(handler, status, data);
+}
+
+"""Send HTML response with CORS headers."""
+impl JacResponseBuilder.send_html(
+    handler: BaseHTTPRequestHandler, status: StatusCode, body: str
+) -> None {
+    import from jaclang.runtimelib.server { ResponseBuilder }
+    ResponseBuilder.send_html(handler, status, body);
+}
+
+"""Send JavaScript response."""
+impl JacResponseBuilder.send_javascript(
+    handler: BaseHTTPRequestHandler, code: str
+) -> None {
+    import from jaclang.runtimelib.server { ResponseBuilder }
+    ResponseBuilder.send_javascript(handler, code);
+}
+
+"""Send CSS response."""
+impl JacResponseBuilder.send_css(
+    handler: BaseHTTPRequestHandler, css_code: str
+) -> None {
+    import from jaclang.runtimelib.server { ResponseBuilder }
+    ResponseBuilder.send_css(handler, css_code);
+}
+
+"""Send static file response (images, fonts, etc.)."""
+impl JacResponseBuilder.send_static_file(
+    handler: BaseHTTPRequestHandler, file_path: Path, content_type: (str | None) = None
+) -> None {
+    raise NotImplementedError('send_static_file method is not implemented');
+}
+
+"""Get byLLM library."""
+impl JacByLLM.get_mtir(
+    caller: Callable,
+    args: dict[((int | str), object)],
+    call_params: dict[(str, object)]
+) -> MTRuntime {
+    return MTIR(caller=caller, args=args, call_params=call_params).runtime;
+}
+
+"""Attach the semstring to the given object."""
+impl JacByLLM.`sem(semstr: str, inner_semstr: dict[(str, str)]) -> Callable {
+    def decorator(`obj: object) -> object {
+        setattr(`obj, '_jac_semstr', semstr);
+        setattr(`obj, '_jac_semstr_inner', inner_semstr);
+        return `obj;
+    }
+    return decorator;
+}
+
+"""Call the LLM model."""
+impl JacByLLM.call_llm(model: object, mt_run: MTRuntime) -> Any {
+    import from jaclang.utils { NonGPT }
+    try {
+        random_value_for_type = cast(
+            Callable[([Any], Any)], NonGPT.random_value_for_type
+        );
+    } except AttributeError {
+        def random_value_for_type(_t: object) -> object {
+            return None;
+        }
+    }
+    try {
+        type_hints = get_type_hints(
+            mt_run.caller,
+            globalns=getattr(mt_run.caller, '__globals__', {}),
+            localns=None,
+            include_extras=True
+        );
+    } except Exception {
+        type_hints = getattr(mt_run.caller, '__annotations__', {});
+    }
+    return_type = type_hints.get('return', Any);
+    return random_value_for_type(return_type);
+}
+
+"""Python library mode decorator for Jac's by llm() syntax."""
+impl JacByLLM.`by(model: object) -> Callable {
+    def _decorator(caller: Callable) -> Callable {
+        def _wrapped_caller(*args: object, **kwargs: object) -> object {
+            invoke_args: dict[((int | str), object)] = {};
+            for (i, arg) in enumerate(args) {
+                invoke_args[i] = arg;
+            }
+            for (key, value) in kwargs.items() {
+                invoke_args[key] = value;
+            }
+            mt_run = JacRuntime.get_mtir(
+                caller=caller, args=invoke_args, call_params=model?.call_params or {}
+            );
+            return JacRuntime.call_llm(model, mt_run);
+        }
+        return _wrapped_caller;
+    }
+    return _decorator;
+}
+
+impl JacByLLM.filter_visitable_by(
+    connected_nodes: list[NodeArchetype], model: object, descriptions: str = ''
+) -> list[NodeArchetype] {
+    import from jaclang.jac0core.helpers { _describe_nodes_list }
+    visitable_list: list = [];
+    """
+        Determine which connected nodes are visitable using an LLM.
+
+        The input represents structurally reachable nodes. This function
+applies
+        semantic reasoning to decide which of those nodes a walker is
+allowed
+        or intended to visit, returning their indexes in priority order.
+
+        Returns an empty list if no nodes are deemed visitable.
+        """;
+    @JacByLLM.by (model=model)
+    def _filter_visitable_by(
+        connected_nodes: list[NodeArchetype], descriptions: str = ''
+    ) -> list[int] {
+        return [];
+    }
+    descriptions = _describe_nodes_list(connected_nodes);
+    indexes = _filter_visitable_by(connected_nodes, descriptions);
+    for idx in indexes {
+        visitable_list.append(connected_nodes[idx]);
+    }
+    return visitable_list;
+}
+
+"""by operator feature for expression composition.
+
+    Currently not implemented - raises NotImplementedError.
+    Plugins like byllm can override this via the plugin hook system.
+    """
+impl JacByLLM.by_operator(lhs: Any, rhs: Any) -> Any {
+    raise NotImplementedError(
+        "The 'by' operator is not yet implemented. This feature is reserved for future use."
+    );
+}
+
+"""Return the default LLM model for use with 'by llm()' syntax.
+
+    The builtin 'llm' name resolves to this method via the plugin hook
+    system. Base implementation returns a minimal stub with call_params={}
+    and __call__ returning self, which works with the random-value fallback
+    in call_llm. Plugins (e.g. byllm) override this to return a configured
+    Model instance based on jac.toml settings.
+    """
+impl JacByLLM.default_llm -> object {
+    _cache = getattr(JacByLLM, '_default_llm_instance', None);
+    if (_cache is not None) {
+        return _cache;
+    }
+    def _stub_call(_self: object, **kwargs: object) -> object {
+        return _self;
+    }
+    _StubCls = `type(
+        '_DefaultLLM', (object, ), {'call_params': {}, '__call__': _stub_call}
+    );
+    instance = _StubCls();
+    JacByLLM._default_llm_instance = instance;
+    return instance;
+}
+
+"""Add MTIR to the node's MTIR map."""
+impl JacByLLM.add_mtir_to_map(scope: str, mtir: Info) -> None {
+    if (JacRuntime.program is None) {
+        raise AttributeError('JacRuntime.program is not initialized');
+    }
+    JacRuntime.program.mtir_map[scope] = mtir;
+}
+
+"""Get MTIR from the node's MTIR map."""
+impl JacByLLM.get_mtir_from_map(scope: str) -> (Info | None) {
+    if (JacRuntime.program is None) {
+        raise AttributeError('JacRuntime.program is not initialized');
+    }
+    if (scope not in JacRuntime.program.mtir_map) {
+        raise KeyError(f"MTIR not found for scope {scope}");
+    }
+    return JacRuntime.program.mtir_map[scope];
+}
+
+"""Create a new execution context.
+
+    Args:
+        user_root: User root ID for permission boundary. Required parameter.
+                   Pass None for CLI/system contexts (uses system_root).
+                   Pass user's root ID for authenticated server requests.
+
+    Storage backend is configured via plugins/environment, not per-context.
+    For file backend: auto-generates path from JacRuntime.base_path_dir.
+    For database backends (jac-scale): configured via environment variables.
+    """
+impl JacUtils.create_j_context(user_root: (str | None)) -> ExecutionContext {
+    import from jaclang.runtimelib.context { ExecutionContext }
+    ctx = ExecutionContext();
+    if (user_root is not None) {
+        ctx.set_user_root(user_root);
+    }
+    return ctx;
+}
+
+"""Attach a JacProgram to the machine."""
+impl JacUtils.attach_program(jac_program: JacProgram) -> None {
+    JacRuntime.program = jac_program;
+}
+
+"""Attach a JacCompiler to the machine."""
+impl JacUtils.attach_compiler(jac_compiler: JacCompiler) -> None {
+    JacRuntime.compiler = jac_compiler;
+}
+
+"""Load a module into the machine."""
+impl JacUtils.load_module(
+    module_name: str, module: types.ModuleType, force: bool = False
+) -> None {
+    if ((module_name not in JacRuntime.loaded_modules) or force) {
+        JacRuntime.loaded_modules[module_name] = module;
+        sys.modules[module_name] = module;
+    }
+}
+
+"""List all loaded modules."""
+impl JacUtils.list_modules -> list[str] {
+    return `list(JacRuntime.loaded_modules.keys());
+}
+
+"""List all walkers in a specific module."""
+impl JacUtils.list_walkers(module_name: str) -> list[str] {
+    module = JacRuntime.loaded_modules.get(module_name);
+    if module {
+        walkers = [];
+        for (name, `obj) in inspect.getmembers(module) {
+            if (
+                isinstance(`obj, `type)
+                and issubclass(`obj, WalkerArchetype)
+                and (`obj.__module__ == module_name)
+            ) {
+                walkers.append(name);
+            }
+        }
+        return walkers;
+    }
+    return [];
+}
+
+"""List all nodes in a specific module."""
+impl JacUtils.list_nodes(module_name: str) -> list[str] {
+    module = JacRuntime.loaded_modules.get(module_name);
+    if module {
+        nodes = [];
+        for (name, `obj) in inspect.getmembers(module) {
+            if (
+                isinstance(`obj, `type)
+                and issubclass(`obj, NodeArchetype)
+                and (`obj.__module__ == module_name)
+            ) {
+                nodes.append(name);
+            }
+        }
+        return nodes;
+    }
+    return [];
+}
+
+"""List all edges in a specific module."""
+impl JacUtils.list_edges(module_name: str) -> list[str] {
+    module = JacRuntime.loaded_modules.get(module_name);
+    if module {
+        edges = [];
+        for (name, `obj) in inspect.getmembers(module) {
+            if (
+                isinstance(`obj, `type)
+                and issubclass(`obj, EdgeArchetype)
+                and (`obj.__module__ == module_name)
+            ) {
+                edges.append(name);
+            }
+        }
+        return edges;
+    }
+    return [];
+}
+
+"""Dynamically creates archetypes (nodes, walkers, etc.) from Jac source
+code.
+
+    This leverages Python's standard import machinery via jac_import(),
+    which will automatically invoke JacMetaImporter.
+    """
+impl JacUtils.create_archetype_from_source(
+    source_code: str,
+    module_name: (str | None) = None,
+    base_path: (str | None) = None,
+    cachable: bool = False,
+    keep_temporary_files: bool = False
+) -> (types.ModuleType | None) {
+    if not base_path {
+        base_path = JacRuntime.base_path_dir or os.getcwd();
+    }
+    if (base_path and not os.path.exists(base_path)) {
+        os.makedirs(base_path);
+    }
+    if not module_name {
+        module_name = f"_dynamic_module_{len(JacRuntime.loaded_modules)}";
+    }
+    import tempfile;
+    with tempfile.NamedTemporaryFile(
+        mode='w',
+        suffix='.jac',
+        prefix=(module_name + '_'),
+        dir=base_path,
+        delete=False
+    ) as tmp_file {
+        tmp_file_path = tmp_file.name;
+        tmp_file.write(source_code);
+    }
+    try {
+        tmp_file_basename = os.path.basename(tmp_file_path);
+        (tmp_module_name, _) = os.path.splitext(tmp_file_basename);
+        result = JacRuntimeInterface.jac_import(
+            target=tmp_module_name,
+            base_path=base_path,
+            override_name=module_name,
+            lng='jac'
+        );
+        module = result[0] if result else None;
+        if module {
+            JacRuntime.loaded_modules[module_name] = module;
+        }
+        return module;
+    } except Exception as e {
+        logger.error(f"Error importing dynamic module '{module_name}':{e}");
+        return None;
+    } finally {
+        if (not keep_temporary_files and os.path.exists(tmp_file_path)) {
+            os.remove(tmp_file_path);
+        }
+    }
+}
+
+"""Reimport the module using Python's reload mechanism."""
+impl JacUtils.update_walker(
+    module_name: str, items: (dict[(str, str | str | None)] | None)
+) -> tuple[(types.ModuleType, ...)] {
+    if (module_name in JacRuntime.loaded_modules) {
+        try {
+            old_module = JacRuntime.loaded_modules[module_name];
+            result = JacRuntimeInterface.jac_import(
+                target=module_name,
+                base_path=(JacRuntime.base_path_dir or os.getcwd()),
+                items=items,
+                reload_module=True,
+                lng='jac'
+            );
+            if items {
+                ret_items = [];
+                for (idx, item_name) in enumerate(items.keys()) {
+                    if (hasattr(old_module, item_name) and (idx < len(result))) {
+                        new_attr = result[idx];
+                        ret_items.append(new_attr);
+                        setattr(old_module, item_name, new_attr);
+                    }
+                }
+                return `tuple(ret_items);
+            }
+            return (old_module, );
+        } except Exception as e {
+            logger.error(f"Failed to update module {module_name}: {e}");
+        }
+    } else {
+        logger.warning(f"Module {module_name} not found in loadedmodules.");
+    }
+    return ();
+}
+
+"""Spawn a node instance of the given node_name with attributes."""
+impl JacUtils.spawn_node(
+    node_name: str, attributes: (dict | None) = None, module_name: str = '__main__'
+) -> NodeArchetype {
+    node_class = JacRuntimeInterface.get_archetype(module_name, node_name);
+    if (isinstance(node_class, `type) and issubclass(node_class, NodeArchetype)) {
+        if (attributes is None) {
+            attributes = {};
+        }
+        node_instance = node_class(**attributes);
+        return node_instance;
+    } else {
+        raise ValueError(f"Node {node_name} not found.");
+    }
+}
+
+"""Spawn a walker instance of the given walker_name."""
+impl JacUtils.spawn_walker(
+    walker_name: str, attributes: (dict | None) = None, module_name: str = '__main__'
+) -> WalkerArchetype {
+    walker_class = JacRuntimeInterface.get_archetype(module_name, walker_name);
+    if (isinstance(walker_class, `type) and issubclass(walker_class, WalkerArchetype)) {
+        if (attributes is None) {
+            attributes = {};
+        }
+        walker_instance = walker_class(**attributes);
+        return walker_instance;
+    } else {
+        raise ValueError(f"Walker {walker_name} not found.");
+    }
+}
+
+"""Retrieve an archetype class from a module."""
+impl JacUtils.get_archetype(
+    module_name: str, archetype_name: str
+) -> (Archetype | None) {
+    module = JacRuntime.loaded_modules.get(module_name);
+    if module {
+        return getattr(module, archetype_name, None);
+    }
+    return None;
+}
+
+"""Run a function in a thread."""
+impl JacUtils.thread_run(func: Callable, *args: object) -> Future {
+    _executor = JacRuntime.pool;
+    return _executor.submit(func, *args);
+}
+
+"""Wait for a thread to finish."""
+impl JacUtils.thread_wait(future: Any) -> None {
+    return future.result();
+}
+
+"""Return plugin metadata.
+
+    Returns:
+        dict with keys:
+            - name: Plugin name (used in [plugins.<name>])
+            - version: Plugin version
+            - description: Brief description
+    """
+impl JacPluginConfig.get_plugin_metadata -> (dict[(str, Any)] | None) {
+    return None;
+}
+
+"""Return the plugin's configuration schema.
+
+    Returns:
+        dict with keys:
+            - section: Section name in jac.toml (e.g., 'byllm' for
+[plugins.byllm])
+            - options: dict mapping option names to their specs:
+                {
+                    'option_name': {
+                        'type': 'str' | 'int' | 'float' | 'bool' | 'list' |
+'dict',
+                        'default': <default_value>,
+                        'description': 'Description of the option',
+                        'env_var': 'OPTIONAL_ENV_VAR_OVERRIDE',
+                        'required': False,
+                    }
+                }
+    """
+impl JacPluginConfig.get_config_schema -> (dict[(str, Any)] | None) {
+    return None;
+}
+
+"""Called when plugin configuration is loaded from jac.toml.
+
+    Args:
+        config: The plugin's configuration values from [plugins.<name>]
+    """
+impl JacPluginConfig.on_config_loaded(config: dict[(str, Any)]) -> None {
+    ;
+}
+
+"""Validate plugin configuration.
+
+    Args:
+        config: The plugin's configuration values
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+impl JacPluginConfig.validate_config(config: dict[(str, Any)]) -> list[str] {
+    return [];
+}
+
+"""Register a custom dependency type.
+
+    Allows plugins to extend [dependencies.*] sections in jac.toml.
+
+    Returns:
+        dict with keys:
+            - name: Dependency type name (e.g., 'npm' for
+[dependencies.npm])
+            - dev_name: Dev dependency section (e.g., 'npm.dev')
+            - cli_flag: CLI flag for 'jac add' (e.g., '--cl')
+            - install_dir: Directory for installed deps (e.g., 'client')
+            - install_handler: Callable to install packages
+            - remove_handler: Callable to remove packages
+    """
+impl JacPluginConfig.register_dependency_type -> (dict[(str, Any)] | None) {
+    return None;
+}
+
+"""Register a project template for jac create.
+
+    Allows plugins to provide custom project templates that can be
+    selected via `jac create --use <name>`.
+
+    Returns:
+        dict with keys:
+            - name: Template name (e.g., 'client')
+            - description: Human-readable description
+            - config: dict for jac.toml content (with {{name}} placeholders)
+            - files: dict[path, content] with {{name}} placeholders
+            - directories: list of directories to create
+            - post_create: optional callable(project_path, project_name)
+    """
+impl JacPluginConfig.register_project_template -> (dict[(str, Any)] | None) {
+    return None;
+}
+
+"""Get UserManager instance (hookable for plugins).
+
+    Plugins can override this to provide custom UserManager implementations.
+    Default returns core UserManager.
+
+    Args:
+        base_path: Base path for user data storage
+
+    Returns:
+        UserManager instance
+    """
+impl JacRuntimeInterface.get_user_manager(base_path: str) -> UserManager {
+    import from jaclang.runtimelib.server { UserManager }
+    return UserManager(base_path=base_path);
+}
+
+"""Get storage backend instance (hookable for plugins).
+
+    Default returns LocalStorage. Plugins (like jac-scale) can override
+    to provide cloud storage backends with full config support.
+
+    Args:
+        base_path: Base directory for file storage.
+        create_dirs: Whether to auto-create directories.
+
+    Returns:
+        Storage instance (LocalStorage by default)
+    """
+impl JacRuntimeInterface.store(
+    base_path: str = './storage', create_dirs: bool = True
+) -> Any {
+    import from jaclang.runtimelib.storage { LocalStorage }
+    return LocalStorage(base_path=base_path, create_dirs=create_dirs);
+}
+
+"""Get or create the JacCompiler singleton.
+
+    The compiler is separate from the program and handles all compilation
+    operations. It persists across program resets and can be reused.
+    """
+impl JacRuntime.get_compiler(cls: Any) -> JacCompiler {
+    if (cls.compiler is None) {
+        import from jaclang.jac0core.compiler { JacCompiler }
+        cls.compiler = JacCompiler();
+    }
+    return cls.compiler;
+}
+
+"""Get or create the JacProgram instance."""
+impl JacRuntime.get_program(cls: Any) -> JacProgram {
+    if (cls.program is None) {
+        import from jaclang.jac0core.program { JacProgram }
+        cls.program = JacProgram();
+    }
+    return cls.program;
+}
+
+"""Set the base path for the machine.
+
+    When base_path is None, L3 persistence is disabled (faster for tests).
+    """
+impl JacRuntime.set_base_path(base_path: (str | None)) -> None {
+    if (base_path is None) {
+        JacRuntime.base_path_dir = None;
+    } else {
+        JacRuntime.base_path_dir = base_path
+            if os.path.isdir(base_path)
+            else os.path.dirname(base_path);
+    }
+}
+
+"""Set the context for the machine."""
+impl JacRuntime.set_context(context: ExecutionContext) -> None {
+    JacRuntime.exec_ctx = context;
+}

--- a/jac/jaclang/jac0core/native_marshal.jac
+++ b/jac/jaclang/jac0core/native_marshal.jac
@@ -71,110 +71,14 @@ obj NativeStructView {
         _native: Any = field(default=None, repr=False),
         _field_meta: dict = field(default_factory=`dict, repr=False);
 
-    def postinit -> None {
-        # from_address: NO copy -- creates view over C memory
-        self._native = self.ct_cls.from_address(self.addr);
-        # Build field metadata lookup (name -> NativeFieldInfo)
-        if (self.layout and hasattr(self.layout, "structs")) {
-            sl = self.layout.structs.get(self.struct_name);
-            if sl {
-                for f in sl.fields {
-                    self._field_meta[f.name] = f;
-                }
-            }
-        }
-    }
-
-    def __getattr__(self: NativeStructView, name: str) -> Any {
-        native = self._native;
-        try {
-            raw = getattr(native, name);
-        } except AttributeError {
-            raise AttributeError(f"'{self.struct_name}' has no field '{name}'");
-        }
-        return self._resolve(name, raw);
-    }
-
-    def _resolve(self: NativeStructView, name: str, raw: Any) -> Any {
-        finfo = self._field_meta.get(name);
-        if finfo is None {
-            return raw;
-        }
-        lt = finfo.llvm_type;
-        # Function pointer: wrap raw address as callable ctypes function
-        if finfo.is_func_ptr {
-            if (raw is None or raw == 0) {
-                return None;
-            }
-            fn_type = _build_cfunctype(finfo);
-            return fn_type(raw);
-        }
-        # String: decode from raw pointer on demand
-        if lt == "i8*" {
-            if (raw is None or raw == 0) {
-                return "";
-            }
-            return ctypes.string_at(raw).decode("utf-8", errors="replace");
-        }
-        # Enum field: ordinal -> enum value
-        if (lt in ("i64", "i32") and finfo.enum_type) {
-            val = int(raw);
-            emap = self.enum_maps.get(finfo.enum_type);
-            if (emap and 0 <= val < len(emap) and emap[val] is not None) {
-                return emap[val];
-            }
-            return val;
-        }
-        # Nested struct pointer
-        if (lt.endswith("*") and not lt.startswith("List.") and lt != "i8*") {
-            sname = lt[:-1];
-            if (raw and raw != 0) {
-                ct_cls = self.ctypes_classes.get(sname);
-                if ct_cls {
-                    return NativeStructView(
-                        raw,
-                        ct_cls,
-                        sname,
-                        self.layout,
-                        self.ctypes_classes,
-                        self.enum_maps
-                    );
-                }
-            }
-            return None;
-        }
-        # List pointer
-        if (lt.startswith("List.") and lt.endswith("*")) {
-            if (raw and raw != 0) {
-                elem_key = lt[5:-1];
-                return NativeListView(
-                    raw, elem_key, self.ctypes_classes, self.enum_maps, self.layout
-                );
-            }
-            return NativeListView.empty();
-        }
-        return raw;
-    }
-
-    def __getitem__(self: NativeStructView, key: str) -> Any {
-        return getattr(self, key);
-    }
-
-    def __contains__(self: NativeStructView, key: str) -> bool {
-        return key in self._field_meta;
-    }
-
-    def keys(self: NativeStructView) -> Any {
-        return self._field_meta.keys();
-    }
-
-    def items(self: NativeStructView) -> Any {
-        return ((k, self[k]) for k in self.keys());
-    }
-
-    def __repr__(self: NativeStructView) -> str {
-        return f"<NativeStructView {self.struct_name}>";
-    }
+    def postinit -> None;
+    def __getattr__(self: NativeStructView, name: str) -> Any;
+    def _resolve(self: NativeStructView, name: str, raw: Any) -> Any;
+    def __getitem__(self: NativeStructView, key: str) -> Any;
+    def __contains__(self: NativeStructView, key: str) -> bool;
+    def keys(self: NativeStructView) -> Any;
+    def items(self: NativeStructView) -> Any;
+    def __repr__(self: NativeStructView) -> str;
 }
 
 
@@ -195,94 +99,17 @@ obj NativeListView {
         _ct_cls: Any = field(default=None, repr=False),
         _struct_name: (str | None) = field(default=None, repr=False);
 
-    def postinit -> None {
-        if (self.list_ptr == 0) {
-            self._count = 0;
-            self._arr = None;
-            self._ct_cls = None;
-            self._struct_name = None;
-            return;
-        }
-        nl = NativeList.from_address(self.list_ptr);
-        self._count = nl.len if (nl.len > 0 and nl.data) else 0;
-
-        # Resolve struct class for ptr elements
-        self._struct_name = self.struct_hint;
-        if (self.elem_key == "ptr" and self._struct_name) {
-            self._ct_cls = self.ctypes_classes.get(self._struct_name);
-        }
-
-        # Create array view over data -- zero-copy via from_address
-        if self._count > 0 {
-            if self.elem_key == "i64" {
-                self._arr = (ctypes.c_int64 * self._count).from_address(nl.data);
-            } elif self.elem_key == "f64" {
-                self._arr = (ctypes.c_double * self._count).from_address(nl.data);
-            } else {
-                # 'ptr' and others
-                self._arr = (ctypes.c_void_p * self._count).from_address(nl.data);
-            }
-        }
-    }
-
+    def postinit -> None;
     @classmethod
     def empty(cls: type) -> NativeListView {
         return cls(list_ptr=0, elem_key="");
     }
 
-    def __len__(self: NativeListView) -> int {
-        return self._count;
-    }
-
-    def __getitem__(self: NativeListView, index: Any) -> Any {
-        if isinstance(index, slice) {
-            return [self[i] for i in range(*index.indices(self._count))];
-        }
-        if index < 0 {
-            index += self._count;
-        }
-        if (index < 0 or index >= self._count) {
-            raise IndexError(f"list index {index} out of range");
-        }
-        raw = self._arr[index];
-        if self.elem_key == "i64" {
-            return int(raw);
-        }
-        if self.elem_key == "f64" {
-            return float(raw);
-        }
-        # Struct pointer element
-        if (self._ct_cls and raw and raw != 0) {
-            return NativeStructView(
-                raw,
-                self._ct_cls,
-                self._struct_name,
-                self.layout,
-                self.ctypes_classes,
-                self.enum_maps
-            );
-        }
-        return raw;
-    }
-
-    def __iter__(self: NativeListView) -> Any {
-        for i in range(len(self)) {
-            yield self[i];
-        }
-    }
-
-    def __eq__(self: NativeListView, other: Any) -> Any {
-        if isinstance(other, list) {
-            return (
-                len(self) == len(other) and all(a == b for (a, b) in zip(self, other))
-            );
-        }
-        return NotImplemented;
-    }
-
-    def __repr__(self: NativeListView) -> str {
-        return f"<NativeListView len={len(self)}>";
-    }
+    def __len__(self: NativeListView) -> int;
+    def __getitem__(self: NativeListView, index: Any) -> Any;
+    def __iter__(self: NativeListView) -> Any;
+    def __eq__(self: NativeListView, other: Any) -> Any;
+    def __repr__(self: NativeListView) -> str;
 }
 
 

--- a/jac/jaclang/jac0core/passes/impl/primitives_py.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/primitives_py.impl.jac
@@ -1,0 +1,853 @@
+"""Implementation for Python backend primitive emitters."""
+
+# =============================================================================
+#  Numeric Types
+# =============================================================================
+impl PyIntEmitter.emit_bit_length(target: str, args: list[str]) -> str {
+    return _mcall(target, "bit_length", args);
+}
+
+impl PyIntEmitter.emit_bit_count(target: str, args: list[str]) -> str {
+    return _mcall(target, "bit_count", args);
+}
+
+impl PyIntEmitter.emit_to_bytes(target: str, args: list[str]) -> str {
+    return _mcall(target, "to_bytes", args);
+}
+
+impl PyIntEmitter.emit_as_integer_ratio(target: str, args: list[str]) -> str {
+    return _mcall(target, "as_integer_ratio", args);
+}
+
+impl PyIntEmitter.emit_conjugate(target: str, args: list[str]) -> str {
+    return _mcall(target, "conjugate", args);
+}
+
+impl PyIntEmitter.emit_from_bytes(args: list[str]) -> str {
+    return _scall("int", "from_bytes", args);
+}
+
+impl PyFloatEmitter.emit_is_integer(target: str, args: list[str]) -> str {
+    return _mcall(target, "is_integer", args);
+}
+
+impl PyFloatEmitter.emit_as_integer_ratio(target: str, args: list[str]) -> str {
+    return _mcall(target, "as_integer_ratio", args);
+}
+
+impl PyFloatEmitter.emit_conjugate(target: str, args: list[str]) -> str {
+    return _mcall(target, "conjugate", args);
+}
+
+impl PyFloatEmitter.emit_hex(target: str, args: list[str]) -> str {
+    return _mcall(target, "hex", args);
+}
+
+impl PyFloatEmitter.emit_fromhex(args: list[str]) -> str {
+    return _scall("float", "fromhex", args);
+}
+
+impl PyComplexEmitter.emit_conjugate(target: str, args: list[str]) -> str {
+    return _mcall(target, "conjugate", args);
+}
+
+# =============================================================================
+#  String Types
+# =============================================================================
+
+# Case conversion
+impl PyStrEmitter.emit_capitalize(target: str, args: list[str]) -> str {
+    return _mcall(target, "capitalize", args);
+}
+
+impl PyStrEmitter.emit_casefold(target: str, args: list[str]) -> str {
+    return _mcall(target, "casefold", args);
+}
+
+impl PyStrEmitter.emit_lower(target: str, args: list[str]) -> str {
+    return _mcall(target, "lower", args);
+}
+
+impl PyStrEmitter.emit_upper(target: str, args: list[str]) -> str {
+    return _mcall(target, "upper", args);
+}
+
+impl PyStrEmitter.emit_title(target: str, args: list[str]) -> str {
+    return _mcall(target, "title", args);
+}
+
+impl PyStrEmitter.emit_swapcase(target: str, args: list[str]) -> str {
+    return _mcall(target, "swapcase", args);
+}
+
+# Search
+impl PyStrEmitter.emit_count(target: str, args: list[str]) -> str {
+    return _mcall(target, "count", args);
+}
+
+impl PyStrEmitter.emit_find(target: str, args: list[str]) -> str {
+    return _mcall(target, "find", args);
+}
+
+impl PyStrEmitter.emit_rfind(target: str, args: list[str]) -> str {
+    return _mcall(target, "rfind", args);
+}
+
+impl PyStrEmitter.emit_index(target: str, args: list[str]) -> str {
+    return _mcall(target, "index", args);
+}
+
+impl PyStrEmitter.emit_rindex(target: str, args: list[str]) -> str {
+    return _mcall(target, "rindex", args);
+}
+
+impl PyStrEmitter.emit_startswith(target: str, args: list[str]) -> str {
+    return _mcall(target, "startswith", args);
+}
+
+impl PyStrEmitter.emit_endswith(target: str, args: list[str]) -> str {
+    return _mcall(target, "endswith", args);
+}
+
+# Modification
+impl PyStrEmitter.emit_replace(target: str, args: list[str]) -> str {
+    return _mcall(target, "replace", args);
+}
+
+impl PyStrEmitter.emit_strip(target: str, args: list[str]) -> str {
+    return _mcall(target, "strip", args);
+}
+
+impl PyStrEmitter.emit_lstrip(target: str, args: list[str]) -> str {
+    return _mcall(target, "lstrip", args);
+}
+
+impl PyStrEmitter.emit_rstrip(target: str, args: list[str]) -> str {
+    return _mcall(target, "rstrip", args);
+}
+
+impl PyStrEmitter.emit_removeprefix(target: str, args: list[str]) -> str {
+    return _mcall(target, "removeprefix", args);
+}
+
+impl PyStrEmitter.emit_removesuffix(target: str, args: list[str]) -> str {
+    return _mcall(target, "removesuffix", args);
+}
+
+# Split and join
+impl PyStrEmitter.emit_split(target: str, args: list[str]) -> str {
+    return _mcall(target, "split", args);
+}
+
+impl PyStrEmitter.emit_rsplit(target: str, args: list[str]) -> str {
+    return _mcall(target, "rsplit", args);
+}
+
+impl PyStrEmitter.emit_splitlines(target: str, args: list[str]) -> str {
+    return _mcall(target, "splitlines", args);
+}
+
+impl PyStrEmitter.emit_join(target: str, args: list[str]) -> str {
+    return _mcall(target, "join", args);
+}
+
+impl PyStrEmitter.emit_partition(target: str, args: list[str]) -> str {
+    return _mcall(target, "partition", args);
+}
+
+impl PyStrEmitter.emit_rpartition(target: str, args: list[str]) -> str {
+    return _mcall(target, "rpartition", args);
+}
+
+# Formatting and alignment
+impl PyStrEmitter.emit_format(target: str, args: list[str]) -> str {
+    return _mcall(target, "format", args);
+}
+
+impl PyStrEmitter.emit_format_map(target: str, args: list[str]) -> str {
+    return _mcall(target, "format_map", args);
+}
+
+impl PyStrEmitter.emit_center(target: str, args: list[str]) -> str {
+    return _mcall(target, "center", args);
+}
+
+impl PyStrEmitter.emit_ljust(target: str, args: list[str]) -> str {
+    return _mcall(target, "ljust", args);
+}
+
+impl PyStrEmitter.emit_rjust(target: str, args: list[str]) -> str {
+    return _mcall(target, "rjust", args);
+}
+
+impl PyStrEmitter.emit_zfill(target: str, args: list[str]) -> str {
+    return _mcall(target, "zfill", args);
+}
+
+impl PyStrEmitter.emit_expandtabs(target: str, args: list[str]) -> str {
+    return _mcall(target, "expandtabs", args);
+}
+
+# Character tests
+impl PyStrEmitter.emit_isalnum(target: str, args: list[str]) -> str {
+    return _mcall(target, "isalnum", args);
+}
+
+impl PyStrEmitter.emit_isalpha(target: str, args: list[str]) -> str {
+    return _mcall(target, "isalpha", args);
+}
+
+impl PyStrEmitter.emit_isascii(target: str, args: list[str]) -> str {
+    return _mcall(target, "isascii", args);
+}
+
+impl PyStrEmitter.emit_isdecimal(target: str, args: list[str]) -> str {
+    return _mcall(target, "isdecimal", args);
+}
+
+impl PyStrEmitter.emit_isdigit(target: str, args: list[str]) -> str {
+    return _mcall(target, "isdigit", args);
+}
+
+impl PyStrEmitter.emit_isidentifier(target: str, args: list[str]) -> str {
+    return _mcall(target, "isidentifier", args);
+}
+
+impl PyStrEmitter.emit_islower(target: str, args: list[str]) -> str {
+    return _mcall(target, "islower", args);
+}
+
+impl PyStrEmitter.emit_isnumeric(target: str, args: list[str]) -> str {
+    return _mcall(target, "isnumeric", args);
+}
+
+impl PyStrEmitter.emit_isprintable(target: str, args: list[str]) -> str {
+    return _mcall(target, "isprintable", args);
+}
+
+impl PyStrEmitter.emit_isspace(target: str, args: list[str]) -> str {
+    return _mcall(target, "isspace", args);
+}
+
+impl PyStrEmitter.emit_istitle(target: str, args: list[str]) -> str {
+    return _mcall(target, "istitle", args);
+}
+
+impl PyStrEmitter.emit_isupper(target: str, args: list[str]) -> str {
+    return _mcall(target, "isupper", args);
+}
+
+# Encoding
+impl PyStrEmitter.emit_encode(target: str, args: list[str]) -> str {
+    return _mcall(target, "encode", args);
+}
+
+# Translation
+impl PyStrEmitter.emit_translate(target: str, args: list[str]) -> str {
+    return _mcall(target, "translate", args);
+}
+
+impl PyStrEmitter.emit_maketrans(args: list[str]) -> str {
+    return _scall("str", "maketrans", args);
+}
+
+# --- PyBytesEmitter ---
+
+# Decoding
+impl PyBytesEmitter.emit_decode(target: str, args: list[str]) -> str {
+    return _mcall(target, "decode", args);
+}
+
+impl PyBytesEmitter.emit_hex(target: str, args: list[str]) -> str {
+    return _mcall(target, "hex", args);
+}
+
+impl PyBytesEmitter.emit_fromhex(args: list[str]) -> str {
+    return _scall("bytes", "fromhex", args);
+}
+
+# Search
+impl PyBytesEmitter.emit_count(target: str, args: list[str]) -> str {
+    return _mcall(target, "count", args);
+}
+
+impl PyBytesEmitter.emit_find(target: str, args: list[str]) -> str {
+    return _mcall(target, "find", args);
+}
+
+impl PyBytesEmitter.emit_rfind(target: str, args: list[str]) -> str {
+    return _mcall(target, "rfind", args);
+}
+
+impl PyBytesEmitter.emit_index(target: str, args: list[str]) -> str {
+    return _mcall(target, "index", args);
+}
+
+impl PyBytesEmitter.emit_rindex(target: str, args: list[str]) -> str {
+    return _mcall(target, "rindex", args);
+}
+
+impl PyBytesEmitter.emit_startswith(target: str, args: list[str]) -> str {
+    return _mcall(target, "startswith", args);
+}
+
+impl PyBytesEmitter.emit_endswith(target: str, args: list[str]) -> str {
+    return _mcall(target, "endswith", args);
+}
+
+# Modification
+impl PyBytesEmitter.emit_replace(target: str, args: list[str]) -> str {
+    return _mcall(target, "replace", args);
+}
+
+impl PyBytesEmitter.emit_strip(target: str, args: list[str]) -> str {
+    return _mcall(target, "strip", args);
+}
+
+impl PyBytesEmitter.emit_lstrip(target: str, args: list[str]) -> str {
+    return _mcall(target, "lstrip", args);
+}
+
+impl PyBytesEmitter.emit_rstrip(target: str, args: list[str]) -> str {
+    return _mcall(target, "rstrip", args);
+}
+
+impl PyBytesEmitter.emit_removeprefix(target: str, args: list[str]) -> str {
+    return _mcall(target, "removeprefix", args);
+}
+
+impl PyBytesEmitter.emit_removesuffix(target: str, args: list[str]) -> str {
+    return _mcall(target, "removesuffix", args);
+}
+
+# Split and join
+impl PyBytesEmitter.emit_split(target: str, args: list[str]) -> str {
+    return _mcall(target, "split", args);
+}
+
+impl PyBytesEmitter.emit_rsplit(target: str, args: list[str]) -> str {
+    return _mcall(target, "rsplit", args);
+}
+
+impl PyBytesEmitter.emit_splitlines(target: str, args: list[str]) -> str {
+    return _mcall(target, "splitlines", args);
+}
+
+impl PyBytesEmitter.emit_join(target: str, args: list[str]) -> str {
+    return _mcall(target, "join", args);
+}
+
+impl PyBytesEmitter.emit_partition(target: str, args: list[str]) -> str {
+    return _mcall(target, "partition", args);
+}
+
+impl PyBytesEmitter.emit_rpartition(target: str, args: list[str]) -> str {
+    return _mcall(target, "rpartition", args);
+}
+
+# Case (ASCII only)
+impl PyBytesEmitter.emit_capitalize(target: str, args: list[str]) -> str {
+    return _mcall(target, "capitalize", args);
+}
+
+impl PyBytesEmitter.emit_lower(target: str, args: list[str]) -> str {
+    return _mcall(target, "lower", args);
+}
+
+impl PyBytesEmitter.emit_upper(target: str, args: list[str]) -> str {
+    return _mcall(target, "upper", args);
+}
+
+impl PyBytesEmitter.emit_title(target: str, args: list[str]) -> str {
+    return _mcall(target, "title", args);
+}
+
+impl PyBytesEmitter.emit_swapcase(target: str, args: list[str]) -> str {
+    return _mcall(target, "swapcase", args);
+}
+
+# Character tests (ASCII only)
+impl PyBytesEmitter.emit_isalnum(target: str, args: list[str]) -> str {
+    return _mcall(target, "isalnum", args);
+}
+
+impl PyBytesEmitter.emit_isalpha(target: str, args: list[str]) -> str {
+    return _mcall(target, "isalpha", args);
+}
+
+impl PyBytesEmitter.emit_isascii(target: str, args: list[str]) -> str {
+    return _mcall(target, "isascii", args);
+}
+
+impl PyBytesEmitter.emit_isdigit(target: str, args: list[str]) -> str {
+    return _mcall(target, "isdigit", args);
+}
+
+impl PyBytesEmitter.emit_islower(target: str, args: list[str]) -> str {
+    return _mcall(target, "islower", args);
+}
+
+impl PyBytesEmitter.emit_isspace(target: str, args: list[str]) -> str {
+    return _mcall(target, "isspace", args);
+}
+
+impl PyBytesEmitter.emit_istitle(target: str, args: list[str]) -> str {
+    return _mcall(target, "istitle", args);
+}
+
+impl PyBytesEmitter.emit_isupper(target: str, args: list[str]) -> str {
+    return _mcall(target, "isupper", args);
+}
+
+# Alignment
+impl PyBytesEmitter.emit_center(target: str, args: list[str]) -> str {
+    return _mcall(target, "center", args);
+}
+
+impl PyBytesEmitter.emit_ljust(target: str, args: list[str]) -> str {
+    return _mcall(target, "ljust", args);
+}
+
+impl PyBytesEmitter.emit_rjust(target: str, args: list[str]) -> str {
+    return _mcall(target, "rjust", args);
+}
+
+impl PyBytesEmitter.emit_zfill(target: str, args: list[str]) -> str {
+    return _mcall(target, "zfill", args);
+}
+
+impl PyBytesEmitter.emit_expandtabs(target: str, args: list[str]) -> str {
+    return _mcall(target, "expandtabs", args);
+}
+
+# Translation
+impl PyBytesEmitter.emit_translate(target: str, args: list[str]) -> str {
+    return _mcall(target, "translate", args);
+}
+
+impl PyBytesEmitter.emit_maketrans(args: list[str]) -> str {
+    return _scall("bytes", "maketrans", args);
+}
+
+# =============================================================================
+#  Collection Types
+# =============================================================================
+impl PyListEmitter.emit_append(target: str, args: list[str]) -> str {
+    return _mcall(target, "append", args);
+}
+
+impl PyListEmitter.emit_extend(target: str, args: list[str]) -> str {
+    return _mcall(target, "extend", args);
+}
+
+impl PyListEmitter.emit_insert(target: str, args: list[str]) -> str {
+    return _mcall(target, "insert", args);
+}
+
+impl PyListEmitter.emit_remove(target: str, args: list[str]) -> str {
+    return _mcall(target, "remove", args);
+}
+
+impl PyListEmitter.emit_pop(target: str, args: list[str]) -> str {
+    return _mcall(target, "pop", args);
+}
+
+impl PyListEmitter.emit_clear(target: str, args: list[str]) -> str {
+    return _mcall(target, "clear", args);
+}
+
+impl PyListEmitter.emit_index(target: str, args: list[str]) -> str {
+    return _mcall(target, "index", args);
+}
+
+impl PyListEmitter.emit_count(target: str, args: list[str]) -> str {
+    return _mcall(target, "count", args);
+}
+
+impl PyListEmitter.emit_sort(target: str, args: list[str]) -> str {
+    return _mcall(target, "sort", args);
+}
+
+impl PyListEmitter.emit_reverse(target: str, args: list[str]) -> str {
+    return _mcall(target, "reverse", args);
+}
+
+impl PyListEmitter.emit_copy(target: str, args: list[str]) -> str {
+    return _mcall(target, "copy", args);
+}
+
+impl PyDictEmitter.emit_get(target: str, args: list[str]) -> str {
+    return _mcall(target, "get", args);
+}
+
+impl PyDictEmitter.emit_keys(target: str, args: list[str]) -> str {
+    return _mcall(target, "keys", args);
+}
+
+impl PyDictEmitter.emit_values(target: str, args: list[str]) -> str {
+    return _mcall(target, "values", args);
+}
+
+impl PyDictEmitter.emit_items(target: str, args: list[str]) -> str {
+    return _mcall(target, "items", args);
+}
+
+impl PyDictEmitter.emit_pop(target: str, args: list[str]) -> str {
+    return _mcall(target, "pop", args);
+}
+
+impl PyDictEmitter.emit_popitem(target: str, args: list[str]) -> str {
+    return _mcall(target, "popitem", args);
+}
+
+impl PyDictEmitter.emit_setdefault(target: str, args: list[str]) -> str {
+    return _mcall(target, "setdefault", args);
+}
+
+impl PyDictEmitter.emit_update(target: str, args: list[str]) -> str {
+    return _mcall(target, "update", args);
+}
+
+impl PyDictEmitter.emit_clear(target: str, args: list[str]) -> str {
+    return _mcall(target, "clear", args);
+}
+
+impl PyDictEmitter.emit_copy(target: str, args: list[str]) -> str {
+    return _mcall(target, "copy", args);
+}
+
+impl PyDictEmitter.emit_fromkeys(args: list[str]) -> str {
+    return _scall("dict", "fromkeys", args);
+}
+
+# Mutation
+impl PySetEmitter.emit_add(target: str, args: list[str]) -> str {
+    return _mcall(target, "add", args);
+}
+
+impl PySetEmitter.emit_remove(target: str, args: list[str]) -> str {
+    return _mcall(target, "remove", args);
+}
+
+impl PySetEmitter.emit_discard(target: str, args: list[str]) -> str {
+    return _mcall(target, "discard", args);
+}
+
+impl PySetEmitter.emit_pop(target: str, args: list[str]) -> str {
+    return _mcall(target, "pop", args);
+}
+
+impl PySetEmitter.emit_clear(target: str, args: list[str]) -> str {
+    return _mcall(target, "clear", args);
+}
+
+# Set algebra
+impl PySetEmitter.emit_union(target: str, args: list[str]) -> str {
+    return _mcall(target, "union", args);
+}
+
+impl PySetEmitter.emit_intersection(target: str, args: list[str]) -> str {
+    return _mcall(target, "intersection", args);
+}
+
+impl PySetEmitter.emit_difference(target: str, args: list[str]) -> str {
+    return _mcall(target, "difference", args);
+}
+
+impl PySetEmitter.emit_symmetric_difference(target: str, args: list[str]) -> str {
+    return _mcall(target, "symmetric_difference", args);
+}
+
+# In-place set algebra
+impl PySetEmitter.emit_update(target: str, args: list[str]) -> str {
+    return _mcall(target, "update", args);
+}
+
+impl PySetEmitter.emit_intersection_update(target: str, args: list[str]) -> str {
+    return _mcall(target, "intersection_update", args);
+}
+
+impl PySetEmitter.emit_difference_update(target: str, args: list[str]) -> str {
+    return _mcall(target, "difference_update", args);
+}
+
+impl PySetEmitter.emit_symmetric_difference_update(target: str, args: list[str]) -> str {
+    return _mcall(target, "symmetric_difference_update", args);
+}
+
+# Tests
+impl PySetEmitter.emit_issubset(target: str, args: list[str]) -> str {
+    return _mcall(target, "issubset", args);
+}
+
+impl PySetEmitter.emit_issuperset(target: str, args: list[str]) -> str {
+    return _mcall(target, "issuperset", args);
+}
+
+impl PySetEmitter.emit_isdisjoint(target: str, args: list[str]) -> str {
+    return _mcall(target, "isdisjoint", args);
+}
+
+impl PySetEmitter.emit_copy(target: str, args: list[str]) -> str {
+    return _mcall(target, "copy", args);
+}
+
+impl PyFrozensetEmitter.emit_union(target: str, args: list[str]) -> str {
+    return _mcall(target, "union", args);
+}
+
+impl PyFrozensetEmitter.emit_intersection(target: str, args: list[str]) -> str {
+    return _mcall(target, "intersection", args);
+}
+
+impl PyFrozensetEmitter.emit_difference(target: str, args: list[str]) -> str {
+    return _mcall(target, "difference", args);
+}
+
+impl PyFrozensetEmitter.emit_symmetric_difference(target: str, args: list[str]) -> str {
+    return _mcall(target, "symmetric_difference", args);
+}
+
+impl PyFrozensetEmitter.emit_issubset(target: str, args: list[str]) -> str {
+    return _mcall(target, "issubset", args);
+}
+
+impl PyFrozensetEmitter.emit_issuperset(target: str, args: list[str]) -> str {
+    return _mcall(target, "issuperset", args);
+}
+
+impl PyFrozensetEmitter.emit_isdisjoint(target: str, args: list[str]) -> str {
+    return _mcall(target, "isdisjoint", args);
+}
+
+impl PyFrozensetEmitter.emit_copy(target: str, args: list[str]) -> str {
+    return _mcall(target, "copy", args);
+}
+
+impl PyTupleEmitter.emit_count(target: str, args: list[str]) -> str {
+    return _mcall(target, "count", args);
+}
+
+impl PyTupleEmitter.emit_index(target: str, args: list[str]) -> str {
+    return _mcall(target, "index", args);
+}
+
+impl PyRangeEmitter.emit_count(target: str, args: list[str]) -> str {
+    return _mcall(target, "count", args);
+}
+
+impl PyRangeEmitter.emit_index(target: str, args: list[str]) -> str {
+    return _mcall(target, "index", args);
+}
+
+# =============================================================================
+#  Builtin Functions
+# =============================================================================
+impl PyBuiltinEmitter.emit_print(args: list[str]) -> str {
+    return _fcall("print", args);
+}
+
+impl PyBuiltinEmitter.emit_input(args: list[str]) -> str {
+    return _fcall("input", args);
+}
+
+impl PyBuiltinEmitter.emit_len(args: list[str]) -> str {
+    return _fcall("len", args);
+}
+
+impl PyBuiltinEmitter.emit_abs(args: list[str]) -> str {
+    return _fcall("abs", args);
+}
+
+impl PyBuiltinEmitter.emit_round(args: list[str]) -> str {
+    return _fcall("round", args);
+}
+
+impl PyBuiltinEmitter.emit_min(args: list[str]) -> str {
+    return _fcall("min", args);
+}
+
+impl PyBuiltinEmitter.emit_max(args: list[str]) -> str {
+    return _fcall("max", args);
+}
+
+impl PyBuiltinEmitter.emit_sum(args: list[str]) -> str {
+    return _fcall("sum", args);
+}
+
+impl PyBuiltinEmitter.emit_sorted(args: list[str]) -> str {
+    return _fcall("sorted", args);
+}
+
+impl PyBuiltinEmitter.emit_reversed(args: list[str]) -> str {
+    return _fcall("reversed", args);
+}
+
+impl PyBuiltinEmitter.emit_enumerate(args: list[str]) -> str {
+    return _fcall("enumerate", args);
+}
+
+impl PyBuiltinEmitter.emit_zip(args: list[str]) -> str {
+    return _fcall("zip", args);
+}
+
+impl PyBuiltinEmitter.emit_map(args: list[str]) -> str {
+    return _fcall("map", args);
+}
+
+impl PyBuiltinEmitter.emit_filter(args: list[str]) -> str {
+    return _fcall("filter", args);
+}
+
+impl PyBuiltinEmitter.emit_any(args: list[str]) -> str {
+    return _fcall("any", args);
+}
+
+impl PyBuiltinEmitter.emit_all(args: list[str]) -> str {
+    return _fcall("all", args);
+}
+
+impl PyBuiltinEmitter.emit_isinstance(args: list[str]) -> str {
+    return _fcall("isinstance", args);
+}
+
+impl PyBuiltinEmitter.emit_issubclass(args: list[str]) -> str {
+    return _fcall("issubclass", args);
+}
+
+impl PyBuiltinEmitter.emit_type(args: list[str]) -> str {
+    return _fcall("type", args);
+}
+
+impl PyBuiltinEmitter.emit_id(args: list[str]) -> str {
+    return _fcall("id", args);
+}
+
+impl PyBuiltinEmitter.emit_hash(args: list[str]) -> str {
+    return _fcall("hash", args);
+}
+
+impl PyBuiltinEmitter.emit_repr(args: list[str]) -> str {
+    return _fcall("repr", args);
+}
+
+impl PyBuiltinEmitter.emit_chr(args: list[str]) -> str {
+    return _fcall("chr", args);
+}
+
+impl PyBuiltinEmitter.emit_ord(args: list[str]) -> str {
+    return _fcall("ord", args);
+}
+
+impl PyBuiltinEmitter.emit_hex(args: list[str]) -> str {
+    return _fcall("hex", args);
+}
+
+impl PyBuiltinEmitter.emit_oct(args: list[str]) -> str {
+    return _fcall("oct", args);
+}
+
+impl PyBuiltinEmitter.emit_bin(args: list[str]) -> str {
+    return _fcall("bin", args);
+}
+
+impl PyBuiltinEmitter.emit_pow(args: list[str]) -> str {
+    return _fcall("pow", args);
+}
+
+impl PyBuiltinEmitter.emit_divmod(args: list[str]) -> str {
+    return _fcall("divmod", args);
+}
+
+impl PyBuiltinEmitter.emit_iter(args: list[str]) -> str {
+    return _fcall("iter", args);
+}
+
+impl PyBuiltinEmitter.emit_next(args: list[str]) -> str {
+    return _fcall("next", args);
+}
+
+impl PyBuiltinEmitter.emit_callable(args: list[str]) -> str {
+    return _fcall("callable", args);
+}
+
+impl PyBuiltinEmitter.emit_getattr(args: list[str]) -> str {
+    return _fcall("getattr", args);
+}
+
+impl PyBuiltinEmitter.emit_setattr(args: list[str]) -> str {
+    return _fcall("setattr", args);
+}
+
+impl PyBuiltinEmitter.emit_hasattr(args: list[str]) -> str {
+    return _fcall("hasattr", args);
+}
+
+impl PyBuiltinEmitter.emit_delattr(args: list[str]) -> str {
+    return _fcall("delattr", args);
+}
+
+impl PyBuiltinEmitter.emit_vars(args: list[str]) -> str {
+    return _fcall("vars", args);
+}
+
+impl PyBuiltinEmitter.emit_dir(args: list[str]) -> str {
+    return _fcall("dir", args);
+}
+
+impl PyBuiltinEmitter.emit_open(args: list[str]) -> str {
+    return _fcall("open", args);
+}
+
+impl PyBuiltinEmitter.emit_format(args: list[str]) -> str {
+    return _fcall("format", args);
+}
+
+impl PyBuiltinEmitter.emit_ascii(args: list[str]) -> str {
+    return _fcall("ascii", args);
+}
+
+# Type conversion builtins
+impl PyBuiltinEmitter.emit_str(args: list[str]) -> str {
+    return _fcall("str", args);
+}
+
+impl PyBuiltinEmitter.emit_int(args: list[str]) -> str {
+    return _fcall("int", args);
+}
+
+impl PyBuiltinEmitter.emit_float(args: list[str]) -> str {
+    return _fcall("float", args);
+}
+
+impl PyBuiltinEmitter.emit_bool(args: list[str]) -> str {
+    return _fcall("bool", args);
+}
+
+impl PyBuiltinEmitter.emit_list(args: list[str]) -> str {
+    return _fcall("list", args);
+}
+
+impl PyBuiltinEmitter.emit_dict(args: list[str]) -> str {
+    return _fcall("dict", args);
+}
+
+impl PyBuiltinEmitter.emit_set(args: list[str]) -> str {
+    return _fcall("set", args);
+}
+
+impl PyBuiltinEmitter.emit_tuple(args: list[str]) -> str {
+    return _fcall("tuple", args);
+}
+
+impl PyBuiltinEmitter.emit_frozenset(args: list[str]) -> str {
+    return _fcall("frozenset", args);
+}
+
+impl PyBuiltinEmitter.emit_bytes(args: list[str]) -> str {
+    return _fcall("bytes", args);
+}
+
+impl PyBuiltinEmitter.emit_complex(args: list[str]) -> str {
+    return _fcall("complex", args);
+}

--- a/jac/jaclang/jac0core/passes/primitives_py.jac
+++ b/jac/jaclang/jac0core/passes/primitives_py.jac
@@ -48,57 +48,24 @@ def _fcall(name: str, args: list[str]) -> str {
 #  Numeric Types
 # =============================================================================
 class PyIntEmitter(IntEmitter) {
-    def emit_bit_length(target: str, args: list[str]) -> str {
-        return _mcall(target, "bit_length", args);
-    }
-
-    def emit_bit_count(target: str, args: list[str]) -> str {
-        return _mcall(target, "bit_count", args);
-    }
-
-    def emit_to_bytes(target: str, args: list[str]) -> str {
-        return _mcall(target, "to_bytes", args);
-    }
-
-    def emit_as_integer_ratio(target: str, args: list[str]) -> str {
-        return _mcall(target, "as_integer_ratio", args);
-    }
-
-    def emit_conjugate(target: str, args: list[str]) -> str {
-        return _mcall(target, "conjugate", args);
-    }
-
-    def emit_from_bytes(args: list[str]) -> str {
-        return _scall("int", "from_bytes", args);
-    }
+    static def emit_bit_length(target: str, args: list[str]) -> str;
+    static def emit_bit_count(target: str, args: list[str]) -> str;
+    static def emit_to_bytes(target: str, args: list[str]) -> str;
+    static def emit_as_integer_ratio(target: str, args: list[str]) -> str;
+    static def emit_conjugate(target: str, args: list[str]) -> str;
+    static def emit_from_bytes(args: list[str]) -> str;
 }
 
 class PyFloatEmitter(FloatEmitter) {
-    def emit_is_integer(target: str, args: list[str]) -> str {
-        return _mcall(target, "is_integer", args);
-    }
-
-    def emit_as_integer_ratio(target: str, args: list[str]) -> str {
-        return _mcall(target, "as_integer_ratio", args);
-    }
-
-    def emit_conjugate(target: str, args: list[str]) -> str {
-        return _mcall(target, "conjugate", args);
-    }
-
-    def emit_hex(target: str, args: list[str]) -> str {
-        return _mcall(target, "hex", args);
-    }
-
-    def emit_fromhex(args: list[str]) -> str {
-        return _scall("float", "fromhex", args);
-    }
+    static def emit_is_integer(target: str, args: list[str]) -> str;
+    static def emit_as_integer_ratio(target: str, args: list[str]) -> str;
+    static def emit_conjugate(target: str, args: list[str]) -> str;
+    static def emit_hex(target: str, args: list[str]) -> str;
+    static def emit_fromhex(args: list[str]) -> str;
 }
 
 class PyComplexEmitter(ComplexEmitter) {
-    def emit_conjugate(target: str, args: list[str]) -> str {
-        return _mcall(target, "conjugate", args);
-    }
+    static def emit_conjugate(target: str, args: list[str]) -> str;
 }
 
 # =============================================================================
@@ -106,796 +73,246 @@ class PyComplexEmitter(ComplexEmitter) {
 # =============================================================================
 class PyStrEmitter(StrEmitter) {
     # Case conversion
-    def emit_capitalize(target: str, args: list[str]) -> str {
-        return _mcall(target, "capitalize", args);
-    }
-
-    def emit_casefold(target: str, args: list[str]) -> str {
-        return _mcall(target, "casefold", args);
-    }
-
-    def emit_lower(target: str, args: list[str]) -> str {
-        return _mcall(target, "lower", args);
-    }
-
-    def emit_upper(target: str, args: list[str]) -> str {
-        return _mcall(target, "upper", args);
-    }
-
-    def emit_title(target: str, args: list[str]) -> str {
-        return _mcall(target, "title", args);
-    }
-
-    def emit_swapcase(target: str, args: list[str]) -> str {
-        return _mcall(target, "swapcase", args);
-    }
+    static def emit_capitalize(target: str, args: list[str]) -> str;
+    static def emit_casefold(target: str, args: list[str]) -> str;
+    static def emit_lower(target: str, args: list[str]) -> str;
+    static def emit_upper(target: str, args: list[str]) -> str;
+    static def emit_title(target: str, args: list[str]) -> str;
+    static def emit_swapcase(target: str, args: list[str]) -> str;
     # Search
-    def emit_count(target: str, args: list[str]) -> str {
-        return _mcall(target, "count", args);
-    }
-
-    def emit_find(target: str, args: list[str]) -> str {
-        return _mcall(target, "find", args);
-    }
-
-    def emit_rfind(target: str, args: list[str]) -> str {
-        return _mcall(target, "rfind", args);
-    }
-
-    def emit_index(target: str, args: list[str]) -> str {
-        return _mcall(target, "index", args);
-    }
-
-    def emit_rindex(target: str, args: list[str]) -> str {
-        return _mcall(target, "rindex", args);
-    }
-
-    def emit_startswith(target: str, args: list[str]) -> str {
-        return _mcall(target, "startswith", args);
-    }
-
-    def emit_endswith(target: str, args: list[str]) -> str {
-        return _mcall(target, "endswith", args);
-    }
+    static def emit_count(target: str, args: list[str]) -> str;
+    static def emit_find(target: str, args: list[str]) -> str;
+    static def emit_rfind(target: str, args: list[str]) -> str;
+    static def emit_index(target: str, args: list[str]) -> str;
+    static def emit_rindex(target: str, args: list[str]) -> str;
+    static def emit_startswith(target: str, args: list[str]) -> str;
+    static def emit_endswith(target: str, args: list[str]) -> str;
     # Modification
-    def emit_replace(target: str, args: list[str]) -> str {
-        return _mcall(target, "replace", args);
-    }
-
-    def emit_strip(target: str, args: list[str]) -> str {
-        return _mcall(target, "strip", args);
-    }
-
-    def emit_lstrip(target: str, args: list[str]) -> str {
-        return _mcall(target, "lstrip", args);
-    }
-
-    def emit_rstrip(target: str, args: list[str]) -> str {
-        return _mcall(target, "rstrip", args);
-    }
-
-    def emit_removeprefix(target: str, args: list[str]) -> str {
-        return _mcall(target, "removeprefix", args);
-    }
-
-    def emit_removesuffix(target: str, args: list[str]) -> str {
-        return _mcall(target, "removesuffix", args);
-    }
+    static def emit_replace(target: str, args: list[str]) -> str;
+    static def emit_strip(target: str, args: list[str]) -> str;
+    static def emit_lstrip(target: str, args: list[str]) -> str;
+    static def emit_rstrip(target: str, args: list[str]) -> str;
+    static def emit_removeprefix(target: str, args: list[str]) -> str;
+    static def emit_removesuffix(target: str, args: list[str]) -> str;
     # Split and join
-    def emit_split(target: str, args: list[str]) -> str {
-        return _mcall(target, "split", args);
-    }
-
-    def emit_rsplit(target: str, args: list[str]) -> str {
-        return _mcall(target, "rsplit", args);
-    }
-
-    def emit_splitlines(target: str, args: list[str]) -> str {
-        return _mcall(target, "splitlines", args);
-    }
-
-    def emit_join(target: str, args: list[str]) -> str {
-        return _mcall(target, "join", args);
-    }
-
-    def emit_partition(target: str, args: list[str]) -> str {
-        return _mcall(target, "partition", args);
-    }
-
-    def emit_rpartition(target: str, args: list[str]) -> str {
-        return _mcall(target, "rpartition", args);
-    }
+    static def emit_split(target: str, args: list[str]) -> str;
+    static def emit_rsplit(target: str, args: list[str]) -> str;
+    static def emit_splitlines(target: str, args: list[str]) -> str;
+    static def emit_join(target: str, args: list[str]) -> str;
+    static def emit_partition(target: str, args: list[str]) -> str;
+    static def emit_rpartition(target: str, args: list[str]) -> str;
     # Formatting and alignment
-    def emit_format(target: str, args: list[str]) -> str {
-        return _mcall(target, "format", args);
-    }
-
-    def emit_format_map(target: str, args: list[str]) -> str {
-        return _mcall(target, "format_map", args);
-    }
-
-    def emit_center(target: str, args: list[str]) -> str {
-        return _mcall(target, "center", args);
-    }
-
-    def emit_ljust(target: str, args: list[str]) -> str {
-        return _mcall(target, "ljust", args);
-    }
-
-    def emit_rjust(target: str, args: list[str]) -> str {
-        return _mcall(target, "rjust", args);
-    }
-
-    def emit_zfill(target: str, args: list[str]) -> str {
-        return _mcall(target, "zfill", args);
-    }
-
-    def emit_expandtabs(target: str, args: list[str]) -> str {
-        return _mcall(target, "expandtabs", args);
-    }
+    static def emit_format(target: str, args: list[str]) -> str;
+    static def emit_format_map(target: str, args: list[str]) -> str;
+    static def emit_center(target: str, args: list[str]) -> str;
+    static def emit_ljust(target: str, args: list[str]) -> str;
+    static def emit_rjust(target: str, args: list[str]) -> str;
+    static def emit_zfill(target: str, args: list[str]) -> str;
+    static def emit_expandtabs(target: str, args: list[str]) -> str;
     # Character tests
-    def emit_isalnum(target: str, args: list[str]) -> str {
-        return _mcall(target, "isalnum", args);
-    }
-
-    def emit_isalpha(target: str, args: list[str]) -> str {
-        return _mcall(target, "isalpha", args);
-    }
-
-    def emit_isascii(target: str, args: list[str]) -> str {
-        return _mcall(target, "isascii", args);
-    }
-
-    def emit_isdecimal(target: str, args: list[str]) -> str {
-        return _mcall(target, "isdecimal", args);
-    }
-
-    def emit_isdigit(target: str, args: list[str]) -> str {
-        return _mcall(target, "isdigit", args);
-    }
-
-    def emit_isidentifier(target: str, args: list[str]) -> str {
-        return _mcall(target, "isidentifier", args);
-    }
-
-    def emit_islower(target: str, args: list[str]) -> str {
-        return _mcall(target, "islower", args);
-    }
-
-    def emit_isnumeric(target: str, args: list[str]) -> str {
-        return _mcall(target, "isnumeric", args);
-    }
-
-    def emit_isprintable(target: str, args: list[str]) -> str {
-        return _mcall(target, "isprintable", args);
-    }
-
-    def emit_isspace(target: str, args: list[str]) -> str {
-        return _mcall(target, "isspace", args);
-    }
-
-    def emit_istitle(target: str, args: list[str]) -> str {
-        return _mcall(target, "istitle", args);
-    }
-
-    def emit_isupper(target: str, args: list[str]) -> str {
-        return _mcall(target, "isupper", args);
-    }
+    static def emit_isalnum(target: str, args: list[str]) -> str;
+    static def emit_isalpha(target: str, args: list[str]) -> str;
+    static def emit_isascii(target: str, args: list[str]) -> str;
+    static def emit_isdecimal(target: str, args: list[str]) -> str;
+    static def emit_isdigit(target: str, args: list[str]) -> str;
+    static def emit_isidentifier(target: str, args: list[str]) -> str;
+    static def emit_islower(target: str, args: list[str]) -> str;
+    static def emit_isnumeric(target: str, args: list[str]) -> str;
+    static def emit_isprintable(target: str, args: list[str]) -> str;
+    static def emit_isspace(target: str, args: list[str]) -> str;
+    static def emit_istitle(target: str, args: list[str]) -> str;
+    static def emit_isupper(target: str, args: list[str]) -> str;
     # Encoding
-    def emit_encode(target: str, args: list[str]) -> str {
-        return _mcall(target, "encode", args);
-    }
+    static def emit_encode(target: str, args: list[str]) -> str;
     # Translation
-    def emit_translate(target: str, args: list[str]) -> str {
-        return _mcall(target, "translate", args);
-    }
-
-    def emit_maketrans(args: list[str]) -> str {
-        return _scall("str", "maketrans", args);
-    }
+    static def emit_translate(target: str, args: list[str]) -> str;
+    static def emit_maketrans(args: list[str]) -> str;
 }
 
 class PyBytesEmitter(BytesEmitter) {
     # Decoding
-    def emit_decode(target: str, args: list[str]) -> str {
-        return _mcall(target, "decode", args);
-    }
-
-    def emit_hex(target: str, args: list[str]) -> str {
-        return _mcall(target, "hex", args);
-    }
-
-    def emit_fromhex(args: list[str]) -> str {
-        return _scall("bytes", "fromhex", args);
-    }
+    static def emit_decode(target: str, args: list[str]) -> str;
+    static def emit_hex(target: str, args: list[str]) -> str;
+    static def emit_fromhex(args: list[str]) -> str;
     # Search
-    def emit_count(target: str, args: list[str]) -> str {
-        return _mcall(target, "count", args);
-    }
-
-    def emit_find(target: str, args: list[str]) -> str {
-        return _mcall(target, "find", args);
-    }
-
-    def emit_rfind(target: str, args: list[str]) -> str {
-        return _mcall(target, "rfind", args);
-    }
-
-    def emit_index(target: str, args: list[str]) -> str {
-        return _mcall(target, "index", args);
-    }
-
-    def emit_rindex(target: str, args: list[str]) -> str {
-        return _mcall(target, "rindex", args);
-    }
-
-    def emit_startswith(target: str, args: list[str]) -> str {
-        return _mcall(target, "startswith", args);
-    }
-
-    def emit_endswith(target: str, args: list[str]) -> str {
-        return _mcall(target, "endswith", args);
-    }
+    static def emit_count(target: str, args: list[str]) -> str;
+    static def emit_find(target: str, args: list[str]) -> str;
+    static def emit_rfind(target: str, args: list[str]) -> str;
+    static def emit_index(target: str, args: list[str]) -> str;
+    static def emit_rindex(target: str, args: list[str]) -> str;
+    static def emit_startswith(target: str, args: list[str]) -> str;
+    static def emit_endswith(target: str, args: list[str]) -> str;
     # Modification
-    def emit_replace(target: str, args: list[str]) -> str {
-        return _mcall(target, "replace", args);
-    }
-
-    def emit_strip(target: str, args: list[str]) -> str {
-        return _mcall(target, "strip", args);
-    }
-
-    def emit_lstrip(target: str, args: list[str]) -> str {
-        return _mcall(target, "lstrip", args);
-    }
-
-    def emit_rstrip(target: str, args: list[str]) -> str {
-        return _mcall(target, "rstrip", args);
-    }
-
-    def emit_removeprefix(target: str, args: list[str]) -> str {
-        return _mcall(target, "removeprefix", args);
-    }
-
-    def emit_removesuffix(target: str, args: list[str]) -> str {
-        return _mcall(target, "removesuffix", args);
-    }
+    static def emit_replace(target: str, args: list[str]) -> str;
+    static def emit_strip(target: str, args: list[str]) -> str;
+    static def emit_lstrip(target: str, args: list[str]) -> str;
+    static def emit_rstrip(target: str, args: list[str]) -> str;
+    static def emit_removeprefix(target: str, args: list[str]) -> str;
+    static def emit_removesuffix(target: str, args: list[str]) -> str;
     # Split and join
-    def emit_split(target: str, args: list[str]) -> str {
-        return _mcall(target, "split", args);
-    }
-
-    def emit_rsplit(target: str, args: list[str]) -> str {
-        return _mcall(target, "rsplit", args);
-    }
-
-    def emit_splitlines(target: str, args: list[str]) -> str {
-        return _mcall(target, "splitlines", args);
-    }
-
-    def emit_join(target: str, args: list[str]) -> str {
-        return _mcall(target, "join", args);
-    }
-
-    def emit_partition(target: str, args: list[str]) -> str {
-        return _mcall(target, "partition", args);
-    }
-
-    def emit_rpartition(target: str, args: list[str]) -> str {
-        return _mcall(target, "rpartition", args);
-    }
+    static def emit_split(target: str, args: list[str]) -> str;
+    static def emit_rsplit(target: str, args: list[str]) -> str;
+    static def emit_splitlines(target: str, args: list[str]) -> str;
+    static def emit_join(target: str, args: list[str]) -> str;
+    static def emit_partition(target: str, args: list[str]) -> str;
+    static def emit_rpartition(target: str, args: list[str]) -> str;
     # Case (ASCII only)
-    def emit_capitalize(target: str, args: list[str]) -> str {
-        return _mcall(target, "capitalize", args);
-    }
-
-    def emit_lower(target: str, args: list[str]) -> str {
-        return _mcall(target, "lower", args);
-    }
-
-    def emit_upper(target: str, args: list[str]) -> str {
-        return _mcall(target, "upper", args);
-    }
-
-    def emit_title(target: str, args: list[str]) -> str {
-        return _mcall(target, "title", args);
-    }
-
-    def emit_swapcase(target: str, args: list[str]) -> str {
-        return _mcall(target, "swapcase", args);
-    }
+    static def emit_capitalize(target: str, args: list[str]) -> str;
+    static def emit_lower(target: str, args: list[str]) -> str;
+    static def emit_upper(target: str, args: list[str]) -> str;
+    static def emit_title(target: str, args: list[str]) -> str;
+    static def emit_swapcase(target: str, args: list[str]) -> str;
     # Character tests (ASCII only)
-    def emit_isalnum(target: str, args: list[str]) -> str {
-        return _mcall(target, "isalnum", args);
-    }
-
-    def emit_isalpha(target: str, args: list[str]) -> str {
-        return _mcall(target, "isalpha", args);
-    }
-
-    def emit_isascii(target: str, args: list[str]) -> str {
-        return _mcall(target, "isascii", args);
-    }
-
-    def emit_isdigit(target: str, args: list[str]) -> str {
-        return _mcall(target, "isdigit", args);
-    }
-
-    def emit_islower(target: str, args: list[str]) -> str {
-        return _mcall(target, "islower", args);
-    }
-
-    def emit_isspace(target: str, args: list[str]) -> str {
-        return _mcall(target, "isspace", args);
-    }
-
-    def emit_istitle(target: str, args: list[str]) -> str {
-        return _mcall(target, "istitle", args);
-    }
-
-    def emit_isupper(target: str, args: list[str]) -> str {
-        return _mcall(target, "isupper", args);
-    }
+    static def emit_isalnum(target: str, args: list[str]) -> str;
+    static def emit_isalpha(target: str, args: list[str]) -> str;
+    static def emit_isascii(target: str, args: list[str]) -> str;
+    static def emit_isdigit(target: str, args: list[str]) -> str;
+    static def emit_islower(target: str, args: list[str]) -> str;
+    static def emit_isspace(target: str, args: list[str]) -> str;
+    static def emit_istitle(target: str, args: list[str]) -> str;
+    static def emit_isupper(target: str, args: list[str]) -> str;
     # Alignment
-    def emit_center(target: str, args: list[str]) -> str {
-        return _mcall(target, "center", args);
-    }
-
-    def emit_ljust(target: str, args: list[str]) -> str {
-        return _mcall(target, "ljust", args);
-    }
-
-    def emit_rjust(target: str, args: list[str]) -> str {
-        return _mcall(target, "rjust", args);
-    }
-
-    def emit_zfill(target: str, args: list[str]) -> str {
-        return _mcall(target, "zfill", args);
-    }
-
-    def emit_expandtabs(target: str, args: list[str]) -> str {
-        return _mcall(target, "expandtabs", args);
-    }
+    static def emit_center(target: str, args: list[str]) -> str;
+    static def emit_ljust(target: str, args: list[str]) -> str;
+    static def emit_rjust(target: str, args: list[str]) -> str;
+    static def emit_zfill(target: str, args: list[str]) -> str;
+    static def emit_expandtabs(target: str, args: list[str]) -> str;
     # Translation
-    def emit_translate(target: str, args: list[str]) -> str {
-        return _mcall(target, "translate", args);
-    }
-
-    def emit_maketrans(args: list[str]) -> str {
-        return _scall("bytes", "maketrans", args);
-    }
+    static def emit_translate(target: str, args: list[str]) -> str;
+    static def emit_maketrans(args: list[str]) -> str;
 }
 
 # =============================================================================
 #  Collection Types
 # =============================================================================
 class PyListEmitter(ListEmitter) {
-    def emit_append(target: str, args: list[str]) -> str {
-        return _mcall(target, "append", args);
-    }
-
-    def emit_extend(target: str, args: list[str]) -> str {
-        return _mcall(target, "extend", args);
-    }
-
-    def emit_insert(target: str, args: list[str]) -> str {
-        return _mcall(target, "insert", args);
-    }
-
-    def emit_remove(target: str, args: list[str]) -> str {
-        return _mcall(target, "remove", args);
-    }
-
-    def emit_pop(target: str, args: list[str]) -> str {
-        return _mcall(target, "pop", args);
-    }
-
-    def emit_clear(target: str, args: list[str]) -> str {
-        return _mcall(target, "clear", args);
-    }
-
-    def emit_index(target: str, args: list[str]) -> str {
-        return _mcall(target, "index", args);
-    }
-
-    def emit_count(target: str, args: list[str]) -> str {
-        return _mcall(target, "count", args);
-    }
-
-    def emit_sort(target: str, args: list[str]) -> str {
-        return _mcall(target, "sort", args);
-    }
-
-    def emit_reverse(target: str, args: list[str]) -> str {
-        return _mcall(target, "reverse", args);
-    }
-
-    def emit_copy(target: str, args: list[str]) -> str {
-        return _mcall(target, "copy", args);
-    }
+    static def emit_append(target: str, args: list[str]) -> str;
+    static def emit_extend(target: str, args: list[str]) -> str;
+    static def emit_insert(target: str, args: list[str]) -> str;
+    static def emit_remove(target: str, args: list[str]) -> str;
+    static def emit_pop(target: str, args: list[str]) -> str;
+    static def emit_clear(target: str, args: list[str]) -> str;
+    static def emit_index(target: str, args: list[str]) -> str;
+    static def emit_count(target: str, args: list[str]) -> str;
+    static def emit_sort(target: str, args: list[str]) -> str;
+    static def emit_reverse(target: str, args: list[str]) -> str;
+    static def emit_copy(target: str, args: list[str]) -> str;
 }
 
 class PyDictEmitter(DictEmitter) {
-    def emit_get(target: str, args: list[str]) -> str {
-        return _mcall(target, "get", args);
-    }
-
-    def emit_keys(target: str, args: list[str]) -> str {
-        return _mcall(target, "keys", args);
-    }
-
-    def emit_values(target: str, args: list[str]) -> str {
-        return _mcall(target, "values", args);
-    }
-
-    def emit_items(target: str, args: list[str]) -> str {
-        return _mcall(target, "items", args);
-    }
-
-    def emit_pop(target: str, args: list[str]) -> str {
-        return _mcall(target, "pop", args);
-    }
-
-    def emit_popitem(target: str, args: list[str]) -> str {
-        return _mcall(target, "popitem", args);
-    }
-
-    def emit_setdefault(target: str, args: list[str]) -> str {
-        return _mcall(target, "setdefault", args);
-    }
-
-    def emit_update(target: str, args: list[str]) -> str {
-        return _mcall(target, "update", args);
-    }
-
-    def emit_clear(target: str, args: list[str]) -> str {
-        return _mcall(target, "clear", args);
-    }
-
-    def emit_copy(target: str, args: list[str]) -> str {
-        return _mcall(target, "copy", args);
-    }
-
-    def emit_fromkeys(args: list[str]) -> str {
-        return _scall("dict", "fromkeys", args);
-    }
+    static def emit_get(target: str, args: list[str]) -> str;
+    static def emit_keys(target: str, args: list[str]) -> str;
+    static def emit_values(target: str, args: list[str]) -> str;
+    static def emit_items(target: str, args: list[str]) -> str;
+    static def emit_pop(target: str, args: list[str]) -> str;
+    static def emit_popitem(target: str, args: list[str]) -> str;
+    static def emit_setdefault(target: str, args: list[str]) -> str;
+    static def emit_update(target: str, args: list[str]) -> str;
+    static def emit_clear(target: str, args: list[str]) -> str;
+    static def emit_copy(target: str, args: list[str]) -> str;
+    static def emit_fromkeys(args: list[str]) -> str;
 }
 
 class PySetEmitter(SetEmitter) {
     # Mutation
-    def emit_add(target: str, args: list[str]) -> str {
-        return _mcall(target, "add", args);
-    }
-
-    def emit_remove(target: str, args: list[str]) -> str {
-        return _mcall(target, "remove", args);
-    }
-
-    def emit_discard(target: str, args: list[str]) -> str {
-        return _mcall(target, "discard", args);
-    }
-
-    def emit_pop(target: str, args: list[str]) -> str {
-        return _mcall(target, "pop", args);
-    }
-
-    def emit_clear(target: str, args: list[str]) -> str {
-        return _mcall(target, "clear", args);
-    }
+    static def emit_add(target: str, args: list[str]) -> str;
+    static def emit_remove(target: str, args: list[str]) -> str;
+    static def emit_discard(target: str, args: list[str]) -> str;
+    static def emit_pop(target: str, args: list[str]) -> str;
+    static def emit_clear(target: str, args: list[str]) -> str;
     # Set algebra
-    def emit_union(target: str, args: list[str]) -> str {
-        return _mcall(target, "union", args);
-    }
-
-    def emit_intersection(target: str, args: list[str]) -> str {
-        return _mcall(target, "intersection", args);
-    }
-
-    def emit_difference(target: str, args: list[str]) -> str {
-        return _mcall(target, "difference", args);
-    }
-
-    def emit_symmetric_difference(target: str, args: list[str]) -> str {
-        return _mcall(target, "symmetric_difference", args);
-    }
+    static def emit_union(target: str, args: list[str]) -> str;
+    static def emit_intersection(target: str, args: list[str]) -> str;
+    static def emit_difference(target: str, args: list[str]) -> str;
+    static def emit_symmetric_difference(target: str, args: list[str]) -> str;
     # In-place set algebra
-    def emit_update(target: str, args: list[str]) -> str {
-        return _mcall(target, "update", args);
-    }
-
-    def emit_intersection_update(target: str, args: list[str]) -> str {
-        return _mcall(target, "intersection_update", args);
-    }
-
-    def emit_difference_update(target: str, args: list[str]) -> str {
-        return _mcall(target, "difference_update", args);
-    }
-
-    def emit_symmetric_difference_update(target: str, args: list[str]) -> str {
-        return _mcall(target, "symmetric_difference_update", args);
-    }
+    static def emit_update(target: str, args: list[str]) -> str;
+    static def emit_intersection_update(target: str, args: list[str]) -> str;
+    static def emit_difference_update(target: str, args: list[str]) -> str;
+    static def emit_symmetric_difference_update(target: str, args: list[str]) -> str;
     # Tests
-    def emit_issubset(target: str, args: list[str]) -> str {
-        return _mcall(target, "issubset", args);
-    }
-
-    def emit_issuperset(target: str, args: list[str]) -> str {
-        return _mcall(target, "issuperset", args);
-    }
-
-    def emit_isdisjoint(target: str, args: list[str]) -> str {
-        return _mcall(target, "isdisjoint", args);
-    }
-
-    def emit_copy(target: str, args: list[str]) -> str {
-        return _mcall(target, "copy", args);
-    }
+    static def emit_issubset(target: str, args: list[str]) -> str;
+    static def emit_issuperset(target: str, args: list[str]) -> str;
+    static def emit_isdisjoint(target: str, args: list[str]) -> str;
+    static def emit_copy(target: str, args: list[str]) -> str;
 }
 
 class PyFrozensetEmitter(FrozensetEmitter) {
-    def emit_union(target: str, args: list[str]) -> str {
-        return _mcall(target, "union", args);
-    }
-
-    def emit_intersection(target: str, args: list[str]) -> str {
-        return _mcall(target, "intersection", args);
-    }
-
-    def emit_difference(target: str, args: list[str]) -> str {
-        return _mcall(target, "difference", args);
-    }
-
-    def emit_symmetric_difference(target: str, args: list[str]) -> str {
-        return _mcall(target, "symmetric_difference", args);
-    }
-
-    def emit_issubset(target: str, args: list[str]) -> str {
-        return _mcall(target, "issubset", args);
-    }
-
-    def emit_issuperset(target: str, args: list[str]) -> str {
-        return _mcall(target, "issuperset", args);
-    }
-
-    def emit_isdisjoint(target: str, args: list[str]) -> str {
-        return _mcall(target, "isdisjoint", args);
-    }
-
-    def emit_copy(target: str, args: list[str]) -> str {
-        return _mcall(target, "copy", args);
-    }
+    static def emit_union(target: str, args: list[str]) -> str;
+    static def emit_intersection(target: str, args: list[str]) -> str;
+    static def emit_difference(target: str, args: list[str]) -> str;
+    static def emit_symmetric_difference(target: str, args: list[str]) -> str;
+    static def emit_issubset(target: str, args: list[str]) -> str;
+    static def emit_issuperset(target: str, args: list[str]) -> str;
+    static def emit_isdisjoint(target: str, args: list[str]) -> str;
+    static def emit_copy(target: str, args: list[str]) -> str;
 }
 
 class PyTupleEmitter(TupleEmitter) {
-    def emit_count(target: str, args: list[str]) -> str {
-        return _mcall(target, "count", args);
-    }
-
-    def emit_index(target: str, args: list[str]) -> str {
-        return _mcall(target, "index", args);
-    }
+    static def emit_count(target: str, args: list[str]) -> str;
+    static def emit_index(target: str, args: list[str]) -> str;
 }
 
 class PyRangeEmitter(RangeEmitter) {
-    def emit_count(target: str, args: list[str]) -> str {
-        return _mcall(target, "count", args);
-    }
-
-    def emit_index(target: str, args: list[str]) -> str {
-        return _mcall(target, "index", args);
-    }
+    static def emit_count(target: str, args: list[str]) -> str;
+    static def emit_index(target: str, args: list[str]) -> str;
 }
 
 # =============================================================================
 #  Builtin Functions
 # =============================================================================
 class PyBuiltinEmitter(BuiltinEmitter) {
-    def emit_print(args: list[str]) -> str {
-        return _fcall("print", args);
-    }
-
-    def emit_input(args: list[str]) -> str {
-        return _fcall("input", args);
-    }
-
-    def emit_len(args: list[str]) -> str {
-        return _fcall("len", args);
-    }
-
-    def emit_abs(args: list[str]) -> str {
-        return _fcall("abs", args);
-    }
-
-    def emit_round(args: list[str]) -> str {
-        return _fcall("round", args);
-    }
-
-    def emit_min(args: list[str]) -> str {
-        return _fcall("min", args);
-    }
-
-    def emit_max(args: list[str]) -> str {
-        return _fcall("max", args);
-    }
-
-    def emit_sum(args: list[str]) -> str {
-        return _fcall("sum", args);
-    }
-
-    def emit_sorted(args: list[str]) -> str {
-        return _fcall("sorted", args);
-    }
-
-    def emit_reversed(args: list[str]) -> str {
-        return _fcall("reversed", args);
-    }
-
-    def emit_enumerate(args: list[str]) -> str {
-        return _fcall("enumerate", args);
-    }
-
-    def emit_zip(args: list[str]) -> str {
-        return _fcall("zip", args);
-    }
-
-    def emit_map(args: list[str]) -> str {
-        return _fcall("map", args);
-    }
-
-    def emit_filter(args: list[str]) -> str {
-        return _fcall("filter", args);
-    }
-
-    def emit_any(args: list[str]) -> str {
-        return _fcall("any", args);
-    }
-
-    def emit_all(args: list[str]) -> str {
-        return _fcall("all", args);
-    }
-
-    def emit_isinstance(args: list[str]) -> str {
-        return _fcall("isinstance", args);
-    }
-
-    def emit_issubclass(args: list[str]) -> str {
-        return _fcall("issubclass", args);
-    }
-
-    def emit_type(args: list[str]) -> str {
-        return _fcall("type", args);
-    }
-
-    def emit_id(args: list[str]) -> str {
-        return _fcall("id", args);
-    }
-
-    def emit_hash(args: list[str]) -> str {
-        return _fcall("hash", args);
-    }
-
-    def emit_repr(args: list[str]) -> str {
-        return _fcall("repr", args);
-    }
-
-    def emit_chr(args: list[str]) -> str {
-        return _fcall("chr", args);
-    }
-
-    def emit_ord(args: list[str]) -> str {
-        return _fcall("ord", args);
-    }
-
-    def emit_hex(args: list[str]) -> str {
-        return _fcall("hex", args);
-    }
-
-    def emit_oct(args: list[str]) -> str {
-        return _fcall("oct", args);
-    }
-
-    def emit_bin(args: list[str]) -> str {
-        return _fcall("bin", args);
-    }
-
-    def emit_pow(args: list[str]) -> str {
-        return _fcall("pow", args);
-    }
-
-    def emit_divmod(args: list[str]) -> str {
-        return _fcall("divmod", args);
-    }
-
-    def emit_iter(args: list[str]) -> str {
-        return _fcall("iter", args);
-    }
-
-    def emit_next(args: list[str]) -> str {
-        return _fcall("next", args);
-    }
-
-    def emit_callable(args: list[str]) -> str {
-        return _fcall("callable", args);
-    }
-
-    def emit_getattr(args: list[str]) -> str {
-        return _fcall("getattr", args);
-    }
-
-    def emit_setattr(args: list[str]) -> str {
-        return _fcall("setattr", args);
-    }
-
-    def emit_hasattr(args: list[str]) -> str {
-        return _fcall("hasattr", args);
-    }
-
-    def emit_delattr(args: list[str]) -> str {
-        return _fcall("delattr", args);
-    }
-
-    def emit_vars(args: list[str]) -> str {
-        return _fcall("vars", args);
-    }
-
-    def emit_dir(args: list[str]) -> str {
-        return _fcall("dir", args);
-    }
-
-    def emit_open(args: list[str]) -> str {
-        return _fcall("open", args);
-    }
-
-    def emit_format(args: list[str]) -> str {
-        return _fcall("format", args);
-    }
-
-    def emit_ascii(args: list[str]) -> str {
-        return _fcall("ascii", args);
-    }
-
+    static def emit_print(args: list[str]) -> str;
+    static def emit_input(args: list[str]) -> str;
+    static def emit_len(args: list[str]) -> str;
+    static def emit_abs(args: list[str]) -> str;
+    static def emit_round(args: list[str]) -> str;
+    static def emit_min(args: list[str]) -> str;
+    static def emit_max(args: list[str]) -> str;
+    static def emit_sum(args: list[str]) -> str;
+    static def emit_sorted(args: list[str]) -> str;
+    static def emit_reversed(args: list[str]) -> str;
+    static def emit_enumerate(args: list[str]) -> str;
+    static def emit_zip(args: list[str]) -> str;
+    static def emit_map(args: list[str]) -> str;
+    static def emit_filter(args: list[str]) -> str;
+    static def emit_any(args: list[str]) -> str;
+    static def emit_all(args: list[str]) -> str;
+    static def emit_isinstance(args: list[str]) -> str;
+    static def emit_issubclass(args: list[str]) -> str;
+    static def emit_type(args: list[str]) -> str;
+    static def emit_id(args: list[str]) -> str;
+    static def emit_hash(args: list[str]) -> str;
+    static def emit_repr(args: list[str]) -> str;
+    static def emit_chr(args: list[str]) -> str;
+    static def emit_ord(args: list[str]) -> str;
+    static def emit_hex(args: list[str]) -> str;
+    static def emit_oct(args: list[str]) -> str;
+    static def emit_bin(args: list[str]) -> str;
+    static def emit_pow(args: list[str]) -> str;
+    static def emit_divmod(args: list[str]) -> str;
+    static def emit_iter(args: list[str]) -> str;
+    static def emit_next(args: list[str]) -> str;
+    static def emit_callable(args: list[str]) -> str;
+    static def emit_getattr(args: list[str]) -> str;
+    static def emit_setattr(args: list[str]) -> str;
+    static def emit_hasattr(args: list[str]) -> str;
+    static def emit_delattr(args: list[str]) -> str;
+    static def emit_vars(args: list[str]) -> str;
+    static def emit_dir(args: list[str]) -> str;
+    static def emit_open(args: list[str]) -> str;
+    static def emit_format(args: list[str]) -> str;
+    static def emit_ascii(args: list[str]) -> str;
     # Type conversion builtins
-    def emit_str(args: list[str]) -> str {
-        return _fcall("str", args);
-    }
-
-    def emit_int(args: list[str]) -> str {
-        return _fcall("int", args);
-    }
-
-    def emit_float(args: list[str]) -> str {
-        return _fcall("float", args);
-    }
-
-    def emit_bool(args: list[str]) -> str {
-        return _fcall("bool", args);
-    }
-
-    def emit_list(args: list[str]) -> str {
-        return _fcall("list", args);
-    }
-
-    def emit_dict(args: list[str]) -> str {
-        return _fcall("dict", args);
-    }
-
-    def emit_set(args: list[str]) -> str {
-        return _fcall("set", args);
-    }
-
-    def emit_tuple(args: list[str]) -> str {
-        return _fcall("tuple", args);
-    }
-
-    def emit_frozenset(args: list[str]) -> str {
-        return _fcall("frozenset", args);
-    }
-
-    def emit_bytes(args: list[str]) -> str {
-        return _fcall("bytes", args);
-    }
-
-    def emit_complex(args: list[str]) -> str {
-        return _fcall("complex", args);
-    }
+    static def emit_str(args: list[str]) -> str;
+    static def emit_int(args: list[str]) -> str;
+    static def emit_float(args: list[str]) -> str;
+    static def emit_bool(args: list[str]) -> str;
+    static def emit_list(args: list[str]) -> str;
+    static def emit_dict(args: list[str]) -> str;
+    static def emit_set(args: list[str]) -> str;
+    static def emit_tuple(args: list[str]) -> str;
+    static def emit_frozenset(args: list[str]) -> str;
+    static def emit_bytes(args: list[str]) -> str;
+    static def emit_complex(args: list[str]) -> str;
 }

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -82,138 +82,46 @@ glob plugin_manager = plugin.PluginManager('jac'),
 """Jac Access Validation Specs."""
 class JacAccessValidation {
     """Resolve the live anchor for an archetype from runtime memory."""
-    static def _resolve_anchor(archetype: Archetype) -> tuple {
-        anchor = archetype.__jac__;
-        jctx = JacRuntimeInterface.get_context();
-        mem_anchor = jctx.mem.get(anchor.id);
-        if (mem_anchor and (mem_anchor is not anchor)) {
-            anchor = mem_anchor;
-        }
-        return (anchor, jctx);
-    }
+    static def _resolve_anchor(archetype: Archetype) -> tuple;
 
     """Check if current root has at least min_level access to target anchor."""
     static def _check_access(
         `to: Anchor, min_level: AccessLevel, operation: str
-    ) -> bool {
-        access_level = JacRuntimeInterface.check_access_level(`to) > min_level;
-        if not access_level {
-            logger.info(
-                "Current root doesn't have " + operation + " access to " + `to.__class__.__name__ + " " + `to.archetype.__class__.__name__ + "[" + str(
-                    `to.id
-                ) + "]"
-            );
-        }
-        return access_level;
-    }
+    ) -> bool;
 
     """Allow all access from target root graph to current Archetype."""
     static def allow_root(
         archetype: Archetype,
         root_id: UUID,
         level: (AccessLevel | int | str | None) = None
-    ) -> None {
-        if (level is None) {
-            level = AccessLevel.READ;
-        }
-        level = AccessLevel.cast(level);
-        (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
-        access = anchor.access.roots;
-        _root_id = str(root_id);
-        if (level != access.anchors.get(_root_id, AccessLevel.NO_ACCESS)) {
-            access.anchors[_root_id] = level;
-            jctx.mem.put(anchor);
-        }
-    }
+    ) -> None;
 
     """Disallow all access from target root graph to current Archetype."""
     static def disallow_root(
         archetype: Archetype,
         root_id: UUID,
         level: (AccessLevel | int | str | None) = None
-    ) -> None {
-        if (level is None) {
-            level = AccessLevel.READ;
-        }
-        level = AccessLevel.cast(level);
-        (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
-        access = anchor.access.roots;
-        access.anchors.pop(str(root_id), None);
-        jctx.mem.put(anchor);
-    }
+    ) -> None;
 
     """Allow everyone to access current Archetype."""
     static def perm_grant(
         archetype: Archetype, level: (AccessLevel | int | str | None) = None
-    ) -> None {
-        if (level is None) {
-            level = AccessLevel.READ;
-        }
-        level = AccessLevel.cast(level);
-        (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
-        if (level != anchor.access.all) {
-            anchor.access.all = level;
-            jctx.mem.put(anchor);
-        }
-    }
+    ) -> None;
 
     """Disallow others to access current Archetype."""
-    static def perm_revoke(archetype: Archetype) -> None {
-        (anchor, jctx) = JacAccessValidation._resolve_anchor(archetype);
-        if (anchor.access.all > AccessLevel.NO_ACCESS) {
-            anchor.access.all = AccessLevel.NO_ACCESS;
-            jctx.mem.put(anchor);
-        }
-    }
+    static def perm_revoke(archetype: Archetype) -> None;
 
     """Read Access Validation."""
-    static def check_read_access(`to: Anchor) -> bool {
-        return JacAccessValidation._check_access(`to, AccessLevel.NO_ACCESS, "read");
-    }
+    static def check_read_access(`to: Anchor) -> bool;
 
     """Connect Access Validation."""
-    static def check_connect_access(`to: Anchor) -> bool {
-        return JacAccessValidation._check_access(`to, AccessLevel.READ, "connect");
-    }
+    static def check_connect_access(`to: Anchor) -> bool;
 
     """Write Access Validation."""
-    static def check_write_access(`to: Anchor) -> bool {
-        return JacAccessValidation._check_access(`to, AccessLevel.CONNECT, "write");
-    }
+    static def check_write_access(`to: Anchor) -> bool;
 
     """Access validation."""
-    static def check_access_level(`to: Anchor, no_custom: bool = False) -> AccessLevel {
-        if (not `to.persistent or (`to.hash == 0)) {
-            return AccessLevel.WRITE;
-        }
-        jctx = JacRuntimeInterface.get_context();
-        jroot = jctx.user_root;
-        if ((jroot == jctx.system_root) or (jroot.id == `to.root) or (jroot == `to)) {
-            return AccessLevel.WRITE;
-        }
-        if (
-            not no_custom
-            and ((custom_level := `to.archetype.__jac_access__()) is not None)
-        ) {
-            return AccessLevel.cast(custom_level);
-        }
-        access_level = AccessLevel.NO_ACCESS;
-        if ((to_access := `to.access).all > AccessLevel.NO_ACCESS) {
-            access_level = to_access.all;
-        }
-        if (`to.root and isinstance((to_root := jctx.mem.get(`to.root)), Anchor)) {
-            if (to_root.access.all > access_level) {
-                access_level = to_root.access.all;
-            }
-            if ((level := to_root.access.roots.check(str(jroot.id))) is not None) {
-                access_level = level;
-            }
-        }
-        if ((level := to_access.roots.check(str(jroot.id))) is not None) {
-            access_level = level;
-        }
-        return access_level;
-    }
+    static def check_access_level(`to: Anchor, no_custom: bool = False) -> AccessLevel;
 }
 
 """Jac Node Operations."""
@@ -221,136 +129,28 @@ class JacNode {
     """Get edges connected to this node."""
     static def get_edges(
         origin: list[NodeArchetype], destination: ObjectSpatialDestination
-    ) -> list[EdgeArchetype] {
-        edges: OrderedDict[(EdgeAnchor, EdgeArchetype)] = OrderedDict();
-        for nd in origin {
-            nanch = nd.__jac__;
-            for anchor in nanch.edges {
-                if (
-                    (source := anchor.source)
-                    and (target := anchor.target)
-                    and destination.edge_filter(anchor.archetype)
-                    and source.archetype
-                    and target.archetype
-                ) {
-                    if (
-                        (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
-                        and (nanch == source)
-                        and destination.node_filter(target.archetype)
-                        and JacRuntimeInterface.check_read_access(target)
-                    ) {
-                        edges[anchor] = anchor.archetype;
-                    }
-                    if (
-                        (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
-                        and (nanch == target)
-                        and destination.node_filter(source.archetype)
-                        and JacRuntimeInterface.check_read_access(source)
-                    ) {
-                        edges[anchor] = anchor.archetype;
-                    }
-                }
-            }
-        }
-        return `list(edges.values());
-    }
+    ) -> list[EdgeArchetype];
 
     """Get edges connected to this node and the node."""
     static def get_edges_with_node(
         origin: list[NodeArchetype],
         destination: ObjectSpatialDestination,
         from_visit: bool = False
-    ) -> list[(EdgeArchetype | NodeArchetype)] {
-        loc: OrderedDict[((NodeAnchor | EdgeAnchor), (NodeArchetype | EdgeArchetype))] = OrderedDict();
-        for nd in origin {
-            nanch = nd.__jac__;
-            for anchor in nanch.edges {
-                if (
-                    (source := anchor.source)
-                    and (target := anchor.target)
-                    and destination.edge_filter(anchor.archetype)
-                    and source.archetype
-                    and target.archetype
-                ) {
-                    if (
-                        (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
-                        and (nanch == source)
-                        and destination.node_filter(target.archetype)
-                        and JacRuntimeInterface.check_read_access(target)
-                    ) {
-                        loc[anchor] = anchor.archetype;
-                        loc[target] = target.archetype;
-                    }
-                    if (
-                        (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
-                        and (nanch == target)
-                        and destination.node_filter(source.archetype)
-                        and JacRuntimeInterface.check_read_access(source)
-                    ) {
-                        loc[anchor] = anchor.archetype;
-                        loc[source] = source.archetype;
-                    }
-                }
-            }
-        }
-        return `list(loc.values());
-    }
+    ) -> list[(EdgeArchetype | NodeArchetype)];
 
     """Get set of nodes connected to this node."""
     static def edges_to_nodes(
         origin: list[NodeArchetype], destination: ObjectSpatialDestination
-    ) -> list[NodeArchetype] {
-        nodes: OrderedDict[(NodeAnchor, NodeArchetype)] = OrderedDict();
-        for nd in origin {
-            nanch = nd.__jac__;
-            for anchor in nanch.edges {
-                if (
-                    (source := anchor.source)
-                    and (target := anchor.target)
-                    and destination.edge_filter(anchor.archetype)
-                    and source.archetype
-                    and target.archetype
-                ) {
-                    if (
-                        (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
-                        and (nanch == source)
-                        and destination.node_filter(target.archetype)
-                        and JacRuntimeInterface.check_read_access(target)
-                    ) {
-                        nodes[target] = target.archetype;
-                    }
-                    if (
-                        (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
-                        and (nanch == target)
-                        and destination.node_filter(source.archetype)
-                        and JacRuntimeInterface.check_read_access(source)
-                    ) {
-                        nodes[source] = source.archetype;
-                    }
-                }
-            }
-        }
-        return `list(nodes.values());
-    }
+    ) -> list[NodeArchetype];
 
     """Remove reference without checking sync status."""
-    static def remove_edge(nd: NodeAnchor, `edge: EdgeAnchor) -> None {
-        for (idx, ed) in enumerate(nd.edges) {
-            if (ed.id == `edge.id) {
-                nd.edges.pop(idx);
-                break;
-            }
-        }
-    }
+    static def remove_edge(nd: NodeAnchor, `edge: EdgeAnchor) -> None;
 }
 
 """Jac Edge Operations."""
 class JacEdge {
     """Detach edge from nodes."""
-    static def detach(`edge: EdgeAnchor) -> None {
-        JacRuntimeInterface.remove_edge(nd=`edge.source, `edge=`edge);
-        JacRuntimeInterface.remove_edge(nd=`edge.target, `edge=`edge);
-    }
+    static def detach(`edge: EdgeAnchor) -> None;
 }
 
 """Jac Edge Operations."""
@@ -365,38 +165,7 @@ class JacWalker {
                 ] | list[NodeArchetype] | list[EdgeArchetype] | NodeArchetype | EdgeArchetype | ObjectSpatialPath
             ),
         insert_loc: int = -1
-    ) -> bool {
-        if isinstance(expr, ObjectSpatialPath) {
-            expr.from_visit = True;
-            expr = JacRuntimeInterface.refs(expr);
-        }
-        if isinstance(`walker, WalkerArchetype) {
-            'Walker visits node.';
-            wanch = `walker.__jac__;
-            before_len = len(wanch.next);
-            next = [];
-            for anchor in (i.__jac__ for i in expr)
-                if isinstance(expr, `list)
-                else [expr.__jac__] {
-                if (anchor not in wanch.ignores) {
-                    if isinstance(anchor, (NodeAnchor, EdgeAnchor)) {
-                        next.append(anchor);
-                    } else {
-                        raise ValueError('Anchor should be NodeAnchor or EdgeAnchor.');
-                    }
-                }
-            }
-            if (insert_loc < -len(wanch.next)) {
-                insert_loc = 0;
-            } elif (insert_loc < 0) {
-                insert_loc += len(wanch.next) + 1;
-            }
-            wanch.next = wanch.next[:insert_loc] + next + wanch.next[insert_loc:];
-            return (len(wanch.next) > before_len);
-        } else {
-            raise TypeError('Invalid walker object');
-        }
-    }
+    ) -> bool;
 
     """Execute all entry abilities for current location.
 
@@ -406,45 +175,7 @@ class JacWalker {
         warch: WalkerArchetype,
         `walker: WalkerAnchor,
         current_loc: (NodeArchetype | EdgeArchetype)
-    ) -> bool {
-        import from jaclang.runtimelib.utils { all_issubclass }
-        for i in warch._jac_entry_funcs_ {
-            if (
-                i.trigger
-                and (
-                    all_issubclass(i.trigger, NodeArchetype)
-                    or all_issubclass(i.trigger, EdgeArchetype)
-                )
-                and isinstance(current_loc, i.trigger)
-            ) {
-                i.func(warch, current_loc);
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in current_loc._jac_entry_funcs_ {
-            if not i.trigger {
-                i.func(current_loc, warch);
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in current_loc._jac_entry_funcs_ {
-            if (
-                i.trigger
-                and all_issubclass(i.trigger, WalkerArchetype)
-                and isinstance(warch, i.trigger)
-            ) {
-                i.func(current_loc, warch);
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        return True;
-    }
+    ) -> bool;
 
     """Execute all exit abilities for current location.
 
@@ -454,45 +185,7 @@ class JacWalker {
         warch: WalkerArchetype,
         `walker: WalkerAnchor,
         current_loc: (NodeArchetype | EdgeArchetype)
-    ) -> bool {
-        import from jaclang.runtimelib.utils { all_issubclass }
-        for i in current_loc._jac_exit_funcs_ {
-            if (
-                i.trigger
-                and all_issubclass(i.trigger, WalkerArchetype)
-                and isinstance(warch, i.trigger)
-            ) {
-                i.func(current_loc, warch);
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in current_loc._jac_exit_funcs_ {
-            if not i.trigger {
-                i.func(current_loc, warch);
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in warch._jac_exit_funcs_ {
-            if (
-                i.trigger
-                and (
-                    all_issubclass(i.trigger, NodeArchetype)
-                    or all_issubclass(i.trigger, EdgeArchetype)
-                )
-                and isinstance(current_loc, i.trigger)
-            ) {
-                i.func(warch, current_loc);
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        return True;
-    }
+    ) -> bool;
 
     """Recursively visit a node with DFS semantics.
 
@@ -506,26 +199,7 @@ class JacWalker {
         warch: WalkerArchetype,
         `walker: WalkerAnchor,
         anchor: (NodeAnchor | EdgeAnchor)
-    ) -> bool {
-        current_loc = anchor.archetype;
-        if not current_loc {
-            return True;
-        }
-        `walker.path.append(anchor);
-        if not JacWalker._execute_entries(warch, `walker, current_loc) {
-            return False;
-        }
-        while `walker.next {
-            child_anchor = `walker.next.pop(0);
-            if (
-                (child_anchor not in `walker.ignores)
-                and not JacWalker._visit_node_recursive(warch, `walker, child_anchor)
-            ) {
-                return False;
-            }
-        }
-        return JacWalker._execute_exits(warch, `walker, current_loc);
-    }
+    ) -> bool;
 
     """Jac's spawn operator feature with recursive DFS semantics.
 
@@ -534,67 +208,7 @@ class JacWalker {
         """
     static def spawn_call(
         `walker: WalkerAnchor, nd: (NodeAnchor | EdgeAnchor)
-    ) -> WalkerArchetype {
-        import from jaclang.runtimelib.context { CallState }
-        warch = `walker.archetype;
-        `walker.path = [];
-        current_loc = nd.archetype;
-        ctx = JacRuntimeInterface.get_context();
-        call_state = ctx.call_state.get(None);
-        owns_call_state = False;
-        if not call_state {
-            call_token = ctx.call_state.set(CallState());
-            call_state = ctx.call_state.get();
-            owns_call_state = True;
-        }
-        try {
-            for i in warch._jac_entry_funcs_ {
-                if not i.trigger {
-                    i.func(warch, current_loc);
-                }
-                if `walker.disengaged {
-                    `walker.ignores = [];
-                    return warch;
-                }
-            }
-            while `walker.next {
-                next_anchor = `walker.next.pop(0);
-                if (
-                    (next_anchor not in `walker.ignores)
-                    and not JacWalker._visit_node_recursive(
-                        warch, `walker, next_anchor
-                    )
-                ) {
-                    break;
-                }
-            }
-            if `walker.path {
-                current_loc = `walker.path[-1].archetype;
-            }
-            for i in warch._jac_exit_funcs_ {
-                if not i.trigger {
-                    i.func(warch, current_loc);
-                }
-                if `walker.disengaged {
-                    break;
-                }
-            }
-            `walker.ignores = [];
-            return warch;
-        } finally {
-            if owns_call_state {
-                reports = [];
-                while not call_state.reports.empty() {
-                    item = call_state.reports.get_nowait();
-                    if item is not call_state._sentinel {
-                        reports.append(item);
-                    }
-                }
-                warch.reports = reports;
-                ctx.call_state.reset(call_token);
-            }
-        }
-    }
+    ) -> WalkerArchetype;
 
     """Async version: Execute all entry abilities for current location.
 
@@ -604,54 +218,7 @@ class JacWalker {
         warch: WalkerArchetype,
         `walker: WalkerAnchor,
         current_loc: (NodeArchetype | EdgeArchetype)
-    ) -> bool {
-        import from jaclang.runtimelib.utils { all_issubclass }
-        for i in warch._jac_entry_funcs_ {
-            if (
-                i.trigger
-                and (
-                    all_issubclass(i.trigger, NodeArchetype)
-                    or all_issubclass(i.trigger, EdgeArchetype)
-                )
-                and isinstance(current_loc, i.trigger)
-            ) {
-                result = i.func(warch, current_loc);
-                if isinstance(result, Coroutine) {
-                    await result;
-                }
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in current_loc._jac_entry_funcs_ {
-            if not i.trigger {
-                result = i.func(current_loc, warch);
-                if isinstance(result, Coroutine) {
-                    await result;
-                }
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in current_loc._jac_entry_funcs_ {
-            if (
-                i.trigger
-                and all_issubclass(i.trigger, WalkerArchetype)
-                and isinstance(warch, i.trigger)
-            ) {
-                result = i.func(current_loc, warch);
-                if isinstance(result, Coroutine) {
-                    await result;
-                }
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        return True;
-    }
+    ) -> bool;
 
     """Async version: Execute all exit abilities for current location.
 
@@ -661,54 +228,7 @@ class JacWalker {
         warch: WalkerArchetype,
         `walker: WalkerAnchor,
         current_loc: (NodeArchetype | EdgeArchetype)
-    ) -> bool {
-        import from jaclang.runtimelib.utils { all_issubclass }
-        for i in current_loc._jac_exit_funcs_ {
-            if (
-                i.trigger
-                and all_issubclass(i.trigger, WalkerArchetype)
-                and isinstance(warch, i.trigger)
-            ) {
-                result = i.func(current_loc, warch);
-                if isinstance(result, Coroutine) {
-                    await result;
-                }
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in current_loc._jac_exit_funcs_ {
-            if not i.trigger {
-                result = i.func(current_loc, warch);
-                if isinstance(result, Coroutine) {
-                    await result;
-                }
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        for i in warch._jac_exit_funcs_ {
-            if (
-                i.trigger
-                and (
-                    all_issubclass(i.trigger, NodeArchetype)
-                    or all_issubclass(i.trigger, EdgeArchetype)
-                )
-                and isinstance(current_loc, i.trigger)
-            ) {
-                result = i.func(warch, current_loc);
-                if isinstance(result, Coroutine) {
-                    await result;
-                }
-            }
-            if `walker.disengaged {
-                return False;
-            }
-        }
-        return True;
-    }
+    ) -> bool;
 
     """Async version: Recursively visit a node with DFS semantics.
 
@@ -722,28 +242,7 @@ class JacWalker {
         warch: WalkerArchetype,
         `walker: WalkerAnchor,
         anchor: (NodeAnchor | EdgeAnchor)
-    ) -> bool {
-        current_loc = anchor.archetype;
-        if not current_loc {
-            return True;
-        }
-        `walker.path.append(anchor);
-        if not await JacWalker._async_execute_entries(warch, `walker, current_loc) {
-            return False;
-        }
-        while `walker.next {
-            child_anchor = `walker.next.pop(0);
-            if (
-                (child_anchor not in `walker.ignores)
-                and not await JacWalker._async_visit_node_recursive(
-                    warch, `walker, child_anchor
-                )
-            ) {
-                return False;
-            }
-        }
-        return await JacWalker._async_execute_exits(warch, `walker, current_loc);
-    }
+    ) -> bool;
 
     """Jac's async spawn operator feature with recursive DFS semantics.
 
@@ -752,132 +251,15 @@ class JacWalker {
         """
     static async def async_spawn_call(
         `walker: WalkerAnchor, nd: (NodeAnchor | EdgeAnchor)
-    ) -> WalkerArchetype {
-        import from jaclang.runtimelib.context { CallState }
-        warch = `walker.archetype;
-        `walker.path = [];
-        current_loc = nd.archetype;
-        ctx = JacRuntimeInterface.get_context();
-        call_state = ctx.call_state.get(None);
-        owns_call_state = False;
-        if not call_state {
-            call_token = ctx.call_state.set(CallState());
-            call_state = ctx.call_state.get();
-            owns_call_state = True;
-        }
-        try {
-            for i in warch._jac_entry_funcs_ {
-                if not i.trigger {
-                    result = i.func(warch, current_loc);
-                    if isinstance(result, Coroutine) {
-                        await result;
-                    }
-                }
-                if `walker.disengaged {
-                    `walker.ignores = [];
-                    return warch;
-                }
-            }
-            while `walker.next {
-                next_anchor = `walker.next.pop(0);
-                if (
-                    (next_anchor not in `walker.ignores)
-                    and not await JacWalker._async_visit_node_recursive(
-                        warch, `walker, next_anchor
-                    )
-                ) {
-                    break;
-                }
-            }
-            if `walker.path {
-                current_loc = `walker.path[-1].archetype;
-            }
-            for i in warch._jac_exit_funcs_ {
-                if not i.trigger {
-                    result = i.func(warch, current_loc);
-                    if isinstance(result, Coroutine) {
-                        await result;
-                    }
-                }
-                if `walker.disengaged {
-                    break;
-                }
-            }
-            `walker.ignores = [];
-            return warch;
-        } finally {
-            if owns_call_state {
-                reports = [];
-                while not call_state.reports.empty() {
-                    item = call_state.reports.get_nowait();
-                    if item is not call_state._sentinel {
-                        reports.append(item);
-                    }
-                }
-                warch.reports = reports;
-                ctx.call_state.reset(call_token);
-            }
-        }
-    }
+    ) -> WalkerArchetype;
 
     """Jac's spawn operator feature."""
     static def `spawn(
         op1: (Archetype | list[Archetype]), op2: (Archetype | list[Archetype])
-    ) -> (WalkerArchetype | Coroutine) {
-        def collect_targets(
-            `walker: WalkerAnchor, items: list[Archetype]
-        ) -> (NodeAnchor | EdgeAnchor) {
-            for i in items {
-                a = i.__jac__;
-                `walker.next.append(a)
-                    if isinstance(a, (NodeAnchor, EdgeAnchor))
-                    else None;
-                if (isinstance(a, EdgeAnchor) and a.target) {
-                    `walker.next.append(a.target);
-                }
-            }
-            return `walker.next[0];
-        }
-        def assign(
-            `walker: WalkerAnchor, t: (Archetype | list[Archetype])
-        ) -> (NodeAnchor | EdgeAnchor) {
-            if isinstance(t, NodeArchetype) {
-                nd = t.__jac__;
-                `walker.next = [nd];
-                return nd;
-            } elif isinstance(t, EdgeArchetype) {
-                `edge = t.__jac__;
-                `walker.next = [`edge, `edge.target];
-                return `edge;
-            } elif (
-                isinstance(t, `list)
-                and all(isinstance(i, (NodeArchetype, EdgeArchetype)) for i in t)
-            ) {
-                return collect_targets(`walker, t);
-            } else {
-                raise TypeError('Invalid target object');
-            }
-        }
-        if isinstance(op1, WalkerArchetype) {
-            (warch, targ) = (op1, op2);
-        } elif isinstance(op2, WalkerArchetype) {
-            (warch, targ) = (op2, op1);
-        } else {
-            raise TypeError('Invalid walker object');
-        }
-        `walker: WalkerAnchor = warch.__jac__;
-        loc: (NodeAnchor | EdgeAnchor) = assign(`walker, targ);
-        if warch.__jac_async__ {
-            return JacRuntimeInterface.async_spawn_call(`walker=`walker, nd=loc);
-        }
-        return JacRuntimeInterface.spawn_call(`walker=`walker, nd=loc);
-    }
+    ) -> (WalkerArchetype | Coroutine);
 
     """Jac's disengage stmt feature."""
-    static def `disengage(`walker: WalkerArchetype) -> bool {
-        `walker.__jac__.disengaged = True;
-        return True;
-    }
+    static def `disengage(`walker: WalkerArchetype) -> bool;
 }
 
 """Default Classes References - direct class attributes (no lazy loading)."""
@@ -909,251 +291,42 @@ class JacBuiltin {
         node_limit: int,
         file: (str | None),
         format: str
-    ) -> str {
-        import from jaclang.runtimelib.utils { traverse_graph }
-        edge_type = edge_type or [];
-        visited_nodes: list[NodeArchetype] = [];
-        node_depths: dict[(NodeArchetype, int)] = {nd: 0};
-        queue: list = [[nd, 0]];
-        connections: list[tuple[(NodeArchetype, NodeArchetype, EdgeArchetype)]] = [];
-        """Depth first search.""";
-        def dfs(nd: NodeArchetype, cur_depth: int) -> None {
-            if (nd not in visited_nodes) {
-                visited_nodes.append(nd);
-                traverse_graph(
-                    nd,
-                    cur_depth,
-                    depth,
-                    edge_type,
-                    traverse,
-                    connections,
-                    node_depths,
-                    visited_nodes,
-                    queue,
-                    bfs,
-                    dfs,
-                    node_limit,
-                    edge_limit
-                );
-            }
-        }
-        if bfs {
-            cur_depth = 0;
-            while queue {
-                (current_node, cur_depth) = queue.pop(0);
-                if (current_node not in visited_nodes) {
-                    visited_nodes.append(current_node);
-                    traverse_graph(
-                        current_node,
-                        cur_depth,
-                        depth,
-                        edge_type,
-                        traverse,
-                        connections,
-                        node_depths,
-                        visited_nodes,
-                        queue,
-                        bfs,
-                        dfs,
-                        node_limit,
-                        edge_limit
-                    );
-                }
-            }
-        } else {
-            dfs(nd, cur_depth=0);
-        }
-        dot_content = 'digraph {\nnode [style="filled", shape="ellipse", fillcolor="invis", fontcolor="black"];\n';
-        mermaid_content = 'flowchart LR\n';
-        for (source, target, `edge) in connections {
-            edge_label = html.escape(str(`edge.__jac__.archetype));
-            dot_content += (
-                f"{visited_nodes.index(source)} -> {visited_nodes.index(target)} " + f' [label="{edge_label
-                    if "GenericEdge" not in edge_label
-                    else ""}"];\n'
-            );
-            if (('GenericEdge' in edge_label) or not edge_label.strip()) {
-                mermaid_content += (
-                    f"{visited_nodes.index(source)} -->{visited_nodes.index(target)}\n"
-                );
-            } else {
-                mermaid_content += (
-                    f'{visited_nodes.index(source)} -->|"{edge_label}"| {visited_nodes.index(
-                        target
-                    )}\n'
-                );
-            }
-        }
-        for node_ in visited_nodes {
-            color = colors[node_depths[node_]]
-                if (node_depths[node_] < 25)
-                else colors[24];
-            label = html.escape(str(node_.__jac__.archetype));
-            dot_content += (
-                f'{visited_nodes.index(node_)} [label="{label}"fillcolor="{color}"];\n'
-            );
-            mermaid_content += f'{visited_nodes.index(node_)}["{label}"]\n';
-        }
-        output = (dot_content + '}') if (format == 'dot') else mermaid_content;
-        if file {
-            with open(file, 'w') as f {
-                f.write(output);
-            }
-        }
-        return output;
-    }
+    ) -> str;
 }
 
 """Jac CLI command."""
 class JacCmd {
     """Create Jac CLI cmds."""
-    static def create_cmd -> None { }
+    static def create_cmd -> None;
 }
 
 """Jac Feature."""
 class JacBasics {
     """Set Class References."""
-    static def setup -> None { }
+    static def setup -> None;
 
     """Get current execution context."""
-    static def get_context -> ExecutionContext {
-        if (JacRuntime.exec_ctx is None) {
-            JacRuntime.exec_ctx = JacRuntimeInterface.create_j_context(user_root=None);
-        }
-        return JacRuntime.exec_ctx;
-    }
+    static def get_context -> ExecutionContext;
 
     """Commit all data from memory to datasource."""
-    static def commit(anchor: Anchor | Archetype | None = None) -> None {
-        if isinstance(anchor, Archetype) {
-            anchor = anchor.__jac__;
-        }
-        ctx = JacRuntimeInterface.get_context();
-        ctx.mem.commit(anchor);
-    }
+    static def commit(anchor: Anchor | Archetype | None = None) -> None;
 
     """Purge current or target graph."""
-    static def reset_graph(`root: (Root | None) = None) -> int {
-        import pickle;
-        import sqlite3;
-        ctx = JacRuntimeInterface.get_context();
-        mem = ctx.mem;
-        ranchor = `root.__jac__ if `root else ctx.user_root;
-        deleted_count = 0;
-        deleted_ids: set[UUID] = `set();
-        persistence = mem.l3;
-        conn = getattr(persistence, '__conn__', None) if persistence else None;
-        if (conn and isinstance(conn, sqlite3.Connection)) {
-            cursor = conn.execute('SELECT data FROM anchors');
-            anchors = [pickle.loads(row[0]) for row in cursor.fetchall()];
-        } else {
-            anchors = `list(mem.get_mem().values());
-        }
-        for anchor in anchors {
-            if ((anchor == ranchor) or (anchor.root != ranchor.id)) {
-                continue;
-            }
-            deleted_ids.add(anchor.id);
-            mem.delete(anchor.id);
-            deleted_count += 1;
-        }
-        ranchor.edges = [
-            e
-            for e in ranchor.edges
-            if (e.id not in deleted_ids)
-        ];
-        mem.commit(ranchor);
-        return deleted_count;
-    }
+    static def reset_graph(`root: (Root | None) = None) -> int;
 
     """Get object given id."""
-    static def get_object(id: str) -> (Archetype | None) {
-        if (id == 'root') {
-            return JacRuntimeInterface.get_context().user_root.archetype;
-        } elif (`obj := JacRuntimeInterface.get_context().mem.get(UUID(id))) {
-            return `obj.archetype;
-        }
-        return None;
-    }
+    static def get_object(id: str) -> (Archetype | None);
 
     """Get object reference id."""
-    static def object_ref(`obj: Archetype) -> str {
-        return `obj.__jac__.id.hex;
-    }
+    static def object_ref(`obj: Archetype) -> str;
 
     """Create a obj archetype."""
-    static def make_archetype(cls: type[Archetype]) -> type[Archetype] {
-        entries: OrderedDict[(str, ObjectSpatialFunction)] = OrderedDict(
-            (fn.name, fn) for fn in cls._jac_entry_funcs_
-        );
-        exits: OrderedDict[(str, ObjectSpatialFunction)] = OrderedDict(
-            (fn.name, fn) for fn in cls._jac_exit_funcs_
-        );
-        for func in cls.__dict__.values() {
-            if callable(func) {
-                if func?.__jac_entry {
-                    entries[func.__name__] = JacRuntimeInterface.DSFunc(
-                        func.__name__, func
-                    );
-                }
-                if func?.__jac_exit {
-                    exits[func.__name__] = JacRuntimeInterface.DSFunc(
-                        func.__name__, func
-                    );
-                }
-            }
-        }
-        cls._jac_entry_funcs_ = [*entries.values()];
-        cls._jac_exit_funcs_ = [*exits.values()];
-        if issubclass(cls, WalkerArchetype)
-        and 'reports' not in cls.__dict__.get('__annotations__', {}) {
-            if not hasattr(cls, '__annotations__') {
-                cls.__annotations__ = {};
-            }
-            cls.__annotations__['reports'] = list;
-            cls.reports = dataclasses.field(
-                default_factory=`list, init=False, repr=False, compare=False
-            );
-        }
-        dataclass(eq=False)(cls);
-        return cls;
-    }
+    static def make_archetype(cls: type[Archetype]) -> type[Archetype];
 
     """Update impl file location."""
     static def impl_patch_filename(
         file_loc: str
-    ) -> Callable[([Callable[(P, T)]], Callable[(P, T)])] {
-        def decorator(func: Callable[(P, T)]) -> Callable[(P, T)] {
-            try {
-                code = func.__code__;
-                new_code = types.CodeType(
-                    code.co_argcount,
-                    code.co_posonlyargcount,
-                    code.co_kwonlyargcount,
-                    code.co_nlocals,
-                    code.co_stacksize,
-                    code.co_flags,
-                    code.co_code,
-                    code.co_consts,
-                    code.co_names,
-                    code.co_varnames,
-                    file_loc,
-                    code.co_name,
-                    code.co_qualname,
-                    code.co_firstlineno,
-                    code.co_linetable,
-                    code.co_exceptiontable,
-                    code.co_freevars,
-                    code.co_cellvars
-                );
-                func.__code__ = new_code;
-            } except AttributeError {
-                ;
-            }
-            return func;
-        }
-        return decorator;
-    }
+    ) -> Callable[([Callable[(P, T)]], Callable[(P, T)])];
 
     """Import a Jac or Python module using Python's standard import machinery.
 
@@ -1193,136 +366,10 @@ system,
         items: (dict[(str, str | str | None)] | None) = None,
         reload_module: (bool | None) = False,
         lng: (str | None) = None
-    ) -> tuple[(types.ModuleType, ...)] {
-        import importlib;
-        import importlib.util;
-        if (lng is None) {
-            lng = infer_language(target, base_path);
-        }
-        _ = JacRuntime.get_program();
-        if target.startswith('.') {
-            caller_dir = base_path
-                if os.path.isdir(base_path)
-                else os.path.dirname(base_path);
-            chomp_target = target;
-            while chomp_target.startswith('.') {
-                if ((len(chomp_target) > 1) and (chomp_target[1] == '.')) {
-                    caller_dir = os.path.dirname(caller_dir);
-                    chomp_target = chomp_target[1:];
-                } else {
-                    chomp_target = chomp_target[1:];
-                    break;
-                }
-            }
-            module_name = chomp_target;
-        } else {
-            module_name = target;
-        }
-        caller_dir = base_path
-            if os.path.isdir(base_path)
-            else os.path.dirname(base_path);
-        original_path = None;
-        if (caller_dir and (caller_dir not in sys.path)) {
-            original_path = sys.path.copy();
-            sys.path.insert(0, caller_dir);
-        }
-        try {
-            if (override_name == '__main__') {
-                import from jaclang.meta_importer { JacMetaImporter }
-                finder = JacMetaImporter();
-                spec = finder.find_spec(module_name, None);
-                if (
-                    spec
-                    and spec.origin
-                    and spec.origin.endswith('.jac')
-                    and (lng == 'py')
-                ) {
-                    spec = None;
-                }
-                if ((not spec or not spec.origin) and (lng == 'py')) {
-                    file_path = os.path.join(caller_dir, f"{module_name}.py");
-                    if os.path.isfile(file_path) {
-                        spec_name = '__main__'
-                            if (override_name == '__main__')
-                            else module_name;
-                        spec = importlib.util.spec_from_file_location(
-                            spec_name, file_path
-                        );
-                    }
-                }
-                if (not spec or not spec.origin) {
-                    raise ImportError(f"Cannot find module {module_name}");
-                }
-                if (('__main__' in sys.modules) and not reload_module) {
-                    module = sys.modules['__main__'];
-                    to_keep = {
-                        k: v
-                        for (k, v) in module.__dict__.items()
-                        if k.startswith('__')
-                    };
-                    module.__dict__.update(to_keep);
-                } else {
-                    module = types.ModuleType('__main__');
-                    sys.modules['__main__'] = module;
-                }
-                module.__file__ = spec.origin;
-                module.__name__ = '__main__';
-                module.__spec__ = spec;
-                if spec.submodule_search_locations {
-                    module.__path__ = spec.submodule_search_locations;
-                }
-                JacRuntimeInterface.load_module('__main__', module);
-                if spec.loader {
-                    spec.loader.exec_module(module);
-                }
-            } elif (reload_module and (module_name in sys.modules)) {
-                module = importlib.reload(sys.modules[module_name]);
-                JacRuntimeInterface.load_module(module_name, module, force=True);
-            } else {
-                module = importlib.import_module(module_name);
-                if reload_module {
-                    JacRuntimeInterface.load_module(module_name, module, force=True);
-                }
-            }
-            if items {
-                imported_items = [];
-                for (item_name, _) in items.items() {
-                    if hasattr(module, item_name) {
-                        item = getattr(module, item_name);
-                        imported_items.append(item);
-                    } else {
-                        raise ImportError(
-                            f"Cannot import name '{item_name}' from '{module_name}'"
-                        );
-                    }
-                }
-                return `tuple(imported_items) if not absorb else (module, );
-            }
-            return (module, );
-        } finally {
-            if (original_path is not None) {
-                sys.path[:] = original_path;
-            }
-        }
-    }
+    ) -> tuple[(types.ModuleType, ...)];
 
     """Create a test."""
-    static def jac_test(description: str = "") -> Callable {
-        import from jaclang.runtimelib.test { JacTestCheck }
-        def decorator(test_fun: Callable) -> Callable {
-            file_path = getfile(test_fun);
-            func_name = test_fun.__name__;
-            def test_deco -> None {
-                test_fun(JacTestCheck());
-            }
-            test_deco.__name__ = test_fun.__name__;
-            JacTestCheck.add_test(
-                file_path, func_name, test_deco, display_name=description
-            );
-            return test_deco;
-        }
-        return decorator;
-    }
+    static def jac_test(description: str = "") -> Callable;
 
     """JSX interface for creating elements.
 
@@ -1338,11 +385,7 @@ system,
         tag: object,
         attributes: (Mapping[(str, object)] | None) = None,
         children: (Sequence[object] | None) = None
-    ) -> JsxElement {
-        `props: dict[(str, object)] = `dict(attributes) if attributes else {};
-        child_list = `list(children) if children else [];
-        return JsxElement(tag=tag, `props=`props, children=child_list);
-    }
+    ) -> JsxElement;
 
     """Run the test suite in the specified .jac file."""
     static def run_test(
@@ -1353,144 +396,32 @@ system,
         maxfail: (int | None) = None,
         directory: (str | None) = None,
         verbose: bool = False
-    ) -> int {
-        import from jaclang.runtimelib.test { JacTestCheck }
-        test_file = False;
-        ret_count = 0;
-        if filepath {
-            if filepath.endswith('.jac') {
-                (base, mod_name) = os.path.split(filepath);
-                base = base or './';
-                mod_name = mod_name[:-4];
-                if mod_name.endswith('.test') {
-                    mod_name = mod_name[:-5];
-                }
-                JacTestCheck.reset();
-                JacRuntimeInterface.jac_import(target=mod_name, base_path=base);
-                JacTestCheck.run_test(
-                    xit, maxfail, verbose, os.path.abspath(filepath), func_name
-                );
-                ret_count = JacTestCheck.failcount;
-            } else {
-                JacConsole.get_console().error('Not a .jac file.');
-            }
-        } else {
-            directory = directory or os.getcwd();
-        }
-        if (filter or directory) {
-            current_dir = directory or os.getcwd();
-            for (root_dir, _, files) in os.walk(current_dir, topdown=True) {
-                files = [
-                    file
-                    for file in files
-                    if fnmatch.fnmatch(file, filter)
-                ]
-                    if filter
-                    else files;
-                files = [
-                    file
-                    for file in files
-                    if not file.endswith(('.test.jac', '.impl.jac'))
-                ];
-                for file in files {
-                    if file.endswith('.jac') {
-                        test_file = True;
-                        JacConsole.get_console().info(
-                            f"\n\n\t\t* Inside {root_dir}/{file} *"
-                        );
-                        JacTestCheck.reset();
-                        JacRuntimeInterface.jac_import(
-                            target=file[:-4], base_path=root_dir
-                        );
-                        JacTestCheck.run_test(
-                            xit, maxfail, verbose, os.path.abspath(file), func_name
-                        );
-                    }
-                    if (JacTestCheck.breaker and (xit or maxfail)) {
-                        break;
-                    }
-                }
-                if (JacTestCheck.breaker and (xit or maxfail)) {
-                    break;
-                }
-            }
-            JacTestCheck.breaker = False;
-            ret_count += JacTestCheck.failcount;
-            JacTestCheck.failcount = 0;
-            if not test_file {
-                JacConsole.get_console().warning('No test files found.');
-            }
-        }
-        return ret_count;
-    }
+    ) -> int;
 
     """Jac's field handler."""
     static def field(
         factory: (Callable[([], T)] | None) = None, `init: bool = True
-    ) -> T {
-        if factory {
-            return field(default_factory=factory);
-        }
-        return field(`init=`init);
-    }
+    ) -> T;
 
     """Jac's report stmt feature."""
-    static def log_report(expr: Any, custom: bool = False) -> None {
-        ctx = JacRuntimeInterface.get_context();
-        if custom {
-            ctx.custom = expr;
-        } else {
-            JacConsole.get_console().print(expr);
-            call_state = ctx.call_state.get(None);
-            if call_state {
-                call_state.reports.put_nowait(expr);
-            }
-        }
-    }
+    static def log_report(expr: Any, custom: bool = False) -> None;
 
     """Jac's apply_dir stmt feature."""
     static def refs(
         path: ObjectSpatialPath | NodeArchetype | list[NodeArchetype]
     ) -> list[NodeArchetype] | list[EdgeArchetype] | list[
         (NodeArchetype | EdgeArchetype)
-    ] {
-        if not isinstance(path, ObjectSpatialPath) {
-            path = ObjectSpatialPath(path, [ObjectSpatialDestination(EdgeDir.OUT)]);
-        }
-        origin = path.origin;
-        destinations = path.destinations[:-1] if path.edge_only else path.destinations;
-        while destinations {
-            dest = path.destinations.pop(0);
-            origin = JacRuntimeInterface.edges_to_nodes(origin, dest);
-        }
-        if path.edge_only {
-            if path.from_visit {
-                return JacRuntimeInterface.get_edges_with_node(
-                    origin, path.destinations[-1]
-                );
-            }
-            return JacRuntimeInterface.get_edges(origin, path.destinations[-1]);
-        }
-        return origin;
-    }
+    ];
 
     """Jac's apply_dir stmt feature."""
     static async def arefs(
         path: ObjectSpatialPath | NodeArchetype | list[NodeArchetype]
-    ) -> None {
-        ;
-    }
+    ) -> None;
 
     """Jac's filter archetype list."""
     static def filter_on(
         items: list[Archetype], func: Callable[([Archetype], bool)]
-    ) -> list[Archetype] {
-        return [
-            item
-            for item in items
-            if func(item)
-        ];
-    }
+    ) -> list[Archetype];
 
     """Jac's connect operator feature."""
     static def connect(
@@ -1500,31 +431,7 @@ system,
         undir: bool = False,
         conn_assign: (tuple[(tuple, tuple)] | None) = None,
         edges_only: bool = False
-    ) -> (list[NodeArchetype] | list[EdgeArchetype]) {
-        left = [left] if isinstance(left, NodeArchetype) else left;
-        right = [right] if isinstance(right, NodeArchetype) else right;
-        edges = [];
-        for i in left {
-            _left = i.__jac__;
-            if JacRuntimeInterface.check_connect_access(_left) {
-                for j in right {
-                    _right = j.__jac__;
-                    if JacRuntimeInterface.check_connect_access(_right) {
-                        edges.append(
-                            JacRuntimeInterface.build_edge(
-                                is_undirected=undir,
-                                conn_type=`edge,
-                                conn_assign=conn_assign
-                            )(
-                                _left, _right
-                            )
-                        );
-                    }
-                }
-            }
-        }
-        return right if not edges_only else edges;
-    }
+    ) -> (list[NodeArchetype] | list[EdgeArchetype]);
 
     """Jac's disconnect operator feature."""
     static def disconnect(
@@ -1532,209 +439,51 @@ system,
         right: (NodeArchetype | list[NodeArchetype]),
         dir: EdgeDir = EdgeDir.OUT,
         filter: (Callable[([EdgeArchetype], bool)] | None) = None
-    ) -> bool {
-        disconnect_occurred = False;
-        left = [left] if isinstance(left, NodeArchetype) else left;
-        right = [right] if isinstance(right, NodeArchetype) else right;
-        for i in left {
-            nd = i.__jac__;
-            for anchor in `set(nd.edges) {
-                if (
-                    (source := anchor.source)
-                    and (target := anchor.target)
-                    and (not filter or filter(anchor.archetype))
-                    and source.archetype
-                    and target.archetype
-                ) {
-                    if (
-                        (dir in [EdgeDir.OUT, EdgeDir.ANY])
-                        and (nd == source)
-                        and (target.archetype in right)
-                        and JacRuntimeInterface.check_connect_access(target)
-                    ) {
-                        JacRuntimeInterface.destroy([anchor])
-                            if anchor.persistent
-                            else JacRuntimeInterface.detach(anchor);
-                        disconnect_occurred = True;
-                    }
-                    if (
-                        (dir in [EdgeDir.IN, EdgeDir.ANY])
-                        and (nd == target)
-                        and (source.archetype in right)
-                        and JacRuntimeInterface.check_connect_access(source)
-                    ) {
-                        JacRuntimeInterface.destroy([anchor])
-                            if anchor.persistent
-                            else JacRuntimeInterface.detach(anchor);
-                        disconnect_occurred = True;
-                    }
-                }
-            }
-        }
-        return disconnect_occurred;
-    }
+    ) -> bool;
 
     """Jac's assign comprehension feature."""
     static def assign_all(
         target: list[T], attr_val: tuple[(tuple[str], tuple[Any])]
-    ) -> list[T] {
-        for `obj in target {
-            (attrs, values) = attr_val;
-            for (attr, value) in zip(attrs, values, strict=False) {
-                setattr(`obj, attr, value);
-            }
-        }
-        return target;
-    }
+    ) -> list[T];
 
     """Jac's safe subscript feature."""
-    static def safe_subscript(`obj: Any, key: Any) -> Any {
-        try {
-            return `obj[key];
-        } except (KeyError, IndexError, TypeError) {
-            return None;
-        }
-    }
+    static def safe_subscript(`obj: Any, key: Any) -> Any;
 
     """Jac's root getter."""
-    static def `root -> Root {
-        return JacRuntime.get_context().get_root();
-    }
+    static def `root -> Root;
 
     """Get all the roots."""
-    static def get_all_root -> list[Root] {
-        jmem = JacRuntimeInterface.get_context().mem;
-        return `list(jmem.get_roots());
-    }
+    static def get_all_root -> list[Root];
 
     """Jac's root getter."""
     static def build_edge(
         is_undirected: bool,
         conn_type: type[EdgeArchetype] | EdgeArchetype | None,
         conn_assign: (tuple[(tuple, tuple)] | None)
-    ) -> Callable[([NodeAnchor, NodeAnchor], EdgeArchetype)] {
-        ct = conn_type or GenericEdge;
-        def builder(source: NodeAnchor, target: NodeAnchor) -> EdgeArchetype {
-            `edge = ct() if isinstance(ct, `type) else ct;
-            eanch = `edge.__jac__=EdgeAnchor(
-                archetype=`edge,
-                source=source,
-                target=target,
-                is_undirected=is_undirected
-            );
-            source.edges.append(eanch);
-            target.edges.append(eanch);
-            if conn_assign {
-                for (fld, val) in zip(conn_assign[0], conn_assign[1], strict=False) {
-                    if hasattr(`edge, fld) {
-                        setattr(`edge, fld, val);
-                    } else {
-                        raise ValueError(f"Invalid attribute: {fld}");
-                    }
-                }
-            }
-            if (source.persistent or target.persistent) {
-                JacRuntimeInterface.save(eanch);
-            }
-            return `edge;
-        }
-        return builder;
-    }
+    ) -> Callable[([NodeAnchor, NodeAnchor], EdgeArchetype)];
 
     """Destroy object."""
-    static def save(`obj: (Archetype | Anchor)) -> None {
-        anchor = `obj.__jac__ if isinstance(`obj, Archetype) else `obj;
-        jctx = JacRuntimeInterface.get_context();
-        if (not anchor.persistent and not anchor.root) {
-            anchor.persistent = True;
-            anchor.root = jctx.user_root.id;
-        }
-        jctx.mem.put(anchor);
-        match anchor {
-            case NodeAnchor():
-                for ed in anchor.edges {
-                    if (ed.is_populated() and not ed.persistent) {
-                        JacRuntimeInterface.save(ed);
-                    }
-                }
-
-            case EdgeAnchor():
-                if (
-                    (src := anchor.source)
-                    and src.is_populated()
-                    and not src.persistent
-                ) {
-                    JacRuntimeInterface.save(src);
-                }
-                if (
-                    (trg := anchor.target)
-                    and trg.is_populated()
-                    and not trg.persistent
-                ) {
-                    JacRuntimeInterface.save(trg);
-                }
-
-            case _:
-                ;
-
-        }
-    }
+    static def save(`obj: (Archetype | Anchor)) -> None;
 
     """Destroy multiple objects passed in a tuple or list."""
-    static def destroy(objs: Archetype | Anchor | list[(Archetype | Anchor)]) -> None {
-        obj_list = objs if isinstance(objs, `list) else [objs];
-        for `obj in obj_list {
-            if not isinstance(`obj, (Archetype, Anchor)) {
-                return;
-            }
-            anchor = `obj.__jac__ if isinstance(`obj, Archetype) else `obj;
-            if JacRuntimeInterface.check_write_access(anchor) {
-                match anchor {
-                    case NodeAnchor():
-                        for `edge in anchor.edges[:] {
-                            JacRuntimeInterface.destroy([`edge]);
-                        }
-
-                    case EdgeAnchor():
-                        JacRuntimeInterface.detach(anchor);
-
-                    case _:
-                        ;
-
-                }
-                JacRuntimeInterface.get_context().mem.delete(anchor.id);
-            }
-        }
-    }
+    static def destroy(objs: Archetype | Anchor | list[(Archetype | Anchor)]) -> None;
 
     """Mark a method as jac entry with this decorator."""
-    static def on_entry(func: Callable) -> Callable {
-        setattr(func, '__jac_entry', True);
-        return func;
-    }
+    static def on_entry(func: Callable) -> Callable;
 
     """Mark a method as jac exit with this decorator."""
-    static def on_exit(func: Callable) -> Callable {
-        setattr(func, '__jac_exit', True);
-        return func;
-    }
+    static def on_exit(func: Callable) -> Callable;
 }
 
 """Jac Client Bundle Operations - Generic interface for client bundling."""
 class JacClientBundle {
     """Get the client bundle builder instance."""
-    static def get_client_bundle_builder -> ClientBundleBuilder {
-        import from jaclang.runtimelib.client_bundle { ClientBundleBuilder }
-        return ClientBundleBuilder();
-    }
+    static def get_client_bundle_builder -> ClientBundleBuilder;
 
     """Build a client bundle for the supplied module."""
     static def build_client_bundle(
         module: types.ModuleType, force: bool = False
-    ) -> ClientBundle {
-        builder = JacRuntimeInterface.get_client_bundle_builder();
-        return builder.build(module, force=force);
-    }
+    ) -> ClientBundle;
 
     """Format a build error for display.
 
@@ -1743,9 +492,7 @@ class JacClientBundle {
         """
     static def format_build_error(
         error_output: str, project_dir: Path, config: object = None
-    ) -> str {
-        return error_output;
-    }
+    ) -> str;
 }
 
 """Jac Console Operations - Generic interface for console output."""
@@ -1757,10 +504,7 @@ implementation.
         The returned instance should be compatible with the JacConsole
 interface.
         """
-    static def get_console -> ConsoleImpl {
-        import from jaclang.cli.console { JacConsole }
-        return JacConsole();
-    }
+    static def get_console -> ConsoleImpl;
 }
 
 """Jac API Server Operations - Generic interface for API server."""
@@ -1770,10 +514,7 @@ class JacAPIServer {
         Plugins can override this hook to provide their own server class.
         The returned class should be compatible with the JacAPIServer interface.
         """
-    static def get_api_server_class -> type {
-        import from jaclang.runtimelib.server { JacAPIServer }
-        return JacAPIServer;
-    }
+    static def get_api_server_class -> type;
 
     """Create the API server instance.
 
@@ -1782,34 +523,7 @@ class JacAPIServer {
     """
     static def create_server(
         jac_server: JacServer, host: str, port: int, max_retries: int = 10
-    ) -> HTTPServer {
-        handler_class = jac_server.create_handler();
-        current_port = port;
-        for _ in range(max_retries) {
-            try {
-                server = HTTPServer((host, current_port), handler_class);
-                if current_port != port {
-                    import from jaclang.cli.console { console }
-                    console.print(
-                        f"  Port {port} is in use, using port {current_port} instead",
-                        style="warning"
-                    );
-                    jac_server.port = current_port;  # Update the server's port
-                }
-                return server;
-            } except OSError as e {
-                # errno 98 = EADDRINUSE (Linux), errno 10048 = WSAEADDRINUSE (Windows)
-                if e.errno in (98, 10048) or "Address already in use" in str(e) {
-                    current_port += 1;
-                } else {
-                    raise;
-                }
-            }
-        }
-        raise OSError(
-            f"Could not find an available port after trying {port}-{current_port}"
-        );
-    }
+    ) -> HTTPServer;
 
     """Render HTML page for client function."""
     static def render_page(
@@ -1817,60 +531,14 @@ class JacAPIServer {
         function_name: str,
         args: dict[(str, Any)],
         username: str
-    ) -> dict[(str, Any)] {
-        import from jaclang.runtimelib.serializer { Serializer }
-        introspector.load();
-        available_exports = (
-            `set(introspector._client_manifest.get('exports', []))
-            or `set(introspector.get_client_functions().keys())
-        );
-        if (function_name not in available_exports) {
-            raise ValueError(f"Client function '{function_name}' not found");
-        }
-        bundle_hash = introspector.ensure_bundle();
-        arg_order = `list(
-            introspector._client_manifest.get('params', {}).get(function_name, [])
-        );
-        globals_payload = {
-            name: Serializer.serialize(value, api_mode=True)
-            for (name, value) in introspector._collect_client_globals().items()
-        };
-        initial_state = {
-            'module': introspector._module.__name__
-                if introspector._module
-                else introspector.module_name,
-            'function': function_name,
-            'args': {
-                key: Serializer.serialize(value, api_mode=True)
-                for (key, value) in args.items()
-            },
-            'globals': globals_payload,
-            'argOrder': arg_order,
-            'endpointEffects': introspector._client_manifest.get(
-                'endpoint_effects', {}
-            )
-        };
-        safe_initial_json = json.dumps(initial_state).replace('</', '<\\/');
-        page = f'<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><title>{html.escape(
-            function_name
-        )}</title></head><body><div id="__jac_root"></div><script id="__jac_init__" type="application/json">{safe_initial_json}</script><script type="module" src="/static/client.js?hash={bundle_hash}"></script></body></html>';
-        return {
-            'html': page,
-            'bundle_hash': bundle_hash,
-            'bundle_code': introspector._bundle.code
-        };
-    }
+    ) -> dict[(str, Any)];
 
     """Get the client JavaScript bundle code.
 
         Plugins can override this hook to provide custom bundle serving logic
         (e.g., serving Vite-built PWA bundles).
     """
-    static def get_client_js(introspector: ModuleIntrospector) -> str {
-        introspector.load();
-        introspector.ensure_bundle();
-        return introspector._bundle.code;
-    }
+    static def get_client_js(introspector: ModuleIntrospector) -> str;
 }
 
 """Jac Response Builder."""
@@ -1880,39 +548,25 @@ class JacResponseBuilder {
         handler: BaseHTTPRequestHandler,
         status: StatusCode,
         data: dict[(str, JsonValue)]
-    ) -> None {
-        import from jaclang.runtimelib.server { ResponseBuilder }
-        ResponseBuilder.send_json(handler, status, data);
-    }
+    ) -> None;
 
     """Send HTML response with CORS headers."""
     static def send_html(
         handler: BaseHTTPRequestHandler, status: StatusCode, body: str
-    ) -> None {
-        import from jaclang.runtimelib.server { ResponseBuilder }
-        ResponseBuilder.send_html(handler, status, body);
-    }
+    ) -> None;
 
     """Send JavaScript response."""
-    static def send_javascript(handler: BaseHTTPRequestHandler, code: str) -> None {
-        import from jaclang.runtimelib.server { ResponseBuilder }
-        ResponseBuilder.send_javascript(handler, code);
-    }
+    static def send_javascript(handler: BaseHTTPRequestHandler, code: str) -> None;
 
     """Send CSS response."""
-    static def send_css(handler: BaseHTTPRequestHandler, css_code: str) -> None {
-        import from jaclang.runtimelib.server { ResponseBuilder }
-        ResponseBuilder.send_css(handler, css_code);
-    }
+    static def send_css(handler: BaseHTTPRequestHandler, css_code: str) -> None;
 
     """Send static file response (images, fonts, etc.)."""
     static def send_static_file(
         handler: BaseHTTPRequestHandler,
         file_path: Path,
         content_type: (str | None) = None
-    ) -> None {
-        raise NotImplementedError('send_static_file method is not implemented');
-    }
+    ) -> None;
 }
 
 """Jac byLLM integration."""
@@ -1922,109 +576,27 @@ class JacByLLM {
         caller: Callable,
         args: dict[((int | str), object)],
         call_params: dict[(str, object)]
-    ) -> MTRuntime {
-        return MTIR(caller=caller, args=args, call_params=call_params).runtime;
-    }
+    ) -> MTRuntime;
 
     """Attach the semstring to the given object."""
-    static def `sem(semstr: str, inner_semstr: dict[(str, str)]) -> Callable {
-        def decorator(`obj: object) -> object {
-            setattr(`obj, '_jac_semstr', semstr);
-            setattr(`obj, '_jac_semstr_inner', inner_semstr);
-            return `obj;
-        }
-        return decorator;
-    }
+    static def `sem(semstr: str, inner_semstr: dict[(str, str)]) -> Callable;
 
     """Call the LLM model."""
-    static def call_llm(model: object, mt_run: MTRuntime) -> Any {
-        import from jaclang.utils { NonGPT }
-        try {
-            random_value_for_type = cast(
-                Callable[([Any], Any)], NonGPT.random_value_for_type
-            );
-        } except AttributeError {
-            def random_value_for_type(_t: object) -> object {
-                return None;
-            }
-        }
-        try {
-            type_hints = get_type_hints(
-                mt_run.caller,
-                globalns=getattr(mt_run.caller, '__globals__', {}),
-                localns=None,
-                include_extras=True
-            );
-        } except Exception {
-            type_hints = getattr(mt_run.caller, '__annotations__', {});
-        }
-        return_type = type_hints.get('return', Any);
-        return random_value_for_type(return_type);
-    }
+    static def call_llm(model: object, mt_run: MTRuntime) -> Any;
 
     """Python library mode decorator for Jac's by llm() syntax."""
-    static def `by(model: object) -> Callable {
-        def _decorator(caller: Callable) -> Callable {
-            def _wrapped_caller(*args: object, **kwargs: object) -> object {
-                invoke_args: dict[((int | str), object)] = {};
-                for (i, arg) in enumerate(args) {
-                    invoke_args[i] = arg;
-                }
-                for (key, value) in kwargs.items() {
-                    invoke_args[key] = value;
-                }
-                mt_run = JacRuntime.get_mtir(
-                    caller=caller,
-                    args=invoke_args,
-                    call_params=model?.call_params or {}
-                );
-                return JacRuntime.call_llm(model, mt_run);
-            }
-            return _wrapped_caller;
-        }
-        return _decorator;
-    }
+    static def `by(model: object) -> Callable;
 
     static def filter_visitable_by(
         connected_nodes: list[NodeArchetype], model: object, descriptions: str = ''
-    ) -> list[NodeArchetype] {
-        import from jaclang.jac0core.helpers { _describe_nodes_list }
-        visitable_list: list = [];
-        """
-            Determine which connected nodes are visitable using an LLM.
-
-            The input represents structurally reachable nodes. This function
-applies
-            semantic reasoning to decide which of those nodes a walker is
-allowed
-            or intended to visit, returning their indexes in priority order.
-
-            Returns an empty list if no nodes are deemed visitable.
-            """;
-        @JacByLLM.by (model=model)
-        def _filter_visitable_by(
-            connected_nodes: list[NodeArchetype], descriptions: str = ''
-        ) -> list[int] {
-            return [];
-        }
-        descriptions = _describe_nodes_list(connected_nodes);
-        indexes = _filter_visitable_by(connected_nodes, descriptions);
-        for idx in indexes {
-            visitable_list.append(connected_nodes[idx]);
-        }
-        return visitable_list;
-    }
+    ) -> list[NodeArchetype];
 
     """by operator feature for expression composition.
 
         Currently not implemented - raises NotImplementedError.
         Plugins like byllm can override this via the plugin hook system.
         """
-    static def by_operator(lhs: Any, rhs: Any) -> Any {
-        raise NotImplementedError(
-            "The 'by' operator is not yet implemented. This feature is reserved for future use."
-        );
-    }
+    static def by_operator(lhs: Any, rhs: Any) -> Any;
 
     """Return the default LLM model for use with 'by llm()' syntax.
 
@@ -2034,40 +606,13 @@ allowed
         in call_llm. Plugins (e.g. byllm) override this to return a configured
         Model instance based on jac.toml settings.
         """
-    static def default_llm -> object {
-        _cache = getattr(JacByLLM, '_default_llm_instance', None);
-        if (_cache is not None) {
-            return _cache;
-        }
-        def _stub_call(_self: object, **kwargs: object) -> object {
-            return _self;
-        }
-        _StubCls = `type(
-            '_DefaultLLM', (object, ), {'call_params': {}, '__call__': _stub_call}
-        );
-        instance = _StubCls();
-        JacByLLM._default_llm_instance = instance;
-        return instance;
-    }
+    static def default_llm -> object;
 
     """Add MTIR to the node's MTIR map."""
-    static def add_mtir_to_map(scope: str, mtir: Info) -> None {
-        if (JacRuntime.program is None) {
-            raise AttributeError('JacRuntime.program is not initialized');
-        }
-        JacRuntime.program.mtir_map[scope] = mtir;
-    }
+    static def add_mtir_to_map(scope: str, mtir: Info) -> None;
 
     """Get MTIR from the node's MTIR map."""
-    static def get_mtir_from_map(scope: str) -> (Info | None) {
-        if (JacRuntime.program is None) {
-            raise AttributeError('JacRuntime.program is not initialized');
-        }
-        if (scope not in JacRuntime.program.mtir_map) {
-            raise KeyError(f"MTIR not found for scope {scope}");
-        }
-        return JacRuntime.program.mtir_map[scope];
-    }
+    static def get_mtir_from_map(scope: str) -> (Info | None);
 }
 
 """Jac Machine Utilities."""
@@ -2083,96 +628,30 @@ class JacUtils {
         For file backend: auto-generates path from JacRuntime.base_path_dir.
         For database backends (jac-scale): configured via environment variables.
         """
-    static def create_j_context(user_root: (str | None)) -> ExecutionContext {
-        import from jaclang.runtimelib.context { ExecutionContext }
-        ctx = ExecutionContext();
-        if (user_root is not None) {
-            ctx.set_user_root(user_root);
-        }
-        return ctx;
-    }
+    static def create_j_context(user_root: (str | None)) -> ExecutionContext;
 
     """Attach a JacProgram to the machine."""
-    static def attach_program(jac_program: JacProgram) -> None {
-        JacRuntime.program = jac_program;
-    }
+    static def attach_program(jac_program: JacProgram) -> None;
 
     """Attach a JacCompiler to the machine."""
-    static def attach_compiler(jac_compiler: JacCompiler) -> None {
-        JacRuntime.compiler = jac_compiler;
-    }
+    static def attach_compiler(jac_compiler: JacCompiler) -> None;
 
     """Load a module into the machine."""
     static def load_module(
         module_name: str, module: types.ModuleType, force: bool = False
-    ) -> None {
-        if ((module_name not in JacRuntime.loaded_modules) or force) {
-            JacRuntime.loaded_modules[module_name] = module;
-            sys.modules[module_name] = module;
-        }
-    }
+    ) -> None;
 
     """List all loaded modules."""
-    static def list_modules -> list[str] {
-        return `list(JacRuntime.loaded_modules.keys());
-    }
+    static def list_modules -> list[str];
 
     """List all walkers in a specific module."""
-    static def list_walkers(module_name: str) -> list[str] {
-        module = JacRuntime.loaded_modules.get(module_name);
-        if module {
-            walkers = [];
-            for (name, `obj) in inspect.getmembers(module) {
-                if (
-                    isinstance(`obj, `type)
-                    and issubclass(`obj, WalkerArchetype)
-                    and (`obj.__module__ == module_name)
-                ) {
-                    walkers.append(name);
-                }
-            }
-            return walkers;
-        }
-        return [];
-    }
+    static def list_walkers(module_name: str) -> list[str];
 
     """List all nodes in a specific module."""
-    static def list_nodes(module_name: str) -> list[str] {
-        module = JacRuntime.loaded_modules.get(module_name);
-        if module {
-            nodes = [];
-            for (name, `obj) in inspect.getmembers(module) {
-                if (
-                    isinstance(`obj, `type)
-                    and issubclass(`obj, NodeArchetype)
-                    and (`obj.__module__ == module_name)
-                ) {
-                    nodes.append(name);
-                }
-            }
-            return nodes;
-        }
-        return [];
-    }
+    static def list_nodes(module_name: str) -> list[str];
 
     """List all edges in a specific module."""
-    static def list_edges(module_name: str) -> list[str] {
-        module = JacRuntime.loaded_modules.get(module_name);
-        if module {
-            edges = [];
-            for (name, `obj) in inspect.getmembers(module) {
-                if (
-                    isinstance(`obj, `type)
-                    and issubclass(`obj, EdgeArchetype)
-                    and (`obj.__module__ == module_name)
-                ) {
-                    edges.append(name);
-                }
-            }
-            return edges;
-        }
-        return [];
-    }
+    static def list_edges(module_name: str) -> list[str];
 
     """Dynamically creates archetypes (nodes, walkers, etc.) from Jac source
 code.
@@ -2186,144 +665,35 @@ code.
         base_path: (str | None) = None,
         cachable: bool = False,
         keep_temporary_files: bool = False
-    ) -> (types.ModuleType | None) {
-        if not base_path {
-            base_path = JacRuntime.base_path_dir or os.getcwd();
-        }
-        if (base_path and not os.path.exists(base_path)) {
-            os.makedirs(base_path);
-        }
-        if not module_name {
-            module_name = f"_dynamic_module_{len(JacRuntime.loaded_modules)}";
-        }
-        import tempfile;
-        with tempfile.NamedTemporaryFile(
-            mode='w',
-            suffix='.jac',
-            prefix=(module_name + '_'),
-            dir=base_path,
-            delete=False
-        ) as tmp_file {
-            tmp_file_path = tmp_file.name;
-            tmp_file.write(source_code);
-        }
-        try {
-            tmp_file_basename = os.path.basename(tmp_file_path);
-            (tmp_module_name, _) = os.path.splitext(tmp_file_basename);
-            result = JacRuntimeInterface.jac_import(
-                target=tmp_module_name,
-                base_path=base_path,
-                override_name=module_name,
-                lng='jac'
-            );
-            module = result[0] if result else None;
-            if module {
-                JacRuntime.loaded_modules[module_name] = module;
-            }
-            return module;
-        } except Exception as e {
-            logger.error(f"Error importing dynamic module '{module_name}':{e}");
-            return None;
-        } finally {
-            if (not keep_temporary_files and os.path.exists(tmp_file_path)) {
-                os.remove(tmp_file_path);
-            }
-        }
-    }
+    ) -> (types.ModuleType | None);
 
     """Reimport the module using Python's reload mechanism."""
     static def update_walker(
         module_name: str, items: (dict[(str, str | str | None)] | None)
-    ) -> tuple[(types.ModuleType, ...)] {
-        if (module_name in JacRuntime.loaded_modules) {
-            try {
-                old_module = JacRuntime.loaded_modules[module_name];
-                result = JacRuntimeInterface.jac_import(
-                    target=module_name,
-                    base_path=(JacRuntime.base_path_dir or os.getcwd()),
-                    items=items,
-                    reload_module=True,
-                    lng='jac'
-                );
-                if items {
-                    ret_items = [];
-                    for (idx, item_name) in enumerate(items.keys()) {
-                        if (hasattr(old_module, item_name) and (idx < len(result))) {
-                            new_attr = result[idx];
-                            ret_items.append(new_attr);
-                            setattr(old_module, item_name, new_attr);
-                        }
-                    }
-                    return `tuple(ret_items);
-                }
-                return (old_module, );
-            } except Exception as e {
-                logger.error(f"Failed to update module {module_name}: {e}");
-            }
-        } else {
-            logger.warning(f"Module {module_name} not found in loadedmodules.");
-        }
-        return ();
-    }
+    ) -> tuple[(types.ModuleType, ...)];
 
     """Spawn a node instance of the given node_name with attributes."""
     static def spawn_node(
         node_name: str, attributes: (dict | None) = None, module_name: str = '__main__'
-    ) -> NodeArchetype {
-        node_class = JacRuntimeInterface.get_archetype(module_name, node_name);
-        if (isinstance(node_class, `type) and issubclass(node_class, NodeArchetype)) {
-            if (attributes is None) {
-                attributes = {};
-            }
-            node_instance = node_class(**attributes);
-            return node_instance;
-        } else {
-            raise ValueError(f"Node {node_name} not found.");
-        }
-    }
+    ) -> NodeArchetype;
 
     """Spawn a walker instance of the given walker_name."""
     static def spawn_walker(
         walker_name: str,
         attributes: (dict | None) = None,
         module_name: str = '__main__'
-    ) -> WalkerArchetype {
-        walker_class = JacRuntimeInterface.get_archetype(module_name, walker_name);
-        if (
-            isinstance(walker_class, `type)
-            and issubclass(walker_class, WalkerArchetype)
-        ) {
-            if (attributes is None) {
-                attributes = {};
-            }
-            walker_instance = walker_class(**attributes);
-            return walker_instance;
-        } else {
-            raise ValueError(f"Walker {walker_name} not found.");
-        }
-    }
+    ) -> WalkerArchetype;
 
     """Retrieve an archetype class from a module."""
     static def get_archetype(
         module_name: str, archetype_name: str
-    ) -> (Archetype | None) {
-        module = JacRuntime.loaded_modules.get(module_name);
-        if module {
-            return getattr(module, archetype_name, None);
-        }
-        return None;
-    }
+    ) -> (Archetype | None);
 
     """Run a function in a thread."""
-    static def thread_run(func: Callable, *args: object) -> Future {
-        _executor = JacRuntime.pool;
-        return _executor.submit(func, *args);
-    }
+    static def thread_run(func: Callable, *args: object) -> Future;
 
     """Wait for a thread to finish."""
-    static def thread_wait(future: Any) -> None {
-        return future.result();
-    }
+    static def thread_wait(future: Any) -> None;
 }
 
 """Plugin configuration hooks for jac.toml integration.
@@ -2340,9 +710,7 @@ class JacPluginConfig {
                 - version: Plugin version
                 - description: Brief description
         """
-    static def get_plugin_metadata -> (dict[(str, Any)] | None) {
-        return None;
-    }
+    static def get_plugin_metadata -> (dict[(str, Any)] | None);
 
     """Return the plugin's configuration schema.
 
@@ -2362,18 +730,14 @@ class JacPluginConfig {
                         }
                     }
         """
-    static def get_config_schema -> (dict[(str, Any)] | None) {
-        return None;
-    }
+    static def get_config_schema -> (dict[(str, Any)] | None);
 
     """Called when plugin configuration is loaded from jac.toml.
 
         Args:
             config: The plugin's configuration values from [plugins.<name>]
         """
-    static def on_config_loaded(config: dict[(str, Any)]) -> None {
-        ;
-    }
+    static def on_config_loaded(config: dict[(str, Any)]) -> None;
 
     """Validate plugin configuration.
 
@@ -2383,9 +747,7 @@ class JacPluginConfig {
         Returns:
             List of error messages (empty if valid)
         """
-    static def validate_config(config: dict[(str, Any)]) -> list[str] {
-        return [];
-    }
+    static def validate_config(config: dict[(str, Any)]) -> list[str];
 
     """Register a custom dependency type.
 
@@ -2401,9 +763,7 @@ class JacPluginConfig {
                 - install_handler: Callable to install packages
                 - remove_handler: Callable to remove packages
         """
-    static def register_dependency_type -> (dict[(str, Any)] | None) {
-        return None;
-    }
+    static def register_dependency_type -> (dict[(str, Any)] | None);
 
     """Register a project template for jac create.
 
@@ -2419,9 +779,7 @@ class JacPluginConfig {
                 - directories: list of directories to create
                 - post_create: optional callable(project_path, project_name)
         """
-    static def register_project_template -> (dict[(str, Any)] | None) {
-        return None;
-    }
+    static def register_project_template -> (dict[(str, Any)] | None);
 }
 
 """Jac Feature."""
@@ -2437,10 +795,7 @@ class JacRuntimeInterface(JacClassReferences, JacAccessValidation, JacNode, JacE
         Returns:
             UserManager instance
         """
-    static def get_user_manager(base_path: str) -> UserManager {
-        import from jaclang.runtimelib.server { UserManager }
-        return UserManager(base_path=base_path);
-    }
+    static def get_user_manager(base_path: str) -> UserManager;
 
     """Get storage backend instance (hookable for plugins).
 
@@ -2454,10 +809,7 @@ class JacRuntimeInterface(JacClassReferences, JacAccessValidation, JacNode, JacE
         Returns:
             Storage instance (LocalStorage by default)
         """
-    static def store(base_path: str = './storage', create_dirs: bool = True) -> Any {
-        import from jaclang.runtimelib.storage { LocalStorage }
-        return LocalStorage(base_path=base_path, create_dirs=create_dirs);
-    }
+    static def store(base_path: str = './storage', create_dirs: bool = True) -> Any;
 }
 
 """Generate three helper classes based on a plugin class.
@@ -2580,42 +932,20 @@ class JacRuntime(JacRuntimeInterface) {
         operations. It persists across program resets and can be reused.
         """
     @classmethod
-    def get_compiler(cls: Any) -> JacCompiler {
-        if (cls.compiler is None) {
-            import from jaclang.jac0core.compiler { JacCompiler }
-            cls.compiler = JacCompiler();
-        }
-        return cls.compiler;
-    }
+    def get_compiler(cls: Any) -> JacCompiler;
 
     """Get or create the JacProgram instance."""
     @classmethod
-    def get_program(cls: Any) -> JacProgram {
-        if (cls.program is None) {
-            import from jaclang.jac0core.program { JacProgram }
-            cls.program = JacProgram();
-        }
-        return cls.program;
-    }
+    def get_program(cls: Any) -> JacProgram;
 
     """Set the base path for the machine.
 
         When base_path is None, L3 persistence is disabled (faster for tests).
         """
-    static def set_base_path(base_path: (str | None)) -> None {
-        if (base_path is None) {
-            JacRuntime.base_path_dir = None;
-        } else {
-            JacRuntime.base_path_dir = base_path
-                if os.path.isdir(base_path)
-                else os.path.dirname(base_path);
-        }
-    }
+    static def set_base_path(base_path: (str | None)) -> None;
 
     """Set the context for the machine."""
-    static def set_context(context: ExecutionContext) -> None {
-        JacRuntime.exec_ctx = context;
-    }
+    static def set_context(context: ExecutionContext) -> None;
 }
 
 """Context manager to temporarily disable external plugins.

--- a/jac/jaclang/runtimelib/storage/impl/local_storage.impl.jac
+++ b/jac/jaclang/runtimelib/storage/impl/local_storage.impl.jac
@@ -1,0 +1,130 @@
+"""Implementation of local filesystem storage."""
+
+impl LocalStorage.init(
+    self: LocalStorage, base_path: str = "./storage", create_dirs: bool = True
+) -> None {
+    self.base_path = base_path;
+    self.create_dirs = create_dirs;
+    if self.create_dirs {
+        Path(self.base_path).mkdir(parents=True, exist_ok=True);
+    }
+}
+
+"""Resolve a relative path to an absolute path within the storage base."""
+impl LocalStorage._resolve_path(self: LocalStorage, path: str) -> Path {
+    return Path(self.base_path) / path.lstrip("/");
+}
+
+impl LocalStorage.upload(
+    self: LocalStorage,
+    source: (str | BinaryIO),
+    destination: str,
+    metadata: (dict[str, str] | None) = None
+) -> str {
+    dest_path = self._resolve_path(destination);
+    dest_path.parent.mkdir(parents=True, exist_ok=True);
+    if isinstance(source, str) {
+        shutil.copy2(source, dest_path);
+    } else {
+        with open(dest_path, "wb") as f {
+            content = source.read();
+            f.write(content if isinstance(content, bytes) else content);
+        }
+    }
+    return str(dest_path);
+}
+
+impl LocalStorage.download(
+    self: LocalStorage, source: str, destination: (str | BinaryIO | None) = None
+) -> (bytes | None) {
+    src_path = self._resolve_path(source);
+    if not src_path.exists() {
+        raise FileNotFoundError(f"File not found: {source}");
+    }
+    if destination is None {
+        with open(src_path, "rb") as f {
+            return f.read();
+        }
+    } elif isinstance(destination, str) {
+        shutil.copy2(src_path, destination);
+        return None;
+    } else {
+        with open(src_path, "rb") as f {
+            destination.write(f.read());
+        }
+        return None;
+    }
+}
+
+impl LocalStorage.delete(self: LocalStorage, path: str) -> bool {
+    file_path = self._resolve_path(path);
+    if file_path.exists() {
+        if file_path.is_dir() {
+            shutil.rmtree(file_path);
+        } else {
+            file_path.unlink();
+        }
+        return True;
+    }
+    return False;
+}
+
+impl LocalStorage.exists(self: LocalStorage, path: str) -> bool {
+    return self._resolve_path(path).exists();
+}
+
+impl LocalStorage.list_files(
+    self: LocalStorage, prefix: str = "", recursive: bool = False
+) -> Generator[str, None, None] {
+    base = self._resolve_path(prefix) if prefix else Path(self.base_path);
+    if base.exists() {
+        if recursive {
+            for item in base.rglob("*") {
+                if item.is_file() {
+                    yield str(item.relative_to(self.base_path));
+                }
+            }
+        } else {
+            for item in base.iterdir() {
+                yield str(item.relative_to(self.base_path));
+            }
+        }
+    }
+}
+
+impl LocalStorage.get_metadata(self: LocalStorage, path: str) -> dict[str, Any] {
+    file_path = self._resolve_path(path);
+    if not file_path.exists() {
+        raise FileNotFoundError(f"File not found: {path}");
+    }
+    stat = file_path.stat();
+    return {
+        "size": stat.st_size,
+        "modified": stat.st_mtime,
+        "created": stat.st_ctime,
+        "is_dir": file_path.is_dir(),
+        "name": file_path.name
+    };
+}
+
+impl LocalStorage.copy(self: LocalStorage, source: str, destination: str) -> bool {
+    src_path = self._resolve_path(source);
+    dest_path = self._resolve_path(destination);
+    if not src_path.exists() {
+        return False;
+    }
+    dest_path.parent.mkdir(parents=True, exist_ok=True);
+    shutil.copy2(src_path, dest_path);
+    return True;
+}
+
+impl LocalStorage.move(self: LocalStorage, source: str, destination: str) -> bool {
+    src_path = self._resolve_path(source);
+    dest_path = self._resolve_path(destination);
+    if not src_path.exists() {
+        return False;
+    }
+    dest_path.parent.mkdir(parents=True, exist_ok=True);
+    shutil.move(str(src_path), str(dest_path));
+    return True;
+}

--- a/jac/jaclang/runtimelib/storage/local_storage.jac
+++ b/jac/jaclang/runtimelib/storage/local_storage.jac
@@ -16,130 +16,29 @@ class LocalStorage(Storage) {
 
     def init(
         self: LocalStorage, base_path: str = "./storage", create_dirs: bool = True
-    ) -> None {
-        self.base_path = base_path;
-        self.create_dirs = create_dirs;
-        if self.create_dirs {
-            Path(self.base_path).mkdir(parents=True, exist_ok=True);
-        }
-    }
+    ) -> None;
 
     """Resolve a relative path to an absolute path within the storage base."""
-    def _resolve_path(self: LocalStorage, path: str) -> Path {
-        return Path(self.base_path) / path.lstrip("/");
-    }
+    def _resolve_path(self: LocalStorage, path: str) -> Path;
 
     override def upload(
         self: LocalStorage,
         source: (str | BinaryIO),
         destination: str,
         metadata: (dict[str, str] | None) = None
-    ) -> str {
-        dest_path = self._resolve_path(destination);
-        dest_path.parent.mkdir(parents=True, exist_ok=True);
-        if isinstance(source, str) {
-            shutil.copy2(source, dest_path);
-        } else {
-            with open(dest_path, "wb") as f {
-                content = source.read();
-                f.write(content if isinstance(content, bytes) else content);
-            }
-        }
-        return str(dest_path);
-    }
+    ) -> str;
 
     override def download(
         self: LocalStorage, source: str, destination: (str | BinaryIO | None) = None
-    ) -> (bytes | None) {
-        src_path = self._resolve_path(source);
-        if not src_path.exists() {
-            raise FileNotFoundError(f"File not found: {source}");
-        }
-        if destination is None {
-            with open(src_path, "rb") as f {
-                return f.read();
-            }
-        } elif isinstance(destination, str) {
-            shutil.copy2(src_path, destination);
-            return None;
-        } else {
-            with open(src_path, "rb") as f {
-                destination.write(f.read());
-            }
-            return None;
-        }
-    }
+    ) -> (bytes | None);
 
-    override def delete(self: LocalStorage, path: str) -> bool {
-        file_path = self._resolve_path(path);
-        if file_path.exists() {
-            if file_path.is_dir() {
-                shutil.rmtree(file_path);
-            } else {
-                file_path.unlink();
-            }
-            return True;
-        }
-        return False;
-    }
-
-    override def exists(self: LocalStorage, path: str) -> bool {
-        return self._resolve_path(path).exists();
-    }
-
+    override def delete(self: LocalStorage, path: str) -> bool;
+    override def exists(self: LocalStorage, path: str) -> bool;
     override def list_files(
         self: LocalStorage, prefix: str = "", recursive: bool = False
-    ) -> Generator[str, None, None] {
-        base = self._resolve_path(prefix) if prefix else Path(self.base_path);
-        if base.exists() {
-            if recursive {
-                for item in base.rglob("*") {
-                    if item.is_file() {
-                        yield str(item.relative_to(self.base_path));
-                    }
-                }
-            } else {
-                for item in base.iterdir() {
-                    yield str(item.relative_to(self.base_path));
-                }
-            }
-        }
-    }
+    ) -> Generator[str, None, None];
 
-    override def get_metadata(self: LocalStorage, path: str) -> dict[str, Any] {
-        file_path = self._resolve_path(path);
-        if not file_path.exists() {
-            raise FileNotFoundError(f"File not found: {path}");
-        }
-        stat = file_path.stat();
-        return {
-            "size": stat.st_size,
-            "modified": stat.st_mtime,
-            "created": stat.st_ctime,
-            "is_dir": file_path.is_dir(),
-            "name": file_path.name
-        };
-    }
-
-    override def copy(self: LocalStorage, source: str, destination: str) -> bool {
-        src_path = self._resolve_path(source);
-        dest_path = self._resolve_path(destination);
-        if not src_path.exists() {
-            return False;
-        }
-        dest_path.parent.mkdir(parents=True, exist_ok=True);
-        shutil.copy2(src_path, dest_path);
-        return True;
-    }
-
-    override def move(self: LocalStorage, source: str, destination: str) -> bool {
-        src_path = self._resolve_path(source);
-        dest_path = self._resolve_path(destination);
-        if not src_path.exists() {
-            return False;
-        }
-        dest_path.parent.mkdir(parents=True, exist_ok=True);
-        shutil.move(str(src_path), str(dest_path));
-        return True;
-    }
+    override def get_metadata(self: LocalStorage, path: str) -> dict[str, Any];
+    override def copy(self: LocalStorage, source: str, destination: str) -> bool;
+    override def move(self: LocalStorage, source: str, destination: str) -> bool;
 }


### PR DESCRIPTION
## Summary
- Extract method implementations into `impl/` files for 11 modules: compiler, runtime, helpers, native_marshal, constant, primitives_py, primitives_es, primitives_native, local_storage, storage, and primitives
- Declaration files now contain only type definitions, `has` fields, and method signatures (`;`-terminated stubs)
- Fix jac0 bootstrap compiler (`jac0.py`) to inherit `@property`, `@classmethod`, and `async` flags from declaration stubs into impl blocks — decorators only need to appear on the declaration, not duplicated in impl files
- Skip emitting stub methods that have matching impl bodies to avoid dead code in generated Python

## New impl files
- `jac0core/impl/compiler.impl.jac`
- `jac0core/impl/runtime.impl.jac`
- `jac0core/impl/helpers.impl.jac`
- `jac0core/impl/native_marshal.impl.jac`
- `jac0core/impl/constant.impl.jac`
- `jac0core/passes/impl/primitives_py.impl.jac`
- `compiler/passes/ecmascript/impl/primitives_es.impl.jac`
- `compiler/passes/native/impl/primitives_native.impl.jac`
- `runtimelib/storage/impl/local_storage.impl.jac`

## Test plan
- [x] Bootstrap import (`import jaclang`) succeeds
- [x] Full test suite passes (2778 passed, 1 xfailed)
- [x] `@property`, `@classmethod`, and `async` decorator inheritance verified
- [x] Pre-commit hooks pass (jac-format, ruff, mypy)