### PR TITLE
fix(compiler): keep declared type when reassigning a global from an impl body (#6107 item 1)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6112.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6112.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: reassigning a module global from an `.impl.jac` body keeps its declared type**: `global x; x = ...` in an implementation file no longer shadows the global with an untyped local, so int arithmetic on it type-checks correctly.

--- a/jac/examples/chess/chess.jac
+++ b/jac/examples/chess/chess.jac
@@ -179,7 +179,7 @@ obj Board {
 # ────────────────────── Game ──────────────────────
 """Top-level game controller: legality checking, turn management, I/O loop."""
 obj Game {
-    has board: Board | None = None,
+    has board: Board by postinit,
         current_turn: Color = Color.WHITE,
         is_over: bool = False,
         move_count: int = 0;

--- a/jac/jaclang/jac0core/passes/decl_impl_match_pass.jac
+++ b/jac/jaclang/jac0core/passes/decl_impl_match_pass.jac
@@ -21,7 +21,10 @@ their behavior in separate files.
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.transform { Transform }
 import from jaclang.jac0core.unitree { Symbol, UniScopeNode }
-import from jaclang.jac0core.passes.sym_tab_build_pass { bind_assignment_targets }
+import from jaclang.jac0core.passes.sym_tab_build_pass {
+    bind_assignment_targets,
+    bind_global_stmt
+}
 import from jaclang.jac0core.diagnostics {
     E2009,
     W2010,

--- a/jac/jaclang/jac0core/passes/impl/decl_impl_match_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/decl_impl_match_pass.impl.jac
@@ -185,6 +185,13 @@ impl DeclImplMatchPass.connect_impls(
         # of truth. Must run before _resolve_symbols_in_subtree because that
         # skips Names whose sym is already set.
         if isinstance(sym.decl.name_of, uni.ImplDef) {
+            # `global x;` must be re-bound before its assignments: it pulls the
+            # decl-module global into the body's Python scope (decl_link is only
+            # reachable now) so the assignment below rebinds the global instead
+            # of shadowing it with an inferred local that drops its type.
+            for global_stmt in sym.decl.name_of.get_all_sub_nodes(uni.GlobalStmt) {
+                bind_global_stmt(global_stmt);
+            }
             for assignment in sym.decl.name_of.get_all_sub_nodes(uni.Assignment) {
                 bind_assignment_targets(assignment);
             }

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -92,9 +92,30 @@ impl SymTabBuildPass.enter_global_stmt(
     # `global x;` from inside a function: pull the module-level symbol into
     # the enclosing python scope so subsequent assignments rebind the global
     # instead of creating a shadow local that bind_assignment_targets would
-    # type as Unknown.
+    # type as Unknown. For impl-file bodies the decl module is not reachable
+    # yet (decl_link unset), so this is a no-op here and re-run by
+    # DeclImplMatchPass.connect_impls.
+    bind_global_stmt(nd);
+}
+
+impl bind_global_stmt(nd: uni.GlobalStmt) -> None {
     py_scope = find_python_scope_node_of(nd);
     if py_scope is None or isinstance(py_scope, uni.Module) {
+        return;
+    }
+    # The global is owned by the module that holds the *declaration*. For an
+    # impl body that is the decl module reached via decl_link; for an inline
+    # body it is simply the enclosing module. decl_link is unset until
+    # DeclImplMatchPass, so impl bodies resolve to None here (no-op) and are
+    # re-run by connect_impls once the link is wired.
+    impl_def = nd.find_parent_of_type(uni.ImplDef);
+    module: (uni.Module | None) = None;
+    if impl_def is not None and impl_def.decl_link is not None {
+        module = impl_def.decl_link.find_parent_of_type(uni.Module);
+    } else {
+        module = py_scope.find_parent_of_type(uni.Module);
+    }
+    if module is None {
         return;
     }
     for name_atom in nd.target {
@@ -103,10 +124,6 @@ impl SymTabBuildPass.enter_global_stmt(
             continue;
         }
         if sym_name in py_scope.names_in_scope {
-            continue;
-        }
-        module = py_scope.find_parent_of_type(uni.Module);
-        if module is None {
             continue;
         }
         global_sym = module.names_in_scope.get(sym_name);

--- a/jac/jaclang/jac0core/passes/sym_tab_build_pass.jac
+++ b/jac/jaclang/jac0core/passes/sym_tab_build_pass.jac
@@ -156,3 +156,15 @@ introduce a local in the nearest Python scope. Used both during
 SymTabBuildPass and, for impl bodies, re-run after DeclImplMatchPass has
 connected the body to its declaration so decl-scope HasVars are reachable."""
 def bind_assignment_targets(nd: uni.Assignment) -> None;
+
+"""Pull the module-level symbols named by a `global x;` statement into the
+enclosing Python scope so a subsequent `x = ...` rebinds the global instead of
+shadowing it with a fresh inferred local (which would drop the global's
+declared type).
+
+The global lives in the module that owns the *declaration*. For an inline body
+that is the enclosing module; for an impl body it is the decl module reached
+via `decl_link`. `decl_link` is unset during SymTabBuildPass, so this is a
+no-op for impl bodies there and is re-run by DeclImplMatchPass.connect_impls
+once the link is wired."""
+def bind_global_stmt(nd: uni.GlobalStmt) -> None;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_impl_global_reassign.impl.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_impl_global_reassign.impl.jac
@@ -1,0 +1,8 @@
+impl random_int(max_val: int) -> int {
+    global _rand_state;
+    _rand_state = (_rand_state * 1103515245 + 12345) % 2147483648;
+    if max_val <= 0 {
+        return 0;
+    }
+    return _rand_state % max_val;
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_impl_global_reassign.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_impl_global_reassign.jac
@@ -1,0 +1,10 @@
+"""Reassigning a module global via `global x;` from an impl-file body.
+
+The global keeps its declared type across the decl/impl boundary, so the
+arithmetic below resolves int operators rather than tripping `__mul__` /
+`__add__` / `__mod__` overload-resolution errors on a shadow `Unknown`.
+"""
+
+glob _rand_state: int = 12345;
+
+def random_int(max_val: int) -> int;

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -2067,6 +2067,23 @@ test "impl_body_type_checking" {
     assert "checker_impl_body.impl.jac" in program.errors_had[2].loc.mod_path;
 }
 
+"""Reassigning a module global from an impl-file body keeps the global's
+declared type. Without decl/impl-aware `global x;` binding the assignment
+would shadow `_rand_state` with an inferred local, dropping its `int` type and
+tripping `__mul__`/`__add__`/`__mod__` overload-resolution errors."""
+test "impl_body_global_reassignment_keeps_declared_type" {
+    program = JacProgram();
+    path = os.path.join(CHECKER_FIXTURES, "checker_impl_global_reassign.jac");
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+
+    assert len(program.errors_had) == 0 , (
+        "Expected no type errors for an impl-body global reassignment, but got " + f"{len(
+            program.errors_had
+        )}:\n" + "\n".join([err.pretty_print() for err in program.errors_had])
+    );
+}
+
 """Test that self.x = value in impl files creates valid archetype attributes."""
 test "impl_self_member_assignment" {
     program = JacProgram();

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -7,7 +7,6 @@ native machine code, and produce correct results when executed via ctypes.
 import ctypes;
 import io;
 import os;
-import pytest;
 import subprocess;
 import sys;
 import tempfile;
@@ -1947,17 +1946,7 @@ def compile_auto_native(file_path: str) -> tuple[uni.Module, JacProgram] {
 }
 
 test "auto promote chess.jac detects native compatible" {
-    # xfail (#6049 section A follow-ups): with native diagnostic suppression
-    # dropped, chess.jac trips type-checker gaps the central evaluator does not
-    # yet model for the native dialect -- nullability narrowing on
-    # `Board | NoneType` and numeric operator-overload resolution
-    # (`__add__`/`__mul__`/`__mod__`). Tracked as separate sub-issues; this test
-    # recovers to green automatically once those land.
-    try {
-        (ir, _) = compile_auto_native(CHESS_JAC);
-    } except AssertionError as e {
-        pytest.xfail(f"#6049 deferred native-dialect type-checker gaps: {e}");
-    }
+    (ir, _) = compile_auto_native(CHESS_JAC);
     assert ir is not None;
     assert ir.gen.native_compat , ("chess.jac should be auto-promoted to native");
     assert ir.gen.native_engine is not None , (
@@ -1966,15 +1955,7 @@ test "auto promote chess.jac detects native compatible" {
 }
 
 test "auto promote chess.jac has entry and key functions" {
-    # xfail (#6049 section A follow-ups): see "detects native compatible" above
-    # -- chess.jac hits unmodeled native-dialect nullability/operator-overload
-    # type-checker gaps once suppression is dropped. Recovers to green once the
-    # deferred sub-issues land.
-    try {
-        (ir, _) = compile_auto_native(CHESS_JAC);
-    } except AssertionError as e {
-        pytest.xfail(f"#6049 deferred native-dialect type-checker gaps: {e}");
-    }
+    (ir, _) = compile_auto_native(CHESS_JAC);
     eng = ir.gen.native_engine;
     assert eng is not None;
     # jac_entry must exist


### PR DESCRIPTION
## What

Closes #6107 item 1 — un-xfails the two `auto promote chess.jac …` native tests by fixing the two error categories that surfaced when the implicit-native diagnostic suppression was dropped in #6096.

Investigation found the 30 chess auto-native errors split cleanly, with different correct homes:

### 1. Compiler bug — `global` reassignment across the decl/impl boundary (6 errors)

Reassigning a module global via `global x; x = ...` inside a function whose body lives in an `.impl.jac` file dropped the global's declared type. `SymTabBuildPass.enter_global_stmt` pulls the module global into the function scope so the later assignment *rebinds* it — but for impl bodies it searched the impl file's own module (which does not hold the global), found nothing, and the assignment then created a shadow local typed from its RHS. That dropped the declared `int`, producing spurious `__mul__`/`__add__`/`__mod__` overload-resolution errors on plain int arithmetic.

Minimal repro (neither the impl split nor the global reassignment triggers it alone):
```jac
// m.jac
glob s: int = 5;
def f() -> int;
// m.impl.jac
impl f() -> int { global s; s = s + 1; return s; }   // __add__ no overload
```

Fix mirrors the deferral that impl-body *assignments* already use: the global-pulling logic is extracted into `bind_global_stmt`, resolves the owning module via `decl_link` (a no-op until the link is wired), and is re-run in `DeclImplMatchPass.connect_impls` before binding assignment targets.

### 2. Chess example — Optional-field anti-pattern (24 errors)

`Game.board` was typed `Board | None = None` and set to `Board()` in `postinit`, then accessed unguarded as `self.board.X` everywhere. The checker correctly refuses to narrow a nullable instance attribute across methods (matching mypy/pyright; it *does* narrow within a method via `is not None` guards). Switching to `has board: Board by postinit` expresses the real invariant and clears all 24.

## Tests

- New regression test `impl_body_global_reassignment_keeps_declared_type` + fixture pair `checker_impl_global_reassign.jac`/`.impl.jac` — asserts an impl-body global reassignment produces zero type errors (fails `6 != 0` before the fix).
- Un-xfailed the two `auto promote chess.jac …` tests in `test_native_gen_pass.jac`.
- Verified: full type-checker suite (212) green; decl_impl_match (17) and sym_tab_build green; `jac check` on chess clean; auto-native chess promotion reports 0 errors and the example still runs.