### PR TITLE
revert: undo email field addition to user registration (#5391)

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,9 +4,6 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.2.12 (Unreleased)
 
-- Added `email` field to `POST /user/register` with `EmailStr` validation.
-- Renamed internal `__system__` user to `system`.
-
 ## jac-scale 0.2.11 (Latest Release)
 
 - **Fix: Sandbox status returns stale RUNNING for dead pods**: `KubernetesSandbox.status()` was returning the cached registry state (often `RUNNING`) when `read_namespaced_pod_status()` threw an exception (pod deleted or unreachable). This caused callers to believe the sandbox was still alive, preventing recovery. Now returns `STOPPED` when the pod query fails so dead pods are detected immediately.

--- a/jac-scale/jac_scale/impl/scheduler.impl.jac
+++ b/jac-scale/jac_scale/impl/scheduler.impl.jac
@@ -161,7 +161,7 @@ impl JacScaleScheduler.create_job(
     interval: (float | None) = None,
     cron: (str | None) = None,
     date: (str | None) = None,
-    created_by: str = 'system',
+    created_by: str = '__system__',
     root_id: (str | None) = None
 ) -> dict {
     if self._apscheduler is None {

--- a/jac-scale/jac_scale/impl/serve.core.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.core.impl.jac
@@ -439,14 +439,6 @@ impl JacAPIServerCore.register_create_user_endpoint -> None {
                     default=None,
                     description='Password for new user',
                     type=ParameterType.BODY
-                ),
-                APIParameter(
-                    name='email',
-                    data_type='email',
-                    required=True,
-                    default=None,
-                    description='Email address for new user',
-                    type=ParameterType.BODY
                 )
             ],
             response_model=None,
@@ -457,13 +449,11 @@ impl JacAPIServerCore.register_create_user_endpoint -> None {
     );
 }
 
-impl JacAPIServerCore.create_user(
-    username: str, password: str, email: str
-) -> TransportResponse {
+impl JacAPIServerCore.create_user(username: str, password: str) -> TransportResponse {
     import traceback;
     import from jaclang.runtimelib.transport { TransportResponse, Meta }
     try {
-        res = self.user_manager.create_user(username, password, email);
+        res = self.user_manager.create_user(username, password);
         if ('error' in res) {
             return TransportResponse.fail(
                 code='USER_EXISTS',
@@ -1109,14 +1099,14 @@ impl JacAPIServerCore.register_api_key_endpoints -> None {
     );
 }
 
-"""Create the system user, initialise JacScaleScheduler, and register /jobs endpoints."""
+"""Create the __system__ user, initialise JacScaleScheduler, and register /jobs endpoints."""
 impl JacAPIServerCore._setup_scheduler -> None {
     scheduler_config = get_scale_config().get_scheduler_config();
     system_password = scheduler_config.get('system_user_password', 'system_secret');
     try {
-        self.user_manager.create_user('system', system_password);
+        self.user_manager.create_user('__system__', system_password);
     } except Exception { }
-    system_token = self.user_manager.create_jwt_token('system');
+    system_token = self.user_manager.create_jwt_token('__system__');
 
     # Initialise JacScaleScheduler singleton
     jac_scheduler = JacScaleScheduler.instance();

--- a/jac-scale/jac_scale/impl/user_manager.impl.jac
+++ b/jac-scale/jac_scale/impl/user_manager.impl.jac
@@ -84,10 +84,8 @@ impl JacScaleUserManager._ensure_connection -> None {
 # ============================================================================
 # User CRUD - delegate to storage or parent
 # ============================================================================
-impl JacScaleUserManager.create_user(
-    username: str, password: str, email: str | None = None
-) -> dict[str, str] {
-    return self._storage.create_user(username, password, email)
+impl JacScaleUserManager.create_user(username: str, password: str) -> dict[str, str] {
+    return self._storage.create_user(username, password)
         if self._storage
         else super.create_user(username, password);
 }

--- a/jac-scale/jac_scale/jserver/impl/jfast_api.impl.jac
+++ b/jac-scale/jac_scale/jserver/impl/jfast_api.impl.jac
@@ -205,8 +205,7 @@ impl JFastApiServer._get_python_type(
         'boolean': bool,
         'list': `list,
         'dict': `dict,
-        'object': `dict,
-        'email': EmailStr
+        'object': `dict
     };
     return type_mapping.get(type_string.lower(), str);
 }

--- a/jac-scale/jac_scale/jserver/jfast_api.jac
+++ b/jac-scale/jac_scale/jserver/jfast_api.jac
@@ -39,7 +39,6 @@ import from pydantic { BaseModel, Field, create_model }
 import from .jserver { APIParameter, HTTPMethod, JEndPoint, JServer, ParameterType }
 import from jaclang.runtimelib.transport { TransportResponse }
 import from jaclang.jac0core.runtime { JacRuntime, JacRuntimeInterface }
-import from pydantic { EmailStr }
 
 glob logger = logging.getLogger(__name__),
      EndpointResponse: TypeAlias = Response | BaseModel | dict[

--- a/jac-scale/jac_scale/mongo_storage.jac
+++ b/jac-scale/jac_scale/mongo_storage.jac
@@ -10,9 +10,7 @@ obj MongoUserStorage {
     has users_col: Collection,
         sso_col: Collection;
 
-    def create_user(
-        username: str, password: str, email: str | None = None
-    ) -> dict[str, str] {
+    def create_user(username: str, password: str) -> dict[str, str] {
         import from jaclang.jac0core.constructs { Root }
         import from jaclang { JacRuntime as Jac }
         import secrets;
@@ -29,7 +27,6 @@ obj MongoUserStorage {
         self.users_col.insert_one(
             {
                 'username': username,
-                'email': email,
                 'password_hash': password_hash,
                 'token': token,
                 'root_id': root_id,

--- a/jac-scale/jac_scale/scheduler.jac
+++ b/jac-scale/jac_scale/scheduler.jac
@@ -15,7 +15,7 @@ glob _jac_scale_scheduler: (JacScaleScheduler | None) = None,
 obj JacScaleScheduler {
     has _apscheduler: Any | None = None,
         _system_token: str | None = None,
-        _system_username: str = 'system',
+        _system_username: str = '__system__',
         _collection: str = 'scheduled_jobs',
         _db: Any | None = None,
         _in_memory_jobs: dict[str, Any] = {},
@@ -36,7 +36,7 @@ obj JacScaleScheduler {
         interval: (float | None) = None,
         cron: (str | None) = None,
         date: (str | None) = None,
-        created_by: str = 'system',
+        created_by: str = '__system__',
         root_id: (str | None) = None
     ) -> dict;
 

--- a/jac-scale/jac_scale/serve.jac
+++ b/jac-scale/jac_scale/serve.jac
@@ -74,7 +74,7 @@ obj JacAPIServerCore {
     # User/Auth endpoints
     def login(username: str, password: str) -> TransportResponse;
     def register_login_endpoint -> None;
-    def create_user(username: str, password: str, email: str) -> TransportResponse;
+    def create_user(username: str, password: str) -> TransportResponse;
     def register_create_user_endpoint -> None;
     def refresh_token(token: (str | None) = None) -> TransportResponse;
     def register_refresh_token_endpoint -> None;

--- a/jac-scale/jac_scale/tests/scale_test_client.jac
+++ b/jac-scale/jac_scale/tests/scale_test_client.jac
@@ -191,9 +191,9 @@ obj ScaleTestClient {
     }
 
     """Register a user and return (username, token) tuple."""
-    def register_user(username: str, password: str, email: str = "test@test.com") -> tuple[str, str] {
+    def register_user(username: str, password: str) -> tuple[str, str] {
         response = self.post(
-            "/user/register", json={"username": username, "password": password, "email": email}
+            "/user/register", json={"username": username, "password": password}
         );
         data = response.json();
         if data.get("ok") and data.get("data") {

--- a/jac-scale/jac_scale/tests/test_admin.jac
+++ b/jac-scale/jac_scale/tests/test_admin.jac
@@ -75,7 +75,7 @@ test "admin login non-admin user rejected" {
 
         client.post(
             "/user/register",
-            json={"username": f"nonmin_{uuid.uuid4().hex[:8]}", "password": "testpass", "email": "test@test.com"}
+            json={"username": f"nonmin_{uuid.uuid4().hex[:8]}", "password": "testpass"}
         );
 
         response = client.post(

--- a/jac-scale/jac_scale/tests/test_memory_hierarchy.jac
+++ b/jac-scale/jac_scale/tests/test_memory_hierarchy.jac
@@ -60,10 +60,10 @@ def extract_transport_response_data(
     return json_response;
 }
 
-def register_user(base_url: str, username: str, password: str = "password123", email: str = "test@test.com") -> str {
+def register_user(base_url: str, username: str, password: str = "password123") -> str {
     res = requests.post(
         f"{base_url}/user/register",
-        json={"username": username, "password": password, "email": email},
+        json={"username": username, "password": password},
         timeout=2
     );
     assert res.status_code == 201 , f"Registration failed: {res.status_code} - {res.text}";
@@ -164,7 +164,7 @@ test "read and write" {
 
         mongo_doc_initial_count = collection.count_documents({});
         assert mongo_doc_initial_count == 4 , (
-            "Initial docs should be 4 (super root, guest_user, admin, system)"
+            "Initial docs should be 4 (super root, guest_user, admin, __system__)"
         );
 
         # Register a user
@@ -172,7 +172,7 @@ test "read and write" {
 
         mongo_doc_after_user_creation_count = collection.count_documents({});
         assert mongo_doc_after_user_creation_count == 5 , (
-            "After user creation docs should be 5 (super root, guest_user, admin, system, created user)"
+            "After user creation docs should be 5 (super root, guest_user, admin, __system__, created user)"
         );
 
         redis_size_before_task_creation = redis_client.dbsize();
@@ -200,7 +200,7 @@ test "read and write" {
 
         redis_size_after_task_read = redis_client.dbsize();
         assert redis_size_after_task_read == 9 , (
-            "Redis should have 9 entries (super root, guest user, admin, system, user, 2 task nodes, 2 edges)"
+            "Redis should have 9 entries (super root, guest user, admin, __system__, user, 2 task nodes, 2 edges)"
         );
     } finally {
         # Teardown
@@ -584,13 +584,13 @@ test "L2 and L3 commit with server restart" {
         # Verify initial state in MongoDB
         initial_mongo_count = collection.count_documents({});
         assert initial_mongo_count == 4 , (
-            f"Initial MongoDB should have 4 docs (super root, guest_user, admin, system), got {initial_mongo_count}"
+            f"Initial MongoDB should have 4 docs (super root, guest_user, admin, __system__), got {initial_mongo_count}"
         );
 
         # Verify initial Redis state (4 initial nodes are cached on startup)
         initial_redis_count = redis_client.dbsize();
         assert initial_redis_count == 4 , (
-            f"Redis should have 4 initial entries (super root, guest_user, admin, system) on startup, got {initial_redis_count} keys"
+            f"Redis should have 4 initial entries (super root, guest_user, admin, __system__) on startup, got {initial_redis_count} keys"
         );
 
         # Register a user to ensure proper caching behavior (authenticated requests)
@@ -775,7 +775,7 @@ test "Redis write cycle via commit" {
     server = start_server(FIXTURES_DIR, JAC_FILE, port);
 
     try {
-        # Initial: 4 nodes in Redis (super_root, guest, admin, system)
+        # Initial: 4 nodes in Redis (super_root, guest, admin, __system__)
         assert redis_client.dbsize() == 4 , "Redis should start with 4 initial nodes";
 
         # Create task

--- a/jac-scale/jac_scale/tests/test_restspec.jac
+++ b/jac-scale/jac_scale/tests/test_restspec.jac
@@ -60,8 +60,8 @@ test "default method walker" {
 test "custom method func" {
     client = make_client("restspec_fixtures.jac");
     try {
-        client.post("/user/register", json={"username": "u1", "password": "p1", "email": "test@test.com"});
-        login = client.post("/user/login", json={"username": "u1", "password": "p1", "email": "test@test.com"});
+        client.post("/user/register", json={"username": "u1", "password": "p1"});
+        login = client.post("/user/login", json={"username": "u1", "password": "p1"});
         token = extract_data(login.json())["token"];
 
         response = client.get(
@@ -78,8 +78,8 @@ test "custom method func" {
 test "custom path func" {
     client = make_client("restspec_fixtures.jac");
     try {
-        client.post("/user/register", json={"username": "u1", "password": "p1", "email": "test@test.com"});
-        login = client.post("/user/login", json={"username": "u1", "password": "p1", "email": "test@test.com"});
+        client.post("/user/register", json={"username": "u1", "password": "p1"});
+        login = client.post("/user/login", json={"username": "u1", "password": "p1"});
         token = extract_data(login.json())["token"];
 
         response = client.get(
@@ -97,8 +97,8 @@ test "custom path func" {
 test "post method func" {
     client = make_client("restspec_fixtures.jac");
     try {
-        client.post("/user/register", json={"username": "u1", "password": "p1", "email": "test@test.com"});
-        login = client.post("/user/login", json={"username": "u1", "password": "p1", "email": "test@test.com"});
+        client.post("/user/register", json={"username": "u1", "password": "p1"});
+        login = client.post("/user/login", json={"username": "u1", "password": "p1"});
         token = extract_data(login.json())["token"];
 
         response = client.post(
@@ -116,8 +116,8 @@ test "post method func" {
 test "default method func" {
     client = make_client("restspec_fixtures.jac");
     try {
-        client.post("/user/register", json={"username": "u1", "password": "p1", "email": "test@test.com"});
-        login = client.post("/user/login", json={"username": "u1", "password": "p1", "email": "test@test.com"});
+        client.post("/user/register", json={"username": "u1", "password": "p1"});
+        login = client.post("/user/login", json={"username": "u1", "password": "p1"});
         token = extract_data(login.json())["token"];
 
         response = client.post(
@@ -151,8 +151,8 @@ test "get walker with params" {
 test "get func with params" {
     client = make_client("restspec_fixtures.jac");
     try {
-        client.post("/user/register", json={"username": "u1", "password": "p1", "email": "test@test.com"});
-        login = client.post("/user/login", json={"username": "u1", "password": "p1", "email": "test@test.com"});
+        client.post("/user/register", json={"username": "u1", "password": "p1"});
+        login = client.post("/user/login", json={"username": "u1", "password": "p1"});
         token = extract_data(login.json())["token"];
 
         response = client.get(
@@ -206,7 +206,7 @@ test "restspec path parameters" {
     client = make_client("restspec_fixtures.jac");
     try {
         # Obtain an auth token (functions require auth, walkers are public)
-        client.post("/user/register", json={"username": "u_pp", "password": "p_pp", "email": "test@test.com"});
+        client.post("/user/register", json={"username": "u_pp", "password": "p_pp"});
         login = client.post(
             "/user/login", json={"username": "u_pp", "password": "p_pp"}
         );

--- a/jac-scale/jac_scale/tests/test_scheduling.jac
+++ b/jac-scale/jac_scale/tests/test_scheduling.jac
@@ -103,7 +103,7 @@ def _stop_server(proc: subprocess.Popen | None) -> None {
 def _get_token(base_url: str, user: str = "testuser", pwd: str = "pass123") -> str {
     requests.post(
         f"{base_url}/user/register",
-        json={"username": user, "password": pwd, "email": "test@test.com"},
+        json={"username": user, "password": pwd},
         timeout=5
     );
     resp = requests.post(
@@ -162,13 +162,13 @@ test "endpoint filtering and startup" {
         resp = requests.post(f"{base_url}/jobs", json={}, timeout=5);
         assert resp.status_code != 404 , "/jobs POST should be registered";
 
-        # system user created at startup
+        # __system__ user created at startup
         resp = requests.post(
             f"{base_url}/user/login",
-            json={"username": "system", "password": "system_secret"},
+            json={"username": "__system__", "password": "system_secret"},
             timeout=5
         ).json();
-        assert resp.get("ok") , "system user must exist and authenticate";
+        assert resp.get("ok") , "__system__ user must exist and authenticate";
         assert _data(resp).get("token");
     } finally {
         _stop_server(sp);

--- a/jac-scale/jac_scale/tests/test_serve.jac
+++ b/jac-scale/jac_scale/tests/test_serve.jac
@@ -354,7 +354,7 @@ test "user registration and login" {
         test_username = f"testuser_{uuid.uuid4().hex[:8]}";
         response = client.post(
             "/user/register",
-            json={"username": test_username, "password": "testpass123", "email": "test@test.com"}
+            json={"username": test_username, "password": "testpass123"}
         );
         result = extract_data(response.json());
         assert "username" in result;
@@ -365,7 +365,7 @@ test "user registration and login" {
         # Test: status code 201 for successful registration
         status_user = f"status_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": status_user, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": status_user, "password": "password123"}
         );
         assert response.status_code == 201;
         data = extract_data(response.json());
@@ -374,7 +374,7 @@ test "user registration and login" {
 
         # Test: status code 400 for duplicate registration
         response = client.post(
-            "/user/register", json={"username": status_user, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": status_user, "password": "password123"}
         );
         assert response.status_code == 400;
 
@@ -382,7 +382,7 @@ test "user registration and login" {
         login_username = f"login_{uuid.uuid4().hex[:8]}";
         response = client.post(
             "/user/register",
-            json={"username": login_username, "password": "loginpass", "email": "test@test.com"}
+            json={"username": login_username, "password": "loginpass"}
         );
         create_result = extract_data(response.json());
         response = client.post(
@@ -403,7 +403,7 @@ test "user registration and login" {
         fail_username = f"fail_{uuid.uuid4().hex[:8]}";
         response = client.post(
             "/user/register",
-            json={"username": fail_username, "password": "correctpass", "email": "test@test.com"}
+            json={"username": fail_username, "password": "correctpass"}
         );
         response = client.post(
             "/user/login", json={"username": fail_username, "password": "wrongpass"}
@@ -495,8 +495,7 @@ test "token refresh functionality" {
             "/user/register",
             json={
                 "username": f"refresh_bearer_{uuid.uuid4().hex[:8]}",
-                "password": "password123",
-                "email": "test@test.com"
+                "password": "password123"
             }
         );
         create_result = extract_data(response.json());
@@ -520,7 +519,7 @@ test "token refresh functionality" {
         # Test: refresh token too old
         old_user = f"refresh_old_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": old_user, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": old_user, "password": "password123"}
         );
         very_old_token = _create_very_old_token(old_user, days_ago=15);
         response = client.post("/user/refresh-token", json={"token": very_old_token});
@@ -540,8 +539,7 @@ test "token refresh functionality" {
             "/user/register",
             json={
                 "username": f"refresh_multi_{uuid.uuid4().hex[:8]}",
-                "password": "password123",
-                "email": "test@test.com"
+                "password": "password123"
             }
         );
         create_result = extract_data(response.json());
@@ -561,7 +559,7 @@ test "token refresh functionality" {
         # Test: refresh token preserves username
         username = f"refresh_preserve_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "password123"}
         );
         create_result = extract_data(response.json());
         original_token = create_result["token"];
@@ -591,7 +589,7 @@ test "integration auth flow" {
 
         # Register
         register_response = client.post(
-            "/user/register", json={"username": username, "password": "secure123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "secure123"}
         );
         assert register_response.status_code == 201;
         data = extract_data(register_response.json());
@@ -635,7 +633,7 @@ test "function calls" {
         # Create a user for authenticated calls
         response = client.post(
             "/user/register",
-            json={"username": f"funcuser_{uuid.uuid4().hex[:8]}", "password": "pass", "email": "test@test.com"}
+            json={"username": f"funcuser_{uuid.uuid4().hex[:8]}", "password": "pass"}
         );
         create_result = extract_data(response.json());
         token = create_result["token"];
@@ -708,7 +706,7 @@ test "walker calls" {
         # Create a user for authenticated calls
         response = client.post(
             "/user/register",
-            json={"username": f"walkeruser_{uuid.uuid4().hex[:8]}", "password": "pass", "email": "test@test.com"}
+            json={"username": f"walkeruser_{uuid.uuid4().hex[:8]}", "password": "pass"}
         );
         create_result = extract_data(response.json());
         token = create_result["token"];
@@ -782,7 +780,7 @@ test "walker calls" {
         # Create a node and verify it appears for authenticated user
         response = client.post(
             "/user/register",
-            json={"username": f"guser_{uuid.uuid4().hex[:8]}", "password": "gpass", "email": "test@test.com"}
+            json={"username": f"guser_{uuid.uuid4().hex[:8]}", "password": "gpass"}
         );
         reg = extract_data(response.json());
         response = client.post(
@@ -810,7 +808,7 @@ test "user management operations" {
         # Test: update username success
         username = f"olduser_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "password123"}
         );
         create_result = extract_data(response.json());
         original_token = create_result["token"];
@@ -847,7 +845,7 @@ test "user management operations" {
         # Test: update username requires auth
         username = f"authtest_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "password123"}
         );
         response = client.put(
             "/user/username",
@@ -858,14 +856,14 @@ test "user management operations" {
         # Test: update username cannot update other users
         user1_name = f"user1_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": user1_name, "password": "pass1", "email": "test@test.com"}
+            "/user/register", json={"username": user1_name, "password": "pass1"}
         );
         user1_result = extract_data(response.json());
         user1_token = user1_result["token"];
 
         user2_name = f"user2_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": user2_name, "password": "pass2", "email": "test@test.com"}
+            "/user/register", json={"username": user2_name, "password": "pass2"}
         );
 
         response = client.put(
@@ -878,14 +876,14 @@ test "user management operations" {
         # Test: update username duplicate fails
         user1_name = f"dup1_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": user1_name, "password": "pass1", "email": "test@test.com"}
+            "/user/register", json={"username": user1_name, "password": "pass1"}
         );
         user1_result = extract_data(response.json());
         user1_token = user1_result["token"];
 
         user2_name = f"dup2_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": user2_name, "password": "pass2", "email": "test@test.com"}
+            "/user/register", json={"username": user2_name, "password": "pass2"}
         );
 
         response = client.put(
@@ -898,7 +896,7 @@ test "user management operations" {
         # Test: update username empty validation
         username = f"testuser_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "password123"}
         );
         user_result = extract_data(response.json());
         token = user_result["token"];
@@ -913,7 +911,7 @@ test "user management operations" {
         # Test: update password success
         username = f"passuser_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "oldpass123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "oldpass123"}
         );
         create_result = extract_data(response.json());
         token = create_result["token"];
@@ -949,7 +947,7 @@ test "user management operations" {
         # Test: update password requires auth
         username = f"noauthuser_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "password123", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "password123"}
         );
 
         response = client.put(
@@ -965,7 +963,7 @@ test "user management operations" {
         # Test: update password wrong current password
         username = f"wrongpass_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "correctpass", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "correctpass"}
         );
         user_result = extract_data(response.json());
         token = user_result["token"];
@@ -984,14 +982,14 @@ test "user management operations" {
         # Test: update password cannot update other users
         user1_name = f"passuser1_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": user1_name, "password": "pass1", "email": "test@test.com"}
+            "/user/register", json={"username": user1_name, "password": "pass1"}
         );
         user1_result = extract_data(response.json());
         user1_token = user1_result["token"];
 
         user2_name = f"passuser2_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": user2_name, "password": "pass2", "email": "test@test.com"}
+            "/user/register", json={"username": user2_name, "password": "pass2"}
         );
 
         response = client.put(
@@ -1008,7 +1006,7 @@ test "user management operations" {
         # Test: update password empty validation
         username = f"emptypass_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "oldpass", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "oldpass"}
         );
         user_result = extract_data(response.json());
         token = user_result["token"];
@@ -1027,7 +1025,7 @@ test "user management operations" {
         # Test: username and password update flow (combined)
         username = f"original_{uuid.uuid4().hex[:8]}";
         response = client.post(
-            "/user/register", json={"username": username, "password": "oldpass", "email": "test@test.com"}
+            "/user/register", json={"username": username, "password": "oldpass"}
         );
         create_result = extract_data(response.json());
         token = create_result["token"];
@@ -1197,7 +1195,7 @@ test "websocket functionality" {
 
         response = requests.post(
             f"{sv_base_url}/user/register",
-            json={"username": username, "password": password, "email": "test@test.com"},
+            json={"username": username, "password": password},
             timeout=10
         );
         assert response.status_code in (200, 201) , f"Failed to create user: {response.text}";
@@ -1233,7 +1231,7 @@ test "websocket functionality" {
         username = f"ws_query_user_{uuid.uuid4().hex[:8]}";
         response = requests.post(
             f"{sv_base_url}/user/register",
-            json={"username": username, "password": password, "email": "test@test.com"},
+            json={"username": username, "password": password},
             timeout=10
         );
         assert response.status_code in (200, 201);
@@ -1321,7 +1319,7 @@ test "websocket functionality" {
 
             response = requests.post(
                 f"{sv_base_url}/user/register",
-                json={"username": username, "password": password, "email": "test@test.com"},
+                json={"username": username, "password": password},
                 timeout=10
             );
             assert response.status_code in (200, 201);
@@ -1479,7 +1477,7 @@ test "dev mode operations" {
         # Test: dev mode walker body parsing
         register_response = requests.post(
             f"{dm_base_url}/user/register",
-            json={"username": f"devtest_{uuid.uuid4().hex[:8]}", "password": "pass", "email": "test@test.com"},
+            json={"username": f"devtest_{uuid.uuid4().hex[:8]}", "password": "pass"},
             timeout=10
         );
         assert register_response.status_code == 201;
@@ -1501,7 +1499,7 @@ test "dev mode operations" {
         # Test: dev mode function body parsing
         register_response = requests.post(
             f"{dm_base_url}/user/register",
-            json={"username": f"devfunc_{uuid.uuid4().hex[:8]}", "password": "pass", "email": "test@test.com"},
+            json={"username": f"devfunc_{uuid.uuid4().hex[:8]}", "password": "pass"},
             timeout=10
         );
         assert register_response.status_code == 201;
@@ -1542,7 +1540,7 @@ test "dev mode operations" {
         username = f"asyncuser_{uuid.uuid4().hex[:8]}";
         register_response = requests.post(
             f"{dm_base_url}/user/register",
-            json={"username": username, "password": "password123", "email": "test@test.com"},
+            json={"username": username, "password": "password123"},
             timeout=10
         );
         assert register_response.status_code == 201;

--- a/jac-scale/jac_scale/tests/test_webhook.jac
+++ b/jac-scale/jac_scale/tests/test_webhook.jac
@@ -223,7 +223,7 @@ def run_normal_walker_accessible_via_walker_test(base_url: str) -> None {
     username = f"normal_walker_user_{uuid.uuid4().hex[:8]}";
     register_response = requests.post(
         f"{base_url}/user/register",
-        json={"username": username, "password": "password123", "email": "test@test.com"},
+        json={"username": username, "password": "password123"},
         timeout=10
     );
     assert register_response.status_code == 201;
@@ -292,7 +292,7 @@ def run_minimal_webhook_with_valid_api_key_test(base_url: str) -> None {
     username = f"minimal_webhook_user_{uuid.uuid4().hex[:8]}";
     register_response = requests.post(
         f"{base_url}/user/register",
-        json={"username": username, "password": "password123", "email": "test@test.com"},
+        json={"username": username, "password": "password123"},
         timeout=10
     );
     assert register_response.status_code == 201;
@@ -343,7 +343,7 @@ def run_webhook_payment_received_test(base_url: str) -> None {
     username = f"payment_user_{uuid.uuid4().hex[:8]}";
     register_response = requests.post(
         f"{base_url}/user/register",
-        json={"username": username, "password": "password123", "email": "test@test.com"},
+        json={"username": username, "password": "password123"},
         timeout=10
     );
     assert register_response.status_code == 201;
@@ -404,7 +404,7 @@ def run_webhook_not_accessible_via_walker_test(base_url: str) -> None {
     username = f"webhook_path_user_{uuid.uuid4().hex[:8]}";
     register_response = requests.post(
         f"{base_url}/user/register",
-        json={"username": username, "password": "password123", "email": "test@test.com"},
+        json={"username": username, "password": "password123"},
         timeout=10
     );
     assert register_response.status_code == 201;
@@ -430,7 +430,7 @@ def run_webhook_revoked_api_key_test(base_url: str) -> None {
     username = f"webhook_revoke_user_{uuid.uuid4().hex[:8]}";
     register_response = requests.post(
         f"{base_url}/user/register",
-        json={"username": username, "password": "password123", "email": "test@test.com"},
+        json={"username": username, "password": "password123"},
         timeout=10
     );
     assert register_response.status_code == 201;

--- a/jac-scale/jac_scale/user_manager.jac
+++ b/jac-scale/jac_scale/user_manager.jac
@@ -35,10 +35,7 @@ obj JacScaleUserManager(UserManager) {
     def postinit -> None;
     def _ensure_connection -> None;
     def _init_sqlite_schema -> None;
-    def create_user(
-        username: str, password: str, email: str | None = None
-    ) -> dict[str, str];
-
+    def create_user(username: str, password: str) -> dict[str, str];
     def authenticate(username: str, password: str) -> (dict[(str, str)] | None);
     def get_root_id(username: str) -> (str | None);
     def get_user(username: str) -> (dict[(str, str)] | None);

--- a/jac-scale/pyproject.toml
+++ b/jac-scale/pyproject.toml
@@ -20,8 +20,7 @@ dependencies = [
     "python-multipart>=0.0.21,<1.0.0",
     "apscheduler>=3.11.2,<4.0.0",
     "prometheus-client>=0.21.0,<1.0.0",
-    "bcrypt>=4.0.0,<5.0.0",
-    "email-validator>=2.0.0,<3.0.0"
+    "bcrypt>=4.0.0,<5.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Reverts #5391 to allow proper discussion on the registration flow before re-introducing the changes.

## Key discussion points

- Should `email` be the unique identifier instead of `username`?
- If both are required, `email` must have a uniqueness constraint — otherwise password reset (the original motivation) won't work
- UX concern: requiring both `username` and `email` for signup adds friction
- Migration strategy needed for `__system__` → `system` rename
- SDK functions (`jacSignup`) need to be updated in sync

Tracked in #5395.