### PR TITLE
fix(jac-scale): align OpenAPI param name with URL template for walker-with-node endpoints

### DIFF
--- a/jac-scale/jac_scale/impl/serve.endpoints.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.endpoints.impl.jac
@@ -74,7 +74,7 @@ impl JacAPIServerEndpoints.create_walker_parameters(
         }
         parameters.append(
             APIParameter(
-                name='node' if (field_name == '_jac_spawn_node') else field_name,
+                name='nd' if (field_name == '_jac_spawn_node') else field_name,
                 data_type=field_type,
                 required=walker_fields[field_name]['required'],
                 default=walker_fields[field_name]['default'],


### PR DESCRIPTION
## Summary

- Fixes 422 "Field required" errors on walker-with-node endpoints (`/walker/{name}/{nd}`) caused by a mismatch between the URL path parameter name (`nd`) and the OpenAPI parameter name (`node`).
- Single-line change: `name='node'` → `name='nd'` in `create_walker_parameters()` so FastAPI correctly binds the `{nd}` path segment to the parameter.

## Details

The URL template on line 17 uses `{nd}`, the callback parameter on line 96 is `nd`, and usage on lines 118-119 references `nd` — but the OpenAPI `APIParameter` on line 77 was named `'node'`. FastAPI generated a schema expecting a `node` path param that didn't exist in the URL, causing every request to the `/{nd}` variant to fail with a 422.

Additionally, `node` is a reserved keyword in Jac, making it unsuitable as a parameter name.