### PR TITLE
fix(jac-scale): remove redundant user_exists() DB call from JWT validation

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/5902.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/5902.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: JWT validation removes redundant user_exists() DB call**: `validate_jwt_token()` previously called `user_exists()` (a MongoDB round-trip) on every authenticated request after already verifying the JWT signature and expiry. Removed the extra call; `jwt.decode()` verification is sufficient.

--- a/docs/docs/community/release_notes/unreleased/jac-scale/pr_jwt_no_user_exists.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/pr_jwt_no_user_exists.bugfix.md
@@ -1,9 +1,0 @@
-**JWT validation: remove redundant user_exists() DB call**
-
-`validate_jwt_token()` previously called `user_exists()` (a MongoDB round-trip) on every
-authenticated request after already verifying the JWT signature and expiry with
-`jwt.decode()`. A valid, unexpired JWT signed with the server secret is sufficient
-proof of a known user — the extra DB call is unnecessary overhead.
-
-Removed the `user_exists()` call; token validation now returns the `user_id` from the
-verified JWT payload directly.

--- a/docs/docs/community/release_notes/unreleased/jac-scale/pr_jwt_no_user_exists.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/pr_jwt_no_user_exists.bugfix.md
@@ -1,0 +1,9 @@
+**JWT validation: remove redundant user_exists() DB call**
+
+`validate_jwt_token()` previously called `user_exists()` (a MongoDB round-trip) on every
+authenticated request after already verifying the JWT signature and expiry with
+`jwt.decode()`. A valid, unexpired JWT signed with the server secret is sufficient
+proof of a known user — the extra DB call is unnecessary overhead.
+
+Removed the `user_exists()` call; token validation now returns the `user_id` from the
+verified JWT payload directly.

--- a/jac-scale/jac_scale/impl/user_manager.impl.jac
+++ b/jac-scale/jac_scale/impl/user_manager.impl.jac
@@ -187,15 +187,15 @@ impl JacScaleUserManager.get_jwt_claims(token: str) -> dict | None {
     }
 }
 
-"""Validate JWT and return user_id if valid."""
+"""Validate JWT and return user_id if valid.
+
+JWT signature and expiry are verified by jwt.decode() — an extra DB round-trip
+to confirm user existence on every request is unnecessary and costly.
+"""
 impl JacScaleUserManager.validate_jwt_token(token: str) -> str | None {
     try {
         decoded = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM]);
-        user_id = decoded.get('user_id');
-        if not user_id {
-            return None;
-        }
-        return user_id if self.user_exists(user_id) else None;
+        return decoded.get('user_id') or None;
     } except Exception as e {
         logger.debug(f"Failed to validate JWT token: {str(e)}");
         return None;


### PR DESCRIPTION
## Summary

`validate_jwt_token()` called `user_exists()` (a MongoDB round-trip) on **every authenticated request** after already verifying the JWT signature and expiry with `jwt.decode()`.

A valid, unexpired JWT signed with the server secret is sufficient proof of a known user — the extra DB call adds latency with no security benefit (a deleted user's token still works until it expires, which is the standard JWT trade-off).

Removed the `user_exists()` call; validation now returns the `user_id` from the verified JWT payload directly.

## Test plan
- [ ] `pytest jac-scale/jac_scale/tests/` passes
- [ ] Authenticated requests no longer trigger a MongoDB lookup in `validate_jwt_token`
- [ ] Expired / tampered tokens are still rejected (jwt.decode raises)