### PR TITLE
docs: standardize entry point to main.jac in production docs 

### DIFF
--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -58,7 +58,7 @@ jac plugins enable scale
 ### Basic Server
 
 ```bash
-jac start app.jac
+jac start main.jac
 ```
 
 ### Server Options
@@ -84,19 +84,19 @@ jac start app.jac
 
 ```bash
 # Custom port
-jac start app.jac --port 3000
+jac start main.jac --port 3000
 
 # Development with HMR (requires jac-client)
-jac start app.jac --dev
+jac start main.jac --dev
 
 # API only -- skip client bundling
-jac start app.jac --dev --no_client
+jac start main.jac --dev --no_client
 
 # Preview generated API endpoints without starting
-jac start app.jac --faux
+jac start main.jac --faux
 
 # Production with profile
-jac start app.jac --port 8000 --profile prod
+jac start main.jac --port 8000 --profile prod
 ```
 
 ### Default Persistence

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -51,7 +51,7 @@ graph TD
 ### 1. Prepare Your Application
 
 ```jac
-# app.jac
+# main.jac
 node Todo {
     has title: str;
     has done: bool = False;
@@ -83,7 +83,7 @@ walker:pub health {
 ### 2. Deploy to Kubernetes
 
 ```bash
-jac start app.jac --scale
+jac start main.jac --scale
 ```
 
 That's it. Your application is now running on Kubernetes.
@@ -102,7 +102,7 @@ That's it. Your application is now running on Kubernetes.
 Deploys without building a Docker image. Fastest for iteration.
 
 ```bash
-jac start app.jac --scale
+jac start main.jac --scale
 ```
 
 ### Production Mode
@@ -110,7 +110,7 @@ jac start app.jac --scale
 Builds a Docker image and pushes to DockerHub before deploying.
 
 ```bash
-jac start app.jac --scale --build
+jac start main.jac --scale --build
 ```
 
 **Requirements for production mode:**
@@ -181,7 +181,7 @@ Configure deployment via environment variables in `.env`:
 Use `jac status` to see the health of all deployment components at a glance:
 
 ```bash
-jac status app.jac
+jac status main.jac
 ```
 
 This displays a table showing each component's status (Running, Degraded, Pending, Restarting, or Not Deployed), pod readiness counts, and service URLs.
@@ -210,7 +210,7 @@ kubectl logs -l app=jaseci -f
 Remove all Kubernetes resources created by jac-scale:
 
 ```bash
-jac destroy app.jac
+jac destroy main.jac
 ```
 
 This removes:
@@ -274,7 +274,7 @@ alias kubectl='microk8s kubectl'
 
 ```bash
 # Check all component statuses at once
-jac status app.jac
+jac status main.jac
 
 # Or use kubectl for more detail
 kubectl get pods
@@ -308,7 +308,7 @@ kubectl logs -l app=redis
 
 ```bash
 # Quick overview of all components
-jac status app.jac
+jac status main.jac
 
 # Describe a pod for events
 kubectl describe pod <pod-name>
@@ -330,7 +330,7 @@ jac create todo --use client
 cd todo
 
 # Deploy to Kubernetes
-jac start app.jac --scale
+jac start main.jac --scale
 ```
 
 Access:

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -28,7 +28,7 @@ graph LR
 ### 1. Create Your Walker
 
 ```jac
-# app.jac
+# main.jac
 node Task {
     has title: str;
     has done: bool = False;
@@ -57,7 +57,7 @@ walker:pub add_task {
 ### 2. Start the Server
 
 ```bash
-jac start app.jac
+jac start main.jac
 ```
 
 Output:
@@ -89,7 +89,7 @@ curl -X POST http://localhost:8000/walker/add_task \
 
 ```bash
 # Custom port
-jac start app.jac --port 3000
+jac start main.jac --port 3000
 ```
 
 If the specified port is already in use, the server automatically finds and uses the next available port:
@@ -103,7 +103,7 @@ Port 3000 is in use, using port 3001 instead
 Hot Module Replacement for development:
 
 ```bash
-jac start app.jac --dev
+jac start main.jac --dev
 ```
 
 Changes to your `.jac` files will automatically reload.
@@ -113,7 +113,7 @@ Changes to your `.jac` files will automatically reload.
 Skip client bundling and only serve the API:
 
 ```bash
-jac start app.jac --dev --no_client
+jac start main.jac --dev --no_client
 ```
 
 ---

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -100,10 +100,12 @@ Port 3000 is in use, using port 3001 instead
 
 ### Development Mode (HMR)
 
+> **Note:** `main.jac` is the default entry point. If your entry point is named `main.jac`, you can omit the filename. If it differs (e.g., `app.jac`), pass it explicitly: `jac start app.jac --dev`.
+
 Hot Module Replacement for development:
 
 ```bash
-jac start main.jac --dev
+jac start --dev
 ```
 
 Changes to your `.jac` files will automatically reload.
@@ -113,7 +115,7 @@ Changes to your `.jac` files will automatically reload.
 Skip client bundling and only serve the API:
 
 ```bash
-jac start main.jac --dev --no_client
+jac start --dev --no_client
 ```
 
 ---


### PR DESCRIPTION
## Summary                                                                                     
  This PR standardizes the Jac application entry point filename from `app.jac` to `main.jac`     
  across production-facing documentation. The goal is to establish `main.jac` as the consistent, 
  conventional entry point name that users see throughout tutorials and reference docs — reducing
   confusion when following multiple guides that previously used different filenames.            
                                                                                                 
  ## Changes                                                                                     
  - **`docs/docs/tutorials/production/local.md`** — Updated `jac start app.jac` and all server   
  configuration variants (`--port`, `--dev`, `--dev --no_client`), as well as the `# app.jac`
  filename comment in the Quick Start code block.
  - **`docs/docs/tutorials/production/kubernetes.md`** — Updated `jac start app.jac --scale`,
  `jac start app.jac --scale --build`, `jac status app.jac`, `jac destroy app.jac` throughout,   
  along with the `# app.jac` filename comment in the Quick Start code block.
  - **`docs/docs/reference/plugins/jac-scale.md`** — Updated `jac start app.jac` and all command 
  variants in the "Starting a Server" section (Basic Server and Examples).                       
                                          
  ## Out of Scope                                                                                
  - **`jac-scale/README.md` (Todo quick-start section)** was intentionally left unchanged. That  
  section references a specific example application with a file literally named `app.jac`, so
  changing the CLI commands there would be misleading.                                           
                  