### PR TITLE
Docs: Reframe language positioning from superset to multi-target compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
 
 # Jaseci Ecosystem
 
-Jac is a programming language designed for humans and AI to build together. It supersets Python and JavaScript with native compilation support, adding constructs that let you weave AI into your code, model complex domains as graphs, and deploy to the cloud -- all without switching languages, managing databases, or writing infrastructure.
+Jac is a programming language designed for humans and AI to build together. With clean, Python-like syntax, Jac compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible) -- giving full access to every library in the PyPI, npm, and native ecosystems. Jac adds constructs that let you weave AI into your code, model complex domains as graphs, and deploy to the cloud -- all without switching languages, managing databases, or writing infrastructure.
 
 This repository houses the Jaseci stack -- the core libraries and tooling that make Jac work:
 
-- **[`jaclang`](jac/):** The Jac programming language -- supersets Python and JavaScript with native compilation support. (`pip install jaclang`)
+- **[`jaclang`](jac/):** The Jac programming language -- compiles to Python bytecode, JavaScript, and native machine code. (`pip install jaclang`)
 - **[`byllm`](jac-byllm/):** Plugin for Jac enabling easy integration of large language models into your applications through the innovative [Meaning Typed Programming](https://arxiv.org/pdf/2405.08965) concept. (`pip install byllm`)
 - **[`jac-client`](jac-client/):** Plugin for Jac to bundle full-stack web applications with full access to the entire npm/node package ecosystem. (`pip install jac-client`)
 - **[`jac-scale`](jac-scale/):** Plugin for Jac enabling fully abstracted and automated deployment and scaling with FastAPI, Redis, MongoDB, and Kubernetes integration. (`pip install jac-scale`)
@@ -56,7 +56,7 @@ Jac imagines what should be abstracted away from the developer and automates it 
 
 - **Full-Stack in One Language:** Build backend logic and frontend interfaces without switching languages. Write React-like components alongside your server code with seamless data flow between them.
 
-- **Python & JavaScript Superset:** Supersets both Python and JavaScript with native compilation support. Access the entire PyPI ecosystem (`numpy`, `pandas`, `torch`, etc.) and npm ecosystem (`react`, `vite`, `tailwind`, etc.) without friction.
+- **Ecosystem-Native Compilation:** Jac compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible). Access the entire PyPI ecosystem (`numpy`, `pandas`, `torch`, etc.), npm ecosystem (`react`, `vite`, `tailwind`, etc.), and native C libraries without friction -- no interop layer, no wrappers.
 
 - **Graph-Native Domain Modeling:** Model complex domains as first-class graphs of objects and deploy agentic **walker** objects to traverse them, performing operations in-situ. No separate database setup or ORM required.
 

--- a/docs/docs/community/release_notes/jac-mcp.md
+++ b/docs/docs/community/release_notes/jac-mcp.md
@@ -3,6 +3,7 @@
 ## jac-mcp 0.1.4 (Unreleased)
 
 - **Fix streamable HTTP transport method issue**: Refactors the server initialization logic for the `streamable-http` transport method.
+- 1 small change/refactor.
 
 ## jac-mcp 0.1.3 (Latest Release)
 

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -76,7 +76,7 @@
                 Jac and Jaseci
             </h1>
             <p class="hero-subtitle animate-on-scroll">
-                The Jac programming language and Jaseci runtime stack supersets Python with
+                The Jac programming language and Jaseci runtime stack features Python-like syntax, compiles to Python bytecode, JavaScript, and native machine code, and adds
                 <a href="https://arxiv.org/abs/2405.08965" target="_blank" class="fancy-link">AI-first constructs</a>,
                 <a href="https://arxiv.org/abs/2503.15812" target="_blank" class="fancy-link">object spatial
                     programming</a>, and
@@ -127,7 +127,7 @@
             <!-- Left: Vertical Tabs Navigation -->
             <div class="vt-vertical-tabs">
                 <button class="vt-tab-btn active" data-index="0" tabindex="0">
-                    Jac Supersets Python
+                    Ecosystem-Native Compilation
                     <a href="#" class="vt-learn-more-link" target="_blank">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                             <path
@@ -176,9 +176,7 @@
             <!-- Right: Content Area -->
             <div class="vt-main-content" id="main-content">
                 <div class="vt-content-heading" id="content-heading">
-                    Jac supersets Python and JavaScript, much like TypeScript
-                    supersets JavaScript or C++ supersets C. It maintains full interoperability with the Python ecosystem,
-                    introducing new features to minimize complexity and accelerate AI application development. We also
+                    Jac features Python-like syntax and compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible). Every library in PyPI, npm, and native C ecosystems works directly -- no interop wrappers needed. Jac introduces new features to minimize complexity and accelerate AI application development. We also
                     provide library mode.
                 </div>
                 <div class="vt-editor">
@@ -325,10 +323,10 @@
                     <div class="carousel-slide">
                         <div class="feature-card">
                             <div class="feature-icon">🐍</div>
-                            <h3 class="feature-title">Jac supersets Python</h3>
+                            <h3 class="feature-title">Ecosystem-Native Compilation</h3>
                             <p class="feature-description">
-                                Jac supersets Python and JavaScript, much like TypeScript
-                                supersets JavaScript or C++ supersets C.
+                                With Python-like syntax, Jac compiles to Python bytecode, JavaScript,
+                                and native machine code -- every library just works.
                             </p>
                         </div>
 
@@ -414,8 +412,8 @@
                     </div>
                     <div class="about-text">
                         <p class="about-description">
-                            Jac is an innovative programming language that supersets Python and JavaScript,
-                            providing seamless access to both the PyPI and npm ecosystems. Created by <strong><a
+                            Jac is an innovative programming language with Python-like syntax that compiles to Python bytecode, JavaScript, and native machine code,
+                            providing seamless access to the PyPI, npm, and native ecosystems. Created by <strong><a
                                     href="https://github.com/marsninja" target="_blank"
                                     class="fancy-link">@marsninja</a></strong>
                             with contributors of <strong><a href="/communityhub/top_contributors/" target="_blank"

--- a/docs/docs/quick-guide/faq.md
+++ b/docs/docs/quick-guide/faq.md
@@ -39,7 +39,7 @@ Answers to common questions about Jac, organized by topic. Click a category to e
         Yes. Jac integrates seamlessly with Python libraries.
 
     ??? question "What's the learning curve coming from Python? How is Jac different from just using Python?"
-        Jac supersets Python -- you'll feel at home. Key differences:
+        Jac compiles to Python bytecode and shares familiar syntax -- you'll feel at home. Key differences:
 
         - Braces `{ }` instead of indentation
         - Semicolons `;` required

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -2,7 +2,7 @@
 
 **The Only Language You Need to Build Anything**
 
-Jac is a programming language designed for humans and AI to build together. It supersets Python and JavaScript with native compilation support, adding constructs that let you weave AI into your code, model complex domains as graphs, and deploy to the cloud -- all without switching languages, managing databases, or writing infrastructure. Jac imagines what should be abstracted away from the developer and automates it through the compiler and runtime.
+Jac is a programming language designed for humans and AI to build together. With clean, Python-like syntax, Jac compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible) -- giving full access to every library in the PyPI, npm, and native ecosystems. Jac adds constructs that let you weave AI into your code, model complex domains as graphs, and deploy to the cloud -- all without switching languages, managing databases, or writing infrastructure. Jac imagines what should be abstracted away from the developer and automates it through the compiler and runtime.
 
 ```jac
 # A complete full-stack AI app in one file
@@ -274,11 +274,11 @@ Jac is designed for developers who want to build AI-powered applications without
 | **Startup Founder** | Ship complete products faster -- one language, one deploy command |
 | **AI/ML Engineer** | Native LLM integration without prompt engineering overhead |
 | **Full-Stack Developer** | React frontend + Python backend, no context switching |
-| **Python Developer** | Familiar syntax with powerful new capabilities (Jac supersets Python) |
+| **Python Developer** | Familiar syntax with powerful new capabilities (Jac compiles to Python bytecode -- all your libraries just work) |
 | **Student/Learner** | Modern language designed for clarity, with clean syntax AI models can read and write |
 
 !!! note "What You Should Know"
-    Jac supersets Python, so **Python familiarity is assumed** throughout these docs. If you plan to use the full-stack features, basic **React/JSX** knowledge helps. No graph database experience is needed -- Jac teaches you that.
+    Jac compiles to Python bytecode, so **Python familiarity is assumed** throughout these docs. If you plan to use the full-stack features, basic **React/JSX** knowledge helps. No graph database experience is needed -- Jac teaches you that.
 
 ---
 

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -8,9 +8,10 @@ This page is a **lookup reference**, not a learning guide. For hands-on learning
 # ============================================================
 # Learn Jac in Y Minutes
 # ============================================================
-# Jac is a superset of Python with graph-native programming,
-# object-spatial walkers, AI-native constructs, and full-stack
-# codespaces -- all with brace-delimited blocks.
+# Jac compiles to Python bytecode, JavaScript, and native machine code.
+# It features graph-native programming, object-spatial walkers,
+# AI-native constructs, and full-stack codespaces -- all with
+# brace-delimited blocks.
 # Run a file with: jac <filename>
 
 # ============================================================

--- a/docs/docs/quick-guide/what-makes-jac-different.md
+++ b/docs/docs/quick-guide/what-makes-jac-different.md
@@ -1,6 +1,6 @@
 # Core Concepts
 
-Most of Jac will be recognizable if you are familiar with another programming language like Python -- Jac supersets Python, so familiar constructs like functions, classes, imports, list comprehensions, and control flow all work as expected. You can explore those in depth in the [language reference](../reference/language/foundation.md).
+Most of Jac will be recognizable if you are familiar with another programming language like Python -- Jac compiles to Python bytecode and shares many of its constructs, so functions, classes, imports, list comprehensions, and control flow all work as expected. You can explore those in depth in the [language reference](../reference/language/foundation.md).
 
 This page focuses on the three concepts that Jac adds beyond traditional programming languages. These are the ideas the rest of the documentation builds on, introduced briefly so you have the vocabulary for the tutorials that follow. Through these concepts three important questions can be answered:
 

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -16,7 +16,7 @@
 
 ### 1 What is Jac?
 
-Jac is an AI-native full-stack programming language that supersets Python and JavaScript with native compilation support. It introduces Object-Spatial Programming (OSP) and novel constructs for AI-integrated programming (such as `by llm()`), providing a unified language for backend, frontend, and AI development with full access to the PyPI and npm ecosystems.
+Jac is an AI-native full-stack programming language with Python-like syntax that compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible). It introduces Object-Spatial Programming (OSP) and novel constructs for AI-integrated programming (such as `by llm()`), providing a unified language for backend, frontend, and AI development with full access to the PyPI, npm, and native ecosystems.
 
 ```jac
 with entry {
@@ -30,7 +30,7 @@ with entry {
 |-----------|-------------|
 | **AI-Native** | LLMs as first-class citizens through Meaning Typed Programming |
 | **Full-Stack** | Backend and frontend in one unified language |
-| **Superset** | Full access to PyPI and npm ecosystems |
+| **Multi-Target** | Compiles to Python bytecode, JS, and native machine code -- full PyPI, npm, and native ecosystem access |
 | **Object-Spatial** | Graph-based domain modeling with mobile walkers |
 | **Cloud-Native** | One-command deployment with automatic scaling |
 | **Human & AI Friendly** | Readable structure for both humans and AI models |

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -4,9 +4,9 @@
 
 ---
 
-## **Jac Supersets Python**
+## **Jac Compiles to Python Bytecode**
 
-Jac supersets Python and JavaScript, giving you full compatibility with both the PyPI and npm ecosystems. You can use your existing Python and JavaScript knowledge while accessing Jac's graph-based and object-spatial programming features.
+Jac compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible), giving you full compatibility with the PyPI, npm, and native ecosystems. You can use your existing Python and JavaScript knowledge while accessing Jac's graph-based and object-spatial programming features.
 
 ### **How it Works: Transpilation to Native Python**
 
@@ -16,7 +16,7 @@ Jac programs execute on the standard Python runtime without requiring custom run
 * **Full Ecosystem Access:** All packages on PyPI, internal libraries, and Python development tools are compatible with Jac.
 * **Readable Output:** The transpiled Python code is clean and maintainable, enabling inspection, debugging, and understanding.
 
-The relationship between Jac and Python is analogous to that of TypeScript and JavaScript: a superset language that compiles to a widely-adopted base language.
+Jac's Python target compiles to standard Python bytecode, giving you native access to the entire Python ecosystem without interop layers or wrappers.
 
 **Example: From Jac to Python**
 
@@ -570,7 +570,7 @@ This pattern provides graph-based capabilities in pure Python without introducin
 
 ### **Key Takeaways**
 
-Jac's design as a Python superset enables complementary use of both languages rather than requiring a choice between them. Key characteristics include:
+Jac's Python bytecode compilation enables complementary use of both languages rather than requiring a choice between them. Key characteristics include:
 
 * **Incremental Adoption:** Projects can begin with Pattern 5 (pure Python + Jac library) and progressively adopt Pattern 1 (pure Jac) as requirements evolve
 * **Full Ecosystem Access:** All Python libraries, frameworks, and development tools remain compatible without modification

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -1,6 +1,6 @@
 # Jac Basics
 
-This tutorial covers the core syntax and concepts you need to start writing Jac programs. If you're coming from Python, most things will look familiar -- Jac is a superset of Python, so your existing knowledge applies directly. The key differences are syntactic (braces instead of indentation, semicolons to end statements) and conceptual (graph-native types, the `has` keyword for fields, `with entry` for entry points).
+This tutorial covers the core syntax and concepts you need to start writing Jac programs. If you're coming from Python, most things will look familiar -- Jac compiles to Python bytecode and shares many of Python's constructs, so your existing knowledge applies directly. The key differences are syntactic (braces instead of indentation, semicolons to end statements) and conceptual (graph-native types, the `has` keyword for fields, `with entry` for entry points).
 
 By the end of this tutorial, you'll be comfortable writing functions, objects, control flow, imports, and simple graph operations in Jac.
 
@@ -12,9 +12,9 @@ By the end of this tutorial, you'll be comfortable writing functions, objects, c
 
 ---
 
-## Jac is a Superset of Python
+## Jac and Python
 
-Jac supersets Python with new paradigms -- familiar Python concepts all apply. The relationship is similar to TypeScript and JavaScript: everything valid in the base language works, and the superset adds new capabilities on top. The main syntactic differences from Python are:
+Jac compiles to Python bytecode, so all Python libraries work natively and familiar Python concepts apply directly. Jac extends these with new paradigms -- graph-native types, object-spatial programming, and AI-native constructs. The main syntactic differences from Python are:
 
 | Python | Jac |
 |--------|-----|

--- a/jac-mcp/tests/qa_server.jac
+++ b/jac-mcp/tests/qa_server.jac
@@ -326,7 +326,7 @@ with entry {
     print("=" * 60);
 }
 
-# NOTE: Jac is a superset of Python -- Python syntax compiles but isn't idiomatic.
+# NOTE: Jac compiles to Python bytecode -- Python syntax compiles but isn't idiomatic.
 # validate_jac alone cannot reject Python-style code. This is by design.
 # The MCP server's defense is the pitfalls guide + system prompt + patterns,
 # not the validator rejecting Python syntax.

--- a/jac/README.md
+++ b/jac/README.md
@@ -2,7 +2,7 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://www.jac-lang.org/assets/logo.png">
     <source media="(prefers-color-scheme: light)" srcset="https://www.jac-lang.org/assets/logo.png">
-    <img alt="Jaclang Programming Language: Unique and Powerful programming language that runs on top of Python"
+    <img alt="Jac Programming Language: compiles to Python bytecode, JavaScript, and native machine code"
          src="https://www.jac-lang.org/assets/logo.png"
          width="20%">
   </picture>
@@ -23,13 +23,13 @@ This is the main source code repository for the [Jac] programming language. It c
 
 ## What and Why is Jac?
 
-- **Native Superset of Python and TypeScript/JavaScript** - Jac is a native superset of both Python and TypeScript/JavaScript, meaning both ecosystems (PyPI and npm) are directly interoperable with Jac without any trickery (no interop interface needed). Every Jac program can be ejected to pure Python, and Python programs can be transpiled to Jac.
+- **Ecosystem-Native Multi-Target Compilation** - With Python-like syntax, Jac compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible). This means every library in PyPI, npm, and native C ecosystems is directly usable from Jac without interop wrappers or foreign function interfaces. Every Jac program can also be ejected to readable Python, and Python programs can be transpiled to Jac.
 
 - **AI as a Programming Language Constructs** - Jac includes a novel (neurosymbolic) language construct that allows replacing code with generative AI models themselves. Jac's philosophy abstracts away prompt engineering. (Imagine taking a function body and swapping it out with a model.)
 
 - **New Modern Abstractions** - Jac introduces a paradigm that reasons about persistence and the notion of users as a language level construct. This enables writing simple programs for which no code changes are needed whether they run in a simple command terminal, or distributed across a large cloud. Jac's philosophy abstracts away dev ops and container/cloud configuration.
 
-- **Jac Improves on Python** - Jac makes multiple thoughtful quality-of-life improvements/additions to Python. These include new modern operators, new types of comprehensions, new ways of organizing modules (i.e., separating implementations from declarations), etc.
+- **Quality-of-Life Beyond Python** - Jac introduces modern operators, new comprehension forms, and module organization that separates declarations from implementations -- going beyond what Python offers while remaining familiar.
 
 ## Quick Start
 

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jaclang"
 version = "0.12.0"
-description = "Jac programming language - a superset of both Python and TypeScript/JavaScript with novel constructs for AI-integrated programming."
+description = "Jac programming language - Python-like syntax, compiles to Python bytecode, JavaScript, and native machine code with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Replaces all "superset of Python" messaging with accurate multi-target compilation framing: **Jac compiles to Python bytecode, JavaScript, and native machine code (C-ABI compatible)**
- Adds **"Python-like syntax"** to hero descriptions for discoverability and onboarding
- Updates 13 files across READMEs, docs landing page, quick guide, tutorials, language reference, pyproject.toml, and jac-mcp tests
- Removes TypeScript/JavaScript analogy (undersells Jac — TS only targets one backend)
- Renames "Jac Improves on Python" → "Quality-of-Life Beyond Python" to avoid derivative framing

## Files changed

| Area | Files |
|------|-------|
| Root | `README.md` |
| jaclang | `jac/README.md`, `jac/pyproject.toml` |
| Landing page | `docs/docs/index.html` |
| Quick guide | `index.md`, `faq.md`, `syntax-cheatsheet.md`, `what-makes-jac-different.md` |
| Reference | `foundation.md`, `python-integration.md` |
| Tutorials | `basics.md` |
| jac-mcp | `tests/qa_server.jac`, release notes |

## Test plan

- [ ] Verify docs site renders correctly with `mkdocs serve`
- [ ] Confirm no remaining "superset" language in user-facing messaging (set operations in `primitives.md` and compiler code are intentionally unchanged)
- [ ] Review landing page (`docs/docs/index.html`) renders correctly