### PR TITLE
fix(memory): tighten types around sqlite cursor/connection access

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5651.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5651.bugfix.md
@@ -1,1 +1,0 @@
-- **Fix: Sqlite memory type narrowing**: Tightened types in `runtimelib/impl/memory.impl.jac` so `self.__conn__` narrows to `Connection` after `_ensure_connection()` (via `assert`) and so `cursor.fetchone()` / `list(cursor)` results are cast to their real tuple shapes. Eliminates spurious unpack and subscript errors; no runtime behavior change.

--- a/docs/docs/community/release_notes/unreleased/jaclang/5651.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5651.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Sqlite memory type narrowing**: Tightened types in `runtimelib/impl/memory.impl.jac` so `self.__conn__` narrows to `Connection` after `_ensure_connection()` (via `assert`) and so `cursor.fetchone()` / `list(cursor)` results are cast to their real tuple shapes. Eliminates spurious unpack and subscript errors; no runtime behavior change.

--- a/docs/docs/community/release_notes/unreleased/jaclang/5651.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5651.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Sqlite memory type narrowing**: Tightened internal type annotations in `runtimelib/impl/memory.impl.jac`. No runtime behavior change.

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -476,7 +476,10 @@ impl SqliteMemory.get(id: UUID) -> (Anchor | None) {
         """,
         (str(id), )
     );
-    row = cursor.fetchone();
+    row = cast(
+        (tuple[str, (str | None), (str | None), (str | None), str, int] | None),
+        cursor.fetchone()
+    );
     if not row {
         return None;
     }
@@ -551,9 +554,11 @@ impl SqliteMemory.put(anchor: Anchor) -> None {
     self.__mem__[anchor.id] = anchor;
     if anchor.persistent {
         self._ensure_connection();
+        assert self.__conn__ is not None;
+        conn = self.__conn__;
         try {
             row = _anchor_to_row(anchor);
-            self.__conn__.execute(
+            conn.execute(
                 """
                 INSERT OR REPLACE INTO anchors
                     (id, type, arch_module, arch_type, fingerprint, data,
@@ -562,7 +567,7 @@ impl SqliteMemory.put(anchor: Anchor) -> None {
                 """,
                 (str(anchor.id), ) + row
             );
-            self.__conn__.commit();
+            conn.commit();
             anchor.hash = Serializer._compute_hash(anchor);
         } except Exception as e {
             logger.warning(f"SqliteMemory.put immediate persist failed: {e}");
@@ -580,8 +585,9 @@ impl SqliteMemory.delete(id: UUID) -> None {
     }
     # Also remove from database immediately if connected
     if self.__conn__ {
-        self.__conn__.execute("DELETE FROM anchors WHERE id = ?", (str(id), ));
-        self.__conn__.commit();
+        conn = cast(sqlite3.Connection, self.__conn__);
+        conn.execute("DELETE FROM anchors WHERE id = ?", (str(id), ));
+        conn.commit();
     }
 }
 
@@ -688,7 +694,8 @@ impl SqliteMemory.sync -> None {
     }
     # Lazily create connection now that we have data to persist
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
     # Handle garbage collected anchors (deletions)
     for anchor in self.__gc__ {
         conn.execute("DELETE FROM anchors WHERE id = ?", (str(anchor.id), ));
@@ -930,32 +937,41 @@ def _sqlite_attempt_recover(conn: sqlite3.Connection, row: tuple) -> tuple {
 """Summary dict for `jac db inspect`."""
 impl SqliteMemory.inspect_summary -> dict {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
     fmt_row = conn.execute(
         "SELECT value FROM schema_meta WHERE key='db_format_version'"
     ).fetchone();
     fmt_version = fmt_row[0] if fmt_row else '?';
-    anchors_rows = list(
-        conn.execute(
-            """
+    anchors_rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                """
         SELECT COALESCE(arch_type, '<none>'), COUNT(*)
         FROM anchors
         GROUP BY arch_type
         ORDER BY COUNT(*) DESC
         """
+            )
         )
     );
-    quarantine_rows = list(
-        conn.execute(
-            """
+    quarantine_rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                """
         SELECT COALESCE(arch_type, '<none>'), COUNT(*)
         FROM anchors_quarantine
         GROUP BY arch_type
         ORDER BY COUNT(*) DESC
         """
+            )
         )
     );
-    (alias_count, ) = conn.execute("SELECT COUNT(*) FROM aliases").fetchone();
+    (alias_count, ) = cast(
+        tuple[int], conn.execute("SELECT COUNT(*) FROM aliases").fetchone()
+    );
     return {
         'format_version': str(fmt_version),
         'anchors_total': sum(r[1] for r in anchors_rows),
@@ -971,10 +987,13 @@ impl SqliteMemory.inspect_summary -> dict {
 """List recent quarantined rows."""
 impl SqliteMemory.list_quarantined(limit: int = 50) -> list {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
-    rows = list(
-        conn.execute(
-            """
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
+    rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                """
         SELECT id, COALESCE(arch_module, '?') || '.' ||
                COALESCE(arch_type, '?'), COALESCE(fingerprint, ''),
                COALESCE(error, ''), COALESCE(quarantined_at, '')
@@ -982,7 +1001,8 @@ impl SqliteMemory.list_quarantined(limit: int = 50) -> list {
         ORDER BY quarantined_at DESC
         LIMIT ?
         """,
-            (limit, )
+                (limit, )
+            )
         )
     );
     return [
@@ -1000,17 +1020,21 @@ impl SqliteMemory.list_quarantined(limit: int = 50) -> list {
 """Full detail of one quarantined row (by id or unique prefix)."""
 impl SqliteMemory.show_quarantined(id_prefix: str) -> (dict | None) {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
-    rows = list(
-        conn.execute(
-            """
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
+    rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                """
         SELECT id, type, arch_module, arch_type, fingerprint, data,
                error, quarantined_at, from_format_version
         FROM anchors_quarantine
         WHERE id = ? OR id LIKE ?
         LIMIT 2
         """,
-            (id_prefix, id_prefix + '%')
+                (id_prefix, id_prefix + '%')
+            )
         )
     );
     if not rows {
@@ -1041,19 +1065,23 @@ impl SqliteMemory.show_quarantined(id_prefix: str) -> (dict | None) {
 """Recover a single quarantined row (or unique prefix)."""
 impl SqliteMemory.recover_one(id_prefix: str) -> tuple {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
     # Pull in DB-resident aliases so CLI-added rescues apply.
     _load_db_aliases(conn);
-    rows = list(
-        conn.execute(
-            """
+    rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                """
         SELECT id, type, arch_module, arch_type, fingerprint, data,
                error, quarantined_at, from_format_version
         FROM anchors_quarantine
         WHERE id = ? OR id LIKE ?
         LIMIT 2
         """,
-            (id_prefix, id_prefix + '%')
+                (id_prefix, id_prefix + '%')
+            )
         )
     );
     if not rows {
@@ -1071,15 +1099,19 @@ impl SqliteMemory.recover_one(id_prefix: str) -> tuple {
 """Recover every quarantined row; return (n_recovered, [(id, reason)...])."""
 impl SqliteMemory.recover_all -> tuple {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
     _load_db_aliases(conn);
-    rows = list(
-        conn.execute(
-            """
+    rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                """
         SELECT id, type, arch_module, arch_type, fingerprint, data,
                error, quarantined_at, from_format_version
         FROM anchors_quarantine
         """
+            )
         )
     );
     recovered = 0;
@@ -1100,11 +1132,15 @@ impl SqliteMemory.recover_all -> tuple {
 """List DB-resident aliases."""
 impl SqliteMemory.list_aliases -> list {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
-    rows = list(
-        conn.execute(
-            "SELECT old_name, new_name, COALESCE(created_at, '') "
-            "FROM aliases ORDER BY created_at"
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
+    rows = cast(
+        list[tuple],
+        list(
+            conn.execute(
+                "SELECT old_name, new_name, COALESCE(created_at, '') "
+                "FROM aliases ORDER BY created_at"
+            )
         )
     );
     return [
@@ -1117,7 +1153,8 @@ impl SqliteMemory.list_aliases -> list {
 """Add (or replace) an alias; merge into the in-process Serializer map."""
 impl SqliteMemory.add_alias(old_name: str, new_name: str) -> None {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
     now = datetime.now(timezone.utc).isoformat();
     conn.execute(
         """
@@ -1134,7 +1171,8 @@ impl SqliteMemory.add_alias(old_name: str, new_name: str) -> None {
 """Remove an alias. Returns True if an entry was deleted."""
 impl SqliteMemory.remove_alias(old_name: str) -> bool {
     self._ensure_connection();
-    conn = cast(sqlite3.Connection, self.__conn__);
+    assert self.__conn__ is not None;
+    conn = self.__conn__;
     cursor = conn.execute("DELETE FROM aliases WHERE old_name = ?", (old_name, ));
     conn.commit();
     removed = cursor.rowcount > 0;


### PR DESCRIPTION
## Summary
- Replace `conn = cast(sqlite3.Connection, self.__conn__)` with `assert self.__conn__ is not None; conn = self.__conn__` at 10 call sites that follow `_ensure_connection()`. The assert is both a type-narrowing hint for the jac checker and a cheap runtime guard that fails loud if the invariant ever breaks. One cast remains in `delete` where the surrounding `if self.__conn__ {}` has already paid for the check.
- Cast `cursor.fetchone()` / `list(conn.execute(...))` results to their real tuple shapes (`tuple[str, str|None, str|None, str|None, str, int] | None`, `tuple[int]`, `list[tuple]`). Typeshed types these as `Any`, which causes jac to flag `(a, b, c) = row` unpacking as `Cannot unpack non-iterable Any` and `r[0]` subscripting as `Type "_T" is not subscriptable`.

Eliminates 10 real diagnostics from [memory.impl.jac](jac/jaclang/runtimelib/impl/memory.impl.jac):
- 2× `E1020 Cannot unpack non-iterable Any`
- 6× `E1040 Type "_T" is not subscriptable`
- 4× `E1099 Cannot access attribute ... for type Connection | None`

Pure type-level changes — no behavioral difference. `jac format --lintfix` and `pre-commit run` both clean.

## Test plan
- [x] `jac format --lintfix jac/jaclang/runtimelib/impl/memory.impl.jac`
- [x] `pre-commit run --files jac/jaclang/runtimelib/impl/memory.impl.jac`
- [x] `jac check` — confirmed the 10 targeted diagnostics are gone; remaining errors in the file are unrelated (yield-in-generator false positive, `Anchor | None` narrowing elsewhere, `self.path` None-ness)