### PR TITLE
fix(type-system): narrow destructure targets by RHS element type

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -23,6 +23,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Starred-Unpack Assignment Is a Narrowing Barrier**: `(head, *rest) = f()` now resets type narrowing on the starred name too. Closes a leak where prior narrowing on `rest` could survive past the unpack.
 - **Fix: Ternary Narrowing Through `and`/`or` Conditions**: `x if a and b else y` now narrows its branches the same way as the equivalent `if a and b:` statement.
 - **Fix: Pre-Statement Narrowing Reaches Inside Ternary Expressions**: A ternary's branches now see the narrowing established by earlier statements (e.g. `if x is None: return`), so access on the narrowed type works the same inside `x.m() if cond else x.m()` as it does in a plain `if`/`else`.
+- **Fix: Destructuring Assignment Narrows by RHS Element Type**: `(x, _) = (5, "ok")` now narrows `x: int | None` to `int` by extracting the element type at position 0 from the concrete tuple RHS, matching pyright. Works for tuple literals, `-> tuple[T1, T2]` function return types, and nested destructuring like `((a, b), c) = ...`. Falls back to the previous conservative reset when the RHS isn't a concrete tuple or the extracted element type doesn't strictly narrow the declared type.
 - **Removed: W2052 Broad Exception Warning**: Removed the `W2052` warning that flagged `except Exception` as overly broad. Catching `Exception` is a legitimate and common pattern at system boundaries (e.g., LLM calls, network I/O), and the warning produced false positives in these cases.
 
 ## jaclang 0.13.5 (Latest Release)

--- a/jac/jaclang/compiler/symbol_utils.jac
+++ b/jac/jaclang/compiler/symbol_utils.jac
@@ -240,6 +240,51 @@ def collect_narrowing_symbols(condition: uni.Expr) -> set[str] {
     return symbols;
 }
 
+"""Find the positional index path of a reference key inside a single
+destructuring target, or `None` if the key isn't written there.
+
+For `(x, _) = ...` with key `"x"` the result is `[0]`; for
+`((a, b), c) = ...` with key `"b"` it's `[0, 1]`. The starred slot in
+`(a, *rest) = ...` is intentionally excluded because its type is the
+list of the tail, not a single element at a fixed index — callers that
+want to narrow `rest` need different logic.
+
+Only the first occurrence wins; a well-formed destructuring target
+binds each key at most once anyway.
+"""
+def find_destructure_index_path(target: uni.UniNode, key: str) -> list[int] | None {
+    if isinstance(target, uni.Name) {
+        return [] if target.value == key else None;
+    }
+    if isinstance(target, uni.AtomTrailer) and target.is_attr {
+        matched_key = get_expr_key(target);
+        return [] if matched_key == key else None;
+    }
+    if isinstance(target, uni.AtomUnit) and isinstance(target.value, uni.UniNode) {
+        return find_destructure_index_path(target.value, key);
+    }
+    if isinstance(target, (uni.TupleVal, uni.ListVal)) and target.values {
+        for (i, sub) in enumerate(target.values) {
+            if not isinstance(sub, uni.UniNode) {
+                continue;
+            }
+            # Skip starred slots — their type isn't a single element.
+            if (
+                isinstance(sub, uni.UnaryExpr)
+                and isinstance(sub.op, uni.Token)
+                and sub.op.name == Tok.STAR_MUL
+            ) {
+                continue;
+            }
+            sub_path = find_destructure_index_path(sub, key);
+            if sub_path is not None {
+                return [i] + sub_path;
+            }
+        }
+    }
+    return None;
+}
+
 """Collect every reference key bound by a single assignment target.
 
 Walks one element of `Assignment.target`, extracting the reference keys

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -3210,20 +3210,22 @@ impl TypeEvaluator._get_type_from_flow_node(
 
         # Assignment predecessor: barrier. An assignment whose target writes
         # the reference key kills any pre-assignment narrowing on this edge.
-        # On a strict narrowing from a flat target (e.g. `int | None` = `int`)
-        # the assigned type becomes the edge's contribution; otherwise the
-        # edge resets to the declared type. Either way, we never fall through.
+        # Flat targets try strict narrowing from the RHS type; destructuring
+        # targets attempt element-type extraction against a concrete tuple
+        # RHS (`(x, _) = (5, "ok")` narrows `x` to `int`); otherwise the edge
+        # resets to the declared type. Either way, we never fall through.
         if isinstance(pred, uni.Assignment) and pred.value {
-            import from jaclang.compiler.symbol_utils { collect_assignment_target_keys }
+            import from jaclang.compiler.symbol_utils {
+                collect_assignment_target_keys,
+                find_destructure_index_path,
+            }
             target_key_matched = False;
             flat_target_matched = False;
+            destructure_path: list[int] | None = None;
             for t in pred.target {
                 written_keys = collect_assignment_target_keys(t);
                 if key in written_keys {
                     target_key_matched = True;
-                    # Strict narrowing is only sound for flat Name/AtomTrailer
-                    # targets. For destructuring (`(x, _) = ...`) we'd need
-                    # element-type inference; conservatively reset instead.
                     if (
                         (isinstance(t, uni.Name) and t.value == key)
                         or (
@@ -3233,25 +3235,48 @@ impl TypeEvaluator._get_type_from_flow_node(
                         )
                     ) {
                         flat_target_matched = True;
+                    } else {
+                        destructure_path = find_destructure_index_path(t, key);
                     }
                     break;
                 }
             }
             if target_key_matched {
                 narrowed_from_assignment: TypeBase | None = None;
+                assigned_type: TypeBase | None = None;
                 if flat_target_matched {
                     assigned_type = self.get_type_of_expression(pred.value);
-                    if (
-                        assigned_type
-                        and not isinstance(assigned_type, types.UnknownType)
-                    ) {
-                        declared_type = target.declared_type;
+                } elif destructure_path is not None and len(destructure_path) > 0 {
+                    # Descend `type_args` along the positional path to pull
+                    # the element type out of a concrete tuple RHS. Mirrors
+                    # the declaration-time tuple-unpack logic.
+                    cursor: TypeBase | None = self.get_type_of_expression(pred.value);
+                    for idx in destructure_path {
                         if (
-                            self.assign_type(assigned_type, declared_type)
-                            and not self.assign_type(declared_type, assigned_type)
+                            isinstance(cursor, types.ClassType)
+                            and cursor.private.type_args
+                            and idx < len(cursor.private.type_args)
                         ) {
-                            narrowed_from_assignment = assigned_type;
+                            cursor = self._convert_to_instance(
+                                cursor.private.type_args[idx]
+                            );
+                        } else {
+                            cursor = None;
+                            break;
                         }
+                    }
+                    assigned_type = cursor;
+                }
+                if (
+                    assigned_type is not None
+                    and not isinstance(assigned_type, types.UnknownType)
+                ) {
+                    declared_type = target.declared_type;
+                    if (
+                        self.assign_type(assigned_type, declared_type)
+                        and not self.assign_type(declared_type, assigned_type)
+                    ) {
+                        narrowed_from_assignment = assigned_type;
                     }
                 }
                 if narrowed_from_assignment is not None {

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_destructure_element_narrowing.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_destructure_element_narrowing.jac
@@ -1,0 +1,44 @@
+"""Destructuring assignment narrows each target to its RHS element type
+when the RHS has a concrete tuple type."""
+
+def make_pair -> tuple[int, str] {
+    return (5, "ok");
+}
+
+
+# Position 0 of a tuple literal narrows `int | None` -> `int`.
+def narrow_tuple_literal_pos0(x: int | None) -> int {
+    (x, _) = (5, "ok");
+    return x;
+}
+
+
+# Position 1 of a tuple literal narrows too.
+def narrow_tuple_literal_pos1(x: int | None) -> int {
+    (_, x) = ("ok", 5);
+    return x;
+}
+
+
+# Typed `tuple[int, str]` return value narrows just like a literal.
+def narrow_typed_return(x: int | None) -> int {
+    (x, _) = make_pair();
+    return x;
+}
+
+
+# Nested destructuring: `b` at path [0, 1] narrows to `int`.
+def narrow_nested(b: int | None) -> int {
+    ((_, b), _) = ((1, 2), 3);
+    return b;
+}
+
+
+# Regression guard: when the RHS element type does NOT strictly narrow
+# the declared type, the edge still resets. Here `x: int | str` and the
+# RHS element is `int | str` (same as declared), so no narrowing fires
+# and `return x` correctly errors against `int`.
+def no_narrow_non_strict(x: int | str, y: int | str) -> int {
+    (x, _) = (y, "ok");
+    return x;
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2065,6 +2065,24 @@ test "tuple_unpack_barrier" {
     assert 'Cannot return int | NoneType' in msg , f"Expected widening-reset error, got: {msg}";
 }
 
+"""Destructuring assignment narrows by RHS element type when available."""
+test "destructure_element_narrowing" {
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_destructure_element_narrowing.jac"),
+        options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    # Four narrowing cases must succeed; only `no_narrow_non_strict`
+    # should error because its RHS element type matches the declared
+    # type and therefore fails the strict-narrowing check.
+    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got " + f"{len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
+    msg = program.errors_had[0].pretty_print();
+    assert 'Cannot return int | str' in msg , f"Expected non-strict-narrow error, got: {msg}";
+}
+
 """Match-case narrowing is killed by a later assignment to the subject."""
 test "match_case_reassign_reset" {
     program = JacProgram();


### PR DESCRIPTION
## Summary

- Destructuring assignment (`(x, _) = (5, \"ok\")`) now narrows `x: int | None` to `int` by extracting the positional element type from the concrete tuple RHS, matching pyright. The barrier used to always reset destructuring targets to the declared type — sound but over-reporting.
- Mirrors the declaration-time tuple-unpack logic at [type_evaluator.impl.jac:1755-1790](jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac#L1755-L1790); falls back to the conservative reset on NamedTuple / variadic / union-of-tuples RHS, which stay tracked as sub-gaps.
- Closes item 1b (concrete-tuple path) from the narrowing follow-up tracker.

## The bug

```jac
def f(x: int | None) -> int {
    (x, _) = (5, \"ok\");
    return x;  // was: error \"Cannot return int | NoneType\"
               // now: OK, x is int
}
```

The Assignment barrier in `_get_type_from_flow_node` has two paths:

1. **Flat target** (`Name` or dotted `AtomTrailer`): evaluate the RHS type, run the strict-narrowing check against declared, use the result as the edge contribution.
2. **Destructuring target** (`TupleVal` / `ListVal`): reset to declared.

Path 2 was the conservative fallback because there was no code to say *which element* of the RHS corresponds to the written key.

## The fix

Two pieces:

**1. New helper `find_destructure_index_path(target, key) -> list[int] | None`** in [jac/jaclang/compiler/symbol_utils.jac](jac/jaclang/compiler/symbol_utils.jac). Walks one element of `Assignment.target` and returns the positional index path of a key, or `None`. Handles:

- flat `Name` / dotted `AtomTrailer` (returns `[]`)
- `AtomUnit` (peels parens)
- `TupleVal` / `ListVal` (recursive; nested `((a, b), c)` with key `\"b\"` returns `[0, 1]`)
- starred slots (`*rest`) are intentionally skipped — the starred type is `list[tail]`, not a single element at a fixed index

**2. Barrier extended** in [jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac](jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac). When the flat-target fast path misses, compute the index path, evaluate the RHS, and descend \`ClassType.private.type_args\` along the path. The resulting element type goes through the existing strict-narrowing check:

\`\`\`jac
} elif destructure_path is not None and len(destructure_path) > 0 {
    cursor: TypeBase | None = self.get_type_of_expression(pred.value);
    for idx in destructure_path {
        if (
            isinstance(cursor, types.ClassType)
            and cursor.private.type_args
            and idx < len(cursor.private.type_args)
        ) {
            cursor = self._convert_to_instance(
                cursor.private.type_args[idx]
            );
        } else {
            cursor = None;
            break;
        }
    }
    assigned_type = cursor;
}
\`\`\`

Guarded failures at any step fall through to the previous reset, keeping everything sound (over-reports, never under-reports).

## Known limitations (tracked as sub-gaps 1b-i through 1b-iii)

| Case | Current | Why |
|---|---|---|
| NamedTuple RHS destructure | Resets | Doesn't check \`is_namedtuple()\` / \`has_vars\` — declaration path at :1770 does |
| Variadic \`tuple[int, ...]\` beyond declared prefix | Resets | \`idx < len(type_args)\` guard |
| Union of tuples on RHS | Resets | \`cursor\` not a \`ClassType\` |
| Starred slot \`*rest\` | Resets | Explicitly skipped in the helper |

All over-report, none under-report. Follow-up item 1b-iv in the tracker covers extracting a shared \`_extract_tuple_element_type\` helper that brings NamedTuple support to both the declaration-time path and the barrier for free.

## Test plan

- [x] New regression fixture \`checker_destructure_element_narrowing\` covers five shapes: position-0 literal, position-1 literal, \`-> tuple[int, str]\` return, nested \`((_, b), _)\` destructure, and a non-strict-narrow case that correctly resets.
- [x] Existing \`checker_tuple_unpack_barrier\` still passes — pins the conservative reset for non-tuple RHS (\`reset_pair() -> tuple[int | None, str]\` still resets because the element type doesn't strictly narrow).
- [x] Existing \`checker_starred_unpack_barrier\` still passes — starred slots still reset.
- [x] Full checker suite: 149 tests pass (was 148).
- [x] \`test_cfg_build_pass.jac\` (14) and \`test_sym_tab_build_pass.jac\` (9) pass.
- [x] \`jac format --lintfix\` clean on touched files.
- [x] Release note under 0.13.6.