### PR TITLE
docs(skills): make JSX statement slots the primary coding style

### DIFF
--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -72,6 +72,36 @@ Use the matching type even when you don't read `e`; for an event not in the tabl
 - **Validation / error boundary:** `JacSchema`, `JacClientErrorBoundary`
 - **DO NOT use:** `useState`, `useEffect` (aliases exist but `has` + `async can with entry` are idiomatic)
 
+## Statement slots: control flow inside JSX
+
+Every `{...}` in JSX child position is a **slot**. The compiler picks the shape from the body's first token:
+
+- **Expression slot** - `{name}`, `{user.email}`, `{<Badge />}`, `{"hi" if cond else "bye"}` - renders one value.
+- **Statement slot** - body starts with `for` / `if` / `while` / `match` / `switch` / `with` / `try` - each JSX statement inside pushes a child into the enclosing element. This is the primary tool for dynamic children: iteration, conditional rendering, empty-state guards, and any combination of them.
+
+```jac
+def:pub ItemList(items: list[Item]) -> JsxElement {
+    return <ul class="items">
+        {if len(items) == 0 {
+            <p class="empty">Nothing yet.</p>
+            return;                        # bare return; ends the slot early
+        }}
+        <h2>Items</h2>
+        {for (i, it) in enumerate(items) {
+            <li key={str(i)} class={"done" if it.done else "todo"}>{it.label}</li>
+        }}
+    </ul>;
+}
+```
+
+**Use a statement slot when** the body has control flow, the row has multiple JSX elements, you need an empty-state guard, you want `enumerate` with destructuring, or you'd otherwise reach for a nested ternary / `cond and <X />` chain. **Use an expression slot / list comprehension when** it's a single value or a one-line `[<li>...</li> for i in items]`.
+
+Caveats specific to slot bodies (also true of comprehensions):
+
+- A bare `return;` inside a slot exits the slot, **not** the enclosing function - the rest of the JSX still renders. Useful for "show empty state, stop here."
+- `T | None` narrowing from the surrounding function does NOT carry into a slot body (E1099). Pull narrowed attrs into typed locals *before* the JSX. See the pitfall below.
+- Slot iteration that yields keyless JSX siblings earns a `W2019` warning - add `key={...}` on the inner element.
+
 ## Pitfalls
 
 The first two bullets below are **silent runtime bugs** (⚠) - no compile error, no obvious failure mode at runtime. Read them every time.
@@ -106,9 +136,10 @@ has posts: list[Post] = [];          # `p` in `for p in posts` is typed Post
 
 - **Call server endpoints POSITIONAL, not kwargs.** `save(a, b)` works; `save(a=a, b=b)` sends empty body → 422. Also: the caller's variable names become the JSON keys - they must match the server parameter names exactly. See `jac-fullstack-patterns`.
 - **JSX ternary is Python-style:** `{X if cond else Y}`. NOT `{cond ? X : Y}` (parse error even inside JSX). Short-circuit also works: `{cond and <X />}`.
-- **Iterate with comprehensions, NOT `.map()`.** `items.map(...)` on a Jac list fails E1030. Use `[<li>...</li> for i in items]` inside JSX. `for i, x in enumerate(items)` parse-fails E0001 - use a single loop var, or `range(len(items))` with index access: `[<li key={str(i)}>{items[i]}</li> for i in range(len(items))]`.
+- **Iterate with statement slots (`{for x in xs { <li>...</li> }}`), NOT `.map()`.** `items.map(...)` on a Jac list fails E1030. A `{...}` slot whose body starts with `for`/`if`/`while`/`match`/`switch`/`with`/`try` is a **statement slot**: each JSX statement inside pushes a child into the parent. It handles `enumerate` cleanly (`for (i, x) in enumerate(items)` - parens required; bare `i, x` parse-fails E0001), composes multi-element rows naturally, and supports an empty-state guard via bare `return;` (see "Statement slots" below). Inline `[<li>...</li> for i in items]` still works for one-line element-per-item lists.
 - **Dict / hook access (`useParams()[k]`, `useLocation()[k]`, generic `[key]`) returns `any` and yields JS `undefined` for missing keys.** Since `undefined !== null` in JS, both `x is None` and `x is not None` MISS undefined - `params["id"] is not None` returns True even when `:id` isn't in the route, and `str(undefined)` produces the literal string `"undefined"`. **Use a truthy check (`if x` / `if not x`) for hook/dict values - it catches both `None` and `undefined`.** The narrowing-friendly `is not None` form is still correct for typed Optionals (`T | None` from `sv import`-ed functions, function params, etc.) where `undefined` can't appear. (Also: `params.get("id")` runtime-fails in the browser since `useParams` returns a plain JS object - always use `[key]`.)
-- **`T | None` narrowing doesn't reach inside JSX list comprehensions / short-circuits.** After `if x is None { return ...; }`, direct `x.attr` works in the function body - but `{[<li>{x.attr}</li> for i in range(len(x.attr))]}` inside JSX fails E1099 because the comprehension is its own scope. **Workaround:** pull each used attribute into a typed local *before* the JSX block (e.g. `title: str = x.title; parts: list[str] = x.parts;`), then reference the locals from JSX. See `jac-types` for the full BROKEN/CORRECT pair.
+- **`T | None` narrowing doesn't reach inside JSX statement slots, list comprehensions, or short-circuits.** After `if x is None { return ...; }`, direct `x.attr` works in the function body - but `{for i in x.parts { ... }}` or `{[<li>{x.attr}</li> for i in range(len(x.attr))]}` inside JSX fails E1099 because the slot/comprehension body is its own scope. **Workaround:** pull each used attribute into a typed local *before* the JSX block (e.g. `title: str = x.title; parts: list[str] = x.parts;`), then reference the locals from JSX. See `jac-types` for the full BROKEN/CORRECT pair.
+- **`unsafe_html(x)` opts out of escaping for raw HTML.** Ambient builtin (no import). `{unsafe_html(c.html_blob)}` renders the string as raw HTML via `dangerouslySetInnerHTML` (React) or `innerHTML` (bare-serve). Use ONLY with trusted content - the `unsafe_` prefix is the security-review marker at the call site; never wrap user input or anything that crossed an unsanitized boundary.
 - **Guard None/null/undefined when iterating or dotting into server data.** Runtime-only failure (`Cannot read properties of null/undefined`), nothing at compile. Four hot spots - single-level access is the most common:
 
 ```

--- a/jac/jaclang/cli/skills/jac-cl-organization.md
+++ b/jac/jaclang/cli/skills/jac-cl-organization.md
@@ -63,7 +63,7 @@ def:pub ItemList() -> JsxElement {
     data = useItems();
     items = data["items"] or [];
     if data["loading"] { return <p>Loading...</p>; }
-    return <ul>{[<li key={jid(i)}>{i.name}</li> for i in items if i is not None]}</ul>;
+    return <ul>{for i in items { if i is not None { <li key={jid(i)}>{i.name}</li> } }}</ul>;
 }
 ```
 

--- a/jac/jaclang/cli/skills/jac-shadcn-components.md
+++ b/jac/jaclang/cli/skills/jac-shadcn-components.md
@@ -312,12 +312,16 @@ def:pub EventListPage() -> JsxElement {
                         </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {[<TableRow key={e["id"]}>
-                            <TableCell>{e["name"]}</TableCell>
-                            <TableCell>
-                                <Badge variant="outline">{e["status"]}</Badge>
-                            </TableCell>
-                        </TableRow> for e in events if e != None]}
+                        {for e in events {
+                            if e != None {
+                                <TableRow key={e["id"]}>
+                                    <TableCell>{e["name"]}</TableCell>
+                                    <TableCell>
+                                        <Badge variant="outline">{e["status"]}</Badge>
+                                    </TableCell>
+                                </TableRow>
+                            }
+                        }}
                     </TableBody>
                 </Table>
             </CardContent>

--- a/jac/jaclang/cli/skills/jac-types.md
+++ b/jac/jaclang/cli/skills/jac-types.md
@@ -109,7 +109,7 @@ def run_callback(cb: any, payload: str) {   # cb: an opaque function reference
 - **E1032** (`Type is Unknown, cannot access attribute`) - inference couldn't figure out a variable's type. Add an explicit annotation (`x: SomeType = ...`) so the rest of the code can narrow.
 - **E1001** (`Cannot assign <Unknown> to T`) - the right-hand side's type doesn't match the declared type. Usually means you need to widen the declared type or narrow the value with an explicit cast/check.
 - **Non-default fields MUST come before defaulted ones** (E2004) - see `jac-has-fields` for the full rule.
-- **`T | None` narrowing doesn't propagate into JSX expressions or list comprehensions.** A guard like `if x is None { return ...; }` narrows `x` to `T` for the rest of the function - direct `x.attr` access works. But inside a JSX list comprehension or short-circuit (`{x and <... x.attr />}`), the narrowing doesn't carry, and `x.attr` fails E1099. **Workaround: after the narrowing guard, pull each used attribute into a typed local before the JSX block.** JSX then references the narrowed local, not the still-Optional `x`. Keep using `T | None` for the field - don't decompose into primitives.
+- **`T | None` narrowing doesn't propagate into JSX expressions, statement slots, or list comprehensions.** A guard like `if x is None { return ...; }` narrows `x` to `T` for the rest of the function - direct `x.attr` access works. But inside a JSX statement slot (`{for i in x.parts { ... }}`), a list comprehension, or a short-circuit (`{x and <... x.attr />}`), the narrowing doesn't carry, and `x.attr` fails E1099. **Workaround: after the narrowing guard, pull each used attribute into a typed local before the JSX block.** JSX then references the narrowed local, not the still-Optional `x`. Keep using `T | None` for the field - don't decompose into primitives.
 
 ```jac
 obj Recipe {                             # in a real app: `sv import`-ed from a .sv.jac
@@ -124,11 +124,12 @@ def:pub RecipeView() -> JsxElement {
     if recipe is None {
         return <div>{"loading..."}</div>;
     }
-    # FRAGILE - works for direct .title, fails for .ingredients inside comprehension
+    # FRAGILE - works for direct .title, fails for .ingredients inside the slot/comprehension
     # return <div>
-    #     <h1>{recipe.title}</h1>                                            # ok
-    #     {[<li>{recipe.ingredients[i]}</li>                                 # ✗ E1099
-    #       for i in range(len(recipe.ingredients))]}
+    #     <h1>{recipe.title}</h1>                          # ok - direct access
+    #     {for ing in recipe.ingredients {                 # ✗ E1099 - slot body is its own scope
+    #         <li key={ing}>{ing}</li>
+    #     }}
     # </div>;
 
     # CORRECT - pull narrowed attrs into typed locals before JSX
@@ -136,7 +137,9 @@ def:pub RecipeView() -> JsxElement {
     ingredients: list[str] = recipe.ingredients;
     return <div>
         <h1>{title}</h1>
-        {[<li key={str(i)}>{ingredients[i]}</li> for i in range(len(ingredients))]}
+        {for ing in ingredients {
+            <li key={ing}>{ing}</li>
+        }}
     </div>;
 }
 ```


### PR DESCRIPTION
## Summary

Follow-up to #6042, which retired `defview` and unified JSX dynamic-children rendering under the `{...}` statement-slot model with `unsafe_html` as the raw-HTML opt-in. This PR rewrites the in-tree skill files (`jac/jaclang/cli/skills/*.md`) so the new slot syntax is presented as the primary coding style for JSX children, instead of list comprehensions.

- **jac-cl-components**: flip the iteration pitfall to recommend `{for x in xs { <li>.../li> }}` over comprehensions (comprehensions remain a footnote for one-liners); add a new top-level "Statement slots" section with a canonical example covering `if` empty-state guard, `for (i, x) in enumerate(items)`, and the bare `return;` early-exit form; add an `unsafe_html(x)` pitfall bullet (escape-hatch + security-review marker); widen the `T | None` narrowing pitfall to cover slot bodies.
- **jac-cl-organization, jac-shadcn-components**: rewrite the comprehension-based list examples (`{[<li ... /> for i in items if ...]}`) in slot form so cross-skill examples are consistent with the new primary style.
- **jac-types**: widen the narrowing-doesn't-propagate rule from "JSX expressions or list comprehensions" to also mention statement slots; switch the BROKEN/CORRECT pair to slot form so the canonical reference example readers land on for this gotcha matches the new primary style.

Skills with no JSX-child-rendering content were not touched: `jac-cl-auth`, `jac-cl-routing`, `jac-cl-styling`, `jac-fullstack-patterns`, `jac-sv-*`, `jac-walker-patterns`, `jac-scaffold`, `jac-core-cheatsheet`, etc.

## Test plan

- [x] All replacement code examples validated against `jac check` via .venv (slot syntax, `enumerate` with parenthesized destructure, `unsafe_html`, narrowing+slot E1099 reproduces as documented).
- [ ] Skim the updated files in PR diff to confirm the slot framing reads cleanly.
- [ ] Sanity-check that the iteration-rule rephrase doesn't accidentally suggest comprehensions are deprecated -- they aren't, they're just no longer the lead recommendation.