### PR TITLE
feat(lang): add `import type` for annotation-only imports

### DIFF
--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -288,16 +288,6 @@ def:pub Counter() -> JsxElement {
 
 ---
 
-### Version 0.12.3
-
-#### 1. Automatic `TYPE_CHECKING` Import Guards
-
-The compiler now automatically detects imports that are only used in type annotations (parameter types, return types, field types) and wraps them in `if typing.TYPE_CHECKING:` guards in the generated Python output.
-
-**Impact:** Existing `if TYPE_CHECKING { ... }` blocks in Jac source still work, but are no longer necessary. You can simplify your code by replacing them with plain imports.
-
----
-
 ### Version 0.12.4
 
 #### 1. `root` Is a Reserved Keyword Again (`SpecialVarRef`)

--- a/docs/docs/community/release_notes/unreleased/jaclang/5898.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5898.feature.md
@@ -1,0 +1,1 @@
+- **Feature: `import type` for annotation-only imports**: A new opt-in `import type from foo { Bar }` form lowers to `if TYPE_CHECKING: from foo import Bar` in the generated Python, breaking circular imports between modules that reference each other only in type signatures.

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -110,10 +110,11 @@ include random;
 # sv import from ...main { MyWalker }       # Server import in client
 # cl import from "@jac/runtime" { Link }    # npm runtime import
 
-# Type-only imports are automatic -- the compiler detects when an import
-# is only used in type annotations and wraps it in TYPE_CHECKING for you.
-# No manual `if TYPE_CHECKING { ... }` blocks needed!
-import from mymodule { MyClass }  # auto-wrapped if only used as a type
+# Type-only import: opt-in, lowers to `if typing.TYPE_CHECKING: ...`
+# Use to break circular imports between modules that reference each other
+# only in type annotations. Don't use for archetype `has` field types or
+# names that decorators (dataclass, Pydantic, FastAPI, ...) resolve at runtime.
+import type from billing { Invoice }
 
 
 # ============================================================

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -86,6 +86,7 @@ Use these appendices when you need to look up a specific keyword, operator, or s
 | `test` | Declaration | Test block |
 | `to` | Control | For loop upper bound |
 | `try` | Control | Try block |
+| `type` | Module | Type-only import marker (`import type from ...`) |
 | `visitor` | OSP | Visiting walker (in node) |
 | `wait` | Concurrency | Wait for concurrent result |
 | `walker` | Archetype | Walker type |
@@ -179,7 +180,7 @@ has_stmt      : "has" (modifier)? NAME ":" type ("=" expr)? ";"
 ability       : async? "can" NAME params? ("->" type)? event_clause? (body | ";")
 event_clause  : "with" type_expr? (entry | exit)
 
-import        : "import" (module | "from" import_path "{" names "}")
+import        : "import" "type"? (module | "from" import_path "{" names "}")
               | "import" "from" STRING "{" extern_decl* "}"  # C library import (na)
 import_path   : (NAME ":")? dotted_name       # Optional namespace prefix (e.g., jac:module)
 entry         : "with" "entry" (":" NAME)? body

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -312,28 +312,6 @@ obj Example {
 }
 ```
 
-#### Automatic `TYPE_CHECKING` Optimization
-
-The Jac compiler automatically detects imports that are **only used in type annotations** (parameter types, return types, field types) and wraps them in a `typing.TYPE_CHECKING` guard in the generated Python. This prevents circular imports and unnecessary runtime dependencies without any manual effort.
-
-```jac
-import from mymodule { MyClass }
-
-obj Example {
-    has ref: MyClass;  # MyClass only used as a type annotation
-}
-```
-
-The compiler sees that `MyClass` never appears in runtime code (no instantiation, no `isinstance` checks, etc.) and automatically generates:
-
-```python
-import typing
-if typing.TYPE_CHECKING:
-    from mymodule import MyClass
-```
-
-If you later add runtime usage like `MyClass()`, the compiler automatically promotes it back to a regular import. No manual `if TYPE_CHECKING` blocks are needed in Jac.
-
 #### Ambient Typing Names
 
 A curated set of annotation-only names from `typing` resolves in user code without an explicit import:
@@ -359,6 +337,35 @@ Names skipped on purpose:
 | `DefaultDict`, `OrderedDict`, `Counter`, `Deque` | the `collections` equivalents |
 
 Runtime values like `cast`, `overload`, `runtime_checkable`, `TYPE_CHECKING`, `get_type_hints`, `get_args`, `get_origin`, and `no_type_check` are not ambient -- import them explicitly when needed.
+
+#### Type-Only Imports (`import type`)
+
+Use `import type` to bring a name into scope **only for type annotations**. The import is registered with the type checker but elided from runtime by lowering to a `typing.TYPE_CHECKING` guard in the generated Python.
+
+```jac
+import type from billing { Invoice }
+
+def total(inv: Invoice) -> int {
+    return inv.amount;
+}
+```
+
+Generated Python:
+
+```python
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from billing import Invoice
+```
+
+This is the supported way to break circular imports between Jac modules whose types reference each other. Combined with `from __future__ import annotations` (always emitted), the annotation stays valid at type-check time without forcing the import to run at module load.
+
+When **not** to use `import type`:
+
+- The name is constructed at runtime (e.g. `Invoice(...)`), used in `isinstance`, or referenced by any decorator that resolves annotations through `typing.get_type_hints` (dataclass, Pydantic, attrs, FastAPI route signatures, SQLAlchemy declarative, msgspec). These libraries call into the module's globals at class-definition time and a `TYPE_CHECKING`-guarded import will not be there. Use a regular `import` for those.
+- The name is used inside an `obj`/`node`/`edge`/`walker` `has` field type. Jac archetypes are dataclass-derived, so the same rule applies: keep them on a regular `import`.
+
+`import type` is opt-in -- a regular `import` still binds the name at runtime exactly as before.
 
 #### The `any` Type and Gradual Typing
 

--- a/docs/docs/reference/language/library-mode.md
+++ b/docs/docs/reference/language/library-mode.md
@@ -344,7 +344,7 @@ The `OPath()` class constructs traversal paths from a given node. The `edge_out(
 
 | Name | Type | Description |
 |------|------|-------------|
-| `TYPE_CHECKING` | bool | Python typing constant for type checking blocks. In Jac source, you rarely need this -- the compiler automatically wraps type-only imports in `TYPE_CHECKING` guards (see [Type Annotations](foundation.md#2-type-annotations)). In library mode Python, use it directly when needed. |
+| `TYPE_CHECKING` | bool | Python typing constant for type checking blocks. Use it in `if TYPE_CHECKING { ... }` guards to break circular imports for type-only references. |
 | `EdgeDir` | Enum | Edge direction enum (IN, OUT, ANY) |
 | `DSFunc` | Type | Object spatial function type alias |
 

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -76,19 +76,17 @@ The compiled output demonstrates how Jac's object-oriented features map to stand
 !!! note
     The transpiler outputs `from jaclang.jac0core.jaclib import ...` internally. The public API `jaclang.lib` re-exports the same symbols and is the recommended import path for library-mode usage.
 
-#### Automatic TYPE_CHECKING Guards
+#### Type-Only Imports
 
-The Jac compiler analyzes import usage and automatically wraps imports that are **only used in type annotations** inside `if typing.TYPE_CHECKING:` guards. This is a common Python pattern to avoid circular imports and reduce runtime overhead, but in Jac you never need to write it manually -- the compiler handles it for you.
-
-For example, if `MyClass` is only used as a type annotation (parameter type, return type, or field type) and never instantiated or used at runtime, the generated Python will include:
+Prefix an import with `type` to mark it as annotation-only. The compiler lowers `import type from foo { Bar }` to:
 
 ```python
-import typing
-if typing.TYPE_CHECKING:
-    from mymodule import MyClass
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from foo import Bar
 ```
 
-This works because Jac always emits `from __future__ import annotations`, which makes all type annotations lazy strings that are never evaluated at runtime.
+Use this to break circular imports between modules that only reference each other in type signatures. Stay with a regular `import` whenever the name is constructed, instance-checked, or consumed by a decorator that resolves annotations at runtime (dataclass, Pydantic, attrs, FastAPI, SQLAlchemy). See [Type-Only Imports (`import type`)](foundation.md#type-only-imports-import-type) for the full rule of thumb.
 
 ---
 

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -401,18 +401,17 @@ with entry {
 
 ### Type-Only Imports
 
-In Python, you often need to wrap imports in `if TYPE_CHECKING:` blocks to avoid circular imports when a type is only used in annotations. Jac handles this automatically -- just write a normal import and the compiler detects whether it's only used in type positions:
+When two modules only reference each other in type annotations, a regular `import` creates a circular import at module load. Mark the import with `type` to tell the compiler it's annotation-only:
 
 ```jac
-import from mymodule { MyClass }
+import type from billing { Invoice }
 
-# MyClass only appears in type annotations, never instantiated here
-def process(item: MyClass) -> MyClass {
-    return item;
+def total(inv: Invoice) -> int {
+    return inv.amount;
 }
 ```
 
-The compiler automatically wraps `MyClass` in a `TYPE_CHECKING` guard in the generated Python output. If you later add runtime usage like `MyClass()`, it automatically becomes a regular import.
+The generated Python lowers this to `if TYPE_CHECKING: from billing import Invoice` (with `TYPE_CHECKING` imported from `typing`), so the import never runs at runtime and the cycle is broken. Keep `import type` to names you only use in `def` parameter/return types -- decorators like `dataclass` and `Pydantic.BaseModel` resolve annotations on archetype `has` fields at class-definition time and need their types as regular runtime imports.
 
 ---
 

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -3640,6 +3640,11 @@ impl EsastGenPass.exit_archetype(nd: uni.Archetype) -> None {
 
 """Process import statement."""
 impl EsastGenPass.exit_import(nd: uni.Import) -> None {
+    # Type-only imports never reach JS runtime: types are erased.
+    if nd.is_typed {
+        nd.gen.es_ast = None;
+        return;
+    }
     # Server-side import (sv keyword) - generate stubs for def:pub functions
     if (
         nd.code_context != CodeContext.CLIENT

--- a/jac/jaclang/compiler/passes/main/cfg_build_pass.jac
+++ b/jac/jaclang/compiler/passes/main/cfg_build_pass.jac
@@ -10,15 +10,10 @@ optimization used during backward CFG walks in type narrowing.
 """
 import from collections.abc { Sequence }
 import from threading { Event }
-import from typing { TYPE_CHECKING, cast }
+import from typing { cast }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes { UniPass }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 """CFG build pass using entry/exit visitor pattern."""
 obj CFGBuildPass(UniPass) {

--- a/jac/jaclang/compiler/passes/main/impl/unitree_enrich_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/unitree_enrich_pass.impl.jac
@@ -1,22 +1,16 @@
 """Implementation of UniTreeEnrichPass and _typebase_to_tag()."""
-import from typing { TYPE_CHECKING }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.type_system.types {
-            TypeBase,
-            ClassType,
-            NeverType,
-            UnknownType,
-            AnyType,
-            TypeVarType,
-            FunctionType,
-            ModuleType,
-            UnionType,
-            OverloadedType,
-            EnumMemberType
-        }
-    }
+import type from jaclang.compiler.type_system.types {
+    TypeBase,
+    ClassType,
+    NeverType,
+    UnknownType,
+    AnyType,
+    TypeVarType,
+    FunctionType,
+    ModuleType,
+    UnionType,
+    OverloadedType,
+    EnumMemberType
 }
 
 impl _typebase_to_tag(t: Any) -> (str | None) {

--- a/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
+++ b/jac/jaclang/compiler/passes/main/pyast_load_pass.jac
@@ -18,18 +18,13 @@ import os;
 import re;
 import from collections.abc { Sequence }
 import from threading { Event }
-import from typing { TYPE_CHECKING, TypeAlias, TypeVar, cast }
+import from typing { TypeAlias, TypeVar, cast }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.constant { Tokens as Tok }
 import from jaclang.jac0core.diagnostics { E5041, E5042 }
 import from jaclang.jac0core.helpers { evaluate_version_condition }
 import from jaclang.jac0core.passes.transform { Transform }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 glob T = TypeVar('T', bound=uni.UniNode);
 

--- a/jac/jaclang/compiler/passes/native/primitives_native.jac
+++ b/jac/jaclang/compiler/passes/native/primitives_native.jac
@@ -9,7 +9,6 @@ to the existing inline codegen in the pass impl files. As inline codegen is
 extracted into emitter methods, they will return ir.Value results instead.
 """
 
-import from typing { TYPE_CHECKING }
 import from llvmlite { ir }
 import from jaclang.compiler.primitives {
     IntEmitter,
@@ -25,12 +24,7 @@ import from jaclang.compiler.primitives {
     RangeEmitter,
     BuiltinEmitter
 }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.passes.native.na_ir_gen_pass { NaIRGenPass }
-    }
-}
+import type from jaclang.compiler.passes.native.na_ir_gen_pass { NaIRGenPass }
 
 # --- Context ----------------------------------------------------------------
 obj NativeEmitCtx {

--- a/jac/jaclang/compiler/passes/tool/doc_ir.jac
+++ b/jac/jaclang/compiler/passes/tool/doc_ir.jac
@@ -1,11 +1,6 @@
 """Document Intermediate Representation (DocIR) classes."""
-import from typing { TYPE_CHECKING, Union }
-
-with entry {
-    if TYPE_CHECKING {
-        import jaclang.jac0core.unitree as uni;
-    }
-}
+import from typing { Union }
+import type jaclang.jac0core.unitree as uni;
 
 # Define DocType for self-referential typing
 glob DocType = Union[

--- a/jac/jaclang/compiler/passes/tool/impl/normalize_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/normalize_pass.impl.jac
@@ -274,6 +274,9 @@ impl NormalizePass.enter_import(nd: uni.Import) -> None {
     } else {
         new_kid.append(nd.gen_token(Tok.KW_IMPORT));
     }
+    if nd.is_typed {
+        new_kid.append(nd.gen_token(Tok.TYP_TYPE));
+    }
     if nd.from_loc {
         new_kid.append(nd.gen_token(Tok.KW_FROM));
         new_kid.append(nd.from_loc);

--- a/jac/jaclang/compiler/passes/tool/impl/unparse_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/unparse_pass.impl.jac
@@ -245,6 +245,9 @@ impl UnparsePass.exit_import(nd: uni.Import) -> None {
     } else {
         parts.append("import");
     }
+    if nd.is_typed {
+        parts.append("type");
+    }
     items = self._comma_sep(nd.items);
     if nd.from_loc {
         parts.append("from");

--- a/jac/jaclang/compiler/type_system/enum_utils.jac
+++ b/jac/jaclang/compiler/type_system/enum_utils.jac
@@ -3,15 +3,9 @@ Utilities for enum type checking.
 
 PyrightReference: packages/pyright-internal/src/analyzer/enums.ts
 """
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
 import from . { types }
-
-with entry {
-    if TYPE_CHECKING {
-        import from .type_evaluator { TypeEvaluator, PrefetchedTypes }
-    }
-}
+import type from .type_evaluator { TypeEvaluator, PrefetchedTypes }
 
 # Names that are excluded from enum membership
 glob ENUM_RESERVED_NAMES: set[str] = {'name','value','_name_','_value_','_ignore_','_order_','__order__','_missing_','_generate_next_value_'};

--- a/jac/jaclang/compiler/type_system/impl/enum_utils.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/enum_utils.impl.jac
@@ -1,18 +1,12 @@
 """
 Implementations for enum type checking utilities.
 """
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.compiler.type_system { types }
 import from jaclang.jac0core.diagnostics { E1001 }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.type_system.type_evaluator {
-            TypeEvaluator,
-            PrefetchedTypes
-        }
-    }
+import type from jaclang.compiler.type_system.type_evaluator {
+    TypeEvaluator,
+    PrefetchedTypes
 }
 
 """Check if a name should be excluded from enum membership."""

--- a/jac/jaclang/compiler/type_system/operations.jac
+++ b/jac/jaclang/compiler/type_system/operations.jac
@@ -3,7 +3,6 @@ Provides type evaluation logic for unary, binary, augmented assignment and terna
 
 PyrightReference: packages/pyright-internal/src/analyzer/operations.ts
 """
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.constant { Tokens as Tok }
 import from . { types as jtypes }
@@ -18,12 +17,7 @@ import from jaclang.jac0core.diagnostics {
     E1114,
     E1115
 }
-
-with entry {
-    if TYPE_CHECKING {
-        import from .type_evaluator { TypeEvaluator }
-    }
-}
+import type from .type_evaluator { TypeEvaluator }
 
 # FIX: py2jac bug - module-level constants must be declared with glob outside with entry block
 # Otherwise they become Field descriptors when accessed from functions

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -9,7 +9,7 @@ PyrightReference:
 import ast as py_ast;
 import os;
 import from pathlib { Path }
-import from typing { TYPE_CHECKING, cast }
+import from typing { cast }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.constant { TOKEN_MAP }
 import from jaclang.jac0core.constant { SymbolType, Tokens as Tok }
@@ -17,12 +17,7 @@ import from jaclang.compiler.passes.main.pyast_load_pass { PyastBuildPass }
 import from jaclang.jac0core.passes.sym_tab_build_pass { SymTabBuildPass }
 import from jaclang.compiler.type_system { types }
 import from jaclang.runtimelib.utils { read_file_with_encoding }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 # FIXME: Conver the bellow to dot import (from . import ...)
 # Currently its not possible with jac+python hybrid repos.

--- a/jac/jaclang/compiler/type_system/types.jac
+++ b/jac/jaclang/compiler/type_system/types.jac
@@ -2,14 +2,9 @@
 import from abc { ABC }
 import from enum { IntEnum, auto }
 import from pathlib { Path }
-import from typing { TYPE_CHECKING, ClassVar }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.unitree { Expr, Symbol }
-        import from jaclang.jac0core.unitree { UniScopeNode as SymbolTable }
-    }
-}
+import from typing { ClassVar }
+import type from jaclang.jac0core.unitree { Expr, Symbol }
+import type from jaclang.jac0core.unitree { UniScopeNode as SymbolTable }
 
 """Enumeration of type categories."""
 enum TypeCategory ( IntEnum ) {

--- a/jac/jaclang/jac.spec
+++ b/jac/jaclang/jac.spec
@@ -406,7 +406,7 @@ assignment_with_target ::=
     ) ";" ";"?
 
 import_stmt ::=
-    ("include" | "import") ("from" from_path)? (
+    ("include" | "import") "type"? ("from" from_path)? (
         import_items
         | (STRING | (NAME | KWESC_NAME) ("." (NAME | KWESC_NAME))*)?
           ("as" (NAME | KWESC_NAME))?

--- a/jac/jaclang/jac0.py
+++ b/jac/jaclang/jac0.py
@@ -390,6 +390,7 @@ class Import:
     names: list = field(default_factory=list)
     alias: str = ""
     is_from: bool = False
+    is_typed: bool = False
 
 
 @dataclass
@@ -1161,6 +1162,11 @@ class Parser:
 
     def _parse_import(self) -> Import:
         self._expect(TT.NAME, "import")
+        # Optional `type` keyword for annotation-only imports.
+        is_typed = False
+        if self._at(TT.NAME, "type"):
+            self._advance()
+            is_typed = True
         if self._at(TT.NAME, "from"):
             self._advance()  # consume 'from'
             module = self._collect_dotted()
@@ -1191,14 +1197,14 @@ class Parser:
                 self._match(TT.COMMA)
             self._expect(TT.RBRACE)
             self._match(TT.SEMI)
-            return Import(module=module, names=names, is_from=True)
+            return Import(module=module, names=names, is_from=True, is_typed=is_typed)
         else:
             module = self._collect_dotted()
             alias = ""
             if self._match(TT.NAME, "as"):
                 alias = self._expect(TT.NAME).value
             self._match(TT.SEMI)
-            return Import(module=module, alias=alias, is_from=False)
+            return Import(module=module, alias=alias, is_from=False, is_typed=is_typed)
 
     # ── Classes ───────────────────────────────────────────────────────────
 
@@ -1749,6 +1755,7 @@ class CodeGen:
         self.indent = 0
         self.needs_dataclass_import = False
         self.needs_enum_import = False
+        self.needs_typing_import = False
         self.impl_registry: dict[str, list[ImplDef]] = {}
         self._in_class = False
 
@@ -1780,6 +1787,8 @@ class CodeGen:
             self._line("from dataclasses import dataclass, field")
         if self.needs_enum_import:
             self._line("import enum")
+        if self.needs_typing_import:
+            self._line("from typing import TYPE_CHECKING")
         self._line()
         for node in module.body:
             self._emit(node)
@@ -1796,6 +1805,9 @@ class CodeGen:
             elif isinstance(node, EnumDef):
                 if not node.bases or node.value_type:
                     self.needs_enum_import = True
+            elif isinstance(node, Import):
+                if node.is_typed:
+                    self.needs_typing_import = True
             elif isinstance(node, WithEntry):
                 self._scan_needs(node.body)
 
@@ -1866,6 +1878,19 @@ class CodeGen:
     # ── Imports ───────────────────────────────────────────────────────────
 
     def _emit_import(self, node: Import) -> None:
+        if node.is_typed:
+            if node.is_from:
+                names = ", ".join(node.names)
+                stmt = f"from {node.module} import {names}"
+            elif node.alias:
+                stmt = f"import {node.module} as {node.alias}"
+            else:
+                stmt = f"import {node.module}"
+            self._line("if TYPE_CHECKING:")
+            self.indent += 1
+            self._line(stmt)
+            self.indent -= 1
+            return
         if node.is_from:
             names = ", ".join(node.names)
             self._line(f"from {node.module} import {names}")

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -2,17 +2,12 @@
 import ast as ast3;
 import from collections.abc { Sequence }
 import from dataclasses { field }
-import from typing { TYPE_CHECKING, Any }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.passes.ecmascript.estree { IndexInfo, SliceInfo }
-        import from jaclang.compiler.passes.ecmascript.estree { Node as EsNode }
-        import from jaclang.compiler.passes.tool.doc_ir { Doc }
-        import from jaclang.jac0core.unitree { Source, Token }
-        import from llvmlite.binding { ModuleRef, ExecutionEngine }
-    }
-}
+import from typing { Any }
+import type from jaclang.compiler.passes.ecmascript.estree { IndexInfo, SliceInfo }
+import type from jaclang.compiler.passes.ecmascript.estree { Node as EsNode }
+import type from jaclang.compiler.passes.tool.doc_ir { Doc }
+import type from jaclang.jac0core.unitree { Source, Token }
+import type from llvmlite.binding { ModuleRef, ExecutionEngine }
 
 """Client-side rendering manifest metadata."""
 obj ClientManifest {

--- a/jac/jaclang/jac0core/helpers.jac
+++ b/jac/jaclang/jac0core/helpers.jac
@@ -9,13 +9,8 @@ import from collections.abc { Callable, Sequence }
 import from dataclasses { fields, is_dataclass }
 import from functools { lru_cache }
 import from traceback { TracebackException }
-import from typing { TYPE_CHECKING, get_args, get_origin }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang { plugin as pluggy }
-    }
-}
+import from typing { get_args, get_origin }
+import type from jaclang { plugin as pluggy }
 
 """Convert pascal case to snake case."""
 @lru_cache(maxsize=256)

--- a/jac/jaclang/jac0core/interop_bridge.jac
+++ b/jac/jaclang/jac0core/interop_bridge.jac
@@ -6,13 +6,7 @@ for native/Python interop.
 import ctypes;
 import logging;
 import from collections.abc { Callable }
-import from typing { TYPE_CHECKING }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.codeinfo { InteropManifest }
-    }
-}
+import type from jaclang.jac0core.codeinfo { InteropManifest }
 
 glob logger = logging.getLogger(__name__),
      JAC_TO_CTYPES: dict[(str, type)] = {

--- a/jac/jaclang/jac0core/jir_passes.jac
+++ b/jac/jaclang/jac0core/jir_passes.jac
@@ -10,7 +10,7 @@ kid/parent, scope chains, symbol tables, and CFG edges.
 import struct;
 import sys;
 import zlib;
-import from typing { Any, TYPE_CHECKING }
+import from typing { Any }
 
 import from jaclang.jac0core.jir_registry {
     FieldKind,
@@ -19,20 +19,15 @@ import from jaclang.jac0core.jir_registry {
     NodeSpec,
     get_class_mapping
 }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.unitree {
-            Module,
-            UniNode,
-            UniScopeNode,
-            UniCFGNode,
-            NameAtom,
-            Symbol,
-            Source,
-            Token
-        }
-    }
+import type from jaclang.jac0core.unitree {
+    Module,
+    UniNode,
+    UniScopeNode,
+    UniCFGNode,
+    NameAtom,
+    Symbol,
+    Source,
+    Token
 }
 
 # --- Constants ---

--- a/jac/jaclang/jac0core/jir_registry.jac
+++ b/jac/jaclang/jac0core/jir_registry.jac
@@ -798,6 +798,7 @@ glob NODE_SPECS: tuple = (
                  FieldDesc(name="from_loc", kind=6),
                  FieldDesc(name="items", kind=5),
                  FieldDesc(name="is_absorb", kind=2),
+                 FieldDesc(name="is_typed", kind=2),
                  FieldDesc(name="clib_decls", kind=5)
              )
          ),

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -5072,6 +5072,12 @@ impl Parser.parse_import_stmt -> Import {
         self.expect(TokenKind.KW_IMPORT);
     }
     kid: list = [self.make_uni_token(self.previous())];
+    # Check for 'import type ...' (type-only import; lowers to TYPE_CHECKING in Python)
+    is_typed = False;
+    if not is_include and self.match_tok(TokenKind.TYP_TYPE) {
+        is_typed = True;
+        kid.append(self.make_uni_token(self.previous()));
+    }
     # Check for 'import from X { Y }' syntax
     from_loc: ModulePath | None = None;
     is_clib_import = False;
@@ -5146,6 +5152,7 @@ impl Parser.parse_import_stmt -> Import {
         from_loc=from_loc,
         items=items,
         is_absorb=is_include,
+        is_typed=is_typed,
         kid=kid,
         doc=None,
         clib_decls=clib_decls

--- a/jac/jaclang/jac0core/passes/annex_pass.jac
+++ b/jac/jaclang/jac0core/passes/annex_pass.jac
@@ -14,16 +14,10 @@ Annex files are discovered from:
 This enables the separation of interface and implementation, as well as test
 code organization.
 """
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.bccache { discover_annex_files, discover_variant_files }
 import from jaclang.jac0core.passes.transform { Transform }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 """Handles loading and attaching of annex files (.impl.jac, .test.jac)."""
 class JacAnnexPass(Transform[uni.Module, uni.Module]) {

--- a/jac/jaclang/jac0core/passes/ast_gen/jsx_processor.jac
+++ b/jac/jaclang/jac0core/passes/ast_gen/jsx_processor.jac
@@ -1,19 +1,14 @@
 """Helpers for generating target-specific JSX AST nodes."""
 import ast as ast3;
-import from typing { TYPE_CHECKING, cast }
+import from typing { cast }
 import jaclang.jac0core.unitree as uni;
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.passes.ecmascript.esast_gen_pass { EsastGenPass }
-        import from jaclang.compiler.passes.ecmascript.estree {
-            Expression,
-            Property,
-            SpreadElement
-        }
-        import from jaclang.jac0core.passes.pyast_gen_pass { PyastGenPass }
-    }
+import type from jaclang.compiler.passes.ecmascript.esast_gen_pass { EsastGenPass }
+import type from jaclang.compiler.passes.ecmascript.estree {
+    Expression,
+    Property,
+    SpreadElement
 }
+import type from jaclang.jac0core.passes.pyast_gen_pass { PyastGenPass }
 
 """Generate ESTree structures for JSX nodes."""
 class EsJsxProcessor {

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -1156,6 +1156,24 @@ impl PyastGenPass.exit_import(nd: uni.Import) -> None {
             )
         );
     }
+    if nd.is_typed {
+        self.typing_imports.add('TYPE_CHECKING');
+        body_stmts = [
+            stmt
+            for stmt in py_nodes
+            if isinstance(stmt, ast3.stmt)
+        ];
+        if body_stmts {
+            wrapped = self.sync(
+                ast3.If(
+                    test=self.sync(ast3.Name(id='TYPE_CHECKING', ctx=ast3.Load())),
+                    body=body_stmts,
+                    orelse=[]
+                )
+            );
+            py_nodes = [wrapped];
+        }
+    }
     nd.gen.py_ast = py_nodes;
 }
 

--- a/jac/jaclang/jac0core/passes/module_codegen_pass.jac
+++ b/jac/jaclang/jac0core/passes/module_codegen_pass.jac
@@ -1,15 +1,9 @@
 """Shared base for codegen passes that operate on Module AST."""
 import from collections.abc { Sequence }
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.constant { CodeContext }
 import from jaclang.jac0core.passes.transform { Transform }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 """Base for all module-level codegen passes.
 

--- a/jac/jaclang/jac0core/passes/transform.jac
+++ b/jac/jaclang/jac0core/passes/transform.jac
@@ -2,17 +2,12 @@
 import time;
 import from abc { ABC, abstractmethod }
 import from threading { Event }
-import from typing { Any, TYPE_CHECKING }
+import from typing { Any }
 import from jaclang.jac0core.codeinfo { CodeLocInfo }
 import from jaclang.jac0core.diagnostics { DiagnosticInfo, Severity, E9001 }
 import from jaclang.jac0core.log { logging }
 import from jaclang.jac0core.unitree { UniNode }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 """Alert interface."""
 obj Alert {

--- a/jac/jaclang/jac0core/passes/uni_pass.jac
+++ b/jac/jaclang/jac0core/passes/uni_pass.jac
@@ -1,14 +1,9 @@
 """Abstract class for IR Passes for Jac."""
 import from threading { Event }
-import from typing { TYPE_CHECKING, TypeVar }
+import from typing { TypeVar }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.module_codegen_pass { ModuleCodegenPass }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.program { JacProgram }
-    }
-}
+import type from jaclang.jac0core.program { JacProgram }
 
 glob T = TypeVar('T', bound=uni.UniNode);
 """Abstract class for IR passes."""

--- a/jac/jaclang/jac0core/program.jac
+++ b/jac/jaclang/jac0core/program.jac
@@ -1,19 +1,13 @@
 """Jac Program module."""
 import types;
 import from threading { Event }
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.compile_options { CompileOptions }
 import from jaclang.jac0core.mtp { Info }
 import from jaclang.jac0core.passes { Alert }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.type_system.type_evaluator { TypeEvaluator }
-        import from jaclang.jac0core.compiler { JacCompiler }
-        import from jaclang.jac0core.passes { Transform }
-    }
-}
+import type from jaclang.compiler.type_system.type_evaluator { TypeEvaluator }
+import type from jaclang.jac0core.compiler { JacCompiler }
+import type from jaclang.jac0core.passes { Transform }
 
 """Holds the state of a compiled Jac program."""
 class JacProgram {

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -56,22 +56,14 @@ import from jaclang.jac0core.constructs {
 import from jaclang.jac0core.modresolver { infer_language }
 import from jaclang.jac0core.mtp { MTIR, Info, MTRuntime }
 import from jaclang.jac0core { plugin }
-
-with entry {
-    if TYPE_CHECKING {
-        import from http.server { BaseHTTPRequestHandler }
-        import from jaclang.cli.console { JacConsole as ConsoleImpl }
-        import from jaclang.jac0core.compiler { JacCompiler }
-        import from jaclang.jac0core.program { JacProgram }
-        import from jaclang.runtimelib.client_bundle {
-            ClientBundle,
-            ClientBundleBuilder
-        }
-        import from jaclang.runtimelib.context { ExecutionContext }
-        import from jaclang.runtimelib.server { JacAPIServer as JacServer }
-        import from jaclang.runtimelib.server { ModuleIntrospector, UserManager }
-    }
-}
+import type from http.server { BaseHTTPRequestHandler }
+import type from jaclang.cli.console { JacConsole as ConsoleImpl }
+import type from jaclang.jac0core.compiler { JacCompiler }
+import type from jaclang.jac0core.program { JacProgram }
+import type from jaclang.runtimelib.client_bundle { ClientBundle, ClientBundleBuilder }
+import type from jaclang.runtimelib.context { ExecutionContext }
+import type from jaclang.runtimelib.server { JacAPIServer as JacServer }
+import type from jaclang.runtimelib.server { ModuleIntrospector, UserManager }
 
 glob plugin_manager = plugin.PluginManager('jac'),
      hookspec = plugin.HookspecMarker('jac'),

--- a/jac/jaclang/jac0core/treeprinter.jac
+++ b/jac/jaclang/jac0core/treeprinter.jac
@@ -2,14 +2,8 @@
 import ast as ast3;
 import builtins;
 import html;
-import from typing { TYPE_CHECKING }
 import jaclang.jac0core.unitree as uni;
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.unitree { UniNode, UniScopeNode }
-    }
-}
+import type from jaclang.jac0core.unitree { UniNode, UniScopeNode }
 
 glob id_bag: dict = {},
      id_used: int = 0,

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -7,7 +7,7 @@ import from copy { copy }
 import from enum { IntEnum }
 import from hashlib { md5 }
 import from types { EllipsisType }
-import from typing { TYPE_CHECKING, Any, cast }
+import from typing { Any, cast }
 import from jaclang.jac0core.bccache { discover_base_file }
 import from jaclang.jac0core.codeinfo { CodeGenTarget, CodeLocInfo }
 import from jaclang.jac0core.constant {
@@ -22,12 +22,7 @@ import from jaclang.jac0core.constant { JacSemTokenModifier as SemTokMod }
 import from jaclang.jac0core.constant { JacSemTokenType as SemTokType }
 import from jaclang.jac0core.constant { Tokens as Tok }
 import from jaclang.jac0core.modresolver { resolve_relative_path }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.compiler.type_system.types { TypeBase }
-    }
-}
+import type from jaclang.compiler.type_system.types { TypeBase }
 
 import from jaclang.jac0core.treeprinter {
     print_ast_tree,
@@ -578,6 +573,7 @@ obj Import(ContextAwareNode, ElementStmt, CodeBlockStmt) {
     has from_loc: (ModulePath | None),
         items: (Sequence[ModuleItem] | Sequence[ModulePath]),
         is_absorb: bool,
+        is_typed: bool = False,
         clib_decls: (Sequence[UniNode] | None) = None,
         hint: (SubTag[Token] | None) by postinit;
 

--- a/jac/jaclang/runtimelib/builtin.jac
+++ b/jac/jaclang/runtimelib/builtin.jac
@@ -3,7 +3,11 @@ import json;
 import from abc { abstractmethod }
 import from collections.abc { Callable }
 import from enum { StrEnum }
-import from typing { TYPE_CHECKING, Any, ClassVar, override }
+import from typing { Any, ClassVar, override }
+import type from enum { IntEnum }
+import type from jaclang.jac0core.constructs { AccessLevel, NodeArchetype }
+import type from jaclang.jac0core.runtime { LLMModel }
+import type from jaclang { JacRuntimeInterface }
 
 enum APIProtocol ( StrEnum ) {
     HTTP = 'http',
@@ -15,15 +19,6 @@ enum APIProtocol ( StrEnum ) {
 enum ScheduleTrigger ( StrEnum ) {
     STATIC = 'static',
     DYNAMIC = 'dynamic'
-}
-
-with entry {
-    if TYPE_CHECKING {
-        import from enum { IntEnum }
-        import from jaclang.jac0core.constructs { AccessLevel, NodeArchetype }
-        import from jaclang.jac0core.runtime { LLMModel }
-        import from jaclang { JacRuntimeInterface }
-    }
 }
 
 def _get_jac -> type[JacRuntimeInterface];

--- a/jac/jaclang/runtimelib/client_bundle.jac
+++ b/jac/jaclang/runtimelib/client_bundle.jac
@@ -5,15 +5,10 @@ import os;
 import from collections.abc { Iterable, Sequence }
 import from pathlib { Path }
 import from types { ModuleType }
-import from typing { TYPE_CHECKING, Any, NamedTuple }
+import from typing { Any, NamedTuple }
 import from jaclang.jac0core.modresolver { convert_to_js_import_path }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.codeinfo { ClientManifest }
-        import from jaclang.jac0core.unitree { Module }
-    }
-}
+import type from jaclang.jac0core.codeinfo { ClientManifest }
+import type from jaclang.jac0core.unitree { Module }
 
 """Raised when the client bundle cannot be generated."""
 class ClientBundleError(RuntimeError) {}

--- a/jac/jaclang/runtimelib/hmr.jac
+++ b/jac/jaclang/runtimelib/hmr.jac
@@ -5,16 +5,11 @@ Uses AST-based classification to determine client vs server declarations.
 """
 
 import from pathlib { Path }
-import from typing { TYPE_CHECKING, Any, Callable }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.runtimelib.watcher {
-            JacFileWatcher,
-            FileChangeEvent,
-            ChangeType
-        }
-    }
+import from typing { Any, Callable }
+import type from jaclang.runtimelib.watcher {
+    JacFileWatcher,
+    FileChangeEvent,
+    ChangeType
 }
 
 """Handles hot reloading of Jac modules."""

--- a/jac/jaclang/runtimelib/server.jac
+++ b/jac/jaclang/runtimelib/server.jac
@@ -13,7 +13,6 @@ import from http.server { BaseHTTPRequestHandler, HTTPServer }
 import from inspect { iscoroutine, isgenerator }
 import from pathlib { Path }
 import from typing {
-    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Generator,
@@ -35,12 +34,7 @@ import from jaclang { JacRuntime as Jac }
 import from jaclang.project.config { get_config }
 import from jaclang.runtimelib.scheduler { Scheduler }
 import from jaclang.jac0core.constant { Constants as Con }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.constructs { Archetype, WalkerArchetype }
-    }
-}
+import type from jaclang.jac0core.constructs { Archetype, WalkerArchetype }
 
 glob JsonValue: TypeAlias = None | str | int | float | bool | list['JsonValue'] | dict[
          (str, 'JsonValue')

--- a/jac/jaclang/runtimelib/testing.jac
+++ b/jac/jaclang/runtimelib/testing.jac
@@ -25,14 +25,9 @@ import json;
 import re;
 import from http.server { BaseHTTPRequestHandler }
 import from pathlib { Path }
-import from typing { TYPE_CHECKING, Any }
+import from typing { Any }
 import from urllib.parse { urlencode }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.runtimelib.server { JacAPIServer }
-    }
-}
+import type from jaclang.runtimelib.server { JacAPIServer }
 
 """HTTP response wrapper for test assertions."""
 obj TestResponse {

--- a/jac/jaclang/runtimelib/utils.jac
+++ b/jac/jaclang/runtimelib/utils.jac
@@ -5,18 +5,12 @@ import from collections.abc { Callable, Iterator }
 import from contextlib { contextmanager }
 import from pathlib { Path }
 import from types { UnionType }
-import from typing { TYPE_CHECKING }
 import from uuid { UUID }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.helpers {
     read_file_with_encoding as read_file_with_encoding
 }
-
-with entry {
-    if TYPE_CHECKING {
-        import from jaclang.jac0core.constructs { NodeArchetype }
-    }
-}
+import type from jaclang.jac0core.constructs { NodeArchetype }
 
 @contextmanager
 def sys_path_context(path: str) -> Iterator[None];

--- a/jac/tests/compiler/passes/main/fixtures/typed_import_circ_a.jac
+++ b/jac/tests/compiler/passes/main/fixtures/typed_import_circ_a.jac
@@ -1,0 +1,10 @@
+"""Circular type-only import: A references B as a type."""
+import type from typed_import_circ_b { B }
+
+obj A {
+    has name: str = "A";
+}
+
+def use_b(b: B) -> A {
+    return A();
+}

--- a/jac/tests/compiler/passes/main/fixtures/typed_import_circ_b.jac
+++ b/jac/tests/compiler/passes/main/fixtures/typed_import_circ_b.jac
@@ -1,0 +1,10 @@
+"""Circular type-only import: B references A as a type."""
+import type from typed_import_circ_a { A }
+
+obj B {
+    has name: str = "B";
+}
+
+def use_a(a: A) -> B {
+    return B();
+}

--- a/jac/tests/compiler/passes/main/test_pyast_gen_pass.jac
+++ b/jac/tests/compiler/passes/main/test_pyast_gen_pass.jac
@@ -422,3 +422,72 @@ test "ClassVar import stays runtime-visible (dataclass can find it)" {
         sys.modules.pop(mod.__name__, None);
     }
 }
+
+test "import type wraps in TYPE_CHECKING and resolves circular imports" {
+    # Compile a module that uses `import type from foo { Bar }` and verify
+    # that the import lowers to `if typing.TYPE_CHECKING: from foo import Bar`
+    # in the generated Python, while the named symbol does NOT appear as a
+    # top-level runtime import.
+    a_path = os.path.join(FIXTURES, "typed_import_circ_a.jac");
+    b_path = os.path.join(FIXTURES, "typed_import_circ_b.jac");
+    a_gen = (prog := JacProgram()).compile(a_path);
+    b_gen = prog.compile(b_path);
+    assert not prog.errors_had , f"Compilation errors: {prog.errors_had}";
+    assert a_gen.gen.py_ast and isinstance(a_gen.gen.py_ast[0], ast3.Module);
+    py_mod: ast3.Module = a_gen.gen.py_ast[0];
+    runtime_import_of_b = False;
+    tc_guarded_b = False;
+    for stmt in py_mod.body {
+        if isinstance(stmt, ast3.ImportFrom)
+        and stmt.module == "typed_import_circ_b"
+        and any(n.name == "B" for n in stmt.names) {
+            runtime_import_of_b = True;
+        }
+        if isinstance(stmt, ast3.If)
+        and (
+            (isinstance(stmt.test, ast3.Name) and stmt.test.id == "TYPE_CHECKING")
+            or (
+                isinstance(stmt.test, ast3.Attribute)
+                and stmt.test.attr == "TYPE_CHECKING"
+            )
+        ) {
+            for inner in stmt.body {
+                if isinstance(inner, ast3.ImportFrom)
+                and inner.module == "typed_import_circ_b"
+                and any(n.name == "B" for n in inner.names) {
+                    tc_guarded_b = True;
+                }
+            }
+        }
+    }
+    assert tc_guarded_b , (
+        "expected `import type from typed_import_circ_b { B }` to lower to "
+        "`if typing.TYPE_CHECKING: from typed_import_circ_b import B`. "
+        "Source:\n" + ast3.unparse(py_mod)
+    );
+    assert not runtime_import_of_b , (
+        "B from `import type` must NOT appear as a top-level runtime "
+        "import.\nSource:\n" + ast3.unparse(py_mod)
+    );
+
+    # End-to-end: actually run both halves and confirm the cycle resolves.
+    a_mod = types.ModuleType("typed_import_circ_a");
+    b_mod = types.ModuleType("typed_import_circ_b");
+    sys.modules[a_mod.__name__] = a_mod;
+    sys.modules[b_mod.__name__] = b_mod;
+    sys.path.insert(0, FIXTURES);
+    try {
+        exec(compile(a_gen.gen.py_ast[0], filename="<a>", mode="exec"), a_mod.__dict__);
+        exec(compile(b_gen.gen.py_ast[0], filename="<b>", mode="exec"), b_mod.__dict__);
+        a_inst = a_mod.__dict__["A"]();
+        b_inst = b_mod.__dict__["B"]();
+        assert a_inst.name == "A";
+        assert b_inst.name == "B";
+    } finally {
+        sys.modules.pop(a_mod.__name__, None);
+        sys.modules.pop(b_mod.__name__, None);
+        if FIXTURES in sys.path {
+            sys.path.remove(FIXTURES);
+        }
+    }
+}

--- a/jac/tests/langserve/test_server.jac
+++ b/jac/tests/langserve/test_server.jac
@@ -271,7 +271,7 @@ test "test_go_to_definition_md_path" {
             (11, 47, "jaclang/jac0core/constant.jac:4:5-4:15"),
             (13, 47, "jaclang/compiler/type_system/type_utils.jac:0:0-0:0"),
             (14, 34, "jaclang/compiler/type_system/__init__.py:0:0-0:0"),
-            (18, 5, "compiler/type_system/types.jac:66:4-66:12"),
+            (18, 5, "compiler/type_system/types.jac:61:4-61:12"),
             (20, 34, "jaclang/jac0core/unitree.jac:0:0-0:0"),
             (22, 22, "tests/langserve/fixtures/circle.jac:7:5-7:8"),
             (23, 28, "jaclang/lsp/uris.jac:0:0-0:0"),


### PR DESCRIPTION
## Summary

- Adds opt-in `import type from foo { Bar }` syntax that lowers to `if TYPE_CHECKING: from foo import Bar` in the generated Python, breaking circular imports between modules that reference each other only in type signatures.
- Migrates 29 production `.jac` files in `compiler/`, `jac0core/`, and `runtimelib/` from the manual `with entry { if TYPE_CHECKING { ... } }` pattern to the new keyword.
- Documents the dataclass / Pydantic / FastAPI caveat (use a regular `import` for archetype `has` field types and any name resolved at decorator/metaclass time via `typing.get_type_hints`); removes earlier docs that incorrectly claimed automatic TYPE_CHECKING wrapping.

## Surface

```jac
import type from billing { Invoice, Receipt as R }
import type pkg.helpers
import type pkg.helpers as helpers
```

Generated Python:

```python
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from billing import Invoice, Receipt as R
```

The codegen adds `TYPE_CHECKING` to the module's typing-imports preamble (which is merged from child passes), so impl-file annexes that introduce a `import type` propagate the typing import correctly into the parent module. JS codegen elides type-only imports entirely. The formatter round-trips the new keyword. `include type` is rejected at parse time.

## Implementation

- **AST**: new `is_typed: bool` on `Import`, registered in the JIR registry.
- **Parser**: optional `KW_TYPE` after `import` (gated `not is_include`).
- **`PyastGenPass.exit_import`**: when `is_typed`, wraps emitted import nodes in `ast3.If(test=Name('TYPE_CHECKING'), body=[...])` and adds `TYPE_CHECKING` to `self.typing_imports` so the `from typing import TYPE_CHECKING` line is included in the preamble.
- **`EsastGenPass.exit_import`**: early return for `is_typed`.
- **`UnparsePass` + `NormalizePass`**: emit/preserve the `type` token in the kid list.
- **`jac0.py`** minimal bootstrap: parses and emits the new form so jac0core modules can use it during initial Python startup.
- **`jac.spec`**: regenerated via `jac grammar -o`.

## Test plan

- [x] `jac test jac/tests/compiler/passes/main/test_pyast_gen_pass.jac` — new test asserts both AST shape (`if TYPE_CHECKING:` wrapper present, name absent at module top level) and end-to-end runtime resolution of a circular type-only import.
- [x] Smoke: `jac jac2py` on every converted file produces valid Python with the expected `from typing import TYPE_CHECKING` preamble and one `if TYPE_CHECKING:` block per `import type`.
- [x] Manual circular-import end-to-end: two modules with mutual type-only imports load without `ImportError`.
- [x] `jac format` round-trips `import type from foo { Bar }` correctly.
- [x] Grammar spec test (`test_grammar_extract_pass`) passes after spec regeneration.
- [ ] Full pytest sweep across `tests/compiler/passes/main`, `tests/compiler/passes/tool`, `tests/compiler/passes/ecmascript`, `tests/language` (interrupted while running locally; re-run on CI).

## Notes

- A prior 0.12.3 attempt to auto-wrap annotation-only imports was reverted as unsound because dataclass / Pydantic / attrs / FastAPI / SQLAlchemy resolve string annotations at runtime through `typing.get_type_hints(cls)` in their decorator/metaclass; the wrapped name is not in module globals at that point and they crash. Making the syntax opt-in keeps the user in control of that distinction. Archetypes (`obj`/`node`/`edge`/`walker`) are dataclass-derived, so `has` field types should stay on a regular `import`.
- `runtime.jac` keeps `TYPE_CHECKING` in its `from typing import { ... }` because line 324 (`TYPE_CHECKING: bool = TYPE_CHECKING;`) consumes it as a runtime value.
- Test fixtures that exercise the manual `if TYPE_CHECKING` pattern (`test_checker_gaps.jac`, `checker_gap_fwd_ref.jac`, `redundant_typing_imports.jac`, `class_entry.jac`) are intentionally kept as-is.