### PR TITLE
fix(checker): allow shorter callables to satisfy longer ones

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5813.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5813.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Spurious W1051/W2001 warnings on `sem Foo.field` targets**: Dotted-path targets in `sem` declarations no longer produce `W1051 "Expression type could not be resolved"` or `W2001 "may be undefined"` warnings on their path segments.

--- a/docs/docs/community/release_notes/unreleased/jaclang/5816.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5816.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Functions with fewer parameters now satisfy callables expecting more**: Assigning a zero-arg handler to a JSX prop like `onClick={handler}` (or any `Callable[[MouseEvent], None]` slot) is accepted, matching TypeScript's contravariant-arity rule.

--- a/jac/jaclang/compiler/passes/main/impl/sem_def_match_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/sem_def_match_pass.impl.jac
@@ -2,6 +2,14 @@
 
 When source_sym_tab and target_sym_tab are the same, this connects within the same module.
 When different, it connects implementations from impl_mod to declarations in the main module.
+
+Walking each SemDef's `target: Sequence[NameAtom]` directly (rather than splitting
+the string-form `sem.A.B.C` of the SemDef's symbol name) lets us bind each target
+Name's `sym` attribute to the resolved Symbol. With those bindings in place, the
+type checker and static analysis passes both gate on `nd.sym is None` and naturally
+skip these path components — they are dotted-path navigation, not standalone
+expressions or undefined references. The bindings also enable IDE features like
+go-to-definition on each segment of `sem Foo.bar.baz`.
 """
 impl SemDefMatchPass.connect_sems(
     source_sym_tab: UniScopeNode, target_sym_tab: UniScopeNode
@@ -11,7 +19,7 @@ impl SemDefMatchPass.connect_sems(
             continue;
         }
         semdef = sym.decl.name_of;
-        target_sym = self.find_symbol_from_dotted_name(sym.sym_name, target_sym_tab);
+        target_sym = self.resolve_sem_target(semdef, target_sym_tab);
         if (target_sym is not None) {
             target_sym.decl.name_of.semstr = semdef.value.lit_value;
             target_sym.semstr = semdef.value.lit_value;
@@ -19,25 +27,35 @@ impl SemDefMatchPass.connect_sems(
     }
 }
 
-"""Find a symbol in the target symbol table by its dotted name.
+"""Walk a SemDef's target chain (e.g., `Foo.bar.baz`) against the target
+symbol table, binding each target Name's `sym` attribute to the resolved
+Symbol along the way.
 
-Example:
-"Foo.bar.baz" will do the following lookups:
-target_sym_tab.lookup("Foo").lookup("bar").lookup("baz")
+Returns the final resolved Symbol, or None if any segment fails to resolve.
+Partial chains still bind every Name they could resolve before the failing
+segment, which keeps IDE tooling useful even when the user is mid-edit.
 """
-impl SemDefMatchPass.find_symbol_from_dotted_name(
-    dotted_name: str, target_sym_tab: UniScopeNode
+impl SemDefMatchPass.resolve_sem_target(
+    semdef: uni.SemDef, target_sym_tab: UniScopeNode
 ) -> (Symbol | None) {
-    parts = dotted_name.removeprefix('sem.').split('.');
     current_sym_tab: (UniScopeNode | None) = target_sym_tab;
     sym: (uni.Symbol | None) = None;
-    for part in parts {
+    for part_node in semdef.target {
         if (current_sym_tab is None) {
             return None;
         }
-        sym = current_sym_tab.lookup(part, deep=False);
+        sym = current_sym_tab.lookup(part_node.sym_name, deep=False);
         if (sym is None) {
             return None;
+        }
+        # Register the segment as a use site of the resolved symbol.
+        # This binds `part_node.sym` (so TypeCheckPass and StaticAnalysisPass
+        # treat it as resolved) and appends the Name to `Symbol.uses` so
+        # find-references / refactor tooling sees each segment of
+        # `sem Foo.bar.baz` as a real reference. The `sym is None` guard
+        # keeps it idempotent across pass reruns.
+        if part_node.sym is None {
+            sym.add_use(part_node);
         }
         current_sym_tab = sym.symbol_table;
     }

--- a/jac/jaclang/compiler/passes/main/sem_def_match_pass.jac
+++ b/jac/jaclang/compiler/passes/main/sem_def_match_pass.jac
@@ -16,8 +16,8 @@ import from jaclang.jac0core.unitree { Symbol, UniScopeNode }
 """Jac Semantic definition match pass."""
 obj SemDefMatchPass(Transform[uni.Module, uni.Module]) {
     def transform(ir_in: uni.Module) -> uni.Module;
-    def find_symbol_from_dotted_name(
-        dotted_name: str, target_sym_tab: UniScopeNode
+    def resolve_sem_target(
+        semdef: uni.SemDef, target_sym_tab: UniScopeNode
     ) -> (Symbol | None);
 
     def connect_sems(

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -2403,28 +2403,14 @@ impl TypeEvaluator._assign_callable(
         for p in (dest_func.parameters or [])
         if not p.is_self and not p.is_cls
     ];
-    # Count required dest parameters (those without default values)
-    dest_required = len(
-        [
-            p
-            for p in dest_params
-            if p.default_value is None
-        ]
-    );
-    # Source must have at least as many params as dest requires
-    if len(src_params) < dest_required {
-        return False;
-    }
-    # Check parameter compatibility (contravariant)
-    for (i, dest_param) in enumerate(dest_params) {
-        if i >= len(src_params) {
-            # Dest has more params than src - extra dest params must have defaults
-            if dest_param.default_value is None {
-                return False;
-            }
-            continue;
-        }
-
+    # Check parameter compatibility (contravariant) for the positional overlap.
+    # If src has fewer params than dest, we allow the extras to be dropped at
+    # the call site (TypeScript-style relaxation). This is the canonical
+    # pattern for event handlers, e.g. `onClick={handler}` where `handler`
+    # ignores the MouseEvent argument.
+    overlap = min(len(src_params), len(dest_params));
+    for i in range(overlap) {
+        dest_param = dest_params[i];
         src_param = src_params[i];
 
         # Skip type checking if either parameter has no type annotation
@@ -2437,20 +2423,25 @@ impl TypeEvaluator._assign_callable(
             return False;
         }
     }
-    # Check extra src params beyond dest count - they must have defaults
-    # (Following Pyright: caller will only pass dest's param count, extras need defaults)
+    # If src has more params than dest, the trailing src params are never
+    # supplied by the caller, so they must have defaults.
     if len(src_params) > len(dest_params) {
         for i in range(len(dest_params), len(src_params)) {
             src_param = src_params[i];
             if src_param.default_value is None {
-                # Extra src param without default - incompatible
                 return False;
             }
         }
     }
-    # Check return type compatibility (covariant)
+    # Check return type compatibility (covariant). Normalize both sides to
+    # instance form: declared return types are recorded as ClassType, but
+    # method types occasionally hold the class form of NoneType for an
+    # implicit-None return, which would spuriously fail assign_type's
+    # instance-only ClassType compare.
     if dest_func.return_type and src_func.return_type {
-        if not self.assign_type(src_func.return_type, dest_func.return_type) {
+        src_ret = self._convert_to_instance(src_func.return_type);
+        dest_ret = self._convert_to_instance(dest_func.return_type);
+        if not self.assign_type(src_ret, dest_ret) {
             return False;
         }
     }

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_callable_param_drop.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_callable_param_drop.jac
@@ -1,0 +1,65 @@
+"""Test fixture: shorter callable assignable to longer (TS-style param drop).
+
+Mirrors TypeScript's rule that a function with fewer parameters is assignable
+to a callable type expecting more, since the extras can be dropped at the call
+site. This is the canonical pattern for React/JSX event handlers — a handler
+written `def click() { ... }` should satisfy `Callable[[MouseEvent], None]`.
+"""
+import from typing { Callable }
+
+
+class MouseEvent {
+    button: int = 0;
+}
+
+
+def no_args() -> None {}
+def one_int(x: int) -> None {}
+def two_ints(x: int, y: int) -> None {}
+
+
+def takes_mouse_handler(cb: Callable[[MouseEvent], None]) -> None {
+    cb(MouseEvent());
+}
+
+
+class Widget {
+    label: str = "";
+
+    def click {}
+
+    def click_one(x: int) {}
+}
+
+
+with entry {
+    # --- Valid: shorter source assignable to longer destination (extras dropped) ---
+
+    # Zero-arg function -> one-arg Callable
+    f1: Callable[[MouseEvent], None] = no_args;  # Ok
+
+    # Zero-arg function -> two-arg Callable
+    f2: Callable[[int, int], None] = no_args;  # Ok
+
+    # One-arg function -> two-arg Callable (drops trailing param)
+    f3: Callable[[int, int], None] = one_int;  # Ok
+
+    # Zero-arg lambda -> Callable expecting an event
+    f4: Callable[[MouseEvent], None] = lambda { };  # Ok
+
+    # Pass shorter callable through a higher-order call site
+    takes_mouse_handler(no_args);  # Ok
+
+    # Bound zero-arg method -> one-arg Callable. Exercises both the param-count
+    # relaxation and the implicit-None return type recorded by methods.
+    w = Widget();
+    f5: Callable[[MouseEvent], None] = w.click;  # Ok
+
+    # Bound one-arg method -> two-arg Callable.
+    f6: Callable[[int, int], None] = w.click_one;  # Ok
+
+    # --- Invalid: longer source NOT assignable to shorter destination ---
+
+    # Two-arg function -> zero-arg Callable (extra src param without default)
+    bad: Callable[[], None] = two_ints;  # Error: extra src params have no defaults
+}

--- a/jac/tests/compiler/passes/main/fixtures/sem_target_no_warnings.jac
+++ b/jac/tests/compiler/passes/main/fixtures/sem_target_no_warnings.jac
@@ -1,0 +1,22 @@
+"""Test: sem targets must not produce spurious W1051/W2001 warnings.
+
+`sem Foo.field = "..."` is a dotted-name path, not a field access. The Name
+nodes inside `SemDef.target` should resolve via the symbol-table walk done
+by SemDefMatchPass — not be treated as standalone module-scope expressions.
+"""
+obj Ingredient {
+    has name: str,
+        cost: float,
+        carby: bool;
+}
+
+sem Ingredient.cost = "Estimated cost in USD";
+sem Ingredient.carby = "True if this ingredient is high in carbohydrates";
+
+obj Outer {
+    obj Inner {
+        has tag: str;
+    }
+}
+
+sem Outer.Inner.tag = "Tag string for the inner object.";

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2003,6 +2003,32 @@ test "callable_type_annotation" {
     );
 }
 
+"""Shorter callables are assignable to longer ones (TS-style param drop).
+
+A function with fewer parameters is a valid value for a callable type expecting
+more — the extras are simply dropped at the call site. This unblocks the React
+idiom `onClick={handler}` where `handler` takes no MouseEvent arg.
+"""
+test "callable_param_drop" {
+    program = JacProgram();
+    path = os.path.join(CHECKER_FIXTURES, "checker_callable_param_drop.jac");
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+
+    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got {len(
+        program.errors_had
+    )}: " + "\n".join([err.pretty_print() for err in program.errors_had]);
+
+    # The lone error is the long-to-short direction, which must still be rejected.
+    assert_error_pretty_found(
+        """
+        bad: Callable[[], None] = two_ints;  # Error: extra src params have no defaults
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    """,
+        program.errors_had[0].pretty_print()
+    );
+}
+
 """Test unbound method call type checking (ParentClass.init(self, ...))."""
 test "unbound_method_call" {
     program = JacProgram();

--- a/jac/tests/compiler/passes/main/test_sem_def_match_pass.jac
+++ b/jac/tests/compiler/passes/main/test_sem_def_match_pass.jac
@@ -3,6 +3,7 @@
 import os;
 import from pathlib { Path }
 import jaclang;
+import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.program { JacProgram }
 
 glob FIXTURES = os.path.join(
@@ -123,4 +124,67 @@ test "sem def match for s e m prefixed functions" {
     assert sym_fetch.decl.name_of.semstr == "Fetch data from the remote source." , (
         f"f-prefix: expected sem string, got '{sym_fetch.decl.name_of.semstr}'"
     );
+}
+
+test "sem target names produce no spurious warnings" {
+    # `sem Foo.field = "..."` is a dotted-name path resolved against the
+    # symbol table — not a chain of module-scope expressions. The Name
+    # nodes inside SemDef.target must not produce W1051 ("type could not
+    # be resolved") or W2001 ("may be undefined") warnings.
+    file_path = os.path.join(FIXTURES, "sem_target_no_warnings.jac");
+    prog = JacProgram();
+    prog.compile(file_path, type_check=True);
+    warning_msgs = [str(w) for w in prog.warnings_had];
+    sem_target_names = ["cost", "carby", "Inner"];
+
+    undef_warnings = [
+        w
+        for w in warning_msgs
+        if "may be undefined" in w and any(f"'{n}'" in w for n in sem_target_names)
+    ];
+    assert len(undef_warnings) == 0 , (
+        f"Expected no W2001 warnings on sem target names, got: {undef_warnings}"
+    );
+
+    unresolved_warnings = [
+        w
+        for w in warning_msgs
+        if "could not be resolved" in w
+    ];
+    assert len(unresolved_warnings) == 0 , (
+        f"Expected no W1051 warnings on sem targets, got: {unresolved_warnings}"
+    );
+
+    # Sem strings must still be linked to their declarations.
+    mod = prog.mod.hub[file_path];
+    sym_ing = mod.lookup("Ingredient");
+    assert sym_ing is not None and sym_ing.symbol_table is not None;
+    sym_cost = sym_ing.symbol_table.lookup("cost");
+    assert sym_cost is not None;
+    assert sym_cost.decl.name_of.semstr == "Estimated cost in USD";
+
+    sym_outer = mod.lookup("Outer");
+    assert sym_outer is not None and sym_outer.symbol_table is not None;
+    sym_inner = sym_outer.symbol_table.lookup("Inner");
+    assert sym_inner is not None and sym_inner.symbol_table is not None;
+    sym_tag = sym_inner.symbol_table.lookup("tag");
+    assert sym_tag is not None;
+    assert sym_tag.decl.name_of.semstr == "Tag string for the inner object.";
+
+    # Each Name in the target chain should be registered as a proper use
+    # of the resolved symbol — sym bound for the type checker / static
+    # analysis passes, AND present in Symbol.uses so find-references and
+    # refactor tooling see each segment as a real reference site.
+    sem_defs = mod.get_all_sub_nodes(typ=uni.SemDef, brute_force=True);
+    for semdef in sem_defs {
+        for part in semdef.target {
+            assert part.sym is not None , (
+                f"sem target Name '{part.sym_name}' has no resolved sym"
+            );
+            assert part in part.sym.uses , (
+                f"sem target Name '{part.sym_name}' is not registered "
+                "in Symbol.uses — find-references will miss it"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Relax `_assign_callable` so that a function with fewer parameters is assignable to a callable type expecting more — TypeScript's contravariant-arity rule. This is the canonical React idiom; previously `<button onClick={handler}>` was rejected unless `handler` explicitly accepted (and ignored) a `MouseEvent` argument.
- Normalize both sides to instance form before the return-type comparison. Bound methods occasionally record an implicit-None return as the class form of `NoneType`; the instance-only `ClassType` assignability check used to spuriously fail there. This was masked previously by the param-count short-circuit and only surfaced once the relaxation above let same-arity bound-method comparisons reach the return check.
- Add a new `checker_callable_param_drop` fixture and test covering free functions, lambdas, bound methods, higher-order call sites, and the longer-to-shorter direction that must still be rejected.

The narrow case in the day-planner example (`onClick={add_new_task}`, `onChange={lambda { toggle(jid(t)); }}`, etc.) now type-checks; the existing strict tests in `checker_callable.jac` continue to pass unchanged.

## Test plan
- [x] `jac test jac/tests/compiler/passes/main/test_checker_pass.jac` — 181 tests pass
- [x] `jac test jac/tests/compiler/passes/main/test_checker_bugs.jac`, `test_checker_gaps.jac`, `test_checker_production.jac`, `test_checker_shortcomings.jac`, `test_typevar.jac` — all pass
- [x] `jac check jac/examples/day_planner/basic/main.jac` — six `E1103` callable-arg-mismatch errors on `onClick`/`onChange` props are gone (only the unrelated `__add__` overload + `.toFixed` warnings remain)
- [x] No regression vs. `main` on `test_language.jac` (same pre-existing fixture-relocation errors before and after)