### PR TITLE
fix(jac-client): type-check fix for onToggleMode lambda

### DIFF
--- a/jac-client/jac_client/templates/fullstack/frontend.cl.jac
+++ b/jac-client/jac_client/templates/fullstack/frontend.cl.jac
@@ -193,7 +193,7 @@ def:pub app -> JsxElement {
             onUsernameChange={lambda e: ChangeEvent { username = e.target.value;}}
             onPasswordChange={lambda e: ChangeEvent { password = e.target.value;}}
             onSubmit={handleSubmit}
-            onToggleMode={lambda {
+            onToggleMode={lambda _e: MouseEvent {
                 isSignup = not isSignup;
                 error = "";
             }}

--- a/jac-client/pyproject.toml
+++ b/jac-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-client"
-version = "0.3.11"
+version = "0.3.12"
 description = "Build full-stack web applications with Jac - one language for frontend and backend."
 authors = [{name = "Jason Mars", email = "jason@mars.ninja"}]
 maintainers = [{name = "Jason Mars", email = "jason@mars.ninja"}]


### PR DESCRIPTION
## Summary
- Fix parameterless lambda passed to `onToggleMode` in the fullstack template's `frontend.cl.jac`
- The `AuthForm` component expects `MouseEventHandler` (`Callable[[MouseEvent], NoneType]`), but the lambda had no parameters, causing `E1100` on `jac check`
- Bump jac-client to 0.3.12