### PR TITLE
fix(langserve): refresh cross-file diagnostics when a dependency changes

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5876.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5876.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: language server refreshes cross-file diagnostics when a dependency changes**: an open consumer file's diagnostics no longer go stale when an imported module is edited; `JacProgram` now mtime-validates its hub on every lookup and the LSP fans out re-checks to open consumers when a dependency receives a `did_save`/`did_change`.

--- a/jac/examples/day_planner/auth/components/AuthForm.cl.jac
+++ b/jac/examples/day_planner/auth/components/AuthForm.cl.jac
@@ -53,7 +53,7 @@ def:pub AuthForm(onAuth: Callable[[], None]) -> JsxElement {
             }
         } else {
             loading = False;
-            error = result["error"] if result["error"] else "Signup failed";
+            error = str(result["error"]) if result["error"] else "Signup failed";
         }
     }
 

--- a/jac/examples/day_planner/walkers/components/AuthForm.cl.jac
+++ b/jac/examples/day_planner/walkers/components/AuthForm.cl.jac
@@ -53,7 +53,7 @@ def:pub AuthForm(onAuth: Callable[[], None]) -> JsxElement {
             }
         } else {
             loading = False;
-            error = result["error"] if result["error"] else "Signup failed";
+            error = str(result["error"]) if result["error"] else "Signup failed";
         }
     }
 

--- a/jac/examples/day_planner/walkers/main.jac
+++ b/jac/examples/day_planner/walkers/main.jac
@@ -51,7 +51,8 @@ node ShoppingItem {
 
 # --- Task Walkers ---
 walker:priv AddTask {
-    has title: str;
+    has title: str,
+        reports: list[Task] = [];
 
     can create with Root entry {
         category = str(categorize(self.title)).split(".")[-1].lower();
@@ -61,7 +62,8 @@ walker:priv AddTask {
 }
 
 walker:priv ListTasks {
-    has results: list[Task] = [];
+    has results: list[Task] = [],
+        reports: list[list[Task]] = [];
 
     can start with Root entry {
         visit [-->];
@@ -111,7 +113,8 @@ walker:priv DeleteTask {
 
 # --- Shopping List Walkers ---
 walker:priv GenerateShoppingList {
-    has meal_description: str;
+    has meal_description: str,
+        reports: list[list[ShoppingItem]] = [];
 
     can generate with Root entry {
         visit [-->];
@@ -134,7 +137,8 @@ walker:priv GenerateShoppingList {
 }
 
 walker:priv GetShoppingList {
-    has items: list[ShoppingItem] = [];
+    has items: list[ShoppingItem] = [],
+        reports: list[list[ShoppingItem]] = [];
 
     can collect with Root entry {
         visit [-->];

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
@@ -69,7 +69,9 @@ impl TypeEvaluator.get_type_of_module_item(node_: uni.ModuleItem) -> types.TypeB
                         );
                         return node_.name.type;
                     }
-                    mod = self._import_module_from_path(path_str);
+                    mod = self._import_module_from_path(
+                        path_str, importer_path=self._resolve_importer_path(node_)
+                    );
 
                     # Check if this is a subpackage's __init__ file (e.g., subpkg/__init__.py)
                     # vs the parent module's __init__ file
@@ -207,7 +209,9 @@ impl TypeEvaluator._resolve_star_import_symbol(
         for ext in (".pyi", ".py", ".jac") {
             candidate = submod_base + ext;
             if Path(candidate).exists() {
-                submod = self._import_module_from_path(candidate);
+                submod = self._import_module_from_path(
+                    candidate, importer_path=self._resolve_importer_path(mod)
+                );
                 break;
             }
         }
@@ -246,9 +250,18 @@ impl TypeEvaluator.get_type_of_module(node_: uni.ModulePath) -> types.TypeBase {
             mod_path = path_list[idx + offset];
 
             if mod_path in self._module_type_cache {
-                npath.type = self._module_type_cache[mod_path];
-                npath._sym_category = SymbolType.MODULE;
-                continue;
+                # Couple this cache to the hub freshness gate. Without this,
+                # a long-lived TypeEvaluator (e.g. on the LSP server) keeps
+                # returning a `ModuleType` whose `symbol_table` points at
+                # the pre-edit IR, so the strict hub eviction below is
+                # short-circuited and consumers stay stale.
+                resolved_for_cache = str(Path(mod_path).resolve());
+                if self.program.is_hub_entry_fresh(resolved_for_cache) {
+                    npath.type = self._module_type_cache[mod_path];
+                    npath._sym_category = SymbolType.MODULE;
+                    continue;
+                }
+                self.program.invalidate_module(resolved_for_cache);
             }
 
             if not Path(mod_path).exists() {
@@ -287,7 +300,9 @@ impl TypeEvaluator.get_type_of_module(node_: uni.ModulePath) -> types.TypeBase {
                 self._module_type_cache[mod_path] = mod_type;
                 continue;
             }
-            mod: uni.Module = self._import_module_from_path(mod_path);
+            mod: uni.Module = self._import_module_from_path(
+                mod_path, importer_path=self._resolve_importer_path(node_)
+            );
             flags = type_utils.compute_module_source_flags(mod_path);
             mod_type = types.ModuleType(
                 mod_name=npath.value,
@@ -313,7 +328,9 @@ impl TypeEvaluator.get_type_of_module(node_: uni.ModulePath) -> types.TypeBase {
 }
 
 """Import a module from the given path."""
-impl TypeEvaluator._import_module_from_path(path: str) -> uni.Module {
+impl TypeEvaluator._import_module_from_path(
+    path: str, importer_path: (str | None) = None
+) -> uni.Module {
     # "../os/path.pyi" and "/abs/os/path.pyi" are the same file but different strings.
     # resolve() converts both to "/abs/os/path.pyi" so hub always returns the same cached module.
     resolved_path = str(Path(path).resolve());
@@ -323,6 +340,27 @@ impl TypeEvaluator._import_module_from_path(path: str) -> uni.Module {
     compiler = self.program._get_compiler();
     target_program = compiler._resolve_program(resolved_path, self.program);
     target_hub = target_program.mod.hub;
+
+    # Hub-tier freshness gate: a long-lived JacProgram (e.g. the LSP)
+    # otherwise returns the same cached IR forever, even after the source
+    # file is rewritten on disk. `is_hub_entry_fresh` compares the source's
+    # current mtime (plus annexes/variants) against the cache stamp set
+    # when the IR was inserted. Stale entries are evicted here so the
+    # branch below falls through to JIR or full recompile.
+    if (
+        resolved_path in self.program.mod.hub
+        and not self.program.is_hub_entry_fresh(resolved_path)
+    ) {
+        self.program.invalidate_module(resolved_path);
+    }
+    if (
+        resolved_path in target_hub
+        and target_program is not self.program
+        and not target_program.is_hub_entry_fresh(resolved_path)
+    ) {
+        target_program.invalidate_module(resolved_path);
+    }
+
     mod: uni.Module;
     if resolved_path in self.program.mod.hub {
         mod = self.program.mod.hub[resolved_path];
@@ -340,6 +378,7 @@ impl TypeEvaluator._import_module_from_path(path: str) -> uni.Module {
                 mod.parent_scope = self.builtins_module;
             }
             target_hub[resolved_path] = mod;
+            target_program.hub_cache_stamp(resolved_path);
         } else {
             # Cache miss — full compile
             mod = self.program.compile(
@@ -349,6 +388,7 @@ impl TypeEvaluator._import_module_from_path(path: str) -> uni.Module {
                 mod.parent_scope = self.builtins_module;
             }
             target_hub[resolved_path] = mod;
+            target_program.hub_cache_stamp(resolved_path);
             # Write JIR module cache for .jac files (best-effort).
             # Only write if no valid cache exists yet — symtab-only compiles
             # lack bytecode and must not overwrite a full cache that has it.
@@ -380,7 +420,43 @@ impl TypeEvaluator._import_module_from_path(path: str) -> uni.Module {
             }
         }
     }
+    # Record the import edge so callers (long-lived clients like the LSP)
+    # can fan out re-checks to open consumers when a target module changes.
+    if importer_path is not None {
+        self.program.record_dependency(importer_path, resolved_path);
+    }
     return mod;
+}
+
+"""Drop per-module entries from the evaluator's caches.
+
+After this returns, no `ModuleType` keyed by `resolved_path` remains in
+`_module_type_cache`, so the next type-of query rebuilds it against the
+fresh hub IR. Symbol tables on already-handed-out `ModuleType` instances
+in client AST nodes can still point at the previous IR — that is fine;
+they are only consulted via this evaluator's lookup paths, which all
+re-route through `_import_module_from_path` and pick up the refreshed
+hub entry."""
+impl TypeEvaluator.forget_module(resolved_path: str) -> None {
+    if resolved_path in self._module_type_cache {
+        del (self._module_type_cache[resolved_path], );
+    }
+}
+
+impl TypeEvaluator._resolve_importer_path(ast_node: uni.UniNode) -> (str | None) {
+    mod = ast_node.find_parent_of_type(uni.Module);
+    if mod is None or mod.source is None {
+        return None;
+    }
+    file_path = mod.source.file_path;
+    if not file_path {
+        return None;
+    }
+    try {
+        return str(Path(file_path).resolve());
+    } except OSError {
+        return None;
+    }
 }
 
 """Try to read a compiled .jac module from the JIR cache. Returns None on any failure."""

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -278,8 +278,26 @@ obj TypeEvaluator {
     def get_type_of_symbol(symbol: uni.Symbol) -> TypeBase;
     # NOTE: This function doesn't exists in pyright, however it exists as a helper function
     # for the following functions.
-    def _import_module_from_path(path: str) -> uni.Module;
+    def _import_module_from_path(
+        path: str, importer_path: (str | None) = None
+    ) -> uni.Module;
+
+    """Resolve the file path of the Module that contains the given AST
+    node, if any. Used by the import resolver to record reverse-dependency
+    edges (importer -> target). Returns None when no parent Module is
+    reachable or its source carries no file path (e.g. anonymous stub
+    modules)."""
+    def _resolve_importer_path(ast_node: uni.UniNode) -> (str | None);
+
     def _try_read_jir_cache(resolved_path: str) -> (uni.Module | None);
+    """Drop per-module entries from the evaluator's caches.
+
+    Called by `JacProgram.invalidate_module` so the evaluator does not
+    keep returning stale `ModuleType` objects (or stale cached attribute
+    types pinned to the old module's symbol table) after the underlying
+    file changes."""
+    def forget_module(resolved_path: str) -> None;
+
     def _reattach_impl_modules(mod: uni.Module, source_path: str) -> None;
     def _resolve_from_path(from_mod: uni.ModulePath) -> Path;
     def _is_fstring_all_literal(fstring: uni.FString) -> bool;

--- a/jac/jaclang/jac0core/impl/program.impl.jac
+++ b/jac/jaclang/jac0core/impl/program.impl.jac
@@ -12,6 +12,119 @@ impl JacProgram.init(
     self._compiler: (JacCompiler | None) = None;
     self._compile_options: CompileOptions = CompileOptions();
     self._native_cache: dict = {};
+    # See `hub_cache_stamp` / `is_hub_entry_fresh`.
+    self._hub_cache_times: dict[str, float] = {};
+    # See `record_dependency` / `transitive_dependents`.
+    self._dependents: dict[str, set[str]] = {};
+}
+
+impl JacProgram.hub_cache_stamp(self: JacProgram, resolved_path: str) -> None {
+    import time;
+    self._hub_cache_times[resolved_path] = time.time();
+}
+
+impl JacProgram.is_hub_entry_fresh(self: JacProgram, resolved_path: str) -> bool {
+    import os;
+    import from jaclang.jac0core.bccache {
+        discover_annex_files,
+        discover_variant_files
+    }
+    cached_at = self._hub_cache_times.get(resolved_path);
+    if cached_at is None {
+        # No stamp recorded for this path. The caller's eviction policy
+        # depends on context: paths that go through `_import_module_from_path`
+        # always get stamped, but `TypeEvaluator._module_type_cache` also
+        # caches external (.js/.ts/asset) modules and special namespace
+        # placeholders that never reach the import resolver. Treat the
+        # absence of a stamp as "trust the existing cache" so we do not
+        # churn those entries on every type-of query.
+        return True;
+    }
+    try {
+        if os.path.getmtime(resolved_path) > cached_at {
+            return False;
+        }
+        # Annex (.impl.jac/.test.jac) and variant (.cl.jac/.sv.jac/.na.jac)
+        # files are spliced into the parent module by the compiler, so
+        # editing them must invalidate the parent's cache too. This
+        # mirrors `is_module_cache_valid` in jac0core.jir.
+        for related in discover_annex_files(resolved_path) {
+            if os.path.getmtime(related) > cached_at {
+                return False;
+            }
+        }
+        for related in discover_variant_files(resolved_path) {
+            if os.path.getmtime(related) > cached_at {
+                return False;
+            }
+        }
+        return True;
+    } except OSError {
+        return False;
+    }
+}
+
+impl JacProgram.record_dependency(
+    self: JacProgram, importer_path: str, target_path: str
+) -> None {
+    if importer_path == target_path {
+        return;
+    }
+    bucket = self._dependents.get(target_path);
+    if bucket is None {
+        bucket = set();
+        self._dependents[target_path] = bucket;
+    }
+    bucket.add(importer_path);
+}
+
+impl JacProgram.transitive_dependents(self: JacProgram, target_path: str) -> set[str] {
+    out: set[str] = set();
+    frontier: list[str] = [target_path];
+    while frontier {
+        current = frontier.pop();
+        for importer in self._dependents.get(current, set()) {
+            if importer in out {
+                continue;
+            }
+            out.add(importer);
+            frontier.append(importer);
+        }
+    }
+    return out;
+}
+
+impl JacProgram.invalidate_module(self: JacProgram, resolved_path: str) -> None {
+    # Drop hub IR + freshness stamp.
+    if resolved_path in self.mod.hub {
+        del (self.mod.hub[resolved_path], );
+    }
+    if resolved_path in self._hub_cache_times {
+        del (self._hub_cache_times[resolved_path], );
+    }
+    # Drop native artifacts referencing this module.
+    if resolved_path in self._native_cache {
+        del (self._native_cache[resolved_path], );
+    }
+    # Drop the type-evaluator's per-path caches; if the evaluator does not
+    # exist yet (no compile has run on this program) there is nothing to do.
+    te = self.type_evaluator;
+    if te is not None {
+        try {
+            te.forget_module(resolved_path);
+        } except AttributeError {
+            # Older TypeEvaluator instances without forget_module. Fall
+            # back to the coarse reset; correctness over performance.
+            self.type_evaluator = None;
+        }
+    }
+    # Drop edges where this module is the importer; they will be re-added
+    # when the module is re-parsed and the import resolver runs again.
+    # Edges where this module is the target (i.e., its dependents) stay,
+    # so future invalidations of this module still fan out correctly.
+    for bucket in self._dependents.values() {
+        bucket.discard(resolved_path);
+    }
 }
 
 impl JacProgram._get_compiler(self: JacProgram) -> JacCompiler {

--- a/jac/jaclang/jac0core/program.jac
+++ b/jac/jaclang/jac0core/program.jac
@@ -21,6 +21,27 @@ class JacProgram {
     def _get_compiler(self: JacProgram) -> JacCompiler;
     def get_type_evaluator(self: JacProgram) -> TypeEvaluator;
     def clear_type_system(self: JacProgram, clear_hub: bool = False) -> None;
+    # Hub cache freshness: timestamp captured when each path was inserted
+    # into `mod.hub` (or refreshed by a re-import). Compared against current
+    # source mtime + annex/variant mtimes by `is_hub_entry_fresh` so a
+    # long-lived JacProgram (e.g. the LSP server) cannot serve stale IR
+    # after a dependency changes on disk.
+    def hub_cache_stamp(self: JacProgram, resolved_path: str) -> None;
+    def is_hub_entry_fresh(self: JacProgram, resolved_path: str) -> bool;
+    # Reverse-dependency map: target_path -> set of importer_paths that
+    # resolved an import to it. Populated by the import resolver and used
+    # by long-lived clients (the LSP) to fan out re-checks when a module
+    # changes.
+    def record_dependency(
+        self: JacProgram, importer_path: str, target_path: str
+    ) -> None;
+
+    def transitive_dependents(self: JacProgram, target_path: str) -> set[str];
+    # Coordinated eviction across hub, type-cache, native cache, and the
+    # rdep stamps. Invariant: after `invalidate_module(p)`, no consumer of
+    # the program's caches references the prior IR for `p`. This is the
+    # only safe entry point for in-place cache busting.
+    def invalidate_module(self: JacProgram, resolved_path: str) -> None;
     def get_bytecode(self: JacProgram, full_target: str) -> (types.CodeType | None);
     def parse_str(
         self: JacProgram,

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -73,6 +73,13 @@ obj JacLangServer(JacProgram, LanguageServer) {
 
     def type_check(file_uri: str) -> None;
     def _do_type_check(file_uri: str) -> None;
+    """React to an external change at `file_uri`: drop the file's IR from
+    `JacProgram` caches and queue a re-check for every open document that
+    transitively imports it. Idempotent and safe to call from any LSP
+    event handler. The owning file's own re-check is not queued here —
+    callers normally pair this with `type_check(file_uri)` for that."""
+    def _fanout_dependents(file_uri: str) -> None;
+
     def get_token_at_position(
         file_path: str, position: lspt.Position
     ) -> Optional[uni.UniNode];

--- a/jac/jaclang/langserve/impl/engine.impl.jac
+++ b/jac/jaclang/langserve/impl/engine.impl.jac
@@ -64,6 +64,55 @@ impl JacLangServer._do_type_check(file_uri: str) -> None {
         # Trigger the worker to pick up the new task.
         self._work_event.set();
     }
+    # Push transitive open consumers into dirty_files so the dispatcher
+    # re-checks them after the primary task finishes. The fanout is
+    # external-event-driven (called from did_open/did_save/did_change),
+    # so dispatcher-induced re-checks of those consumers cannot recurse:
+    # type_check_file does not loop back through _do_type_check.
+    self._fanout_dependents(file_uri);
+}
+
+"""Drop the changed file's IR from program caches and queue every open
+consumer of it for re-check. See `_fanout_dependents` declaration."""
+impl JacLangServer._fanout_dependents(file_uri: str) -> None {
+    import from pathlib { Path }
+    fs_path = uris.to_fs_path(file_uri);
+    if fs_path is None {
+        return;
+    }
+    try {
+        resolved = str(Path(fs_path).resolve());
+    } except OSError {
+        return;
+    }
+    # Defensive eviction. Fix 1's mtime gate already invalidates on a
+    # subsequent compile, but invalidating up front means consumers that
+    # consult cached state outside the import path (hover, completion)
+    # also see fresh data immediately.
+    self.invalidate_module(resolved);
+    dependents = self.transitive_dependents(resolved);
+    if not dependents {
+        return;
+    }
+    with self._state_lock.write_lock() {
+        for dep_path in dependents {
+            dep_uri = uris.from_fs_path(dep_path);
+            if dep_uri is None or dep_uri == file_uri {
+                continue;
+            }
+            # Only re-check files that are actually open: the LSP only
+            # publishes diagnostics for open documents, and re-compiling
+            # closed files is wasted work proportional to the size of the
+            # rdep graph.
+            if dep_uri in self.workspace._text_documents {
+                self.dirty_files[dep_uri] = True;
+                self._idle_event.clear();
+            }
+        }
+        if self.dirty_files {
+            self._work_event.set();
+        }
+    }
 }
 
 """Rebuild a file and its dependencies (typecheck)."""

--- a/jac/tests/langserve/server_test/test_cache_invalidation.jac
+++ b/jac/tests/langserve/server_test/test_cache_invalidation.jac
@@ -1,0 +1,177 @@
+"""Cross-file cache invalidation tests for the Jac language server.
+
+Two failure modes that surfaced when an open file's diagnostics did not
+refresh after a dependency changed:
+
+  1. Disk edit of an imported module is not seen on subsequent did_save
+     because `JacProgram.mod.hub` returns the cached IR forever.
+  2. A consumer file's diagnostics do not auto-refresh when its imported
+     dependency receives an LSP event, because nothing tracks reverse
+     dependents.
+"""
+
+import asyncio;
+import os;
+import shutil;
+import tempfile;
+
+import from pathlib { Path }
+
+import from jaclang.lsp.types {
+    DidChangeTextDocumentParams,
+    DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams,
+    TextDocumentIdentifier,
+    TextDocumentItem,
+    VersionedTextDocumentIdentifier
+}
+
+import from jaclang.langserve.engine { JacLangServer }
+import from jaclang.langserve.server { did_change, did_open, did_save }
+import from jaclang.lsp.server { Workspace }
+import from jaclang.lsp.uris { from_fs_path }
+
+# Library and consumer source pairs. APP_SRC instantiates Foo with field
+# `x`; LIB_BREAK renames the field to `y` so any cached LIB_OK lets APP_SRC
+# pass while a fresh recompile against LIB_BREAK rejects it.
+glob LIB_OK = "obj Foo { has x: int; }\n",
+     LIB_BREAK = "obj Foo { has y: str; }\n",
+     APP_SRC = (
+         "import from .lib { Foo }\n"
+         "with entry {\n"
+         "    f = Foo(x=1);\n"
+         "    print(f.x);\n"
+         "}\n"
+     );
+
+"""Force the file's mtime to advance past any cache fingerprint, with no real-time wait."""
+def _bump_mtime(path: str) {
+    st = os.stat(path);
+    new_t = st.st_mtime + 5.0;
+    os.utime(path, (new_t, new_t));
+}
+
+"""Count error-severity diagnostics for a URI on the language server."""
+def _err_count(ls: JacLangServer, uri: str) -> int {
+    diags = ls.diagnostics.get(uri, []);
+    n = 0;
+    for d in diags {
+        if d?.severity == 1 {
+            n += 1;
+        }
+    }
+    return n;
+}
+
+test "stale dep refreshed on consumer save" {
+    proj = tempfile.mkdtemp(prefix="jac_lsp_invalidation_");
+    lib_path = os.path.join(proj, "lib.jac");
+    app_path = os.path.join(proj, "app.jac");
+    Path(lib_path).write_text(LIB_OK);
+    Path(app_path).write_text(APP_SRC);
+
+    ls = JacLangServer();
+    ls.lsp._workspace = Workspace(root_uri=(from_fs_path(proj) or ""));
+    app_uri = from_fs_path(app_path) or "";
+
+    try {
+        # Phase 1: open the consumer with the dep in OK shape -- baseline 0 errors.
+        # Real LSP flow populates the workspace before invoking the open
+        # handler; mirror that so the server treats the doc as open.
+        app_doc = TextDocumentItem(
+            uri=app_uri, language_id="jac", version=1, text=APP_SRC
+        );
+        ls.workspace.put_text_document(app_doc);
+        asyncio.run(did_open(ls, DidOpenTextDocumentParams(text_document=app_doc)));
+        ls.wait_till_idle_sync(app_uri);
+        assert _err_count(ls, app_uri) == 0 , (
+            "baseline: app should have 0 errors when lib defines field x"
+        );
+
+        # Phase 2: rewrite the dep on disk in a way that breaks the consumer
+        # (Foo.x replaced by Foo.y), and bump its mtime so any mtime-based
+        # freshness check definitely sees the change.
+        Path(lib_path).write_text(LIB_BREAK);
+        _bump_mtime(lib_path);
+
+        # Phase 3: did_save the consumer. After Fix 1 (mtime-validated hub
+        # lookups), the cached lib IR is rejected and a fresh recompile
+        # surfaces the broken usage.
+        asyncio.run(
+            did_save(
+                ls,
+                DidSaveTextDocumentParams(
+                    text_document=TextDocumentIdentifier(uri=app_uri), text=APP_SRC
+                )
+            )
+        );
+        ls.wait_till_idle_sync(app_uri);
+        assert _err_count(ls, app_uri) >= 1 , (
+            "stale dep cache: app must show errors after dep changed on disk"
+        );
+    } finally {
+        ls.shutdown();
+        shutil.rmtree(proj, ignore_errors=True);
+    }
+}
+
+test "consumer auto-rechecked when dep receives did_change" {
+    proj = tempfile.mkdtemp(prefix="jac_lsp_invalidation_");
+    lib_path = os.path.join(proj, "lib.jac");
+    app_path = os.path.join(proj, "app.jac");
+    Path(lib_path).write_text(LIB_OK);
+    Path(app_path).write_text(APP_SRC);
+
+    ls = JacLangServer();
+    ls.lsp._workspace = Workspace(root_uri=(from_fs_path(proj) or ""));
+    lib_uri = from_fs_path(lib_path) or "";
+    app_uri = from_fs_path(app_path) or "";
+
+    try {
+        # Open both files, baseline clean. The real LSP dispatcher puts the
+        # document into the workspace before invoking did_open; mirror that
+        # so the server treats both files as open.
+        lib_doc = TextDocumentItem(
+            uri=lib_uri, language_id="jac", version=1, text=LIB_OK
+        );
+        app_doc = TextDocumentItem(
+            uri=app_uri, language_id="jac", version=1, text=APP_SRC
+        );
+        ls.workspace.put_text_document(lib_doc);
+        ls.workspace.put_text_document(app_doc);
+        asyncio.run(did_open(ls, DidOpenTextDocumentParams(text_document=lib_doc)));
+        ls.wait_till_idle_sync(lib_uri);
+        asyncio.run(did_open(ls, DidOpenTextDocumentParams(text_document=app_doc)));
+        ls.wait_till_idle_sync(app_uri);
+        assert _err_count(ls, app_uri) == 0;
+
+        # Change the dep through did_change. No event for the consumer.
+        ls.workspace.put_text_document(
+            TextDocumentItem(uri=lib_uri, language_id="jac", version=2, text=LIB_BREAK)
+        );
+        Path(lib_path).write_text(LIB_BREAK);
+        _bump_mtime(lib_path);
+        asyncio.run(
+            did_change(
+                ls,
+                DidChangeTextDocumentParams(
+                    text_document=VersionedTextDocumentIdentifier(
+                        uri=lib_uri, version=2
+                    ),
+                    content_changes=[{"text": LIB_BREAK}]
+                )
+            )
+        );
+        # After Fix 2 (reverse-dep enqueue) the dep's check pushes the
+        # consumer into dirty_files; wait_till_idle_sync extends until the
+        # whole queue drains.
+        ls.wait_till_idle_sync(lib_uri);
+
+        assert _err_count(ls, app_uri) >= 1 , (
+            "rdep fanout: app must auto-recheck after its dep changed"
+        );
+    } finally {
+        ls.shutdown();
+        shutil.rmtree(proj, ignore_errors=True);
+    }
+}


### PR DESCRIPTION
## Summary

The Jac LSP held one `JacProgram` for the whole session and served its parsed-module hub keyed by file path with no freshness check. Once a dependency landed in the hub from the first `did_open`, every later type-check of any consumer short-circuited to the cached IR and never re-read the file. `did_save` on the consumer didn't help (the cache hit pre-empted the import resolver), and `did_change` on the dep didn't propagate either (nothing fanned out to open consumers). Users saw stale squiggles until the LSP was restarted.

This lands two layered fixes plus a test file that fails without either fix and passes with both.

### Fix 1 — mtime-validated hub cache

`JacProgram` now stamps `_hub_cache_times[path]` at every hub insertion and exposes `is_hub_entry_fresh(path)` which compares the stamp against the current mtime of the source plus its annexes (`.impl.jac`, `.test.jac`) and variants (`.cl/.sv/.na.jac`) — the same shape as the existing on-disk JIR validity check.

Both hub lookup sites in `TypeEvaluator._import_module_from_path` gate on this and route stale entries through `JacProgram.invalidate_module()`. The same gate is applied at the parallel `_module_type_cache` lookup in `get_type_of_module` so a stale `ModuleType` cannot short-circuit before the hub gate runs.

`JacProgram.invalidate_module(path)` is the single coordinated entry point: it drops the path from `mod.hub`, `_hub_cache_times`, `_native_cache`, `TypeEvaluator._module_type_cache` (via new `forget_module`), and any forward edges in the rdep map. Reverse edges (this module as a target) stay so future invalidations still fan out correctly.

Conservative policy: an unstamped path is treated as fresh, not stale. External (`.js`/`.ts`) and namespace placeholder modules cache `ModuleType` directly without going through the import resolver, and churning them every visit produces spurious errors.

### Fix 2 — Reverse-dependency fanout

`JacProgram` records every successful import edge (`record_dependency(importer, target)`) inside `_import_module_from_path`, with the importer path resolved from the AST via a new `_resolve_importer_path` helper. `transitive_dependents(target)` walks the graph.

`JacLangServer._do_type_check` now calls `_fanout_dependents(file_uri)` after queueing the primary task: it invalidates the changed module from program caches, walks the transitive rdep set, filters to URIs in the workspace's open-documents map, and pushes them into `dirty_files` for the dispatcher to pick up. Fanout is gated on the user-event entry path, not the dispatcher's pickup path, so dispatcher-induced re-checks cannot recurse.

### Overhead

In the noise. Per import lookup: one `stat()` per source plus its annexes/variants — handful of microseconds on a warm dentry cache. Per type-check on a typical file with ~50 transitive imports: under a millisecond. rdep map memory: O(edges in import graph), tens of KB on realistic projects. Per file change: O(open dependents), bounded by editor tab count.

### Bonus commit

The walkers variant of the `day_planner` example tripped the same strict-`any` errors that motivated this work. Adopt the recommended typed-walker-reports migration on the four affected walkers (`AddTask`, `ListTasks`, `GenerateShoppingList`, `GetShoppingList`) and `str(...)`-cast the `jacSignup` error string. `jac check` passes on all four files.

## Test plan

- [x] New `jac/tests/langserve/server_test/test_cache_invalidation.jac` covers both failure modes; both fail without these fixes, both pass after.
- [x] Existing langserve suite: `test_lang_serve` (3), `test_rwlock` (3), `test_sem_tokens` (17), `test_server` (29) — all pass.
- [x] `tests/compiler/passes/main/test_checker_pass.jac` (186 tests) — all pass after the conservative-freshness adjustment that avoids over-eager invalidation of unstamped external-module entries.
- [x] `jac/examples/day_planner` panel checks via CLI continue to pass.
- [x] 21 pre-existing `test_language` walker/edge runtime errors (`ValueError: EdgeAnchor not a valid reference`) reproduce identically on clean `main` — not introduced by this branch.