### PR TITLE
fix(test-native): pin ir to engine so GC cannot strand MCJIT deps

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -34,6 +34,38 @@ jobs:
     - name: Run Jac core tests
       run: pytest -x jac -n auto
 
+  # Temporary verification job: runs ONLY the native pass tests in
+  # isolation. On main this job has been failing deterministically due
+  # to a GC-lifetime bug in compile_native() — ir was being GC'd while
+  # the engine (and ctypes function pointers into JIT code) were still
+  # alive, causing entry_fn() to dereference freed memory. This job
+  # tests the fix: if it stays green across a few runs, the native
+  # bucket can be split out permanently in a follow-up PR and this job
+  # can be removed.
+  test-core-native-isolation-verify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v5
+      with:
+        submodules: true
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.12
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e jac
+        pip install pytest
+        pip install pytest-xdist
+        pip install watchdog
+
+    - name: Run native tests in isolation
+      run: pytest -x jac/tests/compiler/passes/native -n auto
+
   test-client:
     runs-on: ubuntu-latest
     steps:

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -18,7 +18,18 @@ glob FIXTURES = str(
          Path(jaclang.__file__).parent.parent / "tests" / "compiler" / "passes" / "native" / "fixtures"
      );
 
-"""Compile a .na.jac fixture and return the JIT engine."""
+"""Compile a .na.jac fixture and return the JIT engine.
+
+NOTE: `ir.gen` holds Python objects that MCJIT depends on but does not own —
+specifically the LLVM Module (`llvm_ir`) and the list of ctypes interop
+callbacks (`_interop_callbacks`) whose raw addresses are baked into the
+JIT code. If `ir` is garbage-collected while `eng` is still in use, those
+objects die and the next JIT call dereferences freed memory → SIGSEGV.
+
+Most tests unpack this tuple as `(eng, _)` and discard `ir`, so we pin
+`ir` to the engine via a sidecar attribute. Now `ir`'s lifetime tracks
+the engine's, regardless of what the caller does with the returned tuple.
+"""
 def compile_native(fixture: str) -> tuple[ExecutionEngine, uni.Module] {
     prog = JacProgram();
     ir = prog.compile(file_path=str(os.path.join(FIXTURES, fixture)));
@@ -26,6 +37,10 @@ def compile_native(fixture: str) -> tuple[ExecutionEngine, uni.Module] {
     assert not prog.errors_had , f"Compilation errors in {fixture}: {errors}";
     eng = ir.gen.native_engine;
     assert eng is not None , f"No native engine produced for {fixture}";
+    # Pin ir (and therefore ir.gen.llvm_ir / _interop_callbacks) to the
+    # engine so that GC cannot release MCJIT's implicit dependencies
+    # before the engine itself is released.
+    eng._jac_ir_keepalive = ir;
     return (eng, ir);
 }
 


### PR DESCRIPTION
## Summary
Fixes a latent use-after-free in \`compile_native()\` that surfaces as a SIGSEGV when \`jac/tests/compiler/passes/native\` runs in an isolated CI bucket (~88 native tests back-to-back on one xdist worker).

## Root cause
\`compile_native()\` returns \`(eng, ir)\` but most callers unpack as \`(eng, _)\` and discard \`ir\`. Once \`ir\` goes out of scope, \`ir.gen\` is GC'd, which releases the LLVM Module (\`llvm_ir\`), the ctypes interop callbacks (\`_interop_callbacks\`) whose raw addresses are baked into the JIT'd code, and the \`_clib_paths\` load state. The engine itself survives (held by \`eng\`), but now it points into freed Python memory. The next call through a ctypes function pointer (e.g. \`entry_fn()\`) dereferences freed memory → SIGSEGV.

## Why it only surfaced in CI's isolated native bucket
GC timing and xdist scheduling. On CI's 4-CPU runner, ~88 native tests running back-to-back on a single worker creates enough GC pressure to collect \`ir\` while the engine is still live. In the full \`pytest -x jac\` run, native tests are interleaved with non-native tests, so GC runs in a different order and \`ir\` rarely dies before the engine. Locally on a 16-CPU machine the bug never surfaced at all.

The two tests that crashed (in two successive CI runs, different workers) were both regression tests named \"(no segfault)\" / \"(no state corruption)\", both fell on the second compile of a fixture that an earlier test in the same file had already used.

## Fix
One line: pin \`ir\` to the engine via a sidecar attribute (\`eng._jac_ir_keepalive = ir\`). Now \`ir\`'s lifetime tracks the engine's, regardless of whether the caller discards the tuple element.

## Verification
- Local \`jac test jac/tests/compiler/passes/native/test_native_gen_pass.jac\`: 332/332 pass (as before — local never reproduced the bug)
- Added a temporary \`test-core-native-isolation-verify\` CI job that runs \`pytest -x jac/tests/compiler/passes/native -n auto\` in isolation. On main (without this fix) the same invocation segfaults deterministically. With this fix it should stay green.

## Follow-up
Once this is merged, the temporary verification job can either stay as a permanent split bucket (unlocks the test-core 3-way split that was blocked by this bug) or be removed if the split isn't pursued.