### PR TITLE
fix(cfg): resolve all 15 type errors in cfg_build_pass

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5643.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5643.bugfix.md
@@ -1,0 +1,1 @@
+Resolved all 15 type errors in `cfg_build_pass` by restructuring subtype attribute access patterns for proper type narrowing.

--- a/jac/jaclang/compiler/passes/main/cfg_build_pass.jac
+++ b/jac/jaclang/compiler/passes/main/cfg_build_pass.jac
@@ -10,7 +10,7 @@ optimization used during backward CFG walks in type narrowing.
 """
 import from collections.abc { Sequence }
 import from threading { Event }
-import from typing { TYPE_CHECKING }
+import from typing { TYPE_CHECKING, cast }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes { UniPass }
 

--- a/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
@@ -66,12 +66,12 @@ impl CoalesceBBPass.printgraph_cfg -> str {
                     if tail.body and out_head is tail.body[0] {
                         label = ' [label="T"]';
                     } elif tail.else_body {
-                        if isinstance(tail.else_body, uni.ElseIf)
-                        and out_head is tail.else_body {
+                        eb = tail.else_body;
+                        if isinstance(eb, uni.ElseIf) and out_head is eb {
                             label = ' [label="F"]';
-                        } elif isinstance(tail.else_body, uni.ElseStmt)
-                        and tail.else_body.body
-                        and out_head is tail.else_body.body[0] {
+                        } elif isinstance(eb, uni.ElseStmt)
+                        and eb.body
+                        and out_head is eb.body[0] {
                             label = ' [label="F"]';
                         }
                     }
@@ -192,7 +192,7 @@ impl CoalesceBBPass.enter_node(nd: uni.UniNode) -> None {
             is_cfg_node = True;
         }
     }
-    if (is_cfg_node) {
+    if is_cfg_node and isinstance(nd, uni.UniCFGNode) {
         for bbs in self.basic_blocks.values() {
             if (nd in bbs['bb_stmts']) {
                 return;
@@ -289,7 +289,7 @@ impl CFGBuildPass._link_sequential(body: Sequence[uni.CodeBlockStmt]) -> None {
         if self._is_terminal(prev) {
             continue;
         }
-        has_else = prev?.else_body and prev.else_body is not None;
+        has_else = isinstance(prev, uni.AstElseBodyNode) and prev.else_body is not None;
         # Did the exit handler already wire a short-circuit chain? Peel
         # parentheses so `(a and b)` matches `a and b`.
         has_bool_sc = False;
@@ -303,14 +303,14 @@ impl CFGBuildPass._link_sequential(body: Sequence[uni.CodeBlockStmt]) -> None {
             # Exit paths covered -- no direct prev→next edge, unless an
             # empty true body or empty ElseStmt body creates a fall-through.
             self._connect_tails(prev, next);
-            if isinstance(prev, uni.IfStmt)
-            and (
-                not prev.body
-                or (
-                    isinstance(prev.else_body, uni.ElseStmt) and not prev.else_body.body
-                )
-            ) {
-                self.link_bbs(prev, next);
+            if isinstance(prev, uni.IfStmt) {
+                # Fall-through if true body is empty or else body is empty
+                empty_true = not prev.body;
+                eb = prev.else_body;
+                empty_else = isinstance(eb, uni.ElseStmt) and not eb.body;
+                if empty_true or empty_else {
+                    self.link_bbs(prev, next);
+                }
             }
         } elif has_bool_sc {
             # Short-circuit wiring handled false path via BoolExpr chain -- no direct prev→next.
@@ -333,9 +333,10 @@ impl CFGBuildPass._connect_tails(parent: uni.UniNode, target: uni.UniCFGNode) ->
             continue;
         }
         # Skip structural Assignment fields of IterForStmt (iter, count_by)
-        if isinstance(parent, uni.IterForStmt)
-        and (k is parent.iter or k is parent.count_by) {
-            continue;
+        if isinstance(parent, uni.IterForStmt) {
+            if k is parent.iter or k is parent.count_by {
+                continue;
+            }
         }
         if isinstance(k, (uni.Ability, uni.Archetype, uni.ImplDef, uni.Test)) {
             # Scope boundary -- don't recurse into nested scopes
@@ -567,9 +568,11 @@ impl CFGBuildPass._find_parent_of_types(
     cur = nd.parent;
     while cur {
         if isinstance(cur, types) {
-            return cur;
+            # isinstance with a runtime tuple can't be statically narrowed,
+            # but the types param guarantees UniCFGNode subtypes.
+            return cast(uni.UniCFGNode, cur);
         }
-        cur = cur.parent;
+        cur = getattr(cur, 'parent', None);
     }
     return None;
 }
@@ -578,9 +581,10 @@ impl CFGBuildPass._find_parent_of_types(
 impl CFGBuildPass._find_next_cfg_stmt_after(
     parent: uni.UniNode, child: uni.UniNode
 ) -> (uni.UniCFGNode | None) {
-    if parent?.body and isinstance(parent.body, Sequence) {
+    body = getattr(parent, 'body', None);
+    if body is not None and isinstance(body, Sequence) {
         found = False;
-        for stmt in parent.body {
+        for stmt in body {
             if found and isinstance(stmt, uni.CodeBlockStmt) {
                 return stmt;
             }


### PR DESCRIPTION
## Summary

Resolve all remaining type errors in `cfg_build_pass.impl.jac` by restructuring code to give the type checker proper narrowing context. Pure source-level annotation/restructuring — no behavioral changes.

## Changes

| Location | Issue | Fix |
|----------|-------|-----|
| `_link_sequential` | `prev?.else_body` on `CodeBlockStmt` (no `else_body` attr) | Use `isinstance(prev, AstElseBodyNode)` — the mixin that provides `else_body` |
| `_link_sequential` | Nested isinstance+AND not narrowing for `prev.body`/`prev.else_body` | Restructure to nested ifs with local vars |
| `_connect_tails` | `parent.iter`/`parent.count_by` in AND with isinstance | Restructure to nested if |
| `_find_parent_of_types` | `isinstance(cur, types)` with variable tuple can't narrow | Use `cast(UniCFGNode, cur)` |
| `_find_next_cfg_stmt_after` | `parent?.body` on `UniNode` (no `body` attr) | Use `getattr(parent, 'body', None)` |
| `enter_node` | `nd.get_tail()`/`bb_out` on `UniNode` | Add `isinstance(nd, UniCFGNode)` guard |
| `printgraph_cfg` | `tail.else_body.body` — AND narrowing not reaching repeated member access | Extract into local variable `eb` |

## Impact

`jac check cfg_build_pass.jac`:
- **Errors: 15 → 0** ✅
- **Warnings: 17 → 4** (remaining: 2 unused params, 2 Unknown from `getattr`)

## Tests

- All 14 CFG build pass tests pass
- All 174 type checker tests pass