### PR TITLE
feat(jac-mcp): add doc mappings for new fullstack tutorials and diagnostics

### DIFF
--- a/docs/docs/community/release_notes/jac-mcp.md
+++ b/docs/docs/community/release_notes/jac-mcp.md
@@ -3,6 +3,7 @@
 ## jac-mcp 0.1.10 (Unreleased)
 
 - **Content QA fixes**: Updated `root` to `root()` in pitfalls and knowledge map to match current deprecation (W0062). Fixed invalid graph filter syntax `` [-->](`?B) `` → `[-->][?:B]` in pitfalls. Updated `root spawn` → `root() spawn` in client-side examples.
+- **New doc mappings**: Added `jac://docs/tutorial-fullstack-npm`, `jac://docs/tutorial-fullstack-advanced`, and `jac://docs/diagnostics` to DOC_MAPPINGS and knowledge map. Bundled docs updated.
 
 ## jac-mcp 0.1.9 (Latest Release)
 

--- a/jac-mcp/jac_mcp/content/understand.md
+++ b/jac-mcp/jac_mcp/content/understand.md
@@ -91,6 +91,8 @@ triggers re-render. NEVER mutate directly (`items.append(x)` won't re-render - u
   jac://docs/tutorial-fullstack-backend      [M] walker calls from client
   jac://docs/tutorial-fullstack-auth         [M] login, signup, protected routes
   jac://docs/tutorial-fullstack-routing      [M] file-based & manual routing
+  jac://docs/tutorial-fullstack-npm          [M] npm packages, UI libraries, JS interop
+  jac://docs/tutorial-fullstack-advanced     [M] advanced full-stack patterns
   jac://docs/jac-vs-traditional              [S] side-by-side vs Python+React
 
 ### [F] Design Patterns
@@ -167,6 +169,8 @@ decorators, @property). Prefer `obj` for everything else.
   Add login / signup / auth               | jac://docs/tutorial-fullstack-auth
   Manage client state / effects           | jac://docs/tutorial-fullstack-state
   Add routing / pages                     | jac://docs/tutorial-fullstack-routing
+  Use npm packages / UI libraries         | jac://docs/tutorial-fullstack-npm
+  Advanced full-stack patterns            | jac://docs/tutorial-fullstack-advanced
   Look up syntax while coding             | jac://docs/cheatsheet
   Debug a parse or type error             | jac://guide/pitfalls + jac://docs/cheatsheet
   Compare Jac to Python/React             | jac://docs/jac-vs-traditional

--- a/jac-mcp/jac_mcp/impl/resources.impl.jac
+++ b/jac-mcp/jac_mcp/impl/resources.impl.jac
@@ -197,6 +197,16 @@ glob DOC_MAPPINGS: dict[str, tuple] = {
              "fullstack-routing.md",
              "Routing - Full-stack routing tutorial"
          ),
+         "jac://docs/tutorial-fullstack-npm": (
+             "tutorials/fullstack/npm-and-libraries.md",
+             "fullstack-npm-and-libraries.md",
+             "NPM & Libraries - Using npm packages, UI libraries, and JS interop"
+         ),
+         "jac://docs/tutorial-fullstack-advanced": (
+             "tutorials/fullstack/advanced-patterns.md",
+             "fullstack-advanced-patterns.md",
+             "Advanced Patterns - Advanced full-stack patterns"
+         ),
          # --- Deployment & Scaling ---
          "jac://docs/jac-scale": (
              "reference/plugins/jac-scale.md",
@@ -243,6 +253,11 @@ glob DOC_MAPPINGS: dict[str, tuple] = {
              "tutorials/language/debugging.md",
              "debugging.md",
              "Debugging - Debugging techniques tutorial"
+         ),
+         "jac://docs/diagnostics": (
+             "reference/diagnostics.md",
+             "diagnostics.md",
+             "Diagnostics - Compiler diagnostics and error reference"
          ),
          # --- Python Integration ---
          "jac://docs/python-integration": (


### PR DESCRIPTION
## Summary
- Added 3 new entries to `DOC_MAPPINGS` in `resources.impl.jac`: `jac://docs/tutorial-fullstack-npm`, `jac://docs/tutorial-fullstack-advanced`, and `jac://docs/diagnostics`
- Updated knowledge map (`understand.md`) with new URIs in section [E] and the task lookup table
- Added release note bullet to `jac-mcp.md`

## Test plan
- [ ] Verify `jac mcp` serves the new URIs via `get_resource`
- [ ] Verify `search_docs` returns results from the new docs
- [ ] Run `bundle_docs.jac` and confirm all 47 entries bundle cleanly