### PR TITLE
feat(cli): add `jac ai` interactive coding agent

### DIFF
--- a/docs/docs/community/release_notes/unreleased/byllm/6018.feature.md
+++ b/docs/docs/community/release_notes/unreleased/byllm/6018.feature.md
@@ -1,0 +1,1 @@
+- **Tool calling for local models**: byLLM now supports tool calling on backends without server-side tool support by rendering the tool protocol into the prompt and recovering tool calls from the reply.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6018.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6018.feature.md
@@ -1,0 +1,1 @@
+- **`jac ai` interactive coding agent**: A new `jac ai` command launches an interactive Jac coding agent in the terminal, working with local or cloud byLLM models.

--- a/jac-byllm/byllm/impl/schema.impl.jac
+++ b/jac-byllm/byllm/impl/schema.impl.jac
@@ -263,12 +263,20 @@ impl _type_to_schema(
     if isinstance(ty, (FunctionType, MethodType)) {
         hints = get_type_hints(ty);
         hints.pop("return", None);
-        # Use MTIR info if available, otherwise fall back to introspection
+        # Use MTIR info if available, otherwise fall back to introspection.
+        # The function's own type hints are authoritative for *which* params
+        # exist, so iterate those and decorate with the MTIR semstring where
+        # the names line up - a mismatch between hints and info (e.g. a stale
+        # or mis-assigned info) must not crash schema generation.
         if info and info?.params and info.params {
+            sem_by_name = {p.name: p for p in info.params};
             params = {
-                param.name: _type_to_schema(
-                    hints[param.name], param.name, param.semstr, info=param
-                ) for param in info.params
+                param_name: _type_to_schema(
+                    param_type,
+                    param_name,
+                    sem_by_name[param_name].semstr if param_name in sem_by_name else "",
+                    info=sem_by_name.get(param_name)
+                ) for (param_name, param_type) in hints.items()
             };
         } else {
             # Fall back to introspecting the function's type hints

--- a/jac-byllm/byllm/llm.impl/basellm.impl.jac
+++ b/jac-byllm/byllm/llm.impl/basellm.impl.jac
@@ -861,6 +861,100 @@ impl BaseLLM.dispatch_streaming(mt_run: MTRuntime) -> Generator[str, None, None]
     }
 }
 
+"""Dispatch a tool-enabled LLM call with streaming.
+
+Streams the model's content tokens (yielded as they arrive) while collecting
+the full response - content, tool calls and usage - which is reassembled and
+appended to `out` as a single CompletionResult. This lets the ReAct loop
+surface the model's reasoning live, token by token, instead of waiting for the
+whole step to finish. Backends without streaming (e.g. MockLLM) transparently
+fall back to one non-streaming call.
+"""
+impl BaseLLM.dispatch_streaming_with_tools(
+    mt_run: MTRuntime, out: list[CompletionResult]
+) -> Generator[str, None, None] {
+    params = self.make_model_params(mt_run);
+    log_params = self.format_prompt(params);
+    self.log_info(
+        f"Calling LLM (streaming): {self.model_name} with params:\n{log_params}"
+    );
+    self.api_base = params.pop("api_base", DEFAULT_BASE_URL);
+    params.pop("api_key", None);
+    chunks: list = [];
+    content_buf = "";
+    no_stream = False;
+    try {
+        for chunk in self.model_call_with_stream(params) {
+            chunks.append(chunk);
+            delta_content = "";
+            if chunk?.choices and chunk?.choices?[0]?.delta {
+                delta_content = chunk.choices[0].delta?.content or "";
+            } elif isinstance(chunk, dict) {
+                _choices = chunk.get("choices") or [];
+                if _choices {
+                    delta_content = (_choices[0].get("delta") or {}).get("content")
+                    or "";
+                }
+            }
+            if delta_content {
+                content_buf += str(delta_content);
+                yield str(delta_content);
+            }
+        }
+    } except NotImplementedError {
+        # Backend has no streaming - fall back to a single non-streaming call.
+        no_stream = True;
+    }
+    if no_stream {
+        out.append(self.dispatch_no_streaming(mt_run));
+        return;
+    }
+    # Reassemble the streamed chunks into one complete response. litellm's
+    # builder merges native tool-call fragments; the fallback covers backends
+    # whose chunk shape it cannot parse (e.g. in-process llama.cpp).
+    message: object = None;
+    usage_data: dict = {};
+    try {
+        rebuilt = litellm.stream_chunk_builder(chunks);
+        if rebuilt {
+            message = rebuilt.get("choices", [])[0].get("message");
+            usage_data = rebuilt.get("usage", {}) or {};
+        }
+    } except Exception as e {
+        logger.debug(f"stream_chunk_builder failed, using accumulated text: {e}");
+        message = None;
+    }
+    if message is None {
+        message = {"role": "assistant", "content": content_buf};
+    }
+    # For backends without native tool calling, lift any tool call emitted as
+    # plain text into the structured `tool_calls` field (see dispatch_no_streaming).
+    if not self.supports_native_tools {
+        recover_tool_calls(message, [t.get_name() for t in mt_run.tools]);
+    }
+    mt_run.add_message(message);
+    output_content: str = message.get("content") or "";
+    tool_calls: list[ToolCall] = [];
+    tool_calls_list = (message or {}).get("tool_calls") or [];
+    for tool_call in tool_calls_list {
+        if tool := mt_run.get_tool(tool_call.function.name) {
+            args_json = json.loads(tool_call.function.arguments);
+            args = tool.parse_arguments(args_json);
+            tool_calls.append(ToolCall(call_id=tool_call.id, tool=tool, args=args));
+        } else {
+            raise UnknownToolError(
+                f"Attempted to call tool: '{tool_call.function.name}' which was not present."
+            );
+        }
+    }
+    output_value = mt_run.parse_response(output_content)
+        if not tool_calls_list
+        else output_content;
+    out.append(
+        CompletionResult(output=output_value, tool_calls=tool_calls, usage=usage_data)
+    );
+}
+
 """Async dispatch: mirrors dispatch_no_streaming but calls model_call_no_stream_async."""
 impl BaseLLM.adispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
     params = self.make_model_params(mt_run);
@@ -1227,7 +1321,22 @@ impl BaseLLM._invoke_streaming(
             import time as _time;
             _llm_t0 = _time.time();
             try {
-                resp = self.dispatch_no_streaming(mt_run);
+                # Stream the model's content tokens live as `thought` events
+                # while collecting the full response (content + tool calls).
+                _stream_out: list[CompletionResult] = [];
+                for _tok in self.dispatch_streaming_with_tools(mt_run, _stream_out) {
+                    if _tok {
+                        yield StreamEvent(
+                            event_type="thought",
+                            data={
+                                "content": _tok,
+                                "iteration": iter_count,
+                                "streaming": True
+                            }
+                        );
+                    }
+                }
+                resp = _stream_out[0];
             } except litellm.exceptions.ContextWindowExceededError {
                 if not comp_enabled {
                     raise;
@@ -1300,14 +1409,8 @@ impl BaseLLM._invoke_streaming(
                 data={"duration_ms": _llm_ms, "iteration": iter_count}
             );
 
-            # Yield thought if the LLM produced reasoning text
-            if resp.output and str(resp.output).strip() {
-                yield StreamEvent(
-                    event_type="thought",
-                    data={"content": str(resp.output).strip(), "iteration": iter_count}
-                );
-            }
-
+            # The model's reasoning already streamed above as incremental
+            # `thought` events while the call was in flight.
             if resp.tool_calls {
                 # Split at first finish_tool - normalizes history for both modes.
                 non_finish_calls: list = [];
@@ -1408,15 +1511,11 @@ impl BaseLLM._invoke_streaming(
                 # this branch handles MockLLM which bypasses parse_response.)
                 recovery_resp = self._attempt_recovery(mt_run);
                 if recovery_resp is None {
-                    # Plain string return or no finish_tool - yield and exit
+                    # Plain string return or no finish_tool. The answer already
+                    # streamed above as `thought` events, so just close out.
                     yield StreamEvent(
                         event_type="steps_done", data={"iterations": iter_count}
                     );
-                    if resp.output {
-                        yield StreamEvent(
-                            event_type="chunk", data={"content": str(resp.output)}
-                        );
-                    }
                     break;
                 }
                 yield from self._yield_recovery_result(

--- a/jac-byllm/byllm/llm.impl/basellm.impl.jac
+++ b/jac-byllm/byllm/llm.impl/basellm.impl.jac
@@ -709,6 +709,13 @@ impl BaseLLM.make_model_params(mt_run: MTRuntime) -> dict {
     # default to the first allowed enum value for every input. No-op when
     # response_format has no enum-typed properties.
     params = inject_schema_hint(params);
+    # Backends without server-side tool calling (in-process llama.cpp) get the
+    # tool schemas + call protocol rendered straight into the system prompt;
+    # the structured `tools` field is dropped so their unreliable native tool
+    # template is not engaged. The cloud/litellm path keeps `tools` untouched.
+    if not self.supports_native_tools {
+        params = inject_tool_hint(params);
+    }
     return params;
 }
 
@@ -794,6 +801,12 @@ impl BaseLLM.dispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
     message: LiteLLMMessage = response.get("choices", [])[0].get(
         "message"
     );  # type: ignore
+    # For backends without native tool calling, lift any tool call the model
+    # emitted as plain text into the structured `tool_calls` field so the
+    # ReAct loop below sees it. No-op once `tool_calls` is already populated.
+    if not self.supports_native_tools {
+        recover_tool_calls(message, [t.get_name() for t in mt_run.tools]);
+    }
     mt_run.add_message(message);
     output_content: str = message.get("content") or "";  # type: ignore
     self.log_info(f"LLM call completed with response: {output_content}");
@@ -865,6 +878,12 @@ impl BaseLLM.adispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
     message: LiteLLMMessage = response.get("choices", [])[0].get(
         "message"
     );  # type: ignore
+    # For backends without native tool calling, lift any tool call the model
+    # emitted as plain text into the structured `tool_calls` field so the
+    # ReAct loop below sees it. No-op once `tool_calls` is already populated.
+    if not self.supports_native_tools {
+        recover_tool_calls(message, [t.get_name() for t in mt_run.tools]);
+    }
     mt_run.add_message(message);
     output_content: str = message.get("content") or "";  # type: ignore
     self.log_info(f"LLM call completed with response: {output_content}");

--- a/jac-byllm/byllm/llm.impl/basellm.impl.jac
+++ b/jac-byllm/byllm/llm.impl/basellm.impl.jac
@@ -772,6 +772,102 @@ impl BaseLLM.format_prompt(params: dict) -> str {
     return log;
 }
 
+"""Build a ToolCall that reports a malformed-call error back to the model.
+
+When the model emits a tool call byLLM cannot honour - invalid JSON arguments,
+or a tool name that does not exist - the ReAct loop must still answer that
+call_id with a tool result (the provider API requires tool_use/tool_result
+pairing) and let the model retry. This wraps the failure as an ordinary tool
+result so the turn recovers gracefully instead of crashing.
+"""
+def _error_tool_call(call_id: str, tool_name: str, reason: str) -> ToolCall {
+    name = tool_name or "unknown_tool";
+    def _report_error -> str {
+        return (
+            f"Tool error: {reason}. "
+            f"Re-send the {name} call with corrected arguments."
+        );
+    }
+    _report_error.__name__ = name;
+    return ToolCall(call_id=call_id, tool=Tool(func=_report_error), args={});
+}
+
+
+"""Parse raw LLM tool calls into ToolCall objects, tolerating malformed calls.
+
+A tool call the model botches - invalid JSON arguments, or a tool name that
+does not exist - becomes an error ToolCall (see `_error_tool_call`) instead of
+a raised exception. The ReAct loop then answers it with a normal tool result
+so the model can retry, rather than the whole turn crashing on one bad call.
+"""
+def _parse_tool_calls(mt_run: MTRuntime, tool_calls_list: list) -> list[ToolCall] {
+    parsed: list[ToolCall] = [];
+    for tool_call in tool_calls_list {
+        fn = tool_call?.function;
+        call_id = str(tool_call?.id or "");
+        tool_name = str(fn?.name or "") if fn else "";
+        tool = mt_run.get_tool(tool_name);
+        if tool is None {
+            parsed.append(
+                _error_tool_call(call_id, tool_name, f"unknown tool '{tool_name}'")
+            );
+            continue;
+        }
+        try {
+            raw_args = (fn?.arguments or "") if fn else "";
+            args_json = json.loads(raw_args) if raw_args else {};
+            args = tool.parse_arguments(args_json);
+        } except Exception as e {
+            parsed.append(
+                _error_tool_call(call_id, tool_name, f"invalid tool arguments ({e})")
+            );
+            continue;
+        }
+        parsed.append(ToolCall(call_id=call_id, tool=tool, args=args));
+    }
+    return parsed;
+}
+
+
+"""Repair malformed tool-call arguments on an assistant message, in place.
+
+A tool call whose `arguments` string is not valid JSON cannot be replayed to
+the provider API on the next turn - the provider rejects the entire request
+(`Expecting value: line 1 column 1`). Rewrite any such arguments to `"{}"` so
+the message persists and replays cleanly. The model still sees the failure as a
+recoverable tool result: the now-empty arguments make the tool run without its
+required inputs and fail the ordinary, caught way.
+"""
+def _sanitize_tool_calls(message: object) {
+    tool_calls = (message or {}).get("tool_calls") or [];
+    for tc in tool_calls {
+        fn = tc?.function;
+        if fn is None {
+            continue;
+        }
+        raw = fn?.arguments;
+        valid = False;
+        if isinstance(raw, str) and raw.strip() {
+            try {
+                json.loads(raw);
+                valid = True;
+            } except Exception {
+                valid = False;
+            }
+        }
+        if not valid {
+            try {
+                fn.arguments = "{}";
+            } except Exception {
+                if isinstance(fn, dict) {
+                    fn["arguments"] = "{}";
+                }
+            }
+        }
+    }
+}
+
+
 """Dispatch the LLM call without streaming.
 
 Makes a synchronous API call and processes the response, including
@@ -807,22 +903,13 @@ impl BaseLLM.dispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
     if not self.supports_native_tools {
         recover_tool_calls(message, [t.get_name() for t in mt_run.tools]);
     }
+    _sanitize_tool_calls(message);
     mt_run.add_message(message);
     output_content: str = message.get("content") or "";  # type: ignore
     self.log_info(f"LLM call completed with response: {output_content}");
     tool_calls: list[ToolCall] = [];
     tool_calls_list = (message or {}).get("tool_calls") or [];
-    for tool_call in tool_calls_list {
-        if tool := mt_run.get_tool(tool_call.function.name) {
-            args_json = json.loads(tool_call.function.arguments);
-            args = tool.parse_arguments(args_json);
-            tool_calls.append(ToolCall(call_id=tool_call.id, tool=tool, args=args));
-        } else {
-            raise UnknownToolError(
-                f"Attempted to call tool: '{tool_call.function.name}' which was not present."
-            );
-        }
-    }
+    tool_calls = _parse_tool_calls(mt_run, tool_calls_list);
     # Only parse the content as the final output when there are no tool calls.
     # gpt-4o may return non-JSON content alongside tool calls (e.g. "I'll handle that."),
     # which would cause json.loads to fail if we parsed it as the typed response.
@@ -932,21 +1019,12 @@ impl BaseLLM.dispatch_streaming_with_tools(
     if not self.supports_native_tools {
         recover_tool_calls(message, [t.get_name() for t in mt_run.tools]);
     }
+    _sanitize_tool_calls(message);
     mt_run.add_message(message);
     output_content: str = message.get("content") or "";
     tool_calls: list[ToolCall] = [];
     tool_calls_list = (message or {}).get("tool_calls") or [];
-    for tool_call in tool_calls_list {
-        if tool := mt_run.get_tool(tool_call.function.name) {
-            args_json = json.loads(tool_call.function.arguments);
-            args = tool.parse_arguments(args_json);
-            tool_calls.append(ToolCall(call_id=tool_call.id, tool=tool, args=args));
-        } else {
-            raise UnknownToolError(
-                f"Attempted to call tool: '{tool_call.function.name}' which was not present."
-            );
-        }
-    }
+    tool_calls = _parse_tool_calls(mt_run, tool_calls_list);
     output_value = mt_run.parse_response(output_content)
         if not tool_calls_list
         else output_content;
@@ -978,22 +1056,13 @@ impl BaseLLM.adispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult {
     if not self.supports_native_tools {
         recover_tool_calls(message, [t.get_name() for t in mt_run.tools]);
     }
+    _sanitize_tool_calls(message);
     mt_run.add_message(message);
     output_content: str = message.get("content") or "";  # type: ignore
     self.log_info(f"LLM call completed with response: {output_content}");
     tool_calls: list[ToolCall] = [];
     tool_calls_list = (message or {}).get("tool_calls") or [];
-    for tool_call in tool_calls_list {
-        if tool := mt_run.get_tool(tool_call.function.name) {
-            args_json = json.loads(tool_call.function.arguments);
-            args = tool.parse_arguments(args_json);
-            tool_calls.append(ToolCall(call_id=tool_call.id, tool=tool, args=args));
-        } else {
-            raise UnknownToolError(
-                f"Attempted to call tool: '{tool_call.function.name}' which was not present."
-            );
-        }
-    }
+    tool_calls = _parse_tool_calls(mt_run, tool_calls_list);
     output_value = mt_run.parse_response(output_content)
         if not tool_calls_list
         else output_content;

--- a/jac-byllm/byllm/llm.impl/local.impl.jac
+++ b/jac-byllm/byllm/llm.impl/local.impl.jac
@@ -30,6 +30,9 @@ impl LocalLLM.postinit -> None {
         );
     }
     self.spec = s;
+    # llama.cpp has no reliable server-side tool calling: byllm renders the
+    # tool protocol into the prompt and recovers tool calls from the reply.
+    self.supports_native_tools = False;
 }
 
 """Build (or return cached) underlying llama.cpp instance."""

--- a/jac-byllm/byllm/llm.jac
+++ b/jac-byllm/byllm/llm.jac
@@ -41,6 +41,7 @@ import from byllm.config_loader { get_byllm_config }
 import from byllm.telemetry { _emit_agent_telemetry, _current_invocation_id }
 import from byllm.parallel { dispatch_batch, _index_by_identity, _PARALLEL_TOOL_HINT }
 import from byllm.schema { inject_schema_hint }
+import from byllm.tool_protocol { inject_tool_hint, recover_tool_calls }
 
 # Load configuration purely from jac.toml
 glob _byllm_config = get_byllm_config(),
@@ -73,6 +74,10 @@ obj BaseLLM {
         api_key: str = "",
         call_params: dict[(str, object)] = {},
         ctx_window: int = 0,
+        # False for backends without server-side tool calling (in-process
+        # llama.cpp): byllm renders the tool protocol into the prompt and
+        # recovers tool calls from the reply itself. See `byllm.tool_protocol`.
+        supports_native_tools: bool = True,
         _usage_history: list = [];
 
     def __call__(**kwargs: object) -> BaseLLM;

--- a/jac-byllm/byllm/llm.jac
+++ b/jac-byllm/byllm/llm.jac
@@ -93,6 +93,10 @@ obj BaseLLM {
     def format_prompt(params: dict) -> str;
     def dispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult;
     def dispatch_streaming(mt_run: MTRuntime) -> Generator[str, None, None];
+    def dispatch_streaming_with_tools(
+        mt_run: MTRuntime, out: list[CompletionResult]
+    ) -> Generator[str, None, None];
+
     async def adispatch_no_streaming(mt_run: MTRuntime) -> CompletionResult;
     async def adispatch_streaming(mt_run: MTRuntime);
     def model_call_no_stream(params: dict) -> dict;

--- a/jac-byllm/byllm/llm.jac
+++ b/jac-byllm/byllm/llm.jac
@@ -31,6 +31,7 @@ import from byllm.types {
     LiteLLMMessage,
     MockToolCall,
     StreamEvent,
+    Tool,
     ToolCall,
     Message,
     MessageRole,

--- a/jac-byllm/byllm/local_runtime.jac
+++ b/jac-byllm/byllm/local_runtime.jac
@@ -9,6 +9,7 @@ and `llm.impl/local.impl.jac`.
 """
 
 import logging;
+import json;
 import from typing { Any }
 
 glob _logger: logging.Logger = logging.getLogger("byllm.local_runtime"),
@@ -128,12 +129,58 @@ def _flatten_message_content(msg: dict) -> dict {
     return new_msg;
 }
 
+"""Coerce object-shaped tool_calls on an assistant message into plain dicts.
+
+`wrap_tool_call` (and byllm's text-tool-call recovery) attach `SimpleNamespace`
+tool calls so `BaseLLM.dispatch_*` can read `.function.name`. But once that
+assistant turn is replayed into the next request, llama-cpp's Jinja chat
+template iterates `message.tool_calls` expecting OpenAI-shaped dicts and calls
+`.get` on each -- which blows up on a `SimpleNamespace`. Rewrite them to dicts
+here, at the llama-cpp boundary.
+"""
+def _coerce_tool_calls(msg: dict) -> dict {
+    tcs = msg.get("tool_calls");
+    if not isinstance(tcs, list) or not tcs {
+        return msg;
+    }
+    changed = False;
+    coerced: list = [];
+    for tc in tcs {
+        if isinstance(tc, dict) {
+            coerced.append(tc);
+            continue;
+        }
+        fn = tc?.function;
+        fn_args = getattr(fn, "arguments", "") or "";
+        if not isinstance(fn_args, str) {
+            fn_args = json.dumps(fn_args);
+        }
+        coerced.append(
+            {
+                "id": str(getattr(tc, "id", "") or ""),
+                "type": "function",
+                "function": {
+                    "name": str(getattr(fn, "name", "") or ""),
+                    "arguments": fn_args
+                }
+            }
+        );
+        changed = True;
+    }
+    if not changed {
+        return msg;
+    }
+    new_msg: dict = dict(msg);
+    new_msg["tool_calls"] = coerced;
+    return new_msg;
+}
+
 """Normalize a list of LiteLLM messages for llama-cpp consumption."""
 def normalize_messages(messages: list) -> list {
     out: list = [];
     for m in messages {
         if isinstance(m, dict) {
-            out.append(_flatten_message_content(m));
+            out.append(_coerce_tool_calls(_flatten_message_content(m)));
         } else {
             out.append(m);
         }

--- a/jac-byllm/byllm/tool_protocol.jac
+++ b/jac-byllm/byllm/tool_protocol.jac
@@ -1,0 +1,459 @@
+"""Tool-call normalisation for backends without native tool calling.
+
+Frontier cloud providers (OpenAI, Anthropic, Gemini) accept a `tools=` list
+and do two things server-side: render the tools into the prompt, and parse the
+model's reply back into a structured `tool_calls` field. byllm's local route
+(in-process llama.cpp) gets neither -- the GGUF's own chat template renders
+tools inconsistently and llama-cpp's generic handler leaves the model's
+tool-call text sitting in `content`, so the ReAct loop sees zero tool calls.
+
+This module is the tool-call counterpart of `schema.inject_schema_hint`: byllm
+owns the protocol on both ends instead of reverse-engineering each model's
+native format.
+
+  - `inject_tool_hint`  -- request side: render the tool schemas and a strict,
+                           byllm-defined call protocol into the system message,
+                           and drop the structured `tools` field so the local
+                           backend's unreliable native template is not engaged.
+  - `recover_tool_calls` -- response side: when a reply carries no structured
+                           `tool_calls`, lift a tool call back out of the
+                           message content into the OpenAI-shaped field the
+                           ReAct loop already consumes.
+
+Both are gated by `BaseLLM.supports_native_tools`, so the cloud/litellm path is
+left completely untouched.
+"""
+
+import json;
+import re;
+import uuid;
+import from types { SimpleNamespace }
+
+# Marker used to keep `inject_tool_hint` idempotent within a single request.
+glob _TOOL_PROTOCOL_HEADER = "# Calling tools";
+
+#===============================================================================
+# REQUEST SIDE -- render tools + protocol into the prompt
+#===============================================================================
+"""Render one OpenAI tool-schema dict into a compact prompt description."""
+def _render_tool(tool: object) -> str {
+    if not isinstance(tool, dict) {
+        return "";
+    }
+    fn = tool.get("function", {});
+    if not isinstance(fn, dict) {
+        return "";
+    }
+    name = str(fn.get("name", "") or "");
+    if not name {
+        return "";
+    }
+    desc = str(fn.get("description", "") or "");
+    params = fn.get("parameters", {}) or {};
+    props = params.get("properties", {}) if isinstance(params, dict) else {};
+    required = params.get("required", []) if isinstance(params, dict) else [];
+    if not isinstance(props, dict) {
+        props = {};
+    }
+    if not isinstance(required, list) {
+        required = [];
+    }
+    lines: list[str] = [f"- {name}: {desc}"];
+    for (pname, pinfo) in props.items() {
+        ptype = "any";
+        pdesc = "";
+        if isinstance(pinfo, dict) {
+            ptype = str(pinfo.get("type", "any") or "any");
+            pdesc = str(pinfo.get("description", "") or "");
+        }
+        flag = " (required)" if pname in required else "";
+        lines.append(f"    - {pname} [{ptype}]{flag}: {pdesc}");
+    }
+    return "\n".join(lines);
+}
+
+
+"""Build the full tool-use protocol block from a list of tool schemas."""
+def format_tools_for_prompt(tools: list) -> str {
+    rendered: list[str] = [];
+    for tool in tools {
+        block = _render_tool(tool);
+        if block {
+            rendered.append(block);
+        }
+    }
+    if not rendered {
+        return "";
+    }
+    return (
+        _TOOL_PROTOCOL_HEADER + "\n\nYou can call tools. The tools available to you are:\n\n" + "\n".join(
+            rendered
+        ) + "\n\nTo call a tool, reply with ONLY a tool call in exactly this " + "form and nothing else:\n\n" + "<tool_call>{\"name\": \"<tool_name>\", \"arguments\": {<args>}}</tool_call>" + "\n\nRules:\n" + "- Call exactly one tool per reply.\n" + "- \"arguments\" must be a JSON object whose keys match the tool's " + "parameters.\n" + "- Emit nothing outside the <tool_call> tags when calling a tool.\n" + "- After a tool result is returned, call the next tool, or call " + "finish_tool with your final answer to end."
+    );
+}
+
+
+"""Append `block` to the first system message; prepend one when none exists.
+
+Returns a new list -- the caller's input is not mutated. Idempotent: a second
+call within the same request detects the protocol header and is a no-op.
+"""
+def attach_tool_hint(messages: list, block: str) -> list {
+    out: list = list(messages);
+    sys_idx = -1;
+    idx = 0;
+    for raw in out {
+        if isinstance(raw, dict) and raw.get("role") == "system" {
+            sys_idx = idx;
+            break;
+        }
+        idx += 1;
+    }
+    if sys_idx < 0 {
+        result: list = [{"role": "system", "content": block}];
+        result.extend(out);
+        return result;
+    }
+    target_raw = out[sys_idx];
+    if not isinstance(target_raw, dict) {
+        return messages;
+    }
+    # byllm always builds system messages with plain string content; skip
+    # injection for any other shape rather than risk corrupting it.
+    body = target_raw.get("content", "");
+    if not isinstance(body, str) {
+        return messages;
+    }
+    body_text = str(body);
+    if _TOOL_PROTOCOL_HEADER in body_text {
+        return messages;  # already injected -- idempotent
+    }
+    target: dict = dict(target_raw);
+    target["content"] = body_text.rstrip() + "\n\n" + block;
+    out[sys_idx] = target;
+    return out;
+}
+
+
+"""Request-side tool-protocol injection.
+
+Called from `BaseLLM.make_model_params` for backends that lack native tool
+calling. Renders the tool schemas into the system prompt and removes the
+structured `tools` / `tool_choice` params so the local backend's own (and
+unreliable) tool template is not triggered. No-op when there are no tools.
+
+When `tool_choice == "none"` the caller explicitly wants a pure-text reply
+(byLLM's final-answer pass works this way): tools are dropped but the
+protocol is NOT advertised, so the model is not tempted to emit another
+tool call instead of the answer.
+"""
+def inject_tool_hint(params: dict) -> dict {
+    tools = params.get("tools");
+    msgs = params.get("messages");
+    if not tools or not isinstance(tools, list) or not isinstance(msgs, list) {
+        return params;
+    }
+    if params.get("tool_choice") == "none" {
+        bare: dict = dict(params);
+        bare.pop("tools", None);
+        bare.pop("tool_choice", None);
+        return bare;
+    }
+    block = format_tools_for_prompt(tools);
+    if not block {
+        return params;
+    }
+    out: dict = dict(params);
+    out["messages"] = attach_tool_hint(msgs, block);
+    out.pop("tools", None);
+    out.pop("tool_choice", None);
+    return out;
+}
+
+#===============================================================================
+# RESPONSE SIDE -- recover tool calls from message content
+#===============================================================================
+"""Return the balanced `open_ch..close_ch` substring starting at `start`.
+
+Tracks nesting depth while respecting `"`/`'` string literals so brackets
+inside strings do not throw off the count. Returns None when unbalanced.
+"""
+def _balanced(text: str, start: int, open_ch: str, close_ch: str) -> str | None {
+    depth = 0;
+    in_str = False;
+    quote = "";
+    escaped = False;
+    i = start;
+    while i < len(text) {
+        ch = text[i];
+        if in_str {
+            if escaped {
+                escaped = False;
+            } elif ch == "\\" {
+                escaped = True;
+            } elif ch == quote {
+                in_str = False;
+            }
+        } else {
+            if ch == "\"" or ch == "'" {
+                in_str = True;
+                quote = ch;
+            } elif ch == open_ch {
+                depth += 1;
+            } elif ch == close_ch {
+                depth -= 1;
+                if depth == 0 {
+                    return text[start:i + 1];
+                }
+            }
+        }
+        i += 1;
+    }
+    return None;
+}
+
+
+"""Find the first JSON object in `content` that looks like a tool call.
+
+Works whether the model wrapped the call in `<tool_call>` tags, a ```json
+fence, or emitted bare JSON. When `tool_names` is non-empty, objects whose
+name is not a real tool are skipped. Returns {name, arguments, raw, pos}.
+"""
+def _extract_json_call(content: str, tool_names: list) -> dict | None {
+    i = 0;
+    while i < len(content) {
+        if content[i] == "{" {
+            blob = _balanced(content, i, "{", "}");
+            if blob is None {
+                return None;
+            }
+            parsed: object = None;
+            try {
+                parsed = json.loads(blob);
+            } except Exception {
+                parsed = None;
+            }
+            if isinstance(parsed, dict) {
+                name = (
+                    parsed.get("name") or parsed.get("tool") or parsed.get("function")
+                );
+                if (
+                    isinstance(name, str)
+                    and name
+                    and (not tool_names or name in tool_names)
+                ) {
+                    args = (
+                        parsed.get("arguments")
+                        or parsed.get("parameters")
+                        or parsed.get("args")
+                        or {}
+                    );
+                    return {"name": name, "arguments": args, "raw": blob, "pos": i};
+                }
+            }
+            i += len(blob);
+            continue;
+        }
+        i += 1;
+    }
+    return None;
+}
+
+
+"""Split a function-argument string on its top-level commas.
+
+Commas inside quotes or nested brackets are not treated as separators.
+"""
+def _split_top_level(text: str) -> list[str] {
+    parts: list[str] = [];
+    buf = "";
+    depth = 0;
+    in_str = False;
+    quote = "";
+    escaped = False;
+    for ch in text {
+        if in_str {
+            buf += ch;
+            if escaped {
+                escaped = False;
+            } elif ch == "\\" {
+                escaped = True;
+            } elif ch == quote {
+                in_str = False;
+            }
+        } elif ch == "\"" or ch == "'" {
+            in_str = True;
+            quote = ch;
+            buf += ch;
+        } elif ch in "([{" {
+            depth += 1;
+            buf += ch;
+        } elif ch in ")]}" {
+            depth -= 1;
+            buf += ch;
+        } elif ch == "," and depth == 0 {
+            parts.append(buf);
+            buf = "";
+        } else {
+            buf += ch;
+        }
+    }
+    if buf.strip() {
+        parts.append(buf);
+    }
+    return parts;
+}
+
+
+"""Parse one argument value token: JSON literal, quoted string, or bare word."""
+def _parse_value(token: str) -> object {
+    t = token.strip();
+    if not t {
+        return "";
+    }
+    try {
+        return json.loads(t);
+    } except Exception { }
+    if len(t) >= 2 and t[0] == "'" and t[-1] == "'" {
+        return t[1:-1];
+    }
+    return t;
+}
+
+
+"""Parse a `key=value`/`key: value`, ... argument string into a dict.
+
+Accepts both `=` and `:` separators -- small models use either depending on
+whether they think they are writing a call or an object literal.
+"""
+def _parse_kwargs(argstr: str) -> dict {
+    out: dict = {};
+    for part in _split_top_level(argstr) {
+        m = re.match("\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*[:=]\\s*", part);
+        if m is None {
+            continue;
+        }
+        out[m.group(1)] = _parse_value(part[m.end():]);
+    }
+    return out;
+}
+
+
+"""Find the first `tool_name(...)` or `tool_name{...}` call in `content`.
+
+Only call expressions whose name is in `tool_names` are accepted, so prose
+or code snippets that merely mention a function are not misread as a call.
+Small models emit both paren and brace forms, so both are scanned.
+Returns {name, arguments, raw, pos} or None.
+"""
+def _extract_paren_call(content: str, tool_names: list) -> dict | None {
+    for m in re.finditer("([A-Za-z_][A-Za-z0-9_]*)\\s*([\\(\\{])", content) {
+        name = m.group(1);
+        if name not in tool_names {
+            continue;
+        }
+        open_ch = m.group(2);
+        close_ch = ")" if open_ch == "(" else "}";
+        open_idx = m.end() - 1;
+        argblob = _balanced(content, open_idx, open_ch, close_ch);
+        if argblob is None {
+            continue;
+        }
+        return {
+            "name": name,
+            "arguments": _parse_kwargs(argblob[1:-1]),
+            "raw": content[m.start():open_idx + len(argblob)],
+            "pos": m.start()
+        };
+    }
+    return None;
+}
+
+
+"""Find the first tool call in `content`, in JSON or paren-call form.
+
+Small open-weight models are inconsistent -- the same turn may use a JSON
+`<tool_call>` envelope for one tool and `finish_tool(arg=...)` paren syntax
+for another -- so both forms are scanned and the earliest one wins.
+"""
+def _extract_first_tool_call(content: str, tool_names: list) -> dict | None {
+    json_call = _extract_json_call(content, tool_names);
+    paren_call = _extract_paren_call(content, tool_names);
+    if json_call is None {
+        return paren_call;
+    }
+    if paren_call is None {
+        return json_call;
+    }
+    json_pos = int(json_call.get("pos") or 0);
+    paren_pos = int(paren_call.get("pos") or 0);
+    return json_call if json_pos <= paren_pos else paren_call;
+}
+
+
+"""Response-side tool-call recovery.
+
+Two jobs on an OpenAI-shaped reply dict: strip model-specific control tokens
+(e.g. gemma's `<|channel>` reasoning markers) from the content, and -- when
+the reply carries no structured `tool_calls` -- lift a tool call out of the
+text into `message["tool_calls"]` in the same `SimpleNamespace` shape the
+local connector's `wrap_tool_call` produces, so `BaseLLM.dispatch_*` consumes
+it identically to a native tool call. Mutates `message` in place.
+"""
+def recover_tool_calls(message: object, tool_names: list[str] | None = None) -> None {
+    if not isinstance(message, dict) {
+        return;
+    }
+    names: list[str] = tool_names if tool_names is not None else [];
+    content = message.get("content");
+    if not isinstance(content, str) or not content {
+        return;
+    }
+    # Normalise / strip control tokens some local models emit:
+    #  - gemma renders quote characters inside tool calls as `<|"|>` tokens;
+    #  - `<|channel>thought` reasoning headers and `<token|>` closers.
+    stripped = content.replace("<|\"|>", "\"").replace("<|'|>", "'");
+    stripped = re.sub("<\\|[a-z_]+>[a-z]*", "", stripped);
+    stripped = re.sub("<[a-z_]+\\|>", "", stripped);
+    if stripped != content {
+        content = stripped;
+        message["content"] = content;
+    }
+    if message.get("tool_calls") {
+        return;  # already structured -- nothing more to do
+    }
+    call = _extract_first_tool_call(content, names);
+    if call is None {
+        return;
+    }
+    args_raw = call.get("arguments");
+    args: dict = {};
+    if isinstance(args_raw, dict) {
+        args = args_raw;
+    } elif isinstance(args_raw, str) {
+        try {
+            decoded = json.loads(args_raw);
+            if isinstance(decoded, dict) {
+                args = decoded;
+            }
+        } except Exception {
+            args = {};
+        }
+    }
+    tool_call = SimpleNamespace(
+        id="call_" + uuid.uuid4().hex[:12],
+        type="function",
+        function=SimpleNamespace(name=str(call["name"]), arguments=json.dumps(args))
+    );
+    message["tool_calls"] = [tool_call];
+    # Strip the consumed tool-call JSON (and its envelope tags) from the
+    # content so it does not resurface as a stray "thought" in the stream.
+    raw = call.get("raw");
+    if isinstance(raw, str) and raw {
+        cleaned = str(content).replace(raw, "");
+        for tag in ["<tool_call>", "</tool_call>", "<|tool_call|>", "```json", "```"] {
+            cleaned = cleaned.replace(tag, "");
+        }
+        message["content"] = cleaned.strip();
+    }
+}

--- a/jac-byllm/tests/test_byllm.jac
+++ b/jac-byllm/tests/test_byllm.jac
@@ -787,10 +787,11 @@ test "configuration error on bare dict return type" {
     assert raised , "Expected ConfigurationError for bare dict return type";
 }
 
-# UnknownToolError is raised in BaseLLM.dispatch_no_streaming when the LLM responds
-# with a tool_call whose name is not registered in MTRuntime.tools.
+# An unregistered tool name is recovered, not fatal: dispatch_no_streaming
+# returns a tool call that reports the error back so the model can retry,
+# rather than crashing the whole turn.
 # model_call_no_stream is mocked so no real API key is needed.
-test "unknown tool error when llm calls unregistered tool" {
+test "unregistered tool call is recovered not fatal" {
     model = Model(model_name="test-model");
     messages_list = [
         Message(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
@@ -814,18 +815,20 @@ test "unknown tool error when llm calls unregistered tool" {
 
     };
 
-    raised = False;
     with unittest.mock.patch.object(
         model, "model_call_no_stream", return_value=fake_response
     ) {
-        try {
-            model.dispatch_no_streaming(mt_run);
-        } except UnknownToolError as e {
-            raised = True;
-            assert "nonexistent_tool" in str(e) , f"Error should name the tool, got: {e}";
-        }
+        result = model.dispatch_no_streaming(mt_run);
     }
-    assert raised , "Expected UnknownToolError for unregistered tool name";
+    # No exception: the unknown tool is surfaced as a recoverable tool result.
+    assert len(result.tool_calls) == 1 , "Expected one recovered tool call";
+    err_result = result.tool_calls[0]();
+    assert "nonexistent_tool" in str(err_result.content) , (
+        f"Recovered result should name the tool, got: {err_result.content}"
+    );
+    assert "Tool error" in str(err_result.content) , (
+        f"Recovered result should be a tool error, got: {err_result.content}"
+    );
 }
 
 # FinishToolError is raised inside the finish_tool closure when the final output

--- a/jac.toml
+++ b/jac.toml
@@ -3,15 +3,13 @@ name = "jaclang"
 
 [check.lint]
 select = ["all"]
-exclude = ["docs/*", "*/examples/*", "*/tests/*", "console.impl.jac", "cli_boot.jac"]
+exclude = [
+    "docs/*",
+    "*/examples/*",
+    "*/tests/*",
+    "console.impl.jac",
+    "cli_boot.jac",
+]
 
-[dependencies.npm]
-react = "^18.2.0"
-react-dom = "^18.2.0"
-react-router-dom = "^6.22.0"
-react-error-boundary = "^5.0.0"
-react-hook-form = "^7.71.0"
-zod = "^4.3.6"
-"@hookform/resolvers" = "^5.2.2"
-
-[plugins]
+[plugins.byllm.model]
+default_model = "anthropic/claude-opus-4-7"

--- a/jac/jaclang/cli/agent_api.jac
+++ b/jac/jaclang/cli/agent_api.jac
@@ -1,0 +1,46 @@
+"""The `jac ai` agent contract -- the request a pluggable agent receives.
+
+`AgentRequest` is the stable interface between the `jac ai` command and
+whatever implements the `run_ai_agent` hook: the built-in byLLM agent, or a
+plugin that replaces it. It carries the resolved CLI flags plus a
+`CodeIntelligence` handle, so the agent can navigate the project
+semantically -- precise definitions, uses, and types -- rather than by text
+search.
+
+The contract is an object rather than a fixed parameter list so new fields
+can be added without breaking existing agent plugins.
+"""
+
+import os;
+import from jaclang.compiler.code_intel { CodeIntelligence }
+
+
+"""Everything a `jac ai` agent needs to run one session."""
+obj AgentRequest {
+    has prompt: str = "",
+        model: str = "",
+        n_ctx: int = 0,
+        safe: bool = False,
+        cwd: str = "",
+        code_intel: CodeIntelligence | None = None;
+}
+
+
+"""Build an AgentRequest from the resolved `jac ai` flags.
+
+Roots a `CodeIntelligence` at the current working directory; the agent's
+semantic tools share this single handle, so the project is compiled once.
+"""
+def build_agent_request(
+    prompt: str = "", model: str = "", n_ctx: int = 0, safe: bool = False
+) -> AgentRequest {
+    cwd = os.getcwd();
+    return AgentRequest(
+        prompt=prompt,
+        model=model,
+        n_ctx=n_ctx,
+        safe=safe,
+        cwd=cwd,
+        code_intel=CodeIntelligence(proj_dir=cwd)
+    );
+}

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -46,6 +46,14 @@ glob yolo_mode: bool = True,
      # see whether a `--model` flag, jac.toml, or the built-in default won.
      agent_model_source: str = "default";
 
+# The shared CodeIntelligence handle for this session, set by `run_agent` from
+# the AgentRequest. The semantic tools (find_symbol, find_uses, ...) query it
+# so the agent navigates the project by compiler symbol data, not text search.
+glob agent_ci: any = None,
+     # Set by write_file/edit_file after a successful write; the next semantic
+     # query rebuilds the project model so lookups reflect the new source.
+     agent_ci_dirty: bool = False;
+
 """Pick which model `jac ai` should run.
 
 Priority: the `--model` flag (`model_override`), then `[plugins.byllm.model]
@@ -154,6 +162,59 @@ def confirm(action: str) -> bool {
     return answer in ("y", "yes");
 }
 
+
+"""Rebuild the project model after a write and report the diagnostics it caused.
+
+Returns, as a text block appended to the write tool's result, every compiler
+error and warning now in `path` plus any newly introduced in other project
+files the edit affects -- so the model gets compiler feedback, including
+cross-file breakage, on every write without a separate `jac_check` call. A
+dependent module's pre-existing error is not reported: only the delta this
+edit caused. Warnings are included because an undefined name or unresolved
+type surfaces as a warning, not an error. Empty string when the edit
+introduced nothing (or no code intelligence is available).
+"""
+def write_feedback(path: str) -> str {
+    global agent_ci_dirty;
+    if agent_ci is None {
+        return "";
+    }
+    # The write changed the project; mark dirty up front so a failed refresh
+    # still triggers a rebuild on the next semantic query.
+    agent_ci_dirty = True;
+    try {
+        # refresh_and_diff recompiles and returns the diagnostics this edit is
+        # responsible for: all of `path`, plus breakage in dependent modules.
+        diags: list = list(agent_ci.refresh_and_diff(path));
+    } except Exception {
+        return "";
+    }
+    agent_ci_dirty = False;
+    if not diags {
+        return "";
+    }
+    n_err = len(
+        [
+            d
+            for d in diags
+            if d.severity == "error"
+        ]
+    );
+    n_warn = len(diags) - n_err;
+    lines = [
+        f"\ncompiler feedback for editing {path} -- {n_err} error(s), "
+        f"{n_warn} warning(s); fix what you introduced (some may be in other "
+        "files your edit affects):"
+    ];
+    for d in diags[:20] {
+        lines.append("  " + str(d.render()));
+    }
+    if len(diags) > 20 {
+        lines.append(f"  ... and {len(diags) - 20} more");
+    }
+    return "\n".join(lines);
+}
+
 #===============================================================================
 # TOOLS -- plain typed functions; byLLM turns the annotations into JSON schema
 #===============================================================================
@@ -177,7 +238,7 @@ def write_file(path: str, content: str) -> str {
         p = Path(path);
         p.parent.mkdir(parents=True, exist_ok=True);
         p.write_text(content);
-        return f"OK: wrote {len(content)} chars to {path}";
+        return f"OK: wrote {len(content)} chars to {path}" + write_feedback(path);
     } except Exception as e {
         return f"ERROR writing {path}: {e}";
     }
@@ -209,7 +270,7 @@ def edit_file(path: str, old_text: str, new_text: str) -> str {
     }
     try {
         Path(path).write_text(original.replace(old_text, new_text));
-        return f"OK: edited {path}";
+        return f"OK: edited {path}" + write_feedback(path);
     } except Exception as e {
         return f"ERROR writing {path}: {e}";
     }
@@ -423,6 +484,131 @@ sem read_guide = "Read a bundled Jac reference guide in full -- the authoritativ
 sem read_guide.name = "Exact guide name, e.g. 'jac-walker-patterns'.";
 
 
+#===============================================================================
+# SEMANTIC TOOLS -- backed by the Jac compiler's symbol table, not text search
+#===============================================================================
+"""Return the session's CodeIntelligence, rebuilding it if a write happened.
+
+`write_file`/`edit_file` flag the project as dirty; the first semantic query
+after a write recompiles so symbol lookups reflect what the agent just wrote.
+"""
+def code_intel -> any {
+    global agent_ci_dirty;
+    if agent_ci is None {
+        return None;
+    }
+    if agent_ci_dirty {
+        try {
+            agent_ci.refresh();
+        } except Exception { }
+        agent_ci_dirty = False;
+    }
+    return agent_ci;
+}
+
+
+def find_symbol(name: str) -> str {
+    ci = code_intel();
+    if ci is None {
+        return "ERROR: code intelligence is unavailable in this session.";
+    }
+    hits = ci.lookup(name);
+    if not hits {
+        return f"No Jac symbol named '{name}' is defined in this project.";
+    }
+    out: list[str] = [];
+    for info in hits {
+        out.append(str(info.render()));
+    }
+    uses = [
+        r
+        for r in ci.references(name)
+        if r.role == "use"
+    ];
+    if uses {
+        out.append(f"\nused in {len(uses)} place(s):");
+        for r in uses[:25] {
+            out.append("  " + str(r.render()));
+        }
+    }
+    return "\n".join(out);
+}
+
+sem find_symbol = "Look up a Jac symbol (node, walker, edge, obj, enum, ability, ...) by name via the compiler's symbol table. Returns its exact definition site, fields, abilities, base classes, and every place it is used. This is precise -- unlike grep it never matches a comment or an unrelated identifier. Prefer this over grep whenever you know the name of the thing you are looking for.";
+sem find_symbol.name = "The symbol name to look up, e.g. 'User' or 'make_user'.";
+
+
+def find_uses(name: str) -> str {
+    ci = code_intel();
+    if ci is None {
+        return "ERROR: code intelligence is unavailable in this session.";
+    }
+    refs = ci.references(name);
+    if not refs {
+        return f"No definitions or uses of '{name}' were found.";
+    }
+    lines: list[str] = [];
+    for r in refs {
+        lines.append(f"{r.role}  {r.render()}");
+    }
+    return "\n".join(lines);
+}
+
+sem find_uses = "List every definition and use of a symbol across the whole project, computed from the compiler's def/use chains. Use this before renaming or changing a symbol to see exactly what it touches.";
+sem find_uses.name = "The symbol name whose references to list.";
+
+
+def project_map -> str {
+    ci = code_intel();
+    if ci is None {
+        return "ERROR: code intelligence is unavailable in this session.";
+    }
+    archs = ci.archetypes();
+    if not archs {
+        return "(no nodes, walkers, edges, or objects found in the project)";
+    }
+    rows: list[str] = [];
+    for a in archs {
+        rows.append(f"{a.kind:7} {a.name}    [{a.file}:{a.line}]");
+    }
+    return "\n".join(sorted(rows));
+}
+
+sem project_map = "Show every node, walker, edge, and object archetype in the project with its location -- a structural overview built from the compiler, not a directory listing. Use this first to understand an unfamiliar project.";
+
+
+def find_walkers(node_type: str) -> str {
+    ci = code_intel();
+    if ci is None {
+        return "ERROR: code intelligence is unavailable in this session.";
+    }
+    eps = ci.walkers_visiting(node_type);
+    if not eps {
+        return f"No walkers traverse a '{node_type}' node.";
+    }
+    lines: list[str] = [];
+    for ep in eps {
+        lines.append(str(ep.render()));
+    }
+    return "\n".join(lines);
+}
+
+sem find_walkers = "Find every walker entry point that traverses a given node type -- an Object-Spatial query the compiler answers from walker entry signatures. Use this to see how a node is visited.";
+sem find_walkers.node_type = "The node archetype name, e.g. 'User'.";
+
+
+def context_slice(name: str) -> str {
+    ci = code_intel();
+    if ci is None {
+        return "ERROR: code intelligence is unavailable in this session.";
+    }
+    return str(ci.slice_for(name).render());
+}
+
+sem context_slice = "Get a typed context slice for a symbol: its definition, the types it depends on, and where it is used -- a focused, compiler-accurate neighbourhood to read instead of opening whole files.";
+sem context_slice.name = "The symbol to build a context slice around.";
+
+
 # Side-effecting tools must never run concurrently; byLLM keeps any parallel
 # batch that contains one of these sequential.
 with entry {
@@ -453,14 +639,22 @@ Work like this:
 - Decide and commit. When two or more approaches would both work, pick the
   simplest and build it. Do not re-litigate a choice you have already acted on,
   and never write a file just to delete it -- think the choice through first.
+- Navigate by meaning, not text. To find where a node, walker, edge, or
+  ability is defined or used, call find_symbol or find_uses -- they read the
+  compiler's symbol table and are exact. Use project_map for a structural
+  overview of an unfamiliar project, find_walkers to see how a node is
+  traversed, and context_slice to read a symbol's typed neighbourhood. Reserve
+  grep for plain text -- comments, strings, TODOs.
 - Never guess. Read a file before editing it; consult the guides before
   writing unfamiliar Jac. The bundled guides are the authoritative spec for
   correct, idiomatic Jac.
 - Keep files focused and modest in size; split large archetypes into impl
   files. For a large file, write a skeleton first, then fill it with edit_file.
 - Make minimal, targeted changes. Prefer edit_file over rewriting a whole file.
-- Verify. After writing code, run `jac check .` to type-check the whole
-  project and fix every error. For an app, use start_app to confirm it boots.
+- Verify. Every write_file and edit_file result reports the compiler errors
+  that now exist in the file you touched -- fix them before moving on, do not
+  leave a write with errors behind. Run `jac check .` for a whole-project
+  type-check, and start_app to confirm an app boots.
 - When the task is complete, finish with a short plain-language summary of what
   you changed and why.
 
@@ -503,6 +697,11 @@ def ask(message: str) -> str by agent_model(
         edit_file,
         list_dir,
         grep,
+        find_symbol,
+        find_uses,
+        project_map,
+        find_walkers,
+        context_slice,
         run_command,
         jac_check,
         start_app,
@@ -658,24 +857,29 @@ def run_turn(message: str) {
 }
 
 
-"""Entry point for `jac ai`.
+"""Entry point for `jac ai` -- the default `run_ai_agent` hook implementation.
 
-Applies the resolved `--model`, `--n_ctx`, and `--safe` flags, then runs.
-With `initial_prompt`, runs a single turn and exits; otherwise starts an
-interactive read-eval-print loop. Always returns 0 -- a failed turn reports
-its error but does not abort the session.
+`req` is an `AgentRequest`: the resolved `--model`, `--n_ctx`, and `--safe`
+flags, the working directory, and a shared `CodeIntelligence` handle the
+semantic tools query. With a non-empty `prompt`, runs a single turn and exits;
+otherwise starts an interactive read-eval-print loop. Always returns 0 -- a
+failed turn reports its error but does not abort the session.
 """
-def run_agent(
-    initial_prompt: str = "", model: str = "", n_ctx: int = 0, safe: bool = False
-) -> int {
-    global agent_model,yolo_mode;
+def run_agent(req: object) -> int {
+    global agent_model,yolo_mode,agent_ci;
+    # `req` is an AgentRequest; access it untyped so attribute reads
+    # type-check without importing the class into this byLLM-only module.
+    r: any = req;
     # File writes and code execution run without prompting unless `--safe`
     # asks to confirm each one.
-    yolo_mode = not safe;
+    yolo_mode = not r.safe;
+    # The compiler-backed project model the semantic tools navigate.
+    agent_ci = r.code_intel;
+    initial_prompt = str(r.prompt);
     # The import-time `agent_model` already covers jac.toml/default; only
     # rebuild when a flag actually changes the model or its context window.
-    if model or n_ctx > 0 {
-        agent_model = build_model(model, n_ctx);
+    if r.model or r.n_ctx > 0 {
+        agent_model = build_model(str(r.model), int(r.n_ctx));
     }
     print_banner();
     reset_history();

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -44,7 +44,15 @@ glob yolo_mode: bool = True,
      agent_temperature: float | None = None,
      # Where the resolved model came from -- shown in the banner so the user can
      # see whether a `--model` flag, jac.toml, or the built-in default won.
-     agent_model_source: str = "default";
+     agent_model_source: str = "default",
+     # Whether to print the one-line turn summary (duration, tool calls, files
+     # changed, tokens, project health) after each turn. Toggled with `/stats`.
+     show_stats: bool = True;
+
+# Tool names grouped for the turn-stat breakdown: tools that mutate files,
+# and tools that execute code or shell commands. Everything else is a read.
+glob _WRITE_TOOLS: set[str] = {"write_file","edit_file"},
+     _RUN_TOOLS: set[str] = {"run_command","jac_check","start_app"};
 
 # The shared CodeIntelligence handle for this session, set by `run_agent` from
 # the AgentRequest. The semantic tools (find_symbol, find_uses, ...) query it
@@ -651,12 +659,33 @@ Work like this:
 - Keep files focused and modest in size; split large archetypes into impl
   files. For a large file, write a skeleton first, then fill it with edit_file.
 - Make minimal, targeted changes. Prefer edit_file over rewriting a whole file.
-- Verify. Every write_file and edit_file result reports the compiler errors
-  that now exist in the file you touched -- fix them before moving on, do not
-  leave a write with errors behind. Run `jac check .` for a whole-project
-  type-check, and start_app to confirm an app boots.
-- When the task is complete, finish with a short plain-language summary of what
-  you changed and why.
+- Fix as you go. Every write_file and edit_file result reports the compiler
+  errors and warnings your edit caused -- in the file you wrote and in any
+  other file it affects. Fix them before moving on; never leave a write with
+  errors behind.
+- QA before you finish. This is mandatory: never report a task as done until
+  the QA pass below has been run and comes back clean.
+
+QA pass -- before you consider the task done, run every step that applies, in
+order, and fix anything it surfaces (then run the pass again):
+1. `jac check .` -- a whole-project type-check. It must report zero errors.
+2. For any runnable app, call start_app and confirm it boots with no errors in
+   the startup logs.
+3. For a web or fullstack app, also QA it in a real browser with the
+   `agent-browser` CLI, driven through run_command:
+   - Check the CLI first: `command -v agent-browser`. If it is missing, tell
+     the user, suggest they run `npm i -g agent-browser`, skip the browser
+     step, and do NOT install it yourself.
+   - If it is installed, start the server detached so it stays up during the
+     test -- from the app's directory run
+     `nohup jac start <entry> > /tmp/jac_qa.log 2>&1 &` -- wait a few seconds,
+     then read /tmp/jac_qa.log for the URL it serves on.
+   - Drive the browser: `agent-browser open <url>`, `agent-browser snapshot`
+     to read the page, exercise the main user flows with click/type/fill, and
+     check for console or on-page errors. Take an `agent-browser screenshot`.
+   - Stop the server when finished: `pkill -f "jac start"`.
+Once QA is clean, finish with a short plain-language summary of what you
+changed and why, plus one line on the QA you ran and that it passed.
 
 Jac gotchas -- the type checker rejects all of these, so never write them:
 - There is no `pass` statement. For an empty block, write empty braces: `{}`.
@@ -750,6 +779,7 @@ def print_help {
     console.print("  /help    show this help", style="muted");
     console.print("  /clear   reset the conversation", style="muted");
     console.print("  /guides  list the bundled Jac reference guides", style="muted");
+    console.print("  /stats   toggle the per-turn stat line", style="muted");
     console.print("  /exit    quit the session", style="muted");
 }
 
@@ -786,6 +816,122 @@ def preview_result(text: str) -> str {
 }
 
 
+"""Render a token count compactly: 12400 -> '12.4k', 840 -> '840'."""
+def _short_num(n: int) -> str {
+    return f"{n / 1000:.1f}k" if n >= 1000 else str(n);
+}
+
+
+"""Best-effort USD cost for the turn from litellm's price map; 0 if unknown.
+
+Local models and any model litellm does not price raise here and fall back
+to 0 -- which is correct for a local model, and a benign omission otherwise.
+"""
+def _estimate_cost(prompt_tokens: int, completion_tokens: int) -> float {
+    try {
+        import litellm;
+        costs: any = litellm.cost_per_token(
+            model=agent_model.model_name,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens
+        );
+        return float(str(costs[0])) + float(str(costs[1]));
+    } except Exception {
+        return 0.0;
+    }
+}
+
+
+"""Render token usage (and cost, when priced) from a byLLM `usage` total."""
+def _format_tokens(usage: dict[str, object]) -> str {
+    prompt = int(usage.get("prompt_tokens", 0) or 0);
+    completion = int(usage.get("completion_tokens", 0) or 0);
+    if prompt == 0 and completion == 0 {
+        return "";
+    }
+    text = f"{_short_num(prompt)} in / {_short_num(completion)} out";
+    cost = _estimate_cost(prompt, completion);
+    if cost > 0 {
+        text += f" (~${cost:.4f})";
+    }
+    return text;
+}
+
+
+"""Render the project's compiler health from the session's CodeIntelligence.
+
+The count is project-wide, so it catches breakage the turn left in any file.
+Reported only when the turn already built the project model (a write or a
+semantic-tool query): a stat line must stay cheap and must never trigger a
+whole-project compile -- in a large repo that would stall every turn. When
+the model is not yet built there is nothing the turn touched, so the stat is
+simply omitted.
+"""
+def _format_health -> str {
+    ci = code_intel();
+    if ci is None or not ci.is_loaded() {
+        return "";
+    }
+    try {
+        diags: list[any] = list(ci.diagnostics());
+    } except Exception {
+        return "";
+    }
+    n_err = len(
+        [
+            d
+            for d in diags
+            if d.severity == "error"
+        ]
+    );
+    n_warn = len(diags) - n_err;
+    if n_err == 0 and n_warn == 0 {
+        return "project: clean";
+    }
+    return f"project: {n_err} error(s), {n_warn} warning(s)";
+}
+
+
+"""Print the one-line turn summary: duration, tools, files, tokens, health."""
+def print_stats(
+    elapsed: float,
+    n_read: int,
+    n_write: int,
+    n_run: int,
+    files: set[str],
+    usage: dict[str, object]
+) {
+    parts: list[str] = [f"{elapsed:.1f}s"];
+    n_tools = n_read + n_write + n_run;
+    if n_tools > 0 {
+        breakdown: list[str] = [];
+        if n_read {
+            breakdown.append(f"{n_read} read");
+        }
+        if n_write {
+            breakdown.append(f"{n_write} write");
+        }
+        if n_run {
+            breakdown.append(f"{n_run} run");
+        }
+        parts.append(f"{n_tools} tools (" + ", ".join(breakdown) + ")");
+    }
+    if files {
+        suffix = "" if len(files) == 1 else "s";
+        parts.append(f"{len(files)} file{suffix} changed");
+    }
+    tokens = _format_tokens(usage);
+    if tokens {
+        parts.append(tokens);
+    }
+    health = _format_health();
+    if health {
+        parts.append(health);
+    }
+    console.print("  " + "  ·  ".join(parts), style="muted");
+}
+
+
 """Run one agent turn, rendering the full byLLM event stream to the terminal.
 
 `ask` runs with `stream=True, logging=True`, so it yields a StreamEvent for
@@ -804,6 +950,14 @@ def run_turn(message: str) {
     # True while raw model tokens have been written since the last newline,
     # so structured lines (tool calls, results) start cleanly.
     streamed = False;
+    # Turn-stat accumulators -- declared before the try so the `finally` can
+    # render them even if the stream errors out partway through.
+    started = time.time();
+    n_read = 0;
+    n_write = 0;
+    n_run = 0;
+    files: set[str] = set();
+    usage: dict[str, object] = {};
     try {
         for event in event_stream {
             kind = event.event_type;
@@ -820,8 +974,31 @@ def run_turn(message: str) {
                     out.flush();
                     streamed = False;
                 }
-                call = fmt_tool_call(str(data.get("tool", "?")), data.get("args", {}));
-                console.print(f"  ⏺ {call}", style="cyan");
+                tool = str(data.get("tool", "?"));
+                args = data.get("args", {});
+                # Tally the call for the turn stats: writes (and the files they
+                # touch), code/shell runs, and everything else as a read.
+                if tool in _WRITE_TOOLS {
+                    n_write += 1;
+                    if isinstance(args, dict) {
+                        path = args.get("path");
+                        if path {
+                            files.add(str(path));
+                        }
+                    }
+                } elif tool in _RUN_TOOLS {
+                    n_run += 1;
+                } else {
+                    n_read += 1;
+                }
+                console.print(f"  ⏺ {fmt_tool_call(tool, args)}", style="cyan");
+            } elif kind == "usage" {
+                # byLLM emits one `usage` event at stream end with token totals
+                # aggregated across every LLM call in the turn.
+                total = data.get("total", {});
+                if isinstance(total, dict) {
+                    usage = total;
+                }
             } elif kind == "tool_result" {
                 if streamed {
                     out.write("\n");
@@ -853,6 +1030,12 @@ def run_turn(message: str) {
             import traceback;
             traceback.print_exc();
         }
+    } finally {
+        # Always render the turn summary -- a turn cut short by an error or an
+        # interrupt is exactly when its stats are most worth seeing.
+        if show_stats {
+            print_stats(time.time() - started, n_read, n_write, n_run, files, usage);
+        }
     }
 }
 
@@ -866,7 +1049,7 @@ otherwise starts an interactive read-eval-print loop. Always returns 0 -- a
 failed turn reports its error but does not abort the session.
 """
 def run_agent(req: object) -> int {
-    global agent_model,yolo_mode,agent_ci;
+    global agent_model,yolo_mode,agent_ci,show_stats;
     # `req` is an AgentRequest; access it untyped so attribute reads
     # type-check without importing the class into this byLLM-only module.
     r: any = req;
@@ -919,6 +1102,11 @@ def run_agent(req: object) -> int {
                 console.print(f"  {g.name}", style="bold");
                 console.print(f"      {g.description}", style="muted");
             }
+            continue;
+        }
+        if line == "/stats" {
+            show_stats = not show_stats;
+            console.success("Turn stats on." if show_stats else "Turn stats off.");
             continue;
         }
         run_turn(line);

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -590,55 +590,60 @@ def preview_result(text: str) -> str {
 """Run one agent turn, rendering the full byLLM event stream to the terminal.
 
 `ask` runs with `stream=True, logging=True`, so it yields a StreamEvent for
-every step of the ReAct loop -- the model's reasoning (`thought`), each
-`tool_call` and `tool_result`, and finally the answer `chunk`s -- instead of
-going silent while tools run.
+every step of the ReAct loop. Both the model's reasoning (`thought`) and its
+final answer (`chunk`) arrive as token-level events and are written straight
+to stdout as they land, so the whole turn streams live; `tool_call` and
+`tool_result` events punctuate it.
 """
 def run_turn(message: str) {
     console.print("");
-    answering = False;
     # `ask` is typed `-> str` for byLLM's streaming contract, but with
     # logging=True it actually yields StreamEvent objects -- iterate via an
     # `any`-typed handle so attribute access type-checks.
     event_stream: any = ask(message);
-    # Thoughts are buffered, not printed live: byLLM echoes the model's final
-    # reasoning as both a `thought` and the answer `chunk`s. Buffered thoughts
-    # flush only when a tool call follows them (genuine mid-loop reasoning);
-    # the final pre-answer thought is dropped at `steps_done`.
-    pending_thought = "";
+    out: any = sys.stdout;
+    # True while raw model tokens have been written since the last newline,
+    # so structured lines (tool calls, results) start cleanly.
+    streamed = False;
     try {
         for event in event_stream {
             kind = event.event_type;
             data = event.data;
-            if kind == "thought" {
-                pending_thought = str(data.get("content", "")).strip();
+            if kind == "thought" or kind == "chunk" {
+                # Stream every model token live -- reasoning and answer alike.
+                # console.print buffers and takes no flush arg, so write direct.
+                out.write(str(data.get("content", "")));
+                out.flush();
+                streamed = True;
             } elif kind == "tool_call" {
-                if pending_thought {
-                    console.print(pending_thought, style="dim italic");
-                    pending_thought = "";
+                if streamed {
+                    out.write("\n");
+                    out.flush();
+                    streamed = False;
                 }
                 call = fmt_tool_call(str(data.get("tool", "?")), data.get("args", {}));
                 console.print(f"  ⏺ {call}", style="cyan");
             } elif kind == "tool_result" {
+                if streamed {
+                    out.write("\n");
+                    out.flush();
+                    streamed = False;
+                }
                 console.print(
                     f"    {preview_result(str(data.get('result', '')))}", style="dim"
                 );
             } elif kind == "steps_done" {
+                if streamed {
+                    out.write("\n");
+                    out.flush();
+                    streamed = False;
+                }
                 console.print("");
-            } elif kind == "chunk" {
-                # Answer chunks are streaming -- the buffered thought was just
-                # byLLM's echo of the final reasoning, so drop it.
-                pending_thought = "";
-                answering = True;
-                console.print(str(data.get("content", "")), end="");
             }
         }
-        if answering {
-            console.print("");
-        } elif pending_thought {
-            # No answer chunks arrived -- the model's final message itself is
-            # the answer; surface it rather than leaving the turn blank.
-            console.print(pending_thought);
+        if streamed {
+            out.write("\n");
+            out.flush();
         }
     } except KeyboardInterrupt {
         console.print("\n  [interrupted]", style="yellow");

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -32,8 +32,9 @@ import from jaclang.cli.guide_store {
 # MODEL & SESSION STATE
 #===============================================================================
 
-# Skip confirmation prompts; set by `run_agent` from the `--yolo` flag.
-glob yolo_mode: bool = False,
+# Skip confirmation prompts for file writes and code execution. On by default;
+# `run_agent` clears it when the `--safe` flag asks to confirm every action.
+glob yolo_mode: bool = True,
      # Resolved CPU thread count for local inference; shown in the banner. Set by
      # `build_model`; 0 means "not a local model / leave it to the backend".
      agent_threads: int = 0,
@@ -535,6 +536,12 @@ def print_banner {
     if agent_threads > 0 {
         console.print(f"  inference threads: {agent_threads}", style="muted");
     }
+    if yolo_mode {
+        console.print(
+            "  file writes and commands run without confirmation (use --safe to confirm each)",
+            style="yellow"
+        );
+    }
     console.print("  type a request, /help for commands, /exit to quit", style="muted");
     console.print("");
 }
@@ -648,16 +655,18 @@ def run_turn(message: str) {
 
 """Entry point for `jac ai`.
 
-Applies the resolved `--model`, `--n_ctx`, and `--yolo` flags, then runs.
+Applies the resolved `--model`, `--n_ctx`, and `--safe` flags, then runs.
 With `initial_prompt`, runs a single turn and exits; otherwise starts an
 interactive read-eval-print loop. Always returns 0 -- a failed turn reports
 its error but does not abort the session.
 """
 def run_agent(
-    initial_prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False
+    initial_prompt: str = "", model: str = "", n_ctx: int = 0, safe: bool = False
 ) -> int {
     global agent_model,yolo_mode;
-    yolo_mode = yolo;
+    # File writes and code execution run without prompting unless `--safe`
+    # asks to confirm each one.
+    yolo_mode = not safe;
     # The import-time `agent_model` already covers jac.toml/default; only
     # rebuild when a flag actually changes the model or its context window.
     if model or n_ctx > 0 {

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -13,11 +13,13 @@ directly and builds the model from them before the session starts.
 import os;
 import re;
 import sys;
+import time;
 import subprocess;
 import from pathlib { Path }
 
 import from byllm.lib { Model }
 import from byllm.config_loader { get_byllm_config }
+import from byllm.parallel { mark_serialize }
 
 import from jaclang.cli.console { console }
 import from jaclang.cli.guide_store {
@@ -297,35 +299,114 @@ def run_jac_cli(subcommand: str, path: str) -> str {
 }
 
 
-def run_jac(path: str) -> str {
-    if not confirm(f"run `jac run {path}`") {
-        return "DENIED: the user declined to run this file.";
+def run_command(command: str) -> str {
+    if not confirm(f"run shell command: {command}") {
+        return "DENIED: the user declined to run this command.";
     }
-    return run_jac_cli("run", path);
+    # Put the running interpreter's bin directory first on PATH so `jac` (and
+    # other console scripts installed alongside it) resolve even when the
+    # session was launched without the environment activated.
+    env = dict(os.environ);
+    bin_dir = os.path.dirname(sys.executable);
+    if bin_dir {
+        env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "");
+    }
+    try {
+        result = subprocess.run(
+            command, shell=True, capture_output=True, text=True, timeout=180, env=env
+        );
+        combined = ((result.stdout or "") + (result.stderr or "")).strip();
+        return truncate(combined or f"(no output; exit code {result.returncode})");
+    } except subprocess.TimeoutExpired {
+        return f"ERROR: `{command}` timed out after 180s.";
+    } except Exception as e {
+        return f"ERROR running `{command}`: {e}";
+    }
 }
 
-sem run_jac = "Execute a .jac file with `jac run` and return its output.";
-sem run_jac.path = "Path of the .jac file to run.";
+sem run_command = "Run a shell command in the project directory and return its combined output. Use this to scaffold a new project (`jac create --use fullstack <name>`), install dependencies (`jac install`), run a file (`jac run <file>`), run tests, or any other shell task. `jac create` templates: default, client, fullstack.";
+sem run_command.command = "The shell command to run.";
 
 
 def jac_check(path: str) -> str {
-    return run_jac_cli("check", path);
+    return run_jac_cli("check", path or ".");
 }
 
-sem jac_check = "Type-check and compile a .jac file with `jac check`; use this after writing or editing Jac code to confirm it is valid.";
-sem jac_check.path = "Path of the .jac file to check.";
+sem jac_check = "Type-check and compile Jac code with `jac check`. Pass a single file, or a directory (`.` for the whole project) to check everything at once. Use this after writing or editing Jac code to confirm it is valid.";
+sem jac_check.path = "File or directory to check; '.' or empty string checks the whole project.";
+
+
+def start_app(entry_file: str) -> str {
+    entry_path = entry_file or "main.jac";
+    if not confirm(f"start the app with `jac start {entry_path}`") {
+        return "DENIED: the user declined to start the app.";
+    }
+    # `jac start` resolves the project (and its installed deps) from the entry
+    # file's own directory, so run it there -- not wherever the session was
+    # launched -- which matters when the app was scaffolded into a subfolder.
+    work_dir = os.path.dirname(entry_path) or ".";
+    target = os.path.basename(entry_path);
+    try {
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "jaclang", "start", target],
+            cwd=work_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True
+        );
+    } except Exception as e {
+        return f"ERROR launching `jac start {entry_path}`: {e}";
+    }
+    # Let it boot, then stop it -- we only want the startup diagnostics, not a
+    # server left running after the tool returns.
+    time.sleep(12);
+    proc.terminate();
+    try {
+        output = proc.communicate(timeout=10)[0];
+    } except Exception {
+        proc.kill();
+        output = proc.communicate()[0];
+    }
+    return truncate(str(output) if output else "(no startup output)");
+}
+
+sem start_app = "Start the app with `jac start` for ~12 seconds to confirm it boots, then stop it; returns the startup logs. Use this after building an app to catch errors that `jac check` cannot.";
+sem start_app.entry_file = "Entry .jac file to start; empty string means 'main.jac'.";
 
 
 def search_guides(keyword: str) -> str {
-    matches = gs_search(keyword);
-    if not matches {
+    words = [
+        w
+        for w in keyword.lower().split()
+        if w
+    ];
+    if not words {
+        return "(empty search)";
+    }
+    scored: list[tuple[int, str]] = [];
+    for g in gs_list() {
+        haystack = f"{g.name}\n{g.description}\n{g.body}".lower();
+        hits = sum(
+            [
+                1
+                for w in words
+                if w in haystack
+            ]
+        );
+        if hits > 0 {
+            # Negative hit count sorts most-relevant-first under a plain sort.
+            scored.append((-hits, f"{g.name}: {g.description}"));
+        }
+    }
+    if not scored {
         return f"(no guides match '{keyword}')";
     }
-    return "\n".join([f"{g.name}: {g.description}" for g in matches]);
+    scored.sort();
+    return "\n".join([line for (_, line) in scored]);
 }
 
-sem search_guides = "Search the bundled Jac reference guides by keyword; returns matching guide names and descriptions.";
-sem search_guides.keyword = "Keyword or phrase to search guide titles and bodies for.";
+sem search_guides = "Search the bundled Jac reference guides; returns matching guide names and descriptions ranked by relevance. Matches any word in the query, so several keywords broaden the search.";
+sem search_guides.keyword = "Keywords to search guide names, descriptions, and bodies for.";
 
 
 def read_guide(name: str) -> str {
@@ -340,6 +421,16 @@ def read_guide(name: str) -> str {
 sem read_guide = "Read a bundled Jac reference guide in full -- the authoritative spec for writing correct, idiomatic Jac.";
 sem read_guide.name = "Exact guide name, e.g. 'jac-walker-patterns'.";
 
+
+# Side-effecting tools must never run concurrently; byLLM keeps any parallel
+# batch that contains one of these sequential.
+with entry {
+    mark_serialize(write_file);
+    mark_serialize(edit_file);
+    mark_serialize(run_command);
+    mark_serialize(start_app);
+}
+
 #===============================================================================
 # SYSTEM PROMPT & THE AGENT TURN
 #===============================================================================
@@ -348,16 +439,36 @@ You are Jac AI, a coding agent working inside the user's terminal in their Jac
 project. You help the user read, write, and debug Jac code.
 
 Work like this:
-- Use the tools to inspect the project. Never guess a file's contents -- read
-  it first. Never guess Jac syntax -- consult the guides.
-- When unsure how to write something in Jac, call search_guides then read_guide.
-  The bundled guides are the authoritative spec for correct, idiomatic Jac.
+- Plan first. For any multi-file task, open with a short plan -- the files you
+  will create or change and what each is for -- then carry it out.
+- Scaffold, don't hand-build. For a new project or app, run `jac create --use
+  <template> <name>` with run_command instead of writing the project layout by
+  hand. Templates: default, client, fullstack. Then adapt the generated files.
+- Batch aggressively. Independent tool calls run in parallel, so issue them
+  together in ONE step -- never one at a time. Reading five files is one step
+  with five read_file calls. Loading the guides you need is one step. Grepping
+  or checking several paths is one step. Writes to different files go in one
+  step. Sequence a call only when it truly needs an earlier call's output.
+- Decide and commit. When two or more approaches would both work, pick the
+  simplest and build it. Do not re-litigate a choice you have already acted on,
+  and never write a file just to delete it -- think the choice through first.
+- Never guess. Read a file before editing it; consult the guides before
+  writing unfamiliar Jac. The bundled guides are the authoritative spec for
+  correct, idiomatic Jac.
+- Keep files focused and modest in size; split large archetypes into impl
+  files. For a large file, write a skeleton first, then fill it with edit_file.
 - Make minimal, targeted changes. Prefer edit_file over rewriting a whole file.
-- After you write or edit a .jac file, call jac_check on it and fix any errors
-  before moving on.
-- Call exactly one tool at a time and read its result before the next step.
+- Verify. After writing code, run `jac check .` to type-check the whole
+  project and fix every error. For an app, use start_app to confirm it boots.
 - When the task is complete, finish with a short plain-language summary of what
   you changed and why.
+
+Jac gotchas -- the type checker rejects all of these, so never write them:
+- There is no `pass` statement. For an empty block, write empty braces: `{}`.
+- A docstring (`\"\"\"...\"\"\"`) goes immediately BEFORE a declaration, never as
+  the first statement inside a function body -- in a body it is a parse error.
+- The gradual / untyped type is lowercase `any`, with no import. Never write
+  capital `Any`, and never `import from typing { Any }`.
 """;
 
 
@@ -391,8 +502,9 @@ def ask(message: str) -> str by agent_model(
         edit_file,
         list_dir,
         grep,
-        run_jac,
+        run_command,
         jac_check,
+        start_app,
         search_guides,
         read_guide
     ],
@@ -400,7 +512,12 @@ def ask(message: str) -> str by agent_model(
     stream=True,
     logging=True,
     temperature=agent_temperature,
-    max_react_iterations=40
+    max_tokens=8192,
+    parallelize=True,
+    max_react_iterations=80
+    # A generous output ceiling: without it the provider default (~4096 for
+    # Anthropic) truncates large `write_file` tool-call arguments mid-stream,
+    # so the `content` argument never arrives intact.
 );
 
 sem ask = "Continue the coding session by handling the user's latest message.";
@@ -506,7 +623,7 @@ def run_turn(message: str) {
                 # byLLM's echo of the final reasoning, so drop it.
                 pending_thought = "";
                 answering = True;
-                console.print(str(data.get("content", "")), end="", flush=True);
+                console.print(str(data.get("content", "")), end="");
             }
         }
         if answering {

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -1,0 +1,594 @@
+"""Interactive Jac coding agent -- the engine behind `jac ai`.
+
+A terminal coding agent built as a byLLM ReAct loop wired to file and guide
+tools. The agent reads, writes, and debugs Jac code in the current project,
+grounded in the bundled Jac reference guides so it self-serves the
+authoritative spec for idiomatic Jac.
+
+This module is imported lazily by the `jac ai` command, so the core CLI keeps
+no hard dependency on the byLLM plugin. `run_agent` takes the resolved flags
+directly and builds the model from them before the session starts.
+"""
+
+import os;
+import re;
+import sys;
+import subprocess;
+import from pathlib { Path }
+
+import from byllm.lib { Model }
+import from byllm.config_loader { get_byllm_config }
+
+import from jaclang.cli.console { console }
+import from jaclang.cli.guide_store {
+    list_guides as gs_list,
+    get_guide as gs_get,
+    search_guides as gs_search
+}
+
+#===============================================================================
+# MODEL & SESSION STATE
+#===============================================================================
+
+# Skip confirmation prompts; set by `run_agent` from the `--yolo` flag.
+glob yolo_mode: bool = False,
+     # Resolved CPU thread count for local inference; shown in the banner. Set by
+     # `build_model`; 0 means "not a local model / leave it to the backend".
+     agent_threads: int = 0,
+     # Sampling temperature for the agent's calls. Set by `build_model`: a low,
+     # deterministic value for local models, `None` for cloud models (some newer
+     # ones reject `temperature` outright, so it is left to the provider default).
+     agent_temperature: float | None = None,
+     # Where the resolved model came from -- shown in the banner so the user can
+     # see whether a `--model` flag, jac.toml, or the built-in default won.
+     agent_model_source: str = "default";
+
+"""Pick which model `jac ai` should run.
+
+Priority: the `--model` flag (`model_override`), then `[plugins.byllm.model]
+default_model` in jac.toml, then the bundled local model so the command works
+with no API key. Records the winning source in `agent_model_source`.
+"""
+def resolve_model_name(model_override: str = "") -> str {
+    global agent_model_source;
+    flag = model_override.strip();
+    if flag {
+        agent_model_source = "command line";
+        return flag;
+    }
+    # Read the raw [plugins.byllm.model] table -- not the defaults-merged
+    # config -- so an unset `default_model` does not masquerade as a choice.
+    toml_model = "";
+    try {
+        raw = get_byllm_config().get_jac_config().get_plugin_config("byllm");
+        model_section = raw.get("model", {});
+        if isinstance(model_section, dict) {
+            toml_model = str(model_section.get("default_model", "")).strip();
+        }
+    } except Exception {
+        toml_model = "";
+    }
+    if toml_model {
+        agent_model_source = "jac.toml";
+        return toml_model;
+    }
+    agent_model_source = "default";
+    return "local:gemma-4-e4b";
+}
+
+"""Build the agent's LLM, supporting any byLLM-compatible model.
+
+The model name is resolved by `resolve_model_name` (flag, then jac.toml, then
+the bundled local default). Cloud models work out of the box: byLLM's `Model`
+pulls `api_key`/`base_url` from `[plugins.byllm.model]` in jac.toml (or the
+usual provider env vars). Local models additionally read the runtime knobs
+(gpu layers, threads, auto-download) from `[plugins.byllm.local]`; a non-zero
+`n_ctx` overrides the configured context window.
+"""
+def build_model(model_override: str = "", n_ctx: int = 0) -> Model {
+    global agent_threads,agent_temperature;
+    name = resolve_model_name(model_override);
+    cfg: dict[str, object] = {};
+    is_local = name.startswith("local:");
+    # Reset first: a rebuild may swap a local model for a cloud one, and the
+    # banner must not keep showing a stale thread count.
+    agent_threads = 0;
+    # Pin local models to a low temperature for deterministic code edits;
+    # leave cloud models at the provider default (newer ones reject the param).
+    agent_temperature = 0.3 if is_local else None;
+    if is_local {
+        try {
+            cfg = dict(get_byllm_config().get_local_config());
+        } except Exception {
+            cfg = {};
+        }
+        # Cap CPU usage so local inference does not peg (and overheat) the
+        # machine: a jac.toml [plugins.byllm.local] n_threads wins, otherwise
+        # default to half the cores.
+        if not cfg.get("n_threads") {
+            cores = os.cpu_count() or 2;
+            cfg["n_threads"] = max(1, cores // 2);
+        }
+        agent_threads = int(cfg.get("n_threads") or 0);
+    }
+    if n_ctx > 0 {
+        cfg["n_ctx"] = n_ctx;
+    }
+    return Model(model_name=name, config=cfg);
+}
+
+# Built at import time from jac.toml (or the bundled default) so `ask`'s `by`
+# clause always has a model; `run_agent` rebuilds it when flags are passed.
+glob agent_model = build_model(),
+     # The running conversation. byLLM's `conversation=` kwarg splices this list
+     # into each turn and writes the updated history back in place. Pre-seeded with
+     # the agent's system message by `reset_history`.
+     history: list[object] = [];
+
+#===============================================================================
+# TOOL HELPERS
+#===============================================================================
+"""Clip oversized tool output so it does not blow the model's context."""
+def truncate(text: str, limit: int = 12000) -> str {
+    if len(text) > limit {
+        extra = len(text) - limit;
+        return text[:limit] + f"\n... [truncated, {extra} more chars]";
+    }
+    return text;
+}
+
+"""Ask the user to approve a side-effecting action; honours `--yolo`."""
+def confirm(action: str) -> bool {
+    if yolo_mode {
+        return True;
+    }
+    console.print(f"  needs approval: {action}", style="yellow");
+    try {
+        answer = input("  Allow this action? [y/N] ").strip().lower();
+    } except EOFError {
+        return False;
+    }
+    return answer in ("y", "yes");
+}
+
+#===============================================================================
+# TOOLS -- plain typed functions; byLLM turns the annotations into JSON schema
+#===============================================================================
+def read_file(path: str) -> str {
+    try {
+        return truncate(Path(path).read_text());
+    } except Exception as e {
+        return f"ERROR reading {path}: {e}";
+    }
+}
+
+sem read_file = "Read and return the full text of a file.";
+sem read_file.path = "Path to the file to read, relative to the project.";
+
+
+def write_file(path: str, content: str) -> str {
+    if not confirm(f"write {len(content)} chars to {path}") {
+        return "DENIED: the user declined this write.";
+    }
+    try {
+        p = Path(path);
+        p.parent.mkdir(parents=True, exist_ok=True);
+        p.write_text(content);
+        return f"OK: wrote {len(content)} chars to {path}";
+    } except Exception as e {
+        return f"ERROR writing {path}: {e}";
+    }
+}
+
+sem write_file = "Create a file or overwrite it entirely with new content.";
+sem write_file.path = "Path of the file to write.";
+sem write_file.content = "The full new contents of the file.";
+
+
+def edit_file(path: str, old_text: str, new_text: str) -> str {
+    try {
+        original = Path(path).read_text();
+    } except Exception as e {
+        return f"ERROR reading {path}: {e}";
+    }
+    occurrences = original.count(old_text);
+    if occurrences == 0 {
+        return f"ERROR: old_text was not found in {path}. Read the file first.";
+    }
+    if occurrences > 1 {
+        return (
+            f"ERROR: old_text appears {occurrences} times in {path}; "
+            "include more surrounding context so it matches exactly once."
+        );
+    }
+    if not confirm(f"edit {path}") {
+        return "DENIED: the user declined this edit.";
+    }
+    try {
+        Path(path).write_text(original.replace(old_text, new_text));
+        return f"OK: edited {path}";
+    } except Exception as e {
+        return f"ERROR writing {path}: {e}";
+    }
+}
+
+sem edit_file = "Replace one exact, unique occurrence of text in a file.";
+sem edit_file.path = "Path of the file to edit.";
+sem edit_file.old_text = "Exact text to find; must occur exactly once in the file.";
+sem edit_file.new_text = "Text to replace it with.";
+
+
+def list_dir(path: str) -> str {
+    try {
+        target = Path(path or ".");
+        names: list[str] = [];
+        for entry in sorted(target.iterdir()) {
+            if entry.name.startswith(".") {
+                continue;
+            }
+            names.append(entry.name + ("/" if entry.is_dir() else ""));
+        }
+        return "\n".join(names) or "(empty directory)";
+    } except Exception as e {
+        return f"ERROR listing {path}: {e}";
+    }
+}
+
+sem list_dir = "List the entries of a directory (hidden entries excluded).";
+sem list_dir.path = "Directory path; empty string means the current directory.";
+
+
+def grep(pattern: str, path: str) -> str {
+    try {
+        regex = re.compile(pattern);
+    } except Exception as e {
+        return f"ERROR: invalid regular expression: {e}";
+    }
+    search_root = Path(path or ".");
+    if search_root.is_file() {
+        files = [search_root];
+    } elif search_root.is_dir() {
+        files = [
+            f
+            for f in search_root.rglob("*.jac")
+            if f.is_file()
+        ];
+    } else {
+        return f"ERROR: no such path: {path}";
+    }
+    hits: list[str] = [];
+    for f in files {
+        try {
+            text = f.read_text();
+        } except Exception {
+            continue;
+        }
+        for (line_no, line) in enumerate(text.splitlines(), 1) {
+            if regex.search(line) {
+                hits.append(f"{f}:{line_no}: {line.strip()}");
+                if len(hits) >= 100 {
+                    return "\n".join(hits) + "\n... [stopped at 100 matches]";
+                }
+            }
+        }
+    }
+    return "\n".join(hits) or "(no matches)";
+}
+
+sem grep = "Search for a regular expression across .jac files (or one file).";
+sem grep.pattern = "Python regular expression to search for.";
+sem grep.path = "File or directory to search; empty string means current directory.";
+
+
+"""Run a `jac` subcommand on a file and return its combined output."""
+def run_jac_cli(subcommand: str, path: str) -> str {
+    try {
+        result = subprocess.run(
+            [sys.executable, "-m", "jaclang", subcommand, path],
+            capture_output=True,
+            text=True,
+            timeout=120
+        );
+        combined = ((result.stdout or "") + (result.stderr or "")).strip();
+        return truncate(combined or f"(no output; exit code {result.returncode})");
+    } except Exception as e {
+        return f"ERROR running `jac {subcommand} {path}`: {e}";
+    }
+}
+
+
+def run_jac(path: str) -> str {
+    if not confirm(f"run `jac run {path}`") {
+        return "DENIED: the user declined to run this file.";
+    }
+    return run_jac_cli("run", path);
+}
+
+sem run_jac = "Execute a .jac file with `jac run` and return its output.";
+sem run_jac.path = "Path of the .jac file to run.";
+
+
+def jac_check(path: str) -> str {
+    return run_jac_cli("check", path);
+}
+
+sem jac_check = "Type-check and compile a .jac file with `jac check`; use this after writing or editing Jac code to confirm it is valid.";
+sem jac_check.path = "Path of the .jac file to check.";
+
+
+def search_guides(keyword: str) -> str {
+    matches = gs_search(keyword);
+    if not matches {
+        return f"(no guides match '{keyword}')";
+    }
+    return "\n".join([f"{g.name}: {g.description}" for g in matches]);
+}
+
+sem search_guides = "Search the bundled Jac reference guides by keyword; returns matching guide names and descriptions.";
+sem search_guides.keyword = "Keyword or phrase to search guide titles and bodies for.";
+
+
+def read_guide(name: str) -> str {
+    guide = gs_get(name);
+    if guide is None {
+        available = ", ".join([g.name for g in gs_list()]);
+        return f"ERROR: no guide named '{name}'. Available guides: {available}";
+    }
+    return truncate(guide.body, 16000);
+}
+
+sem read_guide = "Read a bundled Jac reference guide in full -- the authoritative spec for writing correct, idiomatic Jac.";
+sem read_guide.name = "Exact guide name, e.g. 'jac-walker-patterns'.";
+
+#===============================================================================
+# SYSTEM PROMPT & THE AGENT TURN
+#===============================================================================
+glob AGENT_RULES = """\
+You are Jac AI, a coding agent working inside the user's terminal in their Jac
+project. You help the user read, write, and debug Jac code.
+
+Work like this:
+- Use the tools to inspect the project. Never guess a file's contents -- read
+  it first. Never guess Jac syntax -- consult the guides.
+- When unsure how to write something in Jac, call search_guides then read_guide.
+  The bundled guides are the authoritative spec for correct, idiomatic Jac.
+- Make minimal, targeted changes. Prefer edit_file over rewriting a whole file.
+- After you write or edit a .jac file, call jac_check on it and fix any errors
+  before moving on.
+- Call exactly one tool at a time and read its result before the next step.
+- When the task is complete, finish with a short plain-language summary of what
+  you changed and why.
+""";
+
+
+"""Build the agent's system message: rules, the guide index, and the cheatsheet."""
+def system_prompt -> str {
+    index_lines: list[str] = [];
+    for g in gs_list() {
+        index_lines.append(f"- {g.name}: {g.description}");
+    }
+    guide_index = "\n".join(index_lines);
+    cheatsheet = gs_get("jac-core-cheatsheet");
+    cheatsheet_body = cheatsheet.body if cheatsheet is not None else "";
+    return (
+        AGENT_RULES + "\n## Reference guides available (open one with read_guide)\n\n" + guide_index + "\n\n## Jac core cheatsheet\n\n" + cheatsheet_body
+    );
+}
+
+
+"""Reset the conversation to just the agent's system message."""
+def reset_history {
+    history.clear();
+    history.append({"role": "system", "content": system_prompt()});
+}
+
+
+"""Address the user's latest message, using tools as needed."""
+def ask(message: str) -> str by agent_model(
+    tools=[
+        read_file,
+        write_file,
+        edit_file,
+        list_dir,
+        grep,
+        run_jac,
+        jac_check,
+        search_guides,
+        read_guide
+    ],
+    conversation=history,
+    stream=True,
+    logging=True,
+    temperature=agent_temperature,
+    max_react_iterations=40
+);
+
+sem ask = "Continue the coding session by handling the user's latest message.";
+sem ask.message = "The user's latest message.";
+
+#===============================================================================
+# TERMINAL UI
+#===============================================================================
+def print_banner {
+    console.print("");
+    console.print("  Jac AI -- interactive coding agent", style="bold");
+    console.print(
+        f"  model: {agent_model.model_name}  (from {agent_model_source})", style="muted"
+    );
+    if agent_threads > 0 {
+        console.print(f"  inference threads: {agent_threads}", style="muted");
+    }
+    console.print("  type a request, /help for commands, /exit to quit", style="muted");
+    console.print("");
+}
+
+
+def print_help {
+    console.print("  /help    show this help", style="muted");
+    console.print("  /clear   reset the conversation", style="muted");
+    console.print("  /guides  list the bundled Jac reference guides", style="muted");
+    console.print("  /exit    quit the session", style="muted");
+}
+
+
+"""Format a tool call as `name(key=value, ...)`, clipping long values."""
+def fmt_tool_call(tool: str, args: object) -> str {
+    parts: list[str] = [];
+    if isinstance(args, dict) {
+        for (key, value) in args.items() {
+            sval = str(value).replace("\n", " ");
+            if len(sval) > 60 {
+                sval = sval[:60] + "...";
+            }
+            parts.append(f"{key}={sval}");
+        }
+    }
+    return f"{tool}(" + ", ".join(parts) + ")";
+}
+
+
+"""Condense a tool result to a single clipped line for the activity log."""
+def preview_result(text: str) -> str {
+    stripped = text.strip();
+    if not stripped {
+        return "(no output)";
+    }
+    lines = stripped.splitlines();
+    head = lines[0];
+    if len(head) > 100 {
+        head = head[:100] + "...";
+    }
+    rest = len(lines) - 1;
+    return head + (f"  (+{rest} more lines)" if rest > 0 else "");
+}
+
+
+"""Run one agent turn, rendering the full byLLM event stream to the terminal.
+
+`ask` runs with `stream=True, logging=True`, so it yields a StreamEvent for
+every step of the ReAct loop -- the model's reasoning (`thought`), each
+`tool_call` and `tool_result`, and finally the answer `chunk`s -- instead of
+going silent while tools run.
+"""
+def run_turn(message: str) {
+    console.print("");
+    answering = False;
+    # `ask` is typed `-> str` for byLLM's streaming contract, but with
+    # logging=True it actually yields StreamEvent objects -- iterate via an
+    # `any`-typed handle so attribute access type-checks.
+    event_stream: any = ask(message);
+    # Thoughts are buffered, not printed live: byLLM echoes the model's final
+    # reasoning as both a `thought` and the answer `chunk`s. Buffered thoughts
+    # flush only when a tool call follows them (genuine mid-loop reasoning);
+    # the final pre-answer thought is dropped at `steps_done`.
+    pending_thought = "";
+    try {
+        for event in event_stream {
+            kind = event.event_type;
+            data = event.data;
+            if kind == "thought" {
+                pending_thought = str(data.get("content", "")).strip();
+            } elif kind == "tool_call" {
+                if pending_thought {
+                    console.print(pending_thought, style="dim italic");
+                    pending_thought = "";
+                }
+                call = fmt_tool_call(str(data.get("tool", "?")), data.get("args", {}));
+                console.print(f"  ⏺ {call}", style="cyan");
+            } elif kind == "tool_result" {
+                console.print(
+                    f"    {preview_result(str(data.get('result', '')))}", style="dim"
+                );
+            } elif kind == "steps_done" {
+                console.print("");
+            } elif kind == "chunk" {
+                # Answer chunks are streaming -- the buffered thought was just
+                # byLLM's echo of the final reasoning, so drop it.
+                pending_thought = "";
+                answering = True;
+                console.print(str(data.get("content", "")), end="", flush=True);
+            }
+        }
+        if answering {
+            console.print("");
+        } elif pending_thought {
+            # No answer chunks arrived -- the model's final message itself is
+            # the answer; surface it rather than leaving the turn blank.
+            console.print(pending_thought);
+        }
+    } except KeyboardInterrupt {
+        console.print("\n  [interrupted]", style="yellow");
+    } except Exception as e {
+        console.print("");
+        console.error(f"agent error: {e}");
+        if os.environ.get("JAC_AI_DEBUG") {
+            import traceback;
+            traceback.print_exc();
+        }
+    }
+}
+
+
+"""Entry point for `jac ai`.
+
+Applies the resolved `--model`, `--n_ctx`, and `--yolo` flags, then runs.
+With `initial_prompt`, runs a single turn and exits; otherwise starts an
+interactive read-eval-print loop. Always returns 0 -- a failed turn reports
+its error but does not abort the session.
+"""
+def run_agent(
+    initial_prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False
+) -> int {
+    global agent_model,yolo_mode;
+    yolo_mode = yolo;
+    # The import-time `agent_model` already covers jac.toml/default; only
+    # rebuild when a flag actually changes the model or its context window.
+    if model or n_ctx > 0 {
+        agent_model = build_model(model, n_ctx);
+    }
+    print_banner();
+    reset_history();
+
+    if initial_prompt {
+        run_turn(initial_prompt);
+        return 0;
+    }
+
+    while True {
+        try {
+            line = input("\n> ").strip();
+        } except EOFError {
+            console.print("");
+            break;
+        } except KeyboardInterrupt {
+            console.print("");
+            continue;
+        }
+        if not line {
+            continue;
+        }
+        if line in ("/exit", "/quit") {
+            break;
+        }
+        if line == "/help" {
+            print_help();
+            continue;
+        }
+        if line == "/clear" {
+            reset_history();
+            console.success("Conversation cleared.");
+            continue;
+        }
+        if line == "/guides" {
+            for g in gs_list() {
+                console.print(f"  {g.name}", style="bold");
+                console.print(f"      {g.description}", style="muted");
+            }
+            continue;
+        }
+        run_turn(line);
+    }
+
+    console.print("Bye.");
+    return 0;
+}

--- a/jac/jaclang/cli/commands/__init__.jac
+++ b/jac/jaclang/cli/commands/__init__.jac
@@ -10,3 +10,4 @@ import from jaclang.cli.commands { tools }
 import from jaclang.cli.commands { config }
 import from jaclang.cli.commands { db }
 import from jaclang.cli.commands { nacompile }
+import from jaclang.cli.commands { ai }

--- a/jac/jaclang/cli/commands/ai.jac
+++ b/jac/jaclang/cli/commands/ai.jac
@@ -1,0 +1,64 @@
+"""AI command: launch an interactive Jac coding agent in the terminal.
+
+`jac ai` starts a coding agent -- a byLLM ReAct loop wired to file and guide
+tools -- that reads, writes, and debugs Jac code in the current project. It is
+grounded in the bundled Jac reference guides (the same ones `jac guide` shows),
+so the agent self-serves the authoritative spec for idiomatic Jac.
+
+The agent works with any byLLM-compatible model -- local llama.cpp builds or
+cloud providers (OpenAI, Anthropic, Gemini, ...). Pick one with `--model`, or
+set `[plugins.byllm.model] default_model` in jac.toml; with neither it falls
+back to the bundled `local:gemma-4-e4b` so it runs with no API key. Cloud
+models read credentials from `[plugins.byllm.model]` in jac.toml (or the usual
+provider env vars). byLLM must be installed -- the command reports how to
+install it when it is missing.
+"""
+
+import from jaclang.cli.command { Arg, ArgKind }
+import from jaclang.cli.registry { get_registry }
+
+glob registry = get_registry();
+
+"""Launch an interactive Jac coding agent powered by a byLLM model."""
+@registry.command(
+    name="ai",
+    help="Launch an interactive Jac coding agent",
+    args=[
+        Arg.create(
+            "prompt",
+            kind=ArgKind.POSITIONAL,
+            default="",
+            help="Optional one-shot request; omit for an interactive session"
+        ),
+        Arg.create(
+            "model",
+            default="",
+            help="Model to use, e.g. local:gemma-4-e4b or openai/gpt-4o",
+            short="m"
+        ),
+        Arg.create(
+            "n_ctx",
+            typ=int,
+            default=0,
+            help="Context-window size for local models (tokens)"
+        ),
+        Arg.create(
+            "yolo",
+            kind=ArgKind.FLAG,
+            typ=bool,
+            default=False,
+            help="Skip confirmation prompts for file writes and code execution"
+        ),
+
+    ],
+    examples=[
+        ("jac ai", "Start a session (uses jac.toml's model, else local default)"),
+        ("jac ai \"add a walker to main.jac\"", "Run a single request and exit"),
+        ("jac ai -m openai/gpt-4o", "Use a cloud model (key from jac.toml or env)"),
+        ("jac ai -m local:gemma-4-e2b", "Use a smaller/faster local model"),
+        ("jac ai --n_ctx 32768", "Give the local model a larger context window"),
+
+    ],
+    group="general"
+)
+def ai(prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False) -> int;

--- a/jac/jaclang/cli/commands/ai.jac
+++ b/jac/jaclang/cli/commands/ai.jac
@@ -43,11 +43,11 @@ glob registry = get_registry();
             help="Context-window size for local models (tokens)"
         ),
         Arg.create(
-            "yolo",
+            "safe",
             kind=ArgKind.FLAG,
             typ=bool,
             default=False,
-            help="Skip confirmation prompts for file writes and code execution"
+            help="Confirm every file write and code execution (off by default)"
         ),
 
     ],
@@ -57,8 +57,9 @@ glob registry = get_registry();
         ("jac ai -m openai/gpt-4o", "Use a cloud model (key from jac.toml or env)"),
         ("jac ai -m local:gemma-4-e2b", "Use a smaller/faster local model"),
         ("jac ai --n_ctx 32768", "Give the local model a larger context window"),
+        ("jac ai --safe", "Approve each file write and command before it runs"),
 
     ],
     group="general"
 )
-def ai(prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False) -> int;
+def ai(prompt: str = "", model: str = "", n_ctx: int = 0, safe: bool = False) -> int;

--- a/jac/jaclang/cli/commands/impl/ai.impl.jac
+++ b/jac/jaclang/cli/commands/impl/ai.impl.jac
@@ -1,22 +1,16 @@
 """Implementation of the `jac ai` command.
 
-This file is intentionally thin: it validates that byLLM is available, then
-hands the user's flags straight to `run_agent`. The agent itself lives in
-`jaclang/cli/ai_agent.jac`, imported lazily here so the core CLI keeps no hard
-dependency on the byLLM plugin.
+This file is intentionally thin: it builds an `AgentRequest` from the user's
+flags and dispatches it through the `run_ai_agent` hook. The core ships a
+built-in byLLM agent as the default hook implementation; a plugin can register
+its own to replace it. Because dispatch goes through the hook, the core CLI
+keeps no hard dependency on the byLLM plugin.
 """
-import from jaclang.cli.console { console }
 
-"""Launch an interactive Jac coding agent powered by a byLLM model."""
+"""Launch an interactive Jac coding agent."""
 impl ai(prompt: str = "", model: str = "", n_ctx: int = 0, safe: bool = False) -> int {
-    try {
-        import from jaclang.cli.ai_agent { run_agent }
-    } except ImportError {
-        console.error(
-            "`jac ai` needs the byLLM plugin, which is not installed.",
-            hint="Install it with:  pip install byllm"
-        );
-        return 1;
-    }
-    return run_agent(prompt, model, n_ctx, safe);
+    import from jaclang.cli.agent_api { build_agent_request }
+    import from jaclang.jac0core.runtime { JacRuntime as Jac }
+    req = build_agent_request(prompt, model, n_ctx, safe);
+    return Jac.run_ai_agent(req);
 }

--- a/jac/jaclang/cli/commands/impl/ai.impl.jac
+++ b/jac/jaclang/cli/commands/impl/ai.impl.jac
@@ -8,7 +8,7 @@ dependency on the byLLM plugin.
 import from jaclang.cli.console { console }
 
 """Launch an interactive Jac coding agent powered by a byLLM model."""
-impl ai(prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False) -> int {
+impl ai(prompt: str = "", model: str = "", n_ctx: int = 0, safe: bool = False) -> int {
     try {
         import from jaclang.cli.ai_agent { run_agent }
     } except ImportError {
@@ -18,5 +18,5 @@ impl ai(prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False) -
         );
         return 1;
     }
-    return run_agent(prompt, model, n_ctx, yolo);
+    return run_agent(prompt, model, n_ctx, safe);
 }

--- a/jac/jaclang/cli/commands/impl/ai.impl.jac
+++ b/jac/jaclang/cli/commands/impl/ai.impl.jac
@@ -1,0 +1,22 @@
+"""Implementation of the `jac ai` command.
+
+This file is intentionally thin: it validates that byLLM is available, then
+hands the user's flags straight to `run_agent`. The agent itself lives in
+`jaclang/cli/ai_agent.jac`, imported lazily here so the core CLI keeps no hard
+dependency on the byLLM plugin.
+"""
+import from jaclang.cli.console { console }
+
+"""Launch an interactive Jac coding agent powered by a byLLM model."""
+impl ai(prompt: str = "", model: str = "", n_ctx: int = 0, yolo: bool = False) -> int {
+    try {
+        import from jaclang.cli.ai_agent { run_agent }
+    } except ImportError {
+        console.error(
+            "`jac ai` needs the byLLM plugin, which is not installed.",
+            hint="Install it with:  pip install byllm"
+        );
+        return 1;
+    }
+    return run_agent(prompt, model, n_ctx, yolo);
+}

--- a/jac/jaclang/cli/skills/jac-by-llm.md
+++ b/jac/jaclang/cli/skills/jac-by-llm.md
@@ -52,8 +52,8 @@ with entry {
 
 ## Pitfalls
 
-- `llm` is an **ambient builtin** - the model powering it is configured project-wide in `jac.toml`. A module-level `glob llm: Model = Model(...)` (as shown above) is an *optional* per-file override, not a requirement: `by llm()` type-checks and runs with no `glob llm` declared at all.
+- `llm` is an **ambient builtin** - the model powering it is configured project-wide in `jac.toml` under `[plugins.byllm.model]` (e.g. `default_model = "gpt-4o-mini"`). A module-level `glob llm: Model = Model(...)` (as shown above) is an *optional* per-file override, not a requirement: `by llm()` type-checks and runs with no `glob llm` declared at all.
 - `by llm(...)` REPLACES the body - never write both `{ body }` and `by llm(...)` on the same signature.
 - Use `sem`, NOT docstrings, for every LLM-visible description. Triple-quoted strings inside a body fail with W0060.
 - Tools are **function references**, NOT strings: `tools=[word_count]`, never `tools=["word_count"]`. Each tool needs its own `sem` and per-arg `sem` so the LLM knows when to call it.
-- Common `by llm(...)` options: `tools`, `temperature`, `max_tokens`, `max_react_iterations`, `stream`, `incl_info` - and more; see the byLLM reference for the full list. The model is normally selected by `jac.toml` / the `Model` instance, not a per-call argument. Note: `jac check` does **not** validate `by llm` keyword names, so a misspelled option surfaces at runtime, not at check time.
+- Common `by llm(...)` options: `tools`, `temperature`, `max_tokens`, `max_react_iterations`, `conversation` (multi-turn history), `on_iteration` (ReAct loop control), `stream`, `incl_info` - and more; see the byLLM reference for the full list. The model is normally selected by `jac.toml` / the `Model` instance, not a per-call argument. Note: `jac check` does **not** validate `by llm` keyword names, so a misspelled option surfaces at runtime, not at check time.

--- a/jac/jaclang/cli/skills/jac-cl-auth.md
+++ b/jac/jaclang/cli/skills/jac-cl-auth.md
@@ -30,7 +30,7 @@ async def handle_register(name: str, email: str, password: str) -> str {
     # Note the per-helper types: jacSignup -> dict, jacLogin -> bool.
     signup_result: dict | None = None;
     login_ok: bool = False;
-    profile_result: Any = None;
+    profile_result: any = None;
 
     signup_result = await jacSignup(email, password);
     if not signup_result["success"] { return "registration failed"; }

--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -34,10 +34,10 @@ def:pub Counter() -> JsxElement {
 
 ## Props
 
-Components declare props as typed function params; callers pass as JSX attributes. Callback props are typed `Any`. Wrap incoming callbacks in a local handler so parent-side data (like a row's id) is closed over when the event fires.
+Components declare props as typed function params; callers pass as JSX attributes. Callback props are typed `any` (lowercase - the gradual type). Wrap incoming callbacks in a local handler so parent-side data (like a row's id) is closed over when the event fires.
 
 ```jac
-def:pub BookCard(bookId: str, title: str, onDelete: Any) -> JsxElement {
+def:pub BookCard(bookId: str, title: str, onDelete: any) -> JsxElement {
     def handle_delete(e: MouseEvent) {
         if onDelete { onDelete(bookId); }
     }
@@ -58,11 +58,11 @@ Call site: `<BookCard bookId={b["id"]} title={b["title"]} onDelete={remove} />`.
 | `onSubmit`, `onReset` | `FormEvent` | `e.preventDefault()` |
 | `onFocus`, `onBlur` | `FocusEvent` | `e.target` |
 
-Fall back to `Any` (capital, built-in) only when you don't read `e`.
+Fall back to `any` (lowercase, the gradual type) only when you don't read `e`.
 
 ## Built-in in `.cl.jac` - NEVER import these
 
-`JsxElement` (the component return type), `Any`, and all DOM event types (`MouseEvent`, `ChangeEvent`, `FormEvent`, `KeyboardEvent`, `InputEvent`, `FocusEvent`) are Jac built-ins in client context. Trying `import from "@jac/runtime" { JsxElement }` is wrong and can fail the Vite build.
+`JsxElement` (the component return type) and all DOM event types (`MouseEvent`, `ChangeEvent`, `FormEvent`, `KeyboardEvent`, `InputEvent`, `FocusEvent`) are Jac built-ins in client context. Trying `import from "@jac/runtime" { JsxElement }` is wrong and can fail the Vite build.
 
 ## Imports from `@jac/runtime` (complete list)
 
@@ -92,13 +92,13 @@ has_filter: bool = bool(useParams()["category"]);
 ```
 
 - **Server RPC import uses `sv import from ..services.X { fn, Types }`** (prefix required). Dot count = how many folders up from THIS file to reach `services/` - for a `components/X.cl.jac` it's 2 dots, for `components/pages/X.cl.jac` it's 3 dots (see `jac-core-cheatsheet` for dot semantics). Plain `import from` to a `.sv.jac` breaks the Vite build. Include obj/node types too - they're needed to type your `has` state (next rule). See `jac-fullstack-patterns`.
-- **Type `has` state with the imported `sv` types - `list[Any]` loses the element type.** Store data from `sv import` calls in fields typed with the actual node/obj. Without it, attribute access in loops fails `E1032: Type is Unknown`.
+- **Type `has` state with the imported `sv` types - `list[any]` loses the element type.** Store data from `sv import` calls in fields typed with the actual node/obj. Without it, attribute access in loops fails `E1032: Type is Unknown`.
 
 ```
 sv import from ..services.linkedin { Post };   # 2 dots: this file is at components/X.cl.jac; `..` walks up to project root, then into services/
 
 # FRAGILE
-has posts: list[Any] = [];           # E1032 on p.title in any loop
+has posts: list[any] = [];           # E1032 on p.title in any loop
 
 # CORRECT
 has posts: list[Post] = [];          # `p` in `for p in posts` is typed Post
@@ -107,7 +107,7 @@ has posts: list[Post] = [];          # `p` in `for p in posts` is typed Post
 - **Call server endpoints POSITIONAL, not kwargs.** `save(a, b)` works; `save(a=a, b=b)` sends empty body → 422. Also: the caller's variable names become the JSON keys - they must match the server parameter names exactly. See `jac-fullstack-patterns`.
 - **JSX ternary is Python-style:** `{X if cond else Y}`. NOT `{cond ? X : Y}` (parse error even inside JSX). Short-circuit also works: `{cond and <X />}`.
 - **Iterate with comprehensions, NOT `.map()`.** `items.map(...)` on a Jac list fails E1030. Use `[<li>...</li> for i in items]` inside JSX. `for i, x in enumerate(items)` parse-fails E0001 - use a single loop var, or `range(len(items))` with index access: `[<li key={str(i)}>{items[i]}</li> for i in range(len(items))]`.
-- **Dict / hook access (`useParams()[k]`, `useLocation()[k]`, generic `[key]`) returns `Any` and yields JS `undefined` for missing keys.** Since `undefined !== null` in JS, both `x is None` and `x is not None` MISS undefined - `params["id"] is not None` returns True even when `:id` isn't in the route, and `str(undefined)` produces the literal string `"undefined"`. **Use a truthy check (`if x` / `if not x`) for hook/dict values - it catches both `None` and `undefined`.** The narrowing-friendly `is not None` form is still correct for typed Optionals (`T | None` from `sv import`-ed functions, function params, etc.) where `undefined` can't appear. (Also: `params.get("id")` runtime-fails in the browser since `useParams` returns a plain JS object - always use `[key]`.)
+- **Dict / hook access (`useParams()[k]`, `useLocation()[k]`, generic `[key]`) returns `any` and yields JS `undefined` for missing keys.** Since `undefined !== null` in JS, both `x is None` and `x is not None` MISS undefined - `params["id"] is not None` returns True even when `:id` isn't in the route, and `str(undefined)` produces the literal string `"undefined"`. **Use a truthy check (`if x` / `if not x`) for hook/dict values - it catches both `None` and `undefined`.** The narrowing-friendly `is not None` form is still correct for typed Optionals (`T | None` from `sv import`-ed functions, function params, etc.) where `undefined` can't appear. (Also: `params.get("id")` runtime-fails in the browser since `useParams` returns a plain JS object - always use `[key]`.)
 - **`T | None` narrowing doesn't reach inside JSX list comprehensions / short-circuits.** After `if x is None { return ...; }`, direct `x.attr` works in the function body - but `{[<li>{x.attr}</li> for i in range(len(x.attr))]}` inside JSX fails E1099 because the comprehension is its own scope. **Workaround:** pull each used attribute into a typed local *before* the JSX block (e.g. `title: str = x.title; parts: list[str] = x.parts;`), then reference the locals from JSX. See `jac-types` for the full BROKEN/CORRECT pair.
 - **Guard None/null/undefined when iterating or dotting into server data.** Runtime-only failure (`Cannot read properties of null/undefined`), nothing at compile. Four hot spots - single-level access is the most common:
 
@@ -129,7 +129,7 @@ Also works: short-circuit in JSX - `{result and <X total={result.total_posts} />
 
 **For server response objects (dicts/lists from `sv import` calls), prefer truthy checks (`if result {`) over `!= None`.** The `!=` operator uses deep equality which calls `Object.keys()` - crashes with `"Cannot convert undefined or null to object"` if the value is `null`/`undefined`. `!= None` is safe for primitives (strings, ints, bools) but not for complex objects returned from server calls.
 
-- **Event params are typed - `MouseEvent`/`ChangeEvent`/etc.** `e: any` (lowercase) is the Python `any()` builtin, fails E1103. Use capital `Any` (no import) for untyped.
+- **Event params are typed - `MouseEvent`/`ChangeEvent`/etc.** Annotate every handler that reads `e` with the real event type, so `e.target` / `e.key` resolve. When you genuinely don't read `e`, fall back to lowercase `any` (the gradual type) - never capital `Any`, which is not the keyword and warns `W2001` ("Name 'Any' may be undefined").
 - **`style` prop takes a `dict[str, object]`, not a CSS string.** `<div style="color: red">` fails E1103. Use inline dict `<div style={{"color": "red"}}>` or move styling to `className` + a CSS file.
 - **JSX uses `className`, curly-brace interpolation `{expr}`, camelCase events** (`onClick`, `onChange`).
 - **No `to cl:` / `cl def:pub` / `cl { }` in `.cl.jac` files.** Extension already sets context. Braced blocks are deprecated (W0064).

--- a/jac/jaclang/cli/skills/jac-cl-styling.md
+++ b/jac/jaclang/cli/skills/jac-cl-styling.md
@@ -8,7 +8,7 @@ description: Tailwind styling patterns in Jac - conditional classes, cn() utilit
 Ternary is Python-style (`A if cond else B`). String concatenation for dynamic classes:
 
 ```jac
-def:pub TabButton(active: bool, children: Any) -> JsxElement {
+def:pub TabButton(active: bool, children: any) -> JsxElement {
     tab_cls = "border-primary text-foreground" if active else "border-transparent text-muted-foreground";
     return <button className={"px-2.5 py-1.5 border-b-2 " + tab_cls}>{children}</button>;
 }
@@ -24,7 +24,7 @@ import from "tailwind-merge" { twMerge }
 
 # Variadic positional args (the clsx / tailwind-merge convention, and how
 # jac-shadcn components call cn) - NOT a single list argument.
-def:pub cn(*inputs: Any) -> Any {
+def:pub cn(*inputs: any) -> any {
     return twMerge(clsx(inputs));
 }
 ```

--- a/jac/jaclang/cli/skills/jac-core-cheatsheet.md
+++ b/jac/jaclang/cli/skills/jac-core-cheatsheet.md
@@ -3,7 +3,7 @@ name: jac-core-cheatsheet
 description: Jac-language baseline - Reading this skill is a must. imports, control flow, lambdas, ternary, string formatting, error handling, top-level execution. Load for basic-syntax questions no specific skill covers.
 ---
 
-**Jac is strict-typed.** Every `def` parameter and return, every `has` field, every typed local needs an explicit type - and the type checker is the authority. **Do NOT fall back to `Any` to silence a type error** - it suppresses real bugs AND cascades into the surrounding code (`Any + Any` rejects `+`, `len(Any)` rejects `Sized`, `Any.attr` fails E1032, etc.). When a value can be missing, declare it explicitly as `T | None` (e.g. `has recipe: Recipe | None = None;`) and guard with `if x is not None { ... }` before accessing attributes. Syntax-wise: Python-flavored, every block is `{ }`-braced, every statement ends with `;`, top-level code runs inside `with entry { ... }`.
+**Jac is strict-typed.** Every `def` parameter and return, every `has` field, every typed local needs an explicit type - and the type checker is the authority. The gradual / escape-hatch type is lowercase `any` (never capital `Any`, which warns W2001). **Do NOT fall back to `any` to silence a type error** - it does not remove the error, it only defers it to the next typed boundary (`any + any` rejects `+` with E1055, `len(any)` isn't `Sized` E1053, returning `any` where a concrete type is declared fails E1002). When a value can be missing, declare it explicitly as `T | None` (e.g. `has recipe: Recipe | None = None;`) and guard with `if x is not None { ... }` before accessing attributes. Syntax-wise: Python-flavored, every block is `{ }`-braced, every statement ends with `;`, top-level code runs inside `with entry { ... }`.
 
 ```jac
 import os;
@@ -101,11 +101,13 @@ If your file gets moved to a different depth, **the dot count must change** to m
 
 ## Pitfalls
 
-- **Reserved keywords cannot be used as variable or parameter names: `visit`, `disengage`, `report`, `spawn`, `with`, `can`, `has`.** (`entry` is *not* reserved - it is fine as an identifier.) To use a reserved keyword as an identifier anyway, escape it with a single **leading** backtick: `` `visit `` (backtick prefix only - no closing backtick; `` `visit` `` is a lexer error).
-- Type system (annotations, unions, optional `T | None`, `Any`, inference, type-error codes) - see `jac-types`.
+- **Reserved keywords cannot be used as variable or parameter names.** This includes declaration words (`node`, `edge`, `walker`, `obj`, `def`, `impl`), OSP / control words (`visit`, `disengage`, `report`, `spawn`, `flow`, `wait`, `skip`, `del`), and `with`, `can`, `has`. (`entry` is *not* reserved - it is fine as an identifier.) To use a reserved keyword as an identifier anyway, escape it with a single **leading** backtick: `` `visit `` (backtick prefix only - no closing backtick; `` `visit` `` is a lexer error).
+- Type system (annotations, unions, optional `T | None`, the `any` escape hatch, inference, type-error codes) - see `jac-types`.
 - Concatenating a string with an Exception fails - wrap with `str(e)`: `"error: " + str(e)`.
 - `import from X { Y };` fails with E0030. **Brace imports take NO trailing semicolon.** Plain module form `import X;` does.
 - Statements end with `;`; blocks use `{ }`. No significant indentation (Python-style).
+- **There is no `pass` statement** (`E0010`). For an intentionally empty block - an empty `except`, a stub branch - write empty braces: `{}`.
+- **Docstrings go immediately before a declaration, never inside its body.** A `"""..."""` inside a function body is rejected - `W0060` always, plus an `E0002` parse error when written without a trailing `;` (the usual docstring form). Put the docstring on the line above the declaration instead.
 - Always use the typed brace lambda: `lambda(x: int) -> int { return x; }` (zero-arg form: `lambda -> int { return 5; }`). The Python form `lambda x: x` parses but is **untyped** - it triggers W1051 type warnings, so don't use it. The invented forms `:x: x` and `<lambda x: x>` are hard parse errors.
 - Ternary is **Python-style**: `A if cond else B`. NOT `cond ? A : B` (JS/C-style) - that's a parse error in Jac.
 - **Python stdlib needs explicit import - Jac auto-imports nothing.** `datetime.now()`, `os.environ`, `json.dumps`, `math.pi`, `random.randint`, etc. ALL need a top-of-file `import from <mod> { name }` or `import <mod>;` first. Common slip: using `datetime.now()` for `created_at` fields without `import from datetime { datetime }` → `NameError: name 'datetime' is not defined` at runtime.

--- a/jac/jaclang/cli/skills/jac-npm-packages.md
+++ b/jac/jaclang/cli/skills/jac-npm-packages.md
@@ -56,7 +56,7 @@ import from react { useRef, useCallback, useMemo, useContext }
 import from react { useRef }
 
 def:pub TextInput() -> JsxElement {
-    inputRef: Any = useRef(None);
+    inputRef: any = useRef(None);
     def handle_click(e: MouseEvent) {
         if inputRef.current { inputRef.current.focus(); }
     }
@@ -73,8 +73,8 @@ def:pub TextInput() -> JsxElement {
 import from react { useRef, useCallback }
 
 def:pub FileUploader() -> JsxElement {
-    fileInputRef: Any = useRef(None);
-    triggerPicker: Any = useCallback(lambda {
+    fileInputRef: any = useRef(None);
+    triggerPicker: any = useCallback(lambda {
         if fileInputRef.current { fileInputRef.current.click(); }
     }, []);
     return <div>
@@ -91,7 +91,7 @@ import from react { useRef }
 
 def:pub SearchBox() -> JsxElement {
     has query: str = "";
-    inputRef: Any = useRef(None);
+    inputRef: any = useRef(None);
     async can with [query] entry {
         if inputRef.current { inputRef.current.focus(); }
     }

--- a/jac/jaclang/cli/skills/jac-scaffold.md
+++ b/jac/jaclang/cli/skills/jac-scaffold.md
@@ -3,7 +3,7 @@ name: jac-scaffold
 description: Bootstrapping a new Jac project - how to use `jac create --use <template>`, what each template lays out on disk, how to fix the deprecated syntax it ships with, and the post-scaffold checklist. Load when starting a new project from scratch. Pair with `jac-fullstack-patterns` when building fullstack.
 ---
 
-Use the Jac CLI's `jac create` to scaffold new projects. Run it via `run_command(...)`. JacCoder no longer ships its own scaffolder - `jac create` is the single source of truth and stays current with Jac releases.
+Use the Jac CLI's `jac create` to scaffold new projects. It is the single source of truth for project layout and stays current with Jac releases.
 
 ## `jac create` - the only scaffolder
 
@@ -25,8 +25,8 @@ Always pass an explicit project name - without one, `jac create` falls back to `
 | `--use <template>` | When to pick it | What ships |
 |---|---|---|
 | (omitted) `default` | Backend / library project, no UI | `main.jac` (a `with entry` stub), `jac.toml`, `AGENTS.md`, `.gitignore` |
-| `client` | Pure client app, no server data | `main.jac` (`to cl:` + `def:pub app`), `components/Button.cl.jac`, `jac.toml`, `README.md`, `.gitignore` |
-| `fullstack` | Client UI + server endpoints | `main.jac`, `endpoints.sv.jac`, `frontend.cl.jac` + `frontend.impl.jac`, `components/*.cl.jac`, `jac.toml`, `README.md`, `.gitignore` |
+| `client` | Pure client app, no server data | `main.jac` (`to cl:` + `def:pub app`), `components/Button.cl.jac`, `assets/`, `jac.toml`, `README.md`, `AGENTS.md`, `.gitignore` |
+| `fullstack` | Client UI + server endpoints | `main.jac`, `endpoints.sv.jac`, `frontend.cl.jac` + `frontend.impl.jac`, `components/*.cl.jac`, `assets/`, `jac.toml`, `README.md`, `AGENTS.md`, `.gitignore` |
 
 The `default` template's `main.jac` is a minimal `with entry { ... }` stub - it does **not** pre-wire endpoints; add `node`/`def:pub` declarations yourself (see `jac-sv-endpoints`).
 
@@ -36,11 +36,11 @@ The `default` template's `main.jac` is a minimal `with entry { ... }` stub - it 
 
 Before running `jac create`:
 
-1. `list_files(workspace)` - see what's already there
-2. If `jac.toml` is present at the workspace root, **do NOT scaffold a new project** - extend the existing one with `write_code` / `edit_code` instead
+1. List the workspace contents - see what's already there
+2. If `jac.toml` is present at the workspace root, **do NOT scaffold a new project** - extend the existing one in place instead
 3. If the workspace is empty, then `jac create` is safe
 
-When called by JacBuilder or any IDE harness, the workspace usually already has a project. Scaffolding into it creates a nested mess. Read first.
+An existing workspace usually already has a project. Scaffolding into it creates a nested mess. Inspect it first.
 
 ## Adapt the output - the `fullstack` template ships deprecated syntax
 
@@ -65,8 +65,8 @@ After `jac create`:
 
 ## Pitfalls
 
-- **Don't hand-write `jac.toml`.** Generate it via `jac create`. For Tailwind setup, follow Build Workflow step 4 for the exact jac.toml format. Load `jac-cl-styling` for styling patterns.
+- **Don't hand-write `jac.toml`.** Generate it via `jac create`. Load `jac-cl-styling` for styling patterns and Tailwind setup.
 - **Match the template to the user's actual need.** Picking `fullstack` for a UI-only spike adds unused server scaffolding; picking `client` for an app that needs persistence forces a later migration.
-- **Don't scaffold into a non-empty workspace.** Run `list_files` first; if a project exists, extend it.
+- **Don't scaffold into a non-empty workspace.** Inspect the workspace first; if a project exists, extend it.
 - **`-s` / `--skip` on `jac create --use client`** skips npm install - convenient for offline scaffolding, but you'll need `jac install` before running.
 - **Project-name argument is optional but defaults to `jactastic`.** Always pass an explicit name.

--- a/jac/jaclang/cli/skills/jac-sv-auth.md
+++ b/jac/jaclang/cli/skills/jac-sv-auth.md
@@ -3,7 +3,7 @@ name: jac-sv-auth
 description: The server-side auth model - deciding which endpoints are public versus authenticated, and isolating data per user. Load when deciding which server functions need login or whose data they should see. Pair with `jac-sv-endpoints` (endpoint visibility), `jac-cl-auth` (client side of the auth loop).
 ---
 
-Jac's server auth model is **isolation, not access control**. There's no explicit user id to check - the runtime handles login via `@jac/runtime` client helpers (`jacLogin`, etc.) and then routes each user's queries to their own subgraph. You pick the endpoint prefix; the runtime does the rest.
+Jac's server auth model is built on **per-user data isolation**. There's no explicit user id to check - the runtime handles login via `@jac/runtime` client helpers (`jacLogin`, etc.) and then routes each user's queries to their own subgraph. You pick the endpoint prefix; the runtime does the rest. (For data that *specific* users share, isolation has an escape hatch - see "Sharing data with specific users" below.)
 
 - **`def:pub`** - anonymous. Anyone can call. `root` is the **shared global graph** - every caller sees the same data.
 - **`def:priv`** - authenticated. Requires login. `root` is the **current user's isolated subgraph** - same code, different data per caller.
@@ -33,6 +33,24 @@ def:priv add_todo(title: str) -> Todo {
 ```
 
 For full CRUD shapes (update / toggle / delete + typed returns + async), see `jac-sv-endpoints`.
+
+## Sharing data with specific users
+
+`def:pub` (one shared global graph) and `def:priv` (per-user isolated graph) are
+not the only two options. For data that some *specific* users share but the
+public must not see - a shared document, a team workspace, a two-player game -
+keep the endpoints `def:priv` and use the ambient permission builtins (no
+import needed):
+
+- `grant(node, level)` - give another user access to a specific node.
+- `revoke(node)` - withdraw that access.
+- `allroots()` - list every user's `root` (returns `list[Root]`), for admin or
+  cross-user views.
+
+This opens a chosen node to chosen users instead of dumping shared state into
+the global `def:pub` graph. The jac-scale reference documents the full
+cross-user permission model (access levels, granting against another user's
+root) - consult it before building a multi-user-shared feature.
 
 ## Pitfalls
 

--- a/jac/jaclang/cli/skills/jac-sv-endpoints.md
+++ b/jac/jaclang/cli/skills/jac-sv-endpoints.md
@@ -63,9 +63,9 @@ def _compute_age(item: Item) -> int {
 
 ## Pitfalls
 
-- `async def:pub` is required when the endpoint uses `await` (external API calls, LLM endpoints). Missing `async` on a body that awaits is a parse/type error.
+- Mark an endpoint `async def:pub` when its body uses `await` (external API calls, LLM endpoints), so the result is awaited rather than handed back as an unresolved coroutine.
 - To delete a node: `del node;` - removes it and all its edges from the graph. Run it inside a loop that matches the id; don't try to pass nodes by reference from the client.
-- Every client-callable endpoint needs an explicit return type. `def:pub add_item(title: str)` with no `-> T` is an error.
+- Give every client-callable endpoint an explicit return type. The return type IS the client's wire format (next bullet); an endpoint with no `-> T` hands the client nothing useful back.
 - **Return type IS the wire format.** Client gets dot access when you return typed nodes/objs (`list[Item]` → `items[0].title`). Returning raw `dict` or `list` loses typing on the client side.
 - `def:pub` = public endpoint (anonymous), `def:priv` = authenticated endpoint (per-user). A plain `def` is **also registered** - as an authenticated endpoint, same as `def:priv`. Only a leading `_` (`def _helper(...)`) keeps a function off the API. See `jac-sv-auth` for the full auth-model semantics.
 - **Use `jid(node)` for cross-RPC node identity; `id(node)` silently breaks lookups.** `id()` returns Python's in-memory address, which changes every server restart AND differs across worker processes - a lookup `for n in [root -->] { if id(n) == client_id { ... } }` returns no match every time, no error, just empty results. Use `jid(node)` (returns a stable persistent string) and compare with `if jid(n) == client_id`.

--- a/jac/jaclang/cli/skills/jac-types.md
+++ b/jac/jaclang/cli/skills/jac-types.md
@@ -80,28 +80,31 @@ has rows: list[dict[str, int]] = [];
 has adjacency: dict[str, list[str]] = {};
 ```
 
-**`any` for pass-through values - NOT for attribute access:**
+**`any` is for opaque pass-through values:**
 
-`any` lets a value be stored, passed, and called without a type. It does **not**
-unlock attribute access: `x.attr` on an `any` value still fails E1032. Use it for
-opaque values (callback references, untyped payloads), not to silence `.attr`.
+`any` lets a value be stored, passed, called, and attribute-accessed - each such
+operation just yields another `any`, with no error. The strictness lands at the
+next *typed* boundary: returning or assigning an `any` where a concrete type is
+declared fails (E1001 / E1002), and operators or builtins that need a real type
+reject it (`any + any` → E1055, `len(any)` → E1053). So `any` defers the type
+error, it does not remove it - prefer the real type.
 
 ```
 def run_callback(cb: any, payload: str) {   # cb: an opaque function reference
-    cb(payload);                             # calling through `any` is allowed
-}                                            # cb.name would fail E1032
+    cb(payload);                             # calling/dotting through `any` - allowed, yields `any`
+}
 ```
 
 ## Pitfalls
 
-- **Do NOT fall back to `any` to silence a type error.** Jac is strict-typed by design; annotating a value `any` suppresses the diagnostic but the value stays untyped - and every downstream operation on it fails: `len(...)` on it → not Sized (E1053), arithmetic → no overload (E1055), `.attr` access → Type Unknown (E1032), assigning it where a `str` is expected → E1001. Fix the actual type instead. Common right answers: type with the imported node/obj (`has recipes: list[Recipe] = []`), use `T | None` for optionals (`has recipe: Recipe | None = None;` + `if recipe is not None { ... }`), or cast at the boundary (`recipe_id: str = str(params["id"]) if params["id"] else "";`).
+- **Do NOT fall back to `any` to silence a type error.** Jac is strict-typed by design; annotating a value `any` suppresses the diagnostic at that spot but the value stays untyped - and it re-fails at the next typed boundary: `len(...)` on it → not Sized (E1053), arithmetic → no overload (E1055), assigning or returning it where a concrete type is declared → E1001/E1002. Fix the actual type instead. Common right answers: type with the imported node/obj (`has recipes: list[Recipe] = []`), use `T | None` for optionals (`has recipe: Recipe | None = None;` + `if recipe is not None { ... }`), or cast at the boundary (`recipe_id: str = str(params["id"]) if params["id"] else "";`).
 - **Every `def` parameter needs a type** (E0052). `def foo(x) -> int` is invalid - must be `def foo(x: int) -> int`.
 - **A `def` that returns a value needs a return type** (E1003). A `def` with no `return` infers `None` - **do not** annotate it `-> None`, that triggers W3037 (`unnecessary-none-return`). Write `def save(x: int) { ... }`, not `def save(x: int) -> None { ... }`.
 - **`has name;`** without a type is a parse error. Always `has name: type;`.
 - `list`, `dict`, `set` without type args default to `list[Any]` (W1036) - add args when you know the element type: `list[str]`, `dict[str, int]`.
 - Use **`T | None`** for optional references. NOT `Optional[T]` (Python stdlib, not idiomatic). Always check `is None` before dereferencing.
 - **The gradual / escape-hatch type is lowercase `any`** - Jac-native, no import needed, type-checks cleanly. Do **NOT** `import from typing { Any }` - that triggers `W1104` (the compiler explicitly tells you to use the `any` keyword instead). Capitalized `Any` is not the keyword: a bare `x: Any` warns `W2001` ("Name 'Any' may be undefined").
-- **Event-handler params take the event type, not `any`.** In a `.cl.jac` handler, `e: any` does not unlock `e.target.value` - annotate the real event type (`e: ChangeEvent`, `e: MouseEvent`, ...). See `jac-cl-components`.
+- **Event-handler params take the event type, not `any`.** In a `.cl.jac` handler, `e: any` leaves `e.target.value` an untyped `any` that then fails when stored in typed state - annotate the real event type (`e: ChangeEvent`, `e: MouseEvent`, ...). See `jac-cl-components`.
 - **E1030** (`Type T has no attribute X`) - you called a method/field that doesn't exist on that type. Example: `items.map(...)` on `list[Item]` fails because lists don't have `.map()`; use comprehensions.
 - **E1032** (`Type is Unknown, cannot access attribute`) - inference couldn't figure out a variable's type. Add an explicit annotation (`x: SomeType = ...`) so the rest of the code can narrow.
 - **E1001** (`Cannot assign <Unknown> to T`) - the right-hand side's type doesn't match the declared type. Usually means you need to widen the declared type or narrow the value with an explicit cast/check.

--- a/jac/jaclang/cli/skills/jac-walker-patterns.md
+++ b/jac/jaclang/cli/skills/jac-walker-patterns.md
@@ -48,7 +48,7 @@ with entry {
 - `disengage;` halts the walker immediately - queued visits are discarded. Use for search-style early exits.
 - **`visit` is a statement, not a method.** `visit [-->]` queues every outgoing edge; `visit (node_expr)` queues one specific node. Variants: `[<--]` incoming, `[-->:EdgeType:]` typed. Do NOT write `self.visit(...)` - a walker has no `visit` attribute (fails E1030).
 - Walkers don't `return` - they `report X;` (appears in `result.reports`) or `disengage;`.
-- Every entry needs `with <NodeType> entry` - bare `can foo { ... }` is invalid.
+- Every entry needs a `with ... entry` clause - bare `can foo { ... }` (no `with`) is invalid (E0034). The clause is either typed (`with Item entry`, fires only on `Item` nodes) or generic (`with entry`, fires on every node).
 - Entry points are **`can`**, NOT `def`. Plain helper methods can still be `def`, but bodies that fire on node arrival must be `can`.
 - **Keyword pairs depend on which side you're writing.** Inside a *walker* entry (`can ... with NodeType entry` in a walker): `self` = the walker, `here` = the current node. Inside a *node* entry (`can ... with WalkerType entry` in a node): `self` = the node, `visitor` = the arriving walker. Mixing them is the #1 walker bug.
-- **No generic `with node entry`.** `node` is a declaration keyword, NOT a type. `can foo with node entry { ... }` fails `jac check` with E2018 - the type must be a declared node archetype (or `Root`). Nodes without a matching entry body are simply passed through - no catch-all needed.
+- **The literal keyword `node` is not a type.** `can foo with node entry { ... }` fails `jac check` with E2018. For a typed entry, name a declared node archetype (or `Root`); for a catch-all that fires on every node, use a generic `with entry` (no type). A node with neither a matching typed entry nor a generic entry is simply passed through.

--- a/jac/jaclang/compiler/code_intel.jac
+++ b/jac/jaclang/compiler/code_intel.jac
@@ -383,6 +383,16 @@ obj CodeIntelligence {
         }
     }
 
+    """Whether `load` has compiled the project at least once.
+
+    Lets a caller read already-built results (e.g. `diagnostics`) without
+    paying for a first compile -- a query that must stay cheap can skip itself
+    when the project model is not yet built.
+    """
+    def is_loaded -> bool {
+        return self._loaded;
+    }
+
     """List the project .jac files that were compiled."""
     def files -> list[str] {
         self._ensure();

--- a/jac/jaclang/compiler/code_intel.jac
+++ b/jac/jaclang/compiler/code_intel.jac
@@ -1,0 +1,913 @@
+"""Compiler-backed code intelligence for tools and agents.
+
+A headless, protocol-agnostic facade over the Jac compiler's symbol tables and
+type information. Where a text search answers "which lines contain this
+string", `CodeIntelligence` answers "where is this symbol defined, everywhere
+it is used, what type it has, and which walkers traverse it" -- the questions
+that require the compiler, not a regex.
+
+It exists so tools and coding agents can navigate the *graph of meaning*
+instead of treating a project as text. The Jac language server consumes the
+same symbol data through its own LSP-shaped surface; this facade returns plain
+Jac objects (`SymbolInfo`, `SourceRef`, ...) so a caller never touches a raw
+AST node or an LSP wire type.
+
+The model is rebuild-on-write: `load` compiles the project once, `refresh`
+rebuilds after an edit. Unlike the language server it does not track
+keystroke-level edits -- an agent writes whole files, so a per-write rebuild
+is enough.
+"""
+
+import os;
+import jaclang.jac0core.unitree as uni;
+import from pathlib { Path }
+import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.passes { Alert }
+
+# Directories never worth compiling -- generated output, vendored deps, VCS.
+glob _SKIP_DIRS: set[str] = {"__pycache__","__jac_gen__",".git",".venv","venv","node_modules","build","dist",".mypy_cache",".pytest_cache"},
+     # Archetype keyword -> readable kind. Falls back to the raw token value.
+     _ARCH_KIND: dict[str, str] = {
+         "node": "node",
+         "walker": "walker",
+         "edge": "edge",
+         "obj": "obj",
+         "class": "class",
+         "enum": "enum"
+     };
+
+
+"""Resolve a path to its canonical absolute form."""
+def _real(path: str) -> str {
+    try {
+        return str(Path(path).resolve());
+    } except Exception {
+        return path;
+    }
+}
+
+
+"""A single source location -- a symbol's definition or one of its uses."""
+obj SourceRef {
+    has file: str,
+        line: int,
+        col: int = 0,
+        role: str = "use",
+        snippet: str = "";
+
+    def render -> str {
+        loc = f"{self.file}:{self.line}";
+        return f"{loc}  {self.snippet}" if self.snippet else loc;
+    }
+}
+
+
+"""A resolved symbol: where it is defined, its kind, type, and structure.
+
+`kind` is one of node/walker/edge/obj/class/enum/ability/field/global/symbol.
+The structural fields (`fields`, `abilities`, `base_classes`) are populated
+only for archetypes; they are empty for everything else.
+"""
+obj SymbolInfo {
+    has name: str,
+        kind: str,
+        file: str,
+        line: int,
+        col: int = 0,
+        type_str: str = "",
+        doc: str = "",
+        signature: str = "",
+        fields: list[str] = [],
+        abilities: list[str] = [],
+        base_classes: list[str] = [],
+        is_genai: bool = False;
+
+    """Render a compact, human/LLM-readable description of the symbol."""
+    def render -> str {
+        head = f"{self.kind} {self.name}";
+        if self.signature {
+            head += self.signature;
+        } elif self.type_str {
+            head += f": {self.type_str}";
+        }
+        lines = [f"{head}    [{self.file}:{self.line}]"];
+        if self.base_classes {
+            lines.append("  extends: " + ", ".join(self.base_classes));
+        }
+        for f in self.fields {
+            lines.append(f"  has {f}");
+        }
+        for a in self.abilities {
+            lines.append(f"  def {a}");
+        }
+        if self.doc {
+            lines.append("  " + self.doc.strip().splitlines()[0]);
+        }
+        return "\n".join(lines);
+    }
+}
+
+
+"""A compiler diagnostic -- an error or warning at a source location."""
+obj Diagnostic {
+    has file: str,
+        line: int,
+        severity: str,
+        message: str;
+
+    def render -> str {
+        return f"{self.severity}: {self.file}:{self.line}: {self.message}";
+    }
+}
+
+
+"""A stable identity key for a diagnostic -- file, line, severity, message.
+
+Used to diff diagnostics across a recompile: a key absent before an edit and
+present after it identifies a problem the edit introduced.
+"""
+def _diag_key(d: Diagnostic) -> str {
+    return f"{_real(d.file)}:{d.line}:{d.severity}:{d.message}";
+}
+
+
+"""A walker entry point: an ability that runs when a walker visits a node."""
+obj EntryPoint {
+    has walker_name: str,
+        ability: str,
+        node_type: str,
+        event: str,
+        file: str = "",
+        line: int = 0;
+
+    def render -> str {
+        return f"{self.walker_name}.{self.ability}  ({self.event} {self.node_type})  [{self.file}:{self.line}]";
+    }
+}
+
+
+"""A typed neighbourhood of code, packed for prompt assembly.
+
+`slice_for` builds one: the target symbol, the symbols of the types it
+depends on (declared field types, base classes), and every place it is used.
+`render` turns it into a compact text block a model can read instead of
+whole files.
+"""
+obj ContextSlice {
+    has query: str,
+        target: SymbolInfo | None = None,
+        related: list[SymbolInfo] = [],
+        uses: list[SourceRef] = [];
+
+    def render -> str {
+        if self.target is None {
+            return f"(no symbol named {self.query} was found)";
+        }
+        parts = ["# Definition", self.target.render()];
+        if self.related {
+            parts.append("\n# Referenced types");
+            for s in self.related {
+                parts.append(s.render());
+            }
+        }
+        if self.uses {
+            parts.append(f"\n# Used in {len(self.uses)} place(s)");
+            for u in self.uses {
+                parts.append("  " + u.render());
+            }
+        }
+        return "\n".join(parts);
+    }
+}
+
+
+"""Compiler-backed semantic queries over a Jac project.
+
+Construct with the project root, call `load` once, then query. After an edit,
+call `refresh` to rebuild. All query methods return plain `SymbolInfo` /
+`SourceRef` / `Diagnostic` objects -- never raw AST nodes.
+"""
+obj CodeIntelligence {
+    has proj_dir: str,
+        type_check: bool = True;
+
+    def postinit {
+        self._root_real: str = _real(self.proj_dir);
+        self.prog: JacProgram = JacProgram();
+        self._files: list[str] = [];
+        self._file_set: set[str] = set();
+        self._compiled: dict[str, uni.Module] = {};
+        # Signature of the project's directory mtimes -- used by `refresh` to
+        # tell a content edit (incremental) from a file appearing/disappearing
+        # (full rediscovery).
+        self._dir_sig: dict[str, float] = {};
+        # Reverse-dependency map: target file -> set of project files that
+        # import it. Built from the modules' own import statements so it is
+        # complete (the compiler's own rdep map misses cache-hit imports).
+        self._rdeps: dict[str, set[str]] = {};
+        self._loaded: bool = False;
+    }
+
+    #-- lifecycle --------------------------------------------------------
+    """Discover and compile every non-annex .jac file under the project root.
+
+    Annex files (`.impl.jac`, `.test.jac`) are skipped: the compiler splices
+    them into their parent module automatically. A file that fails to compile
+    is skipped, not fatal -- partial knowledge still beats none.
+    """
+    def load {
+        self._files = self._discover();
+        self._file_set = {_real(f) for f in self._files};
+        self.prog.errors_had = [];
+        self.prog.warnings_had = [];
+        self._compiled = {};
+        for f in self._files {
+            self._compile_one(f);
+        }
+        self._build_rdeps();
+        self._dir_sig = self._dir_signature();
+        self._loaded = True;
+    }
+
+    """Rebuild after a file was written or deleted.
+
+    With no `file`, or before the first `load`, this is a full build. Given a
+    `file`, it is incremental: only the changed file and the modules that
+    import it (transitively) are recompiled -- the rest are served from the
+    compiler's cache, so the cost is an LSP-save, not a project rebuild. A
+    file appearing or disappearing shifts the directory signature and falls
+    back to a full rediscovery.
+    """
+    def refresh(file: str = "") -> None {
+        if not file or not self._loaded {
+            self.load();
+            return;
+        }
+        if self._dir_signature() != self._dir_sig {
+            self.load();
+            return;
+        }
+        real = _real(file);
+        # The changed file plus every module that imports it (transitively).
+        stale: set[str] = self._transitive_importers(real);
+        stale.add(real);
+        for p in stale {
+            try {
+                self.prog.invalidate_module(p);
+            } except Exception as e {
+                _ = e;
+            }
+        }
+        # Drop the recompile set's old diagnostics; the recompile re-reports
+        # current ones. Untouched files' diagnostics are left intact.
+        self.prog.errors_had = self._keep_diagnostics(self.prog.errors_had, stale);
+        self.prog.warnings_had = self._keep_diagnostics(self.prog.warnings_had, stale);
+        for p in stale {
+            if p in self._file_set {
+                self._compile_one(p);
+            }
+        }
+    }
+
+    """Compile one project file and record the resulting module."""
+    def _compile_one(file: str) {
+        try {
+            mod = self.prog.compile(
+                file_path=file, type_check=self.type_check, no_cgen=True
+            );
+            # Keep the compiled module directly rather than relying on the
+            # program hub: hub routing depends on the project's location.
+            if mod is not None and mod.loc {
+                self._compiled[_real(mod.loc.mod_path)] = mod;
+            }
+        } except Exception as e {
+            # Keep going: one bad file should not blind the agent to the rest.
+            _ = e;
+        }
+    }
+
+    """A directory-mtime signature -- changes when a file is added or removed.
+
+    Editing a file's content does not touch its directory's mtime, so an
+    unchanged signature means an incremental refresh is safe.
+    """
+    def _dir_signature -> dict[str, float] {
+        dirs: set[str] = {self._root_real};
+        for f in self._files {
+            dirs.add(os.path.dirname(_real(f)));
+        }
+        sig: dict[str, float] = {};
+        for d in dirs {
+            try {
+                sig[d] = os.path.getmtime(d);
+            } except OSError as e {
+                _ = e;
+            }
+        }
+        return sig;
+    }
+
+    """Filter alerts down to those whose file is NOT in the stale set."""
+    def _keep_diagnostics(alerts: list[Alert], stale: set[str]) -> list[Alert] {
+        out: list[Alert] = [];
+        for al in alerts {
+            loc = al.loc;
+            if loc is None or _real(loc.mod_path) not in stale {
+                out.append(al);
+            }
+        }
+        return out;
+    }
+
+    """Build the reverse-dependency map from the modules' import statements.
+
+    Resolved here rather than read from the compiler's own rdep map, which is
+    populated opportunistically during import resolution and misses imports
+    served from cache -- leaving `refresh` blind to half a file's importers.
+    """
+    def _build_rdeps {
+        self._rdeps = {};
+        for mod in self._compiled.values() {
+            if mod.loc is None {
+                continue;
+            }
+            importer = _real(mod.loc.mod_path);
+            for imp in mod.get_all_sub_nodes(uni.Import) {
+                paths: list[uni.ModulePath] = [];
+                if imp.from_loc is not None {
+                    paths.append(imp.from_loc);
+                } else {
+                    for item in imp.items {
+                        if isinstance(item, uni.ModulePath) {
+                            paths.append(item);
+                        }
+                    }
+                }
+                for mp in paths {
+                    try {
+                        target = _real(mp.resolve_relative_path());
+                    } except Exception as e {
+                        _ = e;
+                        continue;
+                    }
+                    bucket = self._rdeps.get(target);
+                    if bucket is None {
+                        bucket = set();
+                        self._rdeps[target] = bucket;
+                    }
+                    bucket.add(importer);
+                }
+            }
+        }
+    }
+
+    """Every project file that imports `target`, transitively."""
+    def _transitive_importers(target: str) -> set[str] {
+        out: set[str] = set();
+        frontier: list[str] = [target];
+        while frontier {
+            current = frontier.pop();
+            for importer in self._rdeps.get(current, set()) {
+                if importer not in out {
+                    out.add(importer);
+                    frontier.append(importer);
+                }
+            }
+        }
+        return out;
+    }
+
+    def _ensure {
+        if not self._loaded {
+            self.load();
+        }
+    }
+
+    """List the project .jac files that were compiled."""
+    def files -> list[str] {
+        self._ensure();
+        return list(self._files);
+    }
+
+    #-- internals --------------------------------------------------------
+    def _discover -> list[str] {
+        found: list[str] = [];
+        base = Path(self._root_real);
+        if not base.exists() {
+            return found;
+        }
+        for p in sorted(base.rglob("*.jac")) {
+            if any([part in _SKIP_DIRS or part.startswith(".") for part in p.parts]) {
+                continue;
+            }
+            name = p.name;
+            if name.endswith(".impl.jac") or name.endswith(".test.jac") {
+                continue;
+            }
+            found.append(str(p));
+        }
+        return found;
+    }
+
+    """The compiled modules of the project."""
+    def _modules -> list[uni.Module] {
+        self._ensure();
+        return list(self._compiled.values());
+    }
+
+    """Recursively collect every Symbol reachable from a scope."""
+    def _collect_syms(scope: uni.UniScopeNode, out: list[uni.Symbol]) {
+        for sym in scope.names_in_scope.values() {
+            out.append(sym);
+        }
+        for bucket in scope.names_in_scope_overload.values() {
+            for sym in bucket {
+                out.append(sym);
+            }
+        }
+        for kid in scope.kid_scope {
+            self._collect_syms(kid, out);
+        }
+    }
+
+    """Every Symbol declared anywhere in the project."""
+    def _all_syms -> list[uni.Symbol] {
+        out: list[uni.Symbol] = [];
+        for mod in self._modules() {
+            try {
+                self._collect_syms(mod.sym_tab, out);
+            } except Exception as e {
+                _ = e;
+            }
+        }
+        return out;
+    }
+
+    def _kind_of(owner: uni.UniNode) -> str {
+        if isinstance(owner, uni.Archetype) {
+            raw = "";
+            try {
+                raw = str(owner.arch_type.value);
+            } except Exception as e {
+                _ = e;
+            }
+            return _ARCH_KIND.get(raw, raw or "obj");
+        }
+        if isinstance(owner, uni.Enum) {
+            return "enum";
+        }
+        if isinstance(owner, uni.Ability) {
+            return "ability";
+        }
+        if isinstance(owner, uni.HasVar) {
+            return "field";
+        }
+        if isinstance(owner, uni.Module) {
+            return "module";
+        }
+        return "symbol";
+    }
+
+    def _expr_str(expr: uni.UniNode | None) -> str {
+        if expr is None {
+            return "";
+        }
+        try {
+            return str(expr.unparse()).strip();
+        } except Exception as e {
+            _ = e;
+            return "";
+        }
+    }
+
+    def _doc_of(owner: uni.UniNode) -> str {
+        try {
+            doc = owner?.doc;
+            if doc is not None and doc?.value {
+                return str(doc.value).strip().strip('"');
+            }
+        } except Exception as e {
+            _ = e;
+        }
+        return "";
+    }
+
+    """Build a SymbolInfo from a resolved Symbol, or None if it has no decl."""
+    def _info(sym: uni.Symbol) -> SymbolInfo | None {
+        decl = sym.decl;
+        if decl is None {
+            return None;
+        }
+        owner: uni.UniNode = decl;
+        try {
+            owner = decl.name_of;
+        } except Exception as e {
+            _ = e;
+        }
+        loc = decl.loc;
+        info = SymbolInfo(
+            name=sym.sym_name,
+            kind=self._kind_of(owner),
+            file=loc.mod_path if loc else "",
+            line=loc.first_line if loc else 0,
+            col=loc.col_start if loc else 0,
+            doc=self._doc_of(owner)
+        );
+        if isinstance(owner, uni.Archetype) {
+            self._fill_archetype(info, owner);
+        } elif isinstance(owner, uni.Ability) {
+            info.signature = self._expr_str(owner.signature);
+            info.is_genai = bool(getattr(owner, "is_genai_ability", False));
+        } elif isinstance(owner, uni.HasVar) {
+            info.type_str = self._expr_str(owner.type_tag.tag)
+                if owner.type_tag
+                else "";
+        } else {
+            try {
+                owner_type = owner?.type;
+                info.type_str = str(owner_type) if owner_type else "";
+            } except Exception as e {
+                _ = e;
+            }
+        }
+        return info;
+    }
+
+    def _fill_archetype(info: SymbolInfo, arch: uni.Archetype) {
+        try {
+            for v in arch.get_has_vars() {
+                vt = self._expr_str(v.type_tag.tag) if v.type_tag else "";
+                info.fields.append(
+                    f"{v.name.sym_name}: {vt}" if vt else v.name.sym_name
+                );
+            }
+        } except Exception as e {
+            _ = e;
+        }
+        try {
+            for m in arch.get_methods() {
+                mname = m.name_ref.sym_name if m.name_ref else "?";
+                tag = " by llm" if getattr(m, "is_genai_ability", False) else "";
+                info.abilities.append(mname + "()" + tag);
+            }
+        } except Exception as e {
+            _ = e;
+        }
+        try {
+            if arch.base_classes {
+                for b in arch.base_classes {
+                    info.base_classes.append(self._expr_str(b));
+                }
+            }
+        } except Exception as e {
+            _ = e;
+        }
+    }
+
+    """Find the canonical (non-imported) Symbols matching a name."""
+    def _resolve(name: str) -> list[uni.Symbol] {
+        hits: list[uni.Symbol] = [];
+        seen: set[str] = set();
+        for sym in self._all_syms() {
+            if sym.sym_name != name {
+                continue;
+            }
+            if getattr(sym, "imported", False) {
+                continue;
+            }
+            decl = sym.decl;
+            if decl is None or decl.loc is None {
+                continue;
+            }
+            key = f"{decl.loc.mod_path}:{decl.loc.first_line}";
+            if key in seen {
+                continue;
+            }
+            seen.add(key);
+            hits.append(sym);
+        }
+        return hits;
+    }
+
+    #-- name-addressed queries ------------------------------------------
+    """Look up every project symbol with the given name."""
+    def lookup(name: str) -> list[SymbolInfo] {
+        out: list[SymbolInfo] = [];
+        for sym in self._resolve(name) {
+            info = self._info(sym);
+            if info is not None {
+                out.append(info);
+            }
+        }
+        return out;
+    }
+
+    """The first definition of a symbol, or None if it is unknown."""
+    def definition(name: str) -> SymbolInfo | None {
+        hits = self.lookup(name);
+        return hits[0] if hits else None;
+    }
+
+    """Every definition and use of a symbol, across the whole project.
+
+    This is the precise answer that replaces a text search: it is computed
+    from the symbol table's def/use chains, so it never matches a comment, a
+    string, or an unrelated identifier that happens to share the name.
+    """
+    def references(name: str) -> list[SourceRef] {
+        out: list[SourceRef] = [];
+        seen: set[str] = set();
+        for sym in self._resolve(name) {
+            for (role, nodes) in [("def", sym.defn), ("use", sym.uses)] {
+                for nd in nodes {
+                    loc = nd.loc;
+                    if loc is None {
+                        continue;
+                    }
+                    key = f"{loc.mod_path}:{loc.first_line}:{loc.col_start}";
+                    if key in seen {
+                        continue;
+                    }
+                    seen.add(key);
+                    out.append(
+                        SourceRef(
+                            file=loc.mod_path,
+                            line=loc.first_line,
+                            col=loc.col_start,
+                            role=role
+                        )
+                    );
+                }
+            }
+        }
+        return out;
+    }
+
+    """Distinct files that define or use a symbol."""
+    def importers(name: str) -> list[str] {
+        files: list[str] = [];
+        for ref in self.references(name) {
+            if ref.file not in files {
+                files.append(ref.file);
+            }
+        }
+        return files;
+    }
+
+    """Top-level symbols of one file, or of the whole project if file is empty."""
+    def symbols(file: str = "") -> list[SymbolInfo] {
+        target = _real(file) if file else "";
+        out: list[SymbolInfo] = [];
+        for mod in self._modules() {
+            try {
+                if target and _real(mod.loc.mod_path) != target {
+                    continue;
+                }
+                for sym in mod.sym_tab.names_in_scope.values() {
+                    if getattr(sym, "imported", False) {
+                        continue;
+                    }
+                    info = self._info(sym);
+                    if info is not None {
+                        out.append(info);
+                    }
+                }
+            } except Exception as e {
+                _ = e;
+            }
+        }
+        return out;
+    }
+
+    #-- structural / OSP queries ----------------------------------------
+    """Project archetypes, optionally filtered to one kind (node/walker/...)."""
+    def archetypes(kind: str = "") -> list[SymbolInfo] {
+        out: list[SymbolInfo] = [];
+        for mod in self._modules() {
+            try {
+                for arch in mod.get_all_sub_nodes(uni.Archetype) {
+                    info = self._archetype_info(arch);
+                    if info is not None and (not kind or info.kind == kind) {
+                        out.append(info);
+                    }
+                }
+            } except Exception as e {
+                _ = e;
+            }
+        }
+        return out;
+    }
+
+    def _archetype_info(arch: uni.Archetype) -> SymbolInfo | None {
+        loc = arch.loc;
+        info = SymbolInfo(
+            name=arch.name.sym_name,
+            kind=self._kind_of(arch),
+            file=loc.mod_path if loc else "",
+            line=loc.first_line if loc else 0,
+            doc=self._doc_of(arch)
+        );
+        self._fill_archetype(info, arch);
+        return info;
+    }
+
+    """Every walker entry point in the project, as EntryPoint records."""
+    def entry_points -> list[EntryPoint] {
+        out: list[EntryPoint] = [];
+        for mod in self._modules() {
+            try {
+                for arch in mod.get_all_sub_nodes(uni.Archetype) {
+                    if self._kind_of(arch) != "walker" {
+                        continue;
+                    }
+                    for m in arch.get_methods() {
+                        sig = m.signature;
+                        if not isinstance(sig, uni.EventSignature) {
+                            continue;
+                        }
+                        node_type = self._expr_str(sig.arch_tag_info) or "any";
+                        event = "";
+                        try {
+                            event = str(sig.event.value);
+                        } except Exception as e {
+                            _ = e;
+                        }
+                        mloc = m.loc;
+                        out.append(
+                            EntryPoint(
+                                walker_name=arch.name.sym_name,
+                                ability=m.name_ref.sym_name if m.name_ref else "?",
+                                node_type=node_type,
+                                event=event,
+                                file=mloc.mod_path if mloc else "",
+                                line=mloc.first_line if mloc else 0
+                            )
+                        );
+                    }
+                }
+            } except Exception as e {
+                _ = e;
+            }
+        }
+        return out;
+    }
+
+    """Walker entry points that traverse the given node type.
+
+    A type query, not a search: `walkers_visiting("User")` finds every walker
+    ability declared `with User entry`, resolved through the entry signature.
+    """
+    def walkers_visiting(node_type: str) -> list[EntryPoint] {
+        return [
+            ep
+            for ep in self.entry_points()
+            if ep.node_type == node_type or ep.node_type == "any"
+        ];
+    }
+
+    """The node types a given walker traverses."""
+    def nodes_visited_by(walker_name: str) -> list[EntryPoint] {
+        return [
+            ep
+            for ep in self.entry_points()
+            if ep.walker_name == walker_name
+        ];
+    }
+
+    #-- diagnostics ------------------------------------------------------
+    """Compiler errors and warnings, optionally filtered to one file."""
+    def diagnostics(file: str = "") -> list[Diagnostic] {
+        self._ensure();
+        target = _real(file) if file else "";
+        out: list[Diagnostic] = [];
+        for (sev, alerts) in [
+            ("error", self.prog.errors_had),
+            ("warning", self.prog.warnings_had)
+        ] {
+            for al in alerts {
+                loc = al.loc;
+                path = loc.mod_path if loc else "";
+                if target and (not path or _real(path) != target) {
+                    continue;
+                }
+                out.append(
+                    Diagnostic(
+                        file=path,
+                        line=loc.first_line if loc else 0,
+                        severity=sev,
+                        message=str(al.msg)
+                    )
+                );
+            }
+        }
+        return out;
+    }
+
+    """Refresh after an edit and return the diagnostics the edit is responsible for.
+
+    Every diagnostic now in `file` is returned -- the caller just wrote that
+    file, so all of it is worth seeing (and its line numbers may have shifted,
+    making a per-line diff unreliable). For every *other* project file only
+    the diagnostics this edit newly introduced are returned: a dependent
+    module the edit broke surfaces, while a dependent's pre-existing error is
+    not misattributed to the edit. With no `file` this is a full refresh and
+    returns every diagnostic.
+    """
+    def refresh_and_diff(file: str = "") -> list[Diagnostic] {
+        if not file or not self._loaded {
+            self.refresh(file);
+            return self.diagnostics();
+        }
+        # Snapshot the pre-edit diagnostics; anything not in this set after the
+        # recompile is breakage the edit caused.
+        before: set[str] = {_diag_key(d) for d in self.diagnostics()};
+        self.refresh(file);
+        real = _real(file);
+        out: list[Diagnostic] = [];
+        for d in self.diagnostics() {
+            if _real(d.file) == real or _diag_key(d) not in before {
+                out.append(d);
+            }
+        }
+        return out;
+    }
+
+    #-- context packing --------------------------------------------------
+    """Build a typed context slice around a symbol, for prompt assembly.
+
+    Returns the symbol's definition, the definitions of the types it depends
+    on (field types and base classes, up to `depth` of indirection), and the
+    list of places it is used -- a minimal, complete neighbourhood the model
+    can read instead of whole files.
+    """
+    def slice_for(name: str, depth: int = 1) -> ContextSlice {
+        sl = ContextSlice(query=name);
+        sl.target = self.definition(name);
+        if sl.target is None {
+            return sl;
+        }
+        sl.uses = [
+            r
+            for r in self.references(name)
+            if r.role == "use"
+        ];
+        seen: set[str] = {name};
+        frontier: list[SymbolInfo] = [sl.target];
+        level = 0;
+        while frontier and level < depth {
+            next_frontier: list[SymbolInfo] = [];
+            for info in frontier {
+                for dep in self._type_names(info) {
+                    if dep in seen {
+                        continue;
+                    }
+                    seen.add(dep);
+                    dep_info = self.definition(dep);
+                    if dep_info is not None {
+                        sl.related.append(dep_info);
+                        next_frontier.append(dep_info);
+                    }
+                }
+            }
+            frontier = next_frontier;
+            level += 1;
+        }
+        return sl;
+    }
+
+    """Extract candidate type identifiers a symbol depends on."""
+    def _type_names(info: SymbolInfo) -> list[str] {
+        names: set[str] = set();
+        for b in info.base_classes {
+            for tok in self._idents(b) {
+                names.add(tok);
+            }
+        }
+        for f in info.fields {
+            if ":" in f {
+                for tok in self._idents(f.split(":", 1)[1]) {
+                    names.add(tok);
+                }
+            }
+        }
+        if info.type_str {
+            for tok in self._idents(info.type_str) {
+                names.add(tok);
+            }
+        }
+        return list(names);
+    }
+
+    """Pull capitalised bare identifiers out of a type expression string."""
+    def _idents(text: str) -> list[str] {
+        import re;
+        out: list[str] = [];
+        for tok in re.findall(r"[A-Za-z_][A-Za-z0-9_]*", text) {
+            word = str(tok);
+            if word and word[0].isupper() {
+                out.append(word);
+            }
+        }
+        return out;
+    }
+}

--- a/jac/jaclang/compiler/tests/test_code_intel.jac
+++ b/jac/jaclang/compiler/tests/test_code_intel.jac
@@ -1,0 +1,220 @@
+"""Tests for the compiler-backed CodeIntelligence facade.
+
+Exercises name lookup, cross-module def/use chains, OSP graph queries,
+diagnostics, and typed context slices against a small fixture project
+written into a temp directory (outside the jaclang package, so the
+compiler routes it to a normal program rather than the internal one).
+"""
+
+import os;
+import shutil;
+import tempfile;
+import from pathlib { Path }
+import from jaclang.compiler.code_intel { CodeIntelligence }
+
+# Fixture project source. Docstring lines use single-quoted Jac strings so
+# the embedded triple-quotes need no escaping.
+glob _MODEL = "\n".join(
+         [
+             '"""Domain model for the fixture project."""',
+             "",
+             '"""A person in the system."""',
+             "node User {",
+             "    has name: str;",
+             "    has age: int = 0;",
+             "}",
+             "",
+             '"""A piece of content authored by a user."""',
+             "node Post {",
+             "    has title: str;",
+             '    has body: str = "";',
+             "}",
+             "",
+             '"""Authorship relationship."""',
+             "edge Wrote {}"
+         ]
+     ),
+     _WALKERS = "\n".join(
+         [
+             '"""Walkers that traverse the domain model."""',
+             "",
+             "import from model { User, Post }",
+             "",
+             '"""Build a new user node."""',
+             "def make_user(name: str) -> User {",
+             "    return User(name=name);",
+             "}",
+             "",
+             '"""Visits users and prints their names."""',
+             "walker Crawler {",
+             "    can scan with User entry {",
+             "        print(here.name);",
+             "    }",
+             "}"
+         ]
+     );
+
+
+"""Create a fresh temp project and return its directory."""
+def make_project -> str {
+    proj = tempfile.mkdtemp(prefix="ci_proj_");
+    (Path(proj) / "model.jac").write_text(_MODEL);
+    (Path(proj) / "walkers.jac").write_text(_WALKERS);
+    return proj;
+}
+
+
+"""A freshly loaded CodeIntelligence over a fresh fixture project."""
+def fresh -> CodeIntelligence {
+    ci = CodeIntelligence(proj_dir=make_project());
+    ci.load();
+    return ci;
+}
+
+
+test "discovers project files" {
+    ci = fresh();
+    names = sorted([os.path.basename(f) for f in ci.files()]);
+    assert names == ["model.jac", "walkers.jac"] , names;
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "lookup resolves an archetype by name" {
+    ci = fresh();
+    hits = ci.lookup("User");
+    assert len(hits) == 1 , hits;
+    user = hits[0];
+    assert user.kind == "node" , user.kind;
+    assert os.path.basename(user.file) == "model.jac";
+    assert "name: str" in user.fields , user.fields;
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "definition returns the declaration site" {
+    ci = fresh();
+    post = ci.definition("Post");
+    assert post is not None;
+    assert post.kind == "node";
+    assert post.line > 0;
+    assert "A piece of content" in post.doc , post.doc;
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "references span definition and cross-module uses" {
+    ci = fresh();
+    refs = ci.references("User");
+    files = {os.path.basename(r.file) for r in refs};
+    assert "model.jac" in files , files;
+    assert "walkers.jac" in files , files;
+    roles = {r.role for r in refs};
+    assert "def" in roles , roles;
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "walkers_visiting finds entry points by node type" {
+    ci = fresh();
+    eps = ci.walkers_visiting("User");
+    walkers = {ep.walker_name for ep in eps};
+    assert "Crawler" in walkers , walkers;
+    crawler_ep = [
+        ep
+        for ep in eps
+        if ep.walker_name == "Crawler"
+    ][0];
+    assert crawler_ep.node_type == "User" , crawler_ep.node_type;
+    assert crawler_ep.event == "entry" , crawler_ep.event;
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "nodes_visited_by lists a walker's targets" {
+    ci = fresh();
+    eps = ci.nodes_visited_by("Crawler");
+    assert len(eps) == 1 , eps;
+    assert eps[0].node_type == "User";
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "archetypes filters by kind" {
+    ci = fresh();
+    nodes = {a.name for a in ci.archetypes("node")};
+    assert nodes == {"User","Post"} , nodes;
+    walkers = {a.name for a in ci.archetypes("walker")};
+    assert walkers == {"Crawler"} , walkers;
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "clean project reports no error diagnostics" {
+    ci = fresh();
+    errors = [
+        d
+        for d in ci.diagnostics()
+        if d.severity == "error"
+    ];
+    assert errors == [] , [e.render() for e in errors];
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "slice_for packs a typed neighbourhood" {
+    ci = fresh();
+    sl = ci.slice_for("Crawler");
+    assert sl.target is not None;
+    assert sl.target.name == "Crawler";
+    assert "Crawler" in sl.render();
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "refresh picks up a newly written symbol" {
+    ci = fresh();
+    assert ci.definition("Comment") is None;
+    extra = os.path.join(ci.proj_dir, "extra.jac");
+    Path(extra).write_text("node Comment { has text: str; }\n");
+    ci.refresh(extra);
+    found = ci.definition("Comment");
+    assert found is not None , "refresh did not pick up the new node";
+    assert found.kind == "node";
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "refresh_and_diff surfaces breakage an edit causes in a dependent" {
+    ci = fresh();
+    model_path = os.path.join(ci.proj_dir, "model.jac");
+    # Rename `node User` -> `node Account`; walkers.jac still imports and uses
+    # `User`, so the edit to model.jac breaks the dependent module.
+    Path(model_path).write_text(_MODEL.replace("node User", "node Account"));
+    diags = ci.refresh_and_diff(model_path);
+    hit_files = {os.path.basename(d.file) for d in diags};
+    assert "walkers.jac" in hit_files , [d.render() for d in diags];
+    shutil.rmtree(ci.proj_dir, ignore_errors=True);
+}
+
+
+test "refresh_and_diff does not misattribute a dependent's pre-existing error" {
+    proj = tempfile.mkdtemp(prefix="ci_proj_");
+    model_path = os.path.join(proj, "model.jac");
+    walkers_path = os.path.join(proj, "walkers.jac");
+    Path(model_path).write_text(_MODEL);
+    # walkers.jac is broken from the start: `bad` returns a str from `-> int`.
+    Path(walkers_path).write_text(
+        _WALKERS + "\n\ndef bad() -> int { return \"not an int\"; }\n"
+    );
+    ci = CodeIntelligence(proj_dir=proj);
+    ci.load();
+    pre = {os.path.basename(d.file) for d in ci.diagnostics()};
+    assert "walkers.jac" in pre , pre;
+    # A harmless edit to model.jac must not re-surface walkers.jac's old error.
+    Path(model_path).write_text(_MODEL + "\nnode Tag { has label: str; }\n");
+    diags = ci.refresh_and_diff(model_path);
+    hit_files = {os.path.basename(d.file) for d in diags};
+    assert "walkers.jac" not in hit_files , [d.render() for d in diags];
+    shutil.rmtree(proj, ignore_errors=True);
+}

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -272,6 +272,13 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
      E0107 = _err(
          "E0107", Category.SYNTAX, "Lexer stuck at EOF in mode {mode} (pos={pos})"
      ),
+     # Lexer: warnings
+     W0100 = _warn(
+         "W0100",
+         Category.SYNTAX,
+         "Invalid escape sequence '{esc}'",
+         "Double the backslash for a literal backslash, or prefix the string with r to make it raw."
+     ),
      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
      # Type errors (E1xxx) — type checker and type evaluator
      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -962,6 +962,27 @@ impl JacBuiltin.printgraph(
 """Create Jac CLI cmds."""
 impl JacCmd.create_cmd -> None { }
 
+"""Run the `jac ai` coding agent -- the built-in byLLM implementation.
+
+This is the default hook implementation: it lazily imports the bundled
+byLLM-powered agent so the core CLI keeps no hard dependency on byLLM. A
+plugin that registers its own `run_ai_agent` hook outranks this one and
+replaces the agent entirely.
+"""
+impl JacCmd.run_ai_agent(req: object) -> int {
+    try {
+        import from jaclang.cli.ai_agent { run_agent }
+    } except ImportError {
+        import from jaclang.cli.console { console }
+        console.error(
+            "`jac ai` needs the byLLM plugin, which is not installed.",
+            hint="Install it with:  pip install byllm"
+        );
+        return 1;
+    }
+    return run_agent(req);
+}
+
 """Set Class References."""
 impl JacBasics.setup -> None { }
 

--- a/jac/jaclang/jac0core/parser/impl/lexer.impl.jac
+++ b/jac/jaclang/jac0core/parser/impl/lexer.impl.jac
@@ -168,6 +168,34 @@ impl Lexer.error(
     }
 }
 
+impl Lexer.warning(
+    message: str, start_line: int, start_col: int, start_pos: int, code_str: str = ""
+) {
+    if self?.prog and self.prog is not None and hasattr(self.prog, "warnings_had") {
+        import from jaclang.jac0core.unitree { Token as UniToken, Source }
+        import from jaclang.jac0core.codeinfo { CodeLocInfo }
+        import from jaclang.jac0core.passes.transform { Alert }
+        import from jaclang.jac0core.diagnostics { DIAGNOSTICS }
+        sloc = self.make_loc(start_line, start_col, start_pos);
+        src = Source(self.source, mod_path=self.file_path);
+        tok = UniToken(
+            orig_src=src,
+            name="WARNING",
+            value="",
+            line=sloc.line,
+            end_line=sloc.end_line,
+            col_start=sloc.col_start,
+            col_end=sloc.col_end,
+            pos_start=sloc.pos_start,
+            pos_end=sloc.pos_end
+        );
+        loc = CodeLocInfo(tok, tok);
+        code = DIAGNOSTICS.get(code_str) if code_str else None;
+        alrt = Alert(message, loc, Lexer, code=code);
+        self.prog.warnings_had.append(alrt);
+    }
+}
+
 impl Lexer.is_digit(ch: str) -> bool {
     return ch >= "0" and ch <= "9";
 }
@@ -454,6 +482,16 @@ impl Lexer.scan_string(quote: str) -> Token {
     start_col = self.col;
     start_pos = self.pos;
     value = "";
+    # A leading r/R prefix sits in the source just before the opening quote
+    # (the lexer emits it as a separate name token). A raw string keeps
+    # backslashes literal, so an unknown escape there is intentional.
+    prefix = "";
+    pp = start_pos - 1;
+    while pp >= 0 and self.is_alnum(self.source[pp]) {
+        prefix = self.source[pp] + prefix;
+        pp -= 1;
+    }
+    is_raw = prefix.lower() in ["r", "rb", "br"];
     triple = False;
     # Check for triple-quoted string
     if self.peek() == quote and self.peek(2) == quote {
@@ -499,9 +537,33 @@ impl Lexer.scan_string(quote: str) -> Token {
 
         # Handle escape sequences
         if ch == "\\" {
-            value += self.advance();
+            esc_line = self.line;
+            esc_col = self.col;
+            esc_pos = self.pos;
+            value += self.advance();  # consume the backslash
             if not self.at_end() {
-                value += self.advance();
+                esc = self.current();
+                value += self.advance();  # consume the escaped character
+                # Flag escapes Python does not recognize: the compiler decodes
+                # the literal through Python, which would otherwise leak a bare
+                # SyntaxWarning with no source location. Raw strings are exempt.
+                if (
+                    not is_raw
+                    and esc not in "nrtbfva01234567xNuU"
+                    and esc != "\\"
+                    and esc != "\""
+                    and esc != "'"
+                    and esc != "\n"
+                    and esc != "\r"
+                ) {
+                    self.warning(
+                        f"Invalid escape sequence '\\{esc}'",
+                        esc_line,
+                        esc_col,
+                        esc_pos,
+                        code_str="W0100"
+                    );
+                }
             }
         } else {
             value += self.advance();

--- a/jac/jaclang/jac0core/parser/lexer.na.jac
+++ b/jac/jaclang/jac0core/parser/lexer.na.jac
@@ -63,6 +63,14 @@ obj Lexer {
         start_pos: int,
         code_str: str = ""
     );
+
+    def warning(
+        message: str,
+        start_line: int,
+        start_col: int,
+        start_pos: int,
+        code_str: str = ""
+    );
     # Character classification
     def is_digit(ch: str) -> bool;
     def is_hex_digit(ch: str) -> bool;

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -351,6 +351,15 @@ class JacBuiltin {
 class JacCmd {
     """Create Jac CLI cmds."""
     static def create_cmd -> None;
+
+    """Run the `jac ai` interactive coding agent.
+
+        A hook so the agent engine is pluggable: the core ships a built-in
+        byLLM agent as the default implementation, and a plugin can register
+        its own implementation to replace it. `req` is an `AgentRequest`
+        carrying the resolved flags plus a `CodeIntelligence` handle.
+        """
+    static def run_ai_agent(req: object) -> int;
 }
 
 """Jac Feature."""

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -173,6 +173,32 @@ test "E0117: mixed tabs and spaces" {
     assert prog is not None and has_diagnostic_code(prog, "E0117", in_warnings=True);
 }
 
+test "W0100: invalid escape sequence warns" {
+    prog = JacProgram();
+    prog.compile(use_str='with entry { x = "press \\q now"; }', file_path="test.jac");
+    assert has_diagnostic_code(prog, "W0100", in_warnings=True);
+}
+
+test "W0100: valid escapes do not warn" {
+    prog = JacProgram();
+    prog.compile(
+        use_str='with entry { x = "tab\\there\\nline\\x41"; }', file_path="test.jac"
+    );
+    assert not has_diagnostic_code(prog, "W0100", in_warnings=True);
+}
+
+test "W0100: raw string keeps backslashes and is exempt" {
+    prog = JacProgram();
+    prog.compile(use_str='with entry { x = r"press \\q"; }', file_path="test.jac");
+    assert not has_diagnostic_code(prog, "W0100", in_warnings=True);
+}
+
+test "W0100: each invalid escape warns once" {
+    prog = JacProgram();
+    prog.compile(use_str='with entry { x = "\\q then \\e"; }', file_path="test.jac");
+    assert count_diagnostic_code(prog, "W0100", in_warnings=True) == 2;
+}
+
 
 # ══════════════════════════════════════════════════════════════════
 #  PHASE 2: PARSER / SYNTAX DIAGNOSTICS (E0052-E0078)

--- a/jac/tests/runtimelib/test_ai_agent_hook.jac
+++ b/jac/tests/runtimelib/test_ai_agent_hook.jac
@@ -1,0 +1,41 @@
+"""Tests for the pluggable `run_ai_agent` hook.
+
+`jac ai` dispatches through the `run_ai_agent` hook on `JacCmd`, so a plugin
+can replace the built-in coding agent entirely. These tests verify the
+request contract and that a registered plugin outranks the default.
+"""
+
+import from jaclang.jac0core.runtime { JacRuntime as Jac, hookimpl, plugin_manager }
+import from jaclang.cli.agent_api { build_agent_request }
+
+
+"""A plugin that replaces the agent -- proves the hook is overridable."""
+class FakeAgentPlugin {
+    @hookimpl
+    static def run_ai_agent(req: object) -> int {
+        return 4242;
+    }
+}
+
+
+test "build_agent_request carries the flags and a CodeIntelligence handle" {
+    req = build_agent_request("do a thing", "openai/gpt-4o", 16384, True);
+    assert req.prompt == "do a thing";
+    assert req.model == "openai/gpt-4o";
+    assert req.n_ctx == 16384;
+    assert req.safe == True;
+    assert req.cwd;
+    assert req.code_intel is not None;
+}
+
+
+test "a plugin can replace the run_ai_agent hook" {
+    plug = FakeAgentPlugin();
+    plugin_manager.register(plug, name="fake_agent_hook_test");
+    try {
+        req = build_agent_request("hello", "", 0, True);
+        assert Jac.run_ai_agent(req) == 4242;
+    } finally {
+        plugin_manager.unregister(plug, name="fake_agent_hook_test");
+    }
+}


### PR DESCRIPTION
## What

Adds a `jac ai` command that launches an interactive Jac coding agent in the terminal — a byLLM ReAct loop wired to file and guide tools that reads, writes, and debugs Jac code in the current project, grounded in the bundled Jac reference guides (the same ones `jac guide` shows).

```
jac ai                                  # interactive session
jac ai "add a walker to main.jac"        # one-shot request
jac ai -m openai/gpt-4o                  # cloud model
jac ai -m local:gemma-4-e2b --n_ctx 32768
```

The agent works with any byLLM-compatible model — local llama.cpp builds or cloud providers (OpenAI, Anthropic, Gemini, …). A model is picked via `--model`, `[plugins.byllm.model] default_model` in `jac.toml`, or falls back to the bundled `local:gemma-4-e4b` so it runs with no API key. The CLI keeps no hard dependency on byLLM: the agent module is imported lazily and the command reports an install hint when byLLM is missing.

## Tool protocol for non-native-tool backends

In-process llama.cpp has no reliable server-side tool calling. To make local backends usable as agents, this adds `byllm.tool_protocol`:

- `inject_tool_hint` renders tool schemas and the call protocol into the system prompt, and the structured `tools` field is dropped so the model's unreliable native tool template is not engaged. The cloud/litellm path is untouched.
- `recover_tool_calls` lifts tool calls the model emits as plain text into the structured `tool_calls` field so the ReAct loop sees them.
- `LocalLLM` sets `supports_native_tools = False`; `BaseLLM` gains the flag (default `True`).

`local_runtime` also coerces object-shaped `tool_calls` back into OpenAI-shaped dicts at the llama-cpp boundary, so replayed assistant turns survive llama-cpp's Jinja chat template.

## Notes

- `jac.toml` drops the unused `[dependencies.npm]` block and sets a default byLLM model.