### PR TITLE
chore(examples): type day_planner walker lists and use f-string formatting

### DIFF
--- a/jac/examples/day_planner/walkers/frontend.cl.jac
+++ b/jac/examples/day_planner/walkers/frontend.cl.jac
@@ -5,6 +5,8 @@ import from "@jac/runtime" { jacSignup, jacLogin, jacLogout, jacIsLoggedIn }
 import "./styles.css";
 
 sv import from main {
+    Task,
+    ShoppingItem,
     AddTask,
     ListTasks,
     ToggleTask,
@@ -22,11 +24,11 @@ def:pub app -> JsxElement {
         password: str = "",
         error: str = "",
         loading: bool = False,
-        tasks: list = [],
+        tasks: list[Task] = [],
         taskText: str = "",
         tasksLoading: bool = True,
         mealText: str = "",
-        ingredients: list = [],
+        ingredients: list[ShoppingItem] = [],
         generating: bool = False;
 
     can with entry {
@@ -209,14 +211,14 @@ def:pub app -> JsxElement {
                                                                 if ing.carby
                                                                 else None}
                                                             <span class="ing-cost">
-                                                                ${ing.cost.toFixed(2)}
+                                                                ${f"{ing.cost:.2f}"}
                                                             </span>
                                                         </div>
                                                     </div> for ing in ingredients
                                                 ]}
                                                 <div class="shopping-footer">
                                                     <span class="total">
-                                                        Total: ${totalCost.toFixed(2)}
+                                                        Total: ${f"{totalCost:.2f}"}
                                                     </span>
                                                     <button
                                                         class="btn-clear"

--- a/jac/examples/day_planner/walkers/main.jac
+++ b/jac/examples/day_planner/walkers/main.jac
@@ -65,7 +65,7 @@ walker:priv AddTask {
 }
 
 walker:priv ListTasks {
-    has results: list = [];
+    has results: list[Task] = [];
 
     can start with Root entry {
         visit [-->];
@@ -137,7 +137,7 @@ walker:priv GenerateShoppingList {
 }
 
 walker:priv GetShoppingList {
-    has items: list = [];
+    has items: list[ShoppingItem] = [];
 
     can collect with Root entry {
         visit [-->];


### PR DESCRIPTION
## Summary
- Import `Task` and `ShoppingItem` from `main` into `frontend.cl.jac` and annotate the `tasks` / `ingredients` state with `list[Task]` / `list[ShoppingItem]`.
- Annotate the `ListTasks.results` and `GetShoppingList.items` walker fields with the same typed lists in `main.jac`.
- Replace `cost.toFixed(2)` / `totalCost.toFixed(2)` in the shopping list view with `f"{...:.2f}"` formatting.

## Test plan
- [ ] Run the day_planner example and confirm the shopping list and tasks render unchanged.