### PR TITLE
refactor(types): annotate console proxy as JacConsole

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5800.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5800.refactor.md
@@ -1,0 +1,1 @@
+- **Console Proxy Typing**: Annotated the lazy `console` global in `jaclang.cli.console` as `JacConsole` (with a `cast` over the `_ConsoleProxy` instance) so static type checkers and IDEs resolve `console.print(...)`, `console.error(...)`, `console.spinner(...)`, etc. against the real interface instead of the `Any` returned by `_ConsoleProxy.__getattr__`. No runtime change.

--- a/jac/jaclang/cli/console.jac
+++ b/jac/jaclang/cli/console.jac
@@ -11,7 +11,7 @@ Plugins (like jac-super) can override this to provide Rich-enhanced output.
 import os;
 import sys;
 import from contextlib { contextmanager }
-import from typing { Any }
+import from typing { Any, cast }
 
 """Console utility class for terminal output in Jac CLI.
 
@@ -61,5 +61,7 @@ class _ConsoleProxy {
     }
 }
 
-# Export the proxy as console - provides clean attribute access with lazy initialization
-glob console = _ConsoleProxy();
+# Export the proxy as console - provides clean attribute access with lazy initialization.
+# The annotation lets the type checker resolve `console.print(...)` etc. against the
+# JacConsole interface; the cast satisfies the proxy-to-JacConsole assignment.
+glob console: JacConsole = cast(JacConsole, _ConsoleProxy());


### PR DESCRIPTION
## Summary

- The lazy `console` global in `jaclang.cli.console` is a `_ConsoleProxy` that delegates every attribute access to the resolved singleton via `__getattr__`. Without an annotation, `console.print(...)` and friends type-resolve to `Any`, defeating IDE autocomplete and silencing arg checks at every call site.
- Annotate `console: JacConsole` and `cast` the proxy instance to satisfy the assignment. Runtime is unchanged; the proxy still delegates lazily, but the type checker now sees the real `JacConsole` interface.

## Test plan

- [x] `python -m jaclang check jaclang/cli/banners.jac` — passes (no new errors on `console.*` calls)
- [x] `python -m pytest tests/language/test_cli.jac -x -q -n 4` — 75 passed
- [x] Manual smoke: `from jaclang.cli.console import console; console.print('hi'); console.success('typed')` — output as expected