### PR TITLE
docs(views): document `.style.css` scoped-style annexes

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6103.docs.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6103.docs.md
@@ -1,1 +1,0 @@
-- **Docs: `.style.css` scoped-style annexes**: Documented the `.style.css` annex auto-scoping feature (shipped in #6099) in the jac-client reference, the components tutorial, the syntax cheatsheet, and the client-side agent skills.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6103.docs.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6103.docs.md
@@ -1,0 +1,1 @@
+- **Docs: `.style.css` scoped-style annexes**: Documented the `.style.css` annex auto-scoping feature (shipped in #6099) in the jac-client reference, the components tutorial, the syntax cheatsheet, and the client-side agent skills.

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -1283,6 +1283,7 @@ cl import from react { useState }
 # .na.jac        Native variant
 # .impl.jac      Implementation annex (method bodies)
 # .test.jac      Test annex
+# .style.css     Scoped CSS annex (auto-scopes classes for the matching .cl.jac)
 
 
 # ============================================================
@@ -1331,6 +1332,7 @@ def:pub Greeting(name: str) -> JsxElement {
 # <Box {title} {count} />       Attribute shorthand ({title} -> title={title})
 # <div className="cls">         Class name (not "class")
 # <div style={{"color": "red"}} Inline styles
+#   (classes declared in a same-base-name <Comp>.style.css are auto-scoped)
 # <@expr>...</@expr>            Dynamic tag (tag chosen by expression)
 
 

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1082,6 +1082,72 @@ to cl:
 import "./styles/main.css";
 ```
 
+### Scoped CSS (`.style.css` annexes)
+
+A `.style.css` file that **shares a base name** with a `.cl.jac` module is
+treated as a scoped-style annex -- the two files form one logical module. The
+compiler hashes every class selector the annex declares with a per-module
+digest, rewrites the CSS rule selectors, and rewrites JSX `className`/`class`
+literals in the module that reference a declared class to the same hashed
+form. Class names are scoped to the component automatically, so two modules
+can both declare `.card` without colliding.
+
+Given `Card.style.css` beside `Card.cl.jac`:
+
+```css
+/* Card.style.css */
+.card {
+    padding: 1rem;
+    border: 1px solid #ccc;
+}
+.card-title { font-weight: 600; }
+
+/* :global(...) opts out of scoping -- the inner selector is kept verbatim. */
+:global(html) { box-sizing: border-box; }
+```
+
+```jac
+# Card.cl.jac
+def:pub Card(title: str, body: str) -> JsxElement {
+    return <article className="card">
+        <h2 className="card-title">{title}</h2>
+        <p>{body}</p>
+    </article>;
+}
+```
+
+the compiler hashes the selectors and rewrites the matching `className`
+literals to agree (hashes are stable per module):
+
+```js
+import "./Card.css";
+function Card(props) {
+  const {title, body} = props;
+  return __jacJsx("article", {"className": "card-1419142b"},
+    [__jacJsx("h2", {"className": "card-title-769bf254"}, [title]),
+     __jacJsx("p", {}, [body])]);
+}
+```
+
+```css
+/* emitted sidecar Card.css */
+.card-1419142b { padding: 1rem; border: 1px solid #ccc; }
+.card-title-769bf254 { font-weight: 600; }
+html { box-sizing: border-box; }   /* :global(...) unwrapped */
+```
+
+Key points:
+
+- **No import needed.** The annex is paired by base name; the compiler injects
+  the side-effect `import "./<base>.css";` for you.
+- **Only declared classes are rewritten.** A `className` token with no matching
+  selector in the annex is left untouched, so you can mix scoped and global
+  (e.g. Tailwind) classes in the same `className`.
+- **`:global(...)` is the escape hatch** for selectors that must stay
+  unscoped (resets, third-party class targets, element selectors).
+- Scoped styles are per-module; for app-wide styles (themes, resets, Tailwind)
+  use a plain shared `import "./global.css";` instead.
+
 ### cn() Utility (Tailwind/shadcn)
 
 ```jac

--- a/docs/docs/tutorials/fullstack/components.md
+++ b/docs/docs/tutorials/fullstack/components.md
@@ -574,6 +574,41 @@ def:pub app() -> JsxElement {
 }
 ```
 
+### Scoped Styles (`.style.css`)
+
+Drop a `.style.css` file with the **same base name** as a component and its
+classes are auto-scoped to that component -- no import, no naming collisions.
+The compiler hashes each declared class, rewrites the CSS, and rewrites the
+matching `className` references to agree.
+
+```jac
+# Card.cl.jac
+def:pub Card(title: str) -> JsxElement {
+    return <div className="card">
+        <h2 className="card-title">{title}</h2>
+    </div>;
+}
+```
+
+```css
+/* Card.style.css -- paired by base name, no import required */
+.card {
+    padding: 1rem;
+    border: 1px solid #ccc;
+}
+.card-title { font-weight: 600; }
+
+/* :global(...) opts a selector out of scoping */
+:global(body) { margin: 0; }
+```
+
+At compile time `className="card"` becomes `className="card-1419142b"` and
+the CSS selector is hashed to match, so another component can declare its own
+`.card` without conflict. Tokens not declared in the annex (like Tailwind
+utilities) pass through unchanged. See the
+[jac-client reference](../../reference/plugins/jac-client.md#scoped-css-stylecss-annexes)
+for the full contract.
+
 ---
 
 ## Key Takeaways

--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -164,7 +164,7 @@ Also works: short-circuit in JSX - `{result and <X total={result.total_posts} />
 **For server response objects (dicts/lists from `sv import` calls), prefer truthy checks (`if result {`) over `!= None`.** The `!=` operator uses deep equality which calls `Object.keys()` - crashes with `"Cannot convert undefined or null to object"` if the value is `null`/`undefined`. `!= None` is safe for primitives (strings, ints, bools) but not for complex objects returned from server calls.
 
 - **Event params are typed - `MouseEvent`/`ChangeEvent`/etc.** Annotate every handler that reads `e` with the real event type, so `e.target` / `e.key` resolve. When you genuinely don't read `e`, use the base `Event` type - not `any`, which earns a `W1037` warning (and capital `Any` is not the keyword, warning `W2001` "Name 'Any' may be undefined").
-- **`style` prop takes a `dict[str, object]`, not a CSS string.** `<div style="color: red">` fails E1103. Use inline dict `<div style={{"color": "red"}}>` or move styling to `className` + a CSS file.
+- **`style` prop takes a `dict[str, object]`, not a CSS string.** `<div style="color: red">` fails E1103. Use inline dict `<div style={{"color": "red"}}>`, or move styling to `className` + a same-basename `.style.css` annex (auto-scoped -- see `jac-cl-styling`).
 - **JSX uses `className`, curly-brace interpolation `{expr}`, camelCase events** (`onClick`, `onChange`).
 - **No `to cl:` / `cl def:pub` / `cl { }` wrapper in `.cl.jac` files.** The extension already sets the client context.
 - **Top-level component name is `def:pub app()`** - lowercase. Runtime mounts the literal name.
@@ -174,4 +174,5 @@ Also works: short-circuit in JSX - `{result and <X total={result.total_posts} />
 - `jac-cl-routing` - `Router`/`Route`/`Navigate`/`useNavigate` patterns
 - `jac-cl-auth` - `jacLogin`/`jacSignup`/`jacLogout`, signup→login→def:priv chain
 - `jac-cl-organization` - file layout, component reuse, hook pattern
+- `jac-cl-styling` - Tailwind/`cn()`, semantic tokens, scoped `.style.css` annexes
 - `jac-core-cheatsheet` - imports, lambda, ternary, error handling

--- a/jac/jaclang/cli/skills/jac-cl-organization.md
+++ b/jac/jaclang/cli/skills/jac-cl-organization.md
@@ -12,6 +12,7 @@ my-app/
 ├── components/
 │   ├── Button.cl.jac          # reusable leaf - ONE component per file
 │   ├── ItemCard.cl.jac
+│   ├── ItemCard.style.css     # optional scoped styles - SAME basename
 │   ├── ItemList.cl.jac        # composes ItemCard
 │   ├── Layout.cl.jac          # app shell
 │   └── pages/
@@ -96,6 +97,7 @@ Load `jac-shadcn-components` for the import patterns and full component selectio
 - **Never edit files in `components/ui/`.** These are managed by the jac-shadcn registry. Compose with them in `components/` files instead.
 - **Reuse before creating.** Scan `components/` and `components/pages/` before writing a new file. Duplicate UI = default mistake.
 - **One exported component per file**, basename matches export. `Button.cl.jac` → `Button`.
+- **Scoped styles share the basename.** For plain component CSS, add `Button.style.css` beside `Button.cl.jac` -- classes auto-scope to that component, no import. See `jac-cl-styling`.
 - **PascalCase** for components + files: `UserCard.cl.jac`. `snake_case` for variables, handlers, hooks.
 - **Pages are thin orchestrators.** Read a hook, render a layout, pass data down. JSX > ~80 lines in a page = extract blocks into `components/`.
 - **Domain-meaningful names, not structural.** `CalculatorApp`, not `App`. `recipes_data`, not `data`. `services/recipes.sv.jac`, not `services/api.sv.jac`. Generic `Layout`/`App` only for the single top-level wrapper.

--- a/jac/jaclang/cli/skills/jac-cl-styling.md
+++ b/jac/jaclang/cli/skills/jac-cl-styling.md
@@ -1,7 +1,43 @@
 ---
 name: jac-cl-styling
-description: Tailwind styling patterns in Jac - conditional classes, cn() utility with clsx+tailwind-merge, semantic color tokens. Load when writing dynamic or theme-aware styles.
+description: Styling patterns in Jac - Tailwind conditional classes, cn() utility with clsx+tailwind-merge, semantic color tokens, and auto-scoped .style.css annex files. Load when writing dynamic, theme-aware, or component-scoped styles.
 ---
+
+## Scoped CSS (`.style.css` annex)
+
+For plain (non-Tailwind) component CSS, write a `.style.css` file with the
+**same base name** as the component. Its classes are auto-scoped to that
+module -- no import, no global collisions. The compiler hashes each declared
+class and rewrites the matching `className` literals to agree.
+
+```jac
+# Card.cl.jac
+def:pub Card(title: str) -> JsxElement {
+    return <div className="card">
+        <h2 className="card-title">{title}</h2>
+    </div>;
+}
+```
+
+```css
+/* Card.style.css -- paired by base name; do NOT import it */
+.card { padding: 1rem; border: 1px solid #ccc; }
+.card-title { font-weight: 600; }
+
+/* :global(...) opts out of scoping (resets, element/global targets) */
+:global(body) { margin: 0; }
+```
+
+`className="card"` compiles to `className="card-1419142b"` and the CSS
+selector is hashed to match; another component can declare its own `.card`
+without conflict.
+
+Rules:
+
+- **Base name must match exactly:** `Card.cl.jac` <-> `Card.style.css`. No `import` -- the compiler pairs and injects `import "./Card.css";` itself.
+- **Only declared classes are rewritten.** Undeclared tokens (Tailwind utilities, shadcn classes) pass through untouched, so you can mix scoped + utility classes in one `className`.
+- **`:global(...)`** keeps a selector unscoped -- use it for resets, element selectors, or targeting third-party classes.
+- **Scoped vs global:** use `.style.css` for component-specific classes; use a plain shared `import "./global.css";` (or Tailwind) for app-wide styles.
 
 ## Conditional Classes
 

--- a/jac/jaclang/cli/skills/jac-fullstack-patterns.md
+++ b/jac/jaclang/cli/skills/jac-fullstack-patterns.md
@@ -31,6 +31,7 @@ cl {
 - **Import obj/node TYPES alongside functions** in both places. Missing types → server `NameError` at runtime or lost typed attribute access on the client.
 - **Call server endpoints with POSITIONAL args, not kwargs.** `save_profile(name, email)` works; `save_profile(name=name, email=email)` sends empty body → `422 Field required`.
 - **Client entry is `def:pub app()`** - lowercase `app`. Not `App()`, `ClientApp()`. Runtime mounts the literal name.
+- **Global vs scoped CSS:** import app-wide CSS once in `main.jac`'s `cl { }` block (`import ".styles.global.css";` for themes, resets, Tailwind). For component-specific classes, add a same-basename `Comp.style.css` beside the `.cl.jac` -- it auto-scopes and needs no import. See `jac-cl-styling`.
 - **Start with `jac start --dev main.jac`** (background for hot reload). NOT `jac serve` (deprecated).
 - **HMR only reloads client (`.cl.jac`) files. Server (`.sv.jac`) changes need a full restart.** `def:pub`/`def:priv` endpoints + `glob` declarations evaluate once at server boot - editing a `.sv.jac` does not invalidate cached endpoints. `pkill -f "jac start"` then `jac start --dev main.jac` to pick up changes.
 - **Don't wrap the client entry in `with entry { ... }`.** Runtime mounts `def:pub app` directly.


### PR DESCRIPTION
Documents the `.style.css` annex auto-scoping feature shipped in #6099, across both the mkdocs site and the agent skills.

## mkdocs

- **jac-client reference** — new "Scoped CSS (`.style.css` annexes)" section under Styling, with the full contract: base-name pairing, per-module class hashing, `className` rewrite, `:global(...)` escape hatch, and sidecar CSS emit + auto-injected import (worked example showing `card` -> `card-1419142b`).
- **Components tutorial** — "Scoped Styles" subsection under *Styling Components*, cross-linking the reference.
- **Syntax cheatsheet** — `.style.css` added to the file-extension conventions, plus a note on the JSX `className` reference.

## skills (AI-agent instruction files)

- **jac-cl-styling** — new scoped-CSS section (when to use vs Tailwind, the rules, `:global`) and frontmatter updated to surface it.
- **jac-cl-organization** — `.style.css` shown in the file layout and a "scoped styles share the basename" rule.
- **jac-cl-components** — the `style`-prop rule now points to the `.style.css` annex; added to *See also*.
- **jac-fullstack-patterns** — global-vs-scoped CSS guidance (global import in `main.jac` vs component-adjacent `.style.css`).

Docs/skills only; no code changes.
