### PR TITLE
docs: package Jac skills for plugin and editor install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "jaseci",
+  "owner": {
+    "name": "Jaseci Labs",
+    "email": "jason@mars.ninja"
+  },
+  "description": "Plugins and Agent Skills from the Jaseci project.",
+  "plugins": [
+    {
+      "name": "jac-skills",
+      "source": "./skills",
+      "description": "Curated reference skills for writing Jac code — syntax, types, Object-Spatial Programming, by-llm, and the fullstack client–server model.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "homepage": "https://www.jaseci.org/",
+      "keywords": ["jac", "jaseci", "reference"]
+    }
+  ]
+}

--- a/skills/.claude-plugin/plugin.json
+++ b/skills/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "jac-skills",
+  "version": "1.0.0",
+  "description": "Curated reference skills for writing Jac — the language and fullstack framework from Jaseci. Covers syntax, the type system, Object-Spatial Programming, the by-llm MTP pattern, and the .cl.jac / .sv.jac client–server model.",
+  "author": {
+    "name": "Jaseci Labs",
+    "email": "jason@mars.ninja"
+  },
+  "homepage": "https://www.jaseci.org/",
+  "repository": "https://github.com/jaseci-labs/jaseci",
+  "license": "MIT",
+  "keywords": [
+    "jac",
+    "jaseci",
+    "object-spatial-programming",
+    "fullstack",
+    "reference"
+  ],
+  "skills": "./"
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,57 @@ Each skill is a self-contained `SKILL.md` with YAML frontmatter, kept as the aut
 
 > Why this exists: training-time impressions of Jac are frequently wrong (the syntax has changed; Jac is easily confused with Python or JSX). These skills are the corrective spec.
 
+## Install
+
+These follow the [Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills) open format (`SKILL.md` + YAML frontmatter), which Claude Code, Claude.ai, the Claude Agent SDK, and Cursor all read directly — no conversion needed.
+
+### Claude Code — as a plugin (recommended)
+
+Install and update all skills with one command:
+
+```
+/plugin marketplace add jaseci-labs/jaseci
+/plugin install jac-skills@jaseci
+```
+
+Run `/plugin marketplace update jaseci` to pull later revisions.
+
+### Claude Code — manual
+
+Copy the skill folders into a skills directory Claude Code scans:
+
+```sh
+# Personal (all projects)
+cp -r skills/jac-* ~/.claude/skills/
+
+# Project-scoped (this repo only)
+mkdir -p .claude/skills && cp -r skills/jac-* .claude/skills/
+```
+
+Each `skills/jac-<name>/` directory is self-contained — copy as many or as few as you want.
+
+### Claude.ai
+
+Upload any individual `skills/jac-<name>/` folder in **Settings → Capabilities → Skills**.
+
+### Claude Agent SDK
+
+Point the SDK at a skills directory containing the `jac-*` folders (e.g. via `settingSources` / the `--skills` option), or vendor the folders into your agent's `.claude/skills/`.
+
+### Cursor
+
+Cursor reads the same `SKILL.md` format. Copy the skill folders into a directory Cursor scans:
+
+```sh
+# Personal (all projects)
+cp -r skills/jac-* ~/.cursor/skills/
+
+# Project-scoped (this repo only)
+mkdir -p .cursor/skills && cp -r skills/jac-* .cursor/skills/
+```
+
+Reload the workspace (`Cmd/Ctrl+Shift+P` → **Developer: Reload Window**) to pick them up. Discovered skills appear under **Cursor Settings → Rules** in the *Agent Decides* section, and can be invoked from the `/` menu in Agent chat.
+
 ## Skills
 
 Start with **`jac-core-cheatsheet`** (language baseline) and **`jac-types`** (the type system) - most other skills build on them.


### PR DESCRIPTION
## Summary

Makes the curated Jac reference skills installable across coding agents and editors. The skill files themselves are unchanged — this adds the packaging and documentation that were missing.

- **`skills/.claude-plugin/plugin.json`** — packages the 19 skills as an installable plugin. Uses `"skills": "./"` so the skill folders are discovered in place, with no directory restructuring.
- **`.claude-plugin/marketplace.json`** — marketplace manifest exposing the `jac-skills` plugin for one-command install and updates.
- **`skills/README.md`** — new **Install** section covering: plugin install, manual copy into a scanned skills directory, hosted upload, the Agent SDK, and Cursor.

All targets consume the same `SKILL.md` open format, so a single source of truth serves every harness — no per-editor conversion.

## Test plan

- `plugin.json` and `marketplace.json` validated as well-formed JSON.
- All 19 `skills/jac-*/SKILL.md` directories confirmed present and discoverable under the plugin root.