### PR TITLE
docs(lang): document closures, IIFEs, and anonymous factories

### DIFF
--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -331,18 +331,95 @@ glob numbers = [1, 2, 3, 4, 5];
 glob squared = list(map(lambda x: int : x ** 2, numbers));
 glob evens = list(filter(lambda x: int : x % 2 == 0, numbers));
 
-# Lambda returning lambda
+# Lambda returning lambda (closure -- see callout below)
 glob make_adder = lambda x: int : (lambda y: int : x + y);
 glob add_five = make_adder(5);  # add_five(10) returns 15
 ```
 
-### 8 Immediately Invoked Function Expressions (IIFE)
+!!! info "Closures"
+    A lambda (or nested `def`) captures variables from its enclosing scope, producing a *closure*. Each call to the outer function creates a fresh binding, so independently configured callables don't share state:
+
+    ```jac
+    glob make_adder = lambda x: int : (lambda y: int : x + y);
+
+    with entry {
+        add_five = make_adder(5);
+        add_ten  = make_adder(10);
+        print(add_five(10));   # 15
+        print(add_ten(10));    # 20  (each closure keeps its own captured x)
+    }
+    ```
+
+    Captured values are read freely. To mutate state across calls, prefer returning a configured object (see [IIFE & Anonymous Factories](#8-iife-anonymous-factories) below) over rebinding a captured local.
+
+### 8 IIFE & Anonymous Factories
+
+An *Immediately Invoked Function Expression* defines a function and calls it in the same expression -- useful for inlining a one-shot computation, or for producing a configured value from a private scope.
+
+**Lambda IIFE** (single expression):
 
 ```jac
 with entry {
-    result = (lambda x: int -> int: x * 2)(5);  # result = 10
+    result = (lambda x: int -> int : x * 2)(5);   # result = 10
 }
 ```
+
+**`def` IIFE** (multi-statement, anonymous):
+
+```jac
+with entry {
+    config = (def () -> dict {
+        host = "localhost";
+        port = 8080;
+        return {"host": host, "port": port, "url": f"http://{host}:{port}"};
+    })();
+    print(config);
+}
+```
+
+**Anonymous factory** -- IIFE + closure to produce a configured callable. This is Jac's equivalent of the JS `x => y => x + y` factory idiom:
+
+```jac
+with entry {
+    adder = (def make_adder(x: int) {
+        return lambda y: int : x + y;
+    })(10);
+
+    print(adder(5));   # 15
+}
+```
+
+**Typed-product factory** -- when the product needs methods or a fixed shape, return an `obj` instance instead of a dict. The factory itself is an anonymous lambda that closes over its arguments:
+
+```jac
+obj Counter {
+    has count: int;
+    def inc -> None { self.count += 1; }
+    def get -> int  { return self.count; }
+}
+
+glob make_counter = lambda start: int -> Counter : Counter(count=start);
+
+with entry {
+    c = make_counter(10);
+    c.inc(); c.inc(); c.inc();
+    print(c.get());   # 13
+}
+```
+
+!!! note "Why no anonymous archetypes?"
+    Jac's `obj`, `node`, `edge`, and `walker` archetypes must be declared with a name at module scope -- there is no inline `obj { has x: int; }` expression. For one-off structural products use a `dict`; when you need methods or a stable type, declare a named `obj` once and have the factory return instances of it.
+
+!!! tip "Coming from JavaScript?"
+    | JS idiom | Jac equivalent |
+    |---|---|
+    | `x => x + 1` | `lambda x: int : x + 1` |
+    | `() => ({a: 1})` | `lambda : {"a": 1}` |
+    | `(() => 42)()` | `(def () -> int { return 42; })()` |
+    | `x => y => x + y` | `lambda x: int : (lambda y: int : x + y)` |
+    | anonymous `class { ... }` | not supported -- declare a named `obj` and return instances |
+
+    Jac lambdas require type annotations on parameters and a space before the body colon (`lambda x: int : x + 1`).
 
 ### 9 Decorators
 

--- a/docs/docs/tutorials/fullstack/advanced-patterns.md
+++ b/docs/docs/tutorials/fullstack/advanced-patterns.md
@@ -117,6 +117,9 @@ def buildWsUrl(basePath: str, token: str) -> str {
 
 Jac compiles to JavaScript, and there are several patterns where you need to work with the compiled output in mind.
 
+!!! tip "Lambda, closure, IIFE, and factory analogs from JS"
+    For a side-by-side mapping of common JS function idioms (`x => x + 1`, IIFEs, closure factories) to their Jac equivalents, see [§8 IIFE & Anonymous Factories](../../reference/language/functions-objects.md#8-iife-anonymous-factories) in the language reference.
+
 ### Reflect.construct for `new` Objects
 
 Jac does not have a `new` keyword. For browser built-in constructors, use `Reflect.construct()`:


### PR DESCRIPTION
## **Description**

Expands the **Functions and Objects** language reference to cover patterns that the existing docs only hinted at:

- **§7 Lambda Expressions:** adds a "Closures" admonition that explicitly names what the existing `make_adder` example demonstrates and shows that each call gets its own captured binding.
- **§8 IIFE & Anonymous Factories** (renamed from "IIFE"):
  - `def`-form IIFE (multi-statement) -- the form the test fixtures actually exercise but the docs never showed
  - **Anonymous factory** example (closure-returning IIFE) -- the Jac equivalent of `x => y => x + y`
  - **Typed-product factory** using a named `obj`
  - "Why no anonymous archetypes?" note clarifying when to use `dict` vs a declared `obj`
  - "Coming from JavaScript?" mapping table for common JS function idioms
- Cross-link from `tutorials/fullstack/advanced-patterns.md` -> §8, so JS-leaning fullstack readers can find the analogs without duplicating the table.

Net change: ~85 lines added inside the existing section. No nav changes, no new files.

## Validation

Every new code block was extracted verbatim from the rendered doc and run through the local `jac` toolchain. Outputs matched the expected values in the comments:

| Snippet | Output |
|---|---|
| Closure callout | `15`, `20` |
| Lambda IIFE | `10` |
| `def` IIFE | `{'host': 'localhost', 'port': 8080, 'url': 'http://localhost:8080'}` |
| Anonymous factory | `15` |
| Typed-product factory | `13` |
| JS->Jac table entries | `5`, `{'a': 1}`, `42`, `7` |

## Test plan

- [ ] `mkdocs build` (or local `mkdocs serve`) renders cleanly with no broken anchors
- [ ] The new cross-link from `advanced-patterns.md` resolves to the renamed §8 anchor (`#8-iife-anonymous-factories`)
- [ ] Spot-check the "Coming from JavaScript?" table renders inside the admonition