### PR TITLE
fix(release): authenticate science's GitHub API calls in standalone build

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -95,6 +95,13 @@ jobs:
       - name: Build standalone binary
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # `pex --scie eager` invokes `science`, which queries
+          # api.github.com/repos/astral-sh/python-build-standalone for the
+          # latest CPython interpreter release. Unauthenticated calls share
+          # the runner's IP-pool 60/hour quota and routinely fail on macOS
+          # runners. Pass the workflow token so science makes authenticated
+          # 5000/hour calls instead.
+          SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ github.token }}
         run: |
           VERSION="${{ needs.resolve-versions.outputs.jaclang_version }}"
           ASSET="jac-${VERSION}-${{ matrix.platform }}"
@@ -183,6 +190,8 @@ jobs:
       - name: Build standalone binary
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # See jaclang job above for why this is needed.
+          SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ github.token }}
         run: |
           VERSION="${{ needs.resolve-versions.outputs.jaseci_version }}"
           ASSET="jaseci-${VERSION}-${{ matrix.platform }}"


### PR DESCRIPTION
## Summary

- The `build-standalone-binaries` matrix in the publish-release pipeline intermittently fails on macOS-aarch64 with `403 rate limit exceeded` calling `api.github.com/repos/astral-sh/python-build-standalone/releases/latest`.
- Root cause: `pex --scie eager` invokes `science` under the hood, which queries that endpoint to pick the bundled CPython interpreter. The call is unauthenticated, so it shares the runner's IP-pool 60/hour anonymous quota. macOS-aarch64 runners are scarcer and hit the limit more often.
- Fix: set `SCIENCE_AUTH_API_GITHUB_COM_BEARER` to the workflow token. Science reads per-host bearer credentials from `SCIENCE_AUTH_<HOSTNAME>_BEARER` env vars; this gives it authenticated calls (5000/hour) and eliminates the flake.

## Scope

- **Impact:** Only the post-PyPI standalone-binary build job, which produces the `jac-<ver>-<platform>` and `jaseci-<ver>-<platform>` executables attached to GitHub Releases. PyPI publishing is unaffected (it runs before this job).
- **No code changes outside `.github/workflows/build-standalone.yml`.** Both "Build standalone binary" steps (jaclang and jaseci) get the same env var.
- **Compatible with non-failing runs.** When the rate limit isn't hit, the auth header is just extra; science still works identically.

## Concrete failure observed

```
httpx.HTTPStatusError: Client error '403 rate limit exceeded' for url
'https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest'
```

Failed in `build-standalone-binaries / build-jaclang (macos-latest, macos-aarch64)` and `build-jaseci (macos-latest, macos-aarch64)` on a recent run of `Publish Release`. The Linux jobs in the same matrix succeeded because hosted Linux runners draw from a much larger IP pool that's far from the anonymous quota.

## Test plan

- [x] `python -m yaml.safe_load` parses the modified workflow without error
- [ ] First standalone-binary build after merge: macOS-aarch64 jobs complete successfully (verified at the next release)