### PR TITLE
chore: remove 13 files from .jacignore that now pass jac check

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -50,7 +50,6 @@ level_manager.jac
 llm.jac
 macho_linker.impl.jac
 macho_linker.jac
-main.jac
 memory_hierarchy.jac
 memory.jac
 modresolver.jac
@@ -66,7 +65,6 @@ normalize_pass.jac
 operations.jac
 parser.impl.jac
 parser.jac
-plugin_config.jac
 plugin.jac
 precompile_bytecode.jac
 program.jac
@@ -186,7 +184,6 @@ local_storage.jac
 math_solver.jac
 memory.impl.jac
 model.impl.jac
-module_manager.jac
 monitoring.jac
 native_accel.jac
 normalize_pass.impl.jac
@@ -197,14 +194,11 @@ receipt_analyzer.jac
 resources.impl.jac
 resources.jac
 search.jac
-sem_def_match_pass.impl.jac
-sem_def_match_pass.jac
 semantic_analysis_pass.jac
 serializer.impl.jac
 serializer.jac
 test.impl.jac
 test.jac
-transform.impl.jac
 unitree.impl.jac
 unparse_pass.impl.jac
 uris.impl.jac
@@ -228,11 +222,9 @@ client.impl.jac
 callback.cl.jac
 media.impl.jac
 basellm.impl.jac
-db.jac
 webhook.impl.jac
 serve.endpoints.impl.jac
 serve.static.impl.jac
-db.impl.jac
 # Stricter Unknown discipline -- these files have legitimate type gaps
 # that were previously silent (Unknown treated as Any). Added 2026-03-08.
 AlertContext.cl.jac
@@ -307,7 +299,6 @@ interop_analysis_pass.impl.jac
 interop_bridge.jac
 jaccomplete.impl.jac
 jaccomplete.jac
-jir.impl.jac
 jsx_processor.impl.jac
 level.impl.jac
 lexer.impl.jac
@@ -320,12 +311,10 @@ login.cl.jac
 login.jac
 mockllm.impl.jac
 module_codegen_pass.jac
-module_manager.impl.jac
 mtir.impl.jac
 navigation.jac
 parameter_type_check.impl.jac
 player.impl.jac
-program.impl.jac
 pybc_gen_pass.jac
 refcount.impl.jac
 registry.impl.jac
@@ -339,13 +328,11 @@ tool.impl.jac
 toolcall.impl.jac
 TransactionForm.jac
 transport.impl.jac
-treeprinter.impl.jac
 tuples.impl.jac
 type_hints.jac
 types.impl.jac
 useBudget.jac
 useLocalStorage.jac
-whitespace.jac
 wikipedia_react.jac
 apple.jac
 google.jac


### PR DESCRIPTION
## Summary

Removes 13 files from `.jacignore` that now pass `jac check` cleanly thanks to today's type checker improvements (#5610, #5611, #5612, #5613).

### Files removed

| File | Package |
|------|---------|
| `main.jac` | jaclang |
| `plugin_config.jac` | jaclang |
| `module_manager.jac` | jaclang |
| `module_manager.impl.jac` | jaclang |
| `sem_def_match_pass.jac` | jaclang |
| `sem_def_match_pass.impl.jac` | jaclang |
| `transform.impl.jac` | jaclang |
| `db.jac` | jaclang |
| `db.impl.jac` | jaclang |
| `jir.impl.jac` | jaclang |
| `program.impl.jac` | jaclang |
| `treeprinter.impl.jac` | jaclang |
| `whitespace.jac` | tests |

**.jacignore: 347 → 334 entries**

Each file was verified by running `jac check` individually against current main.

## Test plan

- [x] All 13 files verified passing with `jac check`
- [x] No code changes, only .jacignore removal