### PR TITLE
docs: phase 2 config accuracy fixes for jac.toml plugin sections

### DIFF
--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -340,11 +340,13 @@ discovery = "auto"      # "auto", "manual", or "disabled"
 enabled = ["byllm"] # Explicitly enabled
 disabled = []           # Explicitly disabled
 
-# Plugin-specific settings
-[plugins.byllm]
-model = "gpt-4"
-temperature = 0.7
+# Plugin-specific settings (byllm splits model identity from call params)
+[plugins.byllm.model]
+default_model = "gpt-4o"
 api_key = "${OPENAI_API_KEY}"
+
+[plugins.byllm.call_params]
+temperature = 0.7
 
 # Server settings (jac-scale)
 [plugins.scale.server]
@@ -365,12 +367,13 @@ jaclang = "latest"
 jac_scale = "latest"
 jac_client = "latest"
 jac_byllm = "none"           # Use "none" to skip installation
+jac_mcp = "latest"
 ```
 
 **Prometheus Metrics (jac-scale):**
 
 ```toml
-[plugins.scale.metrics]
+[plugins.scale.monitoring]
 enabled = true
 endpoint = "/metrics"
 namespace = "myapp"
@@ -509,10 +512,10 @@ JAC_PROFILE=production jac run main.jac
 Use environment variable interpolation:
 
 ```toml
-[plugins.byllm]
-api_key = "${OPENAI_API_KEY}"              # Required
-model = "${MODEL:-gpt-3.5-turbo}"          # With default
-secret = "${SECRET:?Secret is required}"   # Required with error
+[plugins.byllm.model]
+api_key = "${OPENAI_API_KEY}"                       # Required
+default_model = "${MODEL:-gpt-4o-mini}"             # With default
+base_url = "${BASE_URL:?Base URL is required}"      # Required with error
 ```
 
 | Syntax | Description |
@@ -681,8 +684,8 @@ exclude = []
 [plugins]
 discovery = "auto"
 
-[plugins.byllm]
-model = "${LLM_MODEL:-gpt-4}"
+[plugins.byllm.model]
+default_model = "${LLM_MODEL:-gpt-4o-mini}"
 api_key = "${OPENAI_API_KEY}"
 
 [scripts]

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -129,34 +129,43 @@ The `jac` command is your primary interface to the Jac toolchain. For the full r
 ### Managing Plugins
 
 ```bash
-# List plugins
+# List installed plugins
 jac plugins list
 
-# Enable plugin
-jac plugins enable byllm
+# Show currently disabled plugins
+jac plugins disabled
 
-# Disable plugin
+# Disable a plugin (writes to jac.toml)
 jac plugins disable byllm
+
+# Re-enable a previously disabled plugin (removes from disabled list)
+jac plugins enable byllm
 
 # Plugin info
 jac plugins info byllm
 ```
+
+`jac plugins enable` and `jac plugins disable` toggle the `disabled` list in
+`[plugins]`; calling `enable` on a plugin that is not currently disabled is
+a no-op.
 
 ### Plugin Configuration
 
 In `jac.toml`:
 
 ```toml
-[plugins.byllm]
-enabled = true
-default_model = "gpt-4"
+[plugins.byllm.model]
+default_model = "gpt-4o"
 
-[plugins.client]
-port = 5173
-typescript = false
+[plugins.byllm.call_params]
+temperature = 0.7
 
-[plugins.scale]
-replicas = 3
+[plugins.client.npm.scoped_registries]
+"@mycompany" = "https://npm.pkg.github.com"
+
+[plugins.scale.server]
+port = 8000
+host = "0.0.0.0"
 ```
 
 ---
@@ -172,7 +181,7 @@ For the full reference, see [Configuration](config/index.md).
 name = "my-app"
 version = "1.0.0"
 description = "My Jac application"
-entry = "main.jac"
+entry-point = "main.jac"
 
 [dependencies]
 numpy = "^1.24.0"
@@ -185,11 +194,8 @@ pytest = "^7.0.0"
 react = "^18.0.0"
 "@mui/material" = "^5.0.0"
 
-[plugins.byllm]
-default_model = "gpt-4"
-
-[plugins.client]
-port = 5173
+[plugins.byllm.model]
+default_model = "gpt-4o"
 
 # Private npm registries (generates .npmrc)
 [plugins.client.npm.scoped_registries]
@@ -250,8 +256,8 @@ JAC_PROFILE=ci jac test
     [serve]
     port = 80
 
-    [plugins.byllm]
-    default_model = "gpt-4"
+    [plugins.byllm.model]
+    default_model = "gpt-4o"
     ```
 
 === "jac.local.toml (gitignored, developer-specific)"
@@ -314,11 +320,13 @@ import from axios { default as axios }
 
 ### TypeScript Configuration
 
-TypeScript is supported through the jac-client Vite toolchain for client-side code. Configure in `jac.toml`:
+TypeScript is supported through the jac-client Vite toolchain for client-side code. Override the generated `tsconfig.json` from `jac.toml`:
 
 ```toml
-[plugins.client]
-typescript = true
+[plugins.client.ts]
+compilerOptions = { target = "ES2022", strict = true }
+include = ["src/**/*"]
+exclude = ["node_modules"]
 ```
 
 > **Note:** Jac does not parse TypeScript files directly. TypeScript support is provided through Vite's built-in TypeScript handling in client-side (`cl {}`) code.

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -130,12 +130,23 @@ Set `docs_enabled = false` to disable Swagger UI, ReDoc, and the OpenAPI JSON en
 
 ### CORS Configuration
 
+In single-process `jac start` mode the FastAPI app installs a permissive
+CORS middleware (`allow_origins=['*']`, all methods/headers); there is
+no `[plugins.scale.cors]` knob to tune it.
+
+In **microservice mode** (`[plugins.scale.microservices] enabled = true`),
+the gateway exposes a configurable CORS section:
+
 ```toml
-[plugins.scale.cors]
+[plugins.scale.microservices.cors]
 allow_origins = ["https://example.com"]
 allow_methods = ["GET", "POST", "PUT", "DELETE"]
 allow_headers = ["*"]
 ```
+
+Defaults are open (`allow_origins = ["*"]`); set `allow_origins = []` to
+disable. Additional CORS keys (`allow_credentials`, `expose_headers`,
+`max_age`) are recognised under the same section.
 
 ---
 
@@ -2324,6 +2335,7 @@ jaclang = "0.1.5"      # Pin to a specific version
 jac_scale = "latest"   # Latest from PyPI (default)
 jac_client = "0.1.0"   # Specific version
 jac_byllm = "none"     # Skip installation entirely
+jac_mcp = "latest"     # Optional MCP server plugin
 ```
 
 | Package | Description |
@@ -2332,6 +2344,7 @@ jac_byllm = "none"     # Skip installation entirely
 | `jac_scale` | This scaling plugin |
 | `jac_client` | Frontend/client support |
 | `jac_byllm` | LLM integration (set to `"none"` to exclude) |
+| `jac_mcp` | MCP server plugin (set to `"none"` to exclude) |
 
 ---
 
@@ -2375,7 +2388,7 @@ On AWS clusters, the NGINX Ingress controller is exposed via a Network Load Bala
 - kube-state-metrics (pod, deployment, replica, restart state)
 - node-exporter (CPU, memory, disk, network per node)
 
-> To collect application metrics, also enable `[plugins.scale.metrics] enabled = true` - see [Prometheus Metrics](#prometheus-metrics).
+> To collect application metrics, also enable `[plugins.scale.monitoring] enabled = true` - see [Prometheus Metrics](#prometheus-metrics).
 
 ---
 
@@ -2556,7 +2569,7 @@ jac-scale provides built-in Prometheus metrics collection for monitoring HTTP re
 Configure metrics in `jac.toml`:
 
 ```toml
-[plugins.scale.metrics]
+[plugins.scale.monitoring]
 enabled = true                  # Enable metrics collection and /metrics endpoint
 endpoint = "/metrics"           # Prometheus scrape endpoint path
 namespace = "myapp"             # Metrics namespace prefix


### PR DESCRIPTION
## Summary

Phase 2 of the docs accuracy roadmap (#5909). Aligns every `jac.toml`
example in the reference docs with the byllm, jac-client, and jac-scale
plugin schemas so users copying snippets get keys the runtime actually
reads.

- **`reference/index.md`** — `entry` -> `entry-point`; flat
  `[plugins.byllm]` and `[plugins.client]` (`port`, `typescript`) blocks
  replaced with the schema-correct nested form (`[plugins.byllm.model]`,
  `[plugins.byllm.call_params]`, `[plugins.client.ts]`,
  `[plugins.client.npm.scoped_registries]`); `jac plugins enable/disable`
  documented as toggles of the `disabled` list.
- **`reference/config/index.md`** — three `[plugins.byllm]` examples
  switched to `[plugins.byllm.model]` / `[plugins.byllm.call_params]`;
  Prometheus block fixed from `[plugins.scale.metrics]` (no such section)
  to `[plugins.scale.monitoring]`; `plugin_versions` example adds
  `jac_mcp` (already supported by the K8s deployer).
- **`reference/plugins/jac-scale.md`** — Prometheus block + cross-ref
  fixed to `[plugins.scale.monitoring]`; CORS section now distinguishes
  single-process mode (hardcoded permissive, no knob) from microservice
  mode (`[plugins.scale.microservices.cors]`); `plugin_versions` example
  adds `jac_mcp`.

Closes the Phase 2 boxes (2.1, 2.2, 2.3) of #5909.

## Test plan

- [x] `mkdocs build --strict` succeeds with no new warnings
- [x] `jac check` + `jac run` on a fresh project whose `jac.toml`
  exercises every documented section (`[plugins.byllm.model]`,
  `[plugins.byllm.call_params]`, `[plugins.byllm.local]`,
  `[plugins.client.ts]`, `[plugins.client.npm.scoped_registries]`,
  `[plugins.scale.server]`, `[plugins.scale.kubernetes.plugin_versions]`,
  `[plugins.scale.monitoring]`, `[plugins.scale.microservices.cors]`)
- [x] grep sweep confirms no remaining `[plugins.scale.metrics]`,
  `[plugins.scale.cors]`, `port = 5173`, `typescript = true|false`,
  or `entry = "main.jac"` outside release-notes