### PR TITLE
fix(byllm): add httpx to jac.toml dependencies

### DIFF
--- a/docs/docs/community/release_notes/unreleased/byllm/6004.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/byllm/6004.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: CI dependency alignment check restored for `byllm`**: `httpx>=0.27.0` was missing from `jac.toml` after being added to `pyproject.toml` in #5944, causing the CI alignment check to fail. Both files are now in sync.

--- a/jac-byllm/jac.toml
+++ b/jac-byllm/jac.toml
@@ -24,6 +24,7 @@ packages = ["byllm*"]
 jaclang = ">=0.15.2"
 litellm = ">=1.70.0,<=1.82.6"  # SECURITY: v1.82.7+ was compromised and yanked from PyPI
 loguru = ">=0.7.2,<0.8.0"
+httpx = ">=0.27.0"
 pillow = ">=12.0.0,<13.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- PR #5944 added `httpx>=0.27.0` to `pyproject.toml` (required for async HTTP clients) but missed the corresponding entry in `jac.toml`
- The CI dep-alignment check caught the mismatch: `[dependencies]: only in pyproject.toml -> ['httpx>=0.27.0']`
- This adds `httpx = ">=0.27.0"` to `jac.toml` to bring both files back in sync

## Test plan
- [x] Verify CI dep-alignment check passes
