### PR TITLE
feat(lint): W3040 — warn on filter comparison tautology from shadowed names

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5679.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5679.feature.md
@@ -1,0 +1,1 @@
+- **New lint: W3040 filter comparison tautology**: The compiler now warns when both sides of a comparison in a filter expression resolve to the same name (e.g., `[?:Task, to_user == to_user]`), which is always true due to node field shadowing. Suggests using a different variable name for the intended enclosing-scope value.

--- a/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
@@ -1979,6 +1979,36 @@ impl JacAutoLintPass._check_is_with_literal(nd: uni.CompareExpr) -> None {
     }
 }
 
+"""W3040: Warn when a filter comparison has identical LHS and RHS names.
+
+In a filter expression like [?:Type, field == field], the LHS is resolved
+as a node field and the RHS — intended to reference an enclosing-scope
+variable — silently rebinds to the same node field, making the comparison
+a tautology (always true).
+"""
+impl JacAutoLintPass._check_filter_compare_tautology(nd: uni.CompareExpr) -> None {
+    import from jaclang.jac0core.diagnostics { W3040 }
+    if self._is_suppressed(W3040) {
+        return;
+    }
+    # Only applies inside a FilterCompr context
+    if not nd.find_parent_of_type(uni.FilterCompr) {
+        return;
+    }
+    left = nd.left;
+    for (i, right) in enumerate(nd.rights) {
+        if (
+            isinstance(left, uni.Name)
+            and isinstance(right, uni.Name)
+            and left.value == right.value
+        ) {
+            self.emit(W3040, node_override=nd, name=left.value);
+        }
+        # For chained comparisons, next left is the current right
+        left = right;
+    }
+}
+
 """W3036: Warn on mutable default argument (list, dict, set)."""
 impl JacAutoLintPass._check_mutable_default(nd: uni.ParamVar) -> None {
     if self._is_suppressed(W3036) {
@@ -2024,6 +2054,7 @@ impl JacAutoLintPass.exit_compare_expr(nd: uni.CompareExpr) -> None {
         return;
     }
     self._check_is_with_literal(nd);
+    self._check_filter_compare_tautology(nd);
 }
 
 """Visitor: check function signatures for too many params."""

--- a/jac/jaclang/compiler/passes/tool/jac_auto_lint_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/jac_auto_lint_pass.jac
@@ -48,7 +48,8 @@ import from jaclang.jac0core.diagnostics {
     W3036,
     W3037,
     W3038,
-    W3039
+    W3039,
+    W3040
 }
 
 """Auto linting pass that applies code style corrections to Jac AST."""
@@ -132,6 +133,7 @@ obj JacAutoLintPass(UniPass) {
     def _check_identical_branches(nd: uni.IfStmt) -> None;
     def _check_too_many_params(nd: uni.FuncSignature) -> None;
     def _check_is_with_literal(nd: uni.CompareExpr) -> None;
+    def _check_filter_compare_tautology(nd: uni.CompareExpr) -> None;
     def _check_mutable_default(nd: uni.ParamVar) -> None;
     def _check_unnecessary_none_return(
         nd: (uni.Ability | uni.LambdaExpr),

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -713,6 +713,12 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          Category.LINT,
          "getattr(obj, 'attr', None) should use null-safe access [getattr-to-null-ok]"
      ),
+     W3040 = _warn(
+         "W3040",
+         Category.LINT,
+         "Filter comparison '{name} == {name}' is always true — "
+         "both sides resolve to the same node field [filter-compare-tautology]"
+     ),
      # Old kebab-case name -> code mapping for jac.toml backward compat
      LINT_ALIASES: dict[str, str] = {
          "staticmethod-to-static": "W3001",
@@ -738,7 +744,8 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "usestate-to-has": "W3038",
          "mutable-default": "W3036",
          "unnecessary-none-return": "W3037",
-         "getattr-to-null-ok": "W3039"
+         "getattr-to-null-ok": "W3039",
+         "filter-compare-tautology": "W3040"
      },
      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
      # Codegen errors (E5xxx/W5xxx)

--- a/jac/tests/compiler/passes/main/fixtures/new_diagnostics/lint_W3040_filter_tautology.jac
+++ b/jac/tests/compiler/passes/main/fixtures/new_diagnostics/lint_W3040_filter_tautology.jac
@@ -1,0 +1,13 @@
+"""Fixture for W3040: Filter comparison tautology on shadowed names."""
+
+node Task {
+    has to_user: str;
+}
+
+walker FindTasks {
+    can find_tasks with root entry {
+        to_user = "alice";
+        # W3040: both sides resolve to the same node field
+        tasks_bad = [root()-->][?:Task, to_user==to_user];
+    }
+}

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -635,6 +635,12 @@ test "W3036: mutable default argument" {
     assert has_diagnostic_code(prog, "W3036", in_warnings=True);
 }
 
+test "W3040: filter comparison tautology on shadowed name" {
+    path = os.path.join(NEW_DIAG_FIXTURES, "lint_W3040_filter_tautology.jac");
+    prog = JacProgram.jac_file_formatter(path, auto_lint=True);
+    assert has_diagnostic_code(prog, "W3040", in_warnings=True);
+}
+
 
 # ══════════════════════════════════════════════════════════════════
 #  PHASE 7: IMPORT DIAGNOSTICS (E/W 4001-4010)


### PR DESCRIPTION
## Summary

Adds a new compile-time lint warning **W3040** that detects filter comparison tautologies caused by name shadowing.

## Problem

In filter expressions like:
```jac
to_user = "alice";
tasks = [root()-->][?:Task, to_user == to_user];  # always true!
```

The LHS `to_user` resolves to the node field, and the RHS `to_user` — intended to reference the enclosing-scope variable — silently rebinds to the same node field. The comparison becomes `field == field`, which is always true. This is a silent, non-obvious bug with no runtime error.

## Solution

New lint rule **W3040 `[filter-compare-tautology]`** detects `CompareExpr` nodes inside `FilterCompr` where both LHS and RHS are `Name` nodes with identical values, and emits a warning:

```
file.jac, line 11, col 41: Filter comparison 'to_user == to_user' is always
true — both sides resolve to the same node field [filter-compare-tautology]
```

### Suppressible
Via `jac.toml`:
```toml
[check.lint]
filter-compare-tautology = false
```

## Changes

| File | Change |
|------|--------|
| `jac/jaclang/jac0core/diagnostics.jac` | Added W3040 diagnostic + alias |
| `jac/jaclang/compiler/passes/tool/jac_auto_lint_pass.jac` | Added W3040 import + method declaration |
| `jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac` | Implementation of `_check_filter_compare_tautology` + call from `exit_compare_expr` |
| `jac/tests/.../lint_W3040_filter_tautology.jac` | Test fixture |
| `jac/tests/.../test_new_diagnostics.jac` | Test case |
| `docs/.../5679.feature.md` | Release note fragment |