### PR TITLE
fix(ci): fix snap PATH for sudo so microk8s works on any Ubuntu version

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -276,14 +276,14 @@ jobs:
 
       - name: Install MicroK8s
         run: |
+          set +e
           sudo snap install microk8s --classic
-          echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"' | sudo tee /etc/sudoers.d/snap-path
-          sudo chmod 440 /etc/sudoers.d/snap-path
-          sleep 30
+          sleep 20
+          set -e
 
       - name: Initialize MicroK8s
         run: |
-          sudo microk8s status --wait-ready --timeout 300
+          sudo microk8s status --wait-ready
           sudo microk8s enable dns storage
 
       - name: Configure kubectl

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -252,7 +252,7 @@ jobs:
         pytest -x -vv -s jac-scale/jac_scale/tests/test_scheduling.jac
 
   test-scale-k8s:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -276,21 +276,20 @@ jobs:
 
       - name: Install MicroK8s
         run: |
-          set +e
           sudo snap install microk8s --classic
-          sleep 20
-          set -e
+          echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"' | sudo tee /etc/sudoers.d/snap-path
+          sudo chmod 440 /etc/sudoers.d/snap-path
+          sleep 30
 
       - name: Initialize MicroK8s
         run: |
-          sudo microk8s status --wait-ready
+          sudo microk8s status --wait-ready --timeout 300
           sudo microk8s enable dns storage
 
       - name: Configure kubectl
         run: |
           mkdir -p ~/.kube
           sudo microk8s config > ~/.kube/config
-
 
       - name: Run K8 tests
         run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -252,7 +252,7 @@ jobs:
         pytest -x -vv -s jac-scale/jac_scale/tests/test_scheduling.jac
 
   test-scale-k8s:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v5

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -280,6 +280,8 @@ jobs:
           sudo snap install microk8s --classic
           sleep 20
           set -e
+          echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"' | sudo tee /etc/sudoers.d/snap-path
+          sudo chmod 440 /etc/sudoers.d/snap-path
 
       - name: Initialize MicroK8s
         run: |


### PR DESCRIPTION
## Summary

Fixes `test-scale-k8s` which has been failing since `ubuntu-latest` upgraded to `ubuntu-24.04`.

Closes #5781

## Root cause

On `ubuntu-24.04`, snap installs binaries to `/snap/bin` but `sudo` has a restricted `secure_path` that excludes it. So `sudo microk8s status --wait-ready` fails with `command not found` even after a successful install. The existing `set +e` was hiding the error silently.

## Fix

Add `/snap/bin` to sudo's `secure_path` via `/etc/sudoers.d/snap-path` right after snap install. This is the correct fix - it works on `ubuntu-22.04`, `ubuntu-24.04`, and any future runner image without needing to manually update a pinned version.

Other improvements:
- Remove `set +e` so snap install failures surface immediately
- Add `--timeout 300` to `microk8s status --wait-ready` for slower runners
- Increase sleep to 30s