### PR TITLE
fix(jaclang): synthesized dataclass init returns None, not Unknown

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6090.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6090.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `super.init(...)` into a parent with an auto-generated constructor now type-checks cleanly**: calls no longer raise a spurious unresolved-type warning.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -69,8 +69,15 @@ impl TypeEvaluator._create_dataclass_init_method(
 ) -> types.FunctionType {
     param_map = self._build_field_params(class_type, skip_deferred=True);
     parameters = list(param_map.values());
+    # `__init__` returns None. Synthesizing UnknownType here used to cascade
+    # into W1051 on every `super.init(...)` call to a dataclass-synthesized
+    # parent, and into E1001 when the call result was assigned to a typed slot.
+    ret_type: TypeBase = types.UnknownType();
+    if self.prefetch and self.prefetch.none_type_class {
+        ret_type = self._convert_to_instance(self.prefetch.none_type_class);
+    }
     return types.FunctionType(
-        func_name="__init__", return_type=types.UnknownType(), parameters=parameters,
+        func_name="__init__", return_type=ret_type, parameters=parameters,
     );
 }
 

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_super_init_dataclass_no_w1051.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_super_init_dataclass_no_w1051.jac
@@ -1,0 +1,47 @@
+# Regression: super.init(...) on a parent whose init is dataclass-synthesized
+# from `has` vars was emitting a spurious W1051 ("Expression type could not be
+# resolved (Unknown)") because the synthesized FunctionType returned by
+# _create_dataclass_init_method had return_type=UnknownType. Arg validation
+# worked, but the call expression itself typed as Unknown.
+#
+# An implicit __init__ returns None in Python; the synthesized init must
+# reflect that so super.init(...) calls type cleanly.
+
+# Single-level inheritance: parent has only `has` fields (synthesized init).
+obj Shape {
+    has shape_type: str;
+}
+
+obj Circle(Shape) {
+    has radius: float;
+
+    def init(radius: float) {
+        super.init("Circle");
+        self.radius = radius;
+    }
+}
+
+# Two-level inheritance: middle and root both rely on synthesized inits.
+obj ColoredShape(Shape) {
+    has color: str;
+}
+
+obj ColoredCircle(ColoredShape) {
+    has radius: float;
+
+    def init(radius: float, color: str) {
+        super.init("ColoredCircle", color);
+        self.radius = radius;
+    }
+}
+
+# The result of super.init(...) must type as None so it can be assigned to a
+# None-annotated variable without E1001.
+obj Box(Shape) {
+    has w: float;
+
+    def init(w: float) {
+        result: None = super.init("Box");
+        self.w = w;
+    }
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2104,6 +2104,31 @@ test "super_init_with_has_vars" {
     );
 }
 
+test "super_init_dataclass_no_w1051" {
+    # Regression: `super.init(...)` on a parent whose constructor is
+    # dataclass-synthesized from `has` fields was emitting a spurious W1051
+    # (Unknown expression type) and an E1001 when the call result was assigned
+    # to a None-annotated slot. Root cause: _create_dataclass_init_method
+    # returned a FunctionType with return_type=UnknownType. Since an implicit
+    # __init__ returns None, the synthesized init must reflect that so member
+    # calls through `super.init(...)` type cleanly.
+    path = os.path.join(CHECKER_FIXTURES, "checker_super_init_dataclass_no_w1051.jac");
+    program = JacProgram();
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+    w1051 = [
+        w
+        for w in program.warnings_had
+        if w.code and w.code.code == "W1051"
+    ];
+    assert len(w1051) == 0 , f"Expected no W1051 on super.init() with synthesized parent init, got {len(
+        w1051
+    )}:\n" + "\n---\n".join(w.pretty_print() for w in w1051);
+    assert len(program.errors_had) == 0 , f"Unexpected errors: {[
+        e.pretty_print() for e in program.errors_had
+    ]}";
+}
+
 test "super_init_with_explicit_init" {
     program = JacProgram();
     path = os.path.join(CHECKER_FIXTURES, "checker_super_init_explicit.jac");


### PR DESCRIPTION
## Summary
- `super.init(...)` into a parent whose constructor is dataclass-synthesized from `has` fields emitted a spurious `W1051` ("Expression type could not be resolved (Unknown)"), and an `E1001` when the call result was bound to a typed slot.
- Root cause: `_create_dataclass_init_method` built a `FunctionType` with `return_type=UnknownType`. An implicit `__init__` returns `None`, so the synthesized init now reflects that — member calls through `super.init(...)` type cleanly.
- Arg validation (arity/type errors) was already correct; only the call expression's result type was wrong.

## Test plan
- [x] New regression test `super_init_dataclass_no_w1051` (fixture `checker_super_init_dataclass_no_w1051.jac`) asserts zero `W1051` and zero errors on valid `super.init(...)` into synthesized parents; fails before the fix (3× W1051 + E1001), passes after.
- [x] Full `test_checker_pass.jac` suite green (210 tests).
- [x] `jac check` on `examples/manual_code/circle_clean.jac` no longer flags `super.init(ShapeType.CIRCLE)`.