### PR TITLE
docs: Separate installer options into individual code blocks

### DIFF
--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -18,17 +18,27 @@ This automatically installs [uv](https://docs.astral.sh/uv/) (if needed), a Pyth
 
 Pass flags after `--` to customize the install:
 
+**Core language only (no plugins):**
+
 ```bash
-# Core language only (no plugins)
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --core
+```
 
-# Specific version
+**Specific version:**
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --version 2.3.1
+```
 
-# Standalone binary (self-contained, no Python/uv needed at runtime)
+**Standalone binary (self-contained, no Python/uv needed at runtime):**
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --standalone
+```
 
-# Uninstall
+**Uninstall:**
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --uninstall
 ```
 


### PR DESCRIPTION
## Summary
- Split the single combined code block for installer flags into separate, labeled code blocks for better readability in the install guide.

## Test plan
- [ ] Verify docs render correctly with `mkdocs serve`