### PR TITLE
feat(types): freeze inferred local variable types at first binding

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6032.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6032.feature.md
@@ -1,0 +1,1 @@
+- **Feature: Freeze inferred local variable types at first binding**: An unannotated local variable's type is now inferred and frozen at its first binding, enforced as if it had an explicit annotation; reassigning an incompatible type is now a type error (E1001). The `None`-sentinel pattern and the discard name `_` remain exempt.

--- a/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
@@ -191,11 +191,19 @@ impl TypeCheckPass.exit_assignment(self: TypeCheckPass, nd: uni.Assignment) -> N
     if ((len(nd.target) == 1) and (nd.value is not None)) {
         target = nd.target[0];
         # Track whether this is a reassignment of a variable whose
-        # declaration has no type annotation.  For such variables the
-        # declared type is *inferred* from the first assignment, so
-        # later reassignments should be allowed to widen the inferred
-        # type — matching Pyright's behaviour for patterns like
-        # `x = None; …; x = value` or `x = 0; …; x = "str"`.
+        # declaration has no type annotation. Such a variable's declared
+        # type is *inferred* and FROZEN at its first binding, exactly as
+        # if that inferred type had been written as an explicit
+        # annotation — so `a = 0; …; a = "str"` is a type error.
+        #
+        # Two exceptions keep idiomatic code annotation-free:
+        #   * the `None`-sentinel pattern (`x = None; …; x = value`):
+        #     when the first binding infers `NoneType`, the inferred type
+        #     may evolve on later writes — mirroring TypeScript's
+        #     strict-mode evolving locals.
+        #   * the discard name `_`: it is a throwaway sink, so every
+        #     binding to it is independent and carries no frozen type.
+        # Any other first-binding type is enforced like an annotation.
         is_unannotated_reassign = False;
         # For assignment targets, use the declared symbol type (not the
         # narrowed type). Narrowing reflects the *current* value; the
@@ -383,13 +391,25 @@ impl TypeCheckPass.exit_assignment(self: TypeCheckPass, nd: uni.Assignment) -> N
                     E1010, node_override=nd, op=nd.aug_op.name, type=left_type.name
                 );
             }
-        } elif (
-            not is_unannotated_reassign
-            and not self.evaluator.assign_type(
-                right_type, left_type, strict=self.evaluator._is_strict_site(nd)
-            )
-        ) {
-            self.emit(E1001, actual=str(right_type), expected=str(left_type));
+        } else {
+            # An unannotated reassignment skips the compatibility check
+            # only for a `None`-sentinel (inferred type may still evolve)
+            # or the `_` discard (every binding to it is independent).
+            # All other unannotated variables are frozen to their
+            # first-binding type (`left_type`) and enforced here.
+            is_evolving_reassign = is_unannotated_reassign
+            and (
+                self.evaluator.is_none_type(left_type)
+                or (isinstance(target, uni.Name) and target.value == "_")
+            );
+            if (
+                not is_evolving_reassign
+                and not self.evaluator.assign_type(
+                    right_type, left_type, strict=self.evaluator._is_strict_site(nd)
+                )
+            ) {
+                self.emit(E1001, actual=str(right_type), expected=str(left_type));
+            }
         }
         # Validate augmented assignment operator (+=, -=, etc.)
         if nd.aug_op is not None {

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -2794,6 +2794,23 @@ impl TypeEvaluator.is_explicit_any(ty: TypeBase) -> bool {
     return False;
 }
 
+"""Whether `ty` is `NoneType` — the type of the literal `None`.
+
+Both the class form and the instance form (`None` the value) are
+recognized, since either may surface depending on how the type was
+produced. Matched by shared identity against the prefetched
+`NoneType` class, the same way `is_any_type` matches `Any`.
+"""
+impl TypeEvaluator.is_none_type(ty: TypeBase) -> bool {
+    if not self.prefetch or not self.prefetch.none_type_class {
+        return False;
+    }
+    return (
+        isinstance(ty, types.ClassType)
+        and ty.shared == self.prefetch.none_type_class.shared
+    );
+}
+
 """Single source of truth for "should Layer 2 strict-Any apply at this
 AST site?". Every assignment-like check (annotated assignment, has-var
 initializer, function arg, return, yield, edge-connection assign)

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -325,6 +325,9 @@ obj TypeEvaluator {
     # Check if a type is Any, object, Unknown, or TypeVar.
     def is_any_type(ty: TypeBase) -> bool;
     def is_explicit_any(ty: TypeBase) -> bool;
+    # Check if a type is `NoneType` (the type of the literal `None`),
+    # in either its class or instance form.
+    def is_none_type(ty: TypeBase) -> bool;
     def _is_strict_site(nd: uni.UniNode) -> bool;
     """True when the pass is currently checking a native (.na.jac) module."""
     def _in_native_context -> bool;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_inferred_type_frozen.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_inferred_type_frozen.jac
@@ -1,0 +1,25 @@
+"""Strict inferred-local typing.
+
+An unannotated local variable is *frozen* to the type inferred at its
+first binding. Reassigning a value of an incompatible type is a type
+error (E1001) — exactly as if the inferred type had been written out as
+an explicit annotation.
+
+The one exception is the `None`-sentinel pattern (`x = None; ...; x = v`):
+when the first binding infers `NoneType`, the variable's type is allowed
+to evolve, matching TypeScript's strict-mode evolving locals.
+"""
+
+with entry {
+    # Frozen to `int` by the first binding — reassigning a `str` is an error.
+    a = 90;
+    a = "some str";  # <-- Error
+
+    # Reassignment within the frozen type is fine.
+    b = 1;
+    b = 2;  # <-- Ok
+
+    # None-sentinel: the inferred type evolves, so reassignment is allowed.
+    found = None;
+    found = 42;  # <-- Ok
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_none_sentinel_reassignment.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_none_sentinel_reassignment.jac
@@ -20,5 +20,5 @@ with entry {
     strict: None = None;
     strict = 7;  # <-- Error
     count = 0;
-    count = "bad";  # <-- Ok (unannotated widens)(same as pyright)
+    count = "bad";  # <-- Error (unannotated var frozen to int at first bind)
 }

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -1263,14 +1263,39 @@ test "union_reassignment" {
     );
 }
 
-test "unannotated_reassignment_widens" {
+test "inferred_local_type_frozen" {
+    # An unannotated local is frozen to the type inferred at its first
+    # binding; reassigning an incompatible type is an error. The
+    # `None`-sentinel pattern is the one exception (the type evolves).
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_inferred_type_frozen.jac"),
+        options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    assert len(program.errors_had) == 1 , f"Expected 1 type error, but got {len(
+        program.errors_had
+    )}: " + "\n".join([err.pretty_print() for err in program.errors_had]);
+    assert program.errors_had[0].code.code == "E1001";
+    assert_error_pretty_found(
+        """
+        a = "some str";  # <-- Error
+    """,
+        program.errors_had[0].pretty_print()
+    );
+}
+
+test "unannotated_reassignment_frozen" {
+    # `None`-sentinel variables evolve their inferred type; every other
+    # unannotated variable is frozen to its first-binding type, and
+    # annotated variables enforce their annotation.
     program = JacProgram();
     mod = program.compile(
         os.path.join(CHECKER_FIXTURES, "checker_none_sentinel_reassignment.jac"),
         options=NO_TC
     );
     TypeCheckPass(ir_in=mod, prog=program);
-    assert len(program.errors_had) == 2 , f"Expected 2 type errors, but got {len(
+    assert len(program.errors_had) == 3 , f"Expected 3 type errors, but got {len(
         program.errors_had
     )}: " + "\n".join([err.pretty_print() for err in program.errors_had]);
     assert_error_pretty_found(
@@ -1286,6 +1311,13 @@ test "unannotated_reassignment_widens" {
         ^^^^^^^^^^^
     """,
         program.errors_had[1].pretty_print()
+    );
+    assert_error_pretty_found(
+        """
+        count = "bad";  # <-- Error
+        ^^^^^^^^^^^^^^
+    """,
+        program.errors_had[2].pretty_print()
     );
 }
 


### PR DESCRIPTION
## Summary

Makes inferred local typing **strict**: an unannotated local variable's type
is inferred and **frozen at its first binding**, then enforced on every
later assignment exactly as if that inferred type had been written out as an
explicit annotation.

```jac
a = 90;
a = "some str";   // now error[E1001]: Cannot assign str to int
```

```jac
a: int = 90;
a = "some str";   // already errored — unchanged
```

## Motivation

Before this change (introduced in #5535) an unannotated variable was allowed
to *widen* its inferred type on every reassignment, so `a = 90; a = "str";`
type-checked clean. That silently swallows accidental variable-name reuse —
a common, real bug. Every comparable statically typed language freezes an
inferred binding instead: TypeScript (`let`), Rust, Go, Swift, Kotlin all
reject the equivalent code. Jac was the outlier, and the outlier behavior
was the bug-friendly one. The strictness is also consistent with Jac's own
stated design ("statically typed at annotation boundaries, inferred inside
bodies") — inference is just the annotation you didn't write.

## Behavior

An unannotated reassignment is checked against the first-binding type, with
two exceptions that keep idiomatic code annotation-free:

- **`None`-sentinel** (`x = None; …; x = value`): when the first binding
  infers `NoneType`, the type may still evolve — this mirrors TypeScript's
  strict-mode evolving locals and preserves the sentinel pattern that #5535
  was added to support.
- **`_` discard**: the throwaway name; every binding to it is independent and
  carries no frozen type.

Variables with an explicit annotation are unaffected — they already enforced
their declared type on every write.

## Implementation

- `exit_assignment` in `type_checker_pass.impl.jac`: the `assign_type`
  compatibility check on an unannotated reassignment is now only skipped for a
  `None`-sentinel or `_` discard; all other unannotated variables are enforced
  against `left_type` (the first-binding type, which the symbol table already
  resolves to).
- Adds `TypeEvaluator.is_none_type` — a reusable `NoneType` predicate
  (the same shared-identity check that was previously inlined in
  `operations.jac`).

## Tests

- New fixture + test `inferred_local_type_frozen` covering the frozen case,
  same-type reassignment, and the `None`-sentinel exception.
- `unannotated_reassignment_widens` → `unannotated_reassignment_frozen`; its
  fixture's plain unannotated reassignment (`count = 0; count = "bad";`) now
  correctly reports an error.
- Full compiler suite green: `2567 passed, 57 skipped`.

## Breaking change

This is a stricter type rule. Code that relied on reassigning an unannotated
variable to an incompatible type will now report E1001. The fix is to add an
explicit union annotation (`x: int | str = …`) — or, for an optional, the
`None`-sentinel form which keeps working unannotated.