### PR TITLE
ci: split checker tests from test-core to jac-check workflow

### DIFF
--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -43,3 +43,18 @@ jobs:
       - name: Run jac check (using .jacignore)
         run: |
           jac check . --ignore tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ') --nowarn
+
+      - name: Install test dependencies
+        run: |
+          pip install pytest
+          pip install pytest-xdist
+
+      - name: Run checker tests
+        run: |
+          pytest -x -n auto \
+            jac/tests/compiler/passes/main/test_checker_bugs.jac \
+            jac/tests/compiler/passes/main/test_checker_gaps.jac \
+            jac/tests/compiler/passes/main/test_checker_pass.jac \
+            jac/tests/compiler/passes/main/test_checker_production.jac \
+            jac/tests/compiler/passes/main/test_checker_shortcomings.jac \
+            jac/tests/langserve/test_server.jac

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -32,7 +32,14 @@ jobs:
         pip install watchdog
 
     - name: Run Jac core tests
-      run: pytest -x jac -n auto
+      run: |
+        pytest -x jac -n auto \
+          --ignore=jac/tests/compiler/passes/main/test_checker_bugs.jac \
+          --ignore=jac/tests/compiler/passes/main/test_checker_gaps.jac \
+          --ignore=jac/tests/compiler/passes/main/test_checker_pass.jac \
+          --ignore=jac/tests/compiler/passes/main/test_checker_production.jac \
+          --ignore=jac/tests/compiler/passes/main/test_checker_shortcomings.jac \
+          --ignore=jac/tests/langserve/test_server.jac
 
   test-client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Move 6 checker-related test files from `test-core` job (~16 min) to `jac-check` workflow (~5 min)
- Reduces `test-core` runtime by running checker tests in parallel via `jac-check`
- Tests moved: `test_checker_bugs.jac`, `test_checker_gaps.jac`, `test_checker_pass.jac`, `test_checker_production.jac`, `test_checker_shortcomings.jac`, `test_server.jac`

## Test plan
- [ ] Verify `jac-check` workflow runs the new checker tests
- [ ] Verify `test-core` excludes the moved tests and runs faster