### PR TITLE
examples(day_planner): add three-variant AI day planner from the first-app tutorial

### DIFF
--- a/jac/examples/day_planner/README.md
+++ b/jac/examples/day_planner/README.md
@@ -1,0 +1,37 @@
+# AI Day Planner -- three variants
+
+A small full-stack day planner with AI-powered task categorization and a meal-to-shopping-list generator. The same UI is implemented three ways so you can compare the architectural styles side by side. All three variants are built end-to-end in the [Build an AI Day Planner](../../../docs/docs/tutorials/first-app/build-ai-day-planner.md) tutorial.
+
+| Variant | Backend style | Auth | Layout |
+|---------|---------------|------|--------|
+| [basic/](basic/) | `def:pub` functions, single file | none (shared graph) | `main.jac` + `styles.css` |
+| [auth/](auth/) | `def:priv` functions, declaration/implementation split | username/password, per-user graph | `main.jac` + `frontend.cl.jac` + `frontend.impl.jac` + `styles.css` |
+| [walkers/](walkers/) | `walker:priv` with object-spatial abilities | username/password, per-user graph | same file split as `auth/` |
+
+The behavior is identical across variants -- what changes is *how* the server is written and how the client invokes it.
+
+## Run any variant
+
+Each variant is a standalone Jac project. Set your Anthropic API key once, then `cd` into the variant you want and start the dev server:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+cd basic            # or auth/  or walkers/
+jac start main.jac
+```
+
+Open http://localhost:8000 to use the app, http://localhost:8000/docs for the OpenAPI/Swagger UI, and http://localhost:8000/graph for a live visualization of the persisted node graph.
+
+## What each variant teaches
+
+**`basic/`** -- the full-stack mental model in one file. AI-typed enums (`Category`, `Unit`) and `obj Ingredient` shape both the LLM output and the client-server contract. `def:pub` exposes endpoints; the `cl def:pub app` component holds reactive `has` state and re-renders on assignment. Everyone shares the same `root` graph.
+
+**`auth/`** -- same app, but private. Switching the endpoints from `def:pub` to `def:priv` gives every authenticated user their own `root` and complete data isolation, with no changes to business logic. The frontend is split into `frontend.cl.jac` (declarations + render tree) and `frontend.impl.jac` (`impl app.method { ... }` bodies). `to cl:` / `to sv:` headers in `main.jac` keep server and client in one entry point.
+
+**`walkers/`** -- the object-spatial reimplementation. Instead of functions reaching into the graph, `walker:priv` agents traverse it with `visit [-->]`, `here`, `report`, and `disengage`. The frontend spawns walkers (`root spawn AddTask(title=...)`) instead of calling functions. `GenerateShoppingList` shows the multi-step pattern: queue traversal of existing items, generate new ones, and let `with ShoppingItem entry` clean up the old set as a side-effect of the visit.
+
+## Tutorial mapping
+
+- `basic/` corresponds to Parts 3-5 of the tutorial (the linear single-file build).
+- `auth/` corresponds to Part 6 (auth + multi-file split).
+- `walkers/` corresponds to Part 7 (OSP).

--- a/jac/examples/day_planner/auth/frontend.cl.jac
+++ b/jac/examples/day_planner/auth/frontend.cl.jac
@@ -1,0 +1,295 @@
+"""AI Day Planner -- Client-Side UI."""
+
+import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
+
+sv import from main {
+    get_tasks,
+    add_task,
+    toggle_task,
+    delete_task,
+    generate_list,
+    get_shopping_list,
+    clear_shopping_list
+}
+
+import "./styles.css";
+
+def:pub app -> JsxElement {
+    has isLoggedIn: bool = False,
+        checkingAuth: bool = True,
+        isSignup: bool = False,
+        username: str = "",
+        password: str = "",
+        error: str = "",
+        loading: bool = False,
+        tasks: list = [],
+        taskText: str = "",
+        tasksLoading: bool = True,
+        mealText: str = "",
+        ingredients: list = [],
+        generating: bool = False;
+
+    can with entry {
+        isLoggedIn = jacIsLoggedIn();
+        checkingAuth = False;
+    }
+
+    can with [isLoggedIn] entry {
+        if isLoggedIn {
+            fetchTasks();
+            fetchShoppingList();
+        }
+    }
+
+    # Method declarations -- bodies are in frontend.impl.jac
+    async def fetchTasks;
+    async def addTask;
+    async def toggleTask(id: str);
+    async def deleteTask(id: str);
+    async def handleLogin;
+    async def handleSignup;
+    def handleLogout;
+    async def handleSubmit(e: FormEvent);
+    def handleTaskKeyPress(e: KeyboardEvent);
+    async def fetchShoppingList;
+    async def generateList;
+    async def clearList;
+    def handleMealKeyPress(e: KeyboardEvent);
+    def getTotal -> float;
+
+    if checkingAuth {
+        return
+            <div class="auth-loading">Loading...</div>;
+    }
+
+    if isLoggedIn {
+        totalCost = getTotal();
+        remaining = len(
+            [
+                t
+                for t in tasks
+                if not t.done
+            ]
+        );
+        return
+            <div class="container">
+                <div class="header">
+                    <div>
+                        <h1>AI Day Planner</h1>
+                        <p class="subtitle">
+                            Task management with AI-powered meal planning
+                        </p>
+                    </div>
+                    <button class="btn-signout" onClick={handleLogout}>Sign Out</button>
+                </div>
+                <div class="two-column">
+                    <div class="column">
+                        <h2>Today's Tasks</h2>
+                        <div class="input-row">
+                            <input
+                                class="input"
+                                value={taskText}
+                                onChange={lambda e: ChangeEvent { taskText = e.target.value;}}
+                                onKeyPress={handleTaskKeyPress}
+                                placeholder="What needs to be done today?"
+                            />
+                            <button class="btn-add" onClick={lambda { addTask();}}>
+                                Add
+                            </button>
+                        </div>
+                        {(<div class="loading-msg">Loading tasks...</div>)
+                            if tasksLoading
+                            else (
+                                <div>
+                                    {(
+                                        <div class="empty-msg">
+                                            No tasks yet. Add one above!
+                                        </div>
+                                    )
+                                        if len(tasks) == 0
+                                        else (
+                                            <div>
+                                                {[
+                                                    <div key={jid(t)} class="task-item">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={t.done}
+                                                            onChange={lambda { toggleTask(
+                                                                jid(t)
+                                                            );}}
+                                                        />
+                                                        <span
+                                                            class={"task-title " + (
+                                                                "task-done"
+                                                                    if t.done
+                                                                    else ""
+                                                            )}
+                                                        >
+                                                            {t.title}
+                                                        </span>
+                                                        {(
+                                                            <span class="category">
+                                                                {t.category}
+                                                            </span>
+                                                        )
+                                                            if t.category
+                                                            and t.category != "other"
+                                                            else None}
+                                                        <button
+                                                            class="btn-delete"
+                                                            onClick={lambda { deleteTask(
+                                                                jid(t)
+                                                            );}}
+                                                        >
+                                                            X
+                                                        </button>
+                                                    </div> for t in tasks
+                                                ]}
+                                            </div>
+                                        )}
+                                </div>
+                            )}
+                        <div class="count">
+                            {remaining} {(
+                                "task" if remaining == 1 else "tasks"
+                            )} remaining
+                        </div>
+                    </div>
+                    <div class="column">
+                        <h2>Meal Shopping List</h2>
+                        <div class="input-row">
+                            <input
+                                class="input"
+                                value={mealText}
+                                onChange={lambda e: ChangeEvent { mealText = e.target.value;}}
+                                onKeyPress={handleMealKeyPress}
+                                placeholder="e.g. 'chicken stir fry for 4'"
+                            />
+                            <button
+                                class="btn-generate"
+                                onClick={lambda { generateList();}}
+                                disabled={generating}
+                            >
+                                {("Generating..." if generating else "Generate")}
+                            </button>
+                        </div>
+                        {(<div class="generating-msg">Generating with AI...</div>)
+                            if generating
+                            else (
+                                <div>
+                                    {(
+                                        <div class="empty-msg">
+                                            Enter a meal above to generate ingredients.
+                                        </div>
+                                    )
+                                        if len(ingredients) == 0
+                                        else (
+                                            <div>
+                                                {[
+                                                    <div
+                                                        key={ing.name}
+                                                        class="ingredient-item"
+                                                    >
+                                                        <div class="ing-info">
+                                                            <span class="ing-name">
+                                                                {ing.name}
+                                                            </span>
+                                                            <span class="ing-qty">
+                                                                {ing.quantity} {ing.unit}
+                                                            </span>
+                                                        </div>
+                                                        <div class="ing-meta">
+                                                            {(
+                                                                <span
+                                                                    class="carb-badge"
+                                                                >
+                                                                    Carbs
+                                                                </span>
+                                                            )
+                                                                if ing.carby
+                                                                else None}
+                                                            <span class="ing-cost">
+                                                                ${ing.cost.toFixed(2)}
+                                                            </span>
+                                                        </div>
+                                                    </div> for ing in ingredients
+                                                ]}
+                                                <div class="shopping-footer">
+                                                    <span class="total">
+                                                        Total: ${totalCost.toFixed(2)}
+                                                    </span>
+                                                    <button
+                                                        class="btn-clear"
+                                                        onClick={lambda { clearList();}}
+                                                    >
+                                                        Clear
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        )}
+                                </div>
+                            )}
+                    </div>
+                </div>
+            </div>;
+    }
+
+    return
+        <div class="auth-container">
+            <div class="auth-card">
+                <h1 class="auth-title">AI Day Planner</h1>
+                <p class="auth-subtitle">
+                    {("Create your account" if isSignup else "Welcome back")}
+                </p>
+                {(<div class="auth-error">{error}</div>) if error else None}
+                <form onSubmit={handleSubmit}>
+                    <div class="form-field">
+                        <label class="form-label">Username</label>
+                        <input
+                            type="text"
+                            value={username}
+                            onChange={lambda e: ChangeEvent { username = e.target.value;}}
+                            placeholder="Enter username"
+                            class="auth-input"
+                        />
+                    </div>
+                    <div class="form-field">
+                        <label class="form-label">Password</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={lambda e: ChangeEvent { password = e.target.value;}}
+                            placeholder="Enter password"
+                            class="auth-input"
+                        />
+                    </div>
+                    <button type="submit" disabled={loading} class="auth-submit">
+                        {(
+                            "Processing..."
+                                if loading
+                                else ("Create Account" if isSignup else "Sign In")
+                        )}
+                    </button>
+                </form>
+                <div class="auth-toggle">
+                    <span class="auth-toggle-text">
+                        {(
+                            "Already have an account? "
+                                if isSignup
+                                else "Don't have an account? "
+                        )}
+                    </span>
+                    <button
+                        type="button"
+                        onClick={lambda {
+                            isSignup = not isSignup;
+                            error = "";
+                        }}
+                        class="auth-toggle-btn"
+                    >
+                        {("Sign In" if isSignup else "Sign Up")}
+                    </button>
+                </div>
+            </div>
+        </div>;
+}

--- a/jac/examples/day_planner/auth/frontend.impl.jac
+++ b/jac/examples/day_planner/auth/frontend.impl.jac
@@ -1,0 +1,134 @@
+"""Implementations for the Day Planner frontend."""
+
+impl app.fetchTasks{
+    tasksLoading = True;
+    tasks = await get_tasks();
+    tasksLoading = False;
+}
+
+impl app.addTask{
+    if not taskText.strip() {
+        return;
+    }
+    task = await add_task(taskText.strip());
+    tasks = tasks + [task];
+    taskText = "";
+}
+
+impl app.toggleTask(id: str) {
+    updated = await toggle_task(id);
+    tasks = [updated if jid(t) == id else t for t in tasks];
+}
+
+impl app.deleteTask(id: str) {
+    await delete_task(id);
+    tasks = [
+        t
+        for t in tasks
+        if jid(t) != id
+    ];
+}
+
+impl app.handleLogin{
+    error = "";
+    if not username.strip() or not password {
+        error = "Please fill in all fields";
+        return;
+    }
+    loading = True;
+    success = await jacLogin(username, password);
+    loading = False;
+    if success {
+        isLoggedIn = True;
+        username = "";
+        password = "";
+    } else {
+        error = "Invalid username or password";
+    }
+}
+
+impl app.handleSignup{
+    error = "";
+    if not username.strip() or not password {
+        error = "Please fill in all fields";
+        return;
+    }
+    if len(password) < 4 {
+        error = "Password must be at least 4 characters";
+        return;
+    }
+    loading = True;
+    result = await jacSignup(username, password);
+    if result["success"] {
+        # /user/register creates the account but does not return a
+        # session token; sign in immediately to establish one.
+        logged_in = await jacLogin(username, password);
+        loading = False;
+        if logged_in {
+            isLoggedIn = True;
+            username = "";
+            password = "";
+        } else {
+            error = "Account created but sign-in failed";
+        }
+    } else {
+        loading = False;
+        error = result["error"] if result["error"] else "Signup failed";
+    }
+}
+
+impl app.handleLogout{
+    jacLogout();
+    isLoggedIn = False;
+    isSignup = False;
+    tasks = [];
+    ingredients = [];
+}
+
+impl app.handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if isSignup {
+        await handleSignup();
+    } else {
+        await handleLogin();
+    }
+}
+
+impl app.handleTaskKeyPress(e: KeyboardEvent) {
+    if e.key == "Enter" {
+        addTask();
+    }
+}
+
+impl app.fetchShoppingList{
+    ingredients = await get_shopping_list();
+}
+
+impl app.generateList{
+    if not mealText.strip() {
+        return;
+    }
+    generating = True;
+    ingredients = await generate_list(mealText.strip());
+    generating = False;
+}
+
+impl app.clearList{
+    await clear_shopping_list();
+    ingredients = [];
+    mealText = "";
+}
+
+impl app.handleMealKeyPress(e: KeyboardEvent) {
+    if e.key == "Enter" {
+        generateList();
+    }
+}
+
+impl app.getTotal -> float {
+    total = 0.0;
+    for ing in ingredients {
+        total = total + ing.cost;
+    }
+    return total;
+}

--- a/jac/examples/day_planner/auth/jac.toml
+++ b/jac/examples/day_planner/auth/jac.toml
@@ -1,0 +1,32 @@
+[project]
+name = "day-planner-auth"
+version = "1.0.0"
+description = "AI Day Planner - authenticated def:priv variant with multi-file frontend"
+entry-point = "main.jac"
+
+[dependencies.npm]
+react = "^18.2.0"
+react-dom = "^18.2.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
+
+[dependencies.npm.dev]
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
+
+[dev-dependencies]
+watchdog = ">=3.0.0"
+
+[serve]
+base_route_app = "app"
+
+[plugins.client]
+
+[plugins.byllm.model]
+default_model = "claude-sonnet-4-20250514"

--- a/jac/examples/day_planner/auth/main.jac
+++ b/jac/examples/day_planner/auth/main.jac
@@ -1,0 +1,121 @@
+"""AI Day Planner -- authenticated, multi-file version."""
+
+to cl:
+
+import from frontend { app as ClientApp }
+
+def:pub app -> JsxElement {
+    return
+        <ClientApp/>;
+}
+
+to sv:
+
+import from byllm.lib { Model }
+
+glob llm = Model(model_name="claude-sonnet-4-20250514");
+
+# --- Enums ---
+enum Category { WORK, PERSONAL, SHOPPING, HEALTH, FITNESS, OTHER }
+
+enum Unit { PIECE, LB, OZ, CUP, TBSP, TSP, BUNCH }
+
+# --- AI Types ---
+obj Ingredient {
+    has name: str,
+        quantity: float,
+        unit: Unit,
+        cost: float,
+        carby: bool;
+}
+
+sem Ingredient.cost = "Estimated cost in USD";
+sem Ingredient.carby = "True if this ingredient is high in carbohydrates";
+
+def categorize(title: str) -> Category by llm();
+sem categorize = "Categorize a task based on its title";
+
+def generate_shopping_list(meal_description: str) -> list[Ingredient] by llm();
+sem generate_shopping_list = "Generate a shopping list of ingredients needed for a described meal";
+
+# --- Data Nodes ---
+node Task {
+    has title: str,
+        done: bool = False,
+        category: str = "other";
+}
+
+node ShoppingItem {
+    has name: str,
+        quantity: float,
+        unit: str,
+        cost: float,
+        carby: bool;
+}
+
+# --- Task Endpoints ---
+"""Add a task with AI categorization."""
+def:priv add_task(title: str) -> Task {
+    category = str(categorize(title)).split(".")[-1].lower();
+    task = root() ++> Task(title=title, category=category);
+    return task[0];
+}
+
+"""Get all tasks."""
+def:priv get_tasks -> list[Task] {
+    return [root()-->][?:Task];
+}
+
+"""Toggle a task's done status."""
+def:priv toggle_task(id: str) -> Task | None {
+    for task in [root()-->][?:Task] {
+        if jid(task) == id {
+            task.done = not task.done;
+            return task;
+        }
+    }
+    return None;
+}
+
+"""Delete a task."""
+def:priv delete_task(id: str) -> dict {
+    for task in [root()-->][?:Task] {
+        if jid(task) == id {
+            del task;
+            return {"deleted": id};
+        }
+    }
+    return {};
+}
+
+# --- Shopping List Endpoints ---
+"""Generate a shopping list from a meal description."""
+def:priv generate_list(meal: str) -> list[ShoppingItem] {
+    for item in [root()-->][?:ShoppingItem] {
+        del item;
+    }
+    ingredients = generate_shopping_list(meal);
+    for ing in ingredients {
+        root() ++> ShoppingItem(
+            name=ing.name,
+            quantity=ing.quantity,
+            unit=str(ing.unit).split(".")[-1].lower(),
+            cost=ing.cost,
+            carby=ing.carby
+        );
+    }
+    return [root()-->][?:ShoppingItem];
+}
+
+"""Get the current shopping list."""
+def:priv get_shopping_list -> list[ShoppingItem] {
+    return [root()-->][?:ShoppingItem];
+}
+
+"""Clear the shopping list."""
+def:priv clear_shopping_list -> dict {
+    for item in [root()-->][?:ShoppingItem] {
+        del item;
+    }
+    return {"cleared": True};
+}

--- a/jac/examples/day_planner/auth/styles.css
+++ b/jac/examples/day_planner/auth/styles.css
@@ -1,0 +1,61 @@
+/* Base */
+.container { max-width: 900px; margin: 40px auto; font-family: system-ui; padding: 20px; }
+h1 { margin: 0; color: #333; }
+h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+.subtitle { margin: 4px 0 0 0; color: #888; font-size: 0.85rem; }
+
+/* Layout */
+.two-column { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+@media (max-width: 700px) { .two-column { grid-template-columns: 1fr; } }
+
+/* Inputs */
+.input-row { display: flex; gap: 8px; margin-bottom: 16px; }
+.input { flex: 1; padding: 10px; border: 1px solid #ddd; border-radius: 6px; font-size: 1rem; }
+
+/* Buttons */
+.btn-add { padding: 10px 20px; background: #4CAF50; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; }
+.btn-generate { padding: 10px 16px; background: #2196F3; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; white-space: nowrap; }
+.btn-generate:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn-delete { background: #e53e3e; color: white; border: none; border-radius: 4px; padding: 4px 8px; cursor: pointer; font-size: 0.85rem; }
+.btn-clear { background: #888; color: white; border: none; border-radius: 4px; padding: 6px 12px; cursor: pointer; font-size: 0.85rem; }
+.btn-signout { padding: 8px 16px; background: #f5f5f5; color: #666; border: 1px solid #ddd; border-radius: 6px; cursor: pointer; }
+
+/* Task Items */
+.task-item { display: flex; align-items: center; padding: 10px; border-bottom: 1px solid #eee; gap: 10px; }
+.task-title { flex: 1; }
+.task-done { text-decoration: line-through; color: #888; }
+.category { padding: 2px 8px; background: #e8f5e9; border-radius: 12px; font-size: 0.75rem; color: #2e7d32; margin-right: 8px; }
+.count { text-align: center; color: #888; margin-top: 12px; font-size: 0.9rem; }
+
+/* Shopping Items */
+.ingredient-item { display: flex; justify-content: space-between; align-items: center; padding: 10px; border-bottom: 1px solid #eee; }
+.ing-info { display: flex; flex-direction: column; gap: 2px; }
+.ing-name { font-weight: 500; }
+.ing-qty { color: #666; font-size: 0.85rem; }
+.ing-meta { display: flex; align-items: center; gap: 8px; }
+.ing-cost { color: #2196F3; font-weight: 600; }
+.carb-badge { padding: 2px 6px; background: #fff3e0; border-radius: 12px; font-size: 0.7rem; color: #e65100; }
+.shopping-footer { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; margin-top: 8px; border-top: 1px solid #ddd; }
+.total { font-weight: 700; color: #2196F3; }
+.generating-msg { text-align: center; padding: 20px; color: #666; }
+
+/* Status Messages */
+.loading-msg { text-align: center; padding: 20px; color: #888; }
+.empty-msg { text-align: center; padding: 30px; color: #888; }
+.auth-loading { display: flex; justify-content: center; align-items: center; min-height: 100vh; color: #888; font-family: system-ui; }
+
+/* Auth Form */
+.auth-container { min-height: 100vh; display: flex; align-items: center; justify-content: center; font-family: system-ui; background: #f5f5f5; }
+.auth-card { background: white; border-radius: 16px; padding: 2.5rem; width: 100%; max-width: 400px; box-shadow: 0 2px 12px rgba(0,0,0,0.08); }
+.auth-title { margin: 0 0 4px 0; text-align: center; font-size: 1.75rem; color: #333; }
+.auth-subtitle { margin: 0 0 24px 0; text-align: center; color: #888; font-size: 0.9rem; }
+.auth-error { margin-bottom: 16px; padding: 10px; background: #fef2f2; border: 1px solid #fecaca; border-radius: 8px; color: #dc2626; font-size: 0.9rem; }
+.form-field { margin-bottom: 16px; }
+.form-label { display: block; color: #555; font-size: 0.85rem; margin-bottom: 6px; }
+.auth-input { width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; font-size: 1rem; box-sizing: border-box; }
+.auth-submit { width: 100%; padding: 12px; background: #4CAF50; color: white; border: none; border-radius: 8px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 8px; }
+.auth-submit:disabled { opacity: 0.6; }
+.auth-toggle { margin-top: 16px; text-align: center; }
+.auth-toggle-text { color: #888; font-size: 0.9rem; }
+.auth-toggle-btn { background: none; border: none; color: #4CAF50; font-weight: 600; cursor: pointer; font-size: 0.9rem; }

--- a/jac/examples/day_planner/basic/jac.toml
+++ b/jac/examples/day_planner/basic/jac.toml
@@ -1,0 +1,32 @@
+[project]
+name = "day-planner-basic"
+version = "1.0.0"
+description = "AI Day Planner - single-file def:pub variant (no auth)"
+entry-point = "main.jac"
+
+[dependencies.npm]
+react = "^18.2.0"
+react-dom = "^18.2.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
+
+[dependencies.npm.dev]
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
+
+[dev-dependencies]
+watchdog = ">=3.0.0"
+
+[serve]
+base_route_app = "app"
+
+[plugins.client]
+
+[plugins.byllm.model]
+default_model = "claude-sonnet-4-20250514"

--- a/jac/examples/day_planner/basic/main.jac
+++ b/jac/examples/day_planner/basic/main.jac
@@ -1,0 +1,267 @@
+import from byllm.lib { Model }
+cl import "./styles.css";
+
+glob llm = Model(model_name="claude-sonnet-4-20250514");
+
+# --- Enums ---
+enum Category { WORK, PERSONAL, SHOPPING, HEALTH, FITNESS, OTHER }
+
+enum Unit { PIECE, LB, OZ, CUP, TBSP, TSP, BUNCH }
+
+# --- AI Types ---
+obj Ingredient {
+    has name: str,
+        quantity: float,
+        unit: Unit,
+        cost: float,
+        carby: bool;
+}
+
+sem Ingredient.cost = "Estimated cost in USD";
+sem Ingredient.carby = "True if this ingredient is high in carbohydrates";
+
+def categorize(title: str) -> Category by llm();
+sem categorize = "Categorize a task based on its title";
+
+def generate_shopping_list(meal_description: str) -> list[Ingredient] by llm();
+sem generate_shopping_list = "Generate a shopping list of ingredients needed for a described meal";
+
+# --- Data Nodes ---
+node Task {
+    has title: str,
+        done: bool = False,
+        category: str = "other";
+}
+
+node ShoppingItem {
+    has name: str,
+        quantity: float,
+        unit: str,
+        cost: float,
+        carby: bool;
+}
+
+# --- Task Endpoints ---
+"""Add a task with AI categorization."""
+def:pub add_task(title: str) -> Task {
+    category = str(categorize(title)).split(".")[-1].lower();
+    task = root() ++> Task(title=title, category=category);
+    return task[0];
+}
+
+"""Get all tasks."""
+def:pub get_tasks -> list[Task] {
+    return [root()-->][?:Task];
+}
+
+"""Toggle a task's done status."""
+def:pub toggle_task(id: str) -> Task | None {
+    for task in [root()-->][?:Task] {
+        if jid(task) == id {
+            task.done = not task.done;
+            return task;
+        }
+    }
+    return None;
+}
+
+"""Delete a task."""
+def:pub delete_task(id: str) -> dict {
+    for task in [root()-->][?:Task] {
+        if jid(task) == id {
+            del task;
+            return {"deleted": id};
+        }
+    }
+    return {};
+}
+
+# --- Shopping List Endpoints ---
+"""Generate a shopping list from a meal description."""
+def:pub generate_list(meal: str) -> list[ShoppingItem] {
+    for item in [root()-->][?:ShoppingItem] {
+        del item;
+    }
+    ingredients = generate_shopping_list(meal);
+    for ing in ingredients {
+        root() ++> ShoppingItem(
+            name=ing.name,
+            quantity=ing.quantity,
+            unit=str(ing.unit).split(".")[-1].lower(),
+            cost=ing.cost,
+            carby=ing.carby
+        );
+    }
+    return [root()-->][?:ShoppingItem];
+}
+
+"""Get the current shopping list."""
+def:pub get_shopping_list -> list[ShoppingItem] {
+    return [root()-->][?:ShoppingItem];
+}
+
+"""Clear the shopping list."""
+def:pub clear_shopping_list -> dict {
+    for item in [root()-->][?:ShoppingItem] {
+        del item;
+    }
+    return {"cleared": True};
+}
+
+# --- Frontend ---
+cl def:pub app -> JsxElement {
+    has tasks: list = [],
+        task_text: str = "",
+        meal_text: str = "",
+        ingredients: list = [],
+        generating: bool = False;
+
+    async can with entry {
+        tasks = await get_tasks();
+        ingredients = await get_shopping_list();
+    }
+
+    async def add_new_task {
+        if task_text.strip() {
+            task = await add_task(task_text.strip());
+            tasks = tasks + [task];
+            task_text = "";
+        }
+    }
+
+    async def toggle(id: str) {
+        updated = await toggle_task(id);
+        tasks = [updated if jid(t) == id else t for t in tasks];
+    }
+
+    async def remove(id: str) {
+        await delete_task(id);
+        tasks = [
+            t
+            for t in tasks
+            if jid(t) != id
+        ];
+    }
+
+    async def generate_meal_list {
+        if meal_text.strip() {
+            generating = True;
+            ingredients = await generate_list(meal_text.strip());
+            generating = False;
+        }
+    }
+
+    async def clear_list {
+        await clear_shopping_list();
+        ingredients = [];
+        meal_text = "";
+    }
+
+    remaining = len(
+        [
+            t
+            for t in tasks
+            if not t.done
+        ]
+    );
+    total_cost = 0.0;
+    for ing in ingredients {
+        total_cost = total_cost + ing.cost;
+    }
+
+    return
+        <div class="container">
+            <h1>AI Day Planner</h1>
+            <div class="two-column">
+                <div class="column">
+                    <h2>Today's Tasks</h2>
+                    <div class="input-row">
+                        <input
+                            class="input"
+                            value={task_text}
+                            onChange={lambda e: ChangeEvent { task_text = e.target.value;}}
+                            onKeyPress={lambda e: KeyboardEvent { if e.key == "Enter" {
+                                add_new_task();
+                            }}}
+                            placeholder="What needs to be done today?"
+                        />
+                        <button class="btn-add" onClick={add_new_task}>Add</button>
+                    </div>
+                    {[
+                        <div key={jid(t)} class="task-item">
+                            <input
+                                type="checkbox"
+                                checked={t.done}
+                                onChange={lambda { toggle(jid(t));}}
+                            />
+                            <span
+                                class={"task-title " + ("task-done" if t.done else "")}
+                            >
+                                {t.title}
+                            </span>
+                            {(<span class="category">{t.category}</span>)
+                                if t.category and t.category != "other"
+                                else None}
+                            <button
+                                class="btn-delete"
+                                onClick={lambda { remove(jid(t));}}
+                            >
+                                X
+                            </button>
+                        </div> for t in tasks
+                    ]}
+                    <div class="count">
+                        {remaining} {("task" if remaining == 1 else "tasks")} remaining
+                    </div>
+                </div>
+                <div class="column">
+                    <h2>Meal Shopping List</h2>
+                    <div class="input-row">
+                        <input
+                            class="input"
+                            value={meal_text}
+                            onChange={lambda e: ChangeEvent { meal_text = e.target.value;}}
+                            onKeyPress={lambda e: KeyboardEvent { if e.key == "Enter" {
+                                generate_meal_list();
+                            }}}
+                            placeholder="Describe a meal, e.g. 'chicken stir fry for 4'"
+                        />
+                        <button
+                            class="btn-generate"
+                            onClick={generate_meal_list}
+                            disabled={generating}
+                        >
+                            {("Generating..." if generating else "Generate")}
+                        </button>
+                    </div>
+                    {(<div class="generating-msg">Generating with AI...</div>)
+                        if generating
+                        else None}
+                    {[
+                        <div key={ing.name} class="ingredient-item">
+                            <div class="ing-info">
+                                <span class="ing-name">{ing.name}</span>
+                                <span class="ing-qty">{ing.quantity} {ing.unit}</span>
+                            </div>
+                            <div class="ing-meta">
+                                {(<span class="carb-badge">Carbs</span>)
+                                    if ing.carby
+                                    else None}
+                                <span class="ing-cost">${ing.cost.toFixed(2)}</span>
+                            </div>
+                        </div> for ing in ingredients
+                    ]}
+                    {(
+                        <div class="shopping-footer">
+                            <span class="total">Total: ${total_cost.toFixed(2)}</span>
+                            <button class="btn-clear" onClick={clear_list}>
+                                Clear
+                            </button>
+                        </div>
+                    )
+                        if len(ingredients) > 0
+                        else None}
+                </div>
+            </div>
+        </div>;
+}

--- a/jac/examples/day_planner/basic/styles.css
+++ b/jac/examples/day_planner/basic/styles.css
@@ -1,0 +1,27 @@
+.container { max-width: 900px; margin: 40px auto; font-family: system-ui; padding: 20px; }
+h1 { text-align: center; margin-bottom: 24px; color: #333; }
+h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
+.two-column { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+@media (max-width: 700px) { .two-column { grid-template-columns: 1fr; } }
+.input-row { display: flex; gap: 8px; margin-bottom: 16px; }
+.input { flex: 1; padding: 10px; border: 1px solid #ddd; border-radius: 6px; font-size: 1rem; }
+.btn-add { padding: 10px 20px; background: #4CAF50; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; }
+.btn-generate { padding: 10px 16px; background: #2196F3; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; white-space: nowrap; }
+.btn-generate:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn-delete { background: #e53e3e; color: white; border: none; border-radius: 4px; padding: 4px 8px; cursor: pointer; font-size: 0.85rem; }
+.btn-clear { background: #888; color: white; border: none; border-radius: 4px; padding: 6px 12px; cursor: pointer; font-size: 0.85rem; }
+.task-item { display: flex; align-items: center; padding: 10px; border-bottom: 1px solid #eee; gap: 10px; }
+.task-title { flex: 1; }
+.task-done { text-decoration: line-through; color: #888; }
+.category { padding: 2px 8px; background: #e8f5e9; border-radius: 12px; font-size: 0.75rem; color: #2e7d32; margin-right: 8px; }
+.count { text-align: center; color: #888; margin-top: 12px; font-size: 0.9rem; }
+.ingredient-item { display: flex; justify-content: space-between; align-items: center; padding: 10px; border-bottom: 1px solid #eee; }
+.ing-info { display: flex; flex-direction: column; gap: 2px; }
+.ing-name { font-weight: 500; }
+.ing-qty { color: #666; font-size: 0.85rem; }
+.ing-meta { display: flex; align-items: center; gap: 8px; }
+.ing-cost { color: #2196F3; font-weight: 600; }
+.carb-badge { padding: 2px 6px; background: #fff3e0; border-radius: 12px; font-size: 0.7rem; color: #e65100; }
+.shopping-footer { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; margin-top: 8px; border-top: 1px solid #ddd; }
+.total { font-weight: 700; color: #2196F3; }
+.generating-msg { text-align: center; padding: 20px; color: #666; }

--- a/jac/examples/day_planner/walkers/frontend.cl.jac
+++ b/jac/examples/day_planner/walkers/frontend.cl.jac
@@ -1,0 +1,295 @@
+"""AI Day Planner -- Client-Side UI."""
+
+import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
+
+import "./styles.css";
+
+sv import from main {
+    AddTask,
+    ListTasks,
+    ToggleTask,
+    DeleteTask,
+    GenerateShoppingList,
+    GetShoppingList,
+    ClearShoppingList
+}
+
+def:pub app -> JsxElement {
+    has isLoggedIn: bool = False,
+        checkingAuth: bool = True,
+        isSignup: bool = False,
+        username: str = "",
+        password: str = "",
+        error: str = "",
+        loading: bool = False,
+        tasks: list = [],
+        taskText: str = "",
+        tasksLoading: bool = True,
+        mealText: str = "",
+        ingredients: list = [],
+        generating: bool = False;
+
+    can with entry {
+        isLoggedIn = jacIsLoggedIn();
+        checkingAuth = False;
+    }
+
+    can with [isLoggedIn] entry {
+        if isLoggedIn {
+            fetchTasks();
+            fetchShoppingList();
+        }
+    }
+
+    # Method declarations -- bodies are in frontend.impl.jac
+    async def fetchTasks;
+    async def addTask;
+    async def toggleTask(id: str);
+    async def deleteTask(id: str);
+    async def handleLogin;
+    async def handleSignup;
+    def handleLogout;
+    async def handleSubmit(e: FormEvent);
+    def handleTaskKeyPress(e: KeyboardEvent);
+    async def fetchShoppingList;
+    async def generateList;
+    async def clearList;
+    def handleMealKeyPress(e: KeyboardEvent);
+    def getTotal -> float;
+
+    if checkingAuth {
+        return
+            <div class="auth-loading">Loading...</div>;
+    }
+
+    if isLoggedIn {
+        totalCost = getTotal();
+        remaining = len(
+            [
+                t
+                for t in tasks
+                if not t.done
+            ]
+        );
+        return
+            <div class="container">
+                <div class="header">
+                    <div>
+                        <h1>AI Day Planner</h1>
+                        <p class="subtitle">
+                            Task management with AI-powered meal planning
+                        </p>
+                    </div>
+                    <button class="btn-signout" onClick={handleLogout}>Sign Out</button>
+                </div>
+                <div class="two-column">
+                    <div class="column">
+                        <h2>Today's Tasks</h2>
+                        <div class="input-row">
+                            <input
+                                class="input"
+                                value={taskText}
+                                onChange={lambda e: ChangeEvent { taskText = e.target.value;}}
+                                onKeyPress={handleTaskKeyPress}
+                                placeholder="What needs to be done today?"
+                            />
+                            <button class="btn-add" onClick={lambda { addTask();}}>
+                                Add
+                            </button>
+                        </div>
+                        {(<div class="loading-msg">Loading tasks...</div>)
+                            if tasksLoading
+                            else (
+                                <div>
+                                    {(
+                                        <div class="empty-msg">
+                                            No tasks yet. Add one above!
+                                        </div>
+                                    )
+                                        if len(tasks) == 0
+                                        else (
+                                            <div>
+                                                {[
+                                                    <div key={jid(t)} class="task-item">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={t.done}
+                                                            onChange={lambda { toggleTask(
+                                                                jid(t)
+                                                            );}}
+                                                        />
+                                                        <span
+                                                            class={"task-title " + (
+                                                                "task-done"
+                                                                    if t.done
+                                                                    else ""
+                                                            )}
+                                                        >
+                                                            {t.title}
+                                                        </span>
+                                                        {(
+                                                            <span class="category">
+                                                                {t.category}
+                                                            </span>
+                                                        )
+                                                            if t.category
+                                                            and t.category != "other"
+                                                            else None}
+                                                        <button
+                                                            class="btn-delete"
+                                                            onClick={lambda { deleteTask(
+                                                                jid(t)
+                                                            );}}
+                                                        >
+                                                            X
+                                                        </button>
+                                                    </div> for t in tasks
+                                                ]}
+                                            </div>
+                                        )}
+                                </div>
+                            )}
+                        <div class="count">
+                            {remaining} {(
+                                "task" if remaining == 1 else "tasks"
+                            )} remaining
+                        </div>
+                    </div>
+                    <div class="column">
+                        <h2>Meal Shopping List</h2>
+                        <div class="input-row">
+                            <input
+                                class="input"
+                                value={mealText}
+                                onChange={lambda e: ChangeEvent { mealText = e.target.value;}}
+                                onKeyPress={handleMealKeyPress}
+                                placeholder="e.g. 'chicken stir fry for 4'"
+                            />
+                            <button
+                                class="btn-generate"
+                                onClick={lambda { generateList();}}
+                                disabled={generating}
+                            >
+                                {("Generating..." if generating else "Generate")}
+                            </button>
+                        </div>
+                        {(<div class="generating-msg">Generating with AI...</div>)
+                            if generating
+                            else (
+                                <div>
+                                    {(
+                                        <div class="empty-msg">
+                                            Enter a meal above to generate ingredients.
+                                        </div>
+                                    )
+                                        if len(ingredients) == 0
+                                        else (
+                                            <div>
+                                                {[
+                                                    <div
+                                                        key={ing.name}
+                                                        class="ingredient-item"
+                                                    >
+                                                        <div class="ing-info">
+                                                            <span class="ing-name">
+                                                                {ing.name}
+                                                            </span>
+                                                            <span class="ing-qty">
+                                                                {ing.quantity} {ing.unit}
+                                                            </span>
+                                                        </div>
+                                                        <div class="ing-meta">
+                                                            {(
+                                                                <span
+                                                                    class="carb-badge"
+                                                                >
+                                                                    Carbs
+                                                                </span>
+                                                            )
+                                                                if ing.carby
+                                                                else None}
+                                                            <span class="ing-cost">
+                                                                ${ing.cost.toFixed(2)}
+                                                            </span>
+                                                        </div>
+                                                    </div> for ing in ingredients
+                                                ]}
+                                                <div class="shopping-footer">
+                                                    <span class="total">
+                                                        Total: ${totalCost.toFixed(2)}
+                                                    </span>
+                                                    <button
+                                                        class="btn-clear"
+                                                        onClick={lambda { clearList();}}
+                                                    >
+                                                        Clear
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        )}
+                                </div>
+                            )}
+                    </div>
+                </div>
+            </div>;
+    }
+
+    return
+        <div class="auth-container">
+            <div class="auth-card">
+                <h1 class="auth-title">AI Day Planner</h1>
+                <p class="auth-subtitle">
+                    {("Create your account" if isSignup else "Welcome back")}
+                </p>
+                {(<div class="auth-error">{error}</div>) if error else None}
+                <form onSubmit={handleSubmit}>
+                    <div class="form-field">
+                        <label class="form-label">Username</label>
+                        <input
+                            type="text"
+                            value={username}
+                            onChange={lambda e: ChangeEvent { username = e.target.value;}}
+                            placeholder="Enter username"
+                            class="auth-input"
+                        />
+                    </div>
+                    <div class="form-field">
+                        <label class="form-label">Password</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={lambda e: ChangeEvent { password = e.target.value;}}
+                            placeholder="Enter password"
+                            class="auth-input"
+                        />
+                    </div>
+                    <button type="submit" disabled={loading} class="auth-submit">
+                        {(
+                            "Processing..."
+                                if loading
+                                else ("Create Account" if isSignup else "Sign In")
+                        )}
+                    </button>
+                </form>
+                <div class="auth-toggle">
+                    <span class="auth-toggle-text">
+                        {(
+                            "Already have an account? "
+                                if isSignup
+                                else "Don't have an account? "
+                        )}
+                    </span>
+                    <button
+                        type="button"
+                        onClick={lambda {
+                            isSignup = not isSignup;
+                            error = "";
+                        }}
+                        class="auth-toggle-btn"
+                    >
+                        {("Sign In" if isSignup else "Sign Up")}
+                    </button>
+                </div>
+            </div>
+        </div>;
+}

--- a/jac/examples/day_planner/walkers/frontend.impl.jac
+++ b/jac/examples/day_planner/walkers/frontend.impl.jac
@@ -1,0 +1,138 @@
+"""Implementations for the Day Planner frontend."""
+
+impl app.fetchTasks{
+    tasksLoading = True;
+    result = root spawn ListTasks();
+    tasks = result.reports[0] if result.reports else [];
+    tasksLoading = False;
+}
+
+impl app.addTask{
+    if not taskText.strip() {
+        return;
+    }
+    response = root spawn AddTask(title=taskText);
+    tasks = tasks + [response.reports[0]];
+    taskText = "";
+}
+
+impl app.toggleTask(id: str) {
+    response = root spawn ToggleTask(task_id=id);
+    updated = response.reports[0];
+    tasks = [updated if jid(t) == id else t for t in tasks];
+}
+
+impl app.deleteTask(id: str) {
+    root spawn DeleteTask(task_id=id);
+    tasks = [
+        t
+        for t in tasks
+        if jid(t) != id
+    ];
+}
+
+impl app.handleLogin{
+    error = "";
+    if not username.strip() or not password {
+        error = "Please fill in all fields";
+        return;
+    }
+    loading = True;
+    success = await jacLogin(username, password);
+    loading = False;
+    if success {
+        isLoggedIn = True;
+        username = "";
+        password = "";
+    } else {
+        error = "Invalid username or password";
+    }
+}
+
+impl app.handleSignup{
+    error = "";
+    if not username.strip() or not password {
+        error = "Please fill in all fields";
+        return;
+    }
+    if len(password) < 4 {
+        error = "Password must be at least 4 characters";
+        return;
+    }
+    loading = True;
+    result = await jacSignup(username, password);
+    if result["success"] {
+        # /user/register creates the account but does not return a
+        # session token; sign in immediately to establish one.
+        logged_in = await jacLogin(username, password);
+        loading = False;
+        if logged_in {
+            isLoggedIn = True;
+            username = "";
+            password = "";
+        } else {
+            error = "Account created but sign-in failed";
+        }
+    } else {
+        loading = False;
+        error = result["error"] if result["error"] else "Signup failed";
+    }
+}
+
+impl app.handleLogout{
+    jacLogout();
+    isLoggedIn = False;
+    isSignup = False;
+    tasks = [];
+    ingredients = [];
+}
+
+impl app.handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if isSignup {
+        await handleSignup();
+    } else {
+        await handleLogin();
+    }
+}
+
+impl app.handleTaskKeyPress(e: KeyboardEvent) {
+    if e.key == "Enter" {
+        addTask();
+    }
+}
+
+impl app.fetchShoppingList{
+    result = root spawn GetShoppingList();
+    ingredients = result.reports[0] if result.reports else [];
+}
+
+impl app.generateList{
+    if not mealText.strip() {
+        return;
+    }
+    generating = True;
+    result = root spawn GenerateShoppingList(meal_description=mealText);
+    ingredients = result.reports[0] if result.reports else [];
+    generating = False;
+}
+
+impl app.clearList{
+    root spawn ClearShoppingList();
+    ingredients = [];
+    mealText = "";
+}
+
+impl app.handleMealKeyPress(e: KeyboardEvent) {
+    if e.key == "Enter" {
+        generateList();
+    }
+}
+
+impl app.getTotal -> float {
+    total = 0.0;
+    for ing in ingredients {
+        total = total + ing.cost;
+    }
+    return total;
+}

--- a/jac/examples/day_planner/walkers/jac.toml
+++ b/jac/examples/day_planner/walkers/jac.toml
@@ -1,0 +1,32 @@
+[project]
+name = "day-planner-walkers"
+version = "1.0.0"
+description = "AI Day Planner - walker:priv variant with object-spatial programming"
+entry-point = "main.jac"
+
+[dependencies.npm]
+react = "^18.2.0"
+react-dom = "^18.2.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
+
+[dependencies.npm.dev]
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
+
+[dev-dependencies]
+watchdog = ">=3.0.0"
+
+[serve]
+base_route_app = "app"
+
+[plugins.client]
+
+[plugins.byllm.model]
+default_model = "claude-sonnet-4-20250514"

--- a/jac/examples/day_planner/walkers/main.jac
+++ b/jac/examples/day_planner/walkers/main.jac
@@ -1,0 +1,164 @@
+"""AI Day Planner -- walker-based version with OSP."""
+
+to cl:
+
+import from frontend { app as ClientApp }
+
+def:pub app -> JsxElement {
+    return
+        <ClientApp/>;
+}
+
+to sv:
+
+import from byllm.lib { Model }
+
+glob llm = Model(model_name="claude-sonnet-4-20250514");
+
+# --- Enums ---
+enum Category { WORK, PERSONAL, SHOPPING, HEALTH, FITNESS, OTHER }
+
+enum Unit { PIECE, LB, OZ, CUP, TBSP, TSP, BUNCH }
+
+# --- AI Types ---
+obj Ingredient {
+    has name: str,
+        quantity: float,
+        unit: Unit,
+        cost: float,
+        carby: bool;
+}
+
+sem Ingredient.cost = "Estimated cost in USD";
+sem Ingredient.carby = "True if this ingredient is high in carbohydrates";
+
+def categorize(title: str) -> Category by llm();
+sem categorize = "Categorize a task based on its title";
+
+def generate_shopping_list(meal_description: str) -> list[Ingredient] by llm();
+sem generate_shopping_list = "Generate a shopping list of ingredients needed for a described meal";
+
+# --- Data Nodes ---
+node Task {
+    has title: str,
+        done: bool = False,
+        category: str = "other";
+}
+
+node ShoppingItem {
+    has name: str,
+        quantity: float,
+        unit: str,
+        cost: float,
+        carby: bool;
+}
+
+# --- Task Walkers ---
+walker:priv AddTask {
+    has title: str;
+
+    can create with Root entry {
+        category = str(categorize(self.title)).split(".")[-1].lower();
+        new_task = here ++> Task(title=self.title, category=category);
+        report new_task[0];
+    }
+}
+
+walker:priv ListTasks {
+    has results: list = [];
+
+    can start with Root entry {
+        visit [-->];
+    }
+
+    can collect with Task entry {
+        self.results.append(here);
+    }
+
+    can done with Root exit {
+        report self.results;
+    }
+}
+
+walker:priv ToggleTask {
+    has task_id: str;
+
+    can search with Root entry {
+        visit [-->];
+    }
+
+    can toggle with Task entry {
+        if jid(here) == self.task_id {
+            here.done = not here.done;
+            report here;
+            disengage;
+        }
+    }
+}
+
+walker:priv DeleteTask {
+    has task_id: str;
+
+    can search with Root entry {
+        visit [-->];
+    }
+
+    can remove with Task entry {
+        if jid(here) == self.task_id {
+            del here;
+            report {"deleted": self.task_id};
+            disengage;
+        }
+    }
+}
+
+# --- Shopping List Walkers ---
+walker:priv GenerateShoppingList {
+    has meal_description: str;
+
+    can generate with Root entry {
+        visit [-->];
+        ingredients = generate_shopping_list(self.meal_description);
+        for ing in ingredients {
+            here ++> ShoppingItem(
+                name=ing.name,
+                quantity=ing.quantity,
+                unit=str(ing.unit).split(".")[-1].lower(),
+                cost=ing.cost,
+                carby=ing.carby
+            );
+        }
+        report [here-->][?:ShoppingItem];
+    }
+
+    can clear_old with ShoppingItem entry {
+        del here;
+    }
+}
+
+walker:priv GetShoppingList {
+    has items: list = [];
+
+    can collect with Root entry {
+        visit [-->];
+    }
+
+    can gather with ShoppingItem entry {
+        self.items.append(here);
+    }
+
+    can done with Root exit {
+        report self.items;
+    }
+}
+
+walker:priv ClearShoppingList {
+    can collect with Root entry {
+        visit [-->];
+    }
+
+    can clear with ShoppingItem entry {
+        del here;
+        report {"cleared": True};
+    }
+}

--- a/jac/examples/day_planner/walkers/styles.css
+++ b/jac/examples/day_planner/walkers/styles.css
@@ -1,0 +1,61 @@
+/* Base */
+.container { max-width: 900px; margin: 40px auto; font-family: system-ui; padding: 20px; }
+h1 { margin: 0; color: #333; }
+h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
+.header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+.subtitle { margin: 4px 0 0 0; color: #888; font-size: 0.85rem; }
+
+/* Layout */
+.two-column { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+@media (max-width: 700px) { .two-column { grid-template-columns: 1fr; } }
+
+/* Inputs */
+.input-row { display: flex; gap: 8px; margin-bottom: 16px; }
+.input { flex: 1; padding: 10px; border: 1px solid #ddd; border-radius: 6px; font-size: 1rem; }
+
+/* Buttons */
+.btn-add { padding: 10px 20px; background: #4CAF50; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; }
+.btn-generate { padding: 10px 16px; background: #2196F3; color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; white-space: nowrap; }
+.btn-generate:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn-delete { background: #e53e3e; color: white; border: none; border-radius: 4px; padding: 4px 8px; cursor: pointer; font-size: 0.85rem; }
+.btn-clear { background: #888; color: white; border: none; border-radius: 4px; padding: 6px 12px; cursor: pointer; font-size: 0.85rem; }
+.btn-signout { padding: 8px 16px; background: #f5f5f5; color: #666; border: 1px solid #ddd; border-radius: 6px; cursor: pointer; }
+
+/* Task Items */
+.task-item { display: flex; align-items: center; padding: 10px; border-bottom: 1px solid #eee; gap: 10px; }
+.task-title { flex: 1; }
+.task-done { text-decoration: line-through; color: #888; }
+.category { padding: 2px 8px; background: #e8f5e9; border-radius: 12px; font-size: 0.75rem; color: #2e7d32; margin-right: 8px; }
+.count { text-align: center; color: #888; margin-top: 12px; font-size: 0.9rem; }
+
+/* Shopping Items */
+.ingredient-item { display: flex; justify-content: space-between; align-items: center; padding: 10px; border-bottom: 1px solid #eee; }
+.ing-info { display: flex; flex-direction: column; gap: 2px; }
+.ing-name { font-weight: 500; }
+.ing-qty { color: #666; font-size: 0.85rem; }
+.ing-meta { display: flex; align-items: center; gap: 8px; }
+.ing-cost { color: #2196F3; font-weight: 600; }
+.carb-badge { padding: 2px 6px; background: #fff3e0; border-radius: 12px; font-size: 0.7rem; color: #e65100; }
+.shopping-footer { display: flex; justify-content: space-between; align-items: center; padding: 12px 0; margin-top: 8px; border-top: 1px solid #ddd; }
+.total { font-weight: 700; color: #2196F3; }
+.generating-msg { text-align: center; padding: 20px; color: #666; }
+
+/* Status Messages */
+.loading-msg { text-align: center; padding: 20px; color: #888; }
+.empty-msg { text-align: center; padding: 30px; color: #888; }
+.auth-loading { display: flex; justify-content: center; align-items: center; min-height: 100vh; color: #888; font-family: system-ui; }
+
+/* Auth Form */
+.auth-container { min-height: 100vh; display: flex; align-items: center; justify-content: center; font-family: system-ui; background: #f5f5f5; }
+.auth-card { background: white; border-radius: 16px; padding: 2.5rem; width: 100%; max-width: 400px; box-shadow: 0 2px 12px rgba(0,0,0,0.08); }
+.auth-title { margin: 0 0 4px 0; text-align: center; font-size: 1.75rem; color: #333; }
+.auth-subtitle { margin: 0 0 24px 0; text-align: center; color: #888; font-size: 0.9rem; }
+.auth-error { margin-bottom: 16px; padding: 10px; background: #fef2f2; border: 1px solid #fecaca; border-radius: 8px; color: #dc2626; font-size: 0.9rem; }
+.form-field { margin-bottom: 16px; }
+.form-label { display: block; color: #555; font-size: 0.85rem; margin-bottom: 6px; }
+.auth-input { width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 8px; font-size: 1rem; box-sizing: border-box; }
+.auth-submit { width: 100%; padding: 12px; background: #4CAF50; color: white; border: none; border-radius: 8px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 8px; }
+.auth-submit:disabled { opacity: 0.6; }
+.auth-toggle { margin-top: 16px; text-align: center; }
+.auth-toggle-text { color: #888; font-size: 0.9rem; }
+.auth-toggle-btn { background: none; border: none; color: #4CAF50; font-weight: 600; cursor: pointer; font-size: 0.9rem; }


### PR DESCRIPTION
## Description

Adds [jac/examples/day_planner/](jac/examples/day_planner/) -- three side-by-side implementations of the same full-stack AI day planner that the [Build an AI Day Planner](docs/docs/tutorials/first-app/build-ai-day-planner.md) tutorial walks through. Same UI and behavior, three different backend styles, so a reader can compare the architectures directly.

| Variant | Backend style | Auth | Tutorial parts |
|---------|---------------|------|---------------|
| [basic/](jac/examples/day_planner/basic/) | \`def:pub\` functions, single file | none (shared graph) | 3-5 |
| [auth/](jac/examples/day_planner/auth/) | \`def:priv\` + declaration/implementation split | username/password, per-user graph | 6 |
| [walkers/](jac/examples/day_planner/walkers/) | \`walker:priv\` with object-spatial abilities | username/password, per-user graph | 7 |

Each variant is a self-contained runnable project with its own \`jac.toml\` declaring \`claude-sonnet-4-20250514\` as the byllm default model. A top-level [README.md](jac/examples/day_planner/README.md) explains the three variants and maps each back to its tutorial section.

## Why

The tutorial currently shows the code inline but has no companion example a reader can clone and run end-to-end. Having all three variants side by side also makes the architectural progression (\`def:pub\` → \`def:priv\` → \`walker:priv\`) something a reader can diff.

## How it was tested

I built each variant from scratch by following the tutorial verbatim, then verified at every layer:

- **Compilation**: each variant builds cleanly with \`jac start main.jac\` (jaclang 0.14.0, Python 3.12.3).
- **API**: \`/function/add_task\`, \`/function/get_tasks\`, \`/function/toggle_task\`, \`/function/delete_task\`, \`/function/generate_list\`, \`/function/get_shopping_list\`, \`/function/clear_shopping_list\` for basic/auth; \`/walker/AddTask\`, \`/walker/ListTasks\`, \`/walker/ToggleTask\`, \`/walker/DeleteTask\`, \`/walker/GenerateShoppingList\`, \`/walker/GetShoppingList\`, \`/walker/ClearShoppingList\` for walkers/. All endpoints exercised via curl or browser.
- **AI**: Anthropic \`claude-sonnet-4-20250514\` correctly classified \"Buy groceries\" → shopping, \"Schedule dentist appointment\" → health, \"Review pull requests\" → work. \"chicken stir fry for 4\" produced a clean \`list[Ingredient]\` with reasonable quantities/units/costs and correct \`carby\` flagging.
- **UI**: end-to-end browser test of the full UX flow -- add task, toggle, delete, generate shopping list, persist across server restart.
- **Auth + isolation** (auth/ and walkers/): signed up alice and bob/carol; verified each user sees their own empty graph after signup and that one user's data is invisible to the other.

## Related

Companion to #5811 (QA findings from running through the tutorial as a fresh student). The example is intentionally faithful to what the tutorial teaches; any wording fixes from #5811 belong against the tutorial, not this example.

## Test plan

- [x] \`jac start\` succeeds from each of the three variant directories
- [x] Tasks add, toggle, and delete via UI in each variant
- [x] AI categorization assigns expected categories
- [x] Shopping list generator returns structured ingredients
- [x] auth/ and walkers/ isolate per-user data
- [x] Persistence across server restart
- [x] Pre-commit hooks (ban-em-dashes, jac-format, markdownlint, etc.) pass