### PR TITLE
refactor(native): remove dead enum_types branch in _resolve_jac_type (#6114)

### DIFF
--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -207,13 +207,11 @@ impl NaIRGenPass._lower_function_type(t: any) -> ir.Type {
 
 """Resolve a Jac type expression to an LLVM type.
 
-The primary path is unified with the central type checker: an annotation
-Expr carries a `.type` (TypeBase) populated by TypeCheckPass, and
-_lower_type maps that TypeBase to an LLVM type. A small name-based path
-follows it for NA-internal runtime types (e.g. native `File`) the central
-checker does not model — those types are registered by NA itself
-(_emit_file_helpers etc.) and only ever resolved via their textual name.
-Unhandled cases default to i64.
+Primary path: an annotation Expr's `.type` (TypeBase, set by TypeCheckPass)
+is mapped via _lower_type. A name-based fallback covers the two cases that
+path can't: NA-internal types the checker doesn't model (e.g. native
+`File`), and annotations in imported `.na.jac` modules, walked without
+TypeCheckPass so carrying `.type = None`. Unhandled cases default to i64.
 """
 impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
     if type_expr is None {
@@ -226,7 +224,8 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
             return lowered;
         }
     }
-    # NA-internal types not modeled by the central checker (e.g. native File).
+    # Name-based fallback (see docstring). No enum branch needed: _codegen_enum
+    # also registers each enum in type_map (same i64), which is checked first.
     type_name = self._get_name(type_expr);
     if type_name is not None {
         if type_name in self.struct_types {
@@ -234,9 +233,6 @@ impl NaIRGenPass._resolve_jac_type(type_expr: (uni.UniNode | None)) -> ir.Type {
         }
         if type_name in self.type_map {
             return self.type_map[type_name];
-        }
-        if type_name in self.enum_types {
-            return self.enum_types[type_name];
         }
     }
     return ir.IntType(64);


### PR DESCRIPTION
## refactor(native): remove dead `enum_types` branch in `_resolve_jac_type`; correct docstring

The safe, self-contained cleanup called out as immediately doable in #6114, independent of the larger Path A work (PRs #6117 / #6118 / #6119).

### What

`NaIRGenPass._resolve_jac_type` (`passes/native/na_ir_gen_pass.impl/types.impl.jac`) ends with a name-based fallback that checks, in order, `struct_types` -> `type_map` -> `enum_types`. The `enum_types` branch is **provably unreachable**:

- The only writer of `enum_types`, `_codegen_enum` (`enums.impl.jac:15-16`), sets `enum_types[name]` and `type_map[name]` to the **identical** value (`ir.IntType(64)`) on adjacent lines.
- `_resolve_jac_type` checks `type_map` **before** `enum_types`.

So any name present in `enum_types` is already in `type_map` with the same value and is returned one branch earlier. The `enum_types` lookup can never fire. This matches the #6114 measurement (`enum_types` branch: **0 hits** across the 340-test native suite).

This PR:
1. Deletes the dead `enum_types` branch.
2. Corrects the function docstring, which claimed the name-based residual is purely "NA-internal runtime types." Per #6114 that is inaccurate -- the residual is also load-bearing for annotations in **imported `.na.jac` modules**, whose ASTs are walked by `_register_imported_struct_types` without passing through `TypeCheckPass` (so they carry `.type = None`). The docstring now documents both cases, and a comment records why no `enum_types` branch is needed.

### What this is NOT

No behavior change. Enum annotations still resolve via the `type_map` branch (same value). This does **not** collapse `_resolve_jac_type` to the unified path, remove the name-based lookup, or touch `_lower_class_type` -- those depend on type-checking imported modules (#6117) and modeling `File` centrally (#6118), and land in the capstone (#6119).

### Testing

- `.venv/bin/pytest -n 15 jac/tests/compiler/passes/native/test_native_gen_pass.jac` -- 340 tests green.

### Refs

Part of #6114 / #6049 section B. Acceptance item: "Remove the dead `enum_types` branch and correct the docstring."
