### PR TITLE
refactor: remove unused entry-point config from jac.toml

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.3.10 (Unreleased)
 
+- **Config Cleanup**: Removed unused `entry-point` field from example `jac.toml` files and jacpack templates.
+
 ## jac-client 0.3.9 (Latest Release)
 
 - **Updated Examples to Use Typed Interop Pattern**: The `basic-full-stack`, `full-stack-with-auth`, and `little-x` examples now use the typed object hydration pattern (`__from_wire`/`__to_wire`) for server/client communication.

--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.2.10 (Unreleased)
 
+- **Config Cleanup**: Removed unused `entry-point` field from example and fixture `jac.toml` files.
+
 ## jac-scale 0.2.9 (Latest Release)
 
 - **Performance: MongoBackend.batch_get()**: New `batch_get(ids)` uses `find({_id: {$in: [...]}})` so edge traversals hit MongoDB with 2-3 queries instead of one per anchor. On cold starts with 100 edges this cuts 201 round-trips down to 3.

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.13.3 (Unreleased)
 
+- **Config Cleanup: Removed Unused `entry-point` Field**: The `entry-point` field in `jac.toml`'s `[project]` section has been removed. This field was defined but never used by any CLI command -- `jac start` and other commands always defaulted to `main.jac` regardless of the config value.
+
 ## jaclang 0.13.2 (Latest Release)
 
 - **Typed Interop: dict[K,V] Return Hydration and Walker Spawn Serialization**: The ES codegen now supports `dict[str, T]` return types with automatic value hydration (`Object.fromEntries(Object.entries(...).map(...))`), wraps `list[T]` returns at call sites with `.map(x => T.__from_wire(x))`, and serializes typed walker `has` fields with `__to_wire()` when spawning from client code. The interop analysis pass also now correctly extracts multi-parameter subscript types (e.g., `dict[str, Metric]` was previously reduced to bare `dict`).

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1012,7 +1012,6 @@ To make any Jac project packable as a template, simply add a `[jacpack]` section
 [project]
 name = "{{name}}"
 version = "0.1.0"
-entry-point = "main.jac"
 
 [dependencies]
 

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -31,7 +31,6 @@ The auto-generated `jac.toml` for a `--use client` project looks like:
 [project]
 name = "myapp"
 version = "0.0.1"
-entry-point = "main.jac"
 ```
 
 You typically don't need to modify this file until you add dependencies or customize settings.
@@ -51,7 +50,6 @@ version = "1.0.0"
 description = "My Jac application"
 authors = ["Your Name <you@example.com>"]
 license = "MIT"
-entry-point = "main.jac"
 jac-version = ">=0.9.0"
 
 [project.urls]
@@ -66,7 +64,6 @@ repository = "https://github.com/user/repo"
 | `description` | Brief description |
 | `authors` | List of authors |
 | `license` | License identifier |
-| `entry-point` | Main file (default: `main.jac`) |
 | `jac-version` | Required Jac version |
 
 ---
@@ -515,7 +512,6 @@ jac start --port 3000
 name = "my-ai-app"
 version = "1.0.0"
 description = "An AI-powered application"
-entry-point = "main.jac"
 
 [dependencies]
 byllm = ">=0.4.8"

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -76,7 +76,6 @@ cl {
 name = "myapp"
 version = "1.0.0"
 description = "Jac client application"
-entry-point = "main.jac"
 
 [dependencies]
 
@@ -264,7 +263,6 @@ cl {
 [project]
 name = "myapp"
 version = "0.1.0"
-entry-point = "main.jac"
 
 [plugins.client]
 # Client-specific config

--- a/jac-client/jac_client/examples/all-in-one/jac.toml
+++ b/jac-client/jac_client/examples/all-in-one/jac.toml
@@ -2,7 +2,6 @@
 name = "all-in-one"
 version = "1.0.0"
 description = "Jac client application: all-in-one"
-entry-point = "main.jac"
 
 [jacpack]
 name = "all-in-one"

--- a/jac-client/jac_client/examples/asset-serving/css-with-image/jac.toml
+++ b/jac-client/jac_client/examples/asset-serving/css-with-image/jac.toml
@@ -2,7 +2,6 @@
 name = "css-with-image"
 version = "1.0.0"
 description = "Jac client application: css-with-image"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/asset-serving/image-asset/jac.toml
+++ b/jac-client/jac_client/examples/asset-serving/image-asset/jac.toml
@@ -2,7 +2,6 @@
 name = "image-asset"
 version = "1.0.0"
 description = "Jac client application: image-asset"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/asset-serving/import-alias/jac.toml
+++ b/jac-client/jac_client/examples/asset-serving/import-alias/jac.toml
@@ -2,7 +2,6 @@
 name = "import-alias"
 version = "1.0.0"
 description = "Jac client application: import-alias"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/basic-auth-with-router/jac.toml
+++ b/jac-client/jac_client/examples/basic-auth-with-router/jac.toml
@@ -2,7 +2,6 @@
 name = "basic-auth-with-router"
 version = "1.0.0"
 description = "Jac client application: basic-auth-with-router"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/basic-auth/jac.toml
+++ b/jac-client/jac_client/examples/basic-auth/jac.toml
@@ -2,7 +2,6 @@
 name = "basic-auth"
 version = "1.0.0"
 description = "Jac client application: basic-auth"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/basic-full-stack/jac.toml
+++ b/jac-client/jac_client/examples/basic-full-stack/jac.toml
@@ -2,7 +2,6 @@
 name = "basic-full-stack"
 version = "1.0.0"
 description = "Jac client application: basic-full-stack"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/basic/jac.toml
+++ b/jac-client/jac_client/examples/basic/jac.toml
@@ -2,7 +2,6 @@
 name = "basic"
 version = "1.0.0"
 description = "Jac client application: basic"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/css-styling/js-styling/jac.toml
+++ b/jac-client/jac_client/examples/css-styling/js-styling/jac.toml
@@ -2,7 +2,6 @@
 name = "js-styling"
 version = "1.0.0"
 description = "Jac client application: js-styling"
-entry-point = "main.jac"
 
 [dependencies.npm]
 "jac-client-node" = "1.0.7"

--- a/jac-client/jac_client/examples/css-styling/material-ui/jac.toml
+++ b/jac-client/jac_client/examples/css-styling/material-ui/jac.toml
@@ -2,7 +2,6 @@
 name = "material-ui"
 version = "1.0.0"
 description = "Jac client application: material-ui"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/css-styling/pure-css/jac.toml
+++ b/jac-client/jac_client/examples/css-styling/pure-css/jac.toml
@@ -2,7 +2,6 @@
 name = "pure-css"
 version = "1.0.0"
 description = "Jac client application: pure-css"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/css-styling/sass-example/jac.toml
+++ b/jac-client/jac_client/examples/css-styling/sass-example/jac.toml
@@ -2,7 +2,6 @@
 name = "sass-example"
 version = "1.0.0"
 description = "Jac client application: sass-example"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/css-styling/styled-components/jac.toml
+++ b/jac-client/jac_client/examples/css-styling/styled-components/jac.toml
@@ -2,7 +2,6 @@
 name = "styled-components"
 version = "1.0.0"
 description = "Jac client application: styled-components"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/css-styling/tailwind-example/jac.toml
+++ b/jac-client/jac_client/examples/css-styling/tailwind-example/jac.toml
@@ -2,7 +2,6 @@
 name = "tailwind-example"
 version = "1.0.0"
 description = "Jac client application: tailwind-example"
-entry-point = "main.jac"
 
 [plugins.client.vite]
 plugins = ["tailwindcss()"]

--- a/jac-client/jac_client/examples/form-handling/jac.toml
+++ b/jac-client/jac_client/examples/form-handling/jac.toml
@@ -2,7 +2,6 @@
 name = "form-handling"
 version = "1.0.0"
 description = "Jac client application: form-handling"
-entry-point = "main.jac"
 
 [dependencies]
 

--- a/jac-client/jac_client/examples/full-stack-with-auth/jac.toml
+++ b/jac-client/jac_client/examples/full-stack-with-auth/jac.toml
@@ -2,7 +2,6 @@
 name = "full-stack-with-auth"
 version = "1.0.0"
 description = "Jac client application: full-stack-with-auth"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/google-auth/jac.toml
+++ b/jac-client/jac_client/examples/google-auth/jac.toml
@@ -2,7 +2,6 @@
 name = "google-auth"
 version = "1.0.0"
 description = "Jac client application: google-auth"
-entry-point = "main.jac"
 
 [dependencies]
 

--- a/jac-client/jac_client/examples/little-x/jac.toml
+++ b/jac-client/jac_client/examples/little-x/jac.toml
@@ -2,7 +2,6 @@
 name = "little-x"
 version = "1.0.0"
 description = "Jac client application: little-x"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/nested-folders/nested-advance/jac.toml
+++ b/jac-client/jac_client/examples/nested-folders/nested-advance/jac.toml
@@ -2,7 +2,6 @@
 name = "nested-advance"
 version = "1.0.0"
 description = "Jac client application: nested-advance"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/nested-folders/nested-basic/jac.toml
+++ b/jac-client/jac_client/examples/nested-folders/nested-basic/jac.toml
@@ -2,7 +2,6 @@
 name = "nested-basic"
 version = "1.0.0"
 description = "Jac client application: nested-basic"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/ts-support/jac.toml
+++ b/jac-client/jac_client/examples/ts-support/jac.toml
@@ -2,7 +2,6 @@
 name = "ts-support"
 version = "1.0.0"
 description = "Jac client application: ts-support"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/examples/with-router/jac.toml
+++ b/jac-client/jac_client/examples/with-router/jac.toml
@@ -2,7 +2,6 @@
 name = "with-router"
 version = "1.0.0"
 description = "Jac client application: with-router"
-entry-point = "main.jac"
 
 [plugins.client]
 # Vite bundler configuration (optional overrides)

--- a/jac-client/jac_client/plugin/cli.jac
+++ b/jac-client/jac_client/plugin/cli.jac
@@ -337,13 +337,7 @@ def _handle_build_target(ctx: HookContext) -> None {
     try {
         entry_file = ctx.get_arg("filename", None);
         if not entry_file {
-            entry_file = config.entry_point;
-        }
-        if not entry_file {
-            console.error("No entry file specified. Use: jac build <file>");
-            ctx.set_data("cancel_execution", True);
-            ctx.set_data("cancel_return_code", 1);
-            return;
+            entry_file = "main.jac";
         }
 
         entry_path = Path(entry_file);
@@ -384,13 +378,7 @@ def _get_start_context(ctx: HookContext) -> tuple | None {
 
     entry_file = ctx.get_arg("filename", None);
     if not entry_file {
-        entry_file = config.entry_point;
-    }
-    if not entry_file {
-        console.error("No entry file specified. Use: jac start <file>");
-        ctx.set_data("cancel_execution", True);
-        ctx.set_data("cancel_return_code", 1);
-        return None;
+        entry_file = "main.jac";
     }
 
     entry_path = Path(entry_file);

--- a/jac-client/jac_client/templates/client.jacpack
+++ b/jac-client/jac_client/templates/client.jacpack
@@ -5,8 +5,7 @@
     "project": {
       "name": "{{name}}",
       "version": "1.0.0",
-      "description": "Jac client application: {{name}}",
-      "entry-point": "main.jac"
+      "description": "Jac client application: {{name}}"
     },
     "dependencies": {},
     "dependencies.npm": {

--- a/jac-client/jac_client/templates/fullstack.jacpack
+++ b/jac-client/jac_client/templates/fullstack.jacpack
@@ -5,8 +5,7 @@
     "project": {
       "name": "{{name}}",
       "version": "0.1.0",
-      "description": "A full-stack Jac application",
-      "entry-point": "main.jac"
+      "description": "A full-stack Jac application"
     },
     "dependencies": {},
     "dependencies.npm": {

--- a/jac-client/jac_client/tests/test_cli.jac
+++ b/jac-client/jac_client/tests/test_cli.jac
@@ -433,7 +433,7 @@ def _create_jac_toml(temp_dir: str, deps: str = "", dev_deps: str = "") -> str {
     deps_section = f"\n{deps}" if deps else "";
     dev_deps_section = f"\n{dev_deps}" if dev_deps else "";
 
-    toml_content = f'[project]\nname = "test-project"\nversion = "1.0.0"\ndescription = "Test project"\nentry-point = "app.jac"\n\n[dependencies.npm]{deps_section}\n\n[dev-dependencies.npm]{dev_deps_section}\n';
+    toml_content = f'[project]\nname = "test-project"\nversion = "1.0.0"\ndescription = "Test project"\n\n[dependencies.npm]{deps_section}\n\n[dev-dependencies.npm]{dev_deps_section}\n';
     config_path = os.path.join(temp_dir, "jac.toml");
     with open(config_path, "w") as f {
         f.write(toml_content);
@@ -471,7 +471,7 @@ test "add npm with mixed deps" {
             os.chdir(temp_dir);
 
             # Create jac.toml with both pypi and npm sections
-            toml_content = '[project]\nname = "fullstack-app"\nversion = "1.0.0"\ndescription = "Test project with mixed deps"\nentry-point = "app.jac"\n\n[dependencies]\nrequests = "~=2.31"\nflask = "~=3.0"\n\n[dependencies.npm]\n\n[dev-dependencies]\npytest = ">=8.0.0"\n';
+            toml_content = '[project]\nname = "fullstack-app"\nversion = "1.0.0"\ndescription = "Test project with mixed deps"\n\n[dependencies]\nrequests = "~=2.31"\nflask = "~=3.0"\n\n[dependencies.npm]\n\n[dev-dependencies]\npytest = ">=8.0.0"\n';
             config_path = os.path.join(temp_dir, "jac.toml");
             with open(config_path, "w") as f {
                 f.write(toml_content);
@@ -842,7 +842,7 @@ test "config files from jac toml" {
             os.chdir(temp_dir);
 
             # Create jac.toml with postcss and tailwind configs
-            toml_content = '[project]\nname = "test-configs"\nversion = "1.0.0"\ndescription = "Test project"\nentry-point = "main.jac"\n\n[plugins.client.configs.postcss]\nplugins = ["tailwindcss", "autoprefixer"]\n\n[plugins.client.configs.tailwind]\ncontent = ["./**/*.jac", "./.jac/client/**/*.{js,jsx}"]\nplugins = []\n\n[plugins.client.configs.tailwind.theme.extend]\ncolors = { primary = "#3490dc" }\n';
+            toml_content = '[project]\nname = "test-configs"\nversion = "1.0.0"\ndescription = "Test project"\n\n[plugins.client.configs.postcss]\nplugins = ["tailwindcss", "autoprefixer"]\n\n[plugins.client.configs.tailwind]\ncontent = ["./**/*.jac", "./.jac/client/**/*.{js,jsx}"]\nplugins = []\n\n[plugins.client.configs.tailwind.theme.extend]\ncolors = { primary = "#3490dc" }\n';
             config_path = os.path.join(temp_dir, "jac.toml");
             with open(config_path, "w") as f {
                 f.write(toml_content);
@@ -896,7 +896,7 @@ test "raw template config files from jac toml" {
 
             # Create jac.toml with raw template config
             raw_content = 'import { defineConfig, defineDocs } from "fumadocs-mdx/config";\n\nexport const docs = defineDocs({\n  dir: "content/docs",\n});\n\nexport default defineConfig({});';
-            toml_content = f'[project]\nname = "test-raw-configs"\nversion = "1.0.0"\ndescription = "Test project"\nentry-point = "main.jac"\n\n[dependencies.npm]\njac-client-node = "1.0.7"\n\n[dependencies.npm.dev]\n"@jac-client/dev-deps" = "2.0.0"\n\n[plugins.client.configs.source]\nextension = ".ts"\nraw = """\n{raw_content}\n"""\n';
+            toml_content = f'[project]\nname = "test-raw-configs"\nversion = "1.0.0"\ndescription = "Test project"\n\n[dependencies.npm]\njac-client-node = "1.0.7"\n\n[dependencies.npm.dev]\n"@jac-client/dev-deps" = "2.0.0"\n\n[plugins.client.configs.source]\nextension = ".ts"\nraw = """\n{raw_content}\n"""\n';
             config_path = os.path.join(temp_dir, "jac.toml");
             with open(config_path, "w") as f {
                 f.write(toml_content);
@@ -937,7 +937,7 @@ test "npmrc from jac toml" {
 
             # Create jac.toml with npm scoped registry and auth config
             # Include required npm deps to avoid auto-injection modifying the file
-            toml_content = '[project]\nname = "test-npmrc"\nversion = "1.0.0"\ndescription = "Test project"\nentry-point = "main.jac"\n\n[dependencies.npm]\njac-client-node = "1.0.7"\n\n[dependencies.npm.dev]\n"@jac-client/dev-deps" = "2.0.0"\n\n[plugins.client.npm.settings]\nregistry = "https://registry.example.com"\nalways-auth = true\nstrict-ssl = false\n\n[plugins.client.npm.scoped_registries]\n"@mycompany" = "https://npm.pkg.github.com"\n"@myorg" = "https://registry.example.com"\n\n[plugins.client.npm.auth."//npm.pkg.github.com/"]\n_authToken = "${NODE_AUTH_TOKEN}"\n';
+            toml_content = '[project]\nname = "test-npmrc"\nversion = "1.0.0"\ndescription = "Test project"\n\n[dependencies.npm]\njac-client-node = "1.0.7"\n\n[dependencies.npm.dev]\n"@jac-client/dev-deps" = "2.0.0"\n\n[plugins.client.npm.settings]\nregistry = "https://registry.example.com"\nalways-auth = true\nstrict-ssl = false\n\n[plugins.client.npm.scoped_registries]\n"@mycompany" = "https://npm.pkg.github.com"\n"@myorg" = "https://registry.example.com"\n\n[plugins.client.npm.auth."//npm.pkg.github.com/"]\n_authToken = "${NODE_AUTH_TOKEN}"\n';
             config_path = os.path.join(temp_dir, "jac.toml");
             with open(config_path, "w") as f {
                 f.write(toml_content);
@@ -1242,7 +1242,7 @@ test "path aliases in generated vite and tsconfig" {
             os.chdir(temp_dir);
 
             # Create jac.toml with path aliases
-            toml_content = '[project]\nname = "test-paths"\nversion = "1.0.0"\ndescription = "Test path aliases"\nentry-point = "main.jac"\n\n[plugins.client.paths]\n"@components/*" = "./components/*"\n"@utils/*" = "./src/utils/*"\n"@shared" = "./shared/index"\n';
+            toml_content = '[project]\nname = "test-paths"\nversion = "1.0.0"\ndescription = "Test path aliases"\n\n[plugins.client.paths]\n"@components/*" = "./components/*"\n"@utils/*" = "./src/utils/*"\n"@shared" = "./shared/index"\n';
             config_path = os.path.join(temp_dir, "jac.toml");
             with open(config_path, "w") as f {
                 f.write(toml_content);

--- a/jac-client/jac_client/tests/test_desktop_api_url.jac
+++ b/jac-client/jac_client/tests/test_desktop_api_url.jac
@@ -185,7 +185,7 @@ test "setup generates main rs with sidecar support" {
             '"""Test."""\ndef:pub hello() -> str { return "hi"; }\n'
         );
         (project_dir / "jac.toml").write_text(
-            '[project]\nname = "test"\nversion = "1.0.0"\nentry-point = "main.jac"\n'
+            '[project]\nname = "test"\nversion = "1.0.0"\n'
         );
         # Run setup
         env = get_env_with_bun();

--- a/jac-client/jac_client/tests/test_it.jac
+++ b/jac-client/jac_client/tests/test_it.jac
@@ -2034,7 +2034,6 @@ test "config_loader_dependency_management" {
             """[project]
 name = "test-project"
 version = "1.0.0"
-entry-point = "main.jac"
 
 [serve]
 base_route_app = "app"

--- a/jac-client/jac_client/tests/test_it_desktop.jac
+++ b/jac-client/jac_client/tests/test_it_desktop.jac
@@ -115,7 +115,7 @@ def get_minimal_desktop_jac -> str {
 
 """Get minimal jac.toml content for desktop testing."""
 def get_minimal_jac_toml(name: str = "test-desktop-app") -> str {
-    return f'[project]\nname = "{name}"\nversion = "1.0.0"\ndescription = "Desktop test app"\nentry-point = "main.jac"\n\n[dependencies.npm]\njac-client-node = "1.0.7"\n\n[dependencies.npm.dev]\n"@jac-client/dev-deps" = "1.0.0"\n\n[serve]\nbase_route_app = "app"\n';
+    return f'[project]\nname = "{name}"\nversion = "1.0.0"\ndescription = "Desktop test app"\n\n[dependencies.npm]\njac-client-node = "1.0.7"\n\n[dependencies.npm.dev]\n"@jac-client/dev-deps" = "1.0.0"\n\n[serve]\nbase_route_app = "app"\n';
 }
 
 # =============================================================================
@@ -454,7 +454,7 @@ test "sidecar module runs directly" {
         # Create a simple backend-only Jac file (no client code)
         backend_jac = '"""Simple backend for sidecar testing."""\n\ndef:pub greet(name: str) -> str {\n    return f"Hello, {name}!";\n}\n\ndef:pub add(a: int, b: int) -> int {\n    return a + b;\n}\n\ndef:pub get_status() -> dict {\n    return {"status": "ok", "version": "1.0.0"};\n}\n';
         (project_dir / "main.jac").write_text(backend_jac);
-        jac_toml = '[project]\nname = "sidecar-test"\nversion = "1.0.0"\ndescription = "Sidecar test"\nentry-point = "main.jac"\n';
+        jac_toml = '[project]\nname = "sidecar-test"\nversion = "1.0.0"\ndescription = "Sidecar test"\n';
         (project_dir / "jac.toml").write_text(jac_toml);
         # Start sidecar by running main.py directly
         port = get_free_port();

--- a/jac-client/jac_client/tests/test_pwa.jac
+++ b/jac-client/jac_client/tests/test_pwa.jac
@@ -5,10 +5,7 @@ import tempfile;
 import from pathlib { Path }
 
 """Create a minimal jac.toml file for PWA testing."""
-def _create_jac_toml_with_pwa(
-    temp_dir: str,
-    pwa_config: dict | None = None
-) -> str {
+def _create_jac_toml_with_pwa(temp_dir: str, pwa_config: dict | None = None) -> str {
     pwa_section = "";
     if pwa_config is not None {
         pwa_lines = ["[plugins.client.pwa]"];
@@ -28,7 +25,6 @@ def _create_jac_toml_with_pwa(
 name = "test-pwa-app"
 version = "1.0.0"
 description = "Test PWA project"
-entry-point = "main.jac"
 
 [dependencies.npm]
 jac-client-node = "1.0.7"
@@ -48,7 +44,6 @@ jac-client-node = "1.0.7"
 # =============================================================================
 # Config Loader Tests
 # =============================================================================
-
 """Test is_pwa_enabled returns False when no PWA section exists."""
 test "is_pwa_enabled returns false without pwa section" {
     import from jac_client.plugin.src.config_loader { JacClientConfig }
@@ -64,7 +59,7 @@ test "is_pwa_enabled returns false without pwa section" {
             }
 
             config = JacClientConfig(Path(temp_dir));
-            assert not config.is_pwa_enabled(), "is_pwa_enabled should return False without PWA section";
+            assert not config.is_pwa_enabled() , "is_pwa_enabled should return False without PWA section";
         } finally {
             os.chdir(original_cwd);
         }
@@ -83,7 +78,7 @@ test "is_pwa_enabled returns true with pwa section" {
             _create_jac_toml_with_pwa(temp_dir, {"theme_color": "#000000"});
 
             config = JacClientConfig(Path(temp_dir));
-            assert config.is_pwa_enabled(), "is_pwa_enabled should return True with PWA section";
+            assert config.is_pwa_enabled() , "is_pwa_enabled should return True with PWA section";
         } finally {
             os.chdir(original_cwd);
         }
@@ -109,10 +104,10 @@ test "get_pwa_config returns correct values" {
             config = JacClientConfig(Path(temp_dir));
             pwa_config = config.get_pwa_config();
 
-            assert pwa_config.get("theme_color") == "#ff0000", "theme_color mismatch";
-            assert pwa_config.get("background_color") == "#ffffff", "background_color mismatch";
-            assert pwa_config.get("install_banner"), "install_banner mismatch";
-            assert pwa_config.get("install_banner_delay") == 5000, "install_banner_delay mismatch";
+            assert pwa_config.get("theme_color") == "#ff0000" , "theme_color mismatch";
+            assert pwa_config.get("background_color") == "#ffffff" , "background_color mismatch";
+            assert pwa_config.get("install_banner") , "install_banner mismatch";
+            assert pwa_config.get("install_banner_delay") == 5000 , "install_banner_delay mismatch";
         } finally {
             os.chdir(original_cwd);
         }
@@ -135,7 +130,7 @@ test "get_pwa_config returns empty dict without pwa section" {
             config = JacClientConfig(Path(temp_dir));
             pwa_config = config.get_pwa_config();
 
-            assert pwa_config == {}, "get_pwa_config should return empty dict without PWA section";
+            assert pwa_config == {} , "get_pwa_config should return empty dict without PWA section";
         } finally {
             os.chdir(original_cwd);
         }
@@ -145,7 +140,6 @@ test "get_pwa_config returns empty dict without pwa section" {
 # =============================================================================
 # Vite Config with PWA Alias Tests
 # =============================================================================
-
 """Test that @jac/pwa alias is added to vite config when PWA is enabled."""
 test "vite config includes pwa alias when enabled" {
     import from jac_client.plugin.src.vite_bundler { ViteBundler }
@@ -164,7 +158,7 @@ test "vite config includes pwa alias when enabled" {
 
             # Verify PWA is detected as enabled via config loader
             config = JacClientConfig(Path(temp_dir));
-            assert config.is_pwa_enabled(), "PWA should be enabled";
+            assert config.is_pwa_enabled() , "PWA should be enabled";
 
             # Create mock entry file
             entry_file = Path(temp_dir) / ".jac" / "client" / "build" / "main.js";
@@ -176,8 +170,8 @@ test "vite config includes pwa alias when enabled" {
             vite_content = vite_config_path.read_text();
 
             # Verify @jac/pwa alias is present
-            assert "@jac/pwa" in vite_content, "@jac/pwa alias should be in vite config when PWA is enabled";
-            assert "pwa_runtime.js" in vite_content, "Should reference pwa_runtime.js";
+            assert "@jac/pwa" in vite_content , "@jac/pwa alias should be in vite config when PWA is enabled";
+            assert "pwa_runtime.js" in vite_content , "Should reference pwa_runtime.js";
         } finally {
             os.chdir(original_cwd);
         }
@@ -205,7 +199,7 @@ test "vite config excludes pwa alias when disabled" {
 
             # Verify PWA is NOT enabled via config loader
             config = JacClientConfig(Path(temp_dir));
-            assert not config.is_pwa_enabled(), "PWA should not be enabled";
+            assert not config.is_pwa_enabled() , "PWA should not be enabled";
 
             # Create mock entry file
             entry_file = Path(temp_dir) / ".jac" / "client" / "build" / "main.js";
@@ -217,7 +211,7 @@ test "vite config excludes pwa alias when disabled" {
             vite_content = vite_config_path.read_text();
 
             # Verify @jac/pwa alias is NOT present
-            assert "@jac/pwa" not in vite_content, "@jac/pwa alias should NOT be in vite config when PWA is disabled";
+            assert "@jac/pwa" not in vite_content , "@jac/pwa alias should NOT be in vite config when PWA is disabled";
         } finally {
             os.chdir(original_cwd);
         }
@@ -227,7 +221,6 @@ test "vite config excludes pwa alias when disabled" {
 # =============================================================================
 # PWA Setup Tests (via jac.toml parsing)
 # =============================================================================
-
 """Test PWA install banner config defaults."""
 test "pwa install banner config defaults" {
     import from jac_client.plugin.src.config_loader { JacClientConfig }
@@ -244,8 +237,8 @@ test "pwa install banner config defaults" {
 
             # Defaults should not be in config (they're applied at runtime)
             # Just verify PWA is enabled
-            assert config.is_pwa_enabled(), "PWA should be enabled";
-            assert "theme_color" in pwa_config, "theme_color should be in config";
+            assert config.is_pwa_enabled() , "PWA should be enabled";
+            assert "theme_color" in pwa_config , "theme_color should be in config";
         } finally {
             os.chdir(original_cwd);
         }
@@ -273,10 +266,10 @@ test "pwa custom banner settings" {
             config = JacClientConfig(Path(temp_dir));
             pwa_config = config.get_pwa_config();
 
-            assert pwa_config.get("install_banner_delay") == 5000, "Custom delay should be 5000";
-            assert pwa_config.get("install_banner_position") == "top", "Position should be top";
-            assert pwa_config.get("install_button_text") == "Get App", "Custom button text";
-            assert pwa_config.get("install_dismiss_text") == "Maybe Later", "Custom dismiss text";
+            assert pwa_config.get("install_banner_delay") == 5000 , "Custom delay should be 5000";
+            assert pwa_config.get("install_banner_position") == "top" , "Position should be top";
+            assert pwa_config.get("install_button_text") == "Get App" , "Custom button text";
+            assert pwa_config.get("install_dismiss_text") == "Maybe Later" , "Custom dismiss text";
         } finally {
             os.chdir(original_cwd);
         }
@@ -291,16 +284,15 @@ test "pwa banner can be disabled" {
         original_cwd = os.getcwd();
         try {
             os.chdir(temp_dir);
-            _create_jac_toml_with_pwa(temp_dir, {
-                "theme_color": "#000000",
-                "install_banner": False
-            });
+            _create_jac_toml_with_pwa(
+                temp_dir, {"theme_color": "#000000", "install_banner": False}
+            );
 
             config = JacClientConfig(Path(temp_dir));
             pwa_config = config.get_pwa_config();
 
-            assert config.is_pwa_enabled(), "PWA should still be enabled";
-            assert not pwa_config.get("install_banner"), "Banner should be disabled";
+            assert config.is_pwa_enabled() , "PWA should still be enabled";
+            assert not pwa_config.get("install_banner") , "Banner should be disabled";
         } finally {
             os.chdir(original_cwd);
         }
@@ -310,7 +302,6 @@ test "pwa banner can be disabled" {
 # =============================================================================
 # PWA Empty Section Edge Case
 # =============================================================================
-
 """Test PWA is enabled with empty section."""
 test "pwa enabled with empty section" {
     import from jac_client.plugin.src.config_loader { JacClientConfig }
@@ -329,7 +320,7 @@ test "pwa enabled with empty section" {
             # Empty section should NOT enable PWA (no keys = empty dict = length 0)
             # This is the expected behavior per is_pwa_enabled implementation
             # Note: An empty TOML section still creates an empty dict
-            assert not config.is_pwa_enabled(), "Empty PWA section should not enable PWA";
+            assert not config.is_pwa_enabled() , "Empty PWA section should not enable PWA";
         } finally {
             os.chdir(original_cwd);
         }

--- a/jac-scale/examples/early-exit/jac.toml
+++ b/jac-scale/examples/early-exit/jac.toml
@@ -2,7 +2,6 @@
 name = "new-app"
 version = "1.0.0"
 description = "Jac client application: new-app"
-entry-point = "src/app.jac"
 
 [dependencies.npm]
 react = "^19.2.0"

--- a/jac-scale/jac_scale/admin/ui/jac.toml
+++ b/jac-scale/jac_scale/admin/ui/jac.toml
@@ -2,7 +2,6 @@
 name = "jac-scale-admin"
 version = "1.0.0"
 description = "JAC-Scale Admin Portal"
-entry-point = "main.jac"
 
 [serve]
 base_route_app = "app"

--- a/jac-scale/jac_scale/tests/fixtures/scale-feats/jac.toml
+++ b/jac-scale/jac_scale/tests/fixtures/scale-feats/jac.toml
@@ -2,7 +2,6 @@
 name = "scale-feats"
 version = "1.0.0"
 description = "Jac client application: scale-feats"
-entry-point = "main.jac"
 
 [dependencies]
 

--- a/jac/jaclang/project/config.jac
+++ b/jac/jaclang/project/config.jac
@@ -20,7 +20,6 @@ obj ProjectConfig {
         license: str = "",
         readme: str = "README.md",
         jac_version: str = "",
-        entry_point: str = "main.jac",
         urls: dict[str, str] = {};
 }
 

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -743,7 +743,6 @@ impl _parse_toml_data(data: dict[str, Any], toml_path: Path | None = None) -> Ja
             license=proj.get("license", ""),
             readme=proj.get("readme", "README.md"),
             jac_version=proj.get("jac-version", ""),
-            entry_point=proj.get("entry-point", "main.jac"),
             urls=proj.get("urls", {})
         );
     }

--- a/jac/jaclang/project/impl/template_registry.impl.jac
+++ b/jac/jaclang/project/impl/template_registry.impl.jac
@@ -139,8 +139,7 @@ def _register_default_template(registry: TemplateRegistry) -> None {
                 "project": {
                     "name": "{{name}}",
                     "version": "0.1.0",
-                    "description": "A Jac project",
-                    "entry-point": "main.jac"
+                    "description": "A Jac project"
                 },
                 "dependencies": {},
                 "dev-dependencies": {"watchdog": ">=3.0.0"}

--- a/jac/tests/project/fixtures/templates/minimal/jac.toml
+++ b/jac/tests/project/fixtures/templates/minimal/jac.toml
@@ -5,7 +5,6 @@
 name = "{{name}}"
 version = "0.1.0"
 description = "Project created from minimal template"
-entry-point = "main.jac"
 
 [dependencies]
 

--- a/jac/tests/project/test_cache_location.jac
+++ b/jac/tests/project/test_cache_location.jac
@@ -10,7 +10,7 @@ import jaclang.project.config as config_mod;
 import jaclang;
 
 
-glob JAC_TOML_CONTENT = "[project]\nname = \"test-project\"\nversion = \"0.1.0\"\ndescription = \"A test project\"\nentry-point = \"main.jac\"\n",
+glob JAC_TOML_CONTENT = "[project]\nname = \"test-project\"\nversion = \"0.1.0\"\ndescription = \"A test project\"\n",
      MAIN_JAC_CONTENT = "\"\"\"Test main file.\"\"\"\n\nwith entry {\n    print(\"Hello, World!\");\n}\n";
 
 

--- a/jac/tests/project/test_config.jac
+++ b/jac/tests/project/test_config.jac
@@ -18,7 +18,7 @@ import from jaclang.project.config {
 import jaclang.project.config as config_mod;
 
 glob FIXTURE_BASE = str(Path(__file__).parent / "fixtures"),
-     JAC_TOML_CONTENT = "[project]\nname = \"test-project\"\nversion = \"0.1.0\"\ndescription = \"A test project\"\nentry-point = \"main.jac\"\n\n[dependencies]\nrequests = \">=2.28.0\"\n\n[dev-dependencies]\npytest = \">=8.0.0\"\n\n[run]\nmain = true\ncache = true\n\n[scripts]\ntest = \"jac test\"\n",
+     JAC_TOML_CONTENT = "[project]\nname = \"test-project\"\nversion = \"0.1.0\"\ndescription = \"A test project\"\n\n[dependencies]\nrequests = \">=2.28.0\"\n\n[dev-dependencies]\npytest = \">=8.0.0\"\n\n[run]\nmain = true\ncache = true\n\n[scripts]\ntest = \"jac test\"\n",
      MAIN_JAC_CONTENT = "\"\"\"Test main file.\"\"\"\n\nwith entry {\n    print(\"Hello, World!\");\n}\n",
      BASE_TOML = "[project]\nname = \"jactastic\"\n\n[serve]\nport = 8090\nbase_route_app = \"app\"\n\n[plugins.client]\n\n[dependencies.npm]\njac-client-node = \"1.0.4\"\n\n[dev-dependencies]\nwatchdog = \">=3.0\"\n",
      PROD_TOML = "[serve]\nport = 80\n\n[plugins.client]\nminify = true\n\n[plugins.byllm]\ndefault_model = \"gpt-4\"\n",
@@ -178,7 +178,6 @@ test "load basic config" {
         assert cfg.project.name == "test-project";
         assert cfg.project.version == "0.1.0";
         assert cfg.project.description == "A test project";
-        assert cfg.project.entry_point == "main.jac";
     }
 }
 
@@ -290,7 +289,7 @@ test "parse minimal config" {
 
 test "parse full config" {
     config_mod._config = None;
-    toml_str = "\n[project]\nname = \"full-project\"\nversion = \"1.2.3\"\ndescription = \"A full project\"\nauthors = [\"Jane Doe <jane@example.com>\"]\nlicense = \"MIT\"\nentry-point = \"app.jac\"\n\n[dependencies]\nnumpy = \">=1.24.0\"\npandas = \">=2.0.0\"\n\n[run]\nsession = \"my_session\"\nmain = false\ncache = false\n\n[build]\ntypecheck = true\n\n[test]\ndirectory = \"tests\"\nverbose = true\nfail_fast = true\nmax_failures = 5\n\n[serve]\nport = 9000\n\n[cache]\nenabled = false\ndir = \".cache\"\n\n[scripts]\nstart = \"jac run app.jac\"\nlint = \"jac lint . --fix\"\n\n[plugins.byllm]\ndefault_model = \"gpt-4\"\ntemperature = 0.7\n\n[environments.development]\n[environments.development.serve]\nport = 3000\n\n[environments.production]\n[environments.production.serve]\nport = 8000\n";
+    toml_str = "\n[project]\nname = \"full-project\"\nversion = \"1.2.3\"\ndescription = \"A full project\"\nauthors = [\"Jane Doe <jane@example.com>\"]\nlicense = \"MIT\"\n\n[dependencies]\nnumpy = \">=1.24.0\"\npandas = \">=2.0.0\"\n\n[run]\nsession = \"my_session\"\nmain = false\ncache = false\n\n[build]\ntypecheck = true\n\n[test]\ndirectory = \"tests\"\nverbose = true\nfail_fast = true\nmax_failures = 5\n\n[serve]\nport = 9000\n\n[cache]\nenabled = false\ndir = \".cache\"\n\n[scripts]\nstart = \"jac run app.jac\"\nlint = \"jac lint . --fix\"\n\n[plugins.byllm]\ndefault_model = \"gpt-4\"\ntemperature = 0.7\n\n[environments.development]\n[environments.development.serve]\nport = 3000\n\n[environments.production]\n[environments.production.serve]\nport = 8000\n";
     cfg = JacConfig.from_toml_str(toml_str);
 
     # Project
@@ -298,7 +297,6 @@ test "parse full config" {
     assert cfg.project.version == "1.2.3";
     assert cfg.project.description == "A full project";
     assert cfg.project.license == "MIT";
-    assert cfg.project.entry_point == "app.jac";
 
     # Dependencies
     assert "numpy" in cfg.dependencies;
@@ -784,9 +782,9 @@ test "merge project kebab case" {
         temp_project = make_temp_project(Path(tmpdir));
         cfg = JacConfig.load(temp_project / "jac.toml");
         overlay = temp_project / "overlay.toml";
-        overlay.write_text("[project]\nentry-point = \"app.jac\"\n");
+        overlay.write_text("[project]\njac-version = \"1.0.0\"\n");
         cfg.merge_from_toml_file(overlay);
-        assert cfg.project.entry_point == "app.jac";
+        assert cfg.project.jac_version == "1.0.0";
     }
 }
 
@@ -1226,10 +1224,10 @@ test "apply profile check with lint" {
 test "apply profile project kebab case" {
     config_mod._config = None;
     cfg = JacConfig.from_toml_str(
-        "[project]\nname = \"test\"\nentry-point = \"main.jac\"\n\n[environments.alt]\n[environments.alt.project]\nentry-point = \"app.jac\"\n"
+        "[project]\nname = \"test\"\njac-version = \"1.0.0\"\n\n[environments.alt]\n[environments.alt.project]\njac-version = \"2.0.0\"\n"
     );
     cfg.apply_profile("alt");
-    assert cfg.project.entry_point == "app.jac";
+    assert cfg.project.jac_version == "2.0.0";
 }
 
 test "apply profile dependencies and scripts" {

--- a/jac/tests/project/test_dependencies.jac
+++ b/jac/tests/project/test_dependencies.jac
@@ -32,7 +32,7 @@ def make_temp_project -> tuple {
 
     jac_toml = project_dir / "jac.toml";
     jac_toml.write_text(
-        '[project]\nname = "test-project"\nversion = "0.1.0"\ndescription = "A test project"\nentry-point = "main.jac"\n\n[dependencies]\nrequests = ">=2.28.0"\n\n[dev-dependencies]\npytest = ">=8.0.0"\n\n[run]\nmain = true\ncache = true\n\n[scripts]\ntest = "jac test"\n'
+        '[project]\nname = "test-project"\nversion = "0.1.0"\ndescription = "A test project"\n\n[dependencies]\nrequests = ">=2.28.0"\n\n[dev-dependencies]\npytest = ">=8.0.0"\n\n[run]\nmain = true\ncache = true\n\n[scripts]\ntest = "jac test"\n'
     );
 
     src_dir = project_dir / "src";

--- a/jac/tests/project/test_template.jac
+++ b/jac/tests/project/test_template.jac
@@ -120,7 +120,7 @@ test "bundle handles binary files" {
         assets_dir.mkdir();
         jac_toml = template_dir / "jac.toml";
         jac_toml.write_text(
-            "[project]\nname = \"{{name}}\"\nversion = \"0.1.0\"\nentry-point = \"main.jac\"\n\n[jacpack]\nname = \"binary-test\"\ndescription = \"Template with binary files\"\njaclang = \"0.9.0\"\n"
+            "[project]\nname = \"{{name}}\"\nversion = \"0.1.0\"\n\n[jacpack]\nname = \"binary-test\"\ndescription = \"Template with binary files\"\njaclang = \"0.9.0\"\n"
         );
         main_jac = template_dir / "main.jac";
         main_jac.write_text('print("Hello");');
@@ -192,7 +192,6 @@ test "load extracts config" {
     template = load_template_from_directory(template_dir);
     assert "project" in template.config;
     assert template.config["project"]["name"] == "{{name}}";
-    assert template.config["project"]["entry-point"] == "main.jac";
 }
 
 # --- RoundTrip tests ---

--- a/jac/tests/runtimelib/fixtures/test_project/jac.toml
+++ b/jac/tests/runtimelib/fixtures/test_project/jac.toml
@@ -1,4 +1,3 @@
 [project]
 name = "test_db_naming"
 version = "1.0.0"
-entry-point = "main.jac"


### PR DESCRIPTION
## Summary

Removes the unused `entry-point` field from `[project]` section in `jac.toml`. This field was defined and parsed but never used -- CLI commands like `jac start` hardcode `default="main.jac"` regardless of the config value.

## Why

The `entry-point` config created confusion: users expected `jac start` to respect their configured entry point, but it was silently ignored.

**Alternatives considered:**
1. **Make CLI use the config** -- Would require changes across multiple commands and could break existing workflows
2. **Remove the unused config** (chosen) -- Cleaner solution since the field never worked anyway

## Backward Compatibility

**Fully backward compatible.** Existing `jac.toml` and `.jacpack` files with `entry-point` will continue to work -- the field is simply ignored during config parsing. No user action required.

## Changes

- `ProjectConfig` schema: removed `entry_point` field
- Config parser: removed parsing logic
- Default template: removed from `template_registry.impl.jac`
- All `jac.toml` files and `.jacpack` templates: removed `entry-point` lines
- Documentation and tests: updated accordingly
