### PR TITLE
Fix failing install.sh when jac is already installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -237,7 +237,7 @@ install_via_uv() {
         if [[ -n "$VERSION" ]]; then
             uv tool install "$spec" "${with_args[@]}" --python ">=3.12" --force
         else
-            uv tool upgrade jaclang "${with_args[@]}" --python ">=3.12"
+            uv tool upgrade jaclang --python ">=3.12"
         fi
     else
         info "Installing jaclang..."


### PR DESCRIPTION
## Summary

Rerunning the install script should upgrade jac, but currently it breaks because `uv tool upgrade` doesn't support a `--with` flag. This PR fixes the typo and force upgrades their jac installation if `version` was not provided. 