### PR TITLE
docs: align reference + tutorials with ambient typing names

### DIFF
--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -334,6 +334,32 @@ if typing.TYPE_CHECKING:
 
 If you later add runtime usage like `MyClass()`, the compiler automatically promotes it back to a regular import. No manual `if TYPE_CHECKING` blocks are needed in Jac.
 
+#### Ambient Typing Names
+
+A curated set of annotation-only names from `typing` resolves in user code without an explicit import:
+
+`Callable`, `Protocol`, `TypeVar`, `Generic`, `Literal`, `ClassVar`, `Annotated`, `Iterable`, `Iterator`, `AsyncIterable`, `AsyncIterator`, `Mapping`, `MutableMapping`, `Sequence`, `MutableSequence`, `Awaitable`, `Coroutine`.
+
+```jac
+def:pub apply(func: Callable[[int, int], int], x: int, y: int) -> int {
+    return func(x, y);
+}
+```
+
+The Python codegen still emits `from typing import Callable` to the generated module preamble, so runtime introspection (`typing.get_type_hints`, pydantic, FastAPI) keeps working. The JS codegen strips annotations from function signatures, so no `typing` import lands in the bundle.
+
+Names skipped on purpose:
+
+| Don't write | Use instead |
+|-------------|-------------|
+| `Any` | the `any` keyword |
+| `Optional[X]` | `X \| None` |
+| `Union[X, Y]` | `X \| Y` |
+| `List[X]`, `Dict[K, V]`, `Set[X]`, `FrozenSet[X]`, `Tuple[X, ...]`, `Type[X]` | the lowercase built-ins (PEP 585) |
+| `DefaultDict`, `OrderedDict`, `Counter`, `Deque` | the `collections` equivalents |
+
+Runtime values like `cast`, `overload`, `runtime_checkable`, `TYPE_CHECKING`, `get_type_hints`, `get_args`, `get_origin`, and `no_type_check` are not ambient -- import them explicitly when needed.
+
 ### 3 Generic Types
 
 Jac will support generic type parameters using Python-style syntax (coming soon):

--- a/docs/docs/reference/persistence.md
+++ b/docs/docs/reference/persistence.md
@@ -103,9 +103,9 @@ Handled by the **coercion table**. `Serializer.coerce(value, target_type)` runs 
 | `str` | `UUID` | `UUID(value)` |
 | value | `Enum` | by value, falls back to by-name lookup |
 | `list` ↔ `tuple` | each other | shallow conversion |
-| `None` | `Optional[T]` | passes through; non-`None` coerces against `T` |
+| `None` | `T \| None` | passes through; non-`None` coerces against `T` |
 
-If a field declared as `Union[A, B, C]`, the coercer tries each variant in order and accepts the first that succeeds.
+If a field is declared as `A \| B \| C`, the coercer tries each variant in order and accepts the first that succeeds.
 
 When coercion **fails** (e.g. `str("abc")` → `int`), the raw stored value is kept, a debug-level log is emitted, and the anchor still loads. Downstream code that uses the field will see the wrong type and may fail at use site -- but no data is lost. (This bias toward "load with bad value" over "block load" is deliberate; you can always inspect the row with `jac db quarantine show` if you've forced it into quarantine via stricter validation, but the default is to keep the data alive.)
 

--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -1876,8 +1876,6 @@ byLLM validates that responses match the declared return type, coercing when pos
 ??? example "Resume Parser"
 
     ```jac
-    import from typing { Optional }
-
     obj Education {
         has degree: str;
         has institution: str;
@@ -1894,7 +1892,7 @@ byLLM validates that responses match the declared return type, coercing when pos
     obj Resume {
         has name: str;
         has email: str;
-        has phone: Optional[str];
+        has phone: str | None;
         has skills: list[str];
         has education: list[Education];
         has experience: list[Experience];

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -65,7 +65,6 @@ import sys, json;
 import datetime as dt;
 
 # From import
-import from typing { List, Dict, Optional }
 import from math { sqrt, pi, log as logarithm }
 
 # Relative imports

--- a/docs/docs/tutorials/ai/structured-outputs.md
+++ b/docs/docs/tutorials/ai/structured-outputs.md
@@ -213,12 +213,10 @@ Found 4 tasks:
 ## Optional Fields
 
 ```jac
-import from typing { Optional }
-
 obj Contact {
     has name: str;
     has email: str;
-    has phone: Optional[str] = None;  # May not be present
+    has phone: str | None = None;  # May not be present
 }
 
 def extract_contact(text: str) -> Contact by llm();
@@ -240,8 +238,6 @@ with entry {
 ## Complex Example: Resume Parser
 
 ```jac
-import from typing { Optional }
-
 obj Education {
     has degree: str;
     has institution: str;
@@ -258,7 +254,7 @@ obj Experience {
 obj Resume {
     has name: str;
     has email: str;
-    has phone: Optional[str];
+    has phone: str | None;
     has skills: list[str];
     has education: list[Education];
     has experience: list[Experience];
@@ -399,7 +395,7 @@ If the LLM returns invalid types, byLLM will:
 | `Enum` | One of fixed choices |
 | `obj` | Structured data |
 | `list[T]` | Multiple items |
-| `Optional[T]` | May be missing |
+| `T \| None` | May be missing |
 | Nested objects | Complex hierarchies |
 
 ---

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -376,7 +376,6 @@ with entry {
 
 ```jac
 import from collections { Counter, defaultdict }
-import from typing { Optional, List }
 
 with entry {
     counts = Counter(["a", "b", "a", "c", "a"]);


### PR DESCRIPTION
## Summary
- Adds an **Ambient Typing Names** subsection to the Foundation reference, listing the 17 annotation-only names from `typing` (`Callable`, `Protocol`, `TypeVar`, `Generic`, `Literal`, `ClassVar`, `Annotated`, `Iterable`, `Iterator`, `AsyncIterable`, `AsyncIterator`, `Mapping`, `MutableMapping`, `Sequence`, `MutableSequence`, `Awaitable`, `Coroutine`) that resolve without an explicit import after #5854, plus a "use this instead" table for `Any`, `Optional`, `Union`, `List`, `Dict`, etc.
- Cleans up example code in `reference/plugins/jac-client.md`, `reference/plugins/byllm.md`, `tutorials/language/basics.md`, and `tutorials/ai/structured-outputs.md` that still imported now-ambient names or used `Optional[T]` instead of `T | None`.
- Updates the `reference/persistence.md` coercion table and the `structured-outputs.md` Key Takeaways table to use the modern PEP 604 spelling.

## Why
After #5854 a curated set of typing names is ambient and #5856 will warn (`W1103`) on redundant `import from typing { ... }` of those names. The docs still showed the old spellings, so users following them would either be told to write code that emits warnings or be steered away from the ambient pattern entirely.

## Files changed
- `docs/docs/reference/language/foundation.md` (new subsection)
- `docs/docs/reference/persistence.md`
- `docs/docs/reference/plugins/byllm.md`
- `docs/docs/reference/plugins/jac-client.md`
- `docs/docs/tutorials/ai/structured-outputs.md`
- `docs/docs/tutorials/language/basics.md`

## Out of scope (intentional)
- `reference/language/library-mode.md` keeps `from typing import Optional` -- that block is pure Python, not Jac.
- The `import typing` / `if typing.TYPE_CHECKING:` references in `python-integration.md`, `foundation.md` (existing section), and `breaking-changes.md` describe the compiler's *generated Python output* for the auto-`TYPE_CHECKING` optimization and stay accurate.
- A cross-reference to `W1103`/`W1104` in `reference/diagnostics.md` is held back until those warning rows actually exist in the diagnostics table.

## Test plan
- [ ] `mkdocs serve` from `docs/` and visually inspect the Foundation, persistence, byLLM, jac-client, basics, and structured-outputs pages.
- [ ] `jac check` the inline Jac snippets touched above (Resume Parser, Contact, Counter example) compiles cleanly with no `W1103` and no `W2001`.