### PR TITLE
docs: teach 'to cl:/sv:/na:' section headers as preferred module-scope form

### DIFF
--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -40,6 +40,50 @@ No code changes are required - the same APIs, configuration, and behavior apply.
 
 ---
 
+### Version 0.13.6
+
+#### 1. `cl { }` / `sv { }` / `na { }` Module-Level Braced Blocks Deprecated
+
+Module-level braced codespace blocks (`cl { ... }`, `sv { ... }`, `na { ... }`) are now discouraged in favor of `to cl:` / `to sv:` / `to na:` section headers. A section header applies until the next header or end of file, which flattens cl/sv/na-heavy modules and eliminates the wrapping brace pair. The single-statement prefix form (`cl stmt`, `sv stmt`, `na stmt`) is unchanged.
+
+The braced block form still parses and compiles, but emits deprecation warning **W0064** when used at module scope. Inner-scope uses (inside a function or class body) do not emit W0064 and remain the recommended way to locally override the active codespace.
+
+**Impact:** Existing module-level `cl { ... }` / `sv { ... }` / `na { ... }` blocks keep working but will produce W0064 diagnostics. Migrate to the section-header form to silence the warning and reduce indentation.
+
+**Before:**
+
+```jac
+cl {
+    def:pub Greeting(props: dict) -> JsxElement {
+        return <h1>Hello, {props.name}!</h1>;
+    }
+
+    def:pub Counter() -> JsxElement {
+        has count: int = 0;
+        return <button onClick={lambda -> None { count = count + 1; }}>{count}</button>;
+    }
+}
+```
+
+**After:**
+
+```jac
+to cl:
+
+def:pub Greeting(props: dict) -> JsxElement {
+    return <h1>Hello, {props.name}!</h1>;
+}
+
+def:pub Counter() -> JsxElement {
+    has count: int = 0;
+    return <button onClick={lambda -> None { count = count + 1; }}>{count}</button>;
+}
+```
+
+`jac format` automatically rewrites module-level braced blocks to section headers.
+
+---
+
 ### Version 0.12.3
 
 #### 1. Automatic `TYPE_CHECKING` Import Guards

--- a/docs/docs/community/internals/jac_import_patterns.md
+++ b/docs/docs/community/internals/jac_import_patterns.md
@@ -106,11 +106,11 @@ Path aliases let you define short prefixes (like `@components`) that map to proj
 Then use them in imports:
 
 ```jac
-cl {
-    import from "@components/Button" { Button }
-    import from "@utils/format" { formatDate }
-    import from "@shared" { constants }
-}
+to cl:
+
+import from "@components/Button" { Button }
+import from "@utils/format" { formatDate }
+import from "@shared" { constants }
 ```
 
 Aliases are resolved by:
@@ -172,45 +172,45 @@ All patterns tested and verified in:
 ### Full Feature Demo
 
 ```jac
-cl {
-    # Named imports
-    import from react { useEffect, useRef }
-    import from lodash { map as mapArray, filter }
+to cl:
 
-    # Default imports
-    import from react { default as React }
-    import from axios { default as axios }
+# Named imports
+import from react { useEffect, useRef }
+import from lodash { map as mapArray, filter }
 
-    # Namespace imports
-    import from "date-fns" { * as DateFns }
-    import from .utils { * as Utils }
+# Default imports
+import from react { default as React }
+import from axios { default as axios }
 
-    # String literal imports (for hyphenated packages)
-    import from "react-dom" { render, hydrate }
-    import from "styled-components" { default as styled }
-    import from "react-router-dom" { BrowserRouter, Route }
+# Namespace imports
+import from "date-fns" { * as DateFns }
+import from .utils { * as Utils }
 
-    # Mixed imports
-    import from react { default as React, useEffect }
+# String literal imports (for hyphenated packages)
+import from "react-dom" { render, hydrate }
+import from "styled-components" { default as styled }
+import from "react-router-dom" { BrowserRouter, Route }
 
-    # Relative paths
-    import from .components.Button { default as Button }
-    import from ..lib.helpers { formatDate }
-    import from ...config.constants { API_URL }
+# Mixed imports
+import from react { default as React, useEffect }
 
-    def MyComponent() {
-        # Reactive state - auto-generates useState
-        has count: int = 0;
+# Relative paths
+import from .components.Button { default as Button }
+import from ..lib.helpers { formatDate }
+import from ...config.constants { API_URL }
 
-        now = DateFns.format(Date.now());
-        axios.get(API_URL);
+def MyComponent() {
+    # Reactive state - auto-generates useState
+    has count: int = 0;
 
-        return count;
-    }
+    now = DateFns.format(Date.now());
+    axios.get(API_URL);
+
+    return count;
 }
 ```
 
-> **Note:** Inside `cl {}` blocks and `.cl.jac` files, use `has` variables for reactive state instead of explicit `useState` calls. The compiler automatically generates `const [count, setCount] = useState(0);`, auto-injects the `useState` import from `@jac-client/utils`, and transforms assignments to setter calls.
+> **Note:** Inside client-tagged code (`to cl:` sections, `.cl.jac` files, and `cl { }` blocks), use `has` variables for reactive state instead of explicit `useState` calls. The compiler automatically generates `const [count, setCount] = useState(0);`, auto-injects the `useState` import from `@jac-client/utils`, and transforms assignments to setter calls.
 
 ### Generated JavaScript Output
 

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -142,11 +142,11 @@ Jac introduces **codespaces** -- regions of code that target different execution
 
 | Codespace | Target | Ecosystem | Syntax |
 |-----------|--------|-----------|--------|
-| **Server** | Python runtime | PyPI (`numpy`, `pandas`, `fastapi`) | `sv { }` or `.sv.jac` |
-| **Client** | Browser/JavaScript | npm (`react`, `tailwind`, `@mui`) | `cl { }` or `.cl.jac` |
-| **Native** | Compiled binary | C ABI | `na { }` or `.na.jac` |
+| **Server** | Python runtime | PyPI (`numpy`, `pandas`, `fastapi`) | `to sv:` or `.sv.jac` |
+| **Client** | Browser/JavaScript | npm (`react`, `tailwind`, `@mui`) | `to cl:` or `.cl.jac` |
+| **Native** | Compiled binary | C ABI | `to na:` or `.na.jac` |
 
-Server definitions are visible to client blocks. When the client calls a server function, the compiler generates the HTTP request, serialization, and routing automatically. You write one language; the compiler produces the interop layer.
+Server definitions are visible to client sections. When the client calls a server function, the compiler generates the HTTP request, serialization, and routing automatically. You write one language; the compiler produces the interop layer.
 
 !!! example "See it in action"
     Want to see exactly how much code Jac eliminates? Check out [Jac vs Traditional Stack](jac-vs-traditional-stack.md) -- a side-by-side comparison showing **~30 lines of Jac** vs **>300 lines** of Python + FastAPI + SQLite + TypeScript + React for the same Todo app.

--- a/docs/docs/quick-guide/jac-vs-traditional-stack.md
+++ b/docs/docs/quick-guide/jac-vs-traditional-stack.md
@@ -1,6 +1,6 @@
 # Jac vs Traditional Stack: A Side-by-Side Comparison
 
-A traditional full-stack web application requires separate projects, frameworks, and glue code -- a Python backend, a React frontend, an ORM, API route definitions, and serialization logic. In Jac, you write all of this in a single file: nodes are your data model, walkers are your API endpoints, and `cl { }` blocks are your UI components. This comparison builds the same Todo app both ways so you can see the difference.
+A traditional full-stack web application requires separate projects, frameworks, and glue code -- a Python backend, a React frontend, an ORM, API route definitions, and serialization logic. In Jac, you write all of this in a single file: nodes are your data model, walkers are your API endpoints, and a `to cl:` section (or `.cl.jac` file) holds your UI components. This comparison builds the same Todo app both ways so you can see the difference.
 
 ---
 

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -1171,16 +1171,16 @@ with entry {
 # FULL-STACK DEVELOPMENT (Codespaces)
 # ============================================================
 # Jac code can target different execution environments:
-#   sv { } = server (Python/PyPI)
-#   cl { } = client (JavaScript/npm)
-#   na { } = native (C ABI)
+#   to sv: = server (Python/PyPI)
+#   to cl: = client (JavaScript/npm)
+#   to na: = native (C ABI)
 
 
 # ============================================================
-# Codespace Blocks
+# Codespace Sections
 # ============================================================
 
-# Server code (default -- code outside any block is server)
+# Server code (default -- code before any header is server)
 node Todo {
     has title: str, done: bool = False;
 }
@@ -1189,29 +1189,32 @@ def:pub get_todos() -> list {
     return [{"title": t.title} for t in [root -->][?:Todo]];
 }
 
-# Client code (compiles to JavaScript/React)
-cl {
-    def:pub app() -> JsxElement {
-        has items: list = [];
+# Client section (compiles to JavaScript/React)
+to cl:
 
-        async can with entry {
-            items = await get_todos();
-        }
+def:pub app() -> JsxElement {
+    has items: list = [];
 
-        return <div>
-            {[<p key={i.title}>{i.title}</p> for i in items]}
-        </div>;
+    async can with entry {
+        items = await get_todos();
     }
+
+    return <div>
+        {[<p key={i.title}>{i.title}</p> for i in items]}
+    </div>;
 }
 
-# Explicit server block
-sv {
-    node Secret { has value: str; }
-}
+# Return to server section
+to sv:
 
-# Single-statement form (no braces)
+node Secret { has value: str; }
+
+# Single-statement form (no header, no braces)
 sv import from .database { connect_db }
 cl import from react { useState }
+
+# Braced form (cl { ... }) is still valid in inner scopes,
+# but emits W0064 at module scope -- prefer `to cl:` / `cl` prefix.
 
 
 # ============================================================
@@ -1229,18 +1232,18 @@ cl import from react { useState }
 # Client Components (JSX)
 # ============================================================
 
-cl {
-    def:pub Counter() -> JsxElement {
-        # `has` in client components becomes React useState
-        has count: int = 0;
+to cl:
 
-        return <div>
-            <p>Count: {count}</p>
-            <button onClick={lambda -> None { count = count + 1; }}>
-                Increment
-            </button>
-        </div>;
-    }
+def:pub Counter() -> JsxElement {
+    # `has` in client components becomes React useState
+    has count: int = 0;
+
+    return <div>
+        <p>Count: {count}</p>
+        <button onClick={lambda -> None { count = count + 1; }}>
+            Increment
+        </button>
+    </div>;
 }
 
 # JSX syntax reference:
@@ -1258,31 +1261,31 @@ cl {
 # Client State & Lifecycle
 # ============================================================
 
-cl {
-    def:pub DataView() -> JsxElement {
-        has data: list = [];
-        has loading: bool = True;
+to cl:
 
-        # Mount effect (runs once on component mount)
-        async can with entry {
-            data = await fetch("/api/data").then(
-                lambda r: any -> any { return r.json(); }
-            );
-            loading = False;
-        }
+def:pub DataView() -> JsxElement {
+    has data: list = [];
+    has loading: bool = True;
 
-        # Dependency effect (runs when userId changes)
-        # async can with [userId] entry { ... }
-
-        # Multiple dependencies
-        # can with (a, b) entry { ... }
-
-        # Cleanup on unmount
-        # can with exit { unsubscribe(); }
-
-        if loading { return <p>Loading...</p>; }
-        return <div>{data}</div>;
+    # Mount effect (runs once on component mount)
+    async can with entry {
+        data = await fetch("/api/data").then(
+            lambda r: any -> any { return r.json(); }
+        );
+        loading = False;
     }
+
+    # Dependency effect (runs when userId changes)
+    # async can with [userId] entry { ... }
+
+    # Multiple dependencies
+    # can with (a, b) entry { ... }
+
+    # Cleanup on unmount
+    # can with exit { unsubscribe(); }
+
+    if loading { return <p>Loading...</p>; }
+    return <div>{data}</div>;
 }
 
 
@@ -1293,26 +1296,26 @@ cl {
 # Import server walkers in client code
 sv import from ...main { AddTodo, GetTodos }
 
-cl {
-    def:pub TodoApp() -> JsxElement {
-        has todos: list = [];
+to cl:
 
-        async can with entry {
-            result = root spawn GetTodos();
-            if result.reports {
-                todos = result.reports[0];
-            }
+def:pub TodoApp() -> JsxElement {
+    has todos: list = [];
+
+    async can with entry {
+        result = root spawn GetTodos();
+        if result.reports {
+            todos = result.reports[0];
         }
-
-        async def add_todo(text: str) -> None {
-            result = root spawn AddTodo(title=text);
-            if result.reports {
-                todos = todos + [result.reports[0]];
-            }
-        }
-
-        return <div>...</div>;
     }
+
+    async def add_todo(text: str) -> None {
+        result = root spawn AddTodo(title=text);
+        if result.reports {
+            todos = todos + [result.reports[0]];
+        }
+    }
+
+    return <div>...</div>;
 }
 
 
@@ -1326,14 +1329,16 @@ cl {
 # pages/(auth)/layout.jac  -> route group  (no URL segment)
 # pages/layout.jac         -> root layout
 
-# Page files export a `page` function:
-# cl { def:pub page() -> JsxElement { ... } }
+# Page files export a `page` function under a `to cl:` section:
+# to cl:
+# def:pub page() -> JsxElement { ... }
 
 # Layout files use <Outlet /> for child routes:
 # cl import from "@jac/runtime" { Outlet }
-# cl { def:pub layout() -> JsxElement {
+# to cl:
+# def:pub layout() -> JsxElement {
 #     return <><nav>...</nav><Outlet /></>;
-# } }
+# }
 
 
 # ============================================================

--- a/docs/docs/quick-guide/what-makes-jac-different.md
+++ b/docs/docs/quick-guide/what-makes-jac-different.md
@@ -12,24 +12,26 @@ This page focuses on the three concepts that Jac adds beyond traditional program
 
 ## 1. How can one language target frontends, backends, and native binaries at the same time?
 
-Similar to namespaces, the Jac language introduces the concept of **codespaces**. A Jac program can contain code that runs in different environments. You denote the codespace either with a **block prefix** inside a file or with a **file extension**:
+Similar to namespaces, the Jac language introduces the concept of **codespaces**. A Jac program can contain code that runs in different environments. You denote the codespace with a **section header** (or **statement prefix**) inside a file, or with a **file extension**:
 
 ```mermaid
 graph LR
     JAC["main.jac"] --> SV["Server (PyPI Ecosystem)
-    sv { }"]
+    to sv:"]
     JAC --> CL["Client (NPM Ecosystem)
-    cl { }"]
+    to cl:"]
     JAC --> NA["Native (C ABI)
-    na { }"]
+    to na:"]
 ```
 
-**Inline blocks** -- mix codespaces in a single file:
+**Section headers** -- partition a file into codespaces at module scope:
 
-- `sv { }` -- code that runs on the server (compiles to Python)
-- `cl { }` -- code that runs in the browser (compiles to JavaScript)
-- `na { }` -- code that runs natively compiled on the host machine (compiles to native binary)
-- Code outside any block defaults to the server codespace
+- `to sv:` -- following code runs on the server (compiles to Python)
+- `to cl:` -- following code runs in the browser (compiles to JavaScript)
+- `to na:` -- following code runs natively compiled on the host machine (compiles to native binary)
+- Code before any header defaults to the server codespace. A header applies until the next `to X:` header or end of file.
+
+A single-statement prefix (`cl def foo() ...`) tags one declaration. The older braced form (`cl { ... }`) still works for inner-scope overrides, but at module scope emits **W0064** pointing at the section-header form.
 
 **File extensions** -- set the default top-level codespace for a file, e.g., for a module `prog`:
 
@@ -38,9 +40,9 @@ graph LR
 - `prog.na.jac` -- top-level code defaults to native
 - `prog.jac` -- defaults to the server codespace
 
-Any `.jac` file can still use all codespace blocks regardless of its extension. The extension only changes what the default is for code outside any block.
+Any `.jac` file can still use all codespace forms regardless of its extension. The extension only changes what the default is for untagged code.
 
-Here's a file that uses two codespaces via inline blocks:
+Here's a file that uses two codespaces via section headers:
 
 ```jac
 # Server codespace (default)
@@ -53,26 +55,25 @@ def:pub add_todo(title: str) -> dict {
     return {"id": jid(todo[0]), "title": todo[0].title};
 }
 
-# Client codespace
-cl {
-    def:pub app -> JsxElement {
-        has items: list = [];
+to cl:
 
-        async def add -> None {
-            todo = await add_todo("New");
-            items = items + [todo];
-        }
+def:pub app -> JsxElement {
+    has items: list = [];
 
-        return <div>
-            <button onClick={lambda -> None { add(); }}>
-                Add
-            </button>
-        </div>;
+    async def add -> None {
+        todo = await add_todo("New");
+        items = items + [todo];
     }
+
+    return <div>
+        <button onClick={lambda -> None { add(); }}>
+            Add
+        </button>
+    </div>;
 }
 ```
 
-The server definitions are visible to the `cl` block. When the client calls `add_todo(...)`, the compiler generates the HTTP call, serialization, and routing between codespaces. You write one language; the compiler produces the interop layer.
+The server definitions are visible to the client section. When the client calls `add_todo(...)`, the compiler generates the HTTP call, serialization, and routing between codespaces. You write one language; the compiler produces the interop layer.
 
 Codespaces are similar to namespaces, but instead of organizing names, they organize where code executes. Interop between them -- function calls, spawn calls, type sharing -- is handled by the compiler and runtime.
 
@@ -211,9 +212,9 @@ In practice, these compose: walkers traverse a graph on the server, delegate dec
 
 | Syntax | Meaning |
 |--------|---------|
-| `sv { }` | Server codespace |
-| `cl { }` | Client codespace |
-| `na { }` | Native codespace |
+| `to sv:` | Server codespace section header |
+| `to cl:` | Client codespace section header |
+| `to na:` | Native codespace section header |
 | `node X { has ...; }` | Declare a graph data type |
 | `root` | Built-in starting node (persistence anchor) |
 | `a ++> b` | Connect node `a` to node `b` |

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -428,10 +428,10 @@ Define global variables that are replaced at compile time in client code via the
 These values are inlined by Vite during bundling. String values must be double-quoted (JSON-encoded). In client code, access them directly:
 
 ```jac
-cl {
-    def:pub Footer() -> JsxElement {
-        return <p>Version: {globalThis.BUILD_VERSION}</p>;
-    }
+to cl:
+
+def:pub Footer() -> JsxElement {
+    return <p>Version: {globalThis.BUILD_VERSION}</p>;
 }
 ```
 

--- a/docs/docs/reference/diagnostics.md
+++ b/docs/docs/reference/diagnostics.md
@@ -109,6 +109,7 @@ Emitted by the parser and lexer during source code parsing.
 | Code | Message |
 |------|---------|
 | `W0060` | Docstrings in Jac go before the declaration, not inside the body |
+| `W0064` | `'{keyword} { ... }'` block syntax is deprecated at module scope. Use the `'to {keyword}:'` section header instead. |
 
 ### Lexer Errors
 

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -286,11 +286,11 @@ VITE_API_URL=https://api.example.com
 Then access in client code:
 
 ```jac
-cl {
-    def:pub app() -> JsxElement {
-        api_url = import.meta.env.VITE_API_URL;
-        return <div>{api_url}</div>;
-    }
+to cl:
+
+def:pub app() -> JsxElement {
+    api_url = import.meta.env.VITE_API_URL;
+    return <div>{api_url}</div>;
 }
 ```
 
@@ -301,12 +301,12 @@ cl {
 ### npm Packages
 
 ```jac
-cl {
-    import from react { useState, useEffect, useCallback }
-    import from "@tanstack/react-query" { useQuery, useMutation }
-    import from lodash { debounce, throttle }
-    import from axios { default as axios }
-}
+to cl:
+
+import from react { useState, useEffect, useCallback }
+import from "@tanstack/react-query" { useQuery, useMutation }
+import from lodash { debounce, throttle }
+import from axios { default as axios }
 ```
 
 ### TypeScript Configuration
@@ -323,26 +323,26 @@ typescript = true
 ### Browser APIs
 
 ```jac
-cl {
-    def:pub app() -> JsxElement {
-        # Window
-        width = window.innerWidth;
+to cl:
 
-        # LocalStorage
-        window.localStorage.setItem("key", "value");
-        value = window.localStorage.getItem("key");
+def:pub app() -> JsxElement {
+    # Window
+    width = window.innerWidth;
 
-        # Document
-        element = document.getElementById("my-id");
+    # LocalStorage
+    window.localStorage.setItem("key", "value");
+    value = window.localStorage.getItem("key");
 
-        return <div>{width}</div>;
-    }
+    # Document
+    element = document.getElementById("my-id");
 
-    # Fetch
-    async def load_data() -> None {
-        response = await fetch("/api/data");
-        data = await response.json();
-    }
+    return <div>{width}</div>;
+}
+
+# Fetch
+async def load_data() -> None {
+    response = await fetch("/api/data");
+    data = await response.json();
 }
 ```
 

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -166,8 +166,9 @@ Use these appendices when you need to look up a specific keyword, operator, or s
 module        : STRING? element*              # Optional module docstring
 element       : STRING? toplevel_stmt         # Optional statement docstring
 toplevel_stmt : import | archetype | ability | impl | test | entry
-              | (cl | sv | na) toplevel_stmt       # Client/server/native prefix
-              | (cl | sv | na) "{" toplevel_stmt* "}"  # Client/server/native block
+              | "to" (cl | sv | na) ":"              # Section header (preferred at module scope)
+              | (cl | sv | na) toplevel_stmt         # Single-statement prefix
+              | (cl | sv | na) "{" toplevel_stmt* "}"  # Braced block (W0064 at module scope)
 
 archetype     : async? (obj | node | edge | walker | enum) NAME inheritance? body
 inheritance   : "(" NAME ("," NAME)* ")"

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -1908,11 +1908,11 @@ Native and Python codespaces can call each other within the same module:
 
 ```jac
 # main.jac (Python/server codespace)
-sv {
-    def process_data(data: list) -> list {
-        # Python code with full PyPI access
-        return sorted(data);
-    }
+to sv:
+
+def process_data(data: list) -> list {
+    # Python code with full PyPI access
+    return sorted(data);
 }
 
 # main.na.jac (native codespace)

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -720,11 +720,11 @@ impl CircleService.describe -> str {
 
 #### Native Variant Files (`.na.jac`)
 
-Native variant files compile to LLVM IR and execute via JIT (MCJIT). Code in `.na.jac` files runs as native machine code, bypassing the Python runtime entirely. This is useful for performance-critical code and for calling C libraries directly. The same functionality is available inside `na {}` blocks in regular `.jac` files.
+Native variant files compile to LLVM IR and execute via JIT (MCJIT). Code in `.na.jac` files runs as native machine code, bypassing the Python runtime entirely. This is useful for performance-critical code and for calling C libraries directly. The same functionality is available in `to na:` sections (or `na` statement prefixes) within regular `.jac` files.
 
 **C Library Imports:**
 
-Native code can import C shared libraries using the `import from` syntax with a library path and extern function declarations, either at the top level of a `.na.jac` file or inside a `na {}` block:
+Native code can import C shared libraries using the `import from` syntax with a library path and extern function declarations, either at the top level of a `.na.jac` file or under a `to na:` section in a regular `.jac` file:
 
 <!-- jac-skip -->
 ```jac

--- a/docs/docs/reference/language/native-pathway.md
+++ b/docs/docs/reference/language/native-pathway.md
@@ -6,7 +6,7 @@
 
 - [Overview](#overview) - What native compilation is and when to use it
 - [Quick Reference](#quick-reference) - At-a-glance summary of capabilities
-- [Native Blocks in Jac Applications](#native-blocks-in-jac-applications) - Mixing `na {}` into Python-backed Jac code
+- [Native Sections in Jac Applications](#native-sections-in-jac-applications) - Mixing `to na:` sections into Python-backed Jac code
 - [Python-Native Interop](#python-native-interop) - How the two codespaces communicate
 - [Standalone Native Binaries](#standalone-native-binaries) - Compiling `.na.jac` files to executables
 - [Type System](#type-system) - Native type mappings and fixed-width types
@@ -24,7 +24,7 @@
 
 Jac's native codespace compiles code to **machine-code via LLVM** -- the same Jac syntax, but running as native instructions instead of on the Python runtime. You can use it in two ways:
 
-1. **Inline `na {}` blocks** -- drop native-compiled functions into any Jac application alongside Python-backed code. The compiler generates the interop layer automatically.
+1. **Inline native sections** -- drop native-compiled functions into any Jac application alongside Python-backed code using a `to na:` section header (or `na` statement prefix). The compiler generates the interop layer automatically.
 2. **Standalone `.na.jac` files** -- compile an entire program to a self-contained binary with `jac nacompile`. No Python runtime, no external compiler, no external linker -- the entire toolchain from source to executable runs within Jac itself.
 
 Native compilation is ideal for:
@@ -39,7 +39,7 @@ Native compilation is ideal for:
 
 | Aspect | Details |
 |--------|---------|
-| **Inline block** | `na { }` in any `.jac` file |
+| **Inline section** | `to na:` section header (or `na` prefix) in any `.jac` file |
 | **Dedicated file** | `.na.jac` extension |
 | **Entry point** | `with entry { }` (standalone binaries only) |
 | **CLI command** | `jac nacompile <file> [-o output]` |
@@ -52,9 +52,15 @@ Native compilation is ideal for:
 
 ---
 
-## Native Blocks in Jac Applications
+## Native Sections in Jac Applications
 
-The most common way to use native compilation is by embedding `na {}` blocks inside a regular `.jac` file. Functions inside a `na {}` block compile to native machine code while the rest of the file runs on Python as usual.
+The most common way to use native compilation is to tag elements of a regular `.jac` file for the native codespace. Functions in a native section compile to native machine code while the rest of the file runs on Python as usual.
+
+There are three ways to select the native codespace inside a file:
+
+- **`to na:` section header** (preferred at module scope) -- every following module-level element compiles native until the next `to X:` header or end of file.
+- **`na` single-statement prefix** -- tags one declaration.
+- **`na { ... }` braced block** -- still valid inside inner scopes or small mixed fragments, but emits **W0064** at module scope pointing at the header form.
 
 ```jac
 # app.jac
@@ -65,21 +71,23 @@ def process_data(items: list[dict]) -> list[dict] {
     return [item for item in items if item["active"]];
 }
 
-na {
-    # Native codespace -- compiles to machine code
-    def compute_checksum(data: list[int]) -> int {
-        has result: int = 0;
-        for val in data {
-            result = (result * 31 + val) % 1000000007;
-        }
-        return result;
-    }
+to na:
 
-    def fibonacci(n: int) -> int {
-        if n <= 1 { return n; }
-        return fibonacci(n - 1) + fibonacci(n - 2);
+# Native codespace -- compiles to machine code
+def compute_checksum(data: list[int]) -> int {
+    has result: int = 0;
+    for val in data {
+        result = (result * 31 + val) % 1000000007;
     }
+    return result;
 }
+
+def fibonacci(n: int) -> int {
+    if n <= 1 { return n; }
+    return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+to sv:
 
 with entry {
     # Call both Python and native functions seamlessly
@@ -90,7 +98,7 @@ with entry {
 
 The compiler handles everything: native functions are JIT-compiled and callable from the Python side without any manual bridging. You write one file, and each codespace compiles to its own backend.
 
-### When to Use `na {}` Blocks
+### When to Use Native Sections
 
 - **Tight loops** over numeric data where Python overhead matters
 - **Recursive algorithms** (e.g., tree traversal, dynamic programming)
@@ -99,13 +107,13 @@ The compiler handles everything: native functions are JIT-compiled and callable 
 
 ### Context Isolation
 
-Native functions inside `na {}` are excluded from Python codegen, and Python functions are excluded from native IR. Each codespace only sees its own definitions at compile time. Cross-codespace calls go through the interop bridge.
+Native-tagged functions are excluded from Python codegen, and Python functions are excluded from native IR. Each codespace only sees its own definitions at compile time. Cross-codespace calls go through the interop bridge.
 
 ---
 
 ## Python-Native Interop
 
-When a `.jac` file contains both Python and `na {}` code, the compiler generates interop stubs automatically:
+When a `.jac` file contains both Python and native-tagged code, the compiler generates interop stubs automatically:
 
 ```jac
 # interop_example.jac
@@ -115,13 +123,15 @@ def py_double(x: int) -> int {
     return x * 2;
 }
 
-na {
-    # Native function that calls the Python function
-    def native_add_one_to_doubled(x: int) -> int {
-        has doubled: int = py_double(x);
-        return doubled + 1;
-    }
+to na:
+
+# Native function that calls the Python function
+def native_add_one_to_doubled(x: int) -> int {
+    has doubled: int = py_double(x);
+    return doubled + 1;
 }
+
+to sv:
 
 with entry {
     print(native_add_one_to_doubled(5));  # prints 11
@@ -576,7 +586,7 @@ The following Jac features are **not yet available** in the native codespace:
 | PyPI imports | No Python ecosystem in native binaries |
 
 !!! tip
-    If you need a feature from the list above, keep that code in the Python codespace and use `na {}` blocks only for the performance-critical parts. The compiler handles the interop automatically.
+    If you need a feature from the list above, keep that code in the Python codespace and use `to na:` sections only for the performance-critical parts. The compiler handles the interop automatically.
 
 ---
 
@@ -699,16 +709,18 @@ def serialize(data: dict) -> str {
     return dumps(data);
 }
 
-na {
-    # Native side -- compiled to machine code
-    def sum_squares(n: int) -> int {
-        has total: int = 0;
-        for i in range(n) {
-            total += i * i;
-        }
-        return total;
+to na:
+
+# Native side -- compiled to machine code
+def sum_squares(n: int) -> int {
+    has total: int = 0;
+    for i in range(n) {
+        total += i * i;
     }
+    return total;
 }
+
+to sv:
 
 with entry {
     result = sum_squares(1000);

--- a/docs/docs/reference/language/primitives.md
+++ b/docs/docs/reference/language/primitives.md
@@ -56,7 +56,7 @@ def:pub Greeting(props: dict) -> JsxElement {
 
 def:pub Counter() -> JsxElement {
     has count: int = 0;
-    return <button onClick={|| count = count + 1}>{count}</button>;
+    return <button onClick={lambda { count = count + 1; }}>{count}</button>;
 }
 ```
 
@@ -89,6 +89,7 @@ cl def greet(name: str) -> str { return "Hello, " + name; }
 
 The braced block still works -- and is useful for **inner-scope overrides** inside a class or function, or for small mixed-codespace fragments -- but at module scope it now emits **W0064** pointing at the section-header form:
 
+<!-- jac-skip -->
 ```jac
 cl {   # W0064: prefer `to cl:` at module level
     def:pub Counter() -> JsxElement { ... }

--- a/docs/docs/reference/language/primitives.md
+++ b/docs/docs/reference/language/primitives.md
@@ -20,9 +20,9 @@ The key insight is that Jac's compiler does not simply transpile syntax; it impl
 ```mermaid
 graph TD
     SRC["Jac Source Code"] --> COMPILER["Jac Compiler"]
-    COMPILER --> PY["Python / Server Backend<br/><code>sv { }</code>"]
-    COMPILER --> ES["ECMAScript / Client Backend<br/><code>cl { }</code>"]
-    COMPILER --> NA["Native / LLVM Backend<br/><code>na { }</code>"]
+    COMPILER --> PY["Python / Server Backend<br/><code>to sv:</code>"]
+    COMPILER --> ES["ECMAScript / Client Backend<br/><code>to cl:</code>"]
+    COMPILER --> NA["Native / LLVM Backend<br/><code>to na:</code>"]
 
     PY --> PRIM["Shared Primitive Semantics<br/>int, float, str, list, dict, ..."]
     ES --> PRIM
@@ -33,58 +33,71 @@ graph TD
 
 ## Codespace Model
 
-A **codespace** determines *where* your code runs. You select a codespace with either a file extension or an inline block prefix:
+A **codespace** determines *where* your code runs. You select a codespace with a file extension or, within a file, one of three forms -- a **section header**, a **single-statement prefix**, or a **braced block**:
 
-| Codespace | Block Prefix | File Extension | Compiles To | Ecosystem |
-|-----------|-------------|----------------|-------------|-----------|
-| Server    | `sv { }` | `.sv.jac` or `.jac` (default) | Python | PyPI |
-| Client    | `cl { }` | `.cl.jac` | JavaScript / TypeScript | npm |
-| Native    | `na { }` | `.na.jac` | LLVM IR → machine code | C ABI |
+| Codespace | Section Header | Statement Prefix | Braced Block | File Extension | Compiles To | Ecosystem |
+|-----------|---------------|-----------------|--------------|----------------|-------------|-----------|
+| Server    | `to sv:` | `sv stmt` | `sv { }` | `.sv.jac` or `.jac` (default) | Python | PyPI |
+| Client    | `to cl:` | `cl stmt` | `cl { }` | `.cl.jac` | JavaScript / TypeScript | npm |
+| Native    | `to na:` | `na stmt` | `na { }` | `.na.jac` | LLVM IR → machine code | C ABI |
 
-Code outside any block defaults to the server codespace. Any `.jac` file can mix codespace blocks:
+Code outside any tagged region defaults to the server codespace.
+
+### Section headers (preferred)
+
+A `to cl:` / `to sv:` / `to na:` header sets the default codespace for **every following module-level element** until the next header or end of file. This keeps cl/sv/na-heavy modules flat -- no wrapping block, no trailing brace far from the opening:
 
 ```jac
-# Server (default codespace)
-def add(a: int, b: int) -> int {
-    return a + b;
+to cl:
+
+def:pub Greeting(props: dict) -> JsxElement {
+    return <h1>Hello, {props.name}!</h1>;
 }
 
-cl {
-    # Client -- compiles to JavaScript
-    def greet(name: str) -> str {
-        return "Hello, " + name;
-    }
+def:pub Counter() -> JsxElement {
+    has count: int = 0;
+    return <button onClick={|| count = count + 1}>{count}</button>;
+}
+```
+
+Headers can be interleaved to partition a mixed module:
+
+```jac
+to sv:
+
+def fetch_items() -> list[dict] {
+    return [{"id": 1, "name": "Item A"}];
 }
 
-na {
-    # Native -- compiles to machine code
-    def fast_sum(n: int) -> int {
-        has total: int = 0;
-        for i in range(n) {
-            total += i;
-        }
-        return total;
-    }
+to cl:
+
+async def load() -> None {
+    items = await fetch_items();   # compiler generates the HTTP call
+}
+```
+
+### Statement prefix and braced block
+
+The single-statement prefix is ideal for a one-off override:
+
+```jac
+# Default server codespace
+def add(a: int, b: int) -> int { return a + b; }
+
+cl def greet(name: str) -> str { return "Hello, " + name; }
+```
+
+The braced block still works -- and is useful for **inner-scope overrides** inside a class or function, or for small mixed-codespace fragments -- but at module scope it now emits **W0064** pointing at the section-header form:
+
+```jac
+cl {   # W0064: prefer `to cl:` at module level
+    def:pub Counter() -> JsxElement { ... }
 }
 ```
 
 ### Cross-Codespace Interop
 
-When code in one codespace calls a function in another, the compiler generates the interop layer automatically -- HTTP calls between server and client, FFI bridges between Python and native, serialization and deserialization at boundaries.
-
-```jac
-# Server function
-def:pub fetch_items() -> list[dict] {
-    return [{"id": 1, "name": "Item A"}];
-}
-
-cl {
-    # Client calls server -- compiler generates the HTTP call
-    async def load() -> None {
-        items = await fetch_items();
-    }
-}
-```
+When code in one codespace calls a function in another, the compiler generates the interop layer automatically -- HTTP calls between server and client, FFI bridges between Python and native, serialization and deserialization at boundaries. See the section-header example above.
 
 ### What Is Shared
 

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1,6 +1,6 @@
 # jac-client Reference
 
-jac-client adds client-side compilation to Jac so you can write React-style UI components using `cl { }` blocks or `.cl.jac` files. The compiler separates your code automatically -- server-side logic compiles to Python, while client-side components compile to JavaScript with React as the rendering engine.
+jac-client adds client-side compilation to Jac so you can write React-style UI components using `to cl:` section headers (or `.cl.jac` files). The compiler separates your code automatically -- server-side logic compiles to Python, while client-side components compile to JavaScript with React as the rendering engine.
 
 You also get project scaffolding (`jac create --use client`), npm dependency management, a Vite-powered dev server with HMR, and automatic HTTP bridge generation so your client components can call server walkers without manual API wiring. This reference covers installation, project structure, the module system, component authoring, and build configuration.
 
@@ -37,7 +37,7 @@ myapp/
 
 ### The `.cl.jac` Convention
 
-Files ending in `.cl.jac` are automatically treated as client-side code -- no `cl { }` wrapper needed:
+Files ending in `.cl.jac` are automatically treated as client-side code -- no `to cl:` header needed:
 
 ```jac
 # components/Header.cl.jac -- automatically client-side
@@ -46,7 +46,7 @@ def:pub Header() -> JsxElement {
 }
 ```
 
-This is equivalent to wrapping the contents in `cl { }` in a regular `.jac` file.
+This is equivalent to starting a regular `.jac` file with a `to cl:` section header.
 
 ---
 
@@ -113,17 +113,17 @@ walker:priv InternalProcess { }
 
 ## Server-Side Development
 
-### Server Code Blocks
+### Server Sections
 
 ```jac
-sv {
-    # Server-only block
-    node User {
-        has email: str;
-    }
+to sv:
+
+# Server-only section
+node User {
+    has email: str;
 }
 
-# Single-statement form (no braces)
+# Single-statement form (no header, no braces)
 sv import from .database { connect_db }
 sv node SecretData { has value: str; }
 ```
@@ -172,25 +172,25 @@ def:pub create_task(title: str) -> Task {
 }
 
 # Client: receives hydrated Task instances
-cl {
-    sv import from .main { get_tasks, create_task }
+to cl:
 
-    def:pub app -> JsxElement {
-        has tasks: list = [];
+sv import from .main { get_tasks, create_task }
 
-        async can with entry {
-            tasks = await get_tasks();  # list of Task objects
-        }
+def:pub app -> JsxElement {
+    has tasks: list = [];
 
-        async def addTask(title: str) -> None {
-            task = await create_task(title);  # a Task object
-            tasks = tasks + [task];
-        }
-
-        return <div>
-            {[<span key={t.title}>{t.title} - {t.done}</span> for t in tasks]}
-        </div>;
+    async can with entry {
+        tasks = await get_tasks();  # list of Task objects
     }
+
+    async def addTask(title: str) -> None {
+        task = await create_task(title);  # a Task object
+        tasks = tasks + [task];
+    }
+
+    return <div>
+        {[<span key={t.title}>{t.title} - {t.done}</span> for t in tasks]}
+    </div>;
 }
 ```
 
@@ -229,19 +229,21 @@ with entry {
 
 ---
 
-## Client Blocks
+## Client Sections
 
-Use `cl { }` to define client-side (React) code:
+Use the `to cl:` section header to tag every following module-level element as client-side (React) code:
 
 ```jac
-cl {
-    def:pub app() -> JsxElement {
-        return <div>
-            <h1>Hello, World!</h1>
-        </div>;
-    }
+to cl:
+
+def:pub app() -> JsxElement {
+    return <div>
+        <h1>Hello, World!</h1>
+    </div>;
 }
 ```
+
+A section header applies until the next `to X:` header or end of file. You can switch back with `to sv:`, `to na:`, or end the file.
 
 ### Single-Statement Forms
 
@@ -252,25 +254,28 @@ cl import from react { useState }
 cl glob THEME: str = "dark";
 ```
 
-This also works for component definitions, which is the preferred shorthand for single-component files:
+This also works for component definitions -- the preferred shorthand for a single tagged declaration inside a mostly-server file:
 
 ```jac
-# Equivalent to wrapping in cl { }
 cl def:pub app -> JsxElement {
     has count: int = 0;
     return <div>Count: {count}</div>;
 }
 ```
 
+### Braced Blocks (legacy / inner-scope)
+
+The older `cl { ... }` braced block still works and is useful for **inner-scope overrides** inside a function or class, but at module scope it emits **W0064** pointing at the section-header form. In `.cl.jac` files or after a `to cl:` header, no wrapper is needed at all.
+
 ### Export Requirement
 
 The entry `app()` function must be exported with `:pub`:
 
 ```jac
-cl {
-    def:pub app() -> JsxElement {  # :pub required
-        return <App />;
-    }
+to cl:
+
+def:pub app() -> JsxElement {  # :pub required
+    return <App />;
 }
 ```
 
@@ -281,45 +286,45 @@ cl {
 ### Function Components
 
 ```jac
-cl {
-    def:pub Button(props: dict) -> JsxElement {
-        return <button
-            className={props.get("className", "")}
-            onClick={props.get("onClick")}
-        >
-            {props.children}
-        </button>;
-    }
+to cl:
+
+def:pub Button(props: dict) -> JsxElement {
+    return <button
+        className={props.get("className", "")}
+        onClick={props.get("onClick")}
+    >
+        {props.children}
+    </button>;
 }
 ```
 
 ### Using Props
 
 ```jac
-cl {
-    def:pub Card(props: dict) -> JsxElement {
-        return <div className="card">
-            <h2>{props["title"]}</h2>
-            <p>{props["description"]}</p>
-            {props.children}
-        </div>;
-    }
+to cl:
+
+def:pub Card(props: dict) -> JsxElement {
+    return <div className="card">
+        <h2>{props["title"]}</h2>
+        <p>{props["description"]}</p>
+        {props.children}
+    </div>;
 }
 ```
 
 ### Composition
 
 ```jac
-cl {
-    def:pub app() -> JsxElement {
-        return <div>
-            <Card title="Welcome" description="Hello!">
-                <Button onClick={lambda -> None { print("clicked"); }}>
-                    Click Me
-                </Button>
-            </Card>
-        </div>;
-    }
+to cl:
+
+def:pub app() -> JsxElement {
+    return <div>
+        <Card title="Welcome" description="Hello!">
+            <Button onClick={lambda -> None { print("clicked"); }}>
+                Click Me
+            </Button>
+        </Card>
+    </div>;
 }
 ```
 
@@ -329,20 +334,20 @@ cl {
 
 ### The `has` Keyword
 
-Inside `cl { }` blocks, `has` creates reactive state:
+Inside client-tagged code (`to cl:` sections, `.cl.jac` files, or `cl { }` blocks), `has` creates reactive state:
 
 ```jac
-cl {
-    def:pub Counter() -> JsxElement {
-        has count: int = 0;  # Compiles to useState(0)
+to cl:
 
-        return <div>
-            <p>Count: {count}</p>
-            <button onClick={lambda -> None { count = count + 1; }}>
-                Increment
-            </button>
-        </div>;
-    }
+def:pub Counter() -> JsxElement {
+    has count: int = 0;  # Compiles to useState(0)
+
+    return <div>
+        <p>Count: {count}</p>
+        <button onClick={lambda -> None { count = count + 1; }}>
+            Increment
+        </button>
+    </div>;
 }
 ```
 
@@ -356,19 +361,19 @@ cl {
 ### Complex State
 
 ```jac
-cl {
-    def:pub Form() -> JsxElement {
-        has name: str = "";
-        has items: list = [];
-        has data: dict = {"key": "value"};
+to cl:
 
-        # Create new references for lists/objects
-        def add_item(item: str) -> None {
-            items = items + [item];  # Concatenate to new list
-        }
+def:pub Form() -> JsxElement {
+    has name: str = "";
+    has items: list = [];
+    has data: dict = {"key": "value"};
 
-        return <div>Form</div>;
+    # Create new references for lists/objects
+    def add_item(item: str) -> None {
+        items = items + [item];  # Concatenate to new list
     }
+
+    return <div>Form</div>;
 }
 ```
 
@@ -401,40 +406,40 @@ Similar to how `has` variables automatically generate `useState`, the `can with 
 | `can with (a, b) entry { ... }` | `useEffect(() => { ... }, [a, b])` |
 
 ```jac
-cl {
-    def:pub DataLoader() -> JsxElement {
-        has data: list = [];
-        has loading: bool = True;
+to cl:
 
-        # Run once on mount (async with IIFE wrapping)
-        async can with entry {
-            data = await fetch_data();
-            loading = False;
-        }
+def:pub DataLoader() -> JsxElement {
+    has data: list = [];
+    has loading: bool = True;
 
-        # Cleanup on unmount
-        can with exit {
-            cleanup_subscriptions();
-        }
-
-        return <div>...</div>;
+    # Run once on mount (async with IIFE wrapping)
+    async can with entry {
+        data = await fetch_data();
+        loading = False;
     }
 
-    def:pub UserProfile(userId: str) -> JsxElement {
-        has user: dict = {};
-
-        # Re-run when userId changes (dependency array)
-        async can with [userId] entry {
-            user = await fetch_user(userId);
-        }
-
-        # Multiple dependencies using tuple syntax
-        async can with (userId, refresh) entry {
-            user = await fetch_user(userId);
-        }
-
-        return <div>{user.name}</div>;
+    # Cleanup on unmount
+    can with exit {
+        cleanup_subscriptions();
     }
+
+    return <div>...</div>;
+}
+
+def:pub UserProfile(userId: str) -> JsxElement {
+    has user: dict = {};
+
+    # Re-run when userId changes (dependency array)
+    async can with [userId] entry {
+        user = await fetch_user(userId);
+    }
+
+    # Multiple dependencies using tuple syntax
+    async can with (userId, refresh) entry {
+        user = await fetch_user(userId);
+    }
+
+    return <div>{user.name}</div>;
 }
 ```
 
@@ -443,48 +448,48 @@ cl {
 You can also use `useEffect` manually by importing it from React:
 
 ```jac
-cl {
-    import from react { useEffect }
+to cl:
 
-    def:pub DataLoader() -> JsxElement {
-        has data: list = [];
-        has loading: bool = True;
+import from react { useEffect }
 
-        # Run once on mount
-        useEffect(lambda -> None {
-            fetch_data();
-        }, []);
+def:pub DataLoader() -> JsxElement {
+    has data: list = [];
+    has loading: bool = True;
 
-        # Run when dependency changes
-        useEffect(lambda -> None {
-            refresh_data();
-        }, [some_dep]);
+    # Run once on mount
+    useEffect(lambda -> None {
+        fetch_data();
+    }, []);
 
-        return <div>...</div>;
-    }
+    # Run when dependency changes
+    useEffect(lambda -> None {
+        refresh_data();
+    }, [some_dep]);
+
+    return <div>...</div>;
 }
 ```
 
 ### useContext
 
 ```jac
-cl {
-    import from react { createContext, useContext }
+to cl:
 
-    glob AppContext = createContext(None);
+import from react { createContext, useContext }
 
-    def:pub AppProvider(props: dict) -> JsxElement {
-        has theme: str = "light";
+glob AppContext = createContext(None);
 
-        return <AppContext.Provider value={{"theme": theme}}>
-            {props.children}
-        </AppContext.Provider>;
-    }
+def:pub AppProvider(props: dict) -> JsxElement {
+    has theme: str = "light";
 
-    def:pub ThemedComponent() -> JsxElement {
-        ctx = useContext(AppContext);
-        return <div className={ctx.theme}>Content</div>;
-    }
+    return <AppContext.Provider value={{"theme": theme}}>
+        {props.children}
+    </AppContext.Provider>;
+}
+
+def:pub ThemedComponent() -> JsxElement {
+    ctx = useContext(AppContext);
+    return <div className={ctx.theme}>Content</div>;
 }
 ```
 
@@ -493,33 +498,33 @@ cl {
 Create reusable state logic by defining functions that use `has`:
 
 ```jac
-cl {
-    import from react { useEffect }
+to cl:
 
-    def use_local_storage(key: str, initial_value: any) -> tuple {
-        has value: any = initial_value;
+import from react { useEffect }
 
-        useEffect(lambda -> None {
-            stored = localStorage.getItem(key);
-            if stored {
-                value = JSON.parse(stored);
-            }
-        }, []);
+def use_local_storage(key: str, initial_value: any) -> tuple {
+    has value: any = initial_value;
 
-        useEffect(lambda -> None {
-            localStorage.setItem(key, JSON.stringify(value));
-        }, [value]);
+    useEffect(lambda -> None {
+        stored = localStorage.getItem(key);
+        if stored {
+            value = JSON.parse(stored);
+        }
+    }, []);
 
-        return (value, lambda v: any -> None { value = v; });
-    }
+    useEffect(lambda -> None {
+        localStorage.setItem(key, JSON.stringify(value));
+    }, [value]);
 
-    def:pub Settings() -> JsxElement {
-        (theme, set_theme) = use_local_storage("theme", "light");
-        return <div>
-            <p>Current: {theme}</p>
-            <button onClick={lambda -> None { set_theme("dark"); }}>Dark</button>
-        </div>;
-    }
+    return (value, lambda v: any -> None { value = v; });
+}
+
+def:pub Settings() -> JsxElement {
+    (theme, set_theme) = use_local_storage("theme", "light");
+    return <div>
+        <p>Current: {theme}</p>
+        <button onClick={lambda -> None { set_theme("dark"); }}>Dark</button>
+    </div>;
 }
 ```
 
@@ -535,28 +540,28 @@ Use native Jac `spawn` syntax to call walkers from client code. First, import yo
 # Import walkers from backend
 sv import from ...main { get_tasks, create_task }
 
-cl {
-    def:pub TaskList() -> JsxElement {
-        has tasks: list = [];
-        has loading: bool = True;
+to cl:
 
-        # Fetch data on component mount
-        async can with entry {
-            result = root() spawn get_tasks();
-            if result.reports and result.reports.length > 0 {
-                tasks = result.reports[0];
-            }
-            loading = False;
+def:pub TaskList() -> JsxElement {
+    has tasks: list = [];
+    has loading: bool = True;
+
+    # Fetch data on component mount
+    async can with entry {
+        result = root() spawn get_tasks();
+        if result.reports and result.reports.length > 0 {
+            tasks = result.reports[0];
         }
-
-        if loading {
-            return <p>Loading...</p>;
-        }
-
-        return <ul>
-            {[<li key={task["id"]}>{task["title"]}</li> for task in tasks]}
-        </ul>;
+        loading = False;
     }
+
+    if loading {
+        return <p>Loading...</p>;
+    }
+
+    return <ul>
+        {[<li key={task["id"]}>{task["title"]}</li> for task in tasks]}
+    </ul>;
 }
 ```
 
@@ -587,39 +592,39 @@ The spawn call returns a result object with:
 ```jac
 sv import from ...main { add_task, toggle_task, delete_task }
 
-cl {
-    def:pub TaskManager() -> JsxElement {
-        has tasks: list = [];
+to cl:
 
-        # Create
-        async def handle_add(title: str) -> None {
-            result = root() spawn add_task(title=title);
-            if result.reports and result.reports.length > 0 {
-                tasks = tasks + [result.reports[0]];
-            }
+def:pub TaskManager() -> JsxElement {
+    has tasks: list = [];
+
+    # Create
+    async def handle_add(title: str) -> None {
+        result = root() spawn add_task(title=title);
+        if result.reports and result.reports.length > 0 {
+            tasks = tasks + [result.reports[0]];
         }
-
-        # Update
-        async def handle_toggle(task_id: str) -> None {
-            result = root() spawn toggle_task(task_id=task_id);
-            if result.reports and result.reports[0]["success"] {
-                tasks = [
-                    {**t, "completed": not t["completed"]} if t["id"] == task_id else t
-                    for t in tasks
-                ];
-            }
-        }
-
-        # Delete
-        async def handle_delete(task_id: str) -> None {
-            result = root() spawn delete_task(task_id=task_id);
-            if result.reports and result.reports[0]["success"] {
-                tasks = [t for t in tasks if t["id"] != task_id];
-            }
-        }
-
-        return <div>...</div>;
     }
+
+    # Update
+    async def handle_toggle(task_id: str) -> None {
+        result = root() spawn toggle_task(task_id=task_id);
+        if result.reports and result.reports[0]["success"] {
+            tasks = [
+                {**t, "completed": not t["completed"]} if t["id"] == task_id else t
+                for t in tasks
+            ];
+        }
+    }
+
+    # Delete
+    async def handle_delete(task_id: str) -> None {
+        result = root() spawn delete_task(task_id=task_id);
+        if result.reports and result.reports[0]["success"] {
+            tasks = [t for t in tasks if t["id"] != task_id];
+        }
+    }
+
+    return <div>...</div>;
 }
 ```
 
@@ -628,34 +633,34 @@ cl {
 Wrap spawn calls in try/catch and track loading/error state:
 
 ```jac
-cl {
-    def:pub SafeDataView() -> JsxElement {
-        has data: any = None;
-        has loading: bool = True;
-        has error: str = "";
+to cl:
 
-        async can with entry {
-            loading = True;
-            try {
-                result = root() spawn get_data();
-                if result.reports and result.reports.length > 0 {
-                    data = result.reports[0];
-                }
-            } except Exception as e {
-                error = f"Failed to load: {e}";
+def:pub SafeDataView() -> JsxElement {
+    has data: any = None;
+    has loading: bool = True;
+    has error: str = "";
+
+    async can with entry {
+        loading = True;
+        try {
+            result = root() spawn get_data();
+            if result.reports and result.reports.length > 0 {
+                data = result.reports[0];
             }
-            loading = False;
+        } except Exception as e {
+            error = f"Failed to load: {e}";
         }
-
-        if loading { return <p>Loading...</p>; }
-        if error {
-            return <div>
-                <p>{error}</p>
-                <button onClick={lambda -> None { location.reload(); }}>Retry</button>
-            </div>;
-        }
-        return <div>{JSON.stringify(data)}</div>;
+        loading = False;
     }
+
+    if loading { return <p>Loading...</p>; }
+    if error {
+        return <div>
+            <p>{error}</p>
+            <button onClick={lambda -> None { location.reload(); }}>Retry</button>
+        </div>;
+    }
+    return <div>{JSON.stringify(data)}</div>;
 }
 ```
 
@@ -664,28 +669,28 @@ cl {
 Use `setInterval` with effect cleanup for periodic data refresh:
 
 ```jac
-cl {
-    import from react { useEffect }
+to cl:
 
-    def:pub LiveData() -> JsxElement {
-        has data: any = None;
+import from react { useEffect }
 
-        async def fetch_data() -> None {
-            result = root() spawn get_live_data();
-            if result.reports and result.reports.length > 0 {
-                data = result.reports[0];
-            }
+def:pub LiveData() -> JsxElement {
+    has data: any = None;
+
+    async def fetch_data() -> None {
+        result = root() spawn get_live_data();
+        if result.reports and result.reports.length > 0 {
+            data = result.reports[0];
         }
-
-        async can with entry { await fetch_data(); }
-
-        useEffect(lambda -> None {
-            interval = setInterval(lambda -> None { fetch_data(); }, 5000);
-            return lambda -> None { clearInterval(interval); };
-        }, []);
-
-        return <div>{data and <p>Last updated: {data["timestamp"]}</p>}</div>;
     }
+
+    async can with entry { await fetch_data(); }
+
+    useEffect(lambda -> None {
+        interval = setInterval(lambda -> None { fetch_data(); }, 5000);
+        return lambda -> None { clearInterval(interval); };
+    }, []);
+
+    return <div>{data and <p>Last updated: {data["timestamp"]}</p>}</div>;
 }
 ```
 
@@ -732,14 +737,14 @@ Each page file exports a `page` function:
 # pages/users/[id].jac
 cl import from "@jac/runtime" { useParams, Link }
 
-cl {
-    def:pub page() -> JsxElement {
-        params = useParams();
-        return <div>
-            <Link to="/users">Back</Link>
-            <h1>User {params.id}</h1>
-        </div>;
-    }
+to cl:
+
+def:pub page() -> JsxElement {
+    params = useParams();
+    return <div>
+        <Link to="/users">Back</Link>
+        <h1>User {params.id}</h1>
+    </div>;
 }
 ```
 
@@ -749,12 +754,12 @@ cl {
 # pages/(auth)/layout.jac -- protects all pages in this group
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
-cl {
-    def:pub layout() -> JsxElement {
-        return <AuthGuard redirect="/login">
-            <Outlet />
-        </AuthGuard>;
-    }
+to cl:
+
+def:pub layout() -> JsxElement {
+    return <AuthGuard redirect="/login">
+        <Outlet />
+    </AuthGuard>;
 }
 ```
 
@@ -765,20 +770,20 @@ For manual routing, import components from `@jac/runtime`:
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-cl {
-    def:pub app() -> JsxElement {
-        return <Router>
-            <nav>
-                <Link to="/">Home</Link>
-                <Link to="/about">About</Link>
-            </nav>
+to cl:
 
-            <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/about" element={<About />} />
-            </Routes>
-        </Router>;
-    }
+def:pub app() -> JsxElement {
+    return <Router>
+        <nav>
+            <Link to="/">Home</Link>
+            <Link to="/about">About</Link>
+        </nav>
+
+        <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+        </Routes>
+    </Router>;
 }
 ```
 
@@ -787,16 +792,16 @@ cl {
 ```jac
 cl import from "@jac/runtime" { useParams }
 
-cl {
-    def:pub UserProfile() -> JsxElement {
-        params = useParams();
-        user_id = params["id"];
+to cl:
 
-        return <div>User: {user_id}</div>;
-    }
+def:pub UserProfile() -> JsxElement {
+    params = useParams();
+    user_id = params["id"];
 
-    # Route: /user/:id
+    return <div>User: {user_id}</div>;
 }
+
+# Route: /user/:id
 ```
 
 ### Programmatic Navigation
@@ -804,21 +809,21 @@ cl {
 ```jac
 cl import from "@jac/runtime" { useNavigate }
 
-cl {
-    def:pub LoginForm() -> JsxElement {
-        navigate = useNavigate();
+to cl:
 
-        async def handle_login() -> None {
-            success = await do_login();
-            if success {
-                navigate("/dashboard");
-            }
+def:pub LoginForm() -> JsxElement {
+    navigate = useNavigate();
+
+    async def handle_login() -> None {
+        success = await do_login();
+        if success {
+            navigate("/dashboard");
         }
-
-        return <button onClick={lambda -> None { handle_login(); }}>
-            Login
-        </button>;
     }
+
+    return <button onClick={lambda -> None { handle_login(); }}>
+        Login
+    </button>;
 }
 ```
 
@@ -827,28 +832,26 @@ cl {
 ```jac
 cl import from "@jac/runtime" { Outlet }
 
+to cl:
+
 # pages/layout.jac -- root layout wrapping all pages
-cl {
-    def:pub layout() -> JsxElement {
-        return <>
-            <nav>...</nav>
-            <main><Outlet /></main>
-            <footer>...</footer>
-        </>;
-    }
+def:pub layout() -> JsxElement {
+    return <>
+        <nav>...</nav>
+        <main><Outlet /></main>
+        <footer>...</footer>
+    </>;
 }
 
 # pages/dashboard/layout.jac -- nested dashboard layout
-cl {
-    def:pub DashboardLayout() -> JsxElement {
-        # Child routes render where Outlet is placed
-        return <div>
-            <Sidebar />
-            <main>
-                <Outlet />
-            </main>
-        </div>;
-    }
+def:pub DashboardLayout() -> JsxElement {
+    # Child routes render where Outlet is placed
+    return <div>
+        <Sidebar />
+        <main>
+            <Outlet />
+        </main>
+    </div>;
 }
 ```
 
@@ -893,27 +896,27 @@ jac-client provides built-in authentication functions via `@jac/runtime`.
 ```jac
 cl import from "@jac/runtime" { jacLogin, useNavigate }
 
-cl {
-    def:pub LoginForm() -> JsxElement {
-        has username: str = "";
-        has password: str = "";
-        has error: str = "";
+to cl:
 
-        navigate = useNavigate();
+def:pub LoginForm() -> JsxElement {
+    has username: str = "";
+    has password: str = "";
+    has error: str = "";
 
-        async def handleLogin(e: FormEvent) -> None {
-            e.preventDefault();
-            # jacLogin returns bool (True = success, False = failure)
-            success = await jacLogin(username, password);
-            if success {
-                navigate("/dashboard");
-            } else {
-                error = "Invalid credentials";
-            }
+    navigate = useNavigate();
+
+    async def handleLogin(e: FormEvent) -> None {
+        e.preventDefault();
+        # jacLogin returns bool (True = success, False = failure)
+        success = await jacLogin(username, password);
+        if success {
+            navigate("/dashboard");
+        } else {
+            error = "Invalid credentials";
         }
-
-        return <form onSubmit={handleLogin}>...</form>;
     }
+
+    return <form onSubmit={handleLogin}>...</form>;
 }
 ```
 
@@ -922,16 +925,16 @@ cl {
 ```jac
 cl import from "@jac/runtime" { jacSignup }
 
-cl {
-    async def handleSignup() -> None {
-        # jacSignup returns dict with success key
-        result = await jacSignup(username, password);
-        if result["success"] {
-            # User registered and logged in
-            navigate("/dashboard");
-        } else {
-            error = result["error"] or "Signup failed";
-        }
+to cl:
+
+async def handleSignup() -> None {
+    # jacSignup returns dict with success key
+    result = await jacSignup(username, password);
+    if result["success"] {
+        # User registered and logged in
+        navigate("/dashboard");
+    } else {
+        error = result["error"] or "Signup failed";
     }
 }
 ```
@@ -941,23 +944,23 @@ cl {
 ```jac
 cl import from "@jac/runtime" { jacLogout, jacIsLoggedIn }
 
-cl {
-    def:pub NavBar() -> JsxElement {
-        isLoggedIn = jacIsLoggedIn();
+to cl:
 
-        def handleLogout() -> None {
-            jacLogout();
-            # Redirect to login
-        }
+def:pub NavBar() -> JsxElement {
+    isLoggedIn = jacIsLoggedIn();
 
-        return <nav>
-            {isLoggedIn and (
-                <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
-            ) or (
-                <a href="/login">Login</a>
-            )}
-        </nav>;
+    def handleLogout() -> None {
+        jacLogout();
+        # Redirect to login
     }
+
+    return <nav>
+        {isLoggedIn and (
+            <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
+        ) or (
+            <a href="/login">Login</a>
+        )}
+    </nav>;
 }
 ```
 
@@ -1000,13 +1003,13 @@ Use `AuthGuard` to protect routes in file-based routing:
 ```jac
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
+to cl:
+
 # pages/(auth)/layout.jac
-cl {
-    def:pub layout() -> JsxElement {
-        return <AuthGuard redirect="/login">
-            <Outlet />
-        </AuthGuard>;
-    }
+def:pub layout() -> JsxElement {
+    return <AuthGuard redirect="/login">
+        <Outlet />
+    </AuthGuard>;
 }
 ```
 
@@ -1017,24 +1020,24 @@ cl {
 ### Inline Styles
 
 ```jac
-cl {
-    def:pub StyledComponent() -> JsxElement {
-        return <div style={{"color": "blue", "padding": "10px"}}>
-            Styled content
-        </div>;
-    }
+to cl:
+
+def:pub StyledComponent() -> JsxElement {
+    return <div style={{"color": "blue", "padding": "10px"}}>
+        Styled content
+    </div>;
 }
 ```
 
 ### CSS Classes
 
 ```jac
-cl {
-    def:pub Card() -> JsxElement {
-        return <div className="card card-primary">
-            Content
-        </div>;
-    }
+to cl:
+
+def:pub Card() -> JsxElement {
+    return <div className="card card-primary">
+        Content
+    </div>;
 }
 ```
 
@@ -1049,34 +1052,34 @@ cl {
 ```
 
 ```jac
-cl {
-    import "./styles/main.css";
-}
+to cl:
+
+import "./styles/main.css";
 ```
 
 ### cn() Utility (Tailwind/shadcn)
 
 ```jac
-cl {
-    # cn() from local lib/utils.ts (shadcn/ui pattern)
-    import from "../lib/utils" { cn }
+to cl:
 
-    def:pub StylingExamples() -> JsxElement {
-        has condition: bool = True;
-        has hasError: bool = False;
-        has isSuccess: bool = True;
+# cn() from local lib/utils.ts (shadcn/ui pattern)
+import from "../lib/utils" { cn }
 
-        className = cn(
-            "base-class",
-            condition and "active",
-            {"error": hasError, "success": isSuccess}
-        );
+def:pub StylingExamples() -> JsxElement {
+    has condition: bool = True;
+    has hasError: bool = False;
+    has isSuccess: bool = True;
 
-        return <div>
-            <div className="p-4 bg-blue-500 text-white">Tailwind</div>
-            <div className={className}>Dynamic</div>
-        </div>;
-    }
+    className = cn(
+        "base-class",
+        condition and "active",
+        {"error": hasError, "success": isSuccess}
+    );
+
+    return <div>
+        <div className="p-4 bg-blue-500 text-white">Tailwind</div>
+        <div className={className}>Dynamic</div>
+    </div>;
 }
 ```
 
@@ -1098,23 +1101,23 @@ cl {
 ### JSX Syntax Reference
 
 ```jac
-cl {
-    def:pub JsxExamples() -> JsxElement {
-        has variable: str = "text";
-        has condition: bool = True;
-        has items: list = [];
-        has props: dict = {};
+to cl:
 
-        return <div>
-            <input type="text" value={variable} />
+def:pub JsxExamples() -> JsxElement {
+    has variable: str = "text";
+    has condition: bool = True;
+    has items: list = [];
+    has props: dict = {};
 
-            {condition and <div>Shown if true</div>}
+    return <div>
+        <input type="text" value={variable} />
 
-            {items}
+        {condition and <div>Shown if true</div>}
 
-            <button {...props}>Click</button>
-        </div>;
-    }
+        {items}
+
+        <button {...props}>Click</button>
+    </div>;
 }
 ```
 
@@ -1139,12 +1142,12 @@ export const Button: React.FC<ButtonProps> = ({ label, onClick }) => {
 ```
 
 ```jac
-cl {
-    import from "./components/Button" { Button }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <Button label="Click" onClick={lambda -> None { }} />;
-    }
+import from "./components/Button" { Button }
+
+def:pub app() -> JsxElement {
+    return <Button label="Click" onClick={lambda -> None { }} />;
 }
 ```
 
@@ -1240,11 +1243,11 @@ The `[plugins.client.paths]` section lets you define custom import path aliases.
 With the above config, you can use aliases in your `.cl.jac` or `cl {}` code:
 
 ```jac
-cl {
-    import from "@components/Button" { Button }
-    import from "@utils/format" { formatDate }
-    import from "@shared" { constants }
-}
+to cl:
+
+import from "@components/Button" { Button }
+import from "@utils/format" { formatDate }
+import from "@shared" { constants }
 ```
 
 | Feature | How It's Applied |
@@ -1288,14 +1291,14 @@ tailwindcss = "^4.0.0"
 Then import Tailwind in your entry CSS and use `className=` in components:
 
 ```jac
-cl {
-    import "./assets/main.css";  # contains: @import "tailwindcss";
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <div className="min-h-screen bg-gray-100 p-8">
-            <h1 className="text-3xl font-bold">Hello</h1>
-        </div>;
-    }
+import "./assets/main.css";  # contains: @import "tailwindcss";
+
+def:pub app() -> JsxElement {
+    return <div className="min-h-screen bg-gray-100 p-8">
+        <h1 className="text-3xl font-bold">Hello</h1>
+    </div>;
 }
 ```
 
@@ -1804,18 +1807,18 @@ For advanced use cases, import the PWA runtime module:
 ```jac
 cl import from "@jac/pwa" { usePwaInstall, PwaInstallButton }
 
-cl {
-    def:pub CustomInstallUI() -> JsxElement {
-        (canInstall, triggerInstall) = usePwaInstall();
+to cl:
 
-        return <div>
-            {canInstall and (
-                <button onClick={lambda -> None { triggerInstall(); }}>
-                    Get the App
-                </button>
-            )}
-        </div>;
-    }
+def:pub CustomInstallUI() -> JsxElement {
+    (canInstall, triggerInstall) = usePwaInstall();
+
+    return <div>
+        {canInstall and (
+            <button onClick={lambda -> None { triggerInstall(); }}>
+                Get the App
+            </button>
+        )}
+    </div>;
 }
 ```
 
@@ -1886,10 +1889,10 @@ Define global variables that are replaced at compile time using the `[plugins.cl
 These values are inlined by Vite during bundling. String values must be double-quoted (JSON-encoded). Access them in client code:
 
 ```jac
-cl {
-    def:pub Footer() -> JsxElement {
-        return <p>Version: {globalThis.BUILD_VERSION}</p>;
-    }
+to cl:
+
+def:pub Footer() -> JsxElement {
+    return <p>Version: {globalThis.BUILD_VERSION}</p>;
 }
 ```
 
@@ -1932,23 +1935,23 @@ In dev mode, API routes are automatically proxied:
 Jac provides ambient DOM types (`ChangeEvent`, `KeyboardEvent`, `MouseEvent`, `FormEvent`, etc.) that are available without import. Use these for type-safe event handling:
 
 ```jac
-cl {
-    def:pub Form() -> JsxElement {
-        has value: str = "";
+to cl:
 
-        return <div>
-            <input
-                value={value}
-                onChange={lambda e: ChangeEvent { value = e.target.value; }}
-                onKeyPress={lambda e: KeyboardEvent {
-                    if e.key == "Enter" { submit(); }
-                }}
-            />
-            <button onClick={lambda -> None { submit(); }}>
-                Submit
-            </button>
-        </div>;
-    }
+def:pub Form() -> JsxElement {
+    has value: str = "";
+
+    return <div>
+        <input
+            value={value}
+            onChange={lambda e: ChangeEvent { value = e.target.value; }}
+            onKeyPress={lambda e: KeyboardEvent {
+                if e.key == "Enter" { submit(); }
+            }}
+        />
+        <button onClick={lambda -> None { submit(); }}>
+            Submit
+        </button>
+    </div>;
 }
 ```
 
@@ -1995,32 +1998,32 @@ The following event and element types are available in all Jac modules without a
 **Usage examples:**
 
 ```jac
-cl {
-    def:pub TypedForm() -> JsxElement {
-        has text: str = "";
-        has checked: bool = False;
+to cl:
 
-        return <div>
-            <input
-                value={text}
-                onChange={lambda e: ChangeEvent { text = e.target.value; }}
-                onKeyDown={lambda e: KeyboardEvent {
-                    if e.key == "Enter" and not e.shiftKey { submit(); }
-                }}
-            />
-            <input
-                type="checkbox"
-                checked={checked}
-                onChange={lambda e: ChangeEvent { checked = e.target.checked; }}
-            />
-            <form onSubmit={lambda e: FormEvent {
-                e.preventDefault();
-                handleSubmit();
-            }}>
-                <button type="submit">Submit</button>
-            </form>
-        </div>;
-    }
+def:pub TypedForm() -> JsxElement {
+    has text: str = "";
+    has checked: bool = False;
+
+    return <div>
+        <input
+            value={text}
+            onChange={lambda e: ChangeEvent { text = e.target.value; }}
+            onKeyDown={lambda e: KeyboardEvent {
+                if e.key == "Enter" and not e.shiftKey { submit(); }
+            }}
+        />
+        <input
+            type="checkbox"
+            checked={checked}
+            onChange={lambda e: ChangeEvent { checked = e.target.checked; }}
+        />
+        <form onSubmit={lambda e: FormEvent {
+            e.preventDefault();
+            handleSubmit();
+        }}>
+            <button type="submit">Submit</button>
+        </form>
+    </div>;
 }
 ```
 
@@ -2040,24 +2043,24 @@ cl {
 ## Conditional Rendering
 
 ```jac
-cl {
-    def:pub ConditionalComponent() -> JsxElement {
-        has show: bool = False;
-        has items: list = [];
+to cl:
 
-        if show {
-            content = <p>Visible</p>;
-        } else {
-            content = <p>Hidden</p>;
-        }
-        return <div>
-            {content}
+def:pub ConditionalComponent() -> JsxElement {
+    has show: bool = False;
+    has items: list = [];
 
-            {show and <p>Only when true</p>}
-
-            {[<li key={item["id"]}>{item["name"]}</li> for item in items]}
-        </div>;
+    if show {
+        content = <p>Visible</p>;
+    } else {
+        content = <p>Hidden</p>;
     }
+    return <div>
+        {content}
+
+        {show and <p>Only when true</p>}
+
+        {[<li key={item["id"]}>{item["name"]}</li> for item in items]}
+    </div>;
 }
 ```
 
@@ -2076,12 +2079,12 @@ Import and wrap `JacClientErrorBoundary` around any subtree where you want to ca
 ```jac
 cl import from "@jac/runtime" { JacClientErrorBoundary }
 
-cl {
-    def:pub app() -> JsxElement {
-        return <JacClientErrorBoundary fallback={<div>Oops! Something went wrong.</div>}>
-            <MainAppComponents />
-        </JacClientErrorBoundary>;
-    }
+to cl:
+
+def:pub app() -> JsxElement {
+    return <JacClientErrorBoundary fallback={<div>Oops! Something went wrong.</div>}>
+        <MainAppComponents />
+    </JacClientErrorBoundary>;
 }
 ```
 
@@ -2104,12 +2107,12 @@ By default, jac-client internally wraps your entire application with `JacClientE
 ### Example with Custom Fallback
 
 ```jac
-cl {
-    def:pub App() -> JsxElement {
-        return <JacClientErrorBoundary fallback={<div className="error">Component failed to load</div>}>
-            <ExpensiveWidget />
-        </JacClientErrorBoundary>;
-    }
+to cl:
+
+def:pub App() -> JsxElement {
+    return <JacClientErrorBoundary fallback={<div className="error">Component failed to load</div>}>
+        <ExpensiveWidget />
+    </JacClientErrorBoundary>;
 }
 ```
 
@@ -2118,16 +2121,16 @@ cl {
 You can nest multiple error boundaries for fine-grained error isolation:
 
 ```jac
-cl {
-    def:pub App() -> JsxElement {
-        return <JacClientErrorBoundary fallback={<div>App error</div>}>
-            <Header />
-            <JacClientErrorBoundary fallback={<div>Content error</div>}>
-                <MainContent />
-            </JacClientErrorBoundary>
-            <Footer />
-        </JacClientErrorBoundary>;
-    }
+to cl:
+
+def:pub App() -> JsxElement {
+    return <JacClientErrorBoundary fallback={<div>App error</div>}>
+        <Header />
+        <JacClientErrorBoundary fallback={<div>Content error</div>}>
+            <MainContent />
+        </JacClientErrorBoundary>
+        <Footer />
+    </JacClientErrorBoundary>;
 }
 ```
 
@@ -2192,24 +2195,24 @@ Jac does not have a `new` keyword. Use `Reflect.construct()` to instantiate brow
 
 <!-- jac-skip -->
 ```jac
-cl {
-    # WebSocket
-    ws = Reflect.construct(WebSocket, [url]);
+to cl:
 
-    # URL
-    url = Reflect.construct(URL, [String(baseUrl)]);
+# WebSocket
+ws = Reflect.construct(WebSocket, [url]);
 
-    # Date
-    now = Reflect.construct(Date, []);
+# URL
+url = Reflect.construct(URL, [String(baseUrl)]);
 
-    # Promise
-    p = Reflect.construct(Promise, [lambda(resolve: Any, reject: Any) {
-        resolve.call(None, "done");
-    }]);
+# Date
+now = Reflect.construct(Date, []);
 
-    # CustomEvent
-    evt = Reflect.construct(CustomEvent, ["my-event", {"detail": data}]);
-}
+# Promise
+p = Reflect.construct(Promise, [lambda(resolve: Any, reject: Any) {
+    resolve.call(None, "done");
+}]);
+
+# CustomEvent
+evt = Reflect.construct(CustomEvent, ["my-event", {"detail": data}]);
 ```
 
 ### Callback Invocations
@@ -2218,12 +2221,12 @@ When passing callbacks to be invoked later, use `.call(None, ...)`:
 
 <!-- jac-skip -->
 ```jac
-cl {
-    handler = myCallback;
-    ws.onmessage = lambda(e: Any) {
-        handler.call(None, JSON.parse(e.data));
-    };
-}
+to cl:
+
+handler = myCallback;
+ws.onmessage = lambda(e: Any) {
+    handler.call(None, JSON.parse(e.data));
+};
 ```
 
 ### Module-Level State
@@ -2231,10 +2234,10 @@ cl {
 Use `glob` for state shared across a module:
 
 ```jac
-cl {
-    glob initialized: bool = False;
-    glob cache: Any = None;
-}
+to cl:
+
+glob initialized: bool = False;
+glob cache: Any = None;
 ```
 
 For more patterns, see the [Advanced Patterns & JS Interop tutorial](../../tutorials/fullstack/advanced-patterns.md).

--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -1793,13 +1793,13 @@ sv import from main {
 **`cl { }` blocks** let you embed client-side code in a server file. This is useful for the entry point:
 
 ```jac
-cl {
-    import from frontend { app as ClientApp }
+to cl:
 
-    def:pub app -> JsxElement {
-        return
-            <ClientApp />;
-    }
+import from frontend { app as ClientApp }
+
+def:pub app -> JsxElement {
+    return
+        <ClientApp />;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/auth.md
+++ b/docs/docs/tutorials/fullstack/auth.md
@@ -38,66 +38,66 @@ cl import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn }
 ```jac
 cl import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn, useNavigate }
 
-cl {
-    def:pub LoginPage() -> JsxElement {
-        has username: str = "";
-        has password: str = "";
-        has error: str = "";
-        has loading: bool = False;
+to cl:
 
-        navigate = useNavigate();
+def:pub LoginPage() -> JsxElement {
+    has username: str = "";
+    has password: str = "";
+    has error: str = "";
+    has loading: bool = False;
 
-        async def handleLogin(e: FormEvent) -> None {
-            e.preventDefault();
-            error = "";
+    navigate = useNavigate();
 
-            if not username or not password {
-                error = "Please fill in all fields";
-                return;
-            }
+    async def handleLogin(e: FormEvent) -> None {
+        e.preventDefault();
+        error = "";
 
-            loading = True;
-            success = await jacLogin(username, password);
-            loading = False;
-
-            if success {
-                navigate("/");
-            } else {
-                error = "Invalid credentials";
-            }
+        if not username or not password {
+            error = "Please fill in all fields";
+            return;
         }
 
-        return <div style={{"maxWidth": "400px", "margin": "0 auto", "padding": "2rem"}}>
-            <h2>Login</h2>
-            <form onSubmit={handleLogin}>
-                {error and <div style={{"color": "red", "marginBottom": "1rem"}}>{error}</div>}
+        loading = True;
+        success = await jacLogin(username, password);
+        loading = False;
 
-                <input
-                    type="text"
-                    value={username}
-                    onChange={lambda e: ChangeEvent { username = e.target.value; }}
-                    placeholder="Username"
-                    style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
-                />
-
-                <input
-                    type="password"
-                    value={password}
-                    onChange={lambda e: ChangeEvent { password = e.target.value; }}
-                    placeholder="Password"
-                    style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
-                />
-
-                <button
-                    type="submit"
-                    disabled={loading}
-                    style={{"width": "100%", "padding": "0.5rem"}}
-                >
-                    {loading and "Logging in..." or "Login"}
-                </button>
-            </form>
-        </div>;
+        if success {
+            navigate("/");
+        } else {
+            error = "Invalid credentials";
+        }
     }
+
+    return <div style={{"maxWidth": "400px", "margin": "0 auto", "padding": "2rem"}}>
+        <h2>Login</h2>
+        <form onSubmit={handleLogin}>
+            {error and <div style={{"color": "red", "marginBottom": "1rem"}}>{error}</div>}
+
+            <input
+                type="text"
+                value={username}
+                onChange={lambda e: ChangeEvent { username = e.target.value; }}
+                placeholder="Username"
+                style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
+            />
+
+            <input
+                type="password"
+                value={password}
+                onChange={lambda e: ChangeEvent { password = e.target.value; }}
+                placeholder="Password"
+                style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
+            />
+
+            <button
+                type="submit"
+                disabled={loading}
+                style={{"width": "100%", "padding": "0.5rem"}}
+            >
+                {loading and "Logging in..." or "Login"}
+            </button>
+        </form>
+    </div>;
 }
 ```
 
@@ -112,17 +112,17 @@ Authenticates a user and stores the JWT token.
 ```jac
 cl import from "@jac/runtime" { jacLogin }
 
-cl {
-    async def handleLogin() -> None {
-        # jacLogin returns bool (True = success, False = failure)
-        success = await jacLogin(username, password);
+to cl:
 
-        if success {
-            # User is now logged in, token stored automatically
-            navigate("/dashboard");
-        } else {
-            error = "Invalid credentials";
-        }
+async def handleLogin() -> None {
+    # jacLogin returns bool (True = success, False = failure)
+    success = await jacLogin(username, password);
+
+    if success {
+        # User is now logged in, token stored automatically
+        navigate("/dashboard");
+    } else {
+        error = "Invalid credentials";
     }
 }
 ```
@@ -134,17 +134,17 @@ Registers a new user account.
 ```jac
 cl import from "@jac/runtime" { jacSignup }
 
-cl {
-    async def handleSignup() -> None {
-        # jacSignup returns dict with success key
-        result = await jacSignup(username, password);
+to cl:
 
-        if result["success"] {
-            # User registered and logged in
-            navigate("/dashboard");
-        } else {
-            error = result["error"] or "Signup failed";
-        }
+async def handleSignup() -> None {
+    # jacSignup returns dict with success key
+    result = await jacSignup(username, password);
+
+    if result["success"] {
+        # User registered and logged in
+        navigate("/dashboard");
+    } else {
+        error = result["error"] or "Signup failed";
     }
 }
 ```
@@ -156,12 +156,12 @@ Clears the authentication token.
 ```jac
 cl import from "@jac/runtime" { jacLogout }
 
-cl {
-    def handleLogout() -> None {
-        jacLogout();
-        # User is now logged out
-        navigate("/login");
-    }
+to cl:
+
+def handleLogout() -> None {
+    jacLogout();
+    # User is now logged out
+    navigate("/login");
 }
 ```
 
@@ -172,18 +172,18 @@ Checks if user is currently authenticated.
 ```jac
 cl import from "@jac/runtime" { jacIsLoggedIn }
 
-cl {
-    def:pub NavBar() -> JsxElement {
-        isLoggedIn = jacIsLoggedIn();
+to cl:
 
-        return <nav>
-            {isLoggedIn and (
-                <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
-            ) or (
-                <a href="/login">Login</a>
-            )}
-        </nav>;
-    }
+def:pub NavBar() -> JsxElement {
+    isLoggedIn = jacIsLoggedIn();
+
+    return <nav>
+        {isLoggedIn and (
+            <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
+        ) or (
+            <a href="/login">Login</a>
+        )}
+    </nav>;
 }
 ```
 
@@ -204,238 +204,238 @@ cl import from "@jac/runtime" {
     useNavigate
 }
 
-cl {
-    # === Login Page ===
-    def:pub LoginPage() -> JsxElement {
-        has username: str = "";
-        has password: str = "";
-        has error: str = "";
-        has loading: bool = False;
+to cl:
 
-        navigate = useNavigate();
+# === Login Page ===
+def:pub LoginPage() -> JsxElement {
+    has username: str = "";
+    has password: str = "";
+    has error: str = "";
+    has loading: bool = False;
 
-        # Check if already logged in
-        can with entry {
-            if jacIsLoggedIn() {
-                navigate("/");
-            }
+    navigate = useNavigate();
+
+    # Check if already logged in
+    can with entry {
+        if jacIsLoggedIn() {
+            navigate("/");
         }
-
-        async def handleLogin(e: FormEvent) -> None {
-            e.preventDefault();
-            error = "";
-
-            if not username.trim() or not password {
-                error = "Please fill in all fields";
-                return;
-            }
-
-            loading = True;
-            success = await jacLogin(username, password);
-            loading = False;
-
-            if success {
-                navigate("/");
-            } else {
-                error = "Invalid username or password";
-            }
-        }
-
-        return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
-            <h2>Login</h2>
-            <form onSubmit={handleLogin}>
-                {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
-
-                <div style={{"marginBottom": "1rem"}}>
-                    <input
-                        type="text"
-                        value={username}
-                        onChange={lambda e: ChangeEvent { username = e.target.value; }}
-                        placeholder="Username"
-                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                    />
-                </div>
-
-                <div style={{"marginBottom": "1rem"}}>
-                    <input
-                        type="password"
-                        value={password}
-                        onChange={lambda e: ChangeEvent { password = e.target.value; }}
-                        placeholder="Password"
-                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                    />
-                </div>
-
-                <button
-                    type="submit"
-                    disabled={loading}
-                    style={{
-                        "width": "100%",
-                        "padding": "0.75rem",
-                        "background": "#3b82f6",
-                        "color": "white",
-                        "border": "none",
-                        "borderRadius": "4px",
-                        "cursor": "pointer"
-                    }}
-                >
-                    {loading and "Logging in..." or "Login"}
-                </button>
-
-                <p style={{"textAlign": "center", "marginTop": "1rem"}}>
-                    Need an account? <Link to="/signup">Sign up</Link>
-                </p>
-            </form>
-        </div>;
     }
 
-    # === Signup Page ===
-    def:pub SignupPage() -> JsxElement {
-        has username: str = "";
-        has password: str = "";
-        has confirmPassword: str = "";
-        has error: str = "";
-        has loading: bool = False;
+    async def handleLogin(e: FormEvent) -> None {
+        e.preventDefault();
+        error = "";
 
-        navigate = useNavigate();
-
-        async def handleSignup(e: FormEvent) -> None {
-            e.preventDefault();
-            error = "";
-
-            if not username.trim() or not password {
-                error = "Please fill in all fields";
-                return;
-            }
-
-            if password != confirmPassword {
-                error = "Passwords don't match";
-                return;
-            }
-
-            if password.length < 6 {
-                error = "Password must be at least 6 characters";
-                return;
-            }
-
-            loading = True;
-            result = await jacSignup(username, password);
-            loading = False;
-
-            if result["success"] {
-                navigate("/");
-            } else {
-                error = result["error"] or "Signup failed";
-            }
+        if not username.trim() or not password {
+            error = "Please fill in all fields";
+            return;
         }
 
-        return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
-            <h2>Create Account</h2>
-            <form onSubmit={handleSignup}>
-                {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
+        loading = True;
+        success = await jacLogin(username, password);
+        loading = False;
 
-                <div style={{"marginBottom": "1rem"}}>
-                    <input
-                        type="text"
-                        value={username}
-                        onChange={lambda e: ChangeEvent { username = e.target.value; }}
-                        placeholder="Username"
-                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                    />
-                </div>
-
-                <div style={{"marginBottom": "1rem"}}>
-                    <input
-                        type="password"
-                        value={password}
-                        onChange={lambda e: ChangeEvent { password = e.target.value; }}
-                        placeholder="Password"
-                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                    />
-                </div>
-
-                <div style={{"marginBottom": "1rem"}}>
-                    <input
-                        type="password"
-                        value={confirmPassword}
-                        onChange={lambda e: ChangeEvent { confirmPassword = e.target.value; }}
-                        placeholder="Confirm Password"
-                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                    />
-                </div>
-
-                <button
-                    type="submit"
-                    disabled={loading}
-                    style={{
-                        "width": "100%",
-                        "padding": "0.75rem",
-                        "background": "#10b981",
-                        "color": "white",
-                        "border": "none",
-                        "borderRadius": "4px",
-                        "cursor": "pointer"
-                    }}
-                >
-                    {loading and "Creating account..." or "Sign Up"}
-                </button>
-
-                <p style={{"textAlign": "center", "marginTop": "1rem"}}>
-                    Already have an account? <Link to="/login">Login</Link>
-                </p>
-            </form>
-        </div>;
+        if success {
+            navigate("/");
+        } else {
+            error = "Invalid username or password";
+        }
     }
 
-    # === Protected Dashboard ===
-    def:pub Dashboard() -> JsxElement {
-        navigate = useNavigate();
+    return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
+        <h2>Login</h2>
+        <form onSubmit={handleLogin}>
+            {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
 
-        # Redirect if not logged in
-        can with entry {
-            if not jacIsLoggedIn() {
-                navigate("/login");
-            }
-        }
+            <div style={{"marginBottom": "1rem"}}>
+                <input
+                    type="text"
+                    value={username}
+                    onChange={lambda e: ChangeEvent { username = e.target.value; }}
+                    placeholder="Username"
+                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                />
+            </div>
 
-        def handleLogout() -> None {
-            jacLogout();
-            navigate("/login");
-        }
+            <div style={{"marginBottom": "1rem"}}>
+                <input
+                    type="password"
+                    value={password}
+                    onChange={lambda e: ChangeEvent { password = e.target.value; }}
+                    placeholder="Password"
+                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                />
+            </div>
 
-        if not jacIsLoggedIn() {
-            return <p>Redirecting...</p>;
-        }
-
-        return <div style={{"padding": "2rem"}}>
-            <h1>Dashboard</h1>
-            <p>Welcome! You are logged in.</p>
             <button
-                onClick={lambda -> None { handleLogout(); }}
+                type="submit"
+                disabled={loading}
                 style={{
-                    "padding": "0.5rem 1rem",
-                    "background": "#ef4444",
+                    "width": "100%",
+                    "padding": "0.75rem",
+                    "background": "#3b82f6",
                     "color": "white",
                     "border": "none",
                     "borderRadius": "4px",
                     "cursor": "pointer"
                 }}
             >
-                Logout
+                {loading and "Logging in..." or "Login"}
             </button>
-        </div>;
+
+            <p style={{"textAlign": "center", "marginTop": "1rem"}}>
+                Need an account? <Link to="/signup">Sign up</Link>
+            </p>
+        </form>
+    </div>;
+}
+
+# === Signup Page ===
+def:pub SignupPage() -> JsxElement {
+    has username: str = "";
+    has password: str = "";
+    has confirmPassword: str = "";
+    has error: str = "";
+    has loading: bool = False;
+
+    navigate = useNavigate();
+
+    async def handleSignup(e: FormEvent) -> None {
+        e.preventDefault();
+        error = "";
+
+        if not username.trim() or not password {
+            error = "Please fill in all fields";
+            return;
+        }
+
+        if password != confirmPassword {
+            error = "Passwords don't match";
+            return;
+        }
+
+        if password.length < 6 {
+            error = "Password must be at least 6 characters";
+            return;
+        }
+
+        loading = True;
+        result = await jacSignup(username, password);
+        loading = False;
+
+        if result["success"] {
+            navigate("/");
+        } else {
+            error = result["error"] or "Signup failed";
+        }
     }
 
-    # === Main App ===
-    def:pub app() -> JsxElement {
-        return <Router>
-            <Routes>
-                <Route path="/" element={<Dashboard />} />
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/signup" element={<SignupPage />} />
-            </Routes>
-        </Router>;
+    return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
+        <h2>Create Account</h2>
+        <form onSubmit={handleSignup}>
+            {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
+
+            <div style={{"marginBottom": "1rem"}}>
+                <input
+                    type="text"
+                    value={username}
+                    onChange={lambda e: ChangeEvent { username = e.target.value; }}
+                    placeholder="Username"
+                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                />
+            </div>
+
+            <div style={{"marginBottom": "1rem"}}>
+                <input
+                    type="password"
+                    value={password}
+                    onChange={lambda e: ChangeEvent { password = e.target.value; }}
+                    placeholder="Password"
+                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                />
+            </div>
+
+            <div style={{"marginBottom": "1rem"}}>
+                <input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={lambda e: ChangeEvent { confirmPassword = e.target.value; }}
+                    placeholder="Confirm Password"
+                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                />
+            </div>
+
+            <button
+                type="submit"
+                disabled={loading}
+                style={{
+                    "width": "100%",
+                    "padding": "0.75rem",
+                    "background": "#10b981",
+                    "color": "white",
+                    "border": "none",
+                    "borderRadius": "4px",
+                    "cursor": "pointer"
+                }}
+            >
+                {loading and "Creating account..." or "Sign Up"}
+            </button>
+
+            <p style={{"textAlign": "center", "marginTop": "1rem"}}>
+                Already have an account? <Link to="/login">Login</Link>
+            </p>
+        </form>
+    </div>;
+}
+
+# === Protected Dashboard ===
+def:pub Dashboard() -> JsxElement {
+    navigate = useNavigate();
+
+    # Redirect if not logged in
+    can with entry {
+        if not jacIsLoggedIn() {
+            navigate("/login");
+        }
     }
+
+    def handleLogout() -> None {
+        jacLogout();
+        navigate("/login");
+    }
+
+    if not jacIsLoggedIn() {
+        return <p>Redirecting...</p>;
+    }
+
+    return <div style={{"padding": "2rem"}}>
+        <h1>Dashboard</h1>
+        <p>Welcome! You are logged in.</p>
+        <button
+            onClick={lambda -> None { handleLogout(); }}
+            style={{
+                "padding": "0.5rem 1rem",
+                "background": "#ef4444",
+                "color": "white",
+                "border": "none",
+                "borderRadius": "4px",
+                "cursor": "pointer"
+            }}
+        >
+            Logout
+        </button>
+    </div>;
+}
+
+# === Main App ===
+def:pub app() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+        </Routes>
+    </Router>;
 }
 ```
 
@@ -449,12 +449,12 @@ For file-based routing, use the built-in `AuthGuard` component:
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
 # pages/(auth)/layout.jac - Protects all routes in (auth) group
-cl {
-    def:pub layout() -> JsxElement {
-        return <AuthGuard redirect="/login">
-            <Outlet />
-        </AuthGuard>;
-    }
+to cl:
+
+def:pub layout() -> JsxElement {
+    return <AuthGuard redirect="/login">
+        <Outlet />
+    </AuthGuard>;
 }
 ```
 
@@ -473,54 +473,54 @@ For complex apps that need shared auth state across components:
 ```jac
 cl import from "@jac/runtime" { jacIsLoggedIn, jacLogin, jacLogout }
 
-cl {
-    import from react { createContext, useContext }
+to cl:
 
-    glob AuthContext = createContext(None);
+import from react { createContext, useContext }
 
-    # Auth Provider component
-    def:pub AuthProvider(props: dict) -> JsxElement {
-        has user: any = None;
-        has loading: bool = True;
+glob AuthContext = createContext(None);
 
-        can with entry {
-            # Check auth status on mount
-            if jacIsLoggedIn() {
-                # Optionally fetch user data from backend
-                user = {"authenticated": True};
-            }
-            loading = False;
+# Auth Provider component
+def:pub AuthProvider(props: dict) -> JsxElement {
+    has user: any = None;
+    has loading: bool = True;
+
+    can with entry {
+        # Check auth status on mount
+        if jacIsLoggedIn() {
+            # Optionally fetch user data from backend
+            user = {"authenticated": True};
         }
-
-        async def login(username: str, password: str) -> bool {
-            success = await jacLogin(username, password);
-            if success {
-                user = {"authenticated": True};
-            }
-            return success;
-        }
-
-        def logout() -> None {
-            jacLogout();
-            user = None;
-        }
-
-        value = {
-            "user": user,
-            "loading": loading,
-            "isAuthenticated": user != None,
-            "login": login,
-            "logout": logout
-        };
-
-        return <AuthContext.Provider value={value}>
-            {props.children}
-        </AuthContext.Provider>;
+        loading = False;
     }
 
-    def useAuth() -> dict {
-        return useContext(AuthContext);
+    async def login(username: str, password: str) -> bool {
+        success = await jacLogin(username, password);
+        if success {
+            user = {"authenticated": True};
+        }
+        return success;
     }
+
+    def logout() -> None {
+        jacLogout();
+        user = None;
+    }
+
+    value = {
+        "user": user,
+        "loading": loading,
+        "isAuthenticated": user != None,
+        "login": login,
+        "logout": logout
+    };
+
+    return <AuthContext.Provider value={value}>
+        {props.children}
+    </AuthContext.Provider>;
+}
+
+def useAuth() -> dict {
+    return useContext(AuthContext);
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/backend.md
+++ b/docs/docs/tutorials/fullstack/backend.md
@@ -119,43 +119,43 @@ Use `root() spawn walker_name()` to call walkers from client code:
 # Import walkers from your main module
 sv import from ...main { get_tasks, add_task, toggle_task }
 
-cl {
-    def:pub TaskList() -> JsxElement {
-        has tasks: list = [];
-        has loading: bool = True;
-        has error: str = "";
+to cl:
 
-        # Fetch data on component mount
-        async can with entry {
-            await load_tasks();
-        }
+def:pub TaskList() -> JsxElement {
+    has tasks: list = [];
+    has loading: bool = True;
+    has error: str = "";
 
-        async def load_tasks() -> None {
-            loading = True;
-            error = "";
-            try {
-                result = root() spawn get_tasks();
-                if result.reports and result.reports.length > 0 {
-                    tasks = result.reports[0];
-                }
-            } except Exception as e {
-                error = f"Failed to load: {e}";
-            }
-            loading = False;
-        }
-
-        if loading {
-            return <p>Loading tasks...</p>;
-        }
-
-        if error {
-            return <p className="error">Error: {error}</p>;
-        }
-
-        return <ul>
-            {[<li key={jid(task)}>{task.title}</li> for task in tasks]}
-        </ul>;
+    # Fetch data on component mount
+    async can with entry {
+        await load_tasks();
     }
+
+    async def load_tasks() -> None {
+        loading = True;
+        error = "";
+        try {
+            result = root() spawn get_tasks();
+            if result.reports and result.reports.length > 0 {
+                tasks = result.reports[0];
+            }
+        } except Exception as e {
+            error = f"Failed to load: {e}";
+        }
+        loading = False;
+    }
+
+    if loading {
+        return <p>Loading tasks...</p>;
+    }
+
+    if error {
+        return <p className="error">Error: {error}</p>;
+    }
+
+    return <ul>
+        {[<li key={jid(task)}>{task.title}</li> for task in tasks]}
+    </ul>;
 }
 ```
 
@@ -173,91 +173,91 @@ cl {
 ```jac
 sv import from ...main { get_tasks, add_task, toggle_task, delete_task }
 
-cl {
-    def:pub TaskManager() -> JsxElement {
-        has tasks: list = [];
-        has new_title: str = "";
-        has loading: bool = True;
+to cl:
 
-        # Load tasks on mount
-        async can with entry {
-            await load_tasks();
-        }
+def:pub TaskManager() -> JsxElement {
+    has tasks: list = [];
+    has new_title: str = "";
+    has loading: bool = True;
 
-        async def load_tasks() -> None {
-            loading = True;
-            result = root() spawn get_tasks();
-            if result.reports and result.reports.length > 0 {
-                tasks = result.reports[0];
-            }
-            loading = False;
-        }
-
-        # Add new task
-        async def handle_add() -> None {
-            if new_title.trim() {
-                result = root() spawn add_task(title=new_title.trim());
-                if result.reports and result.reports.length > 0 {
-                    tasks = tasks + [result.reports[0]];
-                }
-                new_title = "";
-            }
-        }
-
-        # Toggle task completion
-        async def handle_toggle(task_id: str) -> None {
-            result = root() spawn toggle_task(task_id=task_id);
-            if result.reports and result.reports.length > 0 {
-                updated = result.reports[0];
-                tasks = [updated if jid(t) == task_id else t for t in tasks];
-            }
-        }
-
-        # Delete task
-        async def handle_delete(task_id: str) -> None {
-            result = root() spawn delete_task(task_id=task_id);
-            if result.reports and result.reports.length > 0 {
-                tasks = [t for t in tasks if jid(t) != task_id];
-            }
-        }
-
-        return <div>
-            <div className="add-task">
-                <input
-                    value={new_title}
-                    onChange={lambda e: ChangeEvent { new_title = e.target.value; }}
-                    onKeyDown={lambda e: KeyboardEvent {
-                        if e.key == "Enter" { handle_add(); }
-                    }}
-                    placeholder="New task..."
-                />
-                <button onClick={lambda -> None { handle_add(); }}>
-                    Add
-                </button>
-            </div>
-
-            {loading and <p>Loading...</p>}
-
-            <ul className="task-list">
-                {[
-                    <li key={jid(task)}>
-                        <input
-                            type="checkbox"
-                            checked={task.completed}
-                            onChange={lambda -> None { handle_toggle(jid(task)); }}
-                        />
-                        <span className={task.completed and "completed"}>
-                            {task.title}
-                        </span>
-                        <button onClick={lambda -> None { handle_delete(jid(task)); }}>
-                            Delete
-                        </button>
-                    </li>
-                    for task in tasks
-                ]}
-            </ul>
-        </div>;
+    # Load tasks on mount
+    async can with entry {
+        await load_tasks();
     }
+
+    async def load_tasks() -> None {
+        loading = True;
+        result = root() spawn get_tasks();
+        if result.reports and result.reports.length > 0 {
+            tasks = result.reports[0];
+        }
+        loading = False;
+    }
+
+    # Add new task
+    async def handle_add() -> None {
+        if new_title.trim() {
+            result = root() spawn add_task(title=new_title.trim());
+            if result.reports and result.reports.length > 0 {
+                tasks = tasks + [result.reports[0]];
+            }
+            new_title = "";
+        }
+    }
+
+    # Toggle task completion
+    async def handle_toggle(task_id: str) -> None {
+        result = root() spawn toggle_task(task_id=task_id);
+        if result.reports and result.reports.length > 0 {
+            updated = result.reports[0];
+            tasks = [updated if jid(t) == task_id else t for t in tasks];
+        }
+    }
+
+    # Delete task
+    async def handle_delete(task_id: str) -> None {
+        result = root() spawn delete_task(task_id=task_id);
+        if result.reports and result.reports.length > 0 {
+            tasks = [t for t in tasks if jid(t) != task_id];
+        }
+    }
+
+    return <div>
+        <div className="add-task">
+            <input
+                value={new_title}
+                onChange={lambda e: ChangeEvent { new_title = e.target.value; }}
+                onKeyDown={lambda e: KeyboardEvent {
+                    if e.key == "Enter" { handle_add(); }
+                }}
+                placeholder="New task..."
+            />
+            <button onClick={lambda -> None { handle_add(); }}>
+                Add
+            </button>
+        </div>
+
+        {loading and <p>Loading...</p>}
+
+        <ul className="task-list">
+            {[
+                <li key={jid(task)}>
+                    <input
+                        type="checkbox"
+                        checked={task.completed}
+                        onChange={lambda -> None { handle_toggle(jid(task)); }}
+                    />
+                    <span className={task.completed and "completed"}>
+                        {task.title}
+                    </span>
+                    <button onClick={lambda -> None { handle_delete(jid(task)); }}>
+                        Delete
+                    </button>
+                </li>
+                for task in tasks
+            ]}
+        </ul>
+    </div>;
 }
 ```
 
@@ -270,89 +270,89 @@ cl {
 ```jac
 sv import from ...main { submit_data }
 
-cl {
-    def:pub SafeSubmit() -> JsxElement {
-        has error_msg: str = "";
-        has submitting: bool = False;
+to cl:
 
-        async def handle_submit(data: dict) -> None {
-            submitting = True;
-            error_msg = "";
+def:pub SafeSubmit() -> JsxElement {
+    has error_msg: str = "";
+    has submitting: bool = False;
 
-            try {
-                result = root() spawn submit_data(payload=data);
-                if result.reports and result.reports.length > 0 {
-                    response = result.reports[0];
-                    if not response["success"] {
-                        error_msg = response["error"];
-                    }
+    async def handle_submit(data: dict) -> None {
+        submitting = True;
+        error_msg = "";
+
+        try {
+            result = root() spawn submit_data(payload=data);
+            if result.reports and result.reports.length > 0 {
+                response = result.reports[0];
+                if not response["success"] {
+                    error_msg = response["error"];
                 }
-            } except Exception as e {
-                error_msg = f"Network error: {e}";
             }
-
-            submitting = False;
+        } except Exception as e {
+            error_msg = f"Network error: {e}";
         }
 
-        return <div>
-            {error_msg and <div className="error">{error_msg}</div>}
-            <button
-                onClick={lambda -> None { handle_submit({"key": "value"}); }}
-                disabled={submitting}
-            >
-                {("Submitting..." if submitting else "Submit")}
-            </button>
-        </div>;
+        submitting = False;
     }
+
+    return <div>
+        {error_msg and <div className="error">{error_msg}</div>}
+        <button
+            onClick={lambda -> None { handle_submit({"key": "value"}); }}
+            disabled={submitting}
+        >
+            {("Submitting..." if submitting else "Submit")}
+        </button>
+    </div>;
 }
 ```
 
 ### Loading States Pattern
 
 ```jac
-cl {
-    def:pub DataView() -> JsxElement {
-        has data: any = None;
-        has loading: bool = True;
-        has error: str = "";
+to cl:
 
-        async can with entry {
-            await fetch_data();
-        }
+def:pub DataView() -> JsxElement {
+    has data: any = None;
+    has loading: bool = True;
+    has error: str = "";
 
-        async def fetch_data() -> None {
-            loading = True;
-            try {
-                result = root() spawn get_data();
-                if result.reports and result.reports.length > 0 {
-                    data = result.reports[0];
-                }
-            } except Exception as e {
-                error = f"Failed to load: {e}";
+    async can with entry {
+        await fetch_data();
+    }
+
+    async def fetch_data() -> None {
+        loading = True;
+        try {
+            result = root() spawn get_data();
+            if result.reports and result.reports.length > 0 {
+                data = result.reports[0];
             }
-            loading = False;
+        } except Exception as e {
+            error = f"Failed to load: {e}";
         }
+        loading = False;
+    }
 
-        if loading {
-            return <div className="skeleton">
-                <div className="skeleton-line"></div>
-                <div className="skeleton-line"></div>
-            </div>;
-        }
-
-        if error {
-            return <div className="error">
-                <p>{error}</p>
-                <button onClick={lambda -> None { fetch_data(); }}>
-                    Retry
-                </button>
-            </div>;
-        }
-
-        return <div className="data">
-            {JSON.stringify(data)}
+    if loading {
+        return <div className="skeleton">
+            <div className="skeleton-line"></div>
+            <div className="skeleton-line"></div>
         </div>;
     }
+
+    if error {
+        return <div className="error">
+            <p>{error}</p>
+            <button onClick={lambda -> None { fetch_data(); }}>
+                Retry
+            </button>
+        </div>;
+    }
+
+    return <div className="data">
+        {JSON.stringify(data)}
+    </div>;
 }
 ```
 
@@ -363,37 +363,37 @@ cl {
 ### Polling Pattern
 
 ```jac
-cl {
-    import from react { useEffect }
+to cl:
 
-    def:pub LiveData() -> JsxElement {
-        has data: any = None;
-        has loading: bool = True;
+import from react { useEffect }
 
-        async def fetch_data() -> None {
-            result = root() spawn get_live_data();
-            if result.reports and result.reports.length > 0 {
-                data = result.reports[0];
-            }
-            loading = False;
+def:pub LiveData() -> JsxElement {
+    has data: any = None;
+    has loading: bool = True;
+
+    async def fetch_data() -> None {
+        result = root() spawn get_live_data();
+        if result.reports and result.reports.length > 0 {
+            data = result.reports[0];
         }
-
-        # Initial fetch
-        async can with entry {
-            await fetch_data();
-        }
-
-        # Poll every 5 seconds
-        useEffect(lambda -> None {
-            interval = setInterval(lambda -> None { fetch_data(); }, 5000);
-            return lambda -> None { clearInterval(interval); };
-        }, []);
-
-        return <div>
-            {loading and <p>Loading...</p>}
-            {data and <p>Last updated: {data["timestamp"]}</p>}
-        </div>;
+        loading = False;
     }
+
+    # Initial fetch
+    async can with entry {
+        await fetch_data();
+    }
+
+    # Poll every 5 seconds
+    useEffect(lambda -> None {
+        interval = setInterval(lambda -> None { fetch_data(); }, 5000);
+        return lambda -> None { clearInterval(interval); };
+    }, []);
+
+    return <div>
+        {loading and <p>Loading...</p>}
+        {data and <p>Last updated: {data["timestamp"]}</p>}
+    </div>;
 }
 ```
 
@@ -442,72 +442,72 @@ walker:pub toggle_task {
 }
 
 # === Frontend: UI ===
-cl {
-    def:pub app() -> JsxElement {
-        has tasks: list = [];
-        has input_text: str = "";
-        has loading: bool = True;
+to cl:
 
-        # Load tasks on mount
-        async can with entry {
-            result = root() spawn get_tasks();
-            if result.reports {
-                tasks = result.reports;
-            }
-            loading = False;
+def:pub app() -> JsxElement {
+    has tasks: list = [];
+    has input_text: str = "";
+    has loading: bool = True;
+
+    # Load tasks on mount
+    async can with entry {
+        result = root() spawn get_tasks();
+        if result.reports {
+            tasks = result.reports;
         }
-
-        async def add() -> None {
-            if input_text.trim() {
-                result = root() spawn add_task(title=input_text.trim());
-                if result.reports and result.reports.length > 0 {
-                    tasks = tasks + [result.reports[0]];
-                }
-                input_text = "";
-            }
-        }
-
-        async def toggle(task_id: str) -> None {
-            result = root() spawn toggle_task(task_id=task_id);
-            if result.reports and result.reports.length > 0 {
-                updated = result.reports[0];
-                tasks = [updated if jid(t) == task_id else t for t in tasks];
-            }
-        }
-
-        return <div className="app">
-            <h1>My Tasks</h1>
-
-            <div className="input-row">
-                <input
-                    value={input_text}
-                    onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
-                    onKeyDown={lambda e: KeyboardEvent {
-                        if e.key == "Enter" { add(); }
-                    }}
-                    placeholder="Add a task..."
-                />
-                <button onClick={lambda -> None { add(); }}>Add</button>
-            </div>
-
-            {loading and <p>Loading...</p>}
-
-            {not loading and (
-                <ul>
-                    {[
-                        <li
-                            key={jid(t)}
-                            style={{"textDecoration": t.completed and "line-through"}}
-                            onClick={lambda -> None { toggle(jid(t)); }}
-                        >
-                            {t.title}
-                        </li>
-                        for t in tasks
-                    ]}
-                </ul>
-            )}
-        </div>;
+        loading = False;
     }
+
+    async def add() -> None {
+        if input_text.trim() {
+            result = root() spawn add_task(title=input_text.trim());
+            if result.reports and result.reports.length > 0 {
+                tasks = tasks + [result.reports[0]];
+            }
+            input_text = "";
+        }
+    }
+
+    async def toggle(task_id: str) -> None {
+        result = root() spawn toggle_task(task_id=task_id);
+        if result.reports and result.reports.length > 0 {
+            updated = result.reports[0];
+            tasks = [updated if jid(t) == task_id else t for t in tasks];
+        }
+    }
+
+    return <div className="app">
+        <h1>My Tasks</h1>
+
+        <div className="input-row">
+            <input
+                value={input_text}
+                onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
+                onKeyDown={lambda e: KeyboardEvent {
+                    if e.key == "Enter" { add(); }
+                }}
+                placeholder="Add a task..."
+            />
+            <button onClick={lambda -> None { add(); }}>Add</button>
+        </div>
+
+        {loading and <p>Loading...</p>}
+
+        {not loading and (
+            <ul>
+                {[
+                    <li
+                        key={jid(t)}
+                        style={{"textDecoration": t.completed and "line-through"}}
+                        onClick={lambda -> None { toggle(jid(t)); }}
+                    >
+                        {t.title}
+                    </li>
+                    for t in tasks
+                ]}
+            </ul>
+        )}
+    </div>;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/components.md
+++ b/docs/docs/tutorials/fullstack/components.md
@@ -14,17 +14,17 @@ The key difference from a standard React setup: there's no separate JavaScript p
 ## Basic Component
 
 ```jac
-cl {
-    def:pub Greeting(props: dict) -> JsxElement {
-        return <h1>Hello, {props.name}!</h1>;
-    }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <div>
-            <Greeting name="Alice" />
-            <Greeting name="Bob" />
-        </div>;
-    }
+def:pub Greeting(props: dict) -> JsxElement {
+    return <h1>Hello, {props.name}!</h1>;
+}
+
+def:pub app() -> JsxElement {
+    return <div>
+        <Greeting name="Alice" />
+        <Greeting name="Bob" />
+    </div>;
 }
 ```
 
@@ -42,15 +42,15 @@ cl {
 ### HTML Elements
 
 ```jac
-cl {
-    def:pub MyComponent() -> JsxElement {
-        return <div className="container">
-            <h1>Title</h1>
-            <p>Paragraph text</p>
-            <a href="/about">Link</a>
-            <img src="/logo.png" alt="Logo" />
-        </div>;
-    }
+to cl:
+
+def:pub MyComponent() -> JsxElement {
+    return <div className="container">
+        <h1>Title</h1>
+        <p>Paragraph text</p>
+        <a href="/about">Link</a>
+        <img src="/logo.png" alt="Logo" />
+    </div>;
 }
 ```
 
@@ -59,17 +59,17 @@ cl {
 ### JavaScript Expressions
 
 ```jac
-cl {
-    def:pub MyComponent() -> JsxElement {
-        name = "World";
-        items = [1, 2, 3];
+to cl:
 
-        return <div>
-            <p>Hello, {name}!</p>
-            <p>Sum: {1 + 2 + 3}</p>
-            <p>Items: {len(items)}</p>
-        </div>;
-    }
+def:pub MyComponent() -> JsxElement {
+    name = "World";
+    items = [1, 2, 3];
+
+    return <div>
+        <p>Hello, {name}!</p>
+        <p>Sum: {1 + 2 + 3}</p>
+        <p>Items: {len(items)}</p>
+    </div>;
 }
 ```
 
@@ -82,37 +82,37 @@ Use `{ }` to embed any Jac expression.
 ### Ternary Operator
 
 ```jac
-cl {
-    def:pub Status(props: dict) -> JsxElement {
-        return <span>
-            {("Active" if props.active else "Inactive")}
-        </span>;
-    }
+to cl:
+
+def:pub Status(props: dict) -> JsxElement {
+    return <span>
+        {("Active" if props.active else "Inactive")}
+    </span>;
 }
 ```
 
 ### Logical AND
 
 ```jac
-cl {
-    def:pub Notification(props: dict) -> JsxElement {
-        return <div>
-            {props.count > 0 and <span>You have {props.count} messages</span>}
-        </div>;
-    }
+to cl:
+
+def:pub Notification(props: dict) -> JsxElement {
+    return <div>
+        {props.count > 0 and <span>You have {props.count} messages</span>}
+    </div>;
 }
 ```
 
 ### If Statement
 
 ```jac
-cl {
-    def:pub UserGreeting(props: dict) -> JsxElement {
-        if props.isLoggedIn {
-            return <h1>Welcome back!</h1>;
-        }
-        return <h1>Please sign in</h1>;
+to cl:
+
+def:pub UserGreeting(props: dict) -> JsxElement {
+    if props.isLoggedIn {
+        return <h1>Welcome back!</h1>;
     }
+    return <h1>Please sign in</h1>;
 }
 ```
 
@@ -121,22 +121,22 @@ cl {
 ## Lists and Iteration
 
 ```jac
-cl {
-    def:pub TodoList(props: dict) -> JsxElement {
-        return <ul>
-            {[<li key={item.id}>{item.text}</li> for item in props.items]}
-        </ul>;
-    }
+to cl:
 
-    def:pub app() -> JsxElement {
-        todos = [
-            {"id": 1, "text": "Learn Jac"},
-            {"id": 2, "text": "Build app"},
-            {"id": 3, "text": "Deploy"}
-        ];
+def:pub TodoList(props: dict) -> JsxElement {
+    return <ul>
+        {[<li key={item.id}>{item.text}</li> for item in props.items]}
+    </ul>;
+}
 
-        return <TodoList items={todos} />;
-    }
+def:pub app() -> JsxElement {
+    todos = [
+        {"id": 1, "text": "Learn Jac"},
+        {"id": 2, "text": "Build app"},
+        {"id": 3, "text": "Deploy"}
+    ];
+
+    return <TodoList items={todos} />;
 }
 ```
 
@@ -149,62 +149,62 @@ cl {
 ### Click Events
 
 ```jac
-cl {
-    def:pub Button() -> JsxElement {
-        def handle_click() -> None {
-            print("Button clicked!");
-        }
+to cl:
 
-        return <button onClick={lambda -> None { handle_click(); }}>
-            Click me
-        </button>;
+def:pub Button() -> JsxElement {
+    def handle_click() -> None {
+        print("Button clicked!");
     }
+
+    return <button onClick={lambda -> None { handle_click(); }}>
+        Click me
+    </button>;
 }
 ```
 
 ### Input Events
 
 ```jac
-cl {
-    def:pub SearchBox() -> JsxElement {
-        has query: str = "";
+to cl:
 
-        return <input
-            type="text"
-            value={query}
-            onChange={lambda e: ChangeEvent { query = e.target.value; }}
-            placeholder="Search..."
-        />;
-    }
+def:pub SearchBox() -> JsxElement {
+    has query: str = "";
+
+    return <input
+        type="text"
+        value={query}
+        onChange={lambda e: ChangeEvent { query = e.target.value; }}
+        placeholder="Search..."
+    />;
 }
 ```
 
 ### Form Submit
 
 ```jac
-cl {
-    def:pub LoginForm() -> JsxElement {
-        has username: str = "";
-        has password: str = "";
+to cl:
 
-        def handle_submit(e: FormEvent) -> None {
-            e.preventDefault();
-            print(f"Login: {username}");
-        }
+def:pub LoginForm() -> JsxElement {
+    has username: str = "";
+    has password: str = "";
 
-        return <form onSubmit={lambda e: FormEvent { handle_submit(e); }}>
-            <input
-                value={username}
-                onChange={lambda e: ChangeEvent { username = e.target.value; }}
-            />
-            <input
-                type="password"
-                value={password}
-                onChange={lambda e: ChangeEvent { password = e.target.value; }}
-            />
-            <button type="submit">Login</button>
-        </form>;
+    def handle_submit(e: FormEvent) -> None {
+        e.preventDefault();
+        print(f"Login: {username}");
     }
+
+    return <form onSubmit={lambda e: FormEvent { handle_submit(e); }}>
+        <input
+            value={username}
+            onChange={lambda e: ChangeEvent { username = e.target.value; }}
+        />
+        <input
+            type="password"
+            value={password}
+            onChange={lambda e: ChangeEvent { password = e.target.value; }}
+        />
+        <button type="submit">Login</button>
+    </form>;
 }
 ```
 
@@ -215,52 +215,52 @@ cl {
 ### Children
 
 ```jac
-cl {
-    def:pub Card(props: dict) -> JsxElement {
-        return <div className="card">
-            <div className="card-header">{props.title}</div>
-            <div className="card-body">{props.children}</div>
-        </div>;
-    }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <Card title="Welcome">
-            <p>This is the card content.</p>
-            <button>Action</button>
-        </Card>;
-    }
+def:pub Card(props: dict) -> JsxElement {
+    return <div className="card">
+        <div className="card-header">{props.title}</div>
+        <div className="card-body">{props.children}</div>
+    </div>;
+}
+
+def:pub app() -> JsxElement {
+    return <Card title="Welcome">
+        <p>This is the card content.</p>
+        <button>Action</button>
+    </Card>;
 }
 ```
 
 ### Nested Components
 
 ```jac
-cl {
-    def:pub Header() -> JsxElement {
-        return <header>
-            <h1>My App</h1>
-            <Nav />
-        </header>;
-    }
+to cl:
 
-    def:pub Nav() -> JsxElement {
-        return <nav>
-            <a href="/">Home</a>
-            <a href="/about">About</a>
-        </nav>;
-    }
+def:pub Header() -> JsxElement {
+    return <header>
+        <h1>My App</h1>
+        <Nav />
+    </header>;
+}
 
-    def:pub Footer() -> JsxElement {
-        return <footer>© 2024</footer>;
-    }
+def:pub Nav() -> JsxElement {
+    return <nav>
+        <a href="/">Home</a>
+        <a href="/about">About</a>
+    </nav>;
+}
 
-    def:pub app() -> JsxElement {
-        return <div>
-            <Header />
-            <main>Content here</main>
-            <Footer />
-        </div>;
-    }
+def:pub Footer() -> JsxElement {
+    return <footer>© 2024</footer>;
+}
+
+def:pub app() -> JsxElement {
+    return <div>
+        <Header />
+        <main>Content here</main>
+        <Footer />
+    </div>;
 }
 ```
 
@@ -283,15 +283,15 @@ def:pub Header(props: dict) -> JsxElement {
 ### main.jac
 
 ```jac
-cl {
-    import from "./Header.cl.jac" { Header }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <div>
-            <Header title="My App" />
-            <main>Content</main>
-        </div>;
-    }
+import from "./Header.cl.jac" { Header }
+
+def:pub app() -> JsxElement {
+    return <div>
+        <Header title="My App" />
+        <main>Content</main>
+    </div>;
 }
 ```
 
@@ -317,15 +317,15 @@ export function Button({ label, onClick }: ButtonProps) {
 ### main.jac
 
 ```jac
-cl {
-    import from "./Button.tsx" { Button }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <Button
-            label="Click me"
-            onClick={lambda -> None { print("Clicked!"); }}
-        />;
-    }
+import from "./Button.tsx" { Button }
+
+def:pub app() -> JsxElement {
+    return <Button
+        label="Click me"
+        onClick={lambda -> None { print("Clicked!"); }}
+    />;
 }
 ```
 
@@ -336,31 +336,31 @@ cl {
 ### Inline Styles
 
 ```jac
-cl {
-    def:pub StyledBox() -> JsxElement {
-        return <div style={{
-            "backgroundColor": "#f0f0f0",
-            "padding": "20px",
-            "borderRadius": "8px",
-            "boxShadow": "0 2px 4px rgba(0,0,0,0.1)"
-        }}>
-            Styled content
-        </div>;
-    }
+to cl:
+
+def:pub StyledBox() -> JsxElement {
+    return <div style={{
+        "backgroundColor": "#f0f0f0",
+        "padding": "20px",
+        "borderRadius": "8px",
+        "boxShadow": "0 2px 4px rgba(0,0,0,0.1)"
+    }}>
+        Styled content
+    </div>;
 }
 ```
 
 ### CSS Classes
 
 ```jac
-cl {
-    import "./styles.css";
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <div className="container">
-            <h1 className="title">Hello</h1>
-        </div>;
-    }
+import "./styles.css";
+
+def:pub app() -> JsxElement {
+    return <div className="container">
+        <h1 className="title">Hello</h1>
+    </div>;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/npm-and-libraries.md
+++ b/docs/docs/tutorials/fullstack/npm-and-libraries.md
@@ -305,12 +305,12 @@ This fetches resolved `.cl.jac` components into `components/ui/`, installs peer 
 ```jac
 cl import from "./components/ui/button" { Button }
 
-cl {
-    def:pub MyPage() -> JsxElement {
-        return <div>
-            <Button variant="outline">Click me</Button>
-        </div>;
-    }
+to cl:
+
+def:pub MyPage() -> JsxElement {
+    return <div>
+        <Button variant="outline">Click me</Button>
+    </div>;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -69,13 +69,13 @@ Each page file exports a `page` function:
 
 ```jac
 # pages/about.jac
-cl {
-    def:pub page() -> JsxElement {
-        return <div>
-            <h1>About Us</h1>
-            <p>Learn more about our company.</p>
-        </div>;
-    }
+to cl:
+
+def:pub page() -> JsxElement {
+    return <div>
+        <h1>About Us</h1>
+        <p>Learn more about our company.</p>
+    </div>;
 }
 ```
 
@@ -87,32 +87,32 @@ Use square brackets for dynamic URL segments:
 # pages/users/[id].jac
 cl import from "@jac/runtime" { Link, useParams }
 
-cl {
-    def:pub page() -> JsxElement {
-        params = useParams();
-        userId = params.id;
+to cl:
 
-        # Mock data lookup
-        users = {
-            "1": {"name": "Alice", "role": "Admin"},
-            "2": {"name": "Bob", "role": "Developer"}
-        };
+def:pub page() -> JsxElement {
+    params = useParams();
+    userId = params.id;
 
-        user = users[userId];
+    # Mock data lookup
+    users = {
+        "1": {"name": "Alice", "role": "Admin"},
+        "2": {"name": "Bob", "role": "Developer"}
+    };
 
-        if not user {
-            return <div>
-                <h1>User Not Found</h1>
-                <Link to="/users">Back to Users</Link>
-            </div>;
-        }
+    user = users[userId];
 
+    if not user {
         return <div>
-            <Link to="/users">← Back</Link>
-            <h1>User: {user["name"]}</h1>
-            <p>Role: {user["role"]}</p>
+            <h1>User Not Found</h1>
+            <Link to="/users">Back to Users</Link>
         </div>;
     }
+
+    return <div>
+        <Link to="/users">← Back</Link>
+        <h1>User: {user["name"]}</h1>
+        <p>Role: {user["role"]}</p>
+    </div>;
 }
 ```
 
@@ -122,17 +122,17 @@ cl {
 # pages/posts/[slug].jac
 cl import from "@jac/runtime" { Link, useParams }
 
-cl {
-    def:pub page() -> JsxElement {
-        params = useParams();
-        slug = params.slug;  # e.g., "getting-started-with-jac"
+to cl:
 
-        return <article>
-            <Link to="/posts">← All Posts</Link>
-            <h1>Blog Post</h1>
-            <p>Slug: {slug}</p>
-        </article>;
-    }
+def:pub page() -> JsxElement {
+    params = useParams();
+    slug = params.slug;  # e.g., "getting-started-with-jac"
+
+    return <article>
+        <Link to="/posts">← All Posts</Link>
+        <h1>Blog Post</h1>
+        <p>Slug: {slug}</p>
+    </article>;
 }
 ```
 
@@ -144,14 +144,14 @@ Use `[...param]` for catch-all routes (404 pages, docs, etc.):
 # pages/[...notFound].jac
 cl import from "@jac/runtime" { Link }
 
-cl {
-    def:pub page() -> JsxElement {
-        return <div style={{"textAlign": "center", "padding": "2rem"}}>
-            <h1>404 - Page Not Found</h1>
-            <p>The page you are looking for does not exist.</p>
-            <Link to="/">Back to Home</Link>
-        </div>;
-    }
+to cl:
+
+def:pub page() -> JsxElement {
+    return <div style={{"textAlign": "center", "padding": "2rem"}}>
+        <h1>404 - Page Not Found</h1>
+        <p>The page you are looking for does not exist.</p>
+        <Link to="/">Back to Home</Link>
+    </div>;
 }
 ```
 
@@ -185,16 +185,16 @@ Create `layout.jac` to wrap pages with shared UI:
 cl import from "@jac/runtime" { Outlet }
 cl import from ..components.navigation { Navigation }
 
-cl {
-    def:pub layout() -> JsxElement {
-        return <>
-            <Navigation />
-            <main style={{"maxWidth": "960px", "margin": "0 auto"}}>
-                <Outlet />  # Child routes render here
-            </main>
-            <footer>Footer content</footer>
-        </>;
-    }
+to cl:
+
+def:pub layout() -> JsxElement {
+    return <>
+        <Navigation />
+        <main style={{"maxWidth": "960px", "margin": "0 auto"}}>
+            <Outlet />  # Child routes render here
+        </main>
+        <footer>Footer content</footer>
+    </>;
 }
 ```
 
@@ -217,16 +217,16 @@ For explicit route configuration, import from `@jac/runtime`:
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-cl {
-    def:pub app() -> JsxElement {
-        return <Router>
-            <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/about" element={<About />} />
-                <Route path="/contact" element={<Contact />} />
-            </Routes>
-        </Router>;
-    }
+to cl:
+
+def:pub app() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/contact" element={<Contact />} />
+        </Routes>
+    </Router>;
 }
 ```
 
@@ -239,59 +239,59 @@ cl {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-cl {
-    def:pub Home() -> JsxElement {
-        return <div>
-            <h1>Home Page</h1>
-            <p>Welcome to our site!</p>
-        </div>;
-    }
+to cl:
 
-    def:pub About() -> JsxElement {
-        return <div>
-            <h1>About Us</h1>
-            <p>Learn more about our company.</p>
-        </div>;
-    }
+def:pub Home() -> JsxElement {
+    return <div>
+        <h1>Home Page</h1>
+        <p>Welcome to our site!</p>
+    </div>;
+}
 
-    def:pub Contact() -> JsxElement {
-        return <div>
-            <h1>Contact</h1>
-            <p>Get in touch with us.</p>
-        </div>;
-    }
+def:pub About() -> JsxElement {
+    return <div>
+        <h1>About Us</h1>
+        <p>Learn more about our company.</p>
+    </div>;
+}
 
-    def:pub app() -> JsxElement {
-        return <Router>
-            <nav>
-                <Link to="/">Home</Link>
-                <Link to="/about">About</Link>
-                <Link to="/contact">Contact</Link>
-            </nav>
+def:pub Contact() -> JsxElement {
+    return <div>
+        <h1>Contact</h1>
+        <p>Get in touch with us.</p>
+    </div>;
+}
 
-            <main>
-                <Routes>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/about" element={<About />} />
-                    <Route path="/contact" element={<Contact />} />
-                </Routes>
-            </main>
-        </Router>;
-    }
+def:pub app() -> JsxElement {
+    return <Router>
+        <nav>
+            <Link to="/">Home</Link>
+            <Link to="/about">About</Link>
+            <Link to="/contact">Contact</Link>
+        </nav>
+
+        <main>
+            <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/about" element={<About />} />
+                <Route path="/contact" element={<Contact />} />
+            </Routes>
+        </main>
+    </Router>;
 }
 ```
 
 ### Link vs Anchor
 
 ```jac
-cl {
-    # Use Link for internal navigation, anchor for external
-    def:pub NavExample() -> JsxElement {
-        return <div>
-            <Link to="/about">About</Link>
-            <a href="https://example.com">External Site</a>
-        </div>;
-    }
+to cl:
+
+# Use Link for internal navigation, anchor for external
+def:pub NavExample() -> JsxElement {
+    return <div>
+        <Link to="/about">About</Link>
+        <a href="https://example.com">External Site</a>
+    </div>;
 }
 ```
 
@@ -313,16 +313,16 @@ pages/users/[id].jac  # Matches /users/:id
 # pages/users/[id].jac
 cl import from "@jac/runtime" { useParams }
 
-cl {
-    def:pub page() -> JsxElement {
-        params = useParams();
-        user_id = params["id"];
+to cl:
 
-        return <div>
-            <h1>User Profile</h1>
-            <p>Viewing user: {user_id}</p>
-        </div>;
-    }
+def:pub page() -> JsxElement {
+    params = useParams();
+    user_id = params["id"];
+
+    return <div>
+        <h1>User Profile</h1>
+        <p>Viewing user: {user_id}</p>
+    </div>;
 }
 ```
 
@@ -331,24 +331,24 @@ cl {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, useParams }
 
-cl {
-    def:pub UserProfile() -> JsxElement {
-        params = useParams();
-        user_id = params["id"];
+to cl:
 
-        return <div>
-            <h1>User Profile</h1>
-            <p>Viewing user: {user_id}</p>
-        </div>;
-    }
+def:pub UserProfile() -> JsxElement {
+    params = useParams();
+    user_id = params["id"];
 
-    def:pub app() -> JsxElement {
-        return <Router>
-            <Routes>
-                <Route path="/user/:id" element={<UserProfile />} />
-            </Routes>
-        </Router>;
-    }
+    return <div>
+        <h1>User Profile</h1>
+        <p>Viewing user: {user_id}</p>
+    </div>;
+}
+
+def:pub app() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/user/:id" element={<UserProfile />} />
+        </Routes>
+    </Router>;
 }
 ```
 
@@ -357,20 +357,20 @@ cl {
 ```jac
 cl import from "@jac/runtime" { useParams }
 
-cl {
-    def:pub BlogPost() -> JsxElement {
-        params = useParams();
+to cl:
 
-        return <div>
-            <p>Category: {params["category"]}</p>
-            <p>Post ID: {params["postId"]}</p>
-        </div>;
-    }
+def:pub BlogPost() -> JsxElement {
+    params = useParams();
 
-    # Route: /blog/:category/:postId
-    # URL: /blog/tech/123
-    # params = {"category": "tech", "postId": "123"}
+    return <div>
+        <p>Category: {params["category"]}</p>
+        <p>Post ID: {params["postId"]}</p>
+    </div>;
 }
+
+# Route: /blog/:category/:postId
+# URL: /blog/tech/123
+# params = {"category": "tech", "postId": "123"}
 ```
 
 ---
@@ -396,20 +396,20 @@ pages/
 # pages/dashboard/layout.jac
 cl import from "@jac/runtime" { Outlet, Link }
 
-cl {
-    def:pub layout() -> JsxElement {
-        return <div className="dashboard">
-            <aside>
-                <Link to="/dashboard">Overview</Link>
-                <Link to="/dashboard/settings">Settings</Link>
-                <Link to="/dashboard/profile">Profile</Link>
-            </aside>
+to cl:
 
-            <main>
-                <Outlet />
-            </main>
-        </div>;
-    }
+def:pub layout() -> JsxElement {
+    return <div className="dashboard">
+        <aside>
+            <Link to="/dashboard">Overview</Link>
+            <Link to="/dashboard/settings">Settings</Link>
+            <Link to="/dashboard/profile">Profile</Link>
+        </aside>
+
+        <main>
+            <Outlet />
+        </main>
+    </div>;
 }
 ```
 
@@ -418,44 +418,44 @@ cl {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Outlet, Link }
 
-cl {
-    def:pub DashboardLayout() -> JsxElement {
-        return <div className="dashboard">
-            <aside>
-                <Link to="/dashboard">Overview</Link>
-                <Link to="/dashboard/settings">Settings</Link>
-                <Link to="/dashboard/profile">Profile</Link>
-            </aside>
+to cl:
 
-            <main>
-                <Outlet />
-            </main>
-        </div>;
-    }
+def:pub DashboardLayout() -> JsxElement {
+    return <div className="dashboard">
+        <aside>
+            <Link to="/dashboard">Overview</Link>
+            <Link to="/dashboard/settings">Settings</Link>
+            <Link to="/dashboard/profile">Profile</Link>
+        </aside>
 
-    def:pub DashboardHome() -> JsxElement {
-        return <h2>Dashboard Overview</h2>;
-    }
+        <main>
+            <Outlet />
+        </main>
+    </div>;
+}
 
-    def:pub DashboardSettings() -> JsxElement {
-        return <h2>Settings</h2>;
-    }
+def:pub DashboardHome() -> JsxElement {
+    return <h2>Dashboard Overview</h2>;
+}
 
-    def:pub DashboardProfile() -> JsxElement {
-        return <h2>Profile</h2>;
-    }
+def:pub DashboardSettings() -> JsxElement {
+    return <h2>Settings</h2>;
+}
 
-    def:pub app() -> JsxElement {
-        return <Router>
-            <Routes>
-                <Route path="/dashboard" element={<DashboardLayout />}>
-                    <Route index element={<DashboardHome />} />
-                    <Route path="settings" element={<DashboardSettings />} />
-                    <Route path="profile" element={<DashboardProfile />} />
-                </Route>
-            </Routes>
-        </Router>;
-    }
+def:pub DashboardProfile() -> JsxElement {
+    return <h2>Profile</h2>;
+}
+
+def:pub app() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/dashboard" element={<DashboardLayout />}>
+                <Route index element={<DashboardHome />} />
+                <Route path="settings" element={<DashboardSettings />} />
+                <Route path="profile" element={<DashboardProfile />} />
+            </Route>
+        </Routes>
+    </Router>;
 }
 ```
 
@@ -468,32 +468,32 @@ cl {
 ```jac
 cl import from "@jac/runtime" { useNavigate }
 
-cl {
-    def:pub LoginForm() -> JsxElement {
-        has email: str = "";
-        has password: str = "";
+to cl:
 
-        navigate = useNavigate();
+def:pub LoginForm() -> JsxElement {
+    has email: str = "";
+    has password: str = "";
 
-        async def handle_login() -> None {
-            success = await do_login(email, password);
+    navigate = useNavigate();
 
-            if success {
-                # Redirect to dashboard
-                navigate("/dashboard");
-            }
+    async def handle_login() -> None {
+        success = await do_login(email, password);
+
+        if success {
+            # Redirect to dashboard
+            navigate("/dashboard");
         }
-
-        return <form>
-            <input
-                value={email}
-                onChange={lambda e: ChangeEvent { email = e.target.value; }}
-            />
-            <button onClick={lambda -> None { handle_login(); }}>
-                Login
-            </button>
-        </form>;
     }
+
+    return <form>
+        <input
+            value={email}
+            onChange={lambda e: ChangeEvent { email = e.target.value; }}
+        />
+        <button onClick={lambda -> None { handle_login(); }}>
+            Login
+        </button>
+    </form>;
 }
 ```
 
@@ -502,28 +502,28 @@ cl {
 ```jac
 cl import from "@jac/runtime" { useNavigate }
 
-cl {
-    def:pub NavExample() -> JsxElement {
-        navigate = useNavigate();
+to cl:
 
-        return <div>
-            <button onClick={lambda -> None { navigate("/home"); }}>
-                Go Home
-            </button>
+def:pub NavExample() -> JsxElement {
+    navigate = useNavigate();
 
-            <button onClick={lambda -> None { navigate("/login", {"replace": True}); }}>
-                Login (replace)
-            </button>
+    return <div>
+        <button onClick={lambda -> None { navigate("/home"); }}>
+            Go Home
+        </button>
 
-            <button onClick={lambda -> None { navigate(-1); }}>
-                Back
-            </button>
+        <button onClick={lambda -> None { navigate("/login", {"replace": True}); }}>
+            Login (replace)
+        </button>
 
-            <button onClick={lambda -> None { navigate(1); }}>
-                Forward
-            </button>
-        </div>;
-    }
+        <button onClick={lambda -> None { navigate(-1); }}>
+            Back
+        </button>
+
+        <button onClick={lambda -> None { navigate(1); }}>
+            Forward
+        </button>
+    </div>;
 }
 ```
 
@@ -539,12 +539,12 @@ For file-based routing, use the built-in `AuthGuard` component in a layout file:
 # pages/(protected)/layout.jac
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
-cl {
-    def:pub layout() -> JsxElement {
-        return <AuthGuard redirect="/login">
-            <Outlet />
-        </AuthGuard>;
-    }
+to cl:
+
+def:pub layout() -> JsxElement {
+    return <AuthGuard redirect="/login">
+        <Outlet />
+    </AuthGuard>;
 }
 ```
 
@@ -555,23 +555,23 @@ Any pages in the `(protected)` group will require authentication.
 ```jac
 cl import from "@jac/runtime" { useNavigate, jacIsLoggedIn }
 
-cl {
-    def:pub ProtectedRoute(props: dict) -> JsxElement {
-        navigate = useNavigate();
-        isAuthenticated = jacIsLoggedIn();
+to cl:
 
-        can with entry {
-            if not isAuthenticated {
-                navigate("/login", {"replace": True});
-            }
-        }
+def:pub ProtectedRoute(props: dict) -> JsxElement {
+    navigate = useNavigate();
+    isAuthenticated = jacIsLoggedIn();
 
+    can with entry {
         if not isAuthenticated {
-            return <div>Redirecting...</div>;
+            navigate("/login", {"replace": True});
         }
-
-        return <div>{props.children}</div>;
     }
+
+    if not isAuthenticated {
+        return <div>Redirecting...</div>;
+    }
+
+    return <div>{props.children}</div>;
 }
 ```
 
@@ -586,39 +586,39 @@ Access query parameters using `useLocation` and standard URL parsing:
 ```jac
 cl import from "@jac/runtime" { useLocation, useNavigate }
 
-cl {
-    def:pub SearchResults() -> JsxElement {
-        location = useLocation();
-        navigate = useNavigate();
+to cl:
 
-        # Parse query parameters from location.search
-        searchParams = URLSearchParams(location.search);
-        query = searchParams.get("q") or "";
-        page = int(searchParams.get("page") or "1");
+def:pub SearchResults() -> JsxElement {
+    location = useLocation();
+    navigate = useNavigate();
 
-        def updatePage(newPage: int) -> None {
-            navigate(f"/search?q={query}&page={newPage}");
-        }
+    # Parse query parameters from location.search
+    searchParams = URLSearchParams(location.search);
+    query = searchParams.get("q") or "";
+    page = int(searchParams.get("page") or "1");
 
-        return <div>
-            <h2>Results for: {query}</h2>
-            <p>Page: {page}</p>
-
-            <button
-                onClick={lambda -> None { updatePage(page - 1); }}
-                disabled={page <= 1}
-            >
-                Previous
-            </button>
-
-            <button onClick={lambda -> None { updatePage(page + 1); }}>
-                Next
-            </button>
-        </div>;
+    def updatePage(newPage: int) -> None {
+        navigate(f"/search?q={query}&page={newPage}");
     }
 
-    # URL: /search?q=hello&page=2
+    return <div>
+        <h2>Results for: {query}</h2>
+        <p>Page: {page}</p>
+
+        <button
+            onClick={lambda -> None { updatePage(page - 1); }}
+            disabled={page <= 1}
+        >
+            Previous
+        </button>
+
+        <button onClick={lambda -> None { updatePage(page + 1); }}>
+            Next
+        </button>
+    </div>;
 }
+
+# URL: /search?q=hello&page=2
 ```
 
 ---
@@ -628,24 +628,24 @@ cl {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-cl {
-    def:pub NotFound() -> JsxElement {
-        return <div className="error-page">
-            <h1>404</h1>
-            <p>Page not found</p>
-            <Link to="/">Go Home</Link>
-        </div>;
-    }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <Router>
-            <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/about" element={<About />} />
-                <Route path="*" element={<NotFound />} />
-            </Routes>
-        </Router>;
-    }
+def:pub NotFound() -> JsxElement {
+    return <div className="error-page">
+        <h1>404</h1>
+        <p>Page not found</p>
+        <Link to="/">Go Home</Link>
+    </div>;
+}
+
+def:pub app() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+            <Route path="*" element={<NotFound />} />
+        </Routes>
+    </Router>;
 }
 ```
 
@@ -658,30 +658,30 @@ Use `useLocation` with `Link` to create active link styling:
 ```jac
 cl import from "@jac/runtime" { Link, useLocation }
 
-cl {
-    def:pub Navigation() -> JsxElement {
-        location = useLocation();
+to cl:
 
-        def isActive(path: str) -> bool {
-            return location.pathname == path;
-        }
+def:pub Navigation() -> JsxElement {
+    location = useLocation();
 
-        return <nav>
-            <Link
-                to="/"
-                className={"nav-link " + ("active" if isActive("/") else "")}
-            >
-                Home
-            </Link>
-
-            <Link
-                to="/about"
-                className={"nav-link " + ("active" if isActive("/about") else "")}
-            >
-                About
-            </Link>
-        </nav>;
+    def isActive(path: str) -> bool {
+        return location.pathname == path;
     }
+
+    return <nav>
+        <Link
+            to="/"
+            className={"nav-link " + ("active" if isActive("/") else "")}
+        >
+            Home
+        </Link>
+
+        <Link
+            to="/about"
+            className={"nav-link " + ("active" if isActive("/about") else "")}
+        >
+            About
+        </Link>
+    </nav>;
 }
 ```
 
@@ -705,101 +705,101 @@ cl {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link, Outlet, useParams, useNavigate }
 
-cl {
-    # Layout
-    def:pub Layout() -> JsxElement {
-        return <div className="app">
-            <header>
-                <nav>
-                    <Link to="/">Home</Link>
-                    <Link to="/products">Products</Link>
-                    <Link to="/about">About</Link>
-                </nav>
-            </header>
+to cl:
 
-            <main>
-                <Outlet />
-            </main>
+# Layout
+def:pub Layout() -> JsxElement {
+    return <div className="app">
+        <header>
+            <nav>
+                <Link to="/">Home</Link>
+                <Link to="/products">Products</Link>
+                <Link to="/about">About</Link>
+            </nav>
+        </header>
 
-            <footer>
-                <p>© 2024 My App</p>
-            </footer>
-        </div>;
-    }
+        <main>
+            <Outlet />
+        </main>
 
-    # Pages
-    def:pub Home() -> JsxElement {
-        return <div>
-            <h1>Welcome!</h1>
-            <Link to="/products">Browse Products</Link>
-        </div>;
-    }
+        <footer>
+            <p>© 2024 My App</p>
+        </footer>
+    </div>;
+}
 
-    def:pub Products() -> JsxElement {
-        products = [
-            {"id": 1, "name": "Widget A"},
-            {"id": 2, "name": "Widget B"},
-            {"id": 3, "name": "Widget C"}
-        ];
+# Pages
+def:pub Home() -> JsxElement {
+    return <div>
+        <h1>Welcome!</h1>
+        <Link to="/products">Browse Products</Link>
+    </div>;
+}
 
-        return <div>
-            <h1>Products</h1>
-            <ul>
-                {[
-                    <li key={p["id"]}>
-                        <Link to={f"/products/{p['id']}"}>
-                            {p["name"]}
-                        </Link>
-                    </li>
-                    for p in products
-                ]}
-            </ul>
-        </div>;
-    }
+def:pub Products() -> JsxElement {
+    products = [
+        {"id": 1, "name": "Widget A"},
+        {"id": 2, "name": "Widget B"},
+        {"id": 3, "name": "Widget C"}
+    ];
 
-    def:pub ProductDetail() -> JsxElement {
-        params = useParams();
-        navigate = useNavigate();
+    return <div>
+        <h1>Products</h1>
+        <ul>
+            {[
+                <li key={p["id"]}>
+                    <Link to={f"/products/{p['id']}"}>
+                        {p["name"]}
+                    </Link>
+                </li>
+                for p in products
+            ]}
+        </ul>
+    </div>;
+}
 
-        product_id = params["id"];
+def:pub ProductDetail() -> JsxElement {
+    params = useParams();
+    navigate = useNavigate();
 
-        return <div>
-            <button onClick={lambda -> None { navigate(-1); }}>
-                ← Back
-            </button>
-            <h1>Product {product_id}</h1>
-            <p>Details about product {product_id}</p>
-        </div>;
-    }
+    product_id = params["id"];
 
-    def:pub About() -> JsxElement {
-        return <div>
-            <h1>About Us</h1>
-            <p>We make great products.</p>
-        </div>;
-    }
+    return <div>
+        <button onClick={lambda -> None { navigate(-1); }}>
+            ← Back
+        </button>
+        <h1>Product {product_id}</h1>
+        <p>Details about product {product_id}</p>
+    </div>;
+}
 
-    def:pub NotFound() -> JsxElement {
-        return <div>
-            <h1>404 - Not Found</h1>
-            <Link to="/">Go Home</Link>
-        </div>;
-    }
+def:pub About() -> JsxElement {
+    return <div>
+        <h1>About Us</h1>
+        <p>We make great products.</p>
+    </div>;
+}
 
-    # App
-    def:pub app() -> JsxElement {
-        return <Router>
-            <Routes>
-                <Route path="/" element={<Layout />}>
-                    <Route index element={<Home />} />
-                    <Route path="products" element={<Products />} />
-                    <Route path="products/:id" element={<ProductDetail />} />
-                    <Route path="about" element={<About />} />
-                    <Route path="*" element={<NotFound />} />
-                </Route>
-            </Routes>
-        </Router>;
-    }
+def:pub NotFound() -> JsxElement {
+    return <div>
+        <h1>404 - Not Found</h1>
+        <Link to="/">Go Home</Link>
+    </div>;
+}
+
+# App
+def:pub app() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/" element={<Layout />}>
+                <Route index element={<Home />} />
+                <Route path="products" element={<Products />} />
+                <Route path="products/:id" element={<ProductDetail />} />
+                <Route path="about" element={<About />} />
+                <Route path="*" element={<NotFound />} />
+            </Route>
+        </Routes>
+    </Router>;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -58,14 +58,14 @@ walker:pub get_todos {
 }
 
 # Frontend code (inside cl block)
-cl {
-    def:pub app() -> JsxElement {
-        has message: str = "Hello from Jac!";
+to cl:
 
-        return <div>
-            <h1>{message}</h1>
-        </div>;
-    }
+def:pub app() -> JsxElement {
+    has message: str = "Hello from Jac!";
+
+    return <div>
+        <h1>{message}</h1>
+    </div>;
 }
 ```
 
@@ -134,10 +134,10 @@ walker api_endpoint {
 }
 
 # This is frontend code (runs in browser)
-cl {
-    def:pub MyComponent() -> JsxElement {
-        return <div>I run in the browser</div>;
-    }
+to cl:
+
+def:pub MyComponent() -> JsxElement {
+    return <div>I run in the browser</div>;
 }
 ```
 
@@ -163,10 +163,10 @@ walker get_user {
 }
 
 # Frontend
-cl {
-    def:pub app() -> JsxElement {
-        return <div>App</div>;
-    }
+to cl:
+
+def:pub app() -> JsxElement {
+    return <div>App</div>;
 }
 ```
 
@@ -206,15 +206,15 @@ walker get_user {
 
 ```jac
 # main.jac
-cl {
-    import from "./components/Header.cl.jac" { Header }
+to cl:
 
-    def:pub app() -> JsxElement {
-        return <div>
-            <Header />
-            <main>Content</main>
-        </div>;
-    }
+import from "./components/Header.cl.jac" { Header }
+
+def:pub app() -> JsxElement {
+    return <div>
+        <Header />
+        <main>Content</main>
+    </div>;
 }
 ```
 
@@ -244,13 +244,13 @@ axios = "^1.6.0"
 Then use in frontend:
 
 ```jac
-cl {
-    import lodash;
+to cl:
 
-    def:pub app() -> JsxElement {
-        items = lodash.sortBy(["c", "a", "b"]);
-        return <ul>{[<li>{i}</li> for i in items]}</ul>;
-    }
+import lodash;
+
+def:pub app() -> JsxElement {
+    items = lodash.sortBy(["c", "a", "b"]);
+    return <ul>{[<li>{i}</li> for i in items]}</ul>;
 }
 ```
 
@@ -289,18 +289,18 @@ watchdog = ">=3.0.0"
 Create this minimal `main.jac`:
 
 ```jac
-cl {
-    def:pub app() -> JsxElement {
-        has count: int = 0;
+to cl:
 
-        return <div style={{"textAlign": "center", "marginTop": "50px"}}>
-            <h1>Jac Full-Stack</h1>
-            <p>Count: {count}</p>
-            <button onClick={lambda -> None { count = count + 1; }}>
-                Increment
-            </button>
-        </div>;
-    }
+def:pub app() -> JsxElement {
+    has count: int = 0;
+
+    return <div style={{"textAlign": "center", "marginTop": "50px"}}>
+        <h1>Jac Full-Stack</h1>
+        <p>Count: {count}</p>
+        <button onClick={lambda -> None { count = count + 1; }}>
+            Increment
+        </button>
+    </div>;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -16,17 +16,17 @@ This tutorial covers declaring reactive state, handling user input, sharing stat
 Inside `cl { }` blocks, `has` creates reactive state (like React's `useState`). Declaring `has count: int = 0;` inside a component function creates a stateful variable that persists across re-renders and triggers a UI update whenever its value changes:
 
 ```jac
-cl {
-    def:pub Counter() -> JsxElement {
-        has count: int = 0;  # Reactive state
+to cl:
 
-        return <div>
-            <p>Count: {count}</p>
-            <button onClick={lambda -> None { count = count + 1; }}>
-                Increment
-            </button>
-        </div>;
-    }
+def:pub Counter() -> JsxElement {
+    has count: int = 0;  # Reactive state
+
+    return <div>
+        <p>Count: {count}</p>
+        <button onClick={lambda -> None { count = count + 1; }}>
+            Increment
+        </button>
+    </div>;
 }
 ```
 
@@ -41,40 +41,40 @@ cl {
 ## Multiple State Variables
 
 ```jac
-cl {
-    def:pub Form() -> JsxElement {
-        has name: str = "";
-        has email: str = "";
-        has submitted: bool = False;
+to cl:
 
-        def handle_submit() -> None {
-            print(f"Submitting: {name}, {email}");
-            submitted = True;
-        }
+def:pub Form() -> JsxElement {
+    has name: str = "";
+    has email: str = "";
+    has submitted: bool = False;
 
-        if submitted {
-            return <p>Thanks, {name}!</p>;
-        }
-
-        return <form>
-            <input
-                value={name}
-                onChange={lambda e: ChangeEvent { name = e.target.value; }}
-                placeholder="Name"
-            />
-            <input
-                value={email}
-                onChange={lambda e: ChangeEvent { email = e.target.value; }}
-                placeholder="Email"
-            />
-            <button
-                type="button"
-                onClick={lambda -> None { handle_submit(); }}
-            >
-                Submit
-            </button>
-        </form>;
+    def handle_submit() -> None {
+        print(f"Submitting: {name}, {email}");
+        submitted = True;
     }
+
+    if submitted {
+        return <p>Thanks, {name}!</p>;
+    }
+
+    return <form>
+        <input
+            value={name}
+            onChange={lambda e: ChangeEvent { name = e.target.value; }}
+            placeholder="Name"
+        />
+        <input
+            value={email}
+            onChange={lambda e: ChangeEvent { email = e.target.value; }}
+            placeholder="Email"
+        />
+        <button
+            type="button"
+            onClick={lambda -> None { handle_submit(); }}
+        >
+            Submit
+        </button>
+    </form>;
 }
 ```
 
@@ -83,42 +83,42 @@ cl {
 ## Complex State (Objects/Lists)
 
 ```jac
-cl {
-    def:pub TodoApp() -> JsxElement {
-        has todos: list = [];
-        has input_text: str = "";
+to cl:
 
-        def add_todo() -> None {
-            if input_text {
-                todos = todos + [{"id": len(todos), "text": input_text}];
-                input_text = "";
-            }
+def:pub TodoApp() -> JsxElement {
+    has todos: list = [];
+    has input_text: str = "";
+
+    def add_todo() -> None {
+        if input_text {
+            todos = todos + [{"id": len(todos), "text": input_text}];
+            input_text = "";
         }
-
-        def remove_todo(id: int) -> None {
-            todos = [t for t in todos if t["id"] != id];
-        }
-
-        return <div>
-            <input
-                value={input_text}
-                onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
-            />
-            <button onClick={lambda -> None { add_todo(); }}>Add</button>
-
-            <ul>
-                {[
-                    <li key={todo["id"]}>
-                        {todo["text"]}
-                        <button onClick={lambda -> None { remove_todo(todo["id"]); }}>
-                            X
-                        </button>
-                    </li>
-                    for todo in todos
-                ]}
-            </ul>
-        </div>;
     }
+
+    def remove_todo(id: int) -> None {
+        todos = [t for t in todos if t["id"] != id];
+    }
+
+    return <div>
+        <input
+            value={input_text}
+            onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
+        />
+        <button onClick={lambda -> None { add_todo(); }}>Add</button>
+
+        <ul>
+            {[
+                <li key={todo["id"]}>
+                    {todo["text"]}
+                    <button onClick={lambda -> None { remove_todo(todo["id"]); }}>
+                        X
+                    </button>
+                </li>
+                for todo in todos
+            ]}
+        </ul>
+    </div>;
 }
 ```
 
@@ -136,26 +136,26 @@ cl {
 Similar to how `has` automatically generates `useState`, you can use `can with entry` and `can with exit` to automatically generate `useEffect` hooks:
 
 ```jac
-cl {
-    def:pub DataFetcher() -> JsxElement {
-        has data: list = [];
-        has loading: bool = True;
+to cl:
 
-        # Run once on mount - async effects are wrapped in IIFE automatically
-        async can with entry {
-            result = await some_async_operation();
-            data = result;
-            loading = False;
-        }
+def:pub DataFetcher() -> JsxElement {
+    has data: list = [];
+    has loading: bool = True;
 
-        if loading {
-            return <p>Loading...</p>;
-        }
-
-        return <ul>
-            {[<li key={item.id}>{item.name}</li> for item in data]}
-        </ul>;
+    # Run once on mount - async effects are wrapped in IIFE automatically
+    async can with entry {
+        result = await some_async_operation();
+        data = result;
+        loading = False;
     }
+
+    if loading {
+        return <p>Loading...</p>;
+    }
+
+    return <ul>
+        {[<li key={item.id}>{item.name}</li> for item in data]}
+    </ul>;
 }
 ```
 
@@ -164,28 +164,28 @@ cl {
 Use list syntax `[dep1, dep2]` to specify dependencies (similar to React's dependency arrays):
 
 ```jac
-cl {
-    def:pub SearchResults() -> JsxElement {
-        has query: str = "";
-        has results: list = [];
+to cl:
 
-        # Run when query changes
-        async can with [query] entry {
-            if query {
-                results = await search_api(query);
-            }
+def:pub SearchResults() -> JsxElement {
+    has query: str = "";
+    has results: list = [];
+
+    # Run when query changes
+    async can with [query] entry {
+        if query {
+            results = await search_api(query);
         }
-
-        return <div>
-            <input
-                value={query}
-                onChange={lambda e: ChangeEvent { query = e.target.value; }}
-            />
-            <ul>
-                {[<li>{r}</li> for r in results]}
-            </ul>
-        </div>;
     }
+
+    return <div>
+        <input
+            value={query}
+            onChange={lambda e: ChangeEvent { query = e.target.value; }}
+        />
+        <ul>
+            {[<li>{r}</li> for r in results]}
+        </ul>
+    </div>;
 }
 ```
 
@@ -194,24 +194,24 @@ cl {
 Use `can with exit` for cleanup logic (runs on unmount):
 
 ```jac
-cl {
-    def:pub Timer() -> JsxElement {
-        has seconds: int = 0;
+to cl:
 
-        # Setup interval on mount
-        can with entry {
-            intervalId = setInterval(lambda -> None {
-                seconds = seconds + 1;
-            }, 1000);
-        }
+def:pub Timer() -> JsxElement {
+    has seconds: int = 0;
 
-        # Cleanup on unmount
-        can with exit {
-            clearInterval(intervalId);
-        }
-
-        return <p>Seconds: {seconds}</p>;
+    # Setup interval on mount
+    can with entry {
+        intervalId = setInterval(lambda -> None {
+            seconds = seconds + 1;
+        }, 1000);
     }
+
+    # Cleanup on unmount
+    can with exit {
+        clearInterval(intervalId);
+    }
+
+    return <p>Seconds: {seconds}</p>;
 }
 ```
 
@@ -220,18 +220,18 @@ cl {
 The `can with entry/exit` syntax above is the idiomatic approach and should be preferred. However, you can also use `useEffect` manually by importing from React -- this is useful for complex patterns involving `useRef` or `useCallback`:
 
 ```jac
-cl {
-    import from react { useEffect }
+to cl:
 
-    def:pub DataFetcher() -> JsxElement {
-        has data: list = [];
+import from react { useEffect }
 
-        useEffect(lambda -> None {
-            fetch_data();
-        }, []);
+def:pub DataFetcher() -> JsxElement {
+    has data: list = [];
 
-        return <div>...</div>;
-    }
+    useEffect(lambda -> None {
+        fetch_data();
+    }, []);
+
+    return <div>...</div>;
 }
 ```
 
@@ -242,55 +242,55 @@ cl {
 ### Creating Context
 
 ```jac
-cl {
-    import from react { createContext, useContext }
+to cl:
 
-    # Create context
-    glob AppContext = createContext(None);
+import from react { createContext, useContext }
 
-    # Provider component
-    def:pub AppProvider(props: dict) -> JsxElement {
-        has user: any = None;
-        has theme: str = "light";
+# Create context
+glob AppContext = createContext(None);
 
-        value = {
-            "user": user,
-            "theme": theme,
-            "setUser": lambda u: any -> None { user = u; },
-            "setTheme": lambda t: str -> None { theme = t; }
-        };
+# Provider component
+def:pub AppProvider(props: dict) -> JsxElement {
+    has user: any = None;
+    has theme: str = "light";
 
-        return <AppContext.Provider value={value}>
-            {props.children}
-        </AppContext.Provider>;
+    value = {
+        "user": user,
+        "theme": theme,
+        "setUser": lambda u: any -> None { user = u; },
+        "setTheme": lambda t: str -> None { theme = t; }
+    };
+
+    return <AppContext.Provider value={value}>
+        {props.children}
+    </AppContext.Provider>;
+}
+
+# Consumer component
+def:pub UserDisplay() -> JsxElement {
+    ctx = useContext(AppContext);
+
+    if ctx.user {
+        return <p>Welcome, {ctx.user.name}!</p>;
     }
+    return <p>Not logged in</p>;
+}
 
-    # Consumer component
-    def:pub UserDisplay() -> JsxElement {
-        ctx = useContext(AppContext);
+def:pub ThemeToggle() -> JsxElement {
+    ctx = useContext(AppContext);
 
-        if ctx.user {
-            return <p>Welcome, {ctx.user.name}!</p>;
-        }
-        return <p>Not logged in</p>;
-    }
+    return <button onClick={lambda -> None {
+        ctx.setTheme("dark" if ctx.theme == "light" else "light");
+    }}>
+        Toggle Theme ({ctx.theme})
+    </button>;
+}
 
-    def:pub ThemeToggle() -> JsxElement {
-        ctx = useContext(AppContext);
-
-        return <button onClick={lambda -> None {
-            ctx.setTheme("dark" if ctx.theme == "light" else "light");
-        }}>
-            Toggle Theme ({ctx.theme})
-        </button>;
-    }
-
-    def:pub app() -> JsxElement {
-        return <AppProvider>
-            <UserDisplay />
-            <ThemeToggle />
-        </AppProvider>;
-    }
+def:pub app() -> JsxElement {
+    return <AppProvider>
+        <UserDisplay />
+        <ThemeToggle />
+    </AppProvider>;
 }
 ```
 
@@ -301,42 +301,42 @@ cl {
 Create reusable state logic:
 
 ```jac
-cl {
-    import from react { useEffect }
+to cl:
 
-    # Custom hook
-    def use_local_storage(key: str, initial_value: any) -> tuple {
-        has value: any = initial_value;
+import from react { useEffect }
 
-        # Load from localStorage on mount
-        useEffect(lambda -> None {
-            stored = localStorage.getItem(key);
-            if stored {
-                value = JSON.parse(stored);
-            }
-        }, []);
+# Custom hook
+def use_local_storage(key: str, initial_value: any) -> tuple {
+    has value: any = initial_value;
 
-        # Save to localStorage when value changes
-        useEffect(lambda -> None {
-            localStorage.setItem(key, JSON.stringify(value));
-        }, [value]);
+    # Load from localStorage on mount
+    useEffect(lambda -> None {
+        stored = localStorage.getItem(key);
+        if stored {
+            value = JSON.parse(stored);
+        }
+    }, []);
 
-        return (value, lambda v: any -> None { value = v; });
-    }
+    # Save to localStorage when value changes
+    useEffect(lambda -> None {
+        localStorage.setItem(key, JSON.stringify(value));
+    }, [value]);
 
-    def:pub Settings() -> JsxElement {
-        (theme, set_theme) = use_local_storage("theme", "light");
+    return (value, lambda v: any -> None { value = v; });
+}
 
-        return <div>
-            <p>Current theme: {theme}</p>
-            <button onClick={lambda -> None { set_theme("dark"); }}>
-                Dark
-            </button>
-            <button onClick={lambda -> None { set_theme("light"); }}>
-                Light
-            </button>
-        </div>;
-    }
+def:pub Settings() -> JsxElement {
+    (theme, set_theme) = use_local_storage("theme", "light");
+
+    return <div>
+        <p>Current theme: {theme}</p>
+        <button onClick={lambda -> None { set_theme("dark"); }}>
+            Dark
+        </button>
+        <button onClick={lambda -> None { set_theme("light"); }}>
+            Light
+        </button>
+    </div>;
 }
 ```
 
@@ -347,71 +347,71 @@ cl {
 ### Loading State Pattern
 
 ```jac
-cl {
-    def:pub DataComponent() -> JsxElement {
-        has data: any = None;
-        has loading: bool = True;
-        has error: str = "";
+to cl:
 
-        # ... fetch data ...
+def:pub DataComponent() -> JsxElement {
+    has data: any = None;
+    has loading: bool = True;
+    has error: str = "";
 
-        if loading {
-            return <div className="spinner">Loading...</div>;
-        }
+    # ... fetch data ...
 
-        if error {
-            return <div className="error">{error}</div>;
-        }
-
-        return <div>{data}</div>;
+    if loading {
+        return <div className="spinner">Loading...</div>;
     }
+
+    if error {
+        return <div className="error">{error}</div>;
+    }
+
+    return <div>{data}</div>;
 }
 ```
 
 ### Form State Pattern
 
 ```jac
-cl {
-    def:pub ContactForm() -> JsxElement {
-        has form_data: dict = {
-            "name": "",
-            "email": "",
-            "message": ""
-        };
-        has errors: dict = {};
-        has submitting: bool = False;
+to cl:
 
-        def update_field(field: str, value: str) -> None {
-            form_data = {**form_data, field: value};
-        }
+def:pub ContactForm() -> JsxElement {
+    has form_data: dict = {
+        "name": "",
+        "email": "",
+        "message": ""
+    };
+    has errors: dict = {};
+    has submitting: bool = False;
 
-        def validate() -> bool {
-            new_errors = {};
-            if not form_data["name"] {
-                new_errors["name"] = "Name is required";
-            }
-            if "@" not in form_data["email"] {
-                new_errors["email"] = "Invalid email";
-            }
-            errors = new_errors;
-            return len(new_errors) == 0;
-        }
-
-        def handle_submit() -> None {
-            if validate() {
-                submitting = True;
-                # ... submit form ...
-            }
-        }
-
-        return <form>
-            <input
-                value={form_data["name"]}
-                onChange={lambda e: ChangeEvent { update_field("name", e.target.value); }}
-            />
-            {errors.get("name") and <span className="error">{errors["name"]}</span>}
-        </form>;
+    def update_field(field: str, value: str) -> None {
+        form_data = {**form_data, field: value};
     }
+
+    def validate() -> bool {
+        new_errors = {};
+        if not form_data["name"] {
+            new_errors["name"] = "Name is required";
+        }
+        if "@" not in form_data["email"] {
+            new_errors["email"] = "Invalid email";
+        }
+        errors = new_errors;
+        return len(new_errors) == 0;
+    }
+
+    def handle_submit() -> None {
+        if validate() {
+            submitting = True;
+            # ... submit form ...
+        }
+    }
+
+    return <form>
+        <input
+            value={form_data["name"]}
+            onChange={lambda e: ChangeEvent { update_field("name", e.target.value); }}
+        />
+        {errors.get("name") and <span className="error">{errors["name"]}</span>}
+    </form>;
 }
 ```
 

--- a/docs/docs/tutorials/native/chess.md
+++ b/docs/docs/tutorials/native/chess.md
@@ -1,6 +1,6 @@
 # Build a Chess Engine
 
-> **Prerequisites:** Familiarity with [Native Compilation](../../reference/language/native-pathway.md) basics -- `na {}` blocks, `.na.jac` files, and `with entry {}`.
+> **Prerequisites:** Familiarity with [Native Compilation](../../reference/language/native-pathway.md) basics -- `to na:` sections (or `.na.jac` files) and `with entry {}`.
 
 In this tutorial you will explore a fully playable chess engine written in idiomatic Jac, run it on the native compilation pathway, and compile it to a standalone binary. Along the way you will learn:
 

--- a/docs/scripts/validate_docs_code.jac
+++ b/docs/scripts/validate_docs_code.jac
@@ -117,7 +117,8 @@ def validate_code_blocks(code_blocks: list[CodeBlock]) -> list[ValidationResult]
                     for line in output.split("\n")
                     if filename in line or temp_path in line
                 ];
-                has_error = any("error" in line.lower() for line in file_errors);
+                error_pattern = re.compile(r"error\[E\d+\]|\b[1-9]\d* error");
+                has_error = any(error_pattern.search(line) for line in file_errors);
                 results.append(
                     ValidationResult(
                         code_block=block,


### PR DESCRIPTION
## Summary
Documents the section-header syntax introduced in #5536 across the mkdocs site. The new `to cl:` / `to sv:` / `to na:` form is now the preferred way to tag a module-scope codespace; the single-statement prefix (`cl stmt`) is unchanged; the legacy `cl { ... }` braced block is preserved as valid for inner-scope overrides but flagged as W0064 at module scope.

- **Reference / language:** primitives codespace model rewritten around section headers (diagram, table, new "Section headers (preferred)" + "Statement prefix and braced block" subsections); appendices grammar summary adds the `"to" (cl|sv|na) ":"` production; native-pathway renames "Native Blocks" → "Native Sections" and converts all examples; foundation.md interop example updated; functions-objects C-import prose updated; diagnostics.md gains a W0064 row.
- **Reference / plugins / client:** intro, `.cl.jac` convention note, and the Client Blocks → Client Sections section are rewritten; all 43 example blocks converted; prose about `has` reactive state updated to cover all three forms.
- **Reference / index + config + internals:** codespace-example blocks and alias/paths examples converted.
- **Quick-guide:** codespace table, what-makes-jac-different cheatsheet + intro diagram, jac-vs-traditional-stack opening prose, and syntax-cheatsheet examples converted.
- **Community:** new Version 0.13.6 entry in breaking-changes.md with migration example and note that `jac format` auto-rewrites.
- **Tutorials:** 70 module-level braced blocks across `fullstack/{setup,auth,routing,npm-and-libraries,state,components,backend}.md`, `first-app/build-ai-day-planner.md`, and `native/chess.md` converted to section headers.

## Scope preserved intentionally
- One pedagogical `cl { # W0064: prefer to cl: at module level }` example in primitives.md demonstrating the warning.
- Historical v0.9.7 → v0.9.8 migration examples in breaking-changes.md (describing a past change; rewriting would distort the historical record).

## Test plan
- [ ] `mkdocs serve` locally; spot-check primitives, appendices, native-pathway, jac-client, syntax-cheatsheet, and one fullstack tutorial (e.g. `routing.md`) render cleanly with no orphaned closing braces or dead indentation.
- [ ] Verify rendered code-fence content for `to cl:` blocks parses (optional: run `jac check` on representative snippets).
- [ ] Confirm the Version 0.13.6 breaking-changes entry is reachable from the ToC.