### PR TITLE
fix(tools): route ir tool through target program and resolve types

### DIFF
--- a/jac/jaclang/utils/impl/lang_tools.impl.jac
+++ b/jac/jaclang/utils/impl/lang_tools.impl.jac
@@ -73,13 +73,20 @@ impl AstTool.ir(args: list[str]) -> str {
                 ir = prog.compile(
                     use_str=rep.unparse(),
                     file_path=(file_name[:-3] + '.jac'),
-                    no_cgen=True
+                    options=CompileOptions(
+                        type_check=True, no_cgen=True, force_target_program=True
+                    )
                 );
             } except Exception as e {
                 return f"Error While Jac to Py AST conversion: {e}";
             }
         } else {
-            ir = prog.compile(file_name, no_cgen=True);
+            ir = prog.compile(
+                file_name,
+                options=CompileOptions(
+                    type_check=True, no_cgen=True, force_target_program=True
+                )
+            );
         }
         match output {
             case 'sym':
@@ -115,7 +122,10 @@ impl AstTool.ir(args: list[str]) -> str {
                 return ir.unparse();
 
             case 'pyast':
-                ir = prog.compile(file_name);
+                ir = prog.compile(
+                    file_name,
+                    options=CompileOptions(type_check=False, force_target_program=True)
+                );
                 return f"{py_ast.dump(ir.gen.py_ast[0], indent=2)}"
                     if isinstance(ir.gen.py_ast[0], py_ast.AST)
                     else 'Compile failed.';
@@ -124,7 +134,10 @@ impl AstTool.ir(args: list[str]) -> str {
                 return str(DocIRGenPass(ir_in=ir, prog=prog).ir_out.gen.doc_ir);
 
             case 'py':
-                ir = prog.compile(file_name);
+                ir = prog.compile(
+                    file_name,
+                    options=CompileOptions(type_check=False, force_target_program=True)
+                );
                 return f"{ir.gen.py}"
                     if isinstance(ir.gen.py[0], str)
                     else 'Compile failed.';

--- a/jac/jaclang/utils/lang_tools.jac
+++ b/jac/jaclang/utils/lang_tools.jac
@@ -14,6 +14,7 @@ import from jaclang.compiler.passes.main.cfg_build_pass { cfg_dot_from_file }
 import from jaclang.compiler.passes.tool.doc_ir_gen_pass { DocIRGenPass }
 import from jaclang.jac0core.unitree { UniScopeNode }
 import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.compile_options { CompileOptions }
 import from jaclang.jac0core.helpers { pascal_to_snake }
 import from jaclang.runtimelib.utils { read_file_with_encoding }
 """Information about a kid."""


### PR DESCRIPTION
## Summary

- `jac tool ir ast <absolute path>` produced empty output for any file inside the jaclang install tree (e.g. `jac/jaclang/cli/banners.jac`), because `JacCompiler._resolve_program` routes such paths to `internal_program`, leaving the locally-constructed `prog.mod.hub` empty when `AstTool.ir` iterates it.
- Fix all four `prog.compile` sites in `AstTool.ir` to pass `CompileOptions(force_target_program=True)` so the user-constructed `JacProgram` receives the module regardless of path. Same pattern already used by `analysis` (`analysis.impl.jac:81`) and the language server (`engine.impl.jac:103`).
- Enable `type_check=True` on the primary compile so `ast` / `ast.` / `sym` / `sym.` output populates resolved types (`Literal[...]`, `list[...]`, `<module ...>`, function signatures, etc.) instead of empty `Type: ,` fields. `pyast` / `py` recompiles keep `type_check=False` since their output is codegen, not types.

## Repro

Before:
```
$ jac tool ir ast /abs/path/to/jac/jaclang/cli/banners.jac | xxd
00000000: 0a                                       .
```

After:
```
$ jac tool ir ast /abs/path/to/jac/jaclang/cli/banners.jac | head -8
###########
# banners #
###########
1:1 - 81:2      Module,
1:1 - 4:4       +-- String - """Branding and banner utilities for Jac CLI...
...
5:8 - 5:16      |   |   +-- Name - platform - Type: <module platform>, ...
```

## Test plan

- [x] `jac tool ir ast` on absolute path inside `jac/jaclang/` produces full AST (was empty).
- [x] `jac tool ir ast` output identical for absolute and relative paths (modulo embedded path strings).
- [x] All `ir` subcommands (`ast`, `ast.`, `sym`, `sym.`, `unparse`, `docir`, `cfg.`, `pyast`, `py`) verified for both path styles, no errors.
- [x] `Type:` fields populate with 18+ distinct forms (`int`, `LiteralString`, `list[LiteralString]`, `<module sys>`, `<function machine() -> str>`, `_ConsoleProxy`, etc.).
- [x] Buggy file (deliberate type error) does not crash the tool; valid nodes still resolve types.
- [x] Missing-file error path preserved (`Error: <path> not found`).