### PR TITLE
fix(persistence): defer SqliteMemory/MongoBackend put() to sync() (fi…

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/5663.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/5663.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Per-walker atomicity for MongoDB persistence**: `MongoBackend.put()` now defers all writes to `sync()`, which already routes `NodeAnchor` updates through `_put_node_atomic` and other anchors through `_write_to_db`. This restores per-walker transactional boundaries matching `Jac.commit()`'s contract.

--- a/docs/docs/community/release_notes/unreleased/jaclang/5663.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5663.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: "User profile not found" race after walker completion (SQLite)**: `SqliteMemory.put()` is now deferred to `sync()` so atomicity is per-walker instead of per-anchor, eliminating the cross-anchor race reintroduced by #5644 that caused subsequent walkers to see partial state on local/SQLite dev.

--- a/jac-scale/jac_scale/impl/memory_hierarchy.mongo.impl.jac
+++ b/jac-scale/jac_scale/impl/memory_hierarchy.mongo.impl.jac
@@ -221,26 +221,13 @@ impl MongoBackend.get(id: UUID) -> (Anchor | None) {
     return cast(Anchor, anchor);
 }
 
-"""Store anchor in MongoDB. For NodeAnchors with a load snapshot, uses
-an atomic aggregation pipeline to merge edge deltas with the stored
-document, so concurrent writers cannot erase each other's edge changes.
-Newly-created anchors and non-NodeAnchor types take the direct write
-path."""
-impl MongoBackend.put(anchor: Anchor) -> None {
-    if self.client is None or not anchor.persistent {
-        return;
-    }
-    if isinstance(anchor, NodeAnchor) {
-        delta = anchor.edge_delta();
-        if delta is not None {
-            added = [str(eid) for eid in delta[0]];
-            removed = [str(eid) for eid in delta[1]];
-            self._put_node_atomic(anchor, added, removed);
-            return;
-        }
-    }
-    self._write_to_db(anchor);
-}
+"""Stage anchor for persistence. MongoBackend.put is a no-op — all
+persistence flows through sync(), which routes NodeAnchors with a load
+snapshot through the merge-aware _put_node_atomic pipeline and
+everything else through _write_to_db. This matches SqliteMemory.put
+semantics: defer to sync() so cross-anchor consistency holds within a
+walker's transaction boundary (closes issue #5446)."""
+impl MongoBackend.put(anchor: Anchor) -> None { }
 
 """Write anchor directly to MongoDB. Used internally by put() and
 sync() for newly-created anchors or non-NodeAnchor types where edge

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -467,6 +467,7 @@ impl JacWalker.spawn_call(
     ctx = JacRuntimeInterface.get_context();
     call_state = ctx.call_state.get(None);
     owns_call_state = False;
+    walker_succeeded = False;
     if not call_state {
         call_token = ctx.call_state.set(CallState());
         call_state = ctx.call_state.get();
@@ -479,6 +480,7 @@ impl JacWalker.spawn_call(
             }
             if `walker.disengaged {
                 `walker.ignores = [];
+                walker_succeeded = True;
                 return warch;
             }
         }
@@ -503,6 +505,7 @@ impl JacWalker.spawn_call(
             }
         }
         `walker.ignores = [];
+        walker_succeeded = True;
         return warch;
     } finally {
         if owns_call_state {
@@ -515,6 +518,14 @@ impl JacWalker.spawn_call(
             }
             warch.reports = reports;
             ctx.call_state.reset(call_token);
+            # Flush deferred persistence at the outermost spawn boundary, on
+            # success only — mirrors ExecutionManager.spawn_walker so direct
+            # `walker spawn node` flows (tests, `jac run`, CLI) persist without
+            # callers having to call Jac.commit() manually. Skipped on
+            # exception so partial walker state is dropped with the L1 buffer.
+            if walker_succeeded {
+                ctx.mem.commit();
+            }
         }
     }
 }
@@ -681,6 +692,7 @@ impl JacWalker.async_spawn_call(
     ctx = JacRuntimeInterface.get_context();
     call_state = ctx.call_state.get(None);
     owns_call_state = False;
+    walker_succeeded = False;
     if not call_state {
         call_token = ctx.call_state.set(CallState());
         call_state = ctx.call_state.get();
@@ -696,6 +708,7 @@ impl JacWalker.async_spawn_call(
             }
             if `walker.disengaged {
                 `walker.ignores = [];
+                walker_succeeded = True;
                 return warch;
             }
         }
@@ -725,6 +738,7 @@ impl JacWalker.async_spawn_call(
             }
         }
         `walker.ignores = [];
+        walker_succeeded = True;
         return warch;
     } finally {
         if owns_call_state {
@@ -737,6 +751,10 @@ impl JacWalker.async_spawn_call(
             }
             warch.reports = reports;
             ctx.call_state.reset(call_token);
+            # See spawn_call: flush deferred persistence on success only.
+            if walker_succeeded {
+                ctx.mem.commit();
+            }
         }
     }
 }

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -549,99 +549,12 @@ impl SqliteMemory.get(id: UUID) -> (Anchor | None) {
     return cast(Anchor, anchor);
 }
 
-"""Store an anchor. Writes to memory and persists to database.
-
-For NodeAnchors with a load snapshot, uses a BEGIN IMMEDIATE transaction
-to re-read the stored edges and apply the caller's delta, so concurrent
-writers cannot erase each other's edge additions. Newly-created anchors
-and non-NodeAnchor types take the direct write path.
-"""
+"""Store an anchor in L1 memory. DB persistence is deferred to sync() so
+that concurrent writes go through a single merge-aware BEGIN IMMEDIATE
+transaction per walker instead of per-anchor writes that race on
+cross-anchor consistency (closes issue #5446)."""
 impl SqliteMemory.put(anchor: Anchor) -> None {
     self.__mem__[anchor.id] = anchor;
-    if not anchor.persistent {
-        return;
-    }
-    self._ensure_connection();
-    assert self.__conn__ is not None;
-    conn = self.__conn__;
-    try {
-        delta: (tuple[(set[UUID], set[UUID])] | None) = None;
-        if isinstance(anchor, NodeAnchor) {
-            delta = anchor.edge_delta();
-        }
-        if delta is not None {
-            # Merge-aware path: re-read stored edges inside a write lock
-            conn.commit();
-            conn.execute("BEGIN IMMEDIATE");
-            try {
-                added = set(delta[0]);
-                removed = set(delta[1]);
-                cursor = conn.execute(
-                    "SELECT data FROM anchors WHERE id = ?", (str(anchor.id), )
-                );
-                row = cursor.fetchone();
-                if row {
-                    try {
-                        stored = Serializer.deserialize(json.loads(row[0]));
-                    } except Exception {
-                        stored = None;
-                    }
-                    if (isinstance(stored, NodeAnchor) and stored.is_populated()) {
-                        stored_ids = set(e.id for e in stored.edges);
-                        merged_ids = (stored_ids | added) - removed;
-                        edge_by_id = {e.id: e for e in stored.edges};
-                        edge_by_id.update({e.id: e for e in anchor.edges});
-                        anchor.edges = [
-                            edge_by_id[eid]
-                            for eid in merged_ids
-                            if eid in edge_by_id
-                        ];
-                    }
-                }
-                if (
-                    isinstance(anchor, NodeAnchor)
-                    and not anchor.edges
-                    and not isinstance(anchor.archetype, Root)
-                ) {
-                    conn.execute(
-                        "DELETE FROM anchors WHERE id = ?", (str(anchor.id), )
-                    );
-                } else {
-                    row_data = _anchor_to_row(anchor);
-                    conn.execute(
-                        """
-                        INSERT OR REPLACE INTO anchors
-                            (id, type, arch_module, arch_type, fingerprint,
-                             data, format_version, updated_at)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        (str(anchor.id), ) + row_data
-                    );
-                }
-                conn.commit();
-                anchor.hash = Serializer._compute_hash(anchor);
-            } except Exception {
-                conn.rollback();
-                raise;
-            }
-        } else {
-            # Direct write: newly-created anchor or non-NodeAnchor
-            row = _anchor_to_row(anchor);
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO anchors
-                    (id, type, arch_module, arch_type, fingerprint, data,
-                     format_version, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (str(anchor.id), ) + row
-            );
-            conn.commit();
-            anchor.hash = Serializer._compute_hash(anchor);
-        }
-    } except Exception as e {
-        logger.warning(f"SqliteMemory.put persist failed: {e}");
-    }
 }
 
 """Delete an anchor and track for garbage collection (only if persistent)."""


### PR DESCRIPTION
…xes #5446)

Problem
-------
PR #5644 landed merge-aware atomic writes but kept put() eager: every graph mutation committed immediately, one anchor at a time. This re-introduced the concurrent-walker edge-loss race that #5446 was meant to close, because atomicity was at the *anchor* level, not the *walker* level.

Symptom: on SQLite (local dev), after a long-running walker (e.g. JacCoder agent turn) commits mutations, subsequent walkers from the same user hit "User profile not found" because put() wrote partial state that a concurrent walker's commit then overwrote. Prod (MongoDB) masked it because MongoDB uses a single $mergeObjects + $setUnion aggregation pipeline per-document.

Kugesan's original rationale for reverting Thami's deferred-put design (commit 14605380e1) was that test_serializer_social.jac's direct `spawn root` flow never calls Jac.commit() and thus never reaches sync(). That flow isn't used in production (only in one test).

Fix
---
Restore Thami's deferred-put semantics from the original issue_5446 branch:

- SqliteMemory.put: defer to L1 only (self.__mem__[id] = anchor). sync() already does the merge-aware BEGIN IMMEDIATE transaction across all pending anchors — single write per walker commit.
- MongoBackend.put: empty body. sync() already routes through _put_node_atomic for NodeAnchors with a snapshot and _write_to_db otherwise.

Atomicity boundary moves from per-anchor back to per-walker, matching Jac.commit()'s transactional contract and eliminating the cross-anchor race that manifests as "User profile not found" in jac-ide.

Known tradeoff
--------------
Direct `spawn root` flows that never call Jac.commit() / close() won't persist via put() alone. This is Thami's original contract; such flows must call sync() explicitly (same as HTTP server's ExecutionManager does). Proper upstream fix is to hook sync() into the direct-spawn dispatcher's finally path, separately trackable.

Verification
------------
- jac check jac/jaclang/runtimelib/impl/memory.impl.jac — 14 errors (same as main, all pre-existing lint noise)
- jac check jac-ide/main.jac — 1 passed
- Python import of jaclang.runtimelib.memory.SqliteMemory — OK
- Manual test on issue_5446 branch (equivalent design) — user profile race no longer reproduces across tab reloads / multi-browser / agent completion flows

## **Description**
