### PR TITLE
feat(cli): add jac2js command, deprecate jac js alias

### DIFF
--- a/docs/docs/community/release_notes/jac-super.md
+++ b/docs/docs/community/release_notes/jac-super.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-super 0.1.10 (Unreleased)
 
+- **Fix: `JacSuperConsole.warning` Now Writes to Stderr**: `warning()` was incorrectly using `self._console` (stdout) while `error()` already used `_console_stderr`. Warnings now go to stderr as intended, so they no longer corrupt piped command output.
+
 ## jac-super 0.1.9 (Latest Release)
 
 - 1 small refactor/change.

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -33,6 +33,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Hover on LHS Assignment Shows Post-Write Type**: Hover on an assignment target (flat or destructuring) now reflects the post-write effective type instead of the pre-write declared type, matching pyright/pylance.
 - **Fix: NamedTuple Destructure Narrowing**: Destructuring a `NamedTuple` (`(x, _) = point`) now narrows each target to its field type, matching the behavior already available for plain tuple literals.
 - **Removed: W2052 Broad Exception Warning**: Removed the `W2052` warning that flagged `except Exception` as overly broad. Catching `Exception` is a legitimate and common pattern at system boundaries (e.g., LLM calls, network I/O), and the warning produced false positives in these cases.
+- **CLI: `jac jac2js` (and `jac js` deprecated)**: Added `jac jac2js` as the canonical Jac→JavaScript transform command, mirroring `jac jac2py`. `jac js` still works but now emits a deprecation warning on stderr and forwards to `jac jac2js`; it will be removed in a future release. Also fixed a pre-existing bug where `JacSuperConsole.warning` wrote to stdout instead of stderr.
 
 ## jaclang 0.13.5 (Latest Release)
 

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -37,7 +37,7 @@ The CLI is extensible through plugins. When you install plugins like `jac-scale`
 | `jac jac2py` | Convert Jac to Python |
 | `jac tool` | Language tools (IR, AST) |
 | `jac lsp` | Language server |
-| `jac js` | JavaScript output |
+| `jac jac2js` | Convert Jac to JavaScript |
 | `jac build` | Build for target platform (jac-client) |
 | `jac setup` | Setup build target (jac-client) |
 
@@ -1069,12 +1069,12 @@ jac create myproject --use mytemplate
 
 ---
 
-### jac js
+### jac jac2js
 
 Generate JavaScript output from Jac code (used for jac-client frontend compilation).
 
 ```bash
-jac js [-h] filename
+jac jac2js [-h] filename
 ```
 
 | Option | Description | Default |
@@ -1085,8 +1085,12 @@ jac js [-h] filename
 
 ```bash
 # Generate JS from Jac file
-jac js app.jac
+jac jac2js app.jac
 ```
+
+> **Deprecated:** `jac js` is a deprecated alias for `jac jac2js` and will be
+> removed in a future release. It still works but emits a deprecation warning
+> on stderr; update scripts to use `jac jac2js`.
 
 ---
 

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -86,7 +86,7 @@ The `jac` command is your primary interface to the Jac toolchain. For the full r
 |---------|-------------|
 | `jac py2jac <file>` | Convert Python to Jac |
 | `jac jac2py <file>` | Convert Jac to Python |
-| `jac js <file>` | Compile to JavaScript |
+| `jac jac2js <file>` | Compile to JavaScript |
 
 ### Project Commands
 

--- a/jac-super/jac_super/plugin/impl/console.impl.jac
+++ b/jac-super/jac_super/plugin/impl/console.impl.jac
@@ -76,7 +76,7 @@ obj JacSuperConsole(BaseJacConsole) {
     """Override warning to use Rich styling."""
     def warning(message: str, emoji: bool = True) {
         prefix = '⚠' if (emoji and self.use_emoji) else '[WARNING]';
-        self._console.print(f"{prefix} {message}", style='warning');
+        self._console_stderr.print(f"{prefix} {message}", style='warning');
     }
 
     """Override info to use Rich styling."""

--- a/jac/jaclang/cli/commands/impl/transform.impl.jac
+++ b/jac/jaclang/cli/commands/impl/transform.impl.jac
@@ -55,7 +55,7 @@ impl jac2py(filename: str) -> int {
 }
 
 """Convert Jac to JavaScript."""
-impl js(filename: str) -> int {
+impl jac2js(filename: str) -> int {
     import from jaclang.jac0core.program { JacProgram }
     if filename.endswith('.jac') {
         try {
@@ -84,4 +84,13 @@ impl js(filename: str) -> int {
         console.error('Not a .jac file.');
         return 1;
     }
+}
+
+"""Deprecated alias for jac2js. Emits a warning then forwards."""
+impl js(filename: str) -> int {
+    console.warning(
+        "'jac js' is deprecated and will be removed in a future release. "
+        "Use 'jac jac2js' instead."
+    );
+    return jac2js(filename);
 }

--- a/jac/jaclang/cli/commands/transform.jac
+++ b/jac/jaclang/cli/commands/transform.jac
@@ -1,4 +1,4 @@
-"""Transform commands: py2jac, jac2py, js.
+"""Transform commands: py2jac, jac2py, jac2js.
 
 Commands for converting code between Jac, Python, and JavaScript.
 """
@@ -30,10 +30,23 @@ def jac2py(filename: str) -> int;
 
 """Convert Jac to JavaScript."""
 @registry.command(
-    name="js",
+    name="jac2js",
     help="Convert Jac code to JavaScript",
     args=[Arg.create("filename", kind=ArgKind.POSITIONAL, help="Path to .jac file"), ],
-    examples=[("jac js myprogram.jac", "Convert a Jac file to JavaScript"), ],
+    examples=[("jac jac2js myprogram.jac", "Convert a Jac file to JavaScript"), ],
+    group="transform"
+)
+def jac2js(filename: str) -> int;
+
+"""Deprecated alias for jac2js."""
+@registry.command(
+    name="js",
+    help="[Deprecated] Alias for 'jac2js'. Convert Jac code to JavaScript",
+    args=[Arg.create("filename", kind=ArgKind.POSITIONAL, help="Path to .jac file"), ],
+    examples=[
+        ("jac js myprogram.jac", "Deprecated; prefer 'jac jac2js myprogram.jac'"),
+
+    ],
     group="transform"
 )
 def js(filename: str) -> int;


### PR DESCRIPTION
## Summary
- Add `jac jac2js` as the canonical Jac-to-JavaScript transform command, mirroring `jac jac2py` for naming consistency
- Retain `jac js` as a deprecated alias that emits a warning on stderr and forwards to `jac2js` (to be removed in a future release)
- Fix pre-existing bug in `JacSuperConsole.warning` that wrote to stdout instead of stderr, so the deprecation warning does not corrupt piped JS output

## Motivation
The CLI naming was asymmetric: `jac jac2py` (long form) vs `jac js` (short form). Standardizing on the `jac2X` convention is the smaller break since `jac2py` is already heavily used in library-mode docs, and `jac2js` is unambiguous (`jac js` could read as "run as JS"). The internal helper in jac-mcp is already named `_do_jac2js`, so the CLI was the odd one out.

## Changes
- ``jac/jaclang/cli/commands/transform.jac`` — register `jac2js`; mark `js` as `[Deprecated]` alias
- ``jac/jaclang/cli/commands/impl/transform.impl.jac`` — `jac2js` holds the codegen logic; `js` is a thin alias that prints `console.warning(...)` then forwards
- ``jac-super/jac_super/plugin/impl/console.impl.jac`` — `JacSuperConsole.warning` now uses `_console_stderr` (matching how `error` was already implemented)
- ``docs/docs/reference/cli/index.md`` — section retitled to `### jac jac2js` with a deprecation callout
- ``docs/docs/reference/index.md`` — quick reference table updated
- ``docs/docs/community/release_notes/jaclang.md`` — bullet added to 0.13.6 unreleased section

## Test plan
- [x] `jac --help` lists both `jac2js` and `js` (with `[Deprecated]` marker)
- [x] `jac jac2js core_language_features.jac` → exit 0, clean stdout
- [x] `jac js core_language_features.jac` → exit 0, **byte-identical stdout** to `jac2js` (46838 bytes), deprecation warning printed only to stderr
- [x] Existing `cli js command outputs js` and `cl only js command outputs js` tests in `test_js_generation.jac` continue to exercise the deprecated alias path during the deprecation window
- [ ] CI green