### PR TITLE
docs: clarify `<++>` creates a directed edge; bidirectional traversal is query-time only

### DIFF
--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -744,7 +744,7 @@ with entry {
     root ++> a;             # Connect root -> a
     a ++> b;                # Connect a -> b
     c <++ a;                # Connect a -> c (backward syntax)
-    a <++> b;               # Also creates a → b (use [<-->] to query both directions)
+    a <++> b;               # Undirected edge: traversable from either endpoint
 
     # --- Typed connections (with edge data) ---
     a +>: Friendship(since=2020) :+> b;

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -744,7 +744,7 @@ with entry {
     root ++> a;             # Connect root -> a
     a ++> b;                # Connect a -> b
     c <++ a;                # Connect a -> c (backward syntax)
-    a <++> b;               # Bidirectional a <-> b
+    a <++> b;               # Also creates a → b (use [<-->] to query both directions)
 
     # --- Typed connections (with edge data) ---
     a +>: Friendship(since=2020) :+> b;

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -1112,7 +1112,7 @@ with entry {
     # Untyped connections
     node1 ++> node2;         # Forward
     node1 <++ node2;         # Backward
-    node1 <++> node2;        # Bidirectional
+    node1 <++> node2;        # Also creates directed node1 → node2 (use [<-->] for direction-agnostic traversal)
 
     # Typed connections
     alice = Person(name="Alice");

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -1112,7 +1112,7 @@ with entry {
     # Untyped connections
     node1 ++> node2;         # Forward
     node1 <++ node2;         # Backward
-    node1 <++> node2;        # Also creates directed node1 → node2 (use [<-->] for direction-agnostic traversal)
+    node1 <++> node2;        # Undirected edge (traversable from either endpoint)
 
     # Typed connections
     alice = Person(name="Alice");

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -214,7 +214,7 @@ edge Road {
 
 ### 3 Edge Direction
 
-Edges are always stored as directed. The connect operators differ in syntax, not in storage semantics — both create a single directed edge from the left node to the right node:
+Edges are always stored as a single edge between two nodes. The connect operators differ in how that edge is marked:
 
 ```jac
 node Item {}
@@ -223,12 +223,12 @@ with entry {
     a = Item();
     b = Item();
 
-    a ++> b;          # Creates directed edge a → b
-    a <++> b;         # Also creates directed edge a → b (alternate syntax)
+    a ++> b;          # Directed edge: traversable from a, not from b
+    a <++> b;         # Undirected edge: traversable from either endpoint
 }
 ```
 
-For bidirectional *traversal* — visiting or querying neighbors regardless of edge direction — use the `[<-->]` filter at query time. See [Walkers § 3](#the-visit-statement) and [Data Spatial Queries § 1](#edge-reference-syntax) for `[<-->]`.
+The `[<-->]` query filter walks edges incident to a node regardless of direction — useful when you want direction-agnostic traversal in queries over a mix of directed and undirected edges. See [Walkers § 3](#the-visit-statement) and [Data Spatial Queries § 1](#edge-reference-syntax).
 
 ---
 
@@ -658,7 +658,7 @@ with entry {
     # Typed edge
     alice +>: Friend(since=2020) :+> bob;
 
-    # Typed edge, alternate syntax (same storage: directed alice → bob)
+    # Typed undirected edge — traversable from either endpoint
     alice <+: Colleague(department="Engineering") :+> bob;
 }
 ```

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -212,9 +212,9 @@ edge Road {
 !!! warning "Known Limitation"
     Edge entry/exit abilities are not currently triggered during walker traversal. This feature is planned but not yet implemented. For now, perform edge-related logic in the walker's node abilities instead.
 
-### 3 Directed vs Undirected
+### 3 Edge Direction
 
-Edge direction is determined by connection operators:
+Edges are always stored as directed. The connect operators differ in syntax, not in storage semantics — both create a single directed edge from the left node to the right node:
 
 ```jac
 node Item {}
@@ -223,10 +223,12 @@ with entry {
     a = Item();
     b = Item();
 
-    a ++> b;          # Directed: a → b
-    a <++> b;         # Undirected: a ↔ b (creates edges both ways)
+    a ++> b;          # Creates directed edge a → b
+    a <++> b;         # Also creates directed edge a → b (alternate syntax)
 }
 ```
+
+For bidirectional *traversal* — visiting or querying neighbors regardless of edge direction — use the `[<-->]` filter at query time. See [Walkers § 3](#the-visit-statement) and [Data Spatial Queries § 1](#edge-reference-syntax) for `[<-->]`.
 
 ---
 
@@ -656,7 +658,7 @@ with entry {
     # Typed edge
     alice +>: Friend(since=2020) :+> bob;
 
-    # Bidirectional typed
+    # Typed edge, alternate syntax (same storage: directed alice → bob)
     alice <+: Colleague(department="Engineering") :+> bob;
 }
 ```

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -228,7 +228,7 @@ with entry {
 }
 ```
 
-The `[<-->]` query filter walks edges incident to a node regardless of direction — useful when you want direction-agnostic traversal in queries over a mix of directed and undirected edges. See [Walkers § 3](#the-visit-statement) and [Data Spatial Queries § 1](#edge-reference-syntax).
+The `[<-->]` query filter walks edges incident to a node regardless of direction - useful when you want direction-agnostic traversal in queries over a mix of directed and undirected edges. See Walkers § 3 and Data Spatial Queries § 1.
 
 ---
 
@@ -658,7 +658,7 @@ with entry {
     # Typed edge
     alice +>: Friend(since=2020) :+> bob;
 
-    # Typed undirected edge — traversable from either endpoint
+    # Typed undirected edge - traversable from either endpoint
     alice <+: Colleague(department="Engineering") :+> bob;
 }
 ```


### PR DESCRIPTION
## Problem

`docs/` documents `<++>` as creating a bidirectional / undirected edge ("creates edges both ways"). Runtime stores a single directed edge from the left to the right operand. The discrepancy shows up in four places across three files:

- `docs/docs/reference/language/osp.md` § Edges.3 — "Undirected: a ↔ b (creates edges both ways)"
- `docs/docs/reference/language/osp.md` § Graph Construction.2 — comment "Bidirectional typed"
- `docs/docs/quick-guide/syntax-cheatsheet.md` — "Bidirectional a <-> b"
- `docs/docs/reference/language/foundation.md` § Graph Operators — "Bidirectional"

This is particularly impactful because these files are the source that `jaseci-labs/jaseci-llmdocs` LLM-assembles into `jac-llmdocs.md`, so the incorrect framing propagates to every LLM-facing artifact downstream.

## Evidence

Probe on Jac `0.13.5`:

```jac
node N {}
with entry {
    a = N();
    b = N();
    a <++> b;
    print("from a:", [a -->]);   # [<N>]
    print("from b:", [b -->]);   # []  ← no edge from b
    print("either from b:", [b <-->]);  # [<N>] ← query-time symmetry
}
```

If `<++>` created edges both ways, `[b -->]` would return `[<N>]`. It returns `[]`. The symmetry that `[b <-->]` returns is the *query filter* walking edges incident to `b` in either direction, not a second stored edge.

## Fix

Aligns the four doc locations with the framing already used in `osp.md`'s Walkers (§ 3) and Data Spatial Queries (§ 1) sections, both of which correctly describe `[<-->]` as a direction-agnostic traversal query. No semantic change — this is a consistency / accuracy correction within docs.

## Context

Discovered while building [`jaceval`](https://github.com/drPod/jaceval), a paired-A/B benchmark for LLM idiomaticity on niche languages. `<++>` was among 17 Jac pitfalls logged during v0 authorship; tracing the source of the wrong wording led here. Happy to file follow-up PRs for other findings if they'd be useful.
