### PR TITLE
docs: add curated Jac reference skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,37 @@
+# Jac-Skills
+
+Curated reference skills for writing **Jac** - the language and fullstack framework from [Jaseci](https://www.jaseci.org/). Each skill is a focused, self-contained guide to one area of Jac: syntax, type system, Object-Spatial Programming (nodes/edges/walkers), the `by llm()` MTP pattern, and the fullstack `.cl.jac` / `.sv.jac` client–server model.
+
+Each skill is a self-contained `SKILL.md` with YAML frontmatter, kept as the authoritative reference for Jac code generation.
+
+> Why this exists: training-time impressions of Jac are frequently wrong (the syntax has changed; Jac is easily confused with Python or JSX). These skills are the corrective spec.
+
+## Skills
+
+Start with **`jac-core-cheatsheet`** (language baseline) and **`jac-types`** (the type system) - most other skills build on them.
+
+| Skill | What it covers |
+|---|---|
+| `jac-core-cheatsheet` | Language baseline: imports, control flow, lambdas, ternary, strings, error handling. Read first. |
+| `jac-types` | Type system: annotations, generics, unions, optionals, inference, common type errors. |
+| `jac-has-fields` | Declaring typed fields on stateful archetypes - types, defaults, ordering, optionals. |
+| `jac-impl-files` | Splitting declarations from method bodies into `.jac` / `.impl.jac` companion files. |
+| `jac-node-edge-patterns` | Object-Spatial Programming: defining nodes/edges, connecting, querying by type/field. |
+| `jac-walker-patterns` | Walkers that traverse the graph - entry points, visit, the OSP traversal model. |
+| `jac-by-llm` | Delegating a function body to an LLM - structured outputs, tool use, prompt wiring. |
+| `jac-scaffold` | Bootstrapping a project with `jac create --use <template>`. |
+| `jac-fullstack-patterns` | Wiring `main.jac` for a fullstack app - endpoint registration, client mount. |
+| `jac-sv-endpoints` | Server-side callable functions - visibility, typed responses, CRUD basics. |
+| `jac-sv-auth` | Server auth model - public vs authenticated endpoints, per-user data isolation. |
+| `jac-sv-persistence` | Modeling relationships and querying the graph from server endpoints. |
+| `jac-cl-components` | Client UI components - shape, reactive `has` state, mount effects, events. |
+| `jac-cl-organization` | Structuring a multi-component client app - layout, hooks, naming. |
+| `jac-cl-routing` | Multi-page client navigation - routes, redirects, navigation from handlers. |
+| `jac-cl-auth` | Client auth - signup/login/logout, guarding pages behind login. |
+| `jac-cl-styling` | Tailwind patterns - conditional classes, `cn()`, semantic colors. |
+| `jac-npm-packages` | Adding npm packages to `jac.toml` and importing them in `.cl.jac`. |
+| `jac-shadcn-components` | Using pre-installed jac-shadcn primitives from `components/ui/`. |
+
+## Contributing
+
+These skills are actively curated and updated as the Jac language evolves. Open issues and pull requests in this repository.

--- a/skills/jac-by-llm/SKILL.md
+++ b/skills/jac-by-llm/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: jac-by-llm
+description: Delegating a function's body to an LLM call - structured outputs, tool use, prompt wiring. Load when any function or method should be powered by an LLM instead of hand-written logic. Pair with `jac-walker-patterns` when LLMs drive graph agents.
+---
+
+`by llm(...)` replaces a function body with an LLM call. The signature declares typed args and a return type; at call time the LLM generates a value matching the return type, optionally using any functions listed in `tools=[...]` as ReAct helpers. Describe every LLM-visible thing - the function itself, each parameter, each field of a return obj - with `sem` statements, not docstrings. `sem` is the prompt the LLM sees.
+
+```jac
+import from byllm.lib { Model }
+
+glob llm: Model = Model(model_name="gpt-4o");
+
+obj Summary {
+    has title: str;
+    has bullets: list[str];
+}
+
+sem Summary.title   = "A short, specific title capturing the text's topic.";
+sem Summary.bullets = "Key points - each a single concise sentence.";
+
+
+def word_count(text: str) -> int {
+    return len(text.split());
+}
+
+sem word_count      = "Count whitespace-separated words in text.";
+sem word_count.text = "The text to count words in.";
+
+
+def summarize(text: str) -> Summary by llm(temperature=0.2, max_tokens=500);
+
+sem summarize      = "Extract a structured Summary from the given text.";
+sem summarize.text = "The text to summarize.";
+
+
+def analyze(question: str) -> str by llm(
+    tools=[word_count],
+    temperature=0.2,
+    max_react_iterations=5
+);
+
+sem analyze          = "Answer a question. May call word_count as a tool.";
+sem analyze.question = "The question to answer.";
+
+
+with entry {
+    s = summarize("Jac is a graph-native language.");
+    print(s.title);
+    print(analyze("How many words in 'hello world'?"));
+}
+```
+
+## Pitfalls
+
+- A `glob llm: Model = Model(...)` must be in scope. `llm` is a byllm `Model` instance, NOT a keyword.
+- `by llm(...)` REPLACES the body - never write both `{ body }` and `by llm(...)` on the same signature.
+- Use `sem`, NOT docstrings, for every LLM-visible description. Triple-quoted strings inside a body fail with W0060.
+- Tools are **function references**, NOT strings: `tools=[word_count]`, never `tools=["word_count"]`. Each tool needs its own `sem` and per-arg `sem` so the LLM knows when to call it.
+- Valid `by llm` options: `tools`, `temperature`, `max_tokens`, `max_react_iterations`, `stream`, `logging`, `on_iteration`. NOT `prompt=`, `messages=`, `model=` - the model name is set on the `Model` instance, not on the `by llm` call.

--- a/skills/jac-cl-auth/SKILL.md
+++ b/skills/jac-cl-auth/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: jac-cl-auth
+description: Client-side authentication - signing up, logging in, logging out, and protecting pages behind login. Load when adding any auth UI or guarding pages from unauthenticated users. Pair with `jac-sv-auth` (server side of the auth loop), `jac-cl-routing` (post-login navigation).
+---
+
+Client auth uses four helpers from `@jac/runtime`. **Return types differ - get them wrong and the file fails `jac check` with E1001:**
+
+| Helper | Async? | Returns | Pre-declare as |
+|---|---|---|---|
+| `jacSignup(email, password)` | yes | `dict` (account info) | `result: dict \| None = None` |
+| `jacLogin(email, password)` | yes | `bool` | `ok: bool = False` |
+| `jacLogout()` | no | `None` | - (call it, no assign) |
+| `jacIsLoggedIn()` | no | `bool` | - (use inline) |
+
+Both async helpers' return values are truthy on success / falsy on failure, so `if not result { ... }` works for both. But the **types** differ - typing a `jacSignup` result as `bool` fails `jac check` with `E1001: Cannot assign dict to bool`.
+
+## ⚠ Read first - signup + first `def:priv` call must be 3 awaited steps
+
+When the same form that signs a user up also calls a `def:priv` endpoint (saving the new user's profile, preferences, default workspace), the call order is **fixed and each step MUST be awaited**:
+
+1. `await jacSignup(email, password)` - creates the account; **no session yet**
+2. `await jacLogin(email, password)` - establishes the session cookie
+3. `await save_profile(...)` - only NOW does the `def:priv` call have an authenticated session
+
+```jac
+# `save_profile` here is YOUR server function (def:priv) - imported from a .sv.jac module.
+async def handle_register(name: str, email: str, password: str) -> str {
+    # Pre-declare every var that holds an `await` result. `let` scoping in the
+    # generated JS can otherwise leave them undefined at the if-check.
+    # Note the per-helper types: jacSignup -> dict, jacLogin -> bool.
+    signup_result: dict | None = None;
+    login_ok: bool = False;
+    profile_result: Any = None;
+
+    signup_result = await jacSignup(email, password);
+    if not signup_result { return "registration failed"; }
+
+    login_ok = await jacLogin(email, password);
+    if not login_ok { return "login after signup failed"; }
+
+    profile_result = await save_profile(name, email);
+    if profile_result is None { return "save failed"; }
+    if not profile_result.success { return profile_result.message; }
+
+    return "success";
+}
+```
+
+**Why every `await` matters:** all three are async (return Promises). Skipping any `await` fires that call as a background Promise and lets the next line execute immediately. If `save_profile` fires before `jacLogin` completes, the session cookie isn't set yet → server gets the request without auth → `401 Unauthorized`. **Silent at compile time - only surfaces at runtime on first registration.**
+
+**Why pre-declare:** in `.cl.jac`, `var = await fn()` can compile to a JS `let var = ...` that is scoped tighter than the surrounding function (especially around `try`/`except` and certain async patterns), so `if not var { ... }` on the next line throws `ReferenceError: var is not defined`. Declaring `var: T = default;` at the top forces a function-scope `let` that the if-check can see.
+
+---
+
+```jac
+import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn, Navigate }
+
+# Login attempt - call from a submit handler or effect. Returns a status string.
+# Pre-declare `ok` at the top - see "Why pre-declare" above.
+async def try_login(email: str, password: str) -> str {
+    ok: bool = False;
+    try {
+        ok = await jacLogin(email, password);
+        if ok {
+            return "success";
+        }
+        return "invalid credentials";
+    } except Exception as e {
+        return "error";
+    }
+}
+
+# Signup is usually followed by a login to establish the session.
+async def try_signup(email: str, password: str) -> str {
+    signup_result: dict | None = None;       # jacSignup returns dict
+    login_ok: bool = False;                  # jacLogin returns bool
+    try {
+        signup_result = await jacSignup(email, password);
+        if not signup_result {
+            return "signup failed (email may be in use)";
+        }
+        login_ok = await jacLogin(email, password);
+        if login_ok {
+            return "success";
+        }
+        return "login after signup failed";
+    } except Exception as e {
+        return "error";
+    }
+}
+
+# Logout is synchronous - no await.
+def perform_logout() -> None {
+    jacLogout();
+}
+
+# Typical protected page - inline guard at the top.
+def:pub Dashboard() -> JsxElement {
+    if not jacIsLoggedIn() {
+        return <Navigate to="/login" replace={True} />;
+    }
+    return <div className="p-4">Welcome to the dashboard</div>;
+}
+```
+
+## Auth-relevant `@jac/runtime` exports
+
+`jacLogin`, `jacSignup`, `jacLogout`, `jacIsLoggedIn`, plus `Navigate` / `useNavigate` for post-auth redirects. For the full client export list and the "compile-passes-build-fails" rule, see `jac-cl-components`.
+
+## Pitfalls
+
+- Import auth helpers from `@jac/runtime` - see `jac-core-cheatsheet` for import form rules.
+- Post-logout pattern: `jacLogout(); nav("/login");` - synchronous call, then navigate.
+- Post-login navigation uses `useNavigate()` from `jac-cl-routing` - `nav = useNavigate(); ... nav("/dashboard");` after a successful login.
+- **`jacSignup` does NOT establish a session.** ALWAYS follow with a `jacLogin` call using the same credentials - signup alone leaves the user unauthenticated.
+- **`jacLogin` and `jacSignup` are `async` - always `await`. `jacLogout` and `jacIsLoggedIn` are sync - NEVER `await` them.** `await jacLogout()` type-errors; missing `await` on `jacLogin` silently returns a coroutine instead of the result.
+- **Pre-declare any var that holds an `await` result before the assignment.** In `.cl.jac`, `var = await fn()` can compile to a JS `let var = ...` whose scope is tighter than the surrounding function, so a later `if not var { ... }` throws `ReferenceError: var is not defined` at runtime. Compile passes; the page just blanks. Fix: declare the var with a default at the top, then assign.
+
+```jac
+# FRAGILE - runtime ReferenceError on the if-check
+async def handle_login(email: str, password: str) -> str {
+    ok = await jacLogin(email, password);
+    if not ok { return "failed"; }      # ReferenceError: ok is not defined
+    return "success";
+}
+
+# CORRECT - function-scope let, visible to the if-check
+async def handle_login(email: str, password: str) -> str {
+    ok: bool = False;
+    ok = await jacLogin(email, password);
+    if not ok { return "failed"; }
+    return "success";
+}
+```

--- a/skills/jac-cl-components/SKILL.md
+++ b/skills/jac-cl-components/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: jac-cl-components
+description: Writing a client-side UI component - shape, reactive state, mount effects, rendering, event handlers. Load when creating or editing any `.cl.jac` file. Pair with `jac-cl-routing` (multi-page apps), `jac-cl-organization` (file layout & hooks), `jac-cl-auth` (protected pages).
+---
+
+`.cl.jac` files are client-side Jac. A component is a `def:pub` function returning `JsxElement`. State = `has` fields, which compile 1:1 to React `useState` - assign directly (`x = x + 1` re-renders; no `setX(...)` call) but all `useState` semantics apply: writes are async, the closure stays stale until the next render. Mount effects = `async can with entry` (compiles to `useEffect`). Event handlers = `def` methods typed with ambient DOM events (`MouseEvent`, `ChangeEvent`, `FormEvent`, `KeyboardEvent`). No `to cl:` header - the extension sets client context.
+
+```jac
+def:pub Counter() -> JsxElement {
+    has count: int = 0;
+    has label: str = "";
+
+    async can with entry {
+        count = 0;                               # mount effect - runs once
+    }
+
+    def handle_click(e: MouseEvent) -> None {
+        count = count + 1;
+    }
+
+    def handle_input(e: ChangeEvent) -> None {
+        label = e.target.value;                  # .target.value is typed via ChangeEvent
+    }
+
+    return <section className="p-4">
+        <input value={label} onChange={handle_input} />
+        <h1 className="text-xl">
+            {"Clicks: " + str(count) if count > 0 else "Start clicking!"}
+        </h1>
+        <button onClick={handle_click}>+</button>
+    </section>;
+}
+```
+
+## Props
+
+Components declare props as typed function params; callers pass as JSX attributes. Callback props are typed `Any`. Wrap incoming callbacks in a local handler so parent-side data (like a row's id) is closed over when the event fires.
+
+```jac
+def:pub BookCard(bookId: str, title: str, onDelete: Any) -> JsxElement {
+    def handle_delete(e: MouseEvent) -> None {
+        if onDelete { onDelete(bookId); }
+    }
+    return <div>{title} <button onClick={handle_delete}>X</button></div>;
+}
+```
+
+Call site: `<BookCard bookId={b["id"]} title={b["title"]} onDelete={remove} />`.
+
+## Event types (ambient, no import)
+
+| Handler | Type | Access |
+|---|---|---|
+| `onClick`, `onMouseDown`, `onDoubleClick` | `MouseEvent` | `e.clientX`, `e.button` |
+| `onChange` | `ChangeEvent` | `e.target.value` |
+| `onInput` | `InputEvent` | `e.target.value` |
+| `onKeyDown`, `onKeyUp`, `onKeyPress` | `KeyboardEvent` | `e.key`, `e.code` |
+| `onSubmit`, `onReset` | `FormEvent` | `e.preventDefault()` |
+| `onFocus`, `onBlur` | `FocusEvent` | `e.target` |
+
+Fall back to `Any` (capital, built-in) only when you don't read `e`.
+
+## Built-in in `.cl.jac` - NEVER import these
+
+`JsxElement` (the component return type), `Any`, and all DOM event types (`MouseEvent`, `ChangeEvent`, `FormEvent`, `KeyboardEvent`, `InputEvent`, `FocusEvent`) are Jac built-ins in client context. Trying `import from "@jac/runtime" { JsxElement }` is wrong and can fail the Vite build.
+
+## Imports from `@jac/runtime` (complete list)
+
+- **Routing components:** `Router`, `Routes`, `Route`, `Link`, `Navigate`, `Outlet`
+- **Routing hooks:** `useNavigate`, `useLocation`, `useParams`, `useRouter` (NO `useSearchParams`)
+- **Auth:** `jacLogin`, `jacSignup`, `jacLogout`, `jacIsLoggedIn`
+- **Validation / error boundary:** `JacSchema`, `JacClientErrorBoundary`
+- **DO NOT use:** `useState`, `useEffect` (aliases exist but `has` + `async can with entry` are idiomatic)
+
+## Pitfalls
+
+The first two bullets below are **silent runtime bugs** (⚠) - no compile error, no obvious failure mode at runtime. Read them every time.
+
+- ⚠ **Hooks + `has` BEFORE any conditional return.** React hooks must fire in the same order every render. `if not jacIsLoggedIn() { return <Navigate />; } has x: int = 0;` → white screen, no compile error.
+- ⚠ **Mount effects (`async can with entry`) fire even when the component returns `<Navigate>`.** Guard the EFFECT body with `if jacIsLoggedIn() { ... }`, not just the render - otherwise `def:priv` calls fire and return 401 silently.
+
+- **`has` fields are reactive state - assign directly.** `count = count + 1` re-renders. No `setCount`. Non-default fields come before defaulted ones (E2004 - see `jac-has-fields`).
+- **Derived values are locals, not `has` fields.** Anything computable from props/params/hook results gets recomputed every render - so it's a local. Putting it in `has` forces a top-level write to keep it in sync, which can cascade to React error #301. Rule: `has` is only for event-driven or async values (user input, fetch results, server data).
+
+```jac
+# FRAGILE - derived flag stored as state, written from render body
+has has_filter: bool = False;
+if useParams()["category"] { has_filter = True; }
+
+# CORRECT - derived flag is a plain local
+has_filter: bool = bool(useParams()["category"]);
+```
+
+- **Server RPC import uses `sv import from ..services.X { fn, Types }`** (prefix required). Dot count = how many folders up from THIS file to reach `services/` - for a `components/X.cl.jac` it's 2 dots, for `components/pages/X.cl.jac` it's 3 dots (see `jac-core-cheatsheet` for dot semantics). Plain `import from` to a `.sv.jac` breaks the Vite build. Include obj/node types too - they're needed to type your `has` state (next rule). See `jac-fullstack-patterns`.
+- **Type `has` state with the imported `sv` types - `list[Any]` loses the element type.** Store data from `sv import` calls in fields typed with the actual node/obj. Without it, attribute access in loops fails `E1032: Type is Unknown`.
+
+```jac
+sv import from ..services.linkedin { Post };   # 2 dots: this file is at components/X.cl.jac; `..` walks up to project root, then into services/
+
+# FRAGILE
+has posts: list[Any] = [];           # E1032 on p.title in any loop
+
+# CORRECT
+has posts: list[Post] = [];          # `p` in `for p in posts` is typed Post
+```
+
+- **Call server endpoints POSITIONAL, not kwargs.** `save(a, b)` works; `save(a=a, b=b)` sends empty body → 422. Also: the caller's variable names become the JSON keys - they must match the server parameter names exactly. See `jac-fullstack-patterns`.
+- **JSX ternary is Python-style:** `{X if cond else Y}`. NOT `{cond ? X : Y}` (parse error even inside JSX). Short-circuit also works: `{cond and <X />}`.
+- **Iterate with comprehensions, NOT `.map()`.** `items.map(...)` on a Jac list fails E1030. Use `[<li>...</li> for i in items]` inside JSX. `for i, x in enumerate(items)` parse-fails E0001 - use a single loop var, or `range(len(items))` with index access: `[<li key={str(i)}>{items[i]}</li> for i in range(len(items))]`.
+- **Dict / hook access (`useParams()[k]`, `useLocation()[k]`, generic `[key]`) returns `Any` and yields JS `undefined` for missing keys.** Since `undefined !== null` in JS, both `x is None` and `x is not None` MISS undefined - `params["id"] is not None` returns True even when `:id` isn't in the route, and `str(undefined)` produces the literal string `"undefined"`. **Use a truthy check (`if x` / `if not x`) for hook/dict values - it catches both `None` and `undefined`.** The narrowing-friendly `is not None` form is still correct for typed Optionals (`T | None` from `sv import`-ed functions, function params, etc.) where `undefined` can't appear. (Also: `params.get("id")` runtime-fails in the browser since `useParams` returns a plain JS object - always use `[key]`.)
+- **`T | None` narrowing doesn't reach inside JSX list comprehensions / short-circuits.** After `if x is None { return ...; }`, direct `x.attr` works in the function body - but `{[<li>{x.attr}</li> for i in range(len(x.attr))]}` inside JSX fails E1099 because the comprehension is its own scope. **Workaround:** pull each used attribute into a typed local *before* the JSX block (e.g. `title: str = x.title; parts: list[str] = x.parts;`), then reference the locals from JSX. See `jac-types` for the full BROKEN/CORRECT pair.
+- **Guard None/null/undefined when iterating or dotting into server data.** Runtime-only failure (`Cannot read properties of null/undefined`), nothing at compile. Four hot spots - single-level access is the most common:
+
+```
+# FRAGILE - crashes if the value is None/null
+total = result.total_posts;                            # result is None → crash (SINGLE-LEVEL)
+status = result.recipe.status;                         # result.recipe is None → crash (NESTED)
+rows = [<Card title={s["title"]} /> for s in songs];  # any s is None in list → crash
+first = songs[0]["title"];                             # empty list → crash
+
+# SAFE - narrow, filter, or length-check first
+if result is not None { total = result.total_posts; }
+if result.recipe is not None { status = result.recipe.status; }
+rows = [<Card ... /> for s in songs if s is not None];
+if len(songs) > 0 { first = songs[0]["title"]; }
+```
+
+Also works: short-circuit in JSX - `{result and <X total={result.total_posts} />}`.
+
+**For server response objects (dicts/lists from `sv import` calls), prefer truthy checks (`if result {`) over `!= None`.** The `!=` operator uses deep equality which calls `Object.keys()` - crashes with `"Cannot convert undefined or null to object"` if the value is `null`/`undefined`. `!= None` is safe for primitives (strings, ints, bools) but not for complex objects returned from server calls.
+
+- **Event params are typed - `MouseEvent`/`ChangeEvent`/etc.** `e: any` (lowercase) is the Python `any()` builtin, fails E1103. Use capital `Any` (no import) for untyped.
+- **`style` prop takes a `dict[str, object]`, not a CSS string.** `<div style="color: red">` fails E1103. Use inline dict `<div style={{"color": "red"}}>` or move styling to `className` + a CSS file.
+- **JSX uses `className`, curly-brace interpolation `{expr}`, camelCase events** (`onClick`, `onChange`).
+- **No `to cl:` / `cl def:pub` / `cl { }` in `.cl.jac` files.** Extension already sets context. Braced blocks are deprecated (W0064).
+- **Top-level component name is `def:pub app()`** - lowercase. Runtime mounts the literal name.
+
+## See also
+
+- `jac-cl-routing` - `Router`/`Route`/`Navigate`/`useNavigate` patterns
+- `jac-cl-auth` - `jacLogin`/`jacSignup`/`jacLogout`, signup→login→def:priv chain
+- `jac-cl-organization` - file layout, component reuse, hook pattern
+- `jac-core-cheatsheet` - imports, lambda, ternary, error handling

--- a/skills/jac-cl-organization/SKILL.md
+++ b/skills/jac-cl-organization/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: jac-cl-organization
+description: Structuring a multi-component client app - file layout, component reuse, hook pattern, domain-meaningful naming. Load before adding a new component, when a page file is growing, or when several components share state/fetching logic. Pair with `jac-cl-components` (what goes inside each file).
+---
+
+Two disciplines beyond single-component authoring: **reuse before creating** (scan `components/` first), and **extract shared state into a hook** (`def:pub useXxx()` under `hooks/`).
+
+## File layout
+
+```
+my-app/
+├── components/
+│   ├── Button.cl.jac          # reusable leaf - ONE component per file
+│   ├── ItemCard.cl.jac
+│   ├── ItemList.cl.jac        # composes ItemCard
+│   ├── Layout.cl.jac          # app shell
+│   └── pages/
+│       ├── AuthPage.cl.jac    # top-level route targets - thin orchestrators
+│       └── RecipesPage.cl.jac
+├── hooks/
+│   └── useItems.cl.jac        # shared data + handlers, `use` prefix
+└── lib/
+    └── utils.cl.jac           # pure helper fns (cn, formatDate)
+```
+
+## Hook pattern
+
+A hook is a `def:pub` function that owns reactive state + handlers and returns a dict. Consumers destructure the result with `[key]`.
+
+```jac
+node Item {
+    has name: str = "";
+}
+
+def:pub useItems() -> dict {
+    has items: list[Item] = [];
+    has loading: bool = True;
+
+    async can with entry {
+        loading = False;
+    }
+
+    def handle_add(new_item: Item) -> None {
+        items = items + [new_item];
+    }
+
+    return {
+        "items": items,
+        "loading": loading,
+        "handleAdd": handle_add,
+    };
+}
+```
+
+In a real hook, replace the local `Item` declaration with `sv import from ..services.todo { Item, get_items, add_item }` (2 dots = up one folder from `hooks/` into `services/`) and call those in `async can with entry` / handlers. See `jac-fullstack-patterns`.
+
+Consuming:
+
+```
+import from .hooks.useItems { useItems }
+
+def:pub ItemList() -> JsxElement {
+    data = useItems();
+    items = data["items"] or [];
+    if data["loading"] { return <p>Loading...</p>; }
+    return <ul>{[<li key={jid(i)}>{i.name}</li> for i in items if i is not None]}</ul>;
+}
+```
+
+## jac-shadcn project layout
+
+When the project has `components/ui/` (jac-shadcn primitives are pre-installed):
+
+```
+my-app/
+├── components/
+│   ├── ui/                        # ← primitives - import only, never edit
+│   │   ├── button.cl.jac
+│   │   ├── card.cl.jac
+│   │   └── ...                    # 50+ components
+│   ├── EventCard.cl.jac           # ← your composite components using primitives
+│   ├── EventList.cl.jac
+│   └── pages/
+│       └── EventsPage.cl.jac
+├── hooks/
+│   └── useEvents.cl.jac
+└── lib/
+    └── utils.cl.jac               # cn() - always import from here
+```
+
+Load `jac-shadcn-components` for the import patterns and full component selection table.
+
+## Rules
+
+- **In jac-shadcn projects, scan `components/ui/` before building any UI element.** If a primitive exists (Button, Card, Input, Badge, Dialog, Table, etc.), import it - do not re-implement it. Load `jac-shadcn-components` for the import syntax and composition rules.
+- **Never edit files in `components/ui/`.** These are managed by the jac-shadcn registry. Compose with them in `components/` files instead.
+- **Reuse before creating.** Scan `components/` and `components/pages/` before writing a new file. Duplicate UI = default mistake.
+- **One exported component per file**, basename matches export. `Button.cl.jac` → `Button`.
+- **PascalCase** for components + files: `UserCard.cl.jac`. `snake_case` for variables, handlers, hooks.
+- **Pages are thin orchestrators.** Read a hook, render a layout, pass data down. JSX > ~80 lines in a page = extract blocks into `components/`.
+- **Domain-meaningful names, not structural.** `CalculatorApp`, not `App`. `recipes_data`, not `data`. `services/recipes.sv.jac`, not `services/api.sv.jac`. Generic `Layout`/`App` only for the single top-level wrapper.
+- **Hook name = `use<DomainNoun>`** - `useRecipes`, `useAuth`. NOT `useData`, `useStuff`.
+- **Hooks live under `hooks/`, components under `components/`.** Don't mix.
+- **Hook return dicts use `[key]` access, not `.get()`** - see `jac-cl-components`.
+- **Don't call a hook from a non-component `def`.** `has` fields only wire up inside `def:pub` that renders JSX or inside another `useXxx()`.
+- **Extract to a hook when:** data involves async fetch, OR it's shared across ≥2 components, OR there are 3+ related handlers on the same state. Otherwise keep state inline in the component.
+
+## See also
+
+- `jac-cl-components` - single-component shape, state, events, JSX rules
+- `jac-fullstack-patterns` - cl→sv import rules inside hooks

--- a/skills/jac-cl-routing/SKILL.md
+++ b/skills/jac-cl-routing/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: jac-cl-routing
+description: Multi-page navigation on the client - defining routes, redirecting, and navigating between pages from handlers. Load when adding pages or multi-screen flows. Pair with `jac-cl-components` (the components being routed), `jac-cl-auth` (protected routes).
+---
+
+Client routing in Jac uses React-Router v6 primitives re-exported from `@jac/runtime`. `<Router>` wraps the app; `<Routes>` groups a list of `<Route>` entries; each `<Route path="..." element={<Page />}>` renders its element when the path matches. Redirects use `<Navigate to="..." />`. Imperative navigation from a handler uses `useNavigate()`. Protected pages guard themselves inline with `jacIsLoggedIn()`.
+
+```jac
+import from "@jac/runtime" { Navigate, jacIsLoggedIn, useNavigate }
+
+def:pub LoginPage() -> JsxElement {
+    nav = useNavigate();                 # imperative navigation - call nav("/dashboard") from a handler
+
+    def go_home(e: MouseEvent) -> None {
+        nav("/dashboard");
+    }
+
+    return <div className="p-4">
+        <button onClick={go_home}>home</button>
+    </div>;
+}
+
+def:pub DashboardPage() -> JsxElement {
+    # Protected route: inline guard. Components with no `has` / no hooks can
+    # put the guard at the top; components WITH hooks or `has` must put the
+    # guard AFTER those (see `jac-cl-components` rules-of-hooks pitfall).
+    if not jacIsLoggedIn() {
+        return <Navigate to="/login" replace={True} />;
+    }
+    return <div className="p-4">Dashboard</div>;
+}
+```
+
+## Router / Routes / Route wiring
+
+Typically in `AppShell.cl.jac` or `main.jac`.
+
+```
+import from "@jac/runtime" { Router, Routes, Route, Navigate }
+import from .pages.LoginPage { LoginPage }
+import from .pages.DashboardPage { DashboardPage }
+
+def:pub AppShell() -> JsxElement {
+    return <Router>
+        <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace={True} />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+        </Routes>
+    </Router>;
+}
+```
+
+## Routing-relevant `@jac/runtime` exports
+
+`Router`, `Routes`, `Route`, `Link`, `Navigate`, `Outlet`, `useNavigate`, `useLocation`, `useParams`, `useRouter`. For the full client export list, see `jac-cl-components`.
+
+## Pitfalls
+
+- `useNavigate()` returns a function. Use it imperatively in handlers: `nav = useNavigate(); ... nav("/target");`. NOT inside JSX attribute values.
+- **Use `<Link to="/path">label</Link>` for in-app navigation.** For programmatic navigation from a handler, use `useNavigate()` instead. NOT `<a href="/path">` - that triggers a full page reload and loses client state.
+- For querystrings, parse `useLocation().search` manually - there is no `useSearchParams` hook.
+- Protected-route guards with `has`/hooks above - see the hook-ordering rule in `jac-cl-components`.

--- a/skills/jac-cl-styling/SKILL.md
+++ b/skills/jac-cl-styling/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: jac-cl-styling
+description: Tailwind styling patterns in Jac - conditional classes, cn() utility with clsx+tailwind-merge, semantic color tokens. Load when writing dynamic or theme-aware styles.
+---
+
+## Conditional Classes
+
+Ternary is Python-style (`A if cond else B`). String concatenation for dynamic classes:
+
+```jac
+def:pub TabButton(active: bool, children: Any) -> JsxElement {
+    tab_cls = "border-primary text-foreground" if active else "border-transparent text-muted-foreground";
+    return <button className={"px-2.5 py-1.5 border-b-2 " + tab_cls}>{children}</button>;
+}
+```
+
+## cn() Utility (clsx + tailwind-merge)
+
+Handles conditional + merged Tailwind classes. Write in Jac - no TypeScript needed:
+
+```jac
+import from "clsx" { clsx }
+import from "tailwind-merge" { twMerge }
+
+def:pub cn(classes: list) -> Any {
+    return twMerge(clsx(classes));
+}
+```
+
+Required in `jac.toml`: `clsx = "*"` and `tailwind-merge = "*"` under `[dependencies.npm]`.
+
+> **jac-shadcn projects**: `lib/utils.cl.jac` already exports `cn()` - use `import from .lib.utils { cn }`. Don't recreate it and don't add these packages to jac.toml (pre-installed).
+
+Usage (import `cn` from `lib/utils.cl.jac`, then pass a list):
+
+```
+import from ...lib.utils { cn }
+
+className={cn(["base-class", props.className, "extra" if condition else ""])}
+```
+
+## Semantic Color Tokens
+
+Use semantic tokens - they adapt to themes and dark mode. Avoid hardcoded hex/gray values:
+
+```
+CORRECT:  text-foreground  bg-background  border-border
+          text-muted-foreground  bg-muted
+          text-primary  bg-primary  text-primary-foreground
+          text-destructive  bg-destructive/10
+
+AVOID:    text-gray-900  bg-white  border-gray-200  #3b82f6
+```

--- a/skills/jac-core-cheatsheet/SKILL.md
+++ b/skills/jac-core-cheatsheet/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: jac-core-cheatsheet
+description: Jac-language baseline - Reading this skill is a must. imports, control flow, lambdas, ternary, string formatting, error handling, top-level execution. Load for basic-syntax questions no specific skill covers.
+---
+
+**Jac is strict-typed.** Every `def` parameter and return, every `has` field, every typed local needs an explicit type - and the type checker is the authority. **Do NOT fall back to `Any` to silence a type error** - it suppresses real bugs AND cascades into the surrounding code (`Any + Any` rejects `+`, `len(Any)` rejects `Sized`, `Any.attr` fails E1032, etc.). When a value can be missing, declare it explicitly as `T | None` (e.g. `has recipe: Recipe | None = None;`) and guard with `if x is not None { ... }` before accessing attributes. Syntax-wise: Python-flavored, every block is `{ }`-braced, every statement ends with `;`, top-level code runs inside `with entry { ... }`.
+
+```jac
+import os;
+import from math { pi }
+
+
+def double(x: int) -> int {
+    return x * 2;
+}
+
+
+with entry {
+    name: str = "alice";
+    age: int = 30;
+    tags: list[str] = ["a", "b"];
+    meta: dict[str, int] = {"x": 1};
+    manager: str | None = None;
+
+    doubled: list[int] = [n * 2 for n in [1, 2, 3]];
+
+    label: str = "adult" if age >= 18 else "minor";   # ternary: A if cond else B
+
+    square = lambda(x: int) -> int { return x * x; }; # typed lambda with braces
+    print(square(5));
+
+    greeting = f"hello {name}, {len(tags)} tags";
+
+    for n in doubled {
+        if n > 4 {
+            print(f"big: {n}");
+        } elif n > 2 {
+            print(f"mid: {n}");
+        } else {
+            print(f"small: {n}");
+        }
+    }
+
+    try {
+        value = int("not-a-number");
+    } except ValueError as e {
+        print(f"parse error: {str(e)}");
+    }
+}
+```
+
+## Import forms
+
+**Plain `.jac` file imports:**
+
+```
+import os;                              # module - takes `;`
+import from byllm.lib { Model }         # selective - NO `;`
+import ".styles/global.css";            # file - takes `;`
+```
+
+**Client imports (inside `.cl.jac` files, or under `to cl:` in `main.jac`):**
+
+```
+import from .button { Button }                        # relative (dots)
+import from "@jac/runtime" { Router, Routes, Route }  # npm (quoted)
+```
+
+**`main.jac` is the one mixed-context file.** Server imports go at the top (server is the default context - no header needed). Then `to cl:` opens the client section: CSS import, top-level component, `def:pub app()`:
+
+```
+import from services.recipe { ApiResponse, save_profile }   # server: no leading dot
+cl import ".styles.global.css";                             # CSS: cl import prefix required
+to cl:
+import from .components.AppShell { AppShell }               # client: relative dots
+def:pub app() -> JsxElement { return <AppShell />; }
+```
+
+**Relative imports - what each dot means (Python-style):**
+
+Each leading `.` walks ONE folder up from the importing file's directory. Get this wrong and the import resolves to `<Unknown>` → cascading type errors across every use of the imported names. `sv import` carries the same dot semantics as regular `import`.
+
+```
+project_root/
+├── main.jac                          # no dots - services is at the same level: services.recipes
+├── services/recipes.sv.jac
+└── components/
+    ├── AppShell.cl.jac               # ..services.recipes  (up 1, into services)
+    └── pages/
+        └── DetailPage.cl.jac         # ...services.recipes (up 2, into services)
+```
+
+| Dots | Meaning | Use when |
+|---|---|---|
+| `services.X`   | project-root absolute  | importing file is AT the root (e.g. `main.jac`) |
+| `.services.X`  | same folder            | rare - `services/` is a sibling file in this same folder |
+| `..services.X` | one folder up          | importing file is one level deep (`components/X.cl.jac`) |
+| `...services.X`| two folders up         | importing file is two levels deep (`components/pages/X.cl.jac`) |
+
+If your file gets moved to a different depth, **the dot count must change** to match. Wrong dot count = silent import resolution failure = every imported name becomes `<Unknown>`.
+
+## Pitfalls
+
+- **Reserved keywords cannot be used as variable or parameter names: `entry`, `visit`, `disengage`, `report`, `spawn`, `with`, `can`, `has`.** Common mistake: using `entry` as a lambda parameter (e.g. in event handlers). To use a reserved keyword as an identifier, escape it with a backtick prefix: `` `entry` ``.
+- Type system (annotations, unions, optional `T | None`, `Any`, inference, type-error codes) - see `jac-types`.
+- Concatenating a string with an Exception fails - wrap with `str(e)`: `"error: " + str(e)`.
+- `import from X { Y };` fails with E0030. **Brace imports take NO trailing semicolon.** Plain module form `import X;` does.
+- Statements end with `;`; blocks use `{ }`. No significant indentation (Python-style).
+- Lambda requires types AND braces: `lambda(x: int) -> int { return x; }`. NOT `lambda x: x` (Python), `:x: x` (invented), or `<lambda x: x>` (invented) - all fail.
+- Ternary is **Python-style**: `A if cond else B`. NOT `cond ? A : B` (JS/C-style) - that's a parse error in Jac.
+- **Python stdlib needs explicit import - Jac auto-imports nothing.** `datetime.now()`, `os.environ`, `json.dumps`, `math.pi`, `random.randint`, etc. ALL need a top-of-file `import from <mod> { name }` or `import <mod>;` first. Common slip: using `datetime.now()` for `created_at` fields without `import from datetime { datetime }` → `NameError: name 'datetime' is not defined` at runtime.
+- **`import:py` does not exist in Jac.** Use `import from datetime { datetime }` or `import json;`. LLMs commonly hallucinate the `:py` suffix - it causes a parse error.

--- a/skills/jac-fullstack-patterns/SKILL.md
+++ b/skills/jac-fullstack-patterns/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: jac-fullstack-patterns
+description: Wiring `main.jac` as the entry for a fullstack Jac app - server-endpoint registration, client mount, and the `sv import` rules that tie `.cl.jac` to `.sv.jac`. Load when starting a new app, adding the FIRST server endpoint to a client-only app, creating a new `.sv.jac`, or debugging how the top-level pieces connect. Pair with `jac-sv-endpoints` (write the endpoints), `jac-cl-components` (write the UI), `jac-scaffold` (bootstrap a new project).
+---
+
+A fullstack Jac app has three files: `main.jac` (entry + registry), `services/*.sv.jac` (endpoints + types), `components/**/*.cl.jac` (UI). `main.jac` mixes contexts - server imports first (plain, no section header; server is the default), then `to cl:` opens the client section.
+
+```jac
+import from services.recipe {
+    ApiResponse, RecipePayload,
+    save_profile, list_recipes,
+}
+cl import ".styles.global.css";
+
+to cl:
+import from .components.AppShell { AppShell }
+
+def:pub app() -> JsxElement {
+    return <AppShell />;
+}
+```
+
+## Rules
+
+- **`main.jac` is the server's endpoint registry.** EVERY `.sv.jac` you create needs its functions AND obj/node types added to `main.jac`'s `import from services.X { ... }` block. Missing = `404 Not Found` on RPC calls.
+- **Adding a new endpoint is ALWAYS a 2-file change:** the `.sv.jac` service file + the import in `main.jac`. Especially easy to miss when extending a client-only app - no server import block existed before.
+- **In `main.jac`: plain `import from services.X { ... }`** (NEVER `sv import`). Plain = in-process Python import; the endpoint registers at `/function/<name>`.
+- **In `.cl.jac`: `sv import from ..services.X { ... }`** (prefix required). Generates the JS RPC stub. Plain `import from` to a `.sv.jac` fails the Vite build with `Could not resolve "services/X.js"`.
+- **`sv import` in `main.jac` = microservice RPC.** Spawns a separate provider server process; session cookies don't cross → `def:priv` fails with `401 Unauthorized`. Only use for actual microservices.
+- **Import obj/node TYPES alongside functions** in both places. Missing types → server `NameError` at runtime or lost typed attribute access on the client.
+- **Call server endpoints with POSITIONAL args, not kwargs.** `save_profile(name, email)` works; `save_profile(name=name, email=email)` sends empty body → `422 Field required`.
+- **Client entry is `def:pub app()`** - lowercase `app`. Not `App()`, `ClientApp()`. Runtime mounts the literal name.
+- **Start with `jac start --dev main.jac`** (background for hot reload). NOT `jac serve` (deprecated).
+- **HMR only reloads client (`.cl.jac`) files. Server (`.sv.jac`) changes need a full restart.** `def:pub`/`def:priv` endpoints + `glob` declarations evaluate once at server boot - editing a `.sv.jac` does not invalidate cached endpoints. `pkill -f "jac start"` then `jac start --dev main.jac` to pick up changes.
+- **Don't wrap the client entry in `with entry { ... }`.** Runtime mounts `def:pub app` directly.
+- **`cl { ... }` / `sv { ... }` braced blocks are deprecated (W0064).** Use `to cl:` section header; server is default context so no `to sv:` needed.
+- **In `sv import` RPC calls, the caller's local variable names are used as JSON keys - they must exactly match the server-side parameter names.** `get_moves(game_id, r, c)` sends `{"game_id":…, "r":…, "c":…}` but if the server signature is `def:pub get_moves(game_id: str, row: int, col: int)`, it gets 422 because `row` and `col` are missing. Rename caller variables: `get_moves(game_id, row, col)`.
+- **Kill old `jac start` processes before restarting.** If port 8001 is held by a stale process, the new server grabs 8002 but Vite's proxy still points at 8001 → all RPC calls fail. Use `pkill -f "jac start"` before restarting.
+
+## See also
+
+- `jac-scaffold` - project layout, `jac.toml`, scaffolders
+- `jac-sv-endpoints` - writing `def:pub` / `def:priv` endpoints
+- `jac-cl-components` - writing `.cl.jac` + the `sv import` caller form
+- `jac-core-cheatsheet` - import-form rules (brace vs module, when `;` applies)

--- a/skills/jac-has-fields/SKILL.md
+++ b/skills/jac-has-fields/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: jac-has-fields
+description: Declaring typed fields on any stateful Jac archetype - types, defaults, ordering, optional references. Load before defining any type that carries state.
+---
+
+`has` declares typed fields on every Jac archetype. Every field needs a type; defaults are optional. **All non-default fields must be declared before any defaulted field.** No `__init__` - build instances with constructor kwargs.
+
+```jac
+obj User {
+    has name: str;                      # required - REQUIRED fields come first
+    has age: int = 0;                   # defaulted fields come AFTER all required ones
+    has tags: list[str] = [];           # typed list
+    has meta: dict[str, str] = {};      # typed dict
+    has manager: User | None = None;    # optional reference
+}
+
+with entry {
+    alice = User(name="alice");
+    bob   = User(name="bob", age=30);
+    alice.tags.append("admin");
+    print(alice.name, alice.age, alice.tags);
+}
+```
+
+Same `has` syntax on `node`, `edge`, `walker` - only the archetype keyword changes.
+
+## Pitfalls
+
+- Field access is attribute-style: `user.name`, NOT `user["name"]`.
+- For optional references use `T | None` - see `jac-types` for the full type-system rules.
+- `has name;` is invalid - always `has name: type;`. Every field needs an explicit type.
+- **Non-default fields MUST come before default fields.** `has a: int = 0; has b: str;` fails with E2004. Reorder so every required field appears first - this is the #1 has-ordering bug, and the compiler error message is clear but the fix is easy to miss if you don't know the rule.

--- a/skills/jac-impl-files/SKILL.md
+++ b/skills/jac-impl-files/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: jac-impl-files
+description: Splitting an archetype's declarations from its method bodies into companion `.jac` and `.impl.jac` files. Load when a source file grows past ~150 lines, or to separate a clean public-API surface from implementation.
+---
+
+A `.jac` file declares fields, enums, method signatures. A sibling `.impl.jac` (same basename, same directory) supplies the bodies via `impl <name>` blocks. The compiler auto-pairs them - no `import` between them. The `impl` keyword also works in a plain `.jac` file; the split is a discipline, not a syntax requirement.
+
+Single-file form (declaration + impl together - runnable as-is):
+
+```jac
+import math;
+
+obj Shape {
+    has name: str;
+    def area -> float;
+}
+
+obj Circle(Shape) {
+    has radius: float;
+    override def area -> float;
+}
+
+impl Shape.area -> float {
+    return 0.0;
+}
+
+impl Circle.area -> float {
+    return math.pi * self.radius * self.radius;
+}
+
+with entry {
+    print(Circle(name="c", radius=5.0).area());
+}
+```
+
+Same code split: `shapes.jac` holds everything EXCEPT the two `impl` blocks; `shapes.impl.jac` holds them.
+
+## Declaration → matching impl forms
+
+| In `.jac` | In `.impl.jac` |
+|---|---|
+| `def fn_name;` | `impl fn_name { body }` |
+| `def fn_name(args) -> T;` | `impl fn_name(args) -> T { body }` |
+| `def Obj.method;` | `impl Obj.method { body }` |
+| `def Obj.method(args) -> T;` | `impl Obj.method(args) -> T { body }` |
+| `can event with NodeType entry;` | `impl Walker.event { body }` |
+| `enum Color;` | `impl Color { RED = "r", GREEN = "g" }` |
+| `override def method;` (subclass) | `impl Subclass.method { body }` |
+| `def method -> T abs;` (abstract) | (none on base - every subclass MUST `impl`) |
+
+## Rules
+
+- **Same basename, same directory.** `foo.jac` pairs with `foo.impl.jac` only if they sit together.
+- **No `import` between the pair.** Compiler auto-pairs. Adding `import from foo.impl { ... }` is wrong.
+- **Signature must match exactly.** `impl fn(x: int) -> str` paired with `def fn(y: str);` fails. Bare `impl fn { ... }` only matches bare `def fn;`.
+- **`abs` = abstract.** `def area -> float abs;` on the base means every subclass must `impl Subclass.area`. Missing impl fails at instantiation, not at compile.
+- **`override def` is required on subclass overrides.** Without it, `def play;` in a subclass is a NEW method that shadows - doesn't override.
+- **Bodies in `.impl.jac` see the `.jac` file's imports.** Don't re-import inside the impl file.

--- a/skills/jac-node-edge-patterns/SKILL.md
+++ b/skills/jac-node-edge-patterns/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: jac-node-edge-patterns
+description: Shaping the graph - the entities-and-relationships side of Object-Spatial Programming (OSP) in Jac. Defining nodes and edges, connecting them, and reading subsets by type or field. Load when modeling graph-persistent data, writing graph queries, or writing any OSP code. Pair with `jac-walker-patterns` (traversal logic over the graph).
+---
+
+Nodes are graph-persistent entities; edges are connections (plain or typed `edge` archetypes with `has` fields). Connect with arrow operators; read with list-comprehension references.
+
+```jac
+node Person {
+    has name: str;
+}
+
+edge Follows {
+    has since: int = 2024;
+}
+
+with entry {
+    alice = Person(name="alice");
+    bob   = Person(name="bob");
+    carol = Person(name="carol");
+
+    root ++> alice;                              # untyped connection
+    alice +>:Follows(since=2020):+> bob;           # typed connection with has fields
+    alice +>:Follows(since=2023):+> carol;
+
+    all_out     = [alice -->];                     # every outgoing node
+    via_follows = [alice ->:Follows:->];           # filter by edge type (single-arrow form)
+    typed_nodes = [root -->][?:Person];          # filter by node type
+    named_bob   = [alice -->][?name == "bob"];     # node-field predicate
+
+    print([n.name for n in all_out]);
+    print([n.name for n in via_follows]);
+    print([n.name for n in typed_nodes]);
+    print([n.name for n in named_bob]);
+}
+```
+
+## Pitfalls
+
+- Use `node` / `edge` for graph-persistent archetypes. Use `obj` for plain in-memory data that doesn't live on the graph.
+- `<++>` creates edges in BOTH directions - easy to double-count traversals. `<++` is just `++>` written from the other end (same single edge).
+- Typed edge creation uses `+>:E(args):+>` - `+` on BOTH sides of the colons.
+- Edge-type filter uses **single** arrows: `[src ->:E:->]`. The double-arrow form `[src -->:E:-->]` is a parse error.
+- **Edge-typed traversal returns `Unknown`-typed nodes - chain `[?:NodeType]` to recover the type.** `[src ->:E:->]` doesn't tell the type checker which node type the edge points to; downstream attribute access fails `E1053: Cannot assign <Unknown> to parameter ...`. Append the destination node type to narrow:
+
+```jac
+# FRAGILE - conn typed as Unknown; conn.username fails E1053
+for conn in [p ->:Connected:->] { print(conn.username); }
+
+# CORRECT - chain [?:NodeType] to narrow
+for conn in [p ->:Connected:->][?:UserProfile] { print(conn.username); }
+```
+
+- **Deleting edges:** the `del -->` disconnect operator is **untyped-only**. To delete a specific typed edge, query it with `[edge ...]` (single arrows) and iterate-del. `del [a ->:E:-> b];` and `a del-->:E: b;` both parse-fail.
+
+```jac
+# Untyped disconnect
+a del --> b;
+
+# Typed deletion - iterate edge objects and del each
+for e in [edge a ->:E:-> b] { del e; }
+
+# Delete a node (and all its edges)
+del node_var;
+```
+
+- A node needs `root` attachment (or a path from root) to be reachable later. A freshly constructed `Person(name="x")` with no incoming edge is unreachable from `[root -->]` reads - the node exists in memory but no walker or list-read can find it. Always attach: `root ++> person;`.

--- a/skills/jac-npm-packages/SKILL.md
+++ b/skills/jac-npm-packages/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: jac-npm-packages
+description: How to add npm packages to jac.toml and import them in .cl.jac files, including React hooks (useRef, useCallback, useMemo). Load when a task uses third-party npm libraries.
+---
+
+> **jac-shadcn projects** (has `[jac-shadcn]` in jac.toml): all npm packages are pre-configured - tailwindcss, radix-ui, clsx, tailwind-merge, hugeicons, recharts, and more. Do **NOT** add packages to `[dependencies.npm]` manually; they ship with the template.
+
+## Adding npm Packages
+
+Declare all packages in `jac.toml` before running `jac install`. Add under the correct section:
+
+- Regular deps: `[dependencies.npm]`
+- Dev deps (build tools): `[dependencies.npm.dev]`
+
+```toml
+[dependencies.npm]
+"sonner" = "^2.0.0"
+"recharts" = "^2.10.0"
+"clsx" = "*"
+"tailwind-merge" = "*"
+"@monaco-editor/react" = "^4.7.0"
+"@hugeicons/react" = "*"
+"@hugeicons/core-free-icons" = "*"
+"lucide-react" = "*"
+"radix-ui" = "^1.4.3"
+"class-variance-authority" = "^0.7.1"
+```
+
+## Import Syntax
+
+Package names in **double quotes**. Named imports only:
+
+```jac
+import from "sonner" { toast as sonnerToast, Toaster }
+import from "recharts" { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip }
+import from "@monaco-editor/react" { Editor }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { File02Icon, Cancel01Icon }
+import from "lucide-react" { Search, X, Menu, ChevronDown }
+import from "radix-ui" { Dialog as DialogPrimitive }
+import from "clsx" { clsx }
+import from "tailwind-merge" { twMerge }
+```
+
+## React Hooks (Direct Import)
+
+`has` = useState, `async can with entry` = useEffect. For others, import directly:
+
+```jac
+import from react { useRef, useCallback, useMemo, useContext }
+```
+
+**useRef** - DOM reference or mutable value without re-render. `jac check` reports E1032 on `.current` access - known type-stub gap for `useRef`'s return type; works correctly at runtime:
+
+```
+import from react { useRef }
+
+def:pub TextInput() -> JsxElement {
+    inputRef: Any = useRef(None);
+    def handle_click(e: MouseEvent) -> None {
+        if inputRef.current { inputRef.current.focus(); }
+    }
+    return <div>
+        <input ref={inputRef} type="text" />
+        <button onClick={handle_click}>Focus</button>
+    </div>;
+}
+```
+
+**useCallback** - stable function reference (same `.current` caveat applies):
+
+```
+import from react { useRef, useCallback }
+
+def:pub FileUploader() -> JsxElement {
+    fileInputRef: Any = useRef(None);
+    triggerPicker: Any = useCallback(lambda -> None {
+        if fileInputRef.current { fileInputRef.current.click(); }
+    }, []);
+    return <div>
+        <input ref={fileInputRef} type="file" style={{"display": "none"}} />
+        <button onClick={triggerPicker}>Upload</button>
+    </div>;
+}
+```
+
+**Mixing with Jac sugar** - freely allowed in the same component (same `.current` caveat applies):
+
+```
+import from react { useRef }
+
+def:pub SearchBox() -> JsxElement {
+    has query: str = "";
+    inputRef: Any = useRef(None);
+    async can with [query] entry {
+        if inputRef.current { inputRef.current.focus(); }
+    }
+    return <div><input value={query} /></div>;
+}
+```

--- a/skills/jac-scaffold/SKILL.md
+++ b/skills/jac-scaffold/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: jac-scaffold
+description: Bootstrapping a new Jac project - how to use `jac create --use <template>`, what each template lays out on disk, how to fix the deprecated syntax it ships with, and the post-scaffold checklist. Load when starting a new project from scratch. Pair with `jac-fullstack-patterns` when building fullstack.
+---
+
+Use the Jac CLI's `jac create` to scaffold new projects. Run it via `run_command(...)`. JacCoder no longer ships its own scaffolder - `jac create` is the single source of truth and stays current with Jac releases.
+
+## `jac create` - the only scaffolder
+
+```
+jac create myapp                       # default: empty backend project
+jac create myapp --use client          # client-only template
+jac create myapp --use fullstack       # fullstack template
+jac create myapp --use ./local.jacpack # from a local jacpack archive
+jac create --use https://.../t.jacpack # from a URL
+jac create --list_jacpacks             # list available templates
+```
+
+Always pass an explicit project name - without one, `jac create` falls back to `jactastic`, `jactastic1`, etc.
+
+## Templates and what each lays out
+
+| `--use <template>` | When to pick it | What ships |
+|---|---|---|
+| (omitted) | Pure REST/RPC backend, no UI | `main.jac` (with node + `def:pub` endpoints), `jac.toml` |
+| `client` | Pure client app, no server data | `main.jac`, `components/`, `lib/utils.cl.jac`, `styles/global.css`, `jac.toml` |
+| `fullstack` | Client UI + server endpoints + auth | `main.jac` (server imports + `to cl:` + `def:pub app()`), `services/*.sv.jac`, `hooks/*.cl.jac`, `components/`, `lib/utils.cl.jac`, `styles/global.css`, `jac.toml` |
+
+The fullstack layout matches `jac-fullstack-patterns`: server imports plain at the top of `main.jac`, `to cl:` opens the client section, services in `services/*.sv.jac`, hooks call them with `sv import from`.
+
+## Always do this before scaffolding
+
+`jac create` will create a subdirectory at `cwd/<name>` (or `<directory>/<name>` if you pass one). It does NOT detect or refuse if a Jac project already exists nearby - you'll silently nest a new project inside an existing one.
+
+Before running `jac create`:
+
+1. `list_files(workspace)` - see what's already there
+2. If `jac.toml` is present at the workspace root, **do NOT scaffold a new project** - extend the existing one with `write_code` / `edit_code` instead
+3. If the workspace is empty, then `jac create` is safe
+
+When called by JacBuilder or any IDE harness, the workspace usually already has a project. Scaffolding into it creates a nested mess. Read first.
+
+## Adapt the output - `jac create` ships deprecated syntax
+
+`jac create --use fullstack` (and `--use client`) generate code with the old `cl { ... }` / `sv { ... }` braced blocks. These trigger W0064 and will not work going forward. After scaffolding:
+
+1. Open `main.jac`
+2. Replace `cl { ... }` blocks with a `to cl:` section header
+3. Replace `sv { ... }` blocks with a `to sv:` section header
+4. Replace any `cl import …` / `sv import …` prefixes with plain `import from …` (server) or move under `to cl:` (client)
+
+See `jac-fullstack-patterns` for the canonical `main.jac` shape after this fix.
+
+## Post-scaffold checklist
+
+After `jac create`:
+
+1. `cd <project>`
+2. Adapt `cl { }` / `sv { }` blocks (see above) - fix deprecated syntax before running anything
+3. Add any additional npm deps to `jac.toml` (see `jac-npm-packages` skill for format)
+4. `jac install` - run after all jac.toml changes are final
+5. `jac start --dev main.jac` (background, for hot reload). NOT `jac serve` (deprecated).
+
+## Pitfalls
+
+- **Don't hand-write `jac.toml`.** Generate it via `jac create`. For Tailwind setup, follow Build Workflow step 4 for the exact jac.toml format. Load `jac-cl-styling` for styling patterns.
+- **Match the template to the user's actual need.** Picking `fullstack` for a UI-only spike adds unused server scaffolding; picking `client` for an app that needs persistence forces a later migration.
+- **Don't scaffold into a non-empty workspace.** Run `list_files` first; if a project exists, extend it.
+- **`-s` / `--skip` on `jac create --use client`** skips npm install - convenient for offline scaffolding, but you'll need `jac install` before running.
+- **Project-name argument is optional but defaults to `jactastic`.** Always pass an explicit name.

--- a/skills/jac-shadcn-components/SKILL.md
+++ b/skills/jac-shadcn-components/SKILL.md
@@ -1,0 +1,342 @@
+---
+name: jac-shadcn-components
+description: Using pre-installed jac-shadcn primitives from components/ui/ - import patterns, component selection, composition rules, styling, icons, theming. Load when generating components for a project that has components/ui/ or a [jac-shadcn] section in jac.toml. Pair with jac-cl-components (component shape) and jac-cl-organization (file layout).
+---
+
+When `components/ui/` already exists in the project, **never re-implement any primitive** (Button, Card, Input, Dialog, Table, Badge, etc.). Import and compose from those files. Your job is to build **high-level page/feature components** using these primitives.
+
+## Import patterns
+
+```jac
+# Primitive components - path is always .components.ui.<filename-without-ext>
+import from .components.ui.button { Button }
+import from .components.ui.card { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
+import from .components.ui.dialog { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogFooter }
+import from .components.ui.badge { Badge }
+import from .components.ui.table { Table, TableHeader, TableBody, TableRow, TableHead, TableCell }
+import from .components.ui.input { Input }
+import from .components.ui.select { Select, SelectTrigger, SelectContent, SelectGroup, SelectItem, SelectValue }
+import from .components.ui.tabs { Tabs, TabsList, TabsTrigger, TabsContent }
+import from .components.ui.spinner { Spinner }
+import from .components.ui.skeleton { Skeleton }
+import from .components.ui.field { Field, FieldLabel, FieldGroup, FieldContent, FieldError }
+import from .components.ui.label { Label }
+
+# cn() utility - always from lib/utils, not from @jac/runtime
+import from .lib.utils { cn }
+
+# Icons - HugeIcons only
+cl import from "@hugeicons/react" { HugeiconsIcon }
+cl import from "@hugeicons/core-free-icons" { SearchIcon, Add01Icon, Cancel01Icon, Menu01Icon }
+```
+
+## Component selection
+
+| Need | Component(s) |
+|------|-------------|
+| Button / action | `Button` - variants: `default`, `outline`, `ghost`, `destructive`, `secondary`, `link` |
+| Text field | `Input` |
+| Multi-line text | `Textarea` |
+| Dropdown select | `Select` + `SelectTrigger` + `SelectContent` + `SelectGroup` + `SelectItem` + `SelectValue` |
+| Searchable dropdown | `Combobox` |
+| Native `<select>` | `NativeSelect` |
+| Toggle / check | `Switch`, `Checkbox`, `RadioGroup` |
+| 2–5 option toggle | `ToggleGroup` + `ToggleGroupItem` (never a Button loop) |
+| Form field layout | `Field` + `FieldLabel` (never raw div with `space-y-*`) |
+| Form group / fieldset | `FieldGroup`, `FieldSet`, `FieldLegend` |
+| Input with prefix/suffix | `InputGroup` + `InputGroupAddon` + `InputGroupInput` |
+| Data table | `Table` + `TableHeader` + `TableBody` + `TableRow` + `TableHead` + `TableCell` |
+| Data card | `Card` + `CardHeader` + `CardTitle` (+ optional `CardDescription`, `CardContent`, `CardFooter`) |
+| Status label | `Badge` |
+| User avatar | `Avatar` + `AvatarImage` + `AvatarFallback` |
+| Navigation tabs | `Tabs` + `TabsList` + `TabsTrigger` + `TabsContent` |
+| Accordion | `Accordion` + `AccordionItem` + `AccordionTrigger` + `AccordionContent` |
+| Breadcrumb | `Breadcrumb` + `BreadcrumbList` + `BreadcrumbItem` + `BreadcrumbLink` |
+| Modal | `Dialog` + `DialogTrigger` + `DialogContent` + `DialogHeader` + `DialogTitle` |
+| Side panel | `Sheet` + `SheetTrigger` + `SheetContent` + `SheetHeader` + `SheetTitle` |
+| Confirmation | `AlertDialog` + `AlertDialogTrigger` + `AlertDialogContent` + `AlertDialogTitle` + `AlertDialogAction` + `AlertDialogCancel` |
+| Dropdown menu | `DropdownMenu` + `DropdownMenuTrigger` + `DropdownMenuContent` + `DropdownMenuGroup` + `DropdownMenuItem` |
+| Right-click menu | `ContextMenu` + `ContextMenuTrigger` + `ContextMenuContent` + `ContextMenuGroup` + `ContextMenuItem` |
+| Horizontal menu bar | `Menubar` + `MenubarMenu` + `MenubarTrigger` + `MenubarContent` + `MenubarItem` |
+| Tooltip | `Tooltip` + `TooltipTrigger` + `TooltipContent` |
+| Floating panel | `Popover` + `PopoverTrigger` + `PopoverContent` |
+| Hover detail card | `HoverCard` + `HoverCardTrigger` + `HoverCardContent` |
+| Loading skeleton | `Skeleton` |
+| Loading spinner | `Spinner` |
+| Empty state | `Empty` |
+| Alert / banner | `Alert` + `AlertTitle` + `AlertDescription` |
+| Progress bar | `Progress` |
+| Date picker | `Calendar` |
+| Slider | `Slider` |
+| Chart | `Chart` (wraps Recharts) |
+| Scrollable container | `ScrollArea` |
+| Divider | `Separator` |
+| Command palette | `Command` + `CommandInput` + `CommandList` + `CommandItem` |
+| Grouped buttons | `ButtonGroup` + `ButtonGroupSeparator` |
+| App shell navigation | `Sidebar` (⚠ never pass `className` to `Sidebar*` sub-components - className spread bug; wrap with `<div>` instead) |
+| Top navigation | `NavigationMenu` + `NavigationMenuList` + `NavigationMenuItem` + `NavigationMenuTrigger` + `NavigationMenuContent` |
+| Expandable section | `Collapsible` + `CollapsibleTrigger` + `CollapsibleContent` |
+| Drag-resize panels | `Resizable` + `ResizablePanelGroup` + `ResizablePanel` + `ResizableHandle` |
+| Page navigation | `Pagination` + `PaginationContent` + `PaginationItem` + `PaginationPrevious` + `PaginationNext` |
+| Image/content carousel | `Carousel` + `CarouselContent` + `CarouselItem` + `CarouselPrevious` + `CarouselNext` |
+| Keyboard key display | `Kbd` |
+| One-time password input | `OTPInput` |
+| Generic list item | `Item` |
+
+## Composition rules
+
+Violations cause accessibility errors or runtime white screens.
+
+- **`Dialog`, `Sheet`, `Drawer` always need a title.** Use `<DialogTitle className="sr-only">...</DialogTitle>` if visually hidden.
+- **Full Card composition:** `CardHeader` → `CardTitle` (+ optional `CardDescription`) → `CardContent` → optional `CardFooter`. Never bare `<Card>` with raw text children.
+- **`SelectItem` inside `SelectGroup`.** Same for `DropdownMenuItem` → `DropdownMenuGroup`, `ContextMenuItem` → `ContextMenuGroup`.
+- **`TabsTrigger` inside `TabsList`.** `TabsList` inside `Tabs`.
+- **`Avatar` always needs `AvatarFallback`** - shown when image fails to load.
+- **`AlertDialog` requires both `AlertDialogAction` and `AlertDialogCancel`** in the footer.
+- **`ButtonGroup` uses nested `<ButtonGroup>` for gaps** between sections; `<ButtonGroupSeparator>` for subtle 1px dividers only.
+- **`Field` + `FieldLabel` for form fields** - never raw `<div className="flex flex-col gap-2">` with a plain `<label>`.
+
+## Styling rules
+
+- **Semantic colors only.** `bg-primary`, `text-muted-foreground`, `border-border`, `bg-card`. Never `bg-blue-500`, `text-gray-600`.
+- **No `space-x-*` or `space-y-*`.** Use `flex gap-*` or `flex flex-col gap-*`.
+- **Equal width + height → `size-*`.** `size-10` not `w-10 h-10`.
+- **No `dark:` overrides.** CSS variables handle light/dark automatically.
+- **`cn()` always from `.lib.utils`** - never recreate it, never from `@jac/runtime`.
+
+Load `jac-cl-styling` for full conditional class patterns and cn() usage.
+
+## Icon pattern
+
+```jac
+import from .components.ui.button { Button, buttonVariants }
+import from .components.ui.dropdown_menu { DropdownMenuTrigger }
+cl import from "@hugeicons/react" { HugeiconsIcon }
+cl import from "@hugeicons/core-free-icons" { Add01Icon, SearchIcon, MoreVerticalIcon }
+
+# Inline icon
+def:pub InlineIconExample() -> JsxElement {
+    return <HugeiconsIcon icon={SearchIcon} strokeWidth={2} className="size-4" />;
+}
+
+# Icon-only button
+def:pub IconButtonExample() -> JsxElement {
+    return <Button size="icon">
+        <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+    </Button>;
+}
+
+# Radix trigger - no forwardRef, apply buttonVariants() directly
+def:pub RadixTriggerExample() -> JsxElement {
+    return <DropdownMenuTrigger className={buttonVariants().call(None, {"variant": "ghost", "size": "icon"})}>
+        <HugeiconsIcon icon={MoreVerticalIcon} strokeWidth={2} className="size-4" />
+    </DropdownMenuTrigger>;
+}
+```
+
+## Theming
+
+All theming after project initialization is done by **editing `styles/global.css` directly**. The `[jac-shadcn]` fields in `jac.toml` (`style`, `baseColor`, `theme`, `font`, `radius`, etc.) were only used during project scaffolding - changing them post-init has no effect.
+
+> **Style is fixed.** The visual style (nova/vega/maia/lyra/mira) is baked into the component `.cl.jac` files at template creation time and cannot be changed mid-project. The fullstack template ships with `nova`.
+
+### Changing colors
+
+Edit CSS variables in `styles/global.css` using OKLCH format (`oklch(lightness chroma hue)`):
+
+```css
+:root {
+    --primary: oklch(0.852 0.199 91.936);
+    --primary-foreground: oklch(0.421 0.095 57.708);
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+}
+.dark {
+    --primary: oklch(0.795 0.184 86.047);
+    --primary-foreground: oklch(0.421 0.095 57.708);
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+}
+```
+
+Key color variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `--background` / `--foreground` | Page background and default text |
+| `--primary` / `--primary-foreground` | Primary buttons and actions |
+| `--secondary` / `--secondary-foreground` | Secondary actions |
+| `--muted` / `--muted-foreground` | Muted/disabled states |
+| `--accent` / `--accent-foreground` | Hover and accent states |
+| `--destructive` | Error and destructive actions |
+| `--card` / `--card-foreground` | Card surfaces |
+| `--border` | Default border color |
+
+### Changing border radius
+
+Edit `--radius` in `styles/global.css`. All components derive from it:
+
+```css
+:root { --radius: 0.5rem; }  /* try 0.25rem (sharp) to 1rem (pill) */
+```
+
+| Tailwind class | Derived value |
+|---|---|
+| `rounded-sm` | `calc(var(--radius) - 4px)` |
+| `rounded-md` | `calc(var(--radius) - 2px)` |
+| `rounded-lg` | `var(--radius)` |
+| `rounded-xl` | `calc(var(--radius) + 4px)` |
+
+### Changing the font
+
+The template ships with Figtree. To switch fonts, make two changes:
+
+1. In `jac.toml` `[dependencies.npm]` - replace the font package (old one can be removed since it's no longer imported):
+
+```toml
+# remove: "@fontsource-variable/figtree" = "*"
+"@fontsource-variable/inter" = "*"
+```
+
+1. In `styles/global.css` - replace the import and update `--font-sans` in the `@theme inline` block:
+
+```css
+/* replace */
+@import "@fontsource-variable/figtree";
+/* with */
+@import "@fontsource-variable/inter";
+
+/* in @theme inline, replace */
+--font-sans: 'Figtree Variable', sans-serif;
+/* with */
+--font-sans: 'Inter Variable', sans-serif;
+```
+
+Common packages: `inter`, `outfit`, `raleway`, `nunito`, `plus-jakarta-sans`, `geist`. Font family name = package name in title case + " Variable" (e.g. `plus-jakarta-sans` → `'Plus Jakarta Sans Variable'`). No need to run `jac install` manually - it runs automatically before `jac start --dev`.
+
+### Changing sidebar/menu colors
+
+`menuAccent` and `menuColor` were baked into `--sidebar-*` CSS variables in `global.css`. Edit them directly:
+
+```css
+:root {
+    --sidebar: oklch(0.985 0 0);                            /* sidebar background */
+    --sidebar-foreground: oklch(0.145 0 0);                 /* sidebar text */
+    --sidebar-primary: oklch(0.646 0.222 41.116);           /* active item background */
+    --sidebar-primary-foreground: oklch(0.98 0.016 73.684); /* active item text */
+    --sidebar-accent: oklch(0.97 0 0);                      /* hover background */
+    --sidebar-accent-foreground: oklch(0.205 0 0);          /* hover text */
+    --sidebar-border: oklch(0.922 0 0);
+}
+.dark {
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    /* ... same pattern */
+}
+```
+
+### Adding custom colors
+
+Define in `global.css` `:root`/`.dark` blocks, then register in the `@theme inline` block. Never create a new CSS file.
+
+```css
+/* 1. global.css - define */
+:root { --warning: oklch(0.84 0.16 84); --warning-foreground: oklch(0.28 0.07 46); }
+.dark { --warning: oklch(0.41 0.11 46); --warning-foreground: oklch(0.99 0.02 95); }
+
+/* 2. global.css - register */
+@theme inline { --color-warning: var(--warning); --color-warning-foreground: var(--warning-foreground); }
+```
+
+```jac
+def:pub WarningAlert() -> JsxElement {
+    return <div className="bg-warning text-warning-foreground">Warning</div>;
+}
+```
+
+## Complete example
+
+```jac
+import from .components.ui.card { Card, CardHeader, CardTitle, CardContent }
+import from .components.ui.button { Button }
+import from .components.ui.badge { Badge }
+import from .components.ui.table { Table, TableHeader, TableBody, TableRow, TableHead, TableCell }
+import from .components.ui.dialog { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle }
+import from .components.ui.spinner { Spinner }
+import from .lib.utils { cn }
+cl import from "@hugeicons/react" { HugeiconsIcon }
+cl import from "@hugeicons/core-free-icons" { Add01Icon }
+
+def:pub EventListPage() -> JsxElement {
+    has events: list = [];
+    has loading: bool = True;
+
+    async can with entry {
+        # sv import RPC call goes here
+        loading = False;
+    }
+
+    if loading {
+        return <div className="flex items-center justify-center p-8">
+            <Spinner />
+        </div>;
+    }
+
+    return <div className="flex flex-col gap-6 p-6">
+        <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-semibold">Events</h1>
+            <Dialog>
+                <DialogTrigger asChild={True}>
+                    <Button>
+                        <HugeiconsIcon icon={Add01Icon} strokeWidth={2} className="size-4" />
+                        New Event
+                    </Button>
+                </DialogTrigger>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Create Event</DialogTitle>
+                    </DialogHeader>
+                </DialogContent>
+            </Dialog>
+        </div>
+        <Card>
+            <CardHeader>
+                <CardTitle>Upcoming Events</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Status</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {[<TableRow key={e["id"]}>
+                            <TableCell>{e["name"]}</TableCell>
+                            <TableCell>
+                                <Badge variant="outline">{e["status"]}</Badge>
+                            </TableCell>
+                        </TableRow> for e in events if e != None]}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    </div>;
+}
+```
+
+## Rules
+
+- **Never re-implement a primitive.** `components/ui/` has Button, Card, Input, Dialog, Table, etc. Import them; don't write them.
+- **Import path formula:** `import from .components.ui.<filename-without-extension> { ExportedName }`. Filenames match component names: `button.cl.jac` → `Button`, `card.cl.jac` → `Card, CardHeader, ...`.
+- **`cn()` always from `.lib.utils`**, not from `@jac/runtime` or anywhere else. It's pre-implemented - don't recreate it.
+- **Build high-level components in `components/`** (e.g., `EventCard.cl.jac`, `EventsPage.cl.jac`) that compose the primitives. Never add page logic to `components/ui/` files.
+- **Do NOT recreate or edit `global.css` or `jac.toml`** in jac-shadcn projects - they are pre-configured. To change theme, edit CSS variables in `global.css` directly.
+
+## See also
+
+- `jac-cl-components` - component shape, `has` state, event handlers, JSX rules
+- `jac-cl-organization` - file layout, hook pattern, when to extract
+- `jac-cl-styling` - conditional classes, cn() usage, semantic color tokens
+- `jac-npm-packages` - note: in jac-shadcn projects all npm packages are pre-installed

--- a/skills/jac-sv-auth/SKILL.md
+++ b/skills/jac-sv-auth/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: jac-sv-auth
+description: The server-side auth model - deciding which endpoints are public versus authenticated, and isolating data per user. Load when deciding which server functions need login or whose data they should see. Pair with `jac-sv-endpoints` (endpoint visibility), `jac-cl-auth` (client side of the auth loop).
+---
+
+Jac's server auth model is **isolation, not access control**. There's no explicit user id to check - the runtime handles login via `@jac/runtime` client helpers (`jacLogin`, etc.) and then routes each user's queries to their own subgraph. You pick the endpoint prefix; the runtime does the rest.
+
+- **`def:pub`** - anonymous. Anyone can call. `root` is the **shared global graph** - every caller sees the same data.
+- **`def:priv`** - authenticated. Requires login. `root` is the **current user's isolated subgraph** - same code, different data per caller.
+- **Client calls to `def:priv` without a session** throw `UNAUTHORIZED`; the client catches and redirects to `/login` (see `jac-cl-auth`).
+
+```jac
+node Todo {
+    has title: str;
+}
+
+
+# PUBLIC - shared root, everyone sees the same data.
+def:pub total_public_todos() -> int {
+    return len([root -->][?:Todo]);
+}
+
+
+# PRIVATE - per-user root, each caller sees only their own data.
+# Same query code, different subgraph per user.
+def:priv my_todos() -> list[Todo] {
+    return [root -->][?:Todo];
+}
+
+def:priv add_todo(title: str) -> Todo {
+    return (root ++> Todo(title=title))[0];
+}
+```
+
+For full CRUD shapes (update / toggle / delete + typed returns + async), see `jac-sv-endpoints`.
+
+## Pitfalls
+
+- `def:pub` and `def:priv` can live in the **same file** - visibility is per-function, not per-module.
+- On the client side, a call to a `def:priv` endpoint without a valid session raises an error containing `"UNAUTHORIZED"`. Wrap in try/except and redirect to login - see `jac-cl-auth`.
+- There is **no `current_user()` helper**. User identity is implicit in which `root` the endpoint sees. Store per-user metadata (preferences, roles) on nodes reachable from that user's `root` and read it inside `def:priv` endpoints.
+- **`walker:pub`** is a third endpoint flavor for complex traversal-style queries. The client calls it and reads `result.reports`. Niche - prefer `def:pub` / `def:priv` first.
+- **Shared `root` on `def:pub` = shared data - wrong visibility = silent data-leak.** Writing user-specific data (e.g. a user's notes) from a `def:pub` endpoint puts it in the global graph; *every other user calling the same endpoint reads it back*. NO compile error, NO runtime error - only surfaces when User B sees User A's data. If the endpoint writes user-specific data it **must** be `def:priv` (per-user-isolated root). Verify: log in as two different users; if reads from one show the other's data, the visibility is wrong.

--- a/skills/jac-sv-endpoints/SKILL.md
+++ b/skills/jac-sv-endpoints/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: jac-sv-endpoints
+description: Writing server-side functions the client can call - endpoint visibility, typed responses, and the basic create/read/update/delete shape. Load before writing any backend function callable from the client. Pair with `jac-sv-persistence` (graph queries inside endpoint bodies), `jac-sv-auth` (def:pub vs def:priv).
+---
+
+Server endpoints are functions the client invokes as RPC. They live at the top of `main.jac` or in a `.sv.jac` module. Three prefixes control visibility:
+
+- **`def:pub`** - public endpoint. Anyone can call. Use for unauthenticated data (public feeds, listings).
+- **`def:priv`** - private endpoint. Requires login; each user gets their own isolated `root`. Use for per-user data.
+- **`def`** (no prefix) - internal helper. Not client-callable. Use for logic shared between endpoints.
+
+Return types auto-serialize: node archetypes, primitives, `list[T]`, `dict`, `T | None`.
+
+```jac
+node Item {
+    has title: str;
+    has done: bool = False;
+}
+
+
+# Public - anyone can call.
+def:pub list_items() -> list[Item] {
+    return [root -->][?:Item];
+}
+
+def:pub add_item(title: str) -> Item {
+    return (root ++> Item(title=title))[0];
+}
+
+def:pub toggle_item(id: str) -> Item | None {
+    for i in [root -->][?:Item] {
+        if jid(i) == id {
+            i.done = not i.done;
+            return i;
+        }
+    }
+    return None;
+}
+
+def:pub delete_item(id: str) -> bool {
+    for i in [root -->][?:Item] {
+        if jid(i) == id {
+            del i;
+            return True;
+        }
+    }
+    return False;
+}
+
+
+# Private - requires login; root is the current user's subgraph.
+def:priv get_my_items() -> list[Item] {
+    return [root -->][?:Item];
+}
+
+
+# Internal helper (plain def) - callable from endpoints above, NOT from the client.
+def compute_age(item: Item) -> int {
+    return len(item.title);
+}
+```
+
+## Pitfalls
+
+- `async def:pub` is required when the endpoint uses `await` (external API calls, LLM endpoints). Missing `async` on a body that awaits is a parse/type error.
+- To delete a node: `del node;` - removes it and all its edges from the graph. Run it inside a loop that matches the id; don't try to pass nodes by reference from the client.
+- Every client-callable endpoint needs an explicit return type. `def:pub add_item(title: str)` with no `-> T` is an error.
+- **Return type IS the wire format.** Client gets dot access when you return typed nodes/objs (`list[Item]` → `items[0].title`). Returning raw `dict` or `list` loses typing on the client side.
+- `def:pub` = public endpoint (anonymous), `def:priv` = authenticated endpoint (per-user), plain `def` = internal helper (not client-callable). See `jac-sv-auth` for the full auth-model semantics.
+- **Use `jid(node)` for cross-RPC node identity; `id(node)` silently breaks lookups.** `id()` returns Python's in-memory address, which changes every server restart AND differs across worker processes - a lookup `for n in [root -->] { if id(n) == client_id { ... } }` returns no match every time, no error, just empty results. Use `jid(node)` (returns a stable persistent string) and compare with `if jid(n) == client_id`.
+- **Creating a new `services/X.sv.jac` is always a 2-file change.** The new endpoint must ALSO be added to `main.jac`'s plain `import from services.X { fn, Types }` block at the top. Without that import, the dispatcher never sees it and client calls hit `404 Not Found`. Especially easy to miss when extending a client-only app - `main.jac` previously had no server import block at all. See `jac-fullstack-patterns` for the full registry rule.

--- a/skills/jac-sv-persistence/SKILL.md
+++ b/skills/jac-sv-persistence/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: jac-sv-persistence
+description: Modeling relationships and querying the graph from server endpoints - connecting entities, multi-step reads, filtering, counting, and find-by-id patterns. Load when server code needs to store or query relational data. Pair with `jac-sv-endpoints` (persistence runs inside endpoint bodies).
+---
+
+The server's graph IS the database. Create entities by attaching nodes to `root` (or to each other via typed edges); read them with list-comprehension traversals; filter and aggregate with bracket predicates and `len()`. Every endpoint has access to the same graph - writes persist across calls automatically.
+
+```jac
+node User {
+    has name: str;
+}
+
+node Post {
+    has title: str;
+    has published: bool = False;
+}
+
+edge Wrote {
+    has at: str = "";
+}
+
+
+# CREATE - typed edge from user to the new post
+def:pub write_post(user_id: str, title: str) -> Post | None {
+    for u in [root -->][?:User] {
+        if jid(u) == user_id {
+            post = Post(title=title);
+            u +>:Wrote(at="2026-04-21"):+> post;
+            return post;
+        }
+    }
+    return None;
+}
+
+
+# READ - posts written by a specific user (multi-hop through Wrote edges)
+def:pub posts_by(user_id: str) -> list[Post] {
+    for u in [root -->][?:User] {
+        if jid(u) == user_id {
+            return [u ->:Wrote:->];
+        }
+    }
+    return [];
+}
+
+
+# FILTER - posts matching a field predicate
+def:pub published_posts() -> list[Post] {
+    return [root -->][?:Post][?published == True];
+}
+
+
+# AGGREGATE - counts via len() on a list comprehension
+def:pub count_posts() -> int {
+    return len([root -->][?:Post]);
+}
+
+
+# UPDATE - find by jid, mutate in place
+def:pub publish(post_id: str) -> Post | None {
+    for p in [root -->][?:Post] {
+        if jid(p) == post_id {
+            p.published = True;
+            return p;
+        }
+    }
+    return None;
+}
+```
+
+## Common patterns
+
+**List-then-predicate vs filter-in-one-step:**
+
+```
+[root -->][?:Post]                         # all posts
+[root -->][?:Post][?published == True]     # only published
+[root -->][?:Post][?author == "alice"]     # filter by any has-field
+```
+
+**Creating with an untyped edge (no relationship metadata):**
+
+```
+todo = (root ++> Todo(title=title))[0];    # [0] unwraps the edge-creation result
+```
+
+**Attach an existing node to another:**
+
+```
+user +>:Wrote(at="2026-04-21"):+> existing_post;
+```
+
+**Count without materializing:**
+
+```
+total = len([root -->][?:Post]);
+published = len([root -->][?:Post][?published == True]);
+```
+
+## Pitfalls
+
+- Mutate nodes in place - `p.published = True;` inside the loop. Changes persist once the endpoint returns; no explicit save/commit call.
+- Aggregates use `len(...)` on a list expression - no dedicated `count()` query form. `len([root -->][?:Item])` is the idiom.
+- Field-filter syntax is `[?field == value]` with brackets. `(?field == value)` is the **deprecated** parenthesized form (W0061) - always use brackets.
+- `def:priv` endpoints automatically run against a per-user `root` - the same query code gives each user only their own data. Use `def:priv` whenever the data should be user-scoped.
+- A node is not persisted until it's reachable from `root`. `Post(title="x")` alone creates a dangling node; `root ++> Post(title="x")` or attaching via a typed edge from a reachable node is what commits it to the graph.
+- Edge-type filter / creation / deletion syntax (`+>:E:+>`, `[src ->:E:->]`, `[edge a ->:E:-> b]`): see `jac-node-edge-patterns`.
+- **Find-by-id ALWAYS uses `jid()`** - loop, compare, mutate-or-return. NOT Python `id()`. The `jid(node)` string is the only node identity that survives the RPC round-trip.

--- a/skills/jac-types/SKILL.md
+++ b/skills/jac-types/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: jac-types
+description: The Jac type system - type annotations, generics, unions, optionals, inference rules, and common type errors. Load before writing any non-trivial typed function or when debugging a type-check failure.
+---
+
+Jac is statically typed at **annotation boundaries** and inferred inside function bodies. Every `def` parameter and return, and every `has` field, needs an explicit type. Local variables inside bodies get their type from the right-hand side. Types are unified across client (`.cl.jac`) and server code - only the specific types in scope differ (JsxElement in client, node archetypes in server).
+
+```jac
+obj User {
+    has name: str;                       # required - must be passed at construction
+    has age: int = 0;                    # typed primitive with default
+    has tags: list[str] = [];            # generic container
+    has meta: dict[str, int] = {};       # two-type-param generic
+    has manager: User | None = None;     # self-referencing optional
+}
+
+
+def score(points: list[int]) -> int {
+    total = sum(points);                 # inferred int, no annotation needed
+    return total;
+}
+
+
+def greet(u: User) -> str {
+    if u.manager is None {
+        return "Hi " + u.name + ", no manager";
+    }
+    return "Hi " + u.name + ", manager is " + u.manager.name;  # safe - None branch returned
+}
+
+
+def describe(x: int | str) -> str {      # union type: x is either int or str
+    if isinstance(x, int) {
+        return "number: " + str(x);
+    }
+    return "text: " + x;                 # narrowed to str by the isinstance check
+}
+
+
+def log_any(value: Any) -> None {        # Any = escape hatch, no import needed
+    print(value);
+}
+
+
+with entry {
+    alice = User(name="alice", age=30);
+    bob   = User(name="bob", manager=alice);
+
+    print(score([1, 2, 3]));             # 6
+    print(greet(bob));                   # Hi bob, manager is alice
+    print(describe(42));                 # number: 42
+    print(describe("hi"));               # text: hi
+    log_any({"foo": "bar"});             # {'foo': 'bar'}
+}
+```
+
+## Common patterns
+
+**Optional field + None narrowing:**
+
+```
+has owner: User | None = None;
+if self.owner is None { return "no owner"; }
+return self.owner.name;                  # safe - compiler knows owner is User here
+```
+
+**Union type + narrowing with `isinstance`:**
+
+```
+def parse(x: int | str) -> int {
+    if isinstance(x, int) { return x; }
+    return int(x);
+}
+```
+
+**Generic containers nested:**
+
+```
+has rows: list[dict[str, int]] = [];
+has adjacency: dict[str, list[str]] = {};
+```
+
+**`Any` where dynamic access is needed:**
+
+```
+def on_event(e: Any) -> None {
+    print(e.target.value);               # can touch any attribute - no type check
+}
+```
+
+## Pitfalls
+
+- **Do NOT fall back to `Any` to silence a type error.** Jac is strict-typed by design; using `Any` suppresses the diagnostic but the value is still untyped - and every downstream operation on it fails: `len(Any)` → not Sized (E1053), `Any + Any` → no overload (E1055), `Any.attr` → Type Unknown (E1032), `Any | str` ternary → can't assign to `str` (E1001). Fix the actual type instead. Common right answers: type with the imported node/obj (`has recipes: list[Recipe] = []`), use `T | None` for optionals (`has recipe: Recipe | None = None;` + `if recipe is not None { ... }`), or cast at the boundary (`recipe_id: str = str(params["id"]) if params["id"] else "";`).
+- **Every `def` parameter needs a type** (E0052). `def foo(x) -> int` is invalid - must be `def foo(x: int) -> int`.
+- **Every `def` needs an explicit return type.** Even `-> None`.
+- **`has name;`** without a type is a parse error. Always `has name: type;`.
+- `list`, `dict`, `set` without type args default to `list[Any]` (W1036) - add args when you know the element type: `list[str]`, `dict[str, int]`.
+- Use **`T | None`** for optional references. NOT `Optional[T]` (Python stdlib, not idiomatic). Always check `is None` before dereferencing.
+- **`Any`** is Jac-native - no import needed. Do NOT `import from typing { Any }` (Python stdlib, missing in Vite client bundle) or `import from "@jac/runtime" { Any }` (not exported). Just write `e: Any`.
+- **`any` lowercase** refers to the Python `any()` builtin - not the Any type. Using `e: any` in handlers fails **E1103** (function signature mismatch with JSX intrinsic prop type).
+- **E1030** (`Type T has no attribute X`) - you called a method/field that doesn't exist on that type. Example: `items.map(...)` on `list[Item]` fails because lists don't have `.map()`; use comprehensions.
+- **E1032** (`Type is Unknown, cannot access attribute`) - inference couldn't figure out a variable's type. Add an explicit annotation (`x: SomeType = ...`) so the rest of the code can narrow.
+- **E1001** (`Cannot assign <Unknown> to T`) - the right-hand side's type doesn't match the declared type. Usually means you need to widen the declared type or narrow the value with an explicit cast/check.
+- **Non-default fields MUST come before defaulted ones** (E2004) - see `jac-has-fields` for the full rule.
+- **`T | None` narrowing doesn't propagate into JSX expressions or list comprehensions.** A guard like `if x is None { return ...; }` narrows `x` to `T` for the rest of the function - direct `x.attr` access works. But inside a JSX list comprehension or short-circuit (`{x and <... x.attr />}`), the narrowing doesn't carry, and `x.attr` fails E1099. **Workaround: after the narrowing guard, pull each used attribute into a typed local before the JSX block.** JSX then references the narrowed local, not the still-Optional `x`. Keep using `T | None` for the field - don't decompose into primitives.
+
+```jac
+def:pub RecipeView() -> JsxElement {
+    has recipe: Recipe | None = None;
+
+    # Early-return narrows `recipe` to Recipe for direct accesses below
+    if recipe is None {
+        return <div>{"loading..."}</div>;
+    }
+    # FRAGILE - works for direct .title, fails for .ingredients inside comprehension
+    # return <div>
+    #     <h1>{recipe.title}</h1>                                            # ok
+    #     {[<li>{recipe.ingredients[i]}</li>                                 # ✗ E1099
+    #       for i in range(len(recipe.ingredients))]}
+    # </div>;
+
+    # CORRECT - pull narrowed attrs into typed locals before JSX
+    title: str = recipe.title;
+    ingredients: list[str] = recipe.ingredients;
+    return <div>
+        <h1>{title}</h1>
+        {[<li key={str(i)}>{ingredients[i]}</li> for i in range(len(ingredients))]}
+    </div>;
+}
+```

--- a/skills/jac-walker-patterns/SKILL.md
+++ b/skills/jac-walker-patterns/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: jac-walker-patterns
+description: Writing walkers that traverse the graph - the core of Object-Spatial Programming (OSP) in Jac. Entry points, moving between nodes, collecting results, and stopping early. Load before creating, editing, or debugging any walker-based traversal or OSP code. Pair with `jac-node-edge-patterns` (the graph shape the walker moves through).
+---
+
+A walker is a mobile procedure that enters nodes and runs type-matched entry points. Walker state lives on the walker via `has`; traversal is driven by `visit`; results come back via `report`. Entry points can live on **both** sides - the walker reacts to nodes it enters, and nodes can react to arriving walkers.
+
+```jac
+node Item {
+    has name: str;
+
+    can greet with Finder entry {
+        # node side: self = this node, visitor = the arriving walker
+        print(f"{self.name} greeted by {visitor.target}");
+    }
+}
+
+walker Finder {
+    has target: str;
+    has matches: list = [];
+
+    can on_root with Root entry {
+        visit [-->];
+    }
+
+    can on_item with Item entry {
+        # walker side: self = walker, here = current node
+        if here.name == self.target {
+            self.matches.append(here);
+            report here;                  # emit to result.reports
+        }
+        visit [-->];
+    }
+}
+
+with entry {
+    root ++> Item(name="foo");
+    root ++> Item(name="bar");
+
+    result = root spawn Finder(target="foo");
+    print(result.matches);                # [Item(name='foo')]
+}
+```
+
+## Pitfalls
+
+- `Root` in type annotations, bare `root` as a value (canonical). `root()` still compiles for backward-compat but emits a deprecation warning - always write `root`, `root ++> node`, `[root -->]`.
+- `disengage;` halts the walker immediately - queued visits are discarded. Use for search-style early exits.
+- **Use `visit [-->]`** for traversal - NOT `visit(node)` or `self.visit(node)` (parse error E0001: expected `[`). Variants: `[<--]` incoming, `[-->:EdgeType:]` typed.
+- Walkers don't `return` - they `report X;` (appears in `result.reports`) or `disengage;`.
+- Every entry needs `with <NodeType> entry` - bare `can foo { ... }` is invalid.
+- Entry points are **`can`**, NOT `def`. Plain helper methods can still be `def`, but bodies that fire on node arrival must be `can`.
+- **Keyword pairs depend on which side you're writing.** Inside a *walker* entry (`can ... with NodeType entry` in a walker): `self` = the walker, `here` = the current node. Inside a *node* entry (`can ... with WalkerType entry` in a node): `self` = the node, `visitor` = the arriving walker. Mixing them is the #1 walker bug.
+- **No generic `with node entry`.** `node` is a declaration keyword, NOT a type. `can foo with node entry { ... }` parses cleanly but **crashes at runtime**. The type must be a declared node archetype (or `Root`). Nodes without a matching entry body are simply passed through - no catch-all needed.


### PR DESCRIPTION
## Summary

Adds a `skills/` directory of curated reference skills for writing Jac. Each skill is a self-contained `SKILL.md` with YAML frontmatter, acting as an authoritative spec for Jac code generation (training-time impressions of Jac syntax are frequently wrong).

## Contents

- `README.md` - index of all skills
- 19 `SKILL.md` guides covering:
  - Language baseline, type system, has-fields, impl files
  - Object-Spatial Programming: nodes/edges, walkers
  - `by llm()` MTP pattern
  - Fullstack `.cl.jac` / `.sv.jac` client-server model (endpoints, auth, persistence, components, routing, styling)
  - Scaffolding, npm packages, jac-shadcn components

## Notes

- Em-dashes were normalized to hyphens to satisfy the repo's `ban-em-dashes` pre-commit hook.