### PR TITLE
fix(ci): unblock docs deploy by removing unused .git copy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -124,13 +124,11 @@ jobs:
 
           RUN apt-get update && apt-get install -y \
               curl \
-              git \
               graphviz \
               && rm -rf /var/lib/apt/lists/*
 
           WORKDIR /app
 
-          COPY .git/ ./.git/
           COPY docs/ ./docs/
           COPY jac/ ./jac/
           COPY jac-client/ ./jac-client/


### PR DESCRIPTION
## Summary

The `deploy-jac-lang-website` workflow has been failing on `main` since #5846 merged. The inline Dockerfile in `deploy-docs.yml` does `COPY .git/ ./.git/`, but #5846 introduced a repo-root `.dockerignore` that excludes `.git` to keep the build context bounded — so the COPY now resolves to a missing path and the build aborts:

```
[ 4/12] COPY .git/ ./.git/
ERROR: failed to compute cache key: ... "/.git": not found
```

(BuildKit even prints `CopyIgnoredFile: Attempting to Copy file ".git" that is excluded by .dockerignore` right before the error.)

## Fix

Drop the `COPY .git/ ./.git/` line, and also drop `git` from the `apt-get install` list. Nothing in the image actually consumes git:

- `jac/pyproject.toml` has a static version (`"0.14.1"`), no `setuptools_scm`.
- `docs/pyproject.toml` has no `git+` URLs.
- `mkdocs.yml` has no git-based plugins (no `git-revision-date-localized`, `git-authors`, `git-committers`).
- No script in `docs/scripts/` invokes git.
- Release notes under `docs/docs/community/release_notes/` are static markdown.
- The runner-side `Get tag name` step uses git, but that's on the GitHub Actions runner (which has full history via `fetch-depth: 0`), not inside the image.

This also drops ~860MB of dead-weight `.git` objects from every published image.

The repo-root `.dockerignore` and the size-optimization rationale from #5846 are left intact.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, confirm the next `deploy-jac-lang-website` run on `main` succeeds end-to-end (build + smoke test + ECR push)