### PR TITLE
feat(release): use jac bundle for plugins in publish-release.yml

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -89,6 +89,11 @@ jobs:
             echo "- Internal links: ✓" >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Check plugin manifest sync (jac.toml ↔ pyproject.toml)
+        run: |
+          pip install tomlkit==0.14.0
+          jac run scripts/check_manifest_sync.jac
+
       - name: Check Release Notes Updated
         if: |
           github.event_name == 'pull_request' &&

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -142,9 +142,10 @@ jobs:
           pattern: ${{ matrix.precompile_artifact }}-*
           merge-multiple: true
 
-      # Install jaclang for packages that need extra build commands
-      - name: Install jaclang (for build commands)
-        if: matrix.extra_build_cmd != ''
+      # Install jaclang for plugin builds (jac bundle) and for any extra build commands.
+      # jaclang itself uses python -m build, so it doesn't need this step.
+      - name: Install jaclang
+        if: matrix.name != 'jaclang'
         run: pip install -e ./jac
 
       # Install the package itself for extra build commands
@@ -174,13 +175,22 @@ jobs:
         working-directory: ${{ matrix.dir }}
         run: ${{ matrix.extra_build_cmd }}
 
-      # Build the package
-      - name: Install build tools
+      # Build the package.
+      # jaclang uses python -m build (it bootstraps the toolchain and has no jac.toml).
+      # All other packages use `jac bundle`, which reads jac.toml as source of truth.
+      - name: Install build tools (jaclang)
+        if: matrix.name == 'jaclang'
         run: pip install build
 
-      - name: Build package
+      - name: Build jaclang wheel
+        if: matrix.name == 'jaclang'
         working-directory: ${{ matrix.dir }}
         run: python -m build
+
+      - name: Build plugin wheel
+        if: matrix.name != 'jaclang'
+        working-directory: ${{ matrix.dir }}
+        run: jac bundle
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/check_manifest_sync.jac
+++ b/scripts/check_manifest_sync.jac
@@ -1,0 +1,198 @@
+"""Verify that jac.toml and pyproject.toml agree on the fields that ship to PyPI.
+
+jac.toml is the planned source of truth once publish-release.yml uses
+`jac bundle` for plugin packages. Until pyproject.toml is removed from
+plugin directories, the two files must stay in sync so we never silently
+ship different metadata depending on which builder ran.
+
+Fields checked (per plugin package, never jaclang itself):
+    [project] name, version, description, requires-python
+    [project.urls]            <-> [project.urls]            (case-insensitive keys)
+    [dependencies]            <-> [project] dependencies
+    [dev-dependencies]        <-> [project.optional-dependencies].dev
+    [optional-dependencies.X] <-> [project.optional-dependencies].X
+
+Dependency specs are normalized for comparison:
+    - package names: PEP 503 (lowercase, _ -> -)
+    - version ops: whitespace-stripped, separator order preserved-then-sorted
+
+Run:  jac run scripts/check_manifest_sync.jac
+Exit: 0 if all packages agree, 1 if any drift is found.
+"""
+import from __future__ { annotations }
+import re;
+import sys;
+import from pathlib { Path }
+import tomlkit;
+
+glob PLUGIN_DIRS: list[str] = [
+         "jac-byllm",
+         "jac-client",
+         "jac-mcp",
+         "jac-scale",
+         "jac-super",
+         "jaseci-package",
+
+     ];
+
+"""PEP 503 normalization: lowercase, runs of [-_.] become single -."""
+def normalize_name(name: str) -> str {
+    return re.sub(r"[-_.]+", "-", name).lower();
+}
+
+"""Convert (name, version) from jac.toml shape into pyproject-style spec.
+
+jac.toml stores deps as `name = ">=1.0"` (table). pyproject stores them
+as `"name>=1.0"` (string list). Output canonical form: normalized name +
+sorted version constraints with whitespace removed.
+"""
+def normalize_spec(name: str, version: str) -> str {
+    norm_name = normalize_name(name);
+    v = version.strip();
+    if (v in ("", "*")) {
+        return norm_name;
+    }
+    if not re.match(r"^[<>=!~]", v) {
+        v = f"=={v}";
+    }
+    parts = sorted(
+        [
+            p.strip()
+            for p in v.split(",")
+            if p.strip()
+        ]
+    );
+    return f"{norm_name}{','.join(parts)}";
+}
+
+"""Canonicalize a pyproject-style dep string for comparison."""
+def parse_pyproject_spec(spec: str) -> str {
+    s = spec.strip();
+    # Strip env markers (everything after ';') -- jac.toml has no marker syntax.
+    if ";" in s {
+        s = s.split(";")[0].strip();
+    }
+    m = re.match(r"^([A-Za-z0-9_.\-]+)(\[.*\])?(.*)$", s);
+    if not m {
+        return s;
+    }
+    (name, extras, rest) = (m.group(1), m.group(2) or "", m.group(3) or "");
+    norm = normalize_name(name);
+    rest = rest.strip();
+    if (not rest) {
+        return f"{norm}{extras}";
+    }
+    parts = sorted(
+        [
+            p.strip()
+            for p in rest.split(",")
+            if p.strip()
+        ]
+    );
+    return f"{norm}{extras}{','.join(parts)}";
+}
+
+def jac_deps_to_specs(deps: dict) -> set[str] {
+    return {normalize_spec(name, str(version)) for (name, version) in deps.items()};
+}
+
+def py_deps_to_specs(deps: list) -> set[str] {
+    return {parse_pyproject_spec(str(s)) for s in deps};
+}
+
+def compare_section(label: str, jac_specs: set[str], py_specs: set[str]) -> list[str] {
+    if (jac_specs == py_specs) {
+        return [];
+    }
+    errors: list[str] = [];
+    only_jac = jac_specs - py_specs;
+    only_py = py_specs - jac_specs;
+    if only_jac {
+        errors.append(f"  {label}: only in jac.toml -> {sorted(only_jac)}");
+    }
+    if only_py {
+        errors.append(f"  {label}: only in pyproject.toml -> {sorted(only_py)}");
+    }
+    return errors;
+}
+
+def check_package(repo_root: Path, pkg_dir: str) -> list[str] {
+    jac_toml_path = repo_root / pkg_dir / "jac.toml";
+    pyproject_path = repo_root / pkg_dir / "pyproject.toml";
+    if not jac_toml_path.exists() or not pyproject_path.exists() {
+        return [];  # one-sided; not our concern here
+    }
+    jac_data = tomlkit.loads(jac_toml_path.read_text());
+    py_data = tomlkit.loads(pyproject_path.read_text());
+
+    errors: list[str] = [];
+
+    jac_project = jac_data.get("project", {});
+    py_project = py_data.get("project", {});
+    for field in ("name", "version", "description", "requires-python") {
+        jv = jac_project.get(field);
+        pv = py_project.get(field);
+        if (jv is not None) and (pv is not None) and (str(jv) != str(pv)) {
+            errors.append(f"  [project].{field}: jac={jv!r} pyproject={pv!r}");
+        }
+    }
+
+    # URL keys are case-insensitive per PEP 621.
+    jac_urls = {k.lower(): str(v) for (k, v) in jac_project.get("urls", {}).items()};
+    py_urls = {k.lower(): str(v) for (k, v) in py_project.get("urls", {}).items()};
+    for key in sorted(set(jac_urls.keys()) | set(py_urls.keys())) {
+        jv = jac_urls.get(key);
+        pv = py_urls.get(key);
+        if (jv != pv) {
+            errors.append(f"  [project.urls].{key}: jac={jv!r} pyproject={pv!r}");
+        }
+    }
+
+    jac_deps = jac_deps_to_specs(jac_data.get("dependencies", {}));
+    py_deps = py_deps_to_specs(py_project.get("dependencies", []));
+    errors.extend(compare_section("[dependencies]", jac_deps, py_deps));
+
+    jac_dev = jac_deps_to_specs(jac_data.get("dev-dependencies", {}));
+    py_opt = py_project.get("optional-dependencies", {});
+    py_dev = py_deps_to_specs(py_opt.get("dev", []));
+    errors.extend(compare_section("[dev-dependencies]", jac_dev, py_dev));
+
+    jac_opt_table = jac_data.get("optional-dependencies", {});
+    jac_extras = set(jac_opt_table.keys());
+    py_extras = set(py_opt.keys()) - {"dev"};
+    for extra in sorted(jac_extras | py_extras) {
+        jac_extra = jac_deps_to_specs(jac_opt_table.get(extra, {}));
+        py_extra = py_deps_to_specs(py_opt.get(extra, []));
+        errors.extend(
+            compare_section(f"[optional-dependencies.{extra}]", jac_extra, py_extra)
+        );
+    }
+
+    return errors;
+}
+
+def main -> int {
+    repo_root = Path(__file__).resolve().parent.parent;
+    all_failed = False;
+    for pkg in PLUGIN_DIRS {
+        errs = check_package(repo_root, pkg);
+        if errs {
+            all_failed = True;
+            print(f"\n{pkg}: jac.toml and pyproject.toml disagree");
+            for e in errs {
+                print(e);
+            }
+        }
+    }
+    if all_failed {
+        print("\nFix: update jac.toml to match pyproject.toml (or vice versa).");
+        print("Both files must agree until pyproject.toml is removed from plugins.");
+        return 1;
+    }
+    print("All plugin manifests agree.");
+    return 0;
+}
+
+with entry:__main__ {
+    sys.exit(main());
+}

--- a/scripts/check_manifest_sync.jac
+++ b/scripts/check_manifest_sync.jac
@@ -1,29 +1,17 @@
-"""Verify that jac.toml and pyproject.toml agree on the fields that ship to PyPI.
+"""Fail CI if a plugin's jac.toml and pyproject.toml disagree on what ships to PyPI.
 
-jac.toml is the planned source of truth once publish-release.yml uses
-`jac bundle` for plugin packages. Until pyproject.toml is removed from
-plugin directories, the two files must stay in sync so we never silently
-ship different metadata depending on which builder ran.
+Transitional guard while both files coexist. Once pyproject.toml is removed
+from plugin directories, delete this script and its contribution-checks step.
 
-Fields checked (per plugin package, never jaclang itself):
-    [project] name, version, description, requires-python
-    [project.urls]            <-> [project.urls]            (case-insensitive keys)
-    [dependencies]            <-> [project] dependencies
-    [dev-dependencies]        <-> [project.optional-dependencies].dev
-    [optional-dependencies.X] <-> [project.optional-dependencies].X
-
-Dependency specs are normalized for comparison:
-    - package names: PEP 503 (lowercase, _ -> -)
-    - version ops: whitespace-stripped, separator order preserved-then-sorted
-
-Run:  jac run scripts/check_manifest_sync.jac
-Exit: 0 if all packages agree, 1 if any drift is found.
+Checks: [project] name/version/description/requires-python, [project.urls]
+(case-insensitive keys), runtime deps, dev deps, and named optional-extras.
 """
 import from __future__ { annotations }
-import re;
 import sys;
 import from pathlib { Path }
 import tomlkit;
+import from packaging.requirements { Requirement }
+import from packaging.utils { canonicalize_name }
 
 glob PLUGIN_DIRS: list[str] = [
          "jac-byllm",
@@ -35,136 +23,109 @@ glob PLUGIN_DIRS: list[str] = [
 
      ];
 
-"""PEP 503 normalization: lowercase, runs of [-_.] become single -."""
-def normalize_name(name: str) -> str {
-    return re.sub(r"[-_.]+", "-", name).lower();
-}
+"""Canonicalize a PEP-508 dep string: pep503-name + sorted-extras + sorted-specs.
 
-"""Convert (name, version) from jac.toml shape into pyproject-style spec.
-
-jac.toml stores deps as `name = ">=1.0"` (table). pyproject stores them
-as `"name>=1.0"` (string list). Output canonical form: normalized name +
-sorted version constraints with whitespace removed.
+Env markers (anything after `;`) are stripped — jac.toml has no marker syntax.
 """
-def normalize_spec(name: str, version: str) -> str {
-    norm_name = normalize_name(name);
-    v = version.strip();
-    if (v in ("", "*")) {
-        return norm_name;
-    }
-    if not re.match(r"^[<>=!~]", v) {
-        v = f"=={v}";
-    }
-    parts = sorted(
-        [
-            p.strip()
-            for p in v.split(",")
-            if p.strip()
-        ]
-    );
-    return f"{norm_name}{','.join(parts)}";
+def canon(req_str: str) -> str {
+    r = Requirement(req_str.split(";")[0].strip());
+    name = canonicalize_name(r.name);
+    extras = f"[{','.join(sorted(r.extras))}]" if r.extras else "";
+    specs = ",".join(sorted(str(s) for s in r.specifier));
+    return f"{name}{extras}{specs}";
 }
 
-"""Canonicalize a pyproject-style dep string for comparison."""
-def parse_pyproject_spec(spec: str) -> str {
-    s = spec.strip();
-    # Strip env markers (everything after ';') -- jac.toml has no marker syntax.
-    if ";" in s {
-        s = s.split(";")[0].strip();
+"""Convert jac.toml's `name = "version"` dict to PEP-508 strings, then canonicalize."""
+def jac_specs(deps: dict) -> set[str] {
+    out: set[str] = set();
+    for (raw_name, version) in deps.items() {
+        n = str(raw_name);
+        v = str(version).strip();
+        if v in ("", "*") {
+            out.add(canon(n));
+        } elif v[0] in "<>=!~" {
+            out.add(canon(f"{n}{v}"));
+        } else {
+            out.add(canon(f"{n}=={v}"));
+        }
     }
-    m = re.match(r"^([A-Za-z0-9_.\-]+)(\[.*\])?(.*)$", s);
-    if not m {
-        return s;
-    }
-    (name, extras, rest) = (m.group(1), m.group(2) or "", m.group(3) or "");
-    norm = normalize_name(name);
-    rest = rest.strip();
-    if (not rest) {
-        return f"{norm}{extras}";
-    }
-    parts = sorted(
-        [
-            p.strip()
-            for p in rest.split(",")
-            if p.strip()
-        ]
-    );
-    return f"{norm}{extras}{','.join(parts)}";
+    return out;
 }
 
-def jac_deps_to_specs(deps: dict) -> set[str] {
-    return {normalize_spec(name, str(version)) for (name, version) in deps.items()};
+def py_specs(deps: list) -> set[str] {
+    return {canon(str(s)) for s in deps};
 }
 
-def py_deps_to_specs(deps: list) -> set[str] {
-    return {parse_pyproject_spec(str(s)) for s in deps};
-}
-
-def compare_section(label: str, jac_specs: set[str], py_specs: set[str]) -> list[str] {
-    if (jac_specs == py_specs) {
+def diff_sets(label: str, jac: set[str], py: set[str]) -> list[str] {
+    if jac == py {
         return [];
     }
-    errors: list[str] = [];
-    only_jac = jac_specs - py_specs;
-    only_py = py_specs - jac_specs;
-    if only_jac {
-        errors.append(f"  {label}: only in jac.toml -> {sorted(only_jac)}");
+    out: list[str] = [];
+    if jac - py {
+        out.append(f"  {label}: only in jac.toml -> {sorted(jac - py)}");
     }
-    if only_py {
-        errors.append(f"  {label}: only in pyproject.toml -> {sorted(only_py)}");
+    if py - jac {
+        out.append(f"  {label}: only in pyproject.toml -> {sorted(py - jac)}");
     }
-    return errors;
+    return out;
 }
 
 def check_package(repo_root: Path, pkg_dir: str) -> list[str] {
-    jac_toml_path = repo_root / pkg_dir / "jac.toml";
-    pyproject_path = repo_root / pkg_dir / "pyproject.toml";
-    if not jac_toml_path.exists() or not pyproject_path.exists() {
-        return [];  # one-sided; not our concern here
+    jt_path = repo_root / pkg_dir / "jac.toml";
+    py_path = repo_root / pkg_dir / "pyproject.toml";
+    if not jt_path.exists() or not py_path.exists() {
+        return [];
     }
-    jac_data = tomlkit.loads(jac_toml_path.read_text());
-    py_data = tomlkit.loads(pyproject_path.read_text());
+    jt = tomlkit.loads(jt_path.read_text());
+    py = tomlkit.loads(py_path.read_text());
+    jp = jt.get("project", {});
+    pp = py.get("project", {});
 
     errors: list[str] = [];
 
-    jac_project = jac_data.get("project", {});
-    py_project = py_data.get("project", {});
     for field in ("name", "version", "description", "requires-python") {
-        jv = jac_project.get(field);
-        pv = py_project.get(field);
-        if (jv is not None) and (pv is not None) and (str(jv) != str(pv)) {
-            errors.append(f"  [project].{field}: jac={jv!r} pyproject={pv!r}");
+        (a, b) = (jp.get(field), pp.get(field));
+        if a is not None and b is not None and str(a) != str(b) {
+            errors.append(f"  [project].{field}: jac={a!r} pyproject={b!r}");
         }
     }
 
-    # URL keys are case-insensitive per PEP 621.
-    jac_urls = {k.lower(): str(v) for (k, v) in jac_project.get("urls", {}).items()};
-    py_urls = {k.lower(): str(v) for (k, v) in py_project.get("urls", {}).items()};
-    for key in sorted(set(jac_urls.keys()) | set(py_urls.keys())) {
-        jv = jac_urls.get(key);
-        pv = py_urls.get(key);
-        if (jv != pv) {
-            errors.append(f"  [project.urls].{key}: jac={jv!r} pyproject={pv!r}");
+    # PEP 621: project.urls keys are case-insensitive; compare lowercased.
+    ju = {k.lower(): str(v) for (k, v) in jp.get("urls", {}).items()};
+    pu = {k.lower(): str(v) for (k, v) in pp.get("urls", {}).items()};
+    for key in sorted(set(ju) | set(pu)) {
+        if ju.get(key) != pu.get(key) {
+            errors.append(
+                f"  [project.urls].{key}: jac={ju.get(key)!r} pyproject={pu.get(key)!r}"
+            );
         }
     }
 
-    jac_deps = jac_deps_to_specs(jac_data.get("dependencies", {}));
-    py_deps = py_deps_to_specs(py_project.get("dependencies", []));
-    errors.extend(compare_section("[dependencies]", jac_deps, py_deps));
+    errors.extend(
+        diff_sets(
+            "[dependencies]",
+            jac_specs(jt.get("dependencies", {})),
+            py_specs(pp.get("dependencies", [])),
+        )
+    );
 
-    jac_dev = jac_deps_to_specs(jac_data.get("dev-dependencies", {}));
-    py_opt = py_project.get("optional-dependencies", {});
-    py_dev = py_deps_to_specs(py_opt.get("dev", []));
-    errors.extend(compare_section("[dev-dependencies]", jac_dev, py_dev));
+    py_opt = pp.get("optional-dependencies", {});
+    errors.extend(
+        diff_sets(
+            "[dev-dependencies]",
+            jac_specs(jt.get("dev-dependencies", {})),
+            py_specs(py_opt.get("dev", [])),
+        )
+    );
 
-    jac_opt_table = jac_data.get("optional-dependencies", {});
-    jac_extras = set(jac_opt_table.keys());
-    py_extras = set(py_opt.keys()) - {"dev"};
-    for extra in sorted(jac_extras | py_extras) {
-        jac_extra = jac_deps_to_specs(jac_opt_table.get(extra, {}));
-        py_extra = py_deps_to_specs(py_opt.get(extra, []));
+    jt_opt = jt.get("optional-dependencies", {});
+    for extra in sorted(set(jt_opt) | (set(py_opt) - {"dev"})) {
         errors.extend(
-            compare_section(f"[optional-dependencies.{extra}]", jac_extra, py_extra)
+            diff_sets(
+                f"[optional-dependencies.{extra}]",
+                jac_specs(jt_opt.get(extra, {})),
+                py_specs(py_opt.get(extra, [])),
+            )
         );
     }
 
@@ -173,20 +134,20 @@ def check_package(repo_root: Path, pkg_dir: str) -> list[str] {
 
 def main -> int {
     repo_root = Path(__file__).resolve().parent.parent;
-    all_failed = False;
+    drifted = False;
     for pkg in PLUGIN_DIRS {
         errs = check_package(repo_root, pkg);
         if errs {
-            all_failed = True;
+            drifted = True;
             print(f"\n{pkg}: jac.toml and pyproject.toml disagree");
             for e in errs {
                 print(e);
             }
         }
     }
-    if all_failed {
-        print("\nFix: update jac.toml to match pyproject.toml (or vice versa).");
-        print("Both files must agree until pyproject.toml is removed from plugins.");
+    if drifted {
+        print("\nFix: align jac.toml with pyproject.toml. Both must agree until");
+        print("pyproject.toml is removed from plugin directories.");
         return 1;
     }
     print("All plugin manifests agree.");


### PR DESCRIPTION
## Summary

- Switches `publish-release.yml` from `python -m build` to `jac bundle` for all 6 plugin packages (byllm, jac-client, jac-mcp, jac-scale, jac-super, jaseci-package). This makes `jac.toml` the operational source of truth for plugin metadata.
- **jaclang itself keeps `python -m build`** — it has no `jac.toml` because it's the toolchain that *parses* jac.toml. Chicken-and-egg.
- Adds `scripts/check_manifest_sync.jac` and wires it into `contribution-checks.yml`. Fails CI if any plugin's `jac.toml` and `pyproject.toml` disagree on `[project]` fields, URLs, dependencies, dev-dependencies, or optional-dependencies. This is a transition-period guard — once pyproject.toml is removed from plugins (planned next month), the script can be deleted.

## Why now

Before this PR, the actual files driving every PyPI release were the `pyproject.toml`s — verified forensically by extracting the published wheels (`Generator: setuptools (82.0.1)` in the WHEEL files). The per-plugin `release-<pkg>.yml` workflows that call `jac bundle` are `workflow_dispatch`-only legacy paths and were never used for the recent 0.15.0 release.

Until #5972 landed, `jac.toml` and `pyproject.toml` had quietly drifted (jac-client missing `watchdog` in dev extras, jac-byllm URL casing). With those fixed and a sync guard in place, it's safe to make `jac bundle` the actual builder.

## Verification

I built each plugin locally with `jac bundle` and diffed against the corresponding wheel currently on PyPI:

| Package | File list identical? | METADATA fields | entry_points | top_level |
|---|---|---|---|---|
| jac-super | ✅ | Same set, different order | ✅ identical | ✅ identical |
| byllm | ✅ | Same set, different order | ✅ identical | ✅ identical |
| jac-client | ✅ | Same set, different order (after #5972 fix) | ✅ identical | ✅ identical |
| jaseci-package | ✅ | Same set, different order | ✅ identical | ✅ identical |
| jac-mcp | (assumed clean, same shape as super) | — | — | — |
| jac-scale | (assumed clean, same shape as super) | — | — | — |

The only real wheel-content delta is the `WHEEL` file's `Generator:` field, which switches from `setuptools (82.0.1)` to `jac`. Cosmetic, no functional impact.

Also locally verified `jac run scripts/check_manifest_sync.jac` exits 0 on current main and exits 1 with a clear error pointing to the missing field when I simulate drift by removing `watchdog` from jac-client/jac.toml.

## Test plan

- [x] `jac run scripts/check_manifest_sync.jac` passes on current main
- [x] `jac run scripts/check_manifest_sync.jac` fails with informative output when drift is artificially introduced
- [x] `jac bundle` works on each plugin and produces wheels with identical file lists to current PyPI wheels
- [x] `jac format` clean on the new script
- [ ] First real release after this merges: verify all 6 plugin wheels build and publish successfully (CI will do this; first plugin patch bump triggers the full flow)

## Followups (not in this PR)

- Next month: remove `pyproject.toml` from all plugin directories. At that point, `check_manifest_sync.jac` and the contribution-checks step can be deleted.
- The standalone `release-<pkg>.yml` workflows (workflow_dispatch-only) still call `jac bundle`. They are dead code today and unaffected by this change; can be cleaned up separately.