### PR TITLE
fix(jac-super): restore JacConsole contract — redirectable stderr + verbatim print (#5995)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-super/5995.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-super/5995.bugfix.md
@@ -1,0 +1,2 @@
+- **Fix: `JacSuperConsole` honors `sys.stderr` redirection**: `console.error` / `console.warning` now resolve `sys.stderr` per call via `RichConsole(stderr=True)` instead of capturing the stream at construction, so test redirection (`sys.stderr = io.StringIO()`) works again.
+- **Fix: `print` passes long lines through unchanged**: The `print` override now sets `soft_wrap=True`, restoring the documented `JacConsole` contract so JSON, paths, and code snippets are no longer reflowed to the terminal width.

--- a/jac-super/jac_super/plugin/impl/console.impl.jac
+++ b/jac-super/jac_super/plugin/impl/console.impl.jac
@@ -34,8 +34,12 @@ obj JacSuperConsole(BaseJacConsole) {
         _console_stderr: RichConsole by postinit;
 
     def postinit {
+        # Use Rich's `stderr=True` (not `file=sys.stderr`) so the stream is
+        # resolved per call. Passing `file=` would freeze the stream object at
+        # construction, breaking `sys.stderr = io.StringIO()` redirection that
+        # in-process CLI tests rely on (issue #5995, Bug 1).
         self._console = RichConsole(theme=self.JAC_THEME);
-        self._console_stderr = RichConsole(theme=self.JAC_THEME, file=sys.stderr);
+        self._console_stderr = RichConsole(theme=self.JAC_THEME, stderr=True);
     }
 
     """Override print to use Rich console.
@@ -55,6 +59,11 @@ obj JacSuperConsole(BaseJacConsole) {
         style = kwargs.pop('style', None);
         file = kwargs.pop('file', None);
         kwargs.setdefault('markup', False);
+        # Default to soft-wrap on so user content (long paths, JSON, code
+        # snippets) passes through unchanged. Rich's default reflows to the
+        # detected terminal width, violating the base `JacConsole.print`
+        # "pass through unchanged" contract (issue #5995, Bug 2).
+        kwargs.setdefault('soft_wrap', True);
         # Use appropriate console based on file
         console = self._console_stderr if (file == sys.stderr) else self._console;
         if style {

--- a/jac-super/tests/test_console_conformance.jac
+++ b/jac-super/tests/test_console_conformance.jac
@@ -1,0 +1,105 @@
+"""Conformance tests for the JacConsole contract.
+
+The global `console` from `jaclang.cli.console` is a process-wide singleton
+that plugins may override (jac-super installs `JacSuperConsole`). These
+tests pin the parts of the base contract that must remain true regardless
+of which implementation is installed:
+
+  1. `console.error` / `console.warning` honor `sys.stderr` redirection
+     (the standard `sys.stderr = io.StringIO()` test idiom must capture them).
+  2. `console.print` emits user content verbatim — no soft-wrap reflow,
+     no markup stripping — so JSON, paths, and diagnostic snippets stay
+     byte-exact.
+
+A plugin console that breaks any of these regresses every in-process CLI
+caller silently. Keep this file passing for every implementation that
+appears at `jaclang.cli.console.console`.
+"""
+
+import io;
+import sys;
+import from jaclang.cli.console { console }
+
+
+# Force the lazy global `console` to materialize now, with the real
+# `sys.stdout` / `sys.stderr` in place — before any test redirects them.
+# This makes the stderr-binding bug manifest deterministically: every test
+# below starts with an already-constructed console, mirroring real CLI usage
+# where the singleton is built at startup and tests redirect stdio later.
+glob _ = console.print;
+
+
+test "console.error honors sys.stderr redirection" {
+    captured = io.StringIO();
+    saved = sys.stderr;
+    sys.stderr = captured;
+    try {
+        console.error("CONFORM-ERROR-MARKER");
+    } finally {
+        sys.stderr = saved;
+    }
+    text = captured.getvalue();
+    assert "CONFORM-ERROR-MARKER" in text , f"console.error did not honor sys.stderr redirection; captured={text!r}";
+}
+
+
+test "console.warning honors sys.stderr redirection" {
+    captured = io.StringIO();
+    saved = sys.stderr;
+    sys.stderr = captured;
+    try {
+        console.warning("CONFORM-WARNING-MARKER");
+    } finally {
+        sys.stderr = saved;
+    }
+    text = captured.getvalue();
+    assert "CONFORM-WARNING-MARKER" in text , f"console.warning did not honor sys.stderr redirection; captured={text!r}";
+}
+
+
+test "console.error hint honors sys.stderr redirection" {
+    captured = io.StringIO();
+    saved = sys.stderr;
+    sys.stderr = captured;
+    try {
+        console.error("CONFORM-ERROR-WITH-HINT", hint="CONFORM-HINT-MARKER");
+    } finally {
+        sys.stderr = saved;
+    }
+    text = captured.getvalue();
+    assert "CONFORM-ERROR-WITH-HINT" in text , f"console.error did not honor sys.stderr redirection; captured={text!r}";
+    assert "CONFORM-HINT-MARKER" in text , f"console.error hint did not honor sys.stderr redirection; captured={text!r}";
+}
+
+
+test "console.print emits long content verbatim (no soft-wrap reflow)" {
+    long_line = "A" * 300;
+    captured = io.StringIO();
+    saved = sys.stdout;
+    sys.stdout = captured;
+    try {
+        console.print(long_line);
+    } finally {
+        sys.stdout = saved;
+    }
+    out = captured.getvalue().rstrip("\n");
+    assert "\n" not in out , f"console.print soft-wrapped output (300-char input → multiple lines); first 200={out[:200]!r}";
+    assert long_line in out , f"console.print did not emit input verbatim; first 200={out[:200]!r}";
+}
+
+
+test "console.print preserves bracketed content verbatim" {
+    bracketed = "diagnostic snippet: [root()-->][?:Task] arr[0] dict['key']";
+    captured = io.StringIO();
+    saved = sys.stdout;
+    sys.stdout = captured;
+    try {
+        console.print(bracketed);
+    } finally {
+        sys.stdout = saved;
+    }
+    out = captured.getvalue();
+    assert "[root()-->]" in out , f"console.print stripped bracketed markup-like content; captured={out!r}";
+    assert "[?:Task]" in out , f"console.print stripped bracketed markup-like content; captured={out!r}";
+    assert "arr[0]" in out and "dict['key']" in out , f"console.print stripped bracketed code-like content; captured={out!r}";
+}


### PR DESCRIPTION
## Summary

Fixes #5995. `JacSuperConsole` was an incorrect Liskov substitute for the base `JacConsole`, breaking two parts of the documented contract:

- **Bug 1 — stderr binding.** `_console_stderr` was built with `RichConsole(file=sys.stderr)`, which captures the stream object at construction. That opted out of Rich's per-call `sys.stderr` lookup, so `console.error` / `console.warning` silently bypassed the standard `sys.stderr = io.StringIO()` redirection idiom that in-process CLI tests rely on. **Fix:** use `RichConsole(stderr=True)`, which resolves the stream per call.

- **Bug 2 — `print` reflowed long lines.** The `print` override inherited Rich's soft-wrapping default and reflowed JSON, paths, and diagnostic snippets to the detected terminal width, violating the documented "pass through unchanged" contract. **Fix:** `kwargs.setdefault('soft_wrap', True)` next to the existing `markup=False` default.

Both fixes are one-liners that target exactly the lines flagged in the issue.

## Conformance test

Adds `jac-super/tests/test_console_conformance.jac` — 5 in-process tests that pin both behaviors against the global `console` proxy (so they exercise whichever plugin is installed: `JacSuperConsole` here, base `JacConsole` if jac-super is removed).

A module-level materialization forces the lazy singleton to construct with real stdio **before** any test redirects, so the stderr-binding bug manifests deterministically in every stderr test — rather than only in tests that happen to run after the first stderr swap.

Coverage:
- `console.error` honors `sys.stderr` redirection
- `console.warning` honors `sys.stderr` redirection
- `console.error(..., hint=)` honors `sys.stderr` redirection (both message and hint)
- `console.print` emits 300-char input verbatim (no soft-wrap reflow)
- `console.print` preserves bracketed content (regression guard for the existing `markup=False` default)

Before the fix: 4/5 fail. After the fix: 5/5 pass.

## Test plan

- [x] `jac test jac-super/tests/test_console_conformance.jac` — 5/5 pass
- [x] Standalone Python repro from the issue no longer reproduces either bug
- [x] Pre-commit hooks (jac-format etc.) pass
- [x] Existing `jac/tests/language/test_console.jac` failures (W0062/E1001 snippet brackets) are **pre-existing on `main`** and unrelated — they're separate markup-stripping bugs in `jac check`'s diagnostic rendering, worth a follow-up issue