### PR TITLE
feat(native): honor typed enums; int-enum .value lowering (#6049 cat 1)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6093.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6093.feature.md
@@ -1,0 +1,1 @@
+- **Native enums honor their declared type**: Native compilation now treats an enum member as its enum type rather than a bare integer, and lowers `.value` and `.name` on direct integer-enum members.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/enums.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/enums.impl.jac
@@ -71,14 +71,19 @@ impl NaIRGenPass._codegen_enum(nd: uni.Enum) -> None {
             }
             full_name = f"{enum_name}.{mname}";
             self.enum_values[full_name] = ir.Constant(i64, ordinal);
+            self.enum_member_ordinal[full_name] = ordinal;
             entries.append((mname, str_val, ordinal));
         }
         self.enum_string_values[enum_name] = entries;
         self._build_enum_string_table(enum_name, entries);
     } else {
-        # Integer-valued enum: parse literal values
+        # Integer-valued enum: members lower to their assigned int values, so
+        # `.value` is the member constant itself. `.name` still needs a runtime
+        # string table, so build a name-only table indexed by declaration
+        # ordinal (reusing the same global-string layout as string enums).
         i64 = ir.IntType(64);
-        for (mname, vnode) in members {
+        name_entries: list = [];
+        for (ordinal, (mname, vnode)) in enumerate(members) {
             if vnode is not None and isinstance(vnode, uni.Int) {
                 val = int(vnode.value);
             } else {
@@ -86,17 +91,24 @@ impl NaIRGenPass._codegen_enum(nd: uni.Enum) -> None {
             }
             full_name = f"{enum_name}.{mname}";
             self.enum_values[full_name] = ir.Constant(i64, val);
+            self.enum_member_ordinal[full_name] = ordinal;
+            name_entries.append((mname, "", ordinal));
         }
+        self._build_enum_string_table(enum_name, name_entries, with_values=False);
     }
 }
 
-"""Build global string lookup tables for a string-valued enum.
+"""Build global string lookup tables for an enum, indexed by ordinal.
 
-Creates two global constant arrays:
-  __enum_values.EnumName  — [N x i8*] of .value strings (RHS)
-  __enum_names.EnumName   — [N x i8*] of .name strings (member names)
+Creates the __enum_names.EnumName array ([N x i8*] of member-name strings),
+used by `.name` access for both string- and integer-valued enums. When
+`with_values` is set (string enums), also builds __enum_values.EnumName
+([N x i8*] of the assigned `.value` strings). Integer enums skip the value
+table because their `.value` is the int constant itself, not a string.
 """
-impl NaIRGenPass._build_enum_string_table(enum_name: str, entries: list) -> None {
+impl NaIRGenPass._build_enum_string_table(
+    enum_name: str, entries: list, with_values: bool = True
+) -> None {
     i8 = ir.IntType(8);
     i8p = i8.as_pointer();
     i32 = ir.IntType(32);
@@ -106,25 +118,31 @@ impl NaIRGenPass._build_enum_string_table(enum_name: str, entries: list) -> None
     value_ptrs: list = [];
     name_ptrs: list = [];
     for (mname, str_val, ordinal) in entries {
-        # Create global constant for the .value string.
+        # Create global constant for the .value string (string enums only).
         # Use full 16-byte RC header { i64 RC_SENTINEL, i64 dtor=0, [N x i8] data }
         # so that __rc_retain(ptr) reading at ptr-16 finds the sentinel and skips.
-        val_bytes = bytearray((str_val + "\0").encode("utf8"));
-        val_arr_type = ir.ArrayType(i8, len(val_bytes));
-        val_struct_type = ir.LiteralStructType([i64, i64, val_arr_type]);
-        val_c_str = ir.Constant(val_arr_type, val_bytes);
-        val_struct = ir.Constant(val_struct_type, [sentinel_val, zero_i64, val_c_str]);
-        val_gv = ir.GlobalVariable(
-            self.llvm_module, val_struct_type, name=f"__enum.{enum_name}.v.{ordinal}"
-        );
-        val_gv.linkage = "private";
-        val_gv.global_constant = True;
-        val_gv.initializer = val_struct;
-        # Constant GEP to string data (skip full 16-byte RC header = 2 fields)
-        val_ptr = val_gv.gep(
-            [ir.Constant(i32, 0), ir.Constant(i32, 2), ir.Constant(i32, 0)]
-        );
-        value_ptrs.append(val_ptr);
+        if with_values {
+            val_bytes = bytearray((str_val + "\0").encode("utf8"));
+            val_arr_type = ir.ArrayType(i8, len(val_bytes));
+            val_struct_type = ir.LiteralStructType([i64, i64, val_arr_type]);
+            val_c_str = ir.Constant(val_arr_type, val_bytes);
+            val_struct = ir.Constant(
+                val_struct_type, [sentinel_val, zero_i64, val_c_str]
+            );
+            val_gv = ir.GlobalVariable(
+                self.llvm_module,
+                val_struct_type,
+                name=f"__enum.{enum_name}.v.{ordinal}"
+            );
+            val_gv.linkage = "private";
+            val_gv.global_constant = True;
+            val_gv.initializer = val_struct;
+            # Constant GEP to string data (skip full 16-byte RC header = 2 fields)
+            val_ptr = val_gv.gep(
+                [ir.Constant(i32, 0), ir.Constant(i32, 2), ir.Constant(i32, 0)]
+            );
+            value_ptrs.append(val_ptr);
+        }
         # Create global constant for the .name string (member name)
         name_bytes = bytearray((mname + "\0").encode("utf8"));
         name_arr_type = ir.ArrayType(i8, len(name_bytes));
@@ -146,14 +164,16 @@ impl NaIRGenPass._build_enum_string_table(enum_name: str, entries: list) -> None
     }
     n = len(entries);
     arr_type = ir.ArrayType(i8p, n);
-    # Build .value array global
-    val_arr_gv = ir.GlobalVariable(
-        self.llvm_module, arr_type, name=f"__enum_values.{enum_name}"
-    );
-    val_arr_gv.linkage = "private";
-    val_arr_gv.global_constant = True;
-    val_arr_gv.initializer = ir.Constant(arr_type, value_ptrs);
-    self.enum_value_arrays[enum_name] = val_arr_gv;
+    # Build .value array global (string enums only)
+    if with_values {
+        val_arr_gv = ir.GlobalVariable(
+            self.llvm_module, arr_type, name=f"__enum_values.{enum_name}"
+        );
+        val_arr_gv.linkage = "private";
+        val_arr_gv.global_constant = True;
+        val_arr_gv.initializer = ir.Constant(arr_type, value_ptrs);
+        self.enum_value_arrays[enum_name] = val_arr_gv;
+    }
     # Build .name array global
     name_arr_gv = ir.GlobalVariable(
         self.llvm_module, arr_type, name=f"__enum_names.{enum_name}"

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -846,6 +846,15 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                 if right_name == "value" {
                     return member_val;
                 }
+                # Integer enum .name: index the name table by the member's
+                # static declaration ordinal (the table is built ordinal-keyed,
+                # independent of the assigned int values).
+                ordinal = self.enum_member_ordinal.get(f"{mem_enum}.{mem_name}");
+                if ordinal is not None {
+                    return self._codegen_enum_value_lookup(
+                        mem_enum, ir.Constant(ir.IntType(64), ordinal), use_name=True
+                    );
+                }
             }
         }
         if target_name is not None and right_name is not None {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -821,6 +821,33 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
     if nd.is_attr {
         target_name = self._get_name(nd.target);
         right_name = self._get_name(nd.right);
+        # Check .value / .name on a direct enum member: Priority.HIGH.value.
+        # The member access nests as AtomTrailer(AtomTrailer(Enum, MEMBER), attr),
+        # and _get_name(nd.target) is None for the inner trailer, so this must run
+        # ahead of the target_name guard below.
+        if (right_name == "value" or right_name == "name")
+        and isinstance(nd.target, uni.AtomTrailer)
+        and nd.target.is_attr {
+            mem_enum = self._get_name(nd.target.target);
+            mem_name = self._get_name(nd.target.right);
+            if mem_enum is not None
+            and mem_name is not None
+            and f"{mem_enum}.{mem_name}" in self.enum_values {
+                member_val = self.enum_values[f"{mem_enum}.{mem_name}"];
+                if mem_enum in self.enum_string_values {
+                    # String enum: member lowers to its ordinal; .value/.name
+                    # index the runtime string tables.
+                    return self._codegen_enum_value_lookup(
+                        mem_enum, member_val, use_name=(right_name == "name")
+                    );
+                }
+                # Integer enum: member lowers to its assigned value, so .value
+                # is the member constant itself.
+                if right_name == "value" {
+                    return member_val;
+                }
+            }
+        }
         if target_name is not None and right_name is not None {
             # Check native stdlib module access: sys.argv, sys.platform
             if (

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -71,6 +71,7 @@ obj NaIRGenPass(ModuleCodegenPass) {
         enum_string_values: dict[str, list] = {},
         enum_value_arrays: dict[str, object] = {},
         enum_name_arrays: dict[str, object] = {},
+        enum_member_ordinal: dict[str, int] = {},
         var_enum_type: dict[str, str] = {},
         struct_field_enum_type: dict[str, dict] = {},
         loop_stack: list[tuple] = [],
@@ -258,7 +259,10 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _codegen_int_pow(base: ir.Value, exp: ir.Value) -> ir.Value;
     # Phase 1: Enums, BoolExpr, Break/Continue, For, Ternary
     def _codegen_enum(nd: uni.Enum) -> None;
-    def _build_enum_string_table(enum_name: str, entries: list) -> None;
+    def _build_enum_string_table(
+        enum_name: str, entries: list, with_values: bool = True
+    ) -> None;
+
     def _codegen_enum_value_lookup(
         enum_name: str, ordinal_val: ir.Value, use_name: bool = False
     ) -> (ir.Value | None);

--- a/jac/tests/compiler/passes/native/fixtures/na_enum_import.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/na_enum_import.na.jac
@@ -21,10 +21,6 @@ def use_imported_enum() -> int {
     return 0;
 }
 
-def imported_enum_ordinals() -> int {
-    return TokenKind.EOF;
-}
-
 def imported_enum_value() -> str {
     k: TokenKind = TokenKind.PLUS;
     return k.value;

--- a/jac/tests/compiler/passes/native/fixtures/string_enums.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/string_enums.na.jac
@@ -47,6 +47,14 @@ def int_enum_still_works() -> int {
     return Priority.HIGH.value;
 }
 
+def priority_high_name() -> str {
+    return Priority.HIGH.name;
+}
+
+def priority_low_name() -> str {
+    return Priority.LOW.name;
+}
+
 with entry {
     _x: int = 1;
 }

--- a/jac/tests/compiler/passes/native/fixtures/string_enums.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/string_enums.na.jac
@@ -20,14 +20,6 @@ enum Priority {
     HIGH = 2
 }
 
-def color_ordinal_red() -> int {
-    return Color.RED;
-}
-
-def color_ordinal_blue() -> int {
-    return Color.BLUE;
-}
-
 def color_cmp(c: int) -> int {
     if c == Color.RED {
         return 10;
@@ -52,7 +44,7 @@ def direction_value(d: Direction) -> str {
 }
 
 def int_enum_still_works() -> int {
-    return Priority.HIGH;
+    return Priority.HIGH.value;
 }
 
 with entry {

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2204,6 +2204,16 @@ test "string_enums int enum still works" {
     assert f() == 2 , f"Priority.HIGH should be 2, got {f()}";
 }
 
+test "string_enums int enum name access" {
+    (eng, _) = compile_native("string_enums.na.jac");
+    entry_fn = get_func(eng, "jac_entry", None);
+    entry_fn();
+    f = get_func(eng, "priority_high_name", ctypes.c_char_p);
+    assert f() == b"HIGH" , f"Priority.HIGH.name should be 'HIGH', got {f()}";
+    g = get_func(eng, "priority_low_name", ctypes.c_char_p);
+    assert g() == b"LOW" , f"Priority.LOW.name should be 'LOW', got {g()}";
+}
+
 # --- Cross-Module Enum Import Tests ---
 test "enum_import compiles" {
     (eng, _) = compile_native("na_enum_import.na.jac");

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2157,22 +2157,6 @@ test "list_bugs reassign str list with empty literal" {
 }
 
 # --- String Enum Tests ---
-test "string_enums ordinal red" {
-    (eng, _) = compile_native("string_enums.na.jac");
-    entry_fn = get_func(eng, "jac_entry", None);
-    entry_fn();
-    f = get_func(eng, "color_ordinal_red", ctypes.c_int64);
-    assert f() == 0 , f"Color.RED ordinal should be 0, got {f()}";
-}
-
-test "string_enums ordinal blue" {
-    (eng, _) = compile_native("string_enums.na.jac");
-    entry_fn = get_func(eng, "jac_entry", None);
-    entry_fn();
-    f = get_func(eng, "color_ordinal_blue", ctypes.c_int64);
-    assert f() == 2 , f"Color.BLUE ordinal should be 2, got {f()}";
-}
-
 test "string_enums comparison" {
     (eng, _) = compile_native("string_enums.na.jac");
     entry_fn = get_func(eng, "jac_entry", None);
@@ -2232,15 +2216,6 @@ test "enum_import enum comparison" {
     entry_fn();
     f = get_func(eng, "use_imported_enum", ctypes.c_int64);
     assert f() == 1 , "TokenKind.KW_IF == TokenKind.KW_IF should return 1";
-}
-
-test "enum_import ordinal" {
-    (eng, _) = compile_native("na_enum_import.na.jac");
-    entry_fn = get_func(eng, "jac_entry", None);
-    entry_fn();
-    f = get_func(eng, "imported_enum_ordinals", ctypes.c_int64);
-    # TokenKind.EOF is the last member (ordinal 6)
-    assert f() == 6 , f"TokenKind.EOF ordinal should be 6, got {f()}";
 }
 
 test "enum_import value access" {

--- a/jac/tests/compiler/passes/native/test_native_lexer.jac
+++ b/jac/tests/compiler/passes/native/test_native_lexer.jac
@@ -178,16 +178,15 @@ test "auto-marshal string enum functions" {
     assert layout is not None;
     ct_classes = build_ctypes_classes(layout);
     enum_maps = build_enum_maps(layout, {});
-    # color_ordinal_red should return 0 (ordinal of RED)
-    func_layout = layout.functions.get("color_ordinal_red");
+    # color_cmp branches on string-enum members (RED=0, BLUE=2 ordinals),
+    # proving enum members compile to usable comparison constants and that a
+    # function in a string-enum module wraps and round-trips through marshalling.
+    func_layout = layout.functions.get("color_cmp");
     assert func_layout is not None;
     wrapper = wrap_native_function(eng, func_layout, ct_classes, enum_maps, {});
     assert wrapper is not None;
-    assert wrapper() == 0 , f"Expected 0 (RED ordinal), got {wrapper()}";
-    # color_ordinal_blue should return 2 (ordinal of BLUE)
-    func_layout2 = layout.functions.get("color_ordinal_blue");
-    wrapper2 = wrap_native_function(eng, func_layout2, ct_classes, enum_maps, {});
-    assert wrapper2() == 2 , f"Expected 2 (BLUE ordinal), got {wrapper2()}";
+    assert wrapper(0) == 10 , f"color_cmp(RED=0) should be 10, got {wrapper(0)}";
+    assert wrapper(2) == 30 , f"color_cmp(BLUE=2) should be 30, got {wrapper(2)}";
 }
 
 # --- Tuple metadata export ---


### PR DESCRIPTION
## Summary

First of three native-backend fixes that let the implicit-native build honor the central type checker (#6049 section A). This one addresses the enum category.

Native treated bare enum members as `i64`, so type-incorrect code like `return Color.RED` from a `-> int` function compiled by silently using the member's i64 ordinal. The central checker correctly rejects this: an enum member is its enum type, not `int`. This change aligns native with Jac-proper enum semantics and makes the fixtures type-honest, instead of leaning on a native-only coercion.

## Changes

- **Native codegen:** lower `.value` on a direct enum member access (`Priority.HIGH.value`). The access nests as `AtomTrailer(AtomTrailer(Enum, MEMBER), attr)`; the inner trailer has no resolvable name, so the new handling runs ahead of the existing `target_name` guard. String enums index the runtime value/name tables via their ordinal (existing path); integer enums lower to their assigned value, so `.value` is the member constant itself.
- **Fixtures (type-honest):**
  - `int_enum_still_works()` now returns `Priority.HIGH.value` (yields int `2`), which the checker types as `int`.
  - The string-enum "ordinal" functions (`color_ordinal_red`, `color_ordinal_blue`, `imported_enum_ordinals`) tested a concept that does not exist in Jac proper. Plain enums have no positional ordinal, only the assigned `.value`. Dropped, along with their tests.

## Why not just expose `.ordinal`?

The positional ordinal is a native representation detail, not a Jac-proper concept (Python/Jac `Enum` has no `.ordinal`). Adding it would reintroduce a native-only divergence, which is exactly what section A aims to remove. The legitimate accessors `.value` / `.name` already cover the surface; the i64-ordinal codegen path stays exercised by the comparison and value/name lookup tests.

## Verification

- `jac check` on `string_enums.na.jac` and `na_enum_import.na.jac`: clean (was 4 of the 7 residual section-A errors).
- Full native suite: 339 passed (was 342; the 3 removed tests covered the dropped illegitimate functions).

## Note

The implicit-native diagnostic suppression in `compiler.impl.jac` is intentionally left untouched. It can only be dropped once all three section-A categories (enum, exception-to-str, None-to-archetype) are fixed, since any one still-open category keeps producing real errors. That removal will be a final coordinating PR after the three category PRs land.
