### PR TITLE
fix: bind faux-scope assignments to enclosing Python scope

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.13.6 (Unreleased)
 
+- **Fix: Python-Compatible Scoping for Assignments in Non-Scoping Blocks**: Unannotated assignments inside `try`/`except`/`finally`, `if`/`else`, `for`/`while`, and `match` blocks now bind in the nearest enclosing Python scope instead of creating a shadow symbol in the block's faux scope. This eliminates spurious `W2003` "defined but never used" warnings when the same name is assigned across sibling branches (e.g., `category` in `try { ... } except { ... }`), and also fully resolves the former "string slice loses type" type-checker root cause: `while chomp.startswith('.') { chomp = chomp[1:]; ... }` no longer degrades `str` to `Unknown` because the re-assignment updates the single outer symbol instead of forking a branch-local one. Mirrors the existing walrus (`:=`) handling and matches Python semantics exactly.
+
 ## jaclang 0.13.5 (Latest Release)
 
 - **Native: Lambda Expressions and Capturing Closures**: Added lambda expression support in the `na` (native LLVM) codespace. Simple lambdas compile to anonymous LLVM IR functions returned as function pointers. Capturing closures -- lambdas that reference variables from the enclosing scope -- pass captured values as hidden extra parameters, with automatic injection at call sites. No heap allocation required for captures. Leverages the existing indirect function pointer call infrastructure.

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -106,17 +106,6 @@ impl SymTabBuildPass.exit_assignment(self: SymTabBuildPass, nd: uni.Assignment) 
                 sym.add_use(i.name_spec);
             } elif (
                 (nd.type_tag is None)
-                and not isinstance(
-                    i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
-                )
-                and (
-                    (outer := i.sym_tab.lookup(i.sym_name, deep=True)) is not None
-                )
-                and self._outer_has_type_annotation(outer)
-            ) {
-                outer.add_use(i.name_spec);
-            } elif (
-                (nd.type_tag is None)
                 and (
                     (outer_has := i.sym_tab.lookup(i.sym_name, deep=True)) is not None
                 )
@@ -127,6 +116,32 @@ impl SymTabBuildPass.exit_assignment(self: SymTabBuildPass, nd: uni.Assignment) 
                 # the enclosing ability (not an archetype). Assignments to these
                 # names in nested abilities are state mutations, not new locals.
                 outer_has.add_use(i.name_spec);
+            } elif (
+                (nd.type_tag is None)
+                and not isinstance(
+                    i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
+                )
+            ) {
+                # Python semantics: an unannotated assignment inside a non-scoping
+                # block (try/except/finally, if/else, for/while, match) binds in
+                # the nearest enclosing Python scope, not in the inner block.
+                # Without this, two assignments to the same name in sibling
+                # branches would create separate "shadow" symbols in each faux
+                # scope, fragmenting symbol resolution and producing spurious
+                # "defined but never used" warnings. This mirrors the walrus
+                # handling in exit_binary_expr.
+                py_scope = self.find_python_scope_node_of(i);
+                if py_scope is not None {
+                    if (
+                        (outer := py_scope.lookup(i.sym_name, deep=False)) is not None
+                    ) {
+                        outer.add_use(i.name_spec);
+                    } else {
+                        py_scope.def_insert(i, single_decl='local var');
+                    }
+                } else {
+                    i.sym_tab.def_insert(i, single_decl='local var');
+                }
             } else {
                 # Tag enum members with the correct sym_category
                 if isinstance(i.sym_tab, uni.Enum) {

--- a/jac/jaclang/jac0core/passes/sym_tab_build_pass.jac
+++ b/jac/jaclang/jac0core/passes/sym_tab_build_pass.jac
@@ -43,23 +43,6 @@ class SymTabBuildPass(UniPass) {
         self: SymTabBuildPass, nd: uni.UniNode
     ) -> (UniScopeNode | None);
 
-    """Check if a symbol's declaration has an explicit type annotation."""
-    static def _outer_has_type_annotation(sym: uni.Symbol) -> bool {
-        decl = sym.decl;
-        if (decl is None) {
-            return False;
-        }
-        name_of = decl?.name_of;
-        if (name_of is None) {
-            return False;
-        }
-        parent = name_of?.parent;
-        return (
-            (isinstance(parent, uni.Assignment) and (parent.type_tag is not None))
-            or isinstance(name_of, (uni.HasVar, uni.ParamVar))
-        );
-    }
-
     """Create symbols for Name nodes in a module path."""
     def _bind_import_path_symbols(
         self: SymTabBuildPass, module_path: uni.ModulePath

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_narrowing_root_causes.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_narrowing_root_causes.jac
@@ -222,36 +222,39 @@ def fail_assign_to_narrowed_none_local(x: int | None) -> int {
 }
 
 # ============================================================================
-# Root Cause 5: String slicing loses type information
+# Root Cause 5 (FIXED): String slicing preserves type information
 #
-# When a string variable is sliced (e.g., s = s[1:]), the resulting type
-# should still be str, but the type checker resolves it to Unknown.
-# Subsequent string method calls (e.g., .startswith(), .endswith()) then
-# fail with E1032.
+# Regression guard for the former "string slice loses type" root cause.
+# Previously, slicing a str variable produced Unknown and subsequent
+# .startswith()/.endswith() calls emitted E1032. Fixed by:
+#   1) str.__getitem__ returning str via protocol matching fallback,
+#   2) LiteralString flags propagating Instantiable through chained calls,
+#   3) unannotated re-assignments inside non-scoping blocks (while/if/try/...)
+#      binding to the enclosing Python scope so re-slicing no longer creates a
+#      shadow symbol that degrades str to Unknown.
 #
 # Mirrors: runtime.impl.jac line 1096 (chomp_target = chomp_target[1:])
-# then chomp_target.startswith('.') fails
 # ============================================================================
 
-def fail_string_slice_loses_type(target: str) -> str {
+def pass_string_slice_in_while(target: str) -> str {
     chomp = target;
     while chomp.startswith('.') {
-        chomp = chomp[1:];          # slice should preserve str type
-        if chomp.startswith('.') {  # E1032: Unknown has no .startswith
+        chomp = chomp[1:];          # slice preserves str across iterations
+        if chomp.startswith('.') {  # str.startswith resolves cleanly
             continue;
         }
     }
     return chomp;
 }
 
-def fail_string_slice_endswith(path: str) -> bool {
-    base = path[:-3];               # slice should be str
-    return base.endswith(".jac");    # E1032 if slice type is Unknown
+def pass_string_slice_endswith(path: str) -> bool {
+    base = path[:-3];               # slice is str
+    return base.endswith(".jac");    # str.endswith resolves cleanly
 }
 
-def fail_string_index_method(s: str) -> str {
-    c = s[0];                       # indexing str should give str
-    return c.upper();               # E1032 if index type is Unknown
+def pass_string_index_method(s: str) -> str {
+    c = s[0];                       # indexing str gives str
+    return c.upper();               # str.upper resolves cleanly
 }
 
 # ============================================================================

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2824,7 +2824,7 @@ the result to Unknown instead of str. Subsequent string method calls fail with E
 
 Mirrors: runtime.impl.jac line 1096 (chomp_target = chomp_target[1:] -> .startswith fails).
 """
-test "root_cause_5_string_slice_loses_type" {
+test "root_cause_5_string_slice_preserves_type" {
     program = JacProgram();
     mod = program.compile(
         os.path.join(CHECKER_FIXTURES, "checker_narrowing_root_causes.jac"),
@@ -2832,16 +2832,16 @@ test "root_cause_5_string_slice_loses_type" {
     );
     TypeCheckPass(ir_in=mod, prog=program);
 
-    # fail_ functions (lines 234-254) — string slice/index loses str type
+    # Regression guard for the former "string slice loses type" root cause.
+    # The pass_ functions exercise the three patterns that used to degrade
+    # str to Unknown. They must type-check cleanly. See the fixture header
+    # comment above the pass_string_* functions for the full fix summary.
     rc5_errors = [
         e
         for e in program.errors_had
-        if e.loc and 234 <= e.loc.first_line <= 254
+        if e.loc and 239 <= e.loc.first_line <= 258
     ];
-    # PARTIALLY FIXED: str.__getitem__ now returns str via protocol matching fallback.
-    # s[0].upper() chaining now works (LiteralString flags fix propagates Instantiable).
-    # Remaining 2: while-loop re-assignment degrades str to Unknown (.startswith x2).
-    assert len(rc5_errors) == 2 , f"Expected 2 string-slice errors, got {len(
+    assert len(rc5_errors) == 0 , f"Expected 0 string-slice errors, got {len(
         rc5_errors
     )}:\n" + "\n---\n".join(e.pretty_print() for e in rc5_errors);
 }
@@ -3025,9 +3025,10 @@ test "root_causes_total_error_count" {
     );
     TypeCheckPass(ir_in=mod, prog=program);
 
-    # RC9 dropped 3→2 (CFG resolved 1 any-in-union error).
-    # Total: 37 - 1 = 36
-    assert len(program.errors_had) == 36 , f"Expected 36 total errors, got {len(
+    # RC9 dropped 3→2 (CFG resolved 1 any-in-union error): 37 - 1 = 36
+    # RC5 dropped 2→0 (faux-scope re-assignments now bind to Python scope,
+    # preserving str narrowing in while-loop chomp pattern): 36 - 2 = 34
+    assert len(program.errors_had) == 34 , f"Expected 34 total errors, got {len(
         program.errors_had
     )}:\n" + "\n---\n".join(e.pretty_print() for e in program.errors_had);
 }


### PR DESCRIPTION
## Summary

- Unannotated assignments inside `try`/`except`/`finally`, `if`/`else`, `for`/`while`, and `match` blocks now bind in the nearest enclosing Python scope instead of creating a shadow symbol in the block's faux scope. Mirrors the existing walrus (`:=`) handling and matches Python semantics.
- Eliminates spurious `W2003` "defined but never used" warnings on same-name assignments across sibling branches (e.g. `category` in `try { ... } except { ... }` in `examples/mini_todo/main.jac`).
- Fully resolves the former "string slice loses type" type-checker root cause: `while chomp.startswith('.') { chomp = chomp[1:]; ... }` no longer degrades `str` to `Unknown`. The `fail_string_*` fixtures become `pass_string_*` and `root_cause_5` is re-purposed as a positive regression guard.

## Details

The symbol table builder in `sym_tab_build_pass.impl.jac` pushes a new scope for Jac's block constructs (`TryStmt`, `Except`, `IfStmt`, `WhileStmt`, etc.), but Python does not scope on those — assignments within them belong to the enclosing function/module/class frame. `exit_assignment` was creating a fresh local symbol for each branch-assignment of the same name, fragmenting symbol resolution and causing:

1. Spurious `W2003` on the "loser" branch in `try/except` or `if/else` re-assignments to the same name.
2. Type narrowing loss on re-assignments inside loop bodies (the sliced `chomp` degrading to `Unknown` between iterations).

The fix: when an unannotated assignment target lands inside a non-Python-scoping node, redirect the `def_insert` to `find_python_scope_node_of(i)`. If a symbol with the same name already exists there, `add_use` on it; otherwise insert there. The narrower `_outer_has_type_annotation` accommodation is subsumed and removed.

Also cleans up `checker_narrowing_root_causes.jac` fixture naming (`fail_string_*` → `pass_string_*`) and the corresponding test (`root_cause_5_string_slice_loses_type` → `root_cause_5_string_slice_preserves_type`) to reflect that the root cause is no longer active. The `root_causes_total_error_count` assertion drops from 36 to 34 (RC5 dropped 2→0).

Release note added under `jaclang 0.13.6 (Unreleased)`.

## Test plan

- [x] `pytest jac/tests/compiler/passes/main` — 432 passed
- [x] `pytest jac/tests/compiler/passes/main jac/tests/compiler/passes/tool jac/tests/language` — 684 passed, 57 skipped, 1 xfailed
- [x] `pytest jac/tests` — 3108 passed, 57 skipped, 1 xfailed
- [x] `jac check jac/examples/mini_todo/main.jac` — no `W2003` (only unrelated `W2052` broad-except)