### PR TITLE
fix(checker): accept any args for gradual callables; unignore 4 files

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -9,7 +9,6 @@ config.impl.jac
 jac/jaclang/cli/commands/config.jac
 jac/jaclang/project/config.jac
 console.jac
-constant.jac
 # context.impl.jac / context.jac — jac-scale passes, jaclang runtimelib fails
 jac/jaclang/runtimelib/impl/context.impl.jac
 jac/jaclang/runtimelib/context.jac
@@ -31,13 +30,11 @@ es_unparse.impl.jac
 es_unparse.jac
 execution.impl.jac
 execution.jac
-executor.jac
 fantasy_trading_game.jac
 game_obj.jac
 grammar_extract_pass.jac
 guess_game6.jac
 helpers.jac
-help.jac
 interop_analysis_pass.jac
 jac_auto_lint_pass.impl.jac
 jac_auto_lint_pass.jac
@@ -55,7 +52,6 @@ memory.jac
 modresolver.jac
 mtir_gen_pass.impl.jac
 mtir_gen_pass.jac
-mtp.jac
 nacompile.impl.jac
 nacompile.jac
 na_compile_pass.jac

--- a/jac/jaclang/cli/impl/executor.impl.jac
+++ b/jac/jaclang/cli/impl/executor.impl.jac
@@ -130,8 +130,10 @@ impl CommandExecutor.run_handler(spec: CommandSpec, args: dict[str, Any]) -> int
 impl get_executor -> CommandExecutor {
     import from jaclang.cli.executor { CommandExecutor }
     global _executor;
-    if _executor is None {
-        _executor = CommandExecutor();
+    if _executor is not None {
+        return _executor;
     }
-    return _executor;
+    new_executor = CommandExecutor();
+    _executor = new_executor;
+    return new_executor;
 }

--- a/jac/jaclang/cli/impl/help.impl.jac
+++ b/jac/jaclang/cli/impl/help.impl.jac
@@ -96,7 +96,7 @@ impl HelpFormatter.format_main_help(
         lines.append(f"{display_name}:");
 
         # Sort commands alphabetically within group
-        cmds.sort(key=lambda c: str : c.name);
+        cmds.sort(key=lambda c: CommandSpec : c.name);
         for cmd in cmds {
             # Format: "  name        description"
             padding = " " * (12 - len(cmd.name));
@@ -190,7 +190,7 @@ impl HelpFormatter.format_arguments(
             }
             # Add type hint for non-bool
             if arg.typ != bool and arg.kind != ArgKind.FLAG {
-                type_name = arg.typ?.__name__ or str(arg.typ);
+                type_name = str(getattr(arg.typ, '__name__', arg.typ));
                 flag_str += f" {type_name.upper()}";
             }
 
@@ -227,7 +227,7 @@ impl HelpFormatter.format_arguments(
                     flag_str = f"--{arg.name}";
                 }
                 if arg.typ != bool and arg.kind != ArgKind.FLAG {
-                    type_name = arg.typ?.__name__ or str(arg.typ);
+                    type_name = str(getattr(arg.typ, '__name__', arg.typ));
                     flag_str += f" {type_name.upper()}";
                 }
 
@@ -294,18 +294,22 @@ impl HelpFormatter.format_usage(spec: CommandSpec, prog: str = "jac") -> str {
 impl get_command_groups -> CommandGroups {
     import from jaclang.cli.help { CommandGroups }
     global _groups;
-    if _groups is None {
-        _groups = CommandGroups();
+    if _groups is not None {
+        return _groups;
     }
-    return _groups;
+    new_groups = CommandGroups();
+    _groups = new_groups;
+    return new_groups;
 }
 
 """Get the global HelpFormatter instance."""
 impl get_help_formatter -> HelpFormatter {
     import from jaclang.cli.help { HelpFormatter }
     global _formatter;
-    if _formatter is None {
-        _formatter = HelpFormatter();
+    if _formatter is not None {
+        return _formatter;
     }
-    return _formatter;
+    new_formatter = HelpFormatter();
+    _formatter = new_formatter;
+    return new_formatter;
 }

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
@@ -497,6 +497,15 @@ impl TypeEvaluator.match_args_to_params(
 ) -> MatchArgsToParamsResult {
     arg_params: dict[uni.Expr | uni.KWPair, types.Parameter | None] = {};
     argument_errors = False;
+    if func_type.is_gradual_callable_form() {
+        # Gradual callable forms (`Callable[..., T]` or bare `Callable`) accept
+        # any arguments and are compatible with any signature. Skip positional
+        # and keyword matching entirely so calls never raise arity errors.
+        for arg in arg_nodes {
+            arg_params[arg] = None;
+        }
+        return MatchArgsToParamsResult(arg_params=arg_params, argument_errors=False);
+    }
     params_to_match = func_type.parameters.copy();
     if is_unbound_call {
         # Unbound call: caller provides self explicitly

--- a/jac/jaclang/jac0core/mtp.jac
+++ b/jac/jaclang/jac0core/mtp.jac
@@ -118,14 +118,15 @@ def type_to_str(t: object) -> str {
     }
     try {
         import from dataclasses { is_dataclass }
-        if (is_dataclass(t) and t?.name) {
-            return t.name;
+        dc_name = t?.name;
+        if (is_dataclass(t) and dc_name is not None) {
+            return str(dc_name);
         }
     } except Exception {
         ;
     }
     if isinstance(t, `tuple) {
-        head = t[0];
+        head = str(t[0]);
         if (head == 'list') {
             return f"list[{type_to_str(t[1])}]";
         }


### PR DESCRIPTION
## Summary

Fixes a type-checker bug and clears the type errors in four files, removing them from `.jacignore`.

### Checker bug: gradual callables rejected all arguments

`Callable[..., T]` and bare `Callable` are *gradual callable forms* — documented to accept any arguments and be compatible with any signature. But `match_args_to_params` still ran positional/keyword arity checking against their empty parameter list, so every call through one raised `E1051: Too many positional arguments`.

Minimal repro (failed before, passes now):

```jac
def direct(hook: Callable[..., Any]) -> None {
    hook("a", "b");
}
```

Fix: in `match_args_to_params`, bypass arity matching when `func_type.is_gradual_callable_form()` is true.

## Files removed from `.jacignore`

| File | Errors | Fix |
|---|---|---|
| `constant.jac` | 0 | Already passed — stale entry |
| `mtp.jac` | 5 | Null-safe `?.` for `.name` on `object`; `str()` coercion of tuple head |
| `executor.jac` | 5 | Gradual-callable checker fix + singleton rewrite |
| `help.jac` | 8 | Singleton rewrite; wrong lambda param annotation; `?.__name__` → `getattr` |

Detail:

- **Singletons** — the lazy-init pattern `if x is None { x = T() } return x` does not narrow a global past the `if`. Rewritten as early-return: `if x is not None { return x } new = T(); x = new; return new`.
- **help.jac lambda** — `lambda c: str : c.name` annotated `c` as `str`, but `c` is a `CommandSpec`.
- **help.jac type name** — `arg.typ?.__name__ or str(arg.typ)` produced `<Never> | str`; replaced with `str(getattr(arg.typ, '__name__', arg.typ))`.

## Verification

- All four files pass `jac check` and `jac format --check --lintfix`
- 469 type-checker tests (`tests/compiler/passes/main/`) pass — no regressions from the checker change
- 80 CLI tests (`tests/language/test_cli.jac`) pass