### PR TITLE
ci(test-scale-k8s): wait on real microk8s readiness, stop hiding install errors

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -276,10 +276,22 @@ jobs:
 
       - name: Install MicroK8s
         run: |
-          set +e
           sudo snap install microk8s --classic
-          sleep 20
-          set -e
+          # Snap install is asynchronous: wait on the actual symlink rather
+          # than guessing with `sleep`, so a slow snapd doesn't race the next
+          # step into a confusing "command not found".
+          for i in {1..60}; do
+            if [ -x /snap/bin/microk8s ]; then
+              echo "microk8s ready after $((i*2))s"
+              break
+            fi
+            sleep 2
+          done
+          if [ ! -x /snap/bin/microk8s ]; then
+            echo "microk8s not available after 120s" >&2
+            sudo snap changes
+            exit 1
+          fi
 
       - name: Initialize MicroK8s
         run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -276,7 +276,25 @@ jobs:
 
       - name: Install MicroK8s
         run: |
-          sudo snap install microk8s --classic
+          # Wait for snapd to finish seeding before contacting the store —
+          # a cold runner can take ~30s before `snap install` is reliable.
+          sudo snap wait system seed.loaded
+          # Retry on transient store failures ("unable to contact snap store",
+          # rate limits, etc.). Backoff 10s, 20s, 30s, 40s.
+          install_ok=0
+          for attempt in 1 2 3 4 5; do
+            if sudo snap install microk8s --classic; then
+              install_ok=1
+              break
+            fi
+            echo "snap install attempt ${attempt} failed; retrying..." >&2
+            sleep $((attempt * 10))
+          done
+          if [ "$install_ok" != "1" ]; then
+            echo "snap install failed after 5 attempts" >&2
+            sudo snap changes >&2
+            exit 1
+          fi
           # Snap install is asynchronous: wait on the actual symlink rather
           # than guessing with `sleep`, so a slow snapd doesn't race the next
           # step into a confusing "command not found".

--- a/docs/docs/community/release_notes/unreleased/jaclang/5775.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5775.bugfix.md
@@ -1,0 +1,1 @@
+- **CI: `test-scale-k8s` flake on snap install**: The MicroK8s install step now waits on the actual `/snap/bin/microk8s` symlink rather than a blind 20s sleep, and no longer hides install failures behind `set +e`. Eliminates the intermittent "sudo: microk8s: command not found" failures whose true cause was masked by the install step reporting green.


### PR DESCRIPTION
Fixes #5774.

## Summary

The `test-scale-k8s` job intermittently fails in **Initialize MicroK8s** with `sudo: microk8s: command not found`. Root cause analysis is in #5774 — short version: the previous install step did `set +e; snap install; sleep 20; set -e`, which (a) silently swallowed any install failure and (b) used a blind sleep instead of waiting on the actual `/snap/bin/microk8s` symlink that snapd creates asynchronously.

This PR replaces the block with a 120 s wait loop on the symlink, removes `set +e` so install errors surface in the right step, and dumps `sudo snap changes` on timeout so the next flake leaves diagnostic output in the log instead of a bare `exit 1`.

## Test plan

- YAML parses (`python -c 'import yaml; yaml.safe_load(...)'`).
- Pre-commit clean on the changed file.
- Real proof is the next ~10–20 PR runs not flaking; CI flakiness can't be reproduced locally.