### PR TITLE
docs: standardize jac start to use default entry point across documentation 

### DIFF
--- a/docs/docs/quick-guide/faq.md
+++ b/docs/docs/quick-guide/faq.md
@@ -118,7 +118,7 @@ Answers to common questions about Jac, organized by topic. Click a category to e
         `jac clean` requires a Jac project (a directory with `jac.toml`). If you're running standalone `.jac` scripts outside a project, delete the data directory manually: `rm -rf .jac/`. To create a project, run `jac init` or `jac create <name>`.
 
     ??? question "I see 'Address already in use' when running `jac start`."
-        Another process is using the port (default 8000). Either stop the other process or use a different port: `jac start main.jac --port 3000`.
+        Another process is using the port (default 8000). Either stop the other process or use a different port: `jac start --port 3000`.
 
     ??? question "My frontend shows data but fields are empty or undefined."
         When returning node objects directly from `def:pub` endpoints, use `jid(node)` to access the node's unique identity. For reliable client-side access, return explicit dictionaries from your endpoints:

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -87,7 +87,7 @@ This single file defines a persistent data model, an AI-powered categorizer, a R
     ```bash
     pip install jaseci
     export ANTHROPIC_API_KEY="your-key-here"
-    jac start main.jac
+    jac start
     ```
 
     Open [http://localhost:8000](http://localhost:8000) to see it running. Jac supports any [LiteLLM-compatible model](https://docs.litellm.ai/docs/providers) -- use `gemini/gemini-2.5-flash` for a free alternative or `ollama/llama3.2:1b` for local models.
@@ -204,12 +204,12 @@ with entry {
 }
 ```
 
-This same program runs three ways with no code changes:
+This same program runs three ways with no code changes (`main.jac` is the default entry point; omit it or specify a different name explicitly):
 
 | Command | What Happens |
 |---------|-------------|
-| `jac app.jac` | Runs locally, SQLite persistence |
-| `jac start app.jac` | HTTP API server, walkers become REST endpoints |
+| `jac main.jac` | Runs locally, SQLite persistence |
+| `jac start` | HTTP API server, walkers become REST endpoints |
 | `jac start --scale` | Kubernetes deployment with Redis, MongoDB, load balancing |
 
 The runtime handles database schemas, user authentication (per-user graph isolation), API generation (Swagger docs at `/docs`), caching tiers, and Kubernetes orchestration. You write application logic; the runtime handles infrastructure.

--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -219,8 +219,11 @@ With the `jac-client` plugin installed, scaffold a complete full-stack project i
 jac create example --use fullstack
 cd example
 jac add
-jac start main.jac
+jac start
 ```
+
+!!! note
+    `main.jac` is the default entry point. All `jac start` commands in this guide omit the filename. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
 
 This creates a project with a Jac backend and a React frontend, ready to go at `http://localhost:8000`.
 
@@ -234,7 +237,7 @@ This creates a project with a Jac backend and a React frontend, ready to go at `
 jac create my-todo --use https://raw.githubusercontent.com/jaseci-labs/jacpacks/main/multi-user-todo-app/multi-user-todo-app.jacpack
 cd my-todo
 jac add
-jac start main.jac
+jac start
 ```
 
 Want to try one with AI built in? The `multi-user-todo-meals-app` uses Jac's AI integration features to generate smart shopping lists with costs and nutritional info. It works out of the box with an Anthropic API key:
@@ -244,7 +247,7 @@ export ANTHROPIC_API_KEY="your-key-here"
 jac create meals-app --use https://raw.githubusercontent.com/jaseci-labs/jacpacks/main/multi-user-todo-meals-app/multi-user-todo-meals-app.jacpack
 cd meals-app
 jac add
-jac start main.jac
+jac start
 ```
 
 To use any of the other jacpacks, just swap the URL:
@@ -289,7 +292,7 @@ jac create my-app --use client
 
 # Start the development server
 cd my-app
-jac start main.jac
+jac start
 ```
 
 The `--use client` template sets up a complete project with:

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1625,18 +1625,21 @@ jac lint . --fix
 
 ### Production
 
+!!! note
+    `main.jac` is the default entry point. All commands below omit the filename. If your entry point differs (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
+
 ```bash
 # Start locally
 jac start -p 8000
 
 # Deploy to Kubernetes
-jac start main.jac --scale
+jac start --scale
 
 # Check deployment status
-jac status main.jac
+jac status
 
 # Remove deployment
-jac destroy main.jac
+jac destroy
 ```
 
 ## See Also

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1626,7 +1626,7 @@ jac lint . --fix
 ### Production
 
 !!! note
-    `main.jac` is the default entry point. All commands below omit the filename. If your entry point differs (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
+    `main.jac` is the default entry point for `jac start`. If your entry point differs (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
 
 ```bash
 # Start locally
@@ -1636,10 +1636,10 @@ jac start -p 8000
 jac start --scale
 
 # Check deployment status
-jac status
+jac status main.jac
 
 # Remove deployment
-jac destroy
+jac destroy main.jac
 ```
 
 ## See Also

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -54,8 +54,11 @@ pip install jaseci
 jac create myapp --use client
 
 # 3. Run
-jac start main.jac
+jac start
 ```
+
+!!! note
+    `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
 
 ---
 
@@ -196,7 +199,7 @@ port = 5173
 _authToken = "${NODE_AUTH_TOKEN}"
 
 [scripts]
-dev = "jac start main.jac --dev"
+dev = "jac start --dev"
 test = "jac test"
 build = "jac build"
 

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -519,9 +519,12 @@ walker list_todos {
 }
 ```
 
+!!! note
+    `main.jac` is the default entry point. If your file has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+
 ```bash
 # Run as API server
-jac start app.jac
+jac start
 
 # Call via HTTP
 curl -X POST http://localhost:8000/walker/add_todo \

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -147,8 +147,11 @@ walker:pub GetUsers {
 
 Start the server:
 
+!!! note
+    `main.jac` is the default entry point. All `jac start` commands below omit the filename. If your entry point differs (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+
 ```bash
-jac start main.jac --port 8000
+jac start --port 8000
 ```
 
 ### Typed Object Passing
@@ -1604,7 +1607,7 @@ A desktop build produces a Tauri shell that hosts a webview pointed at a bundled
 jac setup desktop
 
 # 2. Development with hot reload
-jac start main.jac --client desktop --dev
+jac start --client desktop --dev
 
 # 3. Build installer for current platform
 jac build --client desktop
@@ -1921,16 +1924,16 @@ jac-client uses [Bun](https://bun.sh/) for package management and JavaScript bun
 
 ```bash
 # Basic
-jac start main.jac
+jac start
 
 # With hot module replacement
-jac start main.jac --dev
+jac start --dev
 
 # HMR without client bundling (API only)
-jac start main.jac --dev --no-client
+jac start --dev --no-client
 
 # Dev server for desktop target
-jac start main.jac --client desktop
+jac start --client desktop
 ```
 
 ### API Proxy
@@ -2263,7 +2266,7 @@ For more patterns, see the [Advanced Patterns & JS Interop tutorial](../../tutor
 
 ```bash
 # Enable with --dev flag
-jac start main.jac --dev
+jac start --dev
 ```
 
 Changes to `.jac` files automatically reload without restart.

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -57,8 +57,10 @@ jac plugins enable scale
 
 ### Basic Server
 
+> **Note:** `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+
 ```bash
-jac start app.jac
+jac start
 ```
 
 ### Server Options
@@ -84,19 +86,19 @@ jac start app.jac
 
 ```bash
 # Custom port
-jac start app.jac --port 3000
+jac start --port 3000
 
 # Development with HMR (requires jac-client)
-jac start app.jac --dev
+jac start --dev
 
 # API only -- skip client bundling
-jac start app.jac --dev --no_client
+jac start --dev --no_client
 
 # Preview generated API endpoints without starting
-jac start app.jac --faux
+jac start --faux
 
 # Production with profile
-jac start app.jac --port 8000 --profile prod
+jac start --port 8000 --profile prod
 ```
 
 ### Default Persistence

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -57,7 +57,8 @@ jac plugins enable scale
 
 ### Basic Server
 
-> **Note:** `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+!!! note
+    `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
 
 ```bash
 jac start

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -2862,7 +2862,7 @@ type = "local"
 **How it works:**
 
 - Allocates a port pair from a pool (base ports 5180-5200, stride of 2)
-- Runs `jac start main.jac --dev -p {port}` as a child process
+- Runs `jac start --dev -p {port}` as a child process
 - Checks for readiness by scanning process output for `"Server ready"`
 - Returns `http://localhost:{port}` as the preview URL
 
@@ -2898,7 +2898,7 @@ network_isolation = true
 
 - Creates a Docker container from `base_image`
 - Copies project files into `/app` via tarball injection
-- Runs `jac install && jac start main.jac --dev -p 8000`
+- Runs `jac install && jac start --dev -p 8000`
 - Applies resource limits (memory, CPU, storage)
 - Optionally creates an isolated Docker bridge network per sandbox
 - Polls container health via HTTP until ready (120s timeout)
@@ -2939,7 +2939,7 @@ security_context = true
 2. Provisions RBAC (ServiceAccount, Role, RoleBinding) for pod management
 3. Packages project files into a ConfigMap (text files in `data`, binary files in `binaryData` as base64)
 4. Creates a pod with an init container that unpacks the ConfigMap into `/app`
-5. Main container runs `jac install && jac start main.jac --dev -p 8000`
+5. Main container runs `jac install && jac start --dev -p 8000`
 6. Creates a Service and Ingress (unless `proxy_mode = true`)
 7. Polls pod readiness (container ready + "Server ready" in logs, 120s timeout)
 8. Returns the preview URL

--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -597,8 +597,12 @@ task_data["done"] = True;   # Update a value
 
 Even without a frontend, you can start the server and interact with your API right away. This is a good practice for verifying your backend logic works correctly before adding UI complexity:
 
+!!! note
+    `main.jac` is the default entry point. Since this project uses `main.jac`, you can omit the filename entirely. Both forms below are equivalent.
+
 ```bash
 jac start main.jac
+# or: jac start
 ```
 
 The server starts on port 8000 by default. Use `--port 3000` to pick a different port.
@@ -1013,7 +1017,7 @@ h1 { text-align: center; margin-bottom: 24px; color: #333; }
     ```
 
 ```bash
-jac start main.jac
+jac start main.jac  # or: jac start
 ```
 
 Open [http://localhost:8000](http://localhost:8000). You should see a clean day planner with an input field and an "Add" button. Try it:
@@ -1689,7 +1693,7 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
 
 ```bash
 export ANTHROPIC_API_KEY="your-key"
-jac start main.jac
+jac start main.jac  # or: jac start
 ```
 
 !!! warning "Common issue"
@@ -2430,7 +2434,7 @@ All the complete files are in the collapsible sections below. Create each file, 
 
 ```bash
 export ANTHROPIC_API_KEY="your-key"
-jac start main.jac
+jac start main.jac  # or: jac start
 ```
 
 Open [http://localhost:8000](http://localhost:8000). You should see a login screen.
@@ -3402,7 +3406,7 @@ All the complete files are in the collapsible sections below. Create each file, 
 
 ```bash
 export ANTHROPIC_API_KEY="your-key"
-jac start main.jac
+jac start main.jac  # or: jac start
 ```
 
 Open [http://localhost:8000](http://localhost:8000). You should see a login screen -- that's authentication working with `walker:priv`.

--- a/docs/docs/tutorials/fullstack/desktop.md
+++ b/docs/docs/tutorials/fullstack/desktop.md
@@ -73,7 +73,7 @@ The next `jac build --client desktop` will pick these up automatically -- you do
 The fastest dev loop is:
 
 ```bash
-jac start main.jac --client desktop --dev
+jac start --client desktop --dev
 ```
 
 This launches the Tauri window pointing at the Vite dev server with HMR enabled. Edit a `.cl.jac` file, save, and the window updates without restarting.

--- a/docs/docs/tutorials/language/osp.md
+++ b/docs/docs/tutorials/language/osp.md
@@ -560,9 +560,12 @@ walker list_todos {
 }
 ```
 
+!!! note
+    `main.jac` is the default entry point. If your file has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+
 ```bash
 # Run as API server
-jac start app.jac
+jac start
 
 # Call via HTTP
 curl -X POST http://localhost:8000/walker/add_todo \

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -82,7 +82,8 @@ walker:pub health {
 
 ### 2. Deploy to Kubernetes
 
-> **Note:** `main.jac` is the default entry point. Commands below omit the filename. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
+!!! note
+    `main.jac` is the default entry point. Commands below omit the filename. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
 
 ```bash
 jac start --scale

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -51,7 +51,7 @@ graph TD
 ### 1. Prepare Your Application
 
 ```jac
-# app.jac
+# main.jac
 node Todo {
     has title: str;
     has done: bool = False;
@@ -82,8 +82,10 @@ walker:pub health {
 
 ### 2. Deploy to Kubernetes
 
+> **Note:** `main.jac` is the default entry point. Commands below omit the filename. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
+
 ```bash
-jac start app.jac --scale
+jac start --scale
 ```
 
 That's it. Your application is now running on Kubernetes.
@@ -102,7 +104,7 @@ That's it. Your application is now running on Kubernetes.
 Deploys without building a Docker image. Fastest for iteration.
 
 ```bash
-jac start app.jac --scale
+jac start --scale
 ```
 
 ### Production Mode
@@ -110,7 +112,7 @@ jac start app.jac --scale
 Builds a Docker image and pushes to DockerHub before deploying.
 
 ```bash
-jac start app.jac --scale --build
+jac start --scale --build
 ```
 
 **Requirements for production mode:**
@@ -181,7 +183,7 @@ Configure deployment via environment variables in `.env`:
 Use `jac status` to see the health of all deployment components at a glance:
 
 ```bash
-jac status app.jac
+jac status
 ```
 
 This displays a table showing each component's status (Running, Degraded, Pending, Restarting, or Not Deployed), pod readiness counts, and service URLs.
@@ -210,7 +212,7 @@ kubectl logs -l app=jaseci -f
 Remove all Kubernetes resources created by jac-scale:
 
 ```bash
-jac destroy app.jac
+jac destroy
 ```
 
 This removes:
@@ -274,7 +276,7 @@ alias kubectl='microk8s kubectl'
 
 ```bash
 # Check all component statuses at once
-jac status app.jac
+jac status
 
 # Or use kubectl for more detail
 kubectl get pods
@@ -308,7 +310,7 @@ kubectl logs -l app=redis
 
 ```bash
 # Quick overview of all components
-jac status app.jac
+jac status
 
 # Describe a pod for events
 kubectl describe pod <pod-name>
@@ -330,7 +332,7 @@ jac create todo --use client
 cd todo
 
 # Deploy to Kubernetes
-jac start app.jac --scale
+jac start --scale
 ```
 
 Access:

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -83,7 +83,7 @@ walker:pub health {
 ### 2. Deploy to Kubernetes
 
 !!! note
-    `main.jac` is the default entry point. Commands below omit the filename. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
+    `main.jac` is the default entry point for `jac start`. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac --scale`.
 
 ```bash
 jac start --scale
@@ -181,10 +181,10 @@ Configure deployment via environment variables in `.env`:
 
 ### Check Status
 
-Use `jac status` to see the health of all deployment components at a glance:
+Use `jac status main.jac` to see the health of all deployment components at a glance:
 
 ```bash
-jac status
+jac status main.jac
 ```
 
 This displays a table showing each component's status (Running, Degraded, Pending, Restarting, or Not Deployed), pod readiness counts, and service URLs.
@@ -213,7 +213,7 @@ kubectl logs -l app=jaseci -f
 Remove all Kubernetes resources created by jac-scale:
 
 ```bash
-jac destroy
+jac destroy main.jac
 ```
 
 This removes:
@@ -277,7 +277,7 @@ alias kubectl='microk8s kubectl'
 
 ```bash
 # Check all component statuses at once
-jac status
+jac status main.jac
 
 # Or use kubectl for more detail
 kubectl get pods
@@ -311,7 +311,7 @@ kubectl logs -l app=redis
 
 ```bash
 # Quick overview of all components
-jac status
+jac status main.jac
 
 # Describe a pod for events
 kubectl describe pod <pod-name>

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -28,7 +28,7 @@ graph LR
 ### 1. Create Your Walker
 
 ```jac
-# app.jac
+# main.jac
 node Task {
     has title: str;
     has done: bool = False;
@@ -56,8 +56,10 @@ walker:pub add_task {
 
 ### 2. Start the Server
 
+> **Note:** `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+
 ```bash
-jac start app.jac
+jac start
 ```
 
 Output:
@@ -89,7 +91,7 @@ curl -X POST http://localhost:8000/walker/add_task \
 
 ```bash
 # Custom port
-jac start app.jac --port 3000
+jac start --port 3000
 ```
 
 If the specified port is already in use, the server automatically finds and uses the next available port:
@@ -103,7 +105,7 @@ Port 3000 is in use, using port 3001 instead
 Hot Module Replacement for development:
 
 ```bash
-jac start app.jac --dev
+jac start --dev
 ```
 
 Changes to your `.jac` files will automatically reload.
@@ -113,7 +115,7 @@ Changes to your `.jac` files will automatically reload.
 Skip client bundling and only serve the API:
 
 ```bash
-jac start app.jac --dev --no_client
+jac start --dev --no_client
 ```
 
 ---

--- a/docs/docs/tutorials/production/local.md
+++ b/docs/docs/tutorials/production/local.md
@@ -56,7 +56,8 @@ walker:pub add_task {
 
 ### 2. Start the Server
 
-> **Note:** `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
+!!! note
+    `main.jac` is the default entry point. If your entry point has a different name (e.g., `app.jac`), pass it explicitly: `jac start app.jac`.
 
 ```bash
 jac start


### PR DESCRIPTION
### Summary

`main.jac` is the default entry point for `jac start`. However, across tutorials and reference documentation, it was being explicitly passed in every command. This adds unnecessary noise and suggests the filename is always required when it is not.

This PR removes the redundant filename from all `jac start` commands where the default applies. It also introduces a clearly placed admonition in each file to explain the convention and when specifying a filename is necessary.

### Changes

* Removed redundant `main.jac` from all `jac start` commands (`--dev`, `--scale`, `--port`, etc.)
* Added a single `!!! note` per file (placed near the first relevant command) explaining:

  * when the entry point can be omitted
  * when it should be explicitly provided
* Updated `quick-guide/index.md` comparison table to clarify usage (`jac main.jac` vs `jac start`)
* Applied consistent updates across tutorials, quick guides, and reference documentation

### Out of Scope

* `jac-scale.md` deeper reference sections
  → These reference a specific named application (`app.jac`) and are intentionally unchanged

* `community/breaking-changes.md` and release notes
  → Historical records; not modified

* `jac db --app app.jac` commands
  → Use a different flag pattern and explicitly require an app context

### Files Changed

* Tutorials & Reference
  `local.md`, `kubernetes.md`, `jac-scale.md`, `osp.md`

* Quick Guide & Core Docs
  `build-ai-day-planner.md`, `desktop.md`, `install.md`, `index.md`

* Additional Docs
  `faq.md`, `jac-client.md`, `cli/index.md`
