### PR TITLE
feat(native): str() of a char* is identity; enables str(e) (#6049 cat 2)

### DIFF
--- a/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
@@ -5825,6 +5825,16 @@ impl NativeBuiltinEmitter.emit_str(
     p = ctx.pass_ref;
     b = get_builder(p);
     i8p = ir.IntType(8).as_pointer();
+    # str() of something already a string (char*) is the string itself.
+    # Native strings and bound exception messages are both i8*, so str(e)
+    # in `except E as e` returns the message rather than formatting the
+    # pointer address.
+    if isinstance(arg_val.type, ir.PointerType) {
+        if arg_val.type != i8p {
+            return b.bitcast(arg_val, i8p, name="str.identity");
+        }
+        return arg_val;
+    }
     rc_alloc_fn = p.rc_alloc_fn;
     buf_ptr = b.call(rc_alloc_fn, [ir.Constant(ir.IntType(64), 32)], name="str.buf");
     snprintf = p._get_or_declare_extern(

--- a/jac/tests/compiler/passes/native/fixtures/exceptions.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/exceptions.na.jac
@@ -25,18 +25,15 @@ def test_try_no_exception() -> int {
 }
 
 # Test 3: Exception with "as" binding — bind exception message.
-# NOTE: native runtime represents Exception as a bare char* message
-# pointer, so `msg = e` produces the message directly. Python semantics
-# would expect `str(e)` here, but the native runtime doesn't yet
-# implement Exception.__str__, so the residual E1001 (`Cannot assign
-# Exception to str`) is accepted as a native-specific divergence —
-# same class as the runtime_errors None-dereference tests.
+# `str(e)` yields the exception's message. The native runtime represents
+# an exception as a char* message pointer, so str() of it is the message
+# string itself; this matches Jac-proper semantics where str(e) is a str.
 def test_except_as_binding() -> str {
     msg: str = "none";
     try {
         raise Exception("caught me");
     } except Exception as e {
-        msg = e;
+        msg = str(e);
     }
     return msg;
 }


### PR DESCRIPTION
## Summary

Second of three native-backend fixes for #6049 section A. This one addresses the exception-to-str category.

Native `emit_str` formatted any non-int/float argument with `"%ld"`, so `str()` of a value that is already a string (or a bound exception message) produced the pointer address rather than the string. The exceptions fixture worked around this by binding `msg = e` directly, which the central checker correctly rejects (`Cannot assign Exception to str`).

## Changes

- **Native codegen:** `emit_str` now returns a string-typed pointer argument unchanged (bitcast to `i8*` when the pointer is some other type), matching Python where `str(s)` is `s` for an existing string. Integer and float arguments keep the `snprintf` formatting path.
- **Fixture (type-honest):** `test_except_as_binding` uses `msg = str(e)`, which the checker types as `str`. Native represents a bound exception as a `char*` message pointer, so `str(e)` yields the message. Behavior is identical to the previous `msg = e` (the value flow is the same pointer), but now type-correct.

## Verification

- `jac check` on `exceptions.na.jac`: clean (was 1 of the 7 residual section-A errors).
- Full native suite: 342 passed.

## Note

As with the enum PR, the implicit-native diagnostic suppression in `compiler.impl.jac` is left untouched here; it can only be dropped once all three section-A categories are fixed. That removal is a final coordinating PR after the category PRs land.
