### PR TITLE
fix: suppress false W2003 warning on by-llm ability parameters

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.13.4 (Unreleased)
 
+- **Fix: False W2003 Warning on `by llm()` Parameters**: Parameters in GenAI abilities (`def foo(x: str) -> T by llm()`) no longer trigger spurious "defined but never used" warnings. The static analysis pass now recognizes `is_genai_ability` alongside `needs_impl` when skipping parameter usage checks.
 - **ES Codegen: `jid()` Moved to Client Runtime**: `jid()` is now a proper runtime function (`_jac.builtin.jid()`) instead of an inline property access (`x._jac_id`). This provides clear, actionable error messages when called on `null` (e.g. server returned an error) or non-node objects, with stack traces pointing to the `.jac` source line. The `assert_no_jac_keywords` test was also improved to strip string literals before scanning, preventing false positives from English words in error messages.
 
 ## jaclang 0.13.3 (Latest Release)

--- a/jac/jaclang/compiler/passes/main/impl/static_analysis_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/static_analysis_pass.impl.jac
@@ -64,9 +64,9 @@ impl StaticAnalysisPass._check_unused_symbols(scope: uni.UniScopeNode) -> None {
         if name in ("self", "super", "init", "postinit") {
             continue;
         }
-        # Skip parameters of abstract abilities (no body to use them in)
+        # Skip parameters of abstract abilities and by-llm abilities
         if sym.sym_type == SymbolType.VAR and isinstance(scope, uni.Ability) {
-            if scope.needs_impl {
+            if scope.needs_impl or scope.is_genai_ability {
                 continue;
             }
         }

--- a/jac/tests/compiler/passes/main/fixtures/static_analysis/genai_ability_params.jac
+++ b/jac/tests/compiler/passes/main/fixtures/static_analysis/genai_ability_params.jac
@@ -1,0 +1,6 @@
+"""Test: by-llm ability parameters should NOT trigger unused warnings."""
+enum Category { WORK, PERSONAL, OTHER }
+
+def categorize(title: str) -> Category by llm();
+
+def summarize(text: str, max_len: int) -> str by llm();

--- a/jac/tests/compiler/passes/main/test_static_analysis_pass.jac
+++ b/jac/tests/compiler/passes/main/test_static_analysis_pass.jac
@@ -80,6 +80,19 @@ test "impl file warnings: undefined name and unreachable code are reported" {
     assert any("Unreachable" in w for w in warning_msgs) , f"Expected unreachable code warning from impl file, got: {warning_msgs}";
 }
 
+test "by-llm ability params produce no unused warnings" {
+    file_path = os.path.join(FIXTURES, "genai_ability_params.jac");
+    prog = JacProgram();
+    prog.compile(file_path, type_check=True);
+    warning_msgs = [str(w) for w in prog.warnings_had];
+    unused_warnings = [
+        w
+        for w in warning_msgs
+        if "defined but never used" in w
+    ];
+    assert len(unused_warnings) == 0 , f"Expected no unused warnings for by-llm params, got: {unused_warnings}";
+}
+
 test "classmethod and staticmethod on obj produce warnings" {
     file_path = os.path.join(FIXTURES, "classmethod_on_obj.jac");
     prog = JacProgram();


### PR DESCRIPTION
## Summary
- Parameters in GenAI abilities (`def foo(x: str) -> T by llm()`) no longer trigger spurious W2003 "defined but never used" warnings
- The static analysis pass now checks `is_genai_ability` alongside `needs_impl` when skipping parameter usage checks
- Added test and fixture covering single and multi-parameter `by llm()` abilities

## Test plan
- [x] All 10 static analysis tests pass (9 existing + 1 new)
- [x] New `genai_ability_params.jac` fixture validates both single and multi-param `by llm()` functions
- [x] `jac check` on `examples/mini_todo/main.jac` no longer emits W2003 for `title`