### PR TITLE
[Docs]: Add Open VSX marketplace, supported IDEs list, and Antigravity to IDE setup

### DIFF
--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -127,7 +127,7 @@ pip install jaseci
 
 ## IDE Setup
 
-The **Jac Language Support** extension is published on both major extension marketplaces:
+The **Jac Language Support** extension is available on both major extension marketplaces:
 
 | Marketplace | Link |
 |-------------|------|


### PR DESCRIPTION
## Summary
- Added Open VSX Registry as a second supported marketplace alongside VS Code Marketplace
- Replaced per-IDE repeated install steps with a single unified install instruction
- Listed all supported IDEs (VS Code, Cursor, Windsurf, Antigravity, VSCodium, Gitpod, Eclipse Theia, Void) as a clean linked list
- Kept the manual VSIX install option for offline/unsupported environments

## Changes
- `jaseci/docs/docs/quick-guide/install.md` — rewrote the IDE Setup section
