### PR TITLE
fix(cfg): link ternary sub-CFG to its enclosing flow node

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -22,6 +22,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Tuple-Unpacking Assignment Is a Narrowing Barrier**: `(x, _) = f()` now resets type narrowing on the reassigned names, just like a plain assignment does.
 - **Fix: Starred-Unpack Assignment Is a Narrowing Barrier**: `(head, *rest) = f()` now resets type narrowing on the starred name too. Closes a leak where prior narrowing on `rest` could survive past the unpack.
 - **Fix: Ternary Narrowing Through `and`/`or` Conditions**: `x if a and b else y` now narrows its branches the same way as the equivalent `if a and b:` statement.
+- **Fix: Pre-Statement Narrowing Reaches Inside Ternary Expressions**: A ternary's branches now see the narrowing established by earlier statements (e.g. `if x is None: return`), so access on the narrowed type works the same inside `x.m() if cond else x.m()` as it does in a plain `if`/`else`.
 - **Removed: W2052 Broad Exception Warning**: Removed the `W2052` warning that flagged `except Exception` as overly broad. Catching `Exception` is a legitimate and common pattern at system boundaries (e.g., LLM calls, network I/O), and the warning produced false positives in these cases.
 
 ## jaclang 0.13.5 (Latest Release)

--- a/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
@@ -516,6 +516,21 @@ impl CFGBuildPass.exit_if_else_expr(nd: uni.IfElseExpr) -> None {
         self.link_bbs(nd.condition, nd.else_value);
     }
 
+    # Connect the ternary sub-CFG to its nearest enclosing CFG node so
+    # that narrowing established upstream flows into the condition and
+    # branches. For a top-level ternary this is the enclosing statement
+    # (CodeBlockStmt); for a nested ternary it is the outer ternary's
+    # branch CfgExpr, which correctly carries the outer ternary's own
+    # narrowing (skipping past it would lose the enclosing narrowing).
+    # Without this edge the sub-CFG is orphaned from surrounding flow
+    # and patterns like
+    # `if x is None { return } return x.m() if isinstance(x, T) else x.m()`
+    # bottom out with the declared type.
+    enclosing_flow = nd.find_parent_of_type(uni.UniCFGNode);
+    if enclosing_flow is not None {
+        self.link_bbs(enclosing_flow, nd.condition);
+    }
+
     for branch in [nd.value, nd.else_value] {
         inner = _unwrap_parens(branch.expr);
         if isinstance(inner, uni.IfElseExpr) {

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_pre_expr_narrowing.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_pre_expr_narrowing.jac
@@ -1,0 +1,46 @@
+"""Pre-statement narrowing must reach inside expression sub-CFGs.
+
+Ternary, walrus, and comprehension expressions introduce sub-CFG nodes
+that aren't directly linked from the surrounding statement flow. The
+walker must fall back to the enclosing statement's narrowing when it
+hits an empty `bb_in` at a sub-CFG entry, otherwise narrowing
+established by an earlier guard is lost inside the expression.
+"""
+
+class Shape {
+    has name: str = "shape";
+}
+
+class Polygon(Shape) {
+    has sides: list[int] = [];
+}
+
+# Pre-narrowing via early-return guard, then ternary in the body.
+# After `if s is None: return ""`, s is Shape (not None).
+# Both branches of the ternary access s.name, which is valid on Shape.
+# Without the fallback, the walker widens s back to Shape | None and
+# the .name access errors against the NoneType arm.
+def f(s: Shape | None) -> str {
+    if s is None {
+        return "";
+    }
+    return s.name if isinstance(s, Polygon) else s.name;
+}
+
+# Same shape but the early return narrows further (to Polygon).
+# Both branches of the ternary should see p as Polygon.
+def g(p: Shape | None) -> int {
+    if p is None or not isinstance(p, Polygon) {
+        return 0;
+    }
+    return p.sides[0] if p.sides else 0;
+}
+
+# Pre-narrowing via if-then-narrowing pattern (no early return).
+def h(s: Shape | None) -> str {
+    result: str = "";
+    if s is not None {
+        result = s.name if isinstance(s, Polygon) else s.name;
+    }
+    return result;
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2000,6 +2000,21 @@ test "assignment_barrier" {
     assert 'Cannot return int | NoneType' in msg , f"Expected widening-reset error, got: {msg}";
 }
 
+"""Pre-statement narrowing reaches inside expression sub-CFGs."""
+test "pre_expr_narrowing" {
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_pre_expr_narrowing.jac"), options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    # All three shapes (early-return guard, OR-inverse guard, if-wrap)
+    # must carry the enclosing statement's narrowing into ternary
+    # branches so member access on the narrowed type succeeds.
+    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
+}
+
 """Ternary conditions with BoolExpr narrow their branches per-operand."""
 test "ternary_bool_cond_narrowing" {
     program = JacProgram();


### PR DESCRIPTION
## Summary

Item #8 from the narrowing follow-up tracker — the biggest open soundness gap surfaced during the #5502 ternary audit. Ternary expressions' sub-CFG wasn't linked to the surrounding statement flow, so narrowing established by an earlier statement was lost inside the ternary's branches.

The CFG graph made it visible: a ternary's operand chain and branch `CfgExpr`s were orphaned from the containing `ReturnStmt`/`Assignment`, with no incoming edge from the surrounding function flow.

## The bug

```jac
def f(s: Shape | None) -> str {
    if s is None {
        return "";
    }
    # s is narrowed to Shape here.
    return s.name if isinstance(s, Polygon) else s.name;
    # Before: both branches widen s back to Shape | None and
    # `s.name` errors with "attribute is missing from NoneType".
}
```

The walker starting inside either ternary branch walked back through the operand chain, reached the condition `CfgExpr` with empty `bb_in`, and returned the declared type — losing the `if s is None: return` narrowing entirely. Three concrete false-positive shapes are covered by the new regression fixture:

1. Early-return guard + ternary with simple condition
2. OR-inverse guard + ternary with truthy condition
3. `if x is not None` wrapping an assignment-as-ternary

## Root cause

`exit_if_else_expr` wired the ternary's internal sub-CFG (condition CfgExpr, operand chain for `and`/`or`, value/else_value branches) but never linked anything *into* `nd.condition` from the surrounding statement flow. The sub-CFG was a self-contained island: reachable going forward from the `IfElseExpr` node, but disconnected from `bb_in` of the enclosing `CodeBlockStmt`.

The existing narrowing walker correctly walks backward through `bb_in` edges, and the `affected_symbols` fast path relies on forward propagation via `link_bbs`. Neither machine reaches a ternary's internals without a real edge from the enclosing statement.

## The fix

One edge in `exit_if_else_expr`. After wiring the ternary's internal structure, call `link_bbs(enclosing_flow, nd.condition)` where `enclosing_flow` is the **nearest enclosing `UniCFGNode`** ancestor:

```jac
enclosing_flow = nd.find_parent_of_type(uni.UniCFGNode);
if enclosing_flow is not None {
    self.link_bbs(enclosing_flow, nd.condition);
}
```

Two cases to understand why `UniCFGNode` rather than `CodeBlockStmt`:

### Top-level ternary

The nearest `UniCFGNode` ancestor is the containing statement (`ReturnStmt`, `Assignment`, etc., all of which subclass `CodeBlockStmt → UniCFGNode`). The walker now walks backward from inside a branch → through the sub-CFG → into the statement's own `bb_in` → upstream statements, picking up their narrowing naturally. `affected_symbols` propagates forward via `link_bbs`, so the fast-path check inside the sub-CFG sees the upstream keys too.

### Nested ternary — the subtle case

For a nested ternary (e.g., `return a if c1 else (b if c2 else d)`), the nearest `UniCFGNode` ancestor of the inner `IfElseExpr` is the **outer ternary's branch `CfgExpr`**, not the top-level `ReturnStmt`. Linking to *that* preserves the outer ternary's own narrowing contribution — specifically the `c1 is False` edge information carried by the outer's else_value branch.

My first attempt used `find_parent_of_type(uni.CodeBlockStmt)` and regressed `checker_isinstance_ternary`: the inner ternary was linked directly to the top `ReturnStmt`, skipping past the outer ternary's condition narrowing. A `str | int | None` variable narrowed to `str | None` on the outer's else edge was widened back to `str | int | None` inside the inner. The `UniCFGNode` version walks *one step* and stops at the outer's branch CfgExpr, which is exactly the right anchor.

## Why no walker-side changes

I initially tried a walker-side fallback: "when you hit a `CfgExpr` with empty `bb_in`, fall back to walking from the enclosing statement." That works for the simple cases but requires a matching hack to the `affected_symbols` fast-path (because the sub-CFG's affected set doesn't contain upstream keys). Both ended up as workarounds pointing at the same missing edge.

The CFG-build fix is the real architectural fix:

- **One edge**, created where the sub-CFG is built, next to the existing wiring logic.
- **No walker changes** — the backward walk is linear and the fast-path optimization keeps working.
- **Forward propagation of `affected_symbols`** happens naturally via `link_bbs`, so upstream narrowing keys end up inside the sub-CFG nodes and the fast path short-circuits correctly.
- **CFG visualization is now connected** — the ternary's operand chain and branches show an actual incoming edge from the enclosing statement in the debug graph.

## Test plan

- [x] New regression `pre_expr_narrowing` covering the three shapes in the repro.
- [x] Existing `checker_isinstance_ternary` (which caught the first, wrong attempt) still passes — this pins the nested-ternary case.
- [x] Existing `checker_ternary_bool_cond_narrowing` (the #5502 regression) still passes — pins the `and`/`or` case.
- [x] All 5 checker test files pass: 200 tests in the core sweep (148 + 18 + 16 + 10 + 9, up from 199).
- [x] `test_cfg_build_pass.jac` (14) and `test_sym_tab_build_pass.jac` (9) pass — the new edge doesn't break sibling CFG semantics.
- [x] `jac format --lintfix` clean on touched files.
- [x] Release notes under 0.13.6.

## Follow-ups

Same-shape gaps for other expression sub-CFGs remain open:

- **Walrus expressions** (`(x := foo())` inside a condition) — no sub-CFG wiring today, but the structural problem is analogous. Tracked as item #3.
- **Comprehensions** — same story. Not currently in the tracker but worth an audit.

Neither is touched by this PR. The fix pattern (link `enclosing_flow → sub_cfg_entry` in the visitor that builds the sub-CFG) will apply to both when we get there.

## Files changed

- `jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac` — add `link_bbs(enclosing_flow, nd.condition)` at the end of `exit_if_else_expr`
- `jac/tests/compiler/passes/main/fixtures/checker/checker_pre_expr_narrowing.jac` — new fixture
- `jac/tests/compiler/passes/main/test_checker_pass.jac` — new test
- `docs/docs/community/release_notes/jaclang.md` — release note under 0.13.6
