### PR TITLE
Add error extraction utility and tests for line/col in parse errors

### DIFF
--- a/docs/docs/community/release_notes/jac-mcp.md
+++ b/docs/docs/community/release_notes/jac-mcp.md
@@ -4,6 +4,7 @@
 
 - **Fix SSE transport method issue**
 - **Fix CompilerBridge tools returning incorrect results**: `check_syntax`, `validate_jac`, and `get_ast` now use the compiler's structured diagnostics and parse API to correctly detect errors and return real AST output
+- **Fix error reporting and example loading**: Syntax errors now report accurate line/column numbers, and `list_examples`/`get_example` work correctly in PyPI installs
 
 ## jac-mcp 0.1.5 (Latest Release)
 

--- a/jac-mcp/jac_mcp/impl/compiler_bridge.impl.jac
+++ b/jac-mcp/jac_mcp/impl/compiler_bridge.impl.jac
@@ -4,6 +4,14 @@ import from typing { Any }
 import tempfile;
 import os;
 import threading;
+"""Extract line, col, and message from an Alert object."""
+def _extract_error_info(alert: object) -> dict[str, Any] {
+    return {
+        "line": alert?.loc?.first_line or 0,
+        "col": alert?.loc?.col_start or 0,
+        "message": alert?.msg or str(alert)
+    };
+}
 
 """Run a function with timeout protection."""
 impl run_with_timeout(func: object, timeout: int = 10) -> tuple {
@@ -62,7 +70,7 @@ impl CompilerBridge.parse_snippet(
 
             errors: list[dict] = [];
             for e in program.errors_had {
-                errors.append({"line": 0, "col": 0, "message": str(e)});
+                errors.append(_extract_error_info(e));
             }
 
             valid = len(errors) == 0 and ir is not None;
@@ -118,10 +126,10 @@ impl CompilerBridge.typecheck_snippet(
             errors: list[dict] = [];
             warnings: list[dict] = [];
             for e in program.errors_had {
-                errors.append({"line": 0, "col": 0, "message": str(e)});
+                errors.append(_extract_error_info(e));
             }
             for w in program.warnings_had {
-                warnings.append({"line": 0, "col": 0, "message": str(w)});
+                warnings.append(_extract_error_info(w));
             }
 
             valid = len(errors) == 0 and ir is not None;
@@ -271,7 +279,7 @@ impl CompilerBridge.get_ast_snippet(code: str, fmt: str = "tree") -> dict[str, A
 
             errors: list[dict] = [];
             for e in program.errors_had {
-                errors.append({"line": 0, "col": 0, "message": str(e)});
+                errors.append(_extract_error_info(e));
             }
 
             if ir is None {

--- a/jac-mcp/pyproject.toml
+++ b/jac-mcp/pyproject.toml
@@ -29,8 +29,7 @@ include = ["jac_mcp*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.jac", "*.impl/*.jac", "*.cl/*.jac"]
-jac_mcp = ["content/*.md", "content/docs/*.md", "content/docs/*.spec", "content/docs/*.jac", "_precompiled/**/*.jir", "_precompiled/manifest.json"]
-
+jac_mcp = ["content/*.md", "content/docs/*.md", "content/docs/*.spec", "content/docs/*.jac", "content/examples/**/*.jac", "_precompiled/**/*.jir", "_precompiled/manifest.json"]
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"

--- a/jac-mcp/tests/test_mcp.jac
+++ b/jac-mcp/tests/test_mcp.jac
@@ -311,6 +311,19 @@ test "parse invalid code" {
     assert len(result["errors"]) > 0;
 }
 
+test "parse errors have correct line and col" {
+    result = CompilerBridge.parse_snippet("obj Foo {\n    has x: int = 5\n}");
+    assert result["valid"] == False;
+    assert len(result["errors"]) > 0;
+    err = result["errors"][0];
+    assert err["line"] > 0 , f"Expected line > 0, got {err['line']}";
+    assert err["col"] > 0 , f"Expected col > 0, got {err['col']}";
+    assert "message" in err;
+    assert len(err["message"]) > 0;
+    assert isinstance(err["line"], int);
+    assert isinstance(err["col"], int);
+}
+
 test "parse empty code" {
     result = CompilerBridge.parse_snippet("");
     assert isinstance(result, dict);


### PR DESCRIPTION
An error extraction utility has been introduced to improve the handling of parse errors by capturing line, column, and message details. Tests ensure that the error information is correctly populated during parsing.

