### PR TITLE
fix(parser): detect JS arrow ('=>') in expression position, emit E0025

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5737.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5737.bugfix.md
@@ -1,0 +1,1 @@
+- **Parser: friendlier error for JavaScript `=>` arrow syntax**: Writing `e => fn(e)` in expression position (JSX slots, assignments, f-strings) now produces a single `E0025` diagnostic with a `lambda` hint instead of a cascade of unrelated parse errors.

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -125,6 +125,12 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "Cannot assign to '{name}' -- it is a built-in reference, not a variable",
          help="Use a different variable name, or use backtick escaping (e.g. `root) to create a local variable with the same name."
      ),
+     E0025 = _err(
+         "E0025",
+         Category.SYNTAX,
+         "JavaScript arrow function syntax ('=>') is not supported in Jac",
+         help="Use Jac lambda syntax instead: 'lambda e: ChangeEvent { ... }' or 'lambda x: int : x + 1'."
+     ),
      # Parser: statement-level errors
      E0030 = _err("E0030", Category.SYNTAX, "Unexpected semicolon at module level"),
      E0031 = _err(

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -143,6 +143,7 @@ import from jaclang.jac0core.diagnostics {
     E0013,
     E0021,
     E0022,
+    E0025,
     E0030,
     E0032,
     E0034,
@@ -815,6 +816,9 @@ impl Parser.parse_expression -> Expr {
         return self.parse_lambda_expr();
     }
     expr = self.parse_concurrent_expr();
+    if self._check_js_arrow_fault() {
+        expr = self._recover_js_arrow_fault(expr);
+    }
     if self.match_tok(TokenKind.KW_IF) {
         if_uni = self.make_uni_token(self.previous());
         condition = self.parse_expression();
@@ -831,6 +835,47 @@ impl Parser.parse_expression -> Expr {
         );
     }
     return expr;
+}
+
+# Detect JavaScript arrow function shape ('=>') in expression position.
+# The lexer emits '=' and '>' as separate tokens; we only recognize the arrow
+# when they are byte-adjacent, so legitimate uses of '=' and '>' are unaffected.
+impl Parser._check_js_arrow_fault -> bool {
+    if not self.check(TokenKind.EQ) {
+        return False;
+    }
+    nxt = self.peek();
+    if nxt.kind != TokenKind.GT {
+        return False;
+    }
+    return self.current().loc.pos_end == nxt.loc.pos_start;
+}
+
+# Emit E0025 for the '=>' span and consume the body so the surrounding
+# parser does not cascade. The body is parsed via the normal expression /
+# block-body routines, so chained arrows, JSX, and nested blocks all
+# recover correctly without a bespoke brace counter.
+impl Parser._recover_js_arrow_fault(left: Expr) -> Expr {
+    eq_tok = self.advance();
+    gt_tok = self.advance();
+    self.emit_diag(E0025, loc=eq_tok.loc.span_to(gt_tok.loc));
+    if self.check(TokenKind.LBRACE) {
+        self.advance();
+        self.parse_code_block_stmts();
+        if self.check(TokenKind.RBRACE) {
+            self.advance();
+        }
+    } elif not self.check_any(
+        TokenKind.SEMI,
+        TokenKind.RBRACE,
+        TokenKind.RPAREN,
+        TokenKind.RSQUARE,
+        TokenKind.COMMA,
+        TokenKind.EOF
+    ) {
+        self.parse_expression();
+    }
+    return left;
 }
 
 impl Parser.parse_concurrent_expr -> Expr {

--- a/jac/jaclang/jac0core/parser/parser.jac
+++ b/jac/jaclang/jac0core/parser/parser.jac
@@ -30,6 +30,7 @@ import from jaclang.jac0core.diagnostics {
     E0021,
     E0022,
     E0023,
+    E0025,
     E0030,
     E0031,
     E0032,
@@ -455,6 +456,8 @@ obj Parser {
     def parse -> Module;
     def parse_module -> Module;
     def parse_expression -> Expr;
+    def _check_js_arrow_fault -> bool;
+    def _recover_js_arrow_fault(left: Expr) -> Expr;
     def parse_concurrent_expr -> Expr;
     def parse_walrus_assign -> Expr;
     def parse_by_expr -> Expr;

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -65,6 +65,17 @@ def compile_only(fixture_name: str) -> tuple {
     return (program, mod);
 }
 
+"""Parse source string with diagnostic capture: returns (program, had_error)."""
+def parse_with_prog(source: str) -> tuple[JacProgram, bool] {
+    prog = JacProgram();
+    try {
+        (_, had_error) = parse(source, "/tmp/test.jac", prog=prog);
+        return (prog, had_error);
+    } except Exception {
+        return (prog, True);
+    }
+}
+
 """Parse source string, return (has_errors: bool, program: JacProgram)."""
 def parse_and_validate(source: str) -> tuple {
     try {
@@ -168,6 +179,69 @@ test "E0117: mixed tabs and spaces" {
 #  Infrastructure: INFRA-8 for E0055-E0058
 #  Milestone: 1 (Context Validity) + 4 (Parser/Lexer Hardening)
 # ══════════════════════════════════════════════════════════════════
+
+# ── E0025: JS arrow function syntax (=>) ───────────────────────────
+test "E0025: js arrow in jsx attribute slot" {
+    src = 'cl { def:pub Foo() -> JsxElement {' + ' return <button onClick={e => doThing(e)}>Click</button>; } }';
+    (prog, _) = parse_with_prog(src);
+    assert has_diagnostic_code(prog, "E0025");
+    assert count_diagnostic_code(prog, "E0025") == 1;
+}
+
+test "E0025: js arrow in jsx child slot" {
+    src = 'cl { def:pub Foo() -> JsxElement {' + ' return <div>{e => fn(e)}</div>; } }';
+    (prog, _) = parse_with_prog(src);
+    assert has_diagnostic_code(prog, "E0025");
+    assert count_diagnostic_code(prog, "E0025") == 1;
+}
+
+test "E0025: js arrow at module level glob" {
+    (prog, _) = parse_with_prog('glob f = x => x + 1;');
+    assert has_diagnostic_code(prog, "E0025");
+    assert count_diagnostic_code(prog, "E0025") == 1;
+}
+
+test "E0025: js arrow with block body" {
+    (prog, _) = parse_with_prog('with entry { f = x => { print(x); }; }');
+    assert has_diagnostic_code(prog, "E0025");
+    assert count_diagnostic_code(prog, "E0025") == 1;
+}
+
+test "E0025: chained arrows emit one diagnostic per arrow" {
+    (prog, _) = parse_with_prog('with entry { f = a => b => c; }');
+    assert count_diagnostic_code(prog, "E0025") == 2;
+}
+
+test "E0025: gte (>=) does not fire" {
+    (prog, had_err) = parse_with_prog('with entry { x = (a >= b); }');
+    assert not had_err;
+    assert not has_diagnostic_code(prog, "E0025");
+}
+
+test "E0025: lambda syntax unaffected" {
+    (prog, had_err) = parse_with_prog('with entry { f = lambda x: int : x + 1; }');
+    assert not had_err;
+    assert not has_diagnostic_code(prog, "E0025");
+}
+
+test "E0025: spaced '= >' is not an arrow" {
+    # '=' and '>' separated by whitespace should never match the arrow shape;
+    # the source is invalid for other reasons, but E0025 must not fire.
+    (prog, _) = parse_with_prog('with entry { x = a = > b; }');
+    assert not has_diagnostic_code(prog, "E0025");
+}
+
+test "E0025: arrow in fstring slot" {
+    (prog, _) = parse_with_prog('with entry { s = f"{x => y}"; }');
+    assert has_diagnostic_code(prog, "E0025");
+}
+
+test "E0025: empty body recovers without crash" {
+    (prog, _) = parse_with_prog('with entry { f = x =>; }');
+    assert has_diagnostic_code(prog, "E0025");
+}
+
+
 test "E0052: missing type annotation on parameter" {
     (has_err, prog) = parse_and_validate('def foo(x) { }');
     assert has_err or (prog is not None and has_diagnostic_code(prog, "E0052"));


### PR DESCRIPTION
## Why this matters

A JS/TS developer hears "Jac has JSX" and writes:

```jsx
<button onClick={e => doThing(e)}>Click</button>
```

It fails — Jac uses `lambda`, not `=>`. The question is **how it fails**.

### Before

```
✖ error[E0001]: Expected '}', got '>'
✖ error[E0005]: Unexpected token '>'
✖ error[E0030]: Unexpected semicolon at module level
✖ error[E0005]: Unexpected token '}'
```

Four cascade errors. None mentions arrow functions. None points at `=>`.

### After

```
✖ error[E0025]: JavaScript arrow function syntax ('=>') is not supported in Jac
  --> file.jac:3:35
    3 |         return <button onClick={e => doThing(e)}>Click</button>;
      |                                   ^^
help: Use Jac lambda syntax instead: 'lambda e: ChangeEvent { ... }' or 'lambda x: int : x + 1'.
```

One error. Right caret. Tells the user what to write instead. The rest of the file still parses, so a single arrow doesn't poison diagnostics for everything below it.

## Approach

Compared to a previous attempt (#5641, reverted in #5733), this lives **only in the parser**:

| Layer | Change |
| --- | --- |
| Lexer | None. `=` and `>` continue to lex as separate tokens. |
| Diagnostic | `E0025` registered in `diagnostics.jac` like every other `E0xxx`. |
| Parser | After `parse_expression` finishes the precedence chain, `_check_js_arrow_fault` recognises `EQ + GT` byte-adjacent (literal `=>` with no whitespace), and `_recover_js_arrow_fault` emits E0025 spanning the `=>` then drains the body using the existing `parse_expression` / `parse_code_block_stmts` routines. |

Why this shape rather than the previous lex-time atomic match + parser drain:
- One layer, not two. No `TokenKind.ERROR` overload, so consumers that pattern-match on tokens stay unaware.
- Recovery reuses existing parser routines, so chained `e => f => g` (flagged as a known follow-up in #5641), nested JSX, and block bodies fall out without a hand-rolled brace counter.
- Adding the next "did you mean X" hint is now a row in the `DIAGNOSTICS` table plus a branch in `parse_expression` — same shape every time.

## Detection scope

The check fires only when **`current() == EQ` and `peek() == GT` and `current().loc.pos_end == peek().loc.pos_start`**. Lookalikes:

| Case | Fires? | Why |
| --- | --- | --- |
| `a >= b`, `a <= b`, `a == b`, `a != b` | No | Multi-char tokens are matched by the lexer; `current()` is `GTE`/`LTE`/`EE`/`NE`, not `EQ`. |
| `a > b`, `a := b` | No | No preceding `EQ` adjacent to `GT`. |
| `a = b > c` | No | After parsing `a`, `EQ` is consumed by the assignment statement; expression-level `parse_expression` sees `b` next, not `=`. |
| `a = >b` (whitespace) | No | Adjacency check fails. |
| `lambda x: int : x + 1` | No | `KW_LAMBDA` early-returns from `parse_expression` before the check. |
| `<button onClick={e => fn(e)}>` | **Yes** | Real bug. |
| `<div>{e => fn(e)}</div>` | **Yes** | Real bug. |
| `glob f = x => x + 1;` | **Yes** | Real bug. |
| `f"{x => y}"` | **Yes** | Real bug (f-string slot is normal expression context). |
| `f = x => { print(x); }` | **Yes** | Real bug; block-body branch of recovery. |
| `f = a => b => c` | **Yes** ×2 | One E0025 per arrow; recovery's recursive `parse_expression` re-detects nested arrows. |

Recovery is purely about diagnostic noise: E0025 is a hard error, the compile pipeline still rejects the file. Without recovery, the four-error cascade above re-appears.

## Tests

10 cases under `PHASE 2` in `test_new_diagnostics.jac`:
- 7 detection cases — JSX attribute slot, JSX child slot, glob assignment, block body, chained arrows (count == 2), f-string slot, empty body (`x =>;`).
- 3 false-positive guards — `>=` (lexer multi-char tokens), `lambda` (early-return path), spaced `= >` (the adjacency check).

A new `parse_with_prog` helper captures parse-stage diagnostics, since the existing `parse_and_validate` returns `prog=None` on parse error.

## Test plan

- [x] 10 new E0025 tests pass under `pytest -n 25`.
- [x] Diagnostics + parser suites: 528 passed, 57 pre-existing skips.
- [x] Full compiler suite: 2520 passed. (3 unrelated subprocess-based tests fail under this workstation env on `main` itself — `python3 -m jaclang.cli.cli ...` and `subprocess.run(["jac", ...])` — predate this change.)
- [x] Spot-checked the user-facing rendering with `jac check`: single E0025 with caret on `=>` and the `help:` line.