### PR TITLE
fix: restore JIR stub symbol names

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5706.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5706.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Restore JIR stub symbol names**: Recreate synthetic stub expression `name_spec` data after JIR cache deserialization to avoid internal checker errors.

--- a/jac/jaclang/jac0core/impl/jir_passes.impl.jac
+++ b/jac/jaclang/jac0core/impl/jir_passes.impl.jac
@@ -603,6 +603,7 @@ impl JirReader._init_caches -> None {
         NameAtom,
         Expr,
         AstSymbolNode,
+        AstSymbolStubNode,
         WalkerStmtOnlyNode,
         Source,
         ParamVar,
@@ -627,6 +628,7 @@ impl JirReader._init_caches -> None {
     self._CodeLocInfo = CodeLocInfo;
     self._Expr = Expr;
     self._AstSymbolNode = AstSymbolNode;
+    self._AstSymbolStubNode = AstSymbolStubNode;
     self._WalkerStmtOnlyNode = WalkerStmtOnlyNode;
     self._Source = Source;
     self._ParamVar = ParamVar;
@@ -914,6 +916,13 @@ impl JirReader._read_node(data: (bytes | memoryview), pos: int, idx: int) -> int
         ir_node.loc = self._CodeLocInfo(*ir_node.resolve_tok_range());
     } except Exception {
         ;
+    }
+
+    # JIR does not serialize synthetic AstSymbolStubNode.name_spec nodes (they are
+    # not children/constructor fields). Recreate them after loc exists so cached
+    # literal/container expressions remain valid AstSymbolNodes.
+    if isinstance(ir_node, self._AstSymbolStubNode) and 'name_spec' not in nd {
+        ir_node._restore_stub_from_jir();
     }
 
     nodes[idx] = ir_node;

--- a/jac/jaclang/jac0core/impl/unitree.impl.jac
+++ b/jac/jaclang/jac0core/impl/unitree.impl.jac
@@ -666,6 +666,17 @@ impl AstSymbolStubNode._init_stub(sym_type: SymbolType) -> None {
     );
 }
 
+impl AstSymbolStubNode._restore_stub_from_jir -> None {
+    sym_type = self.SYMBOL_TYPE if hasattr(self, "SYMBOL_TYPE") else (
+        SymbolType.STRING
+        if isinstance(self, (MultiString, FString))
+        else SymbolType.OBJECT_ARCH
+            if isinstance(self, JsxElement)
+            else SymbolType.SEQUENCE
+    );
+    AstSymbolStubNode._init_stub(self, sym_type=sym_type);
+}
+
 
 @property
 impl AstAccessNode.access_type -> SymbolAccess {

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -217,6 +217,7 @@ obj AstSymbolNode(UniNode) {
 """Nodes that have link to a symbol in symbol table."""
 obj AstSymbolStubNode(AstSymbolNode) {
     def _init_stub(sym_type: SymbolType) -> None;
+    def _restore_stub_from_jir -> None;
 }
 
 """Nodes that have access."""

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -1940,6 +1940,44 @@ test "jir cache preserves generic type inference" {
     }
 }
 
+"""Regression: JIR reader must restore synthetic name specs for stub expressions.
+
+AstSymbolStubNode.name_spec is synthetic (not a constructor field/child), so JIR
+cache reload must recreate it for literals/containers such as MultiString and
+IndexSlice. Without this, later checker passes can raise AttributeError while
+reattaching impl modules from cached imports.
+"""
+test "jir reader restores name specs for stub expressions" {
+    import from jaclang.jac0core.jir_passes { JirWriter, JirReader }
+    import from jaclang.jac0core.program { JacProgram }
+    import from jaclang.jac0core.unitree { IndexSlice, MultiString }
+
+    with tempfile.TemporaryDirectory() as tmpdir {
+        mod_path = os.path.join(tmpdir, "stub_exprs.jac");
+        with open(mod_path, "w") as f {
+            f.write(
+                "def f -> None {\n"
+                "    msg = \"hello\";\n"
+                "    vals = [1, 2, 3];\n"
+                "    first = vals[0];\n"
+                "}\n"
+            );
+        }
+        mod = JacProgram().compile(mod_path, no_cgen=True, type_check=False);
+        assert mod is not None;
+        cached = JirReader(_source_path=mod_path).read_module(JirWriter().write_module(mod));
+        assert cached is not None;
+
+        multi_strings = cached.get_all_sub_nodes(MultiString);
+        index_slices = cached.get_all_sub_nodes(IndexSlice);
+        assert multi_strings , "Expected fixture to contain a MultiString node";
+        assert index_slices , "Expected fixture to contain an IndexSlice node";
+        for nd in multi_strings + index_slices {
+            assert hasattr(nd, "name_spec") , f"{nd.__class__.__name__} missing name_spec after JIR read";
+        }
+    }
+}
+
 """Regression: JIR cache must preserve IndexSlice.slices (Slice is a UniNode).
 
 IndexSlice.Slice was previously a plain inner class without a node ID, so the


### PR DESCRIPTION
## Summary

- Restore synthetic `name_spec` data for cached JIR `AstSymbolNode` stub expressions.
- Add a regression test covering JIR round-trip restoration for `MultiString` and `IndexSlice` nodes.

This is a Stage 3 type-checker robustness cleanup from #5702.

## Why

While probing currently ignored files, `jac check` could raise internal exceptions such as:

```text
AttributeError: 'MultiString' object has no attribute 'name_spec'
AttributeError: 'IndexSlice' object has no attribute 'name_spec'
```

The root cause is JIR cache deserialization. `AstSymbolStubNode.name_spec` is synthetic rather than a constructor field/child, so it is not serialized directly. `JirReader` reconstructs ordinary symbol-node `name_spec` values from real name children, but stub expression nodes like `MultiString` and `IndexSlice` do not have those children. After cache reload, later checker passes can therefore encounter `AstSymbolNode` instances without `name_spec`.

This patch recreates the synthetic symbol stub state when reading cached JIR if an `AstSymbolNode` still lacks `name_spec`.

## Test Plan

- [x] `PATH="/home/ninja/repos/jaseci/.venv-analysis/bin:$PATH" python -m pytest -q jac/tests/language/test_cli.jac -k 'jir and reader and restores and name and specs'`
- [x] `PATH="/home/ninja/repos/jaseci/.venv-analysis/bin:$PATH" python -m pytest -q jac/tests/language/test_cli.jac -x`
- [x] `PATH="/home/ninja/repos/jaseci/.venv-analysis/bin:$PATH" jac check jac/jaclang/jac0core/unitree.jac --nowarn`
  - expected to still fail with ordinary type diagnostics because `unitree.jac` remains ignored,
  - verified it no longer emits `Traceback` or `AttributeError`.
- [x] `PATH="/home/ninja/repos/jaseci/.venv-analysis/bin:$PATH" jac check . --ignore tests checker_*.jac '*_err.jac' $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ') --nowarn`

Results:

```text
1 passed, 75 deselected
76 passed in 28.01s
NO_INTERNAL_ERROR for unitree.jac targeted repro
366 passed in 77.90s
```

Refs #5702
