### PR TITLE
fix(checker): bind sem target Names to symbols in SemDefMatchPass

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5813.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5813.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Spurious W1051/W2001 warnings on `sem Foo.field` targets**: Dotted-path targets in `sem` declarations no longer produce `W1051 "Expression type could not be resolved"` or `W2001 "may be undefined"` warnings on their path segments.

--- a/jac/jaclang/compiler/passes/main/impl/sem_def_match_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/sem_def_match_pass.impl.jac
@@ -2,6 +2,14 @@
 
 When source_sym_tab and target_sym_tab are the same, this connects within the same module.
 When different, it connects implementations from impl_mod to declarations in the main module.
+
+Walking each SemDef's `target: Sequence[NameAtom]` directly (rather than splitting
+the string-form `sem.A.B.C` of the SemDef's symbol name) lets us bind each target
+Name's `sym` attribute to the resolved Symbol. With those bindings in place, the
+type checker and static analysis passes both gate on `nd.sym is None` and naturally
+skip these path components — they are dotted-path navigation, not standalone
+expressions or undefined references. The bindings also enable IDE features like
+go-to-definition on each segment of `sem Foo.bar.baz`.
 """
 impl SemDefMatchPass.connect_sems(
     source_sym_tab: UniScopeNode, target_sym_tab: UniScopeNode
@@ -11,7 +19,7 @@ impl SemDefMatchPass.connect_sems(
             continue;
         }
         semdef = sym.decl.name_of;
-        target_sym = self.find_symbol_from_dotted_name(sym.sym_name, target_sym_tab);
+        target_sym = self.resolve_sem_target(semdef, target_sym_tab);
         if (target_sym is not None) {
             target_sym.decl.name_of.semstr = semdef.value.lit_value;
             target_sym.semstr = semdef.value.lit_value;
@@ -19,25 +27,35 @@ impl SemDefMatchPass.connect_sems(
     }
 }
 
-"""Find a symbol in the target symbol table by its dotted name.
+"""Walk a SemDef's target chain (e.g., `Foo.bar.baz`) against the target
+symbol table, binding each target Name's `sym` attribute to the resolved
+Symbol along the way.
 
-Example:
-"Foo.bar.baz" will do the following lookups:
-target_sym_tab.lookup("Foo").lookup("bar").lookup("baz")
+Returns the final resolved Symbol, or None if any segment fails to resolve.
+Partial chains still bind every Name they could resolve before the failing
+segment, which keeps IDE tooling useful even when the user is mid-edit.
 """
-impl SemDefMatchPass.find_symbol_from_dotted_name(
-    dotted_name: str, target_sym_tab: UniScopeNode
+impl SemDefMatchPass.resolve_sem_target(
+    semdef: uni.SemDef, target_sym_tab: UniScopeNode
 ) -> (Symbol | None) {
-    parts = dotted_name.removeprefix('sem.').split('.');
     current_sym_tab: (UniScopeNode | None) = target_sym_tab;
     sym: (uni.Symbol | None) = None;
-    for part in parts {
+    for part_node in semdef.target {
         if (current_sym_tab is None) {
             return None;
         }
-        sym = current_sym_tab.lookup(part, deep=False);
+        sym = current_sym_tab.lookup(part_node.sym_name, deep=False);
         if (sym is None) {
             return None;
+        }
+        # Register the segment as a use site of the resolved symbol.
+        # This binds `part_node.sym` (so TypeCheckPass and StaticAnalysisPass
+        # treat it as resolved) and appends the Name to `Symbol.uses` so
+        # find-references / refactor tooling sees each segment of
+        # `sem Foo.bar.baz` as a real reference. The `sym is None` guard
+        # keeps it idempotent across pass reruns.
+        if part_node.sym is None {
+            sym.add_use(part_node);
         }
         current_sym_tab = sym.symbol_table;
     }

--- a/jac/jaclang/compiler/passes/main/sem_def_match_pass.jac
+++ b/jac/jaclang/compiler/passes/main/sem_def_match_pass.jac
@@ -16,8 +16,8 @@ import from jaclang.jac0core.unitree { Symbol, UniScopeNode }
 """Jac Semantic definition match pass."""
 obj SemDefMatchPass(Transform[uni.Module, uni.Module]) {
     def transform(ir_in: uni.Module) -> uni.Module;
-    def find_symbol_from_dotted_name(
-        dotted_name: str, target_sym_tab: UniScopeNode
+    def resolve_sem_target(
+        semdef: uni.SemDef, target_sym_tab: UniScopeNode
     ) -> (Symbol | None);
 
     def connect_sems(

--- a/jac/tests/compiler/passes/main/fixtures/sem_target_no_warnings.jac
+++ b/jac/tests/compiler/passes/main/fixtures/sem_target_no_warnings.jac
@@ -1,0 +1,22 @@
+"""Test: sem targets must not produce spurious W1051/W2001 warnings.
+
+`sem Foo.field = "..."` is a dotted-name path, not a field access. The Name
+nodes inside `SemDef.target` should resolve via the symbol-table walk done
+by SemDefMatchPass — not be treated as standalone module-scope expressions.
+"""
+obj Ingredient {
+    has name: str,
+        cost: float,
+        carby: bool;
+}
+
+sem Ingredient.cost = "Estimated cost in USD";
+sem Ingredient.carby = "True if this ingredient is high in carbohydrates";
+
+obj Outer {
+    obj Inner {
+        has tag: str;
+    }
+}
+
+sem Outer.Inner.tag = "Tag string for the inner object.";

--- a/jac/tests/compiler/passes/main/test_sem_def_match_pass.jac
+++ b/jac/tests/compiler/passes/main/test_sem_def_match_pass.jac
@@ -3,6 +3,7 @@
 import os;
 import from pathlib { Path }
 import jaclang;
+import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.program { JacProgram }
 
 glob FIXTURES = os.path.join(
@@ -123,4 +124,67 @@ test "sem def match for s e m prefixed functions" {
     assert sym_fetch.decl.name_of.semstr == "Fetch data from the remote source." , (
         f"f-prefix: expected sem string, got '{sym_fetch.decl.name_of.semstr}'"
     );
+}
+
+test "sem target names produce no spurious warnings" {
+    # `sem Foo.field = "..."` is a dotted-name path resolved against the
+    # symbol table — not a chain of module-scope expressions. The Name
+    # nodes inside SemDef.target must not produce W1051 ("type could not
+    # be resolved") or W2001 ("may be undefined") warnings.
+    file_path = os.path.join(FIXTURES, "sem_target_no_warnings.jac");
+    prog = JacProgram();
+    prog.compile(file_path, type_check=True);
+    warning_msgs = [str(w) for w in prog.warnings_had];
+    sem_target_names = ["cost", "carby", "Inner"];
+
+    undef_warnings = [
+        w
+        for w in warning_msgs
+        if "may be undefined" in w and any(f"'{n}'" in w for n in sem_target_names)
+    ];
+    assert len(undef_warnings) == 0 , (
+        f"Expected no W2001 warnings on sem target names, got: {undef_warnings}"
+    );
+
+    unresolved_warnings = [
+        w
+        for w in warning_msgs
+        if "could not be resolved" in w
+    ];
+    assert len(unresolved_warnings) == 0 , (
+        f"Expected no W1051 warnings on sem targets, got: {unresolved_warnings}"
+    );
+
+    # Sem strings must still be linked to their declarations.
+    mod = prog.mod.hub[file_path];
+    sym_ing = mod.lookup("Ingredient");
+    assert sym_ing is not None and sym_ing.symbol_table is not None;
+    sym_cost = sym_ing.symbol_table.lookup("cost");
+    assert sym_cost is not None;
+    assert sym_cost.decl.name_of.semstr == "Estimated cost in USD";
+
+    sym_outer = mod.lookup("Outer");
+    assert sym_outer is not None and sym_outer.symbol_table is not None;
+    sym_inner = sym_outer.symbol_table.lookup("Inner");
+    assert sym_inner is not None and sym_inner.symbol_table is not None;
+    sym_tag = sym_inner.symbol_table.lookup("tag");
+    assert sym_tag is not None;
+    assert sym_tag.decl.name_of.semstr == "Tag string for the inner object.";
+
+    # Each Name in the target chain should be registered as a proper use
+    # of the resolved symbol — sym bound for the type checker / static
+    # analysis passes, AND present in Symbol.uses so find-references and
+    # refactor tooling see each segment as a real reference site.
+    sem_defs = mod.get_all_sub_nodes(typ=uni.SemDef, brute_force=True);
+    for semdef in sem_defs {
+        for part in semdef.target {
+            assert part.sym is not None , (
+                f"sem target Name '{part.sym_name}' has no resolved sym"
+            );
+            assert part in part.sym.uses , (
+                f"sem target Name '{part.sym_name}' is not registered "
+                "in Symbol.uses — find-references will miss it"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`sem Foo.bar = "..."` is a dotted-path lookup, but `SemDefMatchPass` only attached the sem string to the resolved declaration - it never bound the target `Name` nodes themselves to their symbols. Because the type checker and static analysis pass both gate on `nd.sym is None`, every segment of the sem path was reported as `W1051` ("type could not be resolved") and `W2001` ("may be undefined"). Hits any file with `sem Foo.field = "..."`, including the new [day_planner basic example](jac/examples/day_planner/basic/main.jac#L20-L21).

The fix walks `SemDef.target` AST nodes directly (instead of splitting the `sem.A.B.C` symbol-name string) and registers each segment via the canonical `Symbol.add_use()`. The `nd.sym is None` guard keeps the pass idempotent across reruns. As a side benefit, IDE go-to-definition and find-references now work on each segment of `sem Foo.bar.baz`.

## Test plan

- [x] New `test_sem_def_match_pass.jac` test asserts no `W1051`/`W2001` on sem targets, that sem strings still attach correctly, and that each target Name is registered in `Symbol.uses` (so find-references catches it)
- [x] `test_sem_def_match_pass.jac` (3 tests, including pre-existing regression for issue #5233)
- [x] `test_static_analysis_pass.jac` (12 tests)
- [x] `test_checker_pass.jac` (180 tests)
- [x] `test_checker_bugs.jac` (22 tests)
- [x] `test_checker_gaps.jac` (17 tests)
- [x] `jac check jac/examples/day_planner/basic/main.jac` no longer reports the spurious warnings on lines 20-21