### PR TITLE
fix(ecmascript): correct `in`/`not in` for values of unknown static type

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/5998.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/5998.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Client `in` operator on dynamic values**: `in` / `not in` on a value of unknown static type now produces Python-equivalent membership in transpiled client code instead of emitting a JavaScript `in` that could crash or return wrong results.

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -2290,18 +2290,55 @@ impl EsastGenPass.exit_compare_expr(nd: uni.CompareExpr) -> None {
                 continue;
             }
         }
-        operator = ES_COMPARISON_OPS.get(op_tok) if op_tok else None;
-        operator = operator or '===';
-        comparison: (es.UnaryExpression | es.BinaryExpression);
-        if (op_tok == Tok.KW_NIN) {
-            in_expr = self.sync_loc(
-                es.BinaryExpression(operator='in', left=left, right=right), jac_node=nd
-            );
-            comparison = self.sync_loc(
-                es.UnaryExpression(operator='!', prefix=True, argument=in_expr),
+        comparison: es.Expression;
+        if (op_tok in (Tok.KW_IN, Tok.KW_NIN)) {
+            # The container type could not be resolved statically. A raw JS
+            # `in` is not a valid translation of Jac's `in`: it throws a
+            # TypeError on string operands and tests array indices rather
+            # than element values. Route through the runtime-polymorphic
+            # `_jac.poly.contains`, which dispatches on the value at runtime.
+            contains_callee = self.sync_loc(
+                es.MemberExpression(
+                    object=self.sync_loc(
+                        es.MemberExpression(
+                            object=self.sync_loc(
+                                es.Identifier(name='_jac'), jac_node=nd
+                            ),
+                            property=self.sync_loc(
+                                es.Identifier(name='poly'), jac_node=nd
+                            ),
+                            computed=False
+                        ),
+                        jac_node=nd
+                    ),
+                    property=self.sync_loc(es.Identifier(name='contains'), jac_node=nd),
+                    computed=False
+                ),
                 jac_node=nd
             );
+            self.needs_jac_runtime = True;
+            contains_call = self.sync_loc(
+                es.CallExpression(
+                    callee=cast(es.Expression, contains_callee),
+                    arguments=[cast(es.Expression, right), cast(es.Expression, left)]
+                ),
+                jac_node=nd
+            );
+            if (op_tok == Tok.KW_NIN) {
+                comparison = self.sync_loc(
+                    es.UnaryExpression(
+                        operator='!',
+                        prefix=True,
+                        argument=cast(es.Expression, contains_call)
+                    ),
+                    jac_node=nd
+                );
+            } else {
+                comparison = cast(es.Expression, contains_call);
+            }
         } else {
+            operator = ES_COMPARISON_OPS.get(op_tok) if op_tok else None;
+            operator = operator or '===';
             comparison = self.sync_loc(
                 es.BinaryExpression(operator=operator, left=left, right=right),
                 jac_node=nd

--- a/jac/jaclang/compiler/passes/ecmascript/jac_runtime_js.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/jac_runtime_js.jac
@@ -342,6 +342,18 @@ glob JAC_RUNTIME_JS_OBJECT: str = r"""{
         return a.splice(idx, 1)[0];
       }
       return i === undefined ? a.pop() : a.pop(i);
+    },
+    contains(c, x) {
+      // Python-equivalent membership for a value of unknown static type.
+      // string -> substring; array (list/tuple/range) -> element;
+      // Set/Map -> key/element; plain object (dict) -> own key.
+      if (typeof c === "string") return c.includes(x);
+      if (Array.isArray(c)) return c.includes(x);
+      if (c instanceof Set || c instanceof Map) return c.has(x);
+      if (c !== null && typeof c === "object") {
+        return Object.prototype.hasOwnProperty.call(c, x);
+      }
+      return false;
     }
   },
 

--- a/jac/tests/compiler/passes/ecmascript/fixtures/dynamic_membership.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/dynamic_membership.jac
@@ -1,0 +1,30 @@
+"""Fixture: `in` / `not in` where the container's static type is unknown.
+
+`opaque` is declared to return `any`, so the type evaluator cannot prove the
+static type of `s`, `nums`, or `mapping`. The ECMAScript backend must still
+produce Python-equivalent membership semantics: substring search for strings,
+element search for lists, key search for dicts.
+
+A raw JavaScript `in` is wrong for the dynamic case: it throws a TypeError on
+string operands and tests array *indices* rather than element values.
+"""
+
+cl def opaque(x: any) -> any {
+    return x;
+}
+
+cl def membership() -> dict {
+    s = opaque("hello world");
+    nums = opaque([10, 20, 30]);
+    mapping = opaque({"alpha": 1, "beta": 2});
+    return {
+        "str_hit": "world" in s,
+        "str_miss": "zzz" in s,
+        "str_not_in_hit": "zzz" not in s,
+        "list_hit": 20 in nums,
+        "list_miss": 99 in nums,
+        "list_index_trap": 0 in nums,
+        "dict_hit": "alpha" in mapping,
+        "dict_miss": "gamma" in mapping
+    };
+}

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -1644,3 +1644,41 @@ test "sibling block scopes — try except finally each get their own let" {
         os.unlink(temp_path);
     }
 }
+
+
+test "in/not in on unknown-typed containers matches Python semantics" {
+    import json;
+    # `opaque()` returns `any`, so the backend cannot statically prove the
+    # container types. Membership must still behave like Python: substring
+    # search for strings, element search for lists, key search for dicts.
+    js_code = compile_fixture_to_js("dynamic_membership.jac", FIXTURES);
+    wrapper = js_code + "\nconsole.log(JSON.stringify(membership()));\n";
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", wrapper],
+        capture_output=True,
+        text=True,
+        timeout=30
+    );
+    assert result.returncode == 0 , (
+        "dynamic `in` membership crashed in Node "
+        "(raw JS `in` rejects string/array operands):\n"
+        f"stderr={result.stderr!r}\njs:\n{js_code}"
+    );
+    got: dict = json.loads(result.stdout.strip());
+    expected = {
+        "str_hit": True,
+        "str_miss": False,
+        "str_not_in_hit": True,
+        "list_hit": True,
+        "list_miss": False,
+        "list_index_trap": False,
+        "dict_hit": True,
+        "dict_miss": False
+    };
+    for (key, want) in expected.items() {
+        assert key in got , f"missing key '{key}' in result {got}";
+        assert got[key] == want , (
+            f"membership '{key}': got {got[key]!r}, expected {want!r}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

When the ECMAScript backend cannot resolve the static type of an `in` / `not in` container, `EsastGenPass.exit_compare_expr` fell back to emitting a **raw JavaScript `in` operator**.

JavaScript's `in` is not equivalent to Jac/Python's `in`:

- `x in <string>` → **throws `TypeError: Cannot use 'in' operator ...`** (the right operand must be an object)
- `x in <array>` → tests whether `x` is a valid **index**, not whether it is an **element** → silently wrong results
- `x in <object>` → property-key check (roughly matches a dict key check)

So perfectly valid Jac — e.g. `"@" in some_value` where `some_value` originates from an `any`-typed field — transpiled to client code that either crashed at runtime or returned wrong answers, with no compile-time diagnostic.

Statically-typed operands were already handled correctly: `_try_primitive_op` dispatches to the per-type emitters (`str`/`list` → `.includes()`, `set` → `.has()`, etc.). Only the unknown-type fallback was wrong.

## Fix

- **New runtime helper** `_jac.poly.contains(container, item)` in `jac_runtime_js.jac`, alongside the existing `poly.*` polymorphic helpers. It dispatches on the actual runtime value: substring search for strings, element search for arrays (list/tuple/range), `.has()` for `Set`/`Map`, and own-key search for plain objects (dict).
- **`exit_compare_expr`** now routes the unknown-type `in` / `not in` case through `_jac.poly.contains` (wrapped in `!` for `not in`) instead of emitting raw JS `in`. Statically-typed operands are unaffected — they still dispatch through the per-type emitters.

## Tests

- New fixture `dynamic_membership.jac` — `in` / `not in` over string, list, and dict containers whose static type is erased to `any` via an `any`-returning helper.
- New test in `test_js_generation.jac` compiles the fixture, executes it under Node, and asserts Python-equivalent results — including `0 in [10, 20, 30]` being `false` (the array-index trap) and substring membership not throwing.

The test fails on `main` (Node exits non-zero on the `TypeError`) and passes with this change. The full `test_js_generation` suite (66 tests) passes.