### PR TITLE
chore(tests): clean W2074 f-string lint in passes/main tests

### DIFF
--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -34,6 +34,7 @@ import from pathlib { Path }
 import jaclang;
 import from jaclang.compiler.passes.main.type_checker_pass { TypeCheckPass }
 import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.passes.transform { Alert }
 import from jaclang.compiler.type_system.type_utils { compute_mro_linearization }
 import from jaclang.compiler.type_system.types { ClassType, TypeFlags }
 
@@ -65,9 +66,9 @@ test "bug_1_is_in_returns_unknown_type" {
 
     # Expected: 4 errors (assigning bool to str for is/is_not/in/not_in)
     # Actual: 0 errors (all expressions are UnknownType, assignable to anything)
-    assert len(program.errors_had) == 4 , f"Bug #1: 'is'/'in' operators return UnknownType instead of bool. "
+    assert len(program.errors_had) == 4 , "Bug #1: 'is'/'in' operators return UnknownType instead of bool. "
     f"Expected 4 type errors but got {len(program.errors_had)}. "
-    f"The missing 'return' in operations.jac:141 causes bool results to be discarded.";
+    "The missing 'return' in operations.jac:141 causes bool results to be discarded.";
 }
 
 # =========================================================================
@@ -83,11 +84,11 @@ test "bug_3_list_element_type_first_only" {
 
     # Expected: at least 1 error (list[int|str] not assignable to list[int])
     # Actual: 0 errors (list inferred as list[int], so list[int] -> list[int] is ok)
-    assert len(program.errors_had) >= 1 , f"Bug #3: List element type inference only considers the first element. "
+    assert len(program.errors_had) >= 1 , "Bug #3: List element type inference only considers the first element. "
     f"Expected at least 1 type error for mixed list assignment but got {len(
         program.errors_had
     )}. "
-    f"[1, 'hello'] is typed as list[int] instead of list[int | str].";
+    "[1, 'hello'] is typed as list[int] instead of list[int | str].";
 }
 
 # =========================================================================
@@ -131,9 +132,9 @@ test "bug_6_mro_not_c3_diamond" {
     # Buggy DFS MRO: [D, B, A, C] (A before C)
     expected_c3 = ["D", "B", "C", "A"];
 
-    assert mro_names == expected_c3 , f"Bug #6: MRO is not C3 linearized. "
+    assert mro_names == expected_c3 , "Bug #6: MRO is not C3 linearized. "
     f"Expected {expected_c3} but got {mro_names}. "
-    f"In diamond inheritance, C should come before A in the MRO.";
+    "In diamond inheritance, C should come before A in the MRO.";
 }
 
 # =========================================================================
@@ -150,9 +151,9 @@ test "bug_7_protocol_name_only_check" {
 
     # Expected: 1 error (WrongSignature.draw has wrong param/return types)
     # Actual: 0 errors (protocol check only validates method names exist)
-    assert len(program.errors_had) >= 1 , f"Bug #7: Protocol conformance only checks method names, not signatures. "
+    assert len(program.errors_had) >= 1 , "Bug #7: Protocol conformance only checks method names, not signatures. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"WrongSignature.draw(int)->str should not satisfy Drawable.draw(str)->None.";
+    "WrongSignature.draw(int)->str should not satisfy Drawable.draw(str)->None.";
 }
 
 # =========================================================================
@@ -168,9 +169,9 @@ test "bug_8_dict_tuple_set_return_unknown" {
 
     # Expected: 3 errors (dict->str, tuple->str, set->str assignments)
     # Actual: 0 errors (all literals are UnknownType, assignable to anything)
-    assert len(program.errors_had) == 3 , f"Bug #8: Dict/tuple/set literals return UnknownType. "
+    assert len(program.errors_had) == 3 , "Bug #8: Dict/tuple/set literals return UnknownType. "
     f"Expected 3 type errors but got {len(program.errors_had)}. "
-    f"No case handlers exist for DictVal, TupleVal, SetVal in the evaluator.";
+    "No case handlers exist for DictVal, TupleVal, SetVal in the evaluator.";
 }
 
 # =========================================================================
@@ -192,9 +193,9 @@ test "bug_11_bool_expr_last_operand_only" {
     #
     # With the bug: both pass because result is typed as int (last operand).
     # Expected: 2 errors. Actual: 0 errors.
-    assert len(program.errors_had) == 2 , f"Bug #11: BoolExpr returns last operand type only. "
+    assert len(program.errors_had) == 2 , "Bug #11: BoolExpr returns last operand type only. "
     f"Expected 2 type errors but got {len(program.errors_had)}. "
-    f"'x and y' should be typed as type(x) | type(y), not just type(y).";
+    "'x and y' should be typed as type(x) | type(y), not just type(y).";
 }
 
 # =========================================================================
@@ -210,9 +211,9 @@ test "bug_12_compare_returns_unknown" {
 
     # Expected: 2 errors (assigning comparison bool to str)
     # Actual: 0 errors (comparisons return UnknownType)
-    assert len(program.errors_had) == 2 , f"Bug #12: CompareExpr returns UnknownType instead of bool. "
+    assert len(program.errors_had) == 2 , "Bug #12: CompareExpr returns UnknownType instead of bool. "
     f"Expected 2 type errors but got {len(program.errors_had)}. "
-    f"No case handler exists for CompareExpr in _get_type_of_expression_core.";
+    "No case handler exists for CompareExpr in _get_type_of_expression_core.";
 }
 
 # =========================================================================
@@ -232,9 +233,9 @@ test "bug_13_ternary_returns_unknown" {
     # Note: even check1: str = r1 and check3: str = ... should be ok,
     # but they won't produce errors either way since Unknown is assignable
     # to everything. The bug is that check2 should error but doesn't.
-    assert len(program.errors_had) >= 1 , f"Bug #13: IfExpr (ternary) returns UnknownType. "
+    assert len(program.errors_had) >= 1 , "Bug #13: IfExpr (ternary) returns UnknownType. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"No case handler exists for IfExpr in _get_type_of_expression_core.";
+    "No case handler exists for IfExpr in _get_type_of_expression_core.";
 }
 
 # =========================================================================
@@ -250,9 +251,9 @@ test "bug_15_no_generic_variance_check" {
 
     # Expected: 2 errors (list[int] not assignable to list[str])
     # Actual: 0 errors (same ClassType.shared means assignable)
-    assert len(program.errors_had) >= 1 , f"Bug #15: No generic type argument checking. "
+    assert len(program.errors_had) >= 1 , "Bug #15: No generic type argument checking. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"list[int] should NOT be assignable to list[str].";
+    "list[int] should NOT be assignable to list[str].";
 }
 
 # =========================================================================
@@ -269,9 +270,9 @@ test "bug_23_with_stmt_alias_unknown" {
 
     # Expected: 1 error (TextIOWrapper not assignable to int)
     # With the bug: different error (Unknown cannot access "write")
-    assert len(program.errors_had) == 1 , f"Bug #23: With statement alias typed as Unknown. "
+    assert len(program.errors_had) == 1 , "Bug #23: With statement alias typed as Unknown. "
     f"Expected 1 type error but got {len(program.errors_had)}. "
-    f"'with open(...) as f' should type f as TextIOWrapper, not Unknown.";
+    "'with open(...) as f' should type f as TextIOWrapper, not Unknown.";
 }
 
 # Bug #22: Tuple unpacking in for loops returns UnknownType
@@ -298,9 +299,9 @@ test "bug_22_tuple_unpack_for_loop_unknown" {
     # Total: 5 errors
     #
     # With the bug: 0 errors (all unpacked vars are UnknownType)
-    assert len(program.errors_had) == 5 , f"Bug #22: Tuple unpacking in for loops returns UnknownType. "
+    assert len(program.errors_had) == 5 , "Bug #22: Tuple unpacking in for loops returns UnknownType. "
     f"Expected 5 type errors but got {len(program.errors_had)}. "
-    f"for (a, b) in list[tuple[A, B]] should type a as A and b as B.";
+    "for (a, b) in list[tuple[A, B]] should type a as A and b as B.";
 }
 
 # =========================================================================
@@ -314,7 +315,7 @@ test "bug_any1_typing_any_attr_access" {
     program = compile_and_check("checker_bug_typing_any_attr.jac");
     # Expect 1 error: object.nonexistent (object does not allow arbitrary attr access)
     # Any still allows all attribute access (0 errors for Any tests)
-    assert len(program.errors_had) == 1 , f"Bug #ANY-1: Expected 1 error (object.nonexistent), "
+    assert len(program.errors_had) == 1 , "Bug #ANY-1: Expected 1 error (object.nonexistent), "
     f"got {len(
         program.errors_had
     )} errors. Any must allow all attribute access, but object must not.";
@@ -332,7 +333,7 @@ test "bug_any1_typing_any_attr_access" {
 # =========================================================================
 test "bug_final1_final_unwrap_for_attr_access" {
     program = compile_and_check("checker_bug_final_unwrap_attr.jac");
-    assert len(program.errors_had) == 0 , f"Bug #FINAL-1: attribute access on Final[T] raised E1030 "
+    assert len(program.errors_had) == 0 , "Bug #FINAL-1: attribute access on Final[T] raised E1030 "
     f"({len(program.errors_had)} errors). Final[T] must unwrap to T for member lookup.";
 }
 
@@ -356,10 +357,10 @@ test "bug_tvar1_typevar_dedup_in_extract_type_params" {
 
     # Expected: 1 error (int not assignable to str for `bad: str = m.lookup("key")`)
     # Without fix: 0 errors (V is Unknown, assignable to anything)
-    assert len(program.errors_had) >= 1 , f"Bug #TVAR-1: _extract_type_params duplicates TypeVars from "
-    f"multiple generic bases, causing positional mismatch. "
+    assert len(program.errors_had) >= 1 , "Bug #TVAR-1: _extract_type_params duplicates TypeVars from "
+    "multiple generic bases, causing positional mismatch. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"Without dedup, V in BaseMapping(BaseCollection[K], Generic[K, V]) is unresolved.";
+    "Without dedup, V in BaseMapping(BaseCollection[K], Generic[K, V]) is unresolved.";
 }
 
 # =========================================================================
@@ -381,10 +382,10 @@ test "bug_tvar2_transitive_typevar_propagation" {
 
     # Expected: 1 error (int not assignable to str for `bad: str = c.read("key")`)
     # Without fix: 0 errors (V2 is Unknown, assignable to anything)
-    assert len(program.errors_had) >= 1 , f"Bug #TVAR-2: build_type_var_solution doesn't propagate TypeVars "
-    f"through base_classes chain. "
+    assert len(program.errors_had) >= 1 , "Bug #TVAR-2: build_type_var_solution doesn't propagate TypeVars "
+    "through base_classes chain. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"Without transitive propagation, V2 in BaseReader is unresolved.";
+    "Without transitive propagation, V2 in BaseReader is unresolved.";
 }
 
 # =========================================================================
@@ -407,10 +408,10 @@ test "bug_tvar3_typevar_union_return_type" {
 
     # Expected: 1 error (int | None not assignable to str for `bad: str = s.lookup("key")`)
     # Without fix: 0 errors (V | None is Unknown, assignable to anything)
-    assert len(program.errors_had) >= 1 , f"Bug #TVAR-3: Union return types with TypeVars (V | None) resolve "
-    f"to Unknown due to is_any_type() short-circuit in operations.jac. "
+    assert len(program.errors_had) >= 1 , "Bug #TVAR-3: Union return types with TypeVars (V | None) resolve "
+    "to Unknown due to is_any_type() short-circuit in operations.jac. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"Without the fix, dict.get() and similar methods return Unknown.";
+    "Without the fix, dict.get() and similar methods return Unknown.";
 }
 
 # =========================================================================
@@ -434,7 +435,7 @@ test "bug_tvar4_generic_base_canonical_typevar_order" {
     # Expected: 2 errors on the `bad` lines (24 and 30), NOT on the `good` lines (23 and 29).
     # Without fix: 2 errors on the WRONG lines (23 and 30) because key/value types are swapped,
     # so a count-only check would still pass — we must verify the error locations.
-    assert len(program.errors_had) >= 2 , f"Bug #TVAR-4: Generic[] base must set canonical TypeVar order. "
+    assert len(program.errors_had) >= 2 , "Bug #TVAR-4: Generic[] base must set canonical TypeVar order. "
     f"Expected at least 2 type errors but got {len(program.errors_had)}.";
 
     # Verify errors are on the `bad` assignment lines, not the `good` ones.
@@ -446,12 +447,12 @@ test "bug_tvar4_generic_base_canonical_typevar_order" {
         if e.loc
     ];
     assert 24 in error_lines , f"Expected error on line 24 (bad: int = v), got errors on lines {error_lines}. "
-    f"Without fix, dict.values() yields key type instead of value type.";
+    "Without fix, dict.values() yields key type instead of value type.";
     assert 30 in error_lines , f"Expected error on line 30 (bad2: str = k), got errors on lines {error_lines}.";
     # The `good` lines should NOT have errors.
-    assert 23 not in error_lines , f"Line 23 (good: str = v) should not error — values() yields str, "
+    assert 23 not in error_lines , "Line 23 (good: str = v) should not error — values() yields str, "
     f"but got errors on lines {error_lines}. TypeVar order is likely swapped.";
-    assert 29 not in error_lines , f"Line 29 (good2: int = k) should not error — keys() yields int, "
+    assert 29 not in error_lines , "Line 29 (good2: int = k) should not error — keys() yields int, "
     f"but got errors on lines {error_lines}.";
 }
 
@@ -699,7 +700,7 @@ test "bug_comprehension_narrowing" {
 #   (b) duplicate accessors of the same kind (two `@x.setter def x`)
 # =========================================================================
 """Return E0076 errors emitted while checking a fixture."""
-def _e0076_errors_of(fixture_name: str) -> list {
+def _e0076_errors_of(fixture_name: str) -> list[Alert] {
     program = compile_and_check(fixture_name);
     return [
         e

--- a/jac/tests/compiler/passes/main/test_checker_gaps.jac
+++ b/jac/tests/compiler/passes/main/test_checker_gaps.jac
@@ -68,10 +68,10 @@ test "gap 35 augmented assign no operator check" {
     # Expected: at least 5 errors for invalid augmented operations:
     #   str += int, str += list, list -= int, int += str, bool //= float, str /= str
     # Actual: 0 errors (aug_op is completely ignored in exit_assignment)
-    assert len(program.errors_had) >= 5 , f"Gap #35: Augmented assignment has no operator validation. "
+    assert len(program.errors_had) >= 5 , "Gap #35: Augmented assignment has no operator validation. "
     f"Expected at least 5 type errors but got {len(program.errors_had)}. "
-    f"The type checker ignores nd.aug_op entirely in exit_assignment. "
-    f"str += int, list -= int, int += str, bool //= float, str /= str all go unchecked.";
+    "The type checker ignores nd.aug_op entirely in exit_assignment. "
+    "str += int, list -= int, int += str, bool //= float, str /= str all go unchecked.";
 }
 
 # =========================================================================
@@ -94,10 +94,10 @@ test "gap 36 await returns unknown" {
     # Expected: at least 4 errors (await int->str, await dict->int,
     #   await str->int, await int->str, await int->bool)
     # Actual: 0 errors (AwaitExpr returns UnknownType, assignable to anything)
-    assert len(program.errors_had) >= 4 , f"Gap #36: AwaitExpr returns UnknownType. "
+    assert len(program.errors_had) >= 4 , "Gap #36: AwaitExpr returns UnknownType. "
     f"Expected at least 4 type errors but got {len(program.errors_had)}. "
-    f"No case handler exists for AwaitExpr in _get_type_of_expression_core. "
-    f"await coroutine() falls through to UnknownType instead of the return type.";
+    "No case handler exists for AwaitExpr in _get_type_of_expression_core. "
+    "await coroutine() falls through to UnknownType instead of the return type.";
 }
 
 # =========================================================================
@@ -118,9 +118,9 @@ test "gap 37 yield type checking" {
     # Expected: at least 3 errors for yield type mismatches:
     #   yield "hello" in int gen, yield [1,2] in int gen, yield 3.14 in int gen,
     #   yield 42 in str gen, yield from str_list in int gen
-    assert len(program.errors_had) >= 3 , f"Gap #37: YieldExpr type checking. "
+    assert len(program.errors_had) >= 3 , "Gap #37: YieldExpr type checking. "
     f"Expected at least 3 type errors but got {len(program.errors_had)}. "
-    f"Yield expressions should check value type against declared return type.";
+    "Yield expressions should check value type against declared return type.";
 }
 
 # =========================================================================
@@ -142,10 +142,10 @@ test "gap 38 generic typevar binding" {
     #   Box.get()->str, Box.set("hello"), Pair.first()->int, Pair.second()->str,
     #   Stack.push("pi"), Stack.peek()->str, nested Box[list[int]].get()->list[str]
     # Actual: 0 errors (TypeVar T is not properly bound/substituted)
-    assert len(program.errors_had) >= 6 , f"Gap #38: Generic TypeVar binding is incomplete. "
+    assert len(program.errors_had) >= 6 , "Gap #38: Generic TypeVar binding is incomplete. "
     f"Expected at least 6 type errors but got {len(program.errors_had)}. "
-    f"TypeVar bindings are not propagated through generic class methods. "
-    f"Box[int].get() does not resolve T=int in the return type.";
+    "TypeVar bindings are not propagated through generic class methods. "
+    "Box[int].get() does not resolve T=int in the return type.";
 }
 
 # =========================================================================
@@ -169,10 +169,10 @@ test "gap 40 while condition not checked" {
     #   nonexistent method, wrong arg type, incompatible comparison, chained error
     # Actual: 2 errors (function arg errors caught by exit_func_call, but
     #   nonexistent method and str > int comparison NOT caught)
-    assert len(program.errors_had) >= 3 , f"Gap #40: WhileStmt condition is not type-checked. "
+    assert len(program.errors_had) >= 3 , "Gap #40: WhileStmt condition is not type-checked. "
     f"Expected at least 3 type errors but got {len(program.errors_had)}. "
-    f"No exit_while_stmt handler exists in the type checker pass. "
-    f"Nonexistent methods and wrong arg types in while conditions go unchecked.";
+    "No exit_while_stmt handler exists in the type checker pass. "
+    "Nonexistent methods and wrong arg types in while conditions go unchecked.";
 }
 
 # =========================================================================
@@ -196,10 +196,10 @@ test "gap 41 assert stmt not checked" {
     #   nonexistent method (1), double errors in both (2)
     # Note: str > int comparison (case 5) is NOT caught because
     # str.__gt__ inherits from object.__gt__ which accepts any type.
-    assert len(program.errors_had) >= 5 , f"Gap #41: AssertStmt is not type-checked. "
+    assert len(program.errors_had) >= 5 , "Gap #41: AssertStmt is not type-checked. "
     f"Expected at least 5 type errors but got {len(program.errors_had)}. "
-    f"No exit_assert_stmt handler exists. Nonexistent method calls and "
-    f"binary comparison errors in assert conditions are missed.";
+    "No exit_assert_stmt handler exists. Nonexistent method calls and "
+    "binary comparison errors in assert conditions are missed.";
 }
 
 # =========================================================================
@@ -219,9 +219,9 @@ test "gap 42 delete stmt not checked" {
     # Expected: at least 3 errors:
     #   nonexistent attr, wrong index type, nested nonexistent attr, outer nonexistent
     # Actual: 0 errors (delete target is not type-evaluated)
-    assert len(program.errors_had) >= 3 , f"Gap #42: DeleteStmt is not type-checked. "
+    assert len(program.errors_had) >= 3 , "Gap #42: DeleteStmt is not type-checked. "
     f"Expected at least 3 type errors but got {len(program.errors_had)}. "
-    f"No exit_delete_stmt handler exists. del obj.nonexistent goes unchecked.";
+    "No exit_delete_stmt handler exists. del obj.nonexistent goes unchecked.";
 }
 
 # =========================================================================
@@ -245,10 +245,10 @@ test "gap 43 walker stmts not checked" {
     #   report wrong arg, report nonexistent method
     # Actual: 2 errors (function arg errors caught, but visit-to-non-node
     #   and nonexistent method on self NOT caught)
-    assert len(program.errors_had) >= 4 , f"Gap #43: Walker statements not type-checked. "
+    assert len(program.errors_had) >= 4 , "Gap #43: Walker statements not type-checked. "
     f"Expected at least 4 type errors but got {len(program.errors_had)}. "
-    f"No handlers exist for VisitStmt/DisengageStmt/ReportStmt. "
-    f"visit 42 and report with type errors go completely unchecked.";
+    "No handlers exist for VisitStmt/DisengageStmt/ReportStmt. "
+    "visit 42 and report with type errors go completely unchecked.";
 }
 
 # =========================================================================
@@ -270,10 +270,10 @@ test "gap 44 context manager exit not checked" {
     #   EnterOnlyManager missing __exit__ (x2 for single and multi),
     #   alias type binding (str->int, list[int]->str)
     # Actual: 0 errors (only __enter__ is checked, __exit__ and alias ignored)
-    assert len(program.errors_had) >= 2 , f"Gap #44: Context manager __exit__ not checked. "
+    assert len(program.errors_had) >= 2 , "Gap #44: Context manager __exit__ not checked. "
     f"Expected at least 2 type errors but got {len(program.errors_had)}. "
-    f"exit_with_stmt only checks __enter__, never validates __exit__. "
-    f"Also missing: alias type binding from __enter__ return type.";
+    "exit_with_stmt only checks __enter__, never validates __exit__. "
+    "Also missing: alias type binding from __enter__ return type.";
 }
 
 # =========================================================================
@@ -338,10 +338,10 @@ test "gap 46 impl file standalone scope resolution" {
     # is checked without its parent module's scope. The fix should use
     # discover_base_file() to find checker_gap_impl_scope.jac and compile
     # through the parent, so Calculator, self.value, int, str all resolve.
-    assert len(program.errors_had) == 3 , f"Gap #46: Impl file standalone scope resolution. "
+    assert len(program.errors_had) == 3 , "Gap #46: Impl file standalone scope resolution. "
     f"Expected exactly 3 type errors but got {len(program.errors_had)}. "
-    f"Impl files compiled standalone should use discover_base_file() to find "
-    f"the parent module and check in its full scope context. "
+    "Impl files compiled standalone should use discover_base_file() to find "
+    "the parent module and check in its full scope context. "
     f"Errors: {[e.pretty_print() for e in program.errors_had[:5]]}";
 }
 
@@ -378,10 +378,10 @@ test "gap 47 undeclared attr assignment on archetypes" {
     #
     # Actual (gap): 0 errors — _populate_self_member_symbols adds all
     # self.x = value assignments to the symbol table unconditionally.
-    assert len(program.errors_had) >= 4 , f"Gap #47: Undeclared attr on archetypes. "
+    assert len(program.errors_had) >= 4 , "Gap #47: Undeclared attr on archetypes. "
     f"Expected at least 4 type errors but got {len(program.errors_had)}. "
-    f"obj/node/edge/walker should not allow self.attr = value for attrs "
-    f"not declared in the 'has' block. Only 'class' allows dynamic attrs.";
+    "obj/node/edge/walker should not allow self.attr = value for attrs "
+    "not declared in the 'has' block. Only 'class' allows dynamic attrs.";
 }
 
 # =========================================================================
@@ -432,10 +432,10 @@ test "gap 48 type checker self check" {
         for e in program.errors_had
         if "has no attribute" in str(e) or "Type is Unknown" in str(e)
     ];
-    assert len(false_positives) <= 120 , f"Gap #48: TypeCheckPass self-check. "
+    assert len(false_positives) <= 120 , "Gap #48: TypeCheckPass self-check. "
     f"Expected <= 40 false positives but got {len(false_positives)} "
     f"({len(program.errors_had)} total errors). "
-    f"Significant improvement from 125+ baseline via __init__ param/body fallback. "
+    "Significant improvement from 125+ baseline via __init__ param/body fallback. "
     f"Sample: {[e.pretty_print()[:100] for e in false_positives[:5]]}";
 }
 
@@ -469,10 +469,10 @@ test "gap 49 type checking forward ref" {
     # Actual (gap): 'Path' from TYPE_CHECKING import may resolve to
     # Literal["Path"] or Unknown, so p has wrong type and either
     # false positives or missed errors occur.
-    assert len(program.errors_had) == 2 , f"Gap #49: TYPE_CHECKING forward ref. "
+    assert len(program.errors_had) == 2 , "Gap #49: TYPE_CHECKING forward ref. "
     f"Expected exactly 2 type errors but got {len(program.errors_had)}. "
-    f"String annotations referencing TYPE_CHECKING-guarded imports should "
-    f"resolve to the actual imported type, not Literal or Unknown. "
+    "String annotations referencing TYPE_CHECKING-guarded imports should "
+    "resolve to the actual imported type, not Literal or Unknown. "
     f"Errors: {[e.pretty_print() for e in program.errors_had[:5]]}";
 }
 
@@ -516,10 +516,10 @@ test "gap 50 postinit assignment tracking" {
         if "checker_gap_postinit_tracking.jac" in (e.loc.mod_path or "")
         and 44 <= e.loc.first_line <= 51
     ];
-    assert len(incomplete_errors) >= 1 , f"Gap #50: postinit missing assignment not caught. "
-    f"Incomplete.postinit never assigns to self.z (by postinit field), but "
-    f"no error is produced. The type checker should validate that postinit "
-    f"bodies assign to ALL 'by postinit' fields. "
+    assert len(incomplete_errors) >= 1 , "Gap #50: postinit missing assignment not caught. "
+    "Incomplete.postinit never assigns to self.z (by postinit field), but "
+    "no error is produced. The type checker should validate that postinit "
+    "bodies assign to ALL 'by postinit' fields. "
     f"Total errors: {len(program.errors_had)}, Incomplete errors: {len(
         incomplete_errors
     )}. "
@@ -536,7 +536,7 @@ test "gap 51 property on union type returns function type" {
         for e in program.errors_had
         if "checker_gap_property.jac" in (e.loc.mod_path or "")
     ];
-    assert len(fixture_errors) == 0 , f"Gap #51: Property on union type not unwrapped. "
+    assert len(fixture_errors) == 0 , "Gap #51: Property on union type not unwrapped. "
     f"Expected 0 errors but got {len(fixture_errors)}. "
     f"Errors: {[e.pretty_print()[:100] for e in fixture_errors]}";
 }

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -1782,7 +1782,7 @@ test "property_assignment_type_checking" {
     #   3. b.readonly_val = 1           — read-only   (@property no setter)
     #   4. h.base.cached_num = "wrong"  — str to int  (chained @cached_property)
     #   5. h.base.readonly_val = 2      — read-only   (chained @property no setter)
-    assert len(program.errors_had) == 5 , f"Expected 5 errors, got " + f"{len(
+    assert len(program.errors_had) == 5 , "Expected 5 errors, got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -1869,7 +1869,7 @@ test "property_cfg_narrowing" {
     TypeCheckPass(ir_in=mod, prog=program);
     # Property access inside truthiness guards should narrow (e.g., int | None -> int)
     # No E1053 or E1002 errors — properties are narrowed like regular fields
-    assert len(program.errors_had) == 0 , f"Expected 0 errors, got " + f"{len(
+    assert len(program.errors_had) == 0 , "Expected 0 errors, got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -1885,7 +1885,7 @@ test "native_property_setter_type_checking" {
         options=NO_TC
     );
     TypeCheckPass(ir_in=mod, prog=program);
-    assert len(program.errors_had) == 2 , f"Expected 2 errors, got " + f"{len(
+    assert len(program.errors_had) == 2 , "Expected 2 errors, got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
     # 1. assignment of str to a float-typed writable property
@@ -1905,7 +1905,7 @@ test "type_narrowing" {
 
     # 13 errors: partial union member access now returns resolved types
     # instead of Unknown, preventing one cascading E1002 error.
-    assert len(program.errors_had) == 13 , f"Expected exactly 13 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 13 , "Expected exactly 13 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -2456,7 +2456,7 @@ test "match_type_narrowing" {
     TypeCheckPass(ir_in=mod, prog=program);
 
     # Should have exactly 2 errors (E1 and E2 in the test file)
-    assert len(program.errors_had) == 2 , f"Expected exactly 2 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 2 , "Expected exactly 2 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -2484,7 +2484,7 @@ test "union_subclass_to_base_assignment" {
     TypeCheckPass(ir_in=mod, prog=program);
 
     # Should have exactly 1 error (E1 - wrong type inside match case)
-    assert len(program.errors_had) == 1 , f"Expected exactly 1 type error, but got " + f"{len(
+    assert len(program.errors_had) == 1 , "Expected exactly 1 type error, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -2506,7 +2506,7 @@ test "compound_and_narrowing" {
 
     # CFG correctly reports x.offspring error after early-exit if-body
     # (line 203: Animal has no offspring — only reachable on false branch).
-    assert len(program.errors_had) == 2 , f"Expected 2 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 2 , "Expected 2 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -2520,7 +2520,7 @@ test "assert_isinstance_narrowing" {
     TypeCheckPass(ir_in=mod, prog=program);
 
     # Expect exactly 1 error: the failure case where truthy assert doesn't narrow union
-    assert len(program.errors_had) == 1 , f"Expected 1 type error (truthy assert failure case), but got " + f"{len(
+    assert len(program.errors_had) == 1 , "Expected 1 type error (truthy assert failure case), but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -2539,7 +2539,7 @@ test "assignment_narrowing" {
     TypeCheckPass(ir_in=mod, prog=program);
 
     # All cases should pass - assignment narrows union types appropriately
-    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 0 , "Expected 0 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -2552,7 +2552,7 @@ test "parenthesized_bool_cond" {
         options=NO_TC
     );
     TypeCheckPass(ir_in=mod, prog=program);
-    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 0 , "Expected 0 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -2567,7 +2567,7 @@ test "assignment_barrier" {
     # The widening reassignment in `widen_via_reassign` resets `x` to
     # `int | None`, so `return x` against the `int` return type is the
     # only expected error.
-    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got " + f"{len(
+    assert len(program.errors_had) == 1 , "Expected 1 type error, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
     msg = program.errors_had[0].pretty_print();
@@ -2584,7 +2584,7 @@ test "pre_expr_narrowing" {
     # All three shapes (early-return guard, OR-inverse guard, if-wrap)
     # must carry the enclosing statement's narrowing into ternary
     # branches so member access on the narrowed type succeeds.
-    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 0 , "Expected 0 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -2599,7 +2599,7 @@ test "ternary_bool_cond_narrowing" {
     TypeCheckPass(ir_in=mod, prog=program);
     # All four shapes must narrow cleanly: AND-in-true, OR-inverse-in-else
     # (bare and parenthesized), and the plain if/else control.
-    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 0 , "Expected 0 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -2615,7 +2615,7 @@ test "starred_unpack_barrier" {
     # After `(head, *rest) = ...` inside `if rest is not None`, rest
     # must reset to list[int] | None. The typed-local assignment then
     # fails because list[int] | None is not assignable to list[int].
-    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got " + f"{len(
+    assert len(program.errors_had) == 1 , "Expected 1 type error, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
     msg = program.errors_had[0].pretty_print();
@@ -2632,7 +2632,7 @@ test "tuple_unpack_barrier" {
     TypeCheckPass(ir_in=mod, prog=program);
     # After `(x, _) = reset_pair()` inside `if x is not None`, x must
     # reset to int | None. `return x` then fails against int.
-    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got " + f"{len(
+    assert len(program.errors_had) == 1 , "Expected 1 type error, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
     msg = program.errors_had[0].pretty_print();
@@ -2650,7 +2650,7 @@ test "destructure_element_narrowing" {
     # Four narrowing cases must succeed; only `no_narrow_non_strict`
     # should error because its RHS element type matches the declared
     # type and therefore fails the strict-narrowing check.
-    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got " + f"{len(
+    assert len(program.errors_had) == 1 , "Expected 1 type error, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
     msg = program.errors_had[0].pretty_print();
@@ -2665,7 +2665,7 @@ test "match_case_reassign_reset" {
         options=NO_TC
     );
     TypeCheckPass(ir_in=mod, prog=program);
-    assert len(program.errors_had) == 4 , f"Expected 4 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 4 , "Expected 4 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
     assert 'Cannot assign int to Shape' in program.errors_had[0].pretty_print();
@@ -2684,7 +2684,7 @@ test "guard_narrowing" {
     TypeCheckPass(ir_in=mod, prog=program);
 
     # All cases should pass - if guard narrows T|None to T
-    assert len(program.errors_had) == 0 , f"Expected 0 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 0 , "Expected 0 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 }
@@ -3976,7 +3976,7 @@ test "callable_narrowing" {
     );
     TypeCheckPass(ir_in=mod, prog=program);
 
-    assert len(program.errors_had) == 4 , f"Expected exactly 4 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 4 , "Expected exactly 4 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -4022,7 +4022,7 @@ test "type_alias_narrowing" {
     );
     TypeCheckPass(ir_in=mod, prog=program);
 
-    assert len(program.errors_had) == 2 , f"Expected exactly 2 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 2 , "Expected exactly 2 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -4055,7 +4055,7 @@ test "param_isinstance_narrowing" {
     # The guarded cases should all pass thanks to isinstance narrowing.
     # Error 1: attribute "bark" not found on object
     # Error 2: cascade — return type Unknown vs expected str
-    assert len(program.errors_had) == 2 , f"Expected exactly 2 type errors, but got " + f"{len(
+    assert len(program.errors_had) == 2 , "Expected exactly 2 type errors, but got " + f"{len(
         program.errors_had
     )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
 
@@ -4744,7 +4744,7 @@ test "as_cast_resolves_any_assignment" {
         for e in program.errors_had
         if e.code and e.code.code == "E0002"
     ];
-    assert len(parse_errs) == 0 , f"`expr as Type` should parse, got E0002:\n" + "\n---\n".join(
+    assert len(parse_errs) == 0 , "`expr as Type` should parse, got E0002:\n" + "\n---\n".join(
         e.pretty_print() for e in parse_errs
     );
 }

--- a/jac/tests/compiler/passes/main/test_checker_production.jac
+++ b/jac/tests/compiler/passes/main/test_checker_production.jac
@@ -52,9 +52,9 @@ test "prod a1 dict compr type" {
     program = compile_and_check("checker_prod_dict_compr_type.jac");
 
     # {k: v for ...} must infer as dict[K, V], not just dict
-    assert len(program.errors_had) >= 3 , f"A1: Dict comprehension type inference failed. "
+    assert len(program.errors_had) >= 3 , "A1: Dict comprehension type inference failed. "
     f"Expected >= 3 errors but got {len(program.errors_had)}. "
-    f"Dict comprehensions must infer key/value types, not Unknown.";
+    "Dict comprehensions must infer key/value types, not Unknown.";
 }
 
 # -------------------------------------------------------------------------
@@ -64,9 +64,9 @@ test "prod a2 set compr type" {
     program = compile_and_check("checker_prod_set_compr_type.jac");
 
     # {x * 2 for x in nums} must infer as set[int], not just set
-    assert len(program.errors_had) >= 2 , f"A2: Set comprehension type inference failed. "
+    assert len(program.errors_had) >= 2 , "A2: Set comprehension type inference failed. "
     f"Expected >= 2 errors but got {len(program.errors_had)}. "
-    f"Set comprehensions must infer element type, not Unknown.";
+    "Set comprehensions must infer element type, not Unknown.";
 }
 
 # =========================================================================
@@ -88,9 +88,9 @@ test "prod b1 unknown assign" {
     program = compile_and_check("checker_prod_unknown_assign.jac");
 
     # Assigning Unknown to int, str, list, bool, float should warn/error
-    assert len(program.errors_had) >= 3 , f"B1: Unknown silently assigned to typed variables. "
+    assert len(program.errors_had) >= 3 , "B1: Unknown silently assigned to typed variables. "
     f"Expected >= 3 errors/warnings but got {len(program.errors_had)}. "
-    f"Unknown must not be a universal 'any' type that accepts all assignments.";
+    "Unknown must not be a universal 'any' type that accepts all assignments.";
 }
 
 # -------------------------------------------------------------------------
@@ -100,9 +100,9 @@ test "prod b2 unknown method call" {
     program = compile_and_check("checker_prod_unknown_method_call.jac");
 
     # .nonexistent(), .append(), .upper(), [0] on Unknown should error
-    assert len(program.errors_had) >= 3 , f"B2: Method calls on Unknown silently pass. "
+    assert len(program.errors_had) >= 3 , "B2: Method calls on Unknown silently pass. "
     f"Expected >= 3 errors but got {len(program.errors_had)}. "
-    f"Calling .nonexistent() on Unknown must not silently succeed.";
+    "Calling .nonexistent() on Unknown must not silently succeed.";
 }
 
 # -------------------------------------------------------------------------
@@ -112,9 +112,9 @@ test "prod b3 unknown propagation" {
     program = compile_and_check("checker_prod_unknown_propagation.jac");
 
     # Unknown + 1, Unknown + "hello", -Unknown should not silently produce Unknown
-    assert len(program.errors_had) >= 3 , f"B3: Unknown propagates silently through expressions. "
+    assert len(program.errors_had) >= 3 , "B3: Unknown propagates silently through expressions. "
     f"Expected >= 3 errors but got {len(program.errors_had)}. "
-    f"Arithmetic/string ops on Unknown must not silently produce more Unknown.";
+    "Arithmetic/string ops on Unknown must not silently produce more Unknown.";
 }
 
 # -------------------------------------------------------------------------
@@ -124,9 +124,9 @@ test "prod b4 unknown function arg" {
     program = compile_and_check("checker_prod_unknown_function_arg.jac");
 
     # Passing Unknown to int, str, list[int] params should error
-    assert len(program.errors_had) >= 3 , f"B4: Unknown passed to typed function params silently. "
+    assert len(program.errors_had) >= 3 , "B4: Unknown passed to typed function params silently. "
     f"Expected >= 3 errors but got {len(program.errors_had)}. "
-    f"Unknown must not be silently accepted as int, str, or list[int] argument.";
+    "Unknown must not be silently accepted as int, str, or list[int] argument.";
 }
 
 # -------------------------------------------------------------------------
@@ -136,9 +136,9 @@ test "prod b5 unknown return" {
     program = compile_and_check("checker_prod_unknown_return.jac");
 
     # Returning Unknown where int or str is declared should error
-    assert len(program.errors_had) >= 3 , f"B5: Unknown returned where typed return is declared. "
+    assert len(program.errors_had) >= 3 , "B5: Unknown returned where typed return is declared. "
     f"Expected >= 3 errors but got {len(program.errors_had)}. "
-    f"Returning Unknown for declared -> int or -> str must produce a diagnostic.";
+    "Returning Unknown for declared -> int or -> str must produce a diagnostic.";
 }
 
 # -------------------------------------------------------------------------
@@ -148,9 +148,9 @@ test "prod b6 unknown conditional" {
     program = compile_and_check("checker_prod_unknown_conditional.jac");
 
     # isinstance on Unknown, ternary with Unknown must produce errors
-    assert len(program.errors_had) >= 2 , f"B6: Unknown bypasses conditional type narrowing. "
+    assert len(program.errors_had) >= 2 , "B6: Unknown bypasses conditional type narrowing. "
     f"Expected >= 2 errors but got {len(program.errors_had)}. "
-    f"isinstance() on Unknown must narrow or flag, not silently accept.";
+    "isinstance() on Unknown must narrow or flag, not silently accept.";
 }
 
 # -------------------------------------------------------------------------
@@ -166,10 +166,10 @@ test "prod b7 no return annotation is none" {
 
     # side_effect() and Foo.mutate() have no return annotation -> None.
     # Assigning their result to int/str/list must error.
-    assert len(program.errors_had) >= 4 , f"B7: Omitted return annotation infers Unknown instead of None. "
+    assert len(program.errors_had) >= 4 , "B7: Omitted return annotation infers Unknown instead of None. "
     f"Expected >= 4 errors but got {len(program.errors_had)}. "
-    f"Functions without return annotation must be -> None, not Unknown. "
-    f"Currently construct_types.impl.jac defaults to UnknownType.";
+    "Functions without return annotation must be -> None, not Unknown. "
+    "Currently construct_types.impl.jac defaults to UnknownType.";
 }
 
 # =========================================================================
@@ -194,11 +194,11 @@ test "prod c1 filter compr type" {
         for e in program.errors_had
         if e.code and e.code.code == "E1002"
     ];
-    assert len(e1002_errors) == 0 , f"C1: Filter comprehension returns Unknown instead of list[T]. "
+    assert len(e1002_errors) == 0 , "C1: Filter comprehension returns Unknown instead of list[T]. "
     f"Expected 0 E1002 (return type mismatch) errors but got {len(e1002_errors)}. "
-    f"[root-->][?:Todo] must infer as list[Todo], not Unknown.";
+    "[root-->][?:Todo] must infer as list[Todo], not Unknown.";
 
-    assert len(program.errors_had) >= 2 , f"C1: Filter comprehension type inference failed. "
+    assert len(program.errors_had) >= 2 , "C1: Filter comprehension type inference failed. "
     f"Expected >= 2 errors (str/dict assignment) but got {len(program.errors_had)}. "
-    f"Filter comprehensions with type filter must infer list[FilteredType].";
+    "Filter comprehensions with type filter must infer list[FilteredType].";
 }

--- a/jac/tests/compiler/passes/main/test_checker_shortcomings.jac
+++ b/jac/tests/compiler/passes/main/test_checker_shortcomings.jac
@@ -42,9 +42,9 @@ test "shortcoming_22_destructure_non_iterable" {
     program = compile_and_check("checker_bug_destructure_non_iterable.jac");
 
     # Expected: 3 errors (int, bool, NoneType are not iterable)
-    assert len(program.errors_had) >= 3 , f"#22: No type checking on destructuring RHS. "
+    assert len(program.errors_had) >= 3 , "#22: No type checking on destructuring RHS. "
     f"Expected at least 3 type errors but got {len(program.errors_had)}. "
-    f"'(a, b) = 5' should error because int is not iterable.";
+    "'(a, b) = 5' should error because int is not iterable.";
 }
 
 # =========================================================================
@@ -54,9 +54,9 @@ test "shortcoming_23_set_to_frozenset_unsound" {
     program = compile_and_check("checker_bug_set_to_frozenset.jac");
 
     # Expected: 2 errors (set not assignable to frozenset)
-    assert len(program.errors_had) >= 2 , f"#23: set assignable to frozenset. "
+    assert len(program.errors_had) >= 2 , "#23: set assignable to frozenset. "
     f"Expected at least 2 type errors but got {len(program.errors_had)}. "
-    f"set should NOT be assignable to frozenset (different mutability).";
+    "set should NOT be assignable to frozenset (different mutability).";
 }
 
 # =========================================================================
@@ -69,9 +69,9 @@ test "shortcoming_24_list_compr_unknown" {
     program = compile_and_check("checker_bug_list_compr_unknown.jac");
 
     # Expected: at least 1 error (list assigned to str)
-    assert len(program.errors_had) >= 1 , f"#24: List comprehensions return UnknownType. "
+    assert len(program.errors_had) >= 1 , "#24: List comprehensions return UnknownType. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"[x*2 for x in nums] should infer as list, not Unknown.";
+    "[x*2 for x in nums] should infer as list, not Unknown.";
 }
 
 # =========================================================================
@@ -83,9 +83,9 @@ test "shortcoming_25_dict_compr_unknown" {
     program = compile_and_check("checker_bug_dict_compr_unknown.jac");
 
     # Expected: 1 error (dict assigned to str)
-    assert len(program.errors_had) >= 1 , f"#25: Dict comprehensions return UnknownType. "
+    assert len(program.errors_had) >= 1 , "#25: Dict comprehensions return UnknownType. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"Dict comprehensions should infer as dict, not Unknown.";
+    "Dict comprehensions should infer as dict, not Unknown.";
 }
 
 # =========================================================================
@@ -98,9 +98,9 @@ test "shortcoming_26_lambda_unknown" {
     program = compile_and_check("checker_bug_lambda_unknown.jac");
 
     # Expected: at least 1 error (callable assigned to str, or wrong return type)
-    assert len(program.errors_had) >= 1 , f"#26: Lambda expressions return UnknownType. "
+    assert len(program.errors_had) >= 1 , "#26: Lambda expressions return UnknownType. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"Lambda should infer as callable, not Unknown.";
+    "Lambda should infer as callable, not Unknown.";
 }
 
 # =========================================================================
@@ -113,9 +113,9 @@ test "shortcoming_30_try_except_no_narrowing" {
     program = compile_and_check("checker_bug_try_except_no_narrowing.jac");
 
     # Expected: at least 1 error (ValueError assigned to int, or raise non-exception)
-    assert len(program.errors_had) >= 1 , f"#30: Try/except has no exception type narrowing. "
+    assert len(program.errors_had) >= 1 , "#30: Try/except has no exception type narrowing. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"'except ValueError as e:' should narrow e to ValueError.";
+    "'except ValueError as e:' should narrow e to ValueError.";
 }
 
 # =========================================================================
@@ -128,9 +128,9 @@ test "shortcoming_31_with_stmt_no_check" {
     program = compile_and_check("checker_bug_with_stmt_no_check.jac");
 
     # Expected: at least 1 error (int is not a context manager, or file assigned to int)
-    assert len(program.errors_had) >= 1 , f"#31: With statement does not check context managers. "
+    assert len(program.errors_had) >= 1 , "#31: With statement does not check context managers. "
     f"Expected at least 1 type error but got {len(program.errors_had)}. "
-    f"'with 42 as x:' should error because int is not a context manager.";
+    "'with 42 as x:' should error because int is not a context manager.";
 }
 
 # =========================================================================
@@ -143,9 +143,9 @@ test "shortcoming_33_for_iter_type" {
     program = compile_and_check("checker_bug_for_iter_type.jac");
 
     # Expected: 2 errors (int and bool are not iterable)
-    assert len(program.errors_had) >= 2 , f"#33: For loop does not check iterability. "
+    assert len(program.errors_had) >= 2 , "#33: For loop does not check iterability. "
     f"Expected at least 2 type errors but got {len(program.errors_had)}. "
-    f"'for x in 42:' should error because int is not iterable.";
+    "'for x in 42:' should error because int is not iterable.";
 }
 
 # =========================================================================
@@ -159,7 +159,7 @@ test "shortcoming_34_return_none_implicit" {
     program = compile_and_check("checker_bug_return_none_implicit.jac");
 
     # Expected: 2 errors (maybe_return and always_missing can implicitly return None)
-    assert len(program.errors_had) >= 2 , f"#34: Missing return not detected. "
+    assert len(program.errors_had) >= 2 , "#34: Missing return not detected. "
     f"Expected at least 2 type errors but got {len(program.errors_had)}. "
-    f"Functions declared -> int should error if they can return None.";
+    "Functions declared -> int should error if they can return None.";
 }

--- a/jac/tests/compiler/passes/main/test_decl_impl_match_pass.jac
+++ b/jac/tests/compiler/passes/main/test_decl_impl_match_pass.jac
@@ -221,7 +221,7 @@ test "impl has var type not shadowed" {
             "'tasks' Name node has no symbol — resolution failed"
         );
         assert not isinstance(name_node.sym.decl.name_of, uni.HasVar) , (
-            f"'tasks' should not resolve to HasVar, got "
+            "'tasks' should not resolve to HasVar, got "
             f"{type(name_node.sym.decl.name_of).__name__}"
         );
     }
@@ -324,7 +324,7 @@ test "standalone def/obj/node/walker in .impl.jac get symbol resolution" {
         }
         assert nm.sym is not None , (
             f"Read of local '{nm.value}' at line {nm.loc.first_line} "
-            f"in .impl.jac has unresolved .sym — resolver skipped this subtree"
+            "in .impl.jac has unresolved .sym — resolver skipped this subtree"
         );
         reads_checked += 1;
     }

--- a/jac/tests/compiler/passes/main/test_pyast_gen_pass.jac
+++ b/jac/tests/compiler/passes/main/test_pyast_gen_pass.jac
@@ -315,7 +315,7 @@ with entry {
     prog = JacProgram();
     prog.compile(file_path="test_match.jac", use_str=code);
     assert not prog.errors_had , (
-        f"Match with empty wildcard body should compile cleanly, "
+        "Match with empty wildcard body should compile cleanly, "
         f"got: {[str(e) for e in prog.errors_had]}"
     );
 }

--- a/jac/tests/compiler/passes/main/test_static_analysis_pass.jac
+++ b/jac/tests/compiler/passes/main/test_static_analysis_pass.jac
@@ -224,5 +224,5 @@ test "obj bare assignment to has var name still warns as unused" {
         for w in warning_msgs
         if "defined but never used" in w
     ];
-    assert len(unused_warnings) > 0 , f"Expected unused variable warning for bare 'x' in obj method, got none";
+    assert len(unused_warnings) > 0 , "Expected unused variable warning for bare 'x' in obj method, got none";
 }


### PR DESCRIPTION
## Summary
- Drop the `f"` prefix on concatenated assert-message segments that contained no `{...}` placeholders, across 8 test files in `jac/tests/compiler/passes/main/`. The linter flags those as **W2074** (\"f-string has no placeholders — use a regular string\").
- Annotate `_e0076_errors_of` in `test_checker_bugs.jac` as `-> list[Alert]` (was bare `list`) to clear the single **W1036** in the directory; adds the matching `Alert` import.
- No semantic / assertion-count / message-text changes. Multi-line assert messages still concatenate the same string fragments — only the redundant `f` prefix on placeholder-free fragments is removed.

After this change, `jac check` reports **0 W2074 / 0 W1036** across `jac/tests/compiler/passes/main/`. The two **type errors** that exist in `test_checker_bugs.jac` (E1053 on `Path(jaclang.__file__)` and E1005 on `a_type.shared.mro = ...`) are intentionally **out of scope** here — both are separate, real type-checker findings that deserve their own focused PRs:

| File | W2074 fixed | Other |
|------|-------------|-------|
| `test_checker_gaps.jac`            | 41 |   |
| `test_checker_production.jac`      | 23 |   |
| `test_checker_pass.jac`            | 22 |   |
| `test_checker_shortcomings.jac`    | 18 |   |
| `test_checker_bugs.jac`            | 37 | +1 W1036 (`list` → `list[Alert]`) |
| `test_decl_impl_match_pass.jac`    |  2 |   |
| `test_static_analysis_pass.jac`    |  1 |   |
| `test_pyast_gen_pass.jac`          |  1 |   |
| **Total** | **145** | **+1** |

## Test plan
- [ ] `jac check jac/tests/compiler/passes/main/test_*.jac` shows 0 W2074 and 0 W1036.
- [ ] CI: existing test suite for `passes/main` still passes (we only changed string-literal prefixes; assertion logic and message contents are byte-identical aside from the `f` prefix removal).

## What's next — finishing `jac/tests/compiler/passes/main/`

This PR closes the W2074 / W1036 lint debt in this directory but leaves a small number of real findings worth follow-up PRs:

1. **`test_checker_bugs.jac` E1053** — `Path(jaclang.__file__).parent.parent` flagged because `ModuleType.__file__` is `str | None`. Pyright narrows `__file__` to `str` when a module is resolved via `import X`; Jac currently uses the generic `ModuleType.__file__: str | None` everywhere. Two options:
   - Quick: add `assert jaclang.__file__ is not None;` before the call (silences locally).
   - Real fix: teach the type checker to narrow `__file__` to `str` for statically-imported modules whose source is resolvable (matches pyright's behavior). Same pattern reappears in `jac/jaclang/compiler/tests/test_prim_equivalence.jac:27`.
2. **`test_checker_bugs.jac` E1005** — `a_type.shared.mro = [a_type];` writes a `@property` that has no setter. The other diamond-MRO setup in the same test uses `compute_mro_linearization(...)`; rewrite this manual assignment the same way, or expose a setter / `replace_mro` helper on the `ClassDetailsShared` API.
3. **Lint sweep on the rest of the directory's non-test files** — `compute_mro_linearization` etc. — check whether there are W2074/W1036 hits in `jac/jaclang/compiler/passes/main/` itself (the production code under test).
4. **Same sweep in sibling directories** — `passes/ecmascript/` (2 test files), `passes/native/` (4), `passes/tool/` (4), and `tests/compiler/` (15 files outside `passes/`). Mechanically identical fix; can be one PR per directory or one umbrella PR.