### PR TITLE
Style: Remove per-method docstrings from obj blocks

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -9,7 +9,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Tuple Unpacking in For Loops**: `for (a, b, c) in list[tuple[A, B, C]]` now correctly infers types for unpacked variables instead of `UnknownType`.
 - **Refactor: `GUEST` Constant for Guest Username**: Added a `GUEST = '__guest__'` constant to `Constants` enum and replaced hardcoded `'__guest__'` strings in the stdlib HTTP server with `Con.GUEST.value` for improved maintainability and consistency.
 - **Fix: Native Cross-Module Global Variable Access**: Module-level globals declared in one `.na.jac` file are now correctly accessible from importing modules. Previously, accessing such a global caused a segfault at runtime.
-- 15 small refactors/changes.
+- 16 small refactors/changes.
 - **Fix: HMR Recursive recompilation**: Fixed client-side code recursive recompilation process, preventing cyclic recompilation, and ensuring that all dependencies are up to date.
 - **Fix: Errors in `.impl.jac` Files Now Reported by `jac check` and `jac run`**: Undefined names and unreachable code inside `.impl.jac` files were previously silently ignored. They are now correctly reported as warnings, pointing to the exact file and line.
 - **Fix: HTTP Server Authentication for Imported `:pub` Functions**: Fixed server incorrectly requiring authentication (401) for imported `:pub` functions. The server now inspects source file ASTs to determine access levels for imported function endpoints, matching the existing behavior for imported walkers.

--- a/jac/jaclang/cli/command.jac
+++ b/jac/jaclang/cli/command.jac
@@ -42,7 +42,6 @@ obj Arg {
         metavar: str | None = None,  # Display name in help
         source: str = "jaclang";  # Source plugin that added this arg
 
-    """Create argument with auto-generated short flag."""
     static def create(
         name: str,
         kind: ArgKind = ArgKind.OPTION,
@@ -78,16 +77,9 @@ obj CommandSpec {
         pre_hooks: list[tuple[Callable, str]] = [],  # (hook, source) pairs
         post_hooks: list[tuple[Callable, str]] = [];  # (hook, source) pairs
 
-    """Get all arguments (base + plugin-extended)."""
     def get_all_args -> list[Arg];
-
-    """Add an extension argument from a plugin."""
     def add_extension_arg(arg: Arg, source: str) -> None;
-
-    """Add a pre-execution hook from a plugin."""
     def add_pre_hook(hook: Callable, source: str) -> None;
-
-    """Add a post-execution hook from a plugin."""
     def add_post_hook(hook: Callable, source: str) -> None;
 }
 
@@ -103,12 +95,7 @@ obj HookContext {
         args: dict[str, Any],  # Parsed command arguments
         data: dict[str, Any] = {};  # Mutable context for hook communication
 
-    """Get an argument value with optional default."""
     def get_arg(name: str, `default: Any = None) -> Any;
-
-    """Set a value in the hook data context."""
     def set_data(key: str, value: Any) -> None;
-
-    """Get a value from the hook data context."""
     def get_data(key: str, `default: Any = None) -> Any;
 }

--- a/jac/jaclang/cli/executor.jac
+++ b/jac/jaclang/cli/executor.jac
@@ -27,51 +27,12 @@ Handles the full command lifecycle:
 5. Return final exit code
 """
 obj CommandExecutor {
-    """Execute a command with its hooks.
-
-    Args:
-        spec: The command specification
-        args: Parsed arguments as a dictionary
-
-    Returns:
-        ExecutionResult with return code and any error
-    """
     def execute(spec: CommandSpec, args: dict[str, Any]) -> ExecutionResult;
-
-    """Run all pre-execution hooks for a command.
-
-    Args:
-        spec: The command specification
-        context: The hook context to pass to hooks
-
-    Returns:
-        True if all hooks succeeded, False if any hook cancelled execution
-    """
     def run_pre_hooks(spec: CommandSpec, context: HookContext) -> bool;
-
-    """Run all post-execution hooks for a command.
-
-    Args:
-        spec: The command specification
-        context: The hook context to pass to hooks
-        return_code: The return code from the handler
-
-    Returns:
-        Final return code (hooks may modify it)
-    """
     def run_post_hooks(
         spec: CommandSpec, context: HookContext, return_code: int
     ) -> int;
 
-    """Execute the command handler.
-
-    Args:
-        spec: The command specification
-        args: Arguments to pass to the handler
-
-    Returns:
-        Return code from handler (0 for success)
-    """
     def run_handler(spec: CommandSpec, args: dict[str, Any]) -> int;
 }
 

--- a/jac/jaclang/cli/help.jac
+++ b/jac/jaclang/cli/help.jac
@@ -35,16 +35,9 @@ obj CommandGroups {
             "general"
         ];
 
-    """Get display name for a group."""
     def get_display_name(group: str) -> str;
-
-    """Get group order for sorting (lower = earlier)."""
     def get_order(group: str) -> int;
-
-    """Register a new group (for plugins)."""
     def register_group(name: str, display_name: str, order: int | None = None) -> None;
-
-    """Get all groups in display order."""
     def get_ordered_groups -> list[str];
 }
 
@@ -58,21 +51,13 @@ Provides methods for formatting:
 obj HelpFormatter {
     has groups: CommandGroups = CommandGroups();
 
-    """Format the main help message with grouped commands."""
     def format_main_help(
         commands: list[CommandSpec], prog: str = "jac", version: str | None = None
     ) -> str;
 
-    """Format help for a single command."""
     def format_command_help(spec: CommandSpec) -> str;
-
-    """Format argument list for a command."""
     def format_arguments(args: list[Arg], extra_args: list[Arg] | None = None) -> str;
-
-    """Format examples for a command."""
     def format_examples(examples: list[tuple[str, str]]) -> str;
-
-    """Format a usage line for a command."""
     def format_usage(spec: CommandSpec, prog: str = "jac") -> str;
 }
 

--- a/jac/jaclang/cli/registry.jac
+++ b/jac/jaclang/cli/registry.jac
@@ -26,20 +26,7 @@ obj CommandRegistry {
         parser: argparse.ArgumentParser | None = None,
         sub_parsers: Any = None;
 
-    """Initialize the command registry."""
     def init -> None;
-
-    """Register a new command with metadata.
-
-    Use as a decorator:
-        @registry.command(
-            name="run",
-            help="Run a Jac program",
-            args=[Arg.create("filename", kind=ArgKind.POSITIONAL, help="File to run")],
-            group="execution"
-        )
-        def run_handler(filename: str, **extra) -> int { ... }
-    """
     def command(
         name: str,
         help: str,
@@ -50,17 +37,6 @@ obj CommandRegistry {
         source: str = "jaclang"
     ) -> Callable[[Callable], Callable];
 
-    """Extend an existing command with additional arguments or hooks.
-
-    Plugin API for adding functionality to core commands:
-        registry.extend_command(
-            "run",
-            args=[Arg.create("profile", help="Enable profiling")],
-            pre_hook=setup_profiler,
-            post_hook=dump_profile,
-            source="jac-profiler"
-        )
-    """
     def extend_command(
         command_name: str,
         args: list[Arg] | None = None,
@@ -69,34 +45,13 @@ obj CommandRegistry {
         source: str = "unknown"
     ) -> None;
 
-    """Get a command by name."""
     def get(name: str) -> CommandSpec | None;
-
-    """Check if a command exists."""
     def has_command(name: str) -> bool;
-
-    """Get all commands, optionally filtered by group."""
     def get_all(group: str | None = None) -> list[CommandSpec];
-
-    """Get all command group names."""
     def get_groups -> list[str];
-
-    """Finalize the registry and build argparse parser.
-
-    This should be called after all plugins have registered their commands
-    and extensions. After finalization, the registry is read-only.
-    """
     def finalize -> argparse.ArgumentParser;
-
-    """Apply any pending extensions to a command."""
     def _apply_pending_extensions(name: str) -> None;
-
-    """Build argparse subparser for a command."""
-    def _build_subparser(
-        subparsers: Any, spec: CommandSpec
-    ) -> argparse.ArgumentParser;
-
-    """Add an argument to an argparse parser."""
+    def _build_subparser(subparsers: Any, spec: CommandSpec) -> argparse.ArgumentParser;
     def _add_argument(parser: argparse.ArgumentParser, arg: Arg) -> None;
 }
 

--- a/jac/jaclang/compiler/passes/main/mtir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/main/mtir_gen_pass.jac
@@ -41,40 +41,23 @@ obj MTIRGenPass(UniPass) {
         cancel_token: Any = None;
 
     def postinit -> None;
-    """Check if a type expression represents a primitive type."""
     def _is_primitive_type(type_expr: uni.Expr | None) -> bool;
-
-    """Parse a unitree type expression into a primitive name, ClassInfo,
-    or tuple-based generic representation (using mk_list/mk_dict/mk_tuple)."""
     def _parse_type_expr(
         type_expr: uni.Expr | None, scope: uni.UniScopeNode
     ) -> ClassInfo | str | tuple | None;
 
-    """Extract symbol from type expression if it's not a primitive type."""
     def _extract_type_symbol(
         type_expr: uni.Expr | None, scope: uni.UniScopeNode
     ) -> uni.Symbol | None;
 
-    """Extract enum information from a symbol."""
     def _extract_enum_info(symbol: uni.Symbol) -> EnumInfo;
-
-    """Extract class structure information from a symbol."""
     def _extract_class_info(symbol: uni.Symbol) -> ClassInfo | None;
-
-    """Extract comprehensive information from an Ability node."""
     def _extract_function_info(nd: uni.Ability) -> FunctionInfo;
-
-    """Extract method information from an Ability node."""
     def _extract_method_info(nd: uni.Ability, by_call: bool = False) -> MethodInfo;
-
-    """Get a unique scope string for a given scope node."""
     def _get_scope_str(nd: uni.UniScopeNode) -> str;
-
-    """Extract tools from a by clause expression."""
     def _extract_tools_from_expr(
         expr: uni.Expr, scope: uni.UniScopeNode
     ) -> list[FunctionInfo];
 
-    """Handle entering an ability node for MTIR generation."""
     def enter_ability(nd: uni.Ability) -> None;
 }

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
@@ -82,15 +82,11 @@ obj PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]) {
     def proc_continue(nd: py_ast.Continue) -> uni.CtrlStmt;
     def proc_dict(nd: py_ast.Dict) -> uni.DictVal;
     def proc_dict_comp(nd: py_ast.DictComp) -> uni.DictCompr;
-    """Process python node."""
     def proc_ellipsis(nd: py_ast.Constant) -> None { }
-
     def proc_except_handler(nd: py_ast.ExceptHandler) -> uni.Except;
     def proc_expr(nd: py_ast.Expr) -> uni.ExprStmt;
     def proc_formatted_value(nd: py_ast.FormattedValue) -> uni.FormattedValue;
-    """Process python node."""
     def proc_function_type(nd: py_ast.FunctionType) -> None { }
-
     def proc_generator_exp(nd: py_ast.GeneratorExp) -> uni.GenCompr;
     def proc_global(nd: py_ast.Global) -> uni.GlobalStmt;
     def proc_if_exp(nd: py_ast.IfExp) -> uni.IfElseExpr;
@@ -160,18 +156,10 @@ obj PyastBuildPass(Transform[uni.PythonModuleAst, uni.Module]) {
     def proc_keyword(nd: py_ast.keyword) -> uni.KWPair;
     def proc_match_case(nd: py_ast.match_case) -> uni.MatchCase;
     def proc_withitem(nd: py_ast.withitem) -> uni.ExprAsItem;
-    """Process python node."""
     def proc_param_spec(nd: py_ast.ParamSpec) -> None { }
-
-    """Process python node."""
     def proc_type_alias(nd: py_ast.TypeAlias) -> None { }
-
-    """Process python node."""
     def proc_type_var(nd: py_ast.TypeVar) -> None { }
-
-    """Process python node."""
     def proc_type_var_tuple(nd: py_ast.TypeVarTuple) -> None { }
-
     def convert_to_doc(string: uni.String) -> None;
     def aug_op_map(tok_dict: dict, op: uni.Token) -> str;
 }

--- a/jac/jaclang/compiler/passes/native/elf_linker.jac
+++ b/jac/jaclang/compiler/passes/native/elf_linker.jac
@@ -62,15 +62,11 @@ obj ArchConfig {
         glob_dat_rtype: int,
         gotpcrel_rtypes: set[int];
 
-    """Generate PLT[0] stub bytes (resolver trampoline)."""
     def build_plt0(got_plt_vaddr: int, plt_vaddr: int) -> bytes;
-
-    """Generate a single PLT[n] entry for an external function."""
     def build_plt_entry(
         entry_vaddr: int, got_entry_vaddr: int, idx: int, plt_vaddr: int
     ) -> bytes;
 
-    """Apply a relocation to the given buffer. Returns True if handled."""
     def apply_reloc(
         rtype: int,
         patch_buf: bytearray,
@@ -80,12 +76,10 @@ obj ArchConfig {
         patch_vaddr: int
     ) -> bool;
 
-    """Get the initial GOT.PLT entry address for lazy binding of PLT[idx]."""
     def get_lazy_bind_addr(
         plt_vaddr: int, plt0_size: int, idx: int, plt_entry_size: int
     ) -> int;
 
-    """Create an ArchConfig for the given ELF e_machine value, or None if unsupported."""
     static def from_e_machine(e_machine: int) -> (ArchConfig | None);
 }
 
@@ -102,7 +96,6 @@ obj ElfLinker {
         needed_libs: list[str],
         arch: (ArchConfig | None) = None;
 
-    """Parse a relocatable ELF object and link into an executable."""
     static def link(
         obj_bytes: bytes,
         output_path: str,
@@ -110,9 +103,6 @@ obj ElfLinker {
         crt_objects: list[bytes] = []
     ) -> bool;
 
-    """Parse the ELF relocatable object file."""
     def parse_object -> bool;
-
-    """Build the final ELF executable bytes."""
     def build_executable -> bytes;
 }

--- a/jac/jaclang/compiler/passes/native/macho_linker.jac
+++ b/jac/jaclang/compiler/passes/native/macho_linker.jac
@@ -58,16 +58,12 @@ obj MachOLinker {
         cpu_type: int = 0,
         cpu_subtype: int = 0;
 
-    """Parse a relocatable Mach-O object and link into an executable."""
     static def link(
         obj_bytes: bytes,
         output_path: str,
         needed_libs: list[str] = ["/usr/lib/libSystem.B.dylib"]
     ) -> bool;
 
-    """Parse the Mach-O relocatable object file."""
     def parse_object -> bool;
-
-    """Build the final Mach-O executable bytes."""
     def build_executable -> bytes;
 }

--- a/jac/jaclang/compiler/type_system/types.jac
+++ b/jac/jaclang/compiler/type_system/types.jac
@@ -293,11 +293,7 @@ obj FunctionType(TypeBase) {
     def __str__ -> str;
     def specialize(class_type: ClassType) -> FunctionType;
     def _index_of_type_param(class_type: ClassType, type_var: TypeVarType) -> int;
-    # --- Flag checking methods (following Pyright's pattern) ---
-    """Check if this is a gradual callable form (Callable[..., T])."""
     def is_gradual_callable_form -> bool;
-
-    """Check if this function type was created from a Callable annotation."""
     def is_from_callable_annotation -> bool;
 }
 

--- a/jac/jaclang/jac0core/archetype.jac
+++ b/jac/jaclang/jac0core/archetype.jac
@@ -24,7 +24,6 @@ class AccessLevel(IntEnum) {
         WRITE = 2;
     }
 
-    """Cast access level."""
     static def cast(val: int | str | AccessLevel) -> AccessLevel {
         if isinstance(val, int) {
             return AccessLevel(val);
@@ -112,13 +111,11 @@ obj ObjectSpatialPath {
     ) -> ObjectSpatialPath;
 
     def set_edge_only(self: ObjectSpatialPath) -> ObjectSpatialPath;
-    """Set edge only mode (alias for set_edge_only)."""
     def `edge(self: ObjectSpatialPath) -> ObjectSpatialPath {
         self.edge_only = True;
         return self;
     }
 
-    """Set from visit mode."""
     def `visit(self: ObjectSpatialPath) -> ObjectSpatialPath {
         self.from_visit = True;
         return self;
@@ -221,7 +218,6 @@ class NodeArchetype(Archetype) {
         __jac_base__: ClassVar = True;
     }
 
-    """Create default anchor."""
     @cached_property
     def __jac__(self: NodeArchetype) -> NodeAnchor {
         return NodeAnchor(archetype=self, edges=[]);
@@ -244,7 +240,6 @@ class WalkerArchetype(Archetype) {
         reports: list[Any] = field(default_factory=`list);
     }
 
-    """Create default anchor."""
     @cached_property
     def __jac__(self: WalkerArchetype) -> WalkerAnchor {
         return WalkerAnchor(archetype=self);
@@ -257,7 +252,6 @@ class ObjectArchetype(Archetype) {
         __jac_base__: ClassVar = True;
     }
 
-    """Create default anchor."""
     @cached_property
     def __jac__(self: ObjectArchetype) -> ObjectAnchor {
         return ObjectAnchor(archetype=self);

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -179,7 +179,6 @@ obj CodeGenTarget {
         _auto_promoted_native: bool = False,
         layout_registry: Any = None;
 
-    """Lazy initialization of doc_ir to allow doc_ir.jac conversion."""
     @property
     def doc_ir(self: CodeGenTarget) -> Doc {
         if (self._doc_ir is None) {
@@ -189,7 +188,6 @@ obj CodeGenTarget {
         return self._doc_ir;
     }
 
-    """Set doc_ir value."""
     @doc_ir.setter
     def doc_ir(self: CodeGenTarget, value: Doc) -> None {
         self._doc_ir = value;
@@ -201,7 +199,6 @@ obj CodeLocInfo {
     has first_tok: Token,
         last_tok: Token;
 
-    """Get file source."""
     @property
     def orig_src(self: CodeLocInfo) -> Source {
         return self.first_tok.orig_src;

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -191,13 +191,8 @@ obj _SetupProgress {
 
     def postinit -> None;
     def _get_jaclang_root -> str;
-    """Print the completion summary when the process exits."""
     def _atexit_handler -> None;
-
-    """Called when an internal jaclang module needs compilation (cache miss)."""
     def on_internal_compile(file_path: str) -> None;
-
-    """Whether we're currently in a first-run setup."""
     @property
     def is_active -> bool;
 }
@@ -308,51 +303,25 @@ obj JacCompiler {
 
     has _internal_program: (JacProgram | None) = None;
 
-    """Module hub for jaclang.* modules (lazily initialized)."""
     @property
     def internal_program -> JacProgram;
 
-    """Get the jaclang package root path."""
     @classmethod
     def _get_jaclang_root(cls: Any) -> str;
 
-    """Route jaclang.* files to internal_program, others to target_program."""
     def _resolve_program(file_path: str, target_program: JacProgram) -> JacProgram;
-
-    """Get native interop setup for a module.
-
-        Returns:
-            Tuple of (native_engine, interop_py_funcs_dict).
-            native_engine is None if no native code.
-            interop_py_funcs_dict is None if module not found in hub
-            (caller should not inject into module dict in this case).
-        """
     def get_native_interop_setup(
         full_target: str, target_program: JacProgram
     ) -> tuple[((object | None), (dict[(str, object)] | None))];
 
-    """Get native module layout metadata for auto-marshalling."""
     def get_native_layout(
         full_target: str, target_program: JacProgram
     ) -> (object | None);
 
-    """Get bytecode using 2-tier cache: in-memory -> JIR -> compile.
-
-        Tier 1: in-memory hub (py_bytecode already set).
-        Tier 2: JIR cache fast-path (read_bytecode_only, no AST deserialize).
-        Tier 2.5: precompiled JIR bundle shipped with the package.
-        Tier 3: full compile + atomic JIR write.
-        """
     def get_bytecode(
         full_target: str, target_program: JacProgram
     ) -> (types.CodeType | None);
 
-    """Load native module from cached LLVM IR.
-
-        Creates a fresh MCJIT engine from the cached IR string and sets up
-        interop callbacks. This is much faster than full recompilation since
-        we skip the Jac-AST-LLVM IR pipeline.
-        """
     def _load_native_from_cache(
         full_target: str,
         target_program: JacProgram,
@@ -360,12 +329,6 @@ obj JacCompiler {
         cached_interop: (dict | None)
     ) -> None;
 
-    """Load native module from cached post-optimization bitcode.
-
-        Parses the SEC_NATIVE_OBJ section which contains a platform header
-        followed by LLVM bitcode. Bitcode parsing is faster than text IR
-        parsing and the bitcode is already optimized.
-        """
     def _load_native_from_bitcode(
         full_target: str,
         target_program: JacProgram,
@@ -373,18 +336,12 @@ obj JacCompiler {
         cached_interop: (dict | None)
     ) -> None;
 
-    """Restore side-effects (MTIR, native) from decoded JIR sections."""
     def _restore_sections(
         full_target: str, actual_program: JacProgram, secs: dict[int, bytes]
     ) -> None;
 
-    """Walk up from a .jac file looking for a _precompiled/ JIR bundle."""
     def _get_precompiled_jir_bytecode(full_target: str) -> (bytes | None);
-
-    """Build a JSON-serializable interop dict from a compiled module."""
     def _build_interop_dict(result: uni.Module) -> dict;
-
-    """Parse source string into AST module."""
     def parse_str(
         source_str: str,
         file_path: str,
@@ -392,14 +349,6 @@ obj JacCompiler {
         cancel_token: (Event | None) = None
     ) -> uni.Module;
 
-    """Compile a Jac file into module AST.
-
-        Args:
-            file_path: Path to the Jac file to compile.
-            target_program: JacProgram to store compiled module in.
-            use_str: Optional source string instead of reading from file.
-            options: CompileOptions controlling compilation behavior.
-        """
     def compile(
         file_path: str,
         target_program: JacProgram,
@@ -407,7 +356,6 @@ obj JacCompiler {
         options: (CompileOptions | None) = None
     ) -> uni.Module;
 
-    """Build a Jac file with import dependency resolution."""
     def build(
         file_path: str,
         target_program: JacProgram,
@@ -415,7 +363,6 @@ obj JacCompiler {
         type_check: bool = False
     ) -> uni.Module;
 
-    """Run a list of passes on a module."""
     def run_schedule(
         mod: uni.Module,
         target_program: JacProgram,
@@ -423,11 +370,6 @@ obj JacCompiler {
         cancel_token: (Event | None) = None
     ) -> None;
 
-    """Parse a Jac file/string and optionally load annexes for tooling passes.
-
-    Shared scaffold for jac_file_formatter, jac_str_formatter, and jac_file_linter.
-    Returns (prog, current_mod) or (prog, None) if parse errors occurred.
-    """
     static def _prepare_tool_program(
         source_str: str,
         file_path: str,
@@ -435,16 +377,13 @@ obj JacCompiler {
         load_test_annexes: bool = False
     ) -> tuple[JacProgram, (uni.Module | None)];
 
-    """Format a Jac file."""
     static def jac_file_formatter(
         file_path: str, auto_lint: bool = False
     ) -> JacProgram;
 
-    """Format a Jac source string."""
     static def jac_str_formatter(
         source_str: str, file_path: str, auto_lint: bool = False
     ) -> JacProgram;
 
-    """Lint a Jac file (report only, no formatting or output generation)."""
     static def jac_file_linter(file_path: str) -> JacProgram;
 }

--- a/jac/jaclang/jac0core/helpers.jac
+++ b/jac/jaclang/jac0core/helpers.jac
@@ -248,10 +248,7 @@ def pretty_print_source_location(
 
 """Jac debugger."""
 class Jdb(pdb.Pdb) {
-    """Initialize the Jac debugger."""
     def init(self: Jdb, *args: Any, **kwargs: Any) -> None;
-
-    """Check for breakpoint."""
     def has_breakpoint(self: Jdb, bytecode: bytes) -> bool;
 }
 
@@ -370,11 +367,9 @@ def _describe_nodes_list(objects: Sequence) -> str {
 obj DistFacade {
     has _dist: (object | None);
 
-    """Get the distribution/package name."""
     @property
     def project_name(self: DistFacade) -> str;
 
-    """Get the distribution version."""
     @property
     def version(self: DistFacade) -> str;
 }

--- a/jac/jaclang/jac0core/jir.jac
+++ b/jac/jaclang/jac0core/jir.jac
@@ -104,16 +104,9 @@ Strings are assigned sequential indices. The pool is serialized as:
 """
 class StringPool {
     def init(self: StringPool) -> None;
-    """Intern a string and return its pool index."""
     def intern(self: StringPool, s: str) -> int;
-
-    """Get string by pool index."""
     def get(self: StringPool, idx: int) -> str;
-
-    """Number of strings in pool."""
     def __len__(self: StringPool) -> int;
-
-    """Serialize the pool to bytes."""
     def serialize(self: StringPool) -> bytes;
 }
 
@@ -145,10 +138,7 @@ obj JirHeader {
         string_pool_size: int = 0,
         flags: int = 0;
 
-    """Serialize to 32 bytes."""
     def to_bytes(self: JirHeader) -> bytes;
-
-    """Quick validation: check magic, version, python version."""
     def is_compatible(self: JirHeader) -> bool;
 }
 

--- a/jac/jaclang/jac0core/jir_passes.jac
+++ b/jac/jaclang/jac0core/jir_passes.jac
@@ -148,36 +148,19 @@ obj JirWriter {
         self._inherited_scope_entries = [];
     }
 
-    """Serialize a Module to JIR bytes.
-
-    If sections is provided, TLV section data is appended after the compressed
-    AST payload (bytecode, MTIR, LLVM IR, interop).
-    """
     def write_module(
         module: Module, sections: (dict[int, bytes] | None) = None
     ) -> bytes;
 
-    """Post-order walk, assigning sequential IDs to nodes."""
     def _assign_ids(ir_node: UniNode) -> int;
-
-    """Get the ID for a node, or SENTINEL_NONE if None."""
     def _get_node_id(ir_node: (UniNode | None)) -> int;
-
-    """Serialize a single node to the buffer."""
     def _write_node(buf: bytearray, ir_node: UniNode) -> None;
-
-    """Serialize a Symbol inline."""
     def _write_symbol(buf: bytearray, sym: Symbol) -> None;
-
-    """Serialize a single constructor field by kind."""
     def _write_field(
         buf: bytearray, ir_node: UniNode, field_name: str, kind: int
     ) -> None;
 
-    """Serialize the link table."""
     def _write_link_table(buf: bytearray) -> None;
-
-    """Count total symbols in the module."""
     def _count_symbols(module: Module) -> int;
 }
 
@@ -202,45 +185,25 @@ obj JirReader {
         self._nodes = [];
     }
 
-    """Deserialize bytes into a Module tree. Returns None on failure."""
     def read_module(data: bytes) -> (Module | None);
-
-    """Scan data for trailing TLV sections after the compressed payload."""
     def _read_trailing_sections(data: bytes) -> dict[int, bytes];
-
-    """Create a Source node and set orig_src on all Token nodes."""
     def _wire_source(module: Module) -> None;
-
-    """Derive param_kind for ParamVar nodes from FuncSignature position."""
     def _fix_param_kinds -> None;
-
-    """Pre-cache type checks and enum mappings for fast deserialization."""
     def _init_caches -> None;
-
-    """Resolve a node ID to a node, handling sentinels."""
     def _resolve_node(node_id: int) -> (UniNode | None);
-
-    """Deserialize a single node. Returns new pos."""
     def _read_node(data: (bytes | memoryview), pos: int, idx: int) -> int;
-
-    """Read scope overlay data into a UniScopeNode."""
     def _read_scope_overlay(
         data: (bytes | memoryview), pos: int, scope_node: UniScopeNode
     ) -> int;
 
-    """Read a Symbol from the stream. Returns (symbol_or_none, new_pos)."""
     def _read_symbol(data: (bytes | memoryview), pos: int) -> tuple;
-
-    """Read CFG overlay data into a UniCFGNode."""
     def _read_cfg_overlay(
         data: (bytes | memoryview), pos: int, cfg_node: UniCFGNode
     ) -> int;
 
-    """Read NameAtom overlay data."""
     def _read_name_atom_overlay(
         data: (bytes | memoryview), pos: int, na_node: NameAtom
     ) -> int;
 
-    """Read the link table and wire up deferred references."""
     def _read_link_table(data: (bytes | memoryview), pos: int) -> int;
 }

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -47,7 +47,6 @@ obj UniNode {
         loc: CodeLocInfo by postinit;
 
     def postinit -> None;
-    """Lazy initialization of CodeGenTarget."""
     @property
     def gen -> CodeGenTarget {
         if (self._gen is None) {
@@ -56,91 +55,48 @@ obj UniNode {
         return self._gen;
     }
 
-    """Set CodeGenTarget."""
     @gen.setter
     def gen(value: CodeGenTarget) -> None {
         self._gen = value;
     }
 
-    """Lazy initialization of sub node table."""
     @property
     def _sub_node_tab -> dict[(type, list[UniNode])];
 
-    """Construct sub node table."""
     def _construct_sub_node_tab -> None;
-
-    """Get symbol table."""
     @property
     def sym_tab -> UniScopeNode;
 
-    """Add kid left."""
     def add_kids_left(
         nodes: Sequence[UniNode], pos_update: bool = True, parent_update: bool = False
     ) -> UniNode;
 
-    """Add kid right."""
     def add_kids_right(
         nodes: Sequence[UniNode], pos_update: bool = True, parent_update: bool = False
     ) -> UniNode;
 
-    """Insert kids at position."""
     def insert_kids_at_pos(
         nodes: Sequence[UniNode], pos: int, pos_update: bool = True
     ) -> UniNode;
 
-    """Set kids."""
     def set_kids(nodes: Sequence[UniNode]) -> UniNode;
-
-    """Set parent."""
     def set_parent(parent: UniNode) -> UniNode;
-
     def resolve_tok_range -> tuple[(Token, Token)];
     def gen_token(name: Tok, value: (str | None) = None) -> Token;
-    """Get all sub nodes of type."""
     def get_all_sub_nodes[T](typ: type[T], brute_force: bool = True) -> list[T];
-
-    """Get parent of type."""
     def find_parent_of_type[T](typ: type[T]) -> (T | None);
-
     def parent_of_type[T](typ: type[T]) -> T;
-    """Check if this node is in a client-side context.
-
-        This covers:
-        - Nodes inside an explicit cl {} block in a .jac file
-        - Nodes inside a function marked with CLIENT context in .cl.jac files
-        - Overridden by sv {} blocks (server takes precedence)
-
-        Uses single traversal for efficiency since this is called frequently.
-        """
     def in_client_context -> bool;
-
-    """Check if this node is in a native context.
-
-        This covers:
-        - Nodes inside an explicit na {} block in a .jac file
-        - Nodes inside a function marked with NATIVE context in .na.jac files
-        - Overridden by sv {} or cl {} blocks
-        """
     def in_native_context -> bool;
-
-    """Return dict representation of node."""
     def to_dict -> dict[(str, str)];
-
-    """Print ast."""
     def pp(depth: (int | None) = None) -> str;
-
-    """Print ast."""
     def printgraph -> str;
-
-    """Flatten ast."""
     def flatten -> list[UniNode];
-
     def unparse -> str;
 }
 
 """Symbol."""
 obj Symbol {
-    """Initialize."""
     def init(
         defn: NameAtom,
         access: SymbolAccess,
@@ -148,33 +104,23 @@ obj Symbol {
         imported: bool = False
     ) -> None;
 
-    """Get decl."""
     @property
     def decl -> NameAtom;
 
-    """Get name."""
     @property
     def sym_name -> str;
 
-    """Get sym_type."""
     @property
     def sym_type -> SymbolType;
 
-    """Return a full path of the symbol."""
     @property
     def sym_dotted_name -> str;
 
-    """Get symbol table."""
     @property
     def symbol_table -> (UniScopeNode | None);
 
-    """Add defn."""
     def add_defn(nd: NameAtom) -> None;
-
-    """Add use."""
     def add_use(nd: NameAtom) -> None;
-
-    """Repr."""
     def __repr__ -> str;
 }
 
@@ -195,30 +141,17 @@ obj UniScopeNode(UniNode) {
         names_in_scope_overload: dict[(str, list[Symbol])] by postinit;
 
     def _init_scope(name: str, parent_scope: (UniScopeNode | None) = None) -> None;
-    """Get type."""
     def get_type -> SymbolType;
-
-    """Get parent."""
     def get_parent -> (UniScopeNode | None);
-
     static def get_python_scoping_nodes -> tuple[(type[UniScopeNode], ...)] {
         return (Module, Enum, Archetype, Ability, ImplDef, Test);
     }
 
-    """Lookup a variable in the symbol table."""
     def lookup(
         name: str, deep: bool = True, incl_inner_scope: bool = False
     ) -> (Symbol | None);
 
-    """Lookup all overloads of a symbol in the symbol table."""
     def lookup_all(name: str, deep: bool = True) -> list[Symbol];
-
-    """Set a variable in the symbol table.
-
-        Returns original symbol as collision if single check fails, none
-otherwise.
-        Also updates node.sym to create pointer to symbol.
-        """
     def insert(
         nd: AstSymbolNode,
         access_spec: AstAccessNode | None | SymbolAccess = None,
@@ -227,16 +160,9 @@ otherwise.
         imported: bool = False
     ) -> (UniNode | None);
 
-    """Find a scope in the symbol table."""
     def find_scope(name: str) -> (UniScopeNode | None);
-
-    """Push a new scope onto the symbol table."""
     def link_kid_scope(key_node: UniScopeNode) -> UniScopeNode;
-
-    """Inherit symbol table."""
     def inherit_sym_tab(target_sym_tab: UniScopeNode) -> None;
-
-    """Insert into symbol table."""
     def def_insert(
         nd: AstSymbolNode,
         access_spec: AstAccessNode | None | SymbolAccess = None,
@@ -245,27 +171,15 @@ otherwise.
         imported: bool = False
     ) -> (Symbol | None);
 
-    """Link chain of containing names to symbol."""
     def chain_def_insert(node_list: list[AstSymbolNode]) -> None;
-
-    """Link to symbol."""
     def use_lookup(
         nd: AstSymbolNode, sym_table: (UniScopeNode | None) = None
     ) -> (Symbol | None);
 
-    """Link chain of containing names to symbol."""
     def chain_use_lookup(node_list: Sequence[AstSymbolNode]) -> None;
-
-    """Update python context for definition."""
     def update_py_ctx_for_def(nd: AstSymbolNode) -> None;
-
-    """Pretty print."""
     def sym_pp(depth: (int | None) = None) -> str;
-
-    """Generate dot graph for sym table."""
     def sym_printgraph -> str;
-
-    """Repr."""
     def __repr__ -> str;
 }
 
@@ -290,7 +204,6 @@ obj AstSymbolNode(UniNode) {
     @property
     def py_ctx_func -> type[ast3.AST];
 
-    """Get type symbol table."""
     @property
     def type_sym_tab -> (UniScopeNode | None);
 }
@@ -314,16 +227,9 @@ obj AstAccessNode(UniNode) {
 """Base class for nodes that can be marked with execution context
 (client/server)."""
 obj ContextAwareNode(UniNode) {
-    """Initialize with code context.
-
-        Args:
-            code_context: Code execution context (SERVER or CLIENT), defaults to
-SERVER
-        """
     has code_context: CodeContext by postinit;
 
     def postinit -> None;
-    """Return the original context token (cl or sv) if present on this node."""
     def _source_context_token -> (Token | None);
 }
 
@@ -356,16 +262,12 @@ obj WalkerStmtOnlyNode(UniNode) {
 
 """BasicBlockStmt node type for Jac Uniir."""
 obj UniCFGNode(UniNode) {
-    """Initialize basic block statement node."""
     has bb_in: list[UniCFGNode] by postinit,
         bb_out: list[UniCFGNode] by postinit,
         affected_symbols: set[str] by postinit;
 
     def postinit -> None;
-    """Get head by walking up the CFG iteratively."""
     def get_head -> UniCFGNode;
-
-    """Get tail by walking down the CFG iteratively."""
     def get_tail -> UniCFGNode;
 }
 
@@ -413,13 +315,11 @@ obj Expr(UniNode) {
         attached_tokens: (list[Token] | None) by postinit;
 
     def postinit -> None;
-    """Get type symbol table."""
     @property
     def type_sym_tab -> (UniScopeNode | None) {
         return self._type_sym_tab;
     }
 
-    """Set type symbol table."""
     @type_sym_tab.setter
     def type_sym_tab(type_sym_tab: UniScopeNode) -> None {
         self._type_sym_tab = type_sym_tab;
@@ -442,7 +342,6 @@ obj EnumBlockStmt(UniNode) {
 
 """CodeBlockStmt node type for Jac Ast."""
 obj CodeBlockStmt(UniCFGNode) {
-    """Initialize code block statement node."""
     def postinit -> None;
 }
 
@@ -480,7 +379,6 @@ obj NameAtom(AtomExpr, EnumBlockStmt) {
     @property
     def sym_category -> SymbolType;
 
-    """Create symbol."""
     def create_symbol(
         access: SymbolAccess,
         parent_tab: (UniScopeNode | None) = None,
@@ -490,19 +388,16 @@ obj NameAtom(AtomExpr, EnumBlockStmt) {
     @property
     def clean_type -> str;
 
-    """Get python context function."""
     @property
     def py_ctx_func -> type[ast3.expr_context] {
         return self._py_ctx_func;
     }
 
-    """Set python context function."""
     @py_ctx_func.setter
     def py_ctx_func(py_ctx_func: type[ast3.expr_context]) -> None {
         self._py_ctx_func = py_ctx_func;
     }
 
-    """Resolve semantic token."""
     @property
     def sem_token -> (tuple[(SemTokType, SemTokMod)] | None);
 }
@@ -533,22 +428,11 @@ obj Module(AstDocNode, UniScopeNode) {
         stub_only: bool = False;
 
     def postinit -> None;
-    """Get the base module path that this annex file belongs to.
-
-        Uses discover_base_file to find the base .jac file for annex files
-        (.impl.jac, .test.jac). Handles all discovery scenarios:
-        - Same directory: foo.impl.jac -> foo.jac
-        - Module-specific folder: foo.impl/bar.impl.jac -> foo.jac
-        - Shared folder: impl/foo.impl.jac -> foo.jac
-        """
     @property
     def annexable_by -> (str | None);
 
-    """Get all sub nodes of type."""
     def format -> str;
-
     def unparse(requires_format: bool = True) -> str;
-    """Create a stub module."""
     static def make_stub(
         inject_name: (str | None) = None, inject_src: (Source | None) = None
     ) -> Module {
@@ -563,7 +447,6 @@ obj Module(AstDocNode, UniScopeNode) {
         );
     }
 
-    """Return the full path of the module that contains this node."""
     static def get_href_path(nd: UniNode) -> str {
         parent = nd.find_parent_of_type(Module);
         mod_list: list[(Module | Archetype)] = [];
@@ -583,7 +466,6 @@ obj Module(AstDocNode, UniScopeNode) {
 
 """Whole Program node type for Jac Ast."""
 obj ProgramModule(UniNode) {
-    """Initialize whole program node."""
     has main_mod: (Module | None) = None;
 
     def postinit -> None;
@@ -676,15 +558,12 @@ obj Import(ContextAwareNode, ElementStmt, CodeBlockStmt) {
         clib_decls: (Sequence[UniNode] | None) = None;
 
     def postinit -> None;
-    """Check if import is python."""
     @property
     def is_py -> bool;
 
-    """Check if import is jac."""
     @property
     def is_jac -> bool;
 
-    """Check if import is jac."""
     @property
     def __jac_detected -> bool;
 }
@@ -696,18 +575,13 @@ obj ModulePath(UniNode) {
         alias: (Name | None);
 
     def postinit -> None;
-    """Check if this modulepath is from import."""
     @property
     def is_import_from -> bool;
 
-    """Get path string."""
     @property
     def dot_path_str -> str;
 
-    """Convert an import target string into a relative file path."""
     def resolve_relative_path(target_item: (str | None) = None) -> str;
-
-    """Convert an import target string into a relative file path."""
     def resolve_relative_path_list -> list[str];
 }
 
@@ -723,15 +597,12 @@ obj ModuleItem(UniNode) {
         alias: (Name | None);
 
     def postinit -> None;
-    """Get import parent."""
     @property
     def from_parent -> Import;
 
-    """Get relevant module path."""
     @property
     def from_mod_path -> ModulePath;
 
-    """Resolve path of this item (e.g., 'ir' -> llvmlite/ir/__init__.py)."""
     def resolve_relative_path -> str;
 }
 
@@ -795,7 +666,6 @@ obj Ability(ContextAwareNode, AstAccessNode, ElementStmt, AstAsyncNode, ArchBloc
     @property
     def is_method -> bool;
 
-    """Check if this ability is a class method."""
     @property
     def is_cls_method -> bool;
 
@@ -808,13 +678,7 @@ obj Ability(ContextAwareNode, AstAccessNode, ElementStmt, AstAsyncNode, ArchBloc
     @property
     def is_genai_ability -> bool;
 
-    """Get the range of positional arguments for this ability.
-
-        Returns -1 for maximum number of arguments if there is an unpacked
-parameter (e.g., *args).
-        """
     def get_pos_argc_range -> tuple[(int, int)];
-
     def py_resolve_name -> str;
 }
 
@@ -828,9 +692,7 @@ obj FuncSignature(UniNode) {
         return_type: (Expr | None);
 
     def postinit -> None;
-    """Return all parameters in the declared order."""
     def get_parameters -> list[ParamVar];
-
     @property
     def is_static -> bool;
 
@@ -1019,7 +881,6 @@ obj DeleteStmt(CodeBlockStmt) {
     has target: Expr;
 
     def postinit -> None;
-    """Get Python AST targets (without setting ctx)."""
     @property
     def py_ast_targets -> list[ast3.AST];
 }
@@ -1048,7 +909,6 @@ obj VisitStmt(WalkerStmtOnlyNode, AstElseBodyNode, CodeBlockStmt) {
 
 """DisengageStmt node type for Jac Ast."""
 obj DisengageStmt(WalkerStmtOnlyNode, CodeBlockStmt) {
-    """Initialize disengage statement node."""
     def postinit -> None;
 }
 
@@ -1347,10 +1207,7 @@ obj JsxElement(AtomExpr) {
         is_fragment: bool;
 
     def postinit -> None;
-    """Get the source line after the opening tag's '>' token (body start)."""
     def get_body_start_line -> (int | None);
-
-    """Get the source line of the closing tag's '</' token (body end)."""
     def get_body_end_line -> (int | None);
 }
 
@@ -1391,11 +1248,6 @@ obj JsxText(JsxChild) {
     has value: (str | Token);
 
     def postinit -> None;
-    """Normalize JSX text whitespace (single source of truth).
-
-    HTML-like rules: strip leading/trailing newline+whitespace,
-    collapse internal newline+whitespace sequences to a single space.
-    """
     def get_normalized_text -> str;
 }
 
@@ -1544,7 +1396,6 @@ obj Name(Token, NameAtom) {
         is_kwesc: bool = False
     ) -> None;
 
-    """Generate name from node."""
     static def gen_stub_from_node(
         nd: AstSymbolNode, name_str: str, set_name_of: (AstSymbolNode | None) = None
     ) -> Name {
@@ -1601,7 +1452,6 @@ obj Literal(Token, AtomExpr) {
         pos_end: int
     ) -> None;
 
-    """Return literal value in its python type."""
     @property
     def lit_value -> int | str | float | bool | None | Callable[
         ([], Any)
@@ -1614,7 +1464,6 @@ obj BuiltinType(Name, Literal) {
         SYMBOL_TYPE = SymbolType.VAR;
     }
 
-    """Return literal value in its python type."""
     @property
     def lit_value -> Callable[([], Any)];
 }
@@ -1686,7 +1535,6 @@ obj EmptyToken(Token) {
 
 """Semicolon node type for Jac Ast."""
 obj Semi(Token, CodeBlockStmt) {
-    """Initialize token."""
     def init(
         orig_src: Source,
         name: str,
@@ -1726,7 +1574,6 @@ obj CommentToken(Token) {
 """SourceString node type for Jac Ast."""
 obj Source(EmptyToken) {
     def init(source: str, mod_path: str) -> None;
-    """Return the source code as string."""
     @property
     def code -> str;
 }

--- a/jac/jaclang/project/dep_registry.jac
+++ b/jac/jaclang/project/dep_registry.jac
@@ -34,25 +34,12 @@ obj DependencyRegistry {
     has _types: dict[str, DependencyType] = {},
         _flag_map: dict[str, str] = {};
 
-    """Register a new dependency type from plugin hook data."""
     def register(dep_type_info: dict[(str, Any)]) -> None;
-
-    """Get dependency type by name (e.g., 'npm')."""
     def get_by_name(name: str) -> DependencyType | None;
-
-    """Get dependency type by CLI flag (e.g., '--cl')."""
     def get_by_flag(flag: str) -> DependencyType | None;
-
-    """Get all registered dependency types."""
     def get_all -> dict[str, DependencyType];
-
-    """Get all registered CLI flags."""
     def get_all_flags -> list[str];
-
-    """Check if a dependency type is registered."""
     def has_type(name: str) -> bool;
-
-    """Clear all registered types (for testing)."""
     def clear -> None;
 }
 

--- a/jac/jaclang/project/template_registry.jac
+++ b/jac/jaclang/project/template_registry.jac
@@ -23,7 +23,6 @@ obj ProjectTemplate {
         root_gitignore_entries: list[str] = [],  # entries for project-root .gitignore
         post_create: Callable | None = None;  # optional callback(project_path, project_name)
 
-    """Convert to dict for serialization (e.g., JSON bundling)."""
     def to_dict -> dict[str, Any];
 }
 
@@ -36,22 +35,11 @@ this registry to scaffold projects based on the selected template.
 obj TemplateRegistry {
     has _templates: dict[str, ProjectTemplate] = {};
 
-    """Register a new template from plugin hook data."""
     def register(template_info: dict[str, Any]) -> None;
-
-    """Get template by name (e.g., 'default', 'client')."""
     def get(name: str) -> ProjectTemplate | None;
-
-    """Get the default template."""
     def get_default -> ProjectTemplate;
-
-    """List all registered templates as (name, description) tuples."""
     def list_templates -> list[tuple[str, str]];
-
-    """Check if a template is registered."""
     def has_template(name: str) -> bool;
-
-    """Clear all registered templates (for testing)."""
     def clear -> None;
 }
 

--- a/jac/jaclang/runtimelib/hmr.jac
+++ b/jac/jaclang/runtimelib/hmr.jac
@@ -26,44 +26,23 @@ obj HotReloader {
         _running: bool = False,
         _overlay_entry: bool = False;
 
-    """Start the hot reloader and begin watching for changes."""
     def start -> None;
-
-    """Stop the hot reloader and file watcher."""
     def stop -> None;
-
-    """Callback for file change events from the watcher."""
     def on_file_change(
         event: Any
     ) -> None;  # FileChangeEvent - using Any to avoid circular import
 
 
-    """Process a file change by classifying declarations and taking action."""
     def _process_change(file_path: str) -> None;
-
-    """Reload server-side module in sys.modules."""
     def _reload_server_module(file_path: str) -> None;
-
-    """Recompile client declarations to JavaScript."""
     def _recompile_client_code(
         file_path: str, visited: set | None = None, force: bool = True
     ) -> None;
 
-    """Get client and server declarations from a file."""
     def _classify_declarations(file_path: str) -> tuple[bool, bool];
-
-    """Convert file path to module name."""
     def _path_to_module(file_path: str) -> str;
-
-    """Convert a .jac file path to a .js filename."""
     def _get_js_filename(file_path: str) -> str;
-
-    """Emit a client-side error overlay for compilation errors."""
     def _emit_client_error_overlay(file_path: str, errors: str) -> None;
-
-    """Copy frontend files to compiled directory."""
     def _copy_frontend_files(file_path: str) -> None;
-
-    """Update the entry point to reflect changes in modules."""
     def _update_entry_point -> None;
 }

--- a/jac/jaclang/runtimelib/memory.jac
+++ b/jac/jaclang/runtimelib/memory.jac
@@ -44,45 +44,27 @@ All memory implementations (volatile, cache, persistent, tiered) implement this 
 This enables ExecutionContext to work with any memory type transparently.
 """
 obj Memory {
-    """Check if the memory is available and operational."""
     def is_available -> bool abs;
-
-    """Retrieve an anchor by its UUID."""
     def get(id: UUID) -> (Anchor | None) abs;
-
-    """Store an anchor."""
     def put(anchor: Anchor) -> None abs;
-
-    """Remove an anchor by ID."""
     def delete(id: UUID) -> None abs;
-
-    """Close the memory and release resources."""
     def close -> None abs;
-
-    """Check if an anchor is currently in memory."""
     def `has(id: UUID) -> bool abs;
-
-    """Query all anchors with optional filter."""
     def query(
         filter: (Callable[[Anchor], bool] | None) = None
     ) -> Generator[Anchor, None, None] abs;
 
-    """Get all root anchors."""
     def get_roots -> Generator[Root, None, None] abs;
-
-    """Find anchors by IDs with optional filter."""
     def find(
         ids: (UUID | Iterable[UUID]),
         filter: (Callable[[Anchor], Anchor] | None) = None
     ) -> Generator[Anchor, None, None] abs;
 
-    """Find one anchor by ID(s) with optional filter."""
     def find_one(
         ids: (UUID | Iterable[UUID]),
         filter: (Callable[[Anchor], Anchor] | None) = None
     ) -> (Anchor | None) abs;
 
-    """Commit/sync pending changes. For write-through this flushes to durable storage."""
     def commit(anchor: (Anchor | None) = None) -> None abs;
 }
 
@@ -93,13 +75,8 @@ Cache backends are expected to be fast but data loss is acceptable.
 Used for L2 (local or distributed cache like Redis) in the tiered hierarchy.
 """
 obj CacheMemory(Memory) {
-    """Check if a key exists in the cache without loading the value."""
     def exists(id: UUID) -> bool abs;
-
-    """Store an anchor only if it already exists in the cache."""
     def put_if_exists(anchor: Anchor) -> bool abs;
-
-    """Invalidate a cache entry by ID."""
     def invalidate(id: UUID) -> None abs;
 }
 
@@ -109,10 +86,7 @@ Extends Memory with operations specific to durable storage.
 Implementations must guarantee data durability after sync().
 """
 obj PersistentMemory(Memory) {
-    """Flush pending writes to durable storage."""
     def sync -> None abs;
-
-    """Bulk store multiple anchors efficiently."""
     def bulk_put(anchors: Iterable[Anchor]) -> None abs;
 }
 

--- a/jac/jaclang/runtimelib/testing.jac
+++ b/jac/jaclang/runtimelib/testing.jac
@@ -41,14 +41,10 @@ obj TestResponse {
         text: str,
         _json_cache: (dict[str, Any] | None) = None;
 
-    """Parse response body as JSON."""
     def json -> dict[str, Any];
-
-    """Check if response indicates success (2xx status)."""
     @property
     def ok -> bool;
 
-    """Get data from response, handling TransportResponse envelope."""
     @property
     def data -> (dict[str, Any] | None);
 }
@@ -67,36 +63,29 @@ obj JacTestClient {
         _current_user: (str | None) = None,
         _hot_reloader: (Any | None) = None;
 
-    """Create test client from a .jac file path."""
     static def from_file(
         jac_file: str, base_path: (str | None) = None, module_name: (str | None) = None
     ) -> JacTestClient;
 
-    """Initialize server and handler (lazy loading)."""
     def _ensure_initialized -> None;
-
-    """Make a GET request."""
     def get(
         path: str,
         params: (dict[str, Any] | None) = None,
         headers: (dict[str, str] | None) = None
     ) -> TestResponse;
 
-    """Make a POST request with JSON body."""
     def post(
         path: str,
         json: (dict[str, Any] | None) = None,
         headers: (dict[str, str] | None) = None
     ) -> TestResponse;
 
-    """Make a PUT request with JSON body."""
     def put(
         path: str,
         json: (dict[str, Any] | None) = None,
         headers: (dict[str, str] | None) = None
     ) -> TestResponse;
 
-    """Make a request with specified method."""
     def request(
         method: str,
         path: str,
@@ -105,19 +94,10 @@ obj JacTestClient {
         headers: (dict[str, str] | None) = None
     ) -> TestResponse;
 
-    """Set authentication token for subsequent requests."""
     def set_auth_token(token: str) -> None;
-
-    """Clear authentication token."""
     def clear_auth -> None;
-
-    """Register a new user and set auth token."""
     def register_user(username: str, password: str) -> TestResponse;
-
-    """Login existing user and set auth token."""
     def login(username: str, password: str) -> TestResponse;
-
-    """Internal: Execute request through mock handler."""
     def _execute_request(
         method: str,
         path: str,
@@ -125,24 +105,13 @@ obj JacTestClient {
         headers: (dict[str, str] | None) = None
     ) -> TestResponse;
 
-    """Internal: Parse raw HTTP response."""
     def _parse_response(raw_response: bytes) -> TestResponse;
-
-    """Get the underlying server instance."""
     @property
     def server -> JacAPIServer;
 
-    """Get the user manager for direct manipulation."""
     @property
     def user_manager -> Any;
 
-    """Reload the module (for HMR testing).
-
-    This simulates what the HotReloader does when a file changes,
-    allowing HMR functionality to be tested without real servers.
-    """
     def reload -> None;
-
-    """Cleanup resources."""
     def close -> None;
 }

--- a/jac/jaclang/runtimelib/transport.jac
+++ b/jac/jaclang/runtimelib/transport.jac
@@ -47,14 +47,12 @@ obj TransportResponse {
         error: (ErrorInfo | None) = None,
         meta: Meta = Meta();
 
-    """Create a success response."""
     static def success(
         data: Any = None,
         msg_type: MessageType = MessageType.RESPONSE.value,
         meta: (Meta | None) = None
     ) -> TransportResponse;
 
-    """Create an error response."""
     static def fail(
         code: str,
         message: str,
@@ -70,13 +68,8 @@ obj BaseTransport {
         on_error: (Callable[(..., Any)] | None) = None,
         on_close: (Callable[(..., Any)] | None) = None;
 
-    """Initialize and establish the transport connection."""
     async def connect -> None;
-
-    """Send data through the transport. Protocol-agnostic."""
     async def send(data: Any) -> None;
-
-    """Close the transport connection and cleanup resources."""
     async def close -> None;
 }
 
@@ -85,13 +78,8 @@ obj HTTPTransport(BaseTransport) {
     has handler: Any = None,
         response_data: dict[(str, Any)] = {};
 
-    """HTTP is stateless - nothing to connect."""
     def connect -> None;
-
-    """Serialize and store response data. Triggers on_message callback."""
     def send(data: Any) -> None;
-
-    """HTTP is stateless - nothing to close."""
     def close -> None;
 }
 
@@ -99,13 +87,8 @@ obj HTTPTransport(BaseTransport) {
 obj StreamTransport(BaseTransport) {
     has queue: Any = None;
 
-    """SSE is stateless - nothing to connect."""
     async def connect -> None;
-
-    """Push data to the queue for SSE streaming."""
     async def send(data: Any) -> None;
-
-    """Signal stream end by pushing None to queue."""
     async def close -> None;
 }
 
@@ -113,12 +96,7 @@ obj StreamTransport(BaseTransport) {
 obj WebSocketTransport(BaseTransport) {
     has websocket: Any = None;
 
-    """Accept the WebSocket connection."""
     async def connect -> None;
-
-    """Send JSON data through WebSocket."""
     async def send(data: Any) -> None;
-
-    """Close the WebSocket connection."""
     async def close -> None;
 }

--- a/jac/jaclang/runtimelib/watcher.jac
+++ b/jac/jaclang/runtimelib/watcher.jac
@@ -46,27 +46,12 @@ obj JacFileWatcher {
         _pending_events: dict[str, FileChangeEvent] = {},
         _last_flush: float = 0.0;
 
-    """Start watching for file changes."""
     def start -> None;
-
-    """Stop watching for file changes."""
     def stop -> None;
-
-    """Add a callback to be invoked on file changes."""
     def add_callback(callback: Callable[[FileChangeEvent], None]) -> None;
-
-    """Remove a previously added callback."""
     def remove_callback(callback: Callable[[FileChangeEvent], None]) -> None;
-
-    """Internal: Handle a file change event from watchdog."""
     def _on_change(path: str, change_type: ChangeType) -> None;
-
-    """Internal: Flush pending events after debounce period."""
     def _debounce_flush -> None;
-
-    """Internal: Check if a path matches the watch pattern."""
     def _matches_pattern(path: str) -> bool;
-
-    """Internal: Notify all callbacks of an event."""
     def _notify_callbacks(event: FileChangeEvent) -> None;
 }


### PR DESCRIPTION
## Summary
- Removed per-method docstrings from `obj` blocks that have separated `.impl.jac` files — only the class-level docstring should remain
- Removed excessive blank lines between consecutive method declarations in obj blocks
- 24 files changed, 576 lines removed across jac0core, cli, runtimelib, compiler passes, project, and type system modules

## Test plan
- [x] All pre-commit hooks pass (including jac-format)
- [ ] CI passes