### PR TITLE
fix(ecmascript): emit `!==` for `is not` and honor f-string format specs

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5827.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5827.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `is not` and f-string format specs in JS codegen**: `is not None` now compiles to `!== null` instead of being silently inverted to `===`, and f-string format specs like `f"{x:.2f}"` are honored via the `_jac.builtin.format` runtime helper instead of being dropped.

--- a/jac/examples/day_planner/basic/main.jac
+++ b/jac/examples/day_planner/basic/main.jac
@@ -45,18 +45,18 @@ node ShoppingItem {
 """Add a task with AI categorization."""
 def:pub add_task(title: str) -> Task {
     category = str(categorize(title)).split(".")[-1].lower();
-    task = root() ++> Task(title=title, category=category);
+    task = root ++> Task(title=title, category=category);
     return task[0];
 }
 
 """Get all tasks."""
 def:pub get_tasks -> list[Task] {
-    return [root()-->][?:Task];
+    return [root-->][?:Task];
 }
 
 """Toggle a task's done status."""
 def:pub toggle_task(id: str) -> Task | None {
-    for task in [root()-->][?:Task] {
+    for task in [root-->][?:Task] {
         if jid(task) == id {
             task.done = not task.done;
             return task;
@@ -66,8 +66,8 @@ def:pub toggle_task(id: str) -> Task | None {
 }
 
 """Delete a task."""
-def:pub delete_task(id: str) -> dict {
-    for task in [root()-->][?:Task] {
+def:pub delete_task(id: str) -> dict[str, str] {
+    for task in [root-->][?:Task] {
         if jid(task) == id {
             del task;
             return {"deleted": id};
@@ -79,12 +79,12 @@ def:pub delete_task(id: str) -> dict {
 # --- Shopping List Endpoints ---
 """Generate a shopping list from a meal description."""
 def:pub generate_list(meal: str) -> list[ShoppingItem] {
-    for item in [root()-->][?:ShoppingItem] {
+    for item in [root-->][?:ShoppingItem] {
         del item;
     }
     ingredients = generate_shopping_list(meal);
     for ing in ingredients {
-        root() ++> ShoppingItem(
+        root ++> ShoppingItem(
             name=ing.name,
             quantity=ing.quantity,
             unit=str(ing.unit).split(".")[-1].lower(),
@@ -92,17 +92,17 @@ def:pub generate_list(meal: str) -> list[ShoppingItem] {
             carby=ing.carby
         );
     }
-    return [root()-->][?:ShoppingItem];
+    return [root-->][?:ShoppingItem];
 }
 
 """Get the current shopping list."""
 def:pub get_shopping_list -> list[ShoppingItem] {
-    return [root()-->][?:ShoppingItem];
+    return [root-->][?:ShoppingItem];
 }
 
 """Clear the shopping list."""
-def:pub clear_shopping_list -> dict {
-    for item in [root()-->][?:ShoppingItem] {
+def:pub clear_shopping_list -> dict[str, bool] {
+    for item in [root-->][?:ShoppingItem] {
         del item;
     }
     return {"cleared": True};
@@ -110,10 +110,10 @@ def:pub clear_shopping_list -> dict {
 
 # --- Frontend ---
 cl def:pub app -> JsxElement {
-    has tasks: list = [],
+    has tasks: list[Task] = [],
         task_text: str = "",
         meal_text: str = "",
-        ingredients: list = [],
+        ingredients: list[ShoppingItem] = [],
         generating: bool = False;
 
     async can with entry {
@@ -131,7 +131,9 @@ cl def:pub app -> JsxElement {
 
     async def toggle(id: str) {
         updated = await toggle_task(id);
-        tasks = [updated if jid(t) == id else t for t in tasks];
+        if updated is not None {
+            tasks = [updated if jid(t) == id else t for t in tasks];
+        }
     }
 
     async def remove(id: str) {
@@ -247,13 +249,13 @@ cl def:pub app -> JsxElement {
                                 {(<span class="carb-badge">Carbs</span>)
                                     if ing.carby
                                     else None}
-                                <span class="ing-cost">${ing.cost.toFixed(2)}</span>
+                                <span class="ing-cost">${f"{ing.cost:.2f}"}</span>
                             </div>
                         </div> for ing in ingredients
                     ]}
                     {(
                         <div class="shopping-footer">
-                            <span class="total">Total: ${total_cost.toFixed(2)}</span>
+                            <span class="total">Total: ${f"{total_cost:.2f}"}</span>
                             <button class="btn-clear" onClick={clear_list}>
                                 Clear
                             </button>

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -63,6 +63,8 @@ glob _T = TypeVar('_T', bound=es.Node),
          Tok.GT: '>',
          Tok.LTE: '<=',
          Tok.GTE: '>=',
+         Tok.KW_IS: '===',
+         Tok.KW_ISN: '!==',
          Tok.KW_IN: 'in',
          Tok.KW_NIN: 'in'
      },

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -284,6 +284,36 @@ impl EsastGenPass.exit_f_string(nd: uni.FString) -> None {
 impl EsastGenPass.exit_formatted_value(nd: uni.FormattedValue) -> None {
     expr = nd.format_part.gen.es_ast
     or self.sync_loc(es.Literal(value=''), jac_node=nd.format_part);
+    if nd.format_spec is not None {
+        spec_es = nd.format_spec.gen.es_ast
+        or self.sync_loc(es.Literal(value=''), jac_node=nd.format_spec);
+        format_callee = self.sync_loc(
+            es.MemberExpression(
+                object=self.sync_loc(
+                    es.MemberExpression(
+                        object=self.sync_loc(es.Identifier(name='_jac'), jac_node=nd),
+                        property=self.sync_loc(
+                            es.Identifier(name='builtin'), jac_node=nd
+                        ),
+                        computed=False
+                    ),
+                    jac_node=nd
+                ),
+                property=self.sync_loc(es.Identifier(name='format'), jac_node=nd),
+                computed=False
+            ),
+            jac_node=nd
+        );
+        self.needs_jac_runtime = True;
+        nd.gen.es_ast = self.sync_loc(
+            es.CallExpression(
+                callee=cast(es.Expression, format_callee),
+                arguments=[cast(es.Expression, expr), cast(es.Expression, spec_es)]
+            ),
+            jac_node=nd
+        );
+        return;
+    }
     nd.gen.es_ast = expr;
 }
 

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -477,7 +477,10 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
      ),
      W1050 = _warn("W1050", Category.TYPE, "Unknown intrinsic JSX element '<{tag}>'"),
      W1051 = _warn(
-         "W1051", Category.TYPE, "Expression type could not be resolved (Unknown)"
+         "W1051",
+         Category.TYPE,
+         "Expression type could not be resolved (Unknown)",
+         "Often fixed by adding a more specific type annotation to the relevant declaration (e.g., 'list[Task]' instead of bare 'list', or annotating an unannotated parameter or attribute). Can also indicate an unresolved import, a forward reference the checker cannot bind, or fallout from an upstream error."
      ),
      # Import warnings
      W1100 = _warn("W1100", Category.IMPORT, "Module not found"),

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -1226,3 +1226,52 @@ test "jsx preserves single-space whitespace between adjacent expression children
 
     assert_balanced_syntax(js_code, fixture);
 }
+
+test "is and is not emit identity comparison operators" {
+    # BUG: ES_COMPARISON_OPS had no entries for Tok.KW_IS / Tok.KW_ISN, so
+    # both `is` and `is not` fell through to the `===` default. `is None`
+    # was accidentally correct; `is not None` silently inverted to `===`,
+    # causing branches like `if x is not None { ... }` to run only when x
+    # *was* None.
+    jac_code = "\"\"\"Test is/is not codegen.\"\"\"\n\ncl def check(x: int | None) -> int {\n    if x is None {\n        return 1;\n    }\n    if x is not None {\n        return 2;\n    }\n    return 3;\n}\n";
+
+    temp_path = write_temp_jac(jac_code);
+    try {
+        js_code = compile_fixture_to_js(temp_path);
+        assert "x === null" in js_code , (
+            f"`is None` must emit `=== null`, got:\n{js_code}"
+        );
+        assert "x !== null" in js_code , (
+            f"`is not None` must emit `!== null`, got:\n{js_code}"
+        );
+        assert_balanced_syntax(js_code, temp_path);
+    } finally {
+        os.unlink(temp_path);
+    }
+}
+
+test "fstring format spec invokes runtime format helper" {
+    # BUG: exit_formatted_value ignored nd.format_spec, so format mini-language
+    # specs like `:.2f` were dropped — `f"{x:.2f}"` rendered "8" instead of
+    # "8.00". The fix routes formatted values with a spec through the
+    # _jac.builtin.format runtime helper, which honors precision, width,
+    # alignment, and type specifiers.
+    jac_code = "\"\"\"Test f-string format spec.\"\"\"\n\ncl def fmt_price(x: float) -> str {\n    return f\"${x:.2f}\";\n}\n\ncl def fmt_plain(x: float) -> str {\n    return f\"${x}\";\n}\n";
+
+    temp_path = write_temp_jac(jac_code);
+    try {
+        js_code = compile_fixture_to_js(temp_path);
+        assert "_jac.builtin.format(x, \".2f\")" in js_code , (
+            "`f\"{x:.2f}\"` must compile to a runtime format() call, "
+            f"got:\n{js_code}"
+        );
+        # Bare `f"{x}"` (no spec) must still emit a plain template
+        # interpolation — the runtime call is reserved for spec'd values.
+        assert "${x}" in js_code , (
+            f"Bare `f\"{{x}}\"` should still use plain `${{x}}`, got:\n{js_code}"
+        );
+        assert_balanced_syntax(js_code, temp_path);
+    } finally {
+        os.unlink(temp_path);
+    }
+}


### PR DESCRIPTION
## Summary

Two JS-codegen bugs surfaced while exercising the day_planner basic example:

- **\`is\` / \`is not\` were silently inverted.** \`ES_COMPARISON_OPS\` had no entries for \`Tok.KW_IS\` or \`Tok.KW_ISN\`, so both fell through to the \`'==='\` default. \`is None\` was accidentally correct; \`is not None\` compiled to \`===\`, so \`if x is not None { ... }\` only ran when \`x\` *was* \`None\`. Added the missing entries (\`KW_IS: '==='\`, \`KW_ISN: '!=='\`).
- **F-string format specs were dropped.** \`exit_formatted_value\` ignored \`nd.format_spec\`, so \`f\"{x:.2f}\"\` rendered \`\"8\"\` instead of \`\"8.00\"\`. Formatted values with a spec now route through the existing \`_jac.builtin.format\` runtime helper, which handles precision, width, alignment, and type specifiers (\`dfseboxX%\`). Bare \`f\"{x}\"\` (no spec) still emits a plain template interpolation.

Each test fails before its matching fix and passes after. The day_planner basic example was also tidied up to clear all \`jac check\` diagnostics (bare \`root\`, explicit \`list[Task]\` / \`list[ShoppingItem]\` / \`dict[...]\` annotations) so the in-tree example exercises both fixed paths end-to-end.

## Test plan

- [x] \`jac test jac/tests/compiler/passes/ecmascript/test_js_generation.jac\` (full ES suite): 56 passed (added 2), 2 pre-existing CLI failures unchanged
- [x] New tests fail without their respective fix, pass with it (verified by toggling each fix off and rerunning)
- [x] \`jac check jac/examples/day_planner/basic/main.jac\` clean (0 errors, 0 warnings)
- [x] End-to-end smoke test with \`jac start main.jac\`: add task (LLM categorization), toggle, delete, generate shopping list (LLM), verify \`\$X.XX\` price formatting and total