### PR TITLE
docs: fix fullstack tutorial examples that fail jac check (#6019)

### DIFF
--- a/docs/docs/reference/diagnostics.md
+++ b/docs/docs/reference/diagnostics.md
@@ -128,6 +128,9 @@ Emitted by the parser and lexer during source code parsing.
 | Code | Message |
 |------|---------|
 | `W0060` | Docstrings in Jac go before the declaration, not inside the body |
+| `W0061` | Parenthesized filter syntax `(?:...)` is deprecated. Use bracket syntax `[?:...]` instead. |
+| `W0062` | `'root()'` is deprecated. Use bare `'root'` instead. |
+| `W0063` | JSX spread `{...expr}` is JS-idiomatic. Prefer `{**expr}` in Jac. |
 | `W0064` | `'{keyword} { ... }'` block syntax is deprecated at module scope. Use the `'to {keyword}:'` section header instead. |
 
 ### Lexer Errors
@@ -255,6 +258,15 @@ Emitted by the type checker and type evaluator.
 | `E1098` | Connection type must be an edge instance |
 | `E1099` | Cannot access attribute "{attr}" for type "{type}"; attribute is missing from {missing} |
 
+### Type Warnings
+
+| Code | Message |
+|------|---------|
+| `W1036` | Generic type "{type}" used without type arguments, defaulting to "{type}[Any]"; consider adding explicit type arguments |
+| `W1050` | Unknown intrinsic JSX element '<{tag}>' |
+| `W1051` | Expression type could not be resolved (Unknown) |
+| `W1052` | JSX component '{component}' uses an untyped props bag (`props: any`); its JSX props cannot be type-checked |
+
 ---
 
 ## Import Warnings (W1xxx)
@@ -263,7 +275,9 @@ Emitted by the type checker and type evaluator.
 |------|---------|
 | `W1100` | Module not found |
 | `W1101` | Cannot import name '{name}' from module '{module}' |
-| `W1102` | Imported name '{name}' from foreign-source module '{module}' typed as any |
+| `W1102` | Imported name '{name}' from foreign-source module '{module}' typed as Any |
+| `W1103` | '{name}' is ambient and does not need to be imported from '{module}' |
+| `W1104` | Use the lowercase `any` keyword instead of importing `Any` from typing |
 
 ---
 
@@ -318,6 +332,21 @@ Emitted by `jac lint`. Rules can be configured in [`jac.toml`](config/index.md#c
 | `W3010` | `fix-impl-signature` | Implementation signature does not match declaration | default |
 | `W3011` | `remove-import-semi` | Unnecessary semicolon after import | default |
 | `E3012` | `no-print` | Calling print() is disallowed by rule | all |
+| `W3020` | `unnecessary-pass` | Unnecessary 'pass' in non-empty body | default |
+| `W3021` | `unnecessary-else-after-return` | Unnecessary 'else' after 'return' | default |
+| `W3022` | `nested-if-to-elif` | Nested 'if' in 'else' can be 'elif' | default |
+| `W3023` | `simplify-return-bool` | `if cond return True else return False` can be simplified to `return cond` | default |
+| `W3024` | `repeated-condition` | Repeated condition in if/elif chain | default |
+| `W3025` | `identical-branches` | Identical if/else branches -- the else is redundant | default |
+| `W3030` | `too-many-params` | Function has {count} parameters (threshold is {threshold}) | default |
+| `W3035` | `is-with-literal` | Use '==' instead of 'is' when comparing to a literal | default |
+| `W3036` | `mutable-default` | Mutable default argument '{type}' -- use None and assign inside the function | default |
+| `W3037` | `unnecessary-none-return` | Unnecessary '-> None' return type annotation on '{name}'; functions without a return statement implicitly return None | default |
+| `W3038` | `usestate-to-has` | useState hook for '{name}' can be replaced with `has {name}: {type} = {init}` | default |
+| `W3039` | `getattr-to-null-ok` | getattr(obj, 'attr', None) should use null-safe access | default |
+| `W3040` | `filter-compare-tautology` | Filter comparison '{name} == {name}' is always true | default |
+| `W3041` | `stale-has-read` | Reactive `has` field '{name}' is read after being assigned in the same `can with entry` block | default |
+| `W3042` | `map-lambda-to-comprehension` | `.map(lambda x -> any { return <jsx>; })` can be replaced with comprehension syntax | default |
 
 ---
 

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -29,11 +29,15 @@ cd myapp
 myapp/
 ├── jac.toml           # Project configuration
 ├── main.jac           # Entry point with app() function
+├── README.md          # Project readme
+├── AGENTS.md          # Agent guide for the project
 ├── components/        # Reusable components
-│   └── Button.tsx     # TypeScript components supported
-└── styles/            # CSS files
-    └── main.css
+│   └── Button.cl.jac  # Example component (.cl.jac = client-side)
+└── assets/            # Static assets (images, fonts)
 ```
+
+TypeScript/TSX and CSS files are also supported -- drop a `.tsx` component or
+a `.css` file anywhere in the project and import it from your Jac code.
 
 ### The `.cl.jac` Convention
 
@@ -165,11 +169,11 @@ node Task {
 
 # Server: return typed objects directly
 def:pub get_tasks -> list[Task] {
-    return [root()-->][?:Task];
+    return [root-->][?:Task];
 }
 
 def:pub create_task(title: str) -> Task {
-    task = root() ++> Task(title=title);
+    task = root ++> Task(title=title);
     return task[0];
 }
 
@@ -287,15 +291,20 @@ def:pub app() -> JsxElement {  # :pub required
 
 ### Function Components
 
+Declare each prop as a named, typed parameter -- the type-checker validates
+every JSX call site per attribute. `children` is the special prop that holds
+the JSX nested between a component's tags:
+
 ```jac
 to cl:
 
-def:pub Button(props: dict) -> JsxElement {
-    return <button
-        className={props.get("className", "")}
-        onClick={props.get("onClick")}
-    >
-        {props.children}
+def:pub Button(
+    className: str = "",
+    onClick: MouseEventHandler = None,
+    children: any = None
+) -> JsxElement {
+    return <button className={className} onClick={onClick}>
+        {children}
     </button>;
 }
 ```
@@ -305,11 +314,11 @@ def:pub Button(props: dict) -> JsxElement {
 ```jac
 to cl:
 
-def:pub Card(props: dict) -> JsxElement {
+def:pub Card(title: str, description: str = "", children: any = None) -> JsxElement {
     return <div className="card">
-        <h2>{props["title"]}</h2>
-        <p>{props["description"]}</p>
-        {props.children}
+        <h2>{title}</h2>
+        <p>{description}</p>
+        {children}
     </div>;
 }
 ```
@@ -481,11 +490,11 @@ import from react { createContext, useContext }
 
 glob AppContext = createContext(None);
 
-def:pub AppProvider(props: dict) -> JsxElement {
+def:pub AppProvider(children: any = None) -> JsxElement {
     has theme: str = "light";
 
     return <AppContext.Provider value={{"theme": theme}}>
-        {props.children}
+        {children}
     </AppContext.Provider>;
 }
 
@@ -550,7 +559,7 @@ def:pub TaskList() -> JsxElement {
 
     # Fetch data on component mount
     async can with entry {
-        result = root() spawn get_tasks();
+        result = root spawn get_tasks();
         if result.reports and result.reports.length > 0 {
             tasks = result.reports[0];
         }
@@ -580,8 +589,8 @@ The `spawn` call returns a result object:
 
 | Syntax | Description |
 |--------|-------------|
-| `root() spawn WalkerName()` | Spawn walker from root node |
-| `root() spawn WalkerName(arg=value)` | Spawn with parameters |
+| `root spawn WalkerName()` | Spawn walker from root node |
+| `root spawn WalkerName(arg=value)` | Spawn with parameters |
 | `node_id spawn WalkerName()` | Spawn from specific node |
 
 The spawn call returns a result object with:
@@ -601,7 +610,7 @@ def:pub TaskManager() -> JsxElement {
 
     # Create
     async def handle_add(title: str) -> None {
-        result = root() spawn add_task(title=title);
+        result = root spawn add_task(title=title);
         if result.reports and result.reports.length > 0 {
             tasks = tasks + [result.reports[0]];
         }
@@ -609,7 +618,7 @@ def:pub TaskManager() -> JsxElement {
 
     # Update
     async def handle_toggle(task_id: str) -> None {
-        result = root() spawn toggle_task(task_id=task_id);
+        result = root spawn toggle_task(task_id=task_id);
         if result.reports and result.reports[0]["success"] {
             tasks = [
                 {**t, "completed": not t["completed"]} if t["id"] == task_id else t
@@ -620,7 +629,7 @@ def:pub TaskManager() -> JsxElement {
 
     # Delete
     async def handle_delete(task_id: str) -> None {
-        result = root() spawn delete_task(task_id=task_id);
+        result = root spawn delete_task(task_id=task_id);
         if result.reports and result.reports[0]["success"] {
             tasks = [t for t in tasks if t["id"] != task_id];
         }
@@ -645,7 +654,7 @@ def:pub SafeDataView() -> JsxElement {
     async can with entry {
         loading = True;
         try {
-            result = root() spawn get_data();
+            result = root spawn get_data();
             if result.reports and result.reports.length > 0 {
                 data = result.reports[0];
             }
@@ -679,7 +688,7 @@ def:pub LiveData() -> JsxElement {
     has data: any = None;
 
     async def fetch_data() -> None {
-        result = root() spawn get_live_data();
+        result = root spawn get_live_data();
         if result.reports and result.reports.length > 0 {
             data = result.reports[0];
         }
@@ -687,9 +696,11 @@ def:pub LiveData() -> JsxElement {
 
     async can with entry { await fetch_data(); }
 
-    useEffect(lambda -> None {
-        interval = setInterval(lambda -> None { fetch_data(); }, 5000);
-        return lambda -> None { clearInterval(interval); };
+    # The outer lambda must NOT be annotated `-> None` -- a cleanup effect
+    # returns a function, so `-> None` would be a type error.
+    useEffect(lambda {
+        interval = setInterval(lambda { fetch_data(); }, 5000);
+        return lambda { clearInterval(interval); };
     }, []);
 
     return <div>{data and <p>Last updated: {data["timestamp"]}</p>}</div>;
@@ -745,7 +756,7 @@ def:pub page() -> JsxElement {
     params = useParams();
     return <div>
         <Link to="/users">Back</Link>
-        <h1>User {params.id}</h1>
+        <h1>User {params["id"]}</h1>
     </div>;
 }
 ```
@@ -863,7 +874,7 @@ Import from `@jac/runtime`:
 
 | Hook | Returns | Usage |
 |------|---------|-------|
-| `useParams()` | dict | Access URL parameters: `params.id` |
+| `useParams()` | dict | Access URL parameters: `params["id"]` |
 | `useNavigate()` | function | Navigate programmatically: `navigate("/path")`, `navigate(-1)` |
 | `useLocation()` | object | Current location: `location.pathname`, `location.search` |
 | `Link` | component | Navigation: `<Link to="/path">Text</Link>` |

--- a/docs/docs/tutorials/fullstack/auth.md
+++ b/docs/docs/tutorials/fullstack/auth.md
@@ -482,8 +482,8 @@ import from react { createContext, useContext }
 
 glob AuthContext = createContext(None);
 
-# Auth Provider component
-def:pub AuthProvider(props: dict) -> JsxElement {
+# Auth Provider component -- `children` holds the nested JSX
+def:pub AuthProvider(children: any = None) -> JsxElement {
     has user: any = None;
     has loading: bool = True;
 
@@ -518,7 +518,7 @@ def:pub AuthProvider(props: dict) -> JsxElement {
     };
 
     return <AuthContext.Provider value={value}>
-        {props.children}
+        {children}
     </AuthContext.Provider>;
 }
 

--- a/docs/docs/tutorials/fullstack/backend.md
+++ b/docs/docs/tutorials/fullstack/backend.md
@@ -20,12 +20,12 @@ This tutorial shows how to call backend functions from the frontend, use walkers
 In Jac full-stack apps, the compiler handles the client-server boundary for you. Here's the mental model:
 
 1. **Backend** = Functions or walkers that process data and return results
-2. **Frontend** = Components in `cl { }` blocks
-3. **Connection** = Direct function calls (`await func()`) or walker spawning (`root() spawn Walker()`)
+2. **Frontend** = Components in `to cl:` sections (or `.cl.jac` files)
+3. **Connection** = Direct function calls (`await func()`) or walker spawning (`root spawn Walker()`)
 
 ```mermaid
 graph LR
-    Frontend["Frontend<br/>Component"] <-- "HTTP<br/>function call / root() spawn" --> Backend["Functions or<br/>Walker API"]
+    Frontend["Frontend<br/>Component"] <-- "HTTP<br/>function call / root spawn" --> Backend["Functions or<br/>Walker API"]
 ```
 
 ### Two Backend Approaches
@@ -37,7 +37,7 @@ Jac offers two ways to create backend endpoints:
 | **Functions** | `def:pub get_tasks -> list[Task] { ... }` | Simple CRUD, quick prototyping |
 | **Walkers** | `walker:pub get_tasks { can fetch with Root entry { ... } }` | Graph traversal, multi-step operations |
 
-Both become HTTP endpoints automatically. Functions are simpler -- the frontend calls them directly with `await func()`. Walkers are more powerful -- they traverse the graph and report results, called with `root() spawn Walker()`.
+Both become HTTP endpoints automatically. Functions are simpler -- the frontend calls them directly with `await func()`. Walkers are more powerful -- they traverse the graph and report results, called with `root spawn Walker()`.
 
 Use `def:priv` / `walker:priv` for authenticated endpoints with per-user data isolation. See the [AI Day Planner tutorial](../first-app/build-ai-day-planner.md) for both approaches side by side.
 
@@ -76,7 +76,7 @@ walker:pub add_task {
             title=self.title,
             created_at=datetime.now().isoformat()
         );
-        root() ++> new_task;
+        root ++> new_task;
         report new_task;  # Report the typed Task node
     }
 }
@@ -114,9 +114,9 @@ walker:pub delete_task {
 
 ## Calling Walkers from Frontend
 
-### Basic Pattern with `root() spawn`
+### Basic Pattern with `root spawn`
 
-Use `root() spawn walker_name()` to call walkers from client code:
+Use `root spawn walker_name()` to call walkers from client code:
 
 ```jac
 # Import walkers from your main module
@@ -138,7 +138,7 @@ def:pub TaskList() -> JsxElement {
         loading = True;
         error = "";
         try {
-            result = root() spawn get_tasks();
+            result = root spawn get_tasks();
             if result.reports and result.reports.length > 0 {
                 tasks = result.reports[0];
             }
@@ -162,7 +162,7 @@ def:pub TaskList() -> JsxElement {
 }
 ```
 
-### Understanding `root() spawn` Results
+### Understanding `root spawn` Results
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -190,7 +190,7 @@ def:pub TaskManager() -> JsxElement {
 
     async def load_tasks() -> None {
         loading = True;
-        result = root() spawn get_tasks();
+        result = root spawn get_tasks();
         if result.reports and result.reports.length > 0 {
             tasks = result.reports[0];
         }
@@ -200,7 +200,7 @@ def:pub TaskManager() -> JsxElement {
     # Add new task
     async def handle_add() -> None {
         if new_title.trim() {
-            result = root() spawn add_task(title=new_title.trim());
+            result = root spawn add_task(title=new_title.trim());
             if result.reports and result.reports.length > 0 {
                 tasks = tasks + [result.reports[0]];
             }
@@ -210,7 +210,7 @@ def:pub TaskManager() -> JsxElement {
 
     # Toggle task completion
     async def handle_toggle(task_id: str) -> None {
-        result = root() spawn toggle_task(task_id=task_id);
+        result = root spawn toggle_task(task_id=task_id);
         if result.reports and result.reports.length > 0 {
             updated = result.reports[0];
             tasks = [updated if jid(t) == task_id else t for t in tasks];
@@ -219,7 +219,7 @@ def:pub TaskManager() -> JsxElement {
 
     # Delete task
     async def handle_delete(task_id: str) -> None {
-        result = root() spawn delete_task(task_id=task_id);
+        result = root spawn delete_task(task_id=task_id);
         if result.reports and result.reports.length > 0 {
             tasks = [t for t in tasks if jid(t) != task_id];
         }
@@ -284,7 +284,7 @@ def:pub SafeSubmit() -> JsxElement {
         error_msg = "";
 
         try {
-            result = root() spawn submit_data(payload=data);
+            result = root spawn submit_data(payload=data);
             if result.reports and result.reports.length > 0 {
                 response = result.reports[0];
                 if not response["success"] {
@@ -327,7 +327,7 @@ def:pub DataView() -> JsxElement {
     async def fetch_data() -> None {
         loading = True;
         try {
-            result = root() spawn get_data();
+            result = root spawn get_data();
             if result.reports and result.reports.length > 0 {
                 data = result.reports[0];
             }
@@ -375,7 +375,7 @@ def:pub LiveData() -> JsxElement {
     has loading: bool = True;
 
     async def fetch_data() -> None {
-        result = root() spawn get_live_data();
+        result = root spawn get_live_data();
         if result.reports and result.reports.length > 0 {
             data = result.reports[0];
         }
@@ -387,10 +387,11 @@ def:pub LiveData() -> JsxElement {
         await fetch_data();
     }
 
-    # Poll every 5 seconds
-    useEffect(lambda -> None {
-        interval = setInterval(lambda -> None { fetch_data(); }, 5000);
-        return lambda -> None { clearInterval(interval); };
+    # Poll every 5 seconds. The outer lambda must NOT be annotated `-> None`:
+    # a cleanup effect returns a function, so `-> None` would be a type error.
+    useEffect(lambda {
+        interval = setInterval(lambda { fetch_data(); }, 5000);
+        return lambda { clearInterval(interval); };
     }, []);
 
     return <div>
@@ -425,7 +426,7 @@ walker:pub add_task {
 
     can create with Root entry {
         task = Task(title=self.title);
-        root() ++> task;
+        root ++> task;
         report task;
     }
 }
@@ -454,7 +455,7 @@ def:pub app() -> JsxElement {
 
     # Load tasks on mount
     async can with entry {
-        result = root() spawn get_tasks();
+        result = root spawn get_tasks();
         if result.reports {
             tasks = result.reports;
         }
@@ -463,7 +464,7 @@ def:pub app() -> JsxElement {
 
     async def add() -> None {
         if input_text.trim() {
-            result = root() spawn add_task(title=input_text.trim());
+            result = root spawn add_task(title=input_text.trim());
             if result.reports and result.reports.length > 0 {
                 tasks = tasks + [result.reports[0]];
             }
@@ -472,7 +473,7 @@ def:pub app() -> JsxElement {
     }
 
     async def toggle(task_id: str) -> None {
-        result = root() spawn toggle_task(task_id=task_id);
+        result = root spawn toggle_task(task_id=task_id);
         if result.reports and result.reports.length > 0 {
             updated = result.reports[0];
             tasks = [updated if jid(t) == task_id else t for t in tasks];
@@ -521,7 +522,7 @@ def:pub app() -> JsxElement {
 | Concept | Usage |
 |---------|-------|
 | Import walkers | `sv import from ...main { walker_name }` |
-| Call walker | `result = root() spawn walker_name(args)` |
+| Call walker | `result = root spawn walker_name(args)` |
 | Get results | `result.reports[0]` |
 | Node spawn | `node_id spawn walker_name(args)` |
 | Error handling | `try { ... } except Exception as e { ... }` |

--- a/docs/docs/tutorials/fullstack/components.md
+++ b/docs/docs/tutorials/fullstack/components.md
@@ -1,6 +1,6 @@
 # React-Style Components
 
-Jac's client-side code uses JSX syntax (the same HTML-in-code approach popularized by React) to build UI components. Components are functions declared inside `cl { }` blocks that return `JsxElement` values. Each prop is a named parameter -- the type-checker validates every JSX call site per attribute -- and components compose just like in React, with conditional rendering, list mapping, and event handling.
+Jac's client-side code uses JSX syntax (the same HTML-in-code approach popularized by React) to build UI components. Components are functions declared in client-side code -- a `.cl.jac` file or a `to cl:` section -- that return `JsxElement` values. Each prop is a named parameter -- the type-checker validates every JSX call site per attribute -- and components compose just like in React, with conditional rendering, list mapping, and event handling.
 
 The key difference from a standard React setup: there's no separate JavaScript project, no webpack configuration, and no build toolchain to manage. You write components in Jac syntax, the compiler generates optimized JavaScript, and the dev server bundles and serves it automatically.
 
@@ -34,6 +34,37 @@ def:pub app() -> JsxElement {
 - `def:pub` exports the component
 - Each prop is a named parameter -- `<Greeting name="Alice" />` is type-checked against the `name: str` declaration
 - Self-closing tags: `<Component />`
+
+---
+
+## Typed props and `children`
+
+Declare **every prop as its own named, typed parameter**. The type-checker keys per-attribute validation on parameter names, so each `<Card title="..." />` call site is checked against the declared types -- unknown props, type mismatches, and missing required props are all caught at `jac check` time.
+
+`children` -- the JSX nested between a component's tags -- is just a regular parameter named `children`. It is not special-cased: React's reconciler fills it in and the compiler destructures it like any other prop. (The only genuinely reserved attribute names are `key` and `ref`.)
+
+```jac
+to cl:
+
+def:pub Card(title: str, description: str = "", children: any = None) -> JsxElement {
+    return <div className="card">
+        <h2>{title}</h2>
+        <p>{description}</p>
+        {children}
+    </div>;
+}
+
+def:pub app() -> JsxElement {
+    return <Card title="Welcome" description="Hello!">
+        <p>This is the card content.</p>
+    </Card>;
+}
+```
+
+!!! warning "`children` must have a default value"
+    The prop validator counts only JSX **attributes** toward matched parameters -- nested content does *not* count. A `children` parameter with no default is therefore treated as a *required* prop, and any call site that passes another attribute fails with `error[E1102]: Component 'Card' requires prop 'children'`. Always declare it as `children: any = None`.
+
+There is no `ReactNode`-style union type in Jac, and a children value can be an element, a string, a number, or a list of those -- so `any` is the honest type for a `children` parameter. The parameter type governs only how you use `children` inside the body; it is never checked against the nested content.
 
 ---
 
@@ -236,7 +267,7 @@ def:pub LoginForm() -> JsxElement {
 ```jac
 to cl:
 
-def:pub Card(title: str, children: Any) -> JsxElement {
+def:pub Card(title: str, children: any = None) -> JsxElement {
     return <div className="card">
         <div className="card-header">{title}</div>
         <div className="card-body">{children}</div>
@@ -290,7 +321,7 @@ def:pub app() -> JsxElement {
 ### Header.cl.jac
 
 ```jac
-# No cl { } needed for .cl.jac files
+# No `to cl:` header needed for .cl.jac files
 
 def:pub Header(title: str) -> JsxElement {
     return <header>
@@ -407,7 +438,7 @@ def:pub app() -> JsxElement {
 | Input handler | `onChange={lambda e: ChangeEvent { ... }}` |
 | List rendering | `{[<li>{x}</li> for x in items]}` |
 | Conditional | `{("A" if condition else "B")}` |
-| Children | `def:pub Card(children: Any) { ... }` then `{children}` |
+| Children | `def:pub Card(children: any = None) { ... }` then `{children}` |
 | Forwarding bundle | `def:pub Wrap(props: dict)` (suppress W5015) |
 | Import component | `import from "./File.cl.jac" { Component }` |
 

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -15,10 +15,10 @@ When your application grows beyond a single view, you need routing -- the abilit
     If your app is a single-page application (like the [AI Day Planner tutorial](../first-app/build-ai-day-planner.md)), you don't need routing -- a single `def:pub app -> JsxElement` entry point is sufficient. Add routing when your app needs multiple distinct pages (e.g., dashboard, settings, profile).
 
 !!! tip "Browser APIs in client code"
-    Inside `cl { }` blocks, standard JavaScript browser APIs like `URLSearchParams`, `parseInt`, `setInterval`, `clearInterval`, `localStorage`, and `JSON` are available since client code compiles to JavaScript.
+    Inside client-side code (a `.cl.jac` file or a `to cl:` section), standard JavaScript browser APIs like `URLSearchParams`, `parseInt`, `setInterval`, `clearInterval`, `localStorage`, and `JSON` are available since client code compiles to JavaScript.
 
-!!! note "Route params and `jac check`"
-    `useParams()` and `useSearchParams()` return JS-flavored objects whose dynamic property access (`params.id`, `params.slug`) works at runtime but is not yet typed in the static checker. Snippets that read those props show `E1030` warnings under isolated `jac check`, even though they run cleanly under `jac start`.
+!!! note "Reading route params"
+    `useParams()` returns a `dict`. Read parameters with subscript access -- `params["id"]`, `params["slug"]` -- not dotted attribute access. Dotted access (`params.id`) fails `jac check` with `error[E1030]: Type "dict" has no attribute "id"`.
 
 Jac-client supports two routing approaches:
 
@@ -94,7 +94,7 @@ to cl:
 
 def:pub page() -> JsxElement {
     params = useParams();
-    userId = params.id;
+    userId = params["id"];
 
     # Mock data lookup
     users = {
@@ -129,7 +129,7 @@ to cl:
 
 def:pub page() -> JsxElement {
     params = useParams();
-    slug = params.slug;  # e.g., "getting-started-with-jac"
+    slug = params["slug"];  # e.g., "getting-started-with-jac"
 
     return <article>
         <Link to="/posts">← All Posts</Link>
@@ -560,7 +560,7 @@ cl import from "@jac/runtime" { useNavigate, jacIsLoggedIn }
 
 to cl:
 
-def:pub ProtectedRoute(props: dict) -> JsxElement {
+def:pub ProtectedRoute(children: any = None) -> JsxElement {
     navigate = useNavigate();
     isAuthenticated = jacIsLoggedIn();
 
@@ -574,7 +574,7 @@ def:pub ProtectedRoute(props: dict) -> JsxElement {
         return <div>Redirecting...</div>;
     }
 
-    return <div>{props.children}</div>;
+    return <div>{children}</div>;
 }
 ```
 
@@ -825,7 +825,7 @@ cl import from "@jac/runtime" {
 
 | Hook | Returns | Usage |
 |------|---------|-------|
-| `useParams()` | `dict` | `params.id`, `params.slug` |
+| `useParams()` | `dict` | `params["id"]`, `params["slug"]` |
 | `useNavigate()` | function | `navigate("/path")`, `navigate(-1)` |
 | `useLocation()` | object | `location.pathname`, `location.search` |
 
@@ -850,7 +850,7 @@ cl import from "@jac/runtime" {
 | Concept | Usage |
 |---------|-------|
 | Navigation links | `<Link to="/path">Text</Link>` |
-| URL parameters | `params = useParams(); params.id` |
+| URL parameters | `params = useParams(); params["id"]` |
 | Programmatic nav | `navigate("/path")` or `navigate(-1)` |
 | Query strings | `useLocation().search` + `URLSearchParams` |
 | Nested routes | `<Outlet />` renders child routes |

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -1,6 +1,6 @@
 # Full-Stack Project Setup
 
-Jac's `jac-client` plugin lets you build full-stack web applications where the frontend (React-style JSX components) and backend (walkers, functions, graph operations) live in the same codebase -- even the same file. The compiler separates client and server code automatically: code inside `cl { }` blocks compiles to JavaScript and runs in the browser, while everything else compiles to Python and runs on the server.
+Jac's `jac-client` plugin lets you build full-stack web applications where the frontend (React-style JSX components) and backend (walkers, functions, graph operations) live in the same codebase -- even the same file. The compiler separates client and server code automatically: client-side code -- a `.cl.jac` file or anything under a `to cl:` section header -- compiles to JavaScript and runs in the browser, while everything else compiles to Python and runs on the server.
 
 This means no separate frontend repository, no REST API boilerplate, and no manual data serialization. When a client component calls a server function, the compiler generates the HTTP layer for you. Hot Module Replacement (HMR) is built in, so changes to both frontend and backend code reflect instantly during development.
 
@@ -29,6 +29,7 @@ myapp/
 ├── jac.toml              # Configuration
 ├── main.jac              # Entry point (frontend + backend)
 ├── README.md             # Project readme
+├── AGENTS.md             # Agent guide for the project
 ├── components/           # Reusable UI components
 │   └── Button.cl.jac     # Example button component
 ├── assets/               # Static assets (images, fonts)
@@ -57,7 +58,7 @@ walker:pub get_todos {
     }
 }
 
-# Frontend code (inside cl block)
+# Frontend code (client section)
 to cl:
 
 def:pub app() -> JsxElement {
@@ -75,16 +76,24 @@ def:pub app() -> JsxElement {
 [project]
 name = "myapp"
 version = "1.0.0"
-description = "Jac client application"
+description = "Jac client application: myapp"
 entry-point = "main.jac"
 
-[dependencies]
-
 [dependencies.npm]
-jac-client-node = "1.0.4"
+react = "^18.2.0"
+react-dom = "^18.2.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
 
 [dependencies.npm.dev]
-"@jac-client/dev-deps" = "1.0.0"
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
 
 [dev-dependencies]
 watchdog = ">=3.0.0"
@@ -123,9 +132,9 @@ Open http://localhost:8000/cl/app
 
 ---
 
-## Understanding `cl { }`
+## Understanding `to cl:`
 
-The `cl { }` block marks frontend (client) code:
+The `to cl:` section header marks frontend (client) code -- everything below it, until the next `to X:` header or end of file, compiles to JavaScript/React:
 
 ```jac
 # This is backend code (runs on server)
@@ -143,7 +152,7 @@ def:pub MyComponent() -> JsxElement {
 
 **Key rules:**
 
-- `cl { }` code compiles to JavaScript/React
+- Code under `to cl:` (or in a `.cl.jac` file) compiles to JavaScript/React
 - `def:pub` exports functions (like React components)
 - `app()` is the required entry point
 
@@ -185,7 +194,7 @@ myapp/
     └── About.cl.jac   # Frontend page
 ```
 
-**Note:** `.cl.jac` files are automatically client-side (no `cl { }` needed).
+**Note:** `.cl.jac` files are automatically client-side (no `to cl:` header needed).
 
 ---
 

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -10,13 +10,13 @@ This tutorial covers declaring reactive state, handling user input, sharing stat
 > - Time: ~30 minutes
 
 !!! note "Reactive state, hooks, and `jac check`"
-    Some blocks below mix reactive `has` state with React-flavored helpers (`createContext`, `useContext`, async effect blocks, `props.children`). Jac's bundler wires all of this up at build time, but the static checker has not yet shipped typed stubs for the React/JSX prop boundary, so isolated `jac check` runs flag the corresponding accesses as Unknown. The patterns work as written under `jac start`.
+    Some blocks below mix reactive `has` state with React-flavored helpers (`createContext`, `useContext`, async effect blocks). Jac's bundler wires all of this up at build time, but the static checker has not yet shipped typed stubs for every React import, so isolated `jac check` runs flag the corresponding accesses as Unknown. The patterns work as written under `jac start`.
 
 ---
 
 ## Reactive State with `has`
 
-Inside `cl { }` blocks, `has` creates reactive state (like React's `useState`). Declaring `has count: int = 0;` inside a component function creates a stateful variable that persists across re-renders and triggers a UI update whenever its value changes:
+Inside client-side code (a `.cl.jac` file or a `to cl:` section), `has` creates reactive state (like React's `useState`). Declaring `has count: int = 0;` inside a component function creates a stateful variable that persists across re-renders and triggers a UI update whenever its value changes:
 
 ```jac
 to cl:
@@ -194,25 +194,43 @@ def:pub SearchResults() -> JsxElement {
 
 ### Cleanup Effects
 
-Use `can with exit` for cleanup logic (runs on unmount):
+`can with exit` generates a standalone cleanup `useEffect` -- use it for teardown that does **not** depend on a handle created at mount:
 
 ```jac
 to cl:
 
-def:pub Timer() -> JsxElement {
-    has seconds: int = 0;
+def:pub Subscriber() -> JsxElement {
+    has events: list = [];
 
-    # Setup interval on mount
     can with entry {
-        intervalId = setInterval(lambda -> None {
-            seconds = seconds + 1;
-        }, 1000);
+        subscribe_to_events();
     }
 
     # Cleanup on unmount
     can with exit {
-        clearInterval(intervalId);
+        cleanup_subscriptions();
     }
+
+    return <p>{len(events)} events</p>;
+}
+```
+
+!!! warning "Sharing a handle between setup and cleanup"
+    `can with entry` and `can with exit` compile to *separate* `useEffect` closures, so a variable created in `entry` is not visible from `exit`. When setup produces a handle that cleanup needs -- an interval id, a subscription, an event listener -- do the setup and teardown in a **single** `useEffect` whose callback *returns* the cleanup function:
+
+```jac
+to cl:
+
+import from react { useEffect }
+
+def:pub Timer() -> JsxElement {
+    has seconds: int = 0;
+
+    useEffect(lambda {
+        intervalId = setInterval(lambda { seconds = seconds + 1; }, 1000);
+        # The returned function is the cleanup -- it runs on unmount
+        return lambda { clearInterval(intervalId); };
+    }, []);
 
     return <p>Seconds: {seconds}</p>;
 }
@@ -252,8 +270,8 @@ import from react { createContext, useContext }
 # Create context
 glob AppContext = createContext(None);
 
-# Provider component
-def:pub AppProvider(props: dict) -> JsxElement {
+# Provider component -- `children` is the nested JSX passed between its tags
+def:pub AppProvider(children: any = None) -> JsxElement {
     has user: any = None;
     has theme: str = "light";
 
@@ -265,7 +283,7 @@ def:pub AppProvider(props: dict) -> JsxElement {
     };
 
     return <AppContext.Provider value={value}>
-        {props.children}
+        {children}
     </AppContext.Provider>;
 }
 


### PR DESCRIPTION
Fixes #6019.

A documentation audit found several fullstack tutorial pages with code examples that fail `jac check` against the current compiler. Every fix below was validated by running `jac check` on the extracted snippet.

## Broken code (hard errors)

- **state.md** — timer cleanup declared `intervalId` in `can with entry` and read it from `can with exit`; those compile to *separate* `useEffect` closures, so the handle is invisible to cleanup (`W2001`). Rewritten as a single manual `useEffect` that returns its cleanup, plus a warning callout on the entry/exit closure boundary.
- **backend.md / jac-client.md** — the polling effect annotated the outer lambda `-> None`, but a cleanup effect must return a function (`E1002`). Dropped the annotation.
- **components.md** — capital `Any` → lowercase `any`.
- **jac-client.md / routing.md / auth.md / state.md** — replaced `props: dict` + `props.children` / `props.get()` (`E1030` / `E1103`) with named, typed component parameters and a `children: any = None` parameter.
- **routing.md / jac-client.md** — `useParams().id` dotted access (`E1030`) → subscript access `params["id"]`.

## Stale / inconsistent

- Modernized `cl { }` prose to `to cl:` / `.cl.jac` across the fullstack tutorials.
- `root()` → bare `root` (`W0062`) in backend.md and jac-client.md.
- setup.md / jac-client.md project-structure sections now match current `jac create --use client` output (`.cl.jac` components, `assets/`, `README.md`, `AGENTS.md`, real `jac.toml` dependencies).
- diagnostics.md — added missing real compiler codes: `W0061`–`W0063`, `W1036`, `W1050`–`W1052`, `W1103`, `W1104`, and lint rules `W3020`–`W3042`.

## Also

Adds a **"Typed props and `children`"** section to components.md documenting the recommended named-parameter pattern, including the `children: any = None` requirement (a `children` param with no default is treated as required → `E1102`).

## Out of scope

`npm-and-libraries.md` uses the same `props.children` pattern but with `props: any`, which produces only the `W1052` warning rather than the `E1030` hard error — left untouched as it was not one of the audited findings.
