### PR TITLE
fix(jac-scale): add batch_put to RedisBackend for bulk L2 cache writes

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/5906.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/5906.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: RedisBackend.batch_put for bulk L2 cache writes**: Added `batch_put(anchors)` method to `RedisBackend` so callers can promote multiple anchors into L2 cache in a single logical operation without repeated per-anchor calls.

--- a/jac-scale/jac_scale/impl/memory_hierarchy.redis.impl.jac
+++ b/jac-scale/jac_scale/impl/memory_hierarchy.redis.impl.jac
@@ -174,6 +174,13 @@ impl RedisBackend.batch_get(ids: list[UUID]) -> dict[UUID, Anchor] {
     return result;
 }
 
+"""Batch write anchors to Redis cache."""
+impl RedisBackend.batch_put(anchors: list[Anchor]) -> None {
+    for anchor in anchors {
+        self.put(anchor);
+    }
+}
+
 # CacheMemory-specific methods
 """Check if key exists in cache."""
 impl RedisBackend.exists(id: UUID) -> bool {

--- a/jac-scale/jac_scale/memory_hierarchy.jac
+++ b/jac-scale/jac_scale/memory_hierarchy.jac
@@ -68,6 +68,7 @@ obj RedisBackend(CacheMemory) {
 
     def commit(anchor: (Anchor | None) = None) -> None;
     def batch_get(ids: list[UUID]) -> dict[UUID, Anchor];
+    def batch_put(anchors: list[Anchor]) -> None;
     # CacheMemory-specific
     def exists(id: UUID) -> bool;
     def put_if_exists(anchor: Anchor) -> bool;


### PR DESCRIPTION
## Summary

- Adds `batch_put(anchors: list[Anchor]) -> None` method declaration to `RedisBackend` in `memory_hierarchy.jac`
- Implements the method in `memory_hierarchy.redis.impl.jac` — iterates and calls `self.put()` for each anchor
- Enables callers to promote multiple anchors into L2 cache as a single logical operation

## Motivation

`ScaleTieredMemory.batch_get` promotes L3 hits into L2 cache one anchor at a time via individual `put()` calls. Having `batch_put` on the interface makes bulk promotion explicit and gives a single extension point for future pipeline-based batch writes (e.g., Redis `mset`).

## Test plan

- [ ] Existing jac-scale test suite passes (no regressions to `batch_get` or `put`)
- [ ] `RedisBackend.batch_put` callable from tiered memory commit paths