### PR TITLE
fix: use Starlette add_route() instead of deprecated decorator

### DIFF
--- a/docs/scripts/mkdocs_serve.py
+++ b/docs/scripts/mkdocs_serve.py
@@ -277,12 +277,12 @@ def serve_with_watch(port: int = 8000) -> None:
     app.add_middleware(LiveReloadMiddleware)
 
     # Add health check endpoint
-    @app.route("/health")
     async def health_check(request: Request) -> Response:
         return Response("healthy\n", media_type="text/plain")
 
+    app.add_route("/health", health_check)
+
     # Add Server-Sent Events endpoint for live reload
-    @app.route("/events")
     async def events(request: Request) -> StreamingResponse:
         async def event_generator():
             yield "data: connected\n\n"
@@ -294,6 +294,8 @@ def serve_with_watch(port: int = 8000) -> None:
                     yield "data: ping\n\n"
 
         return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+    app.add_route("/events", events)
 
     app.mount("/", StaticFiles(directory=site_dir, html=True), name="static")
 


### PR DESCRIPTION
## Summary
- Replace `@app.route()` decorator with `app.add_route()` for `/health` and `/events` endpoints
- The decorator syntax was removed in newer Starlette versions, causing CI doc build failures

## Root cause
Starlette deprecated and removed the Flask-style `@app.route()` decorator. The `app.add_route()` method is the stable API.

## Test plan
- [ ] CI docs build passes
- [ ] `/health` endpoint returns "healthy"