### PR TITLE
docs: polish onboarding and package readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,42 @@ The best way to learn Jac is by building something real. The [**Build an AI Day 
 <br>
 
 Get the complete, stable toolkit from PyPI:
-
 ```bash
 pip install jaseci
 ```
 
 The `jaseci` package is a meta-package that bundles `jaclang`, `byllm`, `jac-client`, `jac-scale`, `jac-super`, and `jac-mcp` together for convenience. This is the fastest way to get started with building applications.
+
+</details>
+
+<details>
+<summary><strong>Set up from source</strong></summary>
+
+<br>
+
+If you want to contribute to the Jaseci stack or run the latest code from `main`, clone with submodules and install the package you are working on in editable mode:
+
+```bash
+git clone --recurse-submodules https://github.com/jaseci-labs/jaseci.git
+cd jaseci
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e jac pytest pytest-xdist watchdog
+jac --version
+```
+
+If you already cloned without submodules, initialize them before running compiler/type-checker tests:
+
+```bash
+git submodule update --init --recursive
+```
+
+Core language smoke test:
+
+```bash
+pytest -q jac/tests/language/test_cli.jac -x
+```
 
 </details>
 

--- a/jac-mcp/README.md
+++ b/jac-mcp/README.md
@@ -1,0 +1,96 @@
+# jac-mcp
+
+`jac-mcp` provides a Model Context Protocol (MCP) server for AI-assisted Jac development. It exposes Jac-aware resources, prompts, and tools so MCP-compatible clients can inspect documentation, validate snippets, format code, convert Jac to other targets, and run Jac commands through the same project tooling used by the Jaseci stack.
+
+## Installation
+
+Install from PyPI:
+
+```bash
+pip install jac-mcp
+```
+
+For local development from this repository:
+
+```bash
+git clone --recurse-submodules https://github.com/jaseci-labs/jaseci.git
+cd jaseci
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e jac
+python -m pip install -e jac-mcp
+```
+
+## Usage
+
+Start the MCP server with the default `stdio` transport:
+
+```bash
+jac mcp
+```
+
+Use an HTTP transport when connecting clients that expect a network endpoint:
+
+```bash
+jac mcp --transport streamable-http --host 127.0.0.1 --port 3001
+```
+
+Inspect the resources, tools, and prompts exposed by the server:
+
+```bash
+jac mcp --inspect
+```
+
+## Modes
+
+`jac-mcp` supports three exposure modes for different client and model sizes:
+
+- `lite` - minimal tool/prompt surface for smaller models or constrained contexts
+- `standard` - balanced default surface for day-to-day Jac assistance
+- `full` - complete tool/prompt surface
+
+Select a mode from the CLI:
+
+```bash
+jac mcp --mode lite
+```
+
+Or configure it in `jac.toml`:
+
+```toml
+[plugins.mcp]
+transport = "stdio"
+mode = "standard"
+```
+
+## Available capabilities
+
+The MCP server exposes capabilities such as:
+
+- Jac documentation and knowledge-map resources
+- grammar/spec resources
+- example discovery
+- compiler error explanations
+- AST inspection
+- Jac linting and formatting
+- Jac-to-Python and Jac-to-JavaScript conversion
+- Jac code execution
+- graph visualization
+- Jac CLI command discovery and execution
+
+Use `jac mcp --inspect` for the authoritative list supported by the installed version.
+
+## Development
+
+Run the package tests from the repository root:
+
+```bash
+pytest -q jac-mcp -x
+```
+
+The package depends on `jaclang` and the upstream `mcp` Python package. When working from a fresh clone, initialize submodules before running compiler/type-checker paths:
+
+```bash
+git submodule update --init --recursive
+```

--- a/jac-scale/README.md
+++ b/jac-scale/README.md
@@ -34,7 +34,7 @@ Whether you're developing locally with `jac start` or deploying to production wi
 
 ## Prerequisites
 
-- kubenetes(K8s) installed
+- Kubernetes installed
   - [Minikube Kubernetes](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fwindows%2Fx86-64%2Fstable%2F.exe+download/) (for Windows/Linux)
   - [Docker Desktop with Kubernetes](https://www.docker.com/resources/kubernetes-and-docker/) (alternative for Windows - easier setup)
 

--- a/jac/README.md
+++ b/jac/README.md
@@ -7,9 +7,9 @@
          width="20%">
   </picture>
 
-[Jac Website] | [Getting started] | [Learn] | [Documentation] | [Contributing]
+[Jac Website] | [Getting Started] | [Learn] | [Documentation] | [Contributing]
 
-  [![PyPI version](https://img.shields.io/pypi/v/jaclang.svg)](https://pypi.org/project/jaclang/) [![Tests](https://github.com/Jaseci-Labs/jaclang/actions/workflows/run_pytest.yml/badge.svg)](https://github.com/Jaseci-Labs/jaclang/actions/workflows/run_pytest.yml) [![codecov](https://codecov.io/github/chandralegend/jaclang/graph/badge.svg?token=OAX26B0FE4)](https://codecov.io/github/chandralegend/jaclang)
+  [![PyPI version](https://img.shields.io/pypi/v/jaclang.svg)](https://pypi.org/project/jaclang/) [![Tests](https://github.com/jaseci-labs/jaseci/actions/workflows/test-jaseci.yml/badge.svg)](https://github.com/jaseci-labs/jaseci/actions/workflows/test-jaseci.yml) [![codecov](https://codecov.io/gh/Jaseci-Labs/jaseci/graph/badge.svg)](https://codecov.io/gh/Jaseci-Labs/jaseci)
 </div>
 
 This is the main source code repository for the [Jac] programming language. It contains the compiler, language server, and documentation.
@@ -59,19 +59,18 @@ pip install git+https://github.com/jaseci-labs/jaseci#subdirectory=jac
 
 ## Getting Help
 
-Submit and issue! Community links coming soon.
+Submit an issue or join the Jaseci community Discord from the main repository README.
 
 ## Contributing
 
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+See the [contribution guide](https://www.jac-lang.org/internals/contrib/).
 
 ## License
 
 Jaclang is distributed under the terms of both the MIT license with a few other open source projects vendored
 within with various other licenses that are very permissive.
 
-See [LICENSE-MIT](.guthub/LICENSE), and
-[COPYRIGHT](COPYRIGHT) for details.
+See the repository [LICENSE](../LICENSE) and [COPYRIGHT](COPYRIGHT) for details.
 
 ## Trademark
 


### PR DESCRIPTION
## Summary
- add source setup instructions to the top-level README, including submodule initialization and a smoke test
- add a README for the jac-mcp package so the package readme path resolves and users have usage/configuration guidance
- refresh stale jac README links/badges and fix a jac-scale prerequisite typo

## Test Plan
- [x] git diff --check
- [x] pytest -q jac/tests/language/test_cli.jac -x
- [x] PATH="$PWD/.venv-analysis/bin:$PATH" .venv-analysis/bin/python -m pytest -q jac-mcp -x
