### PR TITLE
fix(examples): mini_todo onClick handler signature

### DIFF
--- a/jac/examples/mini_todo/main.jac
+++ b/jac/examples/mini_todo/main.jac
@@ -65,7 +65,7 @@ cl def:pub app -> JsxElement {
                 onKeyPress={lambda e: KeyboardEvent { if e.key == "Enter" { add(); }}}
                 placeholder="Add a todo..."
             />
-            <button onClick={add}>Add</button>
+            <button onClick={lambda e: MouseEvent { add();}}>Add</button>
             {[
                 <p key={jid(t)}>[{t.priority}]{t.title} ({t.category})</p>
                 for t in todos


### PR DESCRIPTION
## Summary
- Wrap \`add()\` in a \`MouseEvent\` lambda so \`onClick\` satisfies \`Callable[[MouseEvent], NoneType]\`, matching the pattern already used for \`onKeyPress\`/\`onChange\` in the same component
- Resolves E1103 reported by \`jac check examples/mini_todo/main.jac\`

## Test plan
- [x] \`jac check examples/mini_todo/main.jac\` passes (previously failed with 2 errors)