### PR TITLE
ci: auto-trigger CI workflows on release PR creation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -117,3 +117,9 @@ jobs:
             --base main \
             --head "$BRANCH_NAME")
           echo "::notice::Release PR created: $PR_URL"
+
+          # Trigger CI workflows (GITHUB_TOKEN can trigger workflow_dispatch)
+          gh workflow run test-jaseci.yml --ref "$BRANCH_NAME"
+          gh workflow run jac-check.yml --ref "$BRANCH_NAME"
+          gh workflow run docs-validation.yml --ref "$BRANCH_NAME"
+          echo "::notice::CI workflows triggered on $BRANCH_NAME"

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   jac-check:

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test-core:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,25 +124,54 @@ The docs site has three tiers with different expectations for contributors:
 - **Quick Guide** -- Get a quick experience with Jac. Most features don't need to touch this.
 - **Full Reference** -- Must cover everything. **Every feature or change should update the reference docs.**
 
-## Release Flow (for the empowered)
+## Release Flow (for maintainers)
 
 Releasing new versions to PyPI is a two-step process using GitHub Actions.
 
-### Step 1: Create and Merge the Release PR
+```
+┌─────────────────────┐      ┌─────────────────────┐      ┌─────────────────────┐
+│  Create Release PR  │ ───▶ │   Merge to main     │ ───▶ │  Approve & Publish  │
+│  (manual trigger)   │      │   (triggers publish)│      │  (one-click)        │
+└─────────────────────┘      └─────────────────────┘      └─────────────────────┘
+```
+
+### Step 1: Create the Release PR
 
 1. Go to **GitHub Actions** → **Create Release PR**
 2. Click **Run workflow**
-3. For each package, select the version bump type (`skip`, `patch`, `minor`, or `major`)
+3. For each package, select the version bump type (`skip`, `patch`, `minor`, or `major`):
+   - `jaclang`, `jac-byllm`, `jac-client`, `jac-scale`, `jac-super`, `jac-mcp`, `jaseci`
 4. Click **Run workflow**
-5. The workflow creates a PR with all version bumps (example: [PR #4675](https://github.com/jaseci-labs/jaseci/pull/4675))
+5. The workflow validates versions against PyPI, bumps them, and creates a PR from a `release/*` branch
 6. Wait for CI tests to pass, then **approve and merge** the PR to main
 
-### Step 2: Publish to PyPI
+### Step 2: Approve Publishing
 
-After the release PR is merged, go to **GitHub Actions** and run the `Release <package> to PYPI` workflow for each bumped package **in this order**:
+After the release PR is merged, the **Publish Release** workflow triggers automatically:
 
-1. **jaclang** (core - must be first)
-2. **jac-client**, **jac-byllm**, **jac-scale**, **jac-super** (depend on jaclang)
-3. **jaseci** (meta-package - last)
+1. It parses the packages and versions from the PR title
+2. **Manual approval required** (only maintainers with `pypi` environment access can approve):
+   - Go to **GitHub Actions** → find the running **Publish Release** workflow
+   - The workflow will pause at the "approve-release" job waiting for approval
+   - Click on the job, then click **Review deployments**
+   - Select the `pypi` environment and click **Approve and deploy**
+3. The workflow then handles everything automatically:
+   - Precompiles bytecode (for packages that need it)
+   - Builds all packages
+   - Publishes in dependency order (tiered):
+     - **Tier 1**: `jaclang` (base package)
+     - **Tier 2**: `jac-byllm`, `jac-client`, `jac-scale`, `jac-super`, `jac-mcp`
+     - **Tier 3**: `jaseci` (meta-package)
+   - Pushes git tags (`{package}-v{version}`, plus `v{version}` for jaseci)
+   - Creates a GitHub Release with artifacts
+   - Builds standalone binaries (if jaseci was released)
 
-> **Important**: Wait for each workflow to complete before starting the next.
+> **Note**: The workflow waits for each tier to be available on PyPI before publishing the next tier.
+
+### Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Publish workflow didn't trigger | Ensure the PR branch started with `release/` |
+| A tier failed to publish | Re-run the failed job from GitHub Actions; already-published packages are skipped |
+| Version conflict on PyPI | The `Create Release PR` workflow validates this upfront - if you hit this, someone manually published |


### PR DESCRIPTION
## Summary

When the "Create Release PR" workflow creates a PR using `GITHUB_TOKEN`, [CI workflows don't auto-trigger](https://docs.github.com/en/actions/concepts/security/github_token?versionId=free-pro-team%40latest&productId=actions&restPage=tutorials%2Cauthenticate-with-github_token#:~:text=Contexts%20reference.-,When%20GITHUB_TOKEN%20triggers%20workflow%20runs,that%20uses%20the%20GITHUB_TOKEN%20do%20not%20trigger%20a%20GitHub%20Pages%20build.,-Next%20steps). This is a [GitHub security feature](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to prevent infinite loops.

This PR fixes the issue by using `workflow_dispatch` — one of the few events that `GITHUB_TOKEN` **can** trigger.

## Changes

### Workflow changes
- **test-jaseci.yml**: Added `workflow_dispatch` trigger
- **jac-check.yml**: Added `workflow_dispatch` trigger  
- **create-release-pr.yml**: After creating the PR, triggers CI workflows via:
  ```bash
  gh workflow run test-jaseci.yml --ref "$BRANCH_NAME"
  gh workflow run jac-check.yml --ref "$BRANCH_NAME"
  gh workflow run docs-validation.yml --ref "$BRANCH_NAME"
  ```

### Documentation update (CONTRIBUTING.md)
- Updated release flow section (was outdated)
- Added ASCII flow diagram
- Added direct links to workflow files
- Added step-by-step approval instructions
- Added troubleshooting table
- Renamed "for the empowered" → "for maintainers"

## Why not other approaches?

| Approach | Why not |
|----------|---------|
| GitHub App token | Private key is long-lived — if leaked, attacker can generate unlimited tokens |
| PAT | Tied to a person, can be over-scoped, expires |
| Close/reopen PR manually | Works, but adds manual step for every release |
| Close/reopen via workflow | Still uses `GITHUB_TOKEN`, so won't trigger CI either |

`workflow_dispatch` is the cleanest solution — no extra secrets, fully automated.

## Note on `no-ai-coauthor.yml`

This workflow is **not** triggered because it uses `github.base_ref` which is empty for `workflow_dispatch` events, causing it to fail. It's not critical for release PRs anyway since the bot creates the commits.