### PR TITLE
fix(packaging): make the lazy .pth finder resolve .jac submodules

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6010.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6010.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Packaged Jac wheels import without an `__init__.py`**: A `pip install`ed Jac package now resolves its `.jac` submodules automatically, so `jac bundle` projects need no hand-written `__init__.py` bootstrap.

--- a/jac/_jac_finder.py
+++ b/jac/_jac_finder.py
@@ -18,6 +18,10 @@ from types import ModuleType
 class _JacLazyFinder:
     """Stub meta-path finder that triggers full jaclang init on first .jac import."""
 
+    # The file shapes a Jac module can take, kept in sync with JacMetaImporter.
+    _JAC_SUFFIXES = (".jac", ".sv.jac", ".cl.jac", ".na.jac")
+    _JAC_INIT_FILES = ("__init__.jac", "__init__.sv.jac", "__init__.cl.jac")
+
     def find_spec(
         self,
         fullname: str,
@@ -30,22 +34,42 @@ class _JacLazyFinder:
             self._remove()
             return None
 
-        # Check if any search path contains a matching .jac file or package
-        parts = fullname.split(".")
-        search_paths = list(path) if path else sys.path
+        # Mirror JacMetaImporter: for a submodule import `path` already points
+        # inside the parent package, so only the final name component is
+        # appended; for a top-level import the full dotted name is used.
+        if path is None:
+            search_paths: Sequence[str] = sys.path
+            module_parts = fullname.split(".")
+        else:
+            search_paths = list(path)
+            module_parts = fullname.split(".")[-1:]
 
         for base in search_paths:
             if not isinstance(base, str):
                 continue
-            candidate = os.path.join(base, *parts)
-            if os.path.isfile(candidate + ".jac"):
+            candidate = os.path.join(base, *module_parts)
+            if os.path.isdir(candidate) and self._is_jac_package(candidate):
                 return self._bootstrap_and_delegate(fullname, path, target)
-            if os.path.isdir(candidate) and os.path.isfile(
-                os.path.join(candidate, "__init__.jac")
-            ):
-                return self._bootstrap_and_delegate(fullname, path, target)
+            for suffix in self._JAC_SUFFIXES:
+                if os.path.isfile(candidate + suffix):
+                    return self._bootstrap_and_delegate(fullname, path, target)
 
         return None
+
+    @classmethod
+    def _is_jac_package(cls, directory: str) -> bool:
+        """Return True if `directory` is a Jac package or Jac namespace package."""
+        for init_name in cls._JAC_INIT_FILES:
+            if os.path.isfile(os.path.join(directory, init_name)):
+                return True
+        # A directory with .jac files and no __init__.py is a Jac namespace
+        # package; without claiming it, Python would own it as a plain one.
+        if not os.path.isfile(os.path.join(directory, "__init__.py")):
+            try:
+                return any(e.endswith(".jac") for e in os.listdir(directory))
+            except OSError:
+                return False
+        return False
 
     def _bootstrap_and_delegate(
         self,

--- a/jac/jaclang/cli/skills/jac-packaging.md
+++ b/jac/jaclang/cli/skills/jac-packaging.md
@@ -1,6 +1,6 @@
 ---
 name: jac-packaging
-description: Packaging a Jac project as a wheel and publishing it to PyPI - jac.toml metadata, the package-directory layout, the __init__.py bootstrap that makes .jac modules importable after install, console-script entry points, jac bundle, and twine upload. Load when turning a project into a pip-installable CLI tool or an importable library. Pair with `jac-scaffold` (creating the project) and `jac-impl-files` (source layout).
+description: Packaging a Jac project as a wheel and publishing it to PyPI - jac.toml metadata, the package-directory layout, console-script entry points, jac bundle, and twine upload. Load when turning a project into a pip-installable CLI tool or an importable library. Pair with `jac-scaffold` (creating the project) and `jac-impl-files` (source layout).
 ---
 
 `jac bundle` builds a standard PEP 427 wheel (`dist/<name>-<version>-py3-none-any.whl`) straight from `jac.toml` - no `setup.py`, no `pyproject.toml`. Upload it to PyPI with `twine`. This covers both shapes: a **CLI tool** (installs a terminal command) and an **importable library** (`pip install` then `import`).
@@ -14,20 +14,8 @@ greet/                  <- project root (holds jac.toml)
   jac.toml
   README.md
   greet/                <- package dir, name matches project.name
-    __init__.py         <- Python file, NOT .jac - see below
     cli.jac             <- your code, normal Jac
 ```
-
-## The `__init__.py` bootstrap - REQUIRED, easy to miss
-
-The package's `__init__` must be a **Python** file (`__init__.py`), not `__init__.jac`, containing exactly:
-
-```python
-"""mypkg - bootstraps the Jac meta-importer for .jac submodules."""
-import jaclang  # noqa: F401  (registers JacMetaImporter on sys.meta_path)
-```
-
-Why: after a normal `pip install`, a directory with no `__init__.py` is claimed by Python as a *namespace package* before the lazy Jac finder runs - so the `.jac` modules inside it never load and `import mypkg.cli` fails with `ModuleNotFoundError`. A real `__init__.py` makes it a regular package; `import jaclang` inside it registers the importer that loads every `.jac` submodule. Without this, the wheel installs but nothing inside it can be imported.
 
 ## jac.toml for distribution
 
@@ -80,7 +68,6 @@ jac install -e /path/to/lib # install a cloned library editable
 ## Pitfalls
 
 - **No package directory = empty/unimportable wheel.** The `default` scaffold's root-level `main.jac` is for `jac run`, not for distribution. Move code into a `<name>/` package dir.
-- **`__init__.jac` instead of `__init__.py` breaks import after install.** The bootstrap file must be Python. Submodules stay `.jac`.
 - **`requires_python` (underscore) is dropped.** Use `requires-python`.
 - **Entry-point path is the install-time module path**, e.g. `greet.cli:main` - it must match the package dir name, not the source folder you happened to develop in.
 - **First run of an installed Jac command prints `Jac setup complete! (N modules compiled and cached)`** while jaclang compiles its own cache. This is one-time and harmless; it does not repeat on later runs.

--- a/jac/tests/publish/test_pth_finder.jac
+++ b/jac/tests/publish/test_pth_finder.jac
@@ -1,0 +1,71 @@
+"""Tests for the .pth-installed lazy Jac import finder (_jac_finder).
+
+These exercise the path a pip-installed Jac wheel takes: a clean interpreter
+where nobody has imported jaclang yet, relying solely on the jaclang.pth shim
+to make .jac modules importable.
+"""
+
+import sys;
+import tempfile;
+import shutil;
+import from pathlib { Path }
+import from subprocess { run }
+
+
+"""Run a snippet in a clean interpreter where jaclang is not pre-imported."""
+def _run_clean(snippet: str) -> object {
+    return run([sys.executable, "-c", snippet], capture_output=True, text=True);
+}
+
+
+test "lazy finder loads a .jac submodule of a no-__init__ package" {
+    # Mirrors a pip-installed Jac wheel: the package directory has no
+    # __init__.py, so `import pkg.mod` must resolve a .jac submodule without
+    # anything having imported jaclang first -- exactly what jaclang.pth enables.
+    tmp_path = tempfile.mkdtemp();
+    try {
+        pkg = Path(tmp_path) / "demopkg";
+        pkg.mkdir();
+        (pkg / "greet.jac").write_text(
+            'def hello() -> str { return "hi-from-jac"; }\n'
+        );
+
+        snippet = (
+            "import sys; sys.path.insert(0, " + repr(tmp_path) + ");"
+            "import _jac_finder; _jac_finder.install();"
+            "assert 'jaclang' not in sys.modules, 'jaclang imported before first .jac use';"
+            "import demopkg.greet;"
+            "print(demopkg.greet.hello());"
+        );
+        result = _run_clean(snippet);
+
+        assert result.returncode == 0 , result.stderr;
+        assert "hi-from-jac" in result.stdout;
+    } finally {
+        shutil.rmtree(tmp_path, ignore_errors=True);
+    }
+}
+
+
+test "lazy finder loads a top-level .jac module" {
+    # Regression guard: the top-level import path must keep working.
+    tmp_path = tempfile.mkdtemp();
+    try {
+        (Path(tmp_path) / "solo.jac").write_text(
+            'def ping() -> str { return "pong"; }\n'
+        );
+
+        snippet = (
+            "import sys; sys.path.insert(0, " + repr(tmp_path) + ");"
+            "import _jac_finder; _jac_finder.install();"
+            "import solo;"
+            "print(solo.ping());"
+        );
+        result = _run_clean(snippet);
+
+        assert result.returncode == 0 , result.stderr;
+        assert "pong" in result.stdout;
+    } finally {
+        shutil.rmtree(tmp_path, ignore_errors=True);
+    }
+}


### PR DESCRIPTION
## Problem

`jac bundle` wheels were not importable without a hand-written `__init__.py` bootstrap, even though the `jaclang.pth` lazy-import mechanism exists specifically to make that unnecessary.

The lazy finder `_jac_finder._JacLazyFinder.find_spec` always joined the **full** dotted module name onto each search path. For a submodule import, Python passes a `path` that already points inside the parent package, so `import mypkg.cli` was looked up at `.../mypkg/mypkg/cli.jac`, never found, and fell through to `ModuleNotFoundError`. Only top-level `.jac` modules ever resolved through the `.pth` shim.

## Fix

`find_spec` now mirrors `JacMetaImporter.find_spec`:

- top-level imports use the full dotted name against `sys.path`;
- submodule imports use only the final name component against the supplied `path`.

It also recognizes every Jac file shape (`.jac`, `.sv.jac`, `.cl.jac`, `.na.jac`) and Jac package directories, factored into `_is_jac_package`.

With this, a `jac bundle` wheel imports and runs in a fresh interpreter with no `__init__.py` bootstrap file -- the console-script entry point and `import pkg.mod` both work. The `jac-packaging` skill is updated to drop the now-obsolete `__init__.py` guidance.

## Tests

Adds `tests/publish/test_pth_finder.jac`:

- **submodule import** through the lazy finder for a package with no `__init__.py` -- fails before this change, passes after;
- **top-level import** -- regression guard.

Both run in a clean subprocess where `jaclang` is not pre-imported, and assert the finder stays lazy (no `jaclang` in `sys.modules` until the first `.jac` import).

Verified end-to-end: built a `jac bundle` wheel with no `__init__.py`, installed it into a fresh venv, and confirmed the console script and `import pkg.mod` both work cold.