### PR TITLE
fix(type-system): starred-unpack assignment is a narrowing barrier

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -20,6 +20,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Assignment Is a Narrowing Barrier**: Re-assigning a variable inside a narrowed scope (e.g. inside a `case` body) now correctly resets its type for every access that follows.
 - **Fix: Narrowing Through Parenthesized `and`/`or` Conditions**: `if (a and b):` now narrows types the same way as `if a and b:`.
 - **Fix: Tuple-Unpacking Assignment Is a Narrowing Barrier**: `(x, _) = f()` now resets type narrowing on the reassigned names, just like a plain assignment does.
+- **Fix: Starred-Unpack Assignment Is a Narrowing Barrier**: `(head, *rest) = f()` now resets type narrowing on the starred name too. Closes a leak where prior narrowing on `rest` could survive past the unpack.
 - **Removed: W2052 Broad Exception Warning**: Removed the `W2052` warning that flagged `except Exception` as overly broad. Catching `Exception` is a legitimate and common pattern at system boundaries (e.g., LLM calls, network I/O), and the warning produced false positives in these cases.
 
 ## jaclang 0.13.5 (Latest Release)

--- a/jac/jaclang/compiler/symbol_utils.jac
+++ b/jac/jaclang/compiler/symbol_utils.jac
@@ -243,8 +243,9 @@ def collect_narrowing_symbols(condition: uni.Expr) -> set[str] {
 """Collect every reference key bound by a single assignment target.
 
 Walks one element of `Assignment.target`, extracting the reference keys
-it writes. Handles flat names, dotted attribute paths, and recursive
-tuple/list destructuring (e.g. `(a, (b, c)) = ...`).
+it writes. Handles flat names, dotted attribute paths, recursive
+tuple/list destructuring (e.g. `(a, (b, c)) = ...`), and starred
+unpack slots (`(a, *rest) = ...`).
 """
 def collect_assignment_target_keys(target: uni.UniNode) -> set[str] {
     keys: set[str] = set();
@@ -262,6 +263,13 @@ def collect_assignment_target_keys(target: uni.UniNode) -> set[str] {
                 }
             }
         }
+    } elif (
+        isinstance(target, uni.UnaryExpr)
+        and isinstance(target.op, uni.Token)
+        and target.op.name == Tok.STAR_MUL
+    ) {
+        # Starred unpack slot: `*rest` inside (a, *rest) = ...
+        keys.update(collect_assignment_target_keys(target.operand));
     } elif isinstance(target, uni.AtomUnit) and isinstance(target.value, uni.UniNode) {
         # Parenthesized target: `(x) = ...` or `((x, y)) = ...`.
         keys.update(collect_assignment_target_keys(target.value));

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_starred_unpack_barrier.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_starred_unpack_barrier.jac
@@ -1,0 +1,14 @@
+"""Starred-unpack assignment is a narrowing barrier."""
+
+# After `if rest is not None` narrows `rest` to list[int], unpacking
+# into the starred slot `*rest` must reset it back to the declared
+# type. The typed-local assignment then fails because list[int] | None
+# is not assignable to list[int].
+def widen_via_star(rest: list[int] | None) -> int {
+    if rest is not None {
+        (head, *rest) = (1, 2, 3);
+        wrong: list[int] = rest;
+        return 0;
+    }
+    return 0;
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2000,6 +2000,24 @@ test "assignment_barrier" {
     assert 'Cannot return int | NoneType' in msg , f"Expected widening-reset error, got: {msg}";
 }
 
+"""Starred-unpack assignment acts as a narrowing barrier."""
+test "starred_unpack_barrier" {
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_starred_unpack_barrier.jac"),
+        options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    # After `(head, *rest) = ...` inside `if rest is not None`, rest
+    # must reset to list[int] | None. The typed-local assignment then
+    # fails because list[int] | None is not assignable to list[int].
+    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got " + f"{len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
+    msg = program.errors_had[0].pretty_print();
+    assert 'Cannot assign list[int] | NoneType to list[int]' in msg , f"Expected starred-unpack reset error, got: {msg}";
+}
+
 """Tuple-unpacking assignment acts as a narrowing barrier."""
 test "tuple_unpack_barrier" {
     program = JacProgram();


### PR DESCRIPTION
## Summary

Closes a known gap from #5495. Starred-unpack assignment (`(head, *rest) = f()`) now acts as a narrowing barrier, the same way the rest of tuple unpack and plain assignment already do.

Follow-up to #5495.

## The bug

```jac
def take_list(xs: list[int]) -> int { return len(xs); }

def widen_via_star(rest: list[int] | None) -> int {
    if rest is not None {
        (head, *rest) = (1, 2, 3);
        return take_list(rest);   # silently typed clean; should error
    }
    return 0;
}
```

After `if rest is not None`, `rest` narrows to `list[int]`. The starred unpack on the next line reassigns `rest`, but the narrowing survives and the call to `take_list(rest)` type-checks against `list[int]` — hiding a real `list[int] | None` path.

## Root cause

The `collect_assignment_target_keys` helper added in #5495 recursed into `Name`, `AtomTrailer`, `TupleVal`, `ListVal`, and `AtomUnit` targets, but **not** into the starred slot. The starred slot is parsed as `UnaryExpr(op=STAR_MUL, operand=Name)`, and the helper had no matching branch.

Both call sites of the helper missed `*rest` as a result:

- `collect_assigned_symbols` in `symbol_utils.jac` — `affected_symbols` on the unpack statement didn't include `rest`, so the narrowing walker's fast-path check (`key not in pred.affected_symbols`) skipped the Assignment predecessor entirely.
- The Assignment barrier branch in `_get_type_from_flow_node` — even if the walker had reached it, the inner key match would have stayed `False`, fall-through propagated the pre-assignment narrowing.

The symbol-table builder's `_def_insert_unpacking` already recurses into `UnaryExpr(STAR_MUL)`, so symbol creation was correct. Only the barrier-key collector was missing the case.

## The fix

One new branch in `collect_assignment_target_keys`:

```jac
} elif (
    isinstance(target, uni.UnaryExpr)
    and isinstance(target.op, uni.Token)
    and target.op.name == Tok.STAR_MUL
) {
    # Starred unpack slot: `*rest` inside (a, *rest) = ...
    keys.update(collect_assignment_target_keys(target.operand));
}
```

Both call sites (`collect_assigned_symbols` and the barrier branch) pick up the fix automatically through the shared helper.

## Test plan

- [x] New regression test `starred_unpack_barrier` in `test_checker_pass.jac` asserts exactly 1 type error on the bug's canonical shape, with the expected message `Cannot assign list[int] | NoneType to list[int]`.
- [x] All 5 checker test files pass: 199 tests total (was 198).
- [x] `test_sym_tab_build_pass.jac` for-loop test still passes (the fix only touches the key collector, not the symbol-table side).
- [x] `jac format --lintfix` clean on all touched files.
- [x] Release notes entry added to `jaclang.md` 0.13.6.

## Files changed

- `jac/jaclang/compiler/symbol_utils.jac` — one new branch in `collect_assignment_target_keys`
- `jac/tests/compiler/passes/main/fixtures/checker/checker_starred_unpack_barrier.jac` — new fixture
- `jac/tests/compiler/passes/main/test_checker_pass.jac` — new test
- `docs/docs/community/release_notes/jaclang.md` — release note under 0.13.6
