### PR TITLE
docs: add [plugins.scale] and expand add_todo in mini_todo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ def categorize(title: str) -> Category by llm();
 
 def:pub add_todo(title: str) -> Todo {
     try {
-        category = str(categorize(title)).split(".")[-1].lower();
+        result = categorize(title);
+        category = str(result).split(".")[-1].lower();
     } except Exception {
-        category = "other";
+        category = "other (setup AI key)";
     }
-    return (root() ++> Todo(title=title, category=category))[0];
+    todo = Todo(title=title, category=category);
+    root() ++> todo;
+    return todo;
 }
 
 def:pub get_todos -> list[Todo] {
@@ -136,6 +139,8 @@ typescript = "^5.3.3"
 
 [serve]
 base_route_app = "app"
+
+[plugins.scale]
 
 [plugins.client]
 

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -17,11 +17,14 @@ def categorize(title: str) -> Category by llm();
 
 def:pub add_todo(title: str) -> Todo {
     try {
-        category = str(categorize(title)).split(".")[-1].lower();
+        result = categorize(title);
+        category = str(result).split(".")[-1].lower();
     } except Exception {
-        category = "other";
+        category = "other (setup AI key)";
     }
-    return (root() ++> Todo(title=title, category=category))[0];
+    todo = Todo(title=title, category=category);
+    root() ++> todo;
+    return todo;
 }
 
 def:pub get_todos -> list[Todo] {
@@ -70,6 +73,8 @@ This single file defines a persistent data model, an AI-powered categorizer, a R
 
     [serve]
     base_route_app = "app"
+
+    [plugins.scale]
 
     [plugins.client]
 

--- a/jac/examples/mini_todo/main.jac
+++ b/jac/examples/mini_todo/main.jac
@@ -13,7 +13,7 @@ def:pub add_todo(title: str) -> Todo {
         result = categorize(title);
         category = str(result).split(".")[-1].lower();
     } except Exception {
-        category = "other (Needs AI)";
+        category = "other (setup AI key)";
     }
     todo = Todo(title=title, category=category);
     root() ++> todo;


### PR DESCRIPTION
## Summary
- Add `[plugins.scale]` to the jac.toml snippets in the README and quick-guide so the docs match the canonical `jac/examples/mini_todo/jac.toml` (enables the FastAPI-based server with Swagger docs at `/docs` and graph visualizer at `/graph`)
- Use the expanded `add_todo` body in the docs examples to match `mini_todo/main.jac`
- Update the fallback category message from `other (Needs AI)` to `other (setup AI key)` for clearer guidance when no LLM is configured

## Test plan
- [ ] Verify the example in README and quick-guide matches `jac/examples/mini_todo/main.jac`
- [ ] Run `jac start main.jac` in the example dir and confirm `/docs` and `/graph` routes work
- [ ] Add a todo without an API key set and confirm it falls back to `other (setup AI key)`