### PR TITLE
docs(views): document JSX slot extensions from #6085

### DIFF
--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -1327,7 +1327,8 @@ def:pub Greeting(name: str) -> JsxElement {
 # {#* comment *#}               JSX comment (renders nothing)
 # {unsafe_html(x)}              Raw HTML opt-in (escapes off)
 # <@expr />                     Dynamic tag (resolves expr at runtime)
-# <div {...props}>              Spread props
+# <div {**props}>               Spread props ({...props} also works but warns W0063)
+# <Box {title} {count} />       Attribute shorthand ({title} -> title={title})
 # <div className="cls">         Class name (not "class")
 # <div style={{"color": "red"}} Inline styles
 # <@expr>...</@expr>            Dynamic tag (tag chosen by expression)

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1141,10 +1141,12 @@ def:pub JsxExamples() -> JsxElement {
 
         {items}
 
-        <button {...props}>Click</button>
+        <button {**props} {variable}>Click</button>
     </div>;
 }
 ```
+
+Two brace forms appear in attribute position. `{**props}` is a **spread** -- it forwards every key of `props` as an attribute. The JS-idiomatic `{...props}` spread is also accepted but emits `W0063` ("prefer `{**expr}`"), so `{**props}` is the canonical Jac form. `{variable}` is the **`{name}` shorthand** -- when an attribute's value is a variable of the same name it expands to `variable={variable}`, so `<Box {title} {count} {onClick}/>` is sugar for `<Box title={title} count={count} onClick={onClick}/>`. The shorthand is still validated per-attribute against the component signature.
 
 ### Suspense Fallbacks: `try` with `awaiting`
 

--- a/docs/docs/tutorials/fullstack/components.md
+++ b/docs/docs/tutorials/fullstack/components.md
@@ -66,6 +66,8 @@ def:pub app() -> JsxElement {
 
 There is no `ReactNode`-style union type in Jac, and a children value can be an element, a string, a number, or a list of those -- so `any` is the honest type for a `children` parameter. The parameter type governs only how you use `children` inside the body; it is never checked against the nested content.
 
+**`{name}` attribute shorthand:** when a prop's value is a variable of the same name, `<Card {title} {onClose} />` is sugar for `<Card title={title} onClose={onClose} />`. Each shorthand attribute is still validated per-prop against the component signature. This is distinct from the `{**props}` spread (above), which forwards an entire object instead of a single named attribute.
+
 ---
 
 ## Forwarding the props bundle (advanced)
@@ -368,7 +370,7 @@ def:pub ItemList(items: list[str]) -> JsxElement {
 }
 ```
 
-`while` slots that emit keyless JSX get a `W2019` warning -- siblings produced by a loop need a stable `key=` so a re-render keeps their identity.
+Loop slots that emit keyless JSX get a warning -- `W2019` for a `while` loop and `W2021` for a `for` loop. Siblings produced by a loop need a stable `key=` (as in the `<li key={i}>` above) so a re-render keeps their identity.
 
 ### `has`-fields and Handlers
 
@@ -387,6 +389,8 @@ def:pub Counter() -> JsxElement {
     return <button onClick={bump}>Count: {count}</button>;
 }
 ```
+
+Declare `has`-fields at the component scope, never inside a `{...}` slot body. A slot body is a statement template that re-runs on every render, so a `has` there would compile to a conditional `useState` and violate React's rules of hooks -- the compiler rejects it with `E2024`.
 
 ### Dynamic Tags
 

--- a/docs/docs/tutorials/fullstack/npm-and-libraries.md
+++ b/docs/docs/tutorials/fullstack/npm-and-libraries.md
@@ -381,7 +381,7 @@ def:pub Button(props: any) -> JsxElement {
         props.className
     );
 
-    return <button className={computedClass} {...props}>
+    return <button className={computedClass} {**props}>
         {props.children}
     </button>;
 }
@@ -404,13 +404,13 @@ import from "radix-ui" { Dialog as DialogPrimitive }
 import from ...lib.utils { cn }
 
 def:pub Dialog(props: any) -> JsxElement {
-    return <DialogPrimitive.Root {...props}>
+    return <DialogPrimitive.Root {**props}>
         {props.children}
     </DialogPrimitive.Root>;
 }
 
 def:pub DialogTrigger(props: any) -> JsxElement {
-    return <DialogPrimitive.Trigger {...props}>
+    return <DialogPrimitive.Trigger {**props}>
         {props.children}
     </DialogPrimitive.Trigger>;
 }

--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -47,6 +47,8 @@ def:pub BookCard(bookId: str, title: str, onDelete: Callable[([str], None)]) -> 
 
 Call site: `<BookCard bookId={b["id"]} title={b["title"]} onDelete={remove} />`. For an optional callback, type it `Callable[([str], None)] | None` and guard the call: `if onDelete { onDelete(bookId); }`.
 
+**`{name}` shorthand:** when an attribute's value is a bare variable of the same name, `<BookCard {title} {onDelete} />` expands to `title={title} onDelete={onDelete}`. Pure sugar - the type-checker validates it per-attribute exactly like the explicit form. Distinct from the spread, which forwards a whole object: use `{**props}` (the canonical Jac form) - the JS-idiomatic `{...props}` also works but earns a `W0063` warning ("prefer `{**expr}`").
+
 ## Event types (ambient, no import)
 
 | Handler | Type | Access |
@@ -100,7 +102,8 @@ Caveats specific to slot bodies:
 
 - `skip;` inside a slot is the slot early-exit - it ends the current slot's accumulator (rest of *this* slot stops), **not** the enclosing function. Useful for "show empty state, stop here." Bare `return;` inside a slot is rejected (E2020) because it reads like a function-exit but only exits the slot; the value form `return expr;` is also rejected (E2019).
 - Inside a slot body, don't wrap inner control flow with another `{...}` - the body is already in slot mode. Write `if cond { <X/> }` directly, not `{if cond { <X/> }}` (E2023). The `{...}` wrapping is only needed when descending from a JSX element's children into slot mode.
-- Slot iteration that yields keyless JSX siblings earns a `W2019` warning - add `key={...}` on the inner element.
+- Slot iteration that yields keyless JSX siblings earns a warning - `W2019` for a `while` loop, `W2021` for a `for` loop - add `key={...}` on the inner element so siblings keep their identity across re-renders.
+- A `has`-field inside a slot body is rejected (E2024). The slot body is a statement template that re-runs every render, so a `has` there would compile to a conditional `useState` and break React's rules of hooks. Declare reactive state at the component scope (the enclosing `def -> JsxElement` body), never inside a `{...}` slot.
 - `try { ... } awaiting { ... }` in a slot lowers to a `<JacAwaiting fallback={...}>{...}</JacAwaiting>` Suspense wrapper (cl only). The `awaiting` body shows during the dispatched-but-not-joined window of any Suspense-aware primitive inside the `try` body; today Jac's `flow`/`wait` don't suspend, so the fallback only fires when the `try` body opts into something Suspense-shaped (e.g. a fetcher that throws a promise). On `sv` / `na` the `awaiting` body is dropped with `W2020`. `finally` with `awaiting` is rejected (`E2022`).
 
 ## Pitfalls


### PR DESCRIPTION
## Summary

PR #6085 shipped three JSX/view features but only updated `diagnostics.md` and the release notes. This propagates them into the docs and guide skills that actually teach JSX:

- **`{name}` attribute shorthand** — `<Box {title}/>` desugars to `<Box title={title}/>`
- **E2024** — a `has`-field inside a JSX slot body is rejected (a slot body re-runs every render, so it would compile to a conditional `useState` and break the rules of hooks)
- **W2021** — a keyless `for`-loop in a slot warns, mirroring the existing W2019 for `while`

While verifying the spread syntax I also corrected pre-existing guidance: **`{**props}` is the canonical Jac form**; `{...props}` is accepted but emits **W0063**. Several examples taught the warned form without a caveat.

## Changes

| File | Change |
|---|---|
| `jac/jaclang/cli/skills/jac-cl-components.md` (guide skill) | `{name}` shorthand in Props; E2024 + W2021 in slot caveats; `{**props}`-vs-`{...props}`/W0063 note |
| `docs/docs/tutorials/fullstack/components.md` | shorthand in typed-props; W2021 on `for`-loop slots; E2024 on slot `has`-fields |
| `docs/docs/reference/plugins/jac-client.md` | shorthand + spread/W0063 in JSX Syntax Reference |
| `docs/docs/quick-guide/syntax-cheatsheet.md` | preferred spread form + shorthand line |
| `docs/docs/tutorials/fullstack/npm-and-libraries.md` | `{...props}` → `{**props}` in wrapper examples (would have tripped W0063) |

## Notes

- `diagnostics.md` (E2024/W2021 entries) and the `6082.feature.md` release notes were already updated by #6085 and are left unchanged.
- Docs-only change; no source or test changes.