### PR TITLE
fix(jac-client): add missing MouseEvent param to onToggleMode lambda

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -24,7 +24,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 - **Standalone Sidecar Bundling via PyInstaller**: Desktop builds now bundle the Jac sidecar as a standalone executable using PyInstaller by default. The bundled sidecar includes Python, jaclang, jac-client, and configured plugins (jac-scale, byllm, jac-coder via `[desktop.plugins]` in `jac.toml`), eliminating the requirement for end users to have Python installed. Auto-installs Python dependencies from `jac.toml` before bundling. Set `JAC_SIDECAR_STANDALONE=0` to fall back to wrapper script mode.
 - **Debug Diagnostic Page**: Added a debug page to the all-in-one example app for diagnosing sidecar/API connectivity issues. Displays API base URL status, Tauri runtime detection, `get_api_url` invoke results, and interactive buttons to test walker spawning and direct HTTP fetch.
 - **Plugin Reference Docs**: Added `reference/plugins/jac-client.md` documenting jac-client CLI commands and configuration options.
-- 4 small refactors/changes.
+- 5 small refactors/changes.
 
 ## jac-client 0.3.11 (Latest Release)
 

--- a/jac-client/jac_client/templates/fullstack/frontend.cl.jac
+++ b/jac-client/jac_client/templates/fullstack/frontend.cl.jac
@@ -193,7 +193,7 @@ def:pub app -> JsxElement {
             onUsernameChange={lambda e: ChangeEvent { username = e.target.value;}}
             onPasswordChange={lambda e: ChangeEvent { password = e.target.value;}}
             onSubmit={handleSubmit}
-            onToggleMode={lambda {
+            onToggleMode={lambda _e: MouseEvent {
                 isSignup = not isSignup;
                 error = "";
             }}


### PR DESCRIPTION
## Summary
- Add `_e: MouseEvent` parameter to the `onToggleMode` lambda in the fullstack template's `frontend.cl.jac` to match the `MouseEventHandler` signature expected by `AuthForm`
- Fixes `E1100` type error on `jac check`
- Tick small refactors count in release notes

## Test plan
- [ ] `jac check jac-client/jac_client/templates/fullstack/frontend.cl.jac` no longer reports E1100 on line 196