### PR TITLE
fix(cfg): ternary conditions wire BoolExpr operand chain

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -21,6 +21,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Narrowing Through Parenthesized `and`/`or` Conditions**: `if (a and b):` now narrows types the same way as `if a and b:`.
 - **Fix: Tuple-Unpacking Assignment Is a Narrowing Barrier**: `(x, _) = f()` now resets type narrowing on the reassigned names, just like a plain assignment does.
 - **Fix: Starred-Unpack Assignment Is a Narrowing Barrier**: `(head, *rest) = f()` now resets type narrowing on the starred name too. Closes a leak where prior narrowing on `rest` could survive past the unpack.
+- **Fix: Ternary Narrowing Through `and`/`or` Conditions**: `x if a and b else y` now narrows its branches the same way as the equivalent `if a and b:` statement.
 - **Removed: W2052 Broad Exception Warning**: Removed the `W2052` warning that flagged `except Exception` as overly broad. Catching `Exception` is a legitimate and common pattern at system boundaries (e.g., LLM calls, network I/O), and the warning produced false positives in these cases.
 
 ## jaclang 0.13.5 (Latest Release)

--- a/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
@@ -492,10 +492,30 @@ IfElseExpr/BoolExpr so narrowing propagates through nested ternaries."""
 impl CFGBuildPass.exit_if_else_expr(nd: uni.IfElseExpr) -> None {
     import from jaclang.compiler.symbol_utils { collect_narrowing_symbols }
     nd.condition.affected_symbols.update(collect_narrowing_symbols(nd.condition.expr));
-    nd.condition.sc_true_target = nd.value;
-    nd.condition.sc_false_target = nd.else_value;
-    self.link_bbs(nd.condition, nd.value);
-    self.link_bbs(nd.condition, nd.else_value);
+
+    # If the condition is a BoolExpr, wire the operand short-circuit chain
+    # through to the branches the same way `exit_if_stmt` does. This lets
+    # the backward walker traverse operands individually, so per-operand
+    # narrowings accumulate on the edge into the branch (critical for
+    # patterns like `0 if s is None or not isinstance(s, T) else s.m()`
+    # where the else branch needs s narrowed to T via double negation).
+    unwrapped_cond = _unwrap_parens(nd.condition.expr);
+    if isinstance(unwrapped_cond, uni.BoolExpr) and len(unwrapped_cond.values) >= 2 {
+        op_is_and = _bool_is_and(unwrapped_cond);
+        entry = self._wire_bool_operands(
+            unwrapped_cond.values, op_is_and, nd.value, nd.else_value
+        );
+        if entry {
+            self.link_bbs(nd.condition, entry);
+        }
+    } else {
+        # Simple condition: the outer CfgExpr is the branch point.
+        nd.condition.sc_true_target = nd.value;
+        nd.condition.sc_false_target = nd.else_value;
+        self.link_bbs(nd.condition, nd.value);
+        self.link_bbs(nd.condition, nd.else_value);
+    }
+
     for branch in [nd.value, nd.else_value] {
         inner = _unwrap_parens(branch.expr);
         if isinstance(inner, uni.IfElseExpr) {

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_ternary_bool_cond_narrowing.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_ternary_bool_cond_narrowing.jac
@@ -1,0 +1,38 @@
+"""Ternary conditions with BoolExpr narrow their branches per-operand."""
+
+class Shape {}
+
+class Polygon(Shape) {
+    has sides: list[int] = [];
+
+    def corner_count -> int {
+        return len(self.sides);
+    }
+}
+
+# True branch: AND with isinstance — s must be Polygon inside the true
+# branch for `.corner_count()` to resolve.
+def probe_and_true(s: Shape | None) -> int {
+    return s.corner_count() if s is not None and isinstance(s, Polygon) else 0;
+}
+
+# Else branch: OR with inverted predicates — inside the else, both
+# operands are false, so s is not None AND isinstance(s, Polygon).
+# Narrowing must flow through each operand so the else branch sees
+# s as Polygon, not just Shape.
+def probe_or_inverse_else(s: Shape | None) -> int {
+    return 0 if s is None or not isinstance(s, Polygon) else s.corner_count();
+}
+
+# Same shape, parenthesized. Must behave identically.
+def probe_or_inverse_else_parens(s: Shape | None) -> int {
+    return 0 if (s is None or not isinstance(s, Polygon)) else s.corner_count();
+}
+
+# Plain if/else control: already worked before, pin the behavior here.
+def probe_ifstmt_control(s: Shape | None) -> int {
+    if s is None or not isinstance(s, Polygon) {
+        return 0;
+    }
+    return s.corner_count();
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2000,6 +2000,21 @@ test "assignment_barrier" {
     assert 'Cannot return int | NoneType' in msg , f"Expected widening-reset error, got: {msg}";
 }
 
+"""Ternary conditions with BoolExpr narrow their branches per-operand."""
+test "ternary_bool_cond_narrowing" {
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_ternary_bool_cond_narrowing.jac"),
+        options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    # All four shapes must narrow cleanly: AND-in-true, OR-inverse-in-else
+    # (bare and parenthesized), and the plain if/else control.
+    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
+}
+
 """Starred-unpack assignment acts as a narrowing barrier."""
 test "starred_unpack_barrier" {
     program = JacProgram();


### PR DESCRIPTION
## Summary

Item #7 from the narrowing follow-up tracker. The audit started as "do parens around a ternary condition break narrowing?" and surfaced a wider bug: ternary expressions with `and`/`or` conditions don't narrow their branches per-operand, even though the equivalent `if`/`else` statement does. Parens turned out to be a red herring — the bug fires whether or not the condition is parenthesized.

Follow-up to #5490 / #5495 / #5501.

## The bug

```jac
class Polygon(Shape) {
    has sides: list[int] = [];
    def corner_count -> int { return len(self.sides); }
}

# Ternary version: silently typed clean before this PR — but the else
# branch should narrow `s` to `Polygon` via double negation.
def f(s: Shape | None) -> int {
    return 0 if s is None or not isinstance(s, Polygon) else s.corner_count();
}
```

After the OR's two operands are both false in the else branch, `s` must be both **non-None** *and* **a `Polygon`**. The equivalent `if`/`else` statement narrows it correctly. The ternary widened it to `Shape`, hiding the real attribute error on `s.corner_count()`.

## Root cause

`exit_if_else_expr` only wired the **outer CfgExpr** that wraps the entire condition, leaving the inner BoolExpr operand CfgExprs with `None` short-circuit targets (the default from `exit_bool_expr`'s standalone-BoolExpr handling). The walker then only saw the outer CfgExpr and asked `_find_predicate_for` for a single combined predicate over the whole BoolExpr.

For OR-with-inverted-operands (sub-pattern b in `_find_predicate_for`), that function returns only the **first** matching predicate, losing every operand after it:

```jac
# Sub-pattern (b): has inverted predicates (e.g., `not x or not x.y`)
# Return first matching predicate for this target. ...
for p in matched {
    if p.key == key {
        return p;
    }
}
return matched[0];
```

So for `s is None or not isinstance(s, Polygon)`, the engine returned only the `s is None` predicate and lost the `Polygon` half. Inverse-applied on the false edge, it narrowed `s` to `Shape` instead of `Polygon`.

The `if`/`else` statement path doesn't hit this because `exit_if_stmt` already calls `_wire_bool_operands` with the **real** true/false targets (the if-body and else-body), so the walker can traverse the operand CfgExprs individually and per-operand narrowings accumulate naturally on the edge into the branch. The trace makes the divergence obvious:

**If-stmt path:**
```
ReturnStmt#1616 bb_in=['CfgExpr#528']
  CfgExpr#528 expr=UnaryExpr predicate=Polygon(inverted)
    is_false=True narrowed=Polygon pred_narrowed=Shape   ← chain accumulates
```

**Ternary path:**
```
CfgExpr#6896 bb_in=['CfgExpr#6656']
  CfgExpr#6656 expr=BoolExpr predicate=NoneType        ← whole-BoolExpr predicate
    is_false=True narrowed=Shape pred_narrowed=None    ← lost Polygon
```

## The fix

Mirror `exit_if_stmt`. When the ternary's condition is a `BoolExpr` (peeling parens via `_unwrap_parens`), call `_wire_bool_operands` with `nd.value` / `nd.else_value` as the true and false targets, then link `nd.condition → entry` so the walker can traverse the operand chain. Simple (non-BoolExpr) conditions still take the existing direct outer-CfgExpr edge path.

```jac
unwrapped_cond = _unwrap_parens(nd.condition.expr);
if isinstance(unwrapped_cond, uni.BoolExpr) and len(unwrapped_cond.values) >= 2 {
    op_is_and = _bool_is_and(unwrapped_cond);
    entry = self._wire_bool_operands(
        unwrapped_cond.values, op_is_and, nd.value, nd.else_value
    );
    if entry {
        self.link_bbs(nd.condition, entry);
    }
} else {
    nd.condition.sc_true_target = nd.value;
    nd.condition.sc_false_target = nd.else_value;
    self.link_bbs(nd.condition, nd.value);
    self.link_bbs(nd.condition, nd.else_value);
}
```

This brings ternary architecture in line with `if`/`while` and lets the existing per-operand narrowing logic do its job.

## Test plan

- [x] New regression test `ternary_bool_cond_narrowing` in `test_checker_pass.jac` covers four shapes:
  - AND in the true branch (positive narrowing)
  - OR-inverse in the else branch (bare)
  - OR-inverse in the else branch (parenthesized)
  - Plain `if`/`else` control case
- [x] All 5 checker test files pass: 200 tests total (up from 199).
- [x] `test_cfg_build_pass.jac` (14 tests) and `test_sym_tab_build_pass.jac` (9 tests) all pass — the wiring change doesn't regress sibling CFG behavior.
- [x] `jac format --lintfix` clean on all touched files.
- [x] Release notes entry added to `jaclang.md` 0.13.6.

## Files changed

- `jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac` — `exit_if_else_expr` wires BoolExpr operand chain
- `jac/tests/compiler/passes/main/fixtures/checker/checker_ternary_bool_cond_narrowing.jac` — new fixture
- `jac/tests/compiler/passes/main/test_checker_pass.jac` — new test
- `docs/docs/community/release_notes/jaclang.md` — release note under 0.13.6
