### PR TITLE
fix(type-system): hover on LHS assignment shows post-write type

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -24,6 +24,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Ternary Narrowing Through `and`/`or` Conditions**: `x if a and b else y` now narrows its branches the same way as the equivalent `if a and b:` statement.
 - **Fix: Pre-Statement Narrowing Reaches Inside Ternary Expressions**: A ternary's branches now see the narrowing established by earlier statements (e.g. `if x is None: return`), so access on the narrowed type works the same inside `x.m() if cond else x.m()` as it does in a plain `if`/`else`.
 - **Fix: Destructuring Assignment Narrows by RHS Element Type**: `(x, _) = (5, "ok")` now narrows `x: int | None` to `int` by extracting the element type at position 0 from the concrete tuple RHS, matching pyright. Works for tuple literals, `-> tuple[T1, T2]` function return types, and nested destructuring like `((a, b), c) = ...`. Falls back to the previous conservative reset when the RHS isn't a concrete tuple or the extracted element type doesn't strictly narrow the declared type.
+- **Fix: Hover on LHS Assignment Shows Post-Write Type**: Hover on an assignment target (flat or destructuring) now reflects the post-write effective type instead of the pre-write declared type, matching pyright/pylance.
 - **Removed: W2052 Broad Exception Warning**: Removed the `W2052` warning that flagged `except Exception` as overly broad. Catching `Exception` is a legitimate and common pattern at system boundaries (e.g., LLM calls, network I/O), and the warning produced false positives in these cases.
 
 ## jaclang 0.13.5 (Latest Release)

--- a/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
@@ -135,8 +135,14 @@ impl TypeCheckPass.exit_assignment(self: TypeCheckPass, nd: uni.Assignment) -> N
         # variable's declared type determines what can be assigned to it.
         if isinstance(target, uni.Name) and target.sym {
             left_type = self.evaluator.get_type_of_symbol(target.sym);
-            # Cache the type on the Name node for hover info
-            target.type = left_type;
+            # `target.type` is the hover cache — show the post-write type
+            # for re-assignments, declared type otherwise. `left_type`
+            # stays declared for the compat check and bare-generic warnings.
+            if hover_type := self.evaluator._get_type_of_lhs_assignment(target) {
+                target.type = self.evaluator._convert_to_instance(hover_type);
+            } else {
+                target.type = left_type;
+            }
             # Warn on bare generic type annotations (e.g. x: list = [])
             if (
                 nd.type_tag
@@ -983,7 +989,8 @@ impl TypeCheckPass.exit_sub_tag(self: TypeCheckPass, nd: uni.SubTag[uni.T]) -> N
     }
 }
 
-"""Evaluate types for each Name in a tuple/list unpacking pattern."""
+"""Evaluate types for each Name leaf in a destructure pattern, recursing
+into nested containers."""
 impl TypeCheckPass._eval_unpacking_names(
     self: TypeCheckPass, container: uni.Expr
 ) -> None {
@@ -991,6 +998,8 @@ impl TypeCheckPass._eval_unpacking_names(
         for val in container.values {
             if isinstance(val, uni.Name) {
                 self.evaluator.get_type_of_expression(val);
+            } elif isinstance(val, (uni.TupleVal, uni.ListVal)) {
+                self._eval_unpacking_names(val);
             }
         }
     }

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/construct_types.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/construct_types.impl.jac
@@ -42,6 +42,72 @@ impl TypeEvaluator._get_type_of_super(node_: uni.SpecialVarRef) -> TypeBase {
     return types.UnknownType();
 }
 
+"""Type an LHS Name receives from its enclosing assignment, or None.
+
+Flat `x = e` returns the type of `e`. Destructure `(x, _) = e` (and
+nested) descends the RHS tuple's `type_args` by positional path.
+
+None is returned — callers keep the declared type — for the declaration
+site itself (its cached `.type` doubles as the declared-type lookup for
+`_get_type_of_symbol`), augmented assignments, member assignments,
+starred slots, and RHS shapes that aren't a concrete positional tuple.
+"""
+impl TypeEvaluator._get_type_of_lhs_assignment(expr: uni.Name) -> TypeBase | None {
+    import from jaclang.compiler.symbol_utils { find_destructure_index_path }
+    # Declaration site: leave the cached declared type intact.
+    if expr.sym is not None and expr.sym.decl is expr {
+        return None;
+    }
+    # Peel destructure / paren wrappers to find the enclosing Assignment.
+    parent = expr.parent;
+    lhs_root: uni.UniNode = expr;
+    while isinstance(parent, (uni.TupleVal, uni.ListVal, uni.AtomUnit)) {
+        lhs_root = parent;
+        parent = parent.parent;
+    }
+    if not isinstance(parent, uni.Assignment) or parent.value is None {
+        return None;
+    }
+    assignment = parent;
+    # `x += e` evaluates to `x <op> e` — defer to the declared type.
+    if assignment.aug_op is not None {
+        return None;
+    }
+    # Identity check — a TupleVal can appear on both sides, `in` uses equality.
+    target_hit = False;
+    for t in assignment.target {
+        if t is lhs_root {
+            target_hit = True;
+            break;
+        }
+    }
+    if not target_hit {
+        return None;
+    }
+    # Flat: the Name is the target.
+    if lhs_root is expr {
+        return self.get_type_of_expression(assignment.value);
+    }
+    # Destructure: descend `type_args` by positional path.
+    path = find_destructure_index_path(lhs_root, expr.value);
+    if path is None or len(path) == 0 {
+        return None;
+    }
+    cursor: TypeBase | None = self.get_type_of_expression(assignment.value);
+    for idx in path {
+        if (
+            isinstance(cursor, types.ClassType)
+            and cursor.private.type_args
+            and idx < len(cursor.private.type_args)
+        ) {
+            cursor = self._convert_to_instance(cursor.private.type_args[idx]);
+        } else {
+            return None;
+        }
+    }
+    return cursor;
+}
+
 """Return the effective type of the float."""
 impl TypeEvaluator.get_type_of_float(nd: uni.Float) -> TypeBase {
     assert self.prefetch.float_class is not None;

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -1605,6 +1605,12 @@ impl TypeEvaluator._get_type_of_expression_core(
                         }
                         symbol_type = special_form;
                     }
+                    # Write-side short-circuit for LHS re-assignments.
+                    if isinstance(expr, uni.Name) {
+                        if lhs_type := self._get_type_of_lhs_assignment(expr) {
+                            return self._convert_to_instance(lhs_type);
+                        }
+                    }
                     # Use CFG-based narrowing for flow-sensitive type.
                     # Narrowed types represent variable values, so ensure
                     # they are instance types (not instantiable class types).

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -355,6 +355,7 @@ obj TypeEvaluator {
     def _get_enclosing_class(nd: uni.UniNode) -> uni.Archetype | None;
     def _get_type_of_self(node_: uni.SpecialVarRef) -> TypeBase;
     def _get_type_of_super(node_: uni.SpecialVarRef) -> TypeBase;
+    def _get_type_of_lhs_assignment(expr: uni.Name) -> TypeBase | None;
     def _convert_to_instance(jtype: TypeBase) -> TypeBase;
     def _type_in_list(ty: TypeBase, type_list: list[TypeBase]) -> bool;
     def _collect_unique_types(ty: TypeBase, result: list[TypeBase]) -> None;

--- a/jac/tests/langserve/fixtures/hover_lhs_assignment.jac
+++ b/jac/tests/langserve/fixtures/hover_lhs_assignment.jac
@@ -1,0 +1,39 @@
+"""Fixture: hover on an LHS assignment target shows the post-write
+effective type, matching pyright/pylance."""
+
+def flat_narrow(x: int | None) -> int {
+    x = 90;
+    return x;
+}
+
+
+def flat_to_none(x: int | None) -> int | None {
+    x = None;
+    return x;
+}
+
+
+def flat_to_union(x: int | None, y: int | None) -> int | None {
+    x = y;
+    return x;
+}
+
+
+def destructure_narrow(x: int | None) -> int {
+    (x, _) = (5, "ok");
+    return x;
+}
+
+
+def destructure_nested(b: int | None) -> int {
+    ((_, b), _) = ((1, 2), 3);
+    return b;
+}
+
+
+def aug_op(x: int | None) -> int | None {
+    if x is not None {
+        x += 1;
+    }
+    return x;
+}

--- a/jac/tests/langserve/test_server.jac
+++ b/jac/tests/langserve/test_server.jac
@@ -773,11 +773,49 @@ test "test_hover_types" {
             (47, 4, "result1", "Dog"),
             (48, 4, "result2", "Cat"),
             (51, 4, "ok_swap", "tuple"),
+
         ];
         for (line, col, var_name, expected_type) in typevar_cases {
             hover = lsp.get_hover_info(typevar_file, lspt.Position(line, col));
             assert hover is not None , f"Hover should exist for {var_name}";
             assert expected_type in hover.contents.value , f"{var_name} should contain {expected_type}, got: {hover.contents.value}";
+        }
+    } finally {
+        teardown_test();
+    }
+}
+
+"""Hover on an LHS assignment target shows the post-write effective type."""
+test "test_hover_lhs_assignment" {
+    setup_test();
+    try {
+        lsp = create_server("");
+        lhs_file = uris.from_fs_path(fixture_path("hover_lhs_assignment.jac"));
+        lsp.type_check_file(lhs_file);
+
+        # (line, col, desc, expected, should_not_contain)
+        cases: list[tuple] = [
+            (5, 5, "flat_narrow LHS x", "int", "None"),
+            (6, 12, "flat_narrow read x", "int", "None"),
+            (11, 5, "flat_to_none LHS x", "None", "int"),
+            (12, 12, "flat_to_none read x", "None", "int"),
+            (17, 5, "flat_to_union LHS x", "int | NoneType", None),
+            (18, 12, "flat_to_union read x", "int | NoneType", None),
+            (23, 6, "destructure_narrow LHS x", "int", "None"),
+            (24, 12, "destructure_narrow read x", "int", "None"),
+            (29, 10, "destructure_nested LHS b", "int", "None"),
+            (30, 12, "destructure_nested read b", "int", "None"),
+            # aug_op: `x += 1` must not leak the bare RHS type.
+            (36, 9, "aug_op LHS x", "int | NoneType", None),
+        ];
+        for case in cases {
+            (line, col, desc, expected, should_not_contain) = case;
+            hover = lsp.get_hover_info(lhs_file, lspt.Position(line - 1, col - 1));
+            assert hover is not None , f"Hover should exist for {desc} at line {line}";
+            assert expected in hover.contents.value , f"{desc}: expected '{expected}' in hover, got: {hover.contents.value}";
+            if should_not_contain {
+                assert should_not_contain not in hover.contents.value , f"{desc}: should NOT contain '{should_not_contain}', got: {hover.contents.value}";
+            }
         }
     } finally {
         teardown_test();


### PR DESCRIPTION
## Summary

Hover on an LHS assignment target now reflects the post-write effective type instead of the pre-write declared type, matching pyright/pylance. Before:

| Expression | `x` / `b` declared | pyright hover | us (before) | us (after) |
|---|---|---|---|---|
| `x = 90` | `int \| None` | `int` | `int \| None` | `int` |
| `x = None` | `int \| None` | `None` | `int \| None` | `None` |
| `(x, _) = (5, "ok")` | `int \| None` | `int` | `int \| None` | `int` |
| `((_, b), _) = ((1, 2), 3)` | `int \| None` | `int` | *no type shown* | `int` |

Read-side hover was already correct (it goes through the backward CFG walker, which PR #5504 taught to handle the destructure-barrier case). This PR closes the complementary write-side gap.

## Root cause

Two code paths, both wrong for different reasons:

1. **Flat LHS** `x = 90` — the type checker's `exit_assignment` explicitly cached `target.type = get_type_of_symbol(target.sym)` (the declared type) on the LHS Name, pre-populating the hover cache before the evaluator ever dispatched on it.
2. **Destructure leaf** `(x, _) = ...` — the leaf Names reached `case uni.Name()` via `_eval_unpacking_names`, but that case ran the backward CFG walker, which from the LHS position only sees *upstream* narrowings. The assignment's own effect isn't upstream of itself, so it was invisible.

Both paths were answering "what type does `x` have just before this statement?" — the wrong question for a write position.

## The fix

One new helper, called from both sites:

```jac
impl TypeEvaluator._get_type_of_lhs_assignment(expr: uni.Name) -> TypeBase | None {
    # Declaration site: leave the cached declared type intact.
    if expr.sym is not None and expr.sym.decl is expr {
        return None;
    }
    # Peel destructure / paren wrappers to find the enclosing Assignment.
    parent = expr.parent;
    lhs_root: uni.UniNode = expr;
    while isinstance(parent, (uni.TupleVal, uni.ListVal, uni.AtomUnit)) {
        lhs_root = parent;
        parent = parent.parent;
    }
    if not isinstance(parent, uni.Assignment) or parent.value is None {
        return None;
    }
    assignment = parent;
    # `x += e` evaluates to `x <op> e` — defer to the declared type.
    if assignment.aug_op is not None {
        return None;
    }
    # Identity check — a TupleVal can appear on both sides, `in` uses equality.
    target_hit = False;
    for t in assignment.target {
        if t is lhs_root {
            target_hit = True;
            break;
        }
    }
    if not target_hit {
        return None;
    }
    # Flat: the Name is the target.
    if lhs_root is expr {
        return self.get_type_of_expression(assignment.value);
    }
    # Destructure: descend `type_args` by positional path.
    path = find_destructure_index_path(lhs_root, expr.value);
    ...
}
```

Wire points:

- **`exit_assignment`** (`type_checker_pass.impl.jac:136-150`) — replaces the flat-LHS hover cache with the helper's post-write type. `left_type` is kept as the declared type for the downstream compat check and bare-generic warnings.
- **`case uni.Name()`** (`type_evaluator.impl.jac:1608-1617`) — short-circuits for destructure LHS leaves, which reach this path via `_eval_unpacking_names` (now recurses into nested containers so `((a, b), c) = ...` leaves get visited).

## Design properties

- **One helper, two wires.** The logic for "what does this Name become after the assignment" lives in one place. Both call sites call it.
- **Self-guarding.** The declaration-site guard, aug-op guard, and target-identity check live inside the helper — call sites can't forget them.
- **Sound fallthrough.** Every unhandled shape returns `None` and the caller keeps the declared type. No silent wrong values. Unhandled cases (member assignment `obj.x = e`, NamedTuple / variadic / union-of-tuples RHS, starred slots) stay on the existing path.
- **No narrowing-walker interference.** Read-side narrowing still runs its backward CFG walker. The write-side helper short-circuits *before* it, so reads and writes each get the right logic without overlap.

## Test plan

- [x] New regression test `test_hover_lhs_assignment` in `jac/tests/langserve/test_server.jac` covers 11 hover positions across 6 shapes: flat narrowing, flat to None, flat to union (no-narrow), simple destructure, nested destructure, and augmented assignment (pins the aug-op guard).
- [x] Full langserve suite: 27 tests pass.
- [x] Full checker suite: 149 tests pass — including `test_assert_isinstance_narrowing` and `test_type_narrowing` which caught an earlier draft where the declaration-site guard was missing.
- [x] `test_cfg_build_pass.jac` (14) and `test_sym_tab_build_pass.jac` (9) pass.
- [x] `jac format --lintfix` clean on touched files.
- [x] Release note under 0.13.6.

## Not covered by this PR (tracked as sub-gaps)

- `obj.x = e` (member assignment LHS hover) — different AST shape, scoped out to keep this PR focused.
- NamedTuple / variadic tuple / union-of-tuples RHS — same sub-gaps documented under item 1b in the narrowing follow-up tracker.
- Augmented assignment post-write type — the helper correctly defers to the declared type; the real fix is tracker item #2 and will make both the hover path and the assignment barrier produce the right `x <op> e` type uniformly.

All over-report, none under-report.
