### PR TITLE
docs(lang): cover typed-base enum syntax across reference and tutorials

### DIFF
--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -397,9 +397,16 @@ enum Color {
 # Auto-valued enum members
 enum Status { PENDING, ACTIVE, DONE }
 
+# Typed-base shorthand: members ARE instances of T
+# `: int` -> IntEnum, `: str` -> StrEnum, `: T` -> mixin (T, Enum)
+enum HttpStatus: int { OK = 200, NOT_FOUND = 404 }
+enum Tag: str { OPEN = "open", CLOSE = "close" }
+
 with entry {
-    print(Color.RED.value);      # "red"
-    print(Status.ACTIVE.value);  # 2
+    print(Color.RED.value);             # "red"
+    print(Status.ACTIVE.value);         # 2
+    print(HttpStatus.OK == 200);        # True (no .value needed)
+    print(isinstance(Tag.OPEN, str));   # True
 }
 
 

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -315,6 +315,7 @@ def increment -> None {
 | Entry point | `if __name__ == "__main__":` | `with entry { }` |
 | Module variables | Global assignment | `glob` keyword |
 | Enums | `class Color(Enum):` | `enum Color { RED, GREEN, BLUE }` |
+| Typed enums | `class S(IntEnum):` / `class S(StrEnum):` | `enum S: int { ... }` / `enum S: str { ... }` |
 | Error handling | `try: ... except:` | `try { } except Type as e { }` |
 | Imports | `from x import y` | `import from x { y }` |
 | Pattern matching | `match x: case 1:` | `match x { case 1:` (Python-style indentation inside braces) |
@@ -435,6 +436,31 @@ enum Status {
     ACTIVE = "active"
 }
 ```
+
+For `IntEnum`/`StrEnum`, Jac offers a typed-base shorthand `enum X: T { ... }`:
+
+**Python:**
+
+```python
+from enum import IntEnum, StrEnum
+
+class HttpStatus(IntEnum):
+    OK = 200
+    NOT_FOUND = 404
+
+class Tag(StrEnum):
+    OPEN = "open"
+    CLOSE = "close"
+```
+
+**Jac:**
+
+```jac
+enum HttpStatus: int { OK = 200, NOT_FOUND = 404 }
+enum Tag: str { OPEN = "open", CLOSE = "close" }
+```
+
+For any other base `T`, `enum X: T` desugars to the Python mixin form `class X(T, Enum)`.
 
 ### Entry Point
 

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -587,7 +587,51 @@ with entry {
 }
 ```
 
-### 4 Enums with Inline Python
+### 4 Typed-Base Enums
+
+`enum X: T { ... }` declares an enum whose members are instances of `T`. The base type follows the enum name after a colon. `int` and `str` desugar to Python's `IntEnum` and `StrEnum`; any other base `T` desugars to the mixin form `class X(T, Enum)`.
+
+```jac
+enum HttpStatus: int {
+    OK = 200,
+    NOT_FOUND = 404,
+    SERVER_ERROR = 500
+}
+
+enum Tag: str {
+    OPEN = "open",
+    CLOSE = "close"
+}
+
+with entry {
+    # Members compare and behave as the underlying type
+    print(HttpStatus.OK == 200);             # True
+    print(isinstance(Tag.OPEN, str));        # True
+    print(HttpStatus.OK + 1);                # 201 -- arithmetic works
+}
+```
+
+| Declaration | Desugars to |
+|-------------|-------------|
+| `enum X { A = 0 }` | `class X(Enum)` |
+| `enum X: int { A = 0 }` | `class X(IntEnum)` |
+| `enum X: str { A = "a" }` | `class X(StrEnum)` |
+| `enum X: T { A = T(...) }` | `class X(T, Enum)` (mixin) |
+
+The mixin form is useful when members must carry behavior or state from a custom type:
+
+```jac
+obj Box {
+    has size: int = 0;
+}
+
+enum Crate: Box {
+    SMALL = Box(),
+    LARGE = Box()
+}
+```
+
+### 5 Enums with Inline Python
 
 ```jac
 enum HttpStatus {
@@ -605,7 +649,7 @@ enum HttpStatus {
 }
 ```
 
-### 5 Properties and Encapsulation
+### 6 Properties and Encapsulation
 
 ```jac
 obj Account {

--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -506,6 +506,19 @@ sem Personality.AMBIVERT = "Comfortable in both social and solitary settings";
 def classify_personality(bio: str) -> Personality by llm();
 ```
 
+#### Typed-Base Enums
+
+`enum X: T { ... }` declares an enum whose members are `T` instances. This lets a `by llm()` return type flow directly into APIs that expect `int` or `str` without calling `.value`:
+
+```jac
+enum HttpStatus: int { OK = 200, NOT_FOUND = 404, SERVER_ERROR = 500 }
+enum Tag: str { OPEN = "open", CLOSE = "close" }
+
+def get_status(description: str) -> HttpStatus by llm();
+```
+
+`: int` desugars to `IntEnum`, `: str` to `StrEnum`, and any other base `T` to the mixin form `class X(T, Enum)`.
+
 ### Object Types
 
 ```jac

--- a/docs/docs/tutorials/ai/quickstart.md
+++ b/docs/docs/tutorials/ai/quickstart.md
@@ -111,6 +111,9 @@ enum Priority { LOW, MEDIUM, HIGH }
 sem Priority.HIGH = "Urgent: requires immediate attention";
 ```
 
+!!! tip "Typed-base enums"
+    For LLM outputs that should slot directly into `int` or `str` APIs, declare them as `enum X: int { ... }` or `enum X: str { ... }`. Members are real `int`/`str` instances -- no `.value` lookup needed at the call site. See [Structured Outputs](structured-outputs.md#typed-base-enums) for details.
+
 !!! tip "Best practice"
     Always use `sem` to provide context for `by llm()` functions. Docstrings are intended for human documentation (and auto-generated API docs) but are **not** included in compiler-generated prompts. Only `sem` declarations affect LLM behavior.
 

--- a/docs/docs/tutorials/ai/structured-outputs.md
+++ b/docs/docs/tutorials/ai/structured-outputs.md
@@ -77,6 +77,29 @@ enum HttpStatus {
 def get_status(response_description: str) -> HttpStatus by llm();
 ```
 
+### Typed-Base Enums
+
+When you want enum members to behave as their underlying type (so callers can compare against ints or strings without `.value`), use the typed-base shorthand `enum X: T { ... }`:
+
+```jac
+enum HttpStatus: int {
+    OK = 200,
+    NOT_FOUND = 404,
+    SERVER_ERROR = 500
+}
+
+def get_status(response_description: str) -> HttpStatus by llm();
+
+with entry {
+    status = get_status("page missing");
+    if status == 404 {                 # direct int comparison
+        print("not found");
+    }
+}
+```
+
+`: int` desugars to Python's `IntEnum`, `: str` to `StrEnum`. Pass an LLM-typed result straight into a typed API expecting `int` or `str` without converting.
+
 ---
 
 ## Objects (Dataclasses)

--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -1101,6 +1101,9 @@ enum Category { WORK, PERSONAL, SHOPPING, HEALTH, FITNESS, OTHER }
 
 This is a crucial concept: the enum constrains the AI to return *exactly one* of these predefined values. Without it, an LLM might return "shopping", "Shopping", "groceries", or "grocery shopping" -- all meaning the same thing but impossible to handle consistently in code. The enum eliminates that ambiguity entirely, making AI output as predictable as any other function return value.
 
+!!! tip "Typed-base enums"
+    For cases where you want enum members to behave as a primitive type, use `enum X: T { ... }`. `enum Status: str { OK = "ok", FAIL = "fail" }` makes members real `str` instances (no `.value` needed); `enum Code: int { ... }` does the same for `int`. Plain `enum` (used here) stays the right choice when the member identity matters more than the underlying value.
+
 **by llm() -- AI Function Delegation**
 
 Now for the core idea. Pay close attention, because this pattern is central to how Jac integrates AI:

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -317,6 +317,21 @@ with entry {
 }
 ```
 
+### Typed-Base Enums
+
+`enum X: T { ... }` declares an enum whose members are instances of `T`. `: int` desugars to Python's `IntEnum`, `: str` to `StrEnum`, and any other base `T` to the mixin form `class X(T, Enum)`:
+
+```jac
+enum HttpStatus: int { OK = 200, NOT_FOUND = 404 }
+enum Tag: str { OPEN = "open", CLOSE = "close" }
+
+with entry {
+    print(HttpStatus.OK == 200);          # True -- compare directly
+    print(isinstance(Tag.OPEN, str));     # True
+    print(HttpStatus.OK + 1);             # 201 -- arithmetic works
+}
+```
+
 ---
 
 ## Error Handling

--- a/docs/docs/tutorials/native/chess.md
+++ b/docs/docs/tutorials/native/chess.md
@@ -142,6 +142,9 @@ glob PIECE_VALUES: dict[PieceKind, int] = {
 
 **Native features:** enums, global variables, hex/binary literals, dict literals with enum keys.
 
+!!! tip "Typed-base enum shorthand"
+    Plain `enum Color { WHITE = 0, BLACK = 1 }` works here because the members are used as dictionary keys -- their identity matters more than their numeric value. If you wanted `Color.WHITE` to also act as a real `int` (for arithmetic, indexing, or interop with `int`-typed APIs), use the typed-base form: `enum Color: int { WHITE = 0, BLACK = 1 }`. `: int` desugars to Python's `IntEnum`, `: str` to `StrEnum`.
+
 ### Forward Declarations and Function Signatures
 
 Forward declarations let types reference each other before they are fully defined:


### PR DESCRIPTION
## Summary

Documents the `enum X: T { ... }` shorthand introduced in #5802 wherever enums are taught or referenced. The feature shipped without doc updates beyond the release note; this PR closes that gap.

## Changes

**Reference**
- `docs/reference/language/functions-objects.md` — new \"Typed-Base Enums\" section with the desugaring table (`: int` → `IntEnum`, `: str` → `StrEnum`, `: T` → `class X(T, Enum)` mixin) and a mixin example. Subsequent sections renumbered.
- `docs/quick-guide/syntax-cheatsheet.md` — typed-base lines added to the Enums block.
- `docs/reference/language/appendices.md` — typed-enum row in the Python-to-Jac table plus an `IntEnum`/`StrEnum` side-by-side block.
- `docs/reference/plugins/byllm.md` — typed-base sub-block under \"Enum Types\" so byLLM users can flow LLM outputs straight into `int`/`str` APIs.

**Tutorials**
- `docs/tutorials/ai/structured-outputs.md` — new \"Typed-Base Enums\" subsection with a `by llm()` example.
- `docs/tutorials/ai/quickstart.md` — tip near the first `Priority` enum, linking to structured-outputs.
- `docs/tutorials/language/basics.md` — typed-base subsection after the main enum block.
- `docs/tutorials/first-app/build-ai-day-planner.md` — tip near the `Category` enum noting when typed-base is the right call.
- `docs/tutorials/native/chess.md` — tip after `Color`/`PieceKind` explaining the trade-off (the example correctly stays plain because members are used as dict keys, not arithmetic operands).

**Skipped:** `docs/tutorials/ai/multimodal.md` — its `Personality` enum is a pure identity enum; typed-base would be a poor fit there.

## Voice

Written in timeless reference voice — no \"new\", \"now\", or \"no longer\" phrasing. The shorthand is presented as part of the language, not as an addition.

## Test plan

- [x] All new Jac snippets validated:
  - `python3 -m jaclang run` on the runtime example (`HttpStatus: int`, `Tag: str`, `Crate: Box` mixin) — output matches expectations (`True / True / 201 / True`).
  - `python3 -m jaclang check` on the `by llm()` example — passes.
- [x] markdownlint + em-dash + trailing-whitespace pre-commit hooks pass.
- [ ] Docs build (`mkdocs serve`) — please verify in CI.