### PR TITLE
fix(runtime): make allroots() see roots across all memory tiers

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5993.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5993.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Cross-user root discovery**: `allroots()` now returns every root across all memory tiers instead of only the requesting user's own root.

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -662,10 +662,54 @@ impl SqliteMemory.query(
     }
 }
 
-"""Get all root anchors."""
+"""Get all root anchors — the in-process working set plus rows on disk.
+
+Scanning only `__mem__` would make a freshly-opened SqliteMemory (e.g. the L3
+tier of a new server request) report only the roots it had itself loaded,
+silently hiding every root persisted by other requests/users. The disk scan
+reads anchor metadata cheaply, resolves Root (sub)classes without
+deserializing payloads, and only loads the rows that are actually roots.
+"""
 impl SqliteMemory.get_roots -> Generator[Root, None, None] {
-    for anchor in self.__mem__.values() {
+    seen: set[UUID] = set();
+    # In-process working set: includes roots not yet synced to disk.
+    for anchor in list(self.__mem__.values()) {
         if isinstance(anchor.archetype, Root) {
+            seen.add(anchor.id);
+            yield cast(Root, anchor.archetype);
+        }
+    }
+    # Persisted rows on disk that have not been loaded into this session.
+    candidate_ids: list[UUID] = [];
+    with self.__lock__ {
+        if not self.__conn__ and os.path.exists(self.path) {
+            self._ensure_connection();
+        }
+        if self.__conn__ is not None {
+            cursor = self.__conn__.execute(
+                "SELECT id, arch_module, arch_type FROM anchors WHERE type = ?",
+                ("NodeAnchor", )
+            );
+            for row in cursor.fetchall() {
+                arch_module = row[1];
+                arch_type = row[2];
+                uid = UUID(row[0]);
+                if uid in seen or not arch_module or not arch_type {
+                    continue;
+                }
+                cls = Serializer._get_class(arch_module, arch_type);
+                if cls is not None
+                and isinstance(cls, type)
+                and issubclass(cls, Root) {
+                    candidate_ids.append(uid);
+                }
+            }
+        }
+    }
+    for uid in candidate_ids {
+        anchor = self.get(uid);
+        if anchor is not None and isinstance(anchor.archetype, Root) {
+            seen.add(uid);
             yield cast(Root, anchor.archetype);
         }
     }
@@ -1380,6 +1424,36 @@ impl TieredMemory.put(anchor: Anchor) -> None {
     if self.l3 and anchor.persistent {
         if Jac.check_write_access(anchor, op_hint="field_write") {
             self.l3.put(anchor);
+        }
+    }
+}
+
+"""Enumerate roots across every tier — the basis for the `allroots()` builtin.
+
+L1 (this request's working set) holds roots created or mutated in-flight; L3
+(the shared persistent store) holds every root ever committed by any
+request/user. Without merging L3 in, `allroots()` would see only the caller's
+own root and every cross-user query would silently degrade to single-user.
+
+L2 is intentionally skipped: it is a partial cache whose entries are always
+also present in L1 or L3. Results are de-duplicated by archetype identity —
+when a root is resident in more than one tier every tier hands back the same
+anchor object, so the L1 copy (with any uncommitted mutations) wins.
+"""
+impl TieredMemory.get_roots -> Generator[Root, None, None] {
+    seen: set[int] = set();
+    for anchor in list(self.__mem__.values()) {
+        if isinstance(anchor.archetype, Root) {
+            seen.add(id(anchor.archetype));
+            yield cast(Root, anchor.archetype);
+        }
+    }
+    if self.l3 is not None {
+        for l3_root in self.l3.get_roots() {
+            if id(l3_root) not in seen {
+                seen.add(id(l3_root));
+                yield l3_root;
+            }
         }
     }
 }

--- a/jac/jaclang/runtimelib/memory.jac
+++ b/jac/jaclang/runtimelib/memory.jac
@@ -293,6 +293,7 @@ obj TieredMemory(VolatileMemory) {
     # Override only methods that need tiering logic
     def get(id: UUID) -> (Anchor | None);
     def put(anchor: Anchor) -> None;
+    def get_roots -> Generator[Root, None, None];
     def delete(id: UUID) -> None;
     def close -> None;
     def `has(id: UUID) -> bool;

--- a/jac/tests/runtimelib/test_allroots.jac
+++ b/jac/tests/runtimelib/test_allroots.jac
@@ -1,0 +1,89 @@
+"""Tests for cross-tier root discovery (`allroots()` / `get_roots`).
+
+`allroots()` resolves to the memory backend's `get_roots()` (via
+`JacBasics.get_all_root`). In a multi-user server every request gets a fresh L1
+working set over a shared persistent tier: the current user's own root is
+loaded into L1, while other users' roots live only in L3 (or on disk).
+
+A backend that enumerates roots from its in-process working set alone reports
+only the requesting user's own root, so every cross-user walker (discovery,
+follow, cross-user feeds) is silently reduced to single-user. These tests pin
+the expected behavior: `get_roots()` must surface every root across all tiers,
+de-duplicated.
+"""
+
+import os;
+import from tempfile { TemporaryDirectory }
+import from jaclang.jac0core.archetype { NodeAnchor, Root }
+import from jaclang.runtimelib.memory { SqliteMemory, TieredMemory }
+
+
+"""Build a persistent, properly-linked Root anchor."""
+def _make_root -> NodeAnchor {
+    anchor = Root().__jac__;
+    anchor.persistent = True;
+    return anchor;
+}
+
+
+test "TieredMemory.get_roots surfaces roots held only in the L3 tier" {
+    with TemporaryDirectory() as tmpdir {
+        tmem = TieredMemory(base_path=tmpdir);
+        # Two users' roots, persisted to the shared L3 tier. Neither has been
+        # loaded into this request's L1 working set.
+        a = _make_root();
+        b = _make_root();
+        tmem.l3.put(a);
+        tmem.l3.put(b);
+        roots = list(tmem.get_roots());
+        got = {jid(r) for r in roots};
+        assert jid(a.archetype) in got , "root persisted in L3 is invisible to get_roots()";
+        assert jid(b.archetype) in got , "root persisted in L3 is invisible to get_roots()";
+        assert len(roots) == 2 , f"expected 2 roots across tiers, got {len(roots)}";
+        tmem.close();
+    }
+}
+
+
+test "TieredMemory.get_roots merges the L1 request root with other users' L3 roots" {
+    with TemporaryDirectory() as tmpdir {
+        tmem = TieredMemory(base_path=tmpdir);
+        # `mine` models the current request's own root: loaded into L1 and
+        # persisted. `other` models a different user's root that lives only
+        # in the shared L3 tier.
+        mine = _make_root();
+        other = _make_root();
+        tmem.l3.put(mine);
+        tmem.l3.put(other);
+        tmem.__mem__[mine.id] = mine;
+        roots = list(tmem.get_roots());
+        got = {jid(r) for r in roots};
+        assert jid(mine.archetype) in got , "current request's own root missing from get_roots()";
+        assert jid(other.archetype) in got , "another user's root invisible — allroots() is single-user";
+        # A root resident in both tiers must not be double-counted.
+        assert len(roots) == 2 , f"expected 2 distinct roots, got {len(roots)}";
+        tmem.close();
+    }
+}
+
+
+test "SqliteMemory.get_roots surfaces roots persisted to disk by an earlier session" {
+    with TemporaryDirectory() as tmpdir {
+        db_path = os.path.join(tmpdir, "graph.db");
+        # First session: persist two roots and flush to disk.
+        mem = SqliteMemory(path=db_path);
+        a = _make_root();
+        b = _make_root();
+        mem.put(a);
+        mem.put(b);
+        mem.close();
+        # Fresh session over the same database — empty working set.
+        mem2 = SqliteMemory(path=db_path);
+        roots = list(mem2.get_roots());
+        got = {jid(r) for r in roots};
+        assert jid(a.archetype) in got , "root on disk is invisible to a fresh SqliteMemory.get_roots()";
+        assert jid(b.archetype) in got , "root on disk is invisible to a fresh SqliteMemory.get_roots()";
+        assert len(roots) == 2 , f"expected 2 roots from disk, got {len(roots)}";
+        mem2.close();
+    }
+}


### PR DESCRIPTION
## Problem

`allroots()` resolves to the memory backend's `get_roots()` (via `JacBasics.get_all_root`). In a multi-user server every request gets a fresh L1 working set over a shared persistent tier — the requesting user's own root is loaded into L1, while other users' roots live only in L3 (or on disk).

Two defects compounded so `allroots()` returned **only the requesting user's own root**:

1. `TieredMemory.get_roots` was inherited from `VolatileMemory`, which scans only the L1 working set — it never consulted L3.
2. `SqliteMemory.get_roots` scanned only its in-process working set, not the rows on disk. Since a server falls back to SQLite-as-L3 when MongoDB is unavailable, a fixed `TieredMemory` alone would still miss roots persisted by earlier requests.

The effect: every cross-user walker — profile discovery, follow/unfollow, cross-user feeds, trending — silently degraded to single-user.

## Fix

- **`TieredMemory.get_roots`** — new override that merges the L1 working set with `l3.get_roots()`, de-duplicated by archetype identity. L2 is intentionally skipped: it is a partial cache whose entries are always also present in L1 or L3.
- **`SqliteMemory.get_roots`** — yields the in-process working set plus a disk scan that resolves `Root` (sub)classes from anchor metadata (no payload deserialization) and loads only the rows that are actually roots.

## Tests

Adds `jac/tests/runtimelib/test_allroots.jac` with three cases:

- `TieredMemory.get_roots` surfaces roots held only in the L3 tier
- `TieredMemory.get_roots` merges the L1 request root with other users' L3 roots (with de-duplication)
- `SqliteMemory.get_roots` surfaces roots persisted to disk by an earlier session

All three fail on the base and pass with this change. `test_persistence_migration` and `test_layer3_e2e` continue to pass.