### PR TITLE
fix: Route jac check and LSP errors to caller's program for internal files

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -6,6 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 - **Client-Side Error Reporting**: Unhandled JavaScript errors and promise rejections in Jac client apps are now automatically captured and forwarded to the server via `POST /cl/__error__`, where they are logged through both the `jaclang.client_errors` logger and the dev console. Global error handlers (`window.onerror`, `unhandledrejection`) are installed at app initialization, and the `ErrorBoundary` fallback component also reports caught errors. Works with both the stdlib HTTP server and jac-scale (FastAPI).
 - **Centralized Source Mapping**: Added `source_mapping` module to `runtimelib` with VLQ encode/decode, source map generation/parsing, and two-layer resolution (bundle → compiled JS → .jac). Server error endpoints now resolve JS stack traces back to `.jac` file locations. The ES unparse pass tracks output-line → source-line mappings via `es_to_js_with_map()`.
+- **Fix: `jac check` and LSP Silently Swallowed Errors for Jaclang-Internal Files**: Files inside the `jaclang/` package directory (e.g., compiler test fixtures) had their type errors routed to the compiler's `internal_program` instead of the caller's `JacProgram`, causing `jac check` to report PASSED and the LSP to miss diagnostics. Added `force_target_program` option to `CompileOptions` so user-initiated operations always record errors on the correct program. Removed the LSP's `internal_program` error aggregation workaround.
 
 ## jaclang 0.12.2 (Latest Release)
 

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -61,9 +61,15 @@ impl check(
             return (False, 1, 0, [], []);
         }
         try {
+            import from jaclang.jac0core.compile_options { CompileOptions }
             console.print(f"  Checking {file_path}...");
             (err_start, warn_start) = (len(prog.errors_had), len(prog.warnings_had));
-            prog.compile(file_path=file_path, type_check=not parse_only, no_cgen=True);
+            prog.compile(
+                file_path=file_path,
+                options=CompileOptions(
+                    type_check=not parse_only, no_cgen=True, force_target_program=True
+                )
+            );
             new_errors = prog.errors_had[err_start:];
             new_warnings = prog.warnings_had[warn_start:];
             # Filter out errors/warnings from ignored files and non-.jac files

--- a/jac/jaclang/jac0core/compile_options.jac
+++ b/jac/jaclang/jac0core/compile_options.jac
@@ -12,6 +12,7 @@ obj CompileOptions {
         no_cgen: bool = False,
         skip_native_engine: bool = False,
         resolve_annex_parent: bool = False,
+        force_target_program: bool = False,
         cancel_token: Any = None;
 
     """Return a copy with skip_native_engine set."""

--- a/jac/jaclang/jac0core/impl/compile_options.impl.jac
+++ b/jac/jaclang/jac0core/impl/compile_options.impl.jac
@@ -9,6 +9,7 @@ impl CompileOptions.with_skip_native_engine(
         symtab_ir_only=self.symtab_ir_only,
         no_cgen=self.no_cgen,
         skip_native_engine=`skip,
+        force_target_program=self.force_target_program,
         cancel_token=self.cancel_token
     );
 }

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -608,7 +608,11 @@ impl JacCompiler.compile(
             );
         }
     }
-    actual_program = self._resolve_program(file_path, target_program);
+    if options.force_target_program {
+        actual_program = target_program;
+    } else {
+        actual_program = self._resolve_program(file_path, target_program);
+    }
     actual_program._compile_options = options;
     keep_str = use_str or read_file_with_encoding(file_path);
     had_parse_errors = len(actual_program.errors_had);

--- a/jac/jaclang/langserve/impl/engine.impl.jac
+++ b/jac/jaclang/langserve/impl/engine.impl.jac
@@ -92,13 +92,17 @@ impl JacLangServer.type_check_file(
         }
 
         # Compile the main file
+        import from jaclang.jac0core.compile_options { CompileOptions }
         main_doc = self.workspace.get_text_document(uris.from_fs_path(main_path));
         build = self.compile(
-            use_str=main_doc.source,
             file_path=main_path,
-            type_check=True,
-            no_cgen=True,
-            cancel_token=cancel_token,
+            use_str=main_doc.source,
+            options=CompileOptions(
+                type_check=True,
+                no_cgen=True,
+                force_target_program=True,
+                cancel_token=cancel_token
+            )
         );
 
         if cancel_token and cancel_token.is_set() {
@@ -106,15 +110,9 @@ impl JacLangServer.type_check_file(
         }
         self.update_modules(main_path, build);
 
-        # Aggregate errors from internal_program (jaclang.* modules) if any
+        # Publish diagnostics to all involved files
         all_errors = list(self.errors_had);
         all_warnings = list(self.warnings_had);
-        if (self._compiler and self._compiler._internal_program) {
-            all_errors.extend(self._compiler._internal_program.errors_had);
-            all_warnings.extend(self._compiler._internal_program.warnings_had);
-        }
-
-        # Publish diagnostics to all involved files
         for f in files_to_check {
             self.publish_diagnostics(
                 uris.from_fs_path(f),
@@ -680,33 +678,14 @@ impl JacLangServer.get_ir(file_path: str) -> Optional[uni.Module] {
 impl JacLangServer._clear_alerts_for_file(file_path: str) -> None {
     with self._state_lock.write_lock() {
         self.module_manager.clear_alerts_for_file(file_path);
-        # Also clear from internal_program (jaclang.* modules) if it exists
-        if (self._compiler and self._compiler._internal_program) {
-            internal = self._compiler._internal_program;
-            internal.errors_had = [
-                e
-                for e in internal.errors_had
-                if e.loc.mod_path != file_path
-            ];
-            internal.warnings_had = [
-                w
-                for w in internal.warnings_had
-                if w.loc.mod_path != file_path
-            ];
-        }
     }
 }
 
 """Return diagnostics for all files as a dict {uri: diagnostics}."""
 impl JacLangServer.diagnostics -> dict[str, list] {
     with self._state_lock.read_lock() {
-        # Aggregate errors from internal_program (jaclang.* modules) if any
         all_errors = list(self.errors_had);
         all_warnings = list(self.warnings_had);
-        if (self._compiler and self._compiler._internal_program) {
-            all_errors.extend(self._compiler._internal_program.errors_had);
-            all_warnings.extend(self._compiler._internal_program.warnings_had);
-        }
         result = {};
         for file_path in self.mod.hub {
             uri = uris.from_fs_path(file_path);

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -1708,3 +1708,39 @@ test "jir_registry is up to date" {
         "Run `jac gen-jir-registry` to regenerate it."
     );
 }
+
+test "jac check reports errors for files inside jaclang source tree" {
+    # Regression: _resolve_program routed jaclang-internal files to
+    # internal_program, so errors were invisible to the caller's JacProgram.
+    # force_target_program=True (set by jac check) fixes this.
+    internal_fixture = os.path.join(
+        JAC_ROOT, "jaclang", "compiler", "tests", "fixtures", "prim_float.jac"
+    );
+    captured_stdout = io.StringIO();
+    captured_stderr = io.StringIO();
+    old_stdout = sys.stdout;
+    old_stderr = sys.stderr;
+    sys.stdout = captured_stdout;
+    sys.stderr = captured_stderr;
+
+    try {
+        result = analysis.check([internal_fixture]);
+        stdout = captured_stdout.getvalue();
+        stderr = captured_stderr.getvalue();
+    } finally {
+        sys.stdout = old_stdout;
+        sys.stderr = old_stderr;
+    }
+
+    combined = stdout + stderr;
+
+    # prim_float.jac has type errors (unary + returns Unknown) — check must
+    # report them even though the file lives inside the jaclang package.
+    assert result == 1 , (
+        "jac check should report errors for jaclang-internal files, "
+        f"but returned exit code {result}. Output:\n{combined}"
+    );
+    assert "failed" in combined.lower() , (
+        "Expected failure output for jaclang-internal file with type errors"
+    );
+}


### PR DESCRIPTION
## Summary
- `_resolve_program` redirected files inside the `jaclang/` source tree to the compiler's `internal_program`, causing `jac check` to report PASSED and the LSP to miss diagnostics for those files
- Added `force_target_program` flag to `CompileOptions` so user-initiated operations (`jac check`, LSP type checking) bypass the `internal_program` redirect and record errors on the caller's `JacProgram`
- Removed the LSP's `internal_program` error aggregation workaround in `type_check_file`, `_clear_alerts_for_file`, and `diagnostics`

## Test plan
- [x] New regression test: `jac check reports errors for files inside jaclang source tree`
- [x] 43 LSP tests pass
- [x] 270 check-related tests pass
- [x] Manual verification: `jac check` on `prim_float.jac` (inside jaclang tree) now correctly reports 3 type errors instead of PASSED