### PR TITLE
docs: replace manual node ID management with jid() across docs

### DIFF
--- a/docs/docs/quick-guide/faq.md
+++ b/docs/docs/quick-guide/faq.md
@@ -121,7 +121,7 @@ Answers to common questions about Jac, organized by topic. Click a category to e
         Another process is using the port (default 8000). Either stop the other process or use a different port: `jac start main.jac --port 3000`.
 
     ??? question "My frontend shows data but fields are empty or undefined."
-        When returning node objects directly from `def:pub` endpoints, the serialized JSON uses internal field names like `_jac_id` instead of `id`. For reliable client-side access, return explicit dictionaries from your endpoints:
+        When returning node objects directly from `def:pub` endpoints, use `jid(node)` to access the node's unique identity. For reliable client-side access, return explicit dictionaries from your endpoints:
         ```jac
         # Instead of: return task;
         # Use:

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -161,7 +161,6 @@ node SecureRoom {
 
 ```jac
 node Entity {
-    has id: str;
     has created_at: str;
 }
 
@@ -619,7 +618,7 @@ with entry {
 
     <!-- jac-skip: fragment shown in context of a walker ability -->
     ```jac
-    new_node = here ++> Todo(id="123", title="Buy groceries");
+    new_node = here ++> Todo(title="Buy groceries");
     created_todo = new_node[0];  # Access the actual node
     report created_todo;
     ```
@@ -1062,7 +1061,6 @@ walker:priv DeleteItem {
 
 ```jac
 node Item {
-    has id: str;
     has name: str;
 }
 
@@ -1081,7 +1079,7 @@ walker:priv SearchItems {
     can check with Item entry {
         if self.query.lower() in here.name.lower() {
             self.matches.append({
-                "id": here.id,
+                "id": jid(here),
                 "name": here.name,
                 "score": calculate_relevance(here, self.query)
             });
@@ -1109,7 +1107,7 @@ walker:priv GetTree {
             children.append(self.build_tree(child));
         }
         return {
-            "id": node.id,
+            "id": jid(node),
             "name": node.name,
             "children": children
         };

--- a/docs/docs/reference/language/walker-responses.md
+++ b/docs/docs/reference/language/walker-responses.md
@@ -305,7 +305,7 @@ The same applies to `def:pub` functions -- return typed objects instead of manua
 # Bad: Manual dict return
 def:pub get_task(id: str) -> dict {
     task = find_task(id);
-    return {"id": task.id, "title": task.title, "done": task.done};
+    return {"id": jid(task), "title": task.title, "done": task.done};
 }
 
 # Good: Typed return -- client receives a hydrated Task instance

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -119,7 +119,6 @@ walker:priv InternalProcess { }
 sv {
     # Server-only block
     node User {
-        has id: str;
         has email: str;
     }
 }

--- a/docs/docs/tutorials/fullstack/backend.md
+++ b/docs/docs/tutorials/fullstack/backend.md
@@ -46,18 +46,18 @@ Use `def:priv` / `walker:priv` for authenticated endpoints with per-user data is
 
 ```jac
 node Task {
-    has id: str;
     has title: str;
     has created_at: str;
     has completed: bool = False;
 }
 ```
 
+Every node automatically gets a unique identifier from the runtime, accessible via `jid(node)`. You never need to manage IDs manually.
+
 ### Create Walker Endpoints
 
 ```jac
 import from datetime { datetime }
-import uuid;
 
 walker:pub get_tasks {
     can fetch with Root entry {
@@ -70,9 +70,7 @@ walker:pub add_task {
 
     can create with Root entry {
         new_task = Task(
-            id=str(uuid.uuid4()),
             title=self.title,
-            completed=False,
             created_at=datetime.now().isoformat()
         );
         root ++> new_task;
@@ -85,7 +83,7 @@ walker:pub toggle_task {
 
     can toggle with Root entry {
         for task in [-->][?:Task] {
-            if task.id == self.task_id {
+            if jid(task) == self.task_id {
                 task.completed = not task.completed;
                 report task;  # Report the updated Task node
                 return;
@@ -99,7 +97,7 @@ walker:pub delete_task {
 
     can remove with Root entry {
         for task in [-->][?:Task] {
-            if task.id == self.task_id {
+            if jid(task) == self.task_id {
                 del task;
                 report {"success": True};
                 return;
@@ -155,7 +153,7 @@ cl {
         }
 
         return <ul>
-            {[<li key={task.id}>{task.title}</li> for task in tasks]}
+            {[<li key={jid(task)}>{task.title}</li> for task in tasks]}
         </ul>;
     }
 }
@@ -211,7 +209,7 @@ cl {
             result = root spawn toggle_task(task_id=task_id);
             if result.reports and result.reports.length > 0 {
                 updated = result.reports[0];
-                tasks = [updated if t.id == task_id else t for t in tasks];
+                tasks = [updated if jid(t) == task_id else t for t in tasks];
             }
         }
 
@@ -219,7 +217,7 @@ cl {
         async def handle_delete(task_id: str) -> None {
             result = root spawn delete_task(task_id=task_id);
             if result.reports and result.reports.length > 0 {
-                tasks = [t for t in tasks if t.id != task_id];
+                tasks = [t for t in tasks if jid(t) != task_id];
             }
         }
 
@@ -242,16 +240,16 @@ cl {
 
             <ul className="task-list">
                 {[
-                    <li key={task.id}>
+                    <li key={jid(task)}>
                         <input
                             type="checkbox"
                             checked={task.completed}
-                            onChange={lambda -> None { handle_toggle(task.id); }}
+                            onChange={lambda -> None { handle_toggle(jid(task)); }}
                         />
                         <span className={task.completed and "completed"}>
                             {task.title}
                         </span>
-                        <button onClick={lambda -> None { handle_delete(task.id); }}>
+                        <button onClick={lambda -> None { handle_delete(jid(task)); }}>
                             Delete
                         </button>
                     </li>
@@ -408,7 +406,6 @@ cl {
 
 # === Backend: Data Model ===
 node Task {
-    has id: str;
     has title: str;
     has completed: bool = False;
 }
@@ -424,8 +421,7 @@ walker:pub add_task {
     has title: str;
 
     can create with Root entry {
-        import uuid;
-        task = Task(id=str(uuid.uuid4()), title=self.title);
+        task = Task(title=self.title);
         root ++> task;
         report task;
     }
@@ -436,7 +432,7 @@ walker:pub toggle_task {
 
     can toggle with Root entry {
         for t in [-->][?:Task] {
-            if t.id == self.task_id {
+            if jid(t) == self.task_id {
                 t.completed = not t.completed;
                 report t;
                 return;
@@ -475,7 +471,7 @@ cl {
             result = root spawn toggle_task(task_id=task_id);
             if result.reports and result.reports.length > 0 {
                 updated = result.reports[0];
-                tasks = [updated if t.id == task_id else t for t in tasks];
+                tasks = [updated if jid(t) == task_id else t for t in tasks];
             }
         }
 
@@ -500,9 +496,9 @@ cl {
                 <ul>
                     {[
                         <li
-                            key={t.id}
+                            key={jid(t)}
                             style={{"textDecoration": t.completed and "line-through"}}
-                            onClick={lambda -> None { toggle(t.id); }}
+                            onClick={lambda -> None { toggle(jid(t)); }}
                         >
                             {t.title}
                         </li>

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -30,7 +30,6 @@ graph LR
 ```jac
 # app.jac
 node Task {
-    has id: int;
     has title: str;
     has done: bool = False;
 }
@@ -38,7 +37,7 @@ node Task {
 walker:pub get_tasks {
     can fetch with Root entry {
         tasks = [-->][?:Task];
-        report [{"id": t.id, "title": t.title, "done": t.done} for t in tasks];
+        report [{"id": jid(t), "title": t.title, "done": t.done} for t in tasks];
     }
 }
 
@@ -46,10 +45,9 @@ walker:pub add_task {
     has title: str;
 
     can create with Root entry {
-        import random;
-        task = Task(id=random.randint(1, 10000), title=self.title);
+        task = Task(title=self.title);
         root ++> task;
-        report {"id": task.id, "title": task.title, "done": task.done};
+        report {"id": jid(task), "title": task.title, "done": task.done};
     }
 }
 ```
@@ -377,10 +375,8 @@ walker:pub ready {
 ```jac
 # api.jac
 import from datetime { datetime }
-import uuid;
 
 node User {
-    has id: str;
     has name: str;
     has email: str;
     has created_at: str;
@@ -391,7 +387,7 @@ walker:pub list_users {
     can fetch with Root entry {
         users = [-->][?:User];
         report [{
-            "id": u.id,
+            "id": jid(u),
             "name": u.name,
             "email": u.email
         } for u in users];
@@ -404,9 +400,9 @@ walker:pub get_user {
 
     can fetch with Root entry {
         for u in [-->][?:User] {
-            if u.id == self.user_id {
+            if jid(u) == self.user_id {
                 report {
-                    "id": u.id,
+                    "id": jid(u),
                     "name": u.name,
                     "email": u.email,
                     "created_at": u.created_at
@@ -425,13 +421,12 @@ walker:pub create_user {
 
     can create with Root entry {
         user = User(
-            id=str(uuid.uuid4()),
             name=self.name,
             email=self.email,
             created_at=datetime.now().isoformat()
         );
         root ++> user;
-        report {"id": user.id, "name": user.name, "email": user.email};
+        report {"id": jid(user), "name": user.name, "email": user.email};
     }
 }
 
@@ -443,10 +438,10 @@ walker:pub update_user {
 
     can update with Root entry {
         for u in [-->][?:User] {
-            if u.id == self.user_id {
+            if jid(u) == self.user_id {
                 if self.name { u.name = self.name; }
                 if self.email { u.email = self.email; }
-                report {"id": u.id, "name": u.name, "email": u.email};
+                report {"id": jid(u), "name": u.name, "email": u.email};
                 return;
             }
         }
@@ -460,7 +455,7 @@ walker:pub delete_user {
 
     can remove with Root entry {
         for u in [-->][?:User] {
-            if u.id == self.user_id {
+            if jid(u) == self.user_id {
                 del u;
                 report {"deleted": True};
                 return;


### PR DESCRIPTION
## Summary
- Remove the anti-pattern of declaring `has id` on nodes and manually generating UUIDs/random IDs
- Nodes get unique identity automatically via `jid()` -- no manual ID management needed
- Follow-up to #5369 which added `jid()` as an ES codegen builtin

## Changes
- **backend.md**: Remove `has id` from Task (2 definitions), drop `uuid` imports, use `jid()` in walkers and cl components
- **local.md**: Remove `has id` from Task/User, drop `uuid`/`random` imports, use `jid()` throughout
- **osp.md**: Remove `has id` from Entity/Item nodes, remove hardcoded `id="123"`, use `jid()` in SearchItems and GetTree
- **walker-responses.md**: Update "bad example" to use `jid()`
- **jac-client.md**: Remove `has id` from User node example
- **faq.md**: Update prose to reference `jid()` instead of `_jac_id`

## Test plan
- [ ] Verify no remaining `has id` on node types in docs (only `obj` types should have it)
- [ ] Review code examples read naturally with `jid()` calls