### PR TITLE
docs: expand strict-any coverage and recommend typed walker reports

### DIFF
--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -160,6 +160,90 @@ No code changes are required - the same APIs, configuration, and behavior apply.
 
 ---
 
+### Version 0.14.2
+
+#### 1. Strict `any` Semantics in `.jac` Modules
+
+`.jac` source no longer treats `any` as bidirectionally compatible with concrete types. A value of type `any` cannot be silently assigned to a destination with a declared non-`any`, non-`object` type. The check fires at every site where the destination has a declared type:
+
+- annotated assignment (`x: T = src;`)
+- `has`-var initializer (`has x: T = src;`)
+- function argument (`f(src)` against a declared `param: T`)
+- return statement (`return src` from `def f -> T`)
+- yield expression in a typed generator
+- edge-connection assignment (`a ++>:Edge:val=src`)
+
+The check recurses element-wise into containers, so `list[any] -> list[Task]` is rejected the same way `any -> Task` is.
+
+**Permissive cases that still work without ceremony:**
+
+- Inferred locals: `x = py_call();` keeps `x: any` (no annotation, no error).
+- Explicit `any` annotation: `x: any = py_call();` opts in to permissive flow.
+- `any -> object` and `any -> TypeVar`: needed for `print(x)` and generic-bound calls.
+
+`.py` and `.pyi` files keep PEP 484 semantics -- `Any` propagates freely inside Python modules. The strict rule only fires at the `.jac` consumption site.
+
+**Impact:** Code that flowed `any` into typed locals through a typed annotation now produces a type error. The most common trigger is the default `Walker.reports: list[Any]` channel -- `tasks: list[Task] = result.reports;` now errors.
+
+**Before:**
+
+```jac
+node Task { has title: str; }
+
+walker ListTasks {
+    can collect with Root entry {
+        report [-->][?:Task];
+    }
+}
+
+with entry {
+    result = root spawn ListTasks();
+    tasks: list[Task] = result.reports[0];   # silently widened pre-0.14.2,
+                                             # now: Cannot assign list[any] to list[Task]
+}
+```
+
+**After (preferred): type the source.** Declare `has reports: list[T]` on the walker so the report channel is typed end-to-end:
+
+```jac
+walker ListTasks {
+    has reports: list[list[Task]];   # typed at the source
+
+    can collect with Root entry {
+        report [-->][?:Task];
+    }
+}
+
+with entry {
+    result = root spawn ListTasks();
+    tasks: list[Task] = result.reports[0];   # type-safe
+}
+```
+
+For Python utilities, ship a `.pyi` stub alongside the module so the imported names arrive typed at the boundary.
+
+**After (escape valve): accept `any` explicitly.** Keep the source untyped and annotate the receiving local as `any`, then narrow before flowing into typed destinations:
+
+```jac
+with entry {
+    result = root spawn ListTasks();
+    raw: any = result.reports[0];
+    if isinstance(raw, list) {
+        tasks: list[Task] = raw;   # narrowed -- no error
+    }
+}
+```
+
+**Migration:** For each strict-`any` error, choose one of three responses:
+
+1. **Type the source** -- add `has reports: list[T]` (walkers), a `-> T` annotation (functions), or a `.pyi` stub (Python utilities). Preferred for stable APIs.
+2. **Drop the annotation** -- `x = src();` makes `x` inferred-`any` and no check fires.
+3. **Annotate `any` explicitly** -- `x: any = src();` documents the boundary.
+
+See [The `any` Type and Gradual Typing](../reference/language/foundation.md#the-any-type-and-gradual-typing) for the full rule and [Walker Response Patterns](../reference/language/walker-responses.md#typing-your-reports) for typing the walker `reports` channel.
+
+---
+
 ### Version 0.13.6
 
 #### 1. `cl { }` / `sv { }` / `na { }` Module-Level Braced Blocks Deprecated

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -71,6 +71,12 @@ with entry {
     # `any` vs `` `any ``: use `any` for the built-in type (placeholder for
     # any type) and `` `any `` for the built-in Python function.
 
+    # Gradual typing: `any` cannot silently flow into a typed destination
+    # in .jac source. `x: int = py_call()` errors if py_call() returns any --
+    # either type the source (e.g. via .pyi stub) or accept it explicitly:
+    #   raw: any = py_call();   # opt in to permissive flow
+    #   raw = py_call();        # inferred -- raw becomes any, no error
+
     # Union types
     maybe: str | None = None;
 

--- a/docs/docs/reference/diagnostics.md
+++ b/docs/docs/reference/diagnostics.md
@@ -139,6 +139,9 @@ Emitted by the type checker and type evaluator.
 | `E1003` | Return type annotation required when function returns a value |
 | `E1004` | Function '{name}' declared return type {ret_type} but may implicitly return None |
 
+!!! tip "`E1001`/`E1002` with `any` on the right-hand side"
+    A common trigger for `E1001` and `E1002` is Jac's strict gradual-typing rule: in `.jac` source, an `any` value cannot silently flow into a declared non-`any`, non-`object` destination. Three ways to clear it -- type the source (e.g. `has reports: list[T]` on a walker, `.pyi` stub on a Python utility), drop the annotation (`x = src()` makes `x` inferred-`any`), or annotate `any` explicitly (`x: any = src()`) and narrow before downstream use. See [The `any` Type and Gradual Typing](language/foundation.md#the-any-type-and-gradual-typing).
+
 ### Operator Errors
 
 | Code | Message |

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -389,7 +389,7 @@ The check recurses element-wise into containers, so `list[any] -> list[Task]` is
 
 | Approach | When to use |
 |----------|-------------|
-| Type the source | The function has a stable signature. Add a `.pyi` stub for a Python utility, a return annotation on a `def`, or a typed `has reports` declaration on a walker. The boundary becomes strongly typed and downstream `.jac` code stays clean. |
+| Type the source | The function has a stable signature. Add a `.pyi` stub for a Python utility, a return annotation on a `def`, or a typed [`has reports: list[T]`](walker-responses.md#typing-your-reports) declaration on a walker. The boundary becomes strongly typed and downstream `.jac` code stays clean. |
 | Accept `any` at the boundary | The source is intentionally untyped. Annotate the receiving local as `any`, then narrow with `isinstance` or `cast` before flowing into typed destinations. |
 
 ```jac

--- a/docs/docs/reference/language/walker-responses.md
+++ b/docs/docs/reference/language/walker-responses.md
@@ -36,7 +36,13 @@ with entry {
 
 ### Typing Your Reports
 
-By default every walker has `reports: list[any]` -- it accepts any value. Declaring `has reports: list[T]` is a single-source-of-truth contract: `report X` on the write side and `(spawn W).reports[i]` on the read side both type-check against the same `T`.
+**Declare `has reports: list[T]` on every walker.** It is the recommended default, not an opt-in optimization. The declaration is a single-source-of-truth contract: `report X` on the write side and `(spawn W).reports[i]` on the read side both type-check against the same `T`, so a typo or shape drift surfaces at `jac check` time instead of at the call site.
+
+A bare walker assumes `reports: list[any]`. That works, but it propagates `any` into consumer code -- and Jac's [strict gradual-typing rule](foundation.md#the-any-type-and-gradual-typing) will reject the consumer's typed assignment downstream. Typing `reports` at the source is almost always cheaper than annotating every receiving local as `any` and narrowing back.
+
+#### Pattern A: Single typed report (most walkers)
+
+The common case. The walker accumulates results internally and reports once at the end, or mutates state and reports the touched node.
 
 ```jac
 node Task {
@@ -44,6 +50,36 @@ node Task {
     has done: bool = False;
 }
 
+walker:priv ToggleTask {
+    has task_id: str,
+        reports: list[Task] = [];   # typed report channel
+
+    can search with Root entry {
+        visit [-->];
+    }
+
+    can toggle with Task entry {
+        if jid(here) == self.task_id {
+            here.done = not here.done;
+            report here;        # `here` is Task -- type-checked against list[Task]
+            disengage;
+        }
+    }
+}
+
+with entry {
+    result = root spawn ToggleTask(task_id="abc123");
+    toggled: Task = result.reports[0];     # hydrated as Task on the consumer side
+}
+```
+
+Note that `has reports: list[Task] = [];` sits alongside the walker's other `has` declarations -- it is just another field with a default initializer, declared the same way as `task_id`.
+
+#### Pattern B: Single accumulated list (collection walkers)
+
+When the walker reports a *collection* once at exit, the element type is itself a list. The shape becomes `list[list[T]]` -- one outer slot for the single `report` call, one inner element type for each item in the reported list.
+
+```jac
 walker ListTasks {
     has reports: list[list[Task]];
 
@@ -54,16 +90,18 @@ walker ListTasks {
 
 with entry {
     result = root spawn ListTasks();
-    tasks: list[Task] = result.reports[0];  # type-safe
+    tasks: list[Task] = result.reports[0];   # type-safe single-shot collection
 }
 ```
 
-When `has reports` is declared, the type checker enforces two rules:
+#### How the type checker enforces the declaration
+
+When `has reports` is declared, two rules are checked:
 
 1. The declaration itself must be a list type. `has reports: int = 0;` is rejected -- `reports` is the walker's report channel, not arbitrary state, so it must be `list[T]` for some `T`.
 2. Every `report` statement in the walker body must produce a value compatible with the element type `T`. If you `report "oops"` inside `ListTasks` above, the checker flags it as a type error.
 
-If you omit the declaration, the walker behaves exactly as before -- `reports` is `list[any]` and any value can be reported.
+If you omit the declaration, the walker falls back to `reports: list[any]` and any value can be reported -- but downstream code that receives those values into typed destinations will hit Jac's strict-`any` rule. See [The `any` Type and Gradual Typing](foundation.md#the-any-type-and-gradual-typing) for the consumer side.
 
 ## Common Patterns
 
@@ -125,7 +163,8 @@ node Item {
 }
 
 walker:priv FindMatches {
-    has search_term: str;
+    has search_term: str,
+        reports: list[Item] = [];   # one Item per match
 
     can search with Root entry {
         visit [-->];
@@ -133,7 +172,7 @@ walker:priv FindMatches {
 
     can check with Item entry {
         if self.search_term in here.name {
-            report here;  # One report per match
+            report here;  # `here` is Item -- type-checked against list[Item]
         }
     }
 }
@@ -141,7 +180,7 @@ walker:priv FindMatches {
 with entry {
     # Usage
     result = root spawn FindMatches(search_term="test");
-    matches = result.reports;  # Array of all matching nodes
+    matches: list[Item] = result.reports;  # typed end-to-end
 }
 ```
 
@@ -157,7 +196,8 @@ node Item {
 }
 
 walker:priv CreateItem {
-    has name: str;
+    has name: str,
+        reports: list[Item] = [];   # the created Item flows back typed
 
     can create with Root entry {
         new_item = here ++> Item(name=self.name);
@@ -168,7 +208,7 @@ walker:priv CreateItem {
 with entry {
     # Usage
     result = root spawn CreateItem(name="New Item");
-    created = result.reports[0];  # The new item
+    created: Item = result.reports[0];  # hydrated as Item on the client
 }
 ```
 
@@ -299,9 +339,9 @@ with entry {
 
 ## Best Practices
 
-1. **Prefer single reports** - Accumulate data and report once at the end
-2. **Use `with Root exit`** - Best place for final reports after traversal
-3. **Declare `has reports` with a type** - Adding `has reports: list[MyType]` to your walker gives you compile-time checking that every `report` statement produces the right type, and communicates the walker's output contract to readers of the code
+1. **Always declare `has reports: list[T]`** - The default `list[any]` propagates `any` into consumer code, and Jac's strict gradual-typing rule rejects `any` flowing into typed destinations. Typing the report channel at the walker is almost always cheaper than annotating every receiving local as `any` and narrowing back. See [The `any` Type and Gradual Typing](foundation.md#the-any-type-and-gradual-typing).
+2. **Prefer single reports** - Accumulate data and report once at the end
+3. **Use `with Root exit`** - Best place for final reports after traversal
 4. **Report typed objects directly** - Return node/obj instances instead of manually constructing dicts. The runtime automatically serializes typed objects with field metadata, and client code receives them as hydrated typed instances with proper field access (e.g., `task.title` instead of `task["title"]`)
 5. **Always check `.reports`** - It may be empty or undefined
 6. **Use typed return annotations** - For `def:pub` functions, annotate with `-> Task` or `-> list[Task]` instead of `-> dict` or `-> list` to enable automatic type hydration on the client

--- a/jac/examples/day_planner/walkers/main.jac
+++ b/jac/examples/day_planner/walkers/main.jac
@@ -77,7 +77,8 @@ walker:priv ListTasks {
 }
 
 walker:priv ToggleTask {
-    has task_id: str;
+    has task_id: str,
+        reports: list[Task] = [];
 
     can search with Root entry {
         visit [-->];


### PR DESCRIPTION
## Summary

Follow-up to #5859 and #5869. Strengthens the gradual-typing story across the docs surface and threads typed `has reports: list[T]` through every walker example so the recommended pattern is consistent end to end.

- **walker-responses.md** — leads the typing section with "Declare `has reports: list[T]` on every walker" as the default rather than an opt-in optimization. Splits the typing examples into **Pattern A: Single typed report** (mirrors the day_planner `ToggleTask` case — a walker that mutates state and reports a single typed node) and **Pattern B: Single accumulated list** (the `list[list[T]]` shape, one outer slot for the single `report` call wrapping a collection). Updates `FindMatches` and `CreateItem` examples to use typed `reports`. Reorders **Best Practices** so typed reports is item #1. Cross-links to the strict-`any` rule for the consumer-side rejection.
- **breaking-changes.md** — adds a **Version 0.14.2** entry for strict-`any` with the full firing-site list, a before/after walker-reports example, and three migration paths (type the source / drop the annotation / annotate `any` explicitly). The motivating case mirrors the bug from `jac/examples/day_planner/walkers/components/TasksPanel.cl.jac` cited in #5859.
- **foundation.md** — cross-links `has reports: list[T]` from the migration table in the gradual-typing section.
- **syntax-cheatsheet.md** — five-line callout in the types section so the cheatsheet doesn't silently mislead about `any`.
- **diagnostics.md** — admonition under the assignment/return error table calling out strict gradual typing as a common cause of `E1001`/`E1002`.
- **jac/examples/day_planner/walkers/main.jac** — adds typed `reports: list[Task]` to `ToggleTask` so the example follows the recommended pattern.

### Versioning note

The breaking-changes entry is labeled **Version 0.14.2** since `0.14.1` is current and the existing pattern ships breaking changes in patch bumps. If the actual release will be `0.15.0` (the originating PR is `feat(compiler)!:`), update the header before cutting.

## Test plan

- [x] `mkdocs build --strict` passes; new `#the-any-type-and-gradual-typing` and `#typing-your-reports` cross-links resolve cleanly. The remaining anchor warnings in the build output are pre-existing.
- [x] Pre-commit hooks pass (em-dash ban, markdownlint, jac-format).
- [ ] Visual review of:
  - rendered `walker-responses.md` Pattern A / Pattern B split and Best Practices reorder
  - the new `breaking-changes.md` 0.14.2 section (before/after fences and migration table render correctly)
  - the `diagnostics.md` admonition placement under the `E1001`/`E1002` table
- [ ] Confirm the day_planner example still type-checks under strict-Any (`ToggleTask` should now have a typed report channel that accepts `Task`).