### PR TITLE
docs(tutorial): add cross-references to reference documentation

### DIFF
--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -456,6 +456,8 @@ This is useful when data isn't appearing as expected.
 - **`jid(node)`** -- get the built-in unique identifier of any node
 - **`del`** -- remove a node from the graph
 
+> **Deep Dive:** [Object-Spatial Programming](../../reference/language/osp.md) covers the full graph model including typed edges, walkers, and advanced traversals. [Comprehensions & Filters](../../reference/language/advanced.md) has the complete filter syntax reference.
+
 !!! example "Try It Yourself"
     After creating three tasks, mark one as done (`task.done = True`), then use `[root-->][?:Task, done == False]` to list only pending tasks. Verify that the completed task doesn't appear.
 
@@ -1034,6 +1036,8 @@ That last point deserves emphasis. You didn't write any code to save data or loa
 - **`async`** -- marks functions that perform asynchronous operations
 - **JSX syntax** -- `{expression}`, `{[... for x in list]}`, event handlers with lambdas
 - **List comprehensions and `+` operator** -- `[expr for x in list]`, `[x for x in list if cond]`, and `list + [item]` for immutable state updates
+
+> **Deep Dive:** [jac-client Reference](../../reference/plugins/jac-client.md) covers the full frontend API including routing, npm package imports, and advanced component patterns. The [Full-Stack tutorials](../fullstack/setup.md) go deeper on each topic.
 
 !!! example "Try It Yourself"
     Add a "Clear All" button below the task count that deletes every task. You'll need a new `def:pub clear_all_tasks` endpoint on the server and an `async` method in the component that calls it and resets the `tasks` list.
@@ -1708,6 +1712,8 @@ The AI can only pick from the enum values you defined -- `Category` for tasks, `
 - **`sem Type.field = "..."`** -- semantic hints that guide LLM field interpretation
 - **`-> list[Type] by llm()`** -- get validated structured output from the LLM
 - **Jac's type system is the LLM's output schema** -- name things clearly and `by llm()` handles the rest
+
+> **Deep Dive:** [byLLM Reference](../../reference/plugins/byllm.md) covers all AI integration options including model configuration, multi-provider support, and advanced prompt control. [Structured Outputs tutorial](../ai/structured-outputs.md) has more examples of `obj` + `sem` patterns.
 
 !!! example "Try It Yourself"
     Add `SOCIAL` and `FINANCE` to the `Category` enum. Then test how the AI categorizes tasks like "Call mom", "Pay rent", and "Gym at 6pm".
@@ -3408,6 +3414,8 @@ This part introduced Jac's Object-Spatial Programming paradigm:
 | `walker:priv` | Per-user walker with data isolation via private root nodes |
 | Node abilities | When the logic naturally belongs to the data type |
 | Walker abilities | When the logic naturally belongs to the traversal |
+
+> **Deep Dive:** [Object-Spatial Programming Reference](../../reference/language/osp.md) covers advanced walker patterns, entry/exit semantics, and multi-hop traversals. [Walker Patterns](../../reference/language/walker-responses.md) has a quick reference for common walker response patterns.
 
 !!! example "Try It Yourself"
     Write a `CountTasks` walker that reports the total number of tasks and how many are done, without collecting the full task list. Use `self.total: int` and `self.completed: int` counters that increment as the walker visits each `Task` node.


### PR DESCRIPTION
## What

Adds "Deep Dive" links after the "What You Learned" sections in the AI Day Planner tutorial, connecting readers to relevant reference docs.

## Changes

Adds cross-reference links in 4 sections:

- **Part 2 (Nodes)** → OSP reference, Comprehensions & Filters
- **Part 4 (Frontend)** → jac-client reference, Full-Stack tutorials
- **Part 5 (AI)** → byLLM reference, Structured Outputs tutorial
- **Part 7 (Walkers)** → OSP reference, Walker Patterns

## Why

Users finishing a tutorial section often want to go deeper on a specific topic but have to hunt through the docs nav. These links bridge the tutorial → reference gap.