### PR TITLE
ci(build-standalone): pass GITHUB_TOKEN to scie build to avoid API rate limits

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -93,6 +93,8 @@ jobs:
         run: pip install pex
 
       - name: Build standalone binary
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ needs.resolve-versions.outputs.jaclang_version }}"
           ASSET="jac-${VERSION}-${{ matrix.platform }}"
@@ -179,6 +181,8 @@ jobs:
         run: pip install pex
 
       - name: Build standalone binary
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ needs.resolve-versions.outputs.jaseci_version }}"
           ASSET="jaseci-${VERSION}-${{ matrix.platform }}"


### PR DESCRIPTION
## Summary

The `pex --scie` build in `build-standalone.yml` invokes `science`, which queries the GitHub REST API to resolve the latest `python-build-standalone` release. The macOS aarch64 runners regularly hit the **60 req/hr unauthenticated rate limit** because Apple Silicon runners share a small NAT egress pool, causing builds to fail with:

```
httpx.HTTPStatusError: Client error '403 rate limit exceeded' for url
'https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest'
```

This was observed on the latest release run where both `build-jaclang (macos-aarch64)` and `build-jaseci (macos-aarch64)` failed for this exact reason while their Linux counterparts succeeded.

Setting `GITHUB_TOKEN` (the ephemeral, auto-revoked workflow token already used elsewhere in this file) raises the limit to **5,000 req/hr** authenticated. `science` reads `GITHUB_TOKEN` from env automatically.

## Changes

- Add `GITHUB_TOKEN: ${{ github.token }}` to the env of the two `Build standalone binary` steps (jaclang and jaseci matrix jobs).

## Why this is safe

- `github.token` is short-lived (max ~6h) and auto-revoked when the job ends.
- Read-only against public repos by default — exactly the scope `science` needs.
- Already used by `gh release upload` steps in the same workflow, so no new trust surface.
- Works for fork PRs too (only the read scope is needed for the API call).

## Test plan

- [ ] Re-run `publish-release.yml` (or trigger a fresh release) and confirm both `build-jaclang (macos-aarch64)` and `build-jaseci (macos-aarch64)` succeed.
- [ ] Verify Linux jobs continue to succeed (no behavior change expected).