### PR TITLE
fix: declare jac super console type

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -8,7 +8,7 @@ compiler.jac
 config.impl.jac
 jac/jaclang/cli/commands/config.jac
 jac/jaclang/project/config.jac
-console.jac
+jac/jaclang/cli/console.jac
 constant.jac
 # context.impl.jac / context.jac — jac-scale passes, jaclang runtimelib fails
 jac/jaclang/runtimelib/impl/context.impl.jac

--- a/docs/docs/community/release_notes/unreleased/jac-super/5705.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-super/5705.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Declare Jac Super console type**: Add the `JacSuperConsole` declaration so `jac check` can resolve the plugin console implementation.

--- a/jac-super/jac_super/plugin/console.jac
+++ b/jac-super/jac_super/plugin/console.jac
@@ -7,6 +7,8 @@ colorful terminal output with themes, panels, tables, and spinners.
 import from jaclang.jac0core.runtime { hookimpl, plugin_manager }
 import from jaclang.cli.console { JacConsole as BaseJacConsole }
 
+obj JacSuperConsole(BaseJacConsole);
+
 """Jac Super Plugin for console enhancement."""
 class JacSuperPlugin {
     """Get the Rich-enhanced console instance."""


### PR DESCRIPTION
## Summary

- Declare `JacSuperConsole` in `jac-super`'s console plugin interface so `jac check` can resolve its type.
- Narrow the related `.jacignore` entry from bare `console.jac` to the remaining failing core CLI console file.

This is a Stage 2 source cleanup from #5702.

## Why

`jac-super/jac_super/plugin/console.jac` returned `JacSuperConsole()` from a method declared as returning `BaseJacConsole`, but `JacSuperConsole` was only defined in the annexed implementation file. During checking, that made the constructor type `<Unknown>` and produced:

```text
Cannot return <Unknown>, expected JacConsole
```

Adding the interface declaration keeps the implementation unchanged while making the source-level type visible to the checker.

## Test Plan

- [x] `PATH="/home/ninja/repos/jaseci/.venv-analysis/bin:$PATH" jac check jac-super/jac_super/plugin/console.jac --nowarn`
- [x] `PATH="/home/ninja/repos/jaseci/.venv-analysis/bin:$PATH" jac check . --ignore tests checker_*.jac '*_err.jac' $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ') --nowarn`

Result:

```text
367 passed in 79.04s
```

Refs #5702
