### PR TITLE
fix(jac-scale): use aset_user_root in request middleware to unblock event loop

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -202,6 +202,10 @@ jobs:
       run: |
         pytest -x -vv -s jac-scale/jac_scale/tests/test_serve.jac
 
+    - name: Run middleware async root tests
+      run: |
+        pytest -x -vv -s jac-scale/jac_scale/tests/test_middleware_async_root.jac
+
     - name: Run SSO tests
       run: |
         pytest -x jac-scale/jac_scale/tests/test_sso.jac

--- a/docs/docs/community/release_notes/unreleased/jac-scale/5942.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/5942.bugfix.md
@@ -1,0 +1,1 @@
+- **jac-scale: fix blocking event-loop call in request middleware**: `request_context_middleware` was calling `ctx.set_user_root()` synchronously inside an `async def` handler, blocking the uvicorn event loop on every authenticated request. Switched to `await ctx.aset_user_root()` so the user-root anchor load goes through the non-blocking async Redis/MongoDB path.

--- a/jac-scale/jac_scale/jserver/impl/jfast_api.impl.jac
+++ b/jac-scale/jac_scale/jserver/impl/jfast_api.impl.jac
@@ -1135,7 +1135,7 @@ impl JFastApiServer.init(
 
         if user_id {
             try {
-                ctx.set_user_root(user_id);
+                await ctx.aset_user_root(user_id);
             } except ValueError {
                 logger.warning(f"Invalid user_root_id: {user_id}, using system root");
             }

--- a/jac-scale/jac_scale/tests/test_middleware_async_root.jac
+++ b/jac-scale/jac_scale/tests/test_middleware_async_root.jac
@@ -1,0 +1,110 @@
+"""
+Tests for request_context_middleware async user-root resolution.
+
+PR #5942 switched ctx.set_user_root() (blocks event loop) to
+await ctx.aset_user_root() inside the async middleware. These tests verify:
+
+1. aset_user_root is called on the top-level context (no _parent) for
+   authenticated requests — this is the middleware's call site.
+2. aset_user_root is NOT called on the top-level context when user_id
+   is absent (unauthenticated request).
+
+Context: there are two call sites for aset_user_root:
+  a. request_context_middleware (PR #5942): called on the top-level
+     JScaleExecutionContext created by create_j_context — _parent is None.
+  b. _begin_request_context (spawn_walker path): called on a per-request
+     fork — _parent is set. This fires for every walker call regardless
+     of auth status and is intentionally excluded from these assertions.
+"""
+
+import from typing { Any }
+import from jaclang.runtimelib.context { ExecutionContext }
+import from jac_scale.tests.scale_test_client {
+    ScaleTestClient,
+    make_client,
+    extract_data
+}
+
+test "middleware calls aset_user_root on top-level context for authenticated requests" {
+    # Patch aset_user_root to track calls made on top-level contexts
+    # (_parent is None). These are the middleware calls. Calls with _parent
+    # set come from _begin_request_context (spawn_walker path) and are
+    # excluded so the assertion is specific to the middleware fix.
+    client = make_client("test_api.jac");
+    middleware_calls: list[str] = [];
+    original_aset = ExecutionContext.aset_user_root;
+
+    async def tracking_aset(self: Any, root_id: str) {
+        if self._parent is None {
+            middleware_calls.append(root_id);
+        }
+        await original_aset(self, root_id);
+    }
+
+    ExecutionContext.aset_user_root = tracking_aset;
+    try {
+        r = client.post(
+            "/user/register",
+            json={
+                "identities": [{"type": "username", "value": "mw_async_user_5942"}],
+                "credential": {"type": "password", "password": "Pass!5942"}
+            }
+        );
+        assert r.status_code == 201 , f"register failed: {r.text}";
+
+        r = client.post(
+            "/user/login",
+            json={
+                "identity": {"type": "username", "value": "mw_async_user_5942"},
+                "credential": {"type": "password", "password": "Pass!5942"}
+            }
+        );
+        assert r.status_code == 200 , f"login failed: {r.text}";
+        token = extract_data(r.json())["token"];
+
+        r = client.post(
+            "/walker/PublicInfo", json={}, headers={"Authorization": f"Bearer {token}"}
+        );
+        assert r.status_code == 200 , f"walker request failed: {r.status_code} {r.text}";
+    } finally {
+        ExecutionContext.aset_user_root = original_aset;
+        client.close();
+    }
+
+    assert len(middleware_calls) >= 1 , (
+        "aset_user_root was never called on the top-level context for an "
+        "authenticated request — middleware may still use the blocking "
+        "set_user_root path (regression from PR #5942)"
+    );
+}
+
+test "middleware skips aset_user_root on top-level context for unauthenticated requests" {
+    # When no Authorization header is present user_id is None and the
+    # middleware's `if user_id:` branch is not taken — aset_user_root must
+    # not be called on the top-level context (_parent is None).
+    client = make_client("test_api.jac");
+    middleware_calls: list[str] = [];
+    original_aset = ExecutionContext.aset_user_root;
+
+    async def tracking_aset(self: Any, root_id: str) {
+        if self._parent is None {
+            middleware_calls.append(root_id);
+        }
+        await original_aset(self, root_id);
+    }
+
+    ExecutionContext.aset_user_root = tracking_aset;
+    try {
+        r = client.post("/walker/PublicInfo", json={});
+        assert r.status_code == 200 , f"public walker failed without auth: {r.status_code} {r.text}";
+    } finally {
+        ExecutionContext.aset_user_root = original_aset;
+        client.close();
+    }
+
+    assert len(middleware_calls) == 0 , (
+        f"aset_user_root was called {len(middleware_calls)} time(s) on the "
+        "top-level context for an unauthenticated request — middleware should "
+        "only call it when user_id is present"
+    );
+}


### PR DESCRIPTION
## Summary

- `request_context_middleware` was calling `ctx.set_user_root()` synchronously inside an `async def` handler, blocking the uvicorn event loop on every authenticated request
- `set_user_root()` calls `mem.get()` which is a blocking Redis/MongoDB call — even if Redis is warm (~0.1ms), it still blocks the event loop under load
- Switched to `await ctx.aset_user_root()` which goes through `RedisBackend.aget` / `MongoBackend.aget` — the non-blocking async path added in #5907

Note: the system root blocking was already fixed in #5919 (`_process_cache['system_root']`). This PR fixes the remaining user root load.

## Test plan

- [ ] Authenticated walker requests complete correctly (user root resolved via async path)
- [ ] Unauthenticated requests unaffected (user_id is None, aset_user_root not called)