### PR TITLE
fix: goto definition for import module paths and imported items

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -26,6 +26,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Native Cross-Module Method Calls**: Calling a method on a struct type imported from another `.na.jac` module (e.g., `lx.next_token()`, `c.increment()`) was silently dropped, leaving the target variable as a null pointer and producing runtime crashes. Methods on imported struct types are now correctly resolved and emitted.
 - **CLI: `jac run --show-errors` Flag**: Added `-e` / `--show-errors` flag to `jac run` that displays type check errors and warnings after execution. A summary line with error/warning counts is always shown when diagnostics exist. Use `-e` for full details without needing a separate `jac check` step.
 - **Fix: Impl Matching with Forward Declarations**: `impl MyClass.method` now correctly matches declarations when `MyClass` has forward declarations or is reassigned elsewhere. Previously failed with E2009.
+- **Fix: Goto Definition for Import Paths and Imported Items**: Goto definition now works correctly on all parts of an import statement. Previously, intermediate path segments failed to resolve because each was resolved independently; now the full dotted path is resolved once and intermediate paths are derived by walking up the directory tree.
 - 3 small refactors/changes.
 
 ## jaclang 0.12.2 (Latest Release)

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
@@ -109,13 +109,21 @@ impl TypeEvaluator.get_type_of_module(node_: uni.ModulePath) -> types.TypeBase {
             }
 
             if not Path(mod_path).exists() {
-                npath.type = types.UnknownType();
+                # For intermediate path segments (not the last), skip rather than
+                # bail out. Namespace packages and directory-based imports may not
+                # resolve individually but the full path (last segment) may still
+                # resolve correctly.
                 npath._sym_category = SymbolType.MODULE;
+                if idx < len(node_.path) - 1 {
+                    continue;
+                }
+                npath.type = types.UnknownType();
                 self.emit_diag(W1100, npath);
                 return npath.type;
             }
 
             if Path(mod_path).is_dir() {
+                npath._sym_category = SymbolType.MODULE;
                 continue;
             }
             mod: uni.Module = self._import_module_from_path(mod_path);

--- a/jac/jaclang/jac0core/impl/unitree.impl.jac
+++ b/jac/jaclang/jac0core/impl/unitree.impl.jac
@@ -1158,13 +1158,55 @@ impl ModulePath.resolve_relative_path(target_item: (str | None) = None) -> str {
     return resolve_relative_path(target, self.loc.mod_path);
 }
 
-"""Convert an import target string into a relative file path."""
+"""Convert an import target string into a list of file paths, one per segment.
+
+Resolves the FULL dotted path first (which uses sys.path, importlib, etc.)
+and then derives intermediate paths by walking up the directory tree.
+This ensures that intermediate package directories (e.g., 'jaclang.cli')
+resolve correctly even when per-prefix resolution would fail.
+"""
 impl ModulePath.resolve_relative_path_list -> list[str] {
     parts = self.dot_path_str.split('.');
-    paths = [];
-    for i in range(len(parts)) {
-        sub_path = '.'.join(parts[:(i + 1)]);
-        paths.append(resolve_relative_path(sub_path, self.loc.mod_path));
+    if not parts {
+        return [];
+    }
+    # Resolve the full dotted path — this uses the most robust resolution
+    # (sys.path, importlib, typeshed, etc.) and is the authoritative result.
+    full_path = resolve_relative_path(self.dot_path_str, self.loc.mod_path);
+    # Derive intermediate paths by walking up the directory tree.
+    # e.g., jaclang.cli.console -> .../jaclang/cli/console.jac
+    #   console -> .../jaclang/cli/console.jac (the full resolved path)
+    #   cli     -> .../jaclang/cli/            (parent directory)
+    #   jaclang -> .../jaclang/                (grandparent directory)
+    # For each intermediate directory, check for __init__.jac or __init__.py
+    # so that get_type_of_module() can import them properly.
+    paths: list[str] = [''] * len(parts);
+    paths[-1] = full_path;
+    # Walk up from the resolved path's parent directory.
+    # When the full path is a package __init__ file (e.g., pkg/__init__.py),
+    # dirname gives us the package dir itself (which represents the last
+    # segment), so we need to go one level further up.
+    full_basename = os.path.basename(full_path);
+    cur_dir = os.path.dirname(full_path);
+    if full_basename.startswith('__init__') {
+        cur_dir = os.path.dirname(cur_dir);
+    }
+    for i in range(len(parts) - 2, -1, -1) {
+        init_found = False;
+        for init_name in ('__init__.jac', '__init__.py', '__init__.pyi') {
+            init_path = os.path.join(cur_dir, init_name);
+            if os.path.isfile(init_path) {
+                paths[i] = init_path;
+                init_found = True;
+                break;
+            }
+        }
+        if not init_found {
+            # Namespace package (no __init__) — use the directory path itself
+            # so get_type_of_module can handle it via is_dir() check.
+            paths[i] = cur_dir;
+        }
+        cur_dir = os.path.dirname(cur_dir);
     }
     return paths;
 }

--- a/jac/jaclang/langserve/impl/engine.impl.jac
+++ b/jac/jaclang/langserve/impl/engine.impl.jac
@@ -287,6 +287,8 @@ impl JacLangServer.get_references(
 impl JacLangServer.get_definition(
     file_path: str, position: lspt.Position
 ) -> Optional[lspt.Location] {
+    import from pathlib { Path }
+
     def make_location(node_: uni.UniNode, is_module: bool = False) -> lspt.Location {
         mod_path = node_.type.file_uri if is_module else node_.loc.mod_path;
         decl_range = (
@@ -298,6 +300,15 @@ impl JacLangServer.get_definition(
                 )
         );
         return lspt.Location(uri=uris.from_fs_path(str(mod_path)), range=decl_range);
+    }
+    def make_module_location(file_path_str: str) -> lspt.Location {
+        return lspt.Location(
+            uri=uris.from_fs_path(file_path_str),
+            range=lspt.Range(
+                start=lspt.Position(line=0, character=0),
+                end=lspt.Position(line=0, character=0)
+            )
+        );
     }
     node_selected = self.get_token_at_position(file_path, position);
     if not node_selected {
@@ -311,6 +322,78 @@ impl JacLangServer.get_definition(
     if isinstance(parent, uni.AstImplNeedingNode) and parent.body {
         if isinstance(parent.body, uni.ImplDef) {
             return make_location(parent.body.sym.decl);
+        }
+    }
+    ####################################################################
+    ##         Import-aware goto-def (module paths & imported items)  ##
+    ####################################################################
+    # When the cursor is on a module path segment or an imported item,
+    # use direct module resolution as the primary strategy. This is
+    # resilient to partial type evaluation failures.
+    if isinstance(parent, uni.ModulePath) {
+        # Cursor is on a segment of a module path (e.g., "cli" in "jaclang.cli.console")
+        # First try type-based resolution (fast, already computed)
+        if node_type and isinstance(node_type, ModuleType) {
+            return make_location(node_selected, is_module=True);
+        }
+        # Fallback: resolve the module path segment directly via the resolver.
+        import_node = parent.parent_of_type(uni.Import) if parent else None;
+        if import_node and parent.path {
+            try {
+                idx = `list(parent.path).index(node_selected);
+                path_list = parent.resolve_relative_path_list();
+                if idx < len(path_list) {
+                    resolved = path_list[idx];
+                    if Path(resolved).exists() {
+                        return make_module_location(resolved);
+                    }
+                }
+            } except (ValueError, Exception) as e {
+                self.log_py(f"Error resolving module path segment: {e}");
+            }
+        }
+    }
+    if isinstance(parent, uni.ModuleItem) and isinstance(node_selected, uni.Name) {
+        # Cursor is on an imported item name (e.g., "console" in "{ console }")
+        # If the item is a module (e.g., "uris" in "from jaclang.lsp { uris }"),
+        # defer to the type-based handler below which handles ModuleType correctly.
+        if node_type and isinstance(node_type, ModuleType) {
+            return make_location(node_selected, is_module=True);
+        }
+        # Check if sym was already linked to the remote definition by type checker
+        if (
+            node_selected.sym
+            and node_selected.sym.defn
+            and node_selected.sym.defn[0].loc.mod_path != node_selected.loc.mod_path
+        ) {
+            decl = node_selected.sym.defn[0];
+            return make_location(decl);
+        }
+        # Fallback: resolve the target module and look up the symbol directly.
+        import_node = parent.parent_of_type(uni.Import) if parent else None;
+        if import_node and import_node.from_loc {
+            try {
+                mod_path = import_node.from_loc.resolve_relative_path();
+                if Path(mod_path).exists() and not Path(mod_path).is_dir() {
+                    # Try to find the symbol in the target module's hub entry
+                    resolved_path = str(Path(mod_path).resolve());
+                    with self._state_lock.read_lock() {
+                        target_mod = self.mod.hub.get(resolved_path);
+                    }
+                    if target_mod {
+                        sym = target_mod.lookup(
+                            node_selected.value, deep=True, incl_inner_scope=True
+                        );
+                        if sym and sym.defn {
+                            return make_location(sym.defn[0]);
+                        }
+                    }
+                    # If symbol not found in hub, at least navigate to the module
+                    return make_module_location(mod_path);
+                }
+            } except Exception as e {
+                self.log_py(f"Error resolving imported item: {e}");
+            }
         }
     }
     ####################################################################

--- a/jac/tests/langserve/fixtures/local_imports/main.jac
+++ b/jac/tests/langserve/fixtures/local_imports/main.jac
@@ -1,2 +1,3 @@
 import from mypkg_ns.my_mod { add }
 import from mypkg_reg.my_mod { sub }
+import from mypkg_deep.utils.helpers { greet, greeting }

--- a/jac/tests/langserve/fixtures/local_imports/mypkg_deep/utils/helpers.jac
+++ b/jac/tests/langserve/fixtures/local_imports/mypkg_deep/utils/helpers.jac
@@ -1,0 +1,5 @@
+glob greeting = "hello";
+
+def greet(name: str) -> str {
+    return f"{greeting}, {name}!";
+}

--- a/jac/tests/langserve/test_server.jac
+++ b/jac/tests/langserve/test_server.jac
@@ -810,3 +810,37 @@ test "test_namedtuple_hover" {
         teardown_test();
     }
 }
+
+test "test_go_to_definition_import_module_path_and_item" {
+    setup_test();
+    try {
+        lsp = create_server();
+        import_file = uris.from_fs_path(fixture_path("local_imports/main.jac"));
+        lsp.type_check_file(import_file);
+
+        # Line 3: import from mypkg_deep.utils.helpers { greet, greeting }
+        # Test module path segments (each should navigate to the module/directory)
+        positions = [
+            # "mypkg_deep" in module path → namespace package dir
+            (3, 15, "local_imports/mypkg_deep"),
+            # "utils" in module path → namespace package dir
+            (3, 25, "local_imports/mypkg_deep/utils"),
+            # "helpers" in module path → module file at 0:0
+            (3, 31, "local_imports/mypkg_deep/utils/helpers.jac"),
+            # "greet" in { greet, greeting } → definition in helpers.jac
+            (3, 41, "local_imports/mypkg_deep/utils/helpers.jac"),
+            # "greeting" in { greet, greeting } → definition in helpers.jac
+            (3, 48, "local_imports/mypkg_deep/utils/helpers.jac"),
+
+        ];
+
+        for (line, char, expected) in positions {
+            def_loc = lsp.get_definition(import_file, lspt.Position(line - 1, char - 1));
+            assert def_loc is not None , f"Definition at line {line}, col {char} not found";
+            assert expected in str(def_loc) , f"Expected '{expected}' in definition for "
+            f"line {line}, char {char}, got: {def_loc}";
+        }
+    } finally {
+        teardown_test();
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed goto-definition failing on intermediate module path segments (e.g., `cli` in `import from jaclang.cli.console`) by resolving the full dotted path once and deriving intermediate paths by walking up the directory tree
- Made `get_type_of_module()` resilient to missing intermediate segments (namespace packages) — skips instead of bailing out
- Added import-aware `ModulePath` and `ModuleItem` handlers to `get_definition()` with resolver fallback when type info is missing

## Test plan
- [x] All 44 langserve tests pass (including new `test_go_to_definition_import_module_path_and_item`)
- [x] All 97 type checker tests pass
- [x] Verified end-to-end: `import from jaclang.cli.console { console }` — all 4 references resolve correctly
- [ ] Manual IDE testing: trigger goto-def on module path segments and imported items