### PR TITLE
docs: phase 3 language-semantics accuracy fixes (#5909)

### DIFF
--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -294,36 +294,52 @@ def:pub Counter() -> JsxElement {
 
 `root` is again a reserved keyword (`KW_ROOT`) and parses as a `SpecialVarRef`, mirroring how `here` and `visitor` are bound. The type checker resolves it directly to `Root`, the binder rejects local rebinding, and codegen lowers it to `Jac.root()`. This reverses the brief window in 0.12.3 where `root` was an ambient builtin resolved through `jac_builtins.pyi`.
 
-**Impact:** Bare `root` is the canonical form and continues to work as before in walkers, graph operations, and edge expressions. However:
+**Impact:** Bare `root` is the canonical form in `.jac` source and continues to work as before in walkers, graph operations, and edge expressions. However:
 
 - **Backtick escaping is required to shadow it.** Use `` `root `` to declare a parameter, field, or local named `root`.
-- **`root()` is now deprecated.** Bare `root` is canonical; the compiler emits **W0062** when it sees `root()` and lowers it to the same `Jac.root()` call so existing code keeps working.
+- **`root()` is deprecated in `.jac` source.** Bare `root` is canonical; the compiler emits **W0062** when it sees `root()` in a `.jac` file and lowers it to the same `Jac.root()` call so existing code keeps working.
 - **AST introspection sees `SpecialVarRef` with `KW_ROOT` again.** Code that special-cased the post-0.12.3 `Name` shape needs to update.
 - **Bytecode cache must be cleared.** The AST shape for `root` changes from `Name` to `SpecialVarRef`. Run `rm -rf ~/.cache/jac/bytecode/ .jac/cache/` (or your project's configured cache dir) after upgrading.
 
-**Before (0.12.3):**
+!!! note "`.jac` source vs library mode"
+    The deprecation applies to `.jac` source only. In **library mode** (Python files using `from jaclang.lib import root, connect, spawn, ...`), `root` is a Python function and **must be called as `root()`** -- it is not a keyword in that context. See [Library Mode](../reference/language/library-mode.md) for the full Python-side surface.
+
+**Before (0.12.3 `.jac` source):**
 
 ```jac
 # root was an ambient builtin; backtick escaping not needed
 has root: str = "default";
 
 with entry {
-    r = root();              # explicit call, recommended
-    root() ++> Item();       # works, no warning
+    r = root();              # ambient-builtin call, valid in 0.12.3
+    root() ++> Item();       # valid in 0.12.3
 }
 ```
 
-**After:**
+**After (`.jac` source):**
 
 ```jac
+node Item { has name: str = ""; }
+
 # root is a keyword again; backtick to shadow as a field
-has `root: str = "default";
+obj Settings {
+    has `root: str = "default";
+}
 
 with entry {
     r = root;                # bare reference, canonical
     root ++> Item();         # works, no warning
     r2 = root();             # still works but emits W0062
 }
+```
+
+**In library mode (Python):**
+
+```python
+from jaclang.lib import root, connect
+
+# root() is the canonical call form in Python
+connect(left=root(), right=Item())
 ```
 
 ---

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -296,9 +296,9 @@ obj Dog {
         print(f"{self.name} says Woof!");
     }
 
-    # Class method -- Self refers to the class
-    class def create(name: str) -> Self {
-        return Self(name=name);
+    # Static method -- no self or Self; works as a named constructor
+    static def make(name: str) -> Dog {
+        return Dog(name=name);
     }
 
     # Static method -- no self or Self
@@ -427,10 +427,10 @@ type Json = JsonPrimitive | list[Json] | dict[str, Json];
 # Generic type alias
 type NumberList = list[int | float];
 
-# Self type -- refers to the enclosing archetype
+# Recursive types name the enclosing archetype directly
 obj TreeNode {
     has value: int = 0,
-        next: Self | None = None;  # Self = TreeNode here
+        next: TreeNode | None = None;
 }
 
 
@@ -521,8 +521,8 @@ with entry {
 # Decorators
 # ============================================================
 
-# Prefer `class def` for classmethods in obj (see Objects section above)
-# @classmethod decorator is supported for Python `class` compatibility
+# Prefer `static def` for named constructors and `class def` for class-bound
+# methods in `obj`. The @classmethod decorator stays for Python `class` compatibility.
 @classmethod
 def my_class_method(cls: type) -> str {
     return cls.__name__;

--- a/docs/docs/reference/language/appendices.md
+++ b/docs/docs/reference/language/appendices.md
@@ -266,8 +266,10 @@ obj Example {
 ### 5. Walker `visit` is Queued
 
 ```jac
+node Item { has name: str = ""; }
+
 walker Example {
-    can traverse with Node entry {
+    can traverse with Item entry {
         print("Visiting");
         visit [-->];  # Nodes queued, visited AFTER this method
         print("This prints before visiting children");
@@ -275,19 +277,24 @@ walker Example {
 }
 ```
 
+To match every node regardless of type, use the anonymous form `can traverse with entry { ... }` -- there is no built-in `Node` catch-all trigger.
+
 ### 6. `report` vs `return`
 
-<!-- jac-skip -->
 ```jac
+node Item { has value: int = 0; }
+
 walker Example {
-    can collect with Node entry -> object {
+    can collect with Item entry {
         report here.value;  # Continues execution
         visit [-->];        # Still runs
 
-        return here.value;  # Would stop here
+        return;             # Would stop the walker here
     }
 }
 ```
+
+Walker abilities don't carry an arrow-return type annotation -- `report` accumulates results on the walker's `reports` list, and `return` (with no value) ends the current ability.
 
 ### 7. Global Modification Requires Declaration
 
@@ -509,16 +516,21 @@ finally:
 
 **Jac:**
 
-<!-- jac-skip -->
 ```jac
-try {
-    result = divide(10, 0);
-} except ValueError as e {
-    print(f"Error: {e}");
-} finally {
-    print("Done");
+def divide(a: int, b: int) -> int { return a // b; }
+
+with entry {
+    try {
+        result = divide(10, 0);
+    } except ValueError as e {
+        print(f"Error: {e}");
+    } finally {
+        print("Done");
+    }
 }
 ```
+
+Module-level statements (including `try`) must live inside a `with entry { ... }` block or a function body.
 
 For a step-by-step transition guide, see [Jac Basics Tutorial](../../tutorials/language/basics.md).
 

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -454,25 +454,33 @@ obj Container {
 
 ### 4 The `Self` Type
 
-`Self` (capital S) is a special type that refers to the enclosing archetype. It is distinct from `self` (lowercase), which refers to the current instance.
+`Self` (capital S) is a special type that, in instance-method positions, refers to the enclosing archetype. It is distinct from `self` (lowercase), which refers to the current instance. `Self` is most useful for fluent/builder methods that return the receiver:
 
 ```jac
-obj Node {
-    has value: int = 0,
-        next: Self | None = None;  # Self = Node in type annotations
+obj NodeRef {
+    has value: int = 0;
 
-    class def create(v: int) -> Self {  # Self = cls in class methods
-        return Self(value=v);
-    }
-
-    def set_next(n: Self) -> Self {  # Self as parameter and return type
-        self.next = n;
+    def set_value(v: int) -> Self {  # Self as return type
+        self.value = v;
         return self;
     }
 }
 ```
 
-`Self` is polymorphic -- in a subclass, it resolves to the subclass type, not the parent. See [Class Methods and Self](functions-objects.md#6-static-methods-and-class-methods) for usage details.
+For recursive type annotations on fields and parameters, name the enclosing archetype directly:
+
+```jac
+obj LinkedNode {
+    has value: int = 0,
+        next: LinkedNode | None = None;
+
+    static def create(v: int) -> LinkedNode {
+        return LinkedNode(value=v);
+    }
+}
+```
+
+See [Class Methods and Self](functions-objects.md#6-static-methods-and-class-methods) for usage details, including the planned polymorphic `Self` enhancement for `class def` factories.
 
 ### 5 Union Types
 

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -212,7 +212,7 @@ obj Calculator {
 
 ### 6 Static Methods and Class Methods
 
-Jac provides three method modifiers: `def` (instance method, receives `self`), `static def` (no receiver), and `class def` (class method, receives `Self`).
+Jac provides three method modifiers: `def` (instance method, receives `self`), `static def` (no receiver), and `class def` (class method, receives the class itself).
 
 ```jac
 obj Counter {
@@ -223,9 +223,9 @@ obj Counter {
         return Counter.count;
     }
 
-    # Class method -- Self refers to the class itself
-    class def create() -> Self {
-        return Self();
+    # Static factory -- explicit class name keeps the return type clean
+    static def make() -> Counter {
+        return Counter();
     }
 
     # Instance method -- self is the instance
@@ -238,20 +238,20 @@ obj Counter {
 | Modifier | Receiver | Use case |
 |----------|----------|----------|
 | `def` | `self` (implicit) | Instance behavior |
-| `static def` | none | Utility functions |
-| `class def` | `Self` (implicit) | Factory methods, alternative constructors |
+| `static def` | none | Utility functions, named constructors |
+| `class def` | the class (implicit) | Class-bound methods that need access to the class object |
 
-#### Class Methods and `Self`
+#### Factory Methods
 
-`class def` declares a class method. Inside it, `Self` (capital S) refers to the class itself -- equivalent to Python's `cls` parameter, but auto-injected.
+The simplest way to expose a named constructor is a `static def` that returns the enclosing type:
 
 ```jac
 obj Animal {
     has name: str,
         sound: str = "...";
 
-    class def create(name: str) -> Self {
-        return Self(name=name);
+    static def named(name: str) -> Animal {
+        return Animal(name=name);
     }
 
     def speak() -> str {
@@ -264,18 +264,16 @@ obj Dog(Animal) {
 }
 
 with entry {
-    # Self resolves to Dog, not Animal -- polymorphic!
-    d = Dog.create("Rex");
+    a = Animal.named("Rex");
+    print(a.speak());         # Rex says ...
+    d = Dog(name="Rex");
     print(d.speak());         # Rex says woof
-    print(type(d).__name__);  # Dog
 }
 ```
 
-`Self` is polymorphic: when a subclass inherits a `class def`, `Self` resolves to the subclass. This makes factory methods work correctly across inheritance hierarchies without overriding.
-
 #### `Self` as a Type Annotation
 
-`Self` also works as a type annotation in instance methods, enabling fluent/builder patterns:
+`Self` works as a type annotation in instance methods, enabling fluent/builder patterns where each method returns the receiver:
 
 ```jac
 obj QueryBuilder {
@@ -300,9 +298,10 @@ with entry {
 
 | Context | `Self` resolves to |
 |---------|-------------------|
-| `class def` body | the class (`cls` in Python) |
-| `def` body | `type(self)` -- the runtime class |
-| Type annotation | the enclosing class name |
+| Instance `def` return annotation | `type(self)` -- the runtime class, used for fluent return-self |
+
+!!! note "Polymorphic `class def` factories"
+    A `class def` that returns `Self` and constructs `Self(...)` runs correctly today -- subclass calls return subclass instances -- but the static checker does not yet bind `Self` in `class def` return positions or as a callable target. For clean `jac check` output, prefer the `static def` factory above and name the concrete class explicitly. Tracking issue: polymorphic `Self` in `class def` is a planned type-checker enhancement.
 
 ### 7 Lambda Expressions
 

--- a/docs/docs/reference/language/library-mode.md
+++ b/docs/docs/reference/language/library-mode.md
@@ -17,6 +17,9 @@ Library mode is designed for:
 - **Understanding Jac's architecture** by exploring how its transpilation to Python works under the hood
 - **Enterprise and corporate environments** where introducing standard Python libraries is more acceptable than adopting new language syntax
 
+!!! note "`root` is a function in library mode"
+    In `.jac` source, `root` is a reserved keyword and writing `root()` emits warning **W0062** (deprecated; use bare `root`). In **library mode**, `root` is a Python function imported from `jaclang.lib`, so it **must** be called as `root()` -- the bare reference is just the function object. The same applies to other graph builtins (`spawn`, `connect`, `get_all_root`). The deprecation in [breaking-changes.md](../../community/breaking-changes.md#1-root-is-a-reserved-keyword-again-specialvarref) only governs `.jac` source.
+
 ### **Converting Jac Code to Pure Python**
 
 The `jac jac2py` command transpiles Jac source files into equivalent Python code. The generated output:

--- a/docs/docs/reference/language/native-pathway.md
+++ b/docs/docs/reference/language/native-pathway.md
@@ -504,15 +504,17 @@ The same mechanism works with any C-compatible shared library. For example, usin
 <!-- jac-skip -->
 ```jac
 import from "libraylib.so" {
-    def InitWindow(width: i32, height: i32, title: i8*) -> c_void;
+    def InitWindow(width: i32, height: i32, title: str) -> c_void;
     def WindowShouldClose() -> i32;
     def BeginDrawing() -> c_void;
     def EndDrawing() -> c_void;
     def CloseWindow() -> c_void;
     def ClearBackground(color: i32) -> c_void;
-    def DrawText(text: i8*, x: i32, y: i32, fontSize: i32, color: i32) -> c_void;
+    def DrawText(text: str, x: i32, y: i32, fontSize: i32, color: i32) -> c_void;
 }
 ```
+
+C-string parameters use `str` in the declaration; the compiler lowers `str` to the `i8*` ABI shape shown in the [primitive-type table](#primitive-type-mappings) above. The `i8*` form is an internal LLVM type and is not part of Jac's surface syntax.
 
 Any library that exposes a C ABI can be called this way -- just point to the shared library path and declare the function signatures.
 
@@ -703,7 +705,7 @@ HELLO, WORLD!
 # mixed.jac
 
 # Python side -- full ecosystem access
-import:py from json { dumps }
+import from json { dumps }
 
 def serialize(data: dict) -> str {
     return dumps(data);

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -955,16 +955,17 @@ Typed context blocks let you conditionally execute code based on the runtime typ
 The syntax uses `->Type{code}` with no space between the arrow and type name:
 
 ```jac
+node Animal { has name: str = ""; }
+node Dog(Animal) {}
+node Cat(Animal) {}
+
 walker AnimalVisitor {
     can visit with Animal entry {
         # Typed context block for Dog (subtype of Animal)
-        ->Dog{print(f"{here.name} is a {here.breed} dog");}
+        ->Dog{print(f"{here.name} is a dog");}
 
         # Typed context block for Cat (subtype of Animal)
         ->Cat{print(f"{here.name} says meow");}
-
-        # Default case (any other Animal type)
-        ->_{print(f"{here.name} is some animal");}
     }
 }
 ```
@@ -974,36 +975,38 @@ walker AnimalVisitor {
 - No space between `->` and the type name: `->Dog{` not `-> Dog {`
 - Opening brace immediately follows the type
 - Code typically on same line with closing brace
-- Use `->_` for default/catch-all case
+- For a default/catch-all branch, add a final ability triggered on the base type (e.g. `can default with Animal entry { ... }`) or use an `else` branch on an `if isinstance(...)` chain. The `->_{}` wildcard form is not supported.
 
-!!! warning "Known Limitation"
-    The `->_{}` wildcard/default case is not currently supported at runtime and will produce a `name '_' is not defined` error. Use an explicit base type or `else` branch instead.
+### 2 Union-Based Dispatch
 
-### 2 Tuple-Based Dispatch
+A single ability can fire on multiple node types using the `|` union syntax:
 
 ```jac
+node Node1 { has v: int = 0; }
+node Node2 { has v: int = 0; }
+
 walker Processor {
-    can process with (Node1, Node2) entry {
-        # Handle when visiting involves both types
+    can process with Node1 | Node2 entry {
+        # Handles either node type; here is typed as Node1 | Node2
+        print(here.v);
     }
 }
 ```
 
 ### 3 Context Blocks in Nodes
 
-Nodes reacting to different walker types:
+Nodes can react to a specific walker by naming the walker type as the trigger. To handle *any* walker, use the anonymous form (`can handle with entry { ... }`) -- there is no built-in `Walker` catch-all type.
 
 ```jac
+walker Reader {}
+walker Writer { has new_value: int = 0; }
+
 node DataNode {
-    has value: int;
+    has value: int = 0;
 
-    can handle with Walker entry {
-        ->Reader{print(f"Read value: {self.value}");}
-
-        ->Writer{
-            self.value = visitor.new_value;
-            print(f"Updated to: {self.value}");
-        }
+    # Anonymous ability fires for every walker that visits this node
+    can handle with entry {
+        print(f"Visited by {type(visitor).__name__}, value={self.value}");
     }
 }
 ```


### PR DESCRIPTION
## Summary

Phase 3 of the docs accuracy roadmap (#5909) — replaces reference-page claims that the parser/checker do not actually accept with patterns that compile cleanly under `jac check` today, and clarifies the spots where the runtime diverges from the static checker.

### 3.1 `Self` resolution claims (`syntax-cheatsheet.md`, `functions-objects.md`, `foundation.md`)
- Replaced the `class def create(...) -> Self { return Self(...); }` factory examples with `static def` variants that typecheck. Runtime behavior of `class def Self` factories is correct, but the static checker does not yet bind `Self` in `class def` return positions or as a callable target — added a callout describing this as a planned type-checker enhancement.
- Recursive field types now name the enclosing archetype directly (`next: TreeNode | None`, `next: LinkedNode | None`) instead of `Self`, which warns `W2001`.

### 3.2 OSP page (`osp.md`)
- Renamed *Tuple-Based Dispatch* (`with (Node1, Node2) entry`, doesn't parse) to **Union-Based Dispatch** with the `Node1 | Node2` form that actually compiles.
- Replaced `can handle with Walker entry` with the anonymous `can handle with entry { ... }` form (no built-in `Walker` catch-all type).
- Dropped the `->_` wildcard bullet that contradicted the warning callout immediately below. Pointed to typed-trigger and `isinstance` patterns instead.
- Added the `Animal`/`Dog`/`Cat` node declarations so the typed-context-block example self-compiles.

### 3.3 Appendices (`appendices.md`)
- Replaced bogus `Node` triggers with concrete (`Item`) and anonymous-form examples; added a note that there is no built-in `Node` catch-all trigger.
- Removed the unsupported `can ABILITY with TRIGGER entry -> RETURN_TYPE` arrow syntax — walker abilities don't carry an arrow-return.
- Wrapped the module-level `try/except` example in `with entry { ... }` so it parses.

### 3.4 Native pathway (`native-pathway.md`)
- Replaced `i8*` in the raylib-style C-library examples with `str` (which lowers to `i8*` internally per the type-mapping table). Added a one-liner clarifying that `i8*` is an internal LLVM type, not surface syntax.
- Fixed the stale `import:py from json { dumps }` to `import from json { dumps }`.

### 3.5 `root()` library-mode vs `.jac` source
- `breaking-changes.md`: clarified that the `root()` deprecation (W0062) only governs `.jac` source; tightened the before/after wording so it stops reading as if the library-mode call form is being deprecated; added a Python snippet showing `root()` as the canonical library-mode call form.
- `library-mode.md`: added a callout explaining that `root` (and `spawn`/`connect`/`get_all_root`) are Python functions in library mode and **must** be called as `root()`.

## Test plan

- [x] `jac check` (via `.venv/bin/jac`) on each rewritten code block in isolation — every block I touched now passes (warnings unrelated to Phase 3 remain, e.g. W3037 / W2070 / W6001 — those are Phase 7 work).
- [x] Re-extracted every ` ```jac ` block from each affected page and re-ran `jac check`; the only remaining failures on these pages map to Phase 4 / 6.2 (snippet fragmentation) or Phase 5 (toolchain stubs), not Phase 3.
- [x] Verified `.jac` source vs library-mode `root()` distinction by running both forms.