### PR TITLE
fix(jac-scale): resolve SSO callback type errors and unignore providers

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -335,6 +335,3 @@ types.impl.jac
 useBudget.jac
 useLocalStorage.jac
 wikipedia_react.jac
-apple.jac
-google.jac
-github.jac

--- a/jac-scale/jac_scale/sso/apple.jac
+++ b/jac-scale/jac_scale/sso/apple.jac
@@ -62,13 +62,19 @@ obj AppleSSOProvider(SSOProvider) {
 
         with self._apple_sso {
             user_info = await self._apple_sso.verify_and_process(request);
+            if user_info is None {
+                raise RuntimeError("Apple SSO verification returned no user info");
+            }
+            if user_info.email is None or user_info.id is None {
+                raise RuntimeError("Apple SSO user info is missing email or id");
+            }
             return SSOUserInfo(
-                email=user_info.email,
-                external_id=user_info.id,
-                display_name=user_info?.display_name,
-                first_name=user_info?.first_name,
-                last_name=user_info?.last_name,
-                picture=user_info?.picture
+                email=str(user_info.email),
+                external_id=str(user_info.id),
+                display_name=user_info.display_name,
+                first_name=user_info.first_name,
+                last_name=user_info.last_name,
+                picture=user_info.picture
             );
         }
     }

--- a/jac-scale/jac_scale/sso/github.jac
+++ b/jac-scale/jac_scale/sso/github.jac
@@ -62,13 +62,19 @@ obj GithubSSOProvider(SSOProvider) {
 
         with self._github_sso {
             user_info = await self._github_sso.verify_and_process(request);
+            if user_info is None {
+                raise RuntimeError("Github SSO verification returned no user info");
+            }
+            if user_info.email is None or user_info.id is None {
+                raise RuntimeError("Github SSO user info is missing email or id");
+            }
             return SSOUserInfo(
-                email=user_info.email,
-                external_id=user_info.id,
-                display_name=user_info?.display_name,
-                first_name=user_info?.first_name,
-                last_name=user_info?.last_name,
-                picture=user_info?.picture
+                email=str(user_info.email),
+                external_id=str(user_info.id),
+                display_name=user_info.display_name,
+                first_name=user_info.first_name,
+                last_name=user_info.last_name,
+                picture=user_info.picture
             );
         }
     }

--- a/jac-scale/jac_scale/sso/google.jac
+++ b/jac-scale/jac_scale/sso/google.jac
@@ -62,13 +62,19 @@ obj GoogleSSOProvider(SSOProvider) {
 
         with self._google_sso {
             user_info = await self._google_sso.verify_and_process(request);
+            if user_info is None {
+                raise RuntimeError("Google SSO verification returned no user info");
+            }
+            if user_info.email is None or user_info.id is None {
+                raise RuntimeError("Google SSO user info is missing email or id");
+            }
             return SSOUserInfo(
-                email=user_info.email,
-                external_id=user_info.id,
-                display_name=user_info?.display_name,
-                first_name=user_info?.first_name,
-                last_name=user_info?.last_name,
-                picture=user_info?.picture
+                email=str(user_info.email),
+                external_id=str(user_info.id),
+                display_name=user_info.display_name,
+                first_name=user_info.first_name,
+                last_name=user_info.last_name,
+                picture=user_info.picture
             );
         }
     }


### PR DESCRIPTION
## Summary

The Apple, Google, and GitHub SSO providers fed possibly-`None` values from `verify_and_process()` into `SSOUserInfo`, whose `email` and `external_id` fields are non-optional `str`. This caused 4 type errors per file, which is why all three were listed in `.jacignore`.

## Changes

- Guard against `verify_and_process()` returning `None`
- Raise a `RuntimeError` if the provider omits `email` or `id`
- Coerce `email`/`external_id` with `str()` — `OpenID.email` is `EmailStr | None`, which narrows to `object` rather than `str`
- Drop `?.` to `.` on the remaining fields now that `user_info` is narrowed to non-`None`
- Remove `apple.jac`, `google.jac`, and `github.jac` from `.jacignore`

Beyond satisfying the type checker, the callbacks now fail loudly when a provider returns no user info or omits an email/id, instead of constructing an invalid `SSOUserInfo`.

## Verification

- `jac check` — all three files PASS
- `jac format --check` — clean