### PR TITLE
docs: align jac.toml publishing docs with unified [project] section

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1245,7 +1245,7 @@ jac purge
 
 ### jac bundle
 
-Build a standards-compliant Python wheel (`.whl`) from your project's `jac.toml`. The wheel is `pip install`-ready and requires no `pyproject.toml` or `setuptools`. After building, upload to PyPI (or a private registry) with `twine upload dist/*`.
+Build a standards-compliant Python wheel (`.whl`) from your project's `jac.toml`. The wheel is `pip install`-ready and requires no `pyproject.toml` or `setuptools`. After building, upload to PyPI (or a private registry) with `twine upload dist/*`. For the full end-to-end workflow, see the [Publishing Packages](../publishing.md) guide.
 
 ```bash
 jac bundle [-h] [-o OUTPUT]
@@ -1257,10 +1257,12 @@ jac bundle [-h] [-o OUTPUT]
 
 **What it does:**
 
-1. Reads `[package]` from `jac.toml` and validates required fields (`name`, `version`).
-2. Discovers source files under the package directory (defaults to the directory named after the package). Includes `*.jac`, `*.py`, `*.pyi`, `*.lark`, `py.typed`, and `*.jir` by default.
-3. Generates a PEP 427-compliant `.whl` archive with a `METADATA`, `WHEEL`, `RECORD`, and optional `entry_points.txt`.
+1. Reads `[project]` from `jac.toml` and validates required fields (`name`, `version`).
+2. Discovers source files under the package directory (defaults to the directory named after the project, or the explicit `[project.include]` `packages` list). Includes `*.jac`, `*.py`, `*.pyi`, `*.lark`, `py.typed`, and `*.jir` by default.
+3. Generates a PEP 427-compliant `.whl` archive with `METADATA`, `WHEEL`, `RECORD`, `top_level.txt`, and optional `entry_points.txt`. The build is reproducible (fixed ZIP timestamps).
 4. Writes `<name>-<version>-py3-none-any.whl` to the output directory.
+
+> **Note on bytecode:** `jac bundle` ships `.jir` files only if they already exist in your source tree. To pre-compile `.jac` → `.jir` before bundling (so installs skip compilation), run `jac` precompilation first; `jac bundle` itself does not regenerate stale `.jir` files.
 
 **Examples:**
 
@@ -1280,13 +1282,15 @@ pip install dist/mylib-1.0.0-py3-none-any.whl
 
 **Requirements:**
 
-A `[package]` section must exist in `jac.toml`. At minimum:
+A `[project]` section must exist in `jac.toml`. At minimum:
 
 ```toml
-[package]
+[project]
 name = "mylib"
 version = "1.0.0"
 ```
+
+See the [Configuration Reference](../config/index.md#project) for the full set of publishing fields (`license`, `readme`, `authors`, `[project.include]`, and more).
 
 ---
 
@@ -1797,9 +1801,9 @@ Expected project layout:
 
 ```
 mylib/
-├── jac.toml          ← must contain [package] section
+├── jac.toml          ← must contain [project] section
 ├── README.md
-└── mylib/            ← source dir (matches [package] name)
+└── mylib/            ← source dir (matches [project] name)
     ├── __init__.jac
     └── utils.jac
 ```

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -44,32 +44,45 @@ You typically don't need to modify this file until you add dependencies or custo
 
 ### [project]
 
-Project metadata:
+Project metadata. Runtime fields (`entry-point`, `jac-version`) are used by `jac run` and `jac start`. Publishing fields (`license`, `readme`, `keywords`, `requires-python`, `authors`, `maintainers`, and `[project.include]`) are used by `jac bundle` when building a distributable wheel. All publishing fields are optional -- a project that is never published only needs `name`.
 
 ```toml
 [project]
 name = "myapp"
 version = "1.0.0"
 description = "My Jac application"
-authors = ["Your Name <you@example.com>"]
-license = "MIT"
 entry-point = "main.jac"
-jac-version = ">=0.9.0"
+jac-version = ">=0.15.0"
+
+# Publishing metadata -- only needed to run `jac bundle`
+license = "MIT"
+readme = "README.md"
+requires-python = ">=3.12"
+keywords = ["jac", "ai"]
+authors = [{ name = "Your Name", email = "you@example.com" }]
+maintainers = [{ name = "Another Person", email = "them@example.com" }]
 
 [project.urls]
 homepage = "https://example.com"
 repository = "https://github.com/user/repo"
 ```
 
-| Field | Description |
-|-------|-------------|
-| `name` | Project name (required) |
-| `version` | Semantic version |
-| `description` | Brief description |
-| `authors` | List of authors |
-| `license` | License identifier |
-| `entry-point` | Main file (default: `main.jac`) |
-| `jac-version` | Required Jac version |
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Project / PyPI package name (required) |
+| `version` | string | Semantic version (default: `0.1.0`) |
+| `description` | string | One-line summary (also shown on PyPI) |
+| `entry-point` | string | Main file for `jac run` (default: `main.jac`) |
+| `jac-version` | string | Required Jac compiler version |
+| `license` | string | SPDX license identifier (e.g. `"MIT"`) |
+| `readme` | string | Path to README file (default: `README.md`) |
+| `requires-python` | string | Minimum Python version (e.g. `">=3.12"`) |
+| `keywords` | list | Search keywords shown on PyPI |
+| `authors` | list of `{name, email}` | Package authors |
+| `maintainers` | list of `{name, email}` | Package maintainers |
+| `urls` | table | Links shown on PyPI (declared under `[project.urls]`) |
+
+> **Note:** `authors` and `maintainers` also accept a plain string form (`authors = ["Your Name"]`), but the `{ name, email }` table form is recommended -- it is what every plugin `jac.toml` uses and what PyPI renders. See [`[project.include]`](#projectinclude) for controlling which files land in the wheel.
 
 ---
 
@@ -561,61 +574,19 @@ base_url = "${BASE_URL:?Base URL is required}"      # Required with error
 
 ---
 
-### [package]
+### [project.include]
 
-PyPI-publishable package metadata. This section is required to run `jac bundle`. It is separate from `[project]` so that application-level metadata (entry point, run settings) does not pollute the distributed package manifest.
+Controls which files and directories `jac bundle` collects into the wheel.
 
-```toml
-[package]
-name = "mylib"
-version = "1.0.0"
-description = "A Jac library"
-license = "MIT"
-readme = "README.md"
-requires-python = ">=3.12"
-keywords = ["jac", "ai"]
-
-[[package.authors]]
-name = "Your Name"
-email = "you@example.com"
-
-[[package.maintainers]]
-name = "Another Person"
-email = "them@example.com"
-
-[package.urls]
-homepage = "https://example.com"
-repository = "https://github.com/user/mylib"
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Package name on PyPI (required) |
-| `version` | string | Semantic version (required) |
-| `description` | string | One-line summary shown on PyPI |
-| `license` | string | SPDX license identifier (e.g. `"MIT"`) |
-| `readme` | string | Path to README file (default: `README.md`) |
-| `requires-python` | string | Minimum Python version (e.g. `">=3.12"`) |
-| `keywords` | list | Search keywords on PyPI |
-| `authors` | list of `{name, email}` | Package authors |
-| `maintainers` | list of `{name, email}` | Package maintainers |
-| `urls` | table | Links shown on PyPI (homepage, repository, etc.) |
-
-> **Note:** `[project]` fields like `entry-point` and `jac-version` are for running your app. `[package]` fields are for distributing a library. A publishable project can have both.
-
----
-
-### [package.include]
-
-Controls which files and directories are bundled into the wheel.
+> **Note:** Earlier releases used a separate `[package]` / `[package.include]` section for publishing metadata. As of jaclang 0.15, `[package]` has been merged into `[project]` -- all publishing fields now live under `[project]` (see above), and file-inclusion rules live under `[project.include]`. Plain `[package]` tables are no longer read.
 
 ```toml
-[package.include]
+[project.include]
 # Explicit list of package directories to include.
 # Defaults to a directory matching the package name (hyphens replaced with underscores).
 packages = ["mylib", "mylib_utils"]
 
-[package.include.data]
+[project.include.data]
 # "*" sets global file patterns for all packages.
 "*" = ["**/*.jac", "**/*.py", "**/*.pyi", "py.typed"]
 
@@ -623,7 +594,14 @@ packages = ["mylib", "mylib_utils"]
 mylib = ["**/*.lark", "data/*.json", "templates/**/*"]
 ```
 
-**Default included patterns** (when `[package.include.data]` is absent):
+| Key | Description |
+|-----|-------------|
+| `packages` | Glob list of package directories to ship. Defaults to one directory named after the project (hyphens → underscores). |
+| `data` | Map of file-glob patterns. The `"*"` key sets global patterns for every package; a per-package key adds extra patterns on top. |
+
+Simple patterns without a path separator (e.g. `"*.jac"`) are matched recursively, so sub-packages are covered automatically.
+
+**Default included patterns** (when `[project.include.data]` is absent):
 
 | Pattern | Description |
 |---------|-------------|
@@ -632,7 +610,8 @@ mylib = ["**/*.lark", "data/*.json", "templates/**/*"]
 | `**/*.pyi` | Type stub files |
 | `**/*.lark` | Lark grammar files |
 | `**/py.typed` | PEP 561 type marker |
-| `**/*.jir` | Pre-compiled JIR bytecode |
+| `**/*.jir` | Pre-compiled JIR bytecode (collected if already present -- see [`jac bundle`](../cli/index.md#jac-bundle)) |
+| `_precompiled/manifest.json` | JIR precompile manifest |
 
 **Always excluded** (regardless of patterns):
 
@@ -815,4 +794,5 @@ Each line is a filename or pattern that should be skipped during Jac compilation
 ## See Also
 
 - [CLI Reference](../cli/index.md) - Command-line interface documentation
+- [Publishing Packages](../publishing.md) - Building and uploading wheels to PyPI
 - [Plugin Management](../cli/index.md#plugin-management) - Managing plugins

--- a/docs/docs/reference/publishing.md
+++ b/docs/docs/reference/publishing.md
@@ -1,0 +1,147 @@
+# Publishing Packages
+
+Jac projects publish to [PyPI](https://pypi.org) as standard Python wheels -- no `pyproject.toml`, no `setuptools`, no `build` backend. The `jac bundle` command reads your `jac.toml` and produces a PEP 427-compliant `.whl` that `pip install` consumes directly. Anyone can then `pip install` your package, whether or not they use Jac.
+
+This page covers the end-to-end flow: declaring metadata, building a wheel, testing it, and uploading it.
+
+## Overview
+
+The publishing pipeline has three steps:
+
+1. **Declare** package metadata in the `[project]` section of `jac.toml`.
+2. **Build** a wheel with `jac bundle` -- it lands in `dist/`.
+3. **Upload** the wheel to PyPI with `twine` (upload is intentionally out of scope for `jac`).
+
+Jac builds the wheel itself: it generates the `METADATA`, `WHEEL`, `RECORD`, `top_level.txt`, and `entry_points.txt` files and packs them into a reproducible ZIP archive. The result is indistinguishable from a wheel produced by `hatch` or `setuptools`.
+
+## 1. Declare package metadata
+
+All publishing metadata lives in the `[project]` section of `jac.toml`. Only `name` and `version` are strictly required; everything else improves the PyPI listing.
+
+```toml
+[project]
+name = "mylib"
+version = "1.0.0"
+description = "A handy Jac library"
+license = "MIT"
+readme = "README.md"
+requires-python = ">=3.12"
+keywords = ["jac", "jaseci", "ai"]
+authors = [{ name = "Your Name", email = "you@example.com" }]
+maintainers = [{ name = "Your Name", email = "you@example.com" }]
+
+[project.urls]
+homepage = "https://example.com"
+repository = "https://github.com/you/mylib"
+issues = "https://github.com/you/mylib/issues"
+
+[dependencies]
+jaclang = ">=0.15.1"
+requests = ">=2.28.0"
+```
+
+Runtime dependencies declared under `[dependencies]` are written into the wheel's `METADATA` as `Requires-Dist` entries, so `pip install mylib` pulls them in automatically. `[dev-dependencies]` are **not** shipped. `[optional-dependencies.<group>]` become wheel extras (`pip install mylib[<group>]`).
+
+See the [Configuration Reference](config/index.md#project) for the full field list.
+
+!!! note "Migrated from `[package]`?"
+    Releases before jaclang 0.15 used a separate `[package]` section for publishing metadata. It has been merged into `[project]`. If you have an old `jac.toml`, rename `[package]` → `[project]` and `[package.include]` → `[project.include]`; plain `[package]` tables are no longer read.
+
+### Controlling what ships
+
+By default `jac bundle` collects a single directory named after the project (`mylib/`, with hyphens converted to underscores). Override this with `[project.include]`:
+
+```toml
+[project.include]
+packages = ["mylib", "mylib_extras"]
+
+[project.include.data]
+# Extra non-source files to bundle, per package
+mylib = ["templates/**/*", "data/*.json"]
+```
+
+`.jac`, `.py`, `.pyi`, `.lark`, `py.typed`, and `.jir` files are included by default. Build artifacts (`.jac/`, `__pycache__/`, `dist/`, virtualenvs, `.git/`, `*.egg-info/`) are always excluded. See [`[project.include]`](config/index.md#projectinclude) for the full pattern reference.
+
+!!! warning "Single-file modules"
+    `[project.include]` `packages` matches **directories**. A package that is a single top-level `.py`/`.jac` file is not currently collected -- put your code in a directory (a `__init__.jac` is enough) before bundling.
+
+### Console scripts and plugins
+
+Declare CLI commands and Jac plugin entry points with `[entrypoints]`:
+
+```toml
+[entrypoints.scripts]
+# `pip install mylib` adds a `mylib` command on PATH
+mylib = "mylib.cli:main"
+
+[entrypoints.jac]
+# Auto-discovered by Jac's plugin system at startup
+mylib = "mylib.plugin:JacRuntime"
+```
+
+`[entrypoints.scripts]` is written as `[console_scripts]` in the wheel; `[entrypoints.jac]` is the `jac` entry-point group queried by the plugin loader.
+
+## 2. Build the wheel
+
+```bash
+jac bundle
+```
+
+This writes `dist/<name>-<version>-py3-none-any.whl`. Build to a different directory with `-o`:
+
+```bash
+jac bundle -o /tmp/wheels
+```
+
+`jac bundle` ships `.jir` bytecode files only if they already exist in your source tree -- it does not regenerate them. Pre-compile `.jac` → `.jir` first if you want installs to skip compilation. Shipped bytecode is keyed by Python version and validated against a source hash; if it is missing, incompatible, or stale, the runtime transparently falls back to compiling the bundled `.jac` source -- a mismatch never breaks the package.
+
+Wheels are reproducible: every ZIP entry uses a fixed timestamp, so the same source produces a byte-identical wheel.
+
+## 3. Test before uploading
+
+Always install the wheel into a clean environment before publishing:
+
+```bash
+python -m venv test_env
+source test_env/bin/activate
+pip install dist/mylib-1.0.0-py3-none-any.whl
+python -c "import mylib"   # or exercise your console script
+deactivate
+```
+
+## 4. Upload to PyPI
+
+`jac` does not upload -- use [`twine`](https://twine.readthedocs.io/):
+
+```bash
+pip install twine
+
+# Upload to TestPyPI first to verify the listing renders correctly
+twine upload --repository testpypi dist/*
+
+# Then publish to the real index
+twine upload dist/*
+```
+
+In CI, authenticate with an API token: `twine upload dist/* -u __token__ -p "$PYPI_TOKEN"`.
+
+## Editable installs
+
+While developing a library locally, install it in editable mode so changes are picked up without rebuilding:
+
+```bash
+jac install -e .
+```
+
+This installs the project's runtime dependencies and writes a complete `.dist-info/` directory into `site-packages`, so `pip show mylib` and `pip list` report it correctly -- all without a `pyproject.toml`. You can also editable-install a cloned dependency from anywhere:
+
+```bash
+jac install -e /path/to/cloned/lib
+```
+
+## See Also
+
+- [`jac bundle`](cli/index.md#jac-bundle) -- command reference
+- [`jac install`](cli/index.md#jac-install) -- installing dependencies and editable installs
+- [Configuration Reference](config/index.md#project) -- every `jac.toml` field
+- [Plugin Authoring](plugin-authoring.md) -- building distributable Jac plugins

--- a/docs/jac.toml
+++ b/docs/jac.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [project.include]
-modules = ["jac_syntax_highlighter"]
+packages = ["jac_syntax_highlighter"]
 
 [dependencies]
 "pygments" = "<2.20"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
           - CLI Commands: "reference/cli/index.md"
           - Plugin Authoring: "reference/plugin-authoring.md"
           - Configuration: "reference/config/index.md"
+          - Publishing Packages: "reference/publishing.md"
           - Persistence & Schema Migration: "reference/persistence.md"
           - Errors & Warnings: "reference/diagnostics.md"
           - Code Organization: "reference/code-organization.md"

--- a/jac/jaclang/cli/commands/impl/project.impl.jac
+++ b/jac/jaclang/cli/commands/impl/project.impl.jac
@@ -1072,14 +1072,14 @@ impl bundle(output: str = "dist") -> int {
     }
 
     console.print(
-        f"\n📦 Publishing [cyan]{config.project.name}[/cyan] "
+        f"\n📦 Bundling [cyan]{config.project.name}[/cyan] "
         f"v{config.project.version}",
         style="bold"
     );
 
     out_dir = Path(output);
     out_dir.mkdir(parents=True, exist_ok=True);
-    console.print("\n  Pre-compiling .jac → .jir + building wheel...", style="muted");
+    console.print("\n  Building wheel...", style="muted");
     try {
         builder = WheelBuilder(config=config, project_root=config.project_root);
         whl_path = builder.build_to(out_dir);


### PR DESCRIPTION
## Summary

The `[package]` → `[project]` config merge (#5871) was never propagated into the reference docs. They still documented a `[package]` section that no longer exists, contradicting the actual `jac.toml` schema and the release notes.

## Changes

- **Configuration Reference** — rewrote `[project]` to document all publishing fields now living there (`license`, `readme`, `requires-python`, `keywords`, `maintainers`, `[project.include]`), corrected the `authors` example to the canonical `{ name, email }` table form, and removed the dead `[package]` / `[package.include]` sections.
- **CLI Reference** — `jac bundle` now references `[project]` instead of `[package]` in its "What it does", "Requirements", and project-layout sections.
- **New page** — added an end-to-end "Publishing Packages" guide (declare metadata → `jac bundle` → test → `twine upload`), wired into the Developer Workflow nav and cross-linked from the CLI and config references.
- **docs/jac.toml** — fixed the `[project.include]` key (`modules` → `packages`); only `packages`/`data` are parsed, so `modules` was silently ignored.
- **jac bundle CLI output** — corrected misleading console messages (`Publishing` / `Pre-compiling .jac → .jir`); the command neither publishes nor precompiles, it only collects pre-existing `.jir` files.

## Notes

A related runtime bug found while reviewing the precompiled-bytecode path is filed separately as #5978.