### PR TITLE
refactor: Extract shared linker utilities

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -17,6 +17,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Formatter Inline Comment Swallows Next Argument**: Fixed a bug where `jac format` would merge the next function argument into an inline comment when the comment appeared after a comma in a multi-line call (e.g., `candidate[:-4],  # strip trailing .jac` would absorb the following `os.path.abspath(base_dir)` into the comment text). The `CommentInjectionPass` now upgrades soft line breaks to hard line breaks when they follow an inline comment, ensuring subsequent tokens always start on a new line.
 - **Fix: Diagnostic Underlines for Multi-Line Spans**: Fixed `jac check` rendering absurdly wide `^^^^^` underlines when a diagnostic pointed at a node spanning multiple lines (e.g., W2052 on an entire `except` block). The W2052 warning now points at the exception type name token instead of the whole block, and the underline renderer clamps caret width to the end of the source line for any multi-line span.
 - **Fix: Native Cross-Module Method Calls**: Calling a method on a struct type imported from another `.na.jac` module (e.g., `lx.next_token()`, `c.increment()`) was silently dropped, leaving the target variable as a null pointer and producing runtime crashes. Methods on imported struct types are now correctly resolved and emitted.
+- 1 small refactors/changes.
 
 ## jaclang 0.12.2 (Latest Release)
 

--- a/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
@@ -7,6 +7,14 @@ Architecture is auto-detected from the object file.
 
 import struct;
 import os;
+import from jaclang.compiler.passes.native.linker_common {
+    _align,
+    _build_strtab,
+    _append_to_blob,
+    _resolve_seg_vaddr,
+    _find_patch_target,
+    _find_entry_vaddr
+}
 
 # ── ELF header ───────────────────────────────────────────────────
 glob ELFMAG = b"\x7fELF",
@@ -100,29 +108,6 @@ glob R_AARCH64_PREL32 = 261,
      R_AARCH64_GLOB_DAT = 1025,
      R_AARCH64_JUMP_SLOT = 1026,
      R_AARCH64_ABS64 = 257;
-
-
-# ── Helper: align to boundary ────────────────────────────────────
-def _align(value: int, alignment: int) -> int {
-    if alignment <= 1 {
-        return value;
-    }
-    return (value + alignment - 1) & ~(alignment - 1);
-}
-
-
-# ── Helper: build ELF string table ──────────────────────────────
-def _build_strtab(strings: list[str]) -> tuple[bytes, dict[str, int]] {
-    data = bytearray(b"\x00");
-    offsets: dict[str, int] = {};
-    for s in strings {
-        if s not in offsets {
-            offsets[s] = len(data);
-            data.extend(s.encode("utf-8") + b"\x00");
-        }
-    }
-    return (bytes(data), offsets);
-}
 
 
 # ── Helper: build ELF hash table ────────────────────────────────
@@ -628,37 +613,24 @@ impl ElfLinker.build_executable -> bytes {
     for sec in self.sections {
         if sec.typ == SHT_PROGBITS and (sec.flags & SHF_EXECINSTR) {
             if len(sec.data) > 0 {
-                aligned_off = _align(len(code_data), max(sec.align, 1));
-                code_data.extend(b"\x00" * (aligned_off - len(code_data)));
-                code_sections[sec.name] = (len(code_data), len(sec.data));
-                section_placement[sec_idx] = ("code", len(code_data));
-                code_data.extend(sec.data);
+                off = _append_to_blob(code_data, sec.data, sec.align, len(sec.data));
+                code_sections[sec.name] = (off, len(sec.data));
+                section_placement[sec_idx] = ("code", off);
             }
         } elif sec.typ == SHT_PROGBITS
         and (sec.flags & SHF_ALLOC)
         and not (sec.flags & SHF_WRITE) {
             if len(sec.data) > 0 {
-                aligned_off = _align(len(rodata_blob), max(sec.align, 1));
-                rodata_blob.extend(b"\x00" * (aligned_off - len(rodata_blob)));
-                rodata_sections[sec.name] = (len(rodata_blob), len(sec.data));
-                section_placement[sec_idx] = ("rodata", len(rodata_blob));
-                rodata_blob.extend(sec.data);
+                off = _append_to_blob(rodata_blob, sec.data, sec.align, len(sec.data));
+                rodata_sections[sec.name] = (off, len(sec.data));
+                section_placement[sec_idx] = ("rodata", off);
             }
         } elif (sec.flags & SHF_WRITE) and (sec.flags & SHF_ALLOC) {
             alloc_size = sec.mem_size;
             if alloc_size > 0 {
-                aligned_off = _align(len(data_blob), max(sec.align, 1));
-                data_blob.extend(b"\x00" * (aligned_off - len(data_blob)));
-                data_sections[sec.name] = (len(data_blob), alloc_size);
-                section_placement[sec_idx] = ("data", len(data_blob));
-                if len(sec.data) > 0 {
-                    data_blob.extend(sec.data);
-                    if alloc_size > len(sec.data) {
-                        data_blob.extend(b"\x00" * (alloc_size - len(sec.data)));
-                    }
-                } else {
-                    data_blob.extend(b"\x00" * alloc_size);
-                }
+                off = _append_to_blob(data_blob, sec.data, sec.align, alloc_size);
+                data_sections[sec.name] = (off, alloc_size);
+                section_placement[sec_idx] = ("data", off);
             }
         }
         sec_idx += 1;
@@ -947,36 +919,30 @@ impl ElfLinker.build_executable -> bytes {
                 }
             }
             if local is not None {
-                (seg, seg_off) = local;
-                if seg == "code" {
-                    sym_addr = text_vaddr + seg_off;
-                } elif seg == "rodata" {
-                    sym_addr = rodata_vaddr + seg_off;
-                } elif seg == "data" {
-                    sym_addr = data_vaddr + seg_off;
-                }
+                sym_addr = _resolve_seg_vaddr(
+                    local[0], local[1], text_vaddr, rodata_vaddr, data_vaddr
+                );
             }
         }
 
         # Determine target buffer and base vaddr
-        target_is_code = rela.target_sec in code_sections;
-        target_is_data = rela.target_sec in data_sections;
-        target_is_rodata = rela.target_sec in rodata_sections;
-        if target_is_code {
-            sec_blob_off = code_sections[rela.target_sec][0];
-            patch_buf = code_bytes;
-            patch_base_vaddr = text_vaddr + sec_blob_off;
-        } elif target_is_data {
-            sec_blob_off = data_sections[rela.target_sec][0];
-            patch_buf = data_bytes;
-            patch_base_vaddr = data_vaddr + sec_blob_off;
-        } elif target_is_rodata {
-            sec_blob_off = rodata_sections[rela.target_sec][0];
-            patch_buf = rodata_bytes;
-            patch_base_vaddr = rodata_vaddr + sec_blob_off;
+        _pt = _find_patch_target(
+            rela.target_sec,
+            code_sections,
+            rodata_sections,
+            data_sections,
+            code_bytes,
+            rodata_bytes,
+            data_bytes,
+            text_vaddr,
+            rodata_vaddr,
+            data_vaddr
+        );
+        if _pt is not None {
+            (patch_buf, sec_blob_off, patch_base_vaddr) = _pt;
         } else {
-            sec_blob_off = 0;
             patch_buf = code_bytes;
+            sec_blob_off = 0;
             patch_base_vaddr = text_vaddr;
         }
         patch_off = sec_blob_off + rela.offset;
@@ -989,24 +955,7 @@ impl ElfLinker.build_executable -> bytes {
     }
 
     # ── Find entry point ──────────────────────────────────────────
-    # Look for _start (generated by nacompile via inline asm)
-    entry_vaddr = text_vaddr;
-    start_local = local_sym_map.get("_start");
-    if start_local is not None {
-        (seg, seg_off) = start_local;
-        if seg == "code" {
-            entry_vaddr = text_vaddr + seg_off;
-        }
-    } else {
-        # Fallback: look for main
-        main_local = local_sym_map.get("main");
-        if main_local is not None {
-            (seg, seg_off) = main_local;
-            if seg == "code" {
-                entry_vaddr = text_vaddr + seg_off;
-            }
-        }
-    }
+    entry_vaddr = _find_entry_vaddr(local_sym_map, text_vaddr);
 
     # ── Assemble the ELF file ────────────────────────────────────
     output = bytearray(total_file_size);

--- a/jac/jaclang/compiler/passes/native/impl/linker_common.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/linker_common.impl.jac
@@ -1,0 +1,99 @@
+"""Shared linker utility implementations."""
+
+impl _align(value: int, alignment: int) -> int {
+    if alignment <= 1 {
+        return value;
+    }
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+
+impl _build_strtab(
+    strings: list[str], initial_bytes: bytes = b"\x00"
+) -> tuple[bytes, dict[str, int]] {
+    data = bytearray(initial_bytes);
+    offsets: dict[str, int] = {};
+    for s in strings {
+        if s not in offsets {
+            offsets[s] = len(data);
+            data.extend(s.encode("utf-8") + b"\x00");
+        }
+    }
+    return (bytes(data), offsets);
+}
+
+
+"""Align blob, append data (with BSS zero-fill if mem_size > data),
+return the offset where data was placed."""
+impl _append_to_blob(
+    blob: bytearray, data: bytes, alignment: int, mem_size: int
+) -> int {
+    aligned_off = _align(len(blob), max(alignment, 1));
+    blob.extend(b"\x00" * (aligned_off - len(blob)));
+    result_off = len(blob);
+    if len(data) > 0 {
+        blob.extend(data);
+        if mem_size > len(data) {
+            blob.extend(b"\x00" * (mem_size - len(data)));
+        }
+    } else {
+        blob.extend(b"\x00" * mem_size);
+    }
+    return result_off;
+}
+
+
+impl _resolve_seg_vaddr(
+    seg: str, seg_off: int, code_vaddr: int, rodata_vaddr: int, data_vaddr: int
+) -> int {
+    if seg == "code" {
+        return code_vaddr + seg_off;
+    } elif seg == "rodata" {
+        return rodata_vaddr + seg_off;
+    } elif seg == "data" {
+        return data_vaddr + seg_off;
+    }
+    return 0;
+}
+
+
+impl _find_patch_target(
+    target_sec: str,
+    code_sections: dict[str, tuple[int, int]],
+    rodata_sections: dict[str, tuple[int, int]],
+    data_sections: dict[str, tuple[int, int]],
+    code_bytes: bytearray,
+    rodata_bytes: bytearray,
+    data_bytes: bytearray,
+    code_vaddr: int,
+    rodata_vaddr: int,
+    data_vaddr: int
+) -> tuple[bytearray, int, int] | None {
+    if target_sec in code_sections {
+        off = code_sections[target_sec][0];
+        return (code_bytes, off, code_vaddr + off);
+    } elif target_sec in rodata_sections {
+        off = rodata_sections[target_sec][0];
+        return (rodata_bytes, off, rodata_vaddr + off);
+    } elif target_sec in data_sections {
+        off = data_sections[target_sec][0];
+        return (data_bytes, off, data_vaddr + off);
+    }
+    return None;
+}
+
+
+impl _find_entry_vaddr(
+    local_sym_map: dict[str, tuple[str, int]], code_vaddr: int
+) -> int {
+    for name in ["_start", "main"] {
+        local = local_sym_map.get(name);
+        if local is not None {
+            (seg, seg_off) = local;
+            if seg == "code" {
+                return code_vaddr + seg_off;
+            }
+        }
+    }
+    return code_vaddr;
+}

--- a/jac/jaclang/compiler/passes/native/impl/macho_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/macho_linker.impl.jac
@@ -9,6 +9,14 @@ Includes ad-hoc code signing for arm64 macOS.
 import struct;
 import os;
 import hashlib;
+import from jaclang.compiler.passes.native.linker_common {
+    _align,
+    _build_strtab,
+    _append_to_blob,
+    _resolve_seg_vaddr,
+    _find_patch_target,
+    _find_entry_vaddr
+}
 
 # ── Mach-O header constants ──────────────────────────────────────
 glob MH_MAGIC_64 = 0xFEEDFACF,
@@ -102,15 +110,6 @@ glob CSMAGIC_EMBEDDED_SIGNATURE = 0xFADE0CC0,
      CS_PAGE_SIZE_LOG2 = 12;
 
 
-# ── Helper: align to boundary ────────────────────────────────────
-def _align(value: int, alignment: int) -> int {
-    if alignment <= 1 {
-        return value;
-    }
-    return (value + alignment - 1) & ~(alignment - 1);
-}
-
-
 # ── Helper: encode ULEB128 ──────────────────────────────────────
 def _encode_uleb128(value: int) -> bytes {
     result = bytearray();
@@ -126,20 +125,6 @@ def _encode_uleb128(value: int) -> bytes {
         }
     }
     return bytes(result);
-}
-
-
-# ── Helper: build Mach-O string table ────────────────────────────
-def _build_strtab(strings: list[str]) -> tuple[bytes, dict[str, int]] {
-    data = bytearray(b" \x00");  # starts with space + nul (Mach-O convention)
-    offsets: dict[str, int] = {};
-    for s in strings {
-        if s not in offsets {
-            offsets[s] = len(data);
-            data.extend(s.encode("utf-8") + b"\x00");
-        }
-    }
-    return (bytes(data), offsets);
 }
 
 
@@ -551,30 +536,17 @@ impl MachOLinker.build_executable -> bytes {
 
         sec_key = f"{sec.segname}:{sec.name}";
         if is_text and len(sec.data) > 0 {
-            aligned_off = _align(len(code_data), max(sec.align, 1));
-            code_data.extend(b"\x00" * (aligned_off - len(code_data)));
-            code_sections[sec_key] = (len(code_data), len(sec.data));
-            sec_placement[sec_idx] = ("code", len(code_data));
-            code_data.extend(sec.data);
+            off = _append_to_blob(code_data, sec.data, sec.align, len(sec.data));
+            code_sections[sec_key] = (off, len(sec.data));
+            sec_placement[sec_idx] = ("code", off);
         } elif is_rodata {
-            aligned_off = _align(len(rodata_data), max(sec.align, 1));
-            rodata_data.extend(b"\x00" * (aligned_off - len(rodata_data)));
-            rodata_sections[sec_key] = (len(rodata_data), len(sec.data));
-            sec_placement[sec_idx] = ("rodata", len(rodata_data));
-            rodata_data.extend(sec.data);
+            off = _append_to_blob(rodata_data, sec.data, sec.align, len(sec.data));
+            rodata_sections[sec_key] = (off, len(sec.data));
+            sec_placement[sec_idx] = ("rodata", off);
         } elif is_data and sec.size > 0 {
-            aligned_off = _align(len(data_data), max(sec.align, 1));
-            data_data.extend(b"\x00" * (aligned_off - len(data_data)));
-            data_sections[sec_key] = (len(data_data), sec.size);
-            sec_placement[sec_idx] = ("data", len(data_data));
-            if len(sec.data) > 0 {
-                data_data.extend(sec.data);
-                if sec.size > len(sec.data) {
-                    data_data.extend(b"\x00" * (sec.size - len(sec.data)));
-                }
-            } else {
-                data_data.extend(b"\x00" * sec.size);
-            }
+            off = _append_to_blob(data_data, sec.data, sec.align, sec.size);
+            data_sections[sec_key] = (off, sec.size);
+            sec_placement[sec_idx] = ("data", off);
         }
     }
 
@@ -909,7 +881,7 @@ impl MachOLinker.build_executable -> bytes {
     for name in all_extern_syms {
         strtab_names.append(name);
     }
-    (strtab_data, strtab_offsets) = _build_strtab(strtab_names);
+    (strtab_data, strtab_offsets) = _build_strtab(strtab_names, b" \x00");
 
     # Build nlist_64 entries: defined externals first, then undefined
     symtab_entries = bytearray();
@@ -1067,13 +1039,9 @@ impl MachOLinker.build_executable -> bytes {
                 place = local_sym_map.get(sym_name);
                 if place is not None {
                     (seg, seg_off) = place;
-                    if seg == "code" {
-                        sym_addr = text_sec_vaddr + seg_off;
-                    } elif seg == "rodata" {
-                        sym_addr = const_sec_vaddr + seg_off;
-                    } elif seg == "data" {
-                        sym_addr = data_sec_vaddr + seg_off;
-                    }
+                    sym_addr = _resolve_seg_vaddr(
+                        seg, seg_off, text_sec_vaddr, const_sec_vaddr, data_sec_vaddr
+                    );
                 } elif sym_name in got_addr_map {
                     # External data (e.g. __stdinp): resolve via GOT
                     sym_addr = got_addr_map[sym_name];
@@ -1085,36 +1053,29 @@ impl MachOLinker.build_executable -> bytes {
             place = sec_placement.get(target_section_idx);
             if place is not None {
                 (seg, seg_off) = place;
-                if seg == "code" {
-                    sym_addr = text_sec_vaddr + seg_off;
-                } elif seg == "rodata" {
-                    sym_addr = const_sec_vaddr + seg_off;
-                } elif seg == "data" {
-                    sym_addr = data_sec_vaddr + seg_off;
-                }
+                sym_addr = _resolve_seg_vaddr(
+                    seg, seg_off, text_sec_vaddr, const_sec_vaddr, data_sec_vaddr
+                );
             }
         }
 
         # Determine patch buffer
-        target_is_code = rel.target_sec in code_sections;
-        target_is_rodata = rel.target_sec in rodata_sections;
-        target_is_data = rel.target_sec in data_sections;
-
-        if target_is_code {
-            sec_off_in_blob = code_sections[rel.target_sec][0];
-            patch_buf = code_bytes;
-            patch_base_vaddr = text_sec_vaddr + sec_off_in_blob;
-        } elif target_is_rodata {
-            sec_off_in_blob = rodata_sections[rel.target_sec][0];
-            patch_buf = rodata_bytes;
-            patch_base_vaddr = const_sec_vaddr + sec_off_in_blob;
-        } elif target_is_data {
-            sec_off_in_blob = data_sections[rel.target_sec][0];
-            patch_buf = data_bytes;
-            patch_base_vaddr = data_sec_vaddr + sec_off_in_blob;
-        } else {
+        _pt = _find_patch_target(
+            rel.target_sec,
+            code_sections,
+            rodata_sections,
+            data_sections,
+            code_bytes,
+            rodata_bytes,
+            data_bytes,
+            text_sec_vaddr,
+            const_sec_vaddr,
+            data_sec_vaddr
+        );
+        if _pt is None {
             continue;
         }
+        (patch_buf, sec_off_in_blob, patch_base_vaddr) = _pt;
 
         patch_off = sec_off_in_blob + rel.address;
         patch_vaddr = patch_base_vaddr + rel.address;
@@ -1143,14 +1104,16 @@ impl MachOLinker.build_executable -> bytes {
     }
 
     # ── Find entry point (_main) ─────────────────────────────────
-    main_offset = 0;
-    main_place = local_sym_map.get("_main");
-    if main_place is not None {
-        (seg, seg_off) = main_place;
-        if seg == "code" {
-            main_offset = text_sec_foff + seg_off;
+    entry_off = _find_entry_vaddr(local_sym_map, text_sec_vaddr);
+    if entry_off == text_sec_vaddr {
+        _main_local = local_sym_map.get("_main");
+        if _main_local is not None and _main_local[0] == "code" {
+            entry_off = text_sec_vaddr + _main_local[1];
         }
     }
+    main_offset = entry_off - text_sec_vaddr + text_sec_foff
+        if entry_off >= text_sec_vaddr
+        else 0;
 
     # ── Assemble the Mach-O file ─────────────────────────────────
     # First pass: determine total file size for code signature
@@ -1428,13 +1391,9 @@ impl MachOLinker.build_executable -> bytes {
         place = local_sym_map.get(isym_name);
         if place is not None {
             (seg, seg_off) = place;
-            if seg == "code" {
-                isym_vaddr = text_sec_vaddr + seg_off;
-            } elif seg == "rodata" {
-                isym_vaddr = const_sec_vaddr + seg_off;
-            } elif seg == "data" {
-                isym_vaddr = data_sec_vaddr + seg_off;
-            }
+            isym_vaddr = _resolve_seg_vaddr(
+                seg, seg_off, text_sec_vaddr, const_sec_vaddr, data_sec_vaddr
+            );
         }
         got_slot_foff = got_sec_foff + (num_extern_got + i) * 8;
         struct.pack_into("<Q", output, got_slot_foff, isym_vaddr);

--- a/jac/jaclang/compiler/passes/native/linker_common.jac
+++ b/jac/jaclang/compiler/passes/native/linker_common.jac
@@ -1,0 +1,35 @@
+"""Common utilities shared between ELF and Mach-O linkers.
+
+Extracts duplicated patterns: alignment, string table building,
+section blob collection, virtual address resolution, patch target
+dispatch, and entry point lookup.
+"""
+
+def _align(value: int, alignment: int) -> int;
+
+def _build_strtab(
+    strings: list[str], initial_bytes: bytes = b"\x00"
+) -> tuple[bytes, dict[str, int]];
+
+def _append_to_blob(blob: bytearray, data: bytes, alignment: int, mem_size: int) -> int;
+
+def _resolve_seg_vaddr(
+    seg: str, seg_off: int, code_vaddr: int, rodata_vaddr: int, data_vaddr: int
+) -> int;
+
+def _find_patch_target(
+    target_sec: str,
+    code_sections: dict[str, tuple[int, int]],
+    rodata_sections: dict[str, tuple[int, int]],
+    data_sections: dict[str, tuple[int, int]],
+    code_bytes: bytearray,
+    rodata_bytes: bytearray,
+    data_bytes: bytearray,
+    code_vaddr: int,
+    rodata_vaddr: int,
+    data_vaddr: int
+) -> tuple[bytearray, int, int] | None;
+
+def _find_entry_vaddr(
+    local_sym_map: dict[str, tuple[str, int]], code_vaddr: int
+) -> int;


### PR DESCRIPTION
## Summary

- Created `linker_common` module with 6 shared utility functions previously duplicated between ELF and Mach-O linker implementations
- Both linkers now import `_align`, `_build_strtab`, `_append_to_blob`, `_resolve_seg_vaddr`, `_find_patch_target`, and `_find_entry_vaddr` from the shared module
- `_build_strtab` parameterized with `initial_bytes` to handle ELF (`\x00`) vs Mach-O (`\x20\x00`) conventions

## Test plan

- [ ] Verify native compilation still works on Linux (ELF path)
- [ ] Verify native compilation still works on macOS (Mach-O path)
- [ ] Run existing native compilation tests