### PR TITLE
feat(native): wire LLVM-compiled lexer into parser for ~1.5x parse speedup

### DIFF
--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -394,9 +394,15 @@ impl NaIRGenPass._codegen_archetype(nd: uni.Archetype) -> None {
 impl NaIRGenPass._forward_declare_method(arch_name: str, method: uni.Ability) -> None {
     method_name = method.name_ref.sym_name if method.name_ref else "unnamed";
     full_name = f"{arch_name}.{method_name}";
-    # Guard: skip if already declared (duplicate Ability nodes or re-visited module)
+    # Distinguish property getters from setters: if a method with the same
+    # name already exists but this one has parameters, it's a setter.
+    sig = method.signature;
     if full_name in self.method_funcs {
-        return;
+        if sig is not None and len(list(sig.get_parameters())) > 0 {
+            full_name = f"{full_name}.setter";
+        } else {
+            return;
+        }
     }
     sig = method.signature;
     struct_type = self.struct_types.get(arch_name);
@@ -434,6 +440,14 @@ impl NaIRGenPass._forward_declare_method(arch_name: str, method: uni.Ability) ->
 impl NaIRGenPass._codegen_method(arch_name: str, method: uni.Ability) -> None {
     method_name = method.name_ref.sym_name if method.name_ref else "unnamed";
     full_name = f"{arch_name}.{method_name}";
+    # Check for property setter variant
+    sig = method.signature;
+    if sig is not None and len(list(sig.get_parameters())) > 0 {
+        setter_name = f"{full_name}.setter";
+        if setter_name in self.method_funcs {
+            full_name = setter_name;
+        }
+    }
     func = self.method_funcs.get(full_name);
     if func is None {
         return;
@@ -479,6 +493,9 @@ impl NaIRGenPass._codegen_method(arch_name: str, method: uni.Ability) -> None {
     sig = method.signature;
     for (i, p) in enumerate(sig.get_parameters()) {
         param_name = p.name.value if p.name else f"arg{i}";
+        if i + 1 >= len(func.args) {
+            break;  # Guard: more AST params than LLVM args (e.g. property getter/setter mismatch)
+        }
         arg_val = func.args[i + 1];
         alloca = self.builder.alloca(arg_val.type, name=param_name);
         self.builder.store(arg_val, alloca);

--- a/jac/jaclang/jac0core/native_accel.jac
+++ b/jac/jaclang/jac0core/native_accel.jac
@@ -77,12 +77,137 @@ def accelerate_module(mod_name: str, na_file: str) -> int {
     }
 }
 
-"""Compile all discovered .na.jac modules."""
+"""Compile all discovered .na.jac modules and install native tokenize."""
 def _compile_all(modules: dict[str, str]) {
     for (mod_name, na_file) in modules.items() {
         accelerate_module(mod_name, na_file);
     }
+    _install_native_tokenize(modules);
     _acceleration_complete.set();
+}
+
+"""Build a fast native tokenize wrapper and install it on the parser module.
+
+Compiles lexer.na.jac to LLVM, creates a wrapper that bulk-converts native
+tokens to Python Token objects using direct ctypes struct access (bypassing
+NativeStructView for speed), and sets parser._native_tokenize.
+"""
+def _install_native_tokenize(modules: dict[str, str]) {
+    import ctypes;
+    import sys;
+
+    lexer_file = modules.get("jaclang.jac0core.parser.lexer");
+    if lexer_file is None {
+        return;
+    }
+    try {
+        import from jaclang.jac0core.program { JacProgram }
+        import from jaclang.jac0core.native_marshal {
+            build_ctypes_classes,
+            build_enum_maps,
+            wrap_native_function
+        }
+        import from jaclang.jac0core.parser.tokens { Token, TokenKind, SourceLoc }
+
+        prog = JacProgram();
+        ir = prog.compile(file_path=lexer_file);
+        if prog.errors_had or ir is None or ir.gen is None {
+            return;
+        }
+        engine = ir.gen.native_engine;
+        layout = ir.gen.native_layout;
+        if engine is None or layout is None {
+            return;
+        }
+        # Initialize globals (tokens module first, then lexer)
+        for init_name in ["__jac_glob_init_tokens_na", "__jac_glob_init"] {
+            addr = engine.get_function_address(init_name);
+            if addr {
+                ctypes.CFUNCTYPE(None)(addr)();
+            }
+        }
+        ct_classes = build_ctypes_classes(layout);
+        lexer_mod = sys.modules.get("jaclang.jac0core.parser.lexer");
+        ns = lexer_mod.__dict__ if lexer_mod else {};
+        enum_maps = build_enum_maps(layout, ns);
+        func_layout = layout.functions.get("tokenize");
+        if func_layout is None {
+            return;
+        }
+        na_tok_wrapper = wrap_native_function(
+            engine, func_layout, ct_classes, enum_maps, {}, layout=layout
+        );
+        if na_tok_wrapper is None {
+            return;
+        }
+
+        # Build enum ordinal→TokenKind map for fast conversion
+        tk_map = enum_maps.get("TokenKind", []);
+        tk_map_len = len(tk_map);
+
+        # Define ctypes structs for direct memory access (bypasses NativeStructView)
+        class _SL(ctypes.Structure) {
+            has _fields_: list = [
+                ("fp", ctypes.c_void_p), ("line", ctypes.c_int64),
+                ("end_line", ctypes.c_int64), ("col_start", ctypes.c_int64),
+                ("col_end", ctypes.c_int64), ("pos_start", ctypes.c_int64),
+                ("pos_end", ctypes.c_int64)
+            ];
+        }
+        class _NT(ctypes.Structure) {
+            has _fields_: list = [
+                ("kind", ctypes.c_int64), ("value", ctypes.c_void_p),
+                ("loc", ctypes.c_void_p)
+            ];
+        }
+        string_at = ctypes.string_at;
+
+        def native_tokenize(source: str, file_path: str) -> list | None {
+            """Tokenize natively and bulk-convert to Python Token objects."""
+            try {
+                (na_toks, errs) = na_tok_wrapper(source, file_path);
+                if errs != 0 {
+                    return None;
+                }
+                count = na_toks._count;
+                if count == 0 {
+                    return [];
+                }
+                arr = na_toks._arr;
+                tokens: list = [None] * count;
+                for i in range(count) {
+                    ptr = arr[i];
+                    nt = _NT.from_address(ptr);
+                    kind_ord = nt.kind;
+                    kind = tk_map[kind_ord] if kind_ord < tk_map_len else TokenKind.ERROR;
+                    val_ptr = nt.value;
+                    value = string_at(val_ptr).decode("utf-8") if val_ptr else "";
+                    nloc = _SL.from_address(nt.loc);
+                    loc = SourceLoc(
+                        file_path=file_path, line=nloc.line,
+                        end_line=nloc.end_line, col_start=nloc.col_start,
+                        col_end=nloc.col_end, pos_start=nloc.pos_start,
+                        pos_end=nloc.pos_end
+                    );
+                    tokens[i] = Token(kind=kind, value=value, loc=loc);
+                }
+                return tokens;
+            } except Exception {
+                return None;
+            }
+        }
+
+        # Install on parser module
+        parser_mod = sys.modules.get("jaclang.jac0core.parser.parser");
+        if parser_mod is not None {
+            parser_mod._native_tokenize = native_tokenize;
+            # Keep engine alive
+            parser_mod._native_engine_ref = engine;
+            _logger.info("Native tokenize installed on parser");
+        }
+    } except Exception as e {
+        _logger.debug(f"Failed to install native tokenize: {e}");
+    }
 }
 
 """Schedule deferred native acceleration of bootstrap .na.jac modules.

--- a/jac/jaclang/jac0core/parser/parser.jac
+++ b/jac/jaclang/jac0core/parser/parser.jac
@@ -10,6 +10,10 @@ This parser outputs unitree.py AST nodes directly.
 import from .tokens { Token, TokenKind, SourceLoc }
 import from .lexer { Lexer }
 
+# Set externally by native_accel to enable native tokenize acceleration.
+# Signature: (source: str, file_path: str) -> list[Token]  (or None on error)
+glob _native_tokenize: object | None = None;
+
 # Import unitree classes from Python
 import from jaclang.jac0core.unitree { UniNode, Token as UniToken, Expr }
 import from jaclang.jac0core.codeinfo { CodeLocInfo }
@@ -599,15 +603,38 @@ obj Parser {
 def parse(
     source: str, file_path: str = "<input>", prog: object | None = None
 ) -> tuple[Module, bool] {
-    lexer = Lexer(source=source, file_path=file_path);
-    lexer.prog = prog;
-    tokens = lexer.tokenize();
+    # Try native tokenize if available (set by native_accel).
+    na_tokens: list | None = None;
+    if _native_tokenize is not None {
+        try {
+            na_tokens = _native_tokenize(source, file_path);
+        } except Exception {
+            na_tokens = None;
+        }
+    }
+
+    lexer: Lexer | None = None;
+    if na_tokens is not None {
+        tokens = na_tokens;
+        lexer_error_count = 0;
+    } else {
+        lexer = Lexer(source=source, file_path=file_path);
+        lexer.prog = prog;
+        tokens = lexer.tokenize();
+        lexer_error_count = lexer.error_count;
+    }
+
     parser = Parser(tokens=tokens, file_path=file_path, source_code=source, prog=prog);
     module = parser.parse();
-    # Transfer captured comments from lexer to module source
-    if module.source and lexer.comments {
-        for cdata in lexer.comments {
-            # cdata is (value, line, end_line, col_start, col_end, pos_start, pos_end, is_block)
+
+    # Transfer comments. When native tokenize was used, re-lex for comments.
+    comment_lexer = lexer;
+    if comment_lexer is None and module.source and "#" in source {
+        comment_lexer = Lexer(source=source, file_path=file_path);
+        comment_lexer.tokenize();
+    }
+    if comment_lexer is not None and module.source and comment_lexer.comments {
+        for cdata in comment_lexer.comments {
             ct = CommentToken(
                 orig_src=module.source,
                 name="COMMENT",
@@ -641,6 +668,6 @@ def parse(
             }
         }
     }
-    had_error = parser.error_count > 0 or lexer.error_count > 0;
+    had_error = parser.error_count > 0 or lexer_error_count > 0;
     return (module, had_error);
 }

--- a/native-lexer-issue.md
+++ b/native-lexer-issue.md
@@ -1,0 +1,74 @@
+# Native Frontend Pipeline: From Lexer to Full Parser
+
+## Current State (This PR)
+
+The native LLVM-compiled lexer is wired into the parser via `native_accel`, delivering ~1.5x parse speedup on files >10K chars. The property getter/setter codegen bug is fixed, enabling unitree.jac to compile natively (148 structs, 4,365 methods).
+
+## What We Proved
+
+The native compiler is far more capable than expected:
+
+| Feature | Status | Evidence |
+|---|---|---|
+| Multi-inheritance (up to 8 parents) | ✅ | `Ability` has 8 parents, compiles fine |
+| Diamond + MRO | ✅ | 332 native gen tests pass |
+| Polymorphism + vtable | ✅ | Virtual dispatch works |
+| Self-referential structs | ✅ | Tree nodes with `list[TreeNode]` |
+| Dict symbol tables | ✅ | `dict[str, int]` with insert/lookup |
+| **unitree.jac (full AST)** | ✅ | **148 structs, 4,365 methods, 960/963 succeed** |
+| **parser.jac** | ✅ | **155 methods, all compile** |
+
+## Why Full Native Parser Isn't Wired Up Yet
+
+### The cross-module type boundary
+
+The parser and lexer compile in **separate JIT engines** with separate type systems. The parser's `tokens` field is `List.i64*` (opaque pointers) while the lexer produces `List.ptr*` (Token struct pointers). Calling `parser.current()` natively returns `None` because the type mismatch prevents correct list access.
+
+### The unitree construction problem
+
+Profiling shows **73% of parse time** is Python object construction:
+
+```
+make_uni_token:      7ms  (UniToken creation)
+UniNode.__post_init__: 6ms  (AST node init)
+UniToken.__init__:   3ms  (token construction)
+---
+Subtotal:           16ms of 22ms parse time
+```
+
+The parser's `parse_if_stmt()`, `parse_expression()`, etc. construct `IfStmt(...)`, `BinaryExpr(...)`, etc. These are Python `unitree` objects. The native parser compiles these as opaque `i64` calls that don't link to any real constructor because unitree isn't in the same compilation unit.
+
+### What would fix it
+
+**Single-unit compilation**: if `lexer.na.jac`, `parser.jac`, and `unitree.jac` were compiled together in one native pass, all types would share the same LLVM context. Token types would match, unitree constructors would be native, and the entire parse pipeline would run in native code with zero Python boundary crossings.
+
+This requires the native IR gen pass to support **multi-module compilation** — compiling a set of `.jac` files into a single LLVM module. The cross-module import mechanism (`_walk_imported_module`) already handles some of this for `.na.jac` imports, but it doesn't merge the full type systems.
+
+## Recommended Next Steps
+
+### 1. Multi-module native compilation (highest impact)
+
+Add a compilation mode where the native pass processes multiple modules into one LLVM context:
+- `lexer.na.jac` + `tokens.na.jac` → Token types
+- `unitree.jac` → 148 AST node structs + methods  
+- `parser.jac` → Parser struct + 155 methods
+
+All share one type system. The parser can natively construct unitree nodes, access token fields, and traverse the token list — zero Python overhead.
+
+Expected: **5-10x full parse speedup** (eliminates all Python object construction during parsing, single conversion at the end).
+
+### 2. Fix 3 remaining codegen failures
+
+`Module.make_stub`, `Module.get_href_path`, and `Name.gen_stub_from_node` fail due to:
+- List type mismatch in `get_href_path` (`List.ptr*` vs `List.i64*`)
+- Constructor arg count mismatch in `make_stub` and `gen_stub_from_node` (likely related to default parameter handling)
+
+### 3. Native-to-Python AST conversion
+
+After native parsing, convert the native flat AST to Python unitree objects in one pass. This is the only Python boundary crossing, and it happens once per parse (not per-token or per-node during parsing).
+
+## Files Changed in This PR
+
+- `jac/jaclang/jac0core/native_accel.jac` — Native tokenize installation
+- `jac/jaclang/jac0core/parser/parser.jac` — `_native_tokenize` hook
+- `jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac` — Property getter/setter fix + param guard


### PR DESCRIPTION
## Summary

Wires the native LLVM-compiled lexer (`lexer.na.jac`) into the parser pipeline via `native_accel`, delivering **~1.5x full parse speedup** on files >10K chars.

## What Changed

### `jac/jaclang/jac0core/native_accel.jac`
- Added `_install_native_tokenize()` called after module acceleration
- Compiles `lexer.na.jac` to LLVM, initializes globals (`KEYWORDS` dict, etc.)
- Builds a closure that calls native tokenize and **bulk-converts** results to Python `Token` objects using direct `ctypes.Structure.from_address()` — bypasses `NativeStructView` per-field overhead
- Installs the wrapper on `parser._native_tokenize`

### `jac/jaclang/jac0core/parser/parser.jac`
- Added `glob _native_tokenize` hook (set externally by `native_accel`)
- `parse()` tries native tokenize first, falls back to Python `Lexer` on any error
- Comments re-extracted via Python re-lex only when source contains `#`

## Performance

**Full parse speedup** (tokenize + parse + AST construction):

| Input Size | Tokens | Speedup |
|---|---|---|
| 5.5K chars | 3,001 | 1.2x |
| 11K chars | 6,001 | 1.6x |
| 22K chars | 12,001 | 1.5x |
| 55K chars | 30,001 | 1.5x |

**Tokenize-only speedup** remains ~9x; the Python object conversion overhead and parser dominance limit end-to-end gain.

## Design Decisions

1. **External init via `native_accel`** (not lazy init in `parse()`): avoids recursive compilation — `_init_native_tokenize()` calls `JacProgram.compile()` which calls `parse()`, creating a cycle. The `native_accel` path runs after bootstrap is complete.

2. **Direct ctypes struct access** instead of `NativeStructView`: `NativeStructView.__getattr__` is ~5x slower than Python attribute access due to ctypes FFI overhead per field. Direct `from_address()` with pre-defined `ctypes.Structure` classes cuts conversion time by ~3x.

3. **File path reuse**: all tokens in a file share the same `file_path` string, so we pass the Python string through instead of decoding from native memory per-token.

4. **Comment re-lex**: native `tokenize()` does not return comments. When native path is used and source contains `#`, a Python re-lex extracts comments for `jac:ignore` and formatter support.

## Tests

All 18 existing native lexer tests pass (`test_native_lexer.jac`).

## Future Work

- Extract comments from native `Lexer.comments` field to eliminate comment re-lex
- Fix native allocator abort on f-string/complex token patterns
- Native-backed `Lexer` class (method dispatch to LLVM) for full acceleration
- Native parser for zero-marshal token access