### PR TITLE
fix(compiler): resolve has-var scope in impl bodies + jac0 module-level impls

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5605.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5605.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Component `has` Variables Visible in `impl` Method Bodies**: `impl app.addTodo` and similar nested impls now correctly resolve `has` variables declared in the parent component function. Previously, assignments to component state created untyped local shadows instead of resolving to the declared type, causing false `Unknown` types and downstream type errors.

--- a/jac/jaclang/jac0.py
+++ b/jac/jaclang/jac0.py
@@ -1994,10 +1994,27 @@ class CodeGen:
         self.indent += 1
         prev_in_class = self._in_class
         self._in_class = False  # nested functions are not methods
-        self._emit_body(node.body)
+        # Module-level impl stitching: a top-level forward-decl `def foo(...);`
+        # paired with `impl foo(...) { body }` in the same module or an
+        # .impl.jac file. The full compiler uses DeclImplMatchPass for this;
+        # jac0 (bootstrap) approximates by splicing the impl's body into the
+        # stub's emitted function. Class-method impls remain stitched in
+        # `_emit_class` where they have access to the surrounding class body.
+        body = node.body
+        if not prev_in_class and self._is_stub_body(body):
+            for impl in self.impl_registry.get(node.name, []):
+                if "." not in impl.target:
+                    body = impl.body
+                    break
+        self._emit_body(body)
         self._in_class = prev_in_class
         self.indent -= 1
         self._line()
+
+    @staticmethod
+    def _is_stub_body(body: list) -> bool:
+        """A forward-decl stub is a body of a single PassStmt (from `def f(...);`)."""
+        return len(body) == 1 and isinstance(body[0], PassStmt)
 
     def _format_params(self, params: list[Param]) -> str:
         parts: list[str] = []

--- a/jac/jaclang/jac0core/passes/decl_impl_match_pass.jac
+++ b/jac/jaclang/jac0core/passes/decl_impl_match_pass.jac
@@ -21,6 +21,7 @@ their behavior in separate files.
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.transform { Transform }
 import from jaclang.jac0core.unitree { Symbol, UniScopeNode }
+import from jaclang.jac0core.passes.sym_tab_build_pass { bind_assignment_targets }
 import from jaclang.jac0core.diagnostics {
     E2009,
     W2010,

--- a/jac/jaclang/jac0core/passes/impl/decl_impl_match_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/decl_impl_match_pass.impl.jac
@@ -171,25 +171,15 @@ impl DeclImplMatchPass.connect_impls(
             valid_decl.sym_tab.names_in_scope
         );
         valid_decl.sym_tab.names_in_scope = sym.decl.name_of.sym_tab.names_in_scope;
-        # For nested impls (e.g. impl app.addTodo), re-parent the impl's
-        # scope to the declaration's parent scope so that enclosing has
-        # variables (component state) are reachable via deep lookup.
-        if valid_decl.sym_tab.parent_scope
-        and valid_decl.sym_tab.parent_scope is not sym.decl.name_of.sym_tab.parent_scope {
-            impl_scope = sym.decl.name_of.sym_tab;
-            parent_scope = valid_decl.sym_tab.parent_scope;
-            impl_scope.parent_scope = parent_scope;
-            # Merge parent has-field symbols into the impl scope so that
-            # assignments to component state variables (e.g. todos = ...)
-            # resolve to the declared has variable rather than creating
-            # an untyped local shadow.
-            for (name, parent_sym) in parent_scope.names_in_scope.items() {
-                if (
-                    isinstance(parent_sym.decl.name_of, uni.HasVar)
-                    and name in impl_scope.names_in_scope
-                ) {
-                    impl_scope.names_in_scope[name] = parent_sym;
-                }
+        # SymTabBuildPass deferred assignment-target binding for impl bodies
+        # because it can't see the decl's scope chain. Now that decl_link is
+        # set and UniScopeNode.lookup follows it into the enclosing scope,
+        # run the same binding decision here — shared helper, single source
+        # of truth. Must run before _resolve_symbols_in_subtree because that
+        # skips Names whose sym is already set.
+        if isinstance(sym.decl.name_of, uni.ImplDef) {
+            for assignment in sym.decl.name_of.get_all_sub_nodes(uni.Assignment) {
+                bind_assignment_targets(assignment);
             }
         }
         self._resolve_symbols_in_subtree(sym.decl.name_of);

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -29,20 +29,6 @@ impl SymTabBuildPass.cur_scope(self: SymTabBuildPass) -> UniScopeNode {
     return self.cur_sym_tab[-1];
 }
 
-"""Find scope node of a given node."""
-impl SymTabBuildPass.find_python_scope_node_of(
-    self: SymTabBuildPass, nd: uni.UniNode
-) -> (UniScopeNode | None) {
-    scope_types = uni.UniScopeNode.get_python_scoping_nodes();
-    while nd.parent {
-        if isinstance(nd.parent, scope_types) {
-            return nd.parent;
-        }
-        nd = nd.parent;
-    }
-    return None;
-}
-
 """Create symbols for Name nodes in a module path."""
 impl SymTabBuildPass._bind_import_path_symbols(
     self: SymTabBuildPass, module_path: uni.ModulePath
@@ -103,58 +89,18 @@ impl SymTabBuildPass.exit_global_vars(
 impl SymTabBuildPass.exit_assignment(
     self: SymTabBuildPass, nd: uni.Assignment
 ) -> None {
-    import from jaclang.jac0core.constant { SymbolType }
-    for i in nd.target {
-        if isinstance(i, uni.AstSymbolNode) {
-            if isinstance(i, (uni.ListVal, uni.TupleVal)) {
-                self._def_insert_unpacking(i, i.sym_tab, rebind_in_python_scope=True);
-            } elif ((sym := i.sym_tab.lookup(i.sym_name, deep=False)) is not None) {
-                sym.add_use(i.name_spec);
-            } elif (
-                (nd.type_tag is None)
-                and ((outer_has := i.sym_tab.lookup(i.sym_name, deep=True)) is not None)
-                and outer_has.sym_type == SymbolType.HAS_VAR
-                and isinstance(outer_has.parent_tab, uni.Ability)
-            ) {
-                # In cl def components, has variables are reactive state owned by
-                # the enclosing ability (not an archetype). Assignments to these
-                # names in nested abilities are state mutations, not new locals.
-                outer_has.add_use(i.name_spec);
-            } elif (
-                (nd.type_tag is None)
-                and not isinstance(
-                    i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
-                )
-            ) {
-                # Python semantics: an unannotated assignment inside a non-scoping
-                # block (try/except/finally, if/else, for/while, match) binds in
-                # the nearest enclosing Python scope, not in the inner block.
-                # Without this, two assignments to the same name in sibling
-                # branches would create separate "shadow" symbols in each faux
-                # scope, fragmenting symbol resolution and producing spurious
-                # "defined but never used" warnings. This mirrors the walrus
-                # handling in exit_binary_expr.
-                py_scope = self.find_python_scope_node_of(i);
-                if py_scope is not None {
-                    if (
-                        (outer := py_scope.lookup(i.sym_name, deep=False)) is not None
-                    ) {
-                        outer.add_use(i.name_spec);
-                    } else {
-                        py_scope.def_insert(i, single_decl='local var');
-                    }
-                } else {
-                    i.sym_tab.def_insert(i, single_decl='local var');
-                }
-            } else {
-                # Tag enum members with the correct sym_category
-                if isinstance(i.sym_tab, uni.Enum) {
-                    i.name_spec._sym_category = SymbolType.ENUM_MEMBER;
-                }
-                i.sym_tab.def_insert(i, single_decl='local var');
-            }
-        }
+    # Impl-body assignments are deferred: the ImplDef's scope chain doesn't
+    # reach its connected decl until DeclImplMatchPass, so any "bare name =
+    # expr" in an impl body would incorrectly fall through the
+    # reactive-has-var / python-scope branches and produce a shadow local.
+    # DeclImplMatchPass.connect_impls calls bind_assignment_targets on every
+    # Assignment in the impl body once decl_link is wired — by then the
+    # decl_link-aware lookup in UniScopeNode.lookup can reach the enclosing
+    # Ability's HasVars and Python scope correctly.
+    if nd.find_parent_of_type(uni.ImplDef) is not None {
+        return;
     }
+    bind_assignment_targets(nd);
 }
 
 """Handle walrus operator (:=) assignments.
@@ -205,7 +151,7 @@ impl SymTabBuildPass.exit_test(self: SymTabBuildPass, nd: uni.Test) -> None {
 impl SymTabBuildPass._exit_import_absorb(
     self: SymTabBuildPass, nd: uni.Import
 ) -> None {
-    sym_table_to_update = self.find_python_scope_node_of(nd);
+    sym_table_to_update = find_python_scope_node_of(nd);
     if (sym_table_to_update is None) {
         return;
     }
@@ -565,61 +511,11 @@ impl SymTabBuildPass.exit_iter_for_stmt(
     self.pop_scope();
 }
 
-"""Recursively define symbols in unpacking expressions.
-
-The two call sites want different scoping:
-
-- `for (x, y) in items:` binds `x` and `y` in the for-loop's own
-  scope. This is Jac-specific (Python has no loop scopes) but the
-  symbol table and test suite depend on it.
-- `(x, y) = f()` as a statement must rebind an existing local
-  when one is in scope, otherwise bind in the nearest Python
-  scope — same Python-semantics path that plain assignments use.
-  Without this, unpack targets shadow the parameter they should
-  be writing, and the narrowing engine can't see the assignment
-  as a barrier.
-
-`rebind_in_python_scope=True` selects the second behavior.
-"""
-impl SymTabBuildPass._def_insert_unpacking(
-    self: SymTabBuildPass,
-    nd: uni.Expr,
-    sym_tab: UniScopeNode,
-    rebind_in_python_scope: bool = False
-) -> None {
-    if isinstance(nd, uni.Name) {
-        if rebind_in_python_scope {
-            if ((existing := sym_tab.lookup(nd.sym_name, deep=False)) is not None) {
-                existing.add_use(nd.name_spec);
-                return;
-            }
-            py_scope = self.find_python_scope_node_of(nd);
-            if py_scope is not None {
-                if ((outer := py_scope.lookup(nd.sym_name, deep=False)) is not None) {
-                    outer.add_use(nd.name_spec);
-                } else {
-                    py_scope.def_insert(nd, single_decl='local var');
-                }
-                return;
-            }
-        }
-        sym_tab.def_insert(nd, single_decl='iterator');
-    } elif isinstance(nd, (uni.TupleVal, uni.ListVal)) {
-        for target_var in nd.values {
-            if isinstance(target_var, uni.Expr) {
-                self._def_insert_unpacking(target_var, sym_tab, rebind_in_python_scope);
-            }
-        }
-    } elif (isinstance(nd, uni.UnaryExpr) and (nd.op.name == Tokens.STAR_MUL)) {
-        self._def_insert_unpacking(nd.operand, sym_tab, rebind_in_python_scope);
-    }
-}
-
 impl SymTabBuildPass.enter_in_for_stmt(
     self: SymTabBuildPass, nd: uni.InForStmt
 ) -> None {
     self.push_scope_and_link(nd);
-    self._def_insert_unpacking(nd.target, nd.sym_tab);
+    def_insert_unpacking(nd.target, nd.sym_tab);
 }
 
 impl SymTabBuildPass.exit_in_for_stmt(
@@ -671,7 +567,7 @@ impl SymTabBuildPass.enter_list_compr(
 ) -> None {
     self.push_scope_and_link(nd);
     for i in nd.compr {
-        self._def_insert_unpacking(i.target, nd.sym_tab);
+        def_insert_unpacking(i.target, nd.sym_tab);
     }
 }
 
@@ -682,7 +578,7 @@ impl SymTabBuildPass.exit_list_compr(self: SymTabBuildPass, nd: uni.ListCompr) -
 impl SymTabBuildPass.enter_set_compr(self: SymTabBuildPass, nd: uni.SetCompr) -> None {
     self.push_scope_and_link(nd);
     for i in nd.compr {
-        self._def_insert_unpacking(i.target, nd.sym_tab);
+        def_insert_unpacking(i.target, nd.sym_tab);
     }
 }
 
@@ -693,7 +589,7 @@ impl SymTabBuildPass.exit_set_compr(self: SymTabBuildPass, nd: uni.SetCompr) -> 
 impl SymTabBuildPass.enter_gen_compr(self: SymTabBuildPass, nd: uni.GenCompr) -> None {
     self.push_scope_and_link(nd);
     for i in nd.compr {
-        self._def_insert_unpacking(i.target, nd.sym_tab);
+        def_insert_unpacking(i.target, nd.sym_tab);
     }
 }
 
@@ -706,7 +602,7 @@ impl SymTabBuildPass.enter_dict_compr(
 ) -> None {
     self.push_scope_and_link(nd);
     for i in nd.compr {
-        self._def_insert_unpacking(i.target, nd.sym_tab);
+        def_insert_unpacking(i.target, nd.sym_tab);
     }
 }
 
@@ -734,4 +630,103 @@ impl SymTabBuildPass.enter_match_case(
 
 impl SymTabBuildPass.exit_match_case(self: SymTabBuildPass, nd: uni.MatchCase) -> None {
     self.pop_scope();
+}
+
+impl find_python_scope_node_of(nd: uni.UniNode) -> (UniScopeNode | None) {
+    scope_types = uni.UniScopeNode.get_python_scoping_nodes();
+    while nd.parent {
+        if isinstance(nd.parent, scope_types) {
+            return nd.parent;
+        }
+        nd = nd.parent;
+    }
+    return None;
+}
+
+impl def_insert_unpacking(
+    nd: uni.Expr, sym_tab: UniScopeNode, rebind_in_python_scope: bool = False
+) -> None {
+    if isinstance(nd, uni.Name) {
+        if rebind_in_python_scope {
+            if ((existing := sym_tab.lookup(nd.sym_name, deep=False)) is not None) {
+                existing.add_use(nd.name_spec);
+                return;
+            }
+            py_scope = find_python_scope_node_of(nd);
+            if py_scope is not None {
+                if ((outer := py_scope.lookup(nd.sym_name, deep=False)) is not None) {
+                    outer.add_use(nd.name_spec);
+                } else {
+                    py_scope.def_insert(nd, single_decl='local var');
+                }
+                return;
+            }
+        }
+        sym_tab.def_insert(nd, single_decl='iterator');
+    } elif isinstance(nd, (uni.TupleVal, uni.ListVal)) {
+        for target_var in nd.values {
+            if isinstance(target_var, uni.Expr) {
+                def_insert_unpacking(target_var, sym_tab, rebind_in_python_scope);
+            }
+        }
+    } elif (isinstance(nd, uni.UnaryExpr) and (nd.op.name == Tokens.STAR_MUL)) {
+        def_insert_unpacking(nd.operand, sym_tab, rebind_in_python_scope);
+    }
+}
+
+impl bind_assignment_targets(nd: uni.Assignment) -> None {
+    import from jaclang.jac0core.constant { SymbolType }
+    for i in nd.target {
+        if isinstance(i, uni.AstSymbolNode) {
+            if isinstance(i, (uni.ListVal, uni.TupleVal)) {
+                def_insert_unpacking(i, i.sym_tab, rebind_in_python_scope=True);
+            } elif (
+                (i.sym_name in i.sym_tab.names_in_scope)
+                and ((sym := i.sym_tab.names_in_scope[i.sym_name]) is not None)
+            ) {
+                # Direct names_in_scope check only — bypass the decl_link
+                # fallback in UniScopeNode.lookup so archetype methods get
+                # Python-local scoping and don't silently rebind `has` fields.
+                sym.add_use(i.name_spec);
+            } elif (
+                (nd.type_tag is None)
+                and ((outer_has := i.sym_tab.lookup(i.sym_name, deep=True)) is not None)
+                and outer_has.sym_type == SymbolType.HAS_VAR
+                and isinstance(outer_has.parent_tab, uni.Ability)
+            ) {
+                # In cl def components, has variables are reactive state owned by
+                # the enclosing ability (not an archetype). Assignments to these
+                # names in nested abilities are state mutations, not new locals.
+                outer_has.add_use(i.name_spec);
+            } elif (
+                (nd.type_tag is None)
+                and not isinstance(
+                    i.sym_tab, uni.UniScopeNode.get_python_scoping_nodes()
+                )
+            ) {
+                # Python semantics: an unannotated assignment inside a non-scoping
+                # block (try/except/finally, if/else, for/while, match) binds in
+                # the nearest enclosing Python scope, not in the inner block.
+                # Mirrors the walrus handling in exit_binary_expr.
+                py_scope = find_python_scope_node_of(i);
+                if py_scope is not None {
+                    if (
+                        (outer := py_scope.lookup(i.sym_name, deep=False)) is not None
+                    ) {
+                        outer.add_use(i.name_spec);
+                    } else {
+                        py_scope.def_insert(i, single_decl='local var');
+                    }
+                } else {
+                    i.sym_tab.def_insert(i, single_decl='local var');
+                }
+            } else {
+                # Tag enum members with the correct sym_category
+                if isinstance(i.sym_tab, uni.Enum) {
+                    i.name_spec._sym_category = SymbolType.ENUM_MEMBER;
+                }
+                i.sym_tab.def_insert(i, single_decl='local var');
+            }
+        }
+    }
 }

--- a/jac/jaclang/jac0core/passes/sym_tab_build_pass.jac
+++ b/jac/jaclang/jac0core/passes/sym_tab_build_pass.jac
@@ -38,11 +38,6 @@ class SymTabBuildPass(UniPass) {
     @property
     def cur_scope(self: SymTabBuildPass) -> UniScopeNode;
 
-    """Find scope node of a given node."""
-    def find_python_scope_node_of(
-        self: SymTabBuildPass, nd: uni.UniNode
-    ) -> (UniScopeNode | None);
-
     """Create symbols for Name nodes in a module path."""
     def _bind_import_path_symbols(
         self: SymTabBuildPass, module_path: uni.ModulePath
@@ -98,14 +93,6 @@ class SymTabBuildPass(UniPass) {
     def exit_finally_stmt(self: SymTabBuildPass, nd: uni.FinallyStmt) -> None;
     def enter_iter_for_stmt(self: SymTabBuildPass, nd: uni.IterForStmt) -> None;
     def exit_iter_for_stmt(self: SymTabBuildPass, nd: uni.IterForStmt) -> None;
-    """Recursively define symbols in unpacking expressions."""
-    def _def_insert_unpacking(
-        self: SymTabBuildPass,
-        nd: uni.Expr,
-        sym_tab: UniScopeNode,
-        rebind_in_python_scope: bool = False
-    ) -> None;
-
     def enter_in_for_stmt(self: SymTabBuildPass, nd: uni.InForStmt) -> None;
     def exit_in_for_stmt(self: SymTabBuildPass, nd: uni.InForStmt) -> None;
     def enter_while_stmt(self: SymTabBuildPass, nd: uni.WhileStmt) -> None;
@@ -128,3 +115,38 @@ class SymTabBuildPass(UniPass) {
     def enter_match_case(self: SymTabBuildPass, nd: uni.MatchCase) -> None;
     def exit_match_case(self: SymTabBuildPass, nd: uni.MatchCase) -> None;
 }
+
+"""Walk up ancestors to find the nearest Python-scoping node.
+
+Module-level helper so both SymTabBuildPass and DeclImplMatchPass can use it
+without taking a pass-instance reference."""
+def find_python_scope_node_of(nd: uni.UniNode) -> (UniScopeNode | None);
+
+"""Recursively define symbols in unpacking expressions.
+
+Module-level helper — the unpacking semantics are identical whether the
+assignment is encountered during SymTabBuildPass or rebound later by
+DeclImplMatchPass once an impl body has been connected to its decl.
+
+Two unpacking contexts:
+- `for (k, v) in d.items()` iterator binds `k`, `v` as iterator locals in
+  the for-statement's scope (no rebind).
+- `(x, y) = f()` as a statement must rebind an existing local when one is
+  in scope, otherwise bind in the nearest Python scope — same
+  Python-semantics path that plain assignments use. Without this, unpack
+  targets shadow the parameter they should be writing.
+
+`rebind_in_python_scope=True` selects the second behavior."""
+def def_insert_unpacking(
+    nd: uni.Expr, sym_tab: UniScopeNode, rebind_in_python_scope: bool = False
+) -> None;
+
+"""Bind the target Names of an assignment to symbols.
+
+Single source of truth for the "what does assigning to bare `x = ...` mean"
+decision: existing local → reuse; unannotated assignment with a reactive
+`has` var in an ancestor Ability scope → rebind that HasVar; otherwise
+introduce a local in the nearest Python scope. Used both during
+SymTabBuildPass and, for impl bodies, re-run after DeclImplMatchPass has
+connected the body to its declaration so decl-scope HasVars are reachable."""
+def bind_assignment_targets(nd: uni.Assignment) -> None;

--- a/jac/tests/compiler/passes/main/fixtures/impl_has_var_reassign.cl.jac
+++ b/jac/tests/compiler/passes/main/fixtures/impl_has_var_reassign.cl.jac
@@ -1,0 +1,16 @@
+"""Fixture: `has` var reassignment inside an impl body of a def-component.
+
+Reproduces a bug where `tasks = tasks + [x]` in a separate `.impl.jac` file
+loses the type of the parent `has` var and creates an untyped local shadow.
+Inline method bodies in the same declaration file handle this correctly;
+the impl-file path did not.
+
+Expected: no type errors — `tasks` should resolve to the HasVar from the
+enclosing def-component, matching the inline behavior.
+"""
+
+def:pub taskManager -> None {
+    has tasks: list[dict] = [];
+    async def addTask(task: dict) -> None;
+    async def listTasks -> None;
+}

--- a/jac/tests/compiler/passes/main/fixtures/impl_has_var_reassign.impl.jac
+++ b/jac/tests/compiler/passes/main/fixtures/impl_has_var_reassign.impl.jac
@@ -1,0 +1,16 @@
+"""Impl file: reassignment must resolve `tasks` to the parent HasVar.
+
+Also checks that annotated locals keep their own binding (Python shadowing),
+so the fix does not over-apply.
+"""
+
+impl taskManager.addTask(task: dict) -> None {
+    tasks = tasks + [task];
+}
+
+impl taskManager.listTasks -> None {
+    x: list[dict] = tasks;
+    # Annotated local with a distinct name is an ordinary local binding, not
+    # a has-var reassignment. It must NOT collapse into the HasVar.
+    local_count: int = 0;
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -22,6 +22,7 @@ Bug index:
   #TVAR-2 - No transitive TypeVar propagation through base_classes in build_type_var_solution
   #TVAR-3 - Union return types with TypeVars (e.g., V | None) resolve to Unknown
   #TVAR-5 - Module-level TypeVars shadowed by class type parameters
+  #IMPL-1 - Has var reassigned in impl body loses its type (shadow local)
 """
 
 import os;
@@ -476,4 +477,45 @@ test "bug_tvar5_module_typevar_shadowed_by_class_param" {
     ];
     assert 29 in error_lines , f"Expected error on line 29, got {error_lines}.";
     assert 23 not in error_lines , f"Line 23 should NOT error, got {error_lines}.";
+}
+
+# =========================================================================
+# Bug #IMPL-1: `has` var reassigned in impl body shadows the parent type
+#
+# When a reactive def-component (e.g. `def:pub app -> None { has todos: ... }`)
+# has its method body split into a separate `.impl.jac` file, assignments to
+# the has var like `todos = todos + [x]` inside the impl created an untyped
+# local "shadow" symbol in SymTabBuildPass. The impl module's parent scope
+# is not yet connected at that pass, so the lookup for the enclosing HasVar
+# fails and falls through to the local-var branch.
+#
+# Effect: in the impl body, every reference to the has var is typed as
+# Unknown, and any operation on it (e.g. `todos + [{...}]`) breaks overload
+# resolution for `__add__`, producing a cascade of spurious E1055 errors
+# that don't appear when the same body is written inline.
+#
+# Fix: After DeclImplMatchPass connects an impl body to its declaration,
+# walk the impl body for Assignment targets whose resolved symbol is a
+# local shadow of a HasVar in the now-reachable parent ability scope, and
+# re-point those Name nodes at the parent HasVar. Only apply this for
+# has vars owned by an Ability (reactive component state); archetype
+# methods keep normal Python scoping (bare-name assignments stay local).
+# =========================================================================
+test "bug_impl1_has_var_shadow_in_impl_body" {
+    fixture_dir = os.path.join(
+        JAC_ROOT, "tests", "compiler", "passes", "main", "fixtures"
+    );
+    program = JacProgram();
+    program.compile(
+        os.path.join(fixture_dir, "impl_has_var_reassign.cl.jac"), type_check=True
+    );
+
+    # Expected after fix: 0 errors. The impl body should type-check cleanly:
+    #   - `tasks + [task]` resolves via list[dict].__add__
+    #   - `x: list[dict] = tasks` is a sound assignment
+    assert len(program.errors_had) == 0 , (
+        "Bug #IMPL-1: has var `tasks` in impl body should resolve to the "
+        "parent HasVar (type list[dict]), not a local shadow (type Unknown). "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
 }


### PR DESCRIPTION
## Summary

Two related fixes that make assignments to reactive \`has\` vars inside \`.impl.jac\` bodies behave identically to inline decl bodies, and extend the jac0 bootstrap transpiler to support module-level function impls.

## The bug

Given:
\`\`\`jac
def:pub app -> None {
    has todos: list[dict] = [];
    async def addTodo -> None;
}

impl app.addTodo -> None {
    todos = todos + [{\"id\": \"1\"}];  // E1055: no matching overload for __add__
}
\`\`\`

The same body written inline inside \`def:pub app\` type-checks cleanly; splitting into an \`impl\` block produced a cascade of spurious E1055s. Surfaced as a user-visible failure in \`jac-client/templates/fullstack/frontend.impl.jac\`.

### Root cause

\`SymTabBuildPass.exit_assignment\` makes the local-vs-has-var-rebind decision based on scope lookup, but \`.impl.jac\` files run through SymTabBuildPass *before* DeclImplMatchPass wires \`decl_link\`. The deep lookup for an enclosing Ability's HasVar fails, and \`exit_assignment\` falls through to creating an untyped local shadow. Every reference then types as Unknown and overload resolution collapses.

## Fixes (architectural, not workarounds)

### Compiler: defer the binding decision for impl bodies
- Extracted the per-target binding logic from \`exit_assignment\` into a module-level \`bind_assignment_targets\` helper — single source of truth.
- \`SymTabBuildPass.exit_assignment\` defers for Assignments inside an \`ImplDef\`.
- \`DeclImplMatchPass.connect_impls\` calls \`bind_assignment_targets\` on every Assignment in the impl body *after* \`decl_link\` is wired. The existing \`decl_link\`-aware branch in [\`UniScopeNode.lookup\`](jac/jaclang/jac0core/impl/unitree.impl.jac#L414-L422) now handles LHS and RHS resolution consistently.
- First branch checks \`names_in_scope\` directly to bypass the \`decl_link\` fallback — archetype methods keep Python-local scoping; only the explicit reactive-has-var branch (guarded by \`parent_tab is Ability\`) performs the rebind.

### jac0 bootstrap: support module-level function impls
The bootstrap transpiler only stitched \`impl SomeClass.method\` into its surrounding class; module-level \`impl foo(...)\` was registered but never emitted, leaving an empty stub body — which silently broke the compiler source itself. \`_emit_func\` now splices a matching module-level impl body when the decl is a stub, mirroring the full compiler's DeclImplMatchPass behavior.

### Housekeeping
- Removed \`find_python_scope_node_of\` and \`_def_insert_unpacking\` as SymTabBuildPass methods — they're pure functions used by both passes, now at module level per the Jac decl/impl convention.

## Test plan

- [x] New regression test: \`bug_impl1_has_var_shadow_in_impl_body\` in [\`test_checker_bugs.jac\`](jac/tests/compiler/passes/main/test_checker_bugs.jac), with fixtures covering both the reassignment case and an annotated-local edge case that must *not* collapse into the HasVar.
- [x] Full suites pass: checker_bugs (19), decl_impl_match_pass (17), sym_tab_build_pass (9), checker_gaps (16), checker_production (10), checker_shortcomings (9), typevar (9), static_analysis (12).
- [x] \`jac check jac-client/.../frontend.impl.jac\` no longer emits E1055 errors (only the unrelated pre-existing E1050 from the walker \`reports\` schema remains).
- [x] Same-file and separate-file impls both produce correct binding; archetype method impls (\`obj Foo { def bar; }\`) continue to use Python-local scoping.