### PR TITLE
fix(type_system): assert prefetch class fields non-None in operations.jac

### DIFF
--- a/jac/jaclang/compiler/type_system/operations.jac
+++ b/jac/jaclang/compiler/type_system/operations.jac
@@ -134,11 +134,13 @@ def get_numeric_promotion_type(
 
     # Division always returns float
     if op == Tok.DIV {
+        assert evaluator.prefetch.float_class is not None;
         return evaluator._convert_to_instance(evaluator.prefetch.float_class);
     }
 
     # If either operand is float-like, result is float
     if left_is_float or right_is_float {
+        assert evaluator.prefetch.float_class is not None;
         return evaluator._convert_to_instance(evaluator.prefetch.float_class);
     }
 
@@ -150,6 +152,7 @@ def get_numeric_promotion_type(
 
     # If either is plain int, result is int (int is the widest integer)
     if not left_fw or not right_fw {
+        assert evaluator.prefetch.int_class is not None;
         return evaluator._convert_to_instance(evaluator.prefetch.int_class);
     }
 
@@ -268,6 +271,7 @@ def get_type_of_binary_operation(
             }
             # Although None is not a valid class, it can be used as a class in the type annotation.
             if isinstance(ty, jtypes.ClassType) {
+                assert evaluator.prefetch.none_type_class is not None;
                 return ty.shared == evaluator.prefetch.none_type_class.shared;
             }
             return False;
@@ -315,6 +319,7 @@ def get_type_of_binary_operation(
             }
             # Although None is not a valid class, it can be used as a class in the type annotation.
             if isinstance(ty, jtypes.ClassType) {
+                assert evaluator.prefetch.none_type_class is not None;
                 return ty.shared == evaluator.prefetch.none_type_class.shared;
             }
             return False;


### PR DESCRIPTION
## Summary
- Narrow `ClassType | NoneType` to `ClassType` in `get_numeric_promotion_type` before passing `prefetch.float_class` / `prefetch.int_class` to `_convert_to_instance`, clearing E1053.
- Add the same `assert ... is not None` before the two `evaluator.prefetch.none_type_class.shared` accesses inside the `is_annotation_type` helpers, clearing E1099.

## Test plan
- [ ] `jac format --lintfix jac/jaclang/compiler/type_system/operations.jac` (already run locally — no changes)
- [ ] CI type-check on `jac/jaclang/compiler/type_system/operations.jac` shows no E1053/E1099 from these sites
- [ ] Existing type-system tests still pass