### PR TITLE
release: jaclang 0.12.1, jac-byllm 0.5.6, jac-client 0.3.5, jac-scale 0.2.5, jac-super 0.1.7, jac-mcp 0.1.4, jaseci 2.3.5

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -285,6 +285,13 @@ jobs:
     - name: Uninstall editable jaclang
       run: pip uninstall -y jaclang
 
+    - name: Clean egg-info to simulate fresh build (like publish-release)
+      run: |
+        rm -rf jac/jaclang.egg-info
+        rm -rf jac-client/*.egg-info
+        rm -rf jac-scale/*.egg-info
+        rm -rf jac-byllm/*.egg-info
+
     - name: Build and install packages
       run: |
         python -m build jac --wheel

--- a/jac/MANIFEST.in
+++ b/jac/MANIFEST.in
@@ -1,0 +1,2 @@
+include jaclang.pth
+include _jac_finder.py


### PR DESCRIPTION
## Summary
- Add MANIFEST.in to include jaclang.pth and _jac_finder.py in builds
- Update test workflow to simulate publish-release build scenario

## Changes
- `jac/MANIFEST.in` - ensures .pth files are included in isolated builds
- `.github/workflows/test-jaseci.yml` - cleans egg-info to test clean build flow