### PR TITLE
ci: add actions:write permission for workflow_dispatch

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -49,6 +49,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Fixes the HTTP 403 error when `create-release-pr` workflow tries to trigger CI workflows.

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
```

## Changes

Add `actions: write` permission to allow `GITHUB_TOKEN` to trigger workflows via `gh workflow run`.

## Root cause

The previous PR #5280 added `workflow_dispatch` triggers but missed the required permission. The `GITHUB_TOKEN` needs explicit `actions: write` to call the workflow dispatch API.