### PR TITLE
fix(runtime): move app identity onto ExecutionContext to isolate in-process clients

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-client/6069.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jac-client/6069.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: read base path via `Jac.get_base_path_dir()`**: Migrated to the new accessor; the prior `Jac.base_path_dir` class attribute has been removed.

--- a/docs/docs/community/release_notes/unreleased/jac-mcp/6069.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jac-mcp/6069.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: read base path via `Jac.get_base_path_dir()`**: Migrated to the new accessor; the prior `Jac.base_path_dir` class attribute has been removed.

--- a/docs/docs/community/release_notes/unreleased/jac-scale/6069.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/6069.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: read base path via `Jac.get_base_path_dir()`**: Migrated to the new accessor; the prior `Jac.base_path_dir` class attribute has been removed.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6069.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6069.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: in-process clients no longer share app identity**: `ExecutionContext` now owns its own `base_path_dir` and `full_target_path`, so two `JacTestClient` instances (or an embedded REPL / MCP host) in the same process can't poison each other's L3 SQLite file or surface stray anchors through `allroots()`.

--- a/jac-byllm/tests/test_byllm.jac
+++ b/jac-byllm/tests/test_byllm.jac
@@ -620,9 +620,9 @@ test "byllm config defaults to gpt-4o-mini when no jac.toml" {
 test "byllm config uses full_target_path to find jac.toml regardless of cwd" {
     # cwd is /tmp, but full_target_path points at the gemini fixture —
     # the correct jac.toml must still be picked up
-    orig = JacRuntime.full_target_path;
+    orig = JacRuntime.get_full_target_path();
     orig_cwd = os.getcwd();
-    JacRuntime.full_target_path = os.path.join(GEMINI_FIXTURE, "main.jac");
+    JacRuntime.set_full_target_path(os.path.join(GEMINI_FIXTURE, "main.jac"));
     reset_byllm_config();
     os.chdir("/tmp");
     try {
@@ -630,7 +630,7 @@ test "byllm config uses full_target_path to find jac.toml regardless of cwd" {
         assert config.get_model_config()['default_model'] == "gemini/gemini-1.5-pro";
     } finally {
         os.chdir(orig_cwd);
-        JacRuntime.full_target_path = orig;
+        JacRuntime.set_full_target_path(orig);
         reset_byllm_config();
     }
 }

--- a/jac-client/jac_client/plugin/impl/client.impl.jac
+++ b/jac-client/jac_client/plugin/impl/client.impl.jac
@@ -42,7 +42,7 @@ impl JacClient.build_client_bundle(
 impl JacClient.get_client_bundle_builder -> ViteClientBundleBuilder {
     import from jaclang.project.config { find_project_root }
     # Find project root by looking for jac.toml (base_path_dir might be src/ for entry files)
-    base_path_dir = Path(Jac.base_path_dir);
+    base_path_dir = Path(Jac.get_base_path_dir());
     project_root_result = find_project_root(base_path_dir);
     if project_root_result {
         (base_path, _) = project_root_result;
@@ -100,7 +100,7 @@ impl JacClient.render_page(
         raise ValueError(f"Client function '{function_name}' not found");
     }
     import from jaclang.project.config { find_project_root, get_config }
-    base_path_dir = Path(Jac.base_path_dir);
+    base_path_dir = Path(Jac.get_base_path_dir());
     project_root_result = find_project_root(base_path_dir);
     if project_root_result {
         (base_path, _) = project_root_result;
@@ -178,7 +178,7 @@ Otherwise returns the introspector bundle.
 impl JacClient.get_client_js(introspector: ModuleIntrospector) -> str {
     import from jaclang.project.config { find_project_root, get_config }
     # Find project root
-    base_path_dir = Path(Jac.base_path_dir);
+    base_path_dir = Path(Jac.get_base_path_dir());
     project_root_result = find_project_root(base_path_dir);
     if project_root_result {
         (base_path, _) = project_root_result;

--- a/jac-mcp/jac_mcp/impl/compiler_bridge.impl.jac
+++ b/jac-mcp/jac_mcp/impl/compiler_bridge.impl.jac
@@ -523,10 +523,14 @@ impl CompilerBridge.run_snippet(
             base = base or './';
             mod_name = mod_name[:-4];  # Remove .jac
 
-            if not Jac.base_path_dir {
+            if not Jac.get_base_path_dir() {
                 Jac.set_base_path(base);
             }
-            mach = Jac.create_j_context(user_root=None);
+            mach = Jac.create_j_context(
+                user_root=None,
+                base_path_dir=Jac.get_base_path_dir(),
+                full_target_path=Jac.get_full_target_path()
+            );
             Jac.set_context(mach);
 
             try {

--- a/jac-scale/jac_scale/impl/serve.static.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.static.impl.jac
@@ -22,7 +22,9 @@ impl JacAPIServerStatic.serve_static_file(file_path: str) -> Response {
         # Find project root (where jac.toml is) instead of using base_path_dir
         # base_path_dir might be src/ when serving src/app.jac, but we need project root
         import from jaclang.project.config { find_project_root }
-        base_path_dir = Path(Jac.base_path_dir) if Jac.base_path_dir else Path.cwd();
+        base_path_dir = Path(bp_dir)
+            if (bp_dir := Jac.get_context().base_path_dir or Jac.get_base_path_dir())
+            else Path.cwd();
         project_root_result = find_project_root(base_path_dir);
         if project_root_result {
             (base_path, _) = project_root_result;
@@ -285,7 +287,9 @@ impl JacAPIServerStatic.serve_root_asset(file_path: str) -> Response {
     # Find project root (where jac.toml is) instead of using base_path_dir
     # base_path_dir might be src/ when serving src/app.jac, but we need project root
     import from jaclang.project.config { find_project_root }
-    base_path_dir = Path(Jac.base_path_dir) if Jac.base_path_dir else Path.cwd();
+    base_path_dir = Path(bp_dir)
+        if (bp_dir := Jac.get_context().base_path_dir or Jac.get_base_path_dir())
+        else Path.cwd();
     project_root_result = find_project_root(base_path_dir);
     if project_root_result {
         (base_path, _) = project_root_result;

--- a/jac-scale/jac_scale/tests/test_topology_scale.jac
+++ b/jac-scale/jac_scale/tests/test_topology_scale.jac
@@ -32,7 +32,7 @@ edge LivesIn {}
 """Serializer round-trip: topology_index_data bytes must survive serialize/deserialize."""
 test "topology_index_data survives Serializer round-trip" {
     tmpdir = mkdtemp();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     try {
         cfg = JacConfig();
         cfg.run.topology_index = True;
@@ -91,7 +91,7 @@ test "topology_index_data survives Serializer round-trip" {
 """After serialize/deserialize, resolve_chain should still work correctly."""
 test "topology index resolve_chain works after Serializer round-trip" {
     tmpdir = mkdtemp();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     try {
         cfg = JacConfig();
         cfg.run.topology_index = True;
@@ -140,7 +140,7 @@ test "topology index resolve_chain works after Serializer round-trip" {
 """Full persistence: build graph, save to SQLite, reload, verify index + queries."""
 test "topology index survives sqlite persistence round-trip" {
     tmpdir = mkdtemp();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     try {
         cfg = JacConfig();
         cfg.run.topology_index = True;

--- a/jac-scale/jac_scale/tests/test_topology_slice_pushdown.jac
+++ b/jac-scale/jac_scale/tests/test_topology_slice_pushdown.jac
@@ -108,7 +108,7 @@ def _make_scale_memory -> tuple {
 """Slicing must bound MongoDB fetches to ~slice size, not all neighbors."""
 test "edge-ref slice bounds mongodb fetches" {
     _reset_dbs();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     cfg = JacConfig();
     cfg.run.topology_index = True;
     set_config(cfg);
@@ -165,7 +165,7 @@ test "edge-ref slice bounds mongodb fetches" {
 promoted to the L2 cache (today's behavior promotes every loaded item)."""
 test "edge-ref slice bounds redis cache promotions" {
     _reset_dbs();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     cfg = JacConfig();
     cfg.run.topology_index = True;
     set_config(cfg);

--- a/jac/jaclang/cli/commands/cli_helpers.jac
+++ b/jac/jaclang/cli/commands/cli_helpers.jac
@@ -35,11 +35,17 @@ def proc_file(filename: str) -> tuple {
         `exit(1);
     }
     # Only set base path if not already set (allows tests to override)
-    if not Jac.base_path_dir {
+    if not Jac.get_base_path_dir() {
         Jac.set_base_path(base);
     }
-    # CLI contexts use system_root (no user authentication)
-    mach = Jac.create_j_context(user_root=None);
+    # CLI contexts use system_root (no user authentication). Pass the
+    # seeds explicitly so the ctx's L3 path is locked in at postinit
+    # time, immune to later seed mutations by sibling clients.
+    mach = Jac.create_j_context(
+        user_root=None,
+        base_path_dir=Jac.get_base_path_dir(),
+        full_target_path=Jac.get_full_target_path()
+    );
     Jac.set_context(mach);
     return (base, mod, mach);
 }

--- a/jac/jaclang/cli/commands/impl/db.impl.jac
+++ b/jac/jaclang/cli/commands/impl/db.impl.jac
@@ -61,14 +61,14 @@ def _resolve_app_path(explicit: str) -> (str | None) {
 backend is installed via the usual plugin hooks. Returns the live
 PersistentMemory backend, or None on error.
 
-Crucially, we set `JacRuntime.full_target_path` BEFORE creating the
-context -- `get_db_path()` / `get_name()` use that to derive the DB
-filename (`<stem>.db`), and without it the fallback is `main.db`. That
-would make `jac db` point at a different file than `jac enter` created
-(which DOES set the path via _discover_config_from_file), and the CLI
-would appear to "see no data" in an otherwise healthy DB. jac-scale
-overrides the DB path via its config loader and so masks this on
-installs that have jac-scale; pure jaclang deployments hit it.
+We pass `full_target_path` explicitly when constructing the context so
+`get_db_path()` / `get_name()` derive the DB filename from this app's
+stem. Without it the fallback is `main.db`, which would make `jac db`
+point at a different file than `jac enter` created (which DOES set the
+path via _discover_config_from_file), and the CLI would appear to "see
+no data" in an otherwise healthy DB. jac-scale overrides the DB path
+via its config loader and so masks this on installs that have
+jac-scale; pure jaclang deployments hit it.
 """
 def _load_app_and_get_l3(app_path: str) -> (PersistentMemory | None) {
     try {
@@ -81,12 +81,18 @@ def _load_app_and_get_l3(app_path: str) -> (PersistentMemory | None) {
         }
         # Match `jac enter`'s path setup so get_db_path() picks the same
         # backing file the app writes to.
-        Jac.full_target_path = abs_path;
-        if not Jac.base_path_dir {
+        Jac.set_full_target_path(abs_path);
+        if not Jac.get_base_path_dir() {
             Jac.set_base_path(base);
         }
         # Create a fresh CLI execution context so ctx.mem is wired up.
-        mach = Jac.create_j_context(user_root=None);
+        # Pass the seeds explicitly so the ctx's L3 path is locked in at
+        # postinit time, immune to later seed mutations.
+        mach = Jac.create_j_context(
+            user_root=None,
+            base_path_dir=Jac.get_base_path_dir(),
+            full_target_path=abs_path
+        );
         Jac.set_context(mach);
         Jac.jac_import(target=mod, base_path=base, override_name='__main__');
     } except Exception as e {

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -27,8 +27,8 @@ def _discover_config_from_file(filename: str) -> None {
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
 
     file_path = Path(filename).resolve();
-    # Store entry file path for runtime utilities (called before _proc_file)
-    Jac.full_target_path = str(file_path);
+    # Seed the bootstrap target so new contexts get the right L3 identity.
+    Jac.set_full_target_path(str(file_path));
     file_dir = file_path.parent;
 
     # Preserve the active profile from any previously loaded config so that

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -2454,7 +2454,10 @@ impl JacByLLM.get_mtir_from_map(scope: str) -> (Info | None) {
                    Pass user's root ID for authenticated server requests.
 
     Storage backend is configured via plugins/environment, not per-context.
-    For file backend: auto-generates path from JacRuntime.base_path_dir.
+    For file backend: the new ctx's L3 path is derived from its own
+    `base_path_dir` / `full_target_path` (passed explicitly, or seeded
+    from `Jac.get_base_path_dir()` / `Jac.get_full_target_path()` for
+    bootstrap callers that haven't been migrated to explicit args).
     For database backends (jac-scale): configured via environment variables.
     """
 impl JacUtils.create_j_context(
@@ -2568,7 +2571,7 @@ impl JacUtils.create_archetype_from_source(
     keep_temporary_files: bool = False
 ) -> (types.ModuleType | None) {
     if not base_path {
-        base_path = JacRuntime.base_path_dir or os.getcwd();
+        base_path = JacRuntime.get_base_path_dir() or os.getcwd();
     }
     if (base_path and not os.path.exists(base_path)) {
         os.makedirs(base_path);
@@ -2616,7 +2619,7 @@ impl JacUtils.update_walker(
             old_module = JacRuntime.loaded_modules[module_name];
             result = JacRuntimeInterface.jac_import(
                 target=module_name,
-                base_path=(JacRuntime.base_path_dir or os.getcwd()),
+                base_path=(JacRuntime.get_base_path_dir() or os.getcwd()),
                 items=items,
                 reload_module=True,
                 lng='jac'
@@ -2846,18 +2849,38 @@ impl JacRuntime.get_program(cls: any) -> JacProgram {
     return cls.program;
 }
 
-"""Set the base path for the machine.
+"""Return the seed base path for new contexts."""
+impl JacRuntime.get_base_path_dir -> (str | None) {
+    return _default_base_path_dir[0];
+}
+
+"""Return the seed target path for new contexts."""
+impl JacRuntime.get_full_target_path -> (str | None) {
+    return _default_full_target_path[0];
+}
+
+"""Set the seed base path used to bootstrap new contexts.
 
     When base_path is None, L3 persistence is disabled (faster for tests).
+    Already-constructed contexts are unaffected — they carry their own
+    `base_path_dir` captured at postinit time.
     """
 impl JacRuntime.set_base_path(base_path: (str | None)) -> None {
     if (base_path is None) {
-        JacRuntime.base_path_dir = None;
+        _default_base_path_dir[0] = None;
     } else {
-        JacRuntime.base_path_dir = base_path
+        _default_base_path_dir[0] = base_path
             if os.path.isdir(base_path)
             else os.path.dirname(base_path);
     }
+}
+
+"""Set the seed target path used to bootstrap new contexts.
+
+    Already-constructed contexts are unaffected.
+    """
+impl JacRuntime.set_full_target_path(target_path: (str | None)) -> None {
+    _default_full_target_path[0] = target_path;
 }
 
 """Set the context for the machine."""

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -2457,9 +2457,15 @@ impl JacByLLM.get_mtir_from_map(scope: str) -> (Info | None) {
     For file backend: auto-generates path from JacRuntime.base_path_dir.
     For database backends (jac-scale): configured via environment variables.
     """
-impl JacUtils.create_j_context(user_root: (str | None)) -> ExecutionContext {
+impl JacUtils.create_j_context(
+    user_root: (str | None),
+    base_path_dir: (str | None) = None,
+    full_target_path: (str | None) = None
+) -> ExecutionContext {
     import from jaclang.runtimelib.context { ExecutionContext }
-    ctx = ExecutionContext();
+    ctx = ExecutionContext(
+        base_path_dir=base_path_dir, full_target_path=full_target_path
+    );
     if (user_root is not None) {
         ctx.set_user_root(user_root);
     }

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -77,7 +77,16 @@ glob plugin_manager = plugin.PluginManager('jac'),
      StatusCode: TypeAlias = Literal[(200, 201, 400, 401, 404, 500, 503)],
      _request_context: ContextVar[ExecutionContext | None] = ContextVar(
          'request_context', default=None
-     );
+     ),
+     # Pre-context seeds for app identity. CLI bootstrap (`jac enter`,
+     # `jac start`, `jac db`) and pytest harnesses set these BEFORE any
+     # ExecutionContext exists; new contexts snapshot them at postinit
+     # time. Once a ctx is constructed, its own `base_path_dir` /
+     # `full_target_path` fields are authoritative — the seed cannot
+     # poison a live ctx. Live behavior always follows the ctx; these
+     # values are only consulted during ctx construction.
+     _default_base_path_dir: list = [os.getcwd()],
+     _default_full_target_path: list = [None];
 
 """Jac Access Validation Specs."""
 class JacAccessValidation {
@@ -776,12 +785,12 @@ class JacUtils {
                        Pass None for CLI/system contexts (uses system_root).
                        Pass user's root ID for authenticated server requests.
             base_path_dir: Per-context override for the L3 storage root.
-                       When None, the new context snapshots
-                       `JacRuntime.base_path_dir` at construction time.
+                       When None, the new context snapshots the bootstrap
+                       seed (`Jac.get_base_path_dir()`) at construction time.
             full_target_path: Per-context override for the app target file.
                        Drives the L3 SQLite filename via `get_db_path` /
                        `get_name`. When None, the new context snapshots
-                       `JacRuntime.full_target_path` at construction time.
+                       `Jac.get_full_target_path()` at construction time.
 
         Storage backend is configured via plugins/environment, not per-context.
         For file backend: derives the path from the context's own
@@ -1097,11 +1106,17 @@ with entry {
     plugin_manager.add_hookspecs(JacRuntimeSpec);
 }
 
-"""Jac Machine State."""
+"""Jac Machine State.
+
+App identity (`base_path_dir`, `full_target_path`) lives on
+`ExecutionContext`, not here. Bootstrap callers that need to stash a
+value before a ctx exists use `Jac.set_base_path` / `Jac.set_full_target_path`,
+which write to module-level seeds that `ExecutionContext.postinit`
+snapshots from. Live reads go through `Jac.get_context().<field>` so
+multiple in-process clients stay isolated from each other.
+"""
 class JacRuntime(JacRuntimeInterface) {
     with entry {
-        base_path_dir: (str | None) = os.getcwd();
-        full_target_path: (str | None) = None;
         compiler: (JacCompiler | None) = None;
         program: (JacProgram | None) = None;
         pool: ThreadPoolExecutor = ThreadPoolExecutor();
@@ -1129,11 +1144,32 @@ class JacRuntime(JacRuntimeInterface) {
     @classmethod
     def get_program(cls: any) -> JacProgram;
 
-    """Set the base path for the machine.
+    """Return the bootstrap-time default base path used to seed new
+    ExecutionContexts. Live reads should prefer
+    `Jac.get_context().base_path_dir`; this accessor exists for tooling
+    that needs the pre-context default (CLI bootstrap, test snapshots).
+    """
+    static def get_base_path_dir -> (str | None);
+
+    """Return the bootstrap-time default target path used to seed new
+    ExecutionContexts. Live reads should prefer
+    `Jac.get_context().full_target_path`; this accessor exists for
+    tooling that needs the pre-context default.
+    """
+    static def get_full_target_path -> (str | None);
+
+    """Set the seed base path used by new ExecutionContexts.
 
         When base_path is None, L3 persistence is disabled (faster for tests).
+        Mutates only the seed — already-constructed contexts are unaffected.
         """
     static def set_base_path(base_path: (str | None)) -> None;
+
+    """Set the seed target path used by new ExecutionContexts.
+
+        Mutates only the seed — already-constructed contexts are unaffected.
+        """
+    static def set_full_target_path(target_path: (str | None)) -> None;
 
     """Set the context for the machine (global, for backward compatibility)."""
     static def set_context(context: ExecutionContext) -> None;

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -775,12 +775,26 @@ class JacUtils {
             user_root: User root ID for permission boundary. Required parameter.
                        Pass None for CLI/system contexts (uses system_root).
                        Pass user's root ID for authenticated server requests.
+            base_path_dir: Per-context override for the L3 storage root.
+                       When None, the new context snapshots
+                       `JacRuntime.base_path_dir` at construction time.
+            full_target_path: Per-context override for the app target file.
+                       Drives the L3 SQLite filename via `get_db_path` /
+                       `get_name`. When None, the new context snapshots
+                       `JacRuntime.full_target_path` at construction time.
 
         Storage backend is configured via plugins/environment, not per-context.
-        For file backend: auto-generates path from JacRuntime.base_path_dir.
+        For file backend: derives the path from the context's own
+        `base_path_dir` / `full_target_path` (either passed explicitly here
+        or snapshotted from JacRuntime). Subsequent mutations to the global
+        statics never poison an already-constructed ctx.
         For database backends (jac-scale): configured via environment variables.
         """
-    static def create_j_context(user_root: (str | None)) -> ExecutionContext;
+    static def create_j_context(
+        user_root: (str | None),
+        base_path_dir: (str | None) = None,
+        full_target_path: (str | None) = None
+    ) -> ExecutionContext;
 
     """Attach a JacProgram to the machine."""
     static def attach_program(jac_program: JacProgram) -> None;

--- a/jac/jaclang/project/impl/plugin_config.impl.jac
+++ b/jac/jaclang/project/impl/plugin_config.impl.jac
@@ -22,7 +22,7 @@ impl deep_merge(base: dict[str, any], override_dict: dict[str, any]) -> dict[str
 
 """Initialize config loader with project directory."""
 impl PluginConfigBase.postinit{
-    full_target = JacRuntime.full_target_path;
+    full_target = JacRuntime.get_full_target_path();
     project_root_result = find_project_root(Path(full_target)) if full_target else None;
     self.project_dir = (
         self.project_dir

--- a/jac/jaclang/pytest_plugin.py
+++ b/jac/jaclang/pytest_plugin.py
@@ -103,11 +103,18 @@ def _fresh_jac_state(*, clear_modules: bool = True):
         JacRuntime.loaded_modules.clear()
 
     # Set up fresh state with isolated storage (temp directory avoids
-    # stale SQLite data from previous tests)
-    JacRuntime.base_path_dir = tempfile.mkdtemp()
+    # stale SQLite data from previous tests). Seed the bootstrap default
+    # so any subsequent `ExecutionContext()` without explicit args picks
+    # it up. The session-wide exec_ctx is constructed with the seed
+    # passed explicitly so its L3 path is locked in at construction.
+    fresh_base = tempfile.mkdtemp()
+    JacRuntime.set_base_path(fresh_base)
+    JacRuntime.set_full_target_path(None)
     JacRuntime.program = JacProgram()
     JacRuntime.pool = ThreadPoolExecutor()
-    JacRuntime.exec_ctx = JacRuntimeInterface.create_j_context(user_root=None)
+    JacRuntime.exec_ctx = JacRuntimeInterface.create_j_context(
+        user_root=None, base_path_dir=fresh_base, full_target_path=None
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/jac/jaclang/runtimelib/context.jac
+++ b/jac/jaclang/runtimelib/context.jac
@@ -51,13 +51,13 @@ obj ExecutionContext {
         call_state: ContextVar[CallState] = ContextVar('call_state'),
         # Per-context app identity. These decide which L3 backing file
         # ctx.mem points at (via `get_db_path` / `get_name`). Carrying
-        # them on the context rather than on `JacRuntime` statics is what
-        # isolates multiple in-process clients (JacTestClient, embedded
-        # REPL, MCP host) from each other — a stale `full_target_path`
-        # from a prior client cannot poison a freshly-constructed ctx.
-        # If left at None, postinit snapshots from `JacRuntime.base_path_dir`
-        # / `JacRuntime.full_target_path` for back-compat with CLI flows
-        # that set those globals up front.
+        # them on the context isolates multiple in-process clients
+        # (JacTestClient, embedded REPL, MCP host) from each other — a
+        # stale seed from a prior client cannot poison a constructed
+        # ctx. If left at None, postinit snapshots from the bootstrap
+        # seeds (`Jac.get_base_path_dir()` / `Jac.get_full_target_path()`)
+        # so CLI flows that seed app identity before any ctx exists keep
+        # working unchanged.
         base_path_dir: (str | None) = None,
         full_target_path: (str | None) = None,
         # Per-request fork support. When `_parent` is set, postinit skips

--- a/jac/jaclang/runtimelib/context.jac
+++ b/jac/jaclang/runtimelib/context.jac
@@ -49,6 +49,17 @@ obj ExecutionContext {
         user_root: NodeAnchor by postinit,
         entry_node: NodeAnchor by postinit,
         call_state: ContextVar[CallState] = ContextVar('call_state'),
+        # Per-context app identity. These decide which L3 backing file
+        # ctx.mem points at (via `get_db_path` / `get_name`). Carrying
+        # them on the context rather than on `JacRuntime` statics is what
+        # isolates multiple in-process clients (JacTestClient, embedded
+        # REPL, MCP host) from each other — a stale `full_target_path`
+        # from a prior client cannot poison a freshly-constructed ctx.
+        # If left at None, postinit snapshots from `JacRuntime.base_path_dir`
+        # / `JacRuntime.full_target_path` for back-compat with CLI flows
+        # that set those globals up front.
+        base_path_dir: (str | None) = None,
+        full_target_path: (str | None) = None,
         # Per-request fork support. When `_parent` is set, postinit skips
         # creating fresh Memory/system_root and instead shares them with
         # the parent ctx. This lets the server stamp out lightweight

--- a/jac/jaclang/runtimelib/impl/context.impl.jac
+++ b/jac/jaclang/runtimelib/impl/context.impl.jac
@@ -25,16 +25,16 @@ impl ExecutionContext.postinit -> None {
         self.full_target_path = self._parent.full_target_path;
         return;
     }
-    # Snapshot app identity from process-global JacRuntime defaults when
+    # Snapshot app identity from the module-level bootstrap seeds when
     # the caller did not pass explicit values. Doing the snapshot here —
-    # rather than reading the globals later from `get_name`/`get_db_path`
+    # rather than reading the seeds later from `get_name`/`get_db_path`
     # — is what locks in this ctx's persistence path at construction
-    # time, immune to later mutations of the globals by sibling clients.
+    # time, immune to later seed mutations by sibling clients.
     if self.base_path_dir is None {
-        self.base_path_dir = JacRuntime.base_path_dir;
+        self.base_path_dir = JacRuntime.get_base_path_dir();
     }
     if self.full_target_path is None {
-        self.full_target_path = JacRuntime.full_target_path;
+        self.full_target_path = JacRuntime.get_full_target_path();
     }
     # Create TieredMemory - persistence only enabled if base_path_dir is
     # explicitly set. If base_path_dir is None, no L3 persistence (faster

--- a/jac/jaclang/runtimelib/impl/context.impl.jac
+++ b/jac/jaclang/runtimelib/impl/context.impl.jac
@@ -21,11 +21,27 @@ impl ExecutionContext.postinit -> None {
         self.system_root = self._parent.system_root;
         self.user_root = self._parent.user_root;
         self.entry_node = self._parent.entry_node;
+        self.base_path_dir = self._parent.base_path_dir;
+        self.full_target_path = self._parent.full_target_path;
         return;
     }
-    # Create TieredMemory - persistence only enabled if base_path_dir is explicitly set
-    # If base_path_dir is None, no L3 persistence (faster for tests)
-    self.mem = TieredMemory(base_path=JacRuntime.base_path_dir);
+    # Snapshot app identity from process-global JacRuntime defaults when
+    # the caller did not pass explicit values. Doing the snapshot here —
+    # rather than reading the globals later from `get_name`/`get_db_path`
+    # — is what locks in this ctx's persistence path at construction
+    # time, immune to later mutations of the globals by sibling clients.
+    if self.base_path_dir is None {
+        self.base_path_dir = JacRuntime.base_path_dir;
+    }
+    if self.full_target_path is None {
+        self.full_target_path = JacRuntime.full_target_path;
+    }
+    # Create TieredMemory - persistence only enabled if base_path_dir is
+    # explicitly set. If base_path_dir is None, no L3 persistence (faster
+    # for tests).
+    self.mem = TieredMemory(
+        base_path=self.base_path_dir, target_path=self.full_target_path
+    );
     # Try to load system root from storage (TieredMemory handles L1/L3 lookup)
     system_root = cast((NodeAnchor | None), self.mem.get(UUID(Con.SUPER_ROOT_UUID)));
     # Create system root if not found

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -1530,9 +1530,9 @@ impl TieredMemory.postinit -> None {
     if self.base_path {
         # Use project.db for projects, filename.db for standalone apps.
         # `target_path` is the per-context app identity — without it,
-        # `get_db_path` would fall back to the process-global
-        # `JacRuntime.full_target_path`, which can leak across in-process
-        # clients (see context.impl.jac for the rationale).
+        # `get_db_path` would fall back to `Jac.get_full_target_path()`
+        # (the bootstrap seed), which can leak across in-process clients
+        # (see context.impl.jac for the rationale).
         db_path = get_db_path(self.base_path, target_path=self.target_path);
         self.l3 = SqliteMemory(path=db_path);
     } else {

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -1528,8 +1528,12 @@ impl TieredMemory.postinit -> None {
     }
     # Initialize L3 persistence if base_path provided
     if self.base_path {
-        # Use project.db for projects, filename.db for standalone apps
-        db_path = get_db_path(self.base_path);
+        # Use project.db for projects, filename.db for standalone apps.
+        # `target_path` is the per-context app identity — without it,
+        # `get_db_path` would fall back to the process-global
+        # `JacRuntime.full_target_path`, which can leak across in-process
+        # clients (see context.impl.jac for the rationale).
+        db_path = get_db_path(self.base_path, target_path=self.target_path);
         self.l3 = SqliteMemory(path=db_path);
     } else {
         self.l3 = None;

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -1644,12 +1644,13 @@ impl JacAPIServer.create_handler -> type[BaseHTTPRequestHandler] {
             );
             if (is_static_path or is_asset_file) {
                 try {
-                    # Find project root (where jac.toml is) instead of using base_path_dir
-                    # base_path_dir might be src/ when serving src/app.jac, but we need project root
+                    # Find project root (where jac.toml is) instead of using base_path_dir.
+                    # base_path_dir might be src/ when serving src/app.jac, but we
+                    # need project root. Prefer the live ctx's base_path_dir; fall
+                    # back to the seed for non-request paths.
                     import from jaclang.project.config { find_project_root }
-                    base_path_dir = Path(Jac.base_path_dir)
-                        if Jac.base_path_dir
-                        else Path.cwd();
+                    bp_dir = Jac.get_context().base_path_dir or Jac.get_base_path_dir();
+                    base_path_dir = Path(bp_dir) if bp_dir else Path.cwd();
                     project_root_result = find_project_root(base_path_dir);
                     if project_root_result {
                         (base_path, _) = project_root_result;

--- a/jac/jaclang/runtimelib/impl/testing.impl.jac
+++ b/jac/jaclang/runtimelib/impl/testing.impl.jac
@@ -65,11 +65,11 @@ impl JacTestClient._ensure_initialized -> None {
     Jac.set_base_path(self._base_path);
     # Create execution context with this client's OWN base_path + target.
     # Passing them explicitly is what isolates one in-process client from
-    # another: if a prior client (or CLI command) left
-    # `JacRuntime.full_target_path` pointing at a different app, the new
-    # ctx would otherwise inherit that stale identity and `allroots()` /
-    # L3 file routing would mix across clients. See test_context_isolation
-    # for the contract this pins.
+    # another: if a prior client (or CLI command) left a bootstrap seed
+    # pointing at a different app, the new ctx would otherwise inherit
+    # that stale identity and `allroots()` / L3 file routing would mix
+    # across clients. See test_context_isolation for the contract this
+    # pins.
     mach = Jac.create_j_context(
         user_root=None, base_path_dir=self._base_path, full_target_path=self._jac_file
     );

--- a/jac/jaclang/runtimelib/impl/testing.impl.jac
+++ b/jac/jaclang/runtimelib/impl/testing.impl.jac
@@ -63,8 +63,16 @@ impl JacTestClient._ensure_initialized -> None {
     }
     # Set base path for isolated storage
     Jac.set_base_path(self._base_path);
-    # Create execution context
-    mach = Jac.create_j_context(user_root=None);
+    # Create execution context with this client's OWN base_path + target.
+    # Passing them explicitly is what isolates one in-process client from
+    # another: if a prior client (or CLI command) left
+    # `JacRuntime.full_target_path` pointing at a different app, the new
+    # ctx would otherwise inherit that stale identity and `allroots()` /
+    # L3 file routing would mix across clients. See test_context_isolation
+    # for the contract this pins.
+    mach = Jac.create_j_context(
+        user_root=None, base_path_dir=self._base_path, full_target_path=self._jac_file
+    );
     Jac.set_context(mach);
     # Load the Jac module
     Jac.jac_import(target=mod, base_path=base, lng="jac");

--- a/jac/jaclang/runtimelib/impl/utils.impl.jac
+++ b/jac/jaclang/runtimelib/impl/utils.impl.jac
@@ -238,15 +238,18 @@ impl sys_path_context(path: str) -> Iterator[None] {
 }
 
 """Get project name from jac.toml if exists, None otherwise."""
-impl get_name -> str | None {
+impl get_name(target_path: (str | None) = None) -> str | None {
     import from pathlib { Path }
     import from jaclang.project.config { get_config }
     import from jaclang.jac0core.runtime { JacRuntime }
 
-    if not JacRuntime.full_target_path {
+    # Per-context target wins; fall back to the process-global only when
+    # no caller-supplied identity is available.
+    effective_target = target_path or JacRuntime.full_target_path;
+    if not effective_target {
         return None;
     }
-    file_path = Path(JacRuntime.full_target_path);
+    file_path = Path(effective_target);
 
     try {
         # Check ONLY the same directory as the entry file (not parent directories)
@@ -270,7 +273,7 @@ impl get_name -> str | None {
 - Standalone files (no jac.toml) → .jac/data/filename.db
 - Override via JAC_DATA_PATH env var (for AppImage/sidecar mode)
 """
-impl get_db_path(base_path: str) -> (str | None) {
+impl get_db_path(base_path: str, target_path: (str | None) = None) -> (str | None) {
     import os;
     import from pathlib { Path }
     # Check for data path override (used in AppImage/sidecar mode where base_path is read-only)
@@ -282,7 +285,7 @@ impl get_db_path(base_path: str) -> (str | None) {
         data_dir = Path(base_path) / ".jac" / "data";
     }
     # Get project name (either from jac.toml in same dir, or filename stem)
-    if (project_name := get_name()) {
+    if (project_name := get_name(target_path=target_path)) {
         return str(data_dir / f"{project_name}.db");
     }
 

--- a/jac/jaclang/runtimelib/impl/utils.impl.jac
+++ b/jac/jaclang/runtimelib/impl/utils.impl.jac
@@ -243,9 +243,9 @@ impl get_name(target_path: (str | None) = None) -> str | None {
     import from jaclang.project.config { get_config }
     import from jaclang.jac0core.runtime { JacRuntime }
 
-    # Per-context target wins; fall back to the process-global only when
+    # Per-context target wins; fall back to the bootstrap seed only when
     # no caller-supplied identity is available.
-    effective_target = target_path or JacRuntime.full_target_path;
+    effective_target = target_path or JacRuntime.get_full_target_path();
     if not effective_target {
         return None;
     }

--- a/jac/jaclang/runtimelib/memory.jac
+++ b/jac/jaclang/runtimelib/memory.jac
@@ -284,11 +284,11 @@ jac-scale extends this by providing Redis-based L2 and database L3.
 obj TieredMemory(VolatileMemory) {
     has base_path: (str | None) = None,
         # App identity used to derive the L3 SQLite filename. When None,
-        # `get_db_path` falls back to `JacRuntime.full_target_path` for
-        # back-compat with CLI flows that set that global up front. The
+        # `get_db_path` falls back to `Jac.get_full_target_path()` (the
+        # bootstrap seed) for compatibility with CLI flows. The
         # ExecutionContext that owns this memory passes its own captured
         # `full_target_path` here so the filename is decided at this
-        # memory's construction time, not by later global mutations.
+        # memory's construction time, not by later seed mutations.
         target_path: (str | None) = None,
         l2: (CacheMemory | None) by postinit,
         l3: (PersistentMemory | None) by postinit,

--- a/jac/jaclang/runtimelib/memory.jac
+++ b/jac/jaclang/runtimelib/memory.jac
@@ -283,6 +283,13 @@ jac-scale extends this by providing Redis-based L2 and database L3.
 """
 obj TieredMemory(VolatileMemory) {
     has base_path: (str | None) = None,
+        # App identity used to derive the L3 SQLite filename. When None,
+        # `get_db_path` falls back to `JacRuntime.full_target_path` for
+        # back-compat with CLI flows that set that global up front. The
+        # ExecutionContext that owns this memory passes its own captured
+        # `full_target_path` here so the filename is decided at this
+        # memory's construction time, not by later global mutations.
+        target_path: (str | None) = None,
         l2: (CacheMemory | None) by postinit,
         l3: (PersistentMemory | None) by postinit,
         use_cache: bool = False;

--- a/jac/jaclang/runtimelib/sv_client.jac
+++ b/jac/jaclang/runtimelib/sv_client.jac
@@ -117,7 +117,8 @@ def _ensure_available(module_name: str) -> None {
         return;
     }
     import jaclang;
-    base_path = jaclang.JacRuntime?.base_path_dir or '.';
+    bp = jaclang.JacRuntime.get_base_path_dir() if jaclang?.JacRuntime else None;
+    base_path = bp or '.';
     jaclang.JacRuntime.ensure_sv_service(module_name, base_path);
 }
 

--- a/jac/jaclang/runtimelib/utils.jac
+++ b/jac/jaclang/runtimelib/utils.jac
@@ -63,11 +63,21 @@ def to_uuid(id: (UUID | str)) -> UUID {
     return UUID(str(id));
 }
 
-"""Get project name from jac.toml if exists in same directory, None otherwise."""
-def get_name -> (str | None);
+"""Get project name from jac.toml if exists in same directory, None otherwise.
+
+`target_path` is the entry-file path used to discover the project — when
+omitted, falls back to the process-global `JacRuntime.full_target_path`
+for back-compat. Callers that own a per-context identity (an
+ExecutionContext, a JacTestClient) should pass it explicitly so the
+result is independent of ambient global state.
+"""
+def get_name(target_path: (str | None) = None) -> (str | None);
 
 """Get database path:
 - Projects (jac.toml in same dir) → .jac/data/project-name.db
 - Standalone files (no jac.toml) → .jac/data/filename.db
+
+`target_path` is forwarded to `get_name` to derive the filename; see
+`get_name` for back-compat behavior when omitted.
 """
-def get_db_path(base_path: str) -> (str | None);
+def get_db_path(base_path: str, target_path: (str | None) = None) -> (str | None);

--- a/jac/jaclang/runtimelib/utils.jac
+++ b/jac/jaclang/runtimelib/utils.jac
@@ -66,10 +66,10 @@ def to_uuid(id: (UUID | str)) -> UUID {
 """Get project name from jac.toml if exists in same directory, None otherwise.
 
 `target_path` is the entry-file path used to discover the project — when
-omitted, falls back to the process-global `JacRuntime.full_target_path`
-for back-compat. Callers that own a per-context identity (an
-ExecutionContext, a JacTestClient) should pass it explicitly so the
-result is independent of ambient global state.
+omitted, falls back to `Jac.get_full_target_path()` (the bootstrap seed).
+Callers that own a per-context identity (an ExecutionContext, a
+JacTestClient) should pass it explicitly so the result is independent
+of ambient seed state.
 """
 def get_name(target_path: (str | None) = None) -> (str | None);
 

--- a/jac/tests/runtimelib/test_context_isolation.jac
+++ b/jac/tests/runtimelib/test_context_isolation.jac
@@ -1,14 +1,17 @@
 """Tests for ExecutionContext isolation from stale ambient runtime state.
 
-`JacRuntime.base_path_dir` and `JacRuntime.full_target_path` are process-global
-statics that decide where each `ExecutionContext`'s L3 SQLite file lives. Two
-clients in the same process (notably `JacTestClient` instances) need to be
-isolated from each other — a stale `full_target_path` from a prior client must
-not poison the L3 filename of a freshly-created context.
+App identity (`base_path_dir`, `full_target_path`) used to live on
+`JacRuntime` as process-global statics that decided each
+`ExecutionContext`'s L3 SQLite file. Two clients in the same process
+(notably `JacTestClient` instances) need to be isolated from each
+other — a stale `full_target_path` from a prior client must not poison
+the L3 filename of a freshly-created context.
 
 These tests pin the contract: an ExecutionContext's persistence path is
-decided by its own per-context base_path/target_path, not by whatever global
-value happens to be set at construction time.
+decided by its own per-context base_path/target_path, captured at
+construction time. The pre-context seeds (`Jac.set_base_path` /
+`Jac.set_full_target_path`) only feed contexts that don't get explicit
+values; subsequent seed mutations cannot poison a live ctx.
 """
 
 import os;
@@ -19,7 +22,7 @@ import from jaclang.runtimelib.memory { TieredMemory }
 import from jaclang.jac0core.runtime { JacRuntime }
 
 
-test "ExecutionContext uses explicit per-context target_path, ignoring stale ambient state" {
+test "ExecutionContext uses explicit per-context target_path, ignoring stale seed state" {
     # Standalone .jac files (no jac.toml in their directory) — `get_name`
     # resolves to the filename stem, which gives us two distinct
     # identities to assert on without relying on the JacConfig cache
@@ -27,13 +30,13 @@ test "ExecutionContext uses explicit per-context target_path, ignoring stale amb
     with TemporaryDirectory() as proj_a, TemporaryDirectory() as proj_b {
         a_target = str(Path(proj_a) / "alpha_app.jac");
         b_target = str(Path(proj_b) / "beta_app.jac");
-        orig_base = JacRuntime.base_path_dir;
-        orig_target = JacRuntime.full_target_path;
+        orig_base = JacRuntime.get_base_path_dir();
+        orig_target = JacRuntime.get_full_target_path();
         orig_ctx = JacRuntime.exec_ctx;
         try {
-            # Stale ambient state from a hypothetical prior client/CLI run.
-            JacRuntime.base_path_dir = proj_a;
-            JacRuntime.full_target_path = a_target;
+            # Stale seed state from a hypothetical prior client/CLI run.
+            JacRuntime.set_base_path(proj_a);
+            JacRuntime.set_full_target_path(a_target);
 
             # A new context constructed with EXPLICIT per-context base and
             # target — this is the contract a multi-client process needs.
@@ -47,12 +50,12 @@ test "ExecutionContext uses explicit per-context target_path, ignoring stale amb
             # The L3 file must live under proj_b and use beta's identity.
             assert proj_b in l3_path , f"L3 path {l3_path} not under proj_b";
             assert "beta_app" in os.path.basename(l3_path) , f"L3 filename {l3_path} should reflect 'beta_app'";
-            assert "alpha_app" not in l3_path , f"L3 path {l3_path} leaked stale ambient 'alpha_app'";
+            assert "alpha_app" not in l3_path , f"L3 path {l3_path} leaked stale seed 'alpha_app'";
 
             ctx.close();
         } finally {
-            JacRuntime.base_path_dir = orig_base;
-            JacRuntime.full_target_path = orig_target;
+            JacRuntime.set_base_path(orig_base);
+            JacRuntime.set_full_target_path(orig_target);
             JacRuntime.exec_ctx = orig_ctx;
         }
     }
@@ -63,8 +66,8 @@ test "two ExecutionContexts in one process keep independent persistence paths" {
     with TemporaryDirectory() as proj_a, TemporaryDirectory() as proj_b {
         a_target = str(Path(proj_a) / "alpha_app.jac");
         b_target = str(Path(proj_b) / "beta_app.jac");
-        orig_base = JacRuntime.base_path_dir;
-        orig_target = JacRuntime.full_target_path;
+        orig_base = JacRuntime.get_base_path_dir();
+        orig_target = JacRuntime.get_full_target_path();
         orig_ctx = JacRuntime.exec_ctx;
         try {
             ctx_a = ExecutionContext(base_path_dir=proj_a, full_target_path=a_target);
@@ -80,25 +83,26 @@ test "two ExecutionContexts in one process keep independent persistence paths" {
             ctx_a.close();
             ctx_b.close();
         } finally {
-            JacRuntime.base_path_dir = orig_base;
-            JacRuntime.full_target_path = orig_target;
+            JacRuntime.set_base_path(orig_base);
+            JacRuntime.set_full_target_path(orig_target);
             JacRuntime.exec_ctx = orig_ctx;
         }
     }
 }
 
 
-test "ExecutionContext without explicit base/target falls back to JacRuntime statics" {
-    # Back-compat: existing call sites (CLI commands, plugins) that construct
-    # `ExecutionContext()` with no args keep reading from the process-global
-    # JacRuntime fields the same way they always have.
+test "ExecutionContext without explicit base/target falls back to JacRuntime seeds" {
+    # Back-compat: existing call sites (CLI commands, plugins) that
+    # construct `ExecutionContext()` with no args get values from the
+    # pre-context seeds set via `Jac.set_base_path` /
+    # `Jac.set_full_target_path`.
     with TemporaryDirectory() as tmpdir {
-        orig_base = JacRuntime.base_path_dir;
-        orig_target = JacRuntime.full_target_path;
+        orig_base = JacRuntime.get_base_path_dir();
+        orig_target = JacRuntime.get_full_target_path();
         orig_ctx = JacRuntime.exec_ctx;
         try {
-            JacRuntime.base_path_dir = tmpdir;
-            JacRuntime.full_target_path = str(Path(tmpdir) / "standalone.jac");
+            JacRuntime.set_base_path(tmpdir);
+            JacRuntime.set_full_target_path(str(Path(tmpdir) / "standalone.jac"));
 
             ctx = ExecutionContext();
             assert isinstance(ctx.mem, TieredMemory);
@@ -110,8 +114,8 @@ test "ExecutionContext without explicit base/target falls back to JacRuntime sta
 
             ctx.close();
         } finally {
-            JacRuntime.base_path_dir = orig_base;
-            JacRuntime.full_target_path = orig_target;
+            JacRuntime.set_base_path(orig_base);
+            JacRuntime.set_full_target_path(orig_target);
             JacRuntime.exec_ctx = orig_ctx;
         }
     }

--- a/jac/tests/runtimelib/test_context_isolation.jac
+++ b/jac/tests/runtimelib/test_context_isolation.jac
@@ -1,0 +1,118 @@
+"""Tests for ExecutionContext isolation from stale ambient runtime state.
+
+`JacRuntime.base_path_dir` and `JacRuntime.full_target_path` are process-global
+statics that decide where each `ExecutionContext`'s L3 SQLite file lives. Two
+clients in the same process (notably `JacTestClient` instances) need to be
+isolated from each other — a stale `full_target_path` from a prior client must
+not poison the L3 filename of a freshly-created context.
+
+These tests pin the contract: an ExecutionContext's persistence path is
+decided by its own per-context base_path/target_path, not by whatever global
+value happens to be set at construction time.
+"""
+
+import os;
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from jaclang.runtimelib.context { ExecutionContext }
+import from jaclang.runtimelib.memory { TieredMemory }
+import from jaclang.jac0core.runtime { JacRuntime }
+
+
+test "ExecutionContext uses explicit per-context target_path, ignoring stale ambient state" {
+    # Standalone .jac files (no jac.toml in their directory) — `get_name`
+    # resolves to the filename stem, which gives us two distinct
+    # identities to assert on without relying on the JacConfig cache
+    # state (which is process-global and out of scope here).
+    with TemporaryDirectory() as proj_a, TemporaryDirectory() as proj_b {
+        a_target = str(Path(proj_a) / "alpha_app.jac");
+        b_target = str(Path(proj_b) / "beta_app.jac");
+        orig_base = JacRuntime.base_path_dir;
+        orig_target = JacRuntime.full_target_path;
+        orig_ctx = JacRuntime.exec_ctx;
+        try {
+            # Stale ambient state from a hypothetical prior client/CLI run.
+            JacRuntime.base_path_dir = proj_a;
+            JacRuntime.full_target_path = a_target;
+
+            # A new context constructed with EXPLICIT per-context base and
+            # target — this is the contract a multi-client process needs.
+            ctx = ExecutionContext(base_path_dir=proj_b, full_target_path=b_target);
+
+            assert isinstance(ctx.mem, TieredMemory);
+            l3 = ctx.mem.l3;
+            assert l3 is not None , "L3 not initialized";
+            l3_path = l3.path;
+
+            # The L3 file must live under proj_b and use beta's identity.
+            assert proj_b in l3_path , f"L3 path {l3_path} not under proj_b";
+            assert "beta_app" in os.path.basename(l3_path) , f"L3 filename {l3_path} should reflect 'beta_app'";
+            assert "alpha_app" not in l3_path , f"L3 path {l3_path} leaked stale ambient 'alpha_app'";
+
+            ctx.close();
+        } finally {
+            JacRuntime.base_path_dir = orig_base;
+            JacRuntime.full_target_path = orig_target;
+            JacRuntime.exec_ctx = orig_ctx;
+        }
+    }
+}
+
+
+test "two ExecutionContexts in one process keep independent persistence paths" {
+    with TemporaryDirectory() as proj_a, TemporaryDirectory() as proj_b {
+        a_target = str(Path(proj_a) / "alpha_app.jac");
+        b_target = str(Path(proj_b) / "beta_app.jac");
+        orig_base = JacRuntime.base_path_dir;
+        orig_target = JacRuntime.full_target_path;
+        orig_ctx = JacRuntime.exec_ctx;
+        try {
+            ctx_a = ExecutionContext(base_path_dir=proj_a, full_target_path=a_target);
+            ctx_b = ExecutionContext(base_path_dir=proj_b, full_target_path=b_target);
+
+            a_path = ctx_a.mem.l3.path;
+            b_path = ctx_b.mem.l3.path;
+
+            assert a_path != b_path , "two contexts collapsed onto the same L3 file";
+            assert proj_a in a_path and "alpha_app" in os.path.basename(a_path);
+            assert proj_b in b_path and "beta_app" in os.path.basename(b_path);
+
+            ctx_a.close();
+            ctx_b.close();
+        } finally {
+            JacRuntime.base_path_dir = orig_base;
+            JacRuntime.full_target_path = orig_target;
+            JacRuntime.exec_ctx = orig_ctx;
+        }
+    }
+}
+
+
+test "ExecutionContext without explicit base/target falls back to JacRuntime statics" {
+    # Back-compat: existing call sites (CLI commands, plugins) that construct
+    # `ExecutionContext()` with no args keep reading from the process-global
+    # JacRuntime fields the same way they always have.
+    with TemporaryDirectory() as tmpdir {
+        orig_base = JacRuntime.base_path_dir;
+        orig_target = JacRuntime.full_target_path;
+        orig_ctx = JacRuntime.exec_ctx;
+        try {
+            JacRuntime.base_path_dir = tmpdir;
+            JacRuntime.full_target_path = str(Path(tmpdir) / "standalone.jac");
+
+            ctx = ExecutionContext();
+            assert isinstance(ctx.mem, TieredMemory);
+            l3_path = ctx.mem.l3.path;
+            assert tmpdir in l3_path , f"expected {tmpdir} in {l3_path}";
+            # Standalone file (no jac.toml in tmpdir) — get_name() falls back
+            # to the filename stem.
+            assert "standalone" in os.path.basename(l3_path) , f"expected 'standalone' in basename of {l3_path}";
+
+            ctx.close();
+        } finally {
+            JacRuntime.base_path_dir = orig_base;
+            JacRuntime.full_target_path = orig_target;
+            JacRuntime.exec_ctx = orig_ctx;
+        }
+    }
+}

--- a/jac/tests/runtimelib/test_db_naming.jac
+++ b/jac/tests/runtimelib/test_db_naming.jac
@@ -19,7 +19,7 @@ test "different standalone files get separate db files" {
     db_persistent = db_dir / "simple_persistent.db";
     db_connection = db_dir / "simple_node_connection.db";
 
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     try {
         Jac.set_base_path(FIXTURES);
 
@@ -59,7 +59,7 @@ test "running file with same name as project uses project DB name" {
     db_project = db_dir / "test_db_naming.db";
     file_path = Path(FIXTURES) / "test_project";
 
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     try {
         Jac.set_base_path(FIXTURES);
 

--- a/jac/tests/runtimelib/test_jaseci.jac
+++ b/jac/tests/runtimelib/test_jaseci.jac
@@ -245,7 +245,7 @@ def trigger_access_validation_test(
 
 test "walker simple persistent" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         captured = capture_start();
@@ -269,7 +269,7 @@ test "walker simple persistent" {
 
 test "entrypoint root" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.enter(
@@ -297,7 +297,7 @@ test "entrypoint root" {
 
 test "entrypoint non root" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.enter(
@@ -333,7 +333,7 @@ test "entrypoint non root" {
 
 test "get edge" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.run(filename=os.path.join(FIXTURES, "simple_node_connection.jac"));
@@ -364,7 +364,7 @@ test "get edge" {
 
 test "filter on edge get edge" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.run(filename=os.path.join(FIXTURES, "simple_node_connection.jac"));
@@ -383,7 +383,7 @@ test "filter on edge get edge" {
 
 test "filter on edge get node" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.run(filename=os.path.join(FIXTURES, "simple_node_connection.jac"));
@@ -402,7 +402,7 @@ test "filter on edge get node" {
 
 test "filter on node get node" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.run(filename=os.path.join(FIXTURES, "simple_node_connection.jac"));
@@ -421,7 +421,7 @@ test "filter on node get node" {
 
 test "filter on edge visit" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.run(filename=os.path.join(FIXTURES, "simple_node_connection.jac"));
@@ -440,7 +440,7 @@ test "filter on edge visit" {
 
 test "filter on node visit" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.run(filename=os.path.join(FIXTURES, "simple_node_connection.jac"));
@@ -459,7 +459,7 @@ test "filter on node visit" {
 
 test "indirect reference node" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         execution.enter(
@@ -484,7 +484,7 @@ test "indirect reference node" {
 
 test "walker purger" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         captured = capture_start();
@@ -548,7 +548,7 @@ test "walker purger" {
 
 test "other root access" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         ##############################################
@@ -653,7 +653,7 @@ test "other root access" {
 
 test "savable object" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         captured = capture_start();
@@ -722,7 +722,7 @@ test "savable object" {
 
 test "traversing save" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         captured = capture_start();
@@ -755,7 +755,7 @@ test "traversing save" {
 
 test "custom access validation" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         ##############################################
@@ -944,7 +944,7 @@ test "run persistent reuse" {
     import from pickle { loads }
 
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         # Database path is auto-generated at _tmpdir/.jac/data/main.db
@@ -1005,7 +1005,7 @@ test "run persistent reuse" {
 
 test "user isolation via set user root" {
     _tmpdir = mkdtemp();
-    _orig_base = Jac.base_path_dir;
+    _orig_base = Jac.get_base_path_dir();
     Jac.set_base_path(_tmpdir);
     try {
         # Create two separate user roots

--- a/jac/tests/runtimelib/test_permission_diagnostics.jac
+++ b/jac/tests/runtimelib/test_permission_diagnostics.jac
@@ -56,7 +56,7 @@ def _setup_alice_bob -> tuple[(str, str, str)] {
 
 test "edge write across users emits edge_write diagnostic" {
     _tmp = mkdtemp();
-    _orig = Jac.base_path_dir;
+    _orig = Jac.get_base_path_dir();
     Jac.set_base_path(_tmp);
     try {
         (alice, bob, profile_id) = _setup_alice_bob();
@@ -82,7 +82,7 @@ test "edge write across users emits edge_write diagnostic" {
 
 test "field write across users emits field_write diagnostic and persist drops" {
     _tmp = mkdtemp();
-    _orig = Jac.base_path_dir;
+    _orig = Jac.get_base_path_dir();
     Jac.set_base_path(_tmp);
     try {
         (alice, bob, profile_id) = _setup_alice_bob();
@@ -111,7 +111,7 @@ test "field write across users emits field_write diagnostic and persist drops" {
 
 test "delete across users emits delete diagnostic and node survives" {
     _tmp = mkdtemp();
-    _orig = Jac.base_path_dir;
+    _orig = Jac.get_base_path_dir();
     Jac.set_base_path(_tmp);
     try {
         (alice, bob, profile_id) = _setup_alice_bob();
@@ -139,7 +139,7 @@ test "delete across users emits delete diagnostic and node survives" {
 
 test "owner write does not emit diagnostic" {
     _tmp = mkdtemp();
-    _orig = Jac.base_path_dir;
+    _orig = Jac.get_base_path_dir();
     Jac.set_base_path(_tmp);
     try {
         alice = _run("create_other_root");
@@ -163,7 +163,7 @@ test "owner write does not emit diagnostic" {
 
 test "strict mode raises PermissionError on cross-user edge write" {
     _tmp = mkdtemp();
-    _orig = Jac.base_path_dir;
+    _orig = Jac.get_base_path_dir();
     _orig_strict = Jac.strict_permissions;
     Jac.set_base_path(_tmp);
     Jac.strict_permissions = True;
@@ -185,7 +185,7 @@ test "strict mode raises PermissionError on cross-user edge write" {
 
 test "strict mode raises PermissionError on cross-user delete" {
     _tmp = mkdtemp();
-    _orig = Jac.base_path_dir;
+    _orig = Jac.get_base_path_dir();
     _orig_strict = Jac.strict_permissions;
     Jac.set_base_path(_tmp);
     Jac.strict_permissions = True;

--- a/jac/tests/runtimelib/test_topology_integration.jac
+++ b/jac/tests/runtimelib/test_topology_integration.jac
@@ -190,7 +190,7 @@ test "concurrent edge adds merged in sqlite sync" {
 layer — only the sliced subset should hit SQLite, not every neighbor."""
 test "edge-ref slice bounds sqlite l3 fetches" {
     tmpdir = mkdtemp();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     try {
         cfg = JacConfig();
         cfg.run.topology_index = True;
@@ -249,7 +249,7 @@ size from SQLite. Pre-fix this fell through to `plan_query`, which loaded
 all 200 leaves before slicing in Python."""
 test "edge-ref multi-hop slice bounds sqlite l3 fetches" {
     tmpdir = mkdtemp();
-    orig_base = JacRuntime.base_path_dir;
+    orig_base = JacRuntime.get_base_path_dir();
     try {
         cfg = JacConfig();
         cfg.run.topology_index = True;


### PR DESCRIPTION
## Summary

- `JacRuntime.base_path_dir` and `JacRuntime.full_target_path` are now carried on `ExecutionContext` instead of as process-global statics, so two clients in one process (JacTestClient instances, embedded REPL, MCP host) no longer collide on a stale `full_target_path` from a prior client.
- `TieredMemory.postinit` and `get_db_path` / `get_name` take an explicit `target_path` so the L3 SQLite filename is decided at memory-construction time and is immune to later global mutations.
- `JacTestClient._ensure_initialized` passes its own `base_path` and `_jac_file` through `create_j_context` so each test client owns its app identity end-to-end. Request forks inherit identity from the parent ctx, so concurrent server requests stay correct.
- Back-compat: `ExecutionContext()` with no args still snapshots from `JacRuntime` globals at postinit, so existing CLI flows (`jac enter` / `jac start` / `jac db`) are unchanged.

Motivation: closes the root cause behind the three `pytest.skip`-ed `allroots()` tests in `jac/examples/littleX/fullstack/test_littlex.jac` and the misleading `<cwd>/.jac/data/main.db` files that appear when ambient state survives between in-process clients.

## Test plan

- [x] `jac test jac/tests/runtimelib/test_context_isolation.jac` — 3 new tests covering the explicit-pass contract, two-context independence, and back-compat fallback.
- [x] `jac test` on the full `jac/tests/runtimelib/` suite — failure count matches `main` (pre-existing `jac-scale` user-registration / network failures only; no new regressions).
- [x] `jac test jac-scale/jac_scale/tests/test_topology_scale.jac` and `test_sv_auth_forward.jac` — green.
- [x] `jac test jac-byllm/tests/test_byllm.jac` — failure count matches `main`.