### PR TITLE
feat(types): warn on explicit 'any' type annotations

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6033.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6033.feature.md
@@ -1,0 +1,1 @@
+- **Type Checker: Warn on explicit `any` annotations**: Explicitly typing a parameter, return type, field, or assignment `any` now emits a W1037 warning.

--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -34,18 +34,18 @@ def:pub Counter() -> JsxElement {
 
 ## Props
 
-Components declare props as typed function params; callers pass as JSX attributes. Callback props are typed `any` (lowercase - the gradual type). Wrap incoming callbacks in a local handler so parent-side data (like a row's id) is closed over when the event fires.
+Components declare props as typed function params; callers pass as JSX attributes. Type callback props with `Callable[([ArgTypes], ReturnType)]` - `Callable` is ambient, so no import - which catches a mistyped call (wrong arity, wrong arg type, bogus `.member`) at compile time. The escape-hatch `any` disables that checking and earns a `W1037` warning; keep it for genuine interop boundaries only. Wrap incoming callbacks in a local handler so parent-side data (like a row's id) is closed over when the event fires.
 
 ```jac
-def:pub BookCard(bookId: str, title: str, onDelete: any) -> JsxElement {
+def:pub BookCard(bookId: str, title: str, onDelete: Callable[([str], None)]) -> JsxElement {
     def handle_delete(e: MouseEvent) {
-        if onDelete { onDelete(bookId); }
+        onDelete(bookId);
     }
     return <div>{title} <button onClick={handle_delete}>X</button></div>;
 }
 ```
 
-Call site: `<BookCard bookId={b["id"]} title={b["title"]} onDelete={remove} />`.
+Call site: `<BookCard bookId={b["id"]} title={b["title"]} onDelete={remove} />`. For an optional callback, type it `Callable[([str], None)] | None` and guard the call: `if onDelete { onDelete(bookId); }`.
 
 ## Event types (ambient, no import)
 
@@ -58,11 +58,11 @@ Call site: `<BookCard bookId={b["id"]} title={b["title"]} onDelete={remove} />`.
 | `onSubmit`, `onReset` | `FormEvent` | `e.preventDefault()` |
 | `onFocus`, `onBlur` | `FocusEvent` | `e.target` |
 
-Fall back to `any` (lowercase, the gradual type) only when you don't read `e`.
+Use the matching type even when you don't read `e`; for an event not in the table, fall back to the base `Event` type.
 
 ## Built-in in `.cl.jac` - NEVER import these
 
-`JsxElement` (the component return type) and all DOM event types (`MouseEvent`, `ChangeEvent`, `FormEvent`, `KeyboardEvent`, `InputEvent`, `FocusEvent`) are Jac built-ins in client context. Trying `import from "@jac/runtime" { JsxElement }` is wrong and can fail the Vite build.
+`JsxElement` (the component return type) and all DOM event types (`MouseEvent`, `ChangeEvent`, `FormEvent`, `KeyboardEvent`, `InputEvent`, `FocusEvent`, base `Event`) are Jac built-ins in client context; `Callable` is ambient as well. None need an import - `import from "@jac/runtime" { JsxElement }` or `import from typing { Callable }` is wrong and can fail the Vite build.
 
 ## Imports from `@jac/runtime` (complete list)
 
@@ -129,7 +129,7 @@ Also works: short-circuit in JSX - `{result and <X total={result.total_posts} />
 
 **For server response objects (dicts/lists from `sv import` calls), prefer truthy checks (`if result {`) over `!= None`.** The `!=` operator uses deep equality which calls `Object.keys()` - crashes with `"Cannot convert undefined or null to object"` if the value is `null`/`undefined`. `!= None` is safe for primitives (strings, ints, bools) but not for complex objects returned from server calls.
 
-- **Event params are typed - `MouseEvent`/`ChangeEvent`/etc.** Annotate every handler that reads `e` with the real event type, so `e.target` / `e.key` resolve. When you genuinely don't read `e`, fall back to lowercase `any` (the gradual type) - never capital `Any`, which is not the keyword and warns `W2001` ("Name 'Any' may be undefined").
+- **Event params are typed - `MouseEvent`/`ChangeEvent`/etc.** Annotate every handler that reads `e` with the real event type, so `e.target` / `e.key` resolve. When you genuinely don't read `e`, use the base `Event` type - not `any`, which earns a `W1037` warning (and capital `Any` is not the keyword, warning `W2001` "Name 'Any' may be undefined").
 - **`style` prop takes a `dict[str, object]`, not a CSS string.** `<div style="color: red">` fails E1103. Use inline dict `<div style={{"color": "red"}}>` or move styling to `className` + a CSS file.
 - **JSX uses `className`, curly-brace interpolation `{expr}`, camelCase events** (`onClick`, `onChange`).
 - **No `to cl:` / `cl def:pub` / `cl { }` in `.cl.jac` files.** Extension already sets context. Braced blocks are deprecated (W0064).

--- a/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
@@ -220,9 +220,10 @@ impl TypeCheckPass.exit_assignment(self: TypeCheckPass, nd: uni.Assignment) -> N
             } else {
                 target.type = left_type;
             }
-            # Warn on bare generic type annotations (e.g. x: list = [])
+            # Warn on bare generic / explicit-any type annotations (e.g. x: list = [])
             if nd.type_tag and nd.type_tag.tag {
                 self._check_bare_generic(nd.type_tag.tag, left_type);
+                self._check_explicit_any(nd.type_tag.tag);
             }
         } elif isinstance(target, (uni.TupleVal, uni.ListVal)) {
             # Tuple/list unpacking: (px, py) = p; or [a, b] = lst;
@@ -246,8 +247,9 @@ impl TypeCheckPass.exit_assignment(self: TypeCheckPass, nd: uni.Assignment) -> N
             # Propagate type annotation to the target node
             if nd.type_tag and nd.type_tag.tag {
                 declared_type = self.evaluator.get_type_of_expression(nd.type_tag.tag);
-                # Warn on bare generic type annotations (e.g. list instead of list[T])
+                # Warn on bare generic / explicit-any type annotations
                 self._check_bare_generic(nd.type_tag.tag, declared_type);
+                self._check_explicit_any(nd.type_tag.tag);
                 # Convert class type to instance for assignment checking.
                 # Type annotations like `x: int` resolve to the class `int`
                 # (instantiable), but the LHS of an assignment represents an
@@ -545,6 +547,7 @@ impl TypeCheckPass.exit_ability(self: TypeCheckPass, nd: uni.Ability) -> None {
     ) {
         ret_ann_type = self.evaluator.get_type_of_expression(nd.signature.return_type);
         self._check_bare_generic(nd.signature.return_type, ret_ann_type);
+        self._check_explicit_any(nd.signature.return_type);
     }
     # Check for missing return statements on non-None return type functions
     if (
@@ -755,6 +758,32 @@ impl TypeCheckPass._check_bare_generic(
     }
 }
 
+"""Emit W1037 for explicit `any` type annotations.
+
+`any` is the gradual-typing escape hatch: annotating something `any`
+silently disables member-access, call-signature, and assignment checking
+on it. That is occasionally intentional (interop boundaries, genuinely
+dynamic data), so this is a warning rather than an error — but most uses
+are oversights that hide real bugs behind an un-checkable type.
+
+`ann_node` is the annotation AST node (a type-tag expression or signature
+return type). Walks the whole subtree so nested forms each warn at their
+own `any` — `list[any]`, `any | None`, callable params/returns. Matches
+only the lowercase `any` builtin keyword; `Any` imported from `typing`
+resolves through a Name and is left to typeshed-style code."""
+impl TypeCheckPass._check_explicit_any(
+    self: TypeCheckPass, ann_node: uni.UniNode
+) -> None {
+    if isinstance(ann_node, uni.BuiltinType) and ann_node.value == "any" {
+        self.emit(W1037, node_override=ann_node);
+    }
+    for sub in ann_node.get_all_sub_nodes(uni.BuiltinType) {
+        if sub.value == "any" {
+            self.emit(W1037, node_override=sub);
+        }
+    }
+}
+
 """Exit a type alias node."""
 impl TypeCheckPass.exit_type_alias(self: TypeCheckPass, nd: uni.TypeAlias) -> None { }
 
@@ -819,6 +848,7 @@ impl TypeCheckPass.exit_param_var(self: TypeCheckPass, nd: uni.ParamVar) -> None
             and nd.find_parent_of_type(uni.ImplDef) is None
         ) {
             self._check_bare_generic(nd.type_tag.tag, declared_type);
+            self._check_explicit_any(nd.type_tag.tag);
         }
     }
 }
@@ -849,9 +879,10 @@ impl TypeCheckPass.exit_has_var(self: TypeCheckPass, nd: uni.HasVar) -> None {
     if (sym := nd.sym) {
         declared_type = self.evaluator.get_type_of_symbol(sym);
         nd.type = declared_type;
-        # Warn on bare generic type annotations (e.g. has items: list instead of list[T])
+        # Warn on bare generic / explicit-any annotations (e.g. has items: list)
         if nd.type_tag and nd.type_tag.tag {
             self._check_bare_generic(nd.type_tag.tag, declared_type);
+            self._check_explicit_any(nd.type_tag.tag);
         }
         # Walker-specific: `has reports` is the typed view of the walker's
         # report channel. Require a list shape so `report X` (write side)

--- a/jac/jaclang/compiler/passes/main/type_checker_pass.jac
+++ b/jac/jaclang/compiler/passes/main/type_checker_pass.jac
@@ -34,6 +34,7 @@ import from jaclang.jac0core.diagnostics {
     E1116,
     E1117,
     W1036,
+    W1037,
     W1052,
     W2014,
     E2015
@@ -83,6 +84,7 @@ class TypeCheckPass(UniPass) {
         self: TypeCheckPass, ann_node: uni.UniNode, ty: object
     ) -> None;
 
+    def _check_explicit_any(self: TypeCheckPass, ann_node: uni.UniNode) -> None;
     def _check_walker_reports_shape(
         self: TypeCheckPass, nd: uni.HasVar, declared_type: object
     ) -> None;

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -349,6 +349,13 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "Generic type \"{type}\" used without type arguments, defaulting to"
          " \"{type}[Any]\"; consider adding explicit type arguments"
      ),
+     # Explicit `any` annotation warning
+     W1037 = _warn(
+         "W1037",
+         Category.TYPE,
+         "Explicit 'any' type annotation disables type checking here;"
+         " consider a more specific type"
+     ),
      # Subscript / await
      E1040 = _err("E1040", Category.TYPE, "Type \"{type}\" is not subscriptable"),
      E1041 = _err("E1041", Category.TYPE, "Type \"{type}\" is not awaitable"),

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_explicit_any.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_explicit_any.jac
@@ -1,0 +1,34 @@
+"""Explicit `any` annotations on parameters, return types, fields, and
+assignments — including nested forms — should produce W1037 warnings.
+Specific type annotations should not warn."""
+
+# Param + return any (2 warnings)
+def takes_any(x: any) -> any {
+    return x;
+}
+
+# Annotated assignment (1 warning)
+def uses_any -> None {
+    y: any = 5;
+    print(y);
+}
+
+# Nested any inside a generic (1 warning)
+def nested_any(items: list[any]) -> None {
+    print(items);
+}
+
+# any in a union branch (1 warning)
+def union_any -> any | None {
+    return None;
+}
+
+# Field annotation (1 warning)
+obj Box {
+    has payload: any = None;
+}
+
+# Properly typed: should NOT warn
+def typed(x: int) -> str {
+    return str(x);
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -3968,6 +3968,33 @@ test "bare_generic_in_signatures_emits_w1036" {
     )}:\n" + "\n---\n".join(w.pretty_print() for w in bare_generic_warnings);
 }
 
+test "explicit_any_annotations_emit_w1037" {
+    # Explicit `any` annotations disable type checking, so each one — on a
+    # param, return type, field, assignment, or nested inside a generic or
+    # union — should produce a W1037 warning. Specific types must not warn.
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "checker_explicit_any.jac"), options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+
+    explicit_any_warnings = [
+        w
+        for w in program.warnings_had
+        if "W1037" in w.pretty_print()
+    ];
+    # Expected sites (6 total):
+    #   1. `x: any`          param type on `takes_any`
+    #   2. `-> any`          return type on `takes_any`
+    #   3. `y: any = 5`      annotated assignment
+    #   4. `list[any]`       nested any in a generic param
+    #   5. `any | None`      any branch of a union return type
+    #   6. `payload: any`    field annotation
+    assert len(explicit_any_warnings) == 6 , f"Expected 6 W1037 warnings, got {len(
+        explicit_any_warnings
+    )}:\n" + "\n---\n".join(w.pretty_print() for w in explicit_any_warnings);
+}
+
 """Test callable() type narrowing - validates narrowing unions by callability."""
 test "callable_narrowing" {
     program = JacProgram();


### PR DESCRIPTION
## What

Adds **W1037**, a type-checker warning emitted when a parameter, return type, `has` field, or annotated assignment is explicitly typed `any`.

An explicit `any` silently disables member-access, call-signature, and assignment checking on whatever it annotates, so most uses hide real bugs behind an un-checkable type. W1037 nudges toward a concrete type. It stays a warning (not an error), so genuine interop escape hatches still compile.

## Details

- The check walks the whole annotation subtree, so nested forms each warn at their own location: `list[any]`, `any | None`, callable params/returns.
- Matches only the lowercase `any` builtin keyword.
- Reuses the existing bare-generic (`W1036`) plumbing, including the impl-block dedup guard.

## Docs

Updates the `jac-cl-components` guide, which previously typed client callback props `any` (now flagged by W1037), to recommend `Callable[([ArgTypes], ReturnType)]` instead.

## Testing

New `explicit_any_annotations_emit_w1037` test and fixture covering param / return / field / assignment / nested / union sites. All 201 checker-pass tests pass.