### PR TITLE
feat(sv-to-sv): eager auto-spawn of sv-import providers at consumer startup

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.2.14 (Unreleased)
 
+- **Feat: SV-to-SV Eager Auto-Spawn in `jac start`**: `jac start consumer.jac` now brings up every `sv import`-ed provider (including transitive ones) automatically before serving the first request, so single-host multi-service deployments need exactly one terminal and zero env vars.
 - **Fix: ScaleTieredMemory Initialization**: Changed `ScaleTieredMemory.init(use_cache)` to `postinit` lifecycle method with `use_cache` as a class field, fixing initialization order issues.
 - **Fix: Windows Compatibility for Local Sandbox**: Added platform guards for Unix-only APIs, cross-platform temp paths, Windows-compatible shell commands, --jac-cli sidecar support, and increased readiness timeout to 300s.
 - **Fix: Spurious "write access" warnings on system root during sync**: Skip `check_write_access()` for unchanged anchors in MongoDB sync, eliminating noisy `Current root doesn't have write access to NodeAnchor Root` log spam on every authenticated request.

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.13.6 (Unreleased)
 
+- **Feat: SV-to-SV Eager Auto-Spawn**: `jac start consumer.jac` now brings up every `sv import`-ed provider (including transitive ones via BFS) at consumer startup, before the first request arrives; the env var path stays for cross-host providers.
 - **Feat: SV-to-SV Microservice Interop**: `sv import` between two server modules now generates Python HTTP client stubs that route calls through `jaclang.runtimelib.sv_client` instead of loading the provider in-process.
 - **Fix: ES Codegen Method Dispatch on `.cl.jac` Files**: Operator-side primitive dispatch now walks the receiver's MRO, so `"a" in name.lower()` lowers to `.includes()` instead of a runtime-crashing JS `in`. When the receiver's static type isn't a JS-native primitive, Python method idioms (`lower`, `upper`, `strip`, `lstrip`, `rstrip`, `append`, `extend`, `pop`) now route through `_jac.poly.*` runtime helpers that `typeof`-dispatch to the native JS operation, instead of leaking Python identifiers into the JS output.
 - **Fix: Console BrokenPipeError in Sidecar Mode**: Console `print()` and `flush()` now catch `BrokenPipeError`/`OSError`, preventing crashes when stdout is closed (e.g., Tauri sidecar after port discovery).

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -802,33 +802,31 @@ To create a private broadcasting walker, remove `: pub` from the walker definiti
 
 ## Microservice Interop (sv-to-sv)
 
-Jac Scale lets you split a server-side codebase into multiple independently-deployed microservices without changing call sites. When two `sv` (server) modules each run as their own `JacAPIServer`, an `sv import` from one to the other generates HTTP client stubs at compile time, so calls become RPCs over the wire instead of in-process imports.
+Jac Scale lets you split a server-side codebase into multiple independently-deployed microservices without changing call sites. When two `sv` (server) modules each run as their own server process, an `sv import` from one to the other generates HTTP client stubs at compile time, so calls become RPCs over the wire instead of in-process imports.
 
 ### Overview
 
-The `sv import` keyword wires up two flavors of cross-process interop, depending on what context the importer and importee are in:
+The `sv import` keyword has two flavors depending on where the importer and the importee live:
 
-- **cl-to-sv**: client browser code calls server functions over HTTP. Stubs are generated in JavaScript by the ES code generator.
-- **sv-to-sv**: one server module calls another server module that runs as a separate microservice. Stubs are generated in Python by `PyastGenPass` and dispatched through `jaclang.runtimelib.sv_client`.
+- **cl-to-sv**: client code calls server functions. Calls go over HTTP from browser to server.
+- **sv-to-sv**: one server module calls another server module that runs as a separate microservice. Calls go over HTTP from one server process to another.
 
-In the sv-to-sv flavor, `order_service.jac` doing `sv import from inventory_service { check_stock }` does not pull `inventory_service` into the consumer's process. Calling `check_stock(sku)` issues a `POST /function/check_stock` against the inventory service's URL using the same envelope format as cl-to-sv interop.
+In the sv-to-sv flavor, `order_service.jac` doing `sv import from inventory_service { check_stock }` does not load `inventory_service` into the consumer's process. Calling `check_stock(sku)` issues a `POST /function/check_stock` against the inventory service's URL and returns the result. The same source runs unchanged whether `inventory_service` is a separate microservice, a sibling process started by the same `jac start` command, or (when `sv import` is absent) a normal in-process import.
 
-The same source can run as a monolith (single `jac start`) or as separate services with no code changes -- the only difference is whether each module is started as its own server.
-
-For a step-by-step walkthrough that covers project setup, running both services, and watching the round-trip, see the [Microservices tutorial](../../tutorials/production/microservices.md). The rest of this section is a reference for the runtime contract, resolution chain, and plugin hook.
+For a step-by-step walkthrough that covers project setup, running both services, and watching the round-trip, see the [Microservices tutorial](../../tutorials/production/microservices.md). The rest of this section is a reference for the discovery rules, wire contract, and plugin override surface.
 
 ### Requirements
 
-A few preconditions that the resolution chain assumes:
+A few preconditions for `sv import` to work:
 
-- **Public functions only.** Provider functions reachable through `sv import` must be declared `def:pub`. Non-public functions are not registered as `/function/<name>` endpoints, so the generated stub call would 404. Walkers similarly need `walker:pub`.
-- **jac-scale on the consumer.** Resolution paths 1-3 (test client, manual register, env var) live in `jaclang.runtimelib.sv_client` and work in any jaclang install. The auto-spawn fallback (path 4) hangs off `JacAPIServer.ensure_sv_service`, which is provided by jac-scale -- a bare jaclang install does not have it.
-- **Sibling source on the consumer's `base_path`.** When the auto-spawn fallback fires, it loads the missing module from the consumer's `base_path_dir`. If you `jac start /abs/path/consumer.jac` from an unrelated working directory, the auto-spawned sibling will fail to find `provider.jac`. Either keep all services in the same directory and start with the directory as cwd, or set `JAC_SV_<MODULE>_URL` explicitly so the fallback never runs.
-- **Project layout.** `jac start <relative-path>` requires a `jac.toml` in the cwd. Either run `jac create` first, or pass an absolute path.
+- **Public functions only.** Provider functions reached through `sv import` must be declared `def:pub`; non-public functions are not exposed as endpoints, and calls into them return 404. Walkers similarly need `walker:pub`.
+- **jac-scale on the consumer.** Explicit URLs and env vars work with any jaclang install. Automatic spawning of siblings is provided by jac-scale; a bare jaclang install can still call providers registered by URL.
+- **Project layout.** `jac start <relative-path>` requires a `jac.toml` in the current directory. Run `jac create` first, or pass an absolute path.
+- **Services in the same directory when auto-spawning.** If the consumer auto-spawns a provider, it loads the provider source from the directory you ran `jac start` in. Keep all services in the same project directory, or point the consumer at a provider URL explicitly so auto-spawning never runs.
 
 ### Boundary Types
 
-Types that cross the service boundary use the same wire contract as cl-to-sv interop. The compiler emits a lightweight Python stub class for every type referenced in an `sv import` (like `DivResult` above), with `__from_wire` / `__to_wire` helpers that handle (de)serialization.
+Types that cross the service boundary use the same wire contract as cl-to-sv interop. The compiler emits a matching wrapper on the consumer side for every type referenced in an `sv import`, so values serialize transparently into JSON on the way out and deserialize back into the declared type on the way in.
 
 What works:
 
@@ -844,26 +842,26 @@ What doesn't:
 
 Failures (network errors, missing service, error envelope from the provider) raise `RuntimeError` with a message of the form `sv-to-sv RPC '{module}.{func}' failed: {msg}`.
 
-### Eager Startup Discovery
+### Automatic Startup
 
-Every `sv import` in a consumer module emits a compile-time `_declare_consumer_provider(<consumer>, <provider>)` call into the consumer's import-time stubs. At consumer server startup, `JacAPIServer._ensure_sv_siblings()` walks that compile-time-recorded provider list and dispatches every provider through `sv_client.ensure_all(...)` **before** serving the first request. The pass does a BFS over siblings' provider lists to pick up transitive dependencies: if A imports B and B imports C, the root consumer's startup brings up both B and C in order.
+When you run `jac start consumer.jac`, the consumer finds every service it `sv import`s from and brings them all up **before** it starts accepting requests. Transitive dependencies are included: if A imports B and B imports C, starting A brings up all three.
 
-`ensure_all` resolves providers in parallel through a bounded `ThreadPoolExecutor(max_workers=8)` and is **fail-fast**: the first resolution failure cancels pending spawns and re-raises, so misconfiguration surfaces at deploy time rather than at first request.
+Startup is **fail-fast**: if any service fails to come up (missing source file, syntax error, port in use), the consumer crashes at startup with the underlying error. You find out at deploy time, not at first request.
 
-The hook lives in `JacAPIServer.start()`, which only fires under `jac start`. `jac run` does not go through `JacAPIServer` and falls back to lazy per-call resolution via `_ensure_available`.
+Automatic startup only applies to `jac start`. `jac run` is for one-shot scripts and does not bring up long-running sibling services; if it calls an `sv import`-ed function it will try to discover the provider lazily using the rules in [Service Discovery](#service-discovery) below.
 
 ### Service Discovery
 
-When a stub is invoked (or eager startup dispatches it), `sv_client._ensure_available(module_name)` resolves the target service in this order. The first hit wins:
+For each `sv import`-ed provider, the consumer resolves it in this order. The first match wins:
 
-1. **In-process `TestClient`** -- if a `starlette.testclient.TestClient` was registered via `sv_client.register_test_client(module_name, client)`, calls route through it directly with no HTTP. Used by tests for fast in-process runs.
-2. **Explicit URL registration** -- a URL registered via `sv_client.register(module_name, url)`. Useful when an orchestrator (e.g. a service mesh sidecar, custom plugin) knows where each service lives.
-3. **`JAC_SV_<MODULE>_URL` environment variable** -- automatically consulted using the upper-cased module name. The most common production knob when the provider lives on a different host.
-4. **`JacAPIServer.ensure_sv_service` plugin hook** -- the default jac-scale impl spawns a sibling service in a background daemon thread on a deterministic free port in the range `18000-18999`. Spawned siblings carry `is_sv_sibling=True`, which makes them skip their own eager-spawn pass so the root consumer is the sole source of spawns (no cold-start race, no double-spawn on cycles). Plugins can override this to spawn services in containers, K8s jobs, or anywhere else.
+1. **Test client** -- if tests have wired up an in-process `TestClient` for the provider, calls go through it with no HTTP. See [Testing](#testing).
+2. **Explicit URL** -- a URL the consumer was handed programmatically (e.g. by a custom orchestrator). See the [sv_client API](#sv_client-api-reference).
+3. **`JAC_SV_<MODULE>_URL` environment variable** -- automatically consulted using the upper-cased module name. This is the knob to reach for when the provider lives on a different host.
+4. **Automatic spawn** -- jac-scale brings up the provider as a sibling inside the consumer process. This is the path that lets `jac start consumer.jac` run the whole cluster from one command.
 
-The auto-spawned sibling binds `127.0.0.1` only -- it is reachable from inside the consumer process but not from outside. It exists for in-process convenience (single-binary local dev, tests that span service boundaries), not for serving traffic to other hosts. For real multi-host deployments, use path 2 or 3.
+Automatically-spawned siblings are bound to `127.0.0.1` -- they are reachable from inside the consumer process but not from outside. This makes single-command mode a supported deployment for **single-host** setups, but you cannot reach a sibling from another machine. For multi-host deployments, wire the consumer with `JAC_SV_<MODULE>_URL` pointing at the provider running elsewhere.
 
-> **Port range collision.** Avoid using ports `18000-18999` for your manual `jac start --port` flags. That range is reserved for auto-spawned siblings, and a manual port that lands at the same hash slot as a future auto-spawn will collide. Pick something in the 8000s or 9000s for explicit external ports.
+Siblings are assigned ports in the range `18000-18999`. Pick ports outside this range (e.g. in the 8000s) for your own `jac start --port` flags so a manual port does not collide with a future automatic spawn.
 
 ### Production Patterns
 
@@ -900,45 +898,31 @@ export JAC_SV_MATH_SERVICE_URL=http://localhost:8002
 jac start order_service.jac --port 8000
 ```
 
-Alternatively, omit the env vars entirely and let the eager-spawn pass bring up every sv-imported provider at consumer startup. `jac start order_service.jac` alone is enough: before serving the first request, the consumer's startup walks its compile-time provider list, BFSes any transitive providers, and auto-spawns each as a sibling daemon thread. This is a supported deployment mode for **single-host** setups (one process, many logical services). For **multi-host** deployments, use the `JAC_SV_*_URL` env var path instead, since auto-spawned siblings bind `127.0.0.1` only and cannot serve traffic to other hosts.
+Alternatively, omit the env vars entirely and run `jac start order_service.jac` on its own. The consumer will find every service it `sv import`s from and bring them all up automatically (including transitive dependencies) before serving the first request. This is a supported deployment mode for **single-host** setups -- one process, many logical services. For **multi-host** deployments use the `JAC_SV_*_URL` path instead: automatically-started services bind `127.0.0.1` only and cannot serve traffic to other hosts.
 
 #### Troubleshooting
 
-- **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchors persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv -- any `def:pub` call can hit this after a schema change.
-- **`No module named '<provider>'` from the auto-spawn fallback.** The consumer's `base_path_dir` does not contain the provider source. Run the consumer with the project directory as cwd, or set `JAC_SV_<MODULE>_URL` so the fallback never runs.
-- **Stub call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
+- **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchors persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv; any `def:pub` call can hit this after a schema change.
+- **Consumer crashes at startup with `ModuleNotFoundError: No module named '<provider>'`.** Automatic startup could not find the provider source in the directory you ran `jac start` from. Either move all services into the same project directory, or set `JAC_SV_<MODULE>_URL` to point the consumer at a provider running elsewhere.
+- **Cross-service call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
 
 ### Testing
 
-The recommended in-process test pattern uses `TestClient` and short-circuits the resolution chain:
+To test cross-service behavior without real network I/O, wire each provider up as an in-process `TestClient` before constructing the consumer. `sv_client.register_test_client(module_name, client)` routes the consumer's calls through the registered client directly; no sockets, no port allocation, no background threads.
 
 ```jac
 import from jaclang.runtimelib { sv_client }
 import from starlette.testclient { TestClient }
-import from jac_scale.serve { JacAPIServer }
 
-def make_server(mod: str, base_path: str) -> TestClient {
-    srv = JacAPIServer(module_name=mod, port=0, base_path=base_path);
-    srv.load_module();
-    srv.register_health_endpoint();
-    srv.register_functions_endpoints();
-    srv.register_walkers_endpoints();
-    srv.server.create_server();
-    client = TestClient(srv.server.app, raise_server_exceptions=False);
-    sv_client.register_test_client(mod, client);
-    return client;
-}
-
-test "sv-to-sv: consumer reaches provider" {
+test "consumer reaches provider" {
     sv_client.clear_test_clients();
-    prov = make_server("inventory_service", "/path/to/services");
-    cons = make_server("order_service", "/path/to/services");
 
-    prov.post(
-        "/function/add_product",
-        json={"sku": "W", "name": "Widget", "quantity": 50, "price": 9.99}
-    );
-    resp = cons.post(
+    prov_client: TestClient = ...;  # build a TestClient over the provider app
+    cons_client: TestClient = ...;  # build a TestClient over the consumer app
+    sv_client.register_test_client("inventory_service", prov_client);
+
+    # Calls from the consumer into inventory_service now route through prov_client
+    resp = cons_client.post(
         "/function/create_order",
         json={"items": [{"sku": "W", "quantity": 2}]}
     ).json();
@@ -946,39 +930,30 @@ test "sv-to-sv: consumer reaches provider" {
 }
 ```
 
-Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over. With `register_test_client` in place, no real HTTP, port allocation, or background threads are involved -- everything runs in-process through the ASGI test app.
+The two builder steps marked `...` are the boilerplate of standing up a consumer and provider in-process and wrapping each one in a `starlette.testclient.TestClient`. That scaffolding currently leans on hands-on use of jac-scale's server-construction APIs. The sv-to-sv test suite in the jac-scale source tree has a worked example that copies fixture files into a temp directory and brings both services up end-to-end; start there if you need a runnable harness.
+
+Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over from a previous test's registrations.
 
 ### sv_client API Reference
 
-The `jaclang.runtimelib.sv_client` module exposes a small public surface for runtime control. The compiler emits `sv_client.call(...)` for you on every `sv import`-generated stub, so you rarely need to call it directly.
+`jaclang.runtimelib.sv_client` exposes a small control surface for telling the runtime where to find providers. You rarely need it under normal use -- `JAC_SV_<MODULE>_URL` covers most production wiring, and automatic startup covers single-host setups. Reach for these functions when you are writing tests or a custom orchestrator.
 
 | Function | Purpose |
 |---|---|
-| `register(module_name: str, url: str)` | Register a service URL for resolution. |
-| `unregister(module_name: str)` | Remove a previously-registered URL. |
-| `register_test_client(module_name: str, client)` | Register an in-process `TestClient` (testing only). |
-| `unregister_test_client(module_name: str)` | Remove a `TestClient` registration. |
-| `clear_test_clients()` | Drop all `TestClient` registrations. Call between tests. |
-| `resolve_url(module_name: str) -> str` | Look up the registered URL or `JAC_SV_<MOD>_URL` env var. |
-| `call(module_name, func_name, args: dict) -> Any` | Manual RPC dispatch. The compiler generates calls to this. |
-| `ensure_all(module_names: list[str])` | Resolve every named provider in parallel (max 8 workers), fail-fast. Used by the eager startup pass. |
-| `get_consumer_providers(consumer_name: str) -> list[str]` | Return the compile-time provider list for a consumer module. |
-| `clear_consumer_providers()` | Drop all `_declare_consumer_provider` registrations. Call between tests. |
+| `register(module_name: str, url: str)` | Point a provider name at a URL programmatically. Takes precedence over the env var path. |
+| `unregister(module_name: str)` | Remove a registration made via `register`. |
+| `register_test_client(module_name, client)` | Route calls to a provider through an in-process `TestClient` (tests only). See [Testing](#testing). |
+| `unregister_test_client(module_name: str)` | Remove a test-client registration. |
+| `clear_test_clients()` | Drop all test-client registrations. Call between tests to avoid bleed-over. |
+| `resolve_url(module_name: str) -> str` | Look up the URL the consumer would use for a provider (either from `register` or from `JAC_SV_<MOD>_URL`). Returns a string or raises if nothing is registered. |
 
-### Plugin Hook: `ensure_sv_service`
+### Plugin Override: Custom Service Spawning
 
-`JacAPIServer.ensure_sv_service(module_name: str, base_path: str) -> None` is the spawn step in the resolution chain. Plugins override it to spawn services in their own infrastructure -- Docker containers, Kubernetes Jobs, systemd units, or anything else. The signature is stable; plugin overrides written against earlier versions continue to work.
+`JacAPIServer.ensure_sv_service(module_name: str, base_path: str) -> None` is the hook a plugin overrides to change **how** services come up. Default jac-scale behavior spawns a sibling inside the consumer process; a plugin override can launch the service anywhere it wants -- Docker containers, Kubernetes Jobs, systemd units, remote VMs -- as long as it ends by calling `sv_client.register(module_name, <url>)` so subsequent calls skip the hook.
 
-The default jac-scale implementation:
+The hook is called during automatic startup, once per provider, in parallel up to 8 at a time. Overrides must be idempotent and safe to run concurrently. Both properties were already true of the pre-existing lazy contract (concurrent first-call requests could race into the same hook), so a plugin written against any prior version continues to work without modification.
 
-1. Picks a deterministic free port starting at `18000 + (hash(module_name) % 1000)`.
-2. Builds a base `JacAPIServer` with `is_sv_sibling=True`. The sibling flag makes the spawned server skip its own eager-spawn pass at startup, so the parent consumer remains the sole source of spawns and cycles / transitive dependencies converge cleanly.
-3. Wires up a vanilla `http.server.HTTPServer` bound to `127.0.0.1` with the base server's request handler.
-4. Runs `serve_forever` in a daemon thread.
-5. Polls the new server until it returns any non-5xx response (10s deadline). The poll target is `/functions` but a 404 is sufficient -- the check is "the listener is up and serving HTTP", not "this specific endpoint exists".
-6. Calls `sv_client.register(module_name, base_url)` so subsequent calls skip the hook.
-
-A custom plugin replaces this with whatever spawn / health-check / registration logic suits its target environment, then ends with the same `sv_client.register` call. The only behavioral change plugin authors need to be aware of: under the eager-spawn pass, the hook is called at consumer startup (in parallel, up to 8 at a time) instead of lazily on first call, so overrides must be idempotent and safe to run concurrently. Both properties were already requirements of the original lazy contract (two in-flight stub calls can race into `_ensure_available` on main today), so compliant plugins are unaffected.
+The default jac-scale implementation at a high level: pick a free loopback port in `18000-18999`, start an HTTP listener on a daemon thread serving the module's `def:pub` endpoints, wait until the listener responds to an HTTP probe, then register the URL. Consult the jac-scale source if you need the exact details; the contract plugin authors should rely on is the `ensure_sv_service` signature and the requirement to call `sv_client.register` before returning.
 
 ## Storage
 

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -844,14 +844,22 @@ What doesn't:
 
 Failures (network errors, missing service, error envelope from the provider) raise `RuntimeError` with a message of the form `sv-to-sv RPC '{module}.{func}' failed: {msg}`.
 
+### Eager Startup Discovery
+
+Every `sv import` in a consumer module emits a compile-time `_declare_consumer_provider(<consumer>, <provider>)` call into the consumer's import-time stubs. At consumer server startup, `JacAPIServer._ensure_sv_siblings()` walks that compile-time-recorded provider list and dispatches every provider through `sv_client.ensure_all(...)` **before** serving the first request. The pass does a BFS over siblings' provider lists to pick up transitive dependencies: if A imports B and B imports C, the root consumer's startup brings up both B and C in order.
+
+`ensure_all` resolves providers in parallel through a bounded `ThreadPoolExecutor(max_workers=8)` and is **fail-fast**: the first resolution failure cancels pending spawns and re-raises, so misconfiguration surfaces at deploy time rather than at first request.
+
+The hook lives in `JacAPIServer.start()`, which only fires under `jac start`. `jac run` does not go through `JacAPIServer` and falls back to lazy per-call resolution via `_ensure_available`.
+
 ### Service Discovery
 
-When a stub is invoked, `sv_client._ensure_available(module_name)` resolves the target service in this order. The first hit wins:
+When a stub is invoked (or eager startup dispatches it), `sv_client._ensure_available(module_name)` resolves the target service in this order. The first hit wins:
 
 1. **In-process `TestClient`** -- if a `starlette.testclient.TestClient` was registered via `sv_client.register_test_client(module_name, client)`, calls route through it directly with no HTTP. Used by tests for fast in-process runs.
 2. **Explicit URL registration** -- a URL registered via `sv_client.register(module_name, url)`. Useful when an orchestrator (e.g. a service mesh sidecar, custom plugin) knows where each service lives.
-3. **`JAC_SV_<MODULE>_URL` environment variable** -- automatically consulted using the upper-cased module name. The most common production knob.
-4. **`JacAPIServer.ensure_sv_service` plugin hook** -- last-resort fallback that the default jac-scale impl uses to spawn a sibling service in a background daemon thread on a deterministic free port in the range `18000-18999`. Plugins can override this to spawn services in containers, K8s jobs, or anywhere else.
+3. **`JAC_SV_<MODULE>_URL` environment variable** -- automatically consulted using the upper-cased module name. The most common production knob when the provider lives on a different host.
+4. **`JacAPIServer.ensure_sv_service` plugin hook** -- the default jac-scale impl spawns a sibling service in a background daemon thread on a deterministic free port in the range `18000-18999`. Spawned siblings carry `is_sv_sibling=True`, which makes them skip their own eager-spawn pass so the root consumer is the sole source of spawns (no cold-start race, no double-spawn on cycles). Plugins can override this to spawn services in containers, K8s jobs, or anywhere else.
 
 The auto-spawned sibling binds `127.0.0.1` only -- it is reachable from inside the consumer process but not from outside. It exists for in-process convenience (single-binary local dev, tests that span service boundaries), not for serving traffic to other hosts. For real multi-host deployments, use path 2 or 3.
 
@@ -892,7 +900,7 @@ export JAC_SV_MATH_SERVICE_URL=http://localhost:8002
 jac start order_service.jac --port 8000
 ```
 
-Alternatively, omit the env vars and let the default `ensure_sv_service` hook auto-spawn each missing service as a background daemon thread on its first call. This is convenient for prototyping but is not recommended for production: services share a process, the spawned listener is loopback-only, and there's no health monitoring beyond the initial readiness poll.
+Alternatively, omit the env vars entirely and let the eager-spawn pass bring up every sv-imported provider at consumer startup. `jac start order_service.jac` alone is enough: before serving the first request, the consumer's startup walks its compile-time provider list, BFSes any transitive providers, and auto-spawns each as a sibling daemon thread. This is a supported deployment mode for **single-host** setups (one process, many logical services). For **multi-host** deployments, use the `JAC_SV_*_URL` env var path instead, since auto-spawned siblings bind `127.0.0.1` only and cannot serve traffic to other hosts.
 
 #### Troubleshooting
 
@@ -953,21 +961,24 @@ The `jaclang.runtimelib.sv_client` module exposes a small public surface for run
 | `clear_test_clients()` | Drop all `TestClient` registrations. Call between tests. |
 | `resolve_url(module_name: str) -> str` | Look up the registered URL or `JAC_SV_<MOD>_URL` env var. |
 | `call(module_name, func_name, args: dict) -> Any` | Manual RPC dispatch. The compiler generates calls to this. |
+| `ensure_all(module_names: list[str])` | Resolve every named provider in parallel (max 8 workers), fail-fast. Used by the eager startup pass. |
+| `get_consumer_providers(consumer_name: str) -> list[str]` | Return the compile-time provider list for a consumer module. |
+| `clear_consumer_providers()` | Drop all `_declare_consumer_provider` registrations. Call between tests. |
 
 ### Plugin Hook: `ensure_sv_service`
 
-`JacAPIServer.ensure_sv_service(module_name: str, base_path: str) -> None` is the last-resort step in the resolution chain. Plugins override it to spawn services in their own infrastructure -- Docker containers, Kubernetes Jobs, systemd units, or anything else.
+`JacAPIServer.ensure_sv_service(module_name: str, base_path: str) -> None` is the spawn step in the resolution chain. Plugins override it to spawn services in their own infrastructure -- Docker containers, Kubernetes Jobs, systemd units, or anything else. The signature is stable; plugin overrides written against earlier versions continue to work.
 
 The default jac-scale implementation:
 
 1. Picks a deterministic free port starting at `18000 + (hash(module_name) % 1000)`.
-2. Builds a base `JacAPIServer` (not plugin-resolved, to avoid recursion) with `port=0`.
+2. Builds a base `JacAPIServer` with `is_sv_sibling=True`. The sibling flag makes the spawned server skip its own eager-spawn pass at startup, so the parent consumer remains the sole source of spawns and cycles / transitive dependencies converge cleanly.
 3. Wires up a vanilla `http.server.HTTPServer` bound to `127.0.0.1` with the base server's request handler.
 4. Runs `serve_forever` in a daemon thread.
 5. Polls the new server until it returns any non-5xx response (10s deadline). The poll target is `/functions` but a 404 is sufficient -- the check is "the listener is up and serving HTTP", not "this specific endpoint exists".
 6. Calls `sv_client.register(module_name, base_url)` so subsequent calls skip the hook.
 
-A custom plugin replaces this with whatever spawn / health-check / registration logic suits its target environment, then ends with the same `sv_client.register` call.
+A custom plugin replaces this with whatever spawn / health-check / registration logic suits its target environment, then ends with the same `sv_client.register` call. The only behavioral change plugin authors need to be aware of: under the eager-spawn pass, the hook is called at consumer startup (in parallel, up to 8 at a time) instead of lazily on first call, so overrides must be idempotent and safe to run concurrently. Both properties were already requirements of the original lazy contract (two in-flight stub calls can race into `_ensure_available` on main today), so compliant plugins are unaffected.
 
 ## Storage
 

--- a/docs/docs/tutorials/production/microservices.md
+++ b/docs/docs/tutorials/production/microservices.md
@@ -187,9 +187,9 @@ Both error and success cases survive the boundary intact. The `_jac_type` metada
 
 ---
 
-## 6. Auto-Spawn Fallback (Prototyping)
+## 6. Single-Command Mode
 
-For fast local iteration you can skip the second `jac start` entirely. If no `JAC_SV_*_URL` env var is set, the consumer's first call to a missing service triggers `JacAPIServer.ensure_sv_service`, which spawns the provider as a background daemon thread inside the consumer process and registers it under `127.0.0.1` on a port in the 18000-18999 range.
+For single-host setups (one process, many logical services) you can skip the second `jac start` entirely. When the consumer starts, its compile-time-recorded provider list drives an eager spawn pass that brings up every `sv import`-ed provider as a sibling daemon thread **before** serving the first request. A BFS picks up transitive providers too: if A imports B and B imports C, starting A is enough to bring up all three.
 
 Stop both services from the previous step, clear any leftover state, and start only the consumer:
 
@@ -198,7 +198,7 @@ rm -rf .jac/data/
 jac start calculator_service.jac --port 8002
 ```
 
-Now hit `sum_list` again:
+The consumer's startup logs the readiness poll against the eagerly-spawned `math_service` sibling before the "Server ready" banner appears. Hit `sum_list` immediately:
 
 ```bash
 curl -X POST http://localhost:8002/function/sum_list \
@@ -210,11 +210,11 @@ curl -X POST http://localhost:8002/function/sum_list \
 {"ok":true,"data":{"result":6,"reports":[]},...}
 ```
 
-The first call takes a fraction of a second longer because the consumer is spawning the sibling listener and polling it for readiness; subsequent calls are direct.
+First-call latency matches subsequent calls: the sibling was already running when the request arrived. The eager pass is **fail-fast** -- if any provider fails to spawn (missing source file, syntax error, etc.) the consumer crashes at startup, not at first request, so misconfiguration surfaces at deploy time.
 
-> **The auto-spawned sibling is loopback-only.** It binds `127.0.0.1`, not `0.0.0.0`. That makes it convenient for single-binary local dev and tests, but it cannot serve traffic to other hosts. For real deployments, run each service as its own `jac start` and wire them with `JAC_SV_*_URL` env vars (or [override the plugin hook](../../reference/plugins/jac-scale.md#plugin-hook-ensure_sv_service)).
+> **The auto-spawned sibling is loopback-only.** It binds `127.0.0.1`, not `0.0.0.0`. That makes it a supported deployment mode for **single-host** setups -- one `jac start` serves the whole logical cluster -- but it cannot serve traffic to other hosts. For **multi-host** deployments, run each service as its own `jac start` and wire them with `JAC_SV_*_URL` env vars (see section 8), or [override the plugin hook](../../reference/plugins/jac-scale.md#plugin-hook-ensure_sv_service) to spawn siblings in your own infra.
 
-The auto-spawn fallback also requires both services to live in the same directory: it loads the missing module from the consumer's `base_path_dir`, so `jac start` from the project root works, but `jac start /some/abs/path/calc.jac` from an unrelated cwd does not.
+The eager spawn requires every service to live in the same directory: the spawner loads each missing module from the consumer's `base_path_dir`, so `jac start` from the project root works, but `jac start /some/abs/path/calc.jac` from an unrelated cwd does not.
 
 ---
 
@@ -353,7 +353,7 @@ Each consumer process picks up its `JAC_SV_*_URL` vars at the moment of the firs
 ## Common Pitfalls
 
 - **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchor data persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv -- any `def:pub` call can hit this after a schema change.
-- **`No module named '<provider>'` from the auto-spawn fallback.** The consumer's `base_path_dir` does not contain the provider source. Run the consumer from the project root, or set `JAC_SV_<MODULE>_URL` so the fallback never runs.
+- **Consumer crashes at startup with `ModuleNotFoundError: No module named '<provider>'`.** The eager-spawn pass could not find the provider source in the consumer's `base_path_dir`. Run the consumer from the project root (so cwd contains every service's `.jac` file), or set `JAC_SV_<MODULE>_URL` to point at a provider that is already running elsewhere.
 - **Stub call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
 - **`Error: No jac.toml found`.** `jac start <relative-path>` requires a `jac.toml` in the current directory. Run `jac create` (or just create an empty one), or pass an absolute path.
 - **Cross-service errors arrive as `RuntimeError`.** Network failures, missing services, and provider-side error envelopes all surface in the consumer as `RuntimeError("sv-to-sv RPC '{module}.{func}' failed: {msg}")`. Catch them at boundaries where you want graceful degradation.

--- a/docs/docs/tutorials/production/microservices.md
+++ b/docs/docs/tutorials/production/microservices.md
@@ -194,9 +194,11 @@ The core pattern is three lines:
 ```jac
 import from jaclang.runtimelib { sv_client }
 
-sv_client.clear_test_clients();
-sv_client.register_test_client("math_service", math_test_client);
-# ...the consumer's sv-imported calls into math_service now go through math_test_client
+with entry {
+    sv_client.clear_test_clients();
+    sv_client.register_test_client("math_service", math_test_client);
+    # ...the consumer's sv-imported calls into math_service now go through math_test_client
+}
 ```
 
 Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over from a previous test's registrations.

--- a/docs/docs/tutorials/production/microservices.md
+++ b/docs/docs/tutorials/production/microservices.md
@@ -2,7 +2,7 @@
 
 A Jac codebase can run as a single monolith or as several independently-deployed microservices, with no source changes between the two. The trick is the `sv import` keyword: when both the importer and the importee are server-context modules, the compiler generates an HTTP client stub for the imported function instead of pulling the provider into the consumer's process. Calls become RPCs over the wire, but the source still reads like a normal import.
 
-This tutorial walks through splitting a tiny app into two services and watching the round-trip happen, then shows how to point the consumer at a real provider URL and how to test the boundary in-process.
+This tutorial walks through splitting a tiny app into two services, running the whole thing from one command, watching the round-trip happen over real HTTP, and then covers testing and multi-host production deployment.
 
 > **Prerequisites**
 >
@@ -14,17 +14,17 @@ This tutorial walks through splitting a tiny app into two services and watching 
 
 ## Overview
 
-Two services, two `jac start` processes, one HTTP boundary between them. The consumer's `sv import` looks identical to a regular import, but every call out to the provider is a `POST /function/<name>` over the wire.
+Two services, one HTTP boundary between them. The consumer's `sv import` looks identical to a regular import, but every call out to the provider is a `POST /function/<name>` over the wire. The consumer never loads the provider's code into its own memory.
+
+The default single-host deployment runs the whole app from one `jac start` command: the consumer brings the provider up automatically before serving the first request.
 
 ```mermaid
 graph LR
-    Client["Client<br/>(curl, browser)"] -- "POST /function/sum_list" --> Calc["calculator_service<br/>jac start :8002"]
-    Calc -- "POST /function/add (x5)" --> Math["math_service<br/>jac start :8001"]
+    Client["Client<br/>(curl, browser)"] -- "POST /function/sum_list" --> Calc["calculator_service<br/>port 8002"]
+    Calc -- "POST /function/add (x5)" --> Math["math_service<br/>auto-started sibling"]
     Math -- "result" --> Calc
     Calc -- "result" --> Client
 ```
-
-The consumer never imports the provider into its own process. After the call, the consumer's `sys.modules` does not contain `math_service`.
 
 ---
 
@@ -41,7 +41,7 @@ version = "0.1.0"
 EOF
 ```
 
-> **Why `jac.toml`?** `jac start <relative-path>` requires a `jac.toml` in the current directory. Without one, you get `Error: No jac.toml found`. You can also pass an absolute path to `jac start`, but the auto-spawn fallback (covered later) needs both services to live in the same directory anyway, so a project layout is the simplest path.
+> **Why `jac.toml`?** `jac start <relative-path>` requires a `jac.toml` in the current directory. Without one, you get `Error: No jac.toml found`. The services also need to live in the same directory so the consumer can find and auto-start the provider at runtime, so a shared project layout is the simplest path.
 
 ---
 
@@ -109,32 +109,28 @@ Read this file as if `add`, `multiply`, and `divide` were local functions. The c
 
 ---
 
-## 4. Run Both Services
+## 4. Run the App
 
-Open two terminals, both in the `microservices-demo` directory.
-
-**Terminal 1 -- start the provider:**
+From the `microservices-demo` directory, start the consumer:
 
 ```bash
-jac start math_service.jac --port 8001
+jac start calculator_service.jac --port 8002
 ```
 
-**Terminal 2 -- start the consumer with the provider URL:**
+That is all. The consumer finds every service it `sv import`s from (`math_service`, in this case) and brings them up automatically inside the same process before serving the first request. Transitive dependencies come along for free: if `math_service` itself had an `sv import`, that provider would also be auto-started. One command, whole cluster.
 
-```bash
-JAC_SV_MATH_SERVICE_URL=http://localhost:8001 \
-    jac start calculator_service.jac --port 8002
-```
+Startup is **fail-fast**: if any service fails to come up (missing source file, syntax error, port in use), the consumer crashes at startup with the underlying error. You find out at deploy time, not at first request.
 
-The `JAC_SV_<UPPERCASED_MODULE>_URL` env var tells the consumer where to find the named provider. The module name is exactly what you wrote after `sv import from`, upper-cased.
+A couple of things to know about the auto-started services:
 
-> **Avoid ports 18000-18999.** That range is reserved for the auto-spawn fallback (next section). Pick something in the 8000s for explicit external ports.
+- **They are loopback-only.** Auto-started services bind `127.0.0.1`, not `0.0.0.0`, so they cannot serve traffic to other hosts. Single-command mode is a supported deployment for **single-host** setups. When your providers live on different hosts, see [Section 7: Going to Production](#7-going-to-production).
+- **Avoid ports 18000-18999 for your own `--port` flags.** That range is reserved for auto-started sibling services, and a manual port in that range can collide with a future auto-start. Pick something in the 8000s for explicit external ports.
 
 ---
 
 ## 5. Watch the Round-Trip
 
-From a third terminal, exercise the consumer:
+From a second terminal, exercise the consumer:
 
 ```bash
 # Cross-service: 5 add() calls under the hood
@@ -144,24 +140,26 @@ curl -X POST http://localhost:8002/function/sum_list \
 ```
 
 ```json
-{"ok":true,"data":{"result":15,"reports":[]},"error":null,"meta":{"extra":{"http_status":200}}}
+{"ok":true,"type":"response","data":{"result":15,"reports":[]},"error":null,"meta":{"extra":{"http_status":200}}}
 ```
 
-Now look at the **provider** terminal -- you will see five `POST /function/add` lines, one per iteration of the consumer's loop:
+Back in the consumer's terminal you will see the consumer's `sum_list` call followed by five `POST /function/add` lines from the auto-started `math_service` sibling -- one per iteration of the loop -- before the outer `sum_list` closes out:
 
 ```text
-Executing function 'add' with params: {'a': 0, 'b': 1}
-  127.0.0.1:41112 - "POST /function/add HTTP/1.1" 200
-Executing function 'add' with params: {'a': 1, 'b': 2}
-  127.0.0.1:41124 - "POST /function/add HTTP/1.1" 200
-...
+Executing function 'sum_list' with params: {'numbers': [1, 2, 3, 4, 5]}
+127.0.0.1 - "POST /function/add HTTP/1.1" 200 -
+127.0.0.1 - "POST /function/add HTTP/1.1" 200 -
+127.0.0.1 - "POST /function/add HTTP/1.1" 200 -
+127.0.0.1 - "POST /function/add HTTP/1.1" 200 -
+127.0.0.1 - "POST /function/add HTTP/1.1" 200 -
+  127.0.0.1:52652 - "POST /function/sum_list HTTP/1.1" 200
 ```
 
-That is the proof: the consumer's loop is fanning out to the provider on each iteration. The two services are real processes talking over real HTTP.
+That is the proof: the consumer's loop is fanning out to the provider on each iteration, over real HTTP. The auto-started sibling is a separate server inside the same process, not a function call.
 
 ### Boundary Type Round-Trip
 
-`safe_divide` returns a `DivResult` from the provider, which the consumer hands back to its own caller. The compiler generates a Python stub class for `DivResult` on the consumer side with `from_wire` / `to_wire` helpers, so the wrapped object behaves like a normal `obj` instance.
+`safe_divide` returns a `DivResult` from the provider, which the consumer hands back to its own caller. The compiler generates a matching wrapper on the consumer side that serializes and deserializes the type across the wire, so callers see a normal `DivResult` on both sides of the boundary.
 
 ```bash
 curl -X POST http://localhost:8002/function/safe_divide \
@@ -170,7 +168,7 @@ curl -X POST http://localhost:8002/function/safe_divide \
 ```
 
 ```json
-{"ok":true,"data":{"result":{"_jac_type":"DivResult","error":"","result":5.0},"reports":[]},...}
+{"ok":true,"type":"response","data":{"result":{"_jac_type":"DivResult","_jac_id":"...","_jac_archetype":"archetype","error":"","result":5.0},"reports":[]},"error":null,"meta":{"extra":{"http_status":200}}}
 ```
 
 ```bash
@@ -180,114 +178,57 @@ curl -X POST http://localhost:8002/function/safe_divide \
 ```
 
 ```json
-{"ok":true,"data":{"result":{"_jac_type":"DivResult","error":"division by zero","result":null},"reports":[]},...}
+{"ok":true,"type":"response","data":{"result":{"_jac_type":"DivResult","_jac_id":"...","_jac_archetype":"archetype","error":"division by zero","result":null},"reports":[]},"error":null,"meta":{"extra":{"http_status":200}}}
 ```
 
-Both error and success cases survive the boundary intact. The `_jac_type` metadata lets the consumer's runtime hand the caller a real `DivResult` instance, not a raw dict.
+Both error and success cases survive the boundary intact. The `_jac_type` metadata lets the consumer's runtime hand the caller a real `DivResult` instance, not a raw dict; `_jac_id` and `_jac_archetype` are envelope bookkeeping the runtime uses to hydrate the object on the other side.
 
 ---
 
-## 6. Single-Command Mode
+## 6. Test the Boundary In-Process
 
-For single-host setups (one process, many logical services) you can skip the second `jac start` entirely. When the consumer starts, its compile-time-recorded provider list drives an eager spawn pass that brings up every `sv import`-ed provider as a sibling daemon thread **before** serving the first request. A BFS picks up transitive providers too: if A imports B and B imports C, starting A is enough to bring up all three.
+When you write tests for the consumer, you do not want them to hit a real provider over HTTP. Instead, register an in-process `TestClient` for each provider, and the consumer's calls route through it directly -- no sockets, no port allocation, no background threads.
 
-Stop both services from the previous step, clear any leftover state, and start only the consumer:
-
-```bash
-rm -rf .jac/data/
-jac start calculator_service.jac --port 8002
-```
-
-The consumer's startup logs the readiness poll against the eagerly-spawned `math_service` sibling before the "Server ready" banner appears. Hit `sum_list` immediately:
-
-```bash
-curl -X POST http://localhost:8002/function/sum_list \
-  -H "Content-Type: application/json" \
-  -d '{"numbers":[1,2,3]}'
-```
-
-```json
-{"ok":true,"data":{"result":6,"reports":[]},...}
-```
-
-First-call latency matches subsequent calls: the sibling was already running when the request arrived. The eager pass is **fail-fast** -- if any provider fails to spawn (missing source file, syntax error, etc.) the consumer crashes at startup, not at first request, so misconfiguration surfaces at deploy time.
-
-> **The auto-spawned sibling is loopback-only.** It binds `127.0.0.1`, not `0.0.0.0`. That makes it a supported deployment mode for **single-host** setups -- one `jac start` serves the whole logical cluster -- but it cannot serve traffic to other hosts. For **multi-host** deployments, run each service as its own `jac start` and wire them with `JAC_SV_*_URL` env vars (see section 8), or [override the plugin hook](../../reference/plugins/jac-scale.md#plugin-hook-ensure_sv_service) to spawn siblings in your own infra.
-
-The eager spawn requires every service to live in the same directory: the spawner loads each missing module from the consumer's `base_path_dir`, so `jac start` from the project root works, but `jac start /some/abs/path/calc.jac` from an unrelated cwd does not.
-
----
-
-## 7. Test the Boundary In-Process
-
-When you write tests for the consumer, you do not want them to hit a real provider over HTTP. Register an in-process `TestClient` instead, and the consumer's stub calls route through it directly.
+The core pattern is three lines:
 
 ```jac
-# test_microservices.jac
-import sys;
-import shutil;
-import tempfile;
-import from pathlib { Path }
-import from jaclang { JacRuntime as Jac }
-import from jaclang.jac0core.constant { Constants as Con }
 import from jaclang.runtimelib { sv_client }
-import from starlette.testclient { TestClient }
-import from jac_scale.serve { JacAPIServer }
 
-glob HERE: Path = Path(__file__).parent;
-
-def make_server(mod: str, base_path: str) -> TestClient {
-    if mod in Jac.loaded_modules { del Jac.loaded_modules[mod]; }
-    if mod in sys.modules { del sys.modules[mod]; }
-    Jac.jac_import(target=mod, base_path=base_path, lng="jac");
-    srv = JacAPIServer(module_name=mod, port=0, base_path=base_path);
-    srv.load_module();
-    srv.register_health_endpoint();
-    srv.register_walkers_endpoints();
-    srv.register_functions_endpoints();
-    srv.register_create_user_endpoint();
-    srv.register_login_endpoint();
-    srv.user_manager.create_user(Con.GUEST.value, '__no_password__');
-    srv.server.create_server();
-    client = TestClient(srv.server.app, raise_server_exceptions=False);
-    sv_client.register_test_client(mod, client);
-    return client;
-}
-
-test "calculator routes through math via TestClient" {
-    tmp = tempfile.mkdtemp();
-    try {
-        shutil.copy2(HERE / "math_service.jac", Path(tmp) / "math_service.jac");
-        shutil.copy2(HERE / "calculator_service.jac", Path(tmp) / "calculator_service.jac");
-        Jac.set_base_path(tmp);
-        Jac.set_context(Jac.create_j_context(user_root=None));
-        sv_client.clear_test_clients();
-
-        prov = make_server("math_service", tmp);
-        cons = make_server("calculator_service", tmp);
-
-        resp = cons.post(
-            "/function/sum_list", json={"numbers": [1, 2, 3, 4, 5]}
-        ).json();
-        assert resp["ok"] is True;
-        assert resp["data"]["result"] == 15;
-    } finally {
-        shutil.rmtree(tmp, ignore_errors=True);
-    }
-}
+sv_client.clear_test_clients();
+sv_client.register_test_client("math_service", math_test_client);
+# ...the consumer's sv-imported calls into math_service now go through math_test_client
 ```
 
-```bash
-python -m pytest test_microservices.jac -v
-```
+Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over from a previous test's registrations.
 
-Always call `sv_client.clear_test_clients()` between tests to avoid bleed-over from a previous test's registration. With `register_test_client` in place, no real HTTP, port allocation, or background threads are involved -- everything runs in-process through the ASGI test app, which makes the suite fast and deterministic.
+The pieces left unshown here -- building a `TestClient` over a consumer and provider from the same source tree -- require hands-on use of the jac-scale server-construction APIs and are currently more verbose than the tutorial should be. The sv-to-sv test suite in the jac-scale source tree has a worked example that copies fixtures into a temp directory and stands both sides up end-to-end. Start there if you need a ready-to-run harness.
 
 ---
 
-## 8. Going to Production
+## 7. Going to Production
 
-For real deployments, each service runs as its own `Deployment` (or VM, container, systemd unit) and the consumer is told where the provider lives via `JAC_SV_*_URL`.
+Single-command mode is great for a single host, but once your services live on **different hosts** you need to tell each consumer where its providers actually are. The mechanism is the `JAC_SV_<UPPERCASED_MODULE>_URL` environment variable: when set, it takes precedence over auto-start and points the consumer at the URL you provide. The module name is exactly what you wrote after `sv import from`, upper-cased.
+
+### Local Multi-Process
+
+Before jumping to containers, you can test the multi-process flow on your own machine by running each service as its own `jac start` and wiring the consumer with an env var.
+
+Open two terminals, both in the `microservices-demo` directory.
+
+**Terminal 1 -- start the provider:**
+
+```bash
+jac start math_service.jac --port 8001
+```
+
+**Terminal 2 -- start the consumer pointed at the provider URL:**
+
+```bash
+JAC_SV_MATH_SERVICE_URL=http://localhost:8001 \
+    jac start calculator_service.jac --port 8002
+```
+
+Hitting `/function/sum_list` on port 8002 now produces the same round-trip as single-command mode, except the provider logs appear in Terminal 1 instead of being interleaved with the consumer's output. This is the stepping stone to a real multi-host deployment: the env var is the only thing pointing the consumer at the provider, and swapping `localhost` for a cluster DNS name or public hostname is the only change you make when you deploy.
 
 ### Kubernetes
 
@@ -332,31 +273,19 @@ spec:
           value: "http://inventory-service.default.svc.cluster.local:8000"
 ```
 
-The convention is `JAC_SV_<UPPERCASED_MODULE_NAME>_URL`. The module name is exactly the value used in `sv import from <module_name>`. Hyphens in module names become underscores; dots stay as dots.
+Hyphens in module names become underscores in the env var name; dots stay as dots.
 
 For the full Kubernetes deployment story (image building, ingress, autoscaling), see the [Kubernetes tutorial](kubernetes.md) -- it applies here unchanged, you just deploy each service separately and wire them with env vars.
-
-### Local Multi-Service
-
-The same pattern works locally with shell exports:
-
-```bash
-export JAC_SV_INVENTORY_SERVICE_URL=http://localhost:8001
-export JAC_SV_MATH_SERVICE_URL=http://localhost:8002
-jac start order_service.jac --port 8000
-```
-
-Each consumer process picks up its `JAC_SV_*_URL` vars at the moment of the first cross-service call, so you can `export` them in your shell profile or a `.env` file loaded by your dev workflow.
 
 ---
 
 ## Common Pitfalls
 
-- **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchor data persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv -- any `def:pub` call can hit this after a schema change.
-- **Consumer crashes at startup with `ModuleNotFoundError: No module named '<provider>'`.** The eager-spawn pass could not find the provider source in the consumer's `base_path_dir`. Run the consumer from the project root (so cwd contains every service's `.jac` file), or set `JAC_SV_<MODULE>_URL` to point at a provider that is already running elsewhere.
-- **Stub call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
+- **`{"detail":"Invalid anchor id ..."}` 500s.** Stale anchor data persisted from a previous run with a different schema. Stop the server, `rm -rf .jac/data/`, and restart. Not specific to sv-to-sv; any `def:pub` call can hit this after a schema change.
+- **Consumer crashes at startup with `ModuleNotFoundError: No module named '<provider>'`.** Automatic startup could not find the provider source in the directory you ran `jac start` from. Either move all services into the same project directory and run `jac start` from there, or set `JAC_SV_<MODULE>_URL` to point at a provider already running elsewhere.
+- **Cross-service call returns 404.** The provider function is not declared `def:pub`. Walkers similarly need `walker:pub`.
 - **`Error: No jac.toml found`.** `jac start <relative-path>` requires a `jac.toml` in the current directory. Run `jac create` (or just create an empty one), or pass an absolute path.
-- **Cross-service errors arrive as `RuntimeError`.** Network failures, missing services, and provider-side error envelopes all surface in the consumer as `RuntimeError("sv-to-sv RPC '{module}.{func}' failed: {msg}")`. Catch them at boundaries where you want graceful degradation.
+- **Cross-service errors raise an exception.** Network failures, missing services, and error responses from the provider all surface at the call site as an exception with the message `sv-to-sv RPC '<module>.<func>' failed: <reason>`. Catch at the boundaries where you want graceful degradation.
 
 ---
 

--- a/jac-scale/jac_scale/impl/serve.core.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.core.impl.jac
@@ -160,6 +160,7 @@ impl JacAPIServerCore.start(
     on_ready: Callable[..., None] | None = None
 ) -> None {
     self.introspector.load();
+    self._ensure_sv_siblings();
     # Eagerly build client bundle if there are client exports (skip in dev, no_client, or PWA mode)
     if not dev and not no_client {
         client_exports = self.introspector._client_manifest.get('exports', []);

--- a/jac-scale/jac_scale/tests/fixtures/microservice/level_a.jac
+++ b/jac-scale/jac_scale/tests/fixtures/microservice/level_a.jac
@@ -1,0 +1,12 @@
+"""Root consumer in the A->B->C transitive import chain.
+
+sv-imports from level_b only. level_b transitively sv-imports level_c.
+The eager-spawn BFS on level_a's JacAPIServer startup should walk the
+chain and ensure all three services are registered before serving.
+"""
+
+sv import from level_b { level_b_forward }
+
+def:pub level_a_start(msg: str) -> str {
+    return f"level_a -> {level_b_forward(msg)}";
+}

--- a/jac-scale/jac_scale/tests/fixtures/microservice/level_b.jac
+++ b/jac-scale/jac_scale/tests/fixtures/microservice/level_b.jac
@@ -1,0 +1,13 @@
+"""Middle service in the A->B->C transitive import chain.
+
+sv-imports from level_c, so its import-time stubs register level_c
+as a provider of level_b in sv_client._consumer_providers. The root
+consumer (level_a) doesn't directly import level_c; it should pick
+it up via the BFS in JacAPIServer._ensure_sv_siblings.
+"""
+
+sv import from level_c { level_c_ping }
+
+def:pub level_b_forward(msg: str) -> str {
+    return f"level_b -> {level_c_ping(msg)}";
+}

--- a/jac-scale/jac_scale/tests/fixtures/microservice/level_c.jac
+++ b/jac-scale/jac_scale/tests/fixtures/microservice/level_c.jac
@@ -1,0 +1,10 @@
+"""Deepest service in the A->B->C transitive import chain.
+
+Provides a single public function. Has no sv imports of its own.
+Used by the eager-spawn BFS test to verify the root consumer picks up
+transitive providers beyond its direct dependencies.
+"""
+
+def:pub level_c_ping(msg: str) -> str {
+    return f"level_c received: {msg}";
+}

--- a/jac-scale/jac_scale/tests/test_eager_spawn.jac
+++ b/jac-scale/jac_scale/tests/test_eager_spawn.jac
@@ -1,0 +1,326 @@
+"""Tests for sv-to-sv eager auto-spawn at consumer server startup.
+
+The feature: when a consumer server starts, it walks its compile-time
+recorded sv-import providers (populated at consumer module import time
+by PyastGenPass-emitted _declare_consumer_provider calls), BFSes any
+transitive providers, and dispatches them through sv_client.ensure_all
+before serving traffic. Siblings spawned via ensure_sv_service skip
+their own eager-spawn pass so only the root consumer drives spawns.
+
+Tests cover:
+  1. _declare_consumer_provider populates _consumer_providers correctly
+     (including dedup across repeated declarations).
+  2. ensure_all short-circuits when every provider is already a test
+     client or in the registry.
+  3. ensure_all resolves providers via JAC_SV_<MOD>_URL env vars.
+  4. ensure_all fail-fast: first failure cancels pending spawns and
+     re-raises.
+  5. Consumer module import triggers compile-time-emitted
+     _declare_consumer_provider side effect.
+  6. is_sv_sibling=True causes _ensure_sv_siblings to short-circuit,
+     so siblings do not drive their own eager spawn.
+  7. Non-sibling consumer's _ensure_sv_siblings walks direct providers.
+  8. Transitive BFS: consumer imports B, B imports C; root consumer
+     picks up C via the BFS over B's recorded providers.
+"""
+
+import os;
+import sys;
+import shutil;
+import glob;
+import tempfile;
+import from pathlib { Path }
+import from jaclang { JacRuntime as Jac }
+import from jaclang.jac0core.constant { Constants as Con }
+import from jaclang.runtimelib { sv_client as __jac_sv }
+import from starlette.testclient { TestClient }
+import from jac_scale.serve { JacAPIServer }
+
+glob FIXTURES: Path = Path(__file__).parent / "fixtures" / "microservice";
+
+def setup_env -> str {
+    tmp = tempfile.mkdtemp();
+    for f in glob.glob(str(FIXTURES / "*")) {
+        if Path(f).is_file() {
+            shutil.copy2(f, Path(tmp) / Path(f).name);
+        }
+    }
+    Jac.set_base_path(tmp);
+    Jac.set_context(Jac.create_j_context(user_root=None));
+    __jac_sv.clear_test_clients();
+    __jac_sv.clear_consumer_providers();
+    for mod_name in [
+        "level_a",
+        "level_b",
+        "level_c",
+        "math_service",
+        "calculator_service"
+    ] {
+        if mod_name in Jac.loaded_modules {
+            del Jac.loaded_modules[mod_name];
+        }
+        if mod_name in sys.modules {
+            del sys.modules[mod_name];
+        }
+    }
+    return tmp;
+}
+
+def done(tmp: str) {
+    shutil.rmtree(tmp, ignore_errors=True);
+}
+
+"""Register an in-process stub TestClient so ensure_all short-circuits."""
+def make_stub_client(mod: str) -> TestClient {
+    client: TestClient = TestClient.__new__(TestClient);
+    __jac_sv.register_test_client(mod, client);
+    return client;
+}
+
+# -----------------------------------------------------------------------------
+# 1. _declare_consumer_provider registration
+# -----------------------------------------------------------------------------
+test "eager spawn: declare_consumer_provider records and dedupes" {
+    __jac_sv.clear_consumer_providers();
+    __jac_sv._declare_consumer_provider("consumer_x", "prov_a");
+    __jac_sv._declare_consumer_provider("consumer_x", "prov_b");
+    __jac_sv._declare_consumer_provider("consumer_x", "prov_a");  # dup
+    __jac_sv._declare_consumer_provider("consumer_y", "prov_z");
+
+    assert __jac_sv.get_consumer_providers("consumer_x") == ["prov_a", "prov_b"];
+    assert __jac_sv.get_consumer_providers("consumer_y") == ["prov_z"];
+    assert __jac_sv.get_consumer_providers("unknown") == [];
+    __jac_sv.clear_consumer_providers();
+    assert __jac_sv.get_consumer_providers("consumer_x") == [];
+}
+
+# -----------------------------------------------------------------------------
+# 2. ensure_all skips providers that are already resolved
+# -----------------------------------------------------------------------------
+test "eager spawn: ensure_all no-op when all already resolved" {
+    __jac_sv.clear_test_clients();
+    __jac_sv._registry.clear();
+    __jac_sv._registry["already_registered"] = "http://somewhere";
+    make_stub_client("already_test_client");
+
+    # Should not raise and should not add anything new
+    __jac_sv.ensure_all(["already_registered", "already_test_client"]);
+    assert __jac_sv._registry.get("already_registered") == "http://somewhere";
+    assert "already_test_client" in __jac_sv._test_clients;
+
+    __jac_sv.clear_test_clients();
+    del __jac_sv._registry["already_registered"];
+}
+
+# -----------------------------------------------------------------------------
+# 3. ensure_all resolves via JAC_SV_<MOD>_URL env var
+# -----------------------------------------------------------------------------
+test "eager spawn: ensure_all registers URLs from env vars" {
+    __jac_sv.clear_test_clients();
+    __jac_sv._registry.clear();
+    os.environ["JAC_SV_EAGER_ENV_MOD_URL"] = "http://eager-env-mod.example";
+    try {
+        __jac_sv.ensure_all(["eager_env_mod"]);
+        assert __jac_sv._registry.get("eager_env_mod") == "http://eager-env-mod.example";
+    } finally {
+        del os.environ["JAC_SV_EAGER_ENV_MOD_URL"];
+        if "eager_env_mod" in __jac_sv._registry {
+            del __jac_sv._registry["eager_env_mod"];
+        }
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 4. fail-fast on first spawn failure
+# -----------------------------------------------------------------------------
+test "eager spawn: ensure_all fail-fast re-raises first error" {
+    __jac_sv.clear_test_clients();
+    __jac_sv._registry.clear();
+    raised: bool = False;
+    try {
+        __jac_sv.ensure_all(["nonexistent_fail_fast_mod"]);
+    } except Exception {
+        raised = True;
+    }
+    assert raised;
+}
+
+# -----------------------------------------------------------------------------
+# 5. Consumer module import triggers compile-time _declare_consumer_provider
+# -----------------------------------------------------------------------------
+test "eager spawn: consumer module import registers its providers" {
+    tmp = setup_env();
+    try {
+        Jac.jac_import(target="calculator_service", base_path=tmp, lng="jac");
+        providers = __jac_sv.get_consumer_providers("calculator_service");
+        assert "math_service" in providers;
+    } finally {
+        done(tmp);
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 6. is_sv_sibling=True short-circuits _ensure_sv_siblings
+# -----------------------------------------------------------------------------
+test "eager spawn: sibling flag skips the eager spawn pass" {
+    tmp = setup_env();
+    try {
+        Jac.jac_import(target="calculator_service", base_path=tmp, lng="jac");
+        __jac_sv._registry.clear();
+        __jac_sv.clear_test_clients();
+
+        srv = JacAPIServer(
+            module_name="calculator_service", port=0, base_path=tmp, is_sv_sibling=True
+        );
+        srv.load_module();
+        srv._ensure_sv_siblings();
+        # Nothing should have been registered -- siblings do not drive spawns
+        assert "math_service" not in __jac_sv._registry;
+    } finally {
+        done(tmp);
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 7. Non-sibling consumer walks direct providers
+# -----------------------------------------------------------------------------
+test "eager spawn: non-sibling consumer resolves declared providers" {
+    tmp = setup_env();
+    try {
+        Jac.jac_import(target="calculator_service", base_path=tmp, lng="jac");
+        __jac_sv._registry.clear();
+        __jac_sv.clear_test_clients();
+        # Pre-register math_service as a test client so ensure_all short-circuits
+        make_stub_client("math_service");
+
+        srv = JacAPIServer(module_name="calculator_service", port=0, base_path=tmp);
+        srv.load_module();
+        assert srv.is_sv_sibling == False;
+
+        # Should complete without raising -- math_service is already a test client
+        srv._ensure_sv_siblings();
+        assert "math_service" in __jac_sv._test_clients;
+    } finally {
+        done(tmp);
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 8. Transitive BFS: A imports B imports C
+# -----------------------------------------------------------------------------
+test "eager spawn: transitive BFS discovers providers through chain" {
+    tmp = setup_env();
+    try {
+        # Import level_a and level_b so their compile-time
+        # _declare_consumer_provider calls populate the registry.
+        # level_c has no sv imports, so it declares nothing when loaded.
+        Jac.jac_import(target="level_a", base_path=tmp, lng="jac");
+        Jac.jac_import(target="level_b", base_path=tmp, lng="jac");
+
+        # Confirm the import-time registrations landed correctly.
+        assert __jac_sv.get_consumer_providers("level_a") == ["level_b"];
+        assert __jac_sv.get_consumer_providers("level_b") == ["level_c"];
+        assert __jac_sv.get_consumer_providers("level_c") == [];
+
+        __jac_sv._registry.clear();
+        __jac_sv.clear_test_clients();
+        # Pre-register every level as a test client so ensure_all never
+        # hits the real spawn path. We verify the BFS traversal by
+        # monkey-patching ensure_all itself to record its call arguments.
+        make_stub_client("level_b");
+        make_stub_client("level_c");
+
+        # Record ensure_all calls in order
+        calls: list[list[str]] = [];
+        original_ensure_all = __jac_sv.ensure_all;
+        def recording_ensure_all(module_names: list[str]) {
+            calls.append(list(module_names));
+            return original_ensure_all(module_names);
+        }
+        __jac_sv.ensure_all = recording_ensure_all;
+        try {
+            srv = JacAPIServer(module_name="level_a", port=0, base_path=tmp);
+            srv.load_module();
+            srv._ensure_sv_siblings();
+        } finally {
+            __jac_sv.ensure_all = original_ensure_all;
+        }
+
+        # The BFS should have issued exactly two waves:
+        #   Wave 1: ["level_b"] (level_a's direct providers)
+        #   Wave 2: ["level_c"] (discovered via level_b's providers)
+        assert len(calls) == 2 , f"Expected 2 BFS waves, got {len(calls)}: {calls}";
+        assert calls[0] == ["level_b"];
+        assert calls[1] == ["level_c"];
+    } finally {
+        done(tmp);
+    }
+}
+
+# -----------------------------------------------------------------------------
+# 9. Cycle handling: A imports B imports A (via declared providers)
+# -----------------------------------------------------------------------------
+test "eager spawn: cycles do not deadlock or double-spawn" {
+    __jac_sv.clear_consumer_providers();
+    __jac_sv._registry.clear();
+    __jac_sv.clear_test_clients();
+
+    # Simulate a cycle directly via the registration API: A -> B, B -> A
+    __jac_sv._declare_consumer_provider("cycle_a", "cycle_b");
+    __jac_sv._declare_consumer_provider("cycle_b", "cycle_a");
+
+    make_stub_client("cycle_a");
+    make_stub_client("cycle_b");
+
+    # Record calls to ensure_all
+    calls: list[list[str]] = [];
+    original_ensure_all = __jac_sv.ensure_all;
+    def recording_ensure_all(module_names: list[str]) {
+        calls.append(list(module_names));
+        return original_ensure_all(module_names);
+    }
+    __jac_sv.ensure_all = recording_ensure_all;
+
+    try {
+        # Manually walk the BFS logic here (no real server needed)
+        # to verify the visited set prevents the cycle from looping
+        visited: set[str] = set();
+        frontier: list[str] = __jac_sv.get_consumer_providers("cycle_a");
+        max_iterations = 10;
+        iter_count = 0;
+        while frontier and iter_count < max_iterations {
+            iter_count += 1;
+            wave: list[str] = [
+                p
+                for p in frontier
+                if p not in visited
+            ];
+            if not wave {
+                break;
+            }
+            for p in wave {
+                visited.add(p);
+            }
+            __jac_sv.ensure_all(wave);
+            next_frontier: list[str] = [];
+            for provider in wave {
+                for transitive in __jac_sv.get_consumer_providers(provider) {
+                    if transitive not in visited {
+                        next_frontier.append(transitive);
+                    }
+                }
+            }
+            frontier = next_frontier;
+        }
+        # BFS walks 2 hops then terminates: wave 1 = [cycle_b], wave 2 =
+        # [cycle_a] (discovered via cycle_b's providers), then cycle_a's
+        # own provider cycle_b is already visited so the BFS halts.
+        # The key guarantees are: (a) termination, (b) no double-spawn.
+        assert iter_count == 2 , f"BFS should terminate after 2 iterations, got {iter_count}";
+        assert calls == [["cycle_b"], ["cycle_a"]] , f"Expected [cycle_b] then [cycle_a] once each, got {calls}";
+    } finally {
+        __jac_sv.ensure_all = original_ensure_all;
+        __jac_sv.clear_consumer_providers();
+        __jac_sv.clear_test_clients();
+    }
+}

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -1750,7 +1750,12 @@ impl JacAPIServer.ensure_sv_service(module_name: str, base_path: str) -> None {
     if not bind_ok {
         raise RuntimeError(f"Could not find free port near {base_port}");
     }
-    srv = CoreJacAPIServer(module_name=module_name, port=0, base_path=base_path);
+    # is_sv_sibling=True tells the spawned sibling to skip its own
+    # eager-spawn pass (_ensure_sv_siblings), so the parent is the sole
+    # source of provider spawns and we don't race on cold start.
+    srv = CoreJacAPIServer(
+        module_name=module_name, port=0, base_path=base_path, is_sv_sibling=True
+    );
     srv.port = port;
     srv.load_module();
     handler_class = srv.create_handler();

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -161,7 +161,14 @@ impl PyastGenPass._generate_sv_to_sv_stubs(nd: uni.Import) -> bool {
         return False;
     }
     boundary_types = manifest.boundary_types;
-    parts: list[str] = ["from jaclang.runtimelib import sv_client as __jac_sv_client"];
+    # Also record this consumer -> provider edge at import time so the
+    # consumer's server startup can discover every provider it needs
+    # before serving traffic (see sv_client._consumer_providers and
+    # JacAPIServer._ensure_sv_siblings).
+    parts: list[str] = [
+        "from jaclang.runtimelib import sv_client as __jac_sv_client",
+        "__jac_sv_client._declare_consumer_provider(__name__, '" + module_name + "')"
+    ];
     for item in nd.items {
         if not isinstance(item, uni.ModuleItem) {
             continue;

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -1784,6 +1784,57 @@ impl JacAPIServer.print_endpoint_docs -> None {
     print_endpoint_docs(self);
 }
 
+"""Eagerly spawn every sv-to-sv provider this consumer imports.
+
+Walks the consumer's compile-time-recorded provider list (populated by
+PyastGenPass in every `sv import` stub) and dispatches them through
+sv_client.ensure_all. Siblings spawned via ensure_sv_service skip this
+step (is_sv_sibling=True) so only the root consumer drives the spawn.
+
+Performs a BFS over the loaded sibling modules' provider lists to pick
+up transitive providers. If A imports B and B imports C, A's first
+pass spawns B; the BFS then reads B's just-loaded _consumer_providers
+entry and spawns C in a second wave. Terminates when no new providers
+are discovered.
+
+Idempotent: anything already in sv_client._registry or _test_clients
+is skipped by ensure_all without submitting a task.
+
+Fail-fast: ensure_all re-raises the first spawn failure, which
+propagates out of this method and crashes the consumer startup.
+"""
+impl JacAPIServer._ensure_sv_siblings -> None {
+    if self.is_sv_sibling {
+        return;
+    }
+    import from jaclang.runtimelib { sv_client }
+    visited: set[str] = set();
+    frontier: list[str] = sv_client.get_consumer_providers(self.module_name);
+    while frontier {
+        wave: list[str] = [
+            p
+            for p in frontier
+            if p not in visited
+        ];
+        if not wave {
+            break;
+        }
+        for p in wave {
+            visited.add(p);
+        }
+        sv_client.ensure_all(wave);
+        next_frontier: list[str] = [];
+        for provider in wave {
+            for transitive in sv_client.get_consumer_providers(provider) {
+                if transitive not in visited {
+                    next_frontier.append(transitive);
+                }
+            }
+        }
+        frontier = next_frontier;
+    }
+}
+
 """Start the HTTP server."""
 impl JacAPIServer.start(
     dev: bool = False,
@@ -1792,6 +1843,7 @@ impl JacAPIServer.start(
 ) -> None {
     import from pathlib { Path }
     self.introspector.load();
+    self._ensure_sv_siblings();
     # Register scheduled walkers and functions, start scheduler only if needed
     for (name, walker_cls) in self.introspector._walkers.items() {
         if walker_cls?.schedule_spec {

--- a/jac/jaclang/runtimelib/server.jac
+++ b/jac/jaclang/runtimelib/server.jac
@@ -211,6 +211,14 @@ obj JacAPIServer {
     has module_name: str,
         port: int = 8000,
         base_path: str = "",
+        # True when this instance was spawned by another consumer's
+        # eager sv-to-sv spawn pass. Siblings skip their own eager-spawn
+        # step to avoid a cold-start race where multiple consumers each
+        # try to bring up the same transitive provider in parallel. The
+        # parent's spawn pass is the sole source of spawns; siblings
+        # fall back to the normal lazy _ensure_available path for
+        # anything the parent missed.
+        is_sv_sibling: bool = False,
         user_manager: UserManager by postinit,
         execution_manager: ExecutionManager by postinit,
         introspector: ModuleIntrospector by postinit,
@@ -244,6 +252,7 @@ obj JacAPIServer {
 
     def get_client_bundle_code -> str;
     def print_endpoint_docs -> None;
+    def _ensure_sv_siblings -> None;
     def start(
         dev: bool = False,
         no_client: bool = False,

--- a/jac/jaclang/runtimelib/sv_client.jac
+++ b/jac/jaclang/runtimelib/sv_client.jac
@@ -16,7 +16,13 @@ import from typing { Any }
 # Module name -> base URL (set by jac start orchestration or test code)
 glob _registry: dict[str, str] = {},
      # Module name -> TestClient instance (set by tests for in-process routing)
-     _test_clients: dict[str, Any] = {};
+     _test_clients: dict[str, Any] = {},
+     # Consumer module name -> list of provider module names it sv-imports.
+     # Populated at consumer module import time by compile-time-emitted
+     # _declare_consumer_provider() calls in the generated stubs. Read at
+     # consumer server startup by JacAPIServer._ensure_sv_siblings() to
+     # eager-spawn every provider before serving traffic.
+     _consumer_providers: dict[str, list[str]] = {};
 
 """Register a service URL for sv-to-sv resolution."""
 def register(module_name: str, url: str) {
@@ -45,6 +51,36 @@ def unregister_test_client(module_name: str) {
 """Clear all TestClient registrations (between tests)."""
 def clear_test_clients {
     _test_clients.clear();
+}
+
+"""Record that a consumer module sv-imports a given provider module.
+
+Called from the compile-time-generated stub preamble in every consumer
+that has at least one `sv import from <provider>` statement. Idempotent;
+safe to call multiple times for the same (consumer, provider) pair.
+"""
+def _declare_consumer_provider(consumer_name: str, provider_name: str) {
+    if consumer_name not in _consumer_providers {
+        _consumer_providers[consumer_name] = [];
+    }
+    if provider_name not in _consumer_providers[consumer_name] {
+        _consumer_providers[consumer_name].append(provider_name);
+    }
+}
+
+"""Return the list of provider module names a given consumer sv-imports.
+
+Returns an empty list if the consumer has no recorded sv-import providers
+(i.e. it has no `sv import` statements, or its module-level code has not
+yet executed). Used by the eager-spawn pass at consumer server startup.
+"""
+def get_consumer_providers(consumer_name: str) -> list[str] {
+    return list(_consumer_providers.get(consumer_name, []));
+}
+
+"""Clear all consumer-provider declarations (between tests)."""
+def clear_consumer_providers {
+    _consumer_providers.clear();
 }
 
 """Resolve a service URL via registry or environment."""
@@ -128,4 +164,67 @@ def call(module_name: str, func_name: str, args: dict) -> Any {
     raise RuntimeError(
         f"sv-to-sv RPC '{module_name}.{func_name}' failed: {msg or 'unknown error'}"
     );
+}
+
+"""Eagerly resolve every named provider before serving traffic.
+
+Walks providers in parallel through a bounded ThreadPoolExecutor (max 8
+workers), routing each through the existing _ensure_available resolution
+chain (test client, registry, env var, ensure_sv_service plugin hook).
+Idempotent: providers already in _registry / _test_clients are skipped
+without ever submitting a task.
+
+Fail-fast: if any provider fails to resolve, the first failure cancels
+all in-flight spawns and the exception is re-raised at the caller. The
+intent is for the consumer to crash at startup, not at first request, so
+operators discover misconfiguration at deploy time.
+
+Called by JacAPIServer._ensure_sv_siblings() during consumer server
+startup. The bound of 8 caps worst-case startup latency at
+ceil(N/8) * spawn_time; for typical N < 8 every provider spawns in
+parallel and the bound is irrelevant.
+"""
+def ensure_all(module_names: list[str]) -> None {
+    pending: list[str] = [
+        n
+        for n in module_names
+        if n not in _registry and n not in _test_clients
+    ];
+    if not pending {
+        return;
+    }
+    # Typeshed re-exports for `concurrent.futures` do not flow through
+    # Jac's type checker, so bind the names as Any locally and trust the
+    # runtime contract.
+    import from concurrent.futures { ThreadPoolExecutor, as_completed }
+    executor: Any = ThreadPoolExecutor(max_workers=8);
+    futures: dict[Any, str] = {};
+    for name in pending {
+        futures[executor.submit(_ensure_available, name)] = name;
+    }
+    first_error: (Exception | None) = None;
+    try {
+        for future in as_completed(futures) {
+            fut: Any = future;
+            if first_error is not None {
+                continue;
+            }
+            try {
+                fut.result();
+            } except Exception as e {
+                first_error = e;
+                for f in futures {
+                    f_any: Any = f;
+                    if not f_any.done() {
+                        f_any.cancel();
+                    }
+                }
+            }
+        }
+    } finally {
+        executor.shutdown(wait=True);
+    }
+    if first_error is not None {
+        raise first_error;
+    }
 }


### PR DESCRIPTION
## Summary

`jac start consumer.jac` is now enough to bring up every `sv import`-ed provider in a multi-service Jac app. Before serving the first request, the consumer walks its compile-time-recorded provider list, resolves every one through a new `sv_client.ensure_all()` (bounded parallel, fail-fast), and BFSes any transitive providers. Starting a three-service `A -> B -> C` chain now requires one terminal and zero env vars.

Follow-up to jaseci-labs/jaseci#5512 (the original lazy sv-to-sv interop) and jaseci-labs/jaseci#5513 (the docs). Design notes at the top of the first commit message.

## What changed

**Runtime:**
- `sv_client.jac`: new `_consumer_providers` glob, new `_declare_consumer_provider` / `get_consumer_providers` / `clear_consumer_providers` helpers, new `ensure_all(module_names)` using `ThreadPoolExecutor(max_workers=8)` with fail-fast semantics (first error cancels pending spawns and re-raises).
- `runtimelib/server.jac`: new `is_sv_sibling: bool = False` field on `JacAPIServer`. Siblings spawned via `ensure_sv_service` carry this flag to skip their own eager-spawn pass, so the root consumer is the sole source of spawns (no cold-start race, cycles converge cleanly).
- `runtimelib/impl/server.impl.jac`: new `_ensure_sv_siblings` method that short-circuits on `is_sv_sibling`, otherwise calls `sv_client.ensure_all` for direct providers then BFSes the spawned siblings' own provider lists until no new providers are discovered. Called at the top of `start()`.
- `jac0core/impl/runtime.impl.jac`: `ensure_sv_service` now constructs spawned siblings with `is_sv_sibling=True`.
- `jac0core/passes/impl/pyast_gen_pass.impl.jac`: `_generate_sv_to_sv_stubs` emits an extra preamble line per `sv import` statement -- `__jac_sv_client._declare_consumer_provider(__name__, '<provider>')` -- that runs at consumer module import time and populates `_consumer_providers`.
- `jac-scale/serve.core.impl.jac`: `JacAPIServerCore.start` calls `self._ensure_sv_siblings()` right after `introspector.load()` so the hook fires under `jac start`.

**Tests:** 9 new tests in `test_eager_spawn.jac` plus a 3-level fixture chain (`level_a` → `level_b` → `level_c`).

**Docs:** jac-scale reference section rewritten to cover the eager pass, `sv_client` API table extended, tutorial Section 6 reframed from "Auto-Spawn Fallback (Prototyping)" to "Single-Command Mode" as a supported single-host deployment mode.

## Design decisions (user-reviewed before implementation)

| Question | Decision |
|---|---|
| Failure mode | **Fail-fast.** First failure cancels pending spawns and re-raises. Consumer crashes at startup, not at first request. |
| Parallelism bound | **`ThreadPoolExecutor(max_workers=8)`.** Caps worst-case startup latency at `ceil(N/8) × spawn_time`. |
| `jac run` vs `jac start` | **Only `jac start`.** Hook lives in `JacAPIServer.start`. `jac run` falls back to lazy `_ensure_available` for any sv-import stub it hits. |
| Plugin compat | **Preserved.** `ensure_sv_service(module_name, base_path)` signature unchanged. `is_sv_sibling` lives on the server obj, not the hook contract. |

## Testing

**New unit tests (9, all passing):**
1. `_declare_consumer_provider` records and dedupes
2. `ensure_all` no-op when providers already resolved
3. `ensure_all` registers URLs from `JAC_SV_<MOD>_URL` env vars
4. `ensure_all` fail-fast re-raises first error
5. Consumer module import triggers compile-time `_declare_consumer_provider`
6. `is_sv_sibling=True` short-circuits the pass
7. Non-sibling consumer walks declared providers
8. **Transitive BFS**: `A -> B -> C` verified by monkey-patching `ensure_all` to record wave sequence. Wave 1 = `[level_b]`, wave 2 = `[level_c]`.
9. **Cycle handling**: `A <-> B` terminates in 2 waves, each provider ensured exactly once.

**Regression:** 102/102 pass across `test_microservice.jac` (6) + `test_eager_spawn.jac` (9) + `test_mcp.jac` (87). Pre-existing test failures in other jac-scale files (`test_abstractions`, `test_sandbox_factory`, `test_mongo_user_manager`, etc.) are unrelated and reproduce on main.

**End-to-end manual verification:**
```bash
# Single command, no env var, no provider terminal
rm -rf /tmp/sv-qa/.jac
cd /tmp/sv-qa && jac start calculator_service.jac --port 18903
```

Before my changes (main, lazy): first `curl sum_list` takes 127ms (spawn in the hot path), sibling port only appears after the first request.

After my changes: first `curl sum_list` takes 54ms, sibling port `127.0.0.1:18589` (= `18000 + hash("math_service") % 1000`) is already listening when the server readies itself.

```
LISTEN 0 5 127.0.0.1:18589 0.0.0.0:* users:(("jac",pid=N,fd=11))   # eagerly spawned
LISTEN 0 2048 0.0.0.0:18903 0.0.0.0:* users:(("jac",pid=N,fd=15))  # user-started
```

## Test plan

- [ ] CI: `test-scale` job includes `test_eager_spawn.jac`
- [ ] Manual: `jac start calculator_service.jac` with no env var brings up both services in one process
- [ ] Manual: `jac start level_a.jac` brings up all three services (transitive BFS)
- [ ] Manual: Provider with bad syntax causes startup crash (fail-fast)
- [ ] Regression: existing sv-to-sv tests (`test_microservice.jac`) still pass