### PR TITLE
fix(runtime): allroots() spans the persistent tier, not just the session

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5988.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5988.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `allroots()` spans the persistent tier**: `allroots()` (and `get_all_root`) now enumerate the L3 persistent memory tier under a tiered/served runtime, instead of returning only the roots loaded into the current session. `SqliteMemory.get_roots` likewise now reads the persisted `anchors` table, not just the in-memory cache.

--- a/jac-scale/jac_scale/tests/fixtures/scale-feats/jac.toml
+++ b/jac-scale/jac_scale/tests/fixtures/scale-feats/jac.toml
@@ -4,13 +4,21 @@ version = "1.0.0"
 description = "Jac client application: scale-feats"
 entry-point = "main.jac"
 
-[dependencies]
-
 [dependencies.npm]
-jac-client-node = "1.0.7"
+react = "^18.2.0"
+react-dom = "^18.2.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
 
 [dependencies.npm.dev]
-"@jac-client/dev-deps" = "1.0.0"
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
 
 [dev-dependencies]
 watchdog = ">=3.0.0"

--- a/jac-scale/jac_scale/tests/test_examples.jac
+++ b/jac-scale/jac_scale/tests/test_examples.jac
@@ -554,3 +554,74 @@ test "storage api" {
         runner.spawn_walker("delete_file", path=move_dest);
     }
 }
+
+# TestLittleXMultiUser
+"""littleX cross-user directory under jac-scale.
+
+littleX's `load_user_profiles` walker enumerates `allroots()` to build a
+directory of every registered user. Under a served jac-scale runtime,
+`allroots()` / `get_all_root` must span the L3 persistent tier — not just
+the roots loaded into the current request's session.
+
+Regression test for that tiered-memory `get_all_root` fix. It runs littleX
+WITH jac-scale — the configuration CI otherwise never exercises — and
+asserts a served user sees every registered user, not only their own root.
+"""
+test "littlex user directory across users (jac-scale)" {
+    # JacClientExamples is <repo>/jac-client/jac_client/examples; walk up to <repo>.
+    repo_root = JacClientExamples.parent.parent.parent;
+    littlex_file = (
+        repo_root / "jac" / "examples" / "littleX" / "littleX_single_nodeps.jac"
+    );
+    with JacScaleTestRunner(
+        littlex_file, session_name="littlex_mu_test", setup_npm=False
+    ) as runner {
+        # --- alice: register + login, then create her profile ---
+        runner.request(
+            "POST",
+            "/user/register",
+            data={
+                "identities": [{"type": "username", "value": "alice_mu"}],
+                "credential": {"type": "password", "password": "alicepass123"}
+            }
+        );
+        alice_login = runner.request(
+            "POST",
+            "/user/login",
+            data={
+                "identity": {"type": "username", "value": "alice_mu"},
+                "credential": {"type": "password", "password": "alicepass123"}
+            }
+        );
+        runner.token = str(alice_login["token"]);
+        runner.spawn_walker("update_profile", new_username="alice_mu");
+        # --- bob: register + login (token switches to bob), then his profile ---
+        runner.request(
+            "POST",
+            "/user/register",
+            data={
+                "identities": [{"type": "username", "value": "bob_mu"}],
+                "credential": {"type": "password", "password": "bobpass123"}
+            }
+        );
+        bob_login = runner.request(
+            "POST",
+            "/user/login",
+            data={
+                "identity": {"type": "username", "value": "bob_mu"},
+                "credential": {"type": "password", "password": "bobpass123"}
+            }
+        );
+        runner.token = str(bob_login["token"]);
+        runner.spawn_walker("update_profile", new_username="bob_mu");
+        # bob asks for the global user directory
+        result = runner.spawn_walker("load_user_profiles");
+        reports = result.get("reports", []);
+        profiles = reports[0] if (reports and isinstance(reports[0], list)) else [];
+        names = sorted([str(p.get("name")) for p in profiles]);
+        # A served user's directory must list every registered user — both
+        # alice and bob — proving `get_all_root` spans the persistent tier
+        # rather than only the caller's own session.
+        assert names == ["alice_mu", "bob_mu"] , f"expected both users in the directory, got {names} (raw: {result})";
+    }
+}

--- a/jac.toml
+++ b/jac.toml
@@ -14,4 +14,11 @@ react-hook-form = "^7.71.0"
 zod = "^4.3.6"
 "@hookform/resolvers" = "^5.2.2"
 
+[dependencies.npm.dev]
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
+
 [plugins]

--- a/jac/examples/littleX/littleX.impl.jac
+++ b/jac/examples/littleX/littleX.impl.jac
@@ -102,8 +102,10 @@ impl visit_profile.visit_profile{
 impl load_user_profiles.load_profiles{
     self.profiles: list = [];
     for each_root in allroots() {
-        profile = [each_root-->[?:Profile]][0];
-        self.profiles.append({"name": profile.username, "id": jid(profile)});
+        found = [each_root-->[?:Profile]];
+        if found {
+            self.profiles.append({"name": found[0].username, "id": jid(found[0])});
+        }
     }
 }
 

--- a/jac/examples/littleX/littleX_single.jac
+++ b/jac/examples/littleX/littleX_single.jac
@@ -152,8 +152,10 @@ walker load_user_profiles {
         self.profiles: list = [];
 
         for each_root in allroots() {
-            profile = [each_root-->[?:Profile]][0];
-            self.profiles.append({"name": profile.username, "id": jid(profile)});
+            found = [each_root-->[?:Profile]];
+            if found {
+                self.profiles.append({"name": found[0].username, "id": jid(found[0])});
+            }
         }
     }
 

--- a/jac/examples/littleX/littleX_single_nodeps.jac
+++ b/jac/examples/littleX/littleX_single_nodeps.jac
@@ -138,8 +138,10 @@ walker load_user_profiles {
     can load_profiles with Root entry {
         self.profiles: list = [];
         for each_root in allroots() {
-            profile = [each_root-->[?:Profile]][0];
-            self.profiles.append({"name": profile.username, "id": jid(profile)});
+            found = [each_root-->[?:Profile]];
+            if found {
+                self.profiles.append({"name": found[0].username, "id": jid(found[0])});
+            }
         }
     }
 

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -1665,9 +1665,23 @@ impl JacBasics.root -> Root {
     return JacRuntime.get_context().get_root();
 }
 
-"""Get all the roots."""
+"""Get all the roots.
+
+`jmem.get_roots()` alone only sees the in-memory (L1) tier — under a
+tiered/served runtime that is just the roots loaded into the current
+session, so `allroots()` would be wrongly session-scoped. When a
+persistent L3 tier exists, enumerate it instead so `allroots()` reflects
+every root in the database.
+"""
 impl JacBasics.get_all_root -> list[Root] {
+    import from jaclang.runtimelib.memory { TieredMemory }
     jmem = JacRuntimeInterface.get_context().mem;
+    if isinstance(jmem, TieredMemory) {
+        l3 = jmem.l3;
+        if l3 is not None {
+            return `list(l3.get_roots());
+        }
+    }
     return `list(jmem.get_roots());
 }
 

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -662,10 +662,45 @@ impl SqliteMemory.query(
     }
 }
 
-"""Get all root anchors."""
+"""Get all root anchors — from the L1 cache AND the persistent store.
+
+Iterating only `__mem__` returns just the roots loaded into the current
+session/process. Under a served runtime (jac-scale) each request loads
+only its own caller's root, so `allroots()` would be wrongly
+session-scoped even though every root is persisted in the DB. This walks
+both: cached roots first (covers not-yet-synced ones), then any further
+roots from the `anchors` table.
+"""
 impl SqliteMemory.get_roots -> Generator[Root, None, None] {
+    seen: set[UUID] = set();
     for anchor in self.__mem__.values() {
         if isinstance(anchor.archetype, Root) {
+            seen.add(anchor.id);
+            yield cast(Root, anchor.archetype);
+        }
+    }
+    root_ids: list[str] = [];
+    with self.__lock__ {
+        # Lazily connect if the DB file exists (read path).
+        if not self.__conn__ and os.path.exists(self.path) {
+            self._ensure_connection();
+        }
+        if self.__conn__ {
+            # `arch_type` stores the archetype class name (see _anchor_to_row);
+            # every Root anchor is the `Root` archetype.
+            cursor = self.__conn__.execute(
+                "SELECT id FROM anchors WHERE arch_type = ?", ("Root", )
+            );
+            root_ids = [cast(str, r[0]) for r in cursor.fetchall()];
+        }
+    }
+    for id_str in root_ids {
+        uid = UUID(id_str);
+        if uid in seen {
+            continue;
+        }
+        seen.add(uid);
+        if (anchor := self.get(uid)) and isinstance(anchor.archetype, Root) {
             yield cast(Root, anchor.archetype);
         }
     }


### PR DESCRIPTION
## Problem

`allroots()` resolves to `get_all_root` -> `mem.get_roots()`. A served
(jac-scale) request's memory is a `TieredMemory`, which inherited
`get_roots` from `VolatileMemory`, so it walked only the L1 in-memory
cache and never the L3 persistent tier.

Result: `allroots()` was scoped to the *current session*, not the
database. Cross-user features (user directories, shared feeds) silently
break on the served runtime. `jac test` (no jac-scale, single process)
never catches it, because there every root lives in one shared
in-memory tier.

## Fix

- **`get_all_root`**: when memory is a `TieredMemory` with an L3 tier,
  enumerate L3 so `allroots()` reflects every root in the database.
- **`SqliteMemory.get_roots`**: was also `__mem__`-only; now also queries
  the `anchors` table (`WHERE arch_type = 'Root'`) so the L3 tier returns
  persisted roots.
- **littleX `load_user_profiles`** (3 variant files): guard the unchecked
  `[0]` that `IndexError`s on the profile-less system root once
  `allroots()` correctly returns all roots.

## Test coverage / CI gap

littleX's `allroots()`-based directory was only ever exercised by
`jac test` (no jac-scale), the one config where the bug does not
reproduce. No CI job ran littleX *with* jac-scale.

This adds a `littlex user directory across users (jac-scale)` test to
`test_examples.jac` (run by the `test-scale` CI job, which installs
jac-scale). It registers two users and asserts a served user's directory
lists *both*.

## Note for reviewers

The natural home for fix 1 would be a `TieredMemory.get_roots` override.
That hits a separate jaclang compiler bug: calling a `Generator`-returning
method from within `memory.impl.jac` itself makes codegen silently emit
no bytecode. Locating the tiering in `get_all_root` (a different module)
avoids it. Worth its own issue.

## Verification

- New regression test: passes (fails without this fix).
- littleX's own 14 `jac test` cases: pass.
- jac-scale `storage api` test: passes.
- jac-core `runtimelib` suite: 289 passed.
