### PR TITLE
fix(checker): propagate T | None narrowing into comprehension iterators

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5951.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5951.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: type narrowing now reaches inside comprehensions**: `T | None` narrowing established by an enclosing guard propagates into list/dict/set/generator comprehension iterators, conditionals, and output expressions, eliminating spurious `E1099` false positives.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -3558,11 +3558,16 @@ impl TypeEvaluator.postinit -> None {
 # Type narrowing support (CFG-based, flow-sensitive)
 # Pyright-style implementation with affected_symbols optimization.
 # -------------------------------------------------------------------------
-"""Find the nearest enclosing CFG node (CfgExpr or CodeBlockStmt)."""
+"""Find the nearest enclosing CFG node (CfgExpr or CodeBlockStmt).
+
+`InnerCompr` inherits `UniCFGNode` for its scope/symbol bookkeeping but is
+never wired into the CFG, so it has no `bb_in`/`bb_out`. Treat it as
+transparent so narrowing established by an enclosing guard reaches
+references inside the comprehension's iterator and conditional clauses."""
 def _find_cfg_node_for(at_node: uni.UniNode) -> uni.UniCFGNode | None {
     cur: uni.UniNode | None = at_node;
     while cur is not None {
-        if isinstance(cur, uni.UniCFGNode) {
+        if isinstance(cur, uni.UniCFGNode) and not isinstance(cur, uni.InnerCompr) {
             return cur;
         }
         cur = cur.parent;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_compr_narrowing.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_compr_narrowing.jac
@@ -1,0 +1,57 @@
+"""Fixture: `T | None` narrowing must propagate into comprehension iterators.
+
+After `if r is None { return ...; }`, `r` is narrowed to `T` in the function body.
+Pyright and mypy propagate that narrowing into every sub-expression of a
+comprehension (out_expr, the iterator collection, and the conditional).
+Jac previously dropped the narrowing as soon as the lookup walked into an
+`InnerCompr` — an orphan UniCFGNode that is not wired into the CFG —
+producing E1099 false positives on attribute access inside the comprehension.
+
+After the fix, every attribute access below must type-check.
+"""
+
+obj R {
+    has parts: list[str] = [];
+}
+
+# Iterator collection: `r.parts` inside `range(len(...))`.
+def use_iter(r: R | None) -> list[str] {
+    if r is None { return []; }
+    return [str(i) for i in range(len(r.parts))];
+}
+
+# Out expression: `r.parts[i]` as the comprehension output.
+def use_out(r: R | None) -> list[str] {
+    if r is None { return []; }
+    return [r.parts[i] for i in range(5)];
+}
+
+# Conditional clause: narrowed `r` referenced in `if` filter.
+def use_cond(r: R | None) -> list[str] {
+    if r is None { return []; }
+    return [p for p in ["a", "b", "c"] if p in r.parts];
+}
+
+# Combined: all three positions in the same comprehension.
+def use_all(r: R | None) -> list[str] {
+    if r is None { return []; }
+    return [r.parts[i] for i in range(len(r.parts)) if r.parts[i] != ""];
+}
+
+# Dict comprehension: narrowing propagates into kv_pair, iterator, and condition.
+def use_dict(r: R | None) -> dict[int, str] {
+    if r is None { return {}; }
+    return {i: r.parts[i] for i in range(len(r.parts)) if r.parts[i] != ""};
+}
+
+# Set comprehension.
+def use_set(r: R | None) -> set[str] {
+    if r is None { return set(); }
+    return {r.parts[i] for i in range(len(r.parts))};
+}
+
+# Generator comprehension.
+def use_gen(r: R | None) -> list[str] {
+    if r is None { return []; }
+    return list(r.parts[i] for i in range(len(r.parts)));
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -654,3 +654,24 @@ test "bug_none_eq_neq_narrowing" {
         f"Got errors: {[str(e) for e in program.errors_had]}"
     );
 }
+
+# =========================================================================
+# Bug #COMPR-NARROW: `T | None` narrowing did not reach comprehension
+# iterators or conditionals.
+#
+# `InnerCompr` is a `UniCFGNode` but is never wired into the CFG. A
+# reference to a narrowed symbol inside the comprehension's `collection`
+# or `conditional` walks up to the orphan `InnerCompr` and stops, missing
+# the narrowing established by an enclosing guard. Pyright and mypy treat
+# the comprehension as part of the enclosing flow scope; Jac now does too.
+# =========================================================================
+test "bug_comprehension_narrowing" {
+    program = compile_and_check("checker_bug_compr_narrowing.jac");
+
+    assert len(program.errors_had) == 0 , (
+        "`T | None` narrowing established by an enclosing guard must "
+        "propagate into list/dict/set/gen comprehension iterators, out "
+        "expressions, and conditional clauses. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #5947. Type narrowing from an enclosing guard now reaches references inside comprehension iterators, conditionals, and output expressions, eliminating spurious `E1099` errors.

`InnerCompr` is declared as a `UniCFGNode` (for scope/symbol bookkeeping) but is never wired into the CFG. The narrowing walk treated it as the enclosing flow node and stopped, so references inside the comprehension's `collection`/`conditional` never saw the narrowing established by an outer `if r is None { return; }`.

`_find_cfg_node_for` now treats `InnerCompr` as transparent and continues up to the enclosing statement-level CFG node. The comprehension is a sub-expression of its enclosing statement, so that statement's flow context is the correct narrowing source — matching pyright/mypy behavior.

## Test plan
- [x] Existing repro from #5947 passes (`jac check`).
- [x] New fixture `checker_bug_compr_narrowing.jac` covers list/set/dict/generator comprehensions across out-expr, iterator collection, and conditional positions.
- [x] New test `bug_comprehension_narrowing` in `test_checker_bugs.jac` (was failing pre-fix with 8 errors).
- [x] Full `test_checker_pass.jac` + `test_checker_bugs.jac` suites pass (224 tests).
- [x] Compiler passes suite passes (1004 passed / 57 skipped; one unrelated pre-existing PATH failure on `test_jac_format_pass.jac`).
- [x] Langserve suite passes (54 tests).