### PR TITLE
fix(typecheck): emit W0062 for `root()` during type check

### DIFF
--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
@@ -50,6 +50,16 @@ impl TypeEvaluator.validate_call_args(expr: uni.FuncCall) -> TypeBase {
         return caller_type;
     }
 
+    # Deprecated `root()` form: bare `root` is the graph anchor; the call
+    # form would resolve to `Jac.root()()` in codegen. Emit W0062 and reuse
+    # the Root instance type already resolved for the target.
+    if isinstance(expr.target, uni.SpecialVarRef)
+    and expr.target.name == Tok.KW_ROOT
+    and (not expr.params or len(expr.params) == 0) {
+        self.emit_diag(W0062, expr);
+        return caller_type;
+    }
+
     # Special-form handling for enum.auto() -> int
     if isinstance(caller_type, types.ClassType)
     and caller_type.is_builtin("auto")

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -88,6 +88,7 @@ import from jaclang.jac0core.diagnostics {
     E1104,
     E1110,
     E1111,
+    W0062,
     W1050,
     W1051,
     W1100,

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -3061,12 +3061,12 @@ impl PyastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
     } else {
         # Deprecated `root()` form: bare `root` already lowers to Jac.root() in
         # exit_special_var_ref, so wrapping it in another call would produce
-        # `Jac.root()()` (a Root instance called as a function). Emit W0062
-        # and reuse the inner lowering directly.
+        # `Jac.root()()` (a Root instance called as a function). The W0062
+        # diagnostic for this is emitted by the type evaluator; here we just
+        # reuse the inner lowering so codegen stays correct.
         if isinstance(nd.target, uni.SpecialVarRef)
         and nd.target.name == Tok.KW_ROOT
         and (nd.params is None or len(nd.params) == 0) {
-            self.emit(W0062, node_override=nd);
             nd.gen.py_ast = nd.target.gen.py_ast;
             return;
         }

--- a/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
+++ b/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
@@ -39,8 +39,7 @@ import from jaclang.jac0core.diagnostics {
     E5005,
     E5006,
     E5007,
-    E5008,
-    W0062
+    E5008
 }
 
 glob T = TypeVar('T', bound=ast3.AST),


### PR DESCRIPTION
## Summary

- The W0062 deprecation warning for `root()` was only emitted by `PyastGenPass.exit_func_call`, which is gated behind `not options.no_cgen`. `jac check` runs with `no_cgen=True`, so users running the type checker on a file containing `root()` saw a generic `W1051` (\"Expression type could not be resolved\") on every call site instead of the actionable `W0062` (\"Use bare 'root' instead\"). The W1051 fired because the type evaluator has no signature for calling a `Root` instance, so the `FuncCall`'s result type was `Unknown`.
- Move the deprecation detection into `TypeEvaluator.validate_call_args` so `jac check` produces the actionable W0062 and resolves the call to the Root instance type — eliminating the cascading W1051s on every `root()` call site.
- Codegen still rewrites `root()` -> `Jac.root()` so runtime semantics are unchanged. The redundant `self.emit(W0062, ...)` and the now-unused `W0062` import in `pyast_gen_pass` are dropped so the diagnostic is not emitted twice during a full compile.

## Repro

`jac check` on a file containing `task = root() ++> Task(...);`

Before:
```
⚠ warning[W1051]: Expression type could not be resolved (Unknown)
  --> main.jac:48:12
   48 |     task = root() ++> Task(title=title, category=category);
      |            ^^^^^^
```

After:
```
⚠ warning[W0062]: 'root()' is deprecated. Use bare 'root' instead.
  --> main.jac:48:12
   48 |     task = root() ++> Task(title=title, category=category);
      |            ^^^^^^
```

## Test plan

- [x] `jac check` on `examples/day_planner/basic/main.jac` shows W0062 (not W1051) on every `root()` site
- [x] `jac run` on a file using `root() ++> Node(...)` still works at runtime (no `Jac.root()()` regression)
- [x] Only one W0062 fires per call site during a full compile (no duplicate from codegen)
- [x] `jac/tests/language/test_language.jac` passes (88/88)
- [ ] `jac/tests/compiler/` full suite