### PR TITLE
Centralize native type metadata tracking

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5962.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5962.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Centralize native type metadata tracking**: Prefer type evaluator results during native IR type lowering and consolidate repeated backend type bookkeeping.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/comprehensions.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/comprehensions.impl.jac
@@ -215,12 +215,7 @@ impl NaIRGenPass._codegen_compr_loops(
     self.local_vars[loop_var_name] = loop_alloca;
     # Track type info for loop variable
     if inner_type is not None {
-        for (sname, stype) in self.struct_types.items() {
-            if inner_type == stype.as_pointer() {
-                self.type_var_map[loop_var_name] = sname;
-                break;
-            }
-        }
+        self._track_value_type(loop_var_name, inner_type);
     }
     func = self.builder.function;
     cond_bb = func.append_basic_block(name="compr.cond");
@@ -818,12 +813,7 @@ impl NaIRGenPass._codegen_set_compr_loops(
     self.local_vars[loop_var_name] = loop_alloca;
     # Track struct type for the loop variable so field accesses work
     if coll_elem_type_name == "ptr" and actual_elem_type != coll_helpers["elem_type"] {
-        for (sname, stype) in self.struct_types.items() {
-            if actual_elem_type == stype.as_pointer() {
-                self.type_var_map[loop_var_name] = sname;
-                break;
-            }
-        }
+        self._track_value_type(loop_var_name, actual_elem_type);
     }
     func = self.builder.function;
     cond_bb = func.append_basic_block(name="scompr.cond");

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -672,31 +672,14 @@ impl NaIRGenPass._register_imported_globals(nd: uni.GlobalVars) -> None {
             var_type: ir.Type = ir.IntType(64);
             if assign.type_tag and assign.type_tag.tag {
                 var_type = self._resolve_jac_type(assign.type_tag.tag);
-                # Track type annotation node for chained subscript+field access
-                # e.g. ITEMS[i].field chains need the list[Outer] node to bitcast
-                self.var_type_node[var_name] = assign.type_tag.tag;
             }
             global_var = ir.GlobalVariable(self.llvm_module, var_type, name=var_name);
             global_var.linkage = "external";
             self.global_vars[var_name] = global_var;
             self.global_var_types[var_name] = var_type;
-            # Track list element types for imported list globals
-            if isinstance(var_type, ir.PointerType) {
-                for (ename, ltype) in self.list_types.items() {
-                    if var_type == ltype.as_pointer() {
-                        self.var_list_elem_type[var_name] = ename;
-                        break;
-                    }
-                }
-            }
-            # Track dict types for imported dict globals
-            if isinstance(var_type, ir.PointerType) {
-                for (dict_key, dtype) in self.dict_types.items() {
-                    if var_type == dtype.as_pointer() {
-                        self.var_dict_type[var_name] = dict_key;
-                        break;
-                    }
-                }
+            self._track_value_type(var_name, var_type);
+            if assign.type_tag and assign.type_tag.tag {
+                self._track_annotation_type(var_name, assign.type_tag.tag, var_type);
             }
             self.has_native_code = True;
         }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -128,46 +128,11 @@ impl NaIRGenPass._codegen_ability(nd: uni.Ability) -> None {
         self.builder.store(arg_val, alloca);
         self.local_vars[param_name] = alloca;
         self.param_vars.add(param_name);
-        # Track type annotations for parameters
-        if p.type_tag and p.type_tag.tag {
-            self.var_type_node[param_name] = p.type_tag.tag;
-            for (ename, ltype) in self.list_types.items() {
-                if arg_val.type == ltype.as_pointer() {
-                    self.var_list_elem_type[param_name] = ename;
-                    break;
-                }
-            }
-            # Track dict type for dict parameters
-            for (dkey, dtype) in self.dict_types.items() {
-                if arg_val.type == dtype.as_pointer() {
-                    self.var_dict_type[param_name] = dkey;
-                    break;
-                }
-            }
-            # Track set element type for set parameters
-            for (ename, stype) in self.set_types.items() {
-                if arg_val.type == stype.as_pointer() {
-                    self.var_set_elem_type[param_name] = ename;
-                    break;
-                }
-            }
-            # Track struct types (including union T | None)
-            tag_name = self._get_name(p.type_tag.tag);
-            tag_node = p.type_tag.tag;
-            if tag_name is None and isinstance(tag_node, uni.BinaryExpr) {
-                op_val = getattr(tag_node.op, 'value', '');
-                if op_val == "|" {
-                    tag_name = self._get_name(tag_node.left);
-                }
-            }
-            if tag_name is not None and tag_name in self.struct_types {
-                self.type_var_map[param_name] = tag_name;
-            }
-            # Track enum type for enum-typed parameters
-            if tag_name is not None and tag_name in self.enum_types {
-                self.var_enum_type[param_name] = tag_name;
-            }
-        }
+        self._track_param_type(
+            param_name,
+            arg_val.type,
+            p.type_tag.tag if p.type_tag and p.type_tag.tag else None
+        );
     }
     # Generate body via manual tree-walking (handle ImplDef wrapper from DeclImplMatchPass)
     body = ModuleCodegenPass.unwrap_body(nd);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/globals.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/globals.impl.jac
@@ -23,9 +23,6 @@ impl NaIRGenPass._codegen_global_vars(nd: uni.GlobalVars) -> None {
             var_type: ir.Type = ir.IntType(64);  # Default to i64
             if assign.type_tag and assign.type_tag.tag {
                 var_type = self._resolve_jac_type(assign.type_tag.tag);
-                # Track type annotation node for chained subscript+field access
-                # e.g. TABLE[i].field chains need the list[T] node to bitcast
-                self.var_type_node[var_name] = assign.type_tag.tag;
             } elif assign.value is not None {
                 # Infer type from initializer (e.g., glob game = Game())
                 inferred = self._infer_global_init_type(assign.value);
@@ -47,23 +44,9 @@ impl NaIRGenPass._codegen_global_vars(nd: uni.GlobalVars) -> None {
             }
             self.global_vars[var_name] = global_var;
             self.global_var_types[var_name] = var_type;
-            # Track list element types for global lists
-            if isinstance(var_type, ir.PointerType) {
-                for (ename, ltype) in self.list_types.items() {
-                    if var_type == ltype.as_pointer() {
-                        self.var_list_elem_type[var_name] = ename;
-                        break;
-                    }
-                }
-            }
-            # Track dict types for global dicts
-            if isinstance(var_type, ir.PointerType) {
-                for (dict_key, dtype) in self.dict_types.items() {
-                    if var_type == dtype.as_pointer() {
-                        self.var_dict_type[var_name] = dict_key;
-                        break;
-                    }
-                }
+            self._track_value_type(var_name, var_type);
+            if assign.type_tag and assign.type_tag.tag {
+                self._track_annotation_type(var_name, assign.type_tag.tag, var_type);
             }
             self.has_native_code = True;
             # Save assignment node for runtime initialization

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -460,20 +460,11 @@ impl NaIRGenPass._codegen_method(arch_name: str, method: uni.Ability) -> None {
     saved_builder = self.builder;
     saved_locals = self.local_vars;
     saved_param_vars = self.param_vars;
-    saved_type_map = dict(self.type_var_map);
-    saved_type_node = dict(self.var_type_node);
-    saved_list_elem = dict(self.var_list_elem_type);
-    saved_dict_type = dict(self.var_dict_type);
-    saved_set_elem = dict(self.var_set_elem_type);
-    saved_tuple_type = dict(self.var_tuple_type);
+    saved_type_scope = self._save_native_type_scope();
     self.builder = ir.IRBuilder(block);
     self.local_vars = {};
     self.param_vars = set();
-    self.var_type_node = {};
-    self.var_list_elem_type = {};
-    self.var_dict_type = {};
-    self.var_set_elem_type = {};
-    self.var_tuple_type = {};
+    self._reset_native_type_scope();
     # DWARF debug info (JAC_NATIVE_DEBUG=1)
     self._attach_di_subprogram(
         func, full_name, method.loc.first_line if method.loc else 0
@@ -483,17 +474,7 @@ impl NaIRGenPass._codegen_method(arch_name: str, method: uni.Ability) -> None {
     self.builder.store(func.args[0], self_alloca);
     self.local_vars["self"] = self_alloca;
     self.type_var_map["self"] = arch_name;
-    # Re-populate field list/type info from archetype has-declarations
-    if arch_name in self.field_type_node {
-        for (fname, ftn) in self.field_type_node[arch_name].items() {
-            qname = f"self.{fname}";
-            self.var_type_node[qname] = ftn;
-            ename = self._get_list_elem_from_type_node(ftn);
-            if ename is not None {
-                self.var_list_elem_type[qname] = ename;
-            }
-        }
-    }
+    self._track_self_field_types(arch_name);
     # Store other parameters
     sig = method.signature;
     for (i, p) in enumerate(sig.get_parameters()) {
@@ -503,42 +484,11 @@ impl NaIRGenPass._codegen_method(arch_name: str, method: uni.Ability) -> None {
         self.builder.store(arg_val, alloca);
         self.local_vars[param_name] = alloca;
         self.param_vars.add(param_name);
-        # Track type info for struct pointer parameters
-        if isinstance(arg_val.type, ir.PointerType) {
-            for (sname, stype) in self.struct_types.items() {
-                if arg_val.type == stype.as_pointer() {
-                    self.type_var_map[param_name] = sname;
-                    break;
-                }
-            }
-        }
-        # Track Jac type annotation for parameters (enables nested list resolution)
-        if p.type_tag and p.type_tag.tag {
-            self.var_type_node[param_name] = p.type_tag.tag;
-            # Also track list elem type from annotation
-            for (ename, ltype) in self.list_types.items() {
-                if arg_val.type == ltype.as_pointer() {
-                    self.var_list_elem_type[param_name] = ename;
-                    break;
-                }
-            }
-            # Handle union types T | None for struct tracking
-            tag_name = self._get_name(p.type_tag.tag);
-            tag_node = p.type_tag.tag;
-            if tag_name is None and isinstance(tag_node, uni.BinaryExpr) {
-                op_val = getattr(tag_node.op, 'value', '');
-                if op_val == "|" {
-                    tag_name = self._get_name(tag_node.left);
-                }
-            }
-            if tag_name is not None and tag_name in self.struct_types {
-                self.type_var_map[param_name] = tag_name;
-            }
-            # Track enum type for enum-typed method parameters
-            if tag_name is not None and tag_name in self.enum_types {
-                self.var_enum_type[param_name] = tag_name;
-            }
-        }
+        self._track_param_type(
+            param_name,
+            arg_val.type,
+            p.type_tag.tag if p.type_tag and p.type_tag.tag else None
+        );
     }
     # Generate body (handle ImplDef wrapper from DeclImplMatchPass)
     body = ModuleCodegenPass.unwrap_body(method);
@@ -568,12 +518,7 @@ impl NaIRGenPass._codegen_method(arch_name: str, method: uni.Ability) -> None {
     self.builder = saved_builder;
     self.local_vars = saved_locals;
     self.param_vars = saved_param_vars;
-    self.type_var_map = saved_type_map;
-    self.var_type_node = saved_type_node;
-    self.var_list_elem_type = saved_list_elem;
-    self.var_dict_type = saved_dict_type;
-    self.var_set_elem_type = saved_set_elem;
-    self.var_tuple_type = saved_tuple_type;
+    self._restore_native_type_scope(saved_type_scope);
 }
 
 """Generate method body for methods without FuncSignature (e.g., postinit)."""
@@ -589,20 +534,11 @@ impl NaIRGenPass._codegen_no_sig_method(arch_name: str, method: uni.Ability) -> 
     saved_builder = self.builder;
     saved_locals = self.local_vars;
     saved_param_vars = self.param_vars;
-    saved_type_map = dict(self.type_var_map);
-    saved_type_node = dict(self.var_type_node);
-    saved_list_elem = dict(self.var_list_elem_type);
-    saved_dict_type = dict(self.var_dict_type);
-    saved_set_elem = dict(self.var_set_elem_type);
-    saved_tuple_type = dict(self.var_tuple_type);
+    saved_type_scope = self._save_native_type_scope();
     self.builder = ir.IRBuilder(block);
     self.local_vars = {};
     self.param_vars = set();
-    self.var_type_node = {};
-    self.var_list_elem_type = {};
-    self.var_dict_type = {};
-    self.var_set_elem_type = {};
-    self.var_tuple_type = {};
+    self._reset_native_type_scope();
     # DWARF debug info (JAC_NATIVE_DEBUG=1)
     self._attach_di_subprogram(
         func, full_name, method.loc.first_line if method.loc else 0
@@ -612,17 +548,7 @@ impl NaIRGenPass._codegen_no_sig_method(arch_name: str, method: uni.Ability) -> 
     self.builder.store(func.args[0], self_alloca);
     self.local_vars["self"] = self_alloca;
     self.type_var_map["self"] = arch_name;
-    # Re-populate field list/type info from archetype has-declarations
-    if arch_name in self.field_type_node {
-        for (fname, ftn) in self.field_type_node[arch_name].items() {
-            qname = f"self.{fname}";
-            self.var_type_node[qname] = ftn;
-            ename = self._get_list_elem_from_type_node(ftn);
-            if ename is not None {
-                self.var_list_elem_type[qname] = ename;
-            }
-        }
-    }
+    self._track_self_field_types(arch_name);
     # Generate body (handle ImplDef wrapper from DeclImplMatchPass)
     body = ModuleCodegenPass.unwrap_body(method);
     if body is not None {
@@ -644,12 +570,7 @@ impl NaIRGenPass._codegen_no_sig_method(arch_name: str, method: uni.Ability) -> 
     self.builder = saved_builder;
     self.local_vars = saved_locals;
     self.param_vars = saved_param_vars;
-    self.type_var_map = saved_type_map;
-    self.var_type_node = saved_type_node;
-    self.var_list_elem_type = saved_list_elem;
-    self.var_dict_type = saved_dict_type;
-    self.var_set_elem_type = saved_set_elem;
-    self.var_tuple_type = saved_tuple_type;
+    self._restore_native_type_scope(saved_type_scope);
 }
 
 """Generate object instantiation: allocate struct, init fields, call postinit."""

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -1362,73 +1362,9 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
             self.lambda_captures[var_name] = self._pending_lambda_captures;
             self._pending_lambda_captures = None;
         }
-        # Track type info for variables pointing to structs
-        if isinstance(value.type, ir.PointerType) {
-            # Check if it's a known struct pointer type
-            for (sname, stype) in self.struct_types.items() {
-                if value.type == stype.as_pointer() {
-                    self.type_var_map[var_name] = sname;
-                    break;
-                }
-            }
-        }
-        # Track from type_tag annotation (supports T and T | None union types)
+        self._track_value_type(var_name, value.type);
         if nd.type_tag and nd.type_tag.tag {
-            tag_node = nd.type_tag.tag;
-            tag_name = self._get_name(tag_node);
-            # Handle union type: T | None → extract T
-            if tag_name is None and isinstance(tag_node, uni.BinaryExpr) {
-                op_val = getattr(tag_node.op, 'value', '');
-                if op_val == "|" {
-                    tag_name = self._get_name(tag_node.left);
-                }
-            }
-            if tag_name is not None and tag_name in self.struct_types {
-                self.type_var_map[var_name] = tag_name;
-            }
-            # Track enum type for enum-typed variables
-            if tag_name is not None and tag_name in self.enum_types {
-                self.var_enum_type[var_name] = tag_name;
-            }
-            # Store the full type AST node for nested type resolution
-            self.var_type_node[var_name] = tag_node;
-        }
-        # Track list element type for list variables
-        for (ename, ltype) in self.list_types.items() {
-            if value.type == ltype.as_pointer() {
-                self.var_list_elem_type[var_name] = ename;
-                break;
-            }
-        }
-        # Track dict type for dict variables
-        for (dkey, dtype) in self.dict_types.items() {
-            if value.type == dtype.as_pointer() {
-                self.var_dict_type[var_name] = dkey;
-                break;
-            }
-        }
-        # Track set element type for set variables
-        for (ename, stype) in self.set_types.items() {
-            if value.type == stype.as_pointer() {
-                self.var_set_elem_type[var_name] = ename;
-                break;
-            }
-        }
-        # Track tuple type for tuple variables (value or pointer tuples)
-        ttrack_struct: (ir.LiteralStructType | None) = None;
-        if isinstance(value.type, ir.LiteralStructType) {
-            ttrack_struct = value.type;
-        } elif isinstance(value.type, ir.PointerType)
-        and isinstance(value.type.pointee, ir.LiteralStructType) {
-            ttrack_struct = value.type.pointee;
-        }
-        if ttrack_struct is not None {
-            for (tkey, ttype) in self.tuple_types.items() {
-                if str(ttrack_struct) == str(ttype) {
-                    self.var_tuple_type[var_name] = tkey;
-                    break;
-                }
-            }
+            self._track_annotation_type(var_name, nd.type_tag.tag, value.type);
         }
         # Track complex variables
         if value.type == self.complex_struct_type.as_pointer() {
@@ -1869,24 +1805,12 @@ impl NaIRGenPass._codegen_for(nd: uni.InForStmt) -> None {
         }
         if inner_type is not None {
             actual_elem_type = inner_type;
-            # Track inner type info on loop var
-            for (sname, stype) in self.struct_types.items() {
-                if inner_type == stype.as_pointer() {
-                    self.type_var_map[loop_var_name] = sname;
-                    break;
-                }
-            }
-            for (ename, ltype) in self.list_types.items() {
-                if inner_type == ltype.as_pointer() {
-                    self.var_list_elem_type[loop_var_name] = ename;
-                    break;
-                }
-            }
+            self._track_value_type(loop_var_name, inner_type);
             # Propagate inner type node for nested access
             if coll_type_node is not None {
                 (inner_node, _, _) = self._peel_list_type(coll_type_node);
                 if inner_node is not None {
-                    self.var_type_node[loop_var_name] = inner_node;
+                    self._track_annotation_type(loop_var_name, inner_node, inner_type);
                 }
             }
         }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -4,50 +4,10 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
     if type_expr is None {
         return ir.IntType(64);
     }
-    # Tag-first fast path: use pre-computed backend_type_tag from UniTreeEnrichPass.
-    # This avoids re-walking type annotation AST nodes for primitive and simple
-    # collection types that TypeCheckPass already resolved.
-    if isinstance(type_expr, uni.Expr) and type_expr?.backend_type_tag is not None {
-        tag = type_expr.backend_type_tag;
-        if tag == "void" {
-            return ir.VoidType();
-        }
-        if tag.startswith("list[") and tag.endswith("]") {
-            elem_name = tag[5:-1];
-            elem_llvm = self.type_map.get(elem_name);
-            if elem_llvm is not None {
-                na_spec = self._llvm_to_spec(elem_llvm);
-                self._emit_list_helpers(na_spec, elem_llvm);
-                return self.list_types[na_spec].as_pointer();
-            }
-        } elif tag.startswith("dict[") and tag.endswith("]") {
-            inner = tag[5:-1];
-            colon_idx = inner.find(":");
-            if colon_idx > 0 {
-                k_name = inner[:colon_idx];
-                v_name = inner[colon_idx + 1:];
-                k_llvm = self.type_map.get(k_name);
-                v_llvm = self.type_map.get(v_name);
-                if k_llvm is not None and v_llvm is not None {
-                    k_spec = self._llvm_to_spec(k_llvm);
-                    v_spec = self._llvm_to_spec(v_llvm);
-                    self._emit_dict_helpers(k_spec, v_spec, k_llvm, v_llvm, 0);
-                    return self.dict_types[f"{k_spec}:{v_spec}"].as_pointer();
-                }
-            }
-        } elif tag.startswith("set[") and tag.endswith("]") {
-            elem_name = tag[4:-1];
-            elem_llvm = self.type_map.get(elem_name);
-            if elem_llvm is not None {
-                na_spec = self._llvm_to_spec(elem_llvm);
-                self._emit_set_helpers(na_spec, elem_llvm, 0);
-                return self.set_types[na_spec].as_pointer();
-            }
-        } else {
-            llvm_type = self.type_map.get(tag);
-            if llvm_type is not None {
-                return llvm_type;
-            }
+    if isinstance(type_expr, uni.Expr) and type_expr.type is not None {
+        lowered = self._lower_typebase_to_ir(type_expr.type);
+        if lowered is not None {
+            return lowered;
         }
     }
     # Handle Name nodes (type references like `int`, `float`, `Point`)
@@ -118,22 +78,19 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
             return self.set_types["i64"].as_pointer();
         }
     }
-    # Handle union types: T | None → resolve T (BinaryExpr with BW_OR op)
+    # Compatibility fallback for native-only annotation paths that are not yet
+    # populated with analyzer TypeBase data.
     if isinstance(type_expr, uni.BinaryExpr) {
         op_val = getattr(type_expr.op, 'value', '');
         if op_val == "|" {
-            # Resolve left side; right is typically None
             right_name = self._get_name(type_expr.right);
             left_type = self._resolve_jac_type(type_expr.left);
             if right_name == "None" {
-                # T | None → just use T's type (pointers are nullable)
                 return left_type;
             }
-            # For non-None unions, use the left type (simplified)
             return left_type;
         }
     }
-    # Handle list[T] type annotations (AtomTrailer: list[T])
     if isinstance(type_expr, uni.AtomTrailer) and not type_expr.is_attr {
         target_name = self._get_name(type_expr.target);
         if target_name == "list" {
@@ -146,35 +103,26 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
                     } else {
                         elem_type = self._resolve_jac_type(elem_node);
                     }
-                    elem_type_name = "i64";
-                    if isinstance(elem_type, ir.DoubleType) {
-                        elem_type_name = "f64";
-                    } elif isinstance(elem_type, ir.PointerType) {
-                        elem_type_name = "ptr";
-                    }
+                    elem_type_name = self._llvm_to_spec(elem_type);
                     self._emit_list_helpers(elem_type_name, elem_type);
                     return self.list_types[elem_type_name].as_pointer();
                 }
             }
         }
-        # Handle dict[K, V] type annotations
         if target_name == "dict" {
             if type_expr?.right and type_expr.right?.slices {
                 slices = type_expr.right.slices or [];
                 key_node: (object | None) = None;
                 val_node: (object | None) = None;
-                # dict[K, V] may parse as one slice with TupleVal, or two separate slices
                 if len(slices) == 1
                 and slices[0]?.start
                 and isinstance(slices[0].start, uni.TupleVal) {
-                    # Single slice with TupleVal: dict[(K, V)] → extract K and V from tuple values
                     tuple_val = slices[0].start;
                     if tuple_val.values and len(tuple_val.values) >= 2 {
                         key_node = tuple_val.values[0];
                         val_node = tuple_val.values[1];
                     }
                 } elif len(slices) >= 2 {
-                    # Two separate slices
                     key_node = slices[0];
                     val_node = slices[1];
                     if key_node?.start and key_node.start is not None {
@@ -187,24 +135,15 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
                 if key_node is not None and val_node is not None {
                     key_type = self._resolve_jac_type(key_node);
                     val_type = self._resolve_jac_type(val_node);
-                    key_type_name = "i64";
+                    key_type_name = self._llvm_to_spec(key_type);
                     key_size = 0;
-                    if isinstance(key_type, ir.DoubleType) {
-                        key_type_name = "f64";
-                    } elif isinstance(key_type, ir.PointerType) {
-                        key_type_name = "ptr";
-                        # Check if key is a tuple (pointer to LiteralStructType)
-                        if isinstance(key_type.pointee, ir.LiteralStructType) {
-                            key_size = self._get_struct_size(key_type.pointee);
-                            key_type_name = f"tuple{key_size}";
-                        }
+                    if isinstance(key_type, ir.PointerType)
+                    and isinstance(key_type.pointee, ir.LiteralStructType) {
+                        key_size = self._get_struct_size(key_type.pointee);
+                        key_type_name = f"tuple{key_size}";
                     }
-                    val_type_name = "i64";
-                    if isinstance(val_type, ir.DoubleType) {
-                        val_type_name = "f64";
-                    } elif isinstance(val_type, ir.PointerType) {
-                        val_type_name = "ptr";
-                    } elif self?.jacval_type and val_type == self.jacval_type {
+                    val_type_name = self._llvm_to_spec(val_type);
+                    if self?.jacval_type and val_type == self.jacval_type {
                         val_type_name = "jacval";
                     }
                     dict_key = f"{key_type_name}:{val_type_name}";
@@ -215,8 +154,7 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
                 }
             }
         }
-        # Handle set[T] type annotations
-        if target_name == "set" {
+        if target_name == "set" or target_name == "frozenset" {
             if type_expr?.right and type_expr.right?.slices {
                 slices = type_expr.right.slices or [];
                 if slices {
@@ -226,84 +164,45 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
                     } else {
                         elem_type = self._resolve_jac_type(elem_node);
                     }
-                    elem_type_name = "i64";
+                    elem_type_name = self._llvm_to_spec(elem_type);
                     elem_size = 0;
-                    if isinstance(elem_type, ir.DoubleType) {
-                        elem_type_name = "f64";
-                    } elif isinstance(elem_type, ir.PointerType) {
-                        elem_type_name = "ptr";
-                        # Check if this is a tuple (pointer to LiteralStructType)
-                        if isinstance(elem_type.pointee, ir.LiteralStructType) {
-                            elem_size = self._get_struct_size(elem_type.pointee);
-                            elem_type_name = f"tuple{elem_size}";
-                        }
+                    if isinstance(elem_type, ir.PointerType)
+                    and isinstance(elem_type.pointee, ir.LiteralStructType) {
+                        elem_size = self._get_struct_size(elem_type.pointee);
+                        elem_type_name = f"tuple{elem_size}";
                     }
                     self._emit_set_helpers(elem_type_name, elem_type, elem_size);
                     return self.set_types[elem_type_name].as_pointer();
                 }
             }
         }
-        # Handle frozenset[T] type annotations -- same underlying type as set[T]
-        if target_name == "frozenset" {
-            if type_expr?.right and type_expr.right?.slices {
-                slices = type_expr.right.slices or [];
-                if slices {
-                    elem_node = slices[0];
-                    if elem_node?.start and elem_node.start is not None {
-                        elem_type = self._resolve_jac_type(elem_node.start);
-                    } else {
-                        elem_type = self._resolve_jac_type(elem_node);
-                    }
-                    elem_type_name = "i64";
-                    elem_size = 0;
-                    if isinstance(elem_type, ir.DoubleType) {
-                        elem_type_name = "f64";
-                    } elif isinstance(elem_type, ir.PointerType) {
-                        elem_type_name = "ptr";
-                        if isinstance(elem_type.pointee, ir.LiteralStructType) {
-                            elem_size = self._get_struct_size(elem_type.pointee);
-                            elem_type_name = f"tuple{elem_size}";
-                        }
-                    }
-                    self._emit_set_helpers(elem_type_name, elem_type, elem_size);
-                    return self.set_types[elem_type_name].as_pointer();
-                }
-            }
-        }
-        # Handle tuple[T1, T2, ...] type annotations
         if target_name == "tuple" {
             if type_expr?.right and type_expr.right?.slices {
                 slices = type_expr.right.slices or [];
                 elem_types: list[ir.Type] = [];
                 for s in slices {
-                    # Check if slice.start is a TupleVal (tuple[int, int] parses as tuple[(int, int)])
                     if s?.start and isinstance(s.start, uni.TupleVal) {
                         for tv in s.start.values {
-                            et = self._resolve_jac_type(tv);
-                            elem_types.append(et);
+                            elem_types.append(self._resolve_jac_type(tv));
                         }
                     } elif s?.start and s.start is not None {
-                        et = self._resolve_jac_type(s.start);
-                        elem_types.append(et);
+                        elem_types.append(self._resolve_jac_type(s.start));
                     } else {
-                        et = self._resolve_jac_type(s);
-                        elem_types.append(et);
+                        elem_types.append(self._resolve_jac_type(s));
                     }
                 }
                 if elem_types {
-                    n = len(elem_types);
-                    tuple_key = f"Tuple.{n}." + ".".join([str(t) for t in elem_types]);
+                    tuple_key = f"Tuple.{len(elem_types)}." + ".".join(
+                        [str(t) for t in elem_types]
+                    );
                     if tuple_key not in self.tuple_types {
-                        struct_type = ir.LiteralStructType(elem_types);
-                        self.tuple_types[tuple_key] = struct_type;
+                        self.tuple_types[tuple_key] = ir.LiteralStructType(elem_types);
                     }
                     return self.tuple_types[tuple_key].as_pointer();
                 }
             }
         }
     }
-    # Handle Callable[[param_types], ret_type] → function pointer type.
-    # Callable[[i64, i64], i64] parses as AtomTrailer(Name('Callable'), IndexSlice(...)).
     if isinstance(type_expr, uni.AtomTrailer) {
         _kids = type_expr.kid or [];
         if (
@@ -334,6 +233,133 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
         type(type_expr).__name__,
     );
     return ir.IntType(64);
+}
+
+"""Lower analyzer TypeBase objects to LLVM types for native codegen."""
+impl NaIRGenPass._lower_typebase_to_ir(jtype: object) -> (ir.Type | None) {
+    try {
+        import from jaclang.compiler.type_system { types as _jtypes }
+    } except ImportError {
+        return None;
+    }
+    if isinstance(jtype, _jtypes.NeverType) {
+        return ir.VoidType();
+    }
+    if isinstance(jtype, _jtypes.AnyType) {
+        return self.jacval_type;
+    }
+    if isinstance(jtype, _jtypes.EnumMemberType) {
+        if jtype.enum_class and jtype.enum_class.shared.class_name in self.enum_types {
+            return self.enum_types[jtype.enum_class.shared.class_name];
+        }
+        if jtype.enum_class and jtype.enum_class.shared.enum_value_type {
+            return self._lower_typebase_to_ir(jtype.enum_class.shared.enum_value_type);
+        }
+        return ir.IntType(64);
+    }
+    if isinstance(jtype, _jtypes.UnionType) and jtype.types {
+        for candidate in jtype.types {
+            lowered = self._lower_typebase_to_ir(candidate);
+            if lowered is not None and not isinstance(lowered, ir.VoidType) {
+                return lowered;
+            }
+        }
+        return ir.VoidType();
+    }
+    if isinstance(jtype, _jtypes.FunctionType) {
+        ret_type = self._lower_typebase_to_ir(jtype.return_type)
+            if jtype.return_type
+            else ir.VoidType();
+        if ret_type is None {
+            ret_type = ir.IntType(64);
+        }
+        param_types: list[ir.Type] = [];
+        for param in jtype.parameters or [] {
+            ptype = self._lower_typebase_to_ir(param.param_type)
+                if param.param_type
+                else ir.IntType(64);
+            param_types.append(ptype if ptype is not None else ir.IntType(64));
+        }
+        return ir.FunctionType(ret_type, param_types).as_pointer();
+    }
+    if isinstance(jtype, _jtypes.ClassType) {
+        class_name = jtype.shared.class_name;
+        if class_name in ("NoneType", "None") {
+            return ir.VoidType();
+        }
+        if class_name == "Any" {
+            return self.jacval_type;
+        }
+        if class_name in self.type_map {
+            return self.type_map[class_name];
+        }
+        if class_name in self.enum_types {
+            return self.enum_types[class_name];
+        }
+        if class_name in self.struct_types {
+            return self.struct_types[class_name].as_pointer();
+        }
+        type_args = jtype.private.type_args or [];
+        if class_name == "list" {
+            elem_type = self._lower_typebase_to_ir(type_args[0])
+                if len(type_args) >= 1
+                else ir.IntType(64);
+            elem_type = elem_type if elem_type is not None else ir.IntType(64);
+            elem_name = self._llvm_to_spec(elem_type);
+            self._emit_list_helpers(elem_name, elem_type);
+            return self.list_types[elem_name].as_pointer();
+        }
+        if class_name == "dict" {
+            key_type = self._lower_typebase_to_ir(type_args[0])
+                if len(type_args) >= 1
+                else ir.IntType(64);
+            val_type = self._lower_typebase_to_ir(type_args[1])
+                if len(type_args) >= 2
+                else ir.IntType(64);
+            key_type = key_type if key_type is not None else ir.IntType(64);
+            val_type = val_type if val_type is not None else ir.IntType(64);
+            key_name = self._llvm_to_spec(key_type);
+            key_size = 0;
+            if isinstance(key_type, ir.PointerType)
+            and isinstance(key_type.pointee, ir.LiteralStructType) {
+                key_size = self._get_struct_size(key_type.pointee);
+                key_name = f"tuple{key_size}";
+            }
+            val_name = self._llvm_to_spec(val_type);
+            self._emit_dict_helpers(key_name, val_name, key_type, val_type, key_size);
+            return self.dict_types[f"{key_name}:{val_name}"].as_pointer();
+        }
+        if class_name in ("set", "frozenset") {
+            elem_type = self._lower_typebase_to_ir(type_args[0])
+                if len(type_args) >= 1
+                else ir.IntType(64);
+            elem_type = elem_type if elem_type is not None else ir.IntType(64);
+            elem_name = self._llvm_to_spec(elem_type);
+            elem_size = 0;
+            if isinstance(elem_type, ir.PointerType)
+            and isinstance(elem_type.pointee, ir.LiteralStructType) {
+                elem_size = self._get_struct_size(elem_type.pointee);
+                elem_name = f"tuple{elem_size}";
+            }
+            self._emit_set_helpers(elem_name, elem_type, elem_size);
+            return self.set_types[elem_name].as_pointer();
+        }
+        if class_name == "tuple" and type_args {
+            elem_types: list[ir.Type] = [];
+            for arg in type_args {
+                et = self._lower_typebase_to_ir(arg);
+                elem_types.append(et if et is not None else ir.IntType(64));
+            }
+            tuple_key = f"Tuple.{len(elem_types)}." + ".".join(
+                [str(t) for t in elem_types]
+            );
+            if tuple_key not in self.tuple_types {
+                self.tuple_types[tuple_key] = ir.LiteralStructType(elem_types);
+            }
+            return self.tuple_types[tuple_key].as_pointer();
+        }
+    }
+    return None;
 }
 
 """Classify an LLVM ir.Type into the na_type_spec string used as collection helper keys.
@@ -479,6 +505,129 @@ impl NaIRGenPass._get_name(nd: (uni.UniNode | None)) -> (str | None) {
         return nd.value;
     }
     return None;
+}
+
+"""Reset native-side type metadata for a new function/method body."""
+impl NaIRGenPass._reset_native_type_scope -> None {
+    self.var_type_node = {};
+    self.var_list_elem_type = {};
+    self.var_dict_type = {};
+    self.var_set_elem_type = {};
+    self.var_tuple_type = {};
+}
+
+"""Snapshot native-side type metadata before entering a nested codegen scope."""
+impl NaIRGenPass._save_native_type_scope -> tuple {
+    return (
+        dict(self.type_var_map),
+        dict(self.var_type_node),
+        dict(self.var_list_elem_type),
+        dict(self.var_dict_type),
+        dict(self.var_set_elem_type),
+        dict(self.var_tuple_type)
+    );
+}
+
+"""Restore native-side type metadata after leaving a nested codegen scope."""
+impl NaIRGenPass._restore_native_type_scope(state: tuple) -> None {
+    self.type_var_map = state[0];
+    self.var_type_node = state[1];
+    self.var_list_elem_type = state[2];
+    self.var_dict_type = state[3];
+    self.var_set_elem_type = state[4];
+    self.var_tuple_type = state[5];
+}
+
+"""Track semantic annotation-derived native metadata for a name."""
+impl NaIRGenPass._track_annotation_type(
+    name: str, type_node: (object | None), value_type: (ir.Type | None) = None
+) -> None {
+    if type_node is None {
+        return;
+    }
+    self.var_type_node[name] = type_node;
+    if (elem_name := self._get_list_elem_from_type_node(type_node)) is not None {
+        self.var_list_elem_type[name] = elem_name;
+    }
+    tag_name = self._get_name(type_node);
+    if tag_name is None and isinstance(type_node, uni.BinaryExpr) {
+        op_val = getattr(type_node.op, 'value', '');
+        if op_val == "|" {
+            tag_name = self._get_name(type_node.left);
+        }
+    }
+    if tag_name is not None and tag_name in self.struct_types {
+        self.type_var_map[name] = tag_name;
+    }
+    if tag_name is not None and tag_name in self.enum_types {
+        self.var_enum_type[name] = tag_name;
+    }
+    if value_type is not None {
+        self._track_value_type(name, value_type);
+    }
+}
+
+"""Track native metadata that can be derived from an LLVM value type."""
+impl NaIRGenPass._track_value_type(name: str, value_type: ir.Type) -> None {
+    if isinstance(value_type, ir.PointerType) {
+        for (sname, stype) in self.struct_types.items() {
+            if value_type == stype.as_pointer() {
+                self.type_var_map[name] = sname;
+                break;
+            }
+        }
+        for (ename, ltype) in self.list_types.items() {
+            if value_type == ltype.as_pointer() {
+                self.var_list_elem_type[name] = ename;
+                break;
+            }
+        }
+        for (dkey, dtype) in self.dict_types.items() {
+            if value_type == dtype.as_pointer() {
+                self.var_dict_type[name] = dkey;
+                break;
+            }
+        }
+        for (ename, stype) in self.set_types.items() {
+            if value_type == stype.as_pointer() {
+                self.var_set_elem_type[name] = ename;
+                break;
+            }
+        }
+    }
+    ttrack_struct: (ir.LiteralStructType | None) = None;
+    if isinstance(value_type, ir.LiteralStructType) {
+        ttrack_struct = value_type;
+    } elif isinstance(value_type, ir.PointerType)
+    and isinstance(value_type.pointee, ir.LiteralStructType) {
+        ttrack_struct = value_type.pointee;
+    }
+    if ttrack_struct is not None {
+        for (tkey, ttype) in self.tuple_types.items() {
+            if str(ttrack_struct) == str(ttype) {
+                self.var_tuple_type[name] = tkey;
+                break;
+            }
+        }
+    }
+}
+
+"""Track all native metadata for a parameter."""
+impl NaIRGenPass._track_param_type(
+    name: str, value_type: ir.Type, type_node: (object | None)
+) -> None {
+    self._track_value_type(name, value_type);
+    self._track_annotation_type(name, type_node, value_type);
+}
+
+"""Expose field type metadata as self.<field> names inside a method body."""
+impl NaIRGenPass._track_self_field_types(arch_name: str) -> None {
+    if arch_name not in self.field_type_node {
+        return;
+    }
+    for (fname, ftn) in self.field_type_node[arch_name].items() {
+        self._track_annotation_type(f"self.{fname}", ftn, None);
+    }
 }
 
 """Create an alloca in the function entry block (ensures dominance)."""

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -220,6 +220,7 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _get_snprintf_fmt(fmt: str) -> ir.GlobalVariable;
     # Helper methods
     def _resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type;
+    def _lower_typebase_to_ir(jtype: object) -> (ir.Type | None);
     def _llvm_to_spec(t: Any) -> str;
     def _resolve_callable_type(slice: uni.IndexSlice) -> ir.Type;
     def _resolve_func_ptr_type(sig: uni.FuncSignature) -> ir.Type;
@@ -380,6 +381,19 @@ obj NaIRGenPass(ModuleCodegenPass) {
     ) -> (ir.Type | None);
 
     def _resolve_ptr_elem_cast_type(type_node: (object | None)) -> (ir.Type | None);
+    def _reset_native_type_scope -> None;
+    def _save_native_type_scope -> tuple;
+    def _restore_native_type_scope(state: tuple) -> None;
+    def _track_annotation_type(
+        name: str, type_node: (object | None), value_type: (ir.Type | None) = None
+    ) -> None;
+
+    def _track_value_type(name: str, value_type: ir.Type) -> None;
+    def _track_param_type(
+        name: str, value_type: ir.Type, type_node: (object | None)
+    ) -> None;
+
+    def _track_self_field_types(arch_name: str) -> None;
     # Phase 7: String Methods and Builtins
     def _codegen_string_index(
         target_val: ir.Value, index_val: ir.Value


### PR DESCRIPTION
## Summary
- Prefer TypeEvaluator TypeBase data when resolving native Jac annotations to LLVM types.
- Consolidate repeated native type metadata bookkeeping into shared tracking and scope helpers.
- Keep existing AST annotation fallback as compatibility for native paths that are not yet populated with analyzer type data.

## Validation
- PATH=/home/marsninja/repos/jaseci/.venv/bin:$PATH git commit -m "Centralize native type metadata tracking"
- .venv/bin/python -m pytest jac/tests/compiler/passes/native -q

## Notes
This is the first centralization step. The remaining cleanup is to populate TypeBase data for all native-only annotation paths, then remove the fallback AST parsing in _resolve_jac_type.