### PR TITLE
feat(compiler): make curated typing constructs ambient

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5854.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5854.feature.md
@@ -1,0 +1,1 @@
+- **Feature: Curated typing constructs are ambient**: `Callable`, `Protocol`, `TypeVar`, `Generic`, `Iterable`, `Mapping`, and similar annotation-only typing names resolve in user code without `import from typing { ... }`.

--- a/jac/examples/day_planner/auth/components/AuthForm.cl.jac
+++ b/jac/examples/day_planner/auth/components/AuthForm.cl.jac
@@ -6,7 +6,7 @@ flip the app into its logged-in state.
 
 import from "@jac/runtime" { jacLogin, jacSignup }
 
-def:pub AuthForm(onAuth: Any) -> JsxElement {
+def:pub AuthForm(onAuth: Callable[[], None]) -> JsxElement {
     has isSignup: bool = False,
         username: str = "",
         password: str = "",

--- a/jac/examples/day_planner/auth/components/Header.cl.jac
+++ b/jac/examples/day_planner/auth/components/Header.cl.jac
@@ -1,6 +1,6 @@
 """App header with title, subtitle, and sign-out button."""
 
-def:pub Header(onLogout: Any) -> JsxElement {
+def:pub Header(onLogout: Callable[[], None]) -> JsxElement {
     return
         <div class="header">
             <div>

--- a/jac/examples/day_planner/auth/components/TaskItem.cl.jac
+++ b/jac/examples/day_planner/auth/components/TaskItem.cl.jac
@@ -2,7 +2,9 @@
 
 sv import from ..main { Task }
 
-def:pub TaskItem(task: Task, onToggle: Any, onDelete: Any) -> JsxElement {
+def:pub TaskItem(
+    task: Task, onToggle: Callable[[], None], onDelete: Callable[[], None]
+) -> JsxElement {
     return
         <div class="task-item">
             <input type="checkbox" checked={task.done} onChange={onToggle}/>

--- a/jac/examples/day_planner/basic/main.jac
+++ b/jac/examples/day_planner/basic/main.jac
@@ -111,7 +111,9 @@ to cl:
 import "./styles.css";
 
 """Single task row -- presentational; toggle and delete are passed in."""
-def:pub TaskItem(task: Task, onToggle: Any, onDelete: Any) -> JsxElement {
+def:pub TaskItem(
+    task: Task, onToggle: Callable[[], None], onDelete: Callable[[], None]
+) -> JsxElement {
     return
         <div class="task-item">
             <input type="checkbox" checked={task.done} onChange={onToggle}/>

--- a/jac/examples/day_planner/walkers/components/AuthForm.cl.jac
+++ b/jac/examples/day_planner/walkers/components/AuthForm.cl.jac
@@ -6,7 +6,7 @@ flip the app into its logged-in state.
 
 import from "@jac/runtime" { jacLogin, jacSignup }
 
-def:pub AuthForm(onAuth: Any) -> JsxElement {
+def:pub AuthForm(onAuth: Callable[[], None]) -> JsxElement {
     has isSignup: bool = False,
         username: str = "",
         password: str = "",

--- a/jac/examples/day_planner/walkers/components/Header.cl.jac
+++ b/jac/examples/day_planner/walkers/components/Header.cl.jac
@@ -1,6 +1,6 @@
 """App header with title, subtitle, and sign-out button."""
 
-def:pub Header(onLogout: Any) -> JsxElement {
+def:pub Header(onLogout: Callable[[], None]) -> JsxElement {
     return
         <div class="header">
             <div>

--- a/jac/examples/day_planner/walkers/components/TaskItem.cl.jac
+++ b/jac/examples/day_planner/walkers/components/TaskItem.cl.jac
@@ -2,7 +2,9 @@
 
 sv import from ..main { Task }
 
-def:pub TaskItem(task: Task, onToggle: Any, onDelete: Any) -> JsxElement {
+def:pub TaskItem(
+    task: Task, onToggle: Callable[[], None], onDelete: Callable[[], None]
+) -> JsxElement {
     return
         <div class="task-item">
             <input type="checkbox" checked={task.done} onChange={onToggle}/>

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -3312,6 +3312,9 @@ impl TypeEvaluator.postinit -> None {
     self._DOM_TYPES_STUB_FILE_PATH = os.path.join(
         os.path.dirname(__file__), "dom_types.pyi"
     );
+    self._TYPING_AMBIENT_STUB_FILE_PATH = os.path.join(
+        os.path.dirname(__file__), "typing_ambient.pyi"
+    );
     self._ENUM_STUB_FILE_PATH = os.path.join(
         os.path.dirname(__file__), "../../vendor/typeshed/stdlib/enum.pyi"
     );
@@ -3385,6 +3388,23 @@ impl TypeEvaluator.postinit -> None {
         existing = self.builtins_module.names_in_scope.get(name);
         if existing is None or existing.imported {
             self.builtins_module.names_in_scope[name] = sym;
+        }
+    }
+    # Merge curated typing constructs into builtins. The set of names is
+    # owned by typing_ambient.pyi's __all__ — that file is the single source
+    # of truth for both the type checker (this merge) and PyastGenPass
+    # (which auto-emits `from typing import <names>` when references appear).
+    typing_ambient_allowed = read_dunder_all(self._TYPING_AMBIENT_STUB_FILE_PATH);
+    if typing_ambient_allowed is not None {
+        for typing_name in typing_ambient_allowed {
+            typing_sym = self.typing_module.names_in_scope.get(typing_name);
+            if typing_sym is None {
+                continue;
+            }
+            existing_typing = self.builtins_module.names_in_scope.get(typing_name);
+            if existing_typing is None or existing_typing.imported {
+                self.builtins_module.names_in_scope[typing_name] = typing_sym;
+            }
         }
     }
     self._prefetch_types();

--- a/jac/jaclang/compiler/type_system/typing_ambient.pyi
+++ b/jac/jaclang/compiler/type_system/typing_ambient.pyi
@@ -1,0 +1,69 @@
+"""Curated typing constructs available without explicit import.
+
+The TypeEvaluator merges the names listed in __all__ into
+builtins_module.names_in_scope so user code can write
+`def foo(cb: Callable[[], None])` without `import from typing { Callable }`.
+PyastGenPass reads the same __all__ to auto-emit
+`from typing import <names>` in the generated Python whenever an ambient
+name is referenced — preserving runtime resolvability for libraries that
+introspect annotations (typing.get_type_hints, pydantic, FastAPI, ...).
+
+Editing this file is the *only* place to grow or shrink the ambient set.
+
+Skipped on purpose:
+  * Any            — Jac uses the lowercase `any` BuiltinType keyword.
+  * Optional/Union — write `X | None` / `X | Y` (PEP 604).
+  * Dict/List/Set/FrozenSet/Tuple/Type/DefaultDict/OrderedDict/Counter/Deque
+                   — use the lowercase built-ins (PEP 585): dict, list, set,
+                    frozenset, tuple, type, ...
+  * Final         — currently provided as a local stub by jac_builtins.pyi
+                    (the `existing not imported` guard preserves it). When
+                    that stub is removed, add Final here to gain real
+                    typing.Final semantics.
+  * cast / overload / runtime_checkable / TYPE_CHECKING / get_type_hints
+    / get_args / get_origin / no_type_check
+                   — these are *runtime* values, not annotation-only forms.
+                    Importing them explicitly keeps runtime intent obvious.
+"""
+
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Sequence,
+)
+from typing import (
+    Annotated,
+    ClassVar,
+    Generic,
+    Literal,
+    Protocol,
+    TypeVar,
+)
+
+__all__ = [
+    "Annotated",
+    "AsyncIterable",
+    "AsyncIterator",
+    "Awaitable",
+    "Callable",
+    "ClassVar",
+    "Coroutine",
+    "Generic",
+    "Iterable",
+    "Iterator",
+    "Literal",
+    "Mapping",
+    "MutableMapping",
+    "MutableSequence",
+    "Protocol",
+    "Sequence",
+    "TypeVar",
+]

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -14,11 +14,57 @@ impl PyastGenPass._get_builtin_names(cls: Any) -> set[str] {
     return cls._builtin_names;
 }
 
+"""Read __all__ from typing_ambient.pyi, cached after first access."""
+@classmethod
+impl PyastGenPass._get_ambient_typing_names(cls: Any) -> set[str] {
+    if (cls._ambient_typing_names is not None) {
+        return cls._ambient_typing_names;
+    }
+    import os;
+    import ast as py_ast;
+    stub_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "compiler",
+        "type_system",
+        "typing_ambient.pyi"
+    );
+    try {
+        with open(stub_path, encoding="utf-8") as f {
+            tree = py_ast.parse(f.read());
+        }
+        for node in tree.body {
+            if (
+                isinstance(node, py_ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], py_ast.Name)
+                and node.targets[0].id == "__all__"
+                and isinstance(node.value, (py_ast.List, py_ast.Tuple))
+            ) {
+                names: set[str] = `set();
+                for elt in node.value.elts {
+                    if (
+                        isinstance(elt, py_ast.Constant) and isinstance(elt.value, str)
+                    ) {
+                        names.add(elt.value);
+                    }
+                }
+                cls._ambient_typing_names = names;
+                return names;
+            }
+        }
+    } except (OSError, SyntaxError) {
+        pass;
+    }
+    cls._ambient_typing_names = `set();
+    return cls._ambient_typing_names;
+}
+
 impl PyastGenPass.postinit -> None {
     # Initialize by-postinit fields
     self.debuginfo = {'jac_mods': []};
     self.jaclib_imports = `set();
     self.builtin_imports = `set();
+    self.typing_imports = `set();
     self.child_passes = self._init_child_passes(PyastGenPass);
     self.preamble = [
         self.sync(
@@ -694,6 +740,7 @@ impl PyastGenPass.exit_module(nd: uni.Module) -> None {
     for child_pass in self.child_passes {
         self.jaclib_imports.update(child_pass.jaclib_imports);
         self.builtin_imports.update(child_pass.builtin_imports);
+        self.typing_imports.update(child_pass.typing_imports);
     }
     is_builtin_module = (
         nd.loc.mod_path.endswith(('builtin.jac', 'builtin.py'))
@@ -707,6 +754,21 @@ impl PyastGenPass.exit_module(nd: uni.Module) -> None {
                     names=[
                         self.sync(ast3.alias(name=name, asname=None))
                         for name in sorted(self.builtin_imports)
+                    ],
+                    level=0
+                ),
+                jac_node=self.ir_out
+            )
+        );
+    }
+    if self.typing_imports {
+        self.preamble.append(
+            self.sync(
+                ast3.ImportFrom(
+                    module='typing',
+                    names=[
+                        self.sync(ast3.alias(name=name, asname=None))
+                        for name in sorted(self.typing_imports)
                     ],
                     level=0
                 ),
@@ -3553,6 +3615,9 @@ impl PyastGenPass.exit_name(nd: uni.Name) -> None {
     }
     if (name in self._get_builtin_names()) {
         self.builtin_imports.add(name);
+    }
+    if (name in self._get_ambient_typing_names()) {
+        self.typing_imports.add(name);
     }
     nd.gen.py_ast = [self.sync(ast3.Name(id=name, ctx=nd.py_ctx_func()))];
 }

--- a/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
+++ b/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
@@ -99,6 +99,7 @@ obj PyastGenPass(BaseAstGenPass[ast3.AST]) {
         already_added: list[str] = [],
         jaclib_imports: set[str] by postinit,
         builtin_imports: set[str] by postinit,
+        typing_imports: set[str] by postinit,
         _temp_name_counter: int = 0,
         _hoisted_funcs: list[ast3.FunctionDef | ast3.AsyncFunctionDef] = [],
         child_passes: list[PyastGenPass] by postinit,
@@ -107,11 +108,21 @@ obj PyastGenPass(BaseAstGenPass[ast3.AST]) {
 
     with entry {
         _builtin_names: ClassVar[(set[str] | None)] = None;
+        _ambient_typing_names: ClassVar[(set[str] | None)] = None;
     }
 
     """Get the set of builtin names, cached after first successful access."""
     @classmethod
     def _get_builtin_names(cls: Any) -> set[str];
+
+    """Get the curated ambient typing names. Single source of truth is
+    `compiler/type_system/typing_ambient.pyi` — the same file TypeEvaluator
+    uses to drive its merge into `builtins_module`. Parsing the stub's
+    __all__ here lets codegen auto-emit `from typing import <names>` when
+    a reference appears, keeping `typing.get_type_hints` / pydantic /
+    FastAPI annotation introspection working at runtime."""
+    @classmethod
+    def _get_ambient_typing_names(cls: Any) -> set[str];
 
     def postinit -> None;
     """Enter node."""

--- a/jac/tests/compiler/passes/main/fixtures/static_analysis/ambient_typing.jac
+++ b/jac/tests/compiler/passes/main/fixtures/static_analysis/ambient_typing.jac
@@ -1,0 +1,30 @@
+"""Curated typing constructs are ambient: callers should not need
+`import from typing { ... }`. This fixture must produce no W2001 (undefined
+name) or W1051 (unresolved type) warnings, and the generated Python must
+include `from typing import ...` for every ambient name actually used."""
+
+def take_callback(cb: Callable[[], None]) -> None {
+    cb();
+}
+
+def map_keys(m: Mapping[str, int]) -> Sequence[str] {
+    return list(m.keys());
+}
+
+def sum_iter(items: Iterable[int]) -> int {
+    total = 0;
+    for x in items {
+        total = total + x;
+    }
+    return total;
+}
+
+obj Greeter(Protocol) {
+    def greet() -> str;
+}
+
+with entry {
+    take_callback(lambda { print("hi"); });
+    print(map_keys({"a": 1}));
+    print(sum_iter([1, 2, 3]));
+}

--- a/jac/tests/compiler/passes/main/test_static_analysis_pass.jac
+++ b/jac/tests/compiler/passes/main/test_static_analysis_pass.jac
@@ -139,6 +139,30 @@ test "cl def has variables reassigned in nested abilities produce no unused warn
     ]}";
 }
 
+test "ambient typing names resolve without import" {
+    file_path = os.path.join(FIXTURES, "ambient_typing.jac");
+    prog = JacProgram();
+    prog.compile(file_path, type_check=True);
+    warning_msgs = [str(w) for w in prog.warnings_had];
+    error_msgs = [str(e) for e in prog.errors_had];
+    typing_names = ["Callable", "Mapping", "Sequence", "Iterable", "Protocol"];
+    for tname in typing_names {
+        undef = [
+            w
+            for w in warning_msgs
+            if f"'{tname}' may be undefined" in w
+        ];
+        assert len(undef) == 0 , f"{tname} should be ambient: got {undef}";
+    }
+    assert len(error_msgs) == 0 , f"Expected no errors, got: {error_msgs}";
+    py_code = prog.compile(file_path).gen.py;
+    assert py_code is not None , "Expected Python codegen to succeed";
+    assert "from typing import" in py_code , f"Expected typing import auto-injected, got:\n{py_code[:500]}";
+    for tname in typing_names {
+        assert tname in py_code , f"Expected {tname} in injected typing import";
+    }
+}
+
 test "obj bare assignment to has var name still warns as unused" {
     file_path = os.path.join(FIXTURES, "obj_bare_has_assign.jac");
     prog = JacProgram();


### PR DESCRIPTION
## Summary
- Annotation-only typing names (`Callable`, `Protocol`, `TypeVar`, `Generic`, `Literal`, `ClassVar`, `Annotated`, `Iterable`, `Iterator`, `AsyncIterable`, `AsyncIterator`, `Mapping`, `MutableMapping`, `Sequence`, `MutableSequence`, `Awaitable`, `Coroutine`) resolve in user code without `import from typing { ... }`, mirroring how DOM types and `jac_builtins` are already exposed.
- Single source of truth: [`compiler/type_system/typing_ambient.pyi`](https://github.com/marsninja/jaseci/blob/feat/ambient-typing-names/jac/jaclang/compiler/type_system/typing_ambient.pyi). The `__all__` there drives both the `TypeEvaluator` merge into `builtins_module` and the `PyastGenPass` auto-emission of `from typing import <names>` to the Python preamble (so `typing.get_type_hints`, pydantic, FastAPI, etc. still resolve annotations at runtime).
- Day_planner examples (`basic`, `walkers`, `auth`) migrated from `Any` to `Callable[[], None]` for callback props, demonstrating the pattern and clearing W2001/W1051 warnings caused by unimported `Any`.

## Why this matters
Before: writing `Any` (or `Callable[[], None]`) in `.cl.jac` files produced `W2001: Name 'Any' may be undefined` and cascading `W1051` warnings; importing from `typing` worked at type-check time but produced `import { Callable } from "typing"` in the JS output, which browsers cannot resolve. Users were stuck choosing between noisy warnings and broken bundles.

After: annotation-only typing names are ambient. The user writes `def:pub Header(onLogout: Callable[[], None])` directly. The type checker resolves it via the merged `builtins_module`. The Python codegen auto-injects `from typing import Callable` so runtime introspection still works. The JS codegen strips annotations from function signatures as it always has, so no bogus `typing` import ends up in the bundle.

## Skipped on purpose
- `Any` &mdash; use the lowercase `any` BuiltinType keyword (already a token in `constant.jac`).
- `Optional` / `Union` &mdash; use `X | None` / `X | Y` (PEP 604).
- `Dict` / `List` / `Set` / `FrozenSet` / `Tuple` / `Type` / `DefaultDict` / `OrderedDict` / `Counter` / `Deque` &mdash; use the lowercase built-ins (PEP 585).
- `Final` &mdash; preserved as the existing local stub in `jac_builtins.pyi` (the `existing not imported` guard keeps it). Future cleanup can remove that stub and add `Final` to this set for real `typing.Final` semantics.
- `cast` / `overload` / `runtime_checkable` / `TYPE_CHECKING` / `get_type_hints` / `get_args` / `get_origin` / `no_type_check` &mdash; runtime values, not annotation-only forms. Importing them explicitly keeps runtime intent obvious.

## Files
- New: `jac/jaclang/compiler/type_system/typing_ambient.pyi`
- Modified: `jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac` (load the stub + reuse the existing `read_dunder_all` helper to drive the merge)
- Modified: `jac/jaclang/jac0core/passes/pyast_gen_pass.jac` (added `typing_imports: set[str]` field, `_ambient_typing_names` ClassVar cache, and `_get_ambient_typing_names` classmethod decl)
- Modified: `jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac` (impl of the classmethod, exit_name trigger, exit_module aggregation + preamble emission)
- Modified: `jac/examples/day_planner/{basic,walkers/components,auth/components}/*.jac` (Any &rarr; Callable[[], None])
- New: `jac/tests/compiler/passes/main/fixtures/static_analysis/ambient_typing.jac`
- Modified: `jac/tests/compiler/passes/main/test_static_analysis_pass.jac` (asserts ambient names resolve AND that `from typing import` is auto-injected)

## Test plan
- [x] `pytest tests/ -n 20 --ignore=tests/scale` &mdash; 3280 passed, 57 skipped, 0 failed.
- [x] `jac check` on all three day_planner variants (`basic`, `walkers`, `auth`) &mdash; all pass with zero warnings.
- [x] `jac jac2js` on the migrated `.cl.jac` files &mdash; no `import "typing"` line in the JS.
- [x] `jac jac2py` on a fixture using ambient names &mdash; preamble contains exactly `from typing import Callable, Iterable, Mapping, Protocol, Sequence` (only what was used).
- [x] Browser end-to-end: `jac start basic/main.jac` &mdash; bundled `client.js` contains zero references to `typing`.