### PR TITLE
feat(diagnostics): add E0026 for JS ternary (? :) detection

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5760.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5760.bugfix.md
@@ -1,0 +1,1 @@
+- **Parser: Detect JS Ternary Operator Syntax**: The parser now emits diagnostic E0026 when a JavaScript-style ternary expression (`condition ? then : else`) is used in expression position. This syntax is not valid Jac; users are guided to use Jac's `if`-expression form (`then if condition else else`) instead.

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -131,6 +131,12 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "JavaScript arrow function syntax ('=>') is not supported in Jac",
          help="Use Jac lambda syntax instead: 'lambda e: ChangeEvent { ... }' or 'lambda x: int : x + 1'."
      ),
+     E0026 = _err(
+         "E0026",
+         Category.SYNTAX,
+         "JavaScript ternary operator ('? :') is not supported in Jac",
+         help="Use Jac's if-expression instead: 'value_if_true if condition else value_if_false'."
+     ),
      # Parser: statement-level errors
      E0030 = _err("E0030", Category.SYNTAX, "Unexpected semicolon at module level"),
      E0031 = _err(

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -880,8 +880,11 @@ impl Parser._recover_js_arrow_fault(left: Expr) -> Expr {
 }
 
 impl Parser._check_js_ternary_fault -> bool {
-    # COLON is intentionally excluded: `a ? : b` (empty then-branch) should still
-    # trigger E0026. The recovery skips the then-parse when it sees COLON directly.
+    # COLON excluded: `a ? : b` (empty then-branch) must still fire E0026. Including
+    # COLON here would make the check return False, silently falling through to the
+    # LSP placeholder path and producing confusing cascade errors instead. The
+    # then-branch guard inside _recover_js_ternary_fault carries COLON to skip
+    # parsing a missing expression when `?` is followed directly by `:`.
     return not self.check_any(
         TokenKind.SEMI,
         TokenKind.RBRACE,

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -144,6 +144,7 @@ import from jaclang.jac0core.diagnostics {
     E0021,
     E0022,
     E0025,
+    E0026,
     E0030,
     E0032,
     E0034,
@@ -878,6 +879,47 @@ impl Parser._recover_js_arrow_fault(left: Expr) -> Expr {
     return left;
 }
 
+impl Parser._check_js_ternary_fault -> bool {
+    # COLON is intentionally excluded: `a ? : b` (empty then-branch) should still
+    # trigger E0026. The recovery skips the then-parse when it sees COLON directly.
+    return not self.check_any(
+        TokenKind.SEMI,
+        TokenKind.RBRACE,
+        TokenKind.RPAREN,
+        TokenKind.RSQUARE,
+        TokenKind.COMMA,
+        TokenKind.EOF
+    );
+}
+
+impl Parser._recover_js_ternary_fault(left: Expr, q_tok: Token) -> Expr {
+    self.emit_diag(E0026, loc=q_tok.loc);
+    if not self.check_any(
+        TokenKind.SEMI,
+        TokenKind.RBRACE,
+        TokenKind.RPAREN,
+        TokenKind.RSQUARE,
+        TokenKind.COMMA,
+        TokenKind.COLON,
+        TokenKind.EOF
+    ) {
+        self.parse_expression();
+    }
+    if self.match_tok(TokenKind.COLON) {
+        if not self.check_any(
+            TokenKind.SEMI,
+            TokenKind.RBRACE,
+            TokenKind.RPAREN,
+            TokenKind.RSQUARE,
+            TokenKind.COMMA,
+            TokenKind.EOF
+        ) {
+            self.parse_expression();
+        }
+    }
+    return left;
+}
+
 impl Parser.parse_concurrent_expr -> Expr {
     if self.check_any(TokenKind.KW_FLOW, TokenKind.KW_WAIT) {
         tok = self.advance();
@@ -1426,6 +1468,9 @@ impl Parser.parse_atomic_chain -> Expr {
                 dot_uni = self.make_uni_token(self.advance());
             }
             if not dot_uni and null_ok {
+                if self._check_js_ternary_fault() {
+                    return self._recover_js_ternary_fault(expr, first_consumed_tok);
+                }
                 dot_uni = null_ok_uni;
             }
             # Allow NAME, KWESC_NAME, or any keyword as attribute names after DOT

--- a/jac/jaclang/jac0core/parser/parser.jac
+++ b/jac/jaclang/jac0core/parser/parser.jac
@@ -31,6 +31,7 @@ import from jaclang.jac0core.diagnostics {
     E0022,
     E0023,
     E0025,
+    E0026,
     E0030,
     E0031,
     E0032,
@@ -458,6 +459,8 @@ obj Parser {
     def parse_expression -> Expr;
     def _check_js_arrow_fault -> bool;
     def _recover_js_arrow_fault(left: Expr) -> Expr;
+    def _check_js_ternary_fault -> bool;
+    def _recover_js_ternary_fault(left: Expr, q_tok: Token) -> Expr;
     def parse_concurrent_expr -> Expr;
     def parse_walrus_assign -> Expr;
     def parse_by_expr -> Expr;

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -241,6 +241,61 @@ test "E0025: empty body recovers without crash" {
     assert has_diagnostic_code(prog, "E0025");
 }
 
+# ── E0026: JS ternary operator (? :) ───────────────────────────────
+test "E0026: simple inline ternary" {
+    (prog, _) = parse_with_prog('with entry { x = a ? "yes" : "no"; }');
+    assert has_diagnostic_code(prog, "E0026");
+    assert count_diagnostic_code(prog, "E0026") == 1;
+}
+
+test "E0026: ternary in jsx child slot" {
+    src = 'cl { def:pub Foo() -> JsxElement {' + ' return <div>{isActive ? <A /> : <B />}</div>; } }';
+    (prog, _) = parse_with_prog(src);
+    assert has_diagnostic_code(prog, "E0026");
+    assert count_diagnostic_code(prog, "E0026") == 1;
+}
+
+test "E0026: ternary in jsx attribute slot" {
+    src = 'cl { def:pub Foo() -> JsxElement {' + ' return <button onClick={x ? f : g}>Click</button>; } }';
+    (prog, _) = parse_with_prog(src);
+    assert has_diagnostic_code(prog, "E0026");
+    assert count_diagnostic_code(prog, "E0026") == 1;
+}
+
+test "E0026: ternary in fstring slot" {
+    (prog, _) = parse_with_prog('with entry { s = f"{x ? a : b}"; }');
+    assert has_diagnostic_code(prog, "E0026");
+    assert count_diagnostic_code(prog, "E0026") == 1;
+}
+
+test "E0026: chained ternaries emit one diagnostic per question mark" {
+    (prog, _) = parse_with_prog('with entry { x = a ? b : c ? d : e; }');
+    assert count_diagnostic_code(prog, "E0026") == 2;
+}
+
+test "E0026: missing colon recovers without crash" {
+    (prog, _) = parse_with_prog('with entry { x = a ? b; }');
+    assert has_diagnostic_code(prog, "E0026");
+    assert count_diagnostic_code(prog, "E0026") == 1;
+}
+
+test "E0026: null-safe member access (?.) does not fire" {
+    (prog, had_err) = parse_with_prog('with entry { x = user?.email; }');
+    assert not had_err;
+    assert not has_diagnostic_code(prog, "E0026");
+}
+
+test "E0026: null-safe index access (?[]) does not fire" {
+    (prog, had_err) = parse_with_prog('with entry { x = items?[0]; }');
+    assert not had_err;
+    assert not has_diagnostic_code(prog, "E0026");
+}
+
+test "E0026: question mark before terminator does not fire" {
+    (prog, _) = parse_with_prog('with entry { a?; }');
+    assert not has_diagnostic_code(prog, "E0026");
+}
+
 
 test "E0052: missing type annotation on parameter" {
     (has_err, prog) = parse_and_validate('def foo(x) { }');

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -246,6 +246,7 @@ test "E0026: simple inline ternary" {
     (prog, _) = parse_with_prog('with entry { x = a ? "yes" : "no"; }');
     assert has_diagnostic_code(prog, "E0026");
     assert count_diagnostic_code(prog, "E0026") == 1;
+    assert len(prog.errors_had) == 1;  # recovery must suppress cascade errors
 }
 
 test "E0026: ternary in jsx child slot" {
@@ -277,6 +278,17 @@ test "E0026: missing colon recovers without crash" {
     (prog, _) = parse_with_prog('with entry { x = a ? b; }');
     assert has_diagnostic_code(prog, "E0026");
     assert count_diagnostic_code(prog, "E0026") == 1;
+}
+
+test "E0026: empty then-branch (a ? : b) fires E0026" {
+    (prog, _) = parse_with_prog('with entry { x = a ? : b; }');
+    assert has_diagnostic_code(prog, "E0026");
+}
+
+test "E0026: valid jac if-expression does not fire" {
+    (prog, had_err) = parse_with_prog('with entry { x = "yes" if cond else "no"; }');
+    assert not had_err;
+    assert not has_diagnostic_code(prog, "E0026");
 }
 
 test "E0026: null-safe member access (?.) does not fire" {

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -246,7 +246,9 @@ test "E0026: simple inline ternary" {
     (prog, _) = parse_with_prog('with entry { x = a ? "yes" : "no"; }');
     assert has_diagnostic_code(prog, "E0026");
     assert count_diagnostic_code(prog, "E0026") == 1;
-    assert len(prog.errors_had) == 1;  # recovery must suppress cascade errors
+    assert len(
+        prog.errors_had
+    ) == 1;  # without recovery draining both branches, leftover tokens produce E0001/E0005 cascade
 }
 
 test "E0026: ternary in jsx child slot" {


### PR DESCRIPTION
# Why This Matters

A JS/TS developer writing Jac with JSX may naturally use a ternary inside a JSX expression. However, Jac uses:

```jac
value_if_true if condition else value_if_false
```

So the key issue isn’t just that it fails — it’s **how it fails**.

## Before

```text
Failed to compile 'ErrorBanner.cl.jac' for client bundle:
ErrorBanner.cl.jac, line 16, col 47: Missing '}'
ErrorBanner.cl.jac, line 16, col 47: Missing '}'
ErrorBanner.cl.jac, line 16, col 47: Expected 'JSX_TAG_END', got 'STRING'
ErrorBanner.cl.jac, line 16, col 57: Expected '</', got ':'
ErrorBanner.cl.jac, line 16, col 59: Expected 'JSX_NAME', got 'STRING'
ErrorBanner.cl.jac, line 16, col 68: Expected 'JSX_TAG_END', got ','
```

* Six cascading errors
* No mention of ternary operators
* No pointer to `?`
* All errors are downstream parser confusion

**Result:** Completely non-actionable diagnostics.

## After

```text
Failed to compile 'ErrorBanner.cl.jac' for client bundle:
ErrorBanner.cl.jac, line 16, col 45: JavaScript ternary operator ('? :') is not supported in Jac
```

* Single error
* Points directly at `?`
* Rest of the file parses cleanly

**Result:** Clear, actionable feedback.

# Approach

The `?` token already exists in Jac for null-safe access:

* `?.`
* `?[]`

## Current Problem

`parse_atomic_chain`:

* Consumes `?`
* Expects `.` or `[`
* If neither follows → silently falls through
* Leads to cascading parser errors

## Solution

Intercept the fall-through and detect ternary usage.

# Changes by Layer

* **Lexer**
  None — `?` remains `QUESTION`

* **Diagnostic**
  Introduced **E0026** in `diagnostics.jac`

* **Parser**
  Detects and recovers from ternary misuse

# Recovery Behavior

* Emits **E0026** as a **hard error**
* Parser continues to reduce noise
* Compilation still **fails**

**Goal:** Better diagnostics, not silent recovery

# Tests

Located under `E0026` block in `test_new_diagnostics.jac`

## Detection Cases (7)

* Inline ternary
* JSX child slot
* JSX attribute slot
* f-string slot
* Chained ternaries (`count == 2`)
* Missing colon
* Empty then-branch (`a ? : b`)

## False-Positive Guards (4)

* `?.` (null-safe member)
* `?[]` (null-safe index)
* Valid Jac `if` expression
* `?` before statement terminator

# Test Plan

* 11 new E0026 tests pass (`pytest -n 25`)
* Diagnostics + parser suites pass
* No regressions introduced

Manual verification:

```bash
jac check
```

**Result:**

* Single **E0026**
* Correct pointer to `?`
* Includes helpful message

# Summary

This change:

* Eliminates cascading parser noise
* Surfaces a **precise, developer-friendly error**
* Preserves existing syntax behavior
* Improves onboarding for JS/TS developers

**From:** confusing failure
**To:** clear, intent-aware diagnostic

