### PR TITLE
docs: sv-to-sv microservice interop reference + tutorial

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,14 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.13.6 (Unreleased)
 
-<<<<<<< feat/sv-to-sv-microservice-impl
-
 - **Feat: SV-to-SV Microservice Interop**: `sv import` between two server modules now generates Python HTTP client stubs that route calls through `jaclang.runtimelib.sv_client` instead of loading the provider in-process.
-=======
 - **Fix: ES Codegen Method Dispatch on `.cl.jac` Files**: Operator-side primitive dispatch now walks the receiver's MRO, so `"a" in name.lower()` lowers to `.includes()` instead of a runtime-crashing JS `in`. When the receiver's static type isn't a JS-native primitive, Python method idioms (`lower`, `upper`, `strip`, `lstrip`, `rstrip`, `append`, `extend`, `pop`) now route through `_jac.poly.*` runtime helpers that `typeof`-dispatch to the native JS operation, instead of leaking Python identifiers into the JS output.
-
->>>>>>> main
-
 - **Fix: Console BrokenPipeError in Sidecar Mode**: Console `print()` and `flush()` now catch `BrokenPipeError`/`OSError`, preventing crashes when stdout is closed (e.g., Tauri sidecar after port discovery).
 - **Fix: Scheduler Null Safety**: `stop()` and `wait()` now guard against `None` on `_stop_event`, `_done_event`, and `_thread`, preventing `AttributeError` during early shutdown.
 - **Fix: `JAC_DATA_PATH` Environment Variable for Read-Only Deployments**: `UserManager` and `get_db_path()` now honor the `JAC_DATA_PATH` env var, redirecting writable runtime data (database, `.jac/data/`) to a specified path. Enables deployments where the base path is read-only (e.g., AppImage).

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -128,6 +128,8 @@ sv import from .database { connect_db }
 sv node SecretData { has value: str; }
 ```
 
+> **Note on `sv import` between two server modules.** When both the importer and the importee are server-context modules running as separate microservices, `sv import` generates HTTP client stubs instead of pulling the provider into the consumer's process. The same source also works as a monolith. See [Microservice Interop (sv-to-sv)](jac-scale.md#microservice-interop-sv-to-sv) in the jac-scale reference for details.
+
 ### REST API with jac start
 
 Public walkers automatically become REST endpoints:

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -800,6 +800,175 @@ To create a private broadcasting walker, remove `: pub` from the walker definiti
 - WebSocket walkers are **only** accessible via `ws://host/ws/{walker_name}`
 - The connection stays open until the client disconnects
 
+## Microservice Interop (sv-to-sv)
+
+Jac Scale lets you split a server-side codebase into multiple independently-deployed microservices without changing call sites. When two `sv` (server) modules each run as their own `JacAPIServer`, an `sv import` from one to the other generates HTTP client stubs at compile time, so calls become RPCs over the wire instead of in-process imports.
+
+### Overview
+
+The `sv import` keyword wires up two flavors of cross-process interop, depending on what context the importer and importee are in:
+
+- **cl-to-sv**: client browser code calls server functions over HTTP. Stubs are generated in JavaScript by the ES code generator.
+- **sv-to-sv**: one server module calls another server module that runs as a separate microservice. Stubs are generated in Python by `PyastGenPass` and dispatched through `jaclang.runtimelib.sv_client`.
+
+In the sv-to-sv flavor, `order_service.jac` doing `sv import from inventory_service { check_stock }` does not pull `inventory_service` into the consumer's process. Calling `check_stock(sku)` issues a `POST /function/check_stock` against the inventory service's URL using the same envelope format as cl-to-sv interop.
+
+The same source can run as a monolith (single `jac start`) or as separate services with no code changes -- the only difference is whether each module is started as its own server.
+
+For a step-by-step walkthrough that covers project setup, running both services, and watching the round-trip, see the [Microservices tutorial](../../tutorials/production/microservices.md). The rest of this section is a reference for the runtime contract, resolution chain, and plugin hook.
+
+### Requirements
+
+A few preconditions that the resolution chain assumes:
+
+- **Public functions only.** Provider functions reachable through `sv import` must be declared `def:pub`. Non-public functions are not registered as `/function/<name>` endpoints, so the generated stub call would 404. Walkers similarly need `walker:pub`.
+- **jac-scale on the consumer.** Resolution paths 1-3 (test client, manual register, env var) live in `jaclang.runtimelib.sv_client` and work in any jaclang install. The auto-spawn fallback (path 4) hangs off `JacAPIServer.ensure_sv_service`, which is provided by jac-scale -- a bare jaclang install does not have it.
+- **Sibling source on the consumer's `base_path`.** When the auto-spawn fallback fires, it loads the missing module from the consumer's `base_path_dir`. If you `jac start /abs/path/consumer.jac` from an unrelated working directory, the auto-spawned sibling will fail to find `provider.jac`. Either keep all services in the same directory and start with the directory as cwd, or set `JAC_SV_<MODULE>_URL` explicitly so the fallback never runs.
+- **Project layout.** `jac start <relative-path>` requires a `jac.toml` in the cwd. Either run `jac create` first, or pass an absolute path.
+
+### Boundary Types
+
+Types that cross the service boundary use the same wire contract as cl-to-sv interop. The compiler emits a lightweight Python stub class for every type referenced in an `sv import` (like `DivResult` above), with `__from_wire` / `__to_wire` helpers that handle (de)serialization.
+
+What works:
+
+- **`obj` types** -- fields hydrated recursively, including nested objects.
+- **`enum` types** -- serialized by name.
+- **Primitives** -- `int`, `float`, `str`, `bool`, `None`, `list[T]`, `dict[K, V]`.
+- **Bidirectional** -- typed function arguments are wrapped on the way out and unwrapped on the way in.
+
+What doesn't:
+
+- **Walkers, anchors, closures** -- not wire-friendly. Pass identifiers (e.g. `jid`) and re-resolve on the other side.
+- **Live database handles, file handles** -- service-local resources only.
+
+Failures (network errors, missing service, error envelope from the provider) raise `RuntimeError` with a message of the form `sv-to-sv RPC '{module}.{func}' failed: {msg}`.
+
+### Service Discovery
+
+When a stub is invoked, `sv_client._ensure_available(module_name)` resolves the target service in this order. The first hit wins:
+
+1. **In-process `TestClient`** -- if a `starlette.testclient.TestClient` was registered via `sv_client.register_test_client(module_name, client)`, calls route through it directly with no HTTP. Used by tests for fast in-process runs.
+2. **Explicit URL registration** -- a URL registered via `sv_client.register(module_name, url)`. Useful when an orchestrator (e.g. a service mesh sidecar, custom plugin) knows where each service lives.
+3. **`JAC_SV_<MODULE>_URL` environment variable** -- automatically consulted using the upper-cased module name. The most common production knob.
+4. **`JacAPIServer.ensure_sv_service` plugin hook** -- last-resort fallback that the default jac-scale impl uses to spawn a sibling service in a background daemon thread on a deterministic free port in the range `18000-18999`. Plugins can override this to spawn services in containers, K8s jobs, or anywhere else.
+
+The auto-spawned sibling binds `127.0.0.1` only -- it is reachable from inside the consumer process but not from outside. It exists for in-process convenience (single-binary local dev, tests that span service boundaries), not for serving traffic to other hosts. For real multi-host deployments, use path 2 or 3.
+
+> **Port range collision.** Avoid using ports `18000-18999` for your manual `jac start --port` flags. That range is reserved for auto-spawned siblings, and a manual port that lands at the same hash slot as a future auto-spawn will collide. Pick something in the 8000s or 9000s for explicit external ports.
+
+### Production Patterns
+
+#### Kubernetes
+
+Each service is its own `Deployment` + `Service`. Wire the consumer with an env var pointing at the provider's cluster DNS name:
+
+```yaml
+# order-service deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: order-service
+        image: my-registry/order-service:latest
+        env:
+        - name: JAC_SV_INVENTORY_SERVICE_URL
+          value: "http://inventory-service.default.svc.cluster.local:8000"
+```
+
+The convention is `JAC_SV_<UPPERCASED_MODULE_NAME>_URL`. Module name is the value used in `sv import from <module_name>`.
+
+#### Local Development
+
+For multi-service local dev, the simplest pattern is `JAC_SV_*_URL` env vars in a `.env` file or your shell:
+
+```bash
+export JAC_SV_INVENTORY_SERVICE_URL=http://localhost:8001
+export JAC_SV_MATH_SERVICE_URL=http://localhost:8002
+jac start order_service.jac --port 8000
+```
+
+Alternatively, omit the env vars and let the default `ensure_sv_service` hook auto-spawn each missing service as a background daemon thread on its first call. This is convenient for prototyping but is not recommended for production: services share a process, the spawned listener is loopback-only, and there's no health monitoring beyond the initial readiness poll.
+
+#### Troubleshooting
+
+- **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchors persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv -- any `def:pub` call can hit this after a schema change.
+- **`No module named '<provider>'` from the auto-spawn fallback.** The consumer's `base_path_dir` does not contain the provider source. Run the consumer with the project directory as cwd, or set `JAC_SV_<MODULE>_URL` so the fallback never runs.
+- **Stub call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
+
+### Testing
+
+The recommended in-process test pattern uses `TestClient` and short-circuits the resolution chain:
+
+```jac
+import from jaclang.runtimelib { sv_client }
+import from starlette.testclient { TestClient }
+import from jac_scale.serve { JacAPIServer }
+
+def make_server(mod: str, base_path: str) -> TestClient {
+    srv = JacAPIServer(module_name=mod, port=0, base_path=base_path);
+    srv.load_module();
+    srv.register_health_endpoint();
+    srv.register_functions_endpoints();
+    srv.register_walkers_endpoints();
+    srv.server.create_server();
+    client = TestClient(srv.server.app, raise_server_exceptions=False);
+    sv_client.register_test_client(mod, client);
+    return client;
+}
+
+test "sv-to-sv: consumer reaches provider" {
+    sv_client.clear_test_clients();
+    prov = make_server("inventory_service", "/path/to/services");
+    cons = make_server("order_service", "/path/to/services");
+
+    prov.post(
+        "/function/add_product",
+        json={"sku": "W", "name": "Widget", "quantity": 50, "price": 9.99}
+    );
+    resp = cons.post(
+        "/function/create_order",
+        json={"items": [{"sku": "W", "quantity": 2}]}
+    ).json();
+    assert resp["data"]["result"]["success"] is True;
+}
+```
+
+Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over. With `register_test_client` in place, no real HTTP, port allocation, or background threads are involved -- everything runs in-process through the ASGI test app.
+
+### sv_client API Reference
+
+The `jaclang.runtimelib.sv_client` module exposes a small public surface for runtime control. The compiler emits `sv_client.call(...)` for you on every `sv import`-generated stub, so you rarely need to call it directly.
+
+| Function | Purpose |
+|---|---|
+| `register(module_name: str, url: str)` | Register a service URL for resolution. |
+| `unregister(module_name: str)` | Remove a previously-registered URL. |
+| `register_test_client(module_name: str, client)` | Register an in-process `TestClient` (testing only). |
+| `unregister_test_client(module_name: str)` | Remove a `TestClient` registration. |
+| `clear_test_clients()` | Drop all `TestClient` registrations. Call between tests. |
+| `resolve_url(module_name: str) -> str` | Look up the registered URL or `JAC_SV_<MOD>_URL` env var. |
+| `call(module_name, func_name, args: dict) -> Any` | Manual RPC dispatch. The compiler generates calls to this. |
+
+### Plugin Hook: `ensure_sv_service`
+
+`JacAPIServer.ensure_sv_service(module_name: str, base_path: str) -> None` is the last-resort step in the resolution chain. Plugins override it to spawn services in their own infrastructure -- Docker containers, Kubernetes Jobs, systemd units, or anything else.
+
+The default jac-scale implementation:
+
+1. Picks a deterministic free port starting at `18000 + (hash(module_name) % 1000)`.
+2. Builds a base `JacAPIServer` (not plugin-resolved, to avoid recursion) with `port=0`.
+3. Wires up a vanilla `http.server.HTTPServer` bound to `127.0.0.1` with the base server's request handler.
+4. Runs `serve_forever` in a daemon thread.
+5. Polls the new server until it returns any non-5xx response (10s deadline). The poll target is `/functions` but a 404 is sufficient -- the check is "the listener is up and serving HTTP", not "this specific endpoint exists".
+6. Calls `sv_client.register(module_name, base_url)` so subsequent calls skip the hook.
+
+A custom plugin replaces this with whatever spawn / health-check / registration logic suits its target environment, then ends with the same `sv_client.register` call.
+
 ## Storage
 
 Jac provides a built-in storage abstraction for file and blob operations. The core runtime ships with a local filesystem implementation, and jac-scale can override it with cloud storage backends -- all through the same `store()` builtin.

--- a/docs/docs/tutorials/production/microservices.md
+++ b/docs/docs/tutorials/production/microservices.md
@@ -1,0 +1,371 @@
+# Microservices with `sv import`
+
+A Jac codebase can run as a single monolith or as several independently-deployed microservices, with no source changes between the two. The trick is the `sv import` keyword: when both the importer and the importee are server-context modules, the compiler generates an HTTP client stub for the imported function instead of pulling the provider into the consumer's process. Calls become RPCs over the wire, but the source still reads like a normal import.
+
+This tutorial walks through splitting a tiny app into two services and watching the round-trip happen, then shows how to point the consumer at a real provider URL and how to test the boundary in-process.
+
+> **Prerequisites**
+>
+> - Completed: [Local API Server](local.md)
+> - Time: ~20 minutes
+> - Reference: [Microservice Interop in jac-scale](../../reference/plugins/jac-scale.md#microservice-interop-sv-to-sv)
+
+---
+
+## Overview
+
+Two services, two `jac start` processes, one HTTP boundary between them. The consumer's `sv import` looks identical to a regular import, but every call out to the provider is a `POST /function/<name>` over the wire.
+
+```mermaid
+graph LR
+    Client["Client<br/>(curl, browser)"] -- "POST /function/sum_list" --> Calc["calculator_service<br/>jac start :8002"]
+    Calc -- "POST /function/add (x5)" --> Math["math_service<br/>jac start :8001"]
+    Math -- "result" --> Calc
+    Calc -- "result" --> Client
+```
+
+The consumer never imports the provider into its own process. After the call, the consumer's `sys.modules` does not contain `math_service`.
+
+---
+
+## 1. Set Up the Project
+
+Create a working directory with a `jac.toml` so `jac start` recognizes it as a project. The two services live side by side in the same directory.
+
+```bash
+mkdir microservices-demo && cd microservices-demo
+cat > jac.toml <<'EOF'
+[project]
+name = "microservices-demo"
+version = "0.1.0"
+EOF
+```
+
+> **Why `jac.toml`?** `jac start <relative-path>` requires a `jac.toml` in the current directory. Without one, you get `Error: No jac.toml found`. You can also pass an absolute path to `jac start`, but the auto-spawn fallback (covered later) needs both services to live in the same directory anyway, so a project layout is the simplest path.
+
+---
+
+## 2. Create the Provider
+
+`math_service.jac` exposes three public functions and one boundary type.
+
+```jac
+# math_service.jac
+obj DivResult {
+    has result: float | None = None,
+        error: str = "";
+}
+
+def:pub add(a: int, b: int) -> int {
+    return a + b;
+}
+
+def:pub multiply(a: int, b: int) -> int {
+    return a * b;
+}
+
+def:pub divide(a: float, b: float) -> DivResult {
+    if b == 0.0 {
+        return DivResult(error="division by zero");
+    }
+    return DivResult(result=a / b);
+}
+```
+
+The `def:pub` modifier is required: only public functions get registered as `/function/<name>` endpoints, and the consumer's generated stub will 404 against anything else. `DivResult` is a boundary type -- it crosses the wire as JSON and gets re-hydrated on the consumer side.
+
+---
+
+## 3. Create the Consumer
+
+`calculator_service.jac` imports from the provider with `sv import` and uses the imported functions like ordinary local calls.
+
+```jac
+# calculator_service.jac
+sv import from math_service { add, multiply, divide, DivResult }
+
+def:pub sum_list(numbers: list[int]) -> int {
+    result = 0;
+    for n in numbers {
+        result = add(result, n);  # HTTP call to math_service
+    }
+    return result;
+}
+
+def:pub dot_product(a: list[int], b: list[int]) -> int {
+    result = 0;
+    for i in range(len(a)) {
+        result = add(result, multiply(a[i], b[i]));
+    }
+    return result;
+}
+
+def:pub safe_divide(a: float, b: float) -> DivResult {
+    return divide(a, b);  # boundary type round-trips
+}
+```
+
+Read this file as if `add`, `multiply`, and `divide` were local functions. The compiler swaps them out for HTTP stubs at compile time, but the call site does not change.
+
+---
+
+## 4. Run Both Services
+
+Open two terminals, both in the `microservices-demo` directory.
+
+**Terminal 1 -- start the provider:**
+
+```bash
+jac start math_service.jac --port 8001
+```
+
+**Terminal 2 -- start the consumer with the provider URL:**
+
+```bash
+JAC_SV_MATH_SERVICE_URL=http://localhost:8001 \
+    jac start calculator_service.jac --port 8002
+```
+
+The `JAC_SV_<UPPERCASED_MODULE>_URL` env var tells the consumer where to find the named provider. The module name is exactly what you wrote after `sv import from`, upper-cased.
+
+> **Avoid ports 18000-18999.** That range is reserved for the auto-spawn fallback (next section). Pick something in the 8000s for explicit external ports.
+
+---
+
+## 5. Watch the Round-Trip
+
+From a third terminal, exercise the consumer:
+
+```bash
+# Cross-service: 5 add() calls under the hood
+curl -X POST http://localhost:8002/function/sum_list \
+  -H "Content-Type: application/json" \
+  -d '{"numbers":[1,2,3,4,5]}'
+```
+
+```json
+{"ok":true,"data":{"result":15,"reports":[]},"error":null,"meta":{"extra":{"http_status":200}}}
+```
+
+Now look at the **provider** terminal -- you will see five `POST /function/add` lines, one per iteration of the consumer's loop:
+
+```text
+Executing function 'add' with params: {'a': 0, 'b': 1}
+  127.0.0.1:41112 - "POST /function/add HTTP/1.1" 200
+Executing function 'add' with params: {'a': 1, 'b': 2}
+  127.0.0.1:41124 - "POST /function/add HTTP/1.1" 200
+...
+```
+
+That is the proof: the consumer's loop is fanning out to the provider on each iteration. The two services are real processes talking over real HTTP.
+
+### Boundary Type Round-Trip
+
+`safe_divide` returns a `DivResult` from the provider, which the consumer hands back to its own caller. The compiler generates a Python stub class for `DivResult` on the consumer side with `from_wire` / `to_wire` helpers, so the wrapped object behaves like a normal `obj` instance.
+
+```bash
+curl -X POST http://localhost:8002/function/safe_divide \
+  -H "Content-Type: application/json" \
+  -d '{"a":10.0,"b":2.0}'
+```
+
+```json
+{"ok":true,"data":{"result":{"_jac_type":"DivResult","error":"","result":5.0},"reports":[]},...}
+```
+
+```bash
+curl -X POST http://localhost:8002/function/safe_divide \
+  -H "Content-Type: application/json" \
+  -d '{"a":10.0,"b":0.0}'
+```
+
+```json
+{"ok":true,"data":{"result":{"_jac_type":"DivResult","error":"division by zero","result":null},"reports":[]},...}
+```
+
+Both error and success cases survive the boundary intact. The `_jac_type` metadata lets the consumer's runtime hand the caller a real `DivResult` instance, not a raw dict.
+
+---
+
+## 6. Auto-Spawn Fallback (Prototyping)
+
+For fast local iteration you can skip the second `jac start` entirely. If no `JAC_SV_*_URL` env var is set, the consumer's first call to a missing service triggers `JacAPIServer.ensure_sv_service`, which spawns the provider as a background daemon thread inside the consumer process and registers it under `127.0.0.1` on a port in the 18000-18999 range.
+
+Stop both services from the previous step, clear any leftover state, and start only the consumer:
+
+```bash
+rm -rf .jac/data/
+jac start calculator_service.jac --port 8002
+```
+
+Now hit `sum_list` again:
+
+```bash
+curl -X POST http://localhost:8002/function/sum_list \
+  -H "Content-Type: application/json" \
+  -d '{"numbers":[1,2,3]}'
+```
+
+```json
+{"ok":true,"data":{"result":6,"reports":[]},...}
+```
+
+The first call takes a fraction of a second longer because the consumer is spawning the sibling listener and polling it for readiness; subsequent calls are direct.
+
+> **The auto-spawned sibling is loopback-only.** It binds `127.0.0.1`, not `0.0.0.0`. That makes it convenient for single-binary local dev and tests, but it cannot serve traffic to other hosts. For real deployments, run each service as its own `jac start` and wire them with `JAC_SV_*_URL` env vars (or [override the plugin hook](../../reference/plugins/jac-scale.md#plugin-hook-ensure_sv_service)).
+
+The auto-spawn fallback also requires both services to live in the same directory: it loads the missing module from the consumer's `base_path_dir`, so `jac start` from the project root works, but `jac start /some/abs/path/calc.jac` from an unrelated cwd does not.
+
+---
+
+## 7. Test the Boundary In-Process
+
+When you write tests for the consumer, you do not want them to hit a real provider over HTTP. Register an in-process `TestClient` instead, and the consumer's stub calls route through it directly.
+
+```jac
+# test_microservices.jac
+import sys;
+import shutil;
+import tempfile;
+import from pathlib { Path }
+import from jaclang { JacRuntime as Jac }
+import from jaclang.jac0core.constant { Constants as Con }
+import from jaclang.runtimelib { sv_client }
+import from starlette.testclient { TestClient }
+import from jac_scale.serve { JacAPIServer }
+
+glob HERE: Path = Path(__file__).parent;
+
+def make_server(mod: str, base_path: str) -> TestClient {
+    if mod in Jac.loaded_modules { del Jac.loaded_modules[mod]; }
+    if mod in sys.modules { del sys.modules[mod]; }
+    Jac.jac_import(target=mod, base_path=base_path, lng="jac");
+    srv = JacAPIServer(module_name=mod, port=0, base_path=base_path);
+    srv.load_module();
+    srv.register_health_endpoint();
+    srv.register_walkers_endpoints();
+    srv.register_functions_endpoints();
+    srv.register_create_user_endpoint();
+    srv.register_login_endpoint();
+    srv.user_manager.create_user(Con.GUEST.value, '__no_password__');
+    srv.server.create_server();
+    client = TestClient(srv.server.app, raise_server_exceptions=False);
+    sv_client.register_test_client(mod, client);
+    return client;
+}
+
+test "calculator routes through math via TestClient" {
+    tmp = tempfile.mkdtemp();
+    try {
+        shutil.copy2(HERE / "math_service.jac", Path(tmp) / "math_service.jac");
+        shutil.copy2(HERE / "calculator_service.jac", Path(tmp) / "calculator_service.jac");
+        Jac.set_base_path(tmp);
+        Jac.set_context(Jac.create_j_context(user_root=None));
+        sv_client.clear_test_clients();
+
+        prov = make_server("math_service", tmp);
+        cons = make_server("calculator_service", tmp);
+
+        resp = cons.post(
+            "/function/sum_list", json={"numbers": [1, 2, 3, 4, 5]}
+        ).json();
+        assert resp["ok"] is True;
+        assert resp["data"]["result"] == 15;
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+```
+
+```bash
+python -m pytest test_microservices.jac -v
+```
+
+Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over from a previous test's registration. With `register_test_client` in place, no real HTTP, port allocation, or background threads are involved -- everything runs in-process through the ASGI test app, which makes the suite fast and deterministic.
+
+---
+
+## 8. Going to Production
+
+For real deployments, each service runs as its own `Deployment` (or VM, container, systemd unit) and the consumer is told where the provider lives via `JAC_SV_*_URL`.
+
+### Kubernetes
+
+```yaml
+# inventory-service: provider
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: inventory-service
+        image: my-registry/inventory-service:latest
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-service
+spec:
+  selector:
+    app: inventory-service
+  ports:
+  - port: 8000
+---
+# order-service: consumer, points at inventory-service via cluster DNS
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+spec:
+  template:
+    spec:
+      containers:
+      - name: order-service
+        image: my-registry/order-service:latest
+        env:
+        - name: JAC_SV_INVENTORY_SERVICE_URL
+          value: "http://inventory-service.default.svc.cluster.local:8000"
+```
+
+The convention is `JAC_SV_<UPPERCASED_MODULE_NAME>_URL`. The module name is exactly the value used in `sv import from <module_name>`. Hyphens in module names become underscores; dots stay as dots.
+
+For the full Kubernetes deployment story (image building, ingress, autoscaling), see the [Kubernetes tutorial](kubernetes.md) -- it applies here unchanged, you just deploy each service separately and wire them with env vars.
+
+### Local Multi-Service
+
+The same pattern works locally with shell exports:
+
+```bash
+export JAC_SV_INVENTORY_SERVICE_URL=http://localhost:8001
+export JAC_SV_MATH_SERVICE_URL=http://localhost:8002
+jac start order_service.jac --port 8000
+```
+
+Each consumer process picks up its `JAC_SV_*_URL` vars at the moment of the first cross-service call, so you can `export` them in your shell profile or a `.env` file loaded by your dev workflow.
+
+---
+
+## Common Pitfalls
+
+- **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchor data persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv -- any `def:pub` call can hit this after a schema change.
+- **`No module named '<provider>'` from the auto-spawn fallback.** The consumer's `base_path_dir` does not contain the provider source. Run the consumer from the project root, or set `JAC_SV_<MODULE>_URL` so the fallback never runs.
+- **Stub call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
+- **`Error: No jac.toml found`.** `jac start <relative-path>` requires a `jac.toml` in the current directory. Run `jac create` (or just create an empty one), or pass an absolute path.
+- **Cross-service errors arrive as `RuntimeError`.** Network failures, missing services, and provider-side error envelopes all surface in the consumer as `RuntimeError("sv-to-sv RPC '{module}.{func}' failed: {msg}")`. Catch them at boundaries where you want graceful degradation.
+
+---
+
+## What You Built
+
+Two services that read like a single program. The split happens at deploy time, not source time -- the same `calculator_service.jac` runs unchanged whether `math_service` is a module in the same process, a sibling thread, a separate `jac start`, or a Kubernetes Deployment two clusters away.
+
+## Next Steps
+
+- [Microservice Interop reference](../../reference/plugins/jac-scale.md#microservice-interop-sv-to-sv) for the resolution chain, `sv_client` API, and plugin hook details.
+- [Kubernetes tutorial](kubernetes.md) for the full deployment pipeline that packages each service into its own image.
+- [Backend Integration](../fullstack/backend.md) for the cl-to-sv flavor of `sv import`, where a browser client calls a server.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
           - jac-scale Reference: "reference/plugins/jac-scale.md"
           - Learn by Doing:
               - Local API Server: "tutorials/production/local.md"
+              - Microservices with sv import: "tutorials/production/microservices.md"
               - Kubernetes: "tutorials/production/kubernetes.md"
       - Developer Workflow:
           - CLI Commands: "reference/cli/index.md"


### PR DESCRIPTION
## Summary

Documentation pass for the sv-to-sv microservice interop feature that landed in jaseci-labs/jaseci#5512. Adds a reference section, a runnable tutorial, and fixes stray merge conflict markers that ended up in the release notes.

- **Reference (`reference/plugins/jac-scale.md`):** new "Microservice Interop (sv-to-sv)" section covering the resolution chain (TestClient → register → env var → `ensure_sv_service` plugin hook), boundary type contract, `sv_client` API table, plugin hook walkthrough, requirements callout, and a troubleshooting subsection for the gotchas a new user is most likely to hit (stale `.jac/data` anchor errors, auto-spawn `base_path` resolution, missing `def:pub`).
- **Tutorial (`tutorials/production/microservices.md`):** runnable end-to-end walkthrough using a `math_service` + `calculator_service` pair. Covers project setup (`jac.toml`, cwd), running both services with `JAC_SV_*_URL`, watching the round-trip in the provider log, the auto-spawn fallback for fast prototyping, and an in-process `TestClient` pattern for tests. Production section shows the K8s + cluster DNS pattern.
- **Disambiguation note (`reference/plugins/jac-client.md`):** short note in the existing `sv import` section pointing readers at the new jac-scale reference when both sides of the import are server modules, since the existing coverage is cl-to-sv only.
- **Nav (`mkdocs.yml`):** slot the new tutorial under `Deployment & Scaling > Learn by Doing`, between `Local API Server` and `Kubernetes`.
- **Release notes hygiene (`community/release_notes/jaclang.md`):** the SV-to-SV and ES Codegen Method Dispatch entries landed via concurrent PRs and the merge left unresolved `<<<<<<<` / `=======` / `>>>>>>>` markers around the SV-to-SV bullet on `main`. Both entries are real and correct; this PR just deletes the markers.

## Verification

Every code block in the tutorial was exercised end-to-end against `.venv/bin/jac`:

- Two `jac start` processes (`math_service.jac` on 8001, `calculator_service.jac` on 8002) with `JAC_SV_MATH_SERVICE_URL` set: provider log shows the consumer's `sum_list` fanning out as 5× `POST /function/add`. ✅
- Boundary `obj` round-trip via `safe_divide` (both success and `division by zero` paths): `_jac_type` metadata preserved, error string survives the wire. ✅
- Auto-spawn fallback (no env var, no manual provider start): consumer's first call triggers `ensure_sv_service`, sibling listener appears on `127.0.0.1:18712` (`18000 + hash("math_service") % 1000`), subsequent calls reuse the registration. ✅
- In-process `TestClient` test fixture from the tutorial: `pytest test_microservice_demo.jac` passes verbatim. ✅

The QA also surfaced (and the docs now cover) several gotchas: `jac start <relative-path>` requires `jac.toml` in cwd; the auto-spawn fallback requires sibling source on the consumer's `base_path_dir`; ports `18000-18999` are reserved for auto-spawned siblings; the auto-spawned listener binds `127.0.0.1` only; stale `.jac/data/` produces confusing `Invalid anchor id` 500s.

## Test plan

- [ ] `mkdocs build` succeeds with no warnings on the new files
- [ ] All anchor links (`#microservice-interop-sv-to-sv`, `#plugin-hook-ensure_sv_service`) resolve
- [ ] Pre-commit hooks pass (markdownlint, em-dash ban, yaml check)
- [ ] Walk through the tutorial top-to-bottom and reproduce the cross-service round-trip