### PR TITLE
Fix: missing lazy GitHub fetch for example categories in list_examples

### DIFF
--- a/docs/docs/community/release_notes/jac-mcp.md
+++ b/docs/docs/community/release_notes/jac-mcp.md
@@ -5,7 +5,7 @@
 - **Fix SSE transport method issue**
 - **Fix `prompts/get` failing with Pydantic validation error**: System instructions now correctly use `role: "assistant"`
 - **Fix CompilerBridge tools returning incorrect results**: `check_syntax`, `validate_jac`, and `get_ast` now use the compiler's structured diagnostics and parse API to correctly detect errors and return real AST output
-- **Fix error reporting and example loading**: Syntax errors now report accurate line/column numbers, and `list_examples`/`get_example` work correctly in PyPI installs
+- **Fix error reporting and example loading**: Syntax errors now report accurate line/column numbers. `list_examples` now correctly falls back to GitHub API when installed from PyPI, instead of returning an empty list
 - **Fix jac-mcp configuration issue in `jac.toml`***: Respect [plugins.mcp] config from jac.toml in jac mcp, using it as fallback when CLI args are not explicitly provided.
 - **Lazy GitHub-based example fetching**: Examples are now fetched on-demand from GitHub instead of being bundled in the PyPI package, reducing package size and ensuring examples are always up-to-date. Local repo examples are used when available, with GitHub as a fallback
 

--- a/jac-mcp/jac_mcp/impl/tools.impl.jac
+++ b/jac-mcp/jac_mcp/impl/tools.impl.jac
@@ -293,6 +293,21 @@ impl list_examples(category: str | None = None) -> dict[str, Any] {
             }
         }
     }
+    # If no individual examples found, try lazy GitHub fetch (PyPI install)
+    if not examples and "jac://examples/index" in rp._resources {
+        categories = rp._fetch_github_categories();
+        for cat_name in categories {
+            if category is None or category == cat_name {
+                examples.append(
+                    {
+                        "name": cat_name,
+                        "uri": f"jac://examples/{cat_name}",
+                        "description": f"Example Jac code for {cat_name}"
+                    }
+                );
+            }
+        }
+    }
     return {"examples": sorted(examples, key=lambda x : x["name"])};
 }
 

--- a/jac-mcp/tests/test_mcp.jac
+++ b/jac-mcp/tests/test_mcp.jac
@@ -275,6 +275,26 @@ test "list examples returns results" {
     assert isinstance(result["examples"], list);
 }
 
+test "list examples returns results when repo root is None (PyPI install)" {
+    import from unittest.mock { patch, MagicMock }
+
+    # Mock find_repo_root to return None, simulating a PyPI (non-editable) install
+    with patch("jac_mcp.resources.find_repo_root", return_value=None) {
+        tp = ToolProvider();
+        result = tp.call_tool("list_examples", {});
+    }
+    assert "examples" in result;
+    examples = result["examples"];
+    assert len(examples) > 0 , "list_examples should return results via GitHub fallback when repo root is None";
+    names = [e["name"] for e in examples];
+    assert "data_spatial" in names , "Expected 'data_spatial' in GitHub-fetched examples";
+    for ex in examples {
+        assert "name" in ex;
+        assert "uri" in ex;
+        assert ex["uri"].startswith("jac://examples/");
+    }
+}
+
 test "unknown tool returns error" {
     tp = ToolProvider();
     result = tp.call_tool("nonexistent_tool", {});


### PR DESCRIPTION
## **Description**
