### PR TITLE
feat: Windows desktop build improvements for PyInstaller sidecar

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.3.12 (Unreleased)
 
+- **Feat: Windows Desktop Build Improvements**: PyInstaller sidecar now shows build logs, has 2-hour timeout, auto-bundles assets/ and .env, includes UTF-8 runtime hook, and properly bundles jac_client.
+
 ## jac-client 0.3.11 (Latest Release)
 
 - **Replace npm meta-packages with direct dependencies**: Removed `jac-client-node` and `@jac-client/dev-deps` meta-packages in favor of injecting individual npm dependencies (react, vite, typescript, etc.) directly into `jac.toml`. Users can now see and pin exact dependency versions. Existing projects using meta-packages are automatically migrated on next load.

--- a/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
+++ b/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
@@ -9,22 +9,276 @@ import subprocess;
 import json;
 import shutil;
 import os;
+import sys;
 import platform;
 import stat;
+
+# ===============================================================================
+# Constants - Avoid magic numbers/strings throughout the module
+# ===============================================================================
+glob DEFAULT_API_PORT: int = 8000,
+     DEFAULT_VITE_PORT: int = 5173,
+     SUBPROCESS_TIMEOUT_SHORT: int = 5,
+     SUBPROCESS_TIMEOUT_MEDIUM: int = 60,
+     SUBPROCESS_TIMEOUT_LONG: int = 300,
+     SUBPROCESS_TIMEOUT_BUILD: int = 7200,
+     DEFAULT_ICON_COLOR_RGB: tuple[int, int, int, int] = (66, 139, 202, 255),
+     DEFAULT_ICON_SIZE: int = 1024,
+     DEFAULT_WINDOW_WIDTH: int = 1200,
+     DEFAULT_WINDOW_HEIGHT: int = 800,
+     DEFAULT_MIN_WIDTH: int = 800,
+     DEFAULT_MIN_HEIGHT: int = 600;
+
+# ===============================================================================
+# Helper Functions - Extracted to reduce duplication
+# ===============================================================================
+"""Check if a command is available and optionally return its version."""
+def _check_command_available(
+    cmd: list[str], timeout: int = SUBPROCESS_TIMEOUT_SHORT
+) -> tuple[bool, str | None] {
+    try {
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout);
+        if result.returncode == 0 {
+            return (True, result.stdout.strip());
+        }
+    } except Exception as e { }
+    return (False, None);
+}
+
+"""Check if error message indicates FUSE-related issue."""
+def _is_fuse_error(error_output: str) -> bool {
+    error_lower = error_output.lower();
+    return "fuse" in error_lower or "libfuse" in error_lower;
+}
+
+"""Get FUSE installation instructions."""
+def _get_fuse_install_hint -> str {
+    return "Install FUSE with: sudo apt-get install -y libfuse2";
+}
 
 def _make_localhost_url(port: int) -> str {
     return f"http://127.0.0.1:{port}";
 }
 
+"""Join path components into a Path object (type-safe alternative to / operator)."""
+def _join_path(base: Path, *parts: str) -> Path {
+    result: str = str(base);
+    for part in parts {
+        p: str = str(part);
+        result = os.path.join(result, p);
+    }
+    return Path(result);
+}
+
 def _get_toml_api_base_url(project_dir: Path) -> str {
     config_loader = JacClientConfig(project_dir);
-    return config_loader.get_api_config().get('base_url', '');
+    api_config: dict = config_loader.get_api_config();
+    base_url: str = api_config.get('base_url', '');
+    return base_url;
+}
+
+# ===============================================================================
+# Production Build Helpers - GLIBC compatibility and Docker builds
+# ===============================================================================
+"""Get the system GLIBC version on Linux. Returns version string or None."""
+def _get_glibc_version -> str | None {
+    if platform.system() != "Linux" {
+        return None;
+    }
+    try {
+        result = subprocess.run(
+            ["ldd", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
+        );
+        if result.returncode == 0 {
+            stdout_str: str = str(result.stdout);
+            first_line: str = stdout_str.split("\n")[0];
+            parts: list = first_line.split();
+            for p in parts {
+                part: str = str(p);
+                if "." in part {
+                    try {
+                        segments: list = part.split(".");
+                        if len(segments) >= 2 {
+                            int(str(segments[0]));
+                            int(str(segments[1]));
+                            return part;
+                        }
+                    } except Exception { }
+                }
+            }
+        }
+    } except Exception { }
+    return None;
+}
+
+"""Compare two version strings. Returns -1 if v1 < v2, 0 if equal, 1 if v1 > v2."""
+def _compare_versions(v1: str, v2: str) -> int {
+    parts1: list = [];
+    for x in v1.split(".") {
+        try {
+            parts1.append(int(str(x)));
+        } except Exception {
+            parts1.append(0);
+        }
+    }
+    parts2: list = [];
+    for x in v2.split(".") {
+        try {
+            parts2.append(int(str(x)));
+        } except Exception {
+            parts2.append(0);
+        }
+    }
+    while len(parts1) < len(parts2) {
+        parts1.append(0);
+    }
+    while len(parts2) < len(parts1) {
+        parts2.append(0);
+    }
+    for i in range(len(parts1)) {
+        if parts1[i] < parts2[i] {
+            return -1;
+        }
+        if parts1[i] > parts2[i] {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+"""Check GLIBC compatibility for production builds. Returns (is_compatible, version, message)."""
+def _check_glibc_compatibility -> tuple[bool, str | None, str] {
+    if platform.system() != "Linux" {
+        return (True, None, "");
+    }
+    glibc_version = _get_glibc_version();
+    if not glibc_version {
+        return (True, None, "Could not detect GLIBC version");
+    }
+    # GLIBC 2.35 is Ubuntu 22.04 - good target for compatibility
+    if _compare_versions(glibc_version, "2.35") > 0 {
+        msg = "WARNING: GLIBC " + glibc_version + " detected. For production builds targeting older systems, use Docker build or build on Ubuntu 22.04.";
+        return (False, glibc_version, msg);
+    }
+    return (True, glibc_version, "GLIBC " + glibc_version + " OK");
+}
+
+"""Check if Docker is available."""
+def _is_docker_available -> bool {
+    result = _check_command_available(["docker", "--version"]);
+    return result[0];
+}
+
+"""Get the path to the Docker build script."""
+def _get_docker_script_path -> Path | None {
+    try {
+        import from jac_client.plugin.src.targets.desktop { __file__ as desktop_init }
+        desktop_dir: Path = Path(desktop_init).parent;
+        docker_script: Path = Path(str(desktop_dir) + "/docker/build.sh");
+        if docker_script.exists() {
+            return docker_script;
+        }
+    } except Exception { }
+    return None;
+}
+
+"""Find the jaseci monorepo root directory by looking for jac-client."""
+def _find_jaseci_root(start_dir: Path) -> Path | None {
+    search_dir: Path = Path(str(start_dir.resolve()));
+    for _ in range(10) {
+        jac_client_path: Path = Path(str(search_dir) + "/jac-client");
+        if jac_client_path.is_dir() {
+            return search_dir;
+        }
+        parent: Path = search_dir.parent;
+        if str(parent) == str(search_dir) {
+            break;
+        }
+        search_dir = parent;
+    }
+    return None;
+}
+
+"""Run the Docker-based production build."""
+def _run_docker_build(project_dir: Path) -> Path | None {
+    docker_script = _get_docker_script_path();
+    if not docker_script {
+        console.error("Docker build script not found");
+        return None;
+    }
+    if not _is_docker_available() {
+        console.error("Docker is not available. Please install Docker first.");
+        return None;
+    }
+    console.print("\n🐳 Running Docker production build...", style="bold");
+    console.print(f"  Script: {docker_script}", style="muted");
+    console.print(f"  Project: {project_dir}", style="muted");
+    try {
+        result = subprocess.run(
+            ["bash", str(docker_script), str(project_dir)],
+            cwd=str(project_dir),
+            timeout=1800
+        );
+        if result.returncode == 0 {
+            bundle_dir: Path = Path(
+                str(project_dir) + "/src-tauri/target/release/bundle"
+            );
+            appimage_dir: Path = Path(str(bundle_dir) + "/appimage");
+            deb_dir: Path = Path(str(bundle_dir) + "/deb");
+            if appimage_dir.exists() {
+                for f in appimage_dir.iterdir() {
+                    fname: str = str(f.name);
+                    if fname.endswith(".AppImage") {
+                        return f;
+                    }
+                }
+            }
+            if deb_dir.exists() {
+                for f in deb_dir.iterdir() {
+                    fname: str = str(f.name);
+                    if fname.endswith(".deb") {
+                        return f;
+                    }
+                }
+            }
+            return bundle_dir;
+        } else {
+            console.error(f"Docker build failed with exit code {result.returncode}");
+            return None;
+        }
+    } except subprocess.TimeoutExpired {
+        console.error("Docker build timed out after 30 minutes");
+        return None;
+    } except Exception as e {
+        console.error(f"Docker build error: {e}");
+        return None;
+    }
+}
+
+"""Print suggestion to use Docker for production builds."""
+def _suggest_docker_build(project_dir: Path) -> None {
+    docker_script = _get_docker_script_path();
+    console.print("\n[yellow]For production-ready Linux builds, use Docker:[/yellow]");
+    if docker_script {
+        console.print(f"  {docker_script} {project_dir}");
+    } else {
+        console.print("  See jac-client/jac_client/plugin/src/targets/desktop/docker/");
+    }
+    console.print("  This builds in Ubuntu 22.04 for maximum compatibility.\n");
+}
+
+"""Check if running in production build mode (via env var)."""
+def _is_production_build -> bool {
+    return os.environ.get("JAC_PRODUCTION_BUILD", "").lower() in ("1", "true", "yes");
 }
 
 """Setup desktop target - scaffold Tauri project structure."""
 impl DesktopTarget.setup(project_dir: Path) -> None {
     # Define tauri_dir early so we can use it in error handling
-    tauri_dir = project_dir / "src-tauri";
+    tauri_dir: Path = _join_path(project_dir, "src-tauri");
     # Create src-tauri directory structure FIRST (before ANY other operations)
     # This ensures the directory exists even if later steps fail
     console.print("\n🖥️  Setting up desktop target (Tauri)", style="bold");
@@ -38,19 +292,19 @@ impl DesktopTarget.setup(project_dir: Path) -> None {
     if not project_dir.exists() {
         try {
             project_dir.mkdir(parents=True, exist_ok=True);
-        } except Exception as e {
-            raise RuntimeError(f"Failed to create project directory: {e}");
+        } except Exception {
+            raise RuntimeError(f"Failed to create project directory");
         }
     }
     # Create src-tauri directory structure IMMEDIATELY (before imports or any other operations)
     console.print("  Creating src-tauri/ directory structure...", style="muted");
     try {
         tauri_dir.mkdir(parents=True, exist_ok=True);
-        (tauri_dir / "src").mkdir(exist_ok=True);
-        (tauri_dir / "binaries").mkdir(exist_ok=True);
+        _join_path(tauri_dir, "src").mkdir(exist_ok=True);
+        _join_path(tauri_dir, "binaries").mkdir(exist_ok=True);
         console.print(f"  ✔ Created {tauri_dir}", style="success");
-    } except Exception as e {
-        raise RuntimeError(f"Failed to create src-tauri directory: {e}");
+    } except Exception {
+        raise RuntimeError(f"Failed to create src-tauri directory");
     }
     # Wrap rest of setup in try-finally to ensure directory exists even if exceptions occur
     try {
@@ -198,8 +452,13 @@ impl DesktopTarget.setup(project_dir: Path) -> None {
 
         console.success("Desktop target setup complete!");
         console.print("\nNext steps:", style="bold");
-        console.print("  1. Build: jac build main.jac --client desktop");
-        console.print("  2. Dev:   jac start main.jac --client desktop");
+        console.print("  1. Dev:   jac start main.jac --client desktop");
+        console.print("  2. Build: jac build main.jac --client desktop");
+        console.print("\nBuild options:", style="bold");
+        console.print("  --platform <windows|macos|linux|all>  Target platform");
+        console.print(
+            "  --docker                              Production build (Linux, GLIBC compatible)"
+        );
     } finally {
         # ABSOLUTE GUARANTEE: Ensure src-tauri directory exists no matter what
         if not tauri_dir.exists() {
@@ -251,7 +510,7 @@ def _generate_tauri_config(tauri_dir: Path, name: str, identifier: str, version:
             "devUrl": "http://localhost:5173",
             "frontendDist": "../.jac/client/dist"
         },
-        "app": {"windows": [], "security": {"csp": None}},
+        "app": {"withGlobalTauri": True, "windows": [], "security": {"csp": None}},
         "bundle": {"active": True, "targets": "all", "icon": []},
         "plugins": {}
     };
@@ -290,7 +549,7 @@ edition = "2021"
 tauri-build = {{ version = "2.0", features = [] }}
 
 [dependencies]
-tauri = {{ version = "2.0", features = [] }}
+tauri = {{ version = "2.0", features = ["devtools"] }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 
@@ -357,11 +616,12 @@ try:
 except ImportError:
     sys.exit(1)
 ''';
+        python_cmd = "python" if sys.platform == "win32" else "python3";
         result = subprocess.run(
-            ["python3", "-c", python_code, str(icon_path)],
+            [python_cmd, "-c", python_code, str(icon_path)],
             capture_output=True,
             check=True,
-            timeout=5
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         console.print("  ✔ Generated default icon (1024x1024)", style="success");
         console.warning(
@@ -394,7 +654,7 @@ except ImportError:
             ],
             capture_output=True,
             check=True,
-            timeout=5
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         console.print("  ✔ Generated default icon (1024x1024)", style="success");
         console.warning(
@@ -456,6 +716,76 @@ except ImportError:
     console.warning(
         "  Note: Replace icons/icon.png with your app icon (1024x1024 PNG recommended)"
     );
+
+    # Generate ICO for Windows (required by tauri-build)
+    _generate_ico_from_png(icons_dir);
+}
+
+"""Generate ICO file from PNG for Windows builds."""
+def _generate_ico_from_png(icons_dir: Path) -> None {
+    import sys;
+    png_path = icons_dir / "icon.png";
+    ico_path = icons_dir / "icon.ico";
+
+    if not png_path.exists() {
+        return;
+    }
+
+    # Try using PIL directly first (faster, better error messages)
+    try {
+        import from PIL {Image}
+        img = Image.open(str(png_path));
+        # ICO needs multiple sizes - use common Windows icon sizes
+        sizes = [(256, 256), (128, 128), (64, 64), (48, 48), (32, 32), (16, 16)];
+        img.save(str(ico_path), format="ICO", sizes=sizes);
+        console.print("  ✔ Generated icon.ico for Windows", style="success");
+        return;
+    } except ImportError {
+        # PIL not available, try subprocess fallback
+
+    } except Exception as e {
+        console.warning(f"  Could not generate icon.ico: {e}");
+        return;
+    }
+
+    # Fallback: try subprocess (in case PIL is in different Python env)
+    try {
+        import subprocess;
+        python_code = '''
+import sys
+try:
+    from PIL import Image
+    img = Image.open(sys.argv[1])
+    sizes = [(256, 256), (128, 128), (64, 64), (48, 48), (32, 32), (16, 16)]
+    img.save(sys.argv[2], format="ICO", sizes=sizes)
+    sys.exit(0)
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+''';
+        python_cmd = "python" if sys.platform == "win32" else "python3";
+        result = subprocess.run(
+            [python_cmd, "-c", python_code, str(png_path), str(ico_path)],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
+        );
+        if result.returncode == 0 {
+            console.print("  ✔ Generated icon.ico for Windows", style="success");
+            return;
+        } else {
+            console.warning(f"  ICO generation failed: {result.stderr}");
+        }
+    } except Exception as e {
+        console.warning(f"  ICO generation error: {e}");
+    }
+
+    # Final fallback: warn user
+    if sys.platform == "win32" {
+        console.warning(
+            "  Could not generate icon.ico - install Pillow: pip install Pillow"
+        );
+    }
 }
 
 """Generate main.rs.
@@ -463,9 +793,8 @@ except ImportError:
 api_base_url: embed this URL and skip sidecar port discovery.
     Empty string means dynamic discovery at runtime.
 """
-def _generate_main_rs(tauri_dir: Path, api_base_url: str = "") {
+def _generate_main_rs(tauri_dir: Path, api_base_url: str = "") -> None {
     import json;
-
     # Read window config from tauri.conf.json (before we clear windows array)
     config_path = tauri_dir / "tauri.conf.json";
     win_title = "Jac App";
@@ -510,7 +839,7 @@ static API_BASE_URL: Mutex<Option<String>> = Mutex::new(None);
 const CONFIGURED_BASE_URL: &str = "{api_base_url}";
 
 fn find_and_start_sidecar(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error>> {{
-    // Skip sidecar launch — user manages their own backend
+    // Skip sidecar launch - user manages their own backend
     if !CONFIGURED_BASE_URL.is_empty() {{
         let mut url = API_BASE_URL.lock().unwrap();
         *url = Some(CONFIGURED_BASE_URL.to_string());
@@ -521,11 +850,19 @@ fn find_and_start_sidecar(app: &tauri::AppHandle) -> Result<(), Box<dyn std::err
     // Try to find the sidecar in bundled resources
     let resource_dir = app.path().resource_dir()?;
 
-    // Possible sidecar names
+    // Possible sidecar names (onedir paths first, then onefile fallbacks)
     let sidecar_names = if cfg!(windows) {{
-        vec!["binaries/jac-sidecar.exe", "binaries/jac-sidecar.bat"]
+        vec![
+            "binaries/jac-sidecar/jac-sidecar.exe",  // onedir mode
+            "binaries/jac-sidecar.exe",               // onefile fallback
+            "binaries/jac-sidecar.bat",               // wrapper fallback
+        ]
     }} else {{
-        vec!["binaries/jac-sidecar", "binaries/jac-sidecar.sh"]
+        vec![
+            "binaries/jac-sidecar/jac-sidecar",       // onedir mode
+            "binaries/jac-sidecar",                   // onefile fallback
+            "binaries/jac-sidecar.sh",                // wrapper fallback
+        ]
     }};
 
     let mut sidecar_path = None;
@@ -554,25 +891,33 @@ fn find_and_start_sidecar(app: &tauri::AppHandle) -> Result<(), Box<dyn std::err
     }}
 
     if let Some(sidecar_path) = sidecar_path {{
-        // Determine module path (try to find main.jac relative to app)
-        let module_path = if let Ok(exe_path) = std::env::current_exe() {{
-            if let Some(exe_dir) = exe_path.parent() {{
-                // Look for main.jac in parent directories
-                let mut current = exe_dir.to_path_buf();
-                loop {{
-                    let main_jac = current.join("main.jac");
-                    if main_jac.exists() {{
-                        break Some(main_jac);
-                    }}
-                    if !current.pop() {{
-                        break None;
-                    }}
-                }}
+        // Determine module path - check bundled resources first, then parent directories
+        let module_path = {{
+            // First, check in bundled resources (for AppImage/packaged builds)
+            let bundled_main = resource_dir.join("jac").join("main.jac");
+            if bundled_main.exists() {{
+                Some(bundled_main)
             }} else {{
-                None
+                // Fall back to checking parent directories (for dev builds)
+                if let Ok(exe_path) = std::env::current_exe() {{
+                    if let Some(exe_dir) = exe_path.parent() {{
+                        let mut current = exe_dir.to_path_buf();
+                        loop {{
+                            let main_jac = current.join("main.jac");
+                            if main_jac.exists() {{
+                                break Some(main_jac);
+                            }}
+                            if !current.pop() {{
+                                break None;
+                            }}
+                        }}
+                    }} else {{
+                        None
+                    }}
+                }} else {{
+                    None
+                }}
             }}
-        }} else {{
-            None
         }};
 
         // Build command to start sidecar
@@ -598,11 +943,48 @@ fn find_and_start_sidecar(app: &tauri::AppHandle) -> Result<(), Box<dyn std::err
         // Add arguments
         if let Some(ref mp) = module_path {{
             cmd.arg("--module-path").arg(mp);
+            // Also set base-path to the module's parent directory (bundled jac files location)
+            if let Some(parent) = mp.parent() {{
+                cmd.arg("--base-path").arg(parent);
+            }}
         }} else {{
             cmd.arg("--module-path").arg("main.jac");
         }}
         cmd.arg("--port").arg("0"); // OS assigns free port
         cmd.arg("--host").arg("127.0.0.1");
+
+        // Compute writable data path for runtime data (database, etc.)
+        // AppImage bundles are read-only, so we need a writable location
+        #[cfg(windows)]
+        {{
+            // Windows: Use LOCALAPPDATA or USERPROFILE
+            if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {{
+                let data_path = std::path::Path::new(&local_app_data).join("jac-app");
+                cmd.arg("--data-path").arg(data_path);
+            }} else if let Some(user_profile) = std::env::var_os("USERPROFILE") {{
+                let data_path = std::path::Path::new(&user_profile)
+                    .join("AppData")
+                    .join("Local")
+                    .join("jac-app");
+                cmd.arg("--data-path").arg(data_path);
+            }}
+        }}
+        #[cfg(not(windows))]
+        {{
+            // Unix: Use HOME/.local/share/jac-app
+            if let Some(home) = std::env::var_os("HOME") {{
+                let data_path = std::path::Path::new(&home)
+                    .join(".local")
+                    .join("share")
+                    .join("jac-app");
+                cmd.arg("--data-path").arg(data_path);
+            }}
+        }}
+
+        // Remove AppImage-injected Python environment variables that break system Python
+        cmd.env_remove("PYTHONHOME");
+        cmd.env_remove("PYTHONPATH");
+        cmd.env_remove("PYTHONDONTWRITEBYTECODE");
 
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::inherit());
@@ -663,8 +1045,15 @@ fn stop_sidecar() {{
     }}
 }}
 
+/// Tauri command to get the API base URL (fallback if initialization_script timing fails)
+#[tauri::command]
+fn get_api_url() -> Option<String> {{
+    API_BASE_URL.lock().unwrap().clone()
+}}
+
 fn main() {{
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![get_api_url])
         .setup(|app| {{
             // Start sidecar to discover dynamic port
             if let Err(e) = find_and_start_sidecar(app.handle()) {{
@@ -779,6 +1168,12 @@ linux = true
 system_tray = false
 auto_update = false
 notifications = false
+
+# Jac plugins to bundle (set to false to exclude from build)
+[desktop.plugins]
+jac_scale = true   # FastAPI server, auth, scaling features
+byllm = true       # LLM providers integration (litellm)
+jac_coder = true   # AI coding assistant
 ''';
 
     # Append the section
@@ -834,14 +1229,17 @@ def _check_and_install_dependencies {
 def _check_and_install_rust -> bool {
     try {
         result = subprocess.run(
-            ["rustc", "--version"], capture_output=True, text=True, timeout=5
+            ["rustc", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         if result.returncode == 0 {
             version = result.stdout.strip();
             console.print(f"  ✔ Rust toolchain found: {version}", style="success");
             return True;
         }
-    } except Exception { }
+    } except Exception as e { }
 
     # Rust not found
     console.warning("  Rust toolchain not found");
@@ -873,7 +1271,7 @@ def _check_and_install_rust -> bool {
                         "-c",
                         "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
                     ],
-                    timeout=600,  # 10 minute timeout
+                    timeout=SUBPROCESS_TIMEOUT_BUILD,
                     check=False
                 );
                 if result.returncode == 0 {
@@ -895,7 +1293,7 @@ def _check_and_install_rust -> bool {
                                 ["rustc", "--version"],
                                 capture_output=True,
                                 text=True,
-                                timeout=5
+                                timeout=SUBPROCESS_TIMEOUT_SHORT
                             );
                             if verify_result.returncode == 0 {
                                 version = verify_result.stdout.strip();
@@ -904,7 +1302,7 @@ def _check_and_install_rust -> bool {
                                 );
                                 return True;
                             }
-                        } except Exception { }
+                        } except Exception as e { }
                         return True;
                     } else {
                         console.warning(
@@ -931,7 +1329,7 @@ def _check_and_install_rust -> bool {
                 "  Skipping Rust installation. Please install manually.", style="muted"
             );
         }
-    } except Exception {
+    } except Exception as e {
         console.print(
             "  curl not found. Cannot install Rust automatically.", style="muted"
         );
@@ -950,11 +1348,14 @@ def _check_and_install_build_tools(system: str) -> bool {
         # Check for gcc/cc
         try {
             subprocess.run(
-                ["gcc", "--version"], capture_output=True, check=True, timeout=5
+                ["gcc", "--version"],
+                capture_output=True,
+                check=True,
+                timeout=SUBPROCESS_TIMEOUT_SHORT
             );
             console.print("  ✔ Build tools (gcc) found", style="success");
             return True;
-        } except Exception {
+        } except Exception as e {
             console.warning("  Build tools (gcc) not found");
             _try_install_linux_build_tools();
             return False;
@@ -963,13 +1364,16 @@ def _check_and_install_build_tools(system: str) -> bool {
         # Check for Xcode Command Line Tools
         try {
             result = subprocess.run(
-                ["xcode-select", "-p"], capture_output=True, text=True, timeout=5
+                ["xcode-select", "-p"],
+                capture_output=True,
+                text=True,
+                timeout=SUBPROCESS_TIMEOUT_SHORT
             );
             if result.returncode == 0 {
                 console.print("  ✔ Xcode Command Line Tools found", style="success");
                 return True;
             }
-        } except Exception { }
+        } except Exception as e { }
         console.warning("  Xcode Command Line Tools not found");
         console.print("  Install with: xcode-select --install", style="muted");
         console.print("\n  Would you like to open the installer?", style="info");
@@ -981,7 +1385,7 @@ def _check_and_install_build_tools(system: str) -> bool {
                     "  ✔ Installer opened. Please complete the installation.",
                     style="success"
                 );
-            } except Exception {
+            } except Exception as e {
                 console.warning(
                     "  Failed to open installer. Please run: xcode-select --install"
                 );
@@ -1005,9 +1409,6 @@ def _check_and_install_build_tools(system: str) -> bool {
 
 """Try to install Linux build tools."""
 def _try_install_linux_build_tools -> None {
-    import platform as platform_module;
-    import os;
-
     # Detect Linux distribution
     distro = _detect_linux_distro();
 
@@ -1029,13 +1430,15 @@ def _try_install_linux_build_tools -> None {
             if distro in ("ubuntu", "debian") {
                 console.print("  Installing build-essential...", style="muted");
                 result = subprocess.run(
-                    ["sudo", "apt-get", "update"], check=False, timeout=60
+                    ["sudo", "apt-get", "update"],
+                    check=False,
+                    timeout=SUBPROCESS_TIMEOUT_MEDIUM
                 );
                 if result.returncode == 0 {
                     result = subprocess.run(
                         ["sudo", "apt-get", "install", "-y", "build-essential"],
                         check=False,
-                        timeout=300
+                        timeout=SUBPROCESS_TIMEOUT_LONG
                     );
                     if result.returncode == 0 {
                         console.print("  ✔ Build tools installed", style="success");
@@ -1047,7 +1450,7 @@ def _try_install_linux_build_tools -> None {
                 result = subprocess.run(
                     ["sudo", "dnf", "install", "-y", "gcc", "gcc-c++"],
                     check=False,
-                    timeout=300
+                    timeout=SUBPROCESS_TIMEOUT_LONG
                 );
                 if result.returncode == 0 {
                     console.print("  ✔ Build tools installed", style="success");
@@ -1058,7 +1461,7 @@ def _try_install_linux_build_tools -> None {
                 result = subprocess.run(
                     ["sudo", "pacman", "-S", "--noconfirm", "base-devel"],
                     check=False,
-                    timeout=300
+                    timeout=SUBPROCESS_TIMEOUT_LONG
                 );
                 if result.returncode == 0 {
                     console.print("  ✔ Build tools installed", style="success");
@@ -1074,7 +1477,6 @@ def _try_install_linux_build_tools -> None {
 
 """Detect Linux distribution."""
 def _detect_linux_distro -> str | None {
-    import os;
     try {
         # Check /etc/os-release
         if os.path.exists("/etc/os-release") {
@@ -1092,7 +1494,7 @@ def _detect_linux_distro -> str | None {
                 }
             }
         }
-    } except Exception {
+    } except Exception as e {
         return None;
     }
 }
@@ -1103,11 +1505,14 @@ def _check_and_install_linux_dependencies -> None {
     pkg_config_ok = False;
     try {
         subprocess.run(
-            ["pkg-config", "--version"], capture_output=True, check=True, timeout=5
+            ["pkg-config", "--version"],
+            capture_output=True,
+            check=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         console.print("  ✔ pkg-config found", style="success");
         pkg_config_ok = True;
-    } except Exception {
+    } except Exception as e {
         console.warning("  pkg-config not found");
     }
 
@@ -1117,13 +1522,13 @@ def _check_and_install_linux_dependencies -> None {
         result = subprocess.run(
             ["pkg-config", "--exists", "webkit2gtk-4.1"],
             capture_output=True,
-            timeout=5
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         if result.returncode == 0 {
             console.print("  ✔ GTK/WebKit libraries found", style="success");
             webkit_ok = True;
         }
-    } except Exception {
+    } except Exception as e {
         console.warning("  GTK/WebKit libraries not found");
     }
 
@@ -1169,13 +1574,15 @@ def _try_install_linux_system_deps(distro: str) -> None {
             ];
             console.print("  Installing dependencies...", style="muted");
             result = subprocess.run(
-                ["sudo", "apt-get", "update"], check=False, timeout=60
+                ["sudo", "apt-get", "update"],
+                check=False,
+                timeout=SUBPROCESS_TIMEOUT_MEDIUM
             );
             if result.returncode == 0 {
                 result = subprocess.run(
                     ["sudo", "apt-get", "install", "-y"] + deps,
                     check=False,
-                    timeout=600
+                    timeout=SUBPROCESS_TIMEOUT_BUILD
                 );
                 if result.returncode == 0 {
                     console.print("  ✔ Dependencies installed", style="success");
@@ -1193,7 +1600,9 @@ def _try_install_linux_system_deps(distro: str) -> None {
             ];
             console.print("  Installing dependencies...", style="muted");
             result = subprocess.run(
-                ["sudo", "dnf", "install", "-y"] + deps, check=False, timeout=600
+                ["sudo", "dnf", "install", "-y"] + deps,
+                check=False,
+                timeout=SUBPROCESS_TIMEOUT_BUILD
             );
             if result.returncode == 0 {
                 console.print("  ✔ Dependencies installed", style="success");
@@ -1216,7 +1625,7 @@ def _try_install_linux_system_deps(distro: str) -> None {
             result = subprocess.run(
                 ["sudo", "pacman", "-S", "--noconfirm"] + deps,
                 check=False,
-                timeout=600
+                timeout=SUBPROCESS_TIMEOUT_BUILD
             );
             if result.returncode == 0 {
                 console.print("  ✔ Dependencies installed", style="success");
@@ -1295,7 +1704,10 @@ def _check_python_and_jaclang -> None {
 
     try {
         result = subprocess.run(
-            ["python3", "--version"], capture_output=True, text=True, timeout=5
+            ["python3", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         if result.returncode == 0 {
             python_version = result.stdout.strip();
@@ -1303,13 +1715,16 @@ def _check_python_and_jaclang -> None {
             python_ok = True;
             python_cmd = "python3";
         }
-    } except Exception { }
+    } except Exception as e { }
 
     # Try python command as fallback if python3 not found
     if not python_ok {
         try {
             result = subprocess.run(
-                ["python", "--version"], capture_output=True, text=True, timeout=5
+                ["python", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=SUBPROCESS_TIMEOUT_SHORT
             );
             if result.returncode == 0 {
                 python_version = result.stdout.strip();
@@ -1317,7 +1732,7 @@ def _check_python_and_jaclang -> None {
                 python_ok = True;
                 python_cmd = "python";
             }
-        } except Exception { }
+        } except Exception as e { }
     }
 
     if not python_ok {
@@ -1333,20 +1748,21 @@ def _check_python_and_jaclang -> None {
     }
 
     # Check jaclang using the detected python command
+    # Use longer timeout - first run compiles ~20 modules on Windows
     jaclang_ok = False;
     try {
         result = subprocess.run(
             [python_cmd, "-m", "jaclang", "--version"],
             capture_output=True,
             text=True,
-            timeout=5
+            timeout=SUBPROCESS_TIMEOUT_MEDIUM
         );
         if result.returncode == 0 {
             version = result.stdout.strip();
             console.print(f"  ✔ jaclang found: {version}", style="success");
             jaclang_ok = True;
         }
-    } except Exception { }
+    } except Exception as e { }
 
     if not jaclang_ok {
         console.warning("  jaclang not found");
@@ -1362,7 +1778,7 @@ def _check_python_and_jaclang -> None {
                 result = subprocess.run(
                     [python_cmd, "-m", "pip", "install", "jaclang"],
                     check=False,
-                    timeout=300,
+                    timeout=SUBPROCESS_TIMEOUT_LONG,
                     capture_output=False  # Show output
                 );
                 if result.returncode == 0 {
@@ -1387,6 +1803,37 @@ def _check_python_and_jaclang -> None {
             );
         }
     }
+
+    # Check for PyInstaller (optional, for standalone builds)
+    pyinstaller_ok = False;
+    try {
+        result = subprocess.run(
+            [python_cmd, "-m", "PyInstaller", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
+        );
+        if result.returncode == 0 {
+            version = result.stdout.strip();
+            console.print(
+                f"  ✔ PyInstaller found: {version} (standalone builds available)",
+                style="success"
+            );
+            pyinstaller_ok = True;
+        }
+    } except Exception as e { }
+
+    if not pyinstaller_ok {
+        console.print(
+            "  ⚠ PyInstaller not found - required for standalone builds",
+            style="warning"
+        );
+        console.print("  Install with: pip install pyinstaller", style="muted");
+        console.print(
+            "  Without PyInstaller, builds will fall back to wrapper mode (requires Python on user machine)",
+            style="muted"
+        );
+    }
 }
 
 """Check and install Tauri CLI if needed."""
@@ -1395,14 +1842,17 @@ def _check_and_install_tauri_cli -> None {
     cargo_tauri_ok = False;
     try {
         result = subprocess.run(
-            ["cargo", "tauri", "--version"], capture_output=True, text=True, timeout=5
+            ["cargo", "tauri", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         if result.returncode == 0 {
             version = result.stdout.strip();
             console.print(f"  ✔ Tauri CLI found (cargo): {version}", style="success");
             return;
         }
-    } except Exception { }
+    } except Exception as e { }
 
     # Check if bun tauri CLI is available (global install)
     import from jac_client.plugin.utils { get_bun }
@@ -1411,7 +1861,7 @@ def _check_and_install_tauri_cli -> None {
     if bun_path {
         try {
             result = subprocess.run(
-                [bun_path, "pm", "ls", "-g"], capture_output=True, text=True, timeout=5
+                [bun_path, "pm", "ls", "-g"], capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT_SHORT
             );
             if result.returncode == 0 and "@tauri-apps/cli" in result.stdout {
                 console.print("  ✔ Tauri CLI found (bun)", style="success");
@@ -1430,10 +1880,13 @@ def _check_and_install_tauri_cli -> None {
     cargo_available = False;
     try {
         subprocess.run(
-            ["cargo", "--version"], capture_output=True, check=True, timeout=5
+            ["cargo", "--version"],
+            capture_output=True,
+            check=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
         cargo_available = True;
-    } except Exception { }
+    } except Exception as e { }
 
     # Check if bun is available
     bun_available = bun_path is not None;
@@ -1460,7 +1913,7 @@ def _check_and_install_tauri_cli -> None {
                 result = subprocess.run(
                     ["cargo", "install", "tauri-cli"],
                     check=False,
-                    timeout=600,
+                    timeout=SUBPROCESS_TIMEOUT_BUILD,
                     capture_output=False  # Show output
                 );
                 if result.returncode == 0 {
@@ -1479,7 +1932,7 @@ def _check_and_install_tauri_cli -> None {
                 result = subprocess.run(
                     [bun_path, "add", "-g", "@tauri-apps/cli"],
                     check=False,
-                    timeout=300,
+                    timeout=SUBPROCESS_TIMEOUT_LONG,
                     capture_output=False  # Show output
                 );
                 if result.returncode == 0 {
@@ -1519,11 +1972,24 @@ impl DesktopTarget.build(
     entry_file: Path, project_dir: Path, platform: Optional[str] = None
 ) -> Path {
     import from jac_client.plugin.src.vite_bundler { ViteBundler }
+    import platform as platform_mod;
     console.print("\n🖥️  Building desktop app (Tauri)", style="bold");
     # Check if setup has been run
     tauri_dir = project_dir / "src-tauri";
     if not tauri_dir.exists() {
         raise RuntimeError("Desktop target not set up. Run 'jac setup desktop' first.");
+    }
+    # Check GLIBC compatibility for Linux production builds
+    if platform_mod.system() == "Linux" {
+        glibc_check = _check_glibc_compatibility();
+        is_compatible = glibc_check[0];
+        glibc_msg = glibc_check[2];
+        if not is_compatible {
+            console.print(f"\n[yellow]{glibc_msg}[/yellow]");
+            _suggest_docker_build(project_dir);
+        } elif glibc_msg {
+            console.print(f"  {glibc_msg}", style="muted");
+        }
     }
     # Bake TOML base_url into the bundle; otherwise sidecar discovers port at runtime.
     toml_base_url = _get_toml_api_base_url(project_dir);
@@ -1547,7 +2013,19 @@ impl DesktopTarget.build(
     sidecar_bundled = False;
     try {
         console.print("  Step 1.5: Bundling sidecar (Jac backend)...", style="muted");
-        sidecar_path = _bundle_sidecar(entry_file, project_dir, tauri_dir, platform);
+        # Load desktop config to get plugins configuration
+        import from jac_client.plugin.src.desktop_config { DesktopConfig }
+        plugins_config = None;
+        try {
+            desktop_config = DesktopConfig(project_dir=project_dir);
+            plugins_config = desktop_config.get_plugins_config();
+            if plugins_config {
+                console.print(f"  Plugins config: {plugins_config}", style="muted");
+            }
+        } except Exception as config_err {
+            console.warning(f"  Could not load plugins config: {config_err}, using defaults");
+        }
+        sidecar_path = _bundle_sidecar(entry_file, project_dir, tauri_dir, platform, plugins_config);
         if sidecar_path and sidecar_path.exists() {
             console.print(f"  ✔ Sidecar bundled: {sidecar_path}", style="success");
             sidecar_bundled = True;
@@ -1580,10 +2058,11 @@ try:
 except:
     sys.exit(1)  # Error or invalid
 ''';
+            python_cmd = "python" if sys.platform == "win32" else "python3";
             result = subprocess.run(
-                ["python3", "-c", check_code, str(icon_path)],
+                [python_cmd, "-c", check_code, str(icon_path)],
                 capture_output=True,
-                timeout=5
+                timeout=SUBPROCESS_TIMEOUT_SHORT
             );
             if result.returncode != 0 {
                 console.warning(
@@ -1595,7 +2074,7 @@ except:
                 }
                 _generate_default_icons(tauri_dir);
             }
-        } except Exception {
+        } except Exception as e {
             # If check fails, try to regenerate anyway
             console.warning("  Could not verify icon, regenerating...");
             _generate_default_icons(tauri_dir);
@@ -1620,10 +2099,13 @@ def _add_sidecar_to_config(tauri_dir: Path, config: dict) -> None {
     binaries_dir = tauri_dir / "binaries";
     if not binaries_dir.exists() {
         return;  # No binaries directory, skip
-
     }
 
-    # Find sidecar wrapper script (must exist and be executable)
+    # Check for onedir mode folder first (PyInstaller onedir output)
+    onedir_folder = binaries_dir / "jac-sidecar";
+    has_onedir = onedir_folder.exists() and onedir_folder.is_dir();
+
+    # Find sidecar files (onefile mode or wrapper scripts)
     sidecar_files = [];
     for pattern in [
         "jac-sidecar.sh",
@@ -1639,7 +2121,7 @@ def _add_sidecar_to_config(tauri_dir: Path, config: dict) -> None {
         }
     }
 
-    if not sidecar_files {
+    if not sidecar_files and not has_onedir {
         # Remove sidecar from resources if it was previously added but no longer exists
         if "bundle" in config and "resources" in config["bundle"] {
             resources = config["bundle"]["resources"];
@@ -1651,7 +2133,6 @@ def _add_sidecar_to_config(tauri_dir: Path, config: dict) -> None {
             ];
         }
         return;  # No sidecar found, skip
-
     }
 
     # Tauri v2 uses "resources" in bundle section for sidecars
@@ -1664,7 +2145,16 @@ def _add_sidecar_to_config(tauri_dir: Path, config: dict) -> None {
         config["bundle"]["resources"] = [];
     }
 
-    # Add sidecar binary path (relative to tauri_dir)
+    # Add onedir folder glob pattern (all DLLs and exe inside)
+    if has_onedir {
+        onedir_resource = "binaries/jac-sidecar/**/*";
+        if onedir_resource not in config["bundle"]["resources"] {
+            config["bundle"]["resources"].append(onedir_resource);
+            console.print(f"  ✔ Added sidecar folder to config: {onedir_resource}", style="success");
+        }
+    }
+
+    # Add individual sidecar files (onefile mode or wrapper scripts)
     for sidecar_file in sidecar_files {
         rel_path = sidecar_file.relative_to(tauri_dir);
         rel_str = str(rel_path.as_posix());
@@ -1672,6 +2162,74 @@ def _add_sidecar_to_config(tauri_dir: Path, config: dict) -> None {
             config["bundle"]["resources"].append(rel_str);
             console.print(f"  ✔ Added sidecar to config: {rel_str}", style="success");
         }
+    }
+}
+
+"""Bundle jac source files for desktop build."""
+def _bundle_jac_sources(project_dir: Path, tauri_dir: Path, config: dict) -> None {
+    jac_dir = tauri_dir / "jac";
+    jac_dir.mkdir(parents=True, exist_ok=True);
+
+    # Collect all .jac files from project (excluding .jac hidden directories)
+    jac_files = [];
+    for jac_file in project_dir.rglob("*.jac") {
+        # Skip hidden directories and generated files
+        parts = jac_file.relative_to(project_dir).parts;
+        if any(p.startswith(".") for p in parts) {
+            continue;
+        }
+        if "src-tauri" in parts {
+            continue;
+        }
+        jac_files.append(jac_file);
+    }
+
+    if not jac_files {
+        return;
+    }
+
+    # Copy jac files preserving directory structure
+    for jac_file in jac_files {
+        rel_path = jac_file.relative_to(project_dir);
+        dest = jac_dir / rel_path;
+        dest.parent.mkdir(parents=True, exist_ok=True);
+        shutil.copy2(jac_file, dest);
+    }
+
+    console.print(
+        f"  ✔ Bundled {len(jac_files)} .jac file(s) for desktop", style="success"
+    );
+
+    # Copy jac.toml to the jac directory (required for config discovery in bundled app)
+    jac_toml = project_dir / "jac.toml";
+    if jac_toml.exists() {
+        shutil.copy2(jac_toml, jac_dir / "jac.toml");
+        console.print("  ✔ Bundled jac.toml for desktop", style="success");
+    }
+
+    # Copy assets directory to jac directory (for static asset serving by sidecar)
+    assets_dir = project_dir / "assets";
+    jac_assets_dir = jac_dir / "assets";
+    if assets_dir.exists() and assets_dir.is_dir() {
+        if jac_assets_dir.exists() {
+            shutil.rmtree(jac_assets_dir);
+        }
+        shutil.copytree(assets_dir, jac_assets_dir);
+        console.print("  ✔ Bundled assets/ for desktop", style="success");
+    }
+
+    # Add jac/* to bundle resources
+    if "bundle" not in config {
+        config["bundle"] = {};
+    }
+    if "resources" not in config["bundle"] {
+        config["bundle"]["resources"] = [];
+    }
+
+    # Add jac directory pattern if not already present
+    jac_resource = "jac/**/*";
+    if jac_resource not in config["bundle"]["resources"] {
+        config["bundle"]["resources"].append(jac_resource);
     }
 }
 
@@ -1684,20 +2242,19 @@ def _populate_icon_array(tauri_dir: Path, config: dict) {
     if "icon" not in config["bundle"]
     or not config["bundle"]["icon"]
     or len(config["bundle"]["icon"]) == 0 {
-        # Scan icons directory for PNG files
+        # Scan icons directory for PNG and ICO files
         icons_dir = tauri_dir / "icons";
         icon_files = [];
         if icons_dir.exists() {
             for icon_file in icons_dir.iterdir() {
-                if icon_file.is_file() and icon_file.suffix.lower() == ".png" {
+                if icon_file.is_file() and icon_file.suffix.lower() in (".png", ".ico") {
                     # Path relative to tauri.conf.json (which is in tauri_dir)
-                    # So icons/icon.png is the correct relative path
                     icon_rel_path = icon_file.relative_to(tauri_dir);
                     icon_files.append(str(icon_rel_path.as_posix()));
                 }
             }
         }
-        # Sort to ensure consistent ordering (icon.png first if it exists)
+        # Sort to ensure consistent ordering (icon.ico, icon.png)
         icon_files.sort();
         config["bundle"]["icon"] = icon_files;
         if icon_files {
@@ -1749,7 +2306,7 @@ def _update_tauri_config_for_build(
     project_dir: Path,
     web_bundle_path: Path,
     sidecar_bundled: bool = False
-) {
+) -> None {
     import json;
 
     config_path = tauri_dir / "tauri.conf.json";
@@ -1807,6 +2364,9 @@ def _update_tauri_config_for_build(
     # Populate icon array if empty or missing
     _populate_icon_array(tauri_dir, config);
 
+    # Bundle jac source files for desktop build
+    _bundle_jac_sources(project_dir, tauri_dir, config);
+
     # Add sidecar binary if it exists
     _add_sidecar_to_config(tauri_dir, config);
 
@@ -1821,35 +2381,28 @@ def _update_tauri_config_for_build(
 """Check if appimagetool is available and can run."""
 def _check_appimagetool -> tuple[bool, str | None] {
     # First check if the command exists
-    try {
-        result = subprocess.run(
-            ["which", "appimagetool"], capture_output=True, timeout=2
-        );
-        if result.returncode != 0 {
-            return (False, "appimagetool not found in PATH");
-        }
-    } except Exception {
-        return (False, "Could not check for appimagetool");
+    (exists, _) = _check_command_available(["which", "appimagetool"], timeout=2);
+    if not exists {
+        return (False, "appimagetool not found in PATH");
     }
 
     # Try to run appimagetool to see if it works
     try {
         result = subprocess.run(
-            ["appimagetool", "--version"], capture_output=True, timeout=5, text=True
+            ["appimagetool", "--version"],
+            capture_output=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT,
+            text=True
         );
         if result.returncode == 0 {
             return (True, None);
-        } else {
-            # Check if it's a FUSE error
-            error_output = result.stderr or result.stdout or "";
-            if "fuse" in error_output.lower() or "libfuse" in error_output.lower() {
-                return (
-                    False,
-                    "FUSE library not available. Install with: sudo apt-get install libfuse2"
-                );
-            }
-            return (False, f"appimagetool failed: {error_output[:100]}");
         }
+        # Check if it's a FUSE error
+        error_output = result.stderr or result.stdout or "";
+        if _is_fuse_error(error_output) {
+            return (False, _get_fuse_install_hint());
+        }
+        return (False, f"appimagetool failed: {error_output[:100]}");
     } except FileNotFoundError {
         return (False, "appimagetool not found");
     } except subprocess.TimeoutExpired {
@@ -1922,22 +2475,16 @@ def _create_appimage_from_appdir(appdir_path: Path) -> Path | None {
             check=False,  # Don't raise on error, we'll check manually
             capture_output=True,
             text=True,
-            timeout=300  # 5 minute timeout
+            timeout=SUBPROCESS_TIMEOUT_LONG
         );
 
         if result.returncode != 0 {
             error_output = result.stderr or result.stdout or "Unknown error";
-            # Check for FUSE-related errors
-            if "fuse" in error_output.lower()
-            or "libfuse" in error_output.lower()
-            or "FUSE" in error_output {
+            if _is_fuse_error(error_output) {
                 console.warning(
                     "  Failed to create AppImage: FUSE library not available"
                 );
-                console.print(
-                    "  Install FUSE with: sudo apt-get install -y libfuse2",
-                    style="muted"
-                );
+                console.print(f"  {_get_fuse_install_hint()}", style="muted");
                 console.print(
                     "  For WSL2, you may also need: sudo apt-get install -y fuse",
                     style="muted"
@@ -1964,10 +2511,8 @@ def _create_appimage_from_appdir(appdir_path: Path) -> Path | None {
         return None;
     } except Exception as e {
         error_msg = str(e);
-        if "fuse" in error_msg.lower() or "libfuse" in error_msg.lower() {
-            console.warning(
-                "  FUSE library error. Install with: sudo apt-get install -y libfuse2"
-            );
+        if _is_fuse_error(error_msg) {
+            console.warning(f"  FUSE library error. {_get_fuse_install_hint()}");
         } else {
             console.warning(f"  Error creating AppImage: {error_msg[:200]}");
         }
@@ -1976,21 +2521,20 @@ def _create_appimage_from_appdir(appdir_path: Path) -> Path | None {
 }
 
 """Run cargo tauri build and return path to bundle."""
-def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
-    import os;
-
+def _run_tauri_build(tauri_dir: Path, target_platform: Optional[str] = None) -> Path {
+    import platform as platform_mod;
     # Determine target based on platform
     target = None;
-    if platform == "windows" {
+    if target_platform == "windows" {
         target = "x86_64-pc-windows-msvc";
-    } elif platform == "macos" {
+    } elif target_platform == "macos" {
         # Try to detect architecture
-        if platform.machine() == "arm64" {
+        if platform_mod.machine() == "arm64" {
             target = "aarch64-apple-darwin";
         } else {
             target = "x86_64-apple-darwin";
         }
-    } elif platform == "linux" {
+    } elif target_platform == "linux" {
         target = "x86_64-unknown-linux-gnu";
     }
 
@@ -2012,7 +2556,7 @@ def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
                     use_bun = True;
                 }
             }
-        } except Exception {
+        } except Exception as e {
             console.warning("  Failed to check package.json for tauri scripts");
         }
     }
@@ -2073,8 +2617,8 @@ def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
     ];
 
     # For Linux: if no AppImage but AppDir exists, try to create AppImage
-    is_linux_build = (platform == "linux")
-    or (not platform and target and "linux" in target);
+    is_linux_build = (target_platform == "linux")
+    or (not target_platform and target and "linux" in target);
     if not installers and is_linux_build {
         appimage_dir = bundle_dir / "appimage";
         if appimage_dir.exists() {
@@ -2102,53 +2646,562 @@ def _run_tauri_build(tauri_dir: Path, platform: Optional[str] = None) -> Path {
     return bundle_dir;
 }
 
-"""Create Python-based sidecar wrapper script (no PyInstaller needed)."""
+"""Bundle sidecar for desktop distribution.
+
+By default, uses PyInstaller to create a standalone binary with Python + jaclang bundled.
+If PyInstaller fails or is unavailable, falls back to wrapper script that requires system Python.
+
+Set JAC_SIDECAR_STANDALONE=0 to skip PyInstaller and use wrapper script.
+"""
 def _bundle_sidecar(
     entry_file: Path,
     project_dir: Path,
     tauri_dir: Path,
-    platform: Optional[str] = None
+    target_platform: Optional[str] = None,
+    plugins_config: dict | None = None
 ) -> Path | None {
     import platform as platform_module;
-    import stat;
 
     # Determine output directory
     binaries_dir = tauri_dir / "binaries";
     binaries_dir.mkdir(parents=True, exist_ok=True);
 
-    # Determine script name based on platform
-    if platform == "windows"
-    or (platform is None and platform_module.system() == "Windows") {
-        script_name = "jac-sidecar.bat";
-        is_windows = True;
-    } else {
-        script_name = "jac-sidecar.sh";
-        is_windows = False;
+    # Determine platform
+    is_windows = target_platform == "windows"
+    or (target_platform is None and platform_module.system() == "Windows");
+
+    # Use PyInstaller by default for standalone distribution (no Python required on user machine)
+    # Set JAC_SIDECAR_STANDALONE=0 to use wrapper script instead (requires Python + jaclang)
+    use_pyinstaller = os.environ.get("JAC_SIDECAR_STANDALONE", "1") != "0";
+
+    if use_pyinstaller {
+        result = _bundle_sidecar_pyinstaller(
+            entry_file, project_dir, tauri_dir, binaries_dir, is_windows, plugins_config
+        );
+        if result {
+            return result;
+        }
+        console.warning("PyInstaller bundling failed, falling back to wrapper script");
     }
 
-    output_path = binaries_dir / script_name;
+    # Fallback: Create wrapper script
+    return _create_sidecar_wrapper(binaries_dir, is_windows);
+}
 
-    # Create wrapper script that runs Python module
-    # This approach avoids PyInstaller issues and is much simpler
+"""Bundle sidecar using PyInstaller for standalone distribution."""
+def _bundle_sidecar_pyinstaller(
+    entry_file: Path,
+    project_dir: Path,
+    tauri_dir: Path,
+    binaries_dir: Path,
+    is_windows: bool,
+    plugins_config: dict | None = None
+) -> Path | None {
+    import sys;
+    import shutil;
+
+    # Check if PyInstaller is available
+    try {
+        result = subprocess.run(
+            [sys.executable, "-m", "PyInstaller", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        );
+        if result.returncode != 0 {
+            console.warning(
+                "PyInstaller not installed. Install with: pip install pyinstaller"
+            );
+            return None;
+        }
+        pyinstaller_version = result.stdout.strip();
+        console.print(f"  Using PyInstaller {pyinstaller_version}", style="muted");
+    } except Exception as e {
+        console.warning(f"PyInstaller check failed: {e}");
+        return None;
+    }
+
+    # Determine output binary name
+    binary_name = "jac-sidecar.exe" if is_windows else "jac-sidecar";
+
+    # Create entry script for PyInstaller (can't use -m syntax in spec)
+    entry_script = tauri_dir / "sidecar_entry.py";
+    with open(entry_script, "w") as f {
+        f.write(
+            '''#!/usr/bin/env python3
+# Entry point for PyInstaller-bundled sidecar
+# Plugin registration for frozen apps is handled in sidecar/main.py
+
+import os
+import sys
+
+# Force UTF-8 mode on Windows to avoid charmap codec errors
+os.environ["PYTHONUTF8"] = "1"
+
+# Windows multiprocessing freeze support - MUST be called before any other imports
+# This is required for PyInstaller apps that use multiprocessing on Windows
+if sys.platform == "win32":
+    import multiprocessing
+    multiprocessing.freeze_support()
+
+from jac_client.plugin.src.targets.desktop.sidecar.main import main
+if __name__ == "__main__":
+    main()
+'''
+        );
+    }
+
+    # Auto-install Python dependencies from jac.toml before bundling
+    jac_toml_path = project_dir / "jac.toml";
+    if jac_toml_path.exists() {
+        try {
+            import tomllib;
+            with open(jac_toml_path, "rb") as f {
+                toml_data = tomllib.load(f);
+            }
+            python_deps = toml_data.get("dependencies", {});
+
+            # Count valid dependencies first
+            dep_count = 0;
+            for (name, version) in python_deps.items() {
+                if isinstance(version, str) {
+                    dep_count += 1;
+                }
+            }
+
+            if dep_count > 0 {
+                console.print(f"  Installing {dep_count} Python dependencies from jac.toml...", style="muted");
+
+                # Install each dependency
+                for (name, version) in python_deps.items() {
+                    # Skip sub-tables (npm, git, etc.) - only process string values
+                    if not isinstance(version, str) {
+                        continue;
+                    }
+
+                    # Build pip install spec
+                    if version and not version.startswith("*") {
+                        dep_spec = f"{name}{version}";
+                    } else {
+                        dep_spec = name;
+                    }
+
+                    try {
+                        result = subprocess.run(
+                            [sys.executable, "-m", "pip", "install", dep_spec, "-q"],
+                            capture_output=True,
+                            text=True,
+                            timeout=120
+                        );
+                        if result.returncode == 0 {
+                            console.print(f"    ✔ {dep_spec}", style="success");
+                        } else {
+                            console.warning(f"    ✖ Failed to install {dep_spec}: {result.stderr.strip()}");
+                        }
+                    } except Exception as e {
+                        console.warning(f"    ✖ Failed to install {dep_spec}: {e}");
+                    }
+                }
+            }
+        } except Exception as e {
+            console.warning(f"  Could not read dependencies from jac.toml: {e}");
+        }
+    }
+
+    # Create PyInstaller spec file
+    spec_path = tauri_dir / "jac-sidecar.spec";
+    spec_content = _generate_pyinstaller_spec(entry_script, project_dir, binary_name, plugins_config);
+    with open(spec_path, "w") as f {
+        f.write(spec_content);
+    }
+    console.print(f"  Generated PyInstaller spec: {spec_path.name}", style="muted");
+
+    # Create runtime hook to force UTF-8 mode (fixes charmap errors on Windows)
+    runtime_hook = tauri_dir / "rthook_utf8.py";
+    with open(runtime_hook, "w") as f {
+        f.write("import os; os.environ['PYTHONUTF8'] = '1'\n");
+    }
+
+    # Run PyInstaller
+    console.print(
+        "  Bundling sidecar with PyInstaller (this may take a while)...", style="muted"
+    );
+    dist_dir = tauri_dir / "dist";
+    build_dir = tauri_dir / "build";
+
+    try {
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "PyInstaller",
+                # "--clean",
+                "--noconfirm",
+                "--distpath",
+                str(dist_dir),
+                "--workpath",
+                str(build_dir),
+                str(spec_path)
+            ],
+            capture_output=False,
+            timeout=SUBPROCESS_TIMEOUT_BUILD,
+            cwd=str(project_dir)
+        );
+
+        if result.returncode != 0 {
+            console.warning("PyInstaller failed (see output above)");
+            return None;
+        }
+
+        # Find the bundled binary (onedir mode = folder with exe inside)
+        bundled_dir = dist_dir / "jac-sidecar";
+        bundled_binary = bundled_dir / binary_name;
+
+        if not bundled_binary.exists() {
+            # Fallback: check for onefile mode output
+            bundled_binary = dist_dir / binary_name;
+            if not bundled_binary.exists() {
+                console.warning(f"Bundled binary not found at {bundled_binary}");
+                return None;
+            }
+            # Onefile mode - just copy the single binary
+            output_path = binaries_dir / binary_name;
+            shutil.copy2(bundled_binary, output_path);
+        } else {
+            # Onedir mode - copy entire jac-sidecar folder to binaries/
+            output_dir = binaries_dir / "jac-sidecar";
+            if output_dir.exists() {
+                shutil.rmtree(output_dir);
+            }
+            shutil.copytree(bundled_dir, output_dir);
+            output_path = output_dir / binary_name;
+        }
+
+        # Cleanup build artifacts
+        if build_dir.exists() {
+            shutil.rmtree(build_dir);
+        }
+
+        console.print(
+            f"  ✔ Bundled standalone sidecar: {output_path.name}", style="success"
+        );
+        console.print(
+            f"  Size: {output_path.stat().st_size / 1024 / 1024:.1f} MB", style="muted"
+        );
+        return output_path;
+    } except subprocess.TimeoutExpired {
+        console.warning("PyInstaller timed out after 60 minutes");
+        return None;
+    } except Exception as e {
+        console.warning(f"PyInstaller error: {e}");
+        return None;
+    }
+}
+
+"""Generate PyInstaller spec file for sidecar bundling."""
+def _generate_pyinstaller_spec(
+    entry_script: Path, project_dir: Path, binary_name: str,
+    plugins_config: dict | None = None
+) -> str {
+    # Default plugins config - all enabled
+    if plugins_config is None {
+        plugins_config = {
+            'jac_scale': True,
+            'byllm': True,
+            'jac_coder': True
+        };
+    }
+
+    # Convert plugins config to Python code string for the spec file
+    plugins_config_str = str(plugins_config);
+
+    # entry_script is the actual Python file to bundle (sidecar_entry.py)
+    return f'''# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec for Jac Sidecar
+# Auto-generated by jac-client desktop build
+
+import sys
+from pathlib import Path
+
+# Plugin configuration from [desktop.plugins] in jac.toml
+PLUGINS_CONFIG = {plugins_config_str}
+
+# Manual hidden imports - only for stdlib and PyInstaller runtime deps
+# (pip packages like jaclang, jac_client, websockets are handled by collect_all() below)
+hiddenimports = [
+    # Python stdlib modules (can't be collected via collect_all)
+    'sqlite3', 'hashlib', 'secrets', 'http.server', 'json',
+    'asyncio', 'inspect', 'typing', 'pathlib',
+    'pdb', 'bdb', 'cmd', 'code', 'codeop', 'readline',
+    # Windows multiprocessing support (required for frozen apps)
+    'multiprocessing', 'multiprocessing.pool', 'multiprocessing.process',
+    'multiprocessing.spawn', 'multiprocessing.popen_spawn_win32',
+    # PyInstaller runtime deps - use importlib.metadata instead of pkg_resources
+    'appdirs', 'setuptools',
+    'packaging', 'packaging.version', 'packaging.specifiers', 'packaging.requirements',
+    'importlib.metadata', 'importlib.resources',
+    # jaraco packages (setuptools deps for Python 3.12+)
+    'jaraco', 'jaraco.functools', 'jaraco.context', 'jaraco.text',
+]
+
+# Check plugin availability (collect_all() below handles the actual bundling)
+print("\\n[Checking plugins...]")
+if PLUGINS_CONFIG.get('jac_scale', True):
+    try:
+        import jac_scale
+        print("  jac_scale: available")
+    except ImportError:
+        print("  jac_scale: not installed")
+else:
+    print("  jac_scale: disabled in config")
+
+if PLUGINS_CONFIG.get('byllm', True):
+    try:
+        import byllm
+        print("  byllm: available")
+    except ImportError:
+        print("  byllm: not installed")
+else:
+    print("  byllm: disabled in config")
+
+if PLUGINS_CONFIG.get('jac_coder', True):
+    try:
+        import jac_coder
+        print("  jac_coder: available")
+    except ImportError:
+        print("  jac_coder: not installed")
+else:
+    print("  jac_coder: disabled in config")
+
+# Use collect_all() for comprehensive package bundling (scalable approach)
+from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules, copy_metadata
+
+datas = []
+binaries = []
+all_hiddenimports = []
+
+def safe_collect_all(pkg_name):
+    """Safely collect all data, binaries, and imports for a package."""
+    try:
+        d, b, h = collect_all(pkg_name)
+        print(f"  collect_all('{{pkg_name}}'): {{len(d)}} datas, {{len(b)}} binaries, {{len(h)}} imports")
+        return d, b, h
+    except Exception as e:
+        print(f"  collect_all('{{pkg_name}}'): skipped - {{e}}")
+        return [], [], []
+
+def get_package_deps(pkg_name):
+    """Get direct dependencies of a package from its metadata."""
+    try:
+        from importlib.metadata import requires
+        reqs = requires(pkg_name) or []
+        deps = []
+        for req in reqs:
+            # Parse requirement string (e.g., "litellm>=1.81.15,<1.83.0" -> "litellm")
+            dep_name = req.split('[')[0].split('>')[0].split('<')[0].split('=')[0].split('!')[0].split(';')[0].strip()
+            if dep_name:
+                # Convert package name to module name
+                module_name = dep_name.replace('-', '_')
+                deps.append(module_name)
+        return deps
+    except Exception:
+        return []
+
+def collect_with_deps(pkg_name, collected=None):
+    """Collect a package and its dependencies recursively."""
+    if collected is None:
+        collected = set()
+    if pkg_name in collected:
+        return [], [], []
+    collected.add(pkg_name)
+
+    all_d, all_b, all_h = safe_collect_all(pkg_name)
+
+    # Also collect direct dependencies
+    for dep in get_package_deps(pkg_name):
+        if dep not in collected:
+            d, b, h = safe_collect_all(dep)
+            all_d += d
+            all_b += b
+            all_h += h
+            collected.add(dep)
+
+    return all_d, all_b, all_h
+
+# Track collected packages to avoid duplicates
+collected_packages = set()
+
+# Core packages - always bundle completely (with their dependencies)
+print("\\n[Collecting core packages...]")
+for pkg in ['jaclang', 'jac_client', 'setuptools', 'appdirs', 'packaging']:
+    d, b, h = collect_with_deps(pkg, collected_packages)
+    datas += d
+    binaries += b
+    all_hiddenimports += h
+
+# Plugin packages - bundle based on config (with their dependencies)
+print("\\n[Collecting plugin packages...]")
+if PLUGINS_CONFIG.get('jac_scale', True):
+    d, b, h = collect_with_deps('jac_scale', collected_packages)
+    datas += d
+    binaries += b
+    all_hiddenimports += h
+
+if PLUGINS_CONFIG.get('byllm', True):
+    d, b, h = collect_with_deps('byllm', collected_packages)
+    datas += d
+    binaries += b
+    all_hiddenimports += h
+
+if PLUGINS_CONFIG.get('jac_coder', True):
+    d, b, h = collect_with_deps('jac_coder', collected_packages)
+    datas += d
+    binaries += b
+    all_hiddenimports += h
+
+# Merge collected imports with manual hiddenimports
+hiddenimports.extend(all_hiddenimports)
+
+# Add project .jac files
+project_dir = Path(r'{project_dir}')
+for jac_file in project_dir.rglob('*.jac'):
+    rel_path = jac_file.relative_to(project_dir)
+    datas.append((str(jac_file), str(rel_path.parent) or '.'))
+
+# Add jac.toml if exists
+jac_toml = project_dir / 'jac.toml'
+if jac_toml.exists():
+    datas.append((str(jac_toml), '.'))
+
+# Add assets directory if exists (templates, configs, etc.)
+assets_dir = project_dir / 'assets'
+if assets_dir.is_dir():
+    for asset_file in assets_dir.rglob('*'):
+        if asset_file.is_file():
+            rel = asset_file.relative_to(project_dir)
+            datas.append((str(asset_file), str(rel.parent)))
+    print(f"Added assets directory to sidecar bundle")
+
+# Add .env file if exists
+env_file = project_dir / '.env'
+if env_file.is_file():
+    datas.append((str(env_file), '.'))
+    print("Added .env to sidecar bundle")
+
+# Read Python dependencies from jac.toml and add to hiddenimports
+try:
+    import tomllib
+    with open(jac_toml, 'rb') as f:
+        toml_data = tomllib.load(f)
+    # Get [dependencies] section (Python packages)
+    python_deps = toml_data.get('dependencies', {{}})
+    for dep_name, dep_version in python_deps.items():
+        # Skip sub-tables like npm, git, etc.
+        if isinstance(dep_version, str):
+            # Convert package name to module name (e.g., jac-scale -> jac_scale)
+            module_name = dep_name.replace('-', '_')
+            hiddenimports.append(module_name)
+            try:
+                hiddenimports += collect_submodules(module_name)
+            except Exception:
+                pass
+    print(f"Added {{len([d for d in python_deps.values() if isinstance(d, str)])}} Python dependencies from jac.toml")
+
+    # Read [desktop.bundle] extra_data patterns from jac.toml
+    desktop_cfg = toml_data.get('desktop', {{}})
+    bundle_cfg = desktop_cfg.get('bundle', {{}}) if isinstance(desktop_cfg, dict) else {{}}
+    extra_data_patterns = bundle_cfg.get('extra_data', []) if isinstance(bundle_cfg, dict) else []
+    if extra_data_patterns:
+        extra_count = 0
+        for pattern in extra_data_patterns:
+            if isinstance(pattern, str):
+                matched = list(project_dir.glob(pattern))
+                for match in matched:
+                    if match.is_file():
+                        rel = match.relative_to(project_dir)
+                        datas.append((str(match), str(rel.parent) or '.'))
+                        extra_count += 1
+        if extra_count:
+            print(f"Added {{extra_count}} extra data file(s) from [desktop.bundle] extra_data")
+
+except Exception as e:
+    print(f"Warning: Could not read Python dependencies from jac.toml: {{e}}")
+
+# Note: collect_all() already handles submodules, data files, and binaries
+# No need for separate collect_submodules() calls
+
+a = Analysis(
+    [r'{entry_script}'],
+    pathex=[str(project_dir)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=list(set(hiddenimports)),  # deduplicate
+    hookspath=[],
+    hooksconfig={{}},
+    runtime_hooks=[str(Path(r'{entry_script}').parent / 'rthook_utf8.py')],
+    excludes=['tkinter', 'matplotlib', 'numpy', 'pandas', 'scipy', 'pkg_resources'],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+# Use onedir mode instead of onefile - onefile hangs on Windows + Python 3.13
+# due to temp extraction issues. onedir ships DLLs alongside exe, no extraction needed.
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='{binary_name.replace(
+        ".exe", ""
+    )}',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='jac-sidecar',
+)
+''';
+}
+
+"""Create wrapper script for sidecar (requires system Python)."""
+def _create_sidecar_wrapper(binaries_dir: Path, is_windows: bool) -> Path {
+    import stat;
+
     if is_windows {
-        # Windows batch script
-        script_content = f'''@echo off
+        script_name = "jac-sidecar.bat";
+        script_content = '''@echo off
 REM Jac Sidecar Wrapper - Runs Jac backend using system Python
 REM This requires Python and jaclang to be installed
 
 python -m jac_client.plugin.src.targets.desktop.sidecar.main %*
 ''';
     } else {
-        # Unix shell script
+        script_name = "jac-sidecar.sh";
         script_content = '''#!/bin/bash
 # Jac Sidecar Wrapper - Runs Jac backend using system Python
 # This requires Python and jaclang to be installed
 
-exec python -m jac_client.plugin.src.targets.desktop.sidecar.main "$@"
+exec python3 -m jac_client.plugin.src.targets.desktop.sidecar.main "$@"
 ''';
     }
 
-    # Write the wrapper script
+    output_path = binaries_dir / script_name;
     with open(output_path, "w") as f {
         f.write(script_content);
     }
@@ -2160,8 +3213,15 @@ exec python -m jac_client.plugin.src.targets.desktop.sidecar.main "$@"
     }
 
     console.print(f"  ✔ Created sidecar wrapper: {script_name}", style="success");
-    console.print(f"  Note: Requires Python and jaclang to be installed", style="muted");
-    console.print(f"  Run: pip install jaclang", style="muted");
+    console.print(
+        f"  Note: Wrapper mode - requires Python and jaclang on user machine",
+        style="muted"
+    );
+    console.print(f"  Run: pip install jaclang jac-scale", style="muted");
+    console.print(
+        f"  This is fallback mode. For standalone build, ensure PyInstaller succeeds.",
+        style="muted"
+    );
 
     return output_path;
 }
@@ -2255,16 +3315,16 @@ impl DesktopTarget.dev(
         if vite_process {
             try {
                 vite_process.terminate();
-                vite_process.wait(timeout=5);
-            } except Exception {
+                vite_process.wait(timeout=SUBPROCESS_TIMEOUT_SHORT);
+            } except Exception as e {
                 vite_process.kill();
             }
         }
         if server_process {
             try {
                 server_process.terminate();
-                server_process.wait(timeout=5);
-            } except Exception {
+                server_process.wait(timeout=SUBPROCESS_TIMEOUT_SHORT);
+            } except Exception as e {
                 server_process.kill();
             }
         }
@@ -2292,7 +3352,7 @@ impl DesktopTarget.dev(
 }
 
 """Update tauri.conf.json for dev mode (point to dev server)."""
-def _update_tauri_config_for_dev(tauri_dir: Path) {
+def _update_tauri_config_for_dev(tauri_dir: Path) -> None {
     import json;
 
     config_path = tauri_dir / "tauri.conf.json";
@@ -2350,10 +3410,14 @@ def _update_tauri_config_for_dev(tauri_dir: Path) {
 
 """Run tauri dev command."""
 def _run_tauri_dev(tauri_dir: Path) -> subprocess.Popen {
+    import sys;
     # Check if cargo is available
     try {
         subprocess.run(
-            ["cargo", "--version"], capture_output=True, check=True, timeout=5
+            ["cargo", "--version"],
+            capture_output=True,
+            check=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
     } except (
         subprocess.CalledProcessError,
@@ -2366,26 +3430,36 @@ def _run_tauri_dev(tauri_dir: Path) -> subprocess.Popen {
         );
     }
 
-    # Check if build tools (gcc/cc) are available
-    try {
-        subprocess.run(["cc", "--version"], capture_output=True, check=True, timeout=5);
-    } except (
-        subprocess.CalledProcessError,
-        FileNotFoundError,
-        subprocess.TimeoutExpired
-    ) {
-        raise RuntimeError(
-            "Build tools not found. Install build-essential:\n"
-            "  Ubuntu/Debian: sudo apt-get install build-essential\n"
-            "  Fedora: sudo dnf install gcc gcc-c++\n"
-            "  Arch: sudo pacman -S base-devel"
-        );
+    # Check if build tools are available (skip on Windows - MSVC handles this)
+    if sys.platform != "win32" {
+        try {
+            subprocess.run(
+                ["cc", "--version"],
+                capture_output=True,
+                check=True,
+                timeout=SUBPROCESS_TIMEOUT_SHORT
+            );
+        } except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired
+        ) {
+            raise RuntimeError(
+                "Build tools not found. Install build-essential:\n"
+                "  Ubuntu/Debian: sudo apt-get install build-essential\n"
+                "  Fedora: sudo dnf install gcc gcc-c++\n"
+                "  Arch: sudo pacman -S base-devel"
+            );
+        }
     }
 
     # Check if tauri CLI is available via cargo
     try {
         subprocess.run(
-            ["cargo", "tauri", "--version"], capture_output=True, check=True, timeout=5
+            ["cargo", "tauri", "--version"],
+            capture_output=True,
+            check=True,
+            timeout=SUBPROCESS_TIMEOUT_SHORT
         );
     } except (
         subprocess.CalledProcessError,
@@ -2414,7 +3488,7 @@ def _run_tauri_dev(tauri_dir: Path) -> subprocess.Popen {
                     use_bun = True;
                 }
             }
-        } except Exception { }
+        } except Exception as e { }
     }
 
     if use_bun {
@@ -2493,7 +3567,6 @@ impl DesktopTarget.start(
     import from jac_client.plugin.src.targets.web_target { WebTarget }
     import signal;
     import sys;
-    import os;
     console.print("\n🖥️  Starting desktop app (Tauri)", style="bold");
     # Check if setup has been run
     tauri_dir = project_dir / "src-tauri";
@@ -2539,16 +3612,16 @@ impl DesktopTarget.start(
         if tauri_process {
             try {
                 tauri_process.terminate();
-                tauri_process.wait(timeout=5);
-            } except Exception {
+                tauri_process.wait(timeout=SUBPROCESS_TIMEOUT_SHORT);
+            } except Exception as e {
                 tauri_process.kill();
             }
         }
         if server_process {
             try {
                 server_process.terminate();
-                server_process.wait(timeout=5);
-            } except Exception {
+                server_process.wait(timeout=SUBPROCESS_TIMEOUT_SHORT);
+            } except Exception as e {
                 server_process.kill();
             }
         }
@@ -2574,7 +3647,7 @@ impl DesktopTarget.start(
         if return_code != 0 {
             console.warning(f"  Tauri process exited with code {return_code}");
         }
-    } except KeyboardInterrupt {
+    } except KeyboardInterrupt as e {
         console.print(
             "\n  Keyboard interrupt detected. Stopping app...", style="muted"
         );

--- a/jac-client/jac_client/tests/test_desktop_target_config.jac
+++ b/jac-client/jac_client/tests/test_desktop_target_config.jac
@@ -1,0 +1,84 @@
+"""Tests for desktop target build configuration."""
+
+import os;
+import sys;
+import from pathlib { Path }
+
+
+test "desktop_target has increased timeout" {
+    """Verify SUBPROCESS_TIMEOUT_BUILD is at least 3600s."""
+    import from pathlib { Path }
+    target_file = Path(__file__).parent.parent / "plugin" / "src" / "targets" / "impl" / "desktop_target.impl.jac";
+    if target_file.exists() {
+        with open(str(target_file), "r", encoding="utf-8") as f {
+            content = f.read();
+        }
+        assert "SUBPROCESS_TIMEOUT_BUILD" in content;
+        # Check timeout is >= 3600
+        for line in content.split("\n") {
+            if "SUBPROCESS_TIMEOUT_BUILD" in line and "int" in line and "=" in line {
+                # Extract value
+                parts = line.split("=");
+                if len(parts) >= 2 {
+                    try {
+                        val = int(parts[-1].strip().rstrip(",;"));
+                        assert val >= 3600,
+                            f"SUBPROCESS_TIMEOUT_BUILD should be >= 3600, got {val}";
+                    } except ValueError { }
+                }
+            }
+        }
+    }
+}
+
+
+test "desktop_target bundles assets directory" {
+    """Verify PyInstaller spec auto-bundles assets/ directory."""
+    target_file = Path(__file__).parent.parent / "plugin" / "src" / "targets" / "impl" / "desktop_target.impl.jac";
+    if target_file.exists() {
+        with open(str(target_file), "r", encoding="utf-8") as f {
+            content = f.read();
+        }
+        assert "assets" in content and "assets_dir" in content,
+            "desktop_target should auto-bundle assets/ directory";
+    }
+}
+
+
+test "desktop_target bundles env file" {
+    """Verify PyInstaller spec auto-bundles .env file."""
+    target_file = Path(__file__).parent.parent / "plugin" / "src" / "targets" / "impl" / "desktop_target.impl.jac";
+    if target_file.exists() {
+        with open(str(target_file), "r", encoding="utf-8") as f {
+            content = f.read();
+        }
+        assert "env_file" in content or ".env" in content,
+            "desktop_target should auto-bundle .env file";
+    }
+}
+
+
+test "desktop_target shows pyinstaller logs" {
+    """Verify capture_output=False for PyInstaller build visibility."""
+    target_file = Path(__file__).parent.parent / "plugin" / "src" / "targets" / "impl" / "desktop_target.impl.jac";
+    if target_file.exists() {
+        with open(str(target_file), "r", encoding="utf-8") as f {
+            content = f.read();
+        }
+        assert "capture_output=False" in content,
+            "PyInstaller should run with capture_output=False for log visibility";
+    }
+}
+
+
+test "desktop_target includes jac_client in collect_all" {
+    """Verify jac_client is in the core packages list."""
+    target_file = Path(__file__).parent.parent / "plugin" / "src" / "targets" / "impl" / "desktop_target.impl.jac";
+    if target_file.exists() {
+        with open(str(target_file), "r", encoding="utf-8") as f {
+            content = f.read();
+        }
+        assert "'jac_client'" in content,
+            "jac_client should be in the core packages for collect_all";
+    }
+}


### PR DESCRIPTION
- capture_output=False for real-time PyInstaller logs
- Build timeout increased to 7200s (2 hours)
- UTF-8 runtime hook for frozen Python
- Auto-bundle assets/ and .env
- collect_all('jac_client') for proper bundling

