### PR TITLE
chore(tests): clean W2074/W1036 lint in passes/{ecmascript,native,tool} and tests/compiler

### DIFF
--- a/jac/tests/compiler/passes/ecmascript/test_esast_gen_pass.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_esast_gen_pass.jac
@@ -14,8 +14,8 @@ glob JAC_ROOT = str(Path(jaclang.__file__).parent.parent),
      );
 
 """Collect every ESTree node in a depth-first traversal."""
-def walk_es_nodes(nd: es.Node) -> list {
-    result: list = [nd];
+def walk_es_nodes(nd: es.Node) -> list[es.Node] {
+    result: list[es.Node] = [nd];
     for value in vars(nd).values() {
         if isinstance(value, es.Node) {
             result.extend(walk_es_nodes(value));

--- a/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_js_generation.jac
@@ -947,7 +947,7 @@ test "jsx text with quotes does not produce double-double quotes" {
     import re;
     unescaped_double_quotes = re.findall(r'(?<!\\)""', js_code);
     assert len(unescaped_double_quotes) == 0 , (
-        f"Unescaped double-double quotes found in generated JS — "
+        "Unescaped double-double quotes found in generated JS — "
         f"quote characters in JSX text are being double-wrapped:\n{js_code}"
     );
 
@@ -1400,7 +1400,7 @@ test "jsx preserves single-space whitespace between adjacent expression children
 
     # Second span: `{amount} {unit}` — two adjacent expressions only.
     assert "[amount, \" \", unit]" in js_code , (
-        f"Same-line adjacent `{{amount}} {{unit}}` must emit a `\" \"` "
+        "Same-line adjacent `{amount} {unit}` must emit a `\" \"` "
         f"separator child, got:\n{js_code}"
     );
 
@@ -1495,10 +1495,10 @@ test "issue 5930 sibling if else branches each get block scoped let" {
         # And follow-up reassignments inside each branch must NOT redeclare.
         # We assert the absence of `let x = 2` / `let x = 4` to lock that in.
         assert "let x = 2" not in js_code , (
-            f"in-branch reassignment must stay a bare assignment, " f"got:\n{js_code}"
+            "in-branch reassignment must stay a bare assignment, " f"got:\n{js_code}"
         );
         assert "let x = 4" not in js_code , (
-            f"in-branch reassignment must stay a bare assignment, " f"got:\n{js_code}"
+            "in-branch reassignment must stay a bare assignment, " f"got:\n{js_code}"
         );
 
         # And the emitted JS must actually execute in strict mode without
@@ -1515,12 +1515,12 @@ test "issue 5930 sibling if else branches each get block scoped let" {
             timeout=30
         );
         assert result.returncode == 0 , (
-            f"strict-mode node run failed (#5930 regression):\n"
+            "strict-mode node run failed (#5930 regression):\n"
             f"stdout={result.stdout!r}\nstderr={result.stderr!r}\n"
             f"js:\n{js_code}"
         );
         assert "ok" in result.stdout , (
-            f"node run did not reach the success print:\n"
+            "node run did not reach the success print:\n"
             f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
         );
 
@@ -1557,7 +1557,7 @@ test "sibling block scopes — elif chain each branch gets its own let" {
             timeout=30
         );
         assert result.returncode == 0 , (
-            f"strict-mode elif chain run failed:\n"
+            "strict-mode elif chain run failed:\n"
             f"stderr={result.stderr!r}\njs:\n{js_code}"
         );
         assert "ok" in result.stdout;
@@ -1592,8 +1592,8 @@ test "walrus in if-condition still hoists its let despite alt-branch scope final
         # stack-pop and map-pop in `_pop_scope`, this declaration was
         # silently dropped when the if had an else branch.
         assert "let n" in js_code , (
-            f"walrus name `n` from the if-condition must still be hoisted "
-            f"as a `let` declaration when an else branch is present, "
+            "walrus name `n` from the if-condition must still be hoisted "
+            "as a `let` declaration when an else branch is present, "
             f"got:\n{js_code}"
         );
         # And both branches must still get their per-branch `let x`
@@ -1635,7 +1635,7 @@ test "sibling block scopes — try except finally each get their own let" {
             timeout=30
         );
         assert result.returncode == 0 , (
-            f"strict-mode try/except/finally run failed:\n"
+            "strict-mode try/except/finally run failed:\n"
             f"stderr={result.stderr!r}\njs:\n{js_code}"
         );
         assert "ok" in result.stdout;
@@ -1664,7 +1664,7 @@ test "in/not in on unknown-typed containers matches Python semantics" {
         "(raw JS `in` rejects string/array operands):\n"
         f"stderr={result.stderr!r}\njs:\n{js_code}"
     );
-    got: dict = json.loads(result.stdout.strip());
+    got: dict[str, bool] = json.loads(result.stdout.strip());
     expected = {
         "str_hit": True,
         "str_miss": False,

--- a/jac/tests/compiler/passes/native/test_native_gc.jac
+++ b/jac/tests/compiler/passes/native/test_native_gc.jac
@@ -38,7 +38,7 @@ binary's stdin (used for the interactive chess fixture).
 """
 def _run_with_time(
     binary: str,
-    env_extra: dict | None = None,
+    env_extra: dict[str, str] | None = None,
     stdin_data: str | None = None,
     timeout: int = 120,
 ) -> tuple[int, int, str] {

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -809,7 +809,7 @@ test "chess play random moves stress" {
         f"stdout tail: {result.stdout[-500:] if result.stdout else '(empty)'}"
     );
     assert "Game ended." in result.stdout , (
-        f"Expected 'Game ended.' in output.\n"
+        "Expected 'Game ended.' in output.\n"
         f"stdout tail: {result.stdout[-500:] if result.stdout else '(empty)'}"
     );
 }
@@ -1652,12 +1652,12 @@ test "cache marker non native file has no llvmir section in jir" {
         data = cache_path.read_bytes();
         magic_bytes = SECTIONS_MAGIC;
         pos = data.find(magic_bytes, HEADER_SIZE);
-        secs: dict = {};
+        secs: dict[int, bytes] = {};
         if pos >= 0 {
             secs = read_sections(data, pos + len(magic_bytes));
         }
         assert SEC_LLVM_IR not in secs , (
-            f"Non-native file should not have SEC_LLVM_IR in JIR cache"
+            "Non-native file should not have SEC_LLVM_IR in JIR cache"
         );
     } except Exception as e {
         os.unlink(jac_file);
@@ -1990,13 +1990,13 @@ test "auto promote chess.jac runs via cli" {
         f"stderr: {result.stderr[-500:] if result.stderr else '(empty)'}"
     );
     assert "Game ended." in result.stdout , (
-        f"Expected 'Game ended.' in output.\n"
+        "Expected 'Game ended.' in output.\n"
         f"stdout tail: {result.stdout[-500:] if result.stdout else '(empty)'}"
     );
     # Verify the native execution message appears (may be line-wrapped by Rich)
     combined = " ".join((result.stdout + result.stderr).split());
     assert "executed natively" in combined , (
-        f"Expected native execution message.\n" f"output tail: {combined[-500:]}"
+        "Expected native execution message.\n" f"output tail: {combined[-500:]}"
     );
 }
 
@@ -2178,9 +2178,9 @@ test "string_enums comparison" {
     entry_fn = get_func(eng, "jac_entry", None);
     entry_fn();
     f = get_func(eng, "color_cmp", ctypes.c_int64, ctypes.c_int64);
-    assert f(0) == 10 , f"color_cmp(RED=0) should be 10";
-    assert f(1) == 20 , f"color_cmp(GREEN=1) should be 20";
-    assert f(2) == 30 , f"color_cmp(BLUE=2) should be 30";
+    assert f(0) == 10 , "color_cmp(RED=0) should be 10";
+    assert f(1) == 20 , "color_cmp(GREEN=1) should be 20";
+    assert f(2) == 30 , "color_cmp(BLUE=2) should be 30";
 }
 
 test "string_enums value access" {
@@ -2189,8 +2189,8 @@ test "string_enums value access" {
     entry_fn();
     f = get_func(eng, "color_value", ctypes.c_char_p, ctypes.c_int64);
     assert f(0) == b"red" , f"Color.RED.value should be 'red', got {f(0)}";
-    assert f(1) == b"green" , f"Color.GREEN.value should be 'green'";
-    assert f(2) == b"blue" , f"Color.BLUE.value should be 'blue'";
+    assert f(1) == b"green" , "Color.GREEN.value should be 'green'";
+    assert f(2) == b"blue" , "Color.BLUE.value should be 'blue'";
 }
 
 test "string_enums name access" {
@@ -2199,8 +2199,8 @@ test "string_enums name access" {
     entry_fn();
     f = get_func(eng, "color_name", ctypes.c_char_p, ctypes.c_int64);
     assert f(0) == b"RED" , f"Color.RED.name should be 'RED', got {f(0)}";
-    assert f(1) == b"GREEN" , f"Color.GREEN.name should be 'GREEN'";
-    assert f(2) == b"BLUE" , f"Color.BLUE.name should be 'BLUE'";
+    assert f(1) == b"GREEN" , "Color.GREEN.name should be 'GREEN'";
+    assert f(2) == b"BLUE" , "Color.BLUE.name should be 'BLUE'";
 }
 
 test "string_enums direction value" {
@@ -2208,8 +2208,8 @@ test "string_enums direction value" {
     entry_fn = get_func(eng, "jac_entry", None);
     entry_fn();
     f = get_func(eng, "direction_value", ctypes.c_char_p, ctypes.c_int64);
-    assert f(0) == b"N" , f"Direction.NORTH.value should be 'N'";
-    assert f(1) == b"S" , f"Direction.SOUTH.value should be 'S'";
+    assert f(0) == b"N" , "Direction.NORTH.value should be 'N'";
+    assert f(1) == b"S" , "Direction.SOUTH.value should be 'S'";
 }
 
 test "string_enums int enum still works" {
@@ -2231,7 +2231,7 @@ test "enum_import enum comparison" {
     entry_fn = get_func(eng, "jac_entry", None);
     entry_fn();
     f = get_func(eng, "use_imported_enum", ctypes.c_int64);
-    assert f() == 1 , f"TokenKind.KW_IF == TokenKind.KW_IF should return 1";
+    assert f() == 1 , "TokenKind.KW_IF == TokenKind.KW_IF should return 1";
 }
 
 test "enum_import ordinal" {

--- a/jac/tests/compiler/passes/native/test_native_lexer.jac
+++ b/jac/tests/compiler/passes/native/test_native_lexer.jac
@@ -10,6 +10,7 @@ import ctypes;
 import os;
 import sys;
 import from pathlib { Path }
+import from typing { Callable }
 import jaclang;
 import from jaclang.jac0core.codeinfo { NativeFunctionInfo }
 import from jaclang.jac0core.program { JacProgram }
@@ -476,7 +477,7 @@ test "accelerate module compiles lexer" {
     lexer_mod = sys.modules[mod_name];
 
     # Save original functions so we can restore after test
-    saved: dict = {};
+    saved: dict[str, Callable] = {};
     for (name, obj) in list(lexer_mod.__dict__.items()) {
         if callable(obj) and not name.startswith("_") {
             saved[name] = obj;

--- a/jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.jac
@@ -792,26 +792,26 @@ test "nested class impl signature fixed" {
     # NOT: (self, shared, private) which would happen if bug exists
     assert "OuterClass.InnerClass.init" in impl_defs , "OuterClass.InnerClass.init impl not found";
     inner_init_params = get_impl_params(impl_defs["OuterClass.InnerClass.init"]);
-    assert inner_init_params == ["self", "name"] , f"OuterClass.InnerClass.init should be FIXED to [self, name] "
+    assert inner_init_params == ["self", "name"] , "OuterClass.InnerClass.init should be FIXED to [self, name] "
     f"(matching InnerClass.init decl), got: {inner_init_params}. "
-    f"Original impl had [self, a, b]. "
-    f"If you got [self, shared, private], the bug is that auto-lint looked up "
-    f"OuterClass.init instead of InnerClass.init.";
+    "Original impl had [self, a, b]. "
+    "If you got [self, shared, private], the bug is that auto-lint looked up "
+    "OuterClass.init instead of InnerClass.init.";
 
     # OuterClass.AnotherInner.init should be FIXED from (self, foo) to (self, x, y)
     # (plus kwonly z, but we only check positional params here)
     assert "OuterClass.AnotherInner.init" in impl_defs , "OuterClass.AnotherInner.init impl not found";
     another_init_params = get_impl_params(impl_defs["OuterClass.AnotherInner.init"]);
-    assert another_init_params == ["self", "x", "y"] , f"OuterClass.AnotherInner.init should be FIXED to [self, x, y] "
+    assert another_init_params == ["self", "x", "y"] , "OuterClass.AnotherInner.init should be FIXED to [self, x, y] "
     f"(matching AnotherInner.init decl), got: {another_init_params}. "
-    f"Original impl had [self, foo].";
+    "Original impl had [self, foo].";
 
     # OuterClass.process should be FIXED from (wrong) to (data)
     assert "OuterClass.process" in impl_defs , "OuterClass.process impl not found";
     process_params = get_impl_params(impl_defs["OuterClass.process"]);
-    assert process_params == ["data"] , f"OuterClass.process should be FIXED to [data] "
+    assert process_params == ["data"] , "OuterClass.process should be FIXED to [data] "
     f"(matching process decl), got: {process_params}. "
-    f"Original impl had [wrong].";
+    "Original impl had [wrong].";
 }
 
 # ── TestRemoveImportSemicolons ───────────────────────────────────────────

--- a/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
@@ -169,11 +169,11 @@ test "fstring comment not injected" {
     assert fstring_idx is not None , "f-string statement was lost";
     assert after_idx is not None , "'# Comment after' was lost";
     assert before_idx < fstring_idx , (
-        f"Comment before f-string was displaced after it "
+        "Comment before f-string was displaced after it "
         f"(comment at line {before_idx + 1}, f-string at line {fstring_idx + 1}):\n" + formatted
     );
     assert after_idx > fstring_idx , (
-        f"Comment after f-string was displaced before it "
+        "Comment after f-string was displaced before it "
         f"(comment at line {after_idx + 1}, f-string at line {fstring_idx + 1}):\n" + formatted
     );
 

--- a/jac/tests/compiler/test_jir_type_tags.jac
+++ b/jac/tests/compiler/test_jir_type_tags.jac
@@ -147,18 +147,18 @@ test "name_spec restored on AstSymbolStubNode after JIR round-trip" {
     );
 
     # Sanity check: postinit-driven fresh AST has name_spec on every stub node.
-    fresh_counts: dict = {};
+    fresh_counts: dict[str, int] = {};
     for cls in stub_classes {
         nodes = mod.get_all_sub_nodes(cls);
         fresh_counts[cls.__name__] = len(nodes);
         assert len(nodes) > 0 , (
             f"Fixture should contain at least one {cls.__name__}; "
-            f"adjust jir_stub_name_spec.jac"
+            "adjust jir_stub_name_spec.jac"
         );
         for n in nodes {
             assert n.name_spec is not None , (
                 f"Fresh {cls.__name__} has no name_spec — postinit chain "
-                f"is broken (this is not a JIR bug, fixture or class is misdefined)"
+                "is broken (this is not a JIR bug, fixture or class is misdefined)"
             );
         }
     }
@@ -180,11 +180,11 @@ test "name_spec restored on AstSymbolStubNode after JIR round-trip" {
         for n in nodes {
             assert n.name_spec is not None , (
                 f"JIR deserializer dropped name_spec on {cls.__name__}. "
-                f"JirReader._read_node must fabricate a stub Name for "
-                f"AstSymbolStubNode subclasses the same way "
-                f"AstSymbolStubNode._init_stub does — otherwise "
-                f"DeclImplMatchPass._resolve_symbols_in_subtree crashes with "
-                f"AttributeError on chain[0].sym after a JIR cache hit."
+                "JirReader._read_node must fabricate a stub Name for "
+                "AstSymbolStubNode subclasses the same way "
+                "AstSymbolStubNode._init_stub does — otherwise "
+                "DeclImplMatchPass._resolve_symbols_in_subtree crashes with "
+                "AttributeError on chain[0].sym after a JIR cache hit."
             );
             # `.sym` reads self.name_spec.sym — must not raise.
             _ = n.sym;

--- a/jac/tests/compiler/test_parser.jac
+++ b/jac/tests/compiler/test_parser.jac
@@ -222,7 +222,7 @@ test "connect_disconnect_missing_rhs" {
         for e in prog.errors_had
         if e.code and e.code.code == "E0004"
     ];
-    assert len(bad) == 0 , f"E0004 leaked through after E0026 fix:\n" + "\n---\n".join(
+    assert len(bad) == 0 , "E0004 leaked through after E0026 fix:\n" + "\n---\n".join(
         e.pretty_print() for e in bad
     );
 }
@@ -941,8 +941,8 @@ test "decorated class in code block parses as archetype" {
     (mod, err) = rd_parse(load_fixture("decorated_decl_in_code_block.jac"), "");
     assert not err , "Parser reported errors for decorated declarations in code blocks";
 
-    def collect(nd: uni.UniNode) -> list {
-        results: list = [];
+    def collect(nd: uni.UniNode) -> list[uni.Archetype] {
+        results: list[uni.Archetype] = [];
         if isinstance(nd, uni.Archetype) {
             results.append(nd);
         }

--- a/jac/tests/compiler/test_rd_parser_validation.jac
+++ b/jac/tests/compiler/test_rd_parser_validation.jac
@@ -222,13 +222,13 @@ def parse_and_validate(source: str, file_path: str) -> bool {
     }
 }
 
-def strictness_test(name_snippet: tuple) {
+def strictness_test(name_snippet: tuple[str, str]) {
     (name, snippet) = name_snippet;
     rd_ast = parse_with_rd(snippet, "/tmp/strictness_test.jac");
     assert rd_ast is None , f"RD parser must reject '{name}': {snippet}";
 }
 
-def validation_strictness_test(name_snippet: tuple) {
+def validation_strictness_test(name_snippet: tuple[str, str]) {
     (name, snippet) = name_snippet;
     has_errors = parse_and_validate(snippet, "/tmp/strictness_test.jac");
     assert has_errors , f"Parser + ASTValidationPass must reject '{name}': {snippet}";


### PR DESCRIPTION
## Summary
Continuation of #6031. Extends the same lint cleanup beyond `jac/tests/compiler/passes/main/` into its sibling directories (`passes/ecmascript/`, `passes/native/`, `passes/tool/`) and the `tests/compiler/` root (non-`passes` files).

- **W2074** (\"f-string has no placeholders — use a regular string\"): drop the redundant `f` prefix on concatenated assert-message segments with no `{...}` interpolation. Purely mechanical.
- **W1036** (\"generic type used without type arguments\"): annotate each bare `list` / `dict` / `tuple` with the precise element type observed at the use site. No `Any` fallback was needed — every site had a determinable type.

After this change, `jac check` reports **0 W2074 / 0 W1036** across all 10 touched files.

## Files changed (W2074 / W1036)

| File | W2074 | W1036 |
|------|-------|-------|
| `passes/ecmascript/test_esast_gen_pass.jac` | 0 | 2 |
| `passes/ecmascript/test_js_generation.jac` | 10 | 1 |
| `passes/native/test_native_gc.jac` | 0 | 1 |
| `passes/native/test_native_gen_pass.jac` | 14 | 1 |
| `passes/native/test_native_lexer.jac` | 0 | 1 |
| `passes/tool/test_jac_auto_lint_pass.jac` | 8 | 0 |
| `passes/tool/test_jac_format_pass.jac` | 2 | 0 |
| `test_jir_type_tags.jac` | 7 | 1 |
| `test_parser.jac` | 1 | 2 |
| `test_rd_parser_validation.jac` | 0 | 2 |
| **Total** | **42** | **11** |

## Notable W1036 fixes
Each annotation was derived from local evidence at the use site, not guessed:

- `test_esast_gen_pass.jac` — `walk_es_nodes` returns `list[es.Node]` (DFS traversal collecting ESTree nodes).
- `test_js_generation.jac` — `got: dict[str, bool] = json.loads(...)` (compared against an already-typed `dict[str, bool]` expected map).
- `test_native_gc.jac` — `env_extra: dict[str, str] | None` (passed into `os.environ.copy()` merge).
- `test_native_gen_pass.jac` — `secs: dict[int, bytes]` (populated by `read_sections() -> dict[int, bytes]` from `jaclang.jac0core.jir`).
- `test_native_lexer.jac` — `saved: dict[str, Callable]` (module-attr name → callable retained for restore).
- `test_jir_type_tags.jac` — `fresh_counts: dict[str, int]` (`cls.__name__` → `len(nodes)`).
- `test_parser.jac` — `collect(...) -> list[uni.Archetype]` and `results: list[uni.Archetype]`.
- `test_rd_parser_validation.jac` — two test params typed `tuple[str, str]` (unpacked from `dict[str, str]`-sourced iterators).

## Subtle W2074 case
`test_js_generation.jac` line ~1403 used `f\"...{{amount}} {{unit}}...\"` — escaped braces inside what was an unnecessary f-string. Dropping the `f` prefix also converted the doubled-brace escapes back to literal `{...}` so the rendered output is byte-identical.

## Test plan
- [ ] `jac check` reports 0 W2074 and 0 W1036 across all 10 files.
- [ ] CI: existing test suites covered by these files still pass (no assertion logic / message text / test-name changes; only `f`-prefix removal and annotation refinement).

## What's left after this PR

With this merged, the original \"finish `jac/tests/compiler/passes/main/`\" goal is fully complete, plus the lint cleanup has been extended through `passes/ecmascript/`, `passes/native/`, `passes/tool/`, and `tests/compiler/` (non-`passes`).

Still pending from the queue in #6031:

1. **`test_checker_bugs.jac` E1053** — `Path(jaclang.__file__).parent.parent` flagged because `ModuleType.__file__` is typed `str | None` in Jac's `jac_builtins.pyi`. Pyright narrows `__file__` to `str` for statically-imported modules; Jac currently uses the generic `str | None` everywhere. Either silence with `assert jaclang.__file__ is not None;` locally, or — better — teach the type checker to narrow `__file__: str` on `import X` references where the module's source is resolvable. The same pattern reappears in `jac/jaclang/compiler/tests/test_prim_equivalence.jac:27`.
2. **`test_checker_bugs.jac` E1005** — `a_type.shared.mro = [a_type];` writes a `@property` with no setter. The other diamond-MRO setup in the same test uses `compute_mro_linearization(...)`; rewrite this manual assignment to do the same, or expose a setter / `replace_mro` helper on `ClassDetailsShared`.
3. **Production code lint sweep** — `jac/jaclang/compiler/passes/main/` itself (the production code under test) may have its own W2074/W1036 debt; worth a focused sweep.
4. **Wider test-suite sweep** — `jac/tests/` outside `compiler/` (≈51 files) hasn't been touched yet.