### PR TITLE
feat(native): lower CastExpr (value as T) (#6049 cat 3)

### DIFF
--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -88,6 +88,12 @@ impl NaIRGenPass._codegen_expr(nd: (uni.UniNode | None)) -> (ir.Value | None) {
         # Handle parenthesized expressions: (expr) → AtomUnit
     } elif isinstance(nd, uni.AtomUnit) {
         _result = self._codegen_expr(nd.value);
+        # Cast (`value as T`) is type-erased: it evaluates to the inner
+        # value unchanged and only refines the static type. The narrowed
+        # type lets `.attr` on a nullable archetype compile; a None value
+        # then traps at the native deref just like any AttributeError.
+    } elif isinstance(nd, uni.CastExpr) {
+        _result = self._codegen_expr(nd.value);
         # Lambda expressions: emit an anonymous LLVM function and return
         # a function pointer to it.
     } elif isinstance(nd, uni.LambdaExpr) {

--- a/jac/tests/compiler/passes/native/fixtures/runtime_errors.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/runtime_errors.na.jac
@@ -257,20 +257,14 @@ obj SimpleObj {
     }
 }
 
-# Test 19: Field access on None.
-# NOTE: `s: SimpleObj = None` is rejected by the type checker (correctly,
-# since SimpleObj is non-Optional). This fixture intentionally retains
-# the type error to exercise native runtime AttributeError on a None
-# dereference -- the scenario itself is unsafe Jac code that the type
-# system properly disallows. Both `as`-cast workarounds and stubbed-None
-# helpers run into native-codegen gaps (CastExpr is unsupported), so the
-# residual type error is accepted as the cost of testing the runtime
-# trap. Tracked under #6058 fixture-quality notes.
+# Test 19: Field access on None. The variable is honestly typed nullable
+# and the `as` cast asserts non-None so `.val` type-checks; at runtime the
+# value is None and the native deref traps as an AttributeError.
 def test_none_field_access() -> int {
     result: int = 0;
-    s: SimpleObj = None;
+    s: SimpleObj | None = None;
     try {
-        x: int = s.val;
+        x: int = (s as SimpleObj).val;
         result = -1;
     } except AttributeError {
         result = 1;
@@ -278,12 +272,12 @@ def test_none_field_access() -> int {
     return result;
 }
 
-# Test 20: Method call on None -- see Test 19 note re: residual type error.
+# Test 20: Method call on None -- same nullable-plus-cast pattern as Test 19.
 def test_none_method_call() -> int {
     result: int = 0;
-    s: SimpleObj = None;
+    s: SimpleObj | None = None;
     try {
-        x: int = s.get_val();
+        x: int = (s as SimpleObj).get_val();
         result = -1;
     } except AttributeError {
         result = 1;


### PR DESCRIPTION
## Summary

Third of three native-backend fixes for #6049 section A. This one addresses the None-to-archetype category.

`CastExpr` (`value as T`) had no native codegen, so any cast hit the catch-all `E5090` ("unrecognized expression"). The runtime_errors None-dereference fixtures sidestepped that by declaring `s: SimpleObj = None`, which the central checker correctly rejects (`Cannot assign NoneType to SimpleObj`).

## Changes

- **Native codegen:** lower `CastExpr` to its inner value. The cast is type-erased (it evaluates to `value` unchanged and only refines the static type), so codegen returns the inner value directly.
- **Fixtures (type-honest):** `test_none_field_access` and `test_none_method_call` now use `s: SimpleObj | None = None` plus `(s as SimpleObj).val` / `.get_val()`. The cast narrows the type so the access type-checks, while the None value still traps at the native deref as an `AttributeError` -- exactly the runtime behavior these tests exercise.

## Verification

- `jac check` on `runtime_errors.na.jac`: clean (was 2 of the 7 residual section-A errors).
- Full native suite: 342 passed.

## Note

This is the last of the three section-A category fixes (enum, exception-to-str, None-to-archetype). Once all three merge, a final coordinating PR will drop the implicit-native diagnostic suppression in `compiler.impl.jac` so native builds get real type enforcement, and the native suite will be re-run with the suppression gone.
