### PR TITLE
fix(ci): replace `MicroK8s` with `kind` for k8s tests

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -274,18 +274,9 @@ jobs:
           pip install pytest-xdist
           pip install pytest-asyncio
 
-      - name: Install kind and kubectl
+      - name: Write kind config
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/kubectl
-
-      - name: Create kind cluster
-        run: |
-          cat <<EOF | kind create cluster --name jaseci-test --config=-
+          cat <<EOF > /tmp/kind-config.yaml
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
           nodes:
@@ -295,7 +286,13 @@ jobs:
               hostPort: 30080
               protocol: TCP
           EOF
-          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: jaseci-test
+          wait: 120s
+          config: /tmp/kind-config.yaml
 
       - name: Run K8 tests
         run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -274,20 +274,28 @@ jobs:
           pip install pytest-xdist
           pip install pytest-asyncio
 
+      - name: Install kind and kubectl
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
+
       - name: Create kind cluster
-        uses: helm/kind-action@v1
-        with:
-          cluster_name: jaseci-test
-          wait: 120s
-          config: |
-            kind: Cluster
-            apiVersion: kind.x-k8s.io/v1alpha4
-            nodes:
-            - role: control-plane
-              extraPortMappings:
-              - containerPort: 30080
-                hostPort: 30080
-                protocol: TCP
+        run: |
+          cat <<EOF | kind create cluster --name jaseci-test --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+            extraPortMappings:
+            - containerPort: 30080
+              hostPort: 30080
+              protocol: TCP
+          EOF
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
 
       - name: Run K8 tests
         run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -274,28 +274,20 @@ jobs:
           pip install pytest-xdist
           pip install pytest-asyncio
 
-      - name: Install kind and kubectl
-        run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/kubectl
-
       - name: Create kind cluster
-        run: |
-          cat <<EOF | kind create cluster --name jaseci-test --config=-
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          nodes:
-          - role: control-plane
-            extraPortMappings:
-            - containerPort: 30080
-              hostPort: 30080
-              protocol: TCP
-          EOF
-          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: jaseci-test
+          wait: 120s
+          config: |
+            kind: Cluster
+            apiVersion: kind.x-k8s.io/v1alpha4
+            nodes:
+            - role: control-plane
+              extraPortMappings:
+              - containerPort: 30080
+                hostPort: 30080
+                protocol: TCP
 
       - name: Run K8 tests
         run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -274,23 +274,28 @@ jobs:
           pip install pytest-xdist
           pip install pytest-asyncio
 
-      - name: Install MicroK8s
+      - name: Install kind and kubectl
         run: |
-          set +e
-          sudo snap install microk8s --classic
-          sleep 20
-          set -e
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
 
-      - name: Initialize MicroK8s
+      - name: Create kind cluster
         run: |
-          sudo microk8s status --wait-ready
-          sudo microk8s enable dns storage
-
-      - name: Configure kubectl
-        run: |
-          mkdir -p ~/.kube
-          sudo microk8s config > ~/.kube/config
-
+          cat <<EOF | kind create cluster --name jaseci-test --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+            extraPortMappings:
+            - containerPort: 30080
+              hostPort: 30080
+              protocol: TCP
+          EOF
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
 
       - name: Run K8 tests
         run: |

--- a/jac-scale/jac_scale/tests/test_k8s_utils.jac
+++ b/jac-scale/jac_scale/tests/test_k8s_utils.jac
@@ -92,7 +92,6 @@ with entry {
 # --- validate_resource_limits ---
 test "validate resource limits accepts valid pairs" {
     validate_resource_limits("250m", "500m", "256Mi", "512Mi");
-    assert 1 == 2, "INTENTIONAL FAILURE: proving tests actually run in CI";
 }
 
 test "validate resource limits rejects lower limits" {

--- a/jac-scale/jac_scale/tests/test_k8s_utils.jac
+++ b/jac-scale/jac_scale/tests/test_k8s_utils.jac
@@ -92,6 +92,7 @@ with entry {
 # --- validate_resource_limits ---
 test "validate resource limits accepts valid pairs" {
     validate_resource_limits("250m", "500m", "256Mi", "512Mi");
+    assert 1 == 2, "INTENTIONAL FAILURE: proving tests actually run in CI";
 }
 
 test "validate resource limits rejects lower limits" {


### PR DESCRIPTION
## Summary

Replaces MicroK8s with `kind` (Kubernetes IN Docker) in the `test-scale-k8s` CI job.

## Why

MicroK8s uses `snap` which has flaky connectivity to the snap store on GitHub Actions runners - `sudo snap install microk8s` fails intermittently with `unable to contact snap store`, causing `test-scale-k8s` to fail on PRs that have nothing wrong. The original `set +e` was hiding this failure silently, making the tests never actually run reliably.

`kind` is Docker-based. Docker is always available on GitHub Actions runners. No snap, no snap store, no network flakiness. It is also the tool Kubernetes itself uses for its own CI.

## Changes

**Only the CI workflow changes - zero changes to jac-scale source code or tests.**

The jac-scale codebase was already cluster-agnostic:
- All k8s interaction uses standard Python kubernetes client + `kubectl`
- Kubeconfig loaded via standard `load_kube_config()` which reads `~/.kube/config`
- No MicroK8s-specific CLI calls anywhere in the source

Replaced 3 steps (Install MicroK8s + Initialize MicroK8s + Configure kubectl) with 2 steps:

- **Install kind and kubectl** - curl download, no snap needed
- **Create kind cluster** - kind automatically writes `~/.kube/config`, provides a default storage class for PVCs, and the cluster config maps NodePort 30080 to the host for ingress tests

## Related

- Closes #5781