### PR TITLE
docs: document strict Any gradual-typing semantics in .jac modules

### DIFF
--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -360,6 +360,62 @@ Names skipped on purpose:
 
 Runtime values like `cast`, `overload`, `runtime_checkable`, `TYPE_CHECKING`, `get_type_hints`, `get_args`, `get_origin`, and `no_type_check` are not ambient -- import them explicitly when needed.
 
+#### The `any` Type and Gradual Typing
+
+`any` is Jac's gradual-typing escape valve. A value typed as `any` can hold anything, and reading from it produces `any`. Jac applies a strict rule about where `any` is allowed to flow inside `.jac` files: it must not silently widen into a declared non-`any` destination.
+
+**The rule.** A value of type `any` cannot be silently assigned to a destination with a declared non-`any`, non-`object` type. The check fires at every site where the destination has a declared type:
+
+- annotated assignment (`x: T = src;`)
+- `has`-var initializer (`has x: T = src;`)
+- function argument (`f(src)` against a declared `param: T`)
+- return statement (`return src` from `def f -> T`)
+- yield expression in a typed generator
+- edge-connection assignment
+
+The check recurses element-wise into containers, so `list[any] -> list[Task]` is rejected the same way `any -> Task` is.
+
+**Two destinations stay permissive:**
+
+1. **Inferred locals.** A binding without an annotation accepts `any` and itself becomes `any`. `x = py_call();` is fine.
+2. **Explicit `any` annotation.** Annotating the destination as `any` opts into permissive flow. `x: any = py_call();` is fine.
+
+`any -> object` and `any -> T` (where `T` is a `TypeVar`) are also permissive, so `print(x)` and generic-bound calls work without ceremony.
+
+!!! note "`.py` and `.pyi` files keep PEP 484 semantics"
+    `Any` propagates freely inside Python modules. The strict rule only fires at the `.jac` consumption site. A typed `.pyi` stub for a Python utility removes the `any` return type at the boundary, so the strict rule never engages downstream.
+
+**Migration patterns.** Two ways to clear a strict-`any` error at a boundary:
+
+| Approach | When to use |
+|----------|-------------|
+| Type the source | The function has a stable signature. Add a `.pyi` stub for a Python utility, a return annotation on a `def`, or a typed `has reports` declaration on a walker. The boundary becomes strongly typed and downstream `.jac` code stays clean. |
+| Accept `any` at the boundary | The source is intentionally untyped. Annotate the receiving local as `any`, then narrow with `isinstance` or `cast` before flowing into typed destinations. |
+
+```jac
+import json;
+
+def parse(text: str) -> any {
+    return json.loads(text);
+}
+
+obj Task { has title: str = ""; }
+
+with entry {
+    # Inferred destination -- `raw` becomes `any`, no error.
+    raw = parse('{"title": "ship"}');
+
+    # Narrow before flowing into a declared type.
+    if isinstance(raw, dict) {
+        title = raw.get("title", "");
+        if isinstance(title, str) {
+            t = Task(title=title);
+            print(t.title);
+        }
+    }
+}
+```
+
 ### 3 Generic Types
 
 Jac will support generic type parameters using Python-style syntax (coming soon):

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -438,6 +438,9 @@ project/
 
 Jac imports Python modules using standard import mechanisms without requiring configuration.
 
+!!! note "Typing across the boundary"
+    Untyped Python return values arrive in Jac as `any`. Jac's gradual-typing rules apply strictly inside `.jac` source: an `any` value cannot be silently assigned into a declared non-`any` destination. Two ways to handle this at a boundary -- ship a `.pyi` stub alongside the Python utility (the import stays strongly typed and downstream Jac code is unchanged), or annotate the receiving local as `any` and narrow with `isinstance` or `cast` before use. See [The `any` Type and Gradual Typing](foundation.md#the-any-type-and-gradual-typing) for the full rule and migration patterns.
+
 ---
 
 #### **Pattern 4: Mostly Python**


### PR DESCRIPTION
## Summary

- Adds a **The `any` Type and Gradual Typing** subsection to `docs/reference/language/foundation.md` explaining the strict-Any rule landed in #5859: where it fires (annotated assignment, `has` initializer, function arg, return, yield, edge-connection assign), container recursion, the permissive escape valves (inferred locals, explicit `any`, `Any -> object`, `Any -> TypeVar`), PEP 484 behavior in `.py`/`.pyi` files, and migration patterns at the Python boundary.
- Cross-links from `docs/reference/language/python-integration.md`'s "Mostly Jac" pattern, where most users encounter this in practice when calling untyped Python utilities from `.jac` source.
- Slotted as a `####` subsection under "Type Annotations" rather than a new top-level `###` to avoid renumbering later sections and breaking the existing cross-references in `osp.md` / `library-mode.md`.

Depends on #5859 — the docs describe behavior introduced there. Best to land after that PR merges.

## Test plan

- [ ] `mkdocs build --strict` resolves the new `#the-any-type-and-gradual-typing` anchor cleanly (verified locally).
- [ ] Visual review of rendered foundation.md section and the python-integration.md admonition.
- [ ] Spot-check that no em-dashes slipped in (pre-commit hook enforces this).