### PR TITLE
[codex] Fix Jac any annotation typing

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5689.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5689.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Jac `any` annotation typing**: The type checker now treats Jac's lowercase `any` builtin type annotation as `Any` instead of resolving it as Python's built-in `any()` function.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -2,6 +2,12 @@
 impl TypeEvaluator._get_type_of_expression_core(
     expr: uni.Expr, expected_type: TypeBase | None = None
 ) -> TypeBase {
+    if isinstance(expr, uni.BuiltinType) and expr.value == "any" {
+        if self.prefetch and self.prefetch.any_class is not None {
+            return self.prefetch.any_class;
+        }
+        return types.AnyType();
+    }
     match expr {
         case uni.CfgExpr():
             return self._get_type_of_expression_core(expr.expr, expected_type);

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_jac_any_keyword_annotation.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_jac_any_keyword_annotation.jac
@@ -1,0 +1,10 @@
+def passthrough(value: any) -> any {
+    return value;
+}
+
+def test_any_annotation_and_builtin_escape() -> str {
+    from_any: str = passthrough(1);  # Ok: Jac any accepts and returns any.
+    builtin_any: bool = `any([0, 1]);  # Ok: `any is Python's any().
+    builtin_any_bad: str = `any([0]);  # Error: Python any() returns bool.
+    return from_any;
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -1068,6 +1068,23 @@ test "any_type_works_with_any_type" {
     assert len(program.errors_had) == 0;
 }
 
+test "jac any keyword works as annotation" {
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_jac_any_keyword_annotation.jac"),
+        options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    assert len(program.errors_had) == 1;
+    assert_error_pretty_found(
+        """
+        builtin_any_bad: str = `any([0]);  # Error: Python any() returns bool.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    """,
+        program.errors_had[0].pretty_print()
+    );
+}
+
 test "dict_pop" {
     program = JacProgram();
     mod = program.compile(


### PR DESCRIPTION
## Summary

Fixes type checking for Jac's lowercase `any` builtin type annotation so it resolves to the checker's `Any` type instead of the Python built-in `any()` function.

Adds a checker fixture that verifies `any` works in parameter and return annotations, while backtick-escaped `` `any(...)`` continues to resolve as Python's built-in callable returning `bool`.

## Root Cause

`BuiltinType` inherits from `Name`, so lowercase `any` annotation nodes fell through normal name resolution and resolved against `builtins.any`.

## Validation

- `./jac/.venv/bin/jac test jac/tests/compiler/passes/main/test_checker_pass.jac`
