### PR TITLE
Add jac-mcp to jac-scale deployment pipeline

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -9,6 +9,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Client-Side Error Reporting Endpoint**: Added `POST /cl/__error__` endpoint to `JacAPIServerCore` for receiving client-side JavaScript errors. Errors are logged via the `jaclang.client_errors` logger and printed to the dev console with stack traces for visibility.
 - **Source-Mapped Error Stack Traces**: Client error stack traces received at `/cl/__error__` are now resolved from bundled JS locations to original `.jac` file paths and exact line numbers via the centralized `SourceMapper` with two-layer resolution.
 - **Client Error Rate Limiting**: The `/cl/__error__` endpoint now deduplicates identical error messages (10s window) and caps at 20 errors per minute to prevent log flooding from render loops or repeated failures.
+- **jac-mcp Auto-Install in Deployments**: `jac-mcp` is now automatically installed during K8s deployments in both experimental (editable from source) and default (PyPI) modes. Configurable via `plugin_versions.jac_mcp` in `jac.toml` (`latest`, specific version, or `none` to skip).
 
 ## jac-scale 0.2.6 (Latest Release)
 

--- a/jac-scale/jac_scale/targets/kubernetes/templates/base.Dockerfile
+++ b/jac-scale/jac_scale/targets/kubernetes/templates/base.Dockerfile
@@ -17,4 +17,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir jaclang jac-mcp
+RUN pip install --no-cache-dir jaclang


### PR DESCRIPTION
## Summary
- Install jac-mcp automatically during K8s deployments in both experimental (editable) and default (PyPI) modes
- Updated base Dockerfile template to include jac-mcp
- Configurable via `plugin_versions.jac_mcp` in jac.toml (supports `latest`, specific version, or `none` to skip)

## Test plan
- [ ] Deploy with `--experimental` and verify `jac-mcp` is installed via `pip list | grep jac-mcp`
- [ ] Deploy without `--experimental` and verify jac-mcp installs from PyPI
- [ ] Set `jac_mcp = "none"` in plugin_versions and verify it's skipped