### PR TITLE
fix(jac-scale): restore plugin registration + align manifest after #5833

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/6086.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/6086.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix**: `jac-scale` plugin hooks (SSO, auth, `/healthz`, admin) now apply reliably when the module is imported outside the `jac` CLI, restoring SSO endpoints, the `/healthz` probe, and authenticated `/metrics`.

--- a/jac-scale/jac.toml
+++ b/jac-scale/jac.toml
@@ -62,13 +62,17 @@ docker = ">=7.1.0,<8.0.0"
 # bundle them rather than make every user remember `[deploy,data]`.
 "jac-scale[data]" = "*"
 
+[optional-dependencies.aws]
+boto3 = ">=1.40.0"
+
 [optional-dependencies.all]
-"jac-scale[data,monitoring,scheduler,deploy]" = "*"
+"jac-scale[data,monitoring,scheduler,deploy,aws]" = "*"
 
 [optional-dependencies.test]
 "jac-scale[all]" = "*"
 "testcontainers[mongodb,redis]" = "*"
 requests = "*"
+"moto[s3]" = ">=5.0.0"
 
 [entrypoints.jac]
 scale = "jac_scale.plugin:JacCmd"

--- a/jac-scale/jac_scale/plugin.jac
+++ b/jac-scale/jac_scale/plugin.jac
@@ -1458,4 +1458,5 @@ glob func = JacScalePlugin.create_j_context,
 
 with entry {
     func.__signature__ = sig_nodef;
+    plugin_manager.register(JacScalePlugin());
 }


### PR DESCRIPTION
## Summary
- Restore `plugin_manager.register(JacScalePlugin())` in `jac_scale/plugin.jac`'s `with entry` block — accidentally removed during the merge of #5833 into main.
- Align `jac-scale/jac.toml` with `pyproject.toml`: add `[optional-dependencies.aws]` (boto3) and `moto[s3]` to the test extras so `scripts/check_manifest_sync.jac` passes.

## Why main is broken
After #5833 landed, three CI jobs started failing:

1. **`Contribution Checks`** — `scripts/check_manifest_sync.jac` flags `aws` extra and `moto[s3]` test dep as only in `pyproject.toml`.
2. **`test-scale` / `test_serve.jac`** — `AttributeError: 'UserManager' object has no attribute 'sso_initiate'` when the SSO endpoint registers its callback.
3. **`test-scale` / `test_deploy_k8s.jac`** — unauthenticated `/metrics` returns `200` instead of `403`.
4. **Integration tests** — `jac start main.jac` server: `/healthz` returns `404`, server never becomes ready.

All three runtime failures share one root cause: the merge dropped the `plugin_manager.register(JacScalePlugin())` line from `with entry { ... }`. Without it, jac-scale's hooks (`get_user_manager`, `get_api_server_class`, `store`, etc.) never apply when the module is imported outside the jac CLI's setuptools entry-point loader — so `Jac.get_user_manager()` returns the base `UserManager` (no `sso_initiate`, no `/healthz`, no auth wrappers on `/metrics`).

The line existed in `6cff699d2d` (the parent of #5833 on main); it's reinstated verbatim.

## Test plan
- [x] `jac run scripts/check_manifest_sync.jac` → "All plugin manifests agree."
- [x] `pytest -x jac-scale/jac_scale/tests/test_serve.jac` → 27/27 passed locally
- [ ] CI: `test-scale`, integration tests, contribution checks all green