### PR TITLE
docs(byllm): clarify llm is ambient, jac.toml is the typical config

### DIFF
--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -95,29 +95,56 @@ pip install byllm[video]
 
 ## Model Configuration
 
-### Default (Zero-Config)
+`llm` is **ambient** in Jac -- it's a built-in name, you never import it or pass it as an argument. The model that *powers* `llm` is configured project-wide via `jac.toml` (typical), with an optional per-module override (`glob llm = Model(...)`) when one file needs something different from the rest of the project.
 
-`llm` is a **built-in name** in Jac -- just use `by llm()` directly with no imports:
+### Project-wide default (typical: `jac.toml`)
+
+```toml
+# jac.toml
+[plugins.byllm.model]
+default_model = "gpt-4o-mini"
+```
 
 ```jac
-def summarize(text: str) -> str by llm();
+# any file in the project
+def summarize(text: str) -> str by llm();   # uses jac.toml's default
 
 with entry {
     print(summarize("Jac is a programming language..."));
 }
 ```
 
-The default model is `gpt-4o-mini`. Configure it via `jac.toml` (see [Default Model Configuration](#default-model-configuration) below).
+Most projects do this and nothing else: set the default once, and every `by llm()` in the project picks it up. See [Default Model Configuration](#default-model-configuration) for the full schema (api_key, base_url, proxy, verbose, etc.) and [Supported Providers](#supported-providers) for provider name formats.
 
-### Custom Model (Override)
+### Per-module override
 
-For per-file customization, override the builtin with an explicit `Model`:
+When a single file needs a different model -- most often when composing a [`ModelPool`](#modelpool), calling a fine-tuned endpoint, or pinning a specific provider for that module -- redeclare `llm` as a module-level glob:
 
 ```jac
 import from byllm.lib { Model }
 
 glob llm = Model(model_name="gpt-4o");
+
+def summarize(text: str) -> str by llm();   # uses gpt-4o here only
 ```
+
+The glob shadows the project default **for this module only**. Other files keep using whatever `jac.toml` says unless they declare their own `glob llm`.
+
+The name `llm` is just convention -- `by <name>()` accepts any module-level glob whose value is a `Model` (or `ModelPool`). Use whatever name reads best at the call site, especially when one file talks to multiple models:
+
+```jac
+import from byllm.lib { Model }
+
+glob fast_model    = Model(model_name="gpt-4o-mini");
+glob smart_model   = Model(model_name="gpt-4o");
+glob summarizer    = Model(model_name="claude-sonnet-4-6");
+
+def quick_label(text: str) -> str by fast_model();
+def deep_analyze(text: str) -> dict by smart_model();
+def tldr(article: str) -> str by summarizer();
+```
+
+`by llm()` only refers to the ambient builtin when no `glob llm` shadows it. Once you define a glob with the name `llm`, that glob takes over for the module; any other named globs (`fast_model`, `smart_model`, ...) coexist alongside it and are selected explicitly per call.
 
 ### Model Constructor Parameters
 
@@ -205,7 +232,7 @@ byLLM uses [LiteLLM](https://docs.litellm.ai/docs/providers) for model integrati
     export HUGGINGFACE_API_KEY="hf_..."
     ```
 
-You can also override per-file with `glob llm = Model(...)` (see [Custom Model (Override)](#custom-model-override)).
+You can also override per-file with `glob llm = Model(...)` (see [Per-module override](#per-module-override)).
 
 **Provider Model Name Formats:**
 


### PR DESCRIPTION
## Summary

Restructures `reference/plugins/byllm.md`'s **Model Configuration** section so the typical path (`jac.toml`) leads. Adds an explicit section lede on `llm` being ambient, names the precedence between project default and per-module override, and adds a multi-model example clarifying that `llm` is just convention -- any module-level glob holding a `Model` or `ModelPool` works with `by <name>()`.

## Why

The previous structure was:

```
### Default (Zero-Config)
### Custom Model (Override)
```

…which read as two equal-weight options. New readers commonly missed:

1. That `llm` is **ambient** -- never imported, never threaded as an argument.
2. That `jac.toml` is the **typical** config (the toml example was 200 lines later under "Default Model Configuration", behind a forward reference).
3. That the per-module `glob llm = Model(...)` override **only shadows for that module** -- other files in the project keep the toml-level default.
4. That you can name the glob anything (`fast_model`, `summarizer`, ...) and `by <name>()` works for any of them.

## What changed

```
## Model Configuration

[lede: llm is ambient + jac.toml is typical + glob is the optional override]

### Project-wide default (typical: `jac.toml`)
  - jac.toml example
  - bare `by llm()` example using it
  - "Most projects do this and nothing else..." framing
  - forward links to Default Model Configuration + Supported Providers

### Per-module override
  - `glob llm = Model(...)` example
  - explicit "for this module only" precedence note
  - common reasons (composing ModelPool, fine-tuned endpoint, per-file pinning)
  - **multi-model example** (`fast_model` / `smart_model` / `summarizer`)
  - reconciliation note: `by llm()` only resolves to the ambient builtin
    when no `glob llm` shadows it; named globs coexist with `llm`

### Model Constructor Parameters
  ...unchanged
```

Net diff: +34 / -7 on a single file.

## Test plan

- [x] `mkdocs build --strict`: no new warnings or errors introduced.
- [x] Updated the one cross-link in the Supported Providers section that pointed at the old `#custom-model-override` anchor; it now points at the new `#per-module-override`.
- [x] Verified slug compatibility: heading "Per-module override" produces anchor `#per-module-override` consistently across mkdocs and markdownlint's GFM slug rule.
- [x] No code changes; no behaviour changes; no other doc pages modified.

## Notes for reviewers

- Doc-only change, ships independently of any code PR.
- The `Default (Zero-Config)` and `Custom Model (Override)` headings are gone; if any external content links to those anchors, those links would 404 today as well (confirmed via grep across the docs tree).
- Could be folded into a quickstart pass too -- the tutorial already has Cloud / Ollama / `local:*` as parallel tabs, which is fine for a "pick one and run" tutorial. Happy to do a smaller pass there as a follow-up if you want symmetry.