### PR TITLE
[codex] Fix JavaScript kwargs lowering

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5866.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5866.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: JavaScript keyword argument lowering**: Corrected ECMAScript generation for keyword arguments, defaults, method calls, and `**kwargs` spreads.

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -175,6 +175,12 @@ obj SpawnCallParts {
         target: SpawnTargetInfo;
 }
 
+"""Resolved function-call argument slot."""
+obj CallArgSlot {
+    has name: (str | None),
+        value: (es.Expression | es.SpreadElement | None);
+}
+
 """Jac to ECMAScript AST transpilation pass."""
 obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def before_pass -> None;
@@ -299,6 +305,36 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def _collect_pattern_names(target: uni.UniNode) -> list[tuple[(str, uni.Name)]];
     def _is_name_first_definition(name_node: uni.Name) -> bool;
     def exit_assignment(nd: uni.Assignment) -> None;
+    def _resolve_source_module(nd: uni.Import) -> (uni.Module | None);
+    def _ability_from_symbol(sym: (uni.Symbol | None)) -> (uni.Ability | None);
+    def _resolve_sv_import_ability(name: str) -> (uni.Ability | None);
+    def _resolve_call_ability(nd: uni.FuncCall) -> (uni.Ability | None);
+    def _param_names_from_ability(ability_node: uni.Ability) -> list[str];
+    def _resolve_call_arg_slots(
+        nd: uni.FuncCall,
+        args: list[(es.Expression | es.SpreadElement)],
+        props: list[(es.Property | es.SpreadElement)],
+        param_names: list[str],
+        func_name: str,
+        spread_read_source: (es.Expression | None)
+    ) -> list[CallArgSlot];
+
+    def _call_args_from_slots(
+        slots: list[CallArgSlot]
+    ) -> (list[(es.Expression | es.SpreadElement)] | None);
+
+    def _kwargs_spread_arg(
+        props: list[(es.Property | es.SpreadElement)], nd: uni.FuncCall
+    ) -> (es.Expression | None);
+
+    def _kwargs_spread_needs_temp(
+        props: list[(es.Property | es.SpreadElement)]
+    ) -> bool;
+
+    def _wrap_with_kwargs_temp(
+        expr: es.Expression, spread_arg: es.Expression, nd: uni.FuncCall
+    ) -> es.Expression;
+
     def exit_func_call(nd: uni.FuncCall) -> None;
     def exit_index_slice(nd: uni.IndexSlice) -> None;
     def exit_special_var_ref(nd: uni.SpecialVarRef) -> None;

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -958,7 +958,9 @@ impl EsastGenPass._resolve_sv_import_ability(name: str) -> (uni.Ability | None) 
     for imp in self.get_main_mod().get_all_sub_nodes(uni.Import) {
         if imp.code_context == CodeContext.CLIENT
         or not imp.from_loc
-        or not imp.items {
+        or not imp.items
+        or imp._source_context_token() is None
+        or imp._source_context_token().name != Tok.KW_SERVER {
             continue;
         }
         for item in imp.items {
@@ -3526,7 +3528,11 @@ impl EsastGenPass.exit_archetype(nd: uni.Archetype) -> None {
 """Process import statement."""
 impl EsastGenPass.exit_import(nd: uni.Import) -> None {
     # Server-side import (sv keyword) - generate stubs for def:pub functions
-    if nd.code_context != CodeContext.CLIENT {
+    if (
+        nd.code_context != CodeContext.CLIENT
+        and nd._source_context_token() is not None
+        and nd._source_context_token().name == Tok.KW_SERVER
+    ) {
         if (nd.from_loc and nd.items) {
             self._generate_sv_import_stubs(nd);
         }
@@ -5172,7 +5178,12 @@ impl EsastGenPass.exit_node(nd: uni.UniNode) -> None {
         and ((nd.parent is None) or isinstance(nd.parent, uni.Module))
     ) {
         # Allow sv imports to reach exit_import for __jacCallFunction stub generation
-        if not isinstance(nd, (uni.Import, uni.ServerBlock)) {
+        is_sv_import = (
+            isinstance(nd, uni.Import)
+            and nd._source_context_token() is not None
+            and nd._source_context_token().name == Tok.KW_SERVER
+        );
+        if not is_sv_import and not isinstance(nd, uni.ServerBlock) {
             return;
         }
     }
@@ -5197,8 +5208,12 @@ impl EsastGenPass.enter_node(nd: uni.UniNode) -> None {
     ) {
         # Don't prune sv imports or sv blocks - they need to reach
         # exit_import so we can generate __jacCallFunction stubs
-        is_sv_import = isinstance(nd, (uni.Import, uni.ServerBlock));
-        if not is_sv_import {
+        is_sv_import = (
+            isinstance(nd, uni.Import)
+            and nd._source_context_token() is not None
+            and nd._source_context_token().name == Tok.KW_SERVER
+        );
+        if not is_sv_import and not isinstance(nd, uni.ServerBlock) {
             self.prune();
             return;
         }

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -913,6 +913,319 @@ impl EsastGenPass.exit_index_slice(nd: uni.IndexSlice) -> None {
     }
 }
 
+"""Resolve an import's source module in both production and type-check paths."""
+impl EsastGenPass._resolve_source_module(nd: uni.Import) -> (uni.Module | None) {
+    if not nd.from_loc {
+        return None;
+    }
+    import from pathlib { Path }
+    resolved_path = nd.from_loc.resolve_relative_path();
+    abs_path = str(Path(resolved_path).resolve());
+    source_mod = self.prog.mod.hub.get(resolved_path)
+    or self.prog.mod.hub.get(abs_path);
+    if source_mod {
+        return source_mod;
+    }
+    if Path(resolved_path).exists() {
+        source_mod = self.prog.compile(
+            resolved_path, no_cgen=True, type_check=False, symtab_ir_only=True
+        );
+        self.prog.mod.hub[abs_path] = source_mod;
+        return source_mod;
+    }
+    return None;
+}
+
+"""Return the ability node represented by a symbol definition."""
+impl EsastGenPass._ability_from_symbol(
+    sym: (uni.Symbol | None)
+) -> (uni.Ability | None) {
+    if not sym or not sym.defn {
+        return None;
+    }
+    defn_node = sym.defn[0];
+    if isinstance(defn_node, uni.Ability) {
+        return defn_node;
+    }
+    if defn_node.parent and isinstance(defn_node.parent, uni.Ability) {
+        return defn_node.parent;
+    }
+    return None;
+}
+
+"""Resolve an sv-imported function to its source ability."""
+impl EsastGenPass._resolve_sv_import_ability(name: str) -> (uni.Ability | None) {
+    for imp in self.get_main_mod().get_all_sub_nodes(uni.Import) {
+        if imp.code_context == CodeContext.CLIENT
+        or not imp.from_loc
+        or not imp.items {
+            continue;
+        }
+        for item in imp.items {
+            if not isinstance(item, uni.ModuleItem)
+            or not isinstance(item.name, uni.Name) {
+                continue;
+            }
+            local_name = item.alias.sym_name if item.alias else item.name.sym_name;
+            if local_name != name {
+                continue;
+            }
+            source_mod = self._resolve_source_module(imp);
+            if not source_mod {
+                return None;
+            }
+            return self._ability_from_symbol(source_mod.lookup(item.name.sym_name));
+        }
+    }
+    return None;
+}
+
+"""Resolve the statically known ability targeted by a function call."""
+impl EsastGenPass._resolve_call_ability(nd: uni.FuncCall) -> (uni.Ability | None) {
+    if isinstance(nd.target, uni.Name) {
+        target_sym = nd.target.sym;
+        if not target_sym and nd.target.sym_tab {
+            target_sym = nd.target.sym_tab.lookup(nd.target.sym_name, deep=True);
+        }
+        ability_node = self._ability_from_symbol(target_sym);
+        if ability_node {
+            return ability_node;
+        }
+        return self._resolve_sv_import_ability(nd.target.sym_name);
+    }
+    if isinstance(nd.target, uni.AtomTrailer)
+    and isinstance(nd.target.right, uni.Name) {
+        target_sym = nd.target.right.sym;
+        if not target_sym {
+            try {
+                _te = self.prog.get_type_evaluator();
+                if _te {
+                    _te.get_type_of_expression(nd.target);
+                    target_sym = nd.target.right.sym;
+                }
+            } except Exception {
+                target_sym = None;
+            }
+        }
+        return self._ability_from_symbol(target_sym);
+    }
+    return None;
+}
+
+"""Extract normal positional parameter names from an ability."""
+impl EsastGenPass._param_names_from_ability(ability_node: uni.Ability) -> list[str] {
+    if not isinstance(ability_node.signature, uni.FuncSignature) {
+        return [];
+    }
+    sig = ability_node.signature;
+    names: list[str] = [];
+    for p in sig.posonly_params {
+        names.append(p.name.sym_name);
+    }
+    if sig.params {
+        for p in sig.params {
+            names.append(p.name.sym_name);
+        }
+    }
+    for p in sig.kwonlyargs {
+        names.append(p.name.sym_name);
+    }
+    return names;
+}
+
+"""Bind generated positional/keyword args to known parameter slots."""
+impl EsastGenPass._resolve_call_arg_slots(
+    nd: uni.FuncCall,
+    args: list[(es.Expression | es.SpreadElement)],
+    props: list[(es.Property | es.SpreadElement)],
+    param_names: list[str],
+    func_name: str,
+    spread_read_source: (es.Expression | None)
+) -> list[CallArgSlot] {
+    by_name: dict[str, (es.Expression | es.SpreadElement)] = {};
+    extras: list[CallArgSlot] = [];
+    spread_sources: list[es.Expression] = [];
+    seen_names: set[str] = set();
+    for (i, arg) in enumerate(args) {
+        if isinstance(arg, es.SpreadElement) {
+            extras.append(CallArgSlot(name=None, value=arg));
+            continue;
+        }
+        if i < len(param_names) {
+            pname = param_names[i];
+            seen_names.add(pname);
+            by_name[pname] = arg;
+        } else {
+            extras.append(CallArgSlot(name=None, value=arg));
+        }
+    }
+    for kw in props {
+        if isinstance(kw, es.SpreadElement) {
+            spread_sources.append(kw.argument);
+            continue;
+        }
+        kw_name = '';
+        if isinstance(kw.key, es.Identifier) {
+            kw_name = kw.key.name;
+        } elif isinstance(kw.key, es.Literal) {
+            kw_name = str(kw.key.value);
+        }
+        if not kw_name {
+            extras.append(
+                CallArgSlot(
+                    name=None,
+                    value=self.sync_loc(
+                        es.SpreadElement(argument=kw.value), jac_node=nd
+                    )
+                )
+            );
+            continue;
+        }
+        if kw_name in seen_names {
+            self.emit(E5080, node_override=nd, name=kw_name, func=func_name);
+        }
+        seen_names.add(kw_name);
+        by_name[kw_name] = kw.value;
+    }
+    resolved: list[CallArgSlot] = [];
+    for pname in param_names {
+        if pname in by_name {
+            resolved.append(CallArgSlot(name=pname, value=by_name[pname]));
+        } elif spread_sources {
+            spread_source = spread_read_source;
+            if spread_source is None {
+                spread_source = spread_sources[0]
+                    if len(spread_sources) == 1
+                    else self.sync_loc(
+                        es.ObjectExpression(
+                            properties=[
+                                self.sync_loc(
+                                    es.SpreadElement(argument=src), jac_node=nd
+                                ) for src in spread_sources
+                            ]
+                        ),
+                        jac_node=nd
+                    );
+            }
+            resolved.append(
+                CallArgSlot(
+                    name=pname,
+                    value=self.sync_loc(
+                        es.MemberExpression(
+                            object=spread_source,
+                            property=self.sync_loc(
+                                es.Literal(value=pname), jac_node=nd
+                            ),
+                            computed=True
+                        ),
+                        jac_node=nd
+                    )
+                )
+            );
+        } else {
+            resolved.append(CallArgSlot(name=pname, value=None));
+        }
+    }
+    resolved.extend(extras);
+    return resolved;
+}
+
+"""Convert resolved slots to a normal ordered JS argument list."""
+impl EsastGenPass._call_args_from_slots(
+    slots: list[CallArgSlot]
+) -> (list[(es.Expression | es.SpreadElement)] | None) {
+    call_args: list[(es.Expression | es.SpreadElement)] = [];
+    last_value_idx = -1;
+    for (i, slot) in enumerate(slots) {
+        if slot.value is not None {
+            last_value_idx = i;
+        }
+    }
+    if last_value_idx < 0 {
+        return [];
+    }
+    for (i, slot) in enumerate(slots) {
+        if i > last_value_idx {
+            break;
+        }
+        if slot.value is None {
+            call_args.append(es.Identifier(name='undefined'));
+            continue;
+        }
+        if slot.name is None {
+            call_args.append(slot.value);
+            continue;
+        }
+        call_args.append(slot.value);
+    }
+    return call_args;
+}
+
+"""Build the expression that supplies merged **kwargs values, if any."""
+impl EsastGenPass._kwargs_spread_arg(
+    props: list[(es.Property | es.SpreadElement)], nd: uni.FuncCall
+) -> (es.Expression | None) {
+    sources: list[es.Expression] = [];
+    for prop in props {
+        if isinstance(prop, es.SpreadElement) {
+            sources.append(prop.argument);
+        }
+    }
+    if not sources {
+        return None;
+    }
+    if len(sources) == 1 {
+        return sources[0];
+    }
+    return self.sync_loc(
+        es.ObjectExpression(
+            properties=[
+                self.sync_loc(es.SpreadElement(argument=src), jac_node=nd)
+                for src in sources
+            ]
+        ),
+        jac_node=nd
+    );
+}
+
+"""Return true when **kwargs needs a temp to preserve single evaluation."""
+impl EsastGenPass._kwargs_spread_needs_temp(
+    props: list[(es.Property | es.SpreadElement)]
+) -> bool {
+    sources: list[es.Expression] = [];
+    for prop in props {
+        if isinstance(prop, es.SpreadElement) {
+            sources.append(prop.argument);
+        }
+    }
+    if len(sources) > 1 {
+        return True;
+    }
+    if len(sources) == 1 and not isinstance(sources[0], es.Identifier) {
+        return True;
+    }
+    return False;
+}
+
+"""Wrap an expression in an IIFE that binds merged **kwargs once."""
+impl EsastGenPass._wrap_with_kwargs_temp(
+    expr: es.Expression, spread_arg: es.Expression, nd: uni.FuncCall
+) -> es.Expression {
+    temp_id = self.sync_loc(es.Identifier(name='__jac_kwargs'), jac_node=nd);
+    return self.sync_loc(
+        es.CallExpression(
+            callee=self.sync_loc(
+                es.ArrowFunctionExpression(
+                    params=[temp_id], body=expr, expression=True, async_=False
+                ),
+                jac_node=nd
+            ),
+            arguments=[spread_arg]
+        ),
+        jac_node=nd
+    );
+}
+
 """Process function call."""
 impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
     import from jaclang.compiler.type_system { types as jtypes }
@@ -957,41 +1270,41 @@ impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
     }
     # Check for server function call from client context - transform to __jacCallFunction
     if (nd.in_client_context() and isinstance(nd.target, uni.Name)) {
-        # Symbol may not be linked yet, so look it up directly from the symbol table
-        target_sym = nd.target.sym;
-        if not target_sym and nd.target.sym_tab {
-            target_sym = nd.target.sym_tab.lookup(nd.target.sym_name, deep=True);
-        }
-        if (target_sym and target_sym.defn) {
-            defn_node = target_sym.defn[0];
-            if isinstance(defn_node.parent, uni.Ability) {
-                ability_node = defn_node.parent;
-                # A function is a server function if:
-                # 1. It has code_context = SERVER (or default), AND
-                # 2. It is NOT inside a client context (not nested in cl{}), AND
-                # 3. It is a PUBLIC function (def:pub) - this excludes builtins like print
-                is_server_func = (
-                    ability_node.code_context != CodeContext.CLIENT
-                    and not ability_node.in_client_context()
-                    and ability_node.access is not None
-                    and ability_node.access.tag.name == Tok.KW_PUB
-                );
-                if is_server_func {
-                    func_name = nd.target.sym_name;
-                    # Analyze function body for auto-caching effects
-                    effect_key = f"func:{func_name}";
-                    if effect_key not in self.client_manifest.endpoint_effects {
-                        if ability_node.body and isinstance(ability_node.body, list) {
-                            effects = self._analyze_body_effects(ability_node.body);
-                            self.client_manifest.endpoint_effects[effect_key] = effects;
+        ability_node = self._resolve_call_ability(nd);
+        if ability_node {
+            # A function is a server function if:
+            # 1. It has code_context = SERVER (or default), AND
+            # 2. It is NOT inside a client context (not nested in cl{}), AND
+            # 3. It is a PUBLIC function (def:pub) - this excludes builtins like print
+            is_server_func = (
+                ability_node.code_context != CodeContext.CLIENT
+                and not ability_node.in_client_context()
+                and ability_node.access is not None
+                and ability_node.access.tag.name == Tok.KW_PUB
+            );
+            if is_server_func {
+                func_name = nd.target.sym_name;
+                # Analyze function body for auto-caching effects
+                effect_key = f"func:{func_name}";
+                if effect_key not in self.client_manifest.endpoint_effects {
+                    if ability_node.body and isinstance(ability_node.body, list) {
+                        effects = self._analyze_body_effects(ability_node.body);
+                        self.client_manifest.endpoint_effects[effect_key] = effects;
+                    }
+                }
+                param_names: list[str] = self._param_names_from_ability(ability_node);
+                inline_param_type_map: dict[str, str] = {};
+                inline_ret_type: str = '';
+                if isinstance(ability_node.signature, uni.FuncSignature) {
+                    sig = ability_node.signature;
+                    for p in sig.posonly_params {
+                        if p.type_tag
+                        and p.type_tag.tag
+                        and isinstance(p.type_tag.tag, uni.Name) {
+                            inline_param_type_map[p.name.sym_name] = p.type_tag.tag.value;
                         }
                     }
-                    param_names: list[str] = [];
-                    inline_param_type_map: dict[str, str] = {};
-                    inline_ret_type: str = '';
-                    if isinstance(ability_node.signature, uni.FuncSignature) {
-                        sig = ability_node.signature;
-                        param_names = [p.name.sym_name for p in sig.params];
+                    if sig.params {
                         for p in sig.params {
                             if p.type_tag
                             and p.type_tag.tag
@@ -999,287 +1312,239 @@ impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
                                 inline_param_type_map[p.name.sym_name] = p.type_tag.tag.value;
                             }
                         }
-                        if sig.return_type {
-                            if isinstance(sig.return_type, uni.Name) {
-                                inline_ret_type = sig.return_type.value;
+                    }
+                    for p in sig.kwonlyargs {
+                        if p.type_tag
+                        and p.type_tag.tag
+                        and isinstance(p.type_tag.tag, uni.Name) {
+                            inline_param_type_map[p.name.sym_name] = p.type_tag.tag.value;
+                        }
+                    }
+                    if sig.return_type {
+                        if isinstance(sig.return_type, uni.Name) {
+                            inline_ret_type = sig.return_type.value;
+                        }
+                    }
+                    # Use interop manifest for accurate return type (handles dict, list, etc.)
+                    if self.ir_in.gen.interop_manifest and not inline_ret_type {
+                        for b in self.ir_in.gen.interop_manifest.server_exports_to_client {
+                            if b.name == func_name {
+                                inline_ret_type = b.ret_type;
+                                break;
                             }
                         }
-                        # Use interop manifest for accurate return type (handles dict, list, etc.)
-                        if self.ir_in.gen.interop_manifest and not inline_ret_type {
-                            for b in self.ir_in.gen.interop_manifest.server_exports_to_client {
-                                if b.name == func_name {
-                                    inline_ret_type = b.ret_type;
-                                    break;
-                                }
-                            }
-                        }
                     }
-                    inline_boundary = self.ir_in.gen.interop_manifest.boundary_types
-                        if self.ir_in.gen.interop_manifest
-                        else {};
-                    # ─── Unified call-site argument resolution ─────────────
-                    # Map every call-site argument — positional and kwarg —
-                    # onto the server function's parameter list, producing a
-                    # single ordered ``(name, expr)`` list that drives one
-                    # emission loop below.  This collapses what used to be
-                    # two parallel rebuild passes (issue #5852) and lets us
-                    # detect duplicate-argument collisions cleanly.
-                    #
-                    # Slot semantics:
-                    #   * (name, expr)  — named param; ``__to_wire()`` may
-                    #                      wrap ``expr`` in the emit loop.
-                    #   * (None, spread) — ``*lst`` or ``**d`` spread that
-                    #                       must be preserved in source order
-                    #                       and passed through verbatim.
-                    kwarg_props_unresolved = props;
-                    resolved:
-                        list[tuple[(str | None), (es.Expression | es.SpreadElement)]] = [];
-                    seen_names: set[str] = set();
-                    for (i, arg) in enumerate(args) {
-                        if isinstance(arg, es.SpreadElement) {
-                            resolved.append((None, arg));
-                            continue;
-                        }
-                        if i < len(param_names) {
-                            seen_names.add(param_names[i]);
-                            resolved.append((param_names[i], arg));
-                        }
-                        # Excess positional args are silently dropped here;
-                        # arity is validated by the type-checker pass.
+                }
+                inline_boundary = self.ir_in.gen.interop_manifest.boundary_types
+                    if self.ir_in.gen.interop_manifest
+                    else {};
+                spread_arg = self._kwargs_spread_arg(props, nd);
+                use_kwargs_temp = (
+                    spread_arg is not None and self._kwargs_spread_needs_temp(props)
+                );
+                spread_read_source = self.sync_loc(
+                    es.Identifier(name='__jac_kwargs'), jac_node=nd
+                )
+                    if use_kwargs_temp
+                    else None;
+                slots = self._resolve_call_arg_slots(
+                    nd, args, props, param_names, func_name, spread_read_source
+                );
+                rpc_props: list[(es.Property | es.SpreadElement)] = [];
+                for slot in slots {
+                    if slot.value is None {
+                        continue;
                     }
-                    for kw in kwarg_props_unresolved {
-                        if isinstance(kw, es.SpreadElement) {
-                            resolved.append((None, kw));
-                            continue;
-                        }
-                        kw_name = '';
-                        if isinstance(kw.key, es.Identifier) {
-                            kw_name = kw.key.name;
-                        } elif isinstance(kw.key, es.Literal) {
-                            kw_name = str(kw.key.value);
-                        }
-                        if not kw_name {
-                            # Defensive: unrecognised key shape — preserve
-                            # the value as a spread rather than drop it.
-                            resolved.append(
-                                (
-                                    None,
-                                    self.sync_loc(
-                                        es.SpreadElement(argument=kw.value), jac_node=nd
-                                    )
-                                )
-                            );
-                            continue;
-                        }
-                        if kw_name in seen_names {
-                            self.emit(
-                                E5080, node_override=nd, name=kw_name, func=func_name
-                            );
-                            # Last-write-wins so the emitted JS is at least
-                            # internally consistent; the diagnostic stops
-                            # the build at ``jac check`` time.
-                        }
-                        seen_names.add(kw_name);
-                        resolved.append((kw_name, kw.value));
+                    if slot.name is None {
+                        rpc_props.append(slot.value);
+                        continue;
                     }
-
-                    # ─── Single emission loop ──────────────────────────────
-                    # Apply boundary ``__to_wire()`` wrapping where required
-                    # and build the ObjectExpression that becomes the second
-                    # argument to ``__jacCallFunction``.
-                    props = [];
-                    for (slot_name, slot_expr) in resolved {
-                        if slot_name is None {
-                            props.append(slot_expr);
-                            continue;
-                        }
-                        named_value = cast(es.Expression, slot_expr);
-                        ptype = inline_param_type_map.get(slot_name, '');
-                        if ptype in inline_boundary
-                        and inline_boundary[ptype].kind != "enum" {
-                            named_value = self.sync_loc(
-                                es.CallExpression(
-                                    callee=es.MemberExpression(
-                                        object=named_value,
-                                        property=es.Identifier(name='__to_wire'),
-                                        computed=False
-                                    ),
-                                    arguments=[]
-                                ),
-                                jac_node=nd
-                            );
-                        }
-                        props.append(
-                            self.sync_loc(
-                                es.Property(
-                                    key=self.sync_loc(
-                                        es.Literal(value=slot_name), jac_node=nd
-                                    ),
-                                    value=named_value,
-                                    kind='init',
-                                    method=False,
-                                    shorthand=False,
+                    named_value = cast(es.Expression, slot.value);
+                    ptype = inline_param_type_map.get(slot.name, '');
+                    if ptype in inline_boundary
+                    and inline_boundary[ptype].kind != "enum" {
+                        named_value = self.sync_loc(
+                            es.CallExpression(
+                                callee=es.MemberExpression(
+                                    object=named_value,
+                                    property=es.Identifier(name='__to_wire'),
                                     computed=False
                                 ),
-                                jac_node=nd
-                            )
+                                arguments=[]
+                            ),
+                            jac_node=nd
                         );
                     }
-                    args_obj = self.sync_loc(
-                        es.ObjectExpression(properties=props), jac_node=nd
-                    );
-                    # Generate CallExpression without await - the outer AwaitExpr handles that
-                    result_expr: es.Expression = self.sync_loc(
-                        es.CallExpression(
-                            callee=self.sync_loc(
-                                es.Identifier(name='__jacCallFunction'), jac_node=nd
+                    rpc_props.append(
+                        self.sync_loc(
+                            es.Property(
+                                key=self.sync_loc(
+                                    es.Literal(value=slot.name), jac_node=nd
+                                ),
+                                value=named_value,
+                                kind='init',
+                                method=False,
+                                shorthand=False,
+                                computed=False
                             ),
-                            arguments=[
-                                self.sync_loc(es.Literal(value=func_name), jac_node=nd),
-                                args_obj
-                            ]
+                            jac_node=nd
+                        )
+                    );
+                }
+                args_obj: es.Expression = self.sync_loc(
+                    es.ObjectExpression(properties=rpc_props), jac_node=nd
+                );
+                if use_kwargs_temp and spread_arg is not None {
+                    args_obj = self._wrap_with_kwargs_temp(args_obj, spread_arg, nd);
+                }
+                # Generate CallExpression without await - the outer AwaitExpr handles that
+                result_expr: es.Expression = self.sync_loc(
+                    es.CallExpression(
+                        callee=self.sync_loc(
+                            es.Identifier(name='__jacCallFunction'), jac_node=nd
+                        ),
+                        arguments=[
+                            self.sync_loc(es.Literal(value=func_name), jac_node=nd),
+                            args_obj
+                        ]
+                    ),
+                    jac_node=nd
+                );
+                # Wrap return with __from_wire if return type is a boundary type.
+                # We must await the call BEFORE wrapping with __from_wire
+                # so __from_wire receives the resolved value, not a Promise.
+                if inline_ret_type in inline_boundary
+                and inline_boundary[inline_ret_type].kind != "enum" {
+                    result_expr = self.sync_loc(
+                        es.AwaitExpression(argument=result_expr), jac_node=nd
+                    );
+                    result_expr = self.sync_loc(
+                        es.CallExpression(
+                            callee=es.MemberExpression(
+                                object=es.Identifier(name=inline_ret_type),
+                                property=es.Identifier(name='__from_wire'),
+                                computed=False
+                            ),
+                            arguments=[result_expr]
                         ),
                         jac_node=nd
                     );
-                    # Wrap return with __from_wire if return type is a boundary type.
-                    # We must await the call BEFORE wrapping with __from_wire
-                    # so __from_wire receives the resolved value, not a Promise.
-                    if inline_ret_type in inline_boundary
-                    and inline_boundary[inline_ret_type].kind != "enum" {
+                } elif inline_ret_type.startswith("list[")
+                and inline_ret_type.endswith("]") {
+                    inner = inline_ret_type[5:-1];
+                    if inner in inline_boundary
+                    and inline_boundary[inner].kind != "enum" {
+                        # Wrap in AwaitExpression BEFORE chaining .map()
+                        # so the resolved array (not the Promise) gets mapped.
+                        # The outer exit_await_expr will see this is already
+                        # awaited and produce (await call()).map(...).
                         result_expr = self.sync_loc(
                             es.AwaitExpression(argument=result_expr), jac_node=nd
                         );
                         result_expr = self.sync_loc(
                             es.CallExpression(
                                 callee=es.MemberExpression(
-                                    object=es.Identifier(name=inline_ret_type),
-                                    property=es.Identifier(name='__from_wire'),
+                                    object=result_expr,
+                                    property=es.Identifier(name='map'),
                                     computed=False
                                 ),
-                                arguments=[result_expr]
+                                arguments=[
+                                    es.ArrowFunctionExpression(
+                                        params=[es.Identifier(name='x')],
+                                        body=es.CallExpression(
+                                            callee=es.MemberExpression(
+                                                object=es.Identifier(name=inner),
+                                                property=es.Identifier(
+                                                    name='__from_wire'
+                                                ),
+                                                computed=False
+                                            ),
+                                            arguments=[es.Identifier(name='x')]
+                                        ),
+                                        expression=True,
+                                        async_=False
+                                    )
+                                ]
                             ),
                             jac_node=nd
                         );
-                    } elif inline_ret_type.startswith("list[")
-                    and inline_ret_type.endswith("]") {
-                        inner = inline_ret_type[5:-1];
-                        if inner in inline_boundary
-                        and inline_boundary[inner].kind != "enum" {
-                            # Wrap in AwaitExpression BEFORE chaining .map()
-                            # so the resolved array (not the Promise) gets mapped.
-                            # The outer exit_await_expr will see this is already
-                            # awaited and produce (await call()).map(...).
+                    }
+                } elif inline_ret_type.startswith("dict[")
+                and inline_ret_type.endswith("]") {
+                    dict_params = inline_ret_type[5:-1];
+                    comma_pos = dict_params.find(', ');
+                    if comma_pos >= 0 {
+                        val_type = dict_params[comma_pos + 2:].strip();
+                        if val_type in inline_boundary
+                        and inline_boundary[val_type].kind != "enum" {
+                            # Await before dict hydration
                             result_expr = self.sync_loc(
                                 es.AwaitExpression(argument=result_expr), jac_node=nd
+                            );
+                            entries_call = es.CallExpression(
+                                callee=es.MemberExpression(
+                                    object=es.Identifier(name='Object'),
+                                    property=es.Identifier(name='entries'),
+                                    computed=False
+                                ),
+                                arguments=[result_expr]
+                            );
+                            map_call = es.CallExpression(
+                                callee=es.MemberExpression(
+                                    object=entries_call,
+                                    property=es.Identifier(name='map'),
+                                    computed=False
+                                ),
+                                arguments=[
+                                    es.ArrowFunctionExpression(
+                                        params=[
+                                            es.ArrayPattern(
+                                                elements=[
+                                                    es.Identifier(name='k'),
+                                                    es.Identifier(name='v')
+                                                ]
+                                            )
+                                        ],
+                                        body=es.ArrayExpression(
+                                            elements=[
+                                                es.Identifier(name='k'),
+                                                es.CallExpression(
+                                                    callee=es.MemberExpression(
+                                                        object=es.Identifier(
+                                                            name=val_type
+                                                        ),
+                                                        property=es.Identifier(
+                                                            name='__from_wire'
+                                                        ),
+                                                        computed=False
+                                                    ),
+                                                    arguments=[es.Identifier(name='v')]
+                                                )
+                                            ]
+                                        ),
+                                        expression=True,
+                                        async_=False
+                                    )
+                                ]
                             );
                             result_expr = self.sync_loc(
                                 es.CallExpression(
                                     callee=es.MemberExpression(
-                                        object=result_expr,
-                                        property=es.Identifier(name='map'),
+                                        object=es.Identifier(name='Object'),
+                                        property=es.Identifier(name='fromEntries'),
                                         computed=False
                                     ),
-                                    arguments=[
-                                        es.ArrowFunctionExpression(
-                                            params=[es.Identifier(name='x')],
-                                            body=es.CallExpression(
-                                                callee=es.MemberExpression(
-                                                    object=es.Identifier(name=inner),
-                                                    property=es.Identifier(
-                                                        name='__from_wire'
-                                                    ),
-                                                    computed=False
-                                                ),
-                                                arguments=[es.Identifier(name='x')]
-                                            ),
-                                            expression=True,
-                                            async_=False
-                                        )
-                                    ]
+                                    arguments=[map_call]
                                 ),
                                 jac_node=nd
                             );
                         }
-                    } elif inline_ret_type.startswith("dict[")
-                    and inline_ret_type.endswith("]") {
-                        dict_params = inline_ret_type[5:-1];
-                        comma_pos = dict_params.find(', ');
-                        if comma_pos >= 0 {
-                            val_type = dict_params[comma_pos + 2:].strip();
-                            if val_type in inline_boundary
-                            and inline_boundary[val_type].kind != "enum" {
-                                # Await before dict hydration
-                                result_expr = self.sync_loc(
-                                    es.AwaitExpression(argument=result_expr),
-                                    jac_node=nd
-                                );
-                                entries_call = es.CallExpression(
-                                    callee=es.MemberExpression(
-                                        object=es.Identifier(name='Object'),
-                                        property=es.Identifier(name='entries'),
-                                        computed=False
-                                    ),
-                                    arguments=[result_expr]
-                                );
-                                map_call = es.CallExpression(
-                                    callee=es.MemberExpression(
-                                        object=entries_call,
-                                        property=es.Identifier(name='map'),
-                                        computed=False
-                                    ),
-                                    arguments=[
-                                        es.ArrowFunctionExpression(
-                                            params=[
-                                                es.ArrayPattern(
-                                                    elements=[
-                                                        es.Identifier(name='k'),
-                                                        es.Identifier(name='v')
-                                                    ]
-                                                )
-                                            ],
-                                            body=es.ArrayExpression(
-                                                elements=[
-                                                    es.Identifier(name='k'),
-                                                    es.CallExpression(
-                                                        callee=es.MemberExpression(
-                                                            object=es.Identifier(
-                                                                name=val_type
-                                                            ),
-                                                            property=es.Identifier(
-                                                                name='__from_wire'
-                                                            ),
-                                                            computed=False
-                                                        ),
-                                                        arguments=[
-                                                            es.Identifier(name='v')
-                                                        ]
-                                                    )
-                                                ]
-                                            ),
-                                            expression=True,
-                                            async_=False
-                                        )
-                                    ]
-                                );
-                                result_expr = self.sync_loc(
-                                    es.CallExpression(
-                                        callee=es.MemberExpression(
-                                            object=es.Identifier(name='Object'),
-                                            property=es.Identifier(name='fromEntries'),
-                                            computed=False
-                                        ),
-                                        arguments=[map_call]
-                                    ),
-                                    jac_node=nd
-                                );
-                            }
-                        }
                     }
-                    # Auto-inject __jacCallFunction import if not already done
-                    self._inject_runtime_import('__jacCallFunction', nd);
-                    nd.gen.es_ast = result_expr;
-                    return;
                 }
+                # Auto-inject __jacCallFunction import if not already done
+                self._inject_runtime_import('__jacCallFunction', nd);
+                nd.gen.es_ast = result_expr;
+                return;
             }
         }
     }
@@ -1415,20 +1680,47 @@ impl EsastGenPass.exit_func_call(nd: uni.FuncCall) -> None {
     }
     args_obj = self.sync_loc(es.ObjectExpression(properties=props), jac_node=nd);
     callee_expr = cast(es.Expression, callee);
-    call_args: list[(es.Expression | es.SpreadElement)] = [args_obj] if props else args;
+    call_args: list[(es.Expression | es.SpreadElement)] = args;
+    spread_arg = self._kwargs_spread_arg(props, nd);
+    use_kwargs_temp = spread_arg is not None and self._kwargs_spread_needs_temp(props);
+    spread_read_source = self.sync_loc(es.Identifier(name='__jac_kwargs'), jac_node=nd)
+        if use_kwargs_temp
+        else None;
+    if props {
+        ability_node = self._resolve_call_ability(nd);
+        if ability_node {
+            ordered_args = self._call_args_from_slots(
+                self._resolve_call_arg_slots(
+                    nd,
+                    args,
+                    props,
+                    self._param_names_from_ability(ability_node),
+                    nd.target.sym_name if isinstance(nd.target, uni.Name) else "func",
+                    spread_read_source
+                )
+            );
+            call_args = ordered_args if ordered_args is not None else [args_obj];
+        } else {
+            call_args = [args_obj];
+        }
+    }
     if (
         isinstance(callee_type, jtypes.ClassType)
         and callee_type.is_instantiable()
         and isinstance(callee, es.Expression)
     ) {
-        nd.gen.es_ast = self.sync_loc(
+        result_expr: es.Expression = self.sync_loc(
             es.NewExpression(callee=callee_expr, arguments=call_args), jac_node=nd
         );
     } else {
-        nd.gen.es_ast = self.sync_loc(
+        result_expr = self.sync_loc(
             es.CallExpression(callee=callee_expr, arguments=call_args), jac_node=nd
         );
     }
+    if use_kwargs_temp and spread_arg is not None {
+        result_expr = self._wrap_with_kwargs_temp(result_expr, spread_arg, nd);
+    }
+    nd.gen.es_ast = result_expr;
 }
 
 """Process assignment expression."""
@@ -2828,7 +3120,16 @@ impl EsastGenPass.exit_arch_has(nd: uni.ArchHas) -> None {
 impl EsastGenPass.exit_param_var(nd: uni.ParamVar) -> None {
     param_id = self.sync_loc(es.Identifier(name=nd.name.sym_name), jac_node=nd.name);
     self._register_declaration(param_id.name);
-    nd.gen.es_ast = param_id;
+    if nd.value and nd.value.gen.es_ast {
+        nd.gen.es_ast = self.sync_loc(
+            es.AssignmentPattern(
+                left=param_id, right=cast(es.Expression, nd.value.gen.es_ast)
+            ),
+            jac_node=nd
+        );
+    } else {
+        nd.gen.es_ast = param_id;
+    }
 }
 
 """Process function signature."""
@@ -2887,12 +3188,17 @@ impl EsastGenPass.exit_ability(nd: uni.Ability) -> None {
         ) {
             params.append(es.Identifier(name="props"));
             for param in nd.signature.params {
+                param_key = self.sync_loc(
+                    es.Identifier(name=param.name.sym_name), jac_node=param.name
+                );
                 destructure_props.append(
                     self.sync_loc(
                         es.AssignmentProperty(
-                            key=cast(es.Expression, param.gen.es_ast),
+                            key=param_key,
                             value=cast(es.Pattern, param.gen.es_ast),
-                            shorthand=True,
+                            shorthand=not isinstance(
+                                param.gen.es_ast, es.AssignmentPattern
+                            ),
                         ),
                         jac_node=param,
                     )
@@ -3331,11 +3637,7 @@ stubs that call __jacCallFunction() to invoke the server over HTTP.
 """
 impl EsastGenPass._generate_sv_import_stubs(nd: uni.Import) -> None {
     # Resolve the source module to look up function signatures
-    source_mod: uni.Module | None = None;
-    if nd.from_loc {
-        resolved_path = nd.from_loc.resolve_relative_path();
-        source_mod = self.prog.mod.hub.get(resolved_path);
-    }
+    source_mod: uni.Module | None = self._resolve_source_module(nd);
     stubs: list[es.Statement] = [];
     for item in nd.items {
         if not isinstance(item, uni.ModuleItem)

--- a/jac/tests/compiler/passes/ecmascript/fixtures/plain_kwargs_client.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/plain_kwargs_client.cl.jac
@@ -1,0 +1,61 @@
+"""Plain client-side kwargs calls should lower by known function signature."""
+
+def add(a: int, b: int) -> int {
+    return a + b;
+}
+
+def add3(a: int, b: int, c: int) -> int {
+    return a + b + c;
+}
+
+def add_defaults(a: int = 1, b: int = 2) -> int {
+    return a + b;
+}
+
+def get_kw -> dict {
+    return {"a": 1, "b": 2, "c": 3};
+}
+
+obj Counter {
+    def bump(amount: int, mul: int) -> int {
+        return amount * mul;
+    }
+}
+
+def:pub index -> JsxElement {
+    has total: int = 0,
+        mixed: int = 0,
+        defaulted: int = 0,
+        spread_total: int = 0,
+        spread_call_total: int = 0,
+        spread_merge_total: int = 0,
+        spread_override_total: int = 0,
+        method_total: int = 0;
+
+    def call_add -> None {
+        total = add(b=10, a=5);
+        mixed = add(1, b=2);
+        defaulted = add_defaults(b=99);
+        kw: dict = {"a": 7, "b": 8};
+        spread_total = add(**kw);
+        kw1: dict = {"a": 1, "b": 2};
+        kw2: dict = {"b": 20, "c": 30};
+        spread_call_total = add3(**get_kw());
+        spread_merge_total = add3(**kw1, **kw2);
+        spread_override_total = add3(**kw1, **kw2, b=99);
+        counter = Counter();
+        method_total = counter.bump(amount=5, mul=3);
+    }
+
+    return
+        <div>
+            <p>{total}</p>
+            <p>{mixed}</p>
+            <p>{defaulted}</p>
+            <p>{spread_total}</p>
+            <p>{spread_call_total}</p>
+            <p>{spread_merge_total}</p>
+            <p>{spread_override_total}</p>
+            <p>{method_total}</p>
+        </div>;
+}

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -5,6 +5,7 @@ Migrated from test_js_generation.py to native Jac test format.
 
 import os;
 import subprocess;
+import sys;
 import tempfile;
 import from pathlib { Path }
 import jaclang;
@@ -67,6 +68,23 @@ def compile_fixture_to_js(fixture_name: str, fixture_dir: str = "") -> str {
     result = es_to_js(es_ast);
     _js_compile_cache[cache_key] = result;
     return result;
+}
+
+"""Compile a fixture through the normal production codegen path."""
+def compile_fixture_to_js_production(fixture_name: str, fixture_dir: str = "") -> str {
+    fixture_path = fixture_name;
+    if not Path(fixture_path).exists() and fixture_dir {
+        fixture_path = os.path.join(fixture_dir, fixture_name);
+    }
+    prog = JacProgram();
+    ir = prog.compile(file_path=fixture_path);
+    assert not prog.errors_had , (
+        f"Compilation errors in {fixture_name}: {[str(e) for e in prog.errors_had]}"
+    );
+    assert ir.gen.js and ir.gen.js.strip() , (
+        f"Production JS codegen produced no output for {fixture_name}"
+    );
+    return ir.gen.js;
 }
 
 """Ensure generated JavaScript has balanced delimiters."""
@@ -263,7 +281,7 @@ test "cli js command outputs js" {
     env["PYTHONPATH"] = f"{project_root}:{existing}" if existing else project_root;
 
     result = subprocess.run(
-        ["python3", "-m", "jaclang.cli.cli", "js", fixture_file_path],
+        [sys.executable, "-m", "jaclang.cli.cli", "js", fixture_file_path],
         capture_output=True,
         text=True,
         env=env,
@@ -283,7 +301,7 @@ test "cl only js command outputs js" {
     env["PYTHONPATH"] = f"{project_root}:{existing}" if existing else project_root;
 
     result = subprocess.run(
-        ["python3", "-m", "jaclang.cli.cli", "js", fixture_file_path, ],
+        [sys.executable, "-m", "jaclang.cli.cli", "js", fixture_file_path, ],
         capture_output=True,
         text=True,
         env=env,
@@ -293,7 +311,7 @@ test "cl only js command outputs js" {
         f"CLI failed to compile cl only file: {result.stderr}"
     );
     assert len(result.stdout) > 0;
-    assert "function greet(name) {" in result.stdout;
+    assert 'function greet(name = "World") {' in result.stdout;
 }
 
 test "empty file generates minimal js" {
@@ -737,10 +755,10 @@ test "sv import kwargs preserve names in jac call function" {
         "Mixed positional/kwarg call must merge both into the args object;\n" + "got:\n" + js_code
     );
 
-    # ``**dict`` spread: ``add_pair(**kw)`` — keys aren't known at compile
-    # time, so the args object must carry an ObjectExpression spread.
-    assert '__jacCallFunction("add_pair", {...kw})' in js_code , (
-        "**dict spread must compile to ObjectExpression spread element;\n" + "got:\n" + js_code
+    # ``**dict`` spread against a known signature can lower to declared
+    # parameter-key reads, avoiding the old single-object positional shape.
+    assert '__jacCallFunction("add_pair", {"a": kw["a"], "b": kw["b"]})' in js_code , (
+        "**dict spread against known signature must compile to keyed parameter reads;\n" + "got:\n" + js_code
     );
 
     # Sanity: the obvious bug-shape — empty args object — must not appear
@@ -753,6 +771,73 @@ test "sv import kwargs preserve names in jac call function" {
     );
 
     assert_balanced_syntax(js_code, fixture);
+}
+
+test "sv import kwargs preserve names in production jac2js path" {
+    fixture = "sv_import_kwargs_client.cl.jac";
+    js_code = compile_fixture_to_js_production(fixture, FIXTURES);
+
+    assert '__jacCallFunction("greet", {"name": input_text})' in js_code , (
+        "Production jac2js path must lower sv-import kwargs directly into the RPC args object;\n" + "got:\n" + js_code
+    );
+    assert "await greet({name: input_text})" not in js_code , (
+        "Production jac2js path must not pass kwargs object into the generated RPC wrapper;\n" + "got:\n" + js_code
+    );
+    assert '__jacCallFunction("greet", {})' not in js_code , (
+        "Production jac2js path must not emit an empty RPC args object for kwargs calls."
+    );
+}
+
+test "plain client kwargs lower to ordered js arguments" {
+    fixture = "plain_kwargs_client.cl.jac";
+    js_code = compile_fixture_to_js_production(fixture, FIXTURES);
+    compact_js = js_code.replace("\n", "").replace(" ", "");
+
+    assert "setTotal(add(5, 10));" in js_code , (
+        "Known Jac function kwargs must lower to ordered JS positional args;\n" + "got:\n" + js_code
+    );
+    assert "setMixed(add(1, 2));" in js_code , (
+        "Mixed positional/kwarg call must preserve positional args and order kwargs by signature;\n" + "got:\n" + js_code
+    );
+    assert "function add_defaults(a = 1, b = 2)" in js_code , (
+        "Jac default parameter values must be preserved in emitted JS function signatures;\n" + "got:\n" + js_code
+    );
+    assert "setDefaulted(add_defaults(undefined, 99));" in js_code , (
+        "Skipping an earlier defaulted param must emit an undefined placeholder, not collapse positions;\n" + "got:\n" + js_code
+    );
+    assert 'setSpread_total(add(kw["a"], kw["b"]));' in js_code , (
+        "Known **kwargs calls must lower to declared-parameter property reads;\n" + "got:\n" + js_code
+    );
+    assert compact_js.count(")(get_kw()))") == 1 , (
+        "Complex **kwargs source must be evaluated exactly once;\n" + "got:\n" + js_code
+    );
+    assert (
+        'setSpread_call_total((__jac_kwargs=>add3(__jac_kwargs["a"],__jac_kwargs["b"],__jac_kwargs["c"]))(get_kw()));' in compact_js
+    ) , (
+        "Known **function_call() spread must lower through a single-evaluation temp IIFE;\n" + "got:\n" + js_code
+    );
+    assert (
+        'setSpread_merge_total((__jac_kwargs=>add3(__jac_kwargs["a"],__jac_kwargs["b"],__jac_kwargs["c"]))({...kw1,...kw2}));' in compact_js
+    ) , (
+        "Multiple **kwargs spreads must merge earlier and later sources before keyed reads;\n" + "got:\n" + js_code
+    );
+    assert (
+        'setSpread_override_total((__jac_kwargs=>add3(__jac_kwargs["a"],99,__jac_kwargs["c"]))({...kw1,...kw2}));' in compact_js
+    ) , (
+        "Explicit kwargs must override **spread values while preserving other merged keys;\n" + "got:\n" + js_code
+    );
+    assert "setMethod_total(counter.bump(5, 3));" in js_code , (
+        "Known method kwargs must lower to ordered JS positional args;\n" + "got:\n" + js_code
+    );
+    assert "add({b: 10, a: 5})" not in js_code , (
+        "Plain kwargs must not be passed as one positional object argument;\n" + "got:\n" + js_code
+    );
+    assert "add_defaults(99)" not in js_code , (
+        "Defaulted kwargs must not collapse missing earlier params;\n" + "got:\n" + js_code
+    );
+    assert "counter.bump({amount: 5, mul: 3})" not in js_code , (
+        "Method kwargs must not be passed as one positional object argument;\n" + "got:\n" + js_code
+    );
 }
 
 test "sv import duplicate kwarg is a compile error" {


### PR DESCRIPTION
## Summary
- Fix ECMAScript codegen for Jac kwargs calls with known signatures.
- Resolve sv-imported functions in production codegen and emit keyed RPC bodies.
- Preserve default parameter values, method kwargs, **kwargs spreads, multi-spread merging, and single evaluation of complex spread sources.

## Root Cause
JS codegen packed kwargs into one object positional arg unless a narrow sv-import/type-check path rewrote it. Known signatures were not used consistently in production codegen, method calls were not resolved, and **kwargs expansion reused spread expressions per slot or only the last source.

## Validation
- `.venv/bin/jac test jac/tests/compiler/passes/ecmascript/test_js_generation.jac`
- `.venv/bin/jac test jac/tests/compiler/test_typed_interop.jac`