### PR TITLE
fix(ecmascript): follow helper calls in walker effect classification

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6002.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6002.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Walker effect classification follows helper calls**: The reader/writer classifier used for client-side cache invalidation now recurses into `def`/ability helpers, so a walker whose graph mutation lives in a helper is correctly classified as a writer instead of a reader (which previously left the client cache stale until a full page reload).

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -4705,6 +4705,44 @@ Returns dict with 'is_writer' (bool) and 'touches' (list of node type names).
 impl EsastGenPass._analyze_body_effects(body_nodes: Sequence[uni.UniNode]) -> dict {
     is_writer = False;
     touches: set[str] = set();
+    visited_funcs: set[int] = set();
+    """Resolve a called ability's body to a flat statement list (inline or impl).""";
+    def _ability_body(ab: uni.Ability) -> list {
+        ab_body = ab.body;
+        if isinstance(ab_body, list) {
+            return ab_body;
+        }
+        if isinstance(ab_body, uni.ImplDef) and isinstance(ab_body.body, Sequence) {
+            return [stmt for stmt in ab_body.body];
+        }
+        return [];
+    }
+    mod_def_index: dict[int, dict] = {};
+    """Resolve a called name to a module-level def in the call site's module.
+
+    Fallback for when the call's symbol is unresolved -- server walker bodies
+    introspected by the client pass never go through full symbol resolution,
+    so `_resolve_call_ability` (which relies on resolved symbols) returns
+    None. Looking the name up syntactically in the host module still finds
+    the helper.
+    """;
+    def _local_def(call_nd: uni.UniNode, name: str) -> (uni.Ability | None) {
+        host_mod = call_nd.find_parent_of_type(uni.Module);
+        if not host_mod {
+            return None;
+        }
+        index = mod_def_index.get(id(host_mod));
+        if index is None {
+            index = {};
+            for ab in host_mod.get_all_sub_nodes(uni.Ability) {
+                if isinstance(ab.name_ref, uni.Name) and not ab.is_method {
+                    index[ab.name_ref.sym_name] = ab;
+                }
+            }
+            mod_def_index[id(host_mod)] = index;
+        }
+        return index.get(name);
+    }
     """Recursively scan a node and its descendants for effects.""";
     def _scan(nd: uni.UniNode) {
         nonlocal is_writer;
@@ -4769,6 +4807,23 @@ impl EsastGenPass._analyze_body_effects(body_nodes: Sequence[uni.UniNode]) -> di
                     touches.add(target_sym.sym_name);
                     # Constructing a node/edge is a write
                     is_writer = True;
+                }
+            }
+            # Interprocedural: follow the call into a def/ability helper so
+            # graph mutations hidden behind a helper still mark the caller as
+            # a writer (and propagate any node types it touches). Without
+            # this, a walker that delegates its write to a plain `def` is
+            # misclassified as a reader and the client cache is never
+            # invalidated. The visited_funcs guard makes mutual/self
+            # recursion terminate.
+            callee = self._resolve_call_ability(nd);
+            if not callee and isinstance(nd.target, uni.Name) {
+                callee = _local_def(nd, nd.target.sym_name);
+            }
+            if callee and id(callee) not in visited_funcs {
+                visited_funcs.add(id(callee));
+                for stmt in _ability_body(callee) {
+                    _scan(stmt);
                 }
             }
         }

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -695,8 +695,26 @@ impl ModuleIntrospector._analyze_endpoint_effects -> None {
     import from jaclang.jac0core.constructs { WalkerArchetype }
     import from jaclang.jac0core.constant { Tokens as Tok }
     endpoint_effects: dict = {};
-    # Recursively check if an AST subtree contains write operations
-    def has_write_ops(`node: Any) -> bool {
+    # Find a module-level ability (a `def`) by name within a module AST.
+    def find_ability_in_ast(ast_mod: Any, fname: str) -> Any {
+        if not ast_mod {
+            return None;
+        }
+        for item in ast_mod.body {
+            if (
+                isinstance(item, uni.Ability)
+                and item.name_ref is not None
+                and item.name_ref.sym_name == fname
+            ) {
+                return item;
+            }
+        }
+        return None;
+    }
+    # Recursively check if an AST subtree contains write operations. Follows
+    # calls into module-level helper defs (interprocedural) so a graph
+    # mutation hidden behind a helper still marks the caller as a writer.
+    def has_write_ops(`node: Any, ast_mod: Any, seen: set) -> bool {
         if isinstance(`node, uni.DeleteStmt) {
             return True;
         }
@@ -708,10 +726,43 @@ impl ModuleIntrospector._analyze_endpoint_effects -> None {
                 return True;
             }
         }
+        # Field mutation on a non-self target (`n.attr = ...`) writes to a
+        # node/edge attribute. `self.x` is walker-local state, so excluded.
+        if isinstance(`node, uni.Assignment) and `node.target {
+            for tgt in `node.target {
+                if isinstance(tgt, uni.AtomTrailer) and tgt.is_attr {
+                    root_expr = tgt.target;
+                    while isinstance(root_expr, uni.AtomTrailer) {
+                        root_expr = root_expr.target;
+                    }
+                    if not (
+                        isinstance(root_expr, uni.SpecialVarRef)
+                        and root_expr.sym_name == 'self'
+                    ) {
+                        return True;
+                    }
+                }
+            }
+        }
+        # Interprocedural: follow a call into a module-level helper def.
+        if isinstance(`node, uni.FuncCall) and isinstance(`node.target, uni.Name) {
+            fname = `node.target.sym_name;
+            if fname not in seen {
+                seen.add(fname);
+                callee = find_ability_in_ast(ast_mod, fname);
+                if callee and callee.body and hasattr(callee.body, '__iter__') {
+                    for stmt in callee.body {
+                        if has_write_ops(stmt, ast_mod, seen) {
+                            return True;
+                        }
+                    }
+                }
+            }
+        }
         # Recurse into children
         if `node?.kid and `node.kid {
             for child in `node.kid {
-                if has_write_ops(child) {
+                if has_write_ops(child, ast_mod, seen) {
                     return True;
                 }
             }
@@ -739,7 +790,7 @@ impl ModuleIntrospector._analyze_endpoint_effects -> None {
             body = item._get_impl_resolved_body();
             is_writer = False;
             for body_item in body {
-                if has_write_ops(body_item) {
+                if has_write_ops(body_item, mod_ast, set()) {
                     is_writer = True;
                     break;
                 }
@@ -799,7 +850,7 @@ impl ModuleIntrospector._analyze_endpoint_effects -> None {
                     is_writer = False;
                     if item.body and hasattr(item.body, '__iter__') {
                         for body_item in item.body {
-                            if has_write_ops(body_item) {
+                            if has_write_ops(body_item, mod_ast, set()) {
                                 is_writer = True;
                                 break;
                             }

--- a/jac/tests/compiler/test_client_codegen.jac
+++ b/jac/tests/compiler/test_client_codegen.jac
@@ -134,6 +134,26 @@ test "def pub and endpoint effects" {
     }
 }
 
+test "endpoint effects follow helper calls" {
+    prog = JacProgram();
+
+    # A walker (and a def:pub function) whose only graph mutation happens
+    # inside a plain `def` helper. The classifier must follow the call into
+    # the helper -- otherwise the walker is misclassified as a reader and the
+    # client cache is never invalidated after the mutation.
+    code = '"""Interprocedural endpoint effect analysis."""\n\nnode Item {\n    has title: str,\n        tags: list = [];\n}\n\ndef _add_tag(it: Item, label: str) -> None {\n    it.tags = it.tags + [label];\n}\n\nwalker tag_item {\n    has label: str;\n    can do_tag with Root entry {\n        for it in [-->[?:Item]] {\n            _add_tag(it, self.label);\n        }\n    }\n}\n\ndef:pub mark_item(label: str) -> dict {\n    items = [];\n    for it in items {\n        _add_tag(it, label);\n    }\n    return {};\n}\n\ncl {\n    def:pub app() {\n        root spawn tag_item(label="x");\n        result = await mark_item("y");\n    }\n}\n';
+    mod = compile_inline(code, prog);
+    effects = mod.gen.client_manifest.endpoint_effects;
+
+    # The walker mutates Item.tags only inside the `_add_tag` helper.
+    assert "walker:tag_item" in effects , "tag_item should be in endpoint_effects";
+    assert effects["walker:tag_item"]["is_writer"] , "tag_item mutates the graph via a helper -- must be classified as writer";
+
+    # Same for a def:pub function delegating its write to a helper.
+    assert "func:mark_item" in effects , "mark_item should be in endpoint_effects";
+    assert effects["func:mark_item"]["is_writer"] , "mark_item mutates the graph via a helper -- must be classified as writer";
+}
+
 test "jac call function sends params directly" {
     jac_root = Path(jaclang.__file__).resolve().parent.parent.parent;
     runtime_path = (

--- a/jac/tests/runtimelib/fixtures/serve_helper_effects.jac
+++ b/jac/tests/runtimelib/fixtures/serve_helper_effects.jac
@@ -1,0 +1,34 @@
+"""Fixture: a walker that mutates the graph only through a helper def.
+
+Used to verify the runtime endpoint-effect classifier follows calls into
+helper functions instead of misclassifying the walker as a reader.
+"""
+
+node Item {
+    has title: str;
+    has tags: list = [];
+}
+
+# The graph write lives here, in a plain helper -- not in the walker body.
+def _add_tag(it: Item, label: str) -> None {
+    it.tags = it.tags + [label];
+}
+
+# Writer: its only mutation is delegated to the _add_tag helper.
+walker tag_item {
+    has label: str;
+
+    can run with Root entry {
+        items = [-->[?:Item]];
+        for it in items {
+            _add_tag(it, self.label);
+        }
+    }
+}
+
+# Reader: only reports, no mutation.
+walker list_items {
+    can run with Root entry {
+        report [-->[?:Item]];
+    }
+}

--- a/jac/tests/runtimelib/test_serve_client.jac
+++ b/jac/tests/runtimelib/test_serve_client.jac
@@ -1535,6 +1535,27 @@ test "serve blocking sync walkers run concurrently via to_thread" {
     }
 }
 
+test "endpoint effect classifier follows helper calls" {
+    # A walker whose only graph mutation happens inside a plain `def` helper
+    # must still be classified as a writer -- otherwise the client cache is
+    # never invalidated after the mutation. The classifier has to follow the
+    # call into the helper to see the write.
+    import from jaclang.runtimelib.server { ModuleIntrospector }
+
+    jac_file = fixture_abs_path("serve_helper_effects.jac");
+    introspector = ModuleIntrospector(
+        module_name="serve_helper_effects", base_path=str(Path(jac_file).parent)
+    );
+    introspector.load();
+    effects = introspector._client_manifest.get("endpoint_effects", {});
+
+    assert "walker:tag_item" in effects , "tag_item should be classified";
+    assert effects["walker:tag_item"]["is_writer"] , "tag_item mutates the graph via the _add_tag helper -- must be a writer";
+
+    assert "walker:list_items" in effects , "list_items should be classified";
+    assert not effects["walker:list_items"]["is_writer"] , "list_items only reports -- must be a reader";
+}
+
 test "spawn_walker_sync and spawn_walker_async dispatch to explicit paths" {
     # Verifies the explicit sync/async entrypoints on ExecutionManager work
     # standalone (not via the back-compat dispatcher). The handler seam


### PR DESCRIPTION
## Problem

The endpoint-effect classifiers that decide whether a walker or function is a cache **reader** or **writer** only scanned the body directly. A walker whose graph mutation lives inside a plain `def` helper was misclassified as a reader.

Concretely, in a Twitter-like app a `like_tweet` walker that does its mutation through a helper:

```jac
walker like_tweet {
    has tweet_id: str;
    can run with Root entry {
        # ...locate tweet...
        report _toggle_like(tweet, username);   # mutation is in the helper
    }
}

def _toggle_like(tweet: Tweet, username: str) -> dict {
    tweet.likes = tweet.likes + [username];     # <-- the actual graph write
    # ...
}
```

was classified as a **reader**. Because readers don't invalidate the client cache, liking/commenting sent the request to the server but the follow-up `load_feed` returned the stale cached feed, so the UI never updated until a full page reload. Walkers that mutate directly in-body (`create_tweet`, `delete_tweet`) were unaffected.

## Fix

Make both effect classifiers interprocedural:

- **Compile-time** — `EsastGenPass._analyze_body_effects` now resolves `FuncCall`s to their `def`/ability bodies and recurses into them. An `id()`-keyed visited guard terminates on mutual/self recursion. Handles both inline and `impl`-separated bodies.
- **Runtime** — `ModuleIntrospector._analyze_endpoint_effects` follows calls into module-level helper defs, and additionally detects field mutation on non-`self` targets (`n.attr = ...`), which it previously missed entirely.

## Tests

- `test_client_codegen.jac` — `"endpoint effects follow helper calls"`: a walker and a `def:pub` function whose only graph mutation is delegated to a helper must be classified as writers.
- `test_serve_client.jac` — `"endpoint effect classifier follows helper calls"`, with a new `serve_helper_effects.jac` fixture, covering the runtime classifier.

Both fail before the change and pass after. Verified end-to-end against a full-stack app: liking/commenting now updates the UI without a reload, and `load_feed` is correctly re-fetched after the mutation.