### PR TITLE
perf(serializer): cache _get_field_types per class

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,7 +4,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.14.1 (Unreleased)
 
-- **Perf: Cache `Serializer._get_field_types` per class**: `_deserialize_archetype` calls `_get_field_types(cls)` once per anchor to drive Layer 3 field coercion, and the inner `typing.get_type_hints` evaluates string forward-refs via `eval` and walks the MRO — expensive enough to roughly double Mongo-backed test wall-clock (`test_memory_hierarchy` went from ~5m to ~10m after #5561). Results are now memoized on `cls` identity; class annotations are effectively immutable at runtime so no invalidation is wired.
+- **Perf: Cache `Serializer._get_field_types` per class**: `_deserialize_archetype` calls `_get_field_types(cls)` once per anchor to drive Layer 3 field coercion, and the inner `typing.get_type_hints` evaluates string forward-refs via `eval` and walks the MRO - expensive enough to roughly double Mongo-backed test wall-clock (`test_memory_hierarchy` went from ~5m to ~10m after #5561). Results are now memoized on `cls` identity; class annotations are effectively immutable at runtime so no invalidation is wired.
 
 ## jaclang 0.14.0 (Latest Release)
 

--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jaclang 0.14.1 (Unreleased)
 
+- **Perf: Cache `Serializer._get_field_types` per class**: `_deserialize_archetype` calls `_get_field_types(cls)` once per anchor to drive Layer 3 field coercion, and the inner `typing.get_type_hints` evaluates string forward-refs via `eval` and walks the MRO — expensive enough to roughly double Mongo-backed test wall-clock (`test_memory_hierarchy` went from ~5m to ~10m after #5561). Results are now memoized on `cls` identity; class annotations are effectively immutable at runtime so no invalidation is wired.
+
 ## jaclang 0.14.0 (Latest Release)
 
 - **Fix: byllm Provider Config Ignored from `jac.toml`**: The byllm plugin now correctly reads the provider and model from `[plugins.byllm.model]` in `jac.toml`. Previously, `PluginConfigBase` resolved `project_dir` via `cwd`, causing the config lookup to miss the project's `jac.toml` and fall back to the OpenAI default. `PluginConfigBase` now derives the project directory from `JacRuntime.full_target_path` (set by `jac run` before compilation).

--- a/jac/jaclang/runtimelib/impl/serializer.impl.jac
+++ b/jac/jaclang/runtimelib/impl/serializer.impl.jac
@@ -315,7 +315,7 @@ impl Serializer.register_alias(old_name: str, cls: type) -> None {
 Memoized on `cls` identity: `get_type_hints` evaluates forward-refs via
 `eval` and walks the MRO, so calling it on every anchor deserialize
 dominates load cost under Mongo. Annotations are effectively immutable
-at runtime — no invalidation path is wired.
+at runtime, so no invalidation path is wired.
 """
 impl Serializer._get_field_types(cls: type) -> dict[str, object] {
     cached = Serializer._field_types_cache.get(cls);

--- a/jac/jaclang/runtimelib/impl/serializer.impl.jac
+++ b/jac/jaclang/runtimelib/impl/serializer.impl.jac
@@ -310,9 +310,20 @@ impl Serializer.register_alias(old_name: str, cls: type) -> None {
     Serializer._aliases[old_name] = new_name;
 }
 
-"""Return {field_name: resolved_annotation} for a dataclass (empty otherwise)."""
+"""Return {field_name: resolved_annotation} for a dataclass (empty otherwise).
+
+Memoized on `cls` identity: `get_type_hints` evaluates forward-refs via
+`eval` and walks the MRO, so calling it on every anchor deserialize
+dominates load cost under Mongo. Annotations are effectively immutable
+at runtime — no invalidation path is wired.
+"""
 impl Serializer._get_field_types(cls: type) -> dict[str, object] {
+    cached = Serializer._field_types_cache.get(cls);
+    if cached is not None {
+        return cached;
+    }
     if not is_dataclass(cls) {
+        Serializer._field_types_cache[cls] = {};
         return {};
     }
     # Prefer resolved hints (unwraps string forward-refs); fall back to raw.
@@ -327,6 +338,7 @@ impl Serializer._get_field_types(cls: type) -> dict[str, object] {
             out[f.name] = hints[f.name];
         }
     }
+    Serializer._field_types_cache[cls] = out;
     return out;
 }
 

--- a/jac/jaclang/runtimelib/serializer.jac
+++ b/jac/jaclang/runtimelib/serializer.jac
@@ -45,7 +45,12 @@ obj Serializer {
         # Populated by `register_alias` / `archetype_alias` decorator. Used by
         # `_get_class` to resolve renamed or moved archetypes without losing
         # previously persisted anchors.
-        _aliases: dict[str, str] = {};
+        _aliases: dict[str, str] = {},
+        # Cache of {class -> {field_name: resolved_annotation}}. `get_type_hints`
+        # is hot-path on every anchor deserialize and expensive enough to
+        # dominate Mongo load latency without memoization. Class annotations
+        # are effectively immutable at runtime so no invalidation is needed.
+        _field_types_cache: dict[type, dict[str, object]] = {};
 
     """Register a class for deserialization and attach its schema fingerprint."""
     static def register(cls: type) -> None;


### PR DESCRIPTION
## Summary

Follow-up to #5561. `Serializer._get_field_types` calls `typing.get_type_hints(cls)`, which evaluates string forward-refs via `eval` and walks the MRO. Since #5561 it sits on the **hot deserialize path** — called once per anchor from `_deserialize_archetype` to drive field-type coercion — and was not memoized.

In `test-scale` CI, `test_memory_hierarchy` (Mongo-backed) went from ~5m to ~10m after #5561 landed; the uncached `get_type_hints` is the dominant contributor.

## Fix

Add a `_field_types_cache: dict[type, dict[str, object]]` on `Serializer` and short-circuit in `_get_field_types`. Keyed by the class object (hashable by identity). Class annotations are effectively immutable at runtime, so no invalidation path is needed — the registry already rejects unregistered classes at load.

## Test plan

- [x] `jac/tests/runtimelib/test_layer3_coercion_alias.jac` — 15/15 pass (exercises `_get_field_types` + `coerce` paths; same class is re-deserialized multiple times, so this also validates cache hits)
- [x] `jac/tests/runtimelib/test_layer3_e2e.jac` — 3/3 pass (schema-drift + coercion round-trips)
- [ ] CI: confirm `test_memory_hierarchy` wall-clock drops back toward the pre-#5561 baseline