### PR TITLE
security: pin litellm to safe versions after supply chain attack

### DIFF
--- a/docs/docs/community/release_notes/byllm.md
+++ b/docs/docs/community/release_notes/byllm.md
@@ -2,9 +2,11 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **byLLM** (formerly MTLLM). For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## byllm 0.5.10 (Unreleased)
+## byllm 0.6.0 (Latest Release)
 
-## byllm 0.5.9 (Latest Release)
+- **Security: Pin litellm to safe versions**: litellm v1.82.7+ was compromised with a credential-stealing payload (supply chain attack). Pinned dependency to `<=1.82.6` which is verified safe. See [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) for details.
+
+## byllm 0.5.9
 
 - 1 small changes.
 

--- a/jac-byllm/pyproject.toml
+++ b/jac-byllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "byllm"
-version = "0.5.9"
+version = "0.6.0"
 description = "byLLM Provides Easy to use APIs for different LLM Providers to be used with Jaseci's Jaclang Programming Language."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -10,7 +10,7 @@ keywords = ["llm", "jaclang", "jaseci", "byLLM"]
 requires-python = ">=3.11"
 dependencies = [
     "jaclang>=0.13.1",
-    "litellm @ git+https://github.com/BerriAI/litellm.git@61409275c8d8478d0a7ffc23d375a4fd86717b23",  # SECURITY: v1.82.7+ compromised - pinned to v1.82.3-stable
+    "litellm>=1.70.0,<=1.82.6",  # SECURITY: v1.82.7+ was compromised and yanked from PyPI
     "loguru>=0.7.2,<0.8.0",
     "pillow>=12.0.0,<13.0.0",
 ]

--- a/jaseci-package/pyproject.toml
+++ b/jaseci-package/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
 requires-python = ">=3.11"
 dependencies = [
     "jaclang>=0.13.1",
-    "byllm>=0.5.9",
+    "byllm>=0.6.0",
     "jac-client>=0.3.8",
     "jac-scale>=0.2.8",
     "jac-super>=0.1.8",


### PR DESCRIPTION
litellm v1.82.7+ was compromised with a credential-stealing payload. Pin dependency to <=1.82.6 which is verified safe.

Changes:
- jac-byllm: bump to 0.6.0, pin litellm<=1.82.6
- jaseci-package: update byllm dependency to >=0.6.0
- docs: add security note to release notes

Ref: https://github.com/BerriAI/litellm/issues/24512