### PR TITLE
ci(test-jaseci): progressive jac-scale extras instead of [all]

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -191,7 +191,7 @@ jobs:
         pip install -e jac-scale
         pip install -e jac-client
         pip install pytest pytest-asyncio
-        pip install watchdog websockets
+        pip install requests watchdog websockets
 
     - name: Run Backend tests
       run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -184,34 +184,18 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Install Jaseci scale package
+    - name: Install base jac-scale and test deps
       run: |
         python -m pip install --upgrade pip
         pip install -e jac
-        pip install -e "jac-scale[all]"
-        pip install pytest
-        pip install pytest-asyncio
+        pip install -e jac-scale
         pip install -e jac-client
-        pip install testcontainers
-        pip install watchdog
-        pip install python-multipart  # Explicit install to ensure FastAPI form support
-        pip install websockets  # Required for WebSocket test cases
+        pip install pytest pytest-asyncio
+        pip install watchdog websockets
 
     - name: Run Backend tests
       run: |
         pytest -x -vv -s jac-scale/jac_scale/tests/test_serve.jac
-
-    - name: Run Webhook tests (without and with MongoDB)
-      run: |
-        pytest -x -vv -s jac-scale/jac_scale/tests/test_webhook.jac
-
-    - name: Run Memory Hierarchy tests
-      run: |
-        pytest -x -vv -s jac-scale/jac_scale/tests/test_memory_hierarchy.jac
-
-    - name: Run jac-client examples
-      run: |
-        pytest -x jac-scale/jac_scale/tests/test_examples.jac
 
     - name: Run SSO tests
       run: |
@@ -221,6 +205,31 @@ jobs:
       run: |
         pytest -x jac-scale/jac_scale/tests/test_admin.jac
 
+    - name: Run RestSpec tests
+      run: |
+        pytest -x jac-scale/jac_scale/tests/test_restspec.jac
+
+    - name: Run Microservice interop tests
+      run: |
+        pytest -x -vv -s jac-scale/jac_scale/tests/test_microservice.jac
+
+    - name: Run jac-client examples
+      run: |
+        pytest -x jac-scale/jac_scale/tests/test_examples.jac
+
+    - name: Install jac-scale[data] extras
+      run: |
+        pip install -e "jac-scale[data]"
+        pip install testcontainers
+
+    - name: Run Webhook tests (without and with MongoDB)
+      run: |
+        pytest -x -vv -s jac-scale/jac_scale/tests/test_webhook.jac
+
+    - name: Run Memory Hierarchy tests
+      run: |
+        pytest -x -vv -s jac-scale/jac_scale/tests/test_memory_hierarchy.jac
+
     - name: Run MongoDB user manager tests
       run: |
         pytest -x jac-scale/jac_scale/tests/test_mongo_user_manager.jac
@@ -229,17 +238,13 @@ jobs:
       run: |
         pytest -x -vv -s jac-scale/jac_scale/tests/test_serializer_social.jac
 
+    - name: Install jac-scale[scheduler] extras
+      run: |
+        pip install -e "jac-scale[scheduler]"
+
     - name: Run Scheduling tests
       run: |
         pytest -x -vv -s jac-scale/jac_scale/tests/test_scheduling.jac
-
-    - name: Run RestSpec tests
-      run: |
-        pytest -x jac-scale/jac_scale/tests/test_restspec.jac
-
-    - name: Run Microservice interop tests
-      run: |
-        pytest -x -vv -s jac-scale/jac_scale/tests/test_microservice.jac
 
   test-scale-k8s:
     runs-on: ubuntu-latest
@@ -258,7 +263,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e jac
-          pip install -e "jac-scale[all]"
+          pip install -e "jac-scale[deploy]"
           pip install -e jac-client
           pip install pytest
           pip install pytest-xdist


### PR DESCRIPTION
## Summary

Follows up on #5489 (optional jac-scale deps) and #5529 (scheduler graceful degradation) by making CI actually exercise the extras boundaries instead of masking them behind `[all]`.

### `test-scale` job — progressive installs
Tests are grouped by the extras they need, and each extras group is installed only before the steps that require it:

1. **Base `jac-scale`** → `test_serve`, `test_sso`, `test_admin`, `test_restspec`, `test_microservice`, `test_examples`
2. **`+ [data]` (+ testcontainers)** → `test_webhook`, `test_memory_hierarchy`, `test_mongo_user_manager`, `test_serializer_social`
3. **`+ [scheduler]`** → `test_scheduling`

If any "base only" test fails, it means something in `jac_scale` core is still pulling an optional dep that should be guarded (same bug class as #5529).

### `test-scale-k8s` job
Switched from `jac-scale[all]` to `jac-scale[deploy]` so the k8s tests confirm `[deploy]` alone is sufficient for `test_k8s_utils.jac` and `test_deploy_k8s.jac`.

### Notes
- Dropped the redundant explicit `pip install python-multipart` — it's already a base dep in `jac-scale/pyproject.toml`.
- `[monitoring]` has no test coverage anywhere in the repo (no test imports `prometheus_client`); left untouched.
- `test-pypi-build` keeps `[all]` since it's a full-wheel smoke test, not an extras gate.

## Test plan
- [x] `test-scale` job passes with base-only tests running before any extras install
- [x] `test-scale` job passes after `[data]` installed, for MongoDB/redis-backed tests
- [x] `test-scale` job passes after `[scheduler]` installed, for scheduling test
- [x] `test-scale-k8s` job passes with only `[deploy]` installed