### PR TITLE
Docs/fix undirected edges wording

### DIFF
--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -744,7 +744,7 @@ with entry {
     root ++> a;             # Connect root -> a
     a ++> b;                # Connect a -> b
     c <++ a;                # Connect a -> c (backward syntax)
-    a <++> b;               # Bidirectional a <-> b
+    a <++> b;               # Undirected a <-> b
 
     # --- Typed connections (with edge data) ---
     a +>: Friendship(since=2020) :+> b;

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -141,10 +141,10 @@ Use these appendices when you need to look up a specific keyword, operator, or s
 |----------|-------------|
 | `++>` | Forward connect |
 | `<++` | Backward connect |
-| `<++>` | Bidirectional connect |
+| `<++>` | Undirected connect |
 | `+>:T:+>` | Typed forward |
 | `<+:T:<+` | Typed backward |
-| `<+:T:+>` | Typed bidirectional |
+| `<+:T:+>` | Typed undirected |
 | `[-->]` | Outgoing edges |
 | `[<--]` | Incoming edges |
 | `[<-->]` | All edges |

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -1112,7 +1112,7 @@ with entry {
     # Untyped connections
     node1 ++> node2;         # Forward
     node1 <++ node2;         # Backward
-    node1 <++> node2;        # Bidirectional
+    node1 <++> node2;        # Undirected
 
     # Typed connections
     alice = Person(name="Alice");

--- a/docs/docs/reference/language/library-mode.md
+++ b/docs/docs/reference/language/library-mode.md
@@ -374,7 +374,7 @@ The `OPath()` class constructs traversal paths from a given node. The `edge_out(
 |----------|-------------|------------|
 | `connect(left, right, edge, undir, conn_assign, edges_only)` | Connect nodes with edge | `left`: source node(s)<br>`right`: target node(s)<br>`edge`: edge class (optional)<br>`undir`: undirected flag<br>`conn_assign`: attribute assignments<br>`edges_only`: return edges instead of nodes |
 | `disconnect(left, right, dir, filter)` | Remove edges between nodes | `left`: source node(s)<br>`right`: target node(s)<br>`dir`: edge direction<br>`filter`: edge filter function |
-| `build_edge(is_undirected, conn_type, conn_assign)` | Create edge builder function | `is_undirected`: bidirectional flag<br>`conn_type`: edge class<br>`conn_assign`: initial attributes |
+| `build_edge(is_undirected, conn_type, conn_assign)` | Create edge builder function | `is_undirected`: flag for undirected edge<br>`conn_type`: edge class<br>`conn_assign`: initial attributes |
 | `assign_all(target, attr_val)` | Assign attributes to list of objects | `target`: list of objects<br>`attr_val`: tuple of (attrs, values) |
 
 ### **Graph Traversal & Walker Operations**

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -223,8 +223,8 @@ with entry {
     a = Item();
     b = Item();
 
-    a ++> b;          # Directed: a → b
-    a <++> b;         # Undirected: a ↔ b (creates edges both ways)
+    a ++> b;          # Directed: Traversable only from a to b
+    a <++> b;         # Undirected: Traversable from either a or b
 }
 ```
 

--- a/docs/docs/tutorials/language/coding_primer.md
+++ b/docs/docs/tutorials/language/coding_primer.md
@@ -1519,7 +1519,7 @@ graph TD
 
 ### 9.3 Directed vs Undirected Graphs
 
-**Undirected:** Relationship goes both ways
+**Undirected:** Relationship is mutual and traversable in either direction.
 
 ```mermaid
 graph LR
@@ -1717,7 +1717,7 @@ graph TD
 |----------|-----------|---------|
 | `++>` | Forward | `alice ++> bob;` (alice → bob) |
 | `<++` | Backward | `alice <++ bob;` (bob → alice) |
-| `<++>` | Both ways | `alice <++> bob;` (alice ↔ bob) |
+| `<++>` | Undirected | `alice <++> bob;` (alice ↔ bob) |
 
 <div class="code-block">
 
@@ -1730,7 +1730,8 @@ with entry {
     alice = Person(name="Alice");
     bob = Person(name="Bob");
 
-    # Bidirectional connection (mutual friendship)
+    # Undirected connection (mutual friendship)
+    # This creates a single edge traversable from either alice or bob
     alice <++> bob;
 }
 ```


### PR DESCRIPTION
## **Description**
This PR corrects and enhances the Jac documentation regarding edge directionality, specifically focusing on the behavior of the `<++>` (undirected connection) operator.

**Core Changes**
Wording Standardization: Replaced inaccurate descriptions of `<++>` (e.g., "creates edges both ways" or "two edges") with the correct terminology: single undirected edge. This aligns the documentation with the actual behavior of the runtime post-#5575.