### PR TITLE
fix(parser): accept docstring before cl/sv/na context prefix

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5941.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5941.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Docstring before `cl`/`sv`/`na` context prefix**: A `"""docstring"""` immediately before a single-statement `cl`, `sv`, or `na` prefix no longer fails with `E0005`; the docstring attaches to the inner declaration and the prefix tags its code context as before.

--- a/jac/jaclang/jac.spec
+++ b/jac/jaclang/jac.spec
@@ -264,6 +264,7 @@ docstring_target ::=
         | global_var
         | "impl" impl_def
         | module_code
+        | ("cl" | "sv" | "na") element_stmt
     )?
 
 client_block ::= "cl" ("{" element_stmt* "}" | element_stmt)

--- a/jac/jaclang/jac0core/parser/impl/parser.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/parser.impl.jac
@@ -3559,7 +3559,10 @@ impl Parser.parse_element_stmt{
         TokenKind.KW_IMPL,
         TokenKind.TYP_TYPE,
         TokenKind.KW_GLOBAL,
-        TokenKind.KW_WITH
+        TokenKind.KW_WITH,
+        TokenKind.KW_CLIENT,
+        TokenKind.KW_SERVER,
+        TokenKind.KW_NATIVE
     ) {
         return self.parse_docstring_target();
     }
@@ -3711,6 +3714,17 @@ impl Parser.parse_docstring_target{
         result = self.parse_module_code();
         result.doc = elem_doc;
         result.add_kids_left([elem_doc]);
+        return result;
+    }
+    # cl / sv / na single-stmt prefix: recurse into parse_element_stmt so the
+    # prefix is consumed and code_context is tagged on the inner element. The
+    # docstring attaches to that inner element, not to the context prefix.
+    if self.check_any(TokenKind.KW_CLIENT, TokenKind.KW_SERVER, TokenKind.KW_NATIVE) {
+        result = self.parse_element_stmt();
+        if result is not None {
+            result.doc = elem_doc;
+            result.add_kids_left([elem_doc]);
+        }
         return result;
     }
     # Complex case: decorators/async/ability/archetype — dispatch via lookahead

--- a/jac/tests/compiler/test_parser.jac
+++ b/jac/tests/compiler/test_parser.jac
@@ -490,6 +490,61 @@ to cl:
     assert len(mod.body[1].body) == 0;
 }
 
+test "docstring before context prefix" {
+    # Regression: a """docstring""" placed before a `cl`/`sv`/`na` prefix used
+    # to fail with E0005 because the docstring-prefix dispatcher in
+    # parse_element_stmt only knew about the bare declaration keywords
+    # (def/can/obj/node/...) — not the context prefixes. With the fix in
+    # parse_element_stmt + parse_docstring_target, the docstring attaches to
+    # the inner declaration and the prefix tags its code_context.
+    source = """
+def first -> int { return 0; }
+
+\"\"\"Task row docstring.\"\"\"
+cl def cl_fn -> int { return 1; }
+
+\"\"\"Server helper docstring.\"\"\"
+sv def sv_fn -> int { return 2; }
+
+\"\"\"Native fn docstring.\"\"\"
+na def na_fn -> int { return 3; }
+""";
+    prog = JacProgram();
+    mod = prog.parse_str(source, "test.jac");
+    assert not prog.errors_had;
+    # body[0] is the bare `def first` (no docstring, server context by default).
+    # body[1..3] are the three docstring-prefixed prefixed defs.
+    assert len(mod.body) == 4;
+    expected = [
+        (None, CodeContext.SERVER, "first"),
+        ('"""Task row docstring."""', CodeContext.CLIENT, "cl_fn"),
+        ('"""Server helper docstring."""', CodeContext.SERVER, "sv_fn"),
+        ('"""Native fn docstring."""', CodeContext.NATIVE, "na_fn"),
+
+    ];
+    for (stmt, (exp_doc, exp_ctx, exp_name)) in zip(mod.body, expected) {
+        assert isinstance(stmt, uni.Ability) , (
+            f"expected Ability, got {type(stmt).__name__} for {exp_name}"
+        );
+        actual_doc = stmt.doc.value if stmt.doc else None;
+        assert actual_doc == exp_doc , (
+            f"{exp_name}: doc mismatch (got {actual_doc!r}, want {exp_doc!r})"
+        );
+        assert stmt.code_context == exp_ctx , (
+            f"{exp_name}: code_context mismatch "
+            f"(got {stmt.code_context}, want {exp_ctx})"
+        );
+        # And the docstring must appear in the kid chain — confirms it was
+        # actually wired in (not just stashed on .doc).
+        if exp_doc is not None {
+            kid_values = [k?.value for k in stmt.kid];
+            assert exp_doc in kid_values , (
+                f"{exp_name}: docstring not found in kid chain: {kid_values}"
+            );
+        }
+    }
+}
+
 test "cl/sv/na braced-block deprecation warning" {
     # Braced block form emits W0064 for each block
     source = """


### PR DESCRIPTION
## Summary

A `"""docstring"""` immediately before a `cl` / `sv` / `na` single-statement prefix used to fail with `E0005: Unexpected token`. Concrete example that breaks today:

```jac
"""Single task row -- presentational; toggle and delete are passed in."""
cl def:pub TaskItem(
    task: Task, onToggle: Callable[[], None], onDelete: Callable[[], None]
) -> JsxElement { ... }
```

Reproduces against `sv` and `na` prefixes too. The bug blocks every full-stack pattern that documents a client-side component in a mixed (server+client) source file -- including the "complete `main.jac`" listing in `docs/docs/tutorials/first-app/build-ai-day-planner.md` (Part 5).

## Root cause

Two spots in [`parser.impl.jac`](jac/jaclang/jac0core/parser/impl/parser.impl.jac):

1. **`parse_element_stmt`'s docstring-prefix dispatcher** (`check(STRING) and check_peek_any(...)`) only listed the bare declaration keywords (`def`, `can`, `obj`, `node`, `edge`, `walker`, `class`, `enum`, `impl`, `test`, `global`, `with`, `type`, ...). When the next token was `KW_CLIENT` / `KW_SERVER` / `KW_NATIVE`, the STRING fell through to the catch-all `emit_diag(E0005)`.
2. **`parse_docstring_target`** had no branch for the context-prefix tokens, so even if dispatch had reached it, it would have fallen into `_dispatch_decorated` and mis-parsed.

## Fix

- Add `TokenKind.KW_CLIENT`, `TokenKind.KW_SERVER`, `TokenKind.KW_NATIVE` to the `check_peek_any` list in `parse_element_stmt` so a STRING followed by any of those routes to `parse_docstring_target`.
- Add a new branch in `parse_docstring_target` that recurses into `parse_element_stmt` -- letting the existing single-statement `cl`/`sv`/`na` prefix handler consume the prefix and tag `code_context` on the inner element -- then attaches the docstring to that inner element (not to the prefix).

The recursion is safe because the STRING has already been consumed before the recursive call, so the inner `parse_element_stmt` enters the cl/sv/na prefix branch (lines 3456 / 3474 / 3491) and parses the underlying declaration normally.

## Test plan

- [x] New regression test `test "docstring before context prefix"` in [`test_parser.jac`](jac/tests/compiler/test_parser.jac):
  - Builds a 4-stmt module exercising bare `def`, `cl def`, `sv def`, `na def`, each preceded by a docstring.
  - Asserts on each result's `(doc, code_context, name)`.
  - Verifies the docstring appears in the kid chain -- not just stashed on `.doc`.
  - Confirmed it fails on a clean tree (`assert not prog.errors_had` at the top fires) and passes with the fix.
- [x] `python -m jaclang test tests/compiler/test_parser.jac` -- 445 / 445 OK
- [x] `python -m jaclang test tests/compiler/test_rd_parser_validation.jac` -- 546 / 546 OK
- [x] `python -m jaclang test tests/compiler/test_client_codegen.jac` -- 5 / 5 OK
- [x] `python -m jaclang test tests/language/test_language.jac` -- 88 tests, 20 pre-existing edge-anchor errors (verified by stashing the change and re-running on a clean tree -- same count before and after, unrelated to parsing).
- [x] Manually re-pasted the Part 5 "complete `main.jac`" listing from `docs/docs/tutorials/first-app/build-ai-day-planner.md` and confirmed it now compiles, `jac start` boots, and the AI-powered day planner runs end-to-end (task categorization + structured shopping list generation) via the local Gemma model.