### PR TITLE
test(views): executable spec for view-lowering JSX slot extensions (#6082 items 1, 3, 5, 7)

### DIFF
--- a/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/loop_auto_fragment.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/loop_auto_fragment.cl.jac
@@ -1,0 +1,35 @@
+"""Rec 1 — for-loop slot whose body emits multiple keyless JSX siblings.
+
+ViewLowerPass should detect this shape and wrap each iteration in a
+synthesized `<React.Fragment key={jid(tweet)}>...</>` so that one
+iteration is one keyed unit in the React diff, instead of three keyless
+siblings that all share the same diff bucket.
+"""
+
+obj Tweet {
+    has author: str,
+        body: str;
+}
+
+def:pub TweetRow(tweet: Tweet) -> JsxElement {
+    return
+        <div class="row">
+            <h3>{tweet.author}</h3>
+            <p>{tweet.body}</p>
+            <button>like</button>
+        </div>;
+}
+
+"""A list of tweets where each iteration emits three top-level keyless
+JSX statements. Without auto-fragmenting, React diffs them as one flat
+keyless list and loses iteration identity on reorder."""
+def:pub TweetList(tweets: list[Tweet]) -> JsxElement {
+    return
+        <section class="feed">
+            {for tweet in tweets {
+                <h3>{tweet.author}</h3>
+                <p>{tweet.body}</p>
+                <button>like</button>
+            }}
+        </section>;
+}

--- a/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/loop_auto_fragment_counter.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/loop_auto_fragment_counter.cl.jac
@@ -1,0 +1,17 @@
+"""Rec 1.3 — counted IterForStmt inside a JSX slot.
+
+Priority 3 of the auto-fragment key derivation: when the loop is the
+counted form (`for i = 0 to i < N by i += 1`), the synthesized
+`<React.Fragment>` per iteration takes the counter variable as its key
+— no jid() lookup, no lifted key.
+"""
+
+def:pub NumberedList -> JsxElement {
+    return
+        <ul class="numbered">
+            {for i = 0 to i < 5 by i += 1 {
+                <li>Row {i}</li>
+                <hr/>
+            }}
+        </ul>;
+}

--- a/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/loop_auto_fragment_lifted_key.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/loop_auto_fragment_lifted_key.cl.jac
@@ -1,0 +1,28 @@
+"""Rec 1.1 — for-loop slot with one child carrying an explicit `key=`.
+
+Priority 1 of the auto-fragment key derivation: when one child in the
+iteration body has an explicit `key=`, ViewLowerPass should LIFT that
+key onto the synthesized `<React.Fragment>` wrapper and STRIP it from
+the child. The iteration becomes one keyed unit; the child no longer
+carries its own key.
+"""
+
+def:pub Card(item: str) -> JsxElement {
+    return
+        <article class="card">{item}</article>;
+}
+
+def:pub Footer(item: str) -> JsxElement {
+    return
+        <footer class="row-foot">{item} footer</footer>;
+}
+
+def:pub Mixed(items: list[str]) -> JsxElement {
+    return
+        <section class="feed">
+            {for it in items {
+                <Card key={it} item={it}/>
+                <Footer item={it}/>
+            }}
+        </section>;
+}

--- a/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/static_hoist.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/static_hoist.cl.jac
@@ -1,0 +1,22 @@
+"""Rec 4 — static JSX subtree closing only over module-level bindings.
+
+The `<footer>` subtree references only the module-level `BRAND` and
+`YEAR` globals, no `has`-fields, no params, no slot locals. A static
+hoisting analysis can lift this subtree to a module-level const so the
+React renderer reuses one element identity across every render of
+`Page` instead of reconstructing it on every call.
+"""
+
+glob BRAND: str = "Jac",
+     YEAR: int = 2026;
+
+def:pub Page(title: str) -> JsxElement {
+    return
+        <main>
+            <h1>{title}</h1>
+            <footer>
+                <span class="brand">{BRAND}</span>
+                <span class="year">{YEAR}</span>
+            </footer>
+        </main>;
+}

--- a/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/stmt_body_view.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/stmt_body_view.cl.jac
@@ -1,0 +1,19 @@
+"""Rec 6 — statement-level JSX in a `def -> JsxElement` body.
+
+In client context, a `def -> JsxElement` body that contains top-level
+JSX `ExprStmt`s without an explicit `return <jsx>;` should be treated as
+an implicit outer slot — the same accumulator-IIFE lowering as a
+statement slot body, just at function scope.
+
+Today this fixture either fails to compile or compiles to a function
+that returns `undefined` (the JSX statements are evaluated for side
+effects and discarded). The expected behaviour is that the function
+returns the accumulated `<>{children}</>` fragment.
+"""
+
+def:pub Greeting(name: str) -> JsxElement {
+    <h1>Hello, {name}</h1>
+    if name == "admin" {
+        <p>Hello, admin</p>
+    }
+}

--- a/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/try_awaiting_except.cl.jac
+++ b/jac/tests/compiler/passes/ecmascript/fixtures/slot_extensions/try_awaiting_except.cl.jac
@@ -1,0 +1,35 @@
+"""Rec 2 — `try` slot carrying both `awaiting` AND `except` clauses.
+
+Today the `awaiting` clause lowers to `<JacAwaiting fallback={...}>...`
+but the `except` arm is silently parsed and never wired through the
+runtime wrapper. The expected behavior: synthesize a
+`<JacClientErrorBoundary fallback={<>...except body...</>}>`
+around the existing `<JacAwaiting>` so both the loading and error states
+are first-class on the `cl` target.
+"""
+
+obj User {
+    has name: str,
+        bio: str;
+}
+
+def:pub UserCard(user: User) -> JsxElement {
+    return
+        <div class="card">
+            <h2>{user.name}</h2>
+            <p>{user.bio}</p>
+        </div>;
+}
+
+def:pub UserPanel(user: User) -> JsxElement {
+    return
+        <section class="panel">
+            {try {
+                <UserCard user={user}/>
+            } awaiting {
+                <p>Loading…</p>
+            } except Exception {
+                <p>Something went wrong</p>
+            }}
+        </section>;
+}

--- a/jac/tests/compiler/passes/ecmascript/test_jsx_view_lowering_spec.jac
+++ b/jac/tests/compiler/passes/ecmascript/test_jsx_view_lowering_spec.jac
@@ -1,0 +1,202 @@
+"""Executable spec -- view-lowering JSX slot extensions (#6082 Tier 1/2).
+
+Every test in this file is expected to FAIL until the corresponding
+view-lowering extension lands in `ViewLowerPass`. The file is a tracker,
+not a regression guard -- the failure shape codifies the contract the
+implementing PR must satisfy.
+
+Mapping to issue #6082 items:
+
+  - rec 1.1 / 1.2 / 1.3: item 1 (for-loop auto-fragment) priorities 1, 2, 3
+  - rec 2:               item 3 (except + awaiting integration)
+  - rec 4:               item 5 (static JSX subtree hoisting)
+  - rec 6:               item 7 (statement-level JSX in def -> JsxElement)
+
+These items all live in `view_lower_pass.jac` and share the
+`_check_body` / `_lower_body` / `_lower_one` / `_lower_try_with_awaiting`
+recursion, so they bundle into one PR.
+
+rec 4 carries a POST-IMPLEMENTATION TIGHTENING note where the issue body
+leaves the const-naming convention open -- sharpen it once the
+implementer commits to a concrete shape.
+"""
+
+import os;
+import pytest;
+import from pathlib { Path }
+import jaclang;
+import from jaclang.compiler.passes.ecmascript { EsastGenPass }
+import jaclang.compiler.passes.ecmascript.estree as es;
+import from jaclang.compiler.passes.ecmascript.es_unparse { es_to_js }
+import from jaclang.jac0core.program { JacProgram }
+
+glob JAC_ROOT = str(Path(jaclang.__file__).parent.parent),
+     SLOT_EXT = os.path.join(
+         JAC_ROOT,
+         "tests",
+         "compiler",
+         "passes",
+         "ecmascript",
+         "fixtures",
+         "slot_extensions"
+     );
+
+"""Compile a fixture to ESTree and assert no errors were emitted."""
+def compile_to_esast(filename: str) -> es.Program {
+    path = os.path.join(SLOT_EXT, filename);
+    prog = JacProgram();
+    ir = prog.compile(file_path=path, no_cgen=True);
+    assert not prog.errors_had , (
+        f"Compilation errors in {filename}: " + str([str(e) for e in prog.errors_had])
+    );
+    es_pass = EsastGenPass(ir_in=ir, prog=prog);
+    return es_pass.ir_out.gen.es_ast;
+}
+
+# ──────────────────────────────────────────────────────────────────
+# Item 1 -- for-loop auto-fragment + key derivation (3 priorities still failing)
+# ──────────────────────────────────────────────────────────────────
+test "rec 1.1: for-loop auto-fragment lifts an explicit key= from one child" {
+    # Issue #6082 item 1, priority 1: when one child in a for-loop slot
+    # carries an explicit `key=`, ViewLowerPass should LIFT that key to
+    # the synthesized `<React.Fragment>` wrapper and STRIP it from the
+    # child. The iteration is then one keyed unit; the lifted key
+    # expression is what the React diff uses for identity.
+    es_ast = compile_to_esast("loop_auto_fragment_lifted_key.cl.jac");
+    js_code = es_to_js(es_ast);
+
+    assert "__jacJsx(Fragment," in js_code or "React.Fragment" in js_code , (
+        "iteration must be wrapped in a synthesized Fragment:\n" + js_code
+    );
+    # The Fragment must carry the lifted key.
+    import re;
+    frag_match = re.search(r'__jacJsx\(Fragment,\s*\{[^}]*"key":\s*([^,}]+)', js_code);
+    assert frag_match is not None , (
+        "the Fragment wrapper must carry the lifted key:\n" + js_code
+    );
+    # The Card child must no longer carry `key=` after the lift.
+    card_match = re.search(r'__jacJsx\(Card,\s*(\{[^}]*\})', js_code);
+    assert card_match is not None , "the Card call must be present";
+    assert '"key"' not in card_match.group(1) , (
+        "the explicit key= on the child must be stripped after being "
+        "lifted to the Fragment, but it survived in:\n" + card_match.group(1)
+    );
+}
+
+test "rec 1.2: for-loop auto-fragment derives key from jid(loop_var) for typed obj" {
+    # Issue #6082 item 1, priority 2: when the loop var is typed as a
+    # Jac obj or node, the synthesized Fragment's key is derived from
+    # `jid(loop_var)` -- the canonical Jac object identity.
+    es_ast = compile_to_esast("loop_auto_fragment.cl.jac");
+    js_code = es_to_js(es_ast);
+
+    assert "__jacJsx(Fragment," in js_code or "React.Fragment" in js_code , (
+        "iteration must be wrapped in a synthesized Fragment:\n" + js_code
+    );
+    assert '"key":' in js_code , ("the Fragment must carry a key prop:\n" + js_code);
+    assert "_jac.builtin.jid(tweet)" in js_code , (
+        "key should be derived from jid(loop_var) when the loop var is "
+        "a typed obj:\n" + js_code
+    );
+}
+
+test "rec 1.3: for-loop auto-fragment uses the counter for IterForStmt" {
+    # Issue #6082 item 1, priority 3: when the loop is a counted form
+    # (`for i = 0 to i < N by i += 1`), the synthesized Fragment's key
+    # is the loop counter -- no jid() lookup needed and no lifted key.
+    es_ast = compile_to_esast("loop_auto_fragment_counter.cl.jac");
+    js_code = es_to_js(es_ast);
+
+    assert "__jacJsx(Fragment," in js_code or "React.Fragment" in js_code , (
+        "iteration must be wrapped in a synthesized Fragment:\n" + js_code
+    );
+    import re;
+    assert re.search(r'__jacJsx\(Fragment,\s*\{[^}]*"key":\s*i\b', js_code) , (
+        "the Fragment's key should be the counter variable `i`:\n" + js_code
+    );
+    # The counted IterForStmt should lower to a JS counted for-loop
+    # (init / condition / update form), not a `for ... of`.
+    assert re.search(r"for\s*\(\s*(let|var)\s+i\s*=\s*0", js_code) , (
+        "a counted IterForStmt should lower to a JS counted for-loop:\n" + js_code
+    );
+}
+
+# ──────────────────────────────────────────────────────────────────
+# Items 3 / 5 / 7 -- view-lowering extensions
+# ──────────────────────────────────────────────────────────────────
+test "rec 2: try/awaiting with except synthesises a JacClientErrorBoundary wrapper" {
+    # On the cl target, when a slot `try` carries both `awaiting` and at
+    # least one `except` clause, ViewLowerPass should synthesize a
+    # `<JacClientErrorBoundary fallback={...}>` around the existing
+    # `<JacAwaiting fallback={...}>{...}</JacAwaiting>` wrapper. The
+    # except-arm bodies feed the error-boundary's fallback the same way
+    # the awaiting body feeds the suspense fallback.
+    es_ast = compile_to_esast("try_awaiting_except.cl.jac");
+    js_code = es_to_js(es_ast);
+
+    assert "JacClientErrorBoundary" in js_code , (
+        "an except-arm alongside awaiting should synthesize a "
+        "<JacClientErrorBoundary> wrapper:\n" + js_code
+    );
+    import re;
+    assert re.search(
+        r'import\s*\{[^}]*\bJacClientErrorBoundary\b[^}]*\}\s*' + r'from\s*[\'"]@jac/runtime[\'"]',
+        js_code
+    ) , ("JacClientErrorBoundary should be auto-imported from @jac/runtime");
+    # Both the awaiting body and the except body content survive.
+    assert "Loading" in js_code;
+    assert "Something went wrong" in js_code;
+}
+
+test "rec 4: static JSX subtree closing only over module-level bindings is hoisted" {
+    # JSX subtrees whose only free variables are module-level bindings
+    # (no has, no params, no slot locals) are hoisted to a module-level
+    # `const` and referenced from the render site. Solid-style auto-
+    # optimization driven by a pass-internal analysis.
+    #
+    # POST-IMPLEMENTATION TIGHTENING: this test locks in `__jac_static_<N>`
+    # as the const-naming convention, but issue #6082 only specifies "a
+    # module-level `const`". If the implementer picks a different name
+    # (`__jac_view_const_<N>`, `__hoisted_<N>`, ...), loosen the regex to
+    # match whatever scheme they choose rather than rejecting a correct
+    # implementation.
+    es_ast = compile_to_esast("static_hoist.cl.jac");
+    js_code = es_to_js(es_ast);
+
+    # A module-level hoist binding should exist, by convention prefixed
+    # `__jac_static_` to match the ambient-builtin naming style.
+    import re;
+    assert re.search(r"(const|let)\s+__jac_static_\w+\s*=\s*__jacJsx\(", js_code) , (
+        "a static JSX subtree should be hoisted to a module-level const "
+        "named __jac_static_<N>:\n" + js_code
+    );
+    # The render site must reference the hoisted const rather than
+    # inlining the subtree.
+    assert js_code.count("__jac_static_") >= 2 , (
+        "the hoisted const should be both defined and referenced:\n" + js_code
+    );
+}
+
+test "rec 6: def -> JsxElement body with statement-level JSX (no return) lowers to slot IIFE" {
+    # In client context, when a `def -> JsxElement` body contains
+    # top-level JSX ExprStmts without an explicit `return <jsx>;`, apply
+    # the accumulator-IIFE lowering to the function body itself.
+    es_ast = compile_to_esast("stmt_body_view.cl.jac");
+    js_code = es_to_js(es_ast);
+
+    # The function-body-as-outer-slot lowering reuses the slot
+    # accumulator convention.
+    assert "__jac_view_kids" in js_code , (
+        "function-body-position JSX statements should use the same "
+        "accumulator pattern as slot bodies:\n" + js_code
+    );
+    # Both branches' content survives.
+    assert "Hello, admin" in js_code;
+    assert "Hello, " in js_code;
+    # The component returns the accumulated fragment, not undefined.
+    import re;
+    assert re.search(r"return\s+__jacJsx\(", js_code) , (
+        "the implicit outer-slot lowering must return the accumulated "
+        "JSX fragment:\n" + js_code
+    );
+}


### PR DESCRIPTION
**Deliberately RED tracker.** This is a failing-tests-only branch — the executable spec for the four `view_lower_pass.jac` items in #6082 that share the slot-lowering recursion. Each test codifies the contract the implementing PR must satisfy. Split out of #6088 so that CI (`--exitfirst`) stays green on the implementation branch while the spec remains a visible tracker.

## Coverage map

| Test  | #6082 item                                            |
| ----- | ----------------------------------------------------- |
| 1.1   | item 1 priority 1 — lifted explicit `key=`            |
| 1.2   | item 1 priority 2 — `jid(loop_var)` for typed obj     |
| 1.3   | item 1 priority 3 — counter for IterForStmt           |
| 2     | item 3 — try/awaiting + except auto-wrap              |
| 4     | item 5 — static JSX subtree hoisting                  |
| 6     | item 7 — statement-level JSX in def -> JsxElement     |

## Why this grouping

All four items live in `view_lower_pass.jac` and share the `_check_body` / `_lower_body` / `_lower_one` / `_lower_try_with_awaiting` recursion. The issue itself notes "Tier 1 rows 1+2+3+4 bundle naturally — same `_check_body`/`_lower_one` recursion", and item 7 (statement-level JSX) is "the same machinery as a slot body, just at function scope" — a second entry point into the already-parameterized lowering. They review as one surface.

## How to use this PR

- When the implementation lands, each test should turn green; relocate the green tests into `test_slot_extensions.jac` (where the already-shipped #6085 items' positive tests live) and drop them from this file.
- When all six pass, this tracker can be closed.
- rec 4 carries an inline POST-IMPLEMENTATION TIGHTENING note — the `__jac_static_<N>` const-naming assertion is loose where the issue leaves the shape open; tighten it when the implementer commits to a concrete scheme.

## Companions

- #6085 — the four #6082 items already shipped (`{name}` shorthand, E2024, W2021).
- Sibling red-spec trackers split from #6088: Ref/useRef (item 8), scoped `.style.css` styles (item 10), and the streaming items (sv-awaiting + walker progressive frames, gated on design).
