### PR TITLE
feat: Add client-side error reporting to server

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.3.7 (Unreleased)
 
+- **Client-Side Error Reporting**: Added `__jacReportError` and `__jacInstallErrorHandlers` to the client runtime. Global error handlers (`window.onerror`, `unhandledrejection`) are installed at app initialization to automatically capture unhandled JS errors and forward them to the server via `POST /cl/__error__`. The `ErrorBoundary` fallback component also reports caught errors. Entry file generation (`ViteCompiler`) now imports and calls `__jacInstallErrorHandlers()` on startup for both explicit and pages-based routing modes.
+
 ## jac-client 0.3.6 (Latest Release)
 
 - **Fix: Desktop Target Asset Loading**: Fixed an issue where images and other static assets referenced with `/static/assets/` URLs were not loading in desktop (Tauri) builds. Assets are now correctly copied from `compiled/assets/` to `dist/static/assets/` during the build process, ensuring they are available when Tauri serves the frontend bundle. This fix applies to both `jac build --client desktop` and `jac start --client desktop` commands.

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.2.7 (Unreleased)
 
+- **Client-Side Error Reporting Endpoint**: Added `POST /cl/__error__` endpoint to `JacAPIServerCore` for receiving client-side JavaScript errors. Errors are logged via the `jaclang.client_errors` logger and printed to the dev console with stack traces for visibility.
+
 ## jac-scale 0.2.6 (Latest Release)
 
 - **Domain & TLS support (`--enable-tls`)**: Added custom domain name routing and automatic HTTPS via cert-manager + Let's Encrypt. Set `domain` in `jac.toml`, deploy normally, point your CNAME to the NLB, then run `jac start app.jac --scale --enable-tls` to enable HTTPS without a full redeploy. cert-manager is installed automatically and certificates are renewed automatically. Configurable via `domain` and `cert_manager_email` in `[plugins.scale.kubernetes]`.

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.12.3 (Unreleased)
 
+- **Client-Side Error Reporting**: Unhandled JavaScript errors and promise rejections in Jac client apps are now automatically captured and forwarded to the server via `POST /cl/__error__`, where they are logged through both the `jaclang.client_errors` logger and the dev console. Global error handlers (`window.onerror`, `unhandledrejection`) are installed at app initialization, and the `ErrorBoundary` fallback component also reports caught errors. Works with both the stdlib HTTP server and jac-scale (FastAPI).
+
 ## jaclang 0.12.2 (Latest Release)
 
 - **Type Checker: Constrained TypeVar Support**: TypeVars with explicit constraints (`T = TypeVar("T", Foo, Bar)`) now validate operations against all constraint types.

--- a/jac-client/jac_client/plugin/client_runtime.cl.jac
+++ b/jac-client/jac_client/plugin/client_runtime.cl.jac
@@ -73,3 +73,12 @@ async def:pub __cachedEndpointCall(
 
 def:pub __invalidateEndpoint(endpoint_key: str) -> None;
 def:pub __overlaps(list1: list, list2: list) -> bool;
+
+# ============================================================================
+# Client Error Reporting
+# ============================================================================
+def:pub __jacReportError(
+    message: str, stack: str = "", url: str = "", source: str = ""
+) -> None;
+
+def:pub __jacInstallErrorHandlers -> None;

--- a/jac-client/jac_client/plugin/impl/client_runtime.impl.jac
+++ b/jac-client/jac_client/plugin/impl/client_runtime.impl.jac
@@ -456,6 +456,12 @@ impl AuthGuard(redirect: str = "/login") -> JsxElement {
 }
 
 impl ErrorFallback(error: str, resetErrorBoundary: Any) -> JsxElement {
+    # Report error to server for logging
+    try {
+        errMsg = error.error.message if error.error else str(error);
+        errStack = error.error.stack if error.error else "";
+        __jacReportError(errMsg, errStack, "", "ErrorBoundary");
+    } except Exception { }
     return
         <div
             role="alert"
@@ -993,5 +999,67 @@ impl JacForm(props: dict) -> JsxElement {
                 {isSubmitting and "Submitting..."}{not isSubmitting and submitLabel}
             </button>
         </form>
+    );
+}
+
+# ============================================================================
+# Client Error Reporting
+# ============================================================================
+"""Report a client-side error to the server via POST /cl/__error__.
+Fires asynchronously and silently ignores failures (to avoid error loops).
+"""
+impl __jacReportError(
+    message: str, stack: str = "", url: str = "", source: str = ""
+) -> None {
+    try {
+        baseUrl = __getApiBaseUrl();
+        fetch(
+            f"{baseUrl}/cl/__error__",
+            {
+                "method": "POST",
+                "headers": {"Content-Type": "application/json"},
+                "body": JSON.stringify(
+                    {
+                        "message": message,
+                        "stack": stack,
+                        "url": url or window.location.href,
+                        "source": source,
+                        "timestamp": Reflect.construct(Date, []).toISOString()
+                    }
+                )
+            }
+        );
+    } except Exception {
+    # Silently ignore - never let error reporting cause more errors
+    }
+}
+
+"""Install global error handlers to catch unhandled JS errors and rejections.
+Called once during app initialization.
+"""
+impl __jacInstallErrorHandlers -> None {
+    if window.__jacErrorHandlersInstalled {
+        return;
+    }
+    window.__jacErrorHandlersInstalled = True;
+    # Catch synchronous errors (e.g., TypeError, ReferenceError)
+    window.addEventListener(
+        "error",
+        lambda event: Any  -> None { __jacReportError(
+            event.message or "Unknown error",
+            event.error.stack if event.error else "",
+            event.filename or "",
+            "window.onerror"
+        );}
+    );
+    # Catch unhandled promise rejections (e.g., failed fetch, async errors)
+    window.addEventListener(
+        "unhandledrejection",
+        lambda event: Any  -> None { reason = event.reason;message = "";stack = "";if reason {
+            message = reason.message or str(reason);
+            stack = reason.stack or "";
+        } else {
+            message = "Unhandled promise rejection";
+        } __jacReportError(message, stack, "", "unhandledrejection");}
     );
 }

--- a/jac-client/jac_client/plugin/src/impl/compiler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/compiler.impl.jac
@@ -69,7 +69,7 @@ impl ViteCompiler.create_entry_file(self: ViteCompiler, module_path: Path) -> No
     } else {
         # Explicit routing mode: import app from entry module (original behavior)
         app_module_name = module_path.stem;
-        entry_content = f'import React from "react";\nimport {{ createRoot }} from "react-dom/client";\nimport {{ app as App }} from "./{app_module_name}.js";\nimport {{ JacClientErrorBoundary, ErrorFallback }} from "@jac/runtime";\n\nconst root = createRoot(document.getElementById("root"));\nroot.render(\n\tReact.createElement(\n\t\tJacClientErrorBoundary,{{ FallbackComponent: ErrorFallback }},\n\t\tReact.createElement(App, null)\n\t)\n);\n';
+        entry_content = f'import React from "react";\nimport {{ createRoot }} from "react-dom/client";\nimport {{ app as App }} from "./{app_module_name}.js";\nimport {{ JacClientErrorBoundary, ErrorFallback, __jacInstallErrorHandlers }} from "@jac/runtime";\n\n__jacInstallErrorHandlers();\nconst root = createRoot(document.getElementById("root"));\nroot.render(\n\tReact.createElement(\n\t\tJacClientErrorBoundary,{{ FallbackComponent: ErrorFallback }},\n\t\tReact.createElement(App, null)\n\t)\n);\n';
     }
     entry_file.write_text(entry_content, encoding='utf-8');
 }
@@ -94,9 +94,11 @@ impl ViteCompiler._create_pages_entry_content(
     lines.append('import { createRoot } from "react-dom/client";');
     lines.append('import { BrowserRouter, Routes, Route } from "react-router-dom";');
     lines.append(
-        'import { JacClientErrorBoundary, ErrorFallback, AuthGuard } from "@jac/runtime";'
+        'import { JacClientErrorBoundary, ErrorFallback, AuthGuard, __jacInstallErrorHandlers } from "@jac/runtime";'
     );
     lines.append('import { routes, layouts } from "./_routes.js";');
+    lines.append('');
+    lines.append('__jacInstallErrorHandlers();');
     if has_app_wrapper {
         lines.append(f'import {{ app as AppWrapper }} from "./{module_path.stem}.js";');
     }

--- a/jac-scale/jac_scale/impl/serve.core.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.core.impl.jac
@@ -235,6 +235,7 @@ impl JacAPIServerCore.start(
         self.register_websocket_endpoints();
     }
     self.register_root_asset_endpoint();
+    self._register_client_error_endpoint();
     self._configure_openapi_security();
     self.user_manager.create_user(Con.GUEST.value, '__no_password__');
     self._setup_scheduler();
@@ -816,6 +817,58 @@ impl JacAPIServerCore.register_sso_endpoints -> None {
 # ============================================================================
 # HMR (Hot Module Replacement) Support
 # ============================================================================
+"""Register the /cl/__error__ endpoint for client-side error reporting."""
+impl JacAPIServerCore._register_client_error_endpoint -> None {
+    import from fastapi { Request }
+    import from fastapi.responses { JSONResponse }
+    async def client_error_handler(request: Request) -> JSONResponse {
+        try {
+            data = await request.json();
+        } except Exception {
+            return JSONResponse(status_code=400, content={"error": "Invalid JSON"});
+        }
+        message = data.get('message', '');
+        if not message {
+            return JSONResponse(
+                status_code=400, content={"error": "Missing required field: message"}
+            );
+        }
+        stack = data.get('stack', '');
+        url = data.get('url', '');
+        source = data.get('source', '');
+        log_parts = [f"[Client] {message}"];
+        if stack {
+            log_parts.append(f"  Stack: {stack}");
+        }
+        if url {
+            log_parts.append(f"  URL: {url}");
+        }
+        if source {
+            log_parts.append(f"  Source: {source}");
+        }
+        logger.error('\n'.join(log_parts));
+        console.error(f"[Client] {message}");
+        if stack {
+            for line in stack.split('\n') {
+                console.print(f"    {line}");
+            }
+        }
+        return JSONResponse(status_code=200, content={"ok": True});
+    }
+    self.server.add_endpoint(
+        JEndPoint(
+            method=HTTPMethod.POST,
+            path='/cl/__error__',
+            callback=client_error_handler,
+            parameters=[],
+            response_model=None,
+            tags=['Client'],
+            summary='Report client-side error',
+            description='Receives client-side JavaScript errors for server-side logging.'
+        )
+    );
+}
+
 """Enable HMR mode - file changes trigger reload on next request."""
 impl JacAPIServerCore.enable_hmr(hot_reloader: Any) -> None {
     self._hot_reloader = hot_reloader;

--- a/jac-scale/jac_scale/serve.jac
+++ b/jac-scale/jac_scale/serve.jac
@@ -92,6 +92,8 @@ obj JacAPIServerCore {
     def register_update_password_endpoint -> None;
     def register_sso_endpoints -> None;
     def _create_sso_callback_wrapper -> Callable[..., (Response | TransportResponse)];
+    # Client error reporting
+    def _register_client_error_endpoint -> None;
     # HMR support
     def enable_hmr(hot_reloader: Any) -> None;
     def _setup_scheduler -> None;

--- a/jac/jaclang/runtimelib/client_runtime.cl.jac
+++ b/jac/jaclang/runtimelib/client_runtime.cl.jac
@@ -135,3 +135,13 @@ def __jacRegisterClientModule(
 def useState(initialValue: Any) -> list;
 
 def useEffect(effectFn: Any, deps: list = []) -> None;
+
+# ============================================================================
+# Client Error Reporting
+# ============================================================================
+# Report client-side errors to the server for logging
+def __jacReportError(
+    message: str, stack: str = "", url: str = "", source: str = ""
+) -> None;
+# Install global error handlers (window.onerror, unhandledrejection)
+def __jacInstallErrorHandlers -> None;

--- a/jac/jaclang/runtimelib/impl/client_runtime.impl.jac
+++ b/jac/jaclang/runtimelib/impl/client_runtime.impl.jac
@@ -800,6 +800,7 @@ impl __jacRegisterClientModule(
     moduleName: str, clientFunctions: list = [], clientGlobals: dict = {}
 ) -> None {
     __jacEnsureObjectGetPolyfill();
+    __jacInstallErrorHandlers();
     scope = __jacGlobalScope();
     registry = __jacEnsureRegistry();
     moduleFunctions = {};
@@ -897,4 +898,70 @@ impl useEffect(effectFn: Any, deps: list = []) -> None {
     # For now, always run on mount since we don't have React's dep tracking
     # This matches useEffect(() => { ... }, []) behavior
     onMount(effectFn);
+}
+
+# ============================================================================
+# Client Error Reporting
+# ============================================================================
+"""Report a client-side error to the server via POST /cl/__error__.
+Fires asynchronously and silently ignores failures (to avoid error loops).
+"""
+impl __jacReportError(
+    message: str, stack: str = "", url: str = "", source: str = ""
+) -> None {
+    try {
+        fetch(
+            "/cl/__error__",
+            {
+                "method": "POST",
+                "headers": {"Content-Type": "application/json"},
+                "body": JSON.stringify(
+                    {
+                        "message": message,
+                        "stack": stack,
+                        "url": url or window.location.href,
+                        "source": source,
+                        "timestamp": Reflect.construct(Date, []).toISOString()
+                    }
+                )
+            }
+        );
+    } except Exception {
+    # Silently ignore - never let error reporting cause more errors
+    }
+}
+
+"""Install global error handlers to catch unhandled JS errors and rejections.
+Called once during client module initialization.
+"""
+impl __jacInstallErrorHandlers -> None {
+    scope = __jacGlobalScope();
+    if not scope or not scope.addEventListener {
+        return;
+    }
+    # Guard against double-install
+    if scope.__jacErrorHandlersInstalled {
+        return;
+    }
+    scope.__jacErrorHandlersInstalled = True;
+    # Catch synchronous errors (e.g., TypeError, ReferenceError)
+    scope.addEventListener(
+        "error",
+        lambda event: Any  -> None { __jacReportError(
+            event.message or "Unknown error",
+            event.error.stack if event.error else "",
+            event.filename or "",
+            "window.onerror"
+        );}
+    );
+    # Catch unhandled promise rejections (e.g., failed fetch, async errors)
+    scope.addEventListener(
+        "unhandledrejection",
+        lambda event: Any  -> None { reason = event.reason;message = "";stack = "";if reason {
+            message = reason.message or str(reason);
+            stack = reason.stack or "";
+        } else {
+            message = "Unhandled promise rejection";
+        } __jacReportError(message, stack, "", "unhandledrejection");}
+    );
 }

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -1,6 +1,9 @@
+import logging;
 import from jaclang.cli.console { console }
 import from jaclang.cli.banners { JAC_DISCORD_URL }
 import from jaclang.runtimelib.serializer { Serializer }
+
+glob _client_error_logger = logging.getLogger("jaclang.client_errors");
 
 impl UserManager.postinit -> None {
     import sqlite3;
@@ -1598,6 +1601,32 @@ impl JacAPIServer.create_handler -> type[BaseHTTPRequestHandler] {
                     server.execution_handler.spawn_walker(name, fields, username)
                 );
                 self._send_response(response);
+            } elif (path == '/cl/__error__') {
+                message = data.get('message', '');
+                if not message {
+                    Jac.send_json(
+                        self, 400, {'error': 'Missing required field: message'}
+                    );
+                } else {
+                    stack = data.get('stack', '');
+                    url = data.get('url', '');
+                    source = data.get('source', '');
+                    log_parts = [f"[Client] {message}"];
+                    if stack {
+                        log_parts.append(f"  Stack: {stack}");
+                    }
+                    if url {
+                        log_parts.append(f"  URL: {url}");
+                    }
+                    if source {
+                        log_parts.append(f"  Source: {source}");
+                    }
+                    import logging;
+                    logging.getLogger("jaclang.client_errors").error(
+                        '\n'.join(log_parts)
+                    );
+                    Jac.send_json(self, 200, {'ok': True});
+                }
             } else {
                 Jac.send_json(self, 404, {'error': 'Not found'});
             }
@@ -1819,6 +1848,44 @@ impl JacAPIServer.start(
             self.scheduler.stop();
         }
     }
+}
+
+"""Handle a client-side error report posted to /cl/__error__.
+
+Logs the error via the client_errors logger and prints to console.
+Requires at least a 'message' field in the JSON payload.
+"""
+def _handle_client_error(handler: Any, data: dict[str, Any]) -> None {
+    message = data.get('message', '');
+    if not message {
+        Jac.send_json(handler, 400, {'error': 'Missing required field: message'});
+        return;
+    }
+    stack = data.get('stack', '');
+    url = data.get('url', '');
+    source = data.get('source', '');
+    timestamp = data.get('timestamp', '');
+    # Log to the client_errors logger
+    log_parts = [f"[Client] {message}"];
+    if stack {
+        log_parts.append(f"  Stack: {stack}");
+    }
+    if url {
+        log_parts.append(f"  URL: {url}");
+    }
+    if source {
+        log_parts.append(f"  Source: {source}");
+    }
+    log_message = '\n'.join(log_parts);
+    _client_error_logger.error(log_message);
+    # Also print to console for dev visibility
+    console.error(f"[Client] {message}");
+    if stack {
+        for line in stack.split('\n') {
+            console.print(f"    {line}");
+        }
+    }
+    Jac.send_json(handler, 200, {'ok': True});
 }
 
 """Print comprehensive documentation for all endpoints that would be generated."""

--- a/jac/tests/runtimelib/test_client_error_reporting.jac
+++ b/jac/tests/runtimelib/test_client_error_reporting.jac
@@ -1,0 +1,109 @@
+"""Tests for client-side error reporting endpoint.
+
+The /cl/__error__ endpoint allows client-side JavaScript to report
+errors back to the server for logging and observability.
+"""
+
+import io;
+import json;
+import logging;
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from jaclang.runtimelib.testing { JacTestClient }
+
+glob FIXTURES = str(Path(__file__).parent / "fixtures");
+
+def fixture_abs_path(filename: str) -> str {
+    return str((Path(FIXTURES) / filename).resolve());
+}
+
+def make_client(base_path: str) -> JacTestClient {
+    return JacTestClient.from_file(
+        fixture_abs_path("serve_api.jac"), base_path=base_path
+    );
+}
+
+"""Attach a StringIO handler to logger and return (buf, handler, old_level)."""
+def capture_log_start(logger: logging.Logger, level: int = logging.DEBUG) -> tuple {
+    buf = io.StringIO();
+    handler = logging.StreamHandler(buf);
+    handler.setLevel(level);
+    logger.addHandler(handler);
+    old_level = logger.level;
+    logger.setLevel(level);
+    return (buf, handler, old_level);
+}
+
+"""Remove handler and restore logger level."""
+def capture_log_stop(
+    logger: logging.Logger, handler: logging.StreamHandler, old_level: int
+) -> None {
+    logger.removeHandler(handler);
+    logger.setLevel(old_level);
+}
+
+# =============================================================================
+# Client Error Reporting Tests
+# =============================================================================
+test "client error endpoint exists and accepts error reports" {
+    with TemporaryDirectory() as tmpdir {
+        client = make_client(tmpdir);
+        response = client.post(
+            "/cl/__error__",
+            json={
+                "message": "Cannot use 'in' operator to search for '@' in undefined",
+                "stack": "TypeError: Cannot use 'in' operator\n    at LoginPage (login.jac:42)",
+                "url": "http://localhost:8001/",
+                "source": "window.onerror",
+                "timestamp": "2026-03-14T12:00:00Z"
+            }
+        );
+        assert response.status_code == 200;
+        client.close();
+    }
+}
+
+test "client error is logged to server console" {
+    with TemporaryDirectory() as tmpdir {
+        client = make_client(tmpdir);
+        logger = logging.getLogger("jaclang.client_errors");
+        (buf, handler, old_level) = capture_log_start(logger);
+        try {
+            error_msg = "Cannot use 'in' operator to search for '@' in undefined";
+            client.post(
+                "/cl/__error__",
+                json={
+                    "message": error_msg,
+                    "stack": "TypeError: Cannot use 'in' operator\n    at LoginPage (login.jac:42)",
+                    "url": "http://localhost:8001/",
+                    "source": "window.onerror",
+                    "timestamp": "2026-03-14T12:00:00Z"
+                }
+            );
+            log_output = buf.getvalue();
+            assert error_msg in log_output , f"Expected client error in log output, got: {log_output}";
+        } finally {
+            capture_log_stop(logger, handler, old_level);
+        }
+        client.close();
+    }
+}
+
+test "client error endpoint handles missing fields gracefully" {
+    with TemporaryDirectory() as tmpdir {
+        client = make_client(tmpdir);
+        # Minimal payload - just a message
+        response = client.post("/cl/__error__", json={"message": "Something broke"});
+        assert response.status_code == 200;
+        client.close();
+    }
+}
+
+test "client error endpoint rejects empty payload" {
+    with TemporaryDirectory() as tmpdir {
+        client = make_client(tmpdir);
+        response = client.post("/cl/__error__", json={});
+        assert response.status_code == 400;
+        client.close();
+    }
+}


### PR DESCRIPTION
## Summary

- Automatically captures unhandled JavaScript errors (`window.onerror`) and promise rejections (`unhandledrejection`) in Jac client apps and forwards them to the server via `POST /cl/__error__`
- Server-side endpoint logs errors through both the `jaclang.client_errors` logger and dev console for visibility
- `ErrorBoundary` fallback component also reports caught errors
- Works with both the stdlib HTTP server and jac-scale (FastAPI)

## Test plan
- [ ] Verify `/cl/__error__` endpoint accepts POST with `message` field and returns 200
- [ ] Verify missing `message` returns 400
- [ ] Trigger a JS error in a client app and confirm it appears in server logs
- [ ] Verify error handlers install only once (idempotent guard)