### PR TITLE
docs: phase 1 accuracy fixes for top quick-guide pages and day-planner

### DIFF
--- a/docs/docs/quick-guide/faq.md
+++ b/docs/docs/quick-guide/faq.md
@@ -115,13 +115,14 @@ Answers to common questions about Jac, organized by topic. Click a category to e
         The one-line installer uses [uv](https://docs.astral.sh/uv/) to install Jac in an isolated environment, separate from your system Python. This means `pip show` and `pip list` won't find Jac packages. Use `jac --version` instead -- it lists all installed plugins and their versions.
 
     ??? question "`jac clean --all` says 'No jac.toml found'."
-        `jac clean` requires a Jac project (a directory with `jac.toml`). If you're running standalone `.jac` scripts outside a project, delete the data directory manually: `rm -rf .jac/`. To create a project, run `jac init` or `jac create <name>`.
+        `jac clean --all` (and the project-level cleanup flags it implies) needs a Jac project -- a directory with a `jac.toml`. Plain `jac clean` (no flags) only clears the local `.jac/data/` directory, but `--all`, `--cache`, and `--packages` operate on project artifacts and require the project root. If you're running standalone `.jac` scripts outside a project, delete the data directory manually: `rm -rf .jac/`. To create a project, run `jac create <name>`.
 
     ??? question "I see 'Address already in use' when running `jac start`."
         Another process is using the port (default 8000). Either stop the other process or use a different port: `jac start --port 3000`.
 
     ??? question "My frontend shows data but fields are empty or undefined."
         When returning node objects directly from `def:pub` endpoints, use `jid(node)` to access the node's unique identity. For reliable client-side access, return explicit dictionaries from your endpoints:
+        <!-- jac-skip -->
         ```jac
         # Instead of: return task;
         # Use:

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -23,12 +23,12 @@ def:pub add_todo(title: str) -> Todo {
         category = "other (setup AI key)";
     }
     todo = Todo(title=title, category=category);
-    root() ++> todo;
+    root ++> todo;
     return todo;
 }
 
 def:pub get_todos -> list[Todo] {
-    return [root()-->][?:Todo];
+    return [root-->][?:Todo];
 }
 
 cl def:pub app -> JsxElement {
@@ -179,6 +179,7 @@ The return type serves as the output contract -- `enum` means the LLM can only p
 
 For **agentic workflows**, Jac's graph constructs (nodes, edges, walkers) naturally model AI agents that traverse structured state spaces, make decisions with `by llm()`, and call tools:
 
+<!-- jac-skip -->
 ```jac
 def get_weather(city: str) -> str { return fetch_weather_api(city); }
 def search_web(query: str) -> list[str] { return web_search_api(query); }
@@ -204,12 +205,12 @@ with entry {
 }
 ```
 
-This same program runs three ways with no code changes (`main.jac` is the default entry point; omit it or specify a different name explicitly):
+This same program runs three ways with no code changes. `jac start` defaults to `main.jac` if you omit the filename; `jac run` always needs the filename explicitly:
 
 | Command | What Happens |
 |---------|-------------|
 | `jac main.jac` | Runs locally, SQLite persistence |
-| `jac start` | HTTP API server, walkers become REST endpoints |
+| `jac start` (or `jac start main.jac`) | HTTP API server, walkers become REST endpoints |
 | `jac start --scale` | Kubernetes deployment with Redis, MongoDB, load balancing |
 
 The runtime handles database schemas, user authentication (per-user graph isolation), API generation (Swagger docs at `/docs`), caching tiers, and Kubernetes orchestration. You write application logic; the runtime handles infrastructure.
@@ -254,7 +255,7 @@ jac hello.jac
 
 Note: `jac` is shorthand for `jac run` -- both work identically.
 
-> **💡 Tip**: Add `-e` to see type check diagnostics: `jac -e hello.jac`. This shows errors and warnings without needing a separate `jac check`.
+> **💡 Tip**: Add `-e all` to see type check diagnostics: `jac -e all hello.jac`. This shows errors and warnings without needing a separate `jac check`.
 
 **That's it!** You just ran your first Jac program.
 

--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -218,7 +218,7 @@ With the `jac-client` plugin installed, scaffold a complete full-stack project i
 ```bash
 jac create example --use fullstack
 cd example
-jac add
+jac install
 jac start
 ```
 
@@ -236,7 +236,7 @@ This creates a project with a Jac backend and a React frontend, ready to go at `
 ```bash
 jac create my-todo --use https://raw.githubusercontent.com/jaseci-labs/jacpacks/main/multi-user-todo-app/multi-user-todo-app.jacpack
 cd my-todo
-jac add
+jac install
 jac start
 ```
 
@@ -246,7 +246,7 @@ Want to try one with AI built in? The `multi-user-todo-meals-app` uses Jac's AI 
 export ANTHROPIC_API_KEY="your-key-here"
 jac create meals-app --use https://raw.githubusercontent.com/jaseci-labs/jacpacks/main/multi-user-todo-meals-app/multi-user-todo-meals-app.jacpack
 cd meals-app
-jac add
+jac install
 jac start
 ```
 

--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -158,7 +158,7 @@ with entry {
 }
 ```
 
-Jac provides two pattern-matching constructs, each designed for a different purpose. **`switch`/`case`** is for classic simple value matching -- there's no fall-through and no `break` needed, which avoids a common source of bugs in C-family languages:
+Jac provides two pattern-matching constructs, each designed for a different purpose. **`switch`/`case`** is for classic simple value matching. Like C, cases fall through to subsequent cases -- use `return`, `break`, or another control-flow statement to exit a case before the next one runs:
 
 ```jac
 def categorize(fruit: str) -> str {
@@ -172,6 +172,8 @@ def categorize(fruit: str) -> str {
     }
 }
 ```
+
+In the example above, each case ends with `return`, so the function exits before the next case runs. If you want to stay inside `switch` and just stop fall-through, use `break`.
 
 **`match`/`case`**, on the other hand, is for Python-style structural pattern matching -- use it when you need to destructure values or match more complex patterns:
 
@@ -302,9 +304,9 @@ node Task {
 
 with entry {
     # Create tasks and connect them to root
-    root() ++> Task(title="Buy groceries");
-    root() ++> Task(title="Team standup at 10am");
-    root() ++> Task(title="Go for a run");
+    root ++> Task(title="Buy groceries");
+    root ++> Task(title="Team standup at 10am");
+    root ++> Task(title="Go for a run");
 
     print("Created 3 tasks!");
 }
@@ -326,7 +328,7 @@ The `++>` operator returns a list containing the newly created node. You can cap
 
 <!-- jac-skip -->
 ```jac
-result = root() ++> Task(title="Buy groceries");
+result = root ++> Task(title="Buy groceries");
 task = result[0];  # The new Task node
 print(task.title);  # "Buy groceries"
 ```
@@ -368,25 +370,25 @@ Now here's where the two concepts come together. The `[-->]` syntax gives you a 
 
 ```jac
 with entry {
-    root() ++> Task(title="Buy groceries");
-    root() ++> Task(title="Team standup at 10am");
+    root ++> Task(title="Buy groceries");
+    root ++> Task(title="Team standup at 10am");
 
     # Get ALL nodes connected from root
-    everything = [root()-->];
+    everything = [root-->];
 
     # Filter by node type -- same [?:Type] syntax
-    tasks = [root()-->][?:Task];
+    tasks = [root-->][?:Task];
     for task in tasks {
         status = "done" if task.done else "pending";
         print(f"[{status}] {task.title}");
     }
 
     # Filter by field value
-    grocery_tasks = [root()-->][?:Task, title == "Buy groceries"];
+    grocery_tasks = [root-->][?:Task, title == "Buy groceries"];
 }
 ```
 
-`[root()-->]` reads as "all nodes connected *from* root." The `[?:Task]` filter keeps only nodes of type `Task`. Notice the elegance of this design: there's nothing special about graph queries. `[-->]` returns a plain list, and `[?...]` filters it, using the same mechanism it uses on any collection. This composability -- where general-purpose features combine naturally -- is a recurring theme in Jac.
+`[root-->]` reads as "all nodes connected *from* root." The `[?:Task]` filter keeps only nodes of type `Task`. Notice the elegance of this design: there's nothing special about graph queries. `[-->]` returns a plain list, and `[?...]` filters it, using the same mechanism it uses on any collection. This composability -- where general-purpose features combine naturally -- is a recurring theme in Jac.
 
 Other directions work too:
 
@@ -400,7 +402,7 @@ Use `del` to remove a node from the graph:
 
 <!-- jac-skip -->
 ```jac
-for task in [root()-->][?:Task] {
+for task in [root-->][?:Task] {
     if task.title == "Team standup at 10am" {
         del task;
     }
@@ -413,8 +415,8 @@ You can inspect the graph at any time by printing connected nodes:
 
 <!-- jac-skip -->
 ```jac
-print([root()-->]);           # All nodes connected to root
-print([root()-->][?:Task]);   # Just Task nodes
+print([root-->]);           # All nodes connected to root
+print([root-->][?:Task]);   # Just Task nodes
 ```
 
 This is useful when data isn't appearing as expected.
@@ -431,15 +433,17 @@ This is useful when data isn't appearing as expected.
 
     Connect with a typed edge using `+>: EdgeType :+>`:
 
+    <!-- jac-skip -->
     ```jac
-    root() +>: Scheduled(time="9:00am", priority=3) :+> Task(title="Morning run");
+    root +>: Scheduled(time="9:00am", priority=3) :+> Task(title="Morning run");
     ```
 
     And filter queries by edge type:
 
+    <!-- jac-skip -->
     ```jac
-    scheduled_tasks = [root()->:Scheduled:->][?:Task];
-    urgent = [root()->:Scheduled:priority>=3:->][?:Task];
+    scheduled_tasks = [root->:Scheduled:->][?:Task];
+    urgent = [root->:Scheduled:priority>=3:->][?:Task];
     ```
 
     We won't use custom edges in this tutorial (default edges are sufficient), but they're useful for modeling relationships like social networks, org charts, and dependency graphs.
@@ -453,14 +457,14 @@ This is useful when data isn't appearing as expected.
 - **`[?condition]`** -- filter comprehensions on any list of objects
 - **`[?:Type]`** -- typed filter comprehension, works on any collection
 - **`[?:Type, field == val]`** -- combined type and field filtering
-- **`[root()-->]`** -- query all connected nodes (returns a list, filterable like any other)
+- **`[root-->]`** -- query all connected nodes (returns a list, filterable like any other)
 - **`jid(node)`** -- get the built-in unique identifier of any node
 - **`del`** -- remove a node from the graph
 
 > **Deep Dive:** [Object-Spatial Programming](../../reference/language/osp.md) covers the full graph model including typed edges, walkers, and advanced traversals. [Comprehensions & Filters](../../reference/language/advanced.md) has the complete filter syntax reference.
 
 !!! example "Try It Yourself"
-    After creating three tasks, mark one as done (`task.done = True`), then use `[root()-->][?:Task, done == False]` to list only pending tasks. Verify that the completed task doesn't appear.
+    After creating three tasks, mark one as done (`task.done = True`), then use `[root-->][?:Task, done == False]` to list only pending tasks. Verify that the completed task doesn't appear.
 
 ---
 
@@ -486,7 +490,7 @@ In Part 2, you learned that every node has a built-in unique identifier. The `ji
 
 <!-- jac-skip -->
 ```jac
-task = (root() ++> Task(title="Buy groceries"))[0];
+task = (root ++> Task(title="Buy groceries"))[0];
 print(jid(task));  # e.g., "1be2c28fc5924de28c55f68cc5ccaeb6"
 ```
 
@@ -502,7 +506,7 @@ This is one of the most powerful ideas in Jac. Simply mark a function `def:pub` 
 ```jac
 """Add a task and return it."""
 def:pub add_task(title: str) -> Task {
-    task = root() ++> Task(title=title);
+    task = root ++> Task(title=title);
     return task[0];
 }
 ```
@@ -526,18 +530,18 @@ node Task {
 
 """Add a task and return it."""
 def:pub add_task(title: str) -> Task {
-    task = root() ++> Task(title=title);
+    task = root ++> Task(title=title);
     return task[0];
 }
 
 """Get all tasks."""
 def:pub get_tasks -> list[Task] {
-    return [root()-->][?:Task];
+    return [root-->][?:Task];
 }
 
 """Toggle a task's done status."""
 def:pub toggle_task(id: str) -> Task | None {
-    for task in [root()-->][?:Task] {
+    for task in [root-->][?:Task] {
         if jid(task) == id {
             task.done = not task.done;
             return task;
@@ -548,7 +552,7 @@ def:pub toggle_task(id: str) -> Task | None {
 
 """Delete a task."""
 def:pub delete_task(id: str) -> dict {
-    for task in [root()-->][?:Task] {
+    for task in [root-->][?:Task] {
         if jid(task) == id {
             del task;
             return {"deleted": id};
@@ -587,10 +591,10 @@ task_data["done"] = True;   # Update a value
 <!-- jac-skip -->
 ```jac
 # Extract titles from all Task nodes
-[t.title for t in [root()-->][?:Task]]
+[t.title for t in [root-->][?:Task]]
 
 # With a filter condition
-[t.title for t in [root()-->][?:Task] if not t.done]
+[t.title for t in [root-->][?:Task] if not t.done]
 ```
 
 **Run It**
@@ -648,6 +652,7 @@ This loads a CSS file client-side. Add this line at the top of your `main.jac`.
 
 A `cl def:pub` function returning `JsxElement` is a UI component:
 
+<!-- jac-skip -->
 ```jac
 cl def:pub app -> JsxElement {
     has tasks: list = [],
@@ -662,6 +667,7 @@ Notice the `has` keyword appearing again -- you first saw it in `obj` and `node`
 ??? info "You can also use React's `useState` directly"
     Since Jac's client-side code compiles to JavaScript that runs in a React context, you can import and use `useState` from React directly if you prefer:
 
+    <!-- jac-skip -->
     ```jac
     cl import from react { useState }
 
@@ -679,6 +685,7 @@ Notice the `has` keyword appearing again -- you first saw it in `obj` and `node`
 
 **`can with entry`** runs when the component first mounts (like React's `useEffect` on mount):
 
+<!-- jac-skip -->
 ```jac
     async can with entry {
         tasks = await get_tasks();
@@ -690,6 +697,7 @@ This fetches all tasks from the server when the page loads.
 ??? info "You can also use React's `useEffect` directly"
     If you prefer React's hooks, you can import and use `useEffect` directly:
 
+    <!-- jac-skip -->
     ```jac
     cl import from react { useEffect }
 
@@ -731,6 +739,7 @@ onChange={lambda e: ChangeEvent { task_text = e.target.value; }}
 
 This is one of the most important concepts to understand in Jac's full-stack model: **`await add_task(text)`** calls the server function as if it were local code. Behind the scenes, because `add_task` is `def:pub`, Jac generated both an HTTP endpoint on the server *and* a matching typed client stub in the browser automatically. The client stub handles the HTTP request, JSON serialization, and response parsing for you. You never write fetch calls, parse JSON, or handle HTTP status codes -- the boundary between client and server becomes invisible. And because the server declares `-> Task` as the return type, the client receives a proper `Task` object with `.title` and `.done` fields, and you can use `jid(task)` to get its unique identity -- no raw dictionaries or manual ID management.
 
+<!-- jac-skip -->
 ```jac
     async def add_new_task {
         if task_text.strip() {
@@ -767,6 +776,7 @@ This is one of the most important concepts to understand in Jac's full-stack mod
 
 Now that you understand the individual pieces -- reactive state, lifecycle hooks, lambdas, transparent server calls, and JSX rendering -- it's time to assemble them into a working component. Add `cl import "./styles.css";` after your existing import. Start with the input, add button, and a basic task list:
 
+<!-- jac-skip -->
 ```jac
 cl def:pub app -> JsxElement {
     has tasks: list = [],
@@ -814,6 +824,7 @@ This is already functional -- you can type a task, press Enter, and see it appea
 
 Now add checkboxes, delete buttons, and a task counter. Insert these methods after `add_new_task`, and update the task list rendering:
 
+<!-- jac-skip -->
 ```jac
 cl def:pub app -> JsxElement {
     has tasks: list = [],
@@ -919,18 +930,18 @@ h1 { text-align: center; margin-bottom: 24px; color: #333; }
 
     """Add a task and return it."""
     def:pub add_task(title: str) -> Task {
-        task = root() ++> Task(title=title);
+        task = root ++> Task(title=title);
         return task[0];
     }
 
     """Get all tasks."""
     def:pub get_tasks -> list[Task] {
-        return [root()-->][?:Task];
+        return [root-->][?:Task];
     }
 
     """Toggle a task's done status."""
     def:pub toggle_task(id: str) -> Task | None {
-        for task in [root()-->][?:Task] {
+        for task in [root-->][?:Task] {
             if jid(task) == id {
                 task.done = not task.done;
                 return task;
@@ -941,7 +952,7 @@ h1 { text-align: center; margin-bottom: 24px; color: #333; }
 
     """Delete a task."""
     def:pub delete_task(id: str) -> dict {
-        for task in [root()-->][?:Task] {
+        for task in [root-->][?:Task] {
             if jid(task) == id {
                 del task;
                 return {"deleted": id};
@@ -951,7 +962,7 @@ h1 { text-align: center; margin-bottom: 24px; color: #333; }
     }
 
     cl def:pub app -> JsxElement {
-        has tasks: list = [],
+        has tasks: list[Task] = [],
             task_text: str = "";
 
         async can with entry {
@@ -968,6 +979,7 @@ h1 { text-align: center; margin-bottom: 24px; color: #333; }
 
         async def toggle(id: str) {
             updated = await toggle_task(id);
+            if updated is None { return; }
             tasks = [updated if jid(t) == id else t for t in tasks];
         }
 
@@ -1147,7 +1159,7 @@ Then update `add_task` to call the AI:
 """Add a task with AI categorization."""
 def:pub add_task(title: str) -> Task {
     category = str(categorize(title)).split(".")[-1].lower();
-    task = root() ++> Task(title=title, category=category);
+    task = root ++> Task(title=title, category=category);
     return task[0];
 }
 ```
@@ -1206,33 +1218,34 @@ node ShoppingItem {
 
 And three new endpoints:
 
+<!-- jac-skip -->
 ```jac
 """Generate a shopping list from a meal description."""
 def:pub generate_list(meal: str) -> list[ShoppingItem] {
     # Clear old items
-    for item in [root()-->][?:ShoppingItem] {
+    for item in [root-->][?:ShoppingItem] {
         del item;
     }
     # Generate new ones
     ingredients = generate_shopping_list(meal);
     for ing in ingredients {
-        root() ++> ShoppingItem(
+        root ++> ShoppingItem(
             name=ing.name, quantity=ing.quantity,
             unit=str(ing.unit).split(".")[-1].lower(),
             cost=ing.cost, carby=ing.carby
         );
     }
-    return [root()-->][?:ShoppingItem];
+    return [root-->][?:ShoppingItem];
 }
 
 """Get the current shopping list."""
 def:pub get_shopping_list -> list[ShoppingItem] {
-    return [root()-->][?:ShoppingItem];
+    return [root-->][?:ShoppingItem];
 }
 
 """Clear the shopping list."""
 def:pub clear_shopping_list -> dict {
-    for item in [root()-->][?:ShoppingItem] {
+    for item in [root-->][?:ShoppingItem] {
         del item;
     }
     return {"cleared": True};
@@ -1256,6 +1269,7 @@ graph LR
 
 The frontend needs a two-column layout: tasks on the left, shopping list on the right. Update the component with new state, methods, and the shopping panel:
 
+<!-- jac-skip -->
 ```jac
 cl def:pub app -> JsxElement {
     has tasks: list = [],
@@ -1381,13 +1395,13 @@ cl def:pub app -> JsxElement {
                                 {(
                                     <span class="carb-badge">Carbs</span>
                                 ) if ing.carby else None}
-                                <span class="ing-cost">${ing.cost.toFixed(2)}</span>
+                                <span class="ing-cost">${format(ing.cost, ".2f")}</span>
                             </div>
                         </div> for ing in ingredients
                     ]}
                     {(
                         <div class="shopping-footer">
-                            <span class="total">Total: ${total_cost.toFixed(2)}</span>
+                            <span class="total">Total: ${format(total_cost, ".2f")}</span>
                             <button class="btn-clear" onClick={clear_list}>Clear</button>
                         </div>
                     ) if len(ingredients) > 0 else None}
@@ -1487,18 +1501,18 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
     """Add a task with AI categorization."""
     def:pub add_task(title: str) -> Task {
         category = str(categorize(title)).split(".")[-1].lower();
-        task = root() ++> Task(title=title, category=category);
+        task = root ++> Task(title=title, category=category);
         return task[0];
     }
 
     """Get all tasks."""
     def:pub get_tasks -> list[Task] {
-        return [root()-->][?:Task];
+        return [root-->][?:Task];
     }
 
     """Toggle a task's done status."""
     def:pub toggle_task(id: str) -> Task | None {
-        for task in [root()-->][?:Task] {
+        for task in [root-->][?:Task] {
             if jid(task) == id {
                 task.done = not task.done;
                 return task;
@@ -1509,7 +1523,7 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
 
     """Delete a task."""
     def:pub delete_task(id: str) -> dict {
-        for task in [root()-->][?:Task] {
+        for task in [root-->][?:Task] {
             if jid(task) == id {
                 del task;
                 return {"deleted": id};
@@ -1522,28 +1536,28 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
 
     """Generate a shopping list from a meal description."""
     def:pub generate_list(meal: str) -> list[ShoppingItem] {
-        for item in [root()-->][?:ShoppingItem] {
+        for item in [root-->][?:ShoppingItem] {
             del item;
         }
         ingredients = generate_shopping_list(meal);
         for ing in ingredients {
-            root() ++> ShoppingItem(
+            root ++> ShoppingItem(
                 name=ing.name, quantity=ing.quantity,
                 unit=str(ing.unit).split(".")[-1].lower(),
                 cost=ing.cost, carby=ing.carby
             );
         }
-        return [root()-->][?:ShoppingItem];
+        return [root-->][?:ShoppingItem];
     }
 
     """Get the current shopping list."""
     def:pub get_shopping_list -> list[ShoppingItem] {
-        return [root()-->][?:ShoppingItem];
+        return [root-->][?:ShoppingItem];
     }
 
     """Clear the shopping list."""
     def:pub clear_shopping_list -> dict {
-        for item in [root()-->][?:ShoppingItem] {
+        for item in [root-->][?:ShoppingItem] {
             del item;
         }
         return {"cleared": True};
@@ -1552,10 +1566,10 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
     # --- Frontend ---
 
     cl def:pub app -> JsxElement {
-        has tasks: list = [],
+        has tasks: list[Task] = [],
             task_text: str = "",
             meal_text: str = "",
-            ingredients: list = [],
+            ingredients: list[ShoppingItem] = [],
             generating: bool = False;
 
         async can with entry {
@@ -1573,6 +1587,7 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
 
         async def toggle(id: str) {
             updated = await toggle_task(id);
+            if updated is None { return; }
             tasks = [updated if jid(t) == id else t for t in tasks];
         }
 
@@ -1675,13 +1690,13 @@ h2 { margin: 0 0 16px 0; font-size: 1.2rem; color: #444; }
                                     {(
                                         <span class="carb-badge">Carbs</span>
                                     ) if ing.carby else None}
-                                    <span class="ing-cost">${ing.cost.toFixed(2)}</span>
+                                    <span class="ing-cost">${format(ing.cost, ".2f")}</span>
                                 </div>
                             </div> for ing in ingredients
                         ]}
                         {(
                             <div class="shopping-footer">
-                                <span class="total">Total: ${total_cost.toFixed(2)}</span>
+                                <span class="total">Total: ${format(total_cost, ".2f")}</span>
                                 <button class="btn-clear" onClick={clear_list}>Clear</button>
                             </div>
                         ) if len(ingredients) > 0 else None}
@@ -1765,6 +1780,7 @@ As your application grows, keeping everything in a single file becomes hard to n
 
 **`frontend.cl.jac`** -- state, method signatures, and the render tree:
 
+<!-- jac-skip -->
 ```jac
 def:pub app -> JsxElement {
     has tasks: list = [];
@@ -1778,6 +1794,7 @@ def:pub app -> JsxElement {
 
 **`frontend.impl.jac`** -- method bodies in `impl` blocks:
 
+<!-- jac-skip -->
 ```jac
 impl app.fetchTasks {
     tasksLoading = True;
@@ -1820,6 +1837,7 @@ Everything before `to cl:` and everything after the next `to sv:` runs on the se
 
 One more concept to learn before assembling the full app. A **dependency-triggered ability** re-runs whenever specific state changes -- conceptually similar to React's `useEffect` with a dependency array, but expressed more declaratively:
 
+<!-- jac-skip -->
 ```jac
     can with [isLoggedIn] entry {
         if isLoggedIn {
@@ -1920,18 +1938,18 @@ All the complete files are in the collapsible sections below. Create each file, 
     """Add a task with AI categorization."""
     def:priv add_task(title: str) -> Task {
         category = str(categorize(title)).split(".")[-1].lower();
-        task = root() ++> Task(title=title, category=category);
+        task = root ++> Task(title=title, category=category);
         return task[0];
     }
 
     """Get all tasks."""
     def:priv get_tasks -> list[Task] {
-        return [root()-->][?:Task];
+        return [root-->][?:Task];
     }
 
     """Toggle a task's done status."""
     def:priv toggle_task(id: str) -> Task | None {
-        for task in [root()-->][?:Task] {
+        for task in [root-->][?:Task] {
             if jid(task) == id {
                 task.done = not task.done;
                 return task;
@@ -1942,7 +1960,7 @@ All the complete files are in the collapsible sections below. Create each file, 
 
     """Delete a task."""
     def:priv delete_task(id: str) -> dict {
-        for task in [root()-->][?:Task] {
+        for task in [root-->][?:Task] {
             if jid(task) == id {
                 del task;
                 return {"deleted": id};
@@ -1955,28 +1973,28 @@ All the complete files are in the collapsible sections below. Create each file, 
 
     """Generate a shopping list from a meal description."""
     def:priv generate_list(meal: str) -> list[ShoppingItem] {
-        for item in [root()-->][?:ShoppingItem] {
+        for item in [root-->][?:ShoppingItem] {
             del item;
         }
         ingredients = generate_shopping_list(meal);
         for ing in ingredients {
-            root() ++> ShoppingItem(
+            root ++> ShoppingItem(
                 name=ing.name, quantity=ing.quantity,
                 unit=str(ing.unit).split(".")[-1].lower(),
                 cost=ing.cost, carby=ing.carby
             );
         }
-        return [root()-->][?:ShoppingItem];
+        return [root-->][?:ShoppingItem];
     }
 
     """Get the current shopping list."""
     def:priv get_shopping_list -> list[ShoppingItem] {
-        return [root()-->][?:ShoppingItem];
+        return [root-->][?:ShoppingItem];
     }
 
     """Clear the shopping list."""
     def:priv clear_shopping_list -> dict {
-        for item in [root()-->][?:ShoppingItem] {
+        for item in [root-->][?:ShoppingItem] {
             del item;
         }
         return {"cleared": True};
@@ -2157,14 +2175,14 @@ All the complete files are in the collapsible sections below. Create each file, 
                                                             <span class="carb-badge">Carbs</span>
                                                         ) if ing.carby else None}
                                                         <span class="ing-cost">
-                                                            ${ing.cost.toFixed(2)}
+                                                            ${format(ing.cost, ".2f")}
                                                         </span>
                                                     </div>
                                                 </div> for ing in ingredients
                                             ]}
                                             <div class="shopping-footer">
                                                 <span class="total">
-                                                    Total: ${totalCost.toFixed(2)}
+                                                    Total: ${format(totalCost, ".2f")}
                                                 </span>
                                                 <button
                                                     class="btn-clear"
@@ -2244,6 +2262,7 @@ All the complete files are in the collapsible sections below. Create each file, 
 
 ??? note "Complete `frontend.impl.jac`"
 
+    <!-- jac-skip -->
     ```jac
     """Implementations for the Day Planner frontend."""
 
@@ -2508,13 +2527,14 @@ The best way to understand walkers is to compare them directly with the function
 ```jac
 def:priv add_task(title: str) -> Task {
     category = str(categorize(title)).split(".")[-1].lower();
-    task = root() ++> Task(title=title, category=category);
+    task = root ++> Task(title=title, category=category);
     return task[0];
 }
 ```
 
 And here's the same logic as a walker:
 
+<!-- jac-skip -->
 ```jac
 walker AddTask {
     has title: str;
@@ -2553,9 +2573,10 @@ print(result.reports[0]);  # The reported dict
 
 The `AddTask` walker may seem like unnecessary complexity compared to the function. The value of walkers becomes clearer with `ListTasks`, which demonstrates the **accumulator pattern** -- collecting data across multiple nodes as the walker traverses the graph:
 
+<!-- jac-skip -->
 ```jac
 walker ListTasks {
-    has results: list = [];
+    has results: list[Task] = [];
 
     can start with Root entry {
         visit [-->];
@@ -2581,9 +2602,10 @@ A key insight here: the walker's `has results: list = []` state **persists acros
 
 Compare this to the function version:
 
+<!-- jac-skip -->
 ```jac
 def:priv get_tasks -> list[Task] {
-    return [root()-->][?:Task];
+    return [root-->][?:Task];
 }
 ```
 
@@ -2596,6 +2618,7 @@ For this simple, flat graph, the function version is clearly more concise. So wh
 
 So far, all abilities have been defined on the **walker** (e.g., `can collect with Task entry`). But Jac offers an alternative: abilities can also live on the **node** itself. This is an important architectural choice to understand:
 
+<!-- jac-skip -->
 ```jac
 node Task {
     has title: str,
@@ -2626,6 +2649,7 @@ visit [-->] else {         # Fallback if no nodes to visit
 
 **`disengage`** stops the walker immediately -- this is an optimization for cases where you've found what you're looking for and don't need to visit the remaining nodes:
 
+<!-- jac-skip -->
 ```jac
 walker ToggleTask {
     has task_id: str;
@@ -2646,6 +2670,7 @@ Without `disengage`, the walker would continue visiting every remaining node unn
 
 `DeleteTask` follows the same pattern:
 
+<!-- jac-skip -->
 ```jac
 walker DeleteTask {
     has task_id: str;
@@ -2668,6 +2693,7 @@ Note that `DeleteTask` still reports a plain dict rather than a typed object -- 
 
 The `GenerateShoppingList` walker demonstrates the real power of OSP -- performing multiple operations in a single graph traversal. Read this carefully, because the execution order is subtle and important:
 
+<!-- jac-skip -->
 ```jac
 walker GenerateShoppingList {
     has meal_description: str;
@@ -2699,9 +2725,10 @@ Compare this to the function version, where you needed an explicit loop to clear
 
 The remaining shopping walkers follow familiar patterns:
 
+<!-- jac-skip -->
 ```jac
 walker GetShoppingList {
-    has items: list = [];
+    has items: list[ShoppingItem] = [];
 
     can collect with Root entry { visit [-->]; }
 
@@ -3125,14 +3152,14 @@ All the complete files are in the collapsible sections below. Create each file, 
                                                             <span class="carb-badge">Carbs</span>
                                                         ) if ing.carby else None}
                                                         <span class="ing-cost">
-                                                            ${ing.cost.toFixed(2)}
+                                                            ${format(ing.cost, ".2f")}
                                                         </span>
                                                     </div>
                                                 </div> for ing in ingredients
                                             ]}
                                             <div class="shopping-footer">
                                                 <span class="total">
-                                                    Total: ${totalCost.toFixed(2)}
+                                                    Total: ${format(totalCost, ".2f")}
                                                 </span>
                                                 <button
                                                     class="btn-clear"
@@ -3212,6 +3239,7 @@ All the complete files are in the collapsible sections below. Create each file, 
 
 ??? note "Complete `frontend.impl.jac`"
 
+    <!-- jac-skip -->
     ```jac
     """Implementations for the Day Planner frontend."""
 
@@ -3472,7 +3500,7 @@ The concepts you've learned are interconnected. Types constrain AI output. Graph
 
 **Data & Types:** `node`, `edge`, `obj`, `enum`, `has`, `glob`, `sem`, type annotations, `str | None` unions
 
-**Graph:** `root()`, `++>` (create + connect), `+>: Edge :+>` (typed edge), `[root()-->]` (query), `[?:Type]` (filter), `jid()` (node identity), `del` (delete)
+**Graph:** `root`, `++>` (create + connect), `+>: Edge :+>` (typed edge), `[root-->]` (query), `[?:Type]` (filter), `jid()` (node identity), `del` (delete)
 
 **Functions:** `def`, `def:pub`, `def:priv`, `by llm()`, `lambda`, `async`/`await`
 

--- a/jac/jaclang/cli/commands/impl/project.impl.jac
+++ b/jac/jaclang/cli/commands/impl/project.impl.jac
@@ -762,7 +762,9 @@ impl script(name: str = '', list_scripts: bool = False) -> int {
     import from jaclang.project.config { get_config }
     config = get_config();
     if config is None {
-        console.error("No jac.toml found. Run 'jac init' to create a project.");
+        console.error(
+            "No jac.toml found. Run 'jac create <name>' to create a project."
+        );
         return 1;
     }
     if list_scripts or not name {
@@ -819,7 +821,9 @@ impl clean(
     import from jaclang.project.config { get_config }
     config = get_config();
     if config is None {
-        console.error("No jac.toml found. Run 'jac init' to create a project.");
+        console.error(
+            "No jac.toml found. Run 'jac create <name>' to create a project."
+        );
         return 1;
     }
     # Determine which directories to clean

--- a/jac/jaclang/project/impl/dependencies.impl.jac
+++ b/jac/jaclang/project/impl/dependencies.impl.jac
@@ -11,7 +11,9 @@ impl DependencyInstaller.postinit -> None {
         self.config = get_config();
     }
     if self.config is None {
-        raise ValueError("No jac.toml found. Run 'jac init' to create a project.");
+        raise ValueError(
+            "No jac.toml found. Run 'jac create <name>' to create a project."
+        );
     }
     self.venv_dir = self.config.get_venv_dir();
 }


### PR DESCRIPTION
## Summary

Closes the Phase 1 box of #5909 — every code block on the four most-trafficked
new-user pages either compiles cleanly under `jac check` or is
`<!-- jac-skip -->`-marked, with zero deprecation warnings.

- **Day-planner tutorial** (`tutorials/first-app/build-ai-day-planner.md`)
    - Rewrite the `switch`/`case` fall-through callout to match actual
      semantics — verified `switch` *does* fall through, contrary to the prior
      claim of "no fall-through and no `break` needed".
    - Replace every `root()` in `.jac` source with bare `root` (57
      occurrences) so the tutorial no longer emits `W0062` on copy-paste.
    - Type the `cl def:pub app` reactive state with `list[Task]` /
      `list[ShoppingItem]` and add a `None`-guard to `toggle` so the
      *Complete `main.jac`* blocks for Parts 1–4 and Parts 1–5 type-check.
    - Swap `.toFixed(2)` for `format(x, ".2f")` (cross-codespace portable;
      `.toFixed` is JS-only and tripped `W6002` plus a hard `E1030`).
    - `jac-skip` the OSP walker fragments and `frontend.impl.jac` halves —
      they are by-design fragments paired with declarations elsewhere.
- **Welcome** (`quick-guide/index.md`)
    - Drop `root()` from the flagship full-stack example.
    - Fix the broken `jac -e hello.jac` tip — `-e` requires a value, so it's
      now `jac -e all hello.jac`.
    - Clarify the default-entry-point sentence: `jac start` defaults to
      `main.jac`; `jac run` always needs the filename explicitly.
- **Install** (`quick-guide/install.md`)
    - `jac add` → `jac install` in all three flow examples; `jac add` (no
      args) was the install path before the breaking change and now errors
      out.
- **FAQ** (`quick-guide/faq.md`)
    - Drop the non-existent `jac init`.
    - Tighten the `jac clean` description so users know plain `jac clean` is
      data-only and only the project-scoped flags need a `jac.toml`.
- **CLI runtime**
    - `jac script`, `jac clean`, and the dependency installer's
      `No jac.toml found` errors now point users at `jac create <name>`
      instead of the non-existent `jac init`, so the CLI no longer
      contradicts the FAQ.

## Test plan

- [x] `jac check` over every ` ```jac ` block on
  `quick-guide/index.md`, `quick-guide/install.md`, `quick-guide/faq.md`,
  and `tutorials/first-app/build-ai-day-planner.md` — 0 failures, 0
  deprecation warnings.
- [x] Verify `jac create --use client` scaffold matches the tutorial's
  "delete `main.jac` and `components/`" step (it does today).
- [x] Verify `jac -e all hello.jac` runs.
- [x] Verify the runtime error message no longer mentions `jac init`.
- [ ] CI / mkdocs build green.