### PR TITLE
example(mini_todo): add native priority scorer to demo na codespace

### DIFF
--- a/jac/examples/mini_todo/main.jac
+++ b/jac/examples/mini_todo/main.jac
@@ -1,12 +1,29 @@
 node Todo {
     has title: str,
         category: str = "other",
+        priority: int = 0,
         done: bool = False;
 }
 
 enum Category { WORK, PERSONAL, SHOPPING, HEALTH, OTHER }
 
 def categorize(title: str) -> Category by llm();
+
+na def priority_score(title: str) -> int {
+    score: int = 0;
+    for c in title {
+        if c == "!" {
+            score = score + 20;
+        }
+    }
+    if "urgent" in title {
+        score = score + 50;
+    }
+    if score > 100 {
+        score = 100;
+    }
+    return score;
+}
 
 def:pub add_todo(title: str) -> Todo {
     try {
@@ -15,7 +32,7 @@ def:pub add_todo(title: str) -> Todo {
     } except Exception {
         category = "other (setup AI key)";
     }
-    todo = Todo(title=title, category=category);
+    todo = Todo(title=title, category=category, priority=priority_score(title));
     root() ++> todo;
     return todo;
 }
@@ -49,6 +66,9 @@ cl def:pub app -> JsxElement {
                 placeholder="Add a todo..."
             />
             <button onClick={add}>Add</button>
-            {[<p key={jid(t)}>{t.title} ({t.category})</p> for t in todos]}
+            {[
+                <p key={jid(t)}>[{t.priority}]{t.title} ({t.category})</p>
+                for t in todos
+            ]}
         </div>;
 }


### PR DESCRIPTION
## Summary

- Adds a short `na def priority_score(title: str) -> int` to `mini_todo/main.jac` that scores todo urgency from exclamation count (`"!"` → +20 each) and a lowercase `"urgent"` substring check (+50), capped at 100.
- Adds a `priority: int = 0` field to the `Todo` node; wires the native score into `add_todo` and surfaces it in the client UI.
- The example now exercises all three codespaces (`cl` / `sv` / `na`) in one module while staying compact.

## Why

`mini_todo` was a clean two-codespace demo (`cl` + `sv`) but did not touch `na`. A small, well-bounded native scorer (primitive-only boundary: `str` → `int`) makes the example a fuller illustration of the cross-codespace story without adding dependencies.

## Test plan

- [x] `jac start` brings the server up on :8000 with the client bundle built.
- [x] Added four todos via agent-browser, scores matched the `na` function's semantics exactly:
  - `URGENT buy groceries!!!` → **60** (3×20, case-sensitive so "urgent" did not match)
  - `urgent email reply` → **50** (keyword match only)
  - `call mom` → **0**
  - `urgent review paper!!!!!` → **100** (150 pre-cap)
- [x] LLM `categorize(title)` classified each into the right category.
- [x] `jac-format` pre-commit hook ran clean.