### PR TITLE
refactor(jac-scale): simplify admin dashboard pre-build (#5433 follow-up)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -161,10 +161,6 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Set up Bun (for client builds)
-        if: matrix.needs_nodejs == true
-        uses: oven-sh/setup-bun@v2
-
       # Run extra build commands (e.g., bundle_docs for jac-mcp, build_admin_ui for jac-scale)
       - name: Run extra build commands
         if: matrix.extra_build_cmd != ''

--- a/.github/workflows/release-scale.yml
+++ b/.github/workflows/release-scale.yml
@@ -51,8 +51,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
       - name: Download precompiled artifacts
         uses: actions/download-artifact@v4
         with:
@@ -65,7 +63,6 @@ jobs:
           pip install -e ../jac-client
           pip install -e .
           jac run scripts/build_admin_ui.jac
-          pip uninstall -y jac-scale jac-client jaclang
       - name: Install build tools
         run: |
           pip install build twine

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -282,9 +282,6 @@ jobs:
       with:
         node-version: '20'
 
-    - name: Set up Bun
-      uses: oven-sh/setup-bun@v2
-
     - name: Install jaclang for precompilation
       run: pip install -e jac
 

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -347,6 +347,8 @@ jac-scale includes a built-in admin portal for managing users, roles, and SSO co
 
 Navigate to `http://localhost:8000/admin` to access the admin dashboard. On first server start, an admin user is automatically bootstrapped.
 
+When installed from PyPI, the dashboard is pre-built and loads instantly. When running from source (editable install without pre-built assets), the dashboard is built on first access -- this requires Node.js and takes up to 300 seconds.
+
 ### Configuration
 
 ```toml

--- a/jac-scale/jac_scale/admin/impl/admin_portal.impl.jac
+++ b/jac-scale/jac_scale/admin/impl/admin_portal.impl.jac
@@ -1162,60 +1162,46 @@ def _calculate_metrics_summary(metrics_data: list[dict]) -> dict {
     return summary;
 }
 
-"""Get the admin dist directory path - in the running app's .jac folder."""
-impl JacAPIServerAdmin.get_admin_dist_dir -> Path {
-    import os;
-    # Use the current working directory (where the app is being run from)
-    cwd = Path(os.getcwd());
-    return cwd / ".jac" / "admin";
+"""Resolve the admin package directory (where admin_portal.jac lives)."""
+def _get_admin_package_dir() -> Path {
+    import from jac_scale.admin { admin_portal }
+    return Path(admin_portal.__file__).parent;
 }
 
-"""Copy pre-built admin assets from the installed package to the dist directory."""
-def _copy_dir_contents(src: Path, dst: Path) {
-    import shutil;
-    dst.mkdir(parents=True, exist_ok=True);
-    for item in src.iterdir() {
-        dest = dst / item.name;
-        if item.is_dir() {
-            if dest.exists() {
-                shutil.rmtree(dest);
-            }
-            shutil.copytree(item, dest);
-        } else {
-            shutil.copy2(item, dest);
-        }
+"""Get the runtime build output directory for admin client."""
+def _get_admin_runtime_dist_dir() -> Path {
+    import os;
+    return Path(os.getcwd()) / ".jac" / "admin";
+}
+
+"""Get the admin dist directory path - prefer pre-built assets shipped with the package."""
+impl JacAPIServerAdmin.get_admin_dist_dir -> Path {
+    # Check for pre-built assets shipped with the package
+    prebuilt_dir = _get_admin_package_dir() / "_dist";
+    if (prebuilt_dir / "index.html").exists() {
+        logger.debug("Serving admin client from pre-built package assets");
+        return prebuilt_dir;
     }
+    # Fall back to runtime build location
+    return _get_admin_runtime_dist_dir();
 }
 
 """Build the admin client from admin/ui source."""
 impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
-    dist_dir = self.get_admin_dist_dir();
-    index_file = dist_dir / "index.html";
-    # Check if already built/deployed
-    if not force and index_file.exists() {
+    # If pre-built assets exist in the package, no build needed
+    prebuilt_dir = _get_admin_package_dir() / "_dist";
+    if not force and (prebuilt_dir / "index.html").exists() {
+        logger.info("Using pre-built admin client from package");
+        return True;
+    }
+    # Check runtime build cache
+    dist_dir = _get_admin_runtime_dist_dir();
+    if not force and (dist_dir / "index.html").exists() {
         logger.debug("Admin client already built");
         return True;
     }
-
-    import from jac_scale.admin { admin_portal }
-    admin_dir = Path(admin_portal.__file__).parent;
-
-    # Check for pre-built assets bundled with the package
-    bundled_dist = admin_dir / "_dist";
-    if bundled_dist.exists() and (bundled_dist / "index.html").exists() {
-        logger.info("Using pre-built admin client from package");
-        try {
-            _copy_dir_contents(bundled_dist, dist_dir);
-            logger.info("Pre-built admin client deployed successfully");
-            return True;
-        } except Exception as e {
-            logger.error(f"Failed to deploy pre-built admin client: {e}");
-            return False;
-        }
-    }
-
     # Fall back to building from source (dev mode)
-    ui_dir = admin_dir / "ui";
+    ui_dir = _get_admin_package_dir() / "ui";
     if not (ui_dir / "main.jac").exists() {
         logger.error(f"Admin UI source not found at {ui_dir}");
         return False;
@@ -1237,9 +1223,21 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
         }
 
         # Copy built files to .jac/admin
+        import shutil;
         ui_dist = ui_dir / ".jac" / "client" / "dist";
         if ui_dist.exists() {
-            _copy_dir_contents(ui_dist, dist_dir);
+            dist_dir.mkdir(parents=True, exist_ok=True);
+            for item in ui_dist.iterdir() {
+                dest = dist_dir / item.name;
+                if item.is_dir() {
+                    if dest.exists() {
+                        shutil.rmtree(dest);
+                    }
+                    shutil.copytree(item, dest);
+                } else {
+                    shutil.copy2(item, dest);
+                }
+            }
         }
 
         logger.info("Admin client built successfully");

--- a/jac-scale/jac_scale/tests/test_admin.jac
+++ b/jac-scale/jac_scale/tests/test_admin.jac
@@ -472,6 +472,44 @@ test "admin index page" {
     }
 }
 
+test "admin serves pre-built dashboard with valid html" {
+    client = make_client();
+    try {
+        response = client.get("/admin/");
+        if response.status_code == 200 {
+            content = response.text;
+            assert "<!DOCTYPE html>" in content or "<html" in content;
+            assert "<script" in content or "<link" in content;
+        }
+    } finally {
+        client.close();
+    }
+}
+
+test "admin static assets served correctly" {
+    client = make_client();
+    try {
+        # First get the index to find asset references
+        index_resp = client.get("/admin/");
+        if index_resp.status_code == 200 {
+            import re;
+            content = index_resp.text;
+            # Find JS/CSS asset paths in the HTML
+            asset_paths = re.findall(r'(?:src|href)="([^"]+\.(?:js|css))"', content);
+            for asset_path in asset_paths {
+                # Normalize path relative to /admin/
+                if not asset_path.startswith("/") {
+                    asset_path = f"/admin/{asset_path}";
+                }
+                asset_resp = client.get(asset_path);
+                assert asset_resp.status_code == 200, f"Asset {asset_path} returned {asset_resp.status_code}";
+            }
+        }
+    } finally {
+        client.close();
+    }
+}
+
 # ============================================================================
 # Integration Tests
 # ============================================================================

--- a/jac-scale/scripts/build_admin_ui.jac
+++ b/jac-scale/scripts/build_admin_ui.jac
@@ -1,9 +1,7 @@
 """Pre-build the admin dashboard UI for PyPI release.
 
 Runs `jac build main.jac` in the admin UI source directory and copies
-the built output (HTML/JS/CSS) into jac_scale/admin/_dist/ so it ships
-with the package. At runtime, the server copies these bundled assets
-instead of building from source on first request.
+the output into jac_scale/admin/_dist/ so it ships with the package.
 
 Usage (from jac-scale/ directory):
     jac run scripts/build_admin_ui.jac
@@ -15,26 +13,17 @@ import sys;
 
 import from pathlib { Path }
 
-glob w = sys.stdout.write;
-
-"""Run the admin UI build pipeline."""
-def main -> int {
-    script_dir = Path(__file__).resolve().parent;
-    pkg_root = script_dir.parent;
+with entry {
+    pkg_root = Path(__file__).resolve().parent.parent;
     ui_dir = pkg_root / "jac_scale" / "admin" / "ui";
     dist_dst = pkg_root / "jac_scale" / "admin" / "_dist";
 
-    w(f"Admin UI source: {ui_dir}\n");
-    w(f"Bundle destination: {dist_dst}\n\n");
-
-    # Verify source exists
     if not (ui_dir / "main.jac").exists() {
-        w("ERROR: Admin UI source not found (missing main.jac)\n");
-        return 1;
+        print(f"ERROR: Admin UI source not found at {ui_dir}");
+        sys.exit(1);
     }
 
-    # Run jac build
-    w("Building admin UI with `jac build main.jac`...\n");
+    print(f"Building admin UI from {ui_dir}...");
     result = subprocess.run(
         ["jac", "build", "main.jac"],
         cwd=str(ui_dir),
@@ -44,47 +33,21 @@ def main -> int {
     );
 
     if result.returncode != 0 {
-        w(f"ERROR: Build failed:\n{result.stderr}\n");
-        if result.stdout {
-            w(f"stdout:\n{result.stdout}\n");
-        }
-        return 1;
+        print(f"ERROR: Build failed:\n{result.stderr}");
+        sys.exit(1);
     }
 
-    # Locate built output
     ui_dist = ui_dir / ".jac" / "client" / "dist";
-    if not ui_dist.exists() {
-        w(f"ERROR: Build output not found at {ui_dist}\n");
-        return 1;
+    if not (ui_dist / "index.html").exists() {
+        print(f"ERROR: Build output not found at {ui_dist}");
+        sys.exit(1);
     }
 
-    # Copy to package _dist directory
     if dist_dst.exists() {
         shutil.rmtree(str(dist_dst));
     }
     shutil.copytree(str(ui_dist), str(dist_dst));
 
-    # Count bundled files
-    files = list(dist_dst.rglob("*"));
-    file_count = len(
-        [
-            f
-            for f in files
-            if f.is_file()
-        ]
-    );
-    w(f"\nBundled {file_count} files -> {dist_dst}\n");
-
-    # Verify index.html exists
-    if not (dist_dst / "index.html").exists() {
-        w("ERROR: index.html not found in build output\n");
-        return 1;
-    }
-
-    w("Admin UI pre-built successfully.\n");
-    return 0;
-}
-
-with entry {
-    sys.exit(main());
+    file_count = len([f for f in dist_dst.rglob("*") if f.is_file()]);
+    print(f"Bundled {file_count} files -> {dist_dst}");
 }


### PR DESCRIPTION


Simplifies the pre-built admin dashboard implementation from #5433:

Runtime: serve directly from package _dist/ instead of copying to .jac/admin/
- Extract _get_admin_package_dir() and _get_admin_runtime_dist_dir() helpers
- get_admin_dist_dir() checks _dist/ first, falls back to runtime dir
- build_admin_client() skips entirely when pre-built assets exist
- Removes _copy_dir_contents() and the runtime copy-on-first-request step

Build script: 90 lines → 55 lines
- Remove wrapper function, flatten to entry block
- Same functionality, less ceremony

CI: remove redundant Bun setup steps from 3 workflows
- jac-client auto-downloads Bun via its built-in installer
- Node.js setup retained (required by Vite)

Tests: add 2 E2E tests for pre-built dashboard
- Validates HTML content has script/link tags (not an error page)
- Parses index for JS/CSS assets and verifies each returns 200

Docs: note pre-built vs dev behavior in admin portal reference
