### PR TITLE
docs: expand desktop target coverage for jac-client

### DIFF
--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1499,6 +1499,8 @@ jac build [filename] [--client TARGET] [-p PLATFORM]
 | `--client` | Build target (`web`, `desktop`, `pwa`) | `web` |
 | `-p, --platform` | Desktop platform (`windows`, `macos`, `linux`, `all`) | Current platform |
 
+For desktop builds, the **client-only** variant (web bundle inside a Tauri shell, no bundled sidecar) is enabled by setting `client_only = true` under `[desktop]` in `jac.toml` rather than via a CLI flag -- see [Desktop Target → Client-Only Mode](#client-only-mode). In all desktop builds the build environment sets `JAC_BUILD=1` so import-time server starts stay inert.
+
 **Examples:**
 
 ```bash
@@ -1581,12 +1583,16 @@ jac start --dev              # Dev server with HMR
 
 ### Desktop Target (Tauri)
 
-Native desktop applications using Tauri. Creates installers for Windows, macOS, and Linux.
+Native desktop applications using Tauri. The full-stack Jac app -- frontend bundle, Jac runtime, and your backend walkers/functions -- ships as a single installer for Windows, macOS, and Linux. End users do not need Python or Node installed.
+
+**Architecture:**
+
+A desktop build produces a Tauri shell that hosts a webview pointed at a bundled **sidecar** -- a PyInstaller-frozen executable containing Python, jaclang, jac-client, your `.jac` sources, and any configured plugins. On launch, Tauri spawns the sidecar on a free local port, reads `JAC_SIDECAR_PORT=<port>` from its stdout, and injects the resulting URL into the webview before any page JavaScript runs. The webview is the same client bundle the web target produces; the sidecar is the same backend `jac start` would run, just frozen.
 
 **Prerequisites:**
 
 - Rust/Cargo: [rustup.rs](https://rustup.rs)
-- Build tools (platform-specific)
+- Platform build tools (Visual Studio Build Tools on Windows, Xcode Command Line Tools on macOS, `webkit2gtk` + `libssl` + `librsvg` on Linux)
 
 **Setup & Build:**
 
@@ -1608,11 +1614,30 @@ jac build --client desktop --platform linux
 
 **Output:** Installers in `src-tauri/target/release/bundle/`:
 
-- Windows: `.exe` installer
+- Windows: `.exe` installer (NSIS) or `.msi`
 - macOS: `.dmg` or `.app` bundle
 - Linux: `.AppImage`, `.deb`, or `.rpm`
 
-**Configuration:** Edit `src-tauri/tauri.conf.json` to customize window size, title, and app metadata.
+**Configuration:** Window size, title, identifier, and other Tauri metadata are configured under `[desktop]` in `jac.toml` (the build regenerates `src-tauri/tauri.conf.json` from it on every build):
+
+```toml
+[desktop]
+name = "MyApp"
+identifier = "com.example.myapp"
+version = "1.0.0"
+
+[desktop.window]
+title = "MyApp"
+width = 1200
+height = 800
+min_width = 800
+min_height = 600
+
+[desktop.platforms]
+windows = true
+macos = true
+linux = true
+```
 
 **Python Dependencies:**
 
@@ -1624,20 +1649,82 @@ websockets = ">=12.0"
 httpx = ">=0.27.0"
 ```
 
-These are auto-installed before bundling - no manual `pip install` needed.
+These are auto-installed into the bundling environment before PyInstaller runs -- no manual `pip install` needed. During the build, `JAC_BUILD=1` is set in the environment so any Jac code that auto-starts a server at import time stays inert (preventing port conflicts and unnecessary work).
 
 **Plugin Bundling:**
 
-Desktop builds automatically bundle Jac plugins (jac-scale, byllm, jac-coder) and their dependencies into the sidecar executable. Configure which plugins to include via `[desktop.plugins]` in `jac.toml`:
+Desktop builds bundle Jac plugins into the sidecar executable using PyInstaller's `collect_all()` plus `importlib.metadata.requires()` for transitive dependency discovery. Configure which plugins to include via `[desktop.plugins]` in `jac.toml`:
 
 ```toml
 [desktop.plugins]
-jac_scale = true   # Include jac-scale (default: true)
-byllm = true       # Include byllm/litellm for LLM support (default: true)
-jac_coder = true   # Include jac-coder for AI coding features (default: true)
+jac_scale = true   # jac-scale: FastAPI server, auth, persistence (default: true)
+byllm = true       # byllm/litellm for LLM support (default: true)
+jac_coder = true   # jac-coder: AI coding features (default: true)
+jac_mcp = true     # jac-mcp: MCP server integration (default: true)
 ```
 
-**Note:** Plugins must be installed (`pip install jac-scale byllm jac-coder`) before building. The build automatically discovers and bundles all plugin dependencies from their package metadata.
+**Notes:**
+
+- Plugins must be installed (`pip install jac-scale byllm jac-coder jac-mcp`) before building -- the build collects them from your current Python environment.
+- `jac_client` itself is **always** bundled as a core package regardless of this config, because the sidecar entry point imports it directly. Setting `jac_client = false` is ignored.
+- The build excludes build-artifact directories (`src-tauri/`, `node_modules/`, `dist/`, `.jac/client/`) when collecting `.jac` files, so rebuilds do not recursively nest previous sidecar bundles.
+
+**Bundled Jac Sources:**
+
+All `.jac` files, `jac.toml`, and the `assets/` directory are copied into `src-tauri/jac/` and shipped as Tauri bundle resources. At runtime, the sidecar looks up `main.jac` in this bundled location first, falling back to parent directories. This is what makes desktop installs fully self-contained.
+
+#### Data Persistence on Installed Builds
+
+Installed desktop apps live in **read-only** locations -- `/usr/lib/`, `/opt/`, `C:\Program Files\`, or an AppImage's `/tmp/.mount_AppXXX/` squashfs. The Jac runtime and jac-scale write to disk relative to the working directory by default (the SQLite database `database.db`, the `.jac/data/` directory, session files), and those writes will fail or crash on a read-only mount.
+
+The sidecar resolves this at startup, **before** importing any Jac module, by setting the `JAC_DATA_PATH` environment variable to a writable location and `chdir`-ing into it. The Jac runtime's `get_db_path()` and jac-scale's config loader both honor this variable.
+
+**Default fallback chain** (the sidecar picks the first one that exists or can be created and passes a touch/unlink probe):
+
+| Platform | Default | First fallback | Second fallback |
+|----------|---------|----------------|-----------------|
+| Linux / macOS | `~/.local/share/jac-app` | `~/.jac-app` | `/tmp/jac-app-{uid}` |
+| Windows | `%LOCALAPPDATA%\jac-app` | `~/AppData/Local/jac-app` | `%TEMP%\jac-app` |
+
+**Override the default** by passing `--data-path` to the sidecar (useful when running the bundled sidecar binary by hand for debugging, or when wiring it into a launcher you control):
+
+```bash
+./src-tauri/binaries/jac-sidecar --data-path /var/lib/myapp
+```
+
+You can also export `JAC_DATA_PATH` before launching the app to point at a custom location for that run. The path you choose must be writable by the user running the app -- the sidecar will probe it and fail loudly if it cannot.
+
+**AppImage-specific environment cleanup:** AppImage runtimes inject `PYTHONHOME`, `PYTHONPATH`, and `PYTHONDONTWRITEBYTECODE` into the environment, which break the bundled Python interpreter inside the sidecar. The generated Tauri `main.rs` strips these variables before spawning the sidecar process.
+
+#### Client-Only Mode
+
+For setups where the desktop app is just a thin native shell around a remote backend (e.g., a hosted jac-scale deployment), set `client_only = true` under `[desktop]` in `jac.toml`:
+
+```toml
+[desktop]
+client_only = true
+
+[plugins.client.api]
+base_url = "https://api.example.com"
+```
+
+In this mode the build:
+
+- **Skips sidecar bundling entirely** -- no PyInstaller step, no Python bundle, smaller installer.
+- **Requires** `[plugins.client.api] base_url` to be set; the build raises a `RuntimeError` if it is missing, since the webview has no local backend to talk to.
+- **Still produces a full Tauri installer** -- only the backend half is omitted.
+
+It is also useful in CI, where you may want to verify the web bundle compiles inside a desktop build without paying for the PyInstaller round-trip.
+
+#### Runtime API URL Injection (Debugging)
+
+Desktop builds do **not** embed the API base URL at compile time. Tauri allocates the sidecar port dynamically, then injects `window.__JAC_API_BASE_URL__` into the webview via an `initialization_script` before any page JavaScript executes. A `get_api_url` Tauri command is also exposed as a fallback for code that needs to query the URL after page load.
+
+If you are debugging an "API not reachable" issue inside an installed desktop app:
+
+1. Run the sidecar binary directly from `src-tauri/binaries/` -- it logs to stderr and prints `JAC_SIDECAR_PORT=<port>` to stdout on startup.
+2. Use the **Debug** page in the `all-in-one` example app (under `examples/all-in-one/pages/debug.jac`), which shows the resolved API base URL, Tauri runtime detection, `get_api_url` invoke results, and interactive walker/HTTP probes.
+3. Check the data path the sidecar settled on -- it logs `[sidecar] Cannot use data path …` lines for any candidate it had to skip.
 
 ### PWA Target
 

--- a/docs/docs/tutorials/fullstack/desktop.md
+++ b/docs/docs/tutorials/fullstack/desktop.md
@@ -1,0 +1,209 @@
+# Building a Desktop App
+
+This tutorial walks you through shipping an existing Jac full-stack app as a native desktop installer for Windows, macOS, and Linux. Unlike the web target -- which assumes a hosted backend somewhere -- the desktop target packages the **entire** Jac runtime, your `.jac` sources, and any plugins you depend on into a single installer that end users can double-click.
+
+> **Prerequisites**
+>
+> - Completed: [Project Setup](setup.md) -- you have a working `jac start` web app
+> - Installed: [Rust toolchain](https://rustup.rs) (`cargo --version` should work)
+> - Installed: Platform build tools
+>   - **Windows**: Visual Studio Build Tools (with the C++ workload)
+>   - **macOS**: `xcode-select --install`
+>   - **Linux**: `webkit2gtk-4.1`, `libssl-dev`, `librsvg2-dev`, `libayatana-appindicator3-dev`
+> - Time: ~30 minutes (longer on the first build while Rust crates compile)
+
+---
+
+## How a Desktop Build Works
+
+When you run `jac build --client desktop`, the build does five things:
+
+1. **Compiles the client bundle** -- the same Vite build the web target produces.
+2. **Bundles a sidecar** -- PyInstaller freezes Python, jaclang, jac-client, and any plugins you enabled into a single executable. Your `.jac` sources, `jac.toml`, and `assets/` are copied alongside it as bundle resources.
+3. **Generates the Tauri shell** -- regenerates `src-tauri/tauri.conf.json` and `main.rs` from `[desktop]` in your `jac.toml`.
+4. **Builds the installer with Tauri** -- produces a platform-native installer (`.msi`, `.dmg`, `.AppImage`, `.deb`, `.rpm`) under `src-tauri/target/release/bundle/`.
+
+At runtime, the Tauri shell launches the sidecar on a free local port, reads `JAC_SIDECAR_PORT=<port>` from its stdout, and injects the resulting URL into the webview as `window.__JAC_API_BASE_URL__` before any page JavaScript runs. From the user's perspective it's a single double-click; under the hood it's just `jac start` running inside a webview shell.
+
+---
+
+## One-Time Setup
+
+From your project root:
+
+```bash
+jac setup desktop
+```
+
+This creates `src-tauri/` with the Rust project skeleton, default icons, and a `tauri.conf.json` derived from your `jac.toml`. You only need to run this once per project; subsequent builds regenerate the relevant pieces from `jac.toml`.
+
+---
+
+## Configure Window and App Metadata
+
+Open `jac.toml` and add a `[desktop]` section. None of these fields are mandatory -- they default off your `[project]` name and version -- but you'll usually want to override at least the window title and identifier:
+
+```toml
+[desktop]
+name = "Day Planner"
+identifier = "com.example.dayplanner"  # reverse-DNS, used by macOS/Linux
+version = "1.0.0"
+
+[desktop.window]
+title = "Day Planner"
+width = 1200
+height = 800
+min_width = 800
+min_height = 600
+resizable = true
+fullscreen = false
+
+[desktop.platforms]
+windows = true
+macos = true
+linux = true
+```
+
+The next `jac build --client desktop` will pick these up automatically -- you don't need to edit `tauri.conf.json` by hand.
+
+---
+
+## Run a Development Build
+
+The fastest dev loop is:
+
+```bash
+jac start main.jac --client desktop --dev
+```
+
+This launches the Tauri window pointing at the Vite dev server with HMR enabled. Edit a `.cl.jac` file, save, and the window updates without restarting.
+
+For a full installer build:
+
+```bash
+jac build --client desktop
+```
+
+When this finishes, look in `src-tauri/target/release/bundle/`. You'll find one subdirectory per format your platform produces:
+
+- `nsis/` and `msi/` on Windows
+- `dmg/` and `macos/` on macOS
+- `appimage/`, `deb/`, and `rpm/` on Linux
+
+---
+
+## Cross-Platform Builds
+
+By default, `jac build --client desktop` builds for the platform you're running on. To target a different platform, pass `--platform`:
+
+```bash
+jac build --client desktop --platform windows
+jac build --client desktop --platform macos
+jac build --client desktop --platform linux
+jac build --client desktop --platform all
+```
+
+Cross-compilation has the same caveats as any Rust+Tauri project: targeting macOS from Linux requires extra toolchain setup, and code-signing is platform-specific. CI is the easiest way to produce all three -- run a separate matrix job per platform.
+
+---
+
+## Choosing Which Plugins to Bundle
+
+By default the sidecar bundles four Jac plugins: **jac-scale** (FastAPI server, auth, persistence), **byllm** (LLM provider integration), **jac-coder**, and **jac-mcp**. If your app doesn't use one of them, drop it from the bundle to shrink the installer:
+
+```toml
+[desktop.plugins]
+jac_scale = true
+byllm = false       # don't ship LLM providers
+jac_coder = false
+jac_mcp = false
+```
+
+A few rules to know:
+
+- The plugins you list must already be installed in the **build environment** (`pip show jac-scale`, etc.) -- the build collects them from your current Python environment, not from PyPI.
+- `jac_client` is **always** bundled regardless of this section, because the sidecar entry point imports it directly. Setting `jac_client = false` is silently ignored.
+- Python dependencies declared under `[dependencies]` in `jac.toml` are auto-installed before PyInstaller runs -- you don't need to pre-install them yourself.
+
+---
+
+## Where Your Data Lives
+
+This is the part that surprises most people the first time they install their own desktop build:
+
+> The Jac runtime and jac-scale write the SQLite database, session files, and `.jac/data/` to the working directory by default. **An installed desktop app's working directory is read-only.**
+
+`.AppImage` files mount under `/tmp/.mount_AppXXX/` (a read-only squashfs), `.deb` packages install to `/usr/lib/`, `.msi` installers land in `C:\Program Files\`. Writing to any of those will fail or crash, depending on the operation.
+
+The sidecar handles this for you. Before importing any Jac module, it picks a writable path, sets `JAC_DATA_PATH` to it, and `chdir`s in. The Jac runtime's database resolver and jac-scale's config loader both honor this variable, so the database lands in a place the user can actually write to.
+
+The default fallback chain:
+
+| Platform | First choice | Fallback | Last resort |
+|----------|--------------|----------|-------------|
+| Linux / macOS | `~/.local/share/jac-app` | `~/.jac-app` | `/tmp/jac-app-{uid}` |
+| Windows | `%LOCALAPPDATA%\jac-app` | `~/AppData/Local/jac-app` | `%TEMP%\jac-app` |
+
+The sidecar tries each candidate in order and probes it with a touch/unlink test. If none of them work, the app exits with a loud error rather than silently writing to nowhere.
+
+**Override the location** by exporting `JAC_DATA_PATH` before launching the app, or by passing `--data-path` directly to the sidecar binary if you're invoking it manually:
+
+```bash
+./src-tauri/binaries/jac-sidecar --data-path /var/lib/myapp
+```
+
+**Practical implications:**
+
+- During development you can find a user's data with `ls ~/.local/share/jac-app` (Linux/macOS) or `%LOCALAPPDATA%\jac-app` (Windows).
+- Uninstalling the app does **not** delete this directory -- it's user data, not application data.
+- If you want to wipe state during testing, delete that directory and relaunch.
+
+---
+
+## Client-Only Mode (Thin Native Shell)
+
+Sometimes you don't want a sidecar at all -- you have a hosted jac-scale backend somewhere, and the desktop app is just a native window pointing at it. For that, set `client_only = true`:
+
+```toml
+[desktop]
+client_only = true
+
+[plugins.client.api]
+base_url = "https://api.example.com"
+```
+
+In this mode the build:
+
+- **Skips the entire PyInstaller step.** No Python bundle, no plugin collection -- the installer is dramatically smaller and the build is much faster.
+- **Requires** `[plugins.client.api] base_url` to be set. The build raises an error if it isn't, since the webview has nothing local to talk to.
+- **Still produces a full Tauri installer** -- you just get a thin native shell around a remote API.
+
+This is also useful in CI for verifying the web bundle compiles inside a desktop build without paying for the PyInstaller round-trip.
+
+---
+
+## Debugging Installed Builds
+
+When something works in `jac start --dev` but breaks inside the installer, the usual culprits are: the data path is wrong, the sidecar can't find a plugin, or the API URL never reached the webview. The fastest way to triage:
+
+1. **Run the sidecar binary directly.** Find it under `src-tauri/binaries/jac-sidecar` (or `.exe` on Windows) and run it from a terminal. It writes `JAC_SIDECAR_PORT=<port>` to stdout on startup and sends every other log line to stderr -- watch for `[sidecar] Cannot use data path …`, plugin registration messages, and any tracebacks.
+2. **Use the Debug page.** The `all-in-one` example app ships a debug page at `examples/all-in-one/pages/debug.jac` that displays the resolved API base URL, whether `window.__TAURI__` is present, the `get_api_url` Tauri command result, and live walker/HTTP probes. Drop it into your own app while you're tracking down a connectivity issue.
+3. **Check the data path.** The sidecar prints which fallback it settled on. If you see `/tmp/jac-app-{uid}`, that means both your home directory and the platform default failed -- probably a permissions issue.
+
+A few platform-specific quirks worth knowing:
+
+- **AppImage** injects `PYTHONHOME`, `PYTHONPATH`, and `PYTHONDONTWRITEBYTECODE` into the environment, which would break the bundled Python interpreter. The generated `main.rs` strips these before spawning the sidecar -- if you customized `main.rs`, make sure that logic survives.
+- **Windows** doesn't keep stdout open after Tauri reads the port line. The sidecar redirects stdout to stderr after the port handshake to avoid `OSError: [Errno 22] Invalid argument` on subsequent prints. If you customized the sidecar entry point, do the same.
+
+---
+
+## What You've Built
+
+By now you should have:
+
+- A `[desktop]` section in `jac.toml` controlling window, identifier, and bundled plugins.
+- An installer for your platform under `src-tauri/target/release/bundle/`.
+- A clear picture of where the bundled app stores user data and how to redirect it.
+- A debugging path for the inevitable "works in dev, fails when installed" moment.
+
+For the full reference -- including every option in `[desktop]`, the sidecar CLI flags, and the runtime API URL injection mechanism -- see the [jac-client Reference → Desktop Target](../../reference/plugins/jac-client.md#desktop-target-tauri).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
               - Backend Integration: "tutorials/fullstack/backend.md"
               - Authentication: "tutorials/fullstack/auth.md"
               - Routing: "tutorials/fullstack/routing.md"
+              - Desktop App: "tutorials/fullstack/desktop.md"
       - Deployment & Scaling:
           - jac-scale Reference: "reference/plugins/jac-scale.md"
           - Learn by Doing:


### PR DESCRIPTION
## Summary

The recent desktop hardening PRs (#5471, #5493, #5494, #5492, #5467) added substantial user-visible behavior that only landed in the release notes. This PR brings the reference doc and tutorials in line.

### Reference doc — `docs/docs/reference/plugins/jac-client.md`

The Desktop Target section grew from ~60 lines to ~140, now covering:

- **Architecture overview** — Tauri shell + PyInstaller sidecar, the `JAC_SIDECAR_PORT` handshake, and runtime API URL injection via `initialization_script`
- **`[desktop]` config example** — full window/identifier/platforms config (the build regenerates `tauri.conf.json` from `jac.toml` on every build)
- **Refreshed `[desktop.plugins]` example** — includes `jac_mcp = true` (added by #5493) and a note that `jac_client` is always bundled regardless of this config
- **Bundled Jac sources** — how `.jac` files end up in `src-tauri/jac/` as Tauri resources
- **Data Persistence on Installed Builds** (new `####` section) — the `JAC_DATA_PATH` story, fallback chain table for Linux/macOS/Windows, `--data-path` override, and AppImage `PYTHONHOME`/`PYTHONPATH`/`PYTHONDONTWRITEBYTECODE` cleanup. This was the biggest gap PR #5471 left in the docs
- **Client-Only Mode** (new `####` section) — `[desktop] client_only = true` from #5494, with the `[plugins.client.api] base_url` requirement called out
- **Runtime API URL Injection** (new `####` section) — short debugging-oriented note on `window.__JAC_API_BASE_URL__` and the `get_api_url` Tauri command
- **`JAC_BUILD=1`** mention added to the Python Dependencies section
- **CLI table** — added a one-line note pointing to Client-Only Mode and clarifying that it is a TOML toggle, not a CLI flag

### Tutorial — `docs/docs/tutorials/fullstack/desktop.md` (new)

A ~200-line walkthrough covering: architecture, prerequisites, `[desktop]` config, dev vs. installer builds, cross-platform builds, plugin selection (with the `jac_client` gotcha), the data persistence story (with the fallback table), client-only mode, and a debugging triage section.

Wired into mkdocs nav under **Full-Stack Development → Learn by Doing → Desktop App**.

### Deliberately out of scope

- `--jac-cli` multi-mode sidecar flag (#5467) — too internal for end-user docs
- Build artifact exclusion and stdout-to-stderr redirect — covered briefly inline rather than as their own subsections; both are bug-fix internals more than features

## Test plan

- [ ] `mkdocs serve` from `docs/` and verify the Desktop tutorial renders and is reachable from the nav
- [ ] Verify the `#desktop-target-tauri`, `#client-only-mode`, `#data-persistence-on-installed-builds` anchors all resolve
- [ ] Spot-check the `[desktop]` and `[desktop.plugins]` TOML examples against `jac-client/jac_client/plugin/src/impl/desktop_config.impl.jac`