### PR TITLE
fix(jac-super): preserve bracketed user content in console diagnostics

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-super/5828.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-super/5828.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix:** `jac check` diagnostic snippets preserve bracketed source like `[root()-->][?:Task]` and list comprehension RHS verbatim instead of stripping them.

--- a/jac-super/jac_super/plugin/impl/console.impl.jac
+++ b/jac-super/jac_super/plugin/impl/console.impl.jac
@@ -38,11 +38,23 @@ obj JacSuperConsole(BaseJacConsole) {
         self._console_stderr = RichConsole(theme=self.JAC_THEME, file=sys.stderr);
     }
 
-    """Override print to use Rich console."""
+    """Override print to use Rich console.
+
+    Rich's `Console.print` parses bracket-delimited markup like `[red]...[/red]`
+    by default. User-supplied content (file paths, source-line snippets,
+    f-string output) routinely contains square brackets that look like
+    markup — e.g. a diagnostic snippet for `[root()-->][?:Task]` would have
+    the `[root()-->]` interpreted as a malformed tag and stripped, leaving a
+    misleading `[?:Task]` underneath the carets. Disable markup parsing by
+    default; callers that want Rich markup must opt in explicitly via
+    `markup=True`. Auto-highlighting (`highlight`) is left at Rich's default
+    so numbers, strings, paths, and keywords still get their accent colors.
+    """
     def print(*args: Any, **kwargs: Any) {
         # Extract style if provided, otherwise use default
         style = kwargs.pop('style', None);
         file = kwargs.pop('file', None);
+        kwargs.setdefault('markup', False);
         # Use appropriate console based on file
         console = self._console_stderr if (file == sys.stderr) else self._console;
         if style {
@@ -60,29 +72,35 @@ obj JacSuperConsole(BaseJacConsole) {
     """Override success to use Rich styling."""
     def success(message: str, emoji: bool = True) {
         prefix = '✔' if (emoji and self.use_emoji) else '[SUCCESS]';
-        self._console.print(f"{prefix} {message}", style='success');
+        self._console.print(f"{prefix} {message}", style='success', markup=False);
     }
 
     """Override error to use Rich styling with stderr."""
     def error(message: str, hint: (str | None) = None, emoji: bool = True) {
         prefix = '✖' if (emoji and self.use_emoji) else '[ERROR]';
-        self._console_stderr.print(f"{prefix} Error: {message}", style='error');
+        self._console_stderr.print(
+            f"{prefix} Error: {message}", style='error', markup=False
+        );
         if hint {
             hint_prefix = '💡' if self.use_emoji else 'HINT:';
-            self._console_stderr.print(f"{hint_prefix} {hint}", style='info');
+            self._console_stderr.print(
+                f"{hint_prefix} {hint}", style='info', markup=False
+            );
         }
     }
 
     """Override warning to use Rich styling."""
     def warning(message: str, emoji: bool = True) {
         prefix = '⚠' if (emoji and self.use_emoji) else '[WARNING]';
-        self._console_stderr.print(f"{prefix} {message}", style='warning');
+        self._console_stderr.print(
+            f"{prefix} {message}", style='warning', markup=False
+        );
     }
 
     """Override info to use Rich styling."""
     def info(message: str, emoji: bool = True) {
         prefix = 'ℹ' if (emoji and self.use_emoji) else '[INFO]';
-        self._console.print(f"{prefix} {message}", style='info');
+        self._console.print(f"{prefix} {message}", style='info', markup=False);
     }
 
     """Override print_header to use Rich styling."""

--- a/jac/examples/day_planner/auth/frontend.cl.jac
+++ b/jac/examples/day_planner/auth/frontend.cl.jac
@@ -3,6 +3,8 @@
 import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
 
 sv import from main {
+    Task,
+    ShoppingItem,
     get_tasks,
     add_task,
     toggle_task,
@@ -22,11 +24,11 @@ def:pub app -> JsxElement {
         password: str = "",
         error: str = "",
         loading: bool = False,
-        tasks: list = [],
+        tasks: list[Task] = [],
         taskText: str = "",
         tasksLoading: bool = True,
         mealText: str = "",
-        ingredients: list = [],
+        ingredients: list[ShoppingItem] = [],
         generating: bool = False;
 
     can with entry {
@@ -209,14 +211,14 @@ def:pub app -> JsxElement {
                                                                 if ing.carby
                                                                 else None}
                                                             <span class="ing-cost">
-                                                                ${ing.cost.toFixed(2)}
+                                                                ${f"{ing.cost:.2f}"}
                                                             </span>
                                                         </div>
                                                     </div> for ing in ingredients
                                                 ]}
                                                 <div class="shopping-footer">
                                                     <span class="total">
-                                                        Total: ${totalCost.toFixed(2)}
+                                                        Total: ${f"{totalCost:.2f}"}
                                                     </span>
                                                     <button
                                                         class="btn-clear"

--- a/jac/examples/day_planner/auth/frontend.impl.jac
+++ b/jac/examples/day_planner/auth/frontend.impl.jac
@@ -17,7 +17,9 @@ impl app.addTask{
 
 impl app.toggleTask(id: str) {
     updated = await toggle_task(id);
-    tasks = [updated if jid(t) == id else t for t in tasks];
+    if updated is not None {
+        tasks = [updated if jid(t) == id else t for t in tasks];
+    }
 }
 
 impl app.deleteTask(id: str) {

--- a/jac/examples/day_planner/auth/main.jac
+++ b/jac/examples/day_planner/auth/main.jac
@@ -57,18 +57,18 @@ node ShoppingItem {
 """Add a task with AI categorization."""
 def:priv add_task(title: str) -> Task {
     category = str(categorize(title)).split(".")[-1].lower();
-    task = root() ++> Task(title=title, category=category);
+    task = root ++> Task(title=title, category=category);
     return task[0];
 }
 
 """Get all tasks."""
 def:priv get_tasks -> list[Task] {
-    return [root()-->][?:Task];
+    return [root-->][?:Task];
 }
 
 """Toggle a task's done status."""
 def:priv toggle_task(id: str) -> Task | None {
-    for task in [root()-->][?:Task] {
+    for task in [root-->][?:Task] {
         if jid(task) == id {
             task.done = not task.done;
             return task;
@@ -78,8 +78,8 @@ def:priv toggle_task(id: str) -> Task | None {
 }
 
 """Delete a task."""
-def:priv delete_task(id: str) -> dict {
-    for task in [root()-->][?:Task] {
+def:priv delete_task(id: str) -> dict[str, str] {
+    for task in [root-->][?:Task] {
         if jid(task) == id {
             del task;
             return {"deleted": id};
@@ -91,12 +91,12 @@ def:priv delete_task(id: str) -> dict {
 # --- Shopping List Endpoints ---
 """Generate a shopping list from a meal description."""
 def:priv generate_list(meal: str) -> list[ShoppingItem] {
-    for item in [root()-->][?:ShoppingItem] {
+    for item in [root-->][?:ShoppingItem] {
         del item;
     }
     ingredients = generate_shopping_list(meal);
     for ing in ingredients {
-        root() ++> ShoppingItem(
+        root ++> ShoppingItem(
             name=ing.name,
             quantity=ing.quantity,
             unit=str(ing.unit).split(".")[-1].lower(),
@@ -104,17 +104,17 @@ def:priv generate_list(meal: str) -> list[ShoppingItem] {
             carby=ing.carby
         );
     }
-    return [root()-->][?:ShoppingItem];
+    return [root-->][?:ShoppingItem];
 }
 
 """Get the current shopping list."""
 def:priv get_shopping_list -> list[ShoppingItem] {
-    return [root()-->][?:ShoppingItem];
+    return [root-->][?:ShoppingItem];
 }
 
 """Clear the shopping list."""
-def:priv clear_shopping_list -> dict {
-    for item in [root()-->][?:ShoppingItem] {
+def:priv clear_shopping_list -> dict[str, bool] {
+    for item in [root-->][?:ShoppingItem] {
         del item;
     }
     return {"cleared": True};

--- a/jac/tests/language/fixtures/check_diag_brackets_e1001.jac
+++ b/jac/tests/language/fixtures/check_diag_brackets_e1001.jac
@@ -1,0 +1,22 @@
+"""Fixture for jac check diagnostic-snippet rendering test.
+
+Triggers E1001 (assignment type mismatch) where the right-hand side is a
+list comprehension wrapped in square brackets. The rendered source line in
+the diagnostic must preserve the full comprehension — the console must not
+interpret it as Rich markup.
+"""
+
+node Task {
+    has title: str = "";
+}
+
+def maybe_task() -> Task | None {
+    return None;
+}
+
+with entry {
+    tasks: list[Task] = [];
+    updated = maybe_task();
+    tasks = [updated if t.title == "x" else t for t in tasks];
+    print(tasks);
+}

--- a/jac/tests/language/fixtures/check_diag_brackets_w0062.jac
+++ b/jac/tests/language/fixtures/check_diag_brackets_w0062.jac
@@ -1,0 +1,16 @@
+"""Fixture for jac check diagnostic-snippet rendering test.
+
+Triggers W0062 (deprecated `root()`) inside a traversal expression that
+contains square brackets. The rendered source line in the diagnostic must
+preserve the full bracketed text (`[root()-->][?:Task]`) — the console
+must not interpret it as Rich markup.
+"""
+
+node Task {
+    has title: str = "";
+}
+
+with entry {
+    x = [root()-->][?:Task];
+    print(x);
+}

--- a/jac/tests/language/test_console.jac
+++ b/jac/tests/language/test_console.jac
@@ -12,6 +12,8 @@ glob JAC_ROOT = str(Path(jaclang.__file__).parent.parent),
      ),
      EDGE_CASES_FILE = os.path.join(FIXTURES, "console_edge_cases.jac"),
      FSTRING_ENCODING_FILE = os.path.join(FIXTURES, "fstring_encoding.jac"),
+     CHECK_W0062_BRACKETS = os.path.join(FIXTURES, "check_diag_brackets_w0062.jac"),
+     CHECK_E1001_BRACKETS = os.path.join(FIXTURES, "check_diag_brackets_e1001.jac"),
      ESC = '\x1b[';
 
 """Run jac and return (stdout, stderr) tuple."""
@@ -105,6 +107,26 @@ test "Windows console encoding handles unencodable Unicode" {
     # At minimum, the ASCII parts should always be present
     assert 'world' in stdout , "ASCII content missing from output";
     assert 'ESC_NEWLINE' in stdout , "Label missing - possible encoding crash";
+}
+
+# =============================================================================
+# Regression: jac check diagnostic snippets must preserve user source verbatim
+# (Rich markup parsing was eating bracketed text like `[root()-->]` and list
+# comprehensions, leaving misleading snippets like `x = [?:Task];` or
+# `tasks = ;` underneath the carets.)
+# =============================================================================
+test "jac check W0062 snippet preserves bracketed traversal" {
+    (stdout, stderr) = run_jac(['check', CHECK_W0062_BRACKETS]);
+    combined = stdout + stderr;
+    assert 'W0062' in combined , f"W0062 not emitted: {combined!r}";
+    assert '[root()-->][?:Task]' in combined , f"Bracketed traversal stripped from snippet: {combined!r}";
+}
+
+test "jac check E1001 snippet preserves list comprehension RHS" {
+    (stdout, stderr) = run_jac(['check', CHECK_E1001_BRACKETS]);
+    combined = stdout + stderr;
+    assert 'E1001' in combined , f"E1001 not emitted: {combined!r}";
+    assert '[updated if t.title == "x" else t for t in tasks]' in combined , f"List comprehension stripped from snippet: {combined!r}";
 }
 
 test "all edge case patterns preserved" {


### PR DESCRIPTION
## Summary

- `JacSuperConsole` (Rich plugin) forwarded user-supplied messages to `rich.Console.print` with `markup=True` (Rich's default), so square-bracketed content in diagnostic snippets was parsed as Rich markup and stripped. Two visible symptoms:
  - W0062 on `[root()-->][?:Task]` rendered the source line as `x = [?:Task];` (the `[root()-->]` token was eaten as a malformed tag, even though the carets were correctly aimed at the `root()` call).
  - E1001 on a typed-list assignment from a list comprehension rendered the source line as `tasks = ;` (the entire `[updated if ... for ... in ...]` RHS got eaten).
- Fix: pass `markup=False` on `JacSuperConsole.{print,success,error,warning,info}`. `highlight` is left at Rich's default so numbers, strings, paths, and keywords still get their accent colors inside the styled message.
- Adds two regression tests in `tests/language/test_console.jac` that run `jac check` on fixtures containing bracketed traversals and list comprehensions and assert the original source text appears verbatim in the rendered diagnostic.
- Also includes a small example cleanup in `examples/day_planner/auth/` that exercised these diagnostics during dogfooding (W0062, W1036, W6002, E1001).

## Test plan

- [x] `python -m jaclang test jac/tests/language/test_console.jac` (11/11 pass, including the two new tests; both fail on the pre-fix branch)
- [x] `jac check examples/day_planner/auth/{main,frontend.cl,frontend.impl}.jac` is clean
- [x] Visual QA with `FORCE_COLOR=1` confirms warnings remain yellow and errors remain red, with auto-highlighting (numbers in cyan, strings in green, identifiers in magenta) intact inside the styled snippet