### PR TITLE
refactor(runtime): remove vestigial JacRuntime APIs and dead init machinery

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-mcp/6072.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jac-mcp/6072.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: drop redundant `Jac.setup()` calls**: The compiler bridge no longer calls the removed `Jac.setup()` no-op before each command.

--- a/docs/docs/community/release_notes/unreleased/jac-scale/6072.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/6072.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: request middleware uses token-based context push/reset**: jfast_api's per-request context now uses `push_request_context` + `reset_request_context(token)` with an explicit `ctx.close()`, replacing the removed `set_request_context` / `clear_request_context` footgun pair.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6072.breaking.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6072.breaking.md
@@ -1,0 +1,1 @@
+- **Breaking: remove no-op `Jac.setup()` and no-token request-context APIs**: `JacBasics.setup` (empty), `JacRuntime.set_request_context`, and `JacRuntime.clear_request_context` are gone; use `push_request_context` / `reset_request_context` with the returned token for any code that scoped a context to a server request.

--- a/jac-mcp/jac_mcp/impl/compiler_bridge.impl.jac
+++ b/jac-mcp/jac_mcp/impl/compiler_bridge.impl.jac
@@ -57,8 +57,6 @@ impl CompilerBridge.parse_snippet(
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.program { JacProgram }
 
-        Jac.setup();
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jac", delete=False) as f {
             f.write(code);
             tmp_path = f.name;
@@ -111,8 +109,6 @@ impl CompilerBridge.typecheck_snippet(
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.program { JacProgram }
 
-        Jac.setup();
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jac", delete=False) as f {
             f.write(code);
             tmp_path = f.name;
@@ -162,7 +158,6 @@ impl CompilerBridge.format_snippet(code: str) -> dict[str, any] {
     def _do_format -> dict[str, any] {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
 
-        Jac.setup();
         compiler = Jac.get_compiler();
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jac", delete=False) as f {
@@ -208,7 +203,6 @@ impl CompilerBridge.py_to_jac(python_code: str) -> dict[str, any] {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.program { JacProgram }
 
-        Jac.setup();
         compiler = Jac.get_compiler();
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f {
@@ -266,8 +260,6 @@ impl CompilerBridge.get_ast_snippet(code: str, fmt: str = "tree") -> dict[str, a
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.program { JacProgram }
 
-        Jac.setup();
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jac", delete=False) as f {
             f.write(code);
             tmp_path = f.name;
@@ -318,8 +310,6 @@ impl CompilerBridge.lint_snippet(code: str, auto_fix: bool = False) -> dict[str,
     def _do_lint -> dict[str, any] {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.compiler { JacCompiler }
-
-        Jac.setup();
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jac", delete=False) as f {
             f.write(code);
@@ -390,8 +380,6 @@ impl CompilerBridge.jac_to_py(code: str) -> dict[str, any] {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.program { JacProgram }
 
-        Jac.setup();
-
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jac", delete=False) as f {
             f.write(code);
             tmp_path = f.name;
@@ -438,8 +426,6 @@ impl CompilerBridge.jac_to_js(code: str) -> dict[str, any] {
     def _do_jac2js -> dict[str, any] {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.program { JacProgram }
-
-        Jac.setup();
 
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".cl.jac", delete=False
@@ -496,8 +482,6 @@ impl CompilerBridge.run_snippet(
     def _do_run -> dict[str, any] {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
         import from jaclang.jac0core.constructs { WalkerArchetype }
-
-        Jac.setup();
 
         # Create temp file
         with tempfile.NamedTemporaryFile(

--- a/jac-scale/jac_scale/impl/scheduler.impl.jac
+++ b/jac-scale/jac_scale/impl/scheduler.impl.jac
@@ -382,8 +382,6 @@ impl JacScaleScheduler._execute_task(
         }
     } except Exception as e {
         logger.error(f"Error executing {label} '{name}': {e}");
-    } finally {
-        JacRuntime.clear_request_context();
     }
 }
 

--- a/jac-scale/jac_scale/jserver/impl/jfast_api.impl.jac
+++ b/jac-scale/jac_scale/jserver/impl/jfast_api.impl.jac
@@ -1104,7 +1104,7 @@ impl JFastApiServer.init(
 
     async def request_context_middleware(request: Request, call_next: Callable) {
         ctx = JacRuntimeInterface.create_j_context(user_root=None);
-        JacRuntime.set_request_context(ctx);
+        req_token = JacRuntime.push_request_context(ctx);
 
         # Capture Authorization header for sv-to-sv auth propagation.
         # The sv_service_call hookimpl in plugin.jac reads this ContextVar
@@ -1162,7 +1162,8 @@ impl JFastApiServer.init(
             return response;
         } finally {
             try {
-                JacRuntime.clear_request_context();
+                JacRuntime.reset_request_context(req_token);
+                ctx.close();
             } except Exception as e {
                 logger.warning(f"Failed to clear request context: {e}", exc_info=True);
             }

--- a/jac-scale/jac_scale/plugin.jac
+++ b/jac-scale/jac_scale/plugin.jac
@@ -703,8 +703,14 @@ class JacCmd {
 """Jac Scale Plugin Implementation."""
 class JacScalePlugin {
     @hookimpl
-    static def create_j_context(user_root: (str | None)) -> ExecutionContext {
-        # Storage backend configured via environment (MONGODB_URI, etc.)
+    static def create_j_context(
+        user_root: (str | None),
+        base_path_dir: (str | None) = None,
+        full_target_path: (str | None) = None
+    ) -> ExecutionContext {
+        # Storage backend configured via environment (MONGODB_URI, etc.) —
+        # base_path_dir / full_target_path are SQLite-backend artifacts that
+        # don't apply here, but the spec carries them so we accept the kwargs.
         ctx = JScaleExecutionContext();
         if user_root is not None {
             ctx.set_user_root(user_root);

--- a/jac/jaclang/cli/commands/cli_helpers.jac
+++ b/jac/jaclang/cli/commands/cli_helpers.jac
@@ -3,17 +3,6 @@
 import os;
 import from jaclang.cli.console { console }
 
-glob _runtime_initialized = False;
-
-"""Initialize Jac runtime once on first use."""
-def ensure_jac_runtime {
-    global _runtime_initialized;
-    if not _runtime_initialized {
-        import from jaclang.jac0core.runtime { JacRuntime as Jac }
-        Jac.setup();
-        _runtime_initialized = True;
-    }
-}
 
 """Create JacRuntime and return the base path, module name, and runtime state.
 

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -589,7 +589,6 @@ impl `test(
     verbose: bool = False
 ) -> int {
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
-    Jac.setup();
     # e.g. jac test --test_name "typevar7 constrained operations"  (no filepath given)
     if (test_name and not filepath) {
         console.error(

--- a/jac/jaclang/cli/commands/impl/db.impl.jac
+++ b/jac/jaclang/cli/commands/impl/db.impl.jac
@@ -73,7 +73,6 @@ jac-scale; pure jaclang deployments hit it.
 def _load_app_and_get_l3(app_path: str) -> (PersistentMemory | None) {
     try {
         import from jaclang.jac0core.runtime { JacRuntime as Jac }
-        Jac.setup();
         abs_path = os.path.abspath(app_path);
         (base, mod) = os.path.split(abs_path);
         if mod.endswith('.jac') {

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -8,10 +8,7 @@ import os;
 import sys;
 import types;
 import from jaclang.cli.console { console }
-import from jaclang.cli.commands.cli_helpers {
-    ensure_jac_runtime as _ensure_jac_runtime,
-    proc_file as _proc_file
-}
+import from jaclang.cli.commands.cli_helpers { proc_file as _proc_file }
 
 """Discover jac.toml from the file's directory when an absolute/relative path is given.
 
@@ -92,7 +89,6 @@ impl run(
     diagnostics: str = "",
     args: list = []
 ) -> int {
-    _ensure_jac_runtime();
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
     import from jaclang.project.config { get_config }
     # Re-discover config from the file's directory (handles absolute paths)
@@ -246,7 +242,6 @@ impl enter(
     `root: str = '',
     nd: str = ''
 ) -> int {
-    _ensure_jac_runtime();
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
     import from jaclang.jac0core.constructs { WalkerArchetype }
     # Re-discover config from the file's directory (handles absolute paths)
@@ -296,7 +291,6 @@ impl start(
     api_port: int = 0,
     no_client: bool = False
 ) -> int {
-    _ensure_jac_runtime();
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
     import from pathlib { Path }
     if not Path(filename).exists() {

--- a/jac/jaclang/cli/commands/impl/tools.impl.jac
+++ b/jac/jaclang/cli/commands/impl/tools.impl.jac
@@ -5,10 +5,7 @@ Direct implementations - no delegation.
 
 import os;
 import from jaclang.cli.console { console }
-import from jaclang.cli.commands.cli_helpers {
-    ensure_jac_runtime as _ensure_jac_runtime,
-    proc_file as _proc_file
-}
+import from jaclang.cli.commands.cli_helpers { proc_file as _proc_file }
 
 """Run the specified AST tool with optional arguments."""
 impl tool(tool: str, args: list = []) -> int {
@@ -43,7 +40,6 @@ impl dot(
     to_screen: bool = False,
     format: str = "dot"
 ) -> int {
-    _ensure_jac_runtime();
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
     import from jaclang.runtimelib.builtin { printgraph }
     (base, mod, jac_machine) = _proc_file(filename);

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -983,9 +983,6 @@ impl JacCmd.run_ai_agent(req: object) -> int {
     return run_agent(req);
 }
 
-"""Set Class References."""
-impl JacBasics.setup -> None { }
-
 """Get current execution context (request-scoped if available, else global)."""
 impl JacBasics.get_context -> ExecutionContext {
     # Try request-scoped context first (for web servers)
@@ -2888,11 +2885,6 @@ impl JacRuntime.set_context(context: ExecutionContext) -> None {
     JacRuntime.exec_ctx = context;
 }
 
-"""Set request-scoped execution context (for web servers)."""
-impl JacRuntime.set_request_context(context: ExecutionContext) -> None {
-    _request_context.set(context);
-}
-
 """Push a request-scoped execution context; returns a reset token."""
 impl JacRuntime.push_request_context(context: ExecutionContext) -> any {
     return _request_context.set(context);
@@ -2901,13 +2893,4 @@ impl JacRuntime.push_request_context(context: ExecutionContext) -> any {
 """Reset the request-scoped context using a push token."""
 impl JacRuntime.reset_request_context(token: any) -> None {
     _request_context.reset(token);
-}
-
-"""Clear request-scoped context and commit changes."""
-impl JacRuntime.clear_request_context -> None {
-    ctx = _request_context.get();
-    if ctx is not None {
-        ctx.close();
-        _request_context.set(None);
-    }
 }

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -373,9 +373,6 @@ class JacCmd {
 
 """Jac Feature."""
 class JacBasics {
-    """Set Class References."""
-    static def setup -> None;
-
     """Get current execution context (request-scoped if available, else global)."""
     static def get_context -> ExecutionContext;
 
@@ -1171,25 +1168,23 @@ class JacRuntime(JacRuntimeInterface) {
         """
     static def set_full_target_path(target_path: (str | None)) -> None;
 
-    """Set the context for the machine (global, for backward compatibility)."""
+    """Install the process-global execution context for CLI and other
+    non-server callers. Server request paths use `push_request_context`
+    so each request has its own ContextVar-scoped ctx.
+    """
     static def set_context(context: ExecutionContext) -> None;
-
-    """Set request-scoped execution context (for web servers)."""
-    static def set_request_context(context: ExecutionContext) -> None;
 
     """Push a request-scoped execution context and return the reset token.
 
-    Prefer this over `set_request_context` for concurrent servers: the
-    returned token lets the caller restore the prior value in a `finally`
-    block, which keeps concurrent requests (each in its own asyncio Task
-    with its own ContextVar view) from trampling each other's state."""
+    The token lets the caller restore the prior value in a `finally`
+    block. This is the safe way to scope a ctx to a server request:
+    concurrent requests each get their own ContextVar view, and nested
+    pushes compose cleanly. Pair with `reset_request_context`.
+    """
     static def push_request_context(context: ExecutionContext) -> any;
 
     """Reset the request-scoped context using a token from `push_request_context`."""
     static def reset_request_context(token: any) -> None;
-
-    """Clear request-scoped context and commit changes."""
-    static def clear_request_context -> None;
 }
 
 """Context manager to temporarily disable external plugins.

--- a/jac/jaclang/pytest_plugin.py
+++ b/jac/jaclang/pytest_plugin.py
@@ -61,14 +61,17 @@ _jac_runtime_ready = False
 
 
 def _ensure_jac_runtime():
-    """Initialise the Jac runtime exactly once per pytest session."""
+    """Verify that the Jac runtime can be imported, once per pytest session.
+
+    Skips the test if jaclang is broken or otherwise unimportable; otherwise
+    a no-op (Python's import system already handles real initialization).
+    """
     global _jac_runtime_ready
     if _jac_runtime_ready:
         return
     try:
-        from jaclang.jac0core.runtime import JacRuntime
+        from jaclang.jac0core.runtime import JacRuntime  # noqa: F401
 
-        JacRuntime.setup()
         _jac_runtime_ready = True
     except Exception as exc:
         pytest.skip(f"Jac runtime unavailable: {exc}")


### PR DESCRIPTION
## Summary

Cleanup follow-up to #6069 — removes three pieces of bloat that survived the previous refactor:

- **No-token request-context footgun pair.** `JacRuntime.set_request_context` and `clear_request_context` removed. They mutated the ContextVar without returning a token, so callers couldn't restore the prior value safely. The proper pair (`push_request_context` returning a token, `reset_request_context(token)`) stays — it's strictly more capable. jac-scale's jfast_api middleware (the only caller) migrates to the token pair plus an explicit `ctx.close()` in the finally block. A redundant outer `clear_request_context()` in jac-scale's scheduler also goes — `_run()` already handled its own ctx cleanup.

- **`JacBasics.setup` empty no-op + 13 callers.** `impl JacBasics.setup -> None { }` did nothing. All 13 caller sites drop the call (cli_helpers, analysis, db, pytest_plugin, plus 9 sites in jac-mcp's compiler_bridge). The `ensure_jac_runtime()` helper in cli_helpers that wrapped that no-op behind a one-time-init flag goes with it.

- **Stale docs + signature drift.** `JacRuntime.set_context`'s docstring claimed "(global, for backward compatibility)" — it's actually the canonical CLI install path; fixed. jac-scale's `create_j_context` hookimpl still had the pre-#6069 `(user_root)` signature; updated to accept `base_path_dir` and `full_target_path` from the current spec.

Net diff: 12 files, ~46 line removals after additions.

## Test plan

- [x] `jac test jac/tests/runtimelib/test_context_isolation.jac` — green
- [x] Full `jac/tests/runtimelib/` sweep — failure counts match merged main exactly (no new regressions)
- [x] `jac-scale/jac_scale/tests/test_topology_scale.jac` + `test_sv_auth_forward.jac` — green
- [x] `jac-byllm/tests/test_byllm.jac` — failure count matches baseline (2 pre-existing network errors)
- [x] `jac-mcp/tests/test_mcp.jac` — failure count matches baseline (1 pre-existing error)