### PR TITLE
perf(jac-client): skip PyInstaller --clean for faster incremental sidecar builds

### DIFF
--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -4,6 +4,8 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ## jac-client 0.3.13 (Unreleased)
 
+- **Perf: Skip PyInstaller `--clean` for Faster Incremental Sidecar Builds**: The PyInstaller invocation for the desktop sidecar no longer passes `--clean`, so incremental rebuilds reuse the previous build cache instead of wiping it on every run. This significantly cuts rebuild time during iterative development. Use `jac clean` if a fully fresh build is ever needed.
+
 ## jac-client 0.3.12 (Latest Release)
 
 - **Jacpack Template Migration to `to cl:`**: The `client` scaffold's `main.jac` now uses the flatter `to cl:` section-header form instead of wrapping the entire component in a `cl { ... }` block.

--- a/docs/docs/community/release_notes/jac-client.md
+++ b/docs/docs/community/release_notes/jac-client.md
@@ -2,10 +2,6 @@
 
 This document provides a summary of new features, improvements, and bug fixes in each version of **Jac-Client**. For details on changes that might require updates to your existing code, please refer to the [Breaking Changes](../breaking-changes.md) page.
 
-## jac-client 0.3.13 (Unreleased)
-
-- **Perf: Skip PyInstaller `--clean` for Faster Incremental Sidecar Builds**: The PyInstaller invocation for the desktop sidecar no longer passes `--clean`, so incremental rebuilds reuse the previous build cache instead of wiping it on every run. This significantly cuts rebuild time during iterative development. Use `jac clean` if a fully fresh build is ever needed.
-
 ## jac-client 0.3.12 (Latest Release)
 
 - **Jacpack Template Migration to `to cl:`**: The `client` scaffold's `main.jac` now uses the flatter `to cl:` section-header form instead of wrapping the entire component in a `cl { ... }` block.

--- a/docs/docs/community/release_notes/unreleased/jac-client/5577.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jac-client/5577.feature.md
@@ -1,0 +1,1 @@
+- **Perf: Skip PyInstaller `--clean` for Faster Incremental Sidecar Builds**: The PyInstaller invocation for the desktop sidecar no longer passes `--clean`, so incremental rebuilds reuse the previous build cache instead of wiping it on every run. This significantly cuts rebuild time during iterative development. Use `jac clean` if a fully fresh build is ever needed.

--- a/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
+++ b/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
@@ -2652,7 +2652,6 @@ if __name__ == "__main__":
                 sys.executable,
                 "-m",
                 "PyInstaller",
-                "--clean",
                 "--noconfirm",
                 "--distpath",
                 str(dist_dir),

--- a/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
+++ b/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
@@ -240,8 +240,7 @@ impl DesktopTarget.setup(project_dir: Path) -> None {
         }
 
         console.print(
-            f"  Project name: {project_name}, version: {project_version}",
-            style="muted"
+            f"  Project name: {project_name}, version: {project_version}", style="muted"
         );
         console.print(f"  Identifier: {identifier}", style="muted");
 
@@ -320,8 +319,7 @@ impl DesktopTarget.setup(project_dir: Path) -> None {
         } except Exception as e {
             console.warning(f"  Failed to add [desktop] section to jac.toml: {e}");
             console.print(
-                "  Setup will continue, but jac.toml may not be updated.",
-                style="muted"
+                "  Setup will continue, but jac.toml may not be updated.", style="muted"
             );
         }
 
@@ -599,7 +597,9 @@ except ImportError:
     # IDAT chunk - solid blue color with alpha (RGBA: 66, 139, 202, 255 = #428BCA)
     # PNG scanlines: each row is prefixed with filter byte (0 = none)
     row_size = width * 4;  # RGBA = 4 bytes per pixel
-    scanline = bytes([0]) + bytes([66, 139, 202, 255]) * width;  # Filter byte + RGBA data
+    scanline = bytes([0]) + bytes(
+        [66, 139, 202, 255]
+    ) * width;  # Filter byte + RGBA data
     image_data = scanline * height;
 
     # Compress
@@ -1771,7 +1771,9 @@ def _check_and_install_tauri_cli -> None {
         }
     } else {
         console.print("  Skipping Tauri CLI installation.", style="muted");
-        console.print("  It will be needed when building. Install with:", style="muted");
+        console.print(
+            "  It will be needed when building. Install with:", style="muted"
+        );
         if cargo_available {
             console.print("    cargo install tauri-cli", style="muted");
         }
@@ -2502,12 +2504,7 @@ def _bundle_sidecar(
 
     if use_pyinstaller {
         result = _bundle_sidecar_pyinstaller(
-            entry_file,
-            project_dir,
-            tauri_dir,
-            binaries_dir,
-            is_windows,
-            plugins_config
+            entry_file, project_dir, tauri_dir, binaries_dir, is_windows, plugins_config
         );
         if result {
             return result;
@@ -3078,7 +3075,9 @@ impl DesktopTarget.dev(
     # Compile runtime utils (creates client_runtime.js)
     compiler.compile_runtime_utils();
     # Compile the module to create compiled/main.js (or whatever the module name is)
-    (module_js, mod, module_manifest) = compiler.jac_compiler.compile_module(entry_file);
+    (module_js, mod, module_manifest) = compiler.jac_compiler.compile_module(
+        entry_file
+    );
     # Write the compiled module to compiled directory
     module_name = entry_file.stem;
     compiled_module_path = compiler.compiled_dir / f"{module_name}.js";
@@ -3116,7 +3115,9 @@ impl DesktopTarget.dev(
         f"  Step 3: Starting backend server on port {server_port}...", style="muted"
     );
     server_process = _start_backend_server(entry_file, project_dir, server_port);
-    console.print(f"  ✔ Backend server starting on port {server_port}", style="success");
+    console.print(
+        f"  ✔ Backend server starting on port {server_port}", style="success"
+    );
     # Step 4: Launch tauri dev
     console.print("  Step 4: Launching Tauri dev window...", style="muted");
     console.print("  (Press Ctrl+C to stop)", style="muted");
@@ -3409,7 +3410,9 @@ impl DesktopTarget.start(
         f"  Step 3: Starting backend server on port {server_port}...", style="muted"
     );
     server_process = _start_backend_server(entry_file, project_dir, server_port);
-    console.print(f"  ✔ Backend server starting on port {server_port}", style="success");
+    console.print(
+        f"  ✔ Backend server starting on port {server_port}", style="success"
+    );
     # Step 4: Launch tauri dev (which will use the built bundle)
     console.print("  Step 4: Launching Tauri app...", style="muted");
     console.print("  (Press Ctrl+C to stop)", style="muted");

--- a/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
+++ b/jac-client/jac_client/plugin/src/targets/impl/desktop_target.impl.jac
@@ -240,7 +240,8 @@ impl DesktopTarget.setup(project_dir: Path) -> None {
         }
 
         console.print(
-            f"  Project name: {project_name}, version: {project_version}", style="muted"
+            f"  Project name: {project_name}, version: {project_version}",
+            style="muted"
         );
         console.print(f"  Identifier: {identifier}", style="muted");
 
@@ -319,7 +320,8 @@ impl DesktopTarget.setup(project_dir: Path) -> None {
         } except Exception as e {
             console.warning(f"  Failed to add [desktop] section to jac.toml: {e}");
             console.print(
-                "  Setup will continue, but jac.toml may not be updated.", style="muted"
+                "  Setup will continue, but jac.toml may not be updated.",
+                style="muted"
             );
         }
 
@@ -597,9 +599,7 @@ except ImportError:
     # IDAT chunk - solid blue color with alpha (RGBA: 66, 139, 202, 255 = #428BCA)
     # PNG scanlines: each row is prefixed with filter byte (0 = none)
     row_size = width * 4;  # RGBA = 4 bytes per pixel
-    scanline = bytes([0]) + bytes(
-        [66, 139, 202, 255]
-    ) * width;  # Filter byte + RGBA data
+    scanline = bytes([0]) + bytes([66, 139, 202, 255]) * width;  # Filter byte + RGBA data
     image_data = scanline * height;
 
     # Compress
@@ -1771,9 +1771,7 @@ def _check_and_install_tauri_cli -> None {
         }
     } else {
         console.print("  Skipping Tauri CLI installation.", style="muted");
-        console.print(
-            "  It will be needed when building. Install with:", style="muted"
-        );
+        console.print("  It will be needed when building. Install with:", style="muted");
         if cargo_available {
             console.print("    cargo install tauri-cli", style="muted");
         }
@@ -2504,7 +2502,12 @@ def _bundle_sidecar(
 
     if use_pyinstaller {
         result = _bundle_sidecar_pyinstaller(
-            entry_file, project_dir, tauri_dir, binaries_dir, is_windows, plugins_config
+            entry_file,
+            project_dir,
+            tauri_dir,
+            binaries_dir,
+            is_windows,
+            plugins_config
         );
         if result {
             return result;
@@ -3075,9 +3078,7 @@ impl DesktopTarget.dev(
     # Compile runtime utils (creates client_runtime.js)
     compiler.compile_runtime_utils();
     # Compile the module to create compiled/main.js (or whatever the module name is)
-    (module_js, mod, module_manifest) = compiler.jac_compiler.compile_module(
-        entry_file
-    );
+    (module_js, mod, module_manifest) = compiler.jac_compiler.compile_module(entry_file);
     # Write the compiled module to compiled directory
     module_name = entry_file.stem;
     compiled_module_path = compiler.compiled_dir / f"{module_name}.js";
@@ -3115,9 +3116,7 @@ impl DesktopTarget.dev(
         f"  Step 3: Starting backend server on port {server_port}...", style="muted"
     );
     server_process = _start_backend_server(entry_file, project_dir, server_port);
-    console.print(
-        f"  ✔ Backend server starting on port {server_port}", style="success"
-    );
+    console.print(f"  ✔ Backend server starting on port {server_port}", style="success");
     # Step 4: Launch tauri dev
     console.print("  Step 4: Launching Tauri dev window...", style="muted");
     console.print("  (Press Ctrl+C to stop)", style="muted");
@@ -3410,9 +3409,7 @@ impl DesktopTarget.start(
         f"  Step 3: Starting backend server on port {server_port}...", style="muted"
     );
     server_process = _start_backend_server(entry_file, project_dir, server_port);
-    console.print(
-        f"  ✔ Backend server starting on port {server_port}", style="success"
-    );
+    console.print(f"  ✔ Backend server starting on port {server_port}", style="success");
     # Step 4: Launch tauri dev (which will use the built bundle)
     console.print("  Step 4: Launching Tauri app...", style="muted");
     console.print("  (Press Ctrl+C to stop)", style="muted");

--- a/jac-client/jac_client/tests/test_desktop_pyinstaller_clean.jac
+++ b/jac-client/jac_client/tests/test_desktop_pyinstaller_clean.jac
@@ -18,14 +18,14 @@ test "pyinstaller command does not include --clean" {
 
     # Find the PyInstaller subprocess invocation (the arg list that begins with
     # sys.executable, "-m", "PyInstaller").
-    match = re.search(
+    m = re.search(
         r'sys\.executable\s*,\s*"-m"\s*,\s*"PyInstaller"\s*,(.*?)str\(spec_path\)',
         content,
         re.DOTALL
     );
-    assert match is not None , "Could not locate PyInstaller invocation arg list";
+    assert m is not None , "Could not locate PyInstaller invocation arg list";
 
-    args_block = match.group(1);
+    args_block = m.group(1);
     assert '"--clean"' not in args_block , (
         "PyInstaller invocation should not include --clean; it forces a full "
         "rebuild on every run, slowing incremental sidecar builds."

--- a/jac-client/jac_client/tests/test_desktop_pyinstaller_clean.jac
+++ b/jac-client/jac_client/tests/test_desktop_pyinstaller_clean.jac
@@ -27,7 +27,7 @@ test "pyinstaller command does not include --clean" {
 
     args_block = match.group(1);
     assert '"--clean"' not in args_block , (
-        "PyInstaller invocation should not include --clean — it forces a full "
+        "PyInstaller invocation should not include --clean; it forces a full "
         "rebuild on every run, slowing incremental sidecar builds."
     );
     # Sanity check: we still pass --noconfirm so the build is non-interactive.

--- a/jac-client/jac_client/tests/test_desktop_pyinstaller_clean.jac
+++ b/jac-client/jac_client/tests/test_desktop_pyinstaller_clean.jac
@@ -1,0 +1,37 @@
+"""Tests for PyInstaller invocation in desktop sidecar builds.
+
+Validates that the PyInstaller command does not pass --clean, so incremental
+rebuilds can reuse the cache.
+"""
+
+import re;
+import from pathlib { Path }
+
+glob _plugin_src = Path(__file__).parent.parent / "plugin" / "src",
+     _desktop_target_impl_path = _plugin_src / "targets" / "impl" / "desktop_target.impl.jac";
+
+
+test "pyinstaller command does not include --clean" {
+    assert _desktop_target_impl_path.exists();
+
+    content = _desktop_target_impl_path.read_text();
+
+    # Find the PyInstaller subprocess invocation (the arg list that begins with
+    # sys.executable, "-m", "PyInstaller").
+    match = re.search(
+        r'sys\.executable\s*,\s*"-m"\s*,\s*"PyInstaller"\s*,(.*?)str\(spec_path\)',
+        content,
+        re.DOTALL
+    );
+    assert match is not None , "Could not locate PyInstaller invocation arg list";
+
+    args_block = match.group(1);
+    assert '"--clean"' not in args_block , (
+        "PyInstaller invocation should not include --clean — it forces a full "
+        "rebuild on every run, slowing incremental sidecar builds."
+    );
+    # Sanity check: we still pass --noconfirm so the build is non-interactive.
+    assert '"--noconfirm"' in args_block , (
+        "PyInstaller invocation should still include --noconfirm"
+    );
+}


### PR DESCRIPTION
## Summary

Drop `--clean` from the PyInstaller invocation in the desktop sidecar build so incremental rebuilds can reuse the cache.

## Why

`--clean` wipes PyInstaller's work directory on every run, forcing a full re-analysis and re-compilation of the entire sidecar on every build. For iterative development (tweaking the entry point or spec template), this is a significant cost with no correctness benefit — if a fully fresh build is ever needed, `jac clean` already clears the relevant output directories.

`--noconfirm` is retained so the invocation stays non-interactive.

## Test plan

- [x] `test_desktop_pyinstaller_clean.jac` asserts the PyInstaller arg list does not contain `--clean` and still contains `--noconfirm`
- [ ] Run two back-to-back sidecar builds locally and confirm the second one is meaningfully faster