### PR TITLE
fix(manifests): sync jac.toml with pyproject.toml for jac-client and jac-byllm

### DIFF
--- a/jac-byllm/jac.toml
+++ b/jac-byllm/jac.toml
@@ -10,7 +10,7 @@ keywords = ["llm", "jaclang", "jaseci", "byLLM"]
 requires-python = ">=3.12"
 
 [project.urls]
-repository = "https://github.com/Jaseci-Labs/jaseci"
+repository = "https://github.com/jaseci-labs/jaseci"
 homepage = "https://jaseci.org"
 documentation = "https://jac-lang.org"
 source = "https://github.com/jaseci-labs/jaseci/tree/main/jac-byllm"

--- a/jac-client/jac.toml
+++ b/jac-client/jac.toml
@@ -29,6 +29,7 @@ jaclang = ">=0.15.0"
 [dev-dependencies]
 "python-dotenv" = "==1.0.1"
 pytest = "==8.3.5"
+watchdog = ">=3.0.0"
 
 [entrypoints.jac]
 serve = "jac_client.plugin.client:JacClient"


### PR DESCRIPTION
## Summary

- `pyproject.toml` is the operational source of truth for PyPI releases today (`publish-release.yml` uses `python -m build`). `jac.toml` will become the source of truth once the planned migration to `jac bundle` lands.
- Before flipping the orchestrator to `jac bundle`, the two manifests need to agree. Right now they have drifted in two places:
  - **jac-client**: `pyproject.toml` declares `watchdog>=3.0.0` in the `[dev]` extras; `jac.toml`'s `[dev-dependencies]` was missing it. Add it.
  - **jac-byllm**: `repository` URL was `Jaseci-Labs/jaseci` in `jac.toml` vs `jaseci-labs/jaseci` in `pyproject.toml`. Cosmetic only (GitHub is case-insensitive) but worth aligning.

## Why this is a prereq

If `publish-release.yml` switches to `jac bundle` without this fix:
- The next `jac-client` release would silently drop `watchdog` from its `[dev]` extras, breaking `pip install 'jac-client[dev]'` for anyone who depends on it for file-watching.

Other plugin packages (`jac-mcp`, `jac-scale`, `jac-super`, `jaseci-package`) were verified clean — no drift between their two manifests.

## Test plan

- [x] `tomlkit` parses both edited files without error
- [x] `jac-client/jac.toml [dev-dependencies]` now lists `watchdog = ">=3.0.0"` alongside `python-dotenv` and `pytest`
- [x] `jac-byllm/jac.toml` repository URL lowercased to match `pyproject.toml`
- [x] No version bumps; no release-pipeline changes in this PR