### PR TITLE
fix(mini_todo): update npm dependencies and fix add_todo logic

### DIFF
--- a/jac/examples/mini_todo/jac.toml
+++ b/jac/examples/mini_todo/jac.toml
@@ -5,16 +5,28 @@ description = "Minimal full-stack AI todo app"
 entry-point = "main.jac"
 
 [dependencies.npm]
-jac-client-node = "1.0.7"
+react = "^18.2.0"
+react-dom = "^18.2.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
 
 [dependencies.npm.dev]
-"@jac-client/dev-deps" = "2.0.0"
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
 
 [dev-dependencies]
 watchdog = ">=3.0.0"
 
 [serve]
 base_route_app = "app"
+
+[plugins.scale]
 
 [plugins.client]
 

--- a/jac/examples/mini_todo/main.jac
+++ b/jac/examples/mini_todo/main.jac
@@ -9,8 +9,11 @@ enum Category { WORK, PERSONAL, SHOPPING, HEALTH, OTHER }
 def categorize(title: str) -> Category by llm();
 
 def:pub add_todo(title: str) -> Todo {
-    category = str(categorize(title)).split(".")[-1].lower();
-    return (root() ++> Todo(title=title, category=category))[0];
+    result = categorize(title);
+    category = str(result).split(".")[-1].lower();
+    todo = Todo(title=title, category=category);
+    root() ++> todo;
+    return todo;
 }
 
 def:pub get_todos -> list[Todo] {


### PR DESCRIPTION
## Summary
- Replace bundled `jac-client-node` / `@jac-client/dev-deps` with explicit React, Vite, and TypeScript dependencies
- Add `[plugins.scale]` config section
- Fix `add_todo` to perform graph edge creation and return separately, avoiding issues with chained expression return

## Test plan
- [ ] Verify `jac serve` starts the mini_todo app without dependency errors
- [ ] Verify adding a todo correctly creates and returns the node