### PR TITLE
Add Redis Streams, Lists, and distributed locks to jac-scale Db class

### DIFF
--- a/docs/docs/community/release_notes/jac-scale.md
+++ b/docs/docs/community/release_notes/jac-scale.md
@@ -4,6 +4,9 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-scale 0.2.12 (Unreleased)
 
+- **Fix: Warm-started sandbox pods killed immediately by cleanup loop**: `cleanup_expired()` used the pod's K8s `creation_timestamp` to calculate age for TTL expiry. For warm-started sandboxes, the pod was pre-created in the warm pool (often 30+ minutes before being claimed), so it appeared expired the moment it started serving. Now uses the registry's `created_at` (set at claim time) for pods with `jac-sandbox-pool=active`, so TTL counts from when the sandbox actually started, not when the warm pod was pre-created.
+- **Fix: Sandbox pod restart policy changed to Always**: Cold-start and warm-pool pod specs now use `restart_policy="Always"` instead of `"Never"`, so if the `jac start --dev` process exits unexpectedly (e.g. uncaught exception during HMR recompilation), K8s restarts the container automatically instead of permanently killing the pod.
+
 ## jac-scale 0.2.11 (Latest Release)
 
 - **Fix: Sandbox status returns stale RUNNING for dead pods**: `KubernetesSandbox.status()` was returning the cached registry state (often `RUNNING`) when `read_namespaced_pod_status()` threw an exception (pod deleted or unreachable). This caused callers to believe the sandbox was still alive, preventing recovery. Now returns `STOPPED` when the pod query fails so dead pods are detected immediately.

--- a/jac-scale/jac_scale/abstractions/sandbox_environment.jac
+++ b/jac-scale/jac_scale/abstractions/sandbox_environment.jac
@@ -30,6 +30,7 @@ obj SandboxEnvironment {
     has config: SandboxConfig,
         logger: (Logger | None) = None;
 
+    # --- Legacy API (v1) — maintains internal registry ---
     def create(user_id: str, project_id: str, code_path: str) -> SandboxResult;
     def stop(sandbox_id: str) -> None;
     def status(sandbox_id: str) -> SandboxStatus;
@@ -42,4 +43,14 @@ obj SandboxEnvironment {
     def delete_file(sandbox_id: str, path: str) -> dict;
     def list_files(sandbox_id: str, path: str = ".") -> dict;
     def exec_command(sandbox_id: str, command: str, timeout: int = 30) -> dict;
+
+    # --- Stateless API (v2) — caller manages state externally ---
+    # These methods perform K8s operations without touching internal registry.
+    # Used by jac-builder's sandbox_reconciler for graph-based state management.
+    def create_with_rollback(sandbox_id: str, user_id: str, project_id: str, code_path: str) -> SandboxResult;
+    def cleanup_resources(sandbox_id: str, pod_name: str = "", warm_start: bool = False) -> None;
+    def query_pod_status(sandbox_id: str) -> SandboxStatus;
+    def list_all_sandbox_pods -> list[dict];
+    def count_warm_pods -> int;
+    def claim_warm_pod_v2(sandbox_id: str, user_id: str, project_id: str) -> (str | None);
 }

--- a/jac-scale/jac_scale/admin/impl/admin_portal.impl.jac
+++ b/jac-scale/jac_scale/admin/impl/admin_portal.impl.jac
@@ -1179,31 +1179,20 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
         logger.debug("Admin client already built");
         return True;
     }
-    # Get admin UI source directory (may be in read-only site-packages)
+    # Get admin UI source directory
     import from jac_scale.admin { admin_portal }
-    import shutil;
-    import tempfile;
     admin_dir = Path(admin_portal.__file__).parent;
-    ui_src = admin_dir / "ui";
-    if not (ui_src / "main.jac").exists() {
-        logger.error(f"Admin UI source not found at {ui_src}");
+    ui_dir = admin_dir / "ui";
+    if not (ui_dir / "main.jac").exists() {
+        logger.error(f"Admin UI source not found at {ui_dir}");
         return False;
     }
     logger.info("Building admin client...");
     try {
-        # Copy source to a writable location so jac build can create
-        # .jac/ artifacts (site-packages is read-only for non-root users)
-        import os;
-        build_root = Path(os.getcwd()) / ".jac" / "admin_build";
-        if build_root.exists() {
-            shutil.rmtree(build_root);
-        }
-        shutil.copytree(ui_src, build_root);
-
-        # Run jac build in the writable copy
+        # Run jac build in the UI directory
         result = subprocess.run(
             ["jac", "build", "main.jac"],
-            cwd=str(build_root),
+            cwd=str(ui_dir),
             capture_output=True,
             text=True,
             timeout=300
@@ -1215,8 +1204,9 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
         }
 
         # Copy built files to .jac/admin
-        ui_dist = build_root / ".jac" / "client" / "dist";
+        ui_dist = ui_dir / ".jac" / "client" / "dist";
         if ui_dist.exists() {
+            import shutil;
             dist_dir.mkdir(parents=True, exist_ok=True);
             for item in ui_dist.iterdir() {
                 dest = dist_dir / item.name;
@@ -1230,9 +1220,6 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
                 }
             }
         }
-
-        # Clean up the build copy
-        shutil.rmtree(build_root, ignore_errors=True);
 
         logger.info("Admin client built successfully");
         return True;

--- a/jac-scale/jac_scale/admin/impl/admin_portal.impl.jac
+++ b/jac-scale/jac_scale/admin/impl/admin_portal.impl.jac
@@ -1179,20 +1179,31 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
         logger.debug("Admin client already built");
         return True;
     }
-    # Get admin UI source directory
+    # Get admin UI source directory (may be in read-only site-packages)
     import from jac_scale.admin { admin_portal }
+    import shutil;
+    import tempfile;
     admin_dir = Path(admin_portal.__file__).parent;
-    ui_dir = admin_dir / "ui";
-    if not (ui_dir / "main.jac").exists() {
-        logger.error(f"Admin UI source not found at {ui_dir}");
+    ui_src = admin_dir / "ui";
+    if not (ui_src / "main.jac").exists() {
+        logger.error(f"Admin UI source not found at {ui_src}");
         return False;
     }
     logger.info("Building admin client...");
     try {
-        # Run jac build in the UI directory
+        # Copy source to a writable location so jac build can create
+        # .jac/ artifacts (site-packages is read-only for non-root users)
+        import os;
+        build_root = Path(os.getcwd()) / ".jac" / "admin_build";
+        if build_root.exists() {
+            shutil.rmtree(build_root);
+        }
+        shutil.copytree(ui_src, build_root);
+
+        # Run jac build in the writable copy
         result = subprocess.run(
             ["jac", "build", "main.jac"],
-            cwd=str(ui_dir),
+            cwd=str(build_root),
             capture_output=True,
             text=True,
             timeout=300
@@ -1204,9 +1215,8 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
         }
 
         # Copy built files to .jac/admin
-        ui_dist = ui_dir / ".jac" / "client" / "dist";
+        ui_dist = build_root / ".jac" / "client" / "dist";
         if ui_dist.exists() {
-            import shutil;
             dist_dir.mkdir(parents=True, exist_ok=True);
             for item in ui_dist.iterdir() {
                 dest = dist_dir / item.name;
@@ -1220,6 +1230,9 @@ impl JacAPIServerAdmin.build_admin_client(force: bool = False) -> bool {
                 }
             }
         }
+
+        # Clean up the build copy
+        shutil.rmtree(build_root, ignore_errors=True);
 
         logger.info("Admin client built successfully");
         return True;

--- a/jac-scale/jac_scale/db.jac
+++ b/jac-scale/jac_scale/db.jac
@@ -219,4 +219,54 @@ obj Db {
     def find_nodes(
         node_type: str, filter: dict = {}, col_name: str = '_anchors'
     ) -> list;
+
+    # ===== REDIS STREAMS (cross-service event delivery) =====
+    # Keys are raw (no namespace) — shared between independent services.
+
+    """Append fields to a Redis Stream. Returns entry ID (e.g. '1713100000-0')."""
+    def xadd(stream: str, fields: dict, maxlen: int = 0, approximate: bool = True) -> str;
+
+    """Blocking read from one or more streams.
+    streams: {stream_name: last_seen_id} — use '0-0' to read from start.
+    Returns list of (stream_name, [(entry_id, fields_dict), ...])."""
+    def xread(streams: dict, count: int = 100, block: int = 0) -> list;
+
+    """Read entries in an ID range from a stream."""
+    def xrange(stream: str, min_id: str = "-", max_id: str = "+", count: int = 100) -> list;
+
+    """Trim stream to maxlen entries. Returns number of entries removed."""
+    def xtrim(stream: str, maxlen: int, approximate: bool = True) -> int;
+
+    """Get number of entries in a stream."""
+    def xlen(stream: str) -> int;
+
+    """Delete an entire stream key."""
+    def xdel_stream(stream: str) -> bool;
+
+    # ===== REDIS LISTS (cross-service job queue) =====
+
+    """Push value to head of list. Returns new list length."""
+    def lpush(key: str, value: str) -> int;
+
+    """Blocking pop from tail of one or more lists.
+    Returns (key, value) tuple or None on timeout."""
+    def brpop(keys: list, timeout: int = 0) -> tuple | None;
+
+    """Get list length."""
+    def llen(key: str) -> int;
+
+    # ===== REDIS DISTRIBUTED LOCKS =====
+
+    """Acquire a distributed lock (SET key value NX EX ttl).
+    value should be a unique owner ID (e.g. worker UUID).
+    Returns True if lock was acquired."""
+    def acquire_lock(key: str, value: str, ttl: int = 30) -> bool;
+
+    """Release a distributed lock atomically.
+    Only releases if current value matches (prevents releasing another owner's lock).
+    Returns True if lock was released."""
+    def release_lock(key: str, value: str) -> bool;
+
+    """Refresh lock TTL without releasing. Returns True if refreshed."""
+    def refresh_lock(key: str, value: str, ttl: int = 30) -> bool;
 }

--- a/jac-scale/jac_scale/impl/db.impl.jac
+++ b/jac-scale/jac_scale/impl/db.impl.jac
@@ -328,6 +328,153 @@ def get_db -> Db {
     );
 }
 
+# ===== REDIS STREAMS =====
+
+"""Decode bytes to str if needed."""
+def _decode(val: object) -> object {
+    if isinstance(val, bytes) {
+        return val.decode("utf-8");
+    }
+    return val;
+}
+
+"""Lua script: release lock only if value matches owner."""
+glob _RELEASE_LOCK_LUA: str = "if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('del',KEYS[1]) else return 0 end";
+
+"""Lua script: refresh lock TTL only if value matches owner."""
+glob _REFRESH_LOCK_LUA: str = "if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('expire',KEYS[1],ARGV[2]) else return 0 end";
+
+impl Db.xadd(stream: str, fields: dict, maxlen: int = 0, approximate: bool = True) -> str {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("xadd() is Redis-only. Streams are not supported on MongoDB.");
+    }
+    kwargs: dict = {};
+    if maxlen > 0 {
+        kwargs["maxlen"] = maxlen;
+        kwargs["approximate"] = approximate;
+    }
+    result = self.client.xadd(stream, fields, **kwargs);
+    return _decode(result);
+}
+
+impl Db.xread(streams: dict, count: int = 100, block: int = 0) -> list {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("xread() is Redis-only. Streams are not supported on MongoDB.");
+    }
+    raw = self.client.xread(streams, count=count, block=block);
+    if not raw {
+        return [];
+    }
+    decoded: list = [];
+    for item in raw {
+        s_name = _decode(item[0]);
+        d_entries: list = [];
+        for entry in item[1] {
+            e_id = _decode(entry[0]);
+            d_fields: dict = {};
+            for k in entry[1] {
+                d_fields[_decode(k)] = _decode(entry[1][k]);
+            }
+            d_entries.append((e_id, d_fields));
+        }
+        decoded.append((s_name, d_entries));
+    }
+    return decoded;
+}
+
+impl Db.xrange(stream: str, min_id: str = "-", max_id: str = "+", count: int = 100) -> list {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("xrange() is Redis-only. Streams are not supported on MongoDB.");
+    }
+    raw = self.client.xrange(stream, min=min_id, max=max_id, count=count);
+    decoded: list = [];
+    for entry in raw {
+        e_id = _decode(entry[0]);
+        d_fields: dict = {};
+        for k in entry[1] {
+            d_fields[_decode(k)] = _decode(entry[1][k]);
+        }
+        decoded.append((e_id, d_fields));
+    }
+    return decoded;
+}
+
+impl Db.xtrim(stream: str, maxlen: int, approximate: bool = True) -> int {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("xtrim() is Redis-only. Streams are not supported on MongoDB.");
+    }
+    return self.client.xtrim(stream, maxlen=maxlen, approximate=approximate);
+}
+
+impl Db.xlen(stream: str) -> int {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("xlen() is Redis-only. Streams are not supported on MongoDB.");
+    }
+    return self.client.xlen(stream);
+}
+
+impl Db.xdel_stream(stream: str) -> bool {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("xdel_stream() is Redis-only. Streams are not supported on MongoDB.");
+    }
+    return self.client.delete(stream) > 0;
+}
+
+# ===== REDIS LISTS =====
+
+impl Db.lpush(key: str, value: str) -> int {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("lpush() is Redis-only. Lists are not supported on MongoDB.");
+    }
+    return self.client.lpush(key, value);
+}
+
+impl Db.brpop(keys: list, timeout: int = 0) -> tuple | None {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("brpop() is Redis-only. Lists are not supported on MongoDB.");
+    }
+    result = self.client.brpop(keys, timeout=timeout);
+    if result is None {
+        return None;
+    }
+    return (_decode(result[0]), _decode(result[1]));
+}
+
+impl Db.llen(key: str) -> int {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("llen() is Redis-only. Lists are not supported on MongoDB.");
+    }
+    return self.client.llen(key);
+}
+
+# ===== REDIS DISTRIBUTED LOCKS =====
+
+impl Db.acquire_lock(key: str, value: str, ttl: int = 30) -> bool {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("acquire_lock() is Redis-only.");
+    }
+    result = self.client.set(key, value, nx=True, ex=ttl);
+    return result is True;
+}
+
+impl Db.release_lock(key: str, value: str) -> bool {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("release_lock() is Redis-only.");
+    }
+    result = self.client.eval(_RELEASE_LOCK_LUA, 1, key, value);
+    return int(result) == 1;
+}
+
+impl Db.refresh_lock(key: str, value: str, ttl: int = 30) -> bool {
+    if self.db_type != DatabaseType.REDIS {
+        raise NotImplementedError("refresh_lock() is Redis-only.");
+    }
+    result = self.client.eval(_REFRESH_LOCK_LUA, 1, key, value, str(ttl));
+    return int(result) == 1;
+}
+
+# ===== UTILITY =====
+
 impl Db.find_nodes(
     node_type: str, filter: dict = {}, col_name: str = '_anchors'
 ) -> list {

--- a/jac-scale/jac_scale/impl/job_queue.impl.jac
+++ b/jac-scale/jac_scale/impl/job_queue.impl.jac
@@ -1,0 +1,17 @@
+"""JobQueue implementation."""
+
+impl JobQueue.submit(payload: dict) -> int {
+    return self.db.lpush(self.queue_key, json.dumps(payload));
+}
+
+impl JobQueue.consume(timeout: int = 5) -> dict | None {
+    result = self.db.brpop([self.queue_key], timeout=timeout);
+    if result is None {
+        return None;
+    }
+    return json.loads(result[1]);
+}
+
+impl JobQueue.depth() -> int {
+    return self.db.llen(self.queue_key);
+}

--- a/jac-scale/jac_scale/impl/streams.impl.jac
+++ b/jac-scale/jac_scale/impl/streams.impl.jac
@@ -1,0 +1,41 @@
+"""EventStream implementation."""
+
+impl EventStream.publish(event: dict) -> str {
+    return self.db.xadd(
+        self.stream_key,
+        {"data": json.dumps(event)},
+        maxlen=self.max_size,
+        approximate=True
+    );
+}
+
+impl EventStream.read_new(last_id: str = "0-0", count: int = 100, block_ms: int = 0) -> tuple {
+    result = self.db.xread(
+        {self.stream_key: last_id},
+        count=count,
+        block=block_ms
+    );
+    events: list = [];
+    new_last_id = last_id;
+    for item in result {
+        for entry in item[1] {
+            (entry_id, fields) = entry;
+            data_str = fields.get("data", "{}");
+            events.append(json.loads(data_str));
+            new_last_id = entry_id;
+        }
+    }
+    return (events, new_last_id);
+}
+
+impl EventStream.trim() -> int {
+    return self.db.xtrim(self.stream_key, self.max_size);
+}
+
+impl EventStream.length() -> int {
+    return self.db.xlen(self.stream_key);
+}
+
+impl EventStream.clear() -> None {
+    self.db.xdel_stream(self.stream_key);
+}

--- a/jac-scale/jac_scale/job_queue.jac
+++ b/jac-scale/jac_scale/job_queue.jac
@@ -1,0 +1,23 @@
+"""JobQueue — Redis List-backed job queue for cross-service work distribution.
+
+Producer calls submit() to enqueue jobs (LPUSH).
+Consumer calls consume() to dequeue jobs (BRPOP — blocking pop from tail).
+"""
+import json;
+import from jac_scale.db { Db }
+
+
+obj JobQueue {
+    has queue_key: str = "ai:jobs",
+        db: Db;
+
+    """Submit a job payload dict. Returns current queue depth."""
+    def submit(payload: dict) -> int;
+
+    """Blocking consume — waits up to timeout seconds for a job.
+    Returns the job payload dict, or None if timeout expires."""
+    def consume(timeout: int = 5) -> dict | None;
+
+    """Current number of jobs waiting in the queue."""
+    def depth() -> int;
+}

--- a/jac-scale/jac_scale/providers/proxy/sandbox_proxy.jac
+++ b/jac-scale/jac_scale/providers/proxy/sandbox_proxy.jac
@@ -46,7 +46,12 @@ async def watch_pods -> None {
                 pod = event["object"];
                 pod_ip = pod.status.pod_ip if pod.status else None;
                 labels = pod.metadata.labels or {};
-                sandbox_id = labels.get("jac-sandbox-id", pod.metadata.name);
+                sandbox_id = labels.get("jac-sandbox-id", "");
+                if not sandbox_id {
+                    # Warm pool pod (no sandbox-id label) — not routable, skip.
+                    # Also handle DELETED for pods that were warm when deleted.
+                    continue;
+                }
 
                 if etype == "DELETED" {
                     if routes.pop(sandbox_id, None) {

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -486,8 +486,6 @@ obj KubernetesSandbox(SandboxEnvironment) {
     }
 
     def _ensure_warm_pool -> None {
-        """Ensure the warm pool has enough idle pods. Stateless — queries K8s
-        directly, no local pool list. Safe for multi-pod horizontal scaling."""
         if self.config.warm_pool_size <= 0 {
             return;
         }
@@ -525,9 +523,6 @@ obj KubernetesSandbox(SandboxEnvironment) {
     }
 
     def _claim_warm_pod(sandbox_id: str, user_id: str, project_id: str) -> (str | None) {
-        """Claim a warm pod from the K8s pool. Fully stateless — no local pool
-        list, queries K8s directly. Iterates candidates so if one is taken by
-        another instance, we try the next. Safe for multi-pod horizontal scaling."""
         import from kubernetes { client }
         core_v1 = client.CoreV1Api();
         namespace = self.config.namespace;

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -500,21 +500,46 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 namespace,
                 label_selector=f"{_SANDBOX_LABEL}=true,jac-sandbox-pool=warm"
             );
-            warm_count = 0;
+            # Build set of pods that are ACTUALLY still warm (fresh K8s read).
+            # K8s list API may return stale labels, and our local _warm_pool
+            # may contain pods claimed by other jac-builder instances.
+            verified_warm: list = [];
             for p in existing.items {
-                if p.status.phase in ["Pending", "Running"] {
-                    warm_count += 1;
-                    # Track in our pool list
-                    pn = p.metadata.name;
-                    self._lock.acquire();
-                    try {
-                        if pn not in self._warm_pool {
-                            self._warm_pool.append(pn);
-                        }
-                    } finally {
-                        self._lock.release();
+                pn = p.metadata.name;
+                # CRITICAL: Fresh individual read to bypass stale list cache.
+                # Another jac-builder pod may have claimed this warm pod (patched
+                # labels to pool=active + sandbox-id). Without this fresh check,
+                # we'd re-add it to our local pool → duplicate claim → cross-user leak.
+                try {
+                    fresh_pod = core_v1.read_namespaced_pod(pn, namespace);
+                    fresh_labels = fresh_pod.metadata.labels or {};
+                    if fresh_labels.get("jac-sandbox-pool") != "warm" or fresh_labels.get("jac-sandbox-id") {
+                        continue;
+                    }
+                    if fresh_pod.status.phase not in ["Pending", "Running"] {
+                        continue;
+                    }
+                } except Exception {
+                    continue;
+                }
+                verified_warm.append(pn);
+            }
+
+            # Rebuild local pool: remove claimed pods, add newly discovered ones
+            warm_count = len(verified_warm);
+            verified_set = set(verified_warm);
+            self._lock.acquire();
+            try {
+                # Remove pods that are no longer warm (claimed by another instance)
+                self._warm_pool = [p for p in self._warm_pool if p in verified_set];
+                # Add any newly discovered warm pods
+                for pn in verified_warm {
+                    if pn not in self._warm_pool {
+                        self._warm_pool.append(pn);
                     }
                 }
+            } finally {
+                self._lock.release();
             }
 
             # Create pods to reach target size
@@ -557,9 +582,22 @@ obj KubernetesSandbox(SandboxEnvironment) {
             core_v1 = client.CoreV1Api();
             namespace = self.config.namespace;
 
-            # Verify pod is still running
+            # Verify pod is still running AND still warm (not claimed by another pod).
+            # In multi-pod deployments, another jac-builder instance may have
+            # claimed this pod between our pool pop and this K8s read.
             pod = core_v1.read_namespaced_pod_status(pod_name, namespace);
             if pod.status.phase not in ["Pending", "Running"] {
+                return None;
+            }
+            pod_labels = pod.metadata.labels or {};
+            if pod_labels.get("jac-sandbox-pool") != "warm" or pod_labels.get("jac-sandbox-id") {
+                if self.logger {
+                    self.logger.warn(
+                        f"Warm pod {pod_name} already claimed by another instance "
+                        f"(pool={pod_labels.get('jac-sandbox-pool')}, "
+                        f"sid={pod_labels.get('jac-sandbox-id')})"
+                    );
+                }
                 return None;
             }
 
@@ -576,10 +614,40 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 }
             };
             core_v1.patch_namespaced_pod(pod_name, namespace, body);
+
+            # Verify our claim succeeded — another pod may have patched
+            # the same warm pod simultaneously, overwriting our labels.
+            verified = core_v1.read_namespaced_pod(pod_name, namespace);
+            actual_sid = (verified.metadata.labels or {}).get("jac-sandbox-id", "");
+            if actual_sid != sandbox_id {
+                if self.logger {
+                    self.logger.warn(
+                        f"Warm pod {pod_name} claimed by another instance "
+                        f"(expected {sandbox_id}, got {actual_sid})"
+                    );
+                }
+                return None;
+            }
             return pod_name;
         } except Exception as e {
             if self.logger {
                 self.logger.warn(f"Failed to claim warm pod {pod_name}: {str(e)}");
+            }
+            # Return pod to pool if it's still warm in K8s
+            try {
+                pod_check = core_v1.read_namespaced_pod(pod_name, namespace);
+                if (pod_check.metadata.labels or {}).get("jac-sandbox-pool") == "warm" {
+                    self._lock.acquire();
+                    try {
+                        if pod_name not in self._warm_pool {
+                            self._warm_pool.append(pod_name);
+                        }
+                    } finally {
+                        self._lock.release();
+                    }
+                }
+            } except Exception {
+                x = 0;
             }
             return None;
         }
@@ -640,6 +708,26 @@ obj KubernetesSandbox(SandboxEnvironment) {
             chunks = [
                 encoded[i:i + chunk_size] for i in range(0, len(encoded), chunk_size)
             ];
+
+            # Kill any stale processes and wipe caches from a previous user's
+            # session. Warm pods may have leftover Vite/jac processes that serve
+            # cached content from the prior claim — a cross-user data leak.
+            stream(
+                core_v1.connect_get_namespaced_pod_exec,
+                pod_name,
+                namespace,
+                container="sandbox",
+                command=[
+                    "sh", "-c",
+                    "pkill -f 'jac start' 2>/dev/null || true; "
+                    "pkill -f 'node.*vite' 2>/dev/null || true; "
+                    "rm -rf /app/* /app/.* /tmp/code.* /tmp/.vite* 2>/dev/null || true"
+                ],
+                stderr=True,
+                stdout=True,
+                stdin=False,
+                tty=False
+            );
 
             # Write chunks to a temp file inside the pod, then extract
             stream(

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -709,9 +709,12 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 encoded[i:i + chunk_size] for i in range(0, len(encoded), chunk_size)
             ];
 
-            # Kill any stale processes and wipe caches from a previous user's
-            # session. Warm pods may have leftover Vite/jac processes that serve
-            # cached content from the prior claim — a cross-user data leak.
+            # Kill stale processes from a previous user's session, wait for
+            # them to die, then wipe ALL user data. This is a single atomic
+            # shell script — no round-trips between steps, no race windows.
+            # SIGKILL (not SIGTERM) ensures immediate death, and the port-free
+            # loop guarantees the old process has fully released port 8000
+            # before we proceed with code injection.
             stream(
                 core_v1.connect_get_namespaced_pod_exec,
                 pod_name,
@@ -719,9 +722,15 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 container="sandbox",
                 command=[
                     "sh", "-c",
-                    "pkill -f 'jac start' 2>/dev/null || true; "
-                    "pkill -f 'node.*vite' 2>/dev/null || true; "
-                    "rm -rf /app/* /app/.* /tmp/code.* /tmp/.vite* 2>/dev/null || true"
+                    "pkill -9 -f 'jac start' 2>/dev/null || true; "
+                    "pkill -9 -f 'node.*vite' 2>/dev/null || true; "
+                    "pkill -9 -f 'bun' 2>/dev/null || true; "
+                    "for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do "
+                    "  if ! ss -tlnp 2>/dev/null | grep -q ':8000 ' && "
+                    "     ! ss -tlnp 2>/dev/null | grep -q ':8001 '; then break; fi; "
+                    "  sleep 0.25; "
+                    "done; "
+                    "rm -rf /app/* /app/.* /tmp/* /tmp/.* 2>/dev/null || true"
                 ],
                 stderr=True,
                 stdout=True,
@@ -933,7 +942,13 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     # Inject code into the warm pod
                     injected = self._inject_code(claimed_pod, code_path);
                     if not injected {
-                        self._cleanup_k8s_resources(sandbox_id, namespace);
+                        # Delete the warm pod directly by name — _cleanup_k8s_resources
+                        # looks up _registry which has no entry yet (created after injection).
+                        try {
+                            core_v1.delete_namespaced_pod(claimed_pod, namespace);
+                        } except Exception {
+                            ;
+                        }
                         return SandboxResult(
                             success=False,
                             message="Failed to inject code into warm pod"

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -660,8 +660,7 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     "pkill -9 -f 'jac start' 2>/dev/null || true; "
                     "pkill -9 -f 'node.*vite' 2>/dev/null || true; "
                     "pkill -9 -f 'bun' 2>/dev/null || true; "
-                    "find /app -mindepth 1 -not -path '/app/.jac/admin*' -delete 2>/dev/null || true; "
-                    "rm -rf /tmp/* /tmp/.* 2>/dev/null || true"
+                    "rm -rf /app/* /app/.* /tmp/* /tmp/.* 2>/dev/null || true"
                 ],
                 stderr=True,
                 stdout=True,

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -1212,14 +1212,23 @@ obj KubernetesSandbox(SandboxEnvironment) {
             # created_at (claim time) instead of the pod's K8s creation
             # timestamp. The pod was pre-created in the warm pool and may
             # be much older than the active sandbox session.
+            # In multi-pod deployments, the registry only exists on the pod
+            # that created the sandbox — other pods must NOT delete it.
             is_claimed_warm = pod.metadata.labels.get("jac-sandbox-pool") == "active"
                 if pod.metadata.labels
                 else False;
-            registry_key_tmp = self._find_registry_key(pod_name);
-            reg_rec = self._registry.get(registry_key_tmp) if registry_key_tmp else None;
-            if is_claimed_warm and reg_rec {
-                reg_d: dict = dict(reg_rec);
-                age = now - float(reg_d.get("created_at", now));
+            if is_claimed_warm {
+                registry_key_tmp = self._find_registry_key(pod_name);
+                reg_rec = self._registry.get(registry_key_tmp) if registry_key_tmp else None;
+                if reg_rec {
+                    # This pod created the sandbox — use claim time for TTL
+                    reg_d: dict = dict(reg_rec);
+                    age = now - float(reg_d.get("created_at", now));
+                } else {
+                    # Another pod created this sandbox — skip it, don't delete
+                    live_pod_names.add(pod_name);
+                    continue;
+                }
             } else {
                 created: Any = pod.metadata.creation_timestamp;
                 if created {

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -660,7 +660,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     "pkill -9 -f 'jac start' 2>/dev/null || true; "
                     "pkill -9 -f 'node.*vite' 2>/dev/null || true; "
                     "pkill -9 -f 'bun' 2>/dev/null || true; "
-                    "rm -rf /app/* /app/.* /tmp/* /tmp/.* 2>/dev/null || true"
+                    "find /app -mindepth 1 -not -path '/app/.jac/admin*' -delete 2>/dev/null || true; "
+                    "rm -rf /tmp/* /tmp/.* 2>/dev/null || true"
                 ],
                 stderr=True,
                 stdout=True,

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -678,6 +678,7 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     "sh",
                     "-c",
                     "base64 -d /tmp/code.b64 > /tmp/code.tar.gz && "
+                    "rm -rf /app/* && "
                     "tar xzf /tmp/code.tar.gz -C /app && "
                     "rm -f /tmp/code.b64 /tmp/code.tar.gz"
                 ],

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -1560,5 +1560,278 @@ obj KubernetesSandbox(SandboxEnvironment) {
         }
         return None;
     }
+
+    # ================================================================
+    # Stateless API (v2) — used by jac-builder's sandbox_reconciler.
+    #
+    # These methods have NO internal state: no _registry, no _lock,
+    # no _warm_pool. The caller (jac-builder) manages state via
+    # SandboxInstance graph nodes in MongoDB.
+    # ================================================================
+
+    def create_with_rollback(sandbox_id: str, user_id: str, project_id: str, code_path: str) -> SandboxResult {
+        """Create K8s resources for a sandbox with automatic rollback on failure.
+
+        Unlike create(), this method:
+        - Takes sandbox_id as a parameter (caller generates deterministic ID)
+        - Does NOT update _registry (caller manages state)
+        - Does NOT enforce max_per_user (caller handles this)
+        - Does NOT start cleanup loop or warm pool (reconciler handles this)
+        - DOES rollback partial resources on failure
+        """
+        try {
+            self._init_k8s();
+            self._ensure_namespace();
+            self._ensure_rbac();
+        } except Exception as e {
+            return SandboxResult(success=False, message=f"K8s init failed: {str(e)}");
+        }
+
+        import from kubernetes { client }
+        import from kubernetes.client.exceptions { ApiException }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
+        created_resources: list = [];
+
+        try {
+            # 1. Create ConfigMap
+            cm_name = self._create_configmap(sandbox_id, code_path, namespace);
+            created_resources.append(("configmap", cm_name));
+
+            # 2. Create Pod
+            pod_spec = self._build_pod_spec(sandbox_id, cm_name, user_id, project_id);
+            core_v1.create_namespaced_pod(namespace, pod_spec);
+            created_resources.append(("pod", sandbox_id));
+
+            # 3. Create Service (skip in proxy mode)
+            svc_name = "";
+            if not self.config.proxy_mode {
+                svc_name = self._create_service(sandbox_id, namespace);
+                created_resources.append(("service", svc_name));
+            }
+
+            # 4. Create Ingress route
+            ingress = self._get_ingress_provider();
+            url = ingress.create_route(
+                sandbox_id,
+                svc_name,
+                _INTERNAL_PORT,
+                namespace,
+                {
+                    "domain_template": self.config.domain_template,
+                    "ingress_class": self.config.ingress_class,
+                    "tls_enabled": self.config.tls_enabled,
+                    "tls_issuer": self.config.tls_issuer,
+                    "ingress_annotations": self.config.ingress_annotations
+                }
+            );
+            created_resources.append(("ingress", sandbox_id));
+
+            return SandboxResult(
+                success=True,
+                sandbox_id=sandbox_id,
+                url=url,
+                port=_INTERNAL_PORT,
+                message="cold-starting"
+            );
+        } except Exception as e {
+            # Rollback in reverse order
+            for (rtype, rname) in reversed(created_resources) {
+                self._delete_resource_safe(rtype, rname, namespace);
+            }
+            return SandboxResult(success=False, message=str(e));
+        }
+    }
+
+    def cleanup_resources(sandbox_id: str, pod_name: str = "", warm_start: bool = False) -> None {
+        """Stateless K8s resource cleanup — does NOT touch _registry.
+
+        Called by the reconciler when desired_state transitions to stopped/destroyed.
+        """
+        self._init_k8s();
+        import from kubernetes { client }
+        import from kubernetes.client.exceptions { ApiException }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
+        actual_pod = pod_name or sandbox_id;
+
+        # Delete pod
+        try {
+            core_v1.delete_namespaced_pod(actual_pod, namespace);
+        } except ApiException {
+            x = 0;
+        }
+
+        # Delete service
+        if not self.config.proxy_mode {
+            try {
+                core_v1.delete_namespaced_service(f"{sandbox_id}-svc", namespace);
+            } except ApiException {
+                x = 0;
+            }
+        }
+
+        # Delete configmap (skip for warm-started pods)
+        if not warm_start {
+            try {
+                core_v1.delete_namespaced_config_map(f"{sandbox_id}-code", namespace);
+            } except ApiException {
+                x = 0;
+            }
+        }
+
+        # Delete ingress route
+        try {
+            ingress = self._get_ingress_provider();
+            ingress.delete_route(sandbox_id, namespace);
+        } except Exception {
+            x = 0;
+        }
+    }
+
+    def query_pod_status(sandbox_id: str) -> SandboxStatus {
+        """Stateless pod status query — does NOT touch _registry.
+
+        Returns current K8s pod status directly from the API.
+        """
+        self._init_k8s();
+        import from kubernetes { client }
+        import from kubernetes.client.exceptions { ApiException }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
+
+        try {
+            pod = core_v1.read_namespaced_pod_status(sandbox_id, namespace);
+            phase = str(pod.status.phase);
+            if phase == "Running" {
+                ready = True;
+                if pod.status.container_statuses {
+                    for cs in pod.status.container_statuses {
+                        if not cs.ready {
+                            ready = False;
+                            break;
+                        }
+                    }
+                }
+                if ready {
+                    return SandboxStatus(state=SandboxState.RUNNING, sandbox_id=sandbox_id);
+                }
+                return SandboxStatus(state=SandboxState.STARTING, sandbox_id=sandbox_id);
+            } elif phase == "Pending" {
+                return SandboxStatus(state=SandboxState.PENDING, sandbox_id=sandbox_id);
+            } else {
+                return SandboxStatus(state=SandboxState.ERROR, sandbox_id=sandbox_id,
+                    message=f"Pod phase: {phase}");
+            }
+        } except ApiException as e {
+            if e.status == 404 {
+                return SandboxStatus(state=SandboxState.STOPPED, sandbox_id=sandbox_id,
+                    message="Pod not found");
+            }
+            return SandboxStatus(state=SandboxState.ERROR, sandbox_id=sandbox_id,
+                message=str(e));
+        }
+    }
+
+    def list_all_sandbox_pods -> list[dict] {
+        """List all sandbox pods in the namespace. Used by reconciler for drift detection."""
+        self._init_k8s();
+        import from kubernetes { client }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
+        pods = core_v1.list_namespaced_pod(namespace, label_selector=f"{_SANDBOX_LABEL}=true");
+        result: list[dict] = [];
+        for pod in pods.items {
+            labels = pod.metadata.labels or {};
+            result.append({
+                "name": pod.metadata.name,
+                "sandbox_id": labels.get("jac-sandbox-id", pod.metadata.name),
+                "user_id": labels.get("jac-sandbox-user", ""),
+                "project_id": labels.get("jac-sandbox-project", ""),
+                "phase": str(pod.status.phase) if pod.status else "Unknown",
+                "pool": labels.get("jac-sandbox-pool", ""),
+                "created_at": pod.metadata.creation_timestamp.timestamp() if pod.metadata.creation_timestamp else 0
+            });
+        }
+        return result;
+    }
+
+    def count_warm_pods -> int {
+        """Count warm pool pods via K8s label selector."""
+        self._init_k8s();
+        import from kubernetes { client }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
+        pods = core_v1.list_namespaced_pod(namespace, label_selector="jac-sandbox-pool=warm");
+        return len(pods.items);
+    }
+
+    def claim_warm_pod_v2(sandbox_id: str, user_id: str, project_id: str) -> (str | None) {
+        """Claim a warm pod via atomic K8s label patch. Returns pod_name or None.
+
+        This replaces the in-memory _warm_pool list approach. K8s serializes
+        patches per-resource, so only one caller can successfully relabel
+        a warm pod to active.
+        """
+        self._init_k8s();
+        import from kubernetes { client }
+        import from kubernetes.client.exceptions { ApiException }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
+
+        # List warm pods
+        warm_pods = core_v1.list_namespaced_pod(namespace, label_selector="jac-sandbox-pool=warm");
+        for pod in warm_pods.items {
+            pod_name = pod.metadata.name;
+            if str(pod.status.phase) not in ("Pending", "Running") {
+                continue;
+            }
+            # Attempt atomic relabel: warm → active
+            try {
+                body = {
+                    "metadata": {
+                        "labels": {
+                            "jac-sandbox-pool": "active",
+                            "jac-sandbox-id": sandbox_id,
+                            "jac-sandbox-user": user_id[:63],
+                            "jac-sandbox-project": project_id[:63]
+                        }
+                    }
+                };
+                core_v1.patch_namespaced_pod(pod_name, namespace, body);
+                return pod_name;
+            } except ApiException as e {
+                if e.status == 409 {
+                    # Conflict — another caller claimed this pod
+                    continue;
+                }
+                continue;
+            }
+        }
+        return None;
+    }
+
+    def _delete_resource_safe(rtype: str, rname: str, namespace: str) -> None {
+        """Delete a K8s resource, ignoring not-found errors."""
+        import from kubernetes { client }
+        import from kubernetes.client.exceptions { ApiException }
+        core_v1 = client.CoreV1Api();
+        try {
+            if rtype == "pod" {
+                core_v1.delete_namespaced_pod(rname, namespace);
+            } elif rtype == "service" {
+                core_v1.delete_namespaced_service(rname, namespace);
+            } elif rtype == "configmap" {
+                core_v1.delete_namespaced_config_map(rname, namespace);
+            } elif rtype == "ingress" {
+                ingress = self._get_ingress_provider();
+                ingress.delete_route(rname, namespace);
+            }
+        } except ApiException {
+            x = 0;
+        } except Exception {
+            x = 0;
+        }
+    }
 }
 # 1MB

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -29,7 +29,6 @@ obj KubernetesSandbox(SandboxEnvironment) {
         _k8s_initialized: bool = False,
         _rbac_provisioned: bool = False,
         _ingress_provider: Any = None,
-        _warm_pool: list = [],
         _pool_initialized: bool = False,
         _cleanup_started: bool = False;
 
@@ -487,6 +486,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
     }
 
     def _ensure_warm_pool -> None {
+        """Ensure the warm pool has enough idle pods. Stateless — queries K8s
+        directly, no local pool list. Safe for multi-pod horizontal scaling."""
         if self.config.warm_pool_size <= 0 {
             return;
         }
@@ -495,65 +496,22 @@ obj KubernetesSandbox(SandboxEnvironment) {
             core_v1 = client.CoreV1Api();
             namespace = self.config.namespace;
 
-            # List existing warm pods
             existing = core_v1.list_namespaced_pod(
                 namespace,
                 label_selector=f"{_SANDBOX_LABEL}=true,jac-sandbox-pool=warm"
             );
-            # Build set of pods that are ACTUALLY still warm (fresh K8s read).
-            # K8s list API may return stale labels, and our local _warm_pool
-            # may contain pods claimed by other jac-builder instances.
-            verified_warm: list = [];
+            warm_count = 0;
             for p in existing.items {
-                pn = p.metadata.name;
-                # CRITICAL: Fresh individual read to bypass stale list cache.
-                # Another jac-builder pod may have claimed this warm pod (patched
-                # labels to pool=active + sandbox-id). Without this fresh check,
-                # we'd re-add it to our local pool → duplicate claim → cross-user leak.
-                try {
-                    fresh_pod = core_v1.read_namespaced_pod(pn, namespace);
-                    fresh_labels = fresh_pod.metadata.labels or {};
-                    if fresh_labels.get("jac-sandbox-pool") != "warm" or fresh_labels.get("jac-sandbox-id") {
-                        continue;
-                    }
-                    if fresh_pod.status.phase not in ["Pending", "Running"] {
-                        continue;
-                    }
-                } except Exception {
-                    continue;
+                if p.status.phase in ["Pending", "Running"] {
+                    warm_count += 1;
                 }
-                verified_warm.append(pn);
             }
 
-            # Rebuild local pool: remove claimed pods, add newly discovered ones
-            warm_count = len(verified_warm);
-            verified_set = set(verified_warm);
-            self._lock.acquire();
-            try {
-                # Remove pods that are no longer warm (claimed by another instance)
-                self._warm_pool = [p for p in self._warm_pool if p in verified_set];
-                # Add any newly discovered warm pods
-                for pn in verified_warm {
-                    if pn not in self._warm_pool {
-                        self._warm_pool.append(pn);
-                    }
-                }
-            } finally {
-                self._lock.release();
-            }
-
-            # Create pods to reach target size
             needed = self.config.warm_pool_size - warm_count;
             for i in range(needed) {
                 pod_name = f"jac-warm-{str(uuid.uuid4())[:8]}";
                 pod_spec = self._build_warm_pod_spec(pod_name);
                 core_v1.create_namespaced_pod(namespace, pod_spec);
-                self._lock.acquire();
-                try {
-                    self._warm_pool.append(pod_name);
-                } finally {
-                    self._lock.release();
-                }
                 if self.logger {
                     self.logger.info(f"Created warm pool pod: {pod_name}");
                 }
@@ -567,90 +525,72 @@ obj KubernetesSandbox(SandboxEnvironment) {
     }
 
     def _claim_warm_pod(sandbox_id: str, user_id: str, project_id: str) -> (str | None) {
-        self._lock.acquire();
-        try {
-            if not self._warm_pool {
-                return None;
-            }
-            pod_name = self._warm_pool.pop(0);
-        } finally {
-            self._lock.release();
-        }
+        """Claim a warm pod from the K8s pool. Fully stateless — no local pool
+        list, queries K8s directly. Iterates candidates so if one is taken by
+        another instance, we try the next. Safe for multi-pod horizontal scaling."""
+        import from kubernetes { client }
+        core_v1 = client.CoreV1Api();
+        namespace = self.config.namespace;
 
         try {
-            import from kubernetes { client }
-            core_v1 = client.CoreV1Api();
-            namespace = self.config.namespace;
-
-            # Verify pod is still running AND still warm (not claimed by another pod).
-            # In multi-pod deployments, another jac-builder instance may have
-            # claimed this pod between our pool pop and this K8s read.
-            pod = core_v1.read_namespaced_pod_status(pod_name, namespace);
-            if pod.status.phase not in ["Pending", "Running"] {
-                return None;
-            }
-            pod_labels = pod.metadata.labels or {};
-            if pod_labels.get("jac-sandbox-pool") != "warm" or pod_labels.get("jac-sandbox-id") {
-                if self.logger {
-                    self.logger.warn(
-                        f"Warm pod {pod_name} already claimed by another instance "
-                        f"(pool={pod_labels.get('jac-sandbox-pool')}, "
-                        f"sid={pod_labels.get('jac-sandbox-id')})"
-                    );
-                }
-                return None;
-            }
-
-            # Relabel pod from warm → active
-            body = {
-                "metadata": {
-                    "labels": {
-                        _SANDBOX_LABEL: "true",
-                        "jac-sandbox-id": sandbox_id,
-                        "jac-sandbox-pool": "active",
-                        "jac-sandbox-user": user_id,
-                        "jac-sandbox-project": project_id
-                    }
-                }
-            };
-            core_v1.patch_namespaced_pod(pod_name, namespace, body);
-
-            # Verify our claim succeeded — another pod may have patched
-            # the same warm pod simultaneously, overwriting our labels.
-            verified = core_v1.read_namespaced_pod(pod_name, namespace);
-            actual_sid = (verified.metadata.labels or {}).get("jac-sandbox-id", "");
-            if actual_sid != sandbox_id {
-                if self.logger {
-                    self.logger.warn(
-                        f"Warm pod {pod_name} claimed by another instance "
-                        f"(expected {sandbox_id}, got {actual_sid})"
-                    );
-                }
-                return None;
-            }
-            return pod_name;
+            warm_pods = core_v1.list_namespaced_pod(
+                namespace,
+                label_selector=f"{_SANDBOX_LABEL}=true,jac-sandbox-pool=warm"
+            );
         } except Exception as e {
             if self.logger {
-                self.logger.warn(f"Failed to claim warm pod {pod_name}: {str(e)}");
-            }
-            # Return pod to pool if it's still warm in K8s
-            try {
-                pod_check = core_v1.read_namespaced_pod(pod_name, namespace);
-                if (pod_check.metadata.labels or {}).get("jac-sandbox-pool") == "warm" {
-                    self._lock.acquire();
-                    try {
-                        if pod_name not in self._warm_pool {
-                            self._warm_pool.append(pod_name);
-                        }
-                    } finally {
-                        self._lock.release();
-                    }
-                }
-            } except Exception {
-                x = 0;
+                self.logger.warn(f"Failed to list warm pods: {e}");
             }
             return None;
         }
+
+        for candidate in warm_pods.items {
+            pod_name = candidate.metadata.name;
+            try {
+                # Fresh read to bypass stale list cache
+                pod = core_v1.read_namespaced_pod(pod_name, namespace);
+                if pod.status.phase not in ["Pending", "Running"] {
+                    continue;
+                }
+                pod_labels = pod.metadata.labels or {};
+                if pod_labels.get("jac-sandbox-pool") != "warm" or pod_labels.get("jac-sandbox-id") {
+                    continue;
+                }
+
+                # Patch labels: warm → active with our sandbox_id
+                body = {
+                    "metadata": {
+                        "labels": {
+                            _SANDBOX_LABEL: "true",
+                            "jac-sandbox-id": sandbox_id,
+                            "jac-sandbox-pool": "active",
+                            "jac-sandbox-user": user_id,
+                            "jac-sandbox-project": project_id
+                        }
+                    }
+                };
+                core_v1.patch_namespaced_pod(pod_name, namespace, body);
+
+                # Verify our claim stuck — another pod may have patched simultaneously
+                verified = core_v1.read_namespaced_pod(pod_name, namespace);
+                actual_sid = (verified.metadata.labels or {}).get("jac-sandbox-id", "");
+                if actual_sid != sandbox_id {
+                    if self.logger {
+                        self.logger.warn(
+                            f"Warm pod {pod_name} claimed by another instance (got {actual_sid})"
+                        );
+                    }
+                    continue;
+                }
+                return pod_name;
+            } except Exception as e {
+                if self.logger {
+                    self.logger.warn(f"Failed to claim warm pod {pod_name}: {e}");
+                }
+                continue;
+            }
+        }
+        return None;
     }
 
     def _inject_code(pod_name: str, code_path: str) -> bool {
@@ -1370,14 +1310,6 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     ;
                 }
             }
-            self._lock.acquire();
-            try {
-                if pod_name in self._warm_pool {
-                    self._warm_pool.remove(pod_name);
-                }
-            } finally {
-                self._lock.release();
-            }
             cleaned += 1;
         }
 
@@ -1393,11 +1325,6 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 self._registry.pop(key, None);
                 cleaned += 1;
             }
-            self._warm_pool = [
-                p
-                for p in self._warm_pool
-                if p in live_pod_names
-            ];
         } finally {
             self._lock.release();
         }

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -319,7 +319,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
             command=[
                 "bash",
                 "-c",
-                f"cd /app && jac install 2>/dev/null; "
+                f"cd /app && ([ -f .env ] && set -a && . .env && set +a || true) && "
+                f"jac install 2>/dev/null; "
                 f"jac start main.jac -p {_INTERNAL_PORT} --dev"
             ],
             ports=[client.V1ContainerPort(container_port=_INTERNAL_PORT)],
@@ -434,7 +435,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 "bash",
                 "-c",
                 "while [ ! -f /app/.jac-start ]; do sleep 0.5; done; "
-                f"cd /app && jac install 2>/dev/null; "
+                f"cd /app && ([ -f .env ] && set -a && . .env && set +a || true) && "
+                f"jac install 2>/dev/null; "
                 f"jac start main.jac -p {_INTERNAL_PORT} --dev"
             ],
             ports=[client.V1ContainerPort(container_port=_INTERNAL_PORT)],

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -706,7 +706,7 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     "sh",
                     "-c",
                     "base64 -d /tmp/code.b64 > /tmp/code.tar.gz && "
-                    "find /app -mindepth 1 -not -path '/app/.jac/admin*' -delete 2>/dev/null || true && "
+                    "rm -rf /app/* && "
                     "tar xzf /tmp/code.tar.gz -C /app && "
                     "rm -f /tmp/code.b64 /tmp/code.tar.gz"
                 ],

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -1569,16 +1569,9 @@ obj KubernetesSandbox(SandboxEnvironment) {
     # SandboxInstance graph nodes in MongoDB.
     # ================================================================
 
+    """Create K8s resources for a sandbox with automatic rollback on failure.
+    Stateless v2 — caller manages state externally."""
     def create_with_rollback(sandbox_id: str, user_id: str, project_id: str, code_path: str) -> SandboxResult {
-        """Create K8s resources for a sandbox with automatic rollback on failure.
-
-        Unlike create(), this method:
-        - Takes sandbox_id as a parameter (caller generates deterministic ID)
-        - Does NOT update _registry (caller manages state)
-        - Does NOT enforce max_per_user (caller handles this)
-        - Does NOT start cleanup loop or warm pool (reconciler handles this)
-        - DOES rollback partial resources on failure
-        """
         try {
             self._init_k8s();
             self._ensure_namespace();
@@ -1643,11 +1636,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
         }
     }
 
+    """Stateless K8s resource cleanup — does NOT touch _registry."""
     def cleanup_resources(sandbox_id: str, pod_name: str = "", warm_start: bool = False) -> None {
-        """Stateless K8s resource cleanup — does NOT touch _registry.
-
-        Called by the reconciler when desired_state transitions to stopped/destroyed.
-        """
         self._init_k8s();
         import from kubernetes { client }
         import from kubernetes.client.exceptions { ApiException }
@@ -1689,11 +1679,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
         }
     }
 
+    """Stateless pod status query — returns K8s pod status directly from API."""
     def query_pod_status(sandbox_id: str) -> SandboxStatus {
-        """Stateless pod status query — does NOT touch _registry.
-
-        Returns current K8s pod status directly from the API.
-        """
         self._init_k8s();
         import from kubernetes { client }
         import from kubernetes.client.exceptions { ApiException }
@@ -1733,8 +1720,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
         }
     }
 
+    """List all sandbox pods in the namespace. Used by reconciler for drift detection."""
     def list_all_sandbox_pods -> list[dict] {
-        """List all sandbox pods in the namespace. Used by reconciler for drift detection."""
         self._init_k8s();
         import from kubernetes { client }
         core_v1 = client.CoreV1Api();
@@ -1756,8 +1743,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
         return result;
     }
 
+    """Count warm pool pods via K8s label selector."""
     def count_warm_pods -> int {
-        """Count warm pool pods via K8s label selector."""
         self._init_k8s();
         import from kubernetes { client }
         core_v1 = client.CoreV1Api();
@@ -1766,13 +1753,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
         return len(pods.items);
     }
 
+    """Claim a warm pod via atomic K8s label patch. Returns pod_name or None."""
     def claim_warm_pod_v2(sandbox_id: str, user_id: str, project_id: str) -> (str | None) {
-        """Claim a warm pod via atomic K8s label patch. Returns pod_name or None.
-
-        This replaces the in-memory _warm_pool list approach. K8s serializes
-        patches per-resource, so only one caller can successfully relabel
-        a warm pod to active.
-        """
         self._init_k8s();
         import from kubernetes { client }
         import from kubernetes.client.exceptions { ApiException }
@@ -1811,8 +1793,8 @@ obj KubernetesSandbox(SandboxEnvironment) {
         return None;
     }
 
+    """Delete a K8s resource, ignoring not-found errors."""
     def _delete_resource_safe(rtype: str, rname: str, namespace: str) -> None {
-        """Delete a K8s resource, ignoring not-found errors."""
         import from kubernetes { client }
         import from kubernetes.client.exceptions { ApiException }
         core_v1 = client.CoreV1Api();

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -660,11 +660,6 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     "pkill -9 -f 'jac start' 2>/dev/null || true; "
                     "pkill -9 -f 'node.*vite' 2>/dev/null || true; "
                     "pkill -9 -f 'bun' 2>/dev/null || true; "
-                    "for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do "
-                    "  if ! ss -tlnp 2>/dev/null | grep -q ':8000 ' && "
-                    "     ! ss -tlnp 2>/dev/null | grep -q ':8001 '; then break; fi; "
-                    "  sleep 0.25; "
-                    "done; "
                     "rm -rf /app/* /app/.* /tmp/* /tmp/.* 2>/dev/null || true"
                 ],
                 stderr=True,

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -706,7 +706,7 @@ obj KubernetesSandbox(SandboxEnvironment) {
                     "sh",
                     "-c",
                     "base64 -d /tmp/code.b64 > /tmp/code.tar.gz && "
-                    "rm -rf /app/* && "
+                    "find /app -mindepth 1 -not -path '/app/.jac/admin*' -delete 2>/dev/null || true && "
                     "tar xzf /tmp/code.tar.gz -C /app && "
                     "rm -f /tmp/code.b64 /tmp/code.tar.gz"
                 ],

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -374,7 +374,7 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 init_containers=[init_container],
                 containers=[main_container],
                 volumes=volumes,
-                restart_policy="Never",
+                restart_policy="Always",
                 active_deadline_seconds=self.config.ttl_seconds,
                 termination_grace_period_seconds=10,
                 automount_service_account_token=False
@@ -477,7 +477,7 @@ obj KubernetesSandbox(SandboxEnvironment) {
             spec=client.V1PodSpec(
                 containers=[main_container],
                 volumes=volumes,
-                restart_policy="Never",
+                restart_policy="Always",
                 active_deadline_seconds=warm_ttl,
                 termination_grace_period_seconds=10,
                 automount_service_account_token=False

--- a/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
+++ b/jac-scale/jac_scale/providers/sandbox/kubernetes_sandbox.jac
@@ -1208,14 +1208,30 @@ obj KubernetesSandbox(SandboxEnvironment) {
                 }
             }
 
-            created: Any = pod.metadata.creation_timestamp;
-            if created {
-                age = now - created.replace(tzinfo=timezone.utc).timestamp();
-                ttl = self.config.warm_pool_ttl
-                    if (is_warm and self.config.warm_pool_ttl > 0)
-                    else self.config.ttl_seconds;
-                is_expired = age > ttl;
+            # For claimed warm pods (pool=active), use the registry's
+            # created_at (claim time) instead of the pod's K8s creation
+            # timestamp. The pod was pre-created in the warm pool and may
+            # be much older than the active sandbox session.
+            is_claimed_warm = pod.metadata.labels.get("jac-sandbox-pool") == "active"
+                if pod.metadata.labels
+                else False;
+            registry_key_tmp = self._find_registry_key(pod_name);
+            reg_rec = self._registry.get(registry_key_tmp) if registry_key_tmp else None;
+            if is_claimed_warm and reg_rec {
+                reg_d: dict = dict(reg_rec);
+                age = now - float(reg_d.get("created_at", now));
+            } else {
+                created: Any = pod.metadata.creation_timestamp;
+                if created {
+                    age = now - created.replace(tzinfo=timezone.utc).timestamp();
+                } else {
+                    age = 0.0;
+                }
             }
+            ttl = self.config.warm_pool_ttl
+                if (is_warm and self.config.warm_pool_ttl > 0)
+                else self.config.ttl_seconds;
+            is_expired = age > ttl;
             if is_terminal or is_expired {
                 pods_to_delete.append(pod_name);
             } else {

--- a/jac-scale/jac_scale/streams.jac
+++ b/jac-scale/jac_scale/streams.jac
@@ -1,0 +1,32 @@
+"""EventStream — Redis Streams-backed event delivery for cross-service communication.
+
+Replaces in-memory EventBus patterns with a distributed, persistent stream.
+Multiple consumers each track their own cursor (last-seen stream ID) externally.
+"""
+import json;
+import from jac_scale.db { Db }
+
+
+obj EventStream {
+    has stream_key: str,
+        db: Db,
+        max_size: int = 5000;
+
+    """Publish an event dict to the stream. Auto-trims at max_size.
+    Returns the stream entry ID."""
+    def publish(event: dict) -> str;
+
+    """Read events newer than last_id.
+    Returns (events: list[dict], new_last_id: str).
+    Caller stores new_last_id externally and passes it on the next call."""
+    def read_new(last_id: str = "0-0", count: int = 100, block_ms: int = 0) -> tuple;
+
+    """Trim stream to max_size. Returns number of entries removed."""
+    def trim() -> int;
+
+    """Get current stream length."""
+    def length() -> int;
+
+    """Delete the entire stream."""
+    def clear() -> None;
+}

--- a/jac-scale/jac_scale/targets/kubernetes/templates/sandbox-base.Dockerfile
+++ b/jac-scale/jac_scale/targets/kubernetes/templates/sandbox-base.Dockerfile
@@ -9,24 +9,37 @@ RUN apt-get update -qq && \
 RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash
 ENV PATH="/usr/local/bin:$PATH"
 
-# Install Jac ecosystem
-RUN pip install --no-cache-dir jaclang jac-scale jac-client watchdog
+# Install Node.js (agent-browser CLI requires node runtime)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y -qq nodejs > /dev/null 2>&1 && \
+    rm -rf /var/lib/apt/lists/*
 
-# Pre-warm: ensure jac CLI is available
-RUN jac --version
+# Install Chrome system dependencies (agent-browser --with-deps is unreliable)
+RUN apt-get update -qq && \
+    apt-get install -y -qq \
+    libglib2.0-0 libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 \
+    libcups2 libxkbcommon0 libasound2t64 libgbm1 libcairo2 libpango-1.0-0 \
+    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libatspi2.0-0 \
+    fonts-liberation xdg-utils > /dev/null 2>&1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install agent-browser CLI globally (as root)
+RUN npm install -g agent-browser
 
 # Create non-root user for security_context (uid 1000)
 RUN groupadd -g 1000 jac && useradd -u 1000 -g jac -m -s /bin/bash jac
 RUN mkdir -p /app && chown 1000:1000 /app
 
-# Pre-build admin dashboard while still root (site-packages is root-owned,
-# so jac build cannot create .jac/ artifacts there when running as non-root)
-RUN mkdir -p /tmp/admin_build && \
-    cp -r /usr/local/lib/python3.12/site-packages/jac_scale/admin/ui/* /tmp/admin_build/ && \
-    cd /tmp/admin_build && jac build main.jac && \
-    mkdir -p /app/.jac/admin && \
-    cp -r /tmp/admin_build/.jac/client/dist/* /app/.jac/admin/ && \
-    rm -rf /tmp/admin_build && \
-    chown -R 1000:1000 /app/.jac
+# Install Chrome binary as jac user so it lands in /home/jac/.agent-browser/
+# This allows agent-browser to work when pod runs as non-root (uid 1000)
+USER jac
+RUN agent-browser install
+USER root
+
+# Install Jac ecosystem
+RUN pip install --no-cache-dir jaclang jac-scale jac-client byllm watchdog
+
+# Pre-warm: ensure jac CLI is available
+RUN jac --version
 
 WORKDIR /app

--- a/jac-scale/jac_scale/targets/kubernetes/templates/sandbox-base.Dockerfile
+++ b/jac-scale/jac_scale/targets/kubernetes/templates/sandbox-base.Dockerfile
@@ -19,4 +19,14 @@ RUN jac --version
 RUN groupadd -g 1000 jac && useradd -u 1000 -g jac -m -s /bin/bash jac
 RUN mkdir -p /app && chown 1000:1000 /app
 
+# Pre-build admin dashboard while still root (site-packages is root-owned,
+# so jac build cannot create .jac/ artifacts there when running as non-root)
+RUN mkdir -p /tmp/admin_build && \
+    cp -r /usr/local/lib/python3.12/site-packages/jac_scale/admin/ui/* /tmp/admin_build/ && \
+    cd /tmp/admin_build && jac build main.jac && \
+    mkdir -p /app/.jac/admin && \
+    cp -r /tmp/admin_build/.jac/client/dist/* /app/.jac/admin/ && \
+    rm -rf /tmp/admin_build && \
+    chown -R 1000:1000 /app/.jac
+
 WORKDIR /app

--- a/jac-scale/jac_scale/tests/test_sandbox_factory.jac
+++ b/jac-scale/jac_scale/tests/test_sandbox_factory.jac
@@ -491,6 +491,59 @@ test "regular pod spec still uses sandbox ttl_seconds" {
     assert pod.spec.active_deadline_seconds == 1800;
 }
 
+# ---- Restart policy tests ----
+test "cold start pod spec uses restart_policy Always" {
+    config = SandboxConfig(ttl_seconds=1800);
+    sandbox = KubernetesSandbox(config=config);
+    pod: Any = sandbox._build_pod_spec("sbx-rp", "cm-rp", "user1", "proj1");
+
+    assert pod.spec.restart_policy == "Always";
+}
+
+test "warm pod spec uses restart_policy Always" {
+    config = SandboxConfig(warm_pool_size=3);
+    sandbox = KubernetesSandbox(config=config);
+    warm: Any = sandbox._build_warm_pod_spec("warm-rp");
+
+    assert warm.spec.restart_policy == "Always";
+}
+
+# ---- Warm-start TTL uses claim time, not pod creation time ----
+test "cleanup_expired uses registry created_at for claimed warm pods" {
+    import time;
+    config = SandboxConfig(ttl_seconds=1800);
+    sandbox = KubernetesSandbox(config=config);
+
+    # Simulate a claimed warm pod: registry created_at is recent (just claimed),
+    # but the pod's K8s creation_timestamp would be old (pre-created in warm pool).
+    # The cleanup logic should use the registry time, not the pod time.
+    sandbox._registry["claimed-warm-sbx"] = {
+        "sandbox_id": "claimed-warm-sbx",
+        "user_id": "user1",
+        "project_id": "proj1",
+        "pod_name": "jac-warm-old-pod",
+        "namespace": "jac-sandboxes",
+        "status": SandboxState.RUNNING,
+        "url": "http://test.example.com",
+        "port": 8000,
+        "created_at": time.time(),
+        "warm_start": True
+    };
+
+    # _find_registry_key should find it by pod_name
+    found = sandbox._find_registry_key("jac-warm-old-pod");
+    assert found == "claimed-warm-sbx";
+
+    # Verify the registry created_at is recent (< 10 seconds old)
+    reg_d: dict = dict(sandbox._registry["claimed-warm-sbx"]);
+    age = time.time() - float(reg_d.get("created_at", 0));
+    assert age < 10, "Registry created_at should be recent (claim time), not pod creation time";
+
+    # Cleanup: this won't actually query K8s (no cluster) but validates
+    # the registry lookup path used by cleanup_expired
+    sandbox._registry.pop("claimed-warm-sbx", None);
+}
+
 # ---- Sandbox status returns STOPPED for missing pods ----
 test "k8s sandbox status returns STOPPED when pod query fails" {
     config = SandboxConfig();


### PR DESCRIPTION
## Summary

- Extends the `Db` class with cross-service communication primitives: Redis Streams (`xadd`, `xread`, `xrange`, `xtrim`, `xlen`, `xdel_stream`), Redis Lists (`lpush`, `brpop`, `llen`), and distributed locks (`acquire_lock`, `release_lock`, `refresh_lock`)
- Adds `EventStream` abstraction (`streams.jac`) wrapping Redis Streams with cursor-based fan-out — replaces in-memory EventBus patterns for distributed event delivery between independently scaled services
- Adds `JobQueue` abstraction (`job_queue.jac`) wrapping Redis Lists with LPUSH/BRPOP for cross-service work distribution

All new methods use raw keys (no `db_name` namespace) since they are designed for cross-service communication where both services must agree on key names. Lock release/refresh uses Lua scripts for atomicity. Methods raise `NotImplementedError` on MongoDB.

## Test plan

- [ ] Unit test `xadd`/`xread` round-trip with testcontainers Redis
- [ ] Unit test `lpush`/`brpop` round-trip and timeout behavior
- [ ] Unit test `acquire_lock`/`release_lock` contention (two owners)
- [ ] Unit test `EventStream.publish`/`read_new` cursor semantics
- [ ] Unit test `JobQueue.submit`/`consume` serialization round-trip
- [ ] Verify all methods raise `NotImplementedError` on MongoDB `Db` instance