### PR TITLE
fix(planner): pass anchor.archetype to post_filter in _execute_mixed

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6094.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6094.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `_execute_mixed` post-filter now receives the node archetype, not the anchor**: `plan.post_filter` expects an archetype (consistent with `_execute_pushdown` and `_materialize_ids`). Previously passing the raw `NodeAnchor` caused incorrect filtering when `_execute_mixed` was used as the planner strategy.

--- a/jac/jaclang/runtimelib/impl/planner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/planner.impl.jac
@@ -246,7 +246,8 @@ def _execute_mixed(mem: any, plan: QueryPlan, narrowed: set[UUID]) -> list[any] 
         _trace('mixed', plan, f"narrowed={len(narrowed)}");
         result: list = [];
         for anchor in mem.execute_plan(reduced) {
-            if plan.post_filter is not None and not plan.post_filter(anchor) {
+            if plan.post_filter is not None
+            and not plan.post_filter(anchor.archetype) {
                 continue;
             }
             result.append(anchor);


### PR DESCRIPTION
## What

One-line fix in `_execute_mixed` (planner.impl.jac line 249).

`mem.execute_plan(reduced)` yields `NodeAnchor` objects. `plan.post_filter` is the destination's `node_filter` callable, which expects an **archetype** (the user-facing node object, not the storage anchor). The same pattern is applied correctly in both other call sites:

- `_execute_pushdown` (line 206): `plan.post_filter(anchor.archetype)` ✓
- `_materialize_ids` (line 164): `post_filter(anchor.archetype)` ✓
- `_execute_mixed` (line 249): `plan.post_filter(anchor)` ✗ ← this PR

## Impact

`_execute_mixed` is reached when the backend has partial capabilities (can handle `id_in` but not `field_predicates`, for example). Passing the raw anchor instead of the archetype meant `post_filter` received the wrong object type, causing incorrect filtering results — nodes that should have been filtered out were retained, or the filter raised an AttributeError if it accessed a field not present on `NodeAnchor`.

## Test plan

- [ ] Existing planner tests pass: `python3.12 -m pytest jac/tests/ -k planner -v`
- [ ] The `_execute_mixed` path is triggered when a backend narrowing step succeeds but the reduced plan's capabilities aren't fully met — this is exercised by multi-hop tests with partial-capability backends