### PR TITLE
docs: fix switch/match terminology and add destructuring example

### DIFF
--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -180,6 +180,21 @@ In the example above, each case ends with `return`, so the function exits before
 **`match`/`case`**, on the other hand, is for Python-style structural pattern matching -- use it when you need to destructure values or match more complex patterns:
 
 ```jac
+def describe(value: any) -> str {
+    match value {
+        case 0:
+            return "zero";
+        case 1 | 2 | 3:
+            return "small number";
+        case _:
+            return "something else";
+    }
+}
+```
+
+It really shines when you destructure structured data:
+
+```jac
 def describe_point(point: tuple) -> str {
     match point {
         case (0, 0):

--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -160,7 +160,7 @@ with entry {
 }
 ```
 
-Jac provides two pattern-matching constructs, each designed for a different purpose. **`switch`/`case`** is for classic simple value matching. Like C, cases fall through to subsequent cases -- use `return`, `break`, or another control-flow statement to exit a case before the next one runs:
+Jac provides two constructs for branching on values. **`switch`/`case`** is for classic simple value matching. Like C, cases fall through to subsequent cases -- use `return`, `break`, or another control-flow statement to exit a case before the next one runs:
 
 ```jac
 def categorize(fruit: str) -> str {
@@ -180,14 +180,18 @@ In the example above, each case ends with `return`, so the function exits before
 **`match`/`case`**, on the other hand, is for Python-style structural pattern matching -- use it when you need to destructure values or match more complex patterns:
 
 ```jac
-def describe(value: any) -> str {
-    match value {
-        case 0:
-            return "zero";
-        case 1 | 2 | 3:
-            return "small number";
+def describe_point(point: tuple) -> str {
+    match point {
+        case (0, 0):
+            return "origin";
+        case (x, 0):
+            return f"on x-axis at {x}";
+        case (0, y):
+            return f"on y-axis at {y}";
+        case (x, y):
+            return f"at ({x}, {y})";
         case _:
-            return "something else";
+            return "not a point";
     }
 }
 ```


### PR DESCRIPTION
## Summary

Two fixes to the **Build an AI Day Planner** tutorial (`docs/tutorials/first-app/build-ai-day-planner.md`):

1. **Removed "pattern-matching" label from `switch`/`case` intro** — `switch`/`case` is simple value matching (conditional branching), not pattern matching in any formal sense. The introductory sentence now reads "two constructs for branching on values" instead of "two pattern-matching constructs."

2. **Replaced the `match`/`case` example with one that demonstrates destructuring** — The docs claim `match`/`case` is for when you "need to destructure values," but the previous example only matched literal values (`0`, `1 | 2 | 3`, `_`). The new example uses tuple unpacking to show actual structural pattern matching.

Reported by @patrickli0906 in Discord.