### PR TITLE
ci(experiment): pin llvmlite<0.47 to test native segfault hypothesis

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -31,8 +31,45 @@ jobs:
         pip install pytest-xdist
         pip install watchdog
 
+    - name: Show llvmlite version
+      run: pip show llvmlite | grep Version
+
     - name: Run Jac core tests
       run: pytest -x jac -n auto
+
+  # Hypothesis test: isolate jac/tests/compiler/passes/native into its own
+  # job to verify whether pinning llvmlite<0.47 fixes the
+  # `transitive glob init: ... (no segfault)` crash that surfaces when
+  # ~88 native tests run back-to-back on a single xdist worker.
+  # If this job is GREEN, llvmlite 0.47 is the culprit and the pin in
+  # jac/pyproject.toml stands. If RED, the bug is elsewhere and we keep
+  # digging.
+  test-core-native-isolation-experiment:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v5
+      with:
+        submodules: true
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.12
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e jac
+        pip install pytest
+        pip install pytest-xdist
+        pip install watchdog
+
+    - name: Show llvmlite version
+      run: pip show llvmlite | grep Version
+
+    - name: Run native tests in isolation
+      run: pytest -x jac/tests/compiler/passes/native -n auto
 
   test-client:
     runs-on: ubuntu-latest

--- a/jac/pyproject.toml
+++ b/jac/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "artificial-intelligence",
 ]
 requires-python = ">=3.12"
-dependencies = ["llvmlite>=0.43.0"]
+dependencies = ["llvmlite>=0.43.0,<0.47"]
 # Note: lark, pygls are vendored; pluggy replaced by jaclang/plugin.py
 
 [project.urls]


### PR DESCRIPTION
**EXPERIMENT — do not merge as-is.**

## Hypothesis
The `transitive glob init: glob list in deep module is not null (no segfault)` crash that surfaces when \`jac/tests/compiler/passes/native\` runs in an isolated CI bucket (~88 native tests on one xdist worker) is caused by a regression in **llvmlite 0.47.0**.

Evidence:
- Local with llvmlite 0.46.0: 350 tests pass with -n 4 (matching CI worker count). Repeated runs all green.
- Local with llvmlite 0.47.0: also passes locally. So 0.47 alone isn't sufficient — but combined with the CI environment (different CPU model, kernel, memory layout) it triggers.
- CI env shows \`llvmlite 0.47.0\` installed; jac/pyproject.toml has \`llvmlite>=0.43.0\` (no upper pin), so pip always grabs the latest.

## Experiment
1. Pin \`jac\` to \`llvmlite>=0.43.0,<0.47\` in \`jac/pyproject.toml\`.
2. Add a temporary \`test-core-native-isolation-experiment\` job that runs \`pytest -x jac/tests/compiler/passes/native -n auto\` in isolation — this is the same command that consistently failed on the previous measurement branch.
3. Leave the existing \`test-core\` job alone for direct comparison.
4. Both jobs print the installed llvmlite version so we can verify the pin took effect.

## Reading the result
- **Both jobs GREEN** → hypothesis confirmed. llvmlite 0.47 is the culprit. Keep the pin, split the native bucket permanently in a follow-up PR, file an upstream issue against llvmlite.
- **\`test-core-native-isolation-experiment\` RED** → bug is somewhere else (test isolation issue, GC ordering, etc.). Keep digging — likely candidates: \`compile_native()\` engine lifetime, \`get_func()\` returning dangling function pointers, transitive .so loading via \`load_library_permanently\`.

## Test plan
- [x] Local repro attempt: \`pytest -x jac/tests/compiler/passes/native -n 4\` passes consistently with llvmlite 0.46.0
- [x] Local with llvmlite 0.47.0: also passes (so the environment difference matters too)
- [ ] CI: \`test-core-native-isolation-experiment\` should now be green
- [ ] CI: existing \`test-core\` continues to pass