### PR TITLE
fix(compiler): rebuild reverse-dependency map after incremental refresh

### DIFF
--- a/jac/jaclang/compiler/code_intel.jac
+++ b/jac/jaclang/compiler/code_intel.jac
@@ -267,6 +267,10 @@ obj CodeIntelligence {
                 self._compile_one(p);
             }
         }
+        # An edit can add or drop an import, so the reverse-dependency map
+        # must be rebuilt from the recompiled modules -- otherwise the next
+        # refresh would not know a file's new importers.
+        self._build_rdeps();
     }
 
     """Compile one project file and record the resulting module."""


### PR DESCRIPTION
## Summary

`CodeIntelligence.refresh()` recompiles changed project files but did not rebuild the reverse-dependency map afterward.

An edit can add or drop an import, so the rdeps map can go stale. The next refresh would then not know about a file's new importers and would miss recompiling them.

This adds a `_build_rdeps()` call after the recompile loop so the map always reflects the current import graph.

## Test plan

- [ ] Existing compiler tests pass