### PR TITLE
fix(jac-scale): install jac-client from local source in microservice e2e

### DIFF
--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -9,19 +9,6 @@ name: K8s Microservice Real E2E
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'jac-scale/jac_scale/targets/kubernetes/microservice/**'
-      - 'jac-scale/jac_scale/microservices/**'
-      - 'jac-scale/jac_scale/abstractions/service_deployer.jac'
-      - 'jac-scale/jac_scale/abstractions/image_distributor.jac'
-      - 'jac-scale/jac_scale/abstractions/models/deploy_context.jac'
-      - 'jac-scale/jac_scale/factories/deployment_factory.jac'
-      - 'jac-scale/jac_scale/plugin.jac'
-      - 'jac-scale/scripts/k8s_microservice_real_e2e.sh'
-      - 'jac-scale/scripts/Dockerfile.microservice'
-      - 'jac-scale/scripts/dockerignore.microservice'
-      - 'jac-scale/jac_scale/tests/fixtures/k8s_e2e/**'
-      - '.github/workflows/k8s-microservice-real-e2e.yml'
 
 jobs:
   real-e2e:

--- a/jac-scale/scripts/Dockerfile.microservice.exp
+++ b/jac-scale/scripts/Dockerfile.microservice.exp
@@ -1,6 +1,12 @@
-# Experimental Dockerfile: installs jaclang + jac-scale from LOCAL source
-# (the repo's jac/ and jac-scale/) for testing PR code before PyPI ships.
-# Build context = repo root (set by k8s_microservice_real_e2e.sh).
+# Experimental Dockerfile: installs jaclang + jac-scale + jac-client from
+# LOCAL source (the repo's jac/, jac-scale/, jac-client/) for testing PR
+# code before PyPI ships. Build context = repo root (set by
+# k8s_microservice_real_e2e.sh).
+#
+# jac-client must come from local source too: it carries a hookimpl that
+# reads jaclang's app-identity API. When jaclang changes that API in a PR
+# (e.g. removing a static), PyPI's jac-client lags and crashes against
+# the new jaclang inside the container.
 
 FROM python:3.12-slim
 
@@ -16,9 +22,10 @@ RUN pip install --no-cache-dir --upgrade pip
 WORKDIR /build
 COPY jac /build/jac
 COPY jac-scale /build/jac-scale
+COPY jac-client /build/jac-client
 RUN pip install --no-cache-dir -e /build/jac \
     && jac install --no-cache-dir -e /build/jac-scale --extras deploy data \
-    && pip install --no-cache-dir jac-client
+    && pip install --no-cache-dir -e /build/jac-client
 
 ARG PROJECT_PATH=jac-scale/jac_scale/tests/fixtures/k8s_e2e
 WORKDIR /app
@@ -26,5 +33,14 @@ COPY ${PROJECT_PATH} /app
 
 RUN if [ -f jac.toml ]; then jac install || true; fi
 RUN jac --version
+
+# Smoke: assert jaclang + jac-scale + jac-client are all installed from
+# /build/ (i.e. this PR's source), not from a PyPI release that may lag
+# behind the jaclang API this PR ships.
+RUN python -c "import jaclang, jac_scale, jac_client, os; \
+locs = {p.__name__: os.path.dirname(p.__file__) for p in (jaclang, jac_scale, jac_client)}; \
+bad = [(n, l) for n, l in locs.items() if not l.startswith('/build/')]; \
+assert not bad, f'expected local-source install, got PyPI: {bad}'; \
+print('local-source install verified:', locs)"
 
 EXPOSE 8000

--- a/jac-scale/scripts/Dockerfile.microservice.exp
+++ b/jac-scale/scripts/Dockerfile.microservice.exp
@@ -1,12 +1,8 @@
 # Experimental Dockerfile: installs jaclang + jac-scale + jac-client from
-# LOCAL source (the repo's jac/, jac-scale/, jac-client/) for testing PR
-# code before PyPI ships. Build context = repo root (set by
-# k8s_microservice_real_e2e.sh).
-#
-# jac-client must come from local source too: it carries a hookimpl that
-# reads jaclang's app-identity API. When jaclang changes that API in a PR
-# (e.g. removing a static), PyPI's jac-client lags and crashes against
-# the new jaclang inside the container.
+# LOCAL source for testing PR code before PyPI ships. All three must be
+# local: jac-client carries a hookimpl into jaclang's app-identity API,
+# so a PyPI jac-client crashes against a PR that changes that API.
+# Build context = repo root (set by k8s_microservice_real_e2e.sh).
 
 FROM python:3.12-slim
 
@@ -34,9 +30,7 @@ COPY ${PROJECT_PATH} /app
 RUN if [ -f jac.toml ]; then jac install || true; fi
 RUN jac --version
 
-# Smoke: assert jaclang + jac-scale + jac-client are all installed from
-# /build/ (i.e. this PR's source), not from a PyPI release that may lag
-# behind the jaclang API this PR ships.
+# Fail fast if anything resolves to a PyPI install instead of /build/.
 RUN python -c "import jaclang, jac_scale, jac_client, os; \
 locs = {p.__name__: os.path.dirname(p.__file__) for p in (jaclang, jac_scale, jac_client)}; \
 bad = [(n, l) for n, l in locs.items() if not l.startswith('/build/')]; \


### PR DESCRIPTION
## Summary

The K8s microservice e2e Dockerfile (`Dockerfile.microservice.exp`) installs `jaclang` and `jac-scale` from `/build/` (local source) but pulls `jac-client` from **PyPI**. When jaclang changes its app-identity API between PyPI releases of jac-client, the container ends up shipping a jac-client that calls into the new jaclang with the old API and pods CrashLoop on server init.

Concretely, after #6069 merged (it removed `JacRuntime.base_path_dir` on 2026-05-21), every PR's K8s e2e on `main` started failing with:

```
AttributeError: type object 'JacRuntime' has no attribute 'base_path_dir'.
            Did you mean: 'get_base_path_dir'?
  File ".../jac/jaclang/runtimelib/impl/server.impl.jac:525  (Jac.get_client_bundle_builder())
  File ".../jac-client/jac_client/plugin/impl/client.impl.jac:45
```

Source paths in the traceback point at `/home/runner/work/jaseci/jaseci/jac-client/...` because the PyPI tarball baked those paths in at release time. The local jac-client source has already been migrated to `Jac.get_base_path_dir()`; PyPI just lags by one release.

This blocked the K8s e2e on every open PR rebased on top of #6069 (e.g. [run 26222381956 on PR #6077](https://github.com/jaseci-labs/jaseci/actions/runs/26222381956/job/77160421306)).

## Fix

- Copy `jac-client` into `/build/` and install editable, matching how `jac` and `jac-scale` are handled.
- Add a build-time smoke: assert all three packages (`jaclang`, `jac_scale`, `jac_client`) resolve to `/build/`. If anyone reverts to PyPI for any of them, the image build fails fast with a clear message instead of mysteriously inside K8s.

The production `Dockerfile.microservice` is intentionally unchanged: it ships to users who pin PyPI releases, and PyPI is the right install source there (coordinated releases handle API alignment).

## Test plan

- [x] Local image build smoke (`docker build -f jac-scale/scripts/Dockerfile.microservice.exp .`) - verifies all three packages resolve under `/build/`.
- [ ] K8s real-app e2e workflow on this PR - the existing regression test; will go green when the fix lands.