### PR TITLE
ci(test-core-runtime): skip jac/examples/littleX (needs numpy/sklearn)

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -56,7 +56,7 @@ jobs:
         pip install watchdog
 
     - name: Run runtime + langserve + language tests
-      run: pytest -x jac -n auto --ignore=jac/tests/compiler
+      run: pytest -x jac -n auto --ignore=jac/tests/compiler --ignore=jac/examples/littleX
 
   test-client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`jac/examples/littleX/littleX.jac` imports `numpy` and `scikit-learn`. The `test-core-runtime` job installs only `jac`, `pytest`, `pytest-xdist`, and `watchdog`, so collecting `jac/examples/littleX/littleX.test.jac` raises `ModuleNotFoundError: No module named 'numpy'` during import.

Pre-#5694 this was hidden: `pytest_plugin.JacFile.collect` caught every exception during `importlib.import_module` and returned `[]`, so pytest reported "0 collected" and moved on. Once #5694 surfaces real collection errors (which it should), this latent failure becomes visible and breaks the job.

This PR drops `jac/examples/littleX` from the `test-core-runtime` collection set. The example's runtime preconditions (numpy + sklearn) aren't part of jaclang core's test deps and shouldn't be — example apps with heavier deps belong in their own CI lane, not the core runtime job.

## Test plan

- [ ] CI green on `test-core-runtime` job
- [ ] No other examples under `jac/examples/` were relying on numpy/sklearn (verified locally: `circle_pure.test.jac` and `manual_code/` examples don't import them)

## Related

Unblocks #5694 once that PR rebases on this. Sister PR for `jac-client/.../test_desktop_build.jac` (the other latent failure #5694 surfaces) coming separately.
