### PR TITLE
fix: Windows client bundle compilation and path normalization

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,15 +2,17 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.3.9 (Unreleased)
+## jac-client 0.3.10 (Unreleased)
 
 - **Fix: Windows Client Compilation and Page Routing**: Fixed multiple Windows-specific issues preventing client apps from compiling and running. (1) **Path normalization**: Module hub lookups now use cross-platform path comparison, handling Windows case-insensitivity and backslash separators. (2) **JS generation**: The ES pass is now explicitly triggered when generated JavaScript is empty, fixing page files compiling to empty output. (3) **Import paths**: Backslashes are now normalized to forward slashes in generated JavaScript imports, fixing Vite build errors like `"page" is not exported`. These fixes are no-ops on Linux/macOS where paths already work correctly.
+
+## jac-client 0.3.9 (Latest Release)
 
 - **Updated Examples to Use Typed Interop Pattern**: The `basic-full-stack`, `full-stack-with-auth`, and `little-x` examples now use the typed object hydration pattern (`__from_wire`/`__to_wire`) for server/client communication.
 - **Simplified WebTarget Production Preview**: The `start` command for web targets now uses a simple HTTP file server for production preview instead of instantiating a full API server, reducing dependencies and startup complexity.
 - **Jac-Scale Plugin Support for PWA/Web Targets**: Fixed `WebTarget.start()` to use `Jac.get_api_server_class()` plugin hook instead of Python's built-in `http.server`. When jac-scale is installed, `jac start --client pwa` and `jac start --client web` now automatically use jac-scale's FastAPI-based server with JWT authentication, user management, WebSocket support, and admin portal. Previously, these targets ignored jac-scale and always used the basic HTTP server.
 
-## jac-client 0.3.8 (Latest Release)
+## jac-client 0.3.8
 
 ## jac-client 0.3.7
 

--- a/docs/docs/community/release_notes/jac-mcp.md
+++ b/docs/docs/community/release_notes/jac-mcp.md
@@ -1,10 +1,12 @@
 # jac-mcp Release Notes
 
-## jac-mcp 0.1.8 (Unreleased)
+## jac-mcp 0.1.9 (Unreleased)
+
+## jac-mcp 0.1.8 (Latest Release)
 
 - **Full CLI access over MCP**: AI models can now discover and run any `jac` CLI command (including plugin-provided ones) directly from the MCP session. `list_commands` returns a lightweight summary; `get_command(name)` returns full argument details; `execute_command` runs them. Replaces the narrower `start_server`, `create_project`, and `list_templates` tools.
 
-## jac-mcp 0.1.7 (Latest Release)
+## jac-mcp 0.1.7
 
 - 2 small changes.
 - **8 new tools**: AI models can now run Jac code, lint files, convert Jac to Python or JavaScript, visualize graphs, list project templates, scaffold new projects, and start a local server - all from within the MCP session.

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -2,7 +2,9 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Scale**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-scale 0.2.9 (Unreleased)
+## jac-scale 0.2.10 (Unreleased)
+
+## jac-scale 0.2.9 (Latest Release)
 
 - **Performance: MongoBackend.batch_get()**: New `batch_get(ids)` uses `find({_id: {$in: [...]}})` so edge traversals hit MongoDB with 2-3 queries instead of one per anchor. On cold starts with 100 edges this cuts 201 round-trips down to 3.
 - **Extensible Deployment Targets and Image Registries**: `DeploymentTargetFactory` and `ImageRegistryFactory` now support plugin-registered targets via `register(name, factory)`. External packages can register custom deployment targets (e.g. `DeploymentTargetFactory.register("enterprise-kubernetes", my_factory)`) and image registries without modifying jac-scale. Custom targets load their config from `[plugins.scale.<target-name>]` in `jac.toml`.
@@ -10,7 +12,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: HPA config ignored on redeployment**: `create_hpa` silently swallowed 409 Conflict errors when the HPA already existed, so updated `min_replicas`, `max_replicas`, and `cpu_utilization_target` values in `jac.toml` were never applied on subsequent deploys. Changed to a replace-first, create-on-404 pattern consistent with how Ingress and ConfigMap resources are managed, ensuring HPA configuration is always kept in sync with `jac.toml`.
 - **Sandbox Security Hardening**: Hardened K8s sandbox pods by dropping all Linux capabilities (`drop: ALL`), enabling seccomp `RuntimeDefault` profile (~44 dangerous syscalls blocked), disabling service account token automounting (prevents K8s API access from inside sandboxes), and adding a configurable `/app` emptyDir size limit (`app_storage_limit`, default 1Gi) to prevent node disk exhaustion. Applied consistently to both on-demand and warm pool pods. The sandbox base Dockerfile now creates a dedicated non-root user (`jac`, UID 1000) and installs Bun system-wide so it's accessible under the security context.
 
-## jac-scale 0.2.8 (Latest Release)
+## jac-scale 0.2.8
 
 - 1 small changes.
 

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -2,10 +2,12 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jaclang**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jaclang 0.13.2 (Unreleased)
+## jaclang 0.13.3 (Unreleased)
 
 - **Fix: Windows Client Bundle Compilation**: Fixed client bundle compilation failing on Windows with `Client function 'app' not found` error. Added cross-platform path normalization for module hub lookups to handle Windows case-insensitivity and path separator differences. Extracted helper functions to the client bundle module for consistent path handling across the bundle builder and module introspector. The ES pass is now explicitly triggered when generated JavaScript is empty, ensuring code generation completes on Windows where the pass may be skipped during initial compilation due to re-entrancy guards.
 - **Fix: Windows Console Unicode Encoding**: Fixed codec encoding crashes on Windows cmd/PowerShell when printing Unicode characters (emojis, symbols). The console now detects Windows legacy terminals and replaces unencodable characters with safe fallbacks. Windows Terminal continues to use full Unicode support.
+
+## jaclang 0.13.2 (Latest Release)
 
 - **Typed Interop: dict[K,V] Return Hydration and Walker Spawn Serialization**: The ES codegen now supports `dict[str, T]` return types with automatic value hydration (`Object.fromEntries(Object.entries(...).map(...))`), wraps `list[T]` returns at call sites with `.map(x => T.__from_wire(x))`, and serializes typed walker `has` fields with `__to_wire()` when spawning from client code. The interop analysis pass also now correctly extracts multi-parameter subscript types (e.g., `dict[str, Metric]` was previously reduced to bare `dict`).
 - **Fix: ES Codegen RecursionError on Walker/Typed Arg Fixtures**: Guarded an unprotected `get_type_evaluator()` call in `exit_func_call` that caused infinite recursion when compiling fixtures with walker spawns or typed function arguments.
@@ -23,7 +25,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Refactor: TypeEvaluator Converted to `obj` Style with `has` and `postinit`**: `TypeEvaluator` now uses explicit `has` declarations for all 24 instance attributes with proper defaults, replacing the manual `init` method with `postinit`.
 - **Fix: Project Dependencies Now Available to Subprocesses**: Packages installed via `jac install` (stored in `.jac/venv/`) are now accessible to subprocesses spawned from your code. Previously, running `subprocess.Popen(["jac", "mcp", ...])` failed because the venv's `bin/` directory wasn't in PATH. Now `add_venv_to_path()` also prepends the venv's `bin/` directory to `os.environ["PATH"]`, so commands like `jac mcp` work correctly when jac-mcp is installed as a project dependency in `jac.toml`.
 
-## jaclang 0.13.1 (Latest Release)
+## jaclang 0.13.1
 
 - **Fix: MRO Resolution for Classes Imported Through Python `__init__.py` Re-exports**: Inheriting from a class imported through a Python package's `__init__.py` re-export (e.g., `from pkg import Base` where `pkg/__init__.py` does `from .submod import Base`) now works correctly. Previously, the base class resolved to `UnknownType`, breaking the MRO and causing false "has no attribute" errors on inherited members.
 - **Fix: `ExecutionContext` Field Types Corrected to Non-Optional**: Changed `system_root`, `user_root`, and `entry_node` fields on `ExecutionContext` from `NodeAnchor | None` to `NodeAnchor`. These fields are always initialized in `postinit` (defaulting to `system_root`), so the `| None` was incorrect and forced unnecessary null-guard workarounds throughout access validation and anchor persistence code.

--- a/jac-byllm/pyproject.toml
+++ b/jac-byllm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "byllm"
-version = "0.6.0"
+version = "0.6.1"
 description = "byLLM Provides Easy to use APIs for different LLM Providers to be used with Jaseci's Jaclang Programming Language."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["llm", "jaclang", "jaseci", "byLLM"]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.13.1",
+    "jaclang>=0.13.2",
     "litellm>=1.70.0,<=1.82.6",  # SECURITY: v1.82.7+ was compromised and yanked from PyPI
     "loguru>=0.7.2,<0.8.0",
     "pillow>=12.0.0,<13.0.0",

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.3.8"
+version = "0.3.9"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -16,7 +16,7 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.13.1",
+    "jaclang>=0.13.2",
 ]
 
 [project.urls]

--- a/jac-mcp/pyproject.toml
+++ b/jac-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-mcp"
-version = "0.1.7"
+version = "0.1.8"
 description = "MCP server for AI-assisted Jac development"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["jac", "jaclang", "jaseci", "mcp", "ai", "model-context-protocol"]
 requires-python = ">=3.12"
 dependencies = [
-    "jaclang>=0.13.1",
+    "jaclang>=0.13.2",
     "mcp>=1.0.0",
 ]
 

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "jac-scale"
-version = "0.2.8"
+version = "0.2.9"
 description = ""
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "rich>=13.0.0",
-    "jaclang>=0.13.1",
+    "jaclang>=0.13.2",
     "python-dotenv>=1.2.1,<2.0.0",
     "docker>=7.1.0,<8.0.0",
     "kubernetes>=34.1.0,<35.0.0",

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaclang"
-version = "0.13.1"
+version = "0.13.2"
 description = "Jac programming language - Python-like syntax, compiles to Python bytecode, JavaScript, and native machine code with novel constructs for AI-integrated programming."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]

--- a/jaseci-package/pyproject.toml
+++ b/jaseci-package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jaseci"
-version = "2.3.8"
+version = "2.3.9"
 description = "Jaseci - A complete AI-native programming ecosystem with Jac language, LLM integration, and full-stack web apps"
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]
@@ -22,12 +22,12 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jaclang>=0.13.1",
-    "byllm>=0.6.0",
-    "jac-client>=0.3.8",
-    "jac-scale>=0.2.8",
+    "jaclang>=0.13.2",
+    "byllm>=0.6.1",
+    "jac-client>=0.3.9",
+    "jac-scale>=0.2.9",
     "jac-super>=0.1.8",
-    "jac-mcp>=0.1.7",
+    "jac-mcp>=0.1.8",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Add cross-platform path normalization for module hub lookups using os.path.normcase() to handle Windows case-insensitivity and separators
- Ensure EsastGenPass runs when mod.gen.js is empty (Windows may skip ES pass during initial compilation due to re-entrancy guards)
- Fix console Unicode encoding crashes on Windows cmd/PowerShell
- Fix backslash in JS import paths breaking Vite builds

Extracted helper functions to eliminate duplication:
- _lookup_module_in_hub(): normalized hub lookup
- _ensure_js_generated(): explicit ES pass trigger

These are no-ops on Linux/macOS where paths already work correctly.
