### PR TITLE
fix(checker): propagate typed-edge element type in [edge ...] traversals

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5896.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5896.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: typed `[edge ...]` traversals propagate element type**: `[edge a ->:T:-> b]` now resolves to `list[T]` instead of degrading to `list[<Any>]`, so assignments into a `list[T]` no longer require casts. Closes gap 6 of #5885.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -1951,16 +1951,29 @@ impl TypeEvaluator._get_type_of_expression_core(
 
         case uni.EdgeRefTrailer():
             # Edge traversal: [node-->], [node<--], [node->:Edge:->], etc.
-            # Returns list[NodeArchetype] (default) or list[EdgeArchetype] (edges_only).
-            # Two syntax forms place FilterCompr differently:
-            #   [root-->][?:Todo]  — FilterCompr is sibling in AtomTrailer (handled there)
-            #   [-->[?:Todo]]      — FilterCompr is in EdgeRefTrailer.chain (handled here)
+            # Result element type is determined by:
+            #   1. FilterCompr `[?:T]` directly in chain (e.g. [-->[?:Todo]])
+            #   2. EdgeOpRef typed-edge filter `->:T:->` — when edges_only,
+            #      the result element is T itself. Issue #5885 gap 6.
+            # Bare untyped traversals stay as `list[<Any>]` so visit, spawn,
+            # and other consumers retain their gradual-typing semantics.
             if self.prefetch and self.prefetch.list_class {
                 element_type: types.TypeBase = types.AnyType();
                 for chain_item in expr.chain {
                     if isinstance(chain_item, uni.FilterCompr) and chain_item.f_type {
                         ft = self.get_type_of_expression(chain_item.f_type);
                         if isinstance(ft, types.ClassType) {
+                            element_type = self._convert_to_instance(ft);
+                        }
+                    } elif (
+                        isinstance(chain_item, uni.EdgeOpRef)
+                        and expr.edges_only
+                        and chain_item.filter_cond is not None
+                        and chain_item.filter_cond.f_type is not None
+                    ) {
+                        # `[edge ... ->:T:-> ...]` resolves to list[T].
+                        ft = self.get_type_of_expression(chain_item.filter_cond.f_type);
+                        if isinstance(ft, types.ClassType) and ft.is_edge_type() {
                             element_type = self._convert_to_instance(ft);
                         }
                     }

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_edge_ref_typed_result.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_edge_ref_typed_result.jac
@@ -1,0 +1,29 @@
+# Issue #5885 gap 6: edge-ref expression types must propagate parametric
+# element type from EdgeOpRef. `[edge ... ->:T:-> ...]` previously
+# degraded to `list[<Any>]`, forcing casts and flooding downstream
+# assignments with E1001 noise. Typed forms now resolve to `list[T]`.
+
+node Place {
+    has name: str = "x";
+}
+
+edge MyEdge {
+    has weight: int = 1;
+}
+
+edge OtherEdge {
+    has tag: str = "t";
+}
+
+with entry {
+    a: Place = Place();
+    b: Place = Place();
+    a +>: MyEdge :+> b;
+
+    # Typed-edge form on edges_only must yield list[MyEdge].
+    edges_typed: list[MyEdge] = [edge a ->:MyEdge:-> b];          # Ok
+
+    # Wrong typed-edge result element type — must error: the RHS is
+    # list[MyEdge], not list[OtherEdge].
+    bad_edges: list[OtherEdge] = [edge a ->:MyEdge:-> b];         # Error
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -1047,6 +1047,33 @@ test "ability_trigger_archetype" {
     )}:\n" + "\n---\n".join(e.pretty_print() for e in e1117);
 }
 
+test "edge_ref_typed_result" {
+    # Issue #5885 gap 6: typed `[edge ... ->:T:-> ...]` traversals must
+    # propagate `T` as the list element type instead of degrading to
+    # `list[<Any>]`. The Ok line assigns into list[MyEdge]; the Error
+    # line assigns the same expression into list[OtherEdge] so the
+    # checker can prove the propagated element type at the use site.
+    program = JacProgram();
+    path = os.path.join(CHECKER_FIXTURES, "checker_edge_ref_typed_result.jac");
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+    e1001 = [
+        e
+        for e in program.errors_had
+        if e.code and e.code.code == "E1001"
+    ];
+    assert len(e1001) == 1 , f"Expected 1 E1001 (typed edge-ref result mismatch), got {len(
+        e1001
+    )}:\n" + "\n---\n".join(e.pretty_print() for e in e1001);
+    expected_error = """
+        Cannot assign list[MyEdge] to list[OtherEdge]
+            # list[MyEdge], not list[OtherEdge].
+            bad_edges: list[OtherEdge] = [edge a ->:MyEdge:-> b];         # Error
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        """;
+    assert_error_pretty_found(expected_error, e1001[0].pretty_print());
+}
+
 test "root_type" {
     program = JacProgram();
     path = os.path.join(CHECKER_FIXTURES, "checker_root_type.jac");


### PR DESCRIPTION
## Summary

Issue #5885 gap 6: `[edge a ->:T:-> b]` previously degraded to `list[<Any>]`, so assigning into `list[T]` tripped `E1001` in strict mode and forced casts. The `EdgeRefTrailer` evaluator only walked `FilterCompr` chain items (the `[?:T]` form) and ignored the typed-edge filter inside `EdgeOpRef.filter_cond`.

This change extends the chain walk so when `edges_only` is set and the `EdgeOpRef` carries a typed filter, the trailer resolves to `list[T]`. Bare untyped traversals stay as `list[<Any>]` so visit/spawn keep their gradual-typing semantics — flipping those to `list[Node]`/`list[Edge]` would require deeper validator changes (the .pyi `Node`/`Edge` aliases aren't real archetypes).

## Test plan

- [x] New `edge_ref_typed_result` test in `test_checker_pass.jac` with fixture `checker_edge_ref_typed_result.jac`: asserts `list[MyEdge] = [edge a ->:MyEdge:-> b]` is Ok and `list[OtherEdge] = [edge a ->:MyEdge:-> b]` errors with E1001 on `list[MyEdge] -> list[OtherEdge]` (proves propagation).
- [x] `pytest jac/tests/compiler/passes/main/test_checker_pass.jac -n 20` — 192 passed.
- [x] `pytest jac/tests/ -n 20` — 3319 passed, 57 skipped.