### PR TITLE
Preserve TLS state on Ingress redeploys in jac-scale

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/5888.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/5888.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Preserve TLS state on Ingress redeploys**: `jac start --scale` no longer wipes the host, `spec.tls`, and cert-manager / ssl-redirect annotations from an existing Ingress, so HTTPS keeps working after a redeploy.

--- a/jac-scale/jac_scale/targets/kubernetes/ingress.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/ingress.jac
@@ -461,6 +461,79 @@ obj IngressDeployer {
         }
     }
 
+    """Copy TLS state (spec.tls, rule hosts, TLS-related annotations) from a live
+    Ingress into a freshly built body before a full-object replace.
+
+    `replace_namespaced_ingress` is a PUT that overwrites everything jac-scale
+    does not re-include in the body. enable_tls writes spec.tls, sets host on
+    every rule, and adds cert-manager / ssl-redirect annotations; without this
+    helper, every subsequent `jac start --scale` strips them. See issue #5834.
+
+    Returns new_body unchanged if the Ingress doesn't exist yet, or if it has
+    no TLS configured (so the original "wildcard rule until enable_tls" path
+    is preserved on first deploy).
+    """
+    def _preserve_tls_state(
+        ingress_name: str, namespace: str, new_body: dict, networking_v1: Any
+    ) -> dict {
+        try {
+            existing = networking_v1.read_namespaced_ingress(
+                name=ingress_name, namespace=namespace
+            );
+        } except ApiException as e {
+            if e.status == 404 {
+                return new_body;
+            }
+            raise;
+        }
+
+        api_client = client.ApiClient();
+        existing_dict = api_client.sanitize_for_serialization(existing);
+        existing_spec = existing_dict.get('spec', {}) or {};
+        existing_tls = existing_spec.get('tls', []) or [];
+
+        if not existing_tls {
+            return new_body;
+        }
+
+        existing_host = '';
+        for rule in (existing_spec.get('rules', []) or []) {
+            host = rule.get('host', '') or '';
+            if host {
+                existing_host = host;
+                break;
+            }
+        }
+
+        new_body['spec']['tls'] = existing_tls;
+        if existing_host {
+            for rule in (new_body['spec'].get('rules', []) or []) {
+                rule['host'] = existing_host;
+            }
+        }
+
+        existing_ann = (existing_dict.get('metadata', {}) or {}).get('annotations', {})
+        or {};
+        new_ann = new_body['metadata'].get('annotations', {}) or {};
+        for k in [
+            'cert-manager.io/issuer',
+            'nginx.ingress.kubernetes.io/ssl-redirect',
+            'nginx.ingress.kubernetes.io/force-ssl-redirect'
+        ] {
+            if k in existing_ann {
+                new_ann[k] = existing_ann[k];
+            }
+        }
+        new_body['metadata']['annotations'] = new_ann;
+
+        if self.logger {
+            self.logger.info(
+                f"Preserved TLS state on '{ingress_name}' (host='{existing_host}')"
+            );
+        }
+        return new_body;
+    }
+
     """Deploy Ingress routing rules.
 
     Main Ingress: routes /, /grafana (if enabled), /db-dashboard (if enabled).
@@ -574,6 +647,9 @@ obj IngressDeployer {
             },
             'spec': {'ingressClassName': ingress_class, 'rules': [main_rule]}
         };
+        main_ingress = self._preserve_tls_state(
+            ingress_name, namespace, main_ingress, networking_v1
+        );
         try {
             networking_v1.replace_namespaced_ingress(
                 name=ingress_name, namespace=namespace, body=main_ingress
@@ -689,6 +765,9 @@ obj IngressDeployer {
                 },
                 'spec': {'ingressClassName': ingress_class, 'rules': [redis_rule]}
             };
+            redis_ingress = self._preserve_tls_state(
+                redis_ingress_name, namespace, redis_ingress, networking_v1
+            );
             try {
                 networking_v1.replace_namespaced_ingress(
                     name=redis_ingress_name, namespace=namespace, body=redis_ingress

--- a/jac-scale/jac_scale/tests/test_deploy_k8s.jac
+++ b/jac-scale/jac_scale/tests/test_deploy_k8s.jac
@@ -2074,26 +2074,14 @@ test "redis ingress rule must not set host before TLS is enabled" {
     assert "host" not in redis_rule , "Redis ingress rule must not set host before TLS is enabled";
 }
 
-test "redeploy preserves TLS state set by enable_tls (regression for #5834)" {
-    # Regression test: a `jac start --scale` run after `--enable-tls` was
-    # silently wiping spec.tls, the host on rule[0], and the cert-manager /
-    # ssl-redirect annotations because _deploy_ingress_resource issues a full
-    # PUT via replace_namespaced_ingress. Without _preserve_tls_state copying
-    # the live TLS state into the new body, HTTPS falls back to the
-    # controller's self-signed cert in production.
-    k8s_config = KubernetesConfig(
-        domain="app.example.com", cert_manager_email="user@example.com"
-    );
-    ingress_deployer = IngressDeployer(k8s_config, None);
-
-    # Build a real V1Ingress that mirrors the post-enable_tls live state
-    live_ingress = client.V1Ingress(
+"""Build a V1Ingress mirroring the post-enable_tls live state used by
+the TLS-preserve regression tests for #5834."""
+def _make_live_tls_ingress(name: str, domain: str, secret: str) -> Any {
+    return client.V1Ingress(
         metadata=client.V1ObjectMeta(
-            name="myapp-ingress",
+            name=name,
             namespace="default",
             annotations={
-                "jac-scale/domain": "app.example.com",
-                "jac-scale/cert-email": "user@example.com",
                 "cert-manager.io/issuer": "letsencrypt-prod",
                 "nginx.ingress.kubernetes.io/ssl-redirect": "true",
                 "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
@@ -2103,31 +2091,30 @@ test "redeploy preserves TLS state set by enable_tls (regression for #5834)" {
             ingress_class_name="myapp-nginx",
             rules=[
                 client.V1IngressRule(
-                    host="app.example.com",
-                    http=client.V1HTTPIngressRuleValue(
-                        paths=[
-                            client.V1HTTPIngressPath(
-                                path="/",
-                                path_type="Prefix",
-                                backend=client.V1IngressBackend(
-                                    service=client.V1IngressServiceBackend(
-                                        name="myapp-service",
-                                        port=client.V1ServiceBackendPort(number=8000)
-                                    )
-                                )
-                            )
-                        ]
-                    )
+                    host=domain, http=client.V1HTTPIngressRuleValue(paths=[])
                 )
             ],
-            tls=[
-                client.V1IngressTLS(hosts=["app.example.com"], secret_name="myapp-tls")
-            ]
+            tls=[client.V1IngressTLS(hosts=[domain], secret_name=secret)]
         )
     );
+}
+
+test "redeploy preserves TLS state set by enable_tls (regression for #5834)" {
+    # `jac start --scale` run after `--enable-tls` was silently wiping
+    # spec.tls, the host on rule[0], and the cert-manager / ssl-redirect
+    # annotations because _deploy_ingress_resource issues a full PUT via
+    # replace_namespaced_ingress. Without _preserve_tls_state copying the
+    # live TLS state into the new body, HTTPS falls back to the controller's
+    # self-signed cert in production.
+    k8s_config = KubernetesConfig(
+        domain="app.example.com", cert_manager_email="user@example.com"
+    );
+    ingress_deployer = IngressDeployer(k8s_config, None);
 
     mock_networking_v1 = unittest.mock.MagicMock();
-    mock_networking_v1.read_namespaced_ingress.return_value = live_ingress;
+    mock_networking_v1.read_namespaced_ingress.return_value = _make_live_tls_ingress(
+        "myapp-ingress", "app.example.com", "myapp-tls"
+    );
     mock_core_v1 = unittest.mock.MagicMock();
 
     ingress_deployer._deploy_ingress_resource(
@@ -2142,92 +2129,21 @@ test "redeploy preserves TLS state set by enable_tls (regression for #5834)" {
         core_v1=mock_core_v1
     );
 
-    assert mock_networking_v1.replace_namespaced_ingress.called , "replace_namespaced_ingress should be called when ingress already exists";
     body = mock_networking_v1.replace_namespaced_ingress.call_args[1]["body"];
-
-    # TLS spec must survive the redeploy
     tls = body["spec"].get("tls", []);
     assert len(tls) == 1
     and tls[0]["hosts"] == ["app.example.com"]
     and tls[0]["secretName"] == "myapp-tls" , "spec.tls must be preserved on redeploy";
-
-    # Host on the rule must survive the redeploy so nginx routes the cert correctly
-    rule = body["spec"]["rules"][0];
-    assert rule.get("host") == "app.example.com" , "rule host must be preserved on redeploy";
-
-    # cert-manager and ssl-redirect annotations must survive the redeploy
+    assert body["spec"]["rules"][0].get("host") == "app.example.com" , "rule host must be preserved on redeploy";
     ann = body["metadata"]["annotations"];
     assert ann.get("cert-manager.io/issuer") == "letsencrypt-prod" , "cert-manager.io/issuer annotation must be preserved";
     assert ann.get("nginx.ingress.kubernetes.io/ssl-redirect") == "true" , "ssl-redirect annotation must be preserved";
     assert ann.get("nginx.ingress.kubernetes.io/force-ssl-redirect") == "true" , "force-ssl-redirect annotation must be preserved";
 }
 
-test "redeploy does not invent TLS when live ingress has none" {
-    # Negative case: the first-deploy invariant ("wildcard rule until
-    # enable_tls") must hold. _preserve_tls_state should bail when the live
-    # Ingress carries no spec.tls, leaving the new body with no host and no
-    # tls block. Otherwise we'd risk setting a host before the cert exists,
-    # which makes the app unreachable via the raw NLB hostname.
-    k8s_config = KubernetesConfig(
-        domain="app.example.com", cert_manager_email="user@example.com"
-    );
-    ingress_deployer = IngressDeployer(k8s_config, None);
-
-    live_ingress_no_tls = client.V1Ingress(
-        metadata=client.V1ObjectMeta(
-            name="myapp-ingress",
-            namespace="default",
-            annotations={"jac-scale/domain": "app.example.com"}
-        ),
-        spec=client.V1IngressSpec(
-            ingress_class_name="myapp-nginx",
-            rules=[
-                client.V1IngressRule(
-                    http=client.V1HTTPIngressRuleValue(
-                        paths=[
-                            client.V1HTTPIngressPath(
-                                path="/",
-                                path_type="Prefix",
-                                backend=client.V1IngressBackend(
-                                    service=client.V1IngressServiceBackend(
-                                        name="myapp-service",
-                                        port=client.V1ServiceBackendPort(number=8000)
-                                    )
-                                )
-                            )
-                        ]
-                    )
-                )
-            ]
-        )
-    );
-
-    mock_networking_v1 = unittest.mock.MagicMock();
-    mock_networking_v1.read_namespaced_ingress.return_value = live_ingress_no_tls;
-    mock_core_v1 = unittest.mock.MagicMock();
-
-    ingress_deployer._deploy_ingress_resource(
-        app_name="myapp",
-        namespace="default",
-        ingress_class="myapp-nginx",
-        service_port=8000,
-        grafana_enabled=False,
-        redis_dashboard=False,
-        mongo_dashboard=False,
-        networking_v1=mock_networking_v1,
-        core_v1=mock_core_v1
-    );
-
-    body = mock_networking_v1.replace_namespaced_ingress.call_args[1]["body"];
-    assert "tls" not in body["spec"] , "no tls should be added when live ingress has none";
-    assert "host" not in body["spec"]["rules"][0] , "no host should be added when live ingress has no TLS";
-    ann = body["metadata"]["annotations"];
-    assert "cert-manager.io/issuer" not in ann , "cert-manager annotation should not be invented";
-}
-
-test "redeploy preserves TLS on Redis ingress" {
+test "redeploy preserves TLS on Redis ingress (regression for #5834)" {
     # Same regression as the main ingress, but for the RedisInsight Ingress
-    # branch (separate `replace_namespaced_ingress` site, same bug).
+    # write path (a separate replace_namespaced_ingress call site, same bug).
     k8s_config = KubernetesConfig(
         domain="app.example.com",
         cert_manager_email="user@example.com",
@@ -2236,49 +2152,9 @@ test "redeploy preserves TLS on Redis ingress" {
     );
     ingress_deployer = IngressDeployer(k8s_config, None);
 
-    live_main = client.V1Ingress(
-        metadata=client.V1ObjectMeta(
-            name="myapp-ingress",
-            namespace="default",
-            annotations={
-                "cert-manager.io/issuer": "letsencrypt-prod",
-                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
-                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
-            }
-        ),
-        spec=client.V1IngressSpec(
-            ingress_class_name="myapp-nginx",
-            rules=[
-                client.V1IngressRule(
-                    host="app.example.com", http=client.V1HTTPIngressRuleValue(paths=[])
-                )
-            ],
-            tls=[
-                client.V1IngressTLS(hosts=["app.example.com"], secret_name="myapp-tls")
-            ]
-        )
-    );
-    live_redis = client.V1Ingress(
-        metadata=client.V1ObjectMeta(
-            name="myapp-redis-insight-ingress",
-            namespace="default",
-            annotations={
-                "cert-manager.io/issuer": "letsencrypt-prod",
-                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
-                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
-            }
-        ),
-        spec=client.V1IngressSpec(
-            ingress_class_name="myapp-nginx",
-            rules=[
-                client.V1IngressRule(
-                    host="app.example.com", http=client.V1HTTPIngressRuleValue(paths=[])
-                )
-            ],
-            tls=[
-                client.V1IngressTLS(hosts=["app.example.com"], secret_name="myapp-tls")
-            ]
-        )
+    live_main = _make_live_tls_ingress("myapp-ingress", "app.example.com", "myapp-tls");
+    live_redis = _make_live_tls_ingress(
+        "myapp-redis-insight-ingress", "app.example.com", "myapp-tls"
     );
 
     def _read(name: str, namespace: str) -> Any {

--- a/jac-scale/jac_scale/tests/test_deploy_k8s.jac
+++ b/jac-scale/jac_scale/tests/test_deploy_k8s.jac
@@ -2073,3 +2073,247 @@ test "redis ingress rule must not set host before TLS is enabled" {
     redis_rule = redis_created_body["spec"]["rules"][0];
     assert "host" not in redis_rule , "Redis ingress rule must not set host before TLS is enabled";
 }
+
+test "redeploy preserves TLS state set by enable_tls (regression for #5834)" {
+    # Regression test: a `jac start --scale` run after `--enable-tls` was
+    # silently wiping spec.tls, the host on rule[0], and the cert-manager /
+    # ssl-redirect annotations because _deploy_ingress_resource issues a full
+    # PUT via replace_namespaced_ingress. Without _preserve_tls_state copying
+    # the live TLS state into the new body, HTTPS falls back to the
+    # controller's self-signed cert in production.
+    k8s_config = KubernetesConfig(
+        domain="app.example.com", cert_manager_email="user@example.com"
+    );
+    ingress_deployer = IngressDeployer(k8s_config, None);
+
+    # Build a real V1Ingress that mirrors the post-enable_tls live state
+    live_ingress = client.V1Ingress(
+        metadata=client.V1ObjectMeta(
+            name="myapp-ingress",
+            namespace="default",
+            annotations={
+                "jac-scale/domain": "app.example.com",
+                "jac-scale/cert-email": "user@example.com",
+                "cert-manager.io/issuer": "letsencrypt-prod",
+                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
+            }
+        ),
+        spec=client.V1IngressSpec(
+            ingress_class_name="myapp-nginx",
+            rules=[
+                client.V1IngressRule(
+                    host="app.example.com",
+                    http=client.V1HTTPIngressRuleValue(
+                        paths=[
+                            client.V1HTTPIngressPath(
+                                path="/",
+                                path_type="Prefix",
+                                backend=client.V1IngressBackend(
+                                    service=client.V1IngressServiceBackend(
+                                        name="myapp-service",
+                                        port=client.V1ServiceBackendPort(number=8000)
+                                    )
+                                )
+                            )
+                        ]
+                    )
+                )
+            ],
+            tls=[
+                client.V1IngressTLS(hosts=["app.example.com"], secret_name="myapp-tls")
+            ]
+        )
+    );
+
+    mock_networking_v1 = unittest.mock.MagicMock();
+    mock_networking_v1.read_namespaced_ingress.return_value = live_ingress;
+    mock_core_v1 = unittest.mock.MagicMock();
+
+    ingress_deployer._deploy_ingress_resource(
+        app_name="myapp",
+        namespace="default",
+        ingress_class="myapp-nginx",
+        service_port=8000,
+        grafana_enabled=False,
+        redis_dashboard=False,
+        mongo_dashboard=False,
+        networking_v1=mock_networking_v1,
+        core_v1=mock_core_v1
+    );
+
+    assert mock_networking_v1.replace_namespaced_ingress.called , "replace_namespaced_ingress should be called when ingress already exists";
+    body = mock_networking_v1.replace_namespaced_ingress.call_args[1]["body"];
+
+    # TLS spec must survive the redeploy
+    tls = body["spec"].get("tls", []);
+    assert len(tls) == 1
+    and tls[0]["hosts"] == ["app.example.com"]
+    and tls[0]["secretName"] == "myapp-tls" , "spec.tls must be preserved on redeploy";
+
+    # Host on the rule must survive the redeploy so nginx routes the cert correctly
+    rule = body["spec"]["rules"][0];
+    assert rule.get("host") == "app.example.com" , "rule host must be preserved on redeploy";
+
+    # cert-manager and ssl-redirect annotations must survive the redeploy
+    ann = body["metadata"]["annotations"];
+    assert ann.get("cert-manager.io/issuer") == "letsencrypt-prod" , "cert-manager.io/issuer annotation must be preserved";
+    assert ann.get("nginx.ingress.kubernetes.io/ssl-redirect") == "true" , "ssl-redirect annotation must be preserved";
+    assert ann.get("nginx.ingress.kubernetes.io/force-ssl-redirect") == "true" , "force-ssl-redirect annotation must be preserved";
+}
+
+test "redeploy does not invent TLS when live ingress has none" {
+    # Negative case: the first-deploy invariant ("wildcard rule until
+    # enable_tls") must hold. _preserve_tls_state should bail when the live
+    # Ingress carries no spec.tls, leaving the new body with no host and no
+    # tls block. Otherwise we'd risk setting a host before the cert exists,
+    # which makes the app unreachable via the raw NLB hostname.
+    k8s_config = KubernetesConfig(
+        domain="app.example.com", cert_manager_email="user@example.com"
+    );
+    ingress_deployer = IngressDeployer(k8s_config, None);
+
+    live_ingress_no_tls = client.V1Ingress(
+        metadata=client.V1ObjectMeta(
+            name="myapp-ingress",
+            namespace="default",
+            annotations={"jac-scale/domain": "app.example.com"}
+        ),
+        spec=client.V1IngressSpec(
+            ingress_class_name="myapp-nginx",
+            rules=[
+                client.V1IngressRule(
+                    http=client.V1HTTPIngressRuleValue(
+                        paths=[
+                            client.V1HTTPIngressPath(
+                                path="/",
+                                path_type="Prefix",
+                                backend=client.V1IngressBackend(
+                                    service=client.V1IngressServiceBackend(
+                                        name="myapp-service",
+                                        port=client.V1ServiceBackendPort(number=8000)
+                                    )
+                                )
+                            )
+                        ]
+                    )
+                )
+            ]
+        )
+    );
+
+    mock_networking_v1 = unittest.mock.MagicMock();
+    mock_networking_v1.read_namespaced_ingress.return_value = live_ingress_no_tls;
+    mock_core_v1 = unittest.mock.MagicMock();
+
+    ingress_deployer._deploy_ingress_resource(
+        app_name="myapp",
+        namespace="default",
+        ingress_class="myapp-nginx",
+        service_port=8000,
+        grafana_enabled=False,
+        redis_dashboard=False,
+        mongo_dashboard=False,
+        networking_v1=mock_networking_v1,
+        core_v1=mock_core_v1
+    );
+
+    body = mock_networking_v1.replace_namespaced_ingress.call_args[1]["body"];
+    assert "tls" not in body["spec"] , "no tls should be added when live ingress has none";
+    assert "host" not in body["spec"]["rules"][0] , "no host should be added when live ingress has no TLS";
+    ann = body["metadata"]["annotations"];
+    assert "cert-manager.io/issuer" not in ann , "cert-manager annotation should not be invented";
+}
+
+test "redeploy preserves TLS on Redis ingress" {
+    # Same regression as the main ingress, but for the RedisInsight Ingress
+    # branch (separate `replace_namespaced_ingress` site, same bug).
+    k8s_config = KubernetesConfig(
+        domain="app.example.com",
+        cert_manager_email="user@example.com",
+        redis_insight_username="admin",
+        redis_insight_password="hunter2"
+    );
+    ingress_deployer = IngressDeployer(k8s_config, None);
+
+    live_main = client.V1Ingress(
+        metadata=client.V1ObjectMeta(
+            name="myapp-ingress",
+            namespace="default",
+            annotations={
+                "cert-manager.io/issuer": "letsencrypt-prod",
+                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
+            }
+        ),
+        spec=client.V1IngressSpec(
+            ingress_class_name="myapp-nginx",
+            rules=[
+                client.V1IngressRule(
+                    host="app.example.com", http=client.V1HTTPIngressRuleValue(paths=[])
+                )
+            ],
+            tls=[
+                client.V1IngressTLS(hosts=["app.example.com"], secret_name="myapp-tls")
+            ]
+        )
+    );
+    live_redis = client.V1Ingress(
+        metadata=client.V1ObjectMeta(
+            name="myapp-redis-insight-ingress",
+            namespace="default",
+            annotations={
+                "cert-manager.io/issuer": "letsencrypt-prod",
+                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+                "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
+            }
+        ),
+        spec=client.V1IngressSpec(
+            ingress_class_name="myapp-nginx",
+            rules=[
+                client.V1IngressRule(
+                    host="app.example.com", http=client.V1HTTPIngressRuleValue(paths=[])
+                )
+            ],
+            tls=[
+                client.V1IngressTLS(hosts=["app.example.com"], secret_name="myapp-tls")
+            ]
+        )
+    );
+
+    def _read(name: str, namespace: str) -> Any {
+        if name == "myapp-redis-insight-ingress" {
+            return live_redis;
+        }
+        return live_main;
+    }
+
+    mock_networking_v1 = unittest.mock.MagicMock();
+    mock_networking_v1.read_namespaced_ingress.side_effect = _read;
+    mock_core_v1 = unittest.mock.MagicMock();
+
+    ingress_deployer._deploy_ingress_resource(
+        app_name="myapp",
+        namespace="default",
+        ingress_class="myapp-nginx",
+        service_port=8000,
+        grafana_enabled=False,
+        redis_dashboard=True,
+        mongo_dashboard=False,
+        networking_v1=mock_networking_v1,
+        core_v1=mock_core_v1
+    );
+
+    redis_call = None;
+    for call in mock_networking_v1.replace_namespaced_ingress.call_args_list {
+        if call[1]["name"] == "myapp-redis-insight-ingress" {
+            redis_call = call;
+            break;
+        }
+    }
+    assert redis_call is not None , "redis ingress should be replaced";
+    redis_body = redis_call[1]["body"];
+    redis_tls = redis_body["spec"].get("tls", []);
+    assert len(redis_tls) == 1 and redis_tls[0]["secretName"] == "myapp-tls" , "Redis ingress spec.tls must be preserved on redeploy";
+    assert redis_body["spec"]["rules"][0].get("host") == "app.example.com" , "Redis ingress host must be preserved on redeploy";
+}


### PR DESCRIPTION
## Summary

Fixes #5834.

`_deploy_ingress_resource` was rebuilding the Ingress body with no host and no `spec.tls`, then writing it via `replace_namespaced_ingress` (a full-object PUT). Every `jac start --scale` run after `--enable-tls` silently wiped the TLS spec, host, and cert-manager / ssl-redirect annotations, leaving the app on HTTP only and serving the controller's default self-signed cert on HTTPS (browsers saw `ERR_CERT_AUTHORITY_INVALID`).

Hit in production: `maizemind-juncture/jaseci-ingress` and `scoochai/jaseci-ingress` both lost their TLS spec after a redeploy. cert-manager `Certificate` and TLS secret were intact, just no longer referenced by the Ingress.

## Fix

New `_preserve_tls_state` helper: read the live Ingress before each `replace_namespaced_ingress` call. If the live object has `spec.tls`, copy:

- `spec.tls`
- `host` from the existing rules onto every rule we're writing
- `cert-manager.io/issuer`, `nginx.ingress.kubernetes.io/ssl-redirect`, `nginx.ingress.kubernetes.io/force-ssl-redirect` annotations

When the live Ingress has no TLS (or doesn't exist yet) the helper returns the body unchanged, so the existing "wildcard rule until `--enable-tls`" first-deploy path is preserved.

Applied to both the main Ingress and the RedisInsight Ingress write paths.

## Test plan

- [x] Manual: production `scoochai/jaseci-ingress` was patched out-of-band to restore TLS; follow-up redeploys with this fix in place no longer overwrite that state
- [ ] Add unit coverage for `_preserve_tls_state` (404, no-tls, with-tls cases)