### PR TITLE
fix(esast_gen_pass): typed dispatch parity and runtime fallback for cl.jac method calls

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.13.6 (Unreleased)
 
+- **Fix: ES Codegen Method Dispatch on `.cl.jac` Files**: Operator-side primitive dispatch now walks the receiver's MRO, so `"a" in name.lower()` lowers to `.includes()` instead of a runtime-crashing JS `in`. When the receiver's static type isn't a JS-native primitive, Python method idioms (`lower`, `upper`, `strip`, `lstrip`, `rstrip`, `append`, `extend`, `pop`) now route through `_jac.poly.*` runtime helpers that `typeof`-dispatch to the native JS operation, instead of leaking Python identifiers into the JS output.
 - **Fix: Console BrokenPipeError in Sidecar Mode**: Console `print()` and `flush()` now catch `BrokenPipeError`/`OSError`, preventing crashes when stdout is closed (e.g., Tauri sidecar after port discovery).
 - **Fix: Scheduler Null Safety**: `stop()` and `wait()` now guard against `None` on `_stop_event`, `_done_event`, and `_thread`, preventing `AttributeError` during early shutdown.
 - **Fix: `JAC_DATA_PATH` Environment Variable for Read-Only Deployments**: `UserManager` and `get_db_path()` now honor the `JAC_DATA_PATH` env var, redirecting writable runtime data (database, `.jac/data/`) to a specified path. Enables deployments where the base path is read-only (e.g., AppImage).

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -122,6 +122,11 @@ glob _T = TypeVar('_T', bound=es.Node),
          Tok.BW_AND_EQ: "emit_op_iand",
          Tok.BW_XOR_EQ: "emit_op_ixor"
      },
+     # Python-only method names that have no JS equivalent. When the static
+     # type of the receiver cannot be proven (issue #5508 / #5453), the
+     # codegen routes these calls through `_jac.poly.<method>(target, ...)`,
+     # which dispatches to the native JS operation at runtime.
+     POLYMORPHIC_METHODS: set[str] = {"lower","upper","strip","lstrip","rstrip","append","extend","pop"},
      LiteralValue = str | bool | int | float | None;
 
 """Track declarations within a lexical scope."""
@@ -263,6 +268,7 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def exit_switch_stmt(nd: uni.SwitchStmt) -> None;
     def exit_switch_case(nd: uni.SwitchCase) -> None;
     def _ensure_emitters -> None;
+    def _resolve_primitive_type_name(_obj_type: object) -> str;
     def _try_primitive_op(
         expr_node: uni.UniNode,
         emit_method: str,

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -1198,26 +1198,10 @@ impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
         } except Exception {
             _obj_type = None;
         }
-        self._ensure_emitters();
-        _type_name = "";
-        if isinstance(_obj_type, jtypes.ClassType) and _obj_type.shared {
-            # Direct match (e.g. str, list, dict).
-            if _obj_type.shared.class_name in self._primitive_type_names {
-                _type_name = _obj_type.shared.class_name;
-            } else {
-                # Walk the MRO to catch subtypes like LiteralString → str.
-                for _base in _obj_type.shared.mro {
-                    if _base.shared
-                    and _base.shared.class_name in self._primitive_type_names {
-                        _type_name = _base.shared.class_name;
-                        break;
-                    }
-                }
-            }
-        }
+        _type_name = self._resolve_primitive_type_name(_obj_type);
+        _method_name = callee.property.name;
         if _type_name {
             _emitter = self._primitive_emitters.get(_type_name);
-            _method_name = callee.property.name;
             _emit_fn_name = "emit_" + _method_name;
             _emit_fn = getattr(_emitter, _emit_fn_name, None) if _emitter else None;
             if _emit_fn {
@@ -1249,6 +1233,39 @@ impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
                 nd.gen.es_ast = self.sync_loc(es.Identifier(name=_result), jac_node=nd);
                 return;
             }
+        }
+        # --- Polymorphic fallback (issue #5508 / #5453) ---
+        # When the static type of the receiver is not provably a JS-native
+        # primitive (e.g. props of type `dict`, results of `or` widening,
+        # comprehension over an untyped list), the typed dispatch above
+        # cannot pick an emitter, so without a fallback we would otherwise
+        # leak the Python method name verbatim into the JavaScript output
+        # and crash at runtime. Route through `_jac.poly.<method>(target,
+        # ...args)`, which dispatches at runtime based on the JS type.
+        if _method_name in POLYMORPHIC_METHODS {
+            _poly_args: list[(es.Expression | es.SpreadElement)] = [
+                cast(es.Expression, callee.object)
+            ];
+            for _a in args {
+                _poly_args.append(_a);
+            }
+            _poly_callee = es.MemberExpression(
+                object=es.MemberExpression(
+                    object=es.Identifier(name='_jac'),
+                    property=es.Identifier(name='poly'),
+                    computed=False
+                ),
+                property=es.Identifier(name=_method_name),
+                computed=False
+            );
+            self.needs_jac_runtime = True;
+            nd.gen.es_ast = self.sync_loc(
+                es.CallExpression(
+                    callee=cast(es.Expression, _poly_callee), arguments=_poly_args
+                ),
+                jac_node=nd
+            );
+            return;
         }
     }
     # --- Primitive emitter dispatch for builtin function calls ---
@@ -1623,6 +1640,31 @@ impl EsastGenPass._ensure_emitters -> None {
     self._builtin_emitter = _pes.ESBuiltinEmitter();
 }
 
+"""Resolve a Jac type to a primitive type name (e.g. ``str``, ``list``).
+
+Returns the matching primitive name if ``_obj_type`` is a ``ClassType`` whose
+``class_name`` (or any base in its MRO) is registered as a primitive, otherwise
+``""``. Used by both method-call and operator dispatch so that subtypes like
+``LiteralString`` resolve to ``str`` consistently.
+"""
+impl EsastGenPass._resolve_primitive_type_name(_obj_type: object) -> str {
+    import from jaclang.compiler.type_system { types as jtypes }
+    self._ensure_emitters();
+    if not (isinstance(_obj_type, jtypes.ClassType) and _obj_type.shared) {
+        return "";
+    }
+    if _obj_type.shared.class_name in self._primitive_type_names {
+        return _obj_type.shared.class_name;
+    }
+    # Walk the MRO to catch subtypes like LiteralString → str.
+    for _base in _obj_type.shared.mro {
+        if _base.shared and _base.shared.class_name in self._primitive_type_names {
+            return _base.shared.class_name;
+        }
+    }
+    return "";
+}
+
 """Try to dispatch an operator through the primitive emitter system.
 
 Returns an es.Expression (raw Identifier wrapping emitted JS) on success, or None
@@ -1635,7 +1677,6 @@ impl EsastGenPass._try_primitive_op(
     right_es: (es.Expression | None),
     jac_node: uni.UniNode
 ) -> (es.Expression | None) {
-    import from jaclang.compiler.type_system { types as jtypes }
     import from jaclang.compiler.passes.ecmascript.es_unparse { JSCodeGenerator }
     _obj_type = None;
     try {
@@ -1646,15 +1687,10 @@ impl EsastGenPass._try_primitive_op(
     } except Exception {
         _obj_type = None;
     }
-    self._ensure_emitters();
-    if not (
-        isinstance(_obj_type, jtypes.ClassType)
-        and _obj_type.shared
-        and _obj_type.shared.class_name in self._primitive_type_names
-    ) {
+    _type_name = self._resolve_primitive_type_name(_obj_type);
+    if not _type_name {
         return None;
     }
-    _type_name = _obj_type.shared.class_name;
     _emitter = self._primitive_emitters.get(_type_name);
     _emit_fn = getattr(_emitter, emit_method, None) if _emitter else None;
     if not _emit_fn {

--- a/jac/jaclang/compiler/passes/ecmascript/jac_runtime_js.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/jac_runtime_js.jac
@@ -290,6 +290,61 @@ glob JAC_RUNTIME_JS_OBJECT: str = r"""{
     }
   },
 
+  // Runtime-polymorphic helpers used when the static type of the receiver is
+  // not provably str/list/etc., so the codegen cannot pick a typed emitter.
+  // Each helper checks the JS type and dispatches to the native operation;
+  // if the value is not a JS primitive of the expected shape, it falls back
+  // to calling the same-named method on the object so user-defined classes
+  // that implement Python-style methods still work.
+  poly: {
+    lower(s) { return typeof s === "string" ? s.toLowerCase() : s.lower(); },
+    upper(s) { return typeof s === "string" ? s.toUpperCase() : s.upper(); },
+    strip(s, chars) {
+      if (typeof s === "string") {
+        if (chars === undefined) return s.trim();
+        let i = 0, j = s.length;
+        while (i < j && chars.indexOf(s[i]) !== -1) i++;
+        while (j > i && chars.indexOf(s[j - 1]) !== -1) j--;
+        return s.slice(i, j);
+      }
+      return chars === undefined ? s.strip() : s.strip(chars);
+    },
+    lstrip(s, chars) {
+      if (typeof s === "string") {
+        if (chars === undefined) return s.replace(/^\s+/, "");
+        let i = 0;
+        while (i < s.length && chars.indexOf(s[i]) !== -1) i++;
+        return s.slice(i);
+      }
+      return chars === undefined ? s.lstrip() : s.lstrip(chars);
+    },
+    rstrip(s, chars) {
+      if (typeof s === "string") {
+        if (chars === undefined) return s.replace(/\s+$/, "");
+        let j = s.length;
+        while (j > 0 && chars.indexOf(s[j - 1]) !== -1) j--;
+        return s.slice(0, j);
+      }
+      return chars === undefined ? s.rstrip() : s.rstrip(chars);
+    },
+    append(a, x) {
+      if (Array.isArray(a)) { a.push(x); return null; }
+      return a.append(x);
+    },
+    extend(a, b) {
+      if (Array.isArray(a)) { for (const v of b) a.push(v); return null; }
+      return a.extend(b);
+    },
+    pop(a, i) {
+      if (Array.isArray(a)) {
+        if (i === undefined) return a.pop();
+        const idx = i < 0 ? a.length + i : i;
+        return a.splice(idx, 1)[0];
+      }
+      return i === undefined ? a.pop() : a.pop(i);
+    }
+  },
+
   list: {
     remove(arr, val) {
       const i = arr.indexOf(val);

--- a/jac/tests/compiler/passes/ecmascript/fixtures/issue_5508_str_method_dispatch.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/issue_5508_str_method_dispatch.cl.jac
@@ -1,0 +1,44 @@
+"""Regression fixture for issue #5508.
+
+Two failure modes for the type-driven primitive emitter dispatch:
+
+Case 1: ``in`` operator on a string-returning method call.  The receiver of
+``.lower()`` is correctly transpiled to ``.toLowerCase()``, but the
+surrounding ``in`` operator was not, because the operator-side dispatch
+(``_try_primitive_op``) only matched primitive class names directly and did
+not walk the MRO the way the method-side dispatch does.
+
+Case 2: string methods on a value whose static type is not provably ``str``
+(props of type ``dict``, results of ``or`` widening, etc.).  The dispatch
+gives up and emits the Python method name verbatim, producing JavaScript
+that crashes at runtime.
+"""
+
+cl {
+    def:pub case1_in_chain() -> JsxElement {
+        has found: bool = False;
+        can with entry {
+            name = "alice";
+            found = "a" in name.lower();
+        }
+        return <div>{str(found)}</div>;
+    }
+
+    def:pub case2_props_upper(props: dict) -> JsxElement {
+        name = props["name"] or "";
+        initial = name[:1].upper();
+        return <div>{initial}</div>;
+    }
+
+    def:pub case2_props_strip(props: dict) -> JsxElement {
+        raw = props["title"] or "";
+        clean = raw.strip();
+        return <div>{clean}</div>;
+    }
+
+    def:pub case2_props_lower(props: dict) -> JsxElement {
+        raw = props["label"] or "";
+        lower = raw.lower();
+        return <div>{lower}</div>;
+    }
+}

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -666,7 +666,12 @@ test "separated files" {
 
     # Check the spawned walker function is present
     assert "let response = await __jacSpawn(" in js_code;
-    assert "__jacSpawn(\"create_todo\", \"\", {\"text\": input.strip()});" in js_code;
+    # `input` is destructured from useState (external React typings) so its
+    # static type is unknown — `.strip()` routes through the polymorphic
+    # runtime helper instead of leaking the Python method name.
+    assert (
+        "__jacSpawn(\"create_todo\", \"\", {\"text\": _jac.poly.strip(input)});" in js_code
+    );
 }
 
 test "separated defpub generates rpc stubs" {
@@ -876,11 +881,14 @@ test "compr list multiple filters" {
 test "compr list method call" {
     js_code = compile_fixture_to_js("comprehensions.cl.jac", FIXTURES);
 
-    # list_compr_method: [x.strip() for x in items] → items.map(x => x.strip())
-    # items is typed as bare `list` (no element type), so x is Unknown
-    # and strip() correctly stays untranspiled.
-    assert ".strip()" in js_code , (
-        "Method call in comprehension output should be preserved"
+    # list_compr_method: [x.strip() for x in items] → items.map(x => _jac.poly.strip(x))
+    # `items` is typed as bare `list` (no element type), so x is Unknown.
+    # Pre-#5508 the codegen leaked the Python `.strip()` verbatim into JS,
+    # which crashes at runtime. The polymorphic runtime helper dispatches
+    # to `String.prototype.trim` for actual strings.
+    assert "_jac.poly.strip(x)" in js_code , (
+        "Untyped element method calls in comprehensions should route "
+        "through _jac.poly.* runtime helpers"
     );
 }
 
@@ -891,6 +899,67 @@ test "str methods on local vars and chained calls" {
     assert "text.toUpperCase().trim()" in js_code , "chained str.upper().strip() should map to .toUpperCase().trim()";
     assert "text.trim().toUpperCase()" in js_code , "chained str.strip().upper() should map to .trim().toUpperCase()";
     assert "text.toUpperCase().trim().toLowerCase()" in js_code , "triple-chained str.upper().strip().lower() should map to .toUpperCase().trim().toLowerCase()";
+}
+
+test "issue 5508 case1 in operator on str method call" {
+    # Regression for jaseci-labs/jaseci#5508 case 1.
+    # `"a" in name.lower()` was emitting a raw JS `in` operator on a string
+    # because operator-side dispatch (_try_primitive_op) did not walk the MRO
+    # to recognize the LiteralString return type as `str`. The receiver of
+    # `.lower()` got translated to `.toLowerCase()`, but the `in` operator
+    # itself was left untranslated, crashing at runtime in the browser.
+    js_code = compile_fixture_to_js("issue_5508_str_method_dispatch.cl.jac", FIXTURES);
+    assert "name.toLowerCase().includes(\"a\")" in js_code , (
+        "`x in str_method()` should lower to .includes() on the method result"
+    );
+    assert "(\"a\" in name.toLowerCase())" not in js_code , (
+        "raw JS `in` operator on a string would crash at runtime"
+    );
+}
+
+test "issue 5508 case2 str methods on untyped receivers" {
+    # Regression for jaseci-labs/jaseci#5508 case 2 (also covers #5453).
+    # When the static type of the receiver is not provably `str` (props of
+    # type `dict`, results of `or` widening, comprehension over untyped
+    # list, etc.) the codegen used to emit Python method names verbatim
+    # (`.upper`, `.strip`, `.lower`) which crash at runtime in JS. Fall
+    # back to runtime-polymorphic helpers (`_jac.poly.*`) instead.
+    js_code = compile_fixture_to_js("issue_5508_str_method_dispatch.cl.jac", FIXTURES);
+    # Pluck out the user-compiled function bodies (skip the injected
+    # _jac runtime, which legitimately contains `s.upper()` etc. as the
+    # user-class fallback inside its polyfills).
+    user_chunks = [];
+    for fn_name in ["case2_props_upper", "case2_props_strip", "case2_props_lower"] {
+        idx = js_code.find("function " + fn_name);
+        assert idx >= 0 , (f"missing compiled function {fn_name}");
+        user_chunks.append(js_code[idx:idx + 400]);
+    }
+    user_code = "\n".join(user_chunks);
+    # Untyped string methods must NOT survive verbatim into the user code.
+    assert ".upper()" not in user_code , (
+        "Python `.upper()` should not appear verbatim in compiled user JS"
+    );
+    assert ".strip()" not in user_code , (
+        "Python `.strip()` should not appear verbatim in compiled user JS"
+    );
+    assert ".lower()" not in user_code , (
+        "Python `.lower()` (without a static str type) should not appear "
+        "verbatim in compiled user JS"
+    );
+    # Should route through the polymorphic runtime helpers.
+    assert "_jac.poly.upper(" in user_code , (
+        "Untyped .upper() should route through _jac.poly.upper()"
+    );
+    assert "_jac.poly.strip(" in user_code , (
+        "Untyped .strip() should route through _jac.poly.strip()"
+    );
+    assert "_jac.poly.lower(" in user_code , (
+        "Untyped .lower() should route through _jac.poly.lower()"
+    );
+    # The _jac runtime must be injected when poly helpers are used.
+    assert "const _jac = {" in js_code , (
+        "_jac runtime must be injected when _jac.poly.* helpers are emitted"
+    );
 }
 
 test "compr list ternary output" {


### PR DESCRIPTION
## Summary

Two fixes for the type-driven primitive emitter dispatch in the ECMAScript codegen, both motivated by #5508 (and the earlier related #5453):

- **Site B MRO walk.** Operator-side dispatch (`_try_primitive_op`) now resolves the receiver type through the MRO so subtypes like `LiteralString` are recognized as `str`, matching the existing behavior of method-side dispatch. The shared logic is extracted into `_resolve_primitive_type_name` and used by both sites. Without this, expressions like `\"a\" in name.lower()` left the JS `in` operator untranslated even though `name.lower()` itself was correctly lowered to `name.toLowerCase()`, producing a runtime `TypeError`.

- **`_jac.poly` runtime fallback.** When the static receiver type cannot be resolved to a JS-native primitive (e.g. `props: dict` subscript, `useState` destructure, comprehension over bare `list`) but the method name is a known Python idiom, the codegen now routes the call through `_jac.poly.<method>(target, ...)` instead of leaking the Python identifier verbatim into the compiled JavaScript. The polyfill checks `typeof` at runtime and dispatches to the native JS operation for strings/arrays, falling through to a same-named user method for other objects.

The dispatcher covers `lower`, `upper`, `strip`, `lstrip`, `rstrip`, `append`, `extend`, `pop`, gated by an explicit `POLYMORPHIC_METHODS` allowlist so unrelated method calls keep their existing fall-through behavior.

## Before / after

```jac
cl {
    def:pub case1_in_chain() -> JsxElement {
        has found: bool = False;
        can with entry {
            name = \"alice\";
            found = \"a\" in name.lower();
        }
        return <div>{str(found)}</div>;
    }

    def:pub case2_props_upper(props: dict) -> JsxElement {
        name = props[\"name\"] or \"\";
        initial = name[:1].upper();
        return <div>{initial}</div>;
    }
}
```

Before:
```js
setFound((\"a\" in name.toLowerCase()));   // TypeError at runtime
let initial = name.slice(0, 1).upper();    // .upper is not a function
```

After:
```js
setFound(name.toLowerCase().includes(\"a\"));
let initial = _jac.poly.upper(name.slice(0, 1));
```

## Why a runtime fallback (not just a static fix)

The polyfill is genuinely necessary for fully dynamic code (`def f(x: Any) -> str { return x.lower(); }`). But several patterns where it fires today should ideally be handled by tighter type inference upstream — `props: dict` subscript, `… or \"\"` narrowing, `useState` generic propagation, and bare-`list` element-type inference. Those gaps are tracked in #5509; closing each one removes another `_jac.poly.*` call from compiled output and shifts work back to the zero-cost typed-dispatch path.

## Tests

- New fixture `tests/compiler/passes/ecmascript/fixtures/issue_5508_str_method_dispatch.cl.jac` exercises both cases.
- New tests `issue 5508 case1 ...` and `issue 5508 case2 ...` in `test_js_generation.jac` assert the corrected output and that the `_jac` runtime is injected when the polyfill fires.
- Existing `compr list method call` and `separated files` tests, which documented the broken pre-fix output, are updated to assert the new `_jac.poly.*` calls. Their old assertions baked in the bug.

## Test plan

- [x] New \`issue 5508 case1\` test passes (Site B MRO walk).
- [x] New \`issue 5508 case2\` test passes (`_jac.poly.*` fallback fires for untyped receivers and the runtime is injected).
- [x] Updated \`compr list method call\` and \`separated files\` tests pass.
- [x] Full ecmascript suite: 68/68 passing (`pytest tests/compiler/passes/ecmascript/`).
- [x] Full repo suite: 3139 passing; the only failures are a preexisting segfault flake in `test_native_gen_pass.jac::transitive import …` that reproduces on stock `main` and is unrelated to this change.

Fixes #5508
Refs #5453, #5509