### PR TITLE
fix(runtime): respect is_undirected flag during edge traversal

### DIFF
--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -153,8 +153,12 @@ impl JacNode.get_edges(
                 and source.archetype
                 and target.archetype
             ) {
+                # Undirected edges are traversable in both directions.
+                effective_dir = EdgeDir.ANY
+                    if anchor.is_undirected
+                    else destination.direction;
                 if (
-                    (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
+                    (effective_dir in [EdgeDir.OUT, EdgeDir.ANY])
                     and (nanch == source)
                     and destination.node_filter(target.archetype)
                     and JacRuntimeInterface.check_read_access(target)
@@ -162,7 +166,7 @@ impl JacNode.get_edges(
                     edges[anchor] = anchor.archetype;
                 }
                 if (
-                    (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
+                    (effective_dir in [EdgeDir.IN, EdgeDir.ANY])
                     and (nanch == target)
                     and destination.node_filter(source.archetype)
                     and JacRuntimeInterface.check_read_access(source)
@@ -193,8 +197,12 @@ impl JacNode.get_edges_with_node(
                 and source.archetype
                 and target.archetype
             ) {
+                # Undirected edges are traversable in both directions.
+                effective_dir = EdgeDir.ANY
+                    if anchor.is_undirected
+                    else destination.direction;
                 if (
-                    (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
+                    (effective_dir in [EdgeDir.OUT, EdgeDir.ANY])
                     and (nanch == source)
                     and destination.node_filter(target.archetype)
                     and JacRuntimeInterface.check_read_access(target)
@@ -203,7 +211,7 @@ impl JacNode.get_edges_with_node(
                     loc[target] = target.archetype;
                 }
                 if (
-                    (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
+                    (effective_dir in [EdgeDir.IN, EdgeDir.ANY])
                     and (nanch == target)
                     and destination.node_filter(source.archetype)
                     and JacRuntimeInterface.check_read_access(source)
@@ -233,8 +241,12 @@ impl JacNode.edges_to_nodes(
                 and source.archetype
                 and target.archetype
             ) {
+                # Undirected edges are traversable in both directions.
+                effective_dir = EdgeDir.ANY
+                    if anchor.is_undirected
+                    else destination.direction;
                 if (
-                    (destination.direction in [EdgeDir.OUT, EdgeDir.ANY])
+                    (effective_dir in [EdgeDir.OUT, EdgeDir.ANY])
                     and (nanch == source)
                     and destination.node_filter(target.archetype)
                     and JacRuntimeInterface.check_read_access(target)
@@ -242,7 +254,7 @@ impl JacNode.edges_to_nodes(
                     nodes[target] = target.archetype;
                 }
                 if (
-                    (destination.direction in [EdgeDir.IN, EdgeDir.ANY])
+                    (effective_dir in [EdgeDir.IN, EdgeDir.ANY])
                     and (nanch == target)
                     and destination.node_filter(source.archetype)
                     and JacRuntimeInterface.check_read_access(source)

--- a/jac/tests/language/fixtures/undirected_edge_traversal.jac
+++ b/jac/tests/language/fixtures/undirected_edge_traversal.jac
@@ -1,0 +1,47 @@
+"""Fixture for undirected edge traversal regression test.
+
+Verifies that nodes connected via <+:edge:+> (typed bidirectional) or
+<++> (generic bidirectional) can be traversed from both endpoints.
+Prior to the fix, [b ->:friend:->] returned [] when the edge was created
+as a <+:friend:+> b — only [a ->:friend:->] worked.
+"""
+
+node person {
+    has name: str;
+}
+
+edge friend {}
+
+with entry {
+    a = person(name="Alice");
+    b = person(name="Bob");
+    c = person(name="Carol");
+    d = person(name="Dave");
+
+    # Typed bidirectional: <+:edge:+>
+    a <+:friend:+> b;
+
+    # Generic bidirectional: <++>
+    c <++> d;
+
+    # Typed: forward (source -> target, always worked)
+    print([a ->:friend:->]);
+
+    # Typed: reverse (target -> source, was broken)
+    print([b ->:friend:->]);
+
+    # Typed: with explicit target
+    print([b ->:friend:-> a]);
+
+    # Generic: forward
+    print([c -->]);
+
+    # Generic: reverse (was broken)
+    print([d -->]);
+
+    # Edge object reachable from both endpoints via [edge ...]
+    edges_from_a = [edge a ->:friend:->];
+    edges_from_b = [edge b ->:friend:->];
+    print(len(edges_from_a));
+    print(len(edges_from_b));
+}

--- a/jac/tests/language/test_language.jac
+++ b/jac/tests/language/test_language.jac
@@ -836,3 +836,22 @@ test "escape sequences in strings and fstrings" {
     # Test 9: unicode \u001b → ESC (third distinct escape syntax)
     assert "unicode_escape_first_ord:27" in output , f"Unicode escape failed: {output}";
 }
+
+test "undirected edge traversal" {
+    output = run_jac(os.path.join(FIXTURES, "undirected_edge_traversal.jac"));
+    lines = output.strip().split("\n");
+    # Typed bidirectional <+:friend:+>: forward a->b
+    assert lines[0] == "[person(name='Bob')]";
+    # Typed bidirectional <+:friend:+>: reverse b->a (was broken before fix)
+    assert lines[1] == "[person(name='Alice')]";
+    # Typed with explicit target: b ->:friend:-> a
+    assert lines[2] == "[person(name='Alice')]";
+    # Generic bidirectional <++>: forward c->d
+    assert lines[3] == "[person(name='Dave')]";
+    # Generic bidirectional <++>: reverse d->c (was broken before fix)
+    assert lines[4] == "[person(name='Carol')]";
+    # Edge object reachable from source endpoint
+    assert lines[5] == "1";
+    # Edge object reachable from target endpoint (was broken before fix)
+    assert lines[6] == "1";
+}


### PR DESCRIPTION
**Core bug:** 
Bidirectional edges created with `<+:edge:+>` or `<++>` store a single EdgeAnchor with `is_undirected=True` on both nodes' edge lists. However, `get_edges`, `get_edges_with_node`, and `edges_to_nodes` only consulted `destination.direction` against source/target identity, ignoring the undirected nature of the connection. This caused queries like `[target ->:edge:->]` to return empty results.

**Changes:**
- Modified `runtime.impl.jac` to compute an `effective_dir` per-edge.
- If an edge is `marked is_undirected`, its `effective_dir` is set to `ANY`, allowing traversal from either endpoint regardless of query direction.
- Added regression test fixture and integrated it into the language suite.

Fixes issue where symmetric traversal was natively unsupported for bidirectional edges.


