### PR TITLE
fix(native): make native compilation work on macOS

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6009.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6009.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Native compilation now works on macOS**: The native LLVM backend emitted calls to `malloc_usable_size`, a glibc symbol absent from macOS libSystem, so every native binary crashed at load with `Symbol not found: _malloc_usable_size`. The GC-debug emitters now select `malloc_size` on Darwin and `malloc_usable_size` elsewhere.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6009.docs.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6009.docs.md
@@ -1,0 +1,1 @@
+- **CLI: `jac-packaging` reference guide**: A new `jac guide` entry covers packaging a Jac project as a wheel and publishing it to PyPI: `jac.toml` metadata, the package-directory layout, the `__init__.py` bootstrap that makes `.jac` modules importable after install, console-script entry points, `jac bundle`, and twine.

--- a/jac/jaclang/cli/skills/jac-packaging.md
+++ b/jac/jaclang/cli/skills/jac-packaging.md
@@ -1,0 +1,93 @@
+---
+name: jac-packaging
+description: Packaging a Jac project as a wheel and publishing it to PyPI - jac.toml metadata, the package-directory layout, the __init__.py bootstrap that makes .jac modules importable after install, console-script entry points, jac bundle, and twine upload. Load when turning a project into a pip-installable CLI tool or an importable library. Pair with `jac-scaffold` (creating the project) and `jac-impl-files` (source layout).
+---
+
+`jac bundle` builds a standard PEP 427 wheel (`dist/<name>-<version>-py3-none-any.whl`) straight from `jac.toml` - no `setup.py`, no `pyproject.toml`. Upload it to PyPI with `twine`. This covers both shapes: a **CLI tool** (installs a terminal command) and an **importable library** (`pip install` then `import`).
+
+## The package directory - REQUIRED
+
+`jac bundle` packages a directory whose name matches `project.name` (hyphens become underscores: `my-tool` -> `my_tool/`). The `jac create` default template puts `main.jac` at the project ROOT with no such directory - that layout does NOT produce an importable package. Create the package dir yourself:
+
+```
+greet/                  <- project root (holds jac.toml)
+  jac.toml
+  README.md
+  greet/                <- package dir, name matches project.name
+    __init__.py         <- Python file, NOT .jac - see below
+    cli.jac             <- your code, normal Jac
+```
+
+## The `__init__.py` bootstrap - REQUIRED, easy to miss
+
+The package's `__init__` must be a **Python** file (`__init__.py`), not `__init__.jac`, containing exactly:
+
+```python
+"""mypkg - bootstraps the Jac meta-importer for .jac submodules."""
+import jaclang  # noqa: F401  (registers JacMetaImporter on sys.meta_path)
+```
+
+Why: after a normal `pip install`, a directory with no `__init__.py` is claimed by Python as a *namespace package* before the lazy Jac finder runs - so the `.jac` modules inside it never load and `import mypkg.cli` fails with `ModuleNotFoundError`. A real `__init__.py` makes it a regular package; `import jaclang` inside it registers the importer that loads every `.jac` submodule. Without this, the wheel installs but nothing inside it can be imported.
+
+## jac.toml for distribution
+
+```toml
+[project]
+name = "greet"
+version = "0.1.0"
+description = "A tiny Jac CLI app"
+authors = [{name = "Jane Dev", email = "jane@example.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+keywords = ["cli", "greeting"]
+
+[project.urls]
+Homepage = "https://example.com/greet"
+
+[entrypoints.scripts]
+greet = "greet.cli:main"
+
+[dependencies]
+rich = ">=13.0.0"
+```
+
+- **`[project]`** -> wheel `METADATA`. The TOML key is **`requires-python`** (hyphen), not `requires_python` - the underscore form is silently ignored and never reaches `METADATA`.
+- **`[dependencies]`** -> `Requires-Dist` in the wheel, so `pip install` pulls them in.
+- **`[entrypoints.scripts]`** -> `console_scripts` in `entry_points.txt`. Format is `command = "package.module:function"`. The function is called with no arguments; read `sys.argv` for CLI args. Omit this whole section for a pure library.
+
+## Build and publish
+
+```
+jac bundle                 # -> dist/greet-0.1.0-py3-none-any.whl
+jac bundle -o /tmp/wheels  # custom output dir
+twine upload dist/*.whl    # publish to PyPI (twine is a separate pip install)
+```
+
+There is no `jac publish` command - use `twine`. Consumers then `pip install greet`; the CLI command `greet` is on `PATH`, or `import greet` works for a library. `pip install jaclang` is pulled in automatically if you list it (or it rides along as a dependency) - the importer it ships is what runs your `.jac` code.
+
+## What lands in the wheel
+
+`jac bundle` collects `*.jac`, `*.py`, `*.pyi`, `*.lark`, `py.typed`, and `*.jir` from the package directory. It excludes `.jac/`, `__pycache__/`, `dist/`, `build/`, `venv/.venv/env/`, `.git/`, and `node_modules/`. To package extra directories or override patterns, use `[project.include]` with `packages` and `data` keys.
+
+## Editable installs (local development)
+
+```
+jac install -e .            # install the current project editable
+jac install -e /path/to/lib # install a cloned library editable
+```
+
+## Pitfalls
+
+- **No package directory = empty/unimportable wheel.** The `default` scaffold's root-level `main.jac` is for `jac run`, not for distribution. Move code into a `<name>/` package dir.
+- **`__init__.jac` instead of `__init__.py` breaks import after install.** The bootstrap file must be Python. Submodules stay `.jac`.
+- **`requires_python` (underscore) is dropped.** Use `requires-python`.
+- **Entry-point path is the install-time module path**, e.g. `greet.cli:main` - it must match the package dir name, not the source folder you happened to develop in.
+- **First run of an installed Jac command prints `Jac setup complete! (N modules compiled and cached)`** while jaclang compiles its own cache. This is one-time and harmless; it does not repeat on later runs.
+- **`jac bundle` fails with `[project] name is missing`** if `jac.toml` has no `name` - it is required for the wheel filename and `.dist-info`.
+
+## See also
+
+- `jac-scaffold` - `jac create`, templates, the `default` template's layout
+- `jac-impl-files` - splitting `.jac` / `.impl.jac` within the package
+- `jac-core-cheatsheet` - import forms inside `.jac` files

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/gc_debug.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/gc_debug.impl.jac
@@ -377,9 +377,14 @@ impl NaIRGenPass._emit_raw_free_bbs(
     log_raw_bb = func.append_basic_block("log_raw");
     live_rm_bb = func.append_basic_block("live_rm");
     actual_free_bb = func.append_basic_block("actual_free");
-    # log_free_raw: call malloc_usable_size, check debug flag
+    # log_free_raw: call the platform malloc-size intrinsic, check debug flag.
+    # glibc exports malloc_usable_size; macOS libSystem only has malloc_size
+    # (same i64(i8*) signature). Picking the wrong one fails at dyld load with
+    # "Symbol not found: _malloc_usable_size".
     b = ir.IRBuilder(log_free_bb);
-    _msz_fn = self._get_or_declare_extern("malloc_usable_size", i64, [i8_ptr]);
+    import platform;
+    _msz_sym = "malloc_size" if platform.system() == "Darwin" else "malloc_usable_size";
+    _msz_fn = self._get_or_declare_extern(_msz_sym, i64, [i8_ptr]);
     _raw_msz = b.gep(ptr, [ir.Constant(i64, HDR_ALLOC_ID_OFF)], name="raw.msz");
     _msz = b.call(_msz_fn, [_raw_msz], name="msz");
     dbg_flag3 = b.load(self.rc_debug_gv, name="rc.dbg3");
@@ -444,9 +449,12 @@ impl NaIRGenPass._emit_struct_free_log(
     i64 = ir.IntType(64);
     i32 = ir.IntType(32);
     log_struct_line_bb = func.append_basic_block("log_struct_line");
-    # log_free_struct: compute msz, check debug flag
+    # log_free_struct: compute msz, check debug flag.
+    # macOS libSystem has malloc_size, not glibc's malloc_usable_size.
     b = ir.IRBuilder(log_free_struct_bb);
-    _msz_fn = self._get_or_declare_extern("malloc_usable_size", i64, [i8_ptr]);
+    import platform;
+    _msz_sym = "malloc_size" if platform.system() == "Darwin" else "malloc_usable_size";
+    _msz_fn = self._get_or_declare_extern(_msz_sym, i64, [i8_ptr]);
     _msz2 = b.call(_msz_fn, [obj_raw], name="msz2");
     dbg_flag_s = b.load(self.rc_debug_gv, name="rc.dbg.s");
     b.cbranch(

--- a/jac/tests/compiler/passes/native/test_native_gc.jac
+++ b/jac/tests/compiler/passes/native/test_native_gc.jac
@@ -52,19 +52,30 @@ def _run_with_time(
             env[k] = v;
         }
     }
+    # GNU coreutils `time` (Linux) uses `-v` and reports RSS in kbytes; BSD
+    # `time` (macOS) uses `-l` and reports "maximum resident set size" in bytes.
+    is_bsd_time = sys.platform == "darwin";
+    time_flag = "-l" if is_bsd_time else "-v";
     proc = subprocess.run(
-        [time_bin, "-v", binary],
+        [time_bin, time_flag, binary],
         input=stdin_data,
         capture_output=True,
         text=True,
         timeout=timeout,
         env=env,
     );
-    # /usr/bin/time -v writes its summary to stderr after the child's own stderr.
+    # `/usr/bin/time` writes its summary to stderr after the child's own stderr.
     rss_kb = 0;
-    m = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", proc.stderr);
-    if m {
-        rss_kb = int(m.group(1));
+    if is_bsd_time {
+        m = re.search(r"(\d+)\s+maximum resident set size", proc.stderr);
+        if m {
+            rss_kb = int(m.group(1)) // 1024;  # BSD reports bytes
+        }
+    } else {
+        m = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", proc.stderr);
+        if m {
+            rss_kb = int(m.group(1));
+        }
     }
     head = proc.stdout[:200] if proc.stdout else "";
     return (rss_kb, proc.returncode, head);


### PR DESCRIPTION
## Summary

Native compilation (`jac nacompile`) was broken on macOS — every native binary crashed at load. This PR fixes the root cause and a related test-harness incompatibility, then adds a packaging reference guide.

## Fix 1 — `malloc_usable_size` crash

The native LLVM backend's GC-debug emitters (`_emit_raw_free_bbs`, `_emit_struct_free_log` in `gc_debug.impl.jac`) emitted calls to `malloc_usable_size`, a glibc symbol absent from macOS libSystem. Any native binary that reached a free path — effectively all of them — crashed at dyld load:

```
dyld: Symbol not found: _malloc_usable_size
```

Now selects `malloc_size` on Darwin and `malloc_usable_size` elsewhere (identical `i64(i8*)` signature), reusing the existing `platform.system() == "Darwin"` pattern already used for `__stdinp`.

## Fix 2 — GC test harness assumed GNU `time`

`tests/compiler/passes/native/test_native_gc.jac` hardcoded `/usr/bin/time -v` (GNU coreutils). macOS ships BSD `time`, which rejects `-v` (uses `-l`) and reports RSS in bytes, not kbytes — failing 5 GC tests on macOS independent of Fix 1. `_run_with_time` is now platform-conditional.

## Guide — `jac-packaging`

Adds a curated `jac guide` entry covering how to package a Jac project as a wheel and publish to PyPI: `jac.toml` metadata, the package-directory layout, the `__init__.py` bootstrap required for `.jac` modules to import after install, console-script entry points, `jac bundle`, and twine. Covers the pip-installable CLI tool and importable library paths, which had no guide coverage.

## Validation

- `jac nacompile` builds and runs trivial + object/list/string/`+=` programs on macOS arm64.
- Full native suite: **385 passed** (`tests/compiler/passes/native/` + `test_native_marshal.jac`).
- Packaging guide validated end-to-end: built a CLI app wheel, installed it into a clean venv, confirmed the console command and library import both work.