### PR TITLE
feat: show individual walker endpoints in OpenAPI docs during dev mode

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.2.10 (Unreleased)
 
+- **Dev Mode: Individual Walker/Function Endpoints in OpenAPI Docs**: In dev mode (`jac start --dev`), individual walker and function endpoints (e.g., `/walker/CreateTask`, `/walker/PublicInfo`) now appear in the Swagger UI alongside the dynamic catch-all routes. Previously, only the generic `/walker/{walker_name}` catch-all was shown, making it hard to discover and test specific walkers from the docs page.
 - **Dev Mode: API Docs accessible from client URL**: In dev mode (`jac start --dev`), the FastAPI Swagger UI (`/docs`) and OpenAPI spec (`/openapi.json`) are now proxied through the Vite dev server, so you can browse your API docs at the same URL as your app without switching ports.
 - **Security: FastAPI docs disabled in production**: `/docs`, `/redoc`, and `/openapi.json` are no longer exposed in production. They are only available in dev mode.
 - **Health check endpoint**: Added `GET /healthz` for liveness checks. Returns `{"status": "ok"}` with no authentication required. Useful for Kubernetes probes and monitoring.

--- a/jac-scale/jac_scale/impl/serve.core.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.core.impl.jac
@@ -223,23 +223,24 @@ impl JacAPIServerCore.start(
     self.register_graph_endpoint();
     self.register_admin_endpoints();
     self.register_llm_telemetry_endpoints();
-    # Use dynamic routing for HMR support, static routing for production
+    # Register walker/function endpoints (both modes need them for OpenAPI docs)
+    self.register_walkers_endpoints();
+    self.register_functions_endpoints();
+    self.register_webhook_endpoints();
+    self.register_websocket_endpoints();
     if dev {
         # Enable FastAPI docs only in dev mode
         self.server.app.docs_url = "/docs";
         self.server.app.openapi_url = "/openapi.json";
         self.server.app.redoc_url = "/redoc";
         self.server.app.setup();
+        # Dynamic catch-all endpoints handle walkers/functions added via HMR
+        # after startup (specific routes registered above take priority)
         self.register_dynamic_walker_endpoint();
         self.register_dynamic_function_endpoint();
         self.register_dynamic_introspection_endpoints();
         self.register_dynamic_webhook_endpoint();
         self.register_dynamic_websocket_endpoint();
-    } else {
-        self.register_walkers_endpoints();
-        self.register_functions_endpoints();
-        self.register_webhook_endpoints();
-        self.register_websocket_endpoints();
     }
     self.register_root_asset_endpoint();
     self._register_client_error_endpoint();

--- a/jac-scale/jac_scale/tests/test_serve.jac
+++ b/jac-scale/jac_scale/tests/test_serve.jac
@@ -1623,6 +1623,49 @@ test "dev mode operations" {
     }
 }
 
+test "dev mode shows individual walker endpoints in openapi docs" {
+    sp = setup_dev_mode_server();
+    try {
+        # Fetch OpenAPI schema
+        response = requests.get(f"{dm_base_url}/openapi.json", timeout=10);
+        assert response.status_code == 200 , (
+            f"OpenAPI endpoint returned {response.status_code}"
+        );
+        schema = response.json();
+        paths = list(schema.get("paths", {}).keys());
+
+        # Individual walker endpoints should appear (not just catch-all)
+        assert "/walker/CreateTask" in paths , (
+            f"Individual walker endpoint /walker/CreateTask not in OpenAPI docs. "
+            f"Walker paths: {[
+                p
+                for p in paths
+                if 'walker' in p.lower()
+            ]}"
+        );
+        assert "/walker/PublicInfo" in paths , (
+            f"Individual walker endpoint /walker/PublicInfo not in OpenAPI docs. "
+            f"Walker paths: {[
+                p
+                for p in paths
+                if 'walker' in p.lower()
+            ]}"
+        );
+
+        # Dynamic catch-all should also be present (for HMR)
+        assert "/walker/{walker_name}" in paths , (
+            f"Dynamic catch-all /walker/{{walker_name}} not in OpenAPI docs. "
+            f"Walker paths: {[
+                p
+                for p in paths
+                if 'walker' in p.lower()
+            ]}"
+        );
+    } finally {
+        teardown_dev_mode_server(sp);
+    }
+}
+
 # =============================================================================
 # GROUP 7: PORT FALLBACK TESTS
 # =============================================================================


### PR DESCRIPTION
## Summary

- In dev mode (`jac start --dev`), only the dynamic catch-all `/walker/{walker_name}` appeared in Swagger docs, making it impossible to discover or test specific walkers from the docs page
- Now registers individual walker/function endpoints (e.g., `/walker/CreateTask`, `/walker/PublicInfo`) **before** the dynamic catch-all, so they appear in OpenAPI docs with proper parameter schemas
- The dynamic catch-all remains for HMR support (walkers added after startup are immediately available)

## Approach

Considered two alternatives:

1. **Duplicate registration in both branches** - Register static endpoints in both `if dev` and `else` blocks. Identical behavior but duplicated code.
2. **Shared registration before the branch** (chosen) - Register static walker/function/webhook/websocket endpoints once before the `if dev` check, since both modes need them. The `if dev` block only adds the dynamic catch-all endpoints and FastAPI docs on top. Cleaner, no duplication.

FastAPI matches more specific routes first, so `/walker/CreateTask` (static) takes priority over `/walker/{walker_name}` (catch-all). New walkers added via HMR still work through the catch-all.