### PR TITLE
feat(compiler): type-check walker has reports: list[T] declarations

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5857.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5857.feature.md
@@ -1,0 +1,1 @@
+- **Feature: Type-check walker typed reports**: Walker archetypes can now declare `has reports: list[T] = [];` to type their report channel end-to-end. New `E1112` rejects non-list `reports` shapes and `E1113` flags `report X` whose value type isn't assignable to the declared element type `T`. Untyped walkers keep the inherited `list[Any]` and stay permissive.

--- a/docs/docs/reference/language/walker-responses.md
+++ b/docs/docs/reference/language/walker-responses.md
@@ -36,7 +36,7 @@ with entry {
 
 ### Typing Your Reports
 
-By default every walker has `reports: list[any]` -- it accepts any value. You can declare the type explicitly with `has reports` to get compile-time checking on your `report` statements:
+By default every walker has `reports: list[any]` -- it accepts any value. Declaring `has reports: list[T]` is a single-source-of-truth contract: `report X` on the write side and `(spawn W).reports[i]` on the read side both type-check against the same `T`.
 
 ```jac
 node Task {
@@ -58,7 +58,10 @@ with entry {
 }
 ```
 
-When `has reports` is declared, the type checker verifies that every `report` statement in the walker produces a value compatible with the element type of the list. If you `report "oops"` inside `ListTasks` above, the checker flags it as a type error.
+When `has reports` is declared, the type checker enforces two rules:
+
+1. The declaration itself must be a list type. `has reports: int = 0;` is rejected -- `reports` is the walker's report channel, not arbitrary state, so it must be `list[T]` for some `T`.
+2. Every `report` statement in the walker body must produce a value compatible with the element type `T`. If you `report "oops"` inside `ListTasks` above, the checker flags it as a type error.
 
 If you omit the declaration, the walker behaves exactly as before -- `reports` is `list[any]` and any value can be reported.
 

--- a/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
@@ -724,6 +724,10 @@ impl TypeCheckPass.exit_has_var(self: TypeCheckPass, nd: uni.HasVar) -> None {
         if nd.type_tag and nd.type_tag.tag {
             self._check_bare_generic(nd.type_tag.tag, declared_type);
         }
+        # Walker-specific: `has reports` is the typed view of the walker's
+        # report channel. Require a list shape so `report X` (write side)
+        # and `(spawn W).reports` (read side) share a single element type.
+        self._check_walker_reports_shape(nd, declared_type);
         # If there's an initializer, check that its type is compatible
         # with the declared type (e.g., bad1: int = unknown_val;).
         if nd.value is not None and nd.type is not None {
@@ -738,6 +742,85 @@ impl TypeCheckPass.exit_has_var(self: TypeCheckPass, nd: uni.HasVar) -> None {
             }
         }
     }
+}
+
+"""Validate that `has reports` on a walker archetype is a list type.
+
+Untyped/inherited `reports: list[Any]` (from the builtin `Walker` class)
+is unaffected — this check only fires when the user *explicitly* shadows
+`reports` with a concrete shape on a walker archetype.
+"""
+impl TypeCheckPass._check_walker_reports_shape(
+    self: TypeCheckPass, nd: uni.HasVar, declared_type: object
+) -> None {
+    import from jaclang.compiler.type_system { types }
+    if nd.name.value != "reports" {
+        return;
+    }
+    arch = nd.parent.parent if isinstance(nd.parent, uni.ArchHas) else None;
+    if isinstance(arch, uni.ImplDef) and isinstance(arch.decl_link, uni.Archetype) {
+        arch = arch.decl_link;
+    }
+    if not isinstance(arch, uni.Archetype) {
+        return;
+    }
+    if arch.arch_type.value != "walker" {
+        return;
+    }
+    # Don't pile errors on top of upstream type-resolution failures.
+    if isinstance(declared_type, types.UnknownType) {
+        return;
+    }
+    if isinstance(declared_type, types.ClassType) {
+        if declared_type.is_any_type() or declared_type.is_builtin("list") {
+            return;
+        }
+    }
+    self.emit(E1112, node_override=nd, type=str(declared_type));
+}
+
+"""Find the element type of the enclosing walker's declared `has reports: list[T]`.
+
+Returns None when (a) there is no enclosing walker, (b) the walker doesn't
+locally declare `reports`, or (c) the declared shape isn't `list[T]` with a
+concrete element type. Inherited `list[Any]` from the builtin `Walker`
+returns None too — `Any` already permits everything via assign_type, so
+there's nothing to enforce.
+"""
+impl TypeCheckPass._enclosing_walker_report_elem_type(
+    self: TypeCheckPass, nd: uni.UniNode
+) -> object {
+    import from jaclang.compiler.type_system { types }
+    arch = nd.find_parent_of_type(uni.Archetype);
+    if arch is None {
+        impl_def = nd.find_parent_of_type(uni.ImplDef);
+        if impl_def is not None and isinstance(impl_def.decl_link, uni.Archetype) {
+            arch = impl_def.decl_link;
+        }
+    }
+    if not isinstance(arch, uni.Archetype) or arch.arch_type.value != "walker" {
+        return None;
+    }
+    for has_var in arch.get_has_vars() {
+        if has_var.name.value != "reports" {
+            continue;
+        }
+        if has_var.sym is None {
+            return None;
+        }
+        declared = self.evaluator.get_type_of_symbol(has_var.sym);
+        if (
+            isinstance(declared, types.ClassType)
+            and declared.is_builtin("list")
+            and declared.private
+            and declared.private.type_args
+            and len(declared.private.type_args) >= 1
+        ) {
+            return declared.private.type_args[0];
+        }
+        return None;
+    }
+    return None;
 }
 
 """Set type on for loop iteration variable and check iterability."""
@@ -962,9 +1045,25 @@ impl TypeCheckPass.exit_visit_stmt(self: TypeCheckPass, nd: uni.VisitStmt) -> No
     }
 }
 
-"""Type-check report statement expression."""
+"""Type-check report statement expression against the enclosing walker's
+declared `has reports: list[T]` element type.
+
+If the walker doesn't declare a typed `reports` shape, fall back to the
+inherited `list[Any]` and emit no diagnostic — `Any` already permits
+anything. The check only fires when the walker has opted in by writing
+`has reports: list[T]`.
+"""
 impl TypeCheckPass.exit_report_stmt(self: TypeCheckPass, nd: uni.ReportStmt) -> None {
-    self.evaluator.get_type_of_expression(nd.expr);
+    expr_type = self.evaluator.get_type_of_expression(nd.expr);
+    elem_type = self._enclosing_walker_report_elem_type(nd);
+    if elem_type is None {
+        return;
+    }
+    if not self.evaluator.assign_type(expr_type, elem_type) {
+        self.emit(
+            E1113, node_override=nd, actual=str(expr_type), expected=str(elem_type)
+        );
+    }
 }
 
 """Validate postinit bodies assign to all 'by postinit' fields."""

--- a/jac/jaclang/compiler/passes/main/type_checker_pass.jac
+++ b/jac/jaclang/compiler/passes/main/type_checker_pass.jac
@@ -29,6 +29,8 @@ import from jaclang.jac0core.diagnostics {
     E1093,
     E1094,
     E1095,
+    E1112,
+    E1113,
     W1036,
     W2014,
     E2015
@@ -77,4 +79,12 @@ class TypeCheckPass(UniPass) {
     def _check_bare_generic(
         self: TypeCheckPass, ann_node: uni.UniNode, ty: object
     ) -> None;
+
+    def _check_walker_reports_shape(
+        self: TypeCheckPass, nd: uni.HasVar, declared_type: object
+    ) -> None;
+
+    def _enclosing_walker_report_elem_type(
+        self: TypeCheckPass, nd: uni.UniNode
+    ) -> object;
 }

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -475,6 +475,16 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          Category.TYPE,
          "Right operand of \"{op}\" must support \"__contains__\"; \"{type}\" does not"
      ),
+     # Walker reports declaration / usage
+     E1112 = _err(
+         "E1112",
+         Category.TYPE,
+         "Walker `reports` field must be a list type, got \"{type}\"",
+         "Declare it as `has reports: list[T] = [];` so that `report X` and `(spawn W).reports` are typed against `T`."
+     ),
+     E1113 = _err(
+         "E1113", Category.TYPE, "Cannot report \"{actual}\", expected \"{expected}\""
+     ),
      W1050 = _warn("W1050", Category.TYPE, "Unknown intrinsic JSX element '<{tag}>'"),
      W1051 = _warn(
          "W1051",

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_walker_typed_reports.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_walker_typed_reports.jac
@@ -1,0 +1,28 @@
+"""Walker `has reports: list[T]` should drive type-checking of:
+  1. The shape of the declaration itself (must be a list type).
+  2. The element type of every `report X` statement in the walker body.
+"""
+
+obj Task {
+    has title: str = "";
+}
+
+walker GoodWalker {
+    has reports: list[Task] = [];
+
+    can with entry {
+        report Task(title="hi");   # OK: Task is the declared element type
+    }
+}
+
+walker MismatchedReport {
+    has reports: list[Task] = [];
+
+    can with entry {
+        report 42;                 # ERROR: int is not assignable to Task
+    }
+}
+
+walker BadShape {
+    has reports: int = 0;          # ERROR: reports must be a list type
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -4216,6 +4216,41 @@ test "generator_yield_return_type_check" {
     );
 }
 
+test "walker_typed_reports_validation" {
+    # `has reports: list[T]` on a walker should:
+    #   1. Reject non-list shapes (E1112).
+    #   2. Type-check `report X` against the element type T (E1113).
+    path = os.path.join(CHECKER_FIXTURES, "checker_walker_typed_reports.jac");
+    program = JacProgram();
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+    e1112 = [
+        e
+        for e in program.errors_had
+        if e.code and e.code.code == "E1112"
+    ];
+    e1113 = [
+        e
+        for e in program.errors_had
+        if e.code and e.code.code == "E1113"
+    ];
+    assert len(e1112) == 1 , f"Expected 1 E1112 (non-list reports shape), got {len(
+        e1112
+    )}:\n" + "\n---\n".join(e.pretty_print() for e in e1112);
+    assert len(e1113) == 1 , f"Expected 1 E1113 (mismatched report element), got {len(
+        e1113
+    )}:\n" + "\n---\n".join(e.pretty_print() for e in e1113);
+    # No spurious errors on the GoodWalker case.
+    other = [
+        e
+        for e in program.errors_had
+        if e.code and e.code.code not in ("E1112", "E1113")
+    ];
+    assert len(other) == 0 , f"Expected no other errors, got {len(other)}:\n" + "\n---\n".join(
+        e.pretty_print() for e in other
+    );
+}
+
 test "isinstance_and_narrowing" {
     # isinstance(x, T) in LHS of AND should narrow x to T for RHS operands.
     path = os.path.join(CHECKER_FIXTURES, "checker_isinstance_and_narrowing.jac");


### PR DESCRIPTION
## Summary

- Walker archetypes can now opt into a typed report channel by writing `has reports: list[T] = [];`. The type checker validates the shape (`E1112` if not `list[...]`) and verifies every `report X` against the declared element type `T` (`E1113`).
- Untyped walkers keep the inherited `Walker.reports: list[Any]` from the builtin stub, so existing code is unchanged — the strict checks fire only when a walker has explicitly opted in.
- Read-side `(spawn W).reports[0]` typing already worked via MRO. This change closes the loop on the write side and on the declaration shape itself, so a typed walker has a single end-to-end element type.

## Why

`Walker.reports` was `list[Any]`, so any value flowed through `(spawn W).reports[...]` and silently widened the consumer's locals (e.g. `tasks: list[Task]` becoming `list[Any]` after a comprehension that mixed in a reported value). Letting the user pin the channel to `list[T]` and enforcing it on both ends gives Jac the stronger-than-Python typing it leans toward without breaking any existing untyped code.

## Test plan

- [x] New fixture `tests/compiler/passes/main/fixtures/checker/checker_walker_typed_reports.jac` exercises the GoodWalker / mismatched-report / non-list-shape cases.
- [x] New test `walker_typed_reports_validation` asserts exactly 1 `E1112` and 1 `E1113` and no other errors.
- [x] Full `tests/compiler/passes/main/test_checker_pass.jac` suite (202 tests) passes.
- [x] Full `tests/language/test_language.jac` suite (88 tests) passes.
- [x] `jac check jac/examples/day_planner/walkers/components/TasksPanel.cl.jac` still passes (untyped-reports walkers unaffected).