### PR TITLE
fix(jac-scale): graceful scheduler degradation when APScheduler not installed

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -10,6 +10,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Fix: Spurious "write access" warnings on system root during sync**: Skip `check_write_access()` for unchanged anchors in MongoDB sync, eliminating noisy `Current root doesn't have write access to NodeAnchor Root` log spam on every authenticated request.
 
 - **Optional Install Groups**: Heavy dependencies (pymongo, redis, prometheus-client, apscheduler, kubernetes, docker) are no longer required by default. Install only what you need via extras: `pip install jac-scale[data]` (MongoDB + Redis), `[monitoring]` (Prometheus), `[scheduler]` (APScheduler), `[deploy]` (Kubernetes + Docker), or `[all]` for everything. Groups are combinable: `pip install jac-scale[data,monitoring]`. Missing dependencies produce clear error messages with install instructions. Existing users should use `pip install jac-scale[all]` to keep current behavior.
+- **Fix: `jac start` crashes without `jac-scale[scheduler]`**: The scheduler setup in `jac start` unconditionally initialized APScheduler, causing a `'NoneType' object is not callable` error when APScheduler wasn't installed. The scheduler now gracefully degrades: static/interval/cron tasks still work via the core jaclang scheduler, and dynamic scheduling features are skipped with a clear log message when APScheduler is absent.
 - 1 small refactor/change.
 
 ## jac-scale 0.2.13 (Latest Release)

--- a/jac-scale/jac_scale/impl/scheduler.impl.jac
+++ b/jac-scale/jac_scale/impl/scheduler.impl.jac
@@ -41,12 +41,20 @@ impl JacScaleScheduler.setup(system_token: str, server: Any | None = None) -> No
     }
     # APScheduler uses in-memory job store — MongoDB persistence is handled manually
     # via _persist_job / _load_jobs_from_db, avoiding serialisation issues with closures.
-    executors = {'default': ThreadPoolExecutor(10)};
-    job_defaults = {'coalesce': False, 'max_instances': 1};
-    self._apscheduler = BackgroundScheduler(
-        executors=executors, job_defaults=job_defaults
-    );
-    logger.debug("APScheduler initialized with in-memory job store");
+    if HAS_APSCHEDULER {
+        executors = {'default': ThreadPoolExecutor(10)};
+        job_defaults = {'coalesce': False, 'max_instances': 1};
+        self._apscheduler = BackgroundScheduler(
+            executors=executors, job_defaults=job_defaults
+        );
+        logger.debug("APScheduler initialized with in-memory job store");
+    } else {
+        self._apscheduler = None;
+        logger.info(
+            "APScheduler not installed — dynamic scheduling disabled. "
+            "Install with: pip install jac-scale[scheduler]"
+        );
+    }
 }
 
 """Start the APScheduler background scheduler."""
@@ -166,7 +174,7 @@ impl JacScaleScheduler.create_job(
 ) -> dict {
     if self._apscheduler is None {
         raise RuntimeError(
-            "APScheduler is not available. Install apscheduler>=3.0.0,<4.0.0."
+            "APScheduler is not available. Install with: pip install jac-scale[scheduler]"
         );
     }
 

--- a/jac-scale/jac_scale/scheduler.jac
+++ b/jac-scale/jac_scale/scheduler.jac
@@ -2,7 +2,11 @@ import logging;
 import datetime;
 import from typing { Any }
 import from uuid { uuid4 }
-import from jac_scale._optdeps.apscheduler { BackgroundScheduler, ThreadPoolExecutor }
+import from jac_scale._optdeps.apscheduler {
+    BackgroundScheduler,
+    ThreadPoolExecutor,
+    HAS_APSCHEDULER
+}
 import from jac_scale.config_loader { get_scale_config }
 import from jaclang.runtimelib.scheduler { Scheduler, ScheduleTrigger }
 import from jac_scale.db { Db, get_mongo_client }

--- a/jac-scale/jac_scale/tests/test_optional_deps.jac
+++ b/jac-scale/jac_scale/tests/test_optional_deps.jac
@@ -155,8 +155,7 @@ test "utility factory returns noop metrics when prometheus missing" {
     ) {
         config = {"enabled": True, "namespace": "test"};
         collector = UtilityFactory.create_metrics("prometheus", config);
-        assert isinstance(collector, NoOpMetricsCollector),
-            "Should fall back to NoOp when prometheus-client is missing";
+        assert isinstance(collector, NoOpMetricsCollector) , "Should fall back to NoOp when prometheus-client is missing";
     }
 }
 
@@ -182,11 +181,15 @@ test "database factory requires pymongo for mongodb" {
 
     with unittest.mock.patch(
         "jac_scale.factories.database_factory.require_optional",
-        side_effect=ImportError("'pymongo' is required. Install: pip install jac-scale[data]")
+        side_effect=ImportError(
+            "'pymongo' is required. Install: pip install jac-scale[data]"
+        )
     ) {
         raised = False;
         try {
-            DatabaseProviderFactory.create_client(DatabaseType.MONGODB, uri="mongodb://localhost");
+            DatabaseProviderFactory.create_client(
+                DatabaseType.MONGODB, uri="mongodb://localhost"
+            );
         } except ImportError as e {
             raised = True;
             assert "jac-scale[data]" in str(e);
@@ -203,11 +206,15 @@ test "database factory requires redis for redis" {
 
     with unittest.mock.patch(
         "jac_scale.factories.database_factory.require_optional",
-        side_effect=ImportError("'redis' is required. Install: pip install jac-scale[data]")
+        side_effect=ImportError(
+            "'redis' is required. Install: pip install jac-scale[data]"
+        )
     ) {
         raised = False;
         try {
-            DatabaseProviderFactory.create_client(DatabaseType.REDIS, uri="redis://localhost");
+            DatabaseProviderFactory.create_client(
+                DatabaseType.REDIS, uri="redis://localhost"
+            );
         } except ImportError as e {
             raised = True;
             assert "jac-scale[data]" in str(e);
@@ -221,7 +228,9 @@ test "deployment factory requires kubernetes for k8s target" {
 
     with unittest.mock.patch(
         "jac_scale.factories.deployment_factory.require_optional",
-        side_effect=ImportError("'kubernetes' is required. Install: pip install jac-scale[deploy]")
+        side_effect=ImportError(
+            "'kubernetes' is required. Install: pip install jac-scale[deploy]"
+        )
     ) {
         raised = False;
         try {
@@ -272,4 +281,50 @@ test "multiple require_optional calls do not conflict" {
     require_optional("json", "core");
     require_optional("json", "core");
     require_optional("os", "core");
+}
+
+# =============================================================================
+# Scheduler graceful degradation without APScheduler
+# =============================================================================
+test "scheduler setup succeeds without apscheduler installed" {
+    import from jac_scale.scheduler { JacScaleScheduler }
+
+    # Simulate APScheduler not being installed by patching the symbols
+    # in the scheduler module (where setup() reads them at runtime).
+    with unittest.mock.patch("jac_scale.scheduler.HAS_APSCHEDULER", False) {
+        with unittest.mock.patch("jac_scale.scheduler.BackgroundScheduler", None) {
+            with unittest.mock.patch("jac_scale.scheduler.ThreadPoolExecutor", None) {
+                sched = JacScaleScheduler();
+                # setup() should not crash — APScheduler init is skipped gracefully.
+                sched.setup(system_token="test-token");
+                assert sched._apscheduler is None , "APScheduler should be None when package is not installed";
+                # start/stop should be no-ops, not errors.
+                sched.start();
+                sched.stop();
+            }
+        }
+    }
+}
+
+test "scheduler create_job raises clear error without apscheduler" {
+    import from jac_scale.scheduler { JacScaleScheduler }
+
+    with unittest.mock.patch("jac_scale.scheduler.HAS_APSCHEDULER", False) {
+        with unittest.mock.patch("jac_scale.scheduler.BackgroundScheduler", None) {
+            with unittest.mock.patch("jac_scale.scheduler.ThreadPoolExecutor", None) {
+                sched = JacScaleScheduler();
+                sched.setup(system_token="test-token");
+                raised = False;
+                try {
+                    sched.create_job(
+                        name="test_walker", trigger="interval", interval=60.0
+                    );
+                } except RuntimeError as e {
+                    raised = True;
+                    assert "jac-scale[scheduler]" in str(e) , "Error message should include install instructions";
+                }
+                assert raised , "Expected RuntimeError when creating job without APScheduler";
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `jac start` crashed with `'NoneType' object is not callable` when APScheduler wasn't installed, because #5489 made it optional but the scheduler setup still initialized it unconditionally
- Guard APScheduler init behind `HAS_APSCHEDULER` flag so the core jaclang scheduler handles static tasks and dynamic scheduling is cleanly skipped with an informative log message
- Updated `create_job()` error message to point users to `pip install jac-scale[scheduler]`

## Test plan

- [x] `jac start` succeeds without APScheduler installed (logs info message, server starts)
- [x] 2 new unit tests: `setup()`/`start()`/`stop()` succeed without APScheduler; `create_job()` raises clear `RuntimeError`
- [x] All 25 existing `test_optional_deps` tests still pass