### PR TITLE
feat: auto-install bun to .jac/bin/ instead of requiring global install

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.3.11 (Unreleased)
 
+- **Auto-install Bun to .jac/bin/**: Bun is now automatically downloaded and managed inside the project's `.jac/bin/` directory when not found on the system PATH. No global install required, no interactive prompts, no PATH configuration needed. All callers resolve the bun binary via `get_bun()` which returns the absolute path directly, bypassing PATH entirely. Pinned to Bun v1.3.11 with automatic upgrades when the pinned version changes.
+
 ## jac-client 0.3.10 (Latest Release)
 
 - **Dev Mode: API Docs accessible from client URL**: The Vite dev server now proxies `/docs`, `/redoc`, `/openapi.json`, `/admin`, and `/graph` to the API backend, so developers can access all dev tools from the client URL without switching ports.

--- a/jac-client/jac_client/plugin/plugin_config.jac
+++ b/jac-client/jac_client/plugin/plugin_config.jac
@@ -245,11 +245,13 @@ def _post_create_client(project_path: Path, project_name: str) -> None {
             shutil.copy2(configs_npmrc, build_npmrc);
         }
 
-        # Run bun install (ensure bun is available first)
-        import from jac_client.plugin.utils { ensure_bun_available }
-        if not ensure_bun_available() {
-            console.warning("Bun is required. Install manually: https://bun.sh");
+        # Resolve bun binary (system PATH → .jac/bin/ → auto-download)
+        import from jac_client.plugin.utils { get_bun }
+        bun = get_bun();
+        if not bun {
+            console.warning("Bun is required but could not be found or installed.");
             console.print(
+                "  💡 Install manually: https://bun.sh\n"
                 "  💡 You can install packages later with: jac add --cl\n",
                 style="muted"
             );
@@ -262,7 +264,7 @@ def _post_create_client(project_path: Path, project_name: str) -> None {
 
         try {
             console.print("\n  ⏳ Installing packages...\n", style="cyan");
-            subprocess.run(['bun', 'install'], cwd=client_dir, check=True, timeout=300);
+            subprocess.run([bun, 'install'], cwd=client_dir, check=True, timeout=300);
 
             # Move bun.lockb to configs/ if it was created
             build_bun_lockb = client_dir / 'bun.lockb';
@@ -390,8 +392,16 @@ def _regenerate_and_install(project_dir: Path) -> None {
     }
 
     try {
-        # Run bun install
-        subprocess.run(['bun', 'install'], cwd=client_dir, check=True, timeout=300);
+        # Resolve bun binary
+        import from jac_client.plugin.utils { get_bun }
+        bun = get_bun();
+        if not bun {
+            raise RuntimeError(
+                "Bun is required but could not be found or installed. "
+                "Install manually: https://bun.sh"
+            );
+        }
+        subprocess.run([bun, 'install'], cwd=client_dir, check=True, timeout=300);
     } except subprocess.CalledProcessError as e {
         raise RuntimeError(f"Failed to install packages: {e}") from e;
     } finally {

--- a/jac-client/jac_client/plugin/src/impl/package_installer.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/package_installer.impl.jac
@@ -39,12 +39,14 @@ impl PackageInstaller.uninstall_package(
 
 """Regenerate package.json from jac.toml and run bun install."""
 impl PackageInstaller._regenerate_and_install(self: PackageInstaller) -> None {
-    import from jac_client.plugin.utils { ensure_bun_available }
+    import from jac_client.plugin.utils { get_bun }
     import from jaclang.cli.console { console }
-    # Ensure bun is available before proceeding
-    if not ensure_bun_available() {
+    # Resolve bun binary (system PATH → .jac/bin/ → auto-download)
+    bun = get_bun();
+    if not bun {
         raise ClientBundleError(
-            'Bun is required. Install manually: https://bun.sh'
+            'Bun is required but could not be found or installed. '
+            'Install manually: https://bun.sh'
         ) from None;
     }
     # Regenerate package.json from updated jac.toml
@@ -56,7 +58,7 @@ impl PackageInstaller._regenerate_and_install(self: PackageInstaller) -> None {
         # Run bun install to actually install the packages
         console.print("\n  ⏳ Installing packages...\n");
         result = subprocess.run(
-            ['bun', 'install'], cwd=self.project_dir, check=False, text=True
+            [bun, 'install'], cwd=self.project_dir, check=False, text=True
         );
         if result.returncode != 0 {
             raise ClientBundleError('Failed to install packages (see output above)');

--- a/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
@@ -1,4 +1,19 @@
 import from jaclang.cli.console { console }
+import from jac_client.plugin.utils { get_bun }
+import from jaclang.runtimelib.client_bundle { ClientBundleError }
+
+
+"""Resolve the bun binary path or raise an error."""
+def _require_bun -> str {
+    bun = get_bun();
+    if not bun {
+        raise ClientBundleError(
+            'Bun is required but could not be found or installed. '
+            'Install manually: https://bun.sh'
+        ) from None;
+    }
+    return bun;
+}
 
 """Get the client build directory from project config."""
 impl ViteBundler._get_client_dir(self: ViteBundler) -> Path {
@@ -717,13 +732,9 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
     import sys;
     import time;
     import shutil;
-    import from jac_client.plugin.utils { ensure_bun_available, ensure_client_deps }
-    # Ensure bun is available before proceeding
-    if not ensure_bun_available() {
-        raise ClientBundleError(
-            'Bun is required. Install manually: https://bun.sh'
-        ) from None;
-    }
+    import from jac_client.plugin.utils { ensure_client_deps }
+    # Resolve bun binary (system PATH → .jac/bin/ → auto-download)
+    bun = _require_bun();
     # Ensure client npm deps are configured; prompt to install defaults if missing
     if not ensure_client_deps(self.config_loader) {
         raise ClientBundleError(
@@ -756,40 +767,33 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
             if configs_npmrc.exists() and not build_npmrc.exists() {
                 shutil.copy2(configs_npmrc, build_npmrc);
             }
-            try {
-                # Install to .jac/client/node_modules with progress feedback
-                console.print("\n  ⏳ Installing dependencies...\n");
-                start_time = time.time();
-                result = subprocess.run(
-                    ['bun', 'install'],
-                    cwd=build_dir,
-                    check=False,
-                    text=True,
-                    capture_output=True
-                );
-                elapsed = time.time() - start_time;
-                if result.returncode != 0 {
-                    error_output = result.stderr or result.stdout;
-                    error_msg = f"Dependency installation failed after {elapsed:.1f}s\n\n{error_output}\nCommand: bun install";
-                    raise ClientBundleError(error_msg) from None;
-                }
-                console.print(f"\n  ✔ Dependencies installed ({elapsed:.1f}s)");
-            } except FileNotFoundError {
-                # This shouldn't happen since we check for bun at the start
-                raise ClientBundleError(
-                    'Bun command not found. Install Bun: https://bun.sh'
-                ) from None;
+            # Install to .jac/client/node_modules with progress feedback
+            console.print("\n  ⏳ Installing dependencies...\n");
+            start_time = time.time();
+            result = subprocess.run(
+                [bun, 'install'],
+                cwd=build_dir,
+                check=False,
+                text=True,
+                capture_output=True
+            );
+            elapsed = time.time() - start_time;
+            if result.returncode != 0 {
+                error_output = result.stderr or result.stdout;
+                error_msg = f"Dependency installation failed after {elapsed:.1f}s\n\n{error_output}\nCommand: bun install";
+                raise ClientBundleError(error_msg) from None;
             }
+            console.print(f"\n  ✔ Dependencies installed ({elapsed:.1f}s)");
         }
         if self.config_path {
             # Make config path relative to build_dir (where vite runs from)
             try {
                 config_rel = self.config_path.relative_to(build_dir);
-                command = ['bun', 'x', 'vite', 'build', '--config', str(config_rel)];
+                command = [bun, 'x', 'vite', 'build', '--config', str(config_rel)];
             } except ValueError {
                 # Config is outside client build dir, use absolute path
                 command = [
-                    'bun',
+                    bun,
                     'x',
                     'vite',
                     'build',
@@ -801,9 +805,9 @@ impl ViteBundler.build(self: ViteBundler, entry_file: Optional[Path] = None) -> 
             generated_config = self.create_vite_config(entry_file);
             # Config is in configs/, make it relative to build_dir
             config_rel = generated_config.relative_to(build_dir);
-            command = ['bun', 'x', 'vite', 'build', '--config', str(config_rel)];
+            command = [bun, 'x', 'vite', 'build', '--config', str(config_rel)];
         } else {
-            command = ['bun', 'run', 'build'];
+            command = [bun, 'run', 'build'];
         }
         # Run vite from client build directory so it can find node_modules
         console.print("\n  ⏳ Building client bundle...\n");
@@ -974,8 +978,9 @@ def _toml_config_from_raw(config_data: dict) -> str {
 
 """Build the Vite dev server command."""
 def _build_vite_dev_command(config_rel: Path, port: int) -> list[str] {
+    bun = _require_bun();
     return [
-        'bun',
+        bun,
         'x',
         'vite',
         '--config',
@@ -1130,6 +1135,7 @@ impl ViteBundler._ensure_dev_index_html(self: ViteBundler, build_dir: Path) -> N
 
 """Ensure dev dependencies are installed."""
 impl ViteBundler._ensure_dev_dependencies(self: ViteBundler, build_dir: Path) -> None {
+    bun = _require_bun();
     import time;
     node_modules = build_dir / 'node_modules';
     if node_modules.exists() {
@@ -1153,9 +1159,7 @@ impl ViteBundler._ensure_dev_dependencies(self: ViteBundler, build_dir: Path) ->
     try {
         console.print("\n  ⏳ Installing dependencies...\n");
         start_time = time.time();
-        result = subprocess.run(
-            ['bun', 'install'], cwd=build_dir, check=False, text=True
-        );
+        result = subprocess.run([bun, 'install'], cwd=build_dir, check=False, text=True);
         elapsed = time.time() - start_time;
 
         if result.returncode != 0 {

--- a/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
+++ b/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
@@ -1407,16 +1407,20 @@ def _check_and_install_tauri_cli -> None {
     } except Exception { }
 
     # Check if bun tauri CLI is available (global install)
+    import from jac_client.plugin.utils { get_bun }
     bun_tauri_ok = False;
-    try {
-        result = subprocess.run(
-            ["bun", "pm", "ls", "-g"], capture_output=True, text=True, timeout=5
-        );
-        if result.returncode == 0 and "@tauri-apps/cli" in result.stdout {
-            console.print("  ✔ Tauri CLI found (bun)", style="success");
-            return;
-        }
-    } except Exception { }
+    bun_path = get_bun();
+    if bun_path {
+        try {
+            result = subprocess.run(
+                [bun_path, "pm", "ls", "-g"], capture_output=True, text=True, timeout=5
+            );
+            if result.returncode == 0 and "@tauri-apps/cli" in result.stdout {
+                console.print("  ✔ Tauri CLI found (bun)", style="success");
+                return;
+            }
+        } except Exception { }
+    }
 
     # Tauri CLI not found
     console.warning("  Tauri CLI not found");
@@ -1434,11 +1438,7 @@ def _check_and_install_tauri_cli -> None {
     } except Exception { }
 
     # Check if bun is available
-    bun_available = False;
-    try {
-        subprocess.run(["bun", "--version"], capture_output=True, check=True, timeout=5);
-        bun_available = True;
-    } except Exception { }
+    bun_available = bun_path is not None;
 
     if not cargo_available and not bun_available {
         console.print(
@@ -1475,11 +1475,11 @@ def _check_and_install_tauri_cli -> None {
                 console.warning(f"  Error installing via cargo: {e}");
             }
         }
-        if bun_available {
+        if bun_available and bun_path {
             console.print("  Installing Tauri CLI via bun...", style="muted");
             try {
                 result = subprocess.run(
-                    ["bun", "add", "-g", "@tauri-apps/cli"],
+                    [bun_path, "add", "-g", "@tauri-apps/cli"],
                     check=False,
                     timeout=300,
                     capture_output=False  # Show output
@@ -2020,16 +2020,18 @@ def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
     }
 
     if use_bun {
-        # Ensure bun is available
-        import from jac_client.plugin.utils { ensure_bun_available }
-        if not ensure_bun_available() {
+        # Resolve bun binary (system PATH → .jac/bin/ → auto-download)
+        import from jac_client.plugin.utils { get_bun }
+        bun = get_bun();
+        if not bun {
             console.error(
-                "Bun is required for this project. Install manually: https://bun.sh"
+                "Bun is required for this project but could not be found or installed. "
+                "Install manually: https://bun.sh"
             );
             raise RuntimeError("Bun is required") from None;
         }
         # Use bun run tauri build
-        build_cmd = ["bun", "run", "tauri", "build"];
+        build_cmd = [bun, "run", "tauri", "build"];
         if target {
             build_cmd.extend(["--", "--target", target]);
         }
@@ -2418,16 +2420,18 @@ def _run_tauri_dev(tauri_dir: Path) -> subprocess.Popen {
     }
 
     if use_bun {
-        # Ensure bun is available
-        import from jac_client.plugin.utils { ensure_bun_available }
-        if not ensure_bun_available() {
+        # Resolve bun binary (system PATH → .jac/bin/ → auto-download)
+        import from jac_client.plugin.utils { get_bun }
+        bun = get_bun();
+        if not bun {
             console.error(
-                "Bun is required for this project. Install manually: https://bun.sh"
+                "Bun is required for this project but could not be found or installed. "
+                "Install manually: https://bun.sh"
             );
             raise RuntimeError("Bun is required") from None;
         }
         # Use bun run tauri dev
-        dev_cmd = ["bun", "run", "tauri", "dev"];
+        dev_cmd = [bun, "run", "tauri", "dev"];
     } else {
         # Use cargo tauri dev directly
         dev_cmd = ["cargo", "tauri", "dev"];

--- a/jac-client/jac_client/plugin/utils/__init__.jac
+++ b/jac-client/jac_client/plugin/utils/__init__.jac
@@ -1,4 +1,4 @@
 """Utility modules for jac-client plugin."""
 
-import from .bun_installer { ensure_bun_available, prompt_install_bun }
+import from .bun_installer { get_bun, ensure_bun_available, prompt_install_bun }
 import from .client_deps { ensure_client_deps }

--- a/jac-client/jac_client/plugin/utils/bun_installer.jac
+++ b/jac-client/jac_client/plugin/utils/bun_installer.jac
@@ -1,16 +1,29 @@
 """Bun installer utility for jac-client.
 
-Provides functions to check for Bun availability and prompt for installation.
+Provides functions to resolve the bun binary path, auto-installing
+a project-local copy to .jac/bin/ if bun is not on the system PATH.
 """
 
-"""Check if bun is available, add to PATH if needed, or prompt to install.
+"""Resolve the path to the bun binary.
 
-Returns True if bun is available (or was successfully installed), False otherwise.
+Resolution order:
+  1. System PATH (use the user's global bun if present)
+  2. .jac/bin/bun (project-local, managed by jac)
+  3. Auto-download to .jac/bin/ (silent, no prompt)
+
+Returns the absolute path as a string, or None if unavailable.
+"""
+def get_bun -> str | None;
+
+"""Check if bun is available (legacy entry point).
+
+Delegates to get_bun() and ensures the resolved path is on PATH.
+Returns True if bun is available, False otherwise.
 """
 def ensure_bun_available -> bool;
 
-"""Prompt user to install Bun and install if confirmed.
+"""Prompt user to install Bun (legacy, now auto-installs).
 
-Returns True if installation succeeded, False otherwise.
+Kept for backward compatibility. Delegates to ensure_bun_available().
 """
 def prompt_install_bun -> bool;

--- a/jac-client/jac_client/plugin/utils/impl/bun_installer.impl.jac
+++ b/jac-client/jac_client/plugin/utils/impl/bun_installer.impl.jac
@@ -1,94 +1,232 @@
-"""Implementation of Bun installer utility."""
+"""Implementation of Bun installer utility.
 
-"""Check if bun is available, add to PATH if needed, or prompt to install."""
-impl ensure_bun_available -> bool {
-    import os;
-    import shutil;
-    # Check if bun is already in PATH
-    if shutil.which("bun") {
-        return True;
-    }
-    # Check if bun exists at ~/.bun/bin but not in PATH
-    bun_bin = os.path.expanduser("~/.bun/bin");
-    bun_path = os.path.join(bun_bin, "bun");
-    if os.path.exists(bun_path) {
-        # Add to PATH for current process
-        current_path = os.environ.get("PATH", "");
-        os.environ["PATH"] = f"{bun_bin}:{current_path}";
-        return True;
-    }
-    # Bun not found - prompt to install
-    return prompt_install_bun();
+Auto-manages a project-local bun binary inside .jac/bin/ so users
+never need to install bun globally.  The resolution order is:
+
+  1. System PATH (if the user already has bun installed, use it)
+  2. .jac/bin/bun (project-local, managed by jac)
+  3. Auto-download to .jac/bin/ (silent, no prompt)
+"""
+
+import os;
+import platform;
+import shutil;
+import subprocess;
+import sys;
+import zipfile;
+
+import from pathlib { Path }
+import from jaclang.cli.console { console }
+import from jaclang.project.config { get_config }
+
+# Pin the bun version jac-client ships with.
+# Bump this when a new bun release is validated.
+glob BUN_VERSION = "1.3.11",
+     # Map (system, machine) to bun release asset name.
+     _PLATFORM_MAP: dict[str, dict[str, str]] = {
+         "Darwin": {
+             "arm64": "bun-darwin-aarch64",
+             "aarch64": "bun-darwin-aarch64",
+             "x86_64": "bun-darwin-x64"
+         },
+         "Linux": {
+             "x86_64": "bun-linux-x64",
+             "aarch64": "bun-linux-aarch64",
+             "arm64": "bun-linux-aarch64"
+         },
+         "Windows": {
+             "AMD64": "bun-windows-x64",
+             "x86_64": "bun-windows-x64",
+             "aarch64": "bun-windows-aarch64"
+         }
+     };
+
+
+"""Return the resolved asset name for the current platform, or None."""
+def _get_platform_asset -> str | None {
+    system = platform.system();
+    machine = platform.machine();
+    system_map = _PLATFORM_MAP.get(system, {});
+    return system_map.get(machine, None);
 }
 
-"""Prompt user to install Bun and install if confirmed."""
-impl prompt_install_bun -> bool {
-    import os;
-    import subprocess;
-    import sys;
-    import shutil;
-    import from jaclang.cli.console { console }
-    console.error("\n  ⚠ Bun is required but not installed.");
-    console.error(
-        "  Bun is a fast JavaScript runtime used for package management and bundling."
-    );
-    console.error("  Learn more: https://bun.sh\n");
-    try {
-        response = input("  Install Bun now? [Y/n]: ").strip().lower();
-    } except (EOFError, KeyboardInterrupt) {
-        console.error("");
-        return False;
-    }
-    if response and response not in ('y', 'yes', '') {
-        return False;
-    }
-    console.print("\n  ⏳ Installing Bun...");
-    try {
-        # Check if curl is available
-        subprocess.run(
-            ["curl", "--version"], capture_output=True, check=True, timeout=5
-        );
 
-        # Install Bun via official script
-        result = subprocess.run(
-            ["sh", "-c", "curl -fsSL https://bun.sh/install | bash"],
-            timeout=120,
-            check=False
-        );
+"""Return the .jac/bin directory for the current project, creating it if needed."""
+def _get_jac_bin_dir -> Path {
+    config = get_config();
+    if config and config.project_root {
+        base = config.get_build_dir();
+    } else {
+        base = Path.cwd() / ".jac";
+    }
+    bin_dir = base / "bin";
+    bin_dir.mkdir(parents=True, exist_ok=True);
+    return bin_dir;
+}
 
-        if result.returncode == 0 {
-            console.print("  ✔ Bun installed successfully!");
-            # Add Bun to PATH for current session
-            bun_bin = os.path.expanduser("~/.bun/bin");
-            if os.path.exists(bun_bin) {
-                current_path = os.environ.get("PATH", "");
-                os.environ["PATH"] = f"{bun_bin}:{current_path}";
-                # Verify installation
-                if shutil.which("bun") {
-                    verify = subprocess.run(
-                        ["bun", "--version"], capture_output=True, text=True
-                    );
-                    if verify.returncode == 0 {
-                        console.print(f"  ✔ Verified: Bun {verify.stdout.strip()}");
-                        return True;
+
+"""Download and extract bun to .jac/bin/.
+
+Returns the path to the bun binary, or None on failure.
+"""
+def _download_bun(bin_dir: Path) -> Path | None {
+    import tempfile;
+    import urllib.request;
+    import urllib.error;
+
+    asset_name = _get_platform_asset();
+    if not asset_name {
+        console.print(
+            f"  [red]✖[/red] Unsupported platform: {platform.system()} {platform.machine()}"
+        );
+        return None;
+    }
+
+    url = f"https://github.com/oven-sh/bun/releases/download/bun-v{BUN_VERSION}/{asset_name}.zip";
+    is_windows = platform.system() == "Windows";
+    bun_name = "bun.exe" if is_windows else "bun";
+    bun_path = bin_dir / bun_name;
+
+    console.print(f"\n  ⏳ Installing Bun v{BUN_VERSION} to .jac/bin/ ...");
+
+    try {
+        with tempfile.TemporaryDirectory() as tmp {
+            zip_path = os.path.join(tmp, "bun.zip");
+            # Download
+            urllib.request.urlretrieve(url, zip_path);
+            # Extract — bun zips contain a single directory with the binary
+            with zipfile.ZipFile(zip_path, "r") as zf {
+                # Find the bun binary inside the archive
+                members = zf.namelist();
+                bun_member = None;
+                for m in members {
+                    if m.endswith(f"/{bun_name}") or m == bun_name {
+                        bun_member = m;
+                        break;
                     }
                 }
+                if not bun_member {
+                    console.print("  [red]✖[/red] Could not find bun binary in archive");
+                    return None;
+                }
+                # Extract just the binary
+                extracted = zf.extract(bun_member, tmp);
+                shutil.move(extracted, str(bun_path));
             }
-            console.error("  ⚠ Bun installed but may require terminal restart.");
-            console.error("  Run: source ~/.bashrc (or restart terminal)");
-            return True;
-        } else {
-            console.error("  ✖ Bun installation failed.");
-            return False;
+            # Make executable
+            if not is_windows {
+                os.chmod(str(bun_path), 0o755);
+            }
         }
+
+        # Write version marker so we know when to upgrade
+        version_file = bin_dir / ".bun-version";
+        version_file.write_text(BUN_VERSION);
+
+        # Verify
+        result = subprocess.run(
+            [str(bun_path), "--version"], capture_output=True, text=True, timeout=10
+        );
+        if result.returncode == 0 {
+            console.print(
+                f"  [green]✔[/green] Bun {result.stdout.strip()} installed to .jac/bin/"
+            );
+            return bun_path;
+        } else {
+            console.print("  [red]✖[/red] Downloaded bun binary failed verification");
+            bun_path.unlink(missing_ok=True);
+            return None;
+        }
+    } except urllib.error.URLError as e {
+        console.print(f"  [red]✖[/red] Download failed: {e}");
+        return None;
+    } except zipfile.BadZipFile {
+        console.print("  [red]✖[/red] Downloaded file is not a valid zip");
+        return None;
     } except subprocess.TimeoutExpired {
-        console.error("  ✖ Installation timed out.");
-        return False;
-    } except FileNotFoundError {
-        console.error("  ✖ curl not found. Please install Bun manually: https://bun.sh");
-        return False;
+        console.print("  [red]✖[/red] Bun verification timed out");
+        return None;
     } except Exception as e {
-        console.error(f"  ✖ Installation failed: {e}");
+        console.print(f"  [red]✖[/red] Installation failed: {e}");
+        return None;
+    }
+}
+
+
+"""Resolve the path to the bun binary.
+
+Resolution order:
+  1. System PATH
+  2. .jac/bin/bun (project-local, check version)
+  3. Auto-download to .jac/bin/
+
+Returns the absolute path to bun, or None if unavailable.
+"""
+impl get_bun -> str | None {
+    is_windows = platform.system() == "Windows";
+    bun_name = "bun.exe" if is_windows else "bun";
+
+    # 1. System PATH
+    system_bun = shutil.which("bun");
+    if system_bun {
+        return system_bun;
+    }
+
+    # 2. .jac/bin/bun (may already be downloaded)
+    bin_dir = _get_jac_bin_dir();
+    local_bun = bin_dir / bun_name;
+
+    if local_bun.exists() {
+        # Check if version matches (upgrade if stale)
+        version_file = bin_dir / ".bun-version";
+        if version_file.exists() and version_file.read_text().strip() == BUN_VERSION {
+            return str(local_bun);
+        }
+        # Version mismatch — re-download
+        console.print(f"  [yellow]⚠[/yellow] Upgrading Bun to v{BUN_VERSION}...");
+        local_bun.unlink(missing_ok=True);
+    }
+
+    # 3. Auto-download
+    result = _download_bun(bin_dir);
+    if result {
+        return str(result);
+    }
+
+    return None;
+}
+
+
+"""Check if bun is available, add to PATH if needed, or prompt to install.
+
+Legacy entry point — now delegates to get_bun().
+Returns True if bun is available, False otherwise.
+"""
+impl ensure_bun_available -> bool {
+    bun_path = get_bun();
+    if bun_path is None {
+        console.print(
+            "\n  [red]✖[/red] Bun is required but could not be installed automatically."
+        );
+        console.print("  Install manually: https://bun.sh\n");
         return False;
     }
+
+    # Ensure the directory containing bun is on PATH for subprocess calls
+    # that use shell=True or rely on PATH resolution.
+    bun_dir = str(Path(bun_path).parent);
+    current_path = os.environ.get("PATH", "");
+    if bun_dir not in current_path.split(os.pathsep) {
+        os.environ["PATH"] = f"{bun_dir}{os.pathsep}{current_path}";
+    }
+    return True;
+}
+
+
+"""Prompt user to install Bun and install if confirmed.
+
+Kept for backward compatibility but no longer prompts — auto-installs.
+"""
+impl prompt_install_bun -> bool {
+    return ensure_bun_available();
 }

--- a/jac-client/jac_client/tests/test_helpers.jac
+++ b/jac-client/jac_client/tests/test_helpers.jac
@@ -28,8 +28,12 @@ def get_jac_command -> list[str] {
 
 """Get environment dict with bun in PATH."""
 def get_env_with_bun -> dict[str, str] {
+    import from jac_client.plugin.utils { get_bun }
     env = os.environ.copy();
-    bun_path = shutil.which("bun");
+    bun_path = get_bun();
+    if not bun_path {
+        bun_path = shutil.which("bun");
+    }
     if bun_path {
         bun_dir = str(Path(bun_path).parent);
         current_path = env.get("PATH", "");


### PR DESCRIPTION
## Problem

Bun is required for `jac serve`, `jac build`, and all client-side operations, but the current approach:
- Prompts the user interactively (`Install Bun now? [Y/n]`)
- Installs globally to `~/.bun/bin`
- Fails silently in CI/headless environments (EOFError on input)
- Requires PATH to be configured correctly
- Pollutes the user's global environment

## Solution

Auto-download bun to `.jac/bin/` (the existing project-local toolchain directory) and resolve it by absolute path — no PATH configuration needed.

### Resolution order
1. **System PATH** — if the user already has bun installed globally, use it
2. **`.jac/bin/bun`** — project-local, version-pinned binary
3. **Auto-download** — silent download from GitHub releases, no prompt

### The elegant part
All subprocess calls now use `get_bun()` which returns the **absolute path** to the bun binary. This means even if PATH is misconfigured, broken, or empty, jac will find its own bun. No PATH manipulation needed at call sites.

### Changes
- `bun_installer`: New `get_bun()` → returns absolute path, auto-downloads to `.jac/bin/`
- `vite_bundler`: All `["bun", ...]` → `[bun, ...]` (resolved path)
- `package_installer`: Same pattern
- `desktop_target`: Same pattern for tauri build/dev
- `plugin_config`: Same pattern for project init
- Pin bun v1.3.11 with `.bun-version` marker for controlled upgrades

### Benefits
- **Zero friction**: `jac serve` just works on a fresh machine
- **Project-scoped**: clean uninstall = `rm -rf .jac/`
- **CI-friendly**: no interactive prompts, no global state
- **Version-controlled**: pinned bun version avoids works-on-my-machine
- **PATH-independent**: absolute paths bypass misconfigured environments
- **Same pattern as**: Gradle wrapper, Playwright browsers, Tauri toolchains