### PR TITLE
refactor(examples): adopt {name} JSX attribute shorthand

### DIFF
--- a/jac/examples/day_planner/auth/components/ShoppingPanel.cl.jac
+++ b/jac/examples/day_planner/auth/components/ShoppingPanel.cl.jac
@@ -70,7 +70,7 @@ def:pub ShoppingPanel -> JsxElement {
                 <div class="empty-msg">Enter a meal above to generate ingredients.</div>
                 skip;
             }for ing in ingredients {
-                <IngredientItem key={ing.name} ing={ing}/>
+                <IngredientItem key={ing.name} {ing}/>
             }<div class="shopping-footer">
                 <span class="total">Total: ${f"{totalCost:.2f}"}</span>
                 <button class="btn-clear" onClick={lambda { clearList(); }}>

--- a/jac/examples/day_planner/walkers/components/ShoppingPanel.cl.jac
+++ b/jac/examples/day_planner/walkers/components/ShoppingPanel.cl.jac
@@ -72,7 +72,7 @@ def:pub ShoppingPanel -> JsxElement {
                 <div class="empty-msg">Enter a meal above to generate ingredients.</div>
                 skip;
             }for ing in ingredients {
-                <IngredientItem key={ing.name} ing={ing}/>
+                <IngredientItem key={ing.name} {ing}/>
             }<div class="shopping-footer">
                 <span class="total">Total: ${f"{totalCost:.2f}"}</span>
                 <button class="btn-clear" onClick={lambda { clearList(); }}>

--- a/jac/examples/littleX/components/AuthForm.cl.jac
+++ b/jac/examples/littleX/components/AuthForm.cl.jac
@@ -36,7 +36,7 @@ def:pub AuthForm(
                     {if error {
                         <div className="lx-auth-error">{error}</div>
                     }}
-                    <form onSubmit={onSubmit} className="lx-auth-form-fields">
+                    <form {onSubmit} className="lx-auth-form-fields">
                         <input
                             className="lx-input"
                             type="text"

--- a/jac/examples/littleX/components/Button.cl.jac
+++ b/jac/examples/littleX/components/Button.cl.jac
@@ -27,8 +27,8 @@ def:pub Button(
     return
         <button
             style={{** base_styles, ** variant_styles[variant]}}
-            onClick={onClick}
-            disabled={disabled}
+            {onClick}
+            {disabled}
         >
             {label}
         </button>;

--- a/jac/examples/littleX/components/ChannelsTab.cl.jac
+++ b/jac/examples/littleX/components/ChannelsTab.cl.jac
@@ -219,12 +219,12 @@ def:pub ChannelsTab(
                 for tweet in channelPosts {
                     <TweetCard
                         key={tweet.id}
-                        tweet={tweet}
+                        {tweet}
                         myUsername={profileUsername}
-                        onLike={onLike}
-                        onComment={onComment}
-                        onDelete={onDelete}
-                        onRepost={onRepost}
+                        {onLike}
+                        {onComment}
+                        {onDelete}
+                        {onRepost}
                     />
                 }
             } }

--- a/jac/examples/littleX/components/Composer.cl.jac
+++ b/jac/examples/littleX/components/Composer.cl.jac
@@ -32,12 +32,12 @@ def:pub Composer(
             <div className="lx-composer-body">
                 <textarea
                     className="lx-composer-textarea"
-                    placeholder={placeholder}
-                    value={value}
+                    {placeholder}
+                    {value}
                     onChange={lambda e: ChangeEvent { changeFn.call(
                         None, e.target.value
                     ); }}
-                    rows={rows}
+                    {rows}
                 />
                 <div className="lx-composer-footer">
                     {if showCharRing {

--- a/jac/examples/littleX/components/FeedTab.cl.jac
+++ b/jac/examples/littleX/components/FeedTab.cl.jac
@@ -31,7 +31,7 @@ def:pub FeedTab(
                 placeholder="What's happening?"
                 value={composerText}
                 onChange={onComposerChange}
-                onPost={onPost}
+                {onPost}
                 rows={3}
                 buttonLabel="Post"
                 showCharRing={True}
@@ -48,12 +48,12 @@ def:pub FeedTab(
             }for tweet in tweets {
                 <TweetCard
                     key={tweet.id}
-                    tweet={tweet}
+                    {tweet}
                     myUsername={profileUsername}
-                    onLike={onLike}
-                    onComment={onComment}
-                    onDelete={onDelete}
-                    onRepost={onRepost}
+                    {onLike}
+                    {onComment}
+                    {onDelete}
+                    {onRepost}
                 />
             }}
         </div>;

--- a/jac/examples/littleX/components/ProfileTab.cl.jac
+++ b/jac/examples/littleX/components/ProfileTab.cl.jac
@@ -93,12 +93,12 @@ def:pub ProfileTab(
             {for tweet in myTweets {
                 <TweetCard
                     key={tweet.id}
-                    tweet={tweet}
+                    {tweet}
                     myUsername={profileUsername}
-                    onLike={onLike}
-                    onComment={onComment}
-                    onDelete={onDelete}
-                    onRepost={onRepost}
+                    {onLike}
+                    {onComment}
+                    {onDelete}
+                    {onRepost}
                 />
             }}
         </div>;

--- a/jac/examples/littleX/frontend.cl.jac
+++ b/jac/examples/littleX/frontend.cl.jac
@@ -106,7 +106,7 @@ def:pub app -> JsxElement {
     if not isLoggedIn {
         return
             <AuthForm
-                isSignup={isSignup}
+                {isSignup}
                 username={authUsername}
                 password={authPassword}
                 error={authError}
@@ -146,11 +146,11 @@ def:pub app -> JsxElement {
     return
         <div className="lx-root">
             <Sidebar
-                activeTab={activeTab}
-                displayUsername={displayUsername}
-                profileUsername={profileUsername}
-                profileAvatar={profileAvatar}
-                notifCount={notifCount}
+                {activeTab}
+                {displayUsername}
+                {profileUsername}
+                {profileAvatar}
+                {notifCount}
                 onNavigate={navigate}
                 onLogout={handleLogout}
             />
@@ -187,15 +187,15 @@ def:pub app -> JsxElement {
                 </div>
                 {if activeTab == "feed" {
                     <FeedTab
-                        showWelcome={showWelcome}
+                        {showWelcome}
                         onDismissWelcome={handleDismissWelcome}
-                        profileAvatar={profileAvatar}
-                        profileUsername={profileUsername}
-                        composerText={composerText}
+                        {profileAvatar}
+                        {profileUsername}
+                        {composerText}
                         onComposerChange={lambda v: str { composerText = v; }}
                         onPost={postTweet}
-                        feedLoading={feedLoading}
-                        tweets={tweets}
+                        {feedLoading}
+                        {tweets}
                         onLike={handleLike}
                         onComment={handleComment}
                         onDelete={handleDelete}
@@ -203,20 +203,20 @@ def:pub app -> JsxElement {
                     />
                 } elif activeTab == "explore" {
                     <ExploreTab
-                        allProfiles={allProfiles}
-                        followingIds={followingIds}
-                        myProfileId={myProfileId}
+                        {allProfiles}
+                        {followingIds}
+                        {myProfileId}
                         onFollow={handleFollow}
                         onUnfollow={handleUnfollow}
                     />
                 } elif activeTab == "channels" {
                     <ChannelsTab
-                        channels={channels}
-                        channelsLoading={channelsLoading}
-                        selectedChannel={selectedChannel}
-                        channelPosts={channelPosts}
-                        profileAvatar={profileAvatar}
-                        profileUsername={profileUsername}
+                        {channels}
+                        {channelsLoading}
+                        {selectedChannel}
+                        {channelPosts}
+                        {profileAvatar}
+                        {profileUsername}
                         onCreateChannel={handleCreateChannel}
                         onJoinChannel={handleJoinChannel}
                         onLeaveChannel={handleLeaveChannel}
@@ -230,12 +230,12 @@ def:pub app -> JsxElement {
                     />
                 } elif activeTab == "profile" {
                     <ProfileTab
-                        myProfile={myProfile}
-                        displayUsername={displayUsername}
-                        profileAvatar={profileAvatar}
-                        profileUsername={profileUsername}
-                        editingBio={editingBio}
-                        bioText={bioText}
+                        {myProfile}
+                        {displayUsername}
+                        {profileAvatar}
+                        {profileUsername}
+                        {editingBio}
+                        {bioText}
                         onBioChange={lambda v: str { bioText = v; }}
                         onSaveBio={handleSaveBio}
                         onCancelEditBio={lambda { editingBio = False; }}
@@ -247,24 +247,20 @@ def:pub app -> JsxElement {
                 }   }
             </main>
             <RightSidebar
-                searchQuery={searchQuery}
+                {searchQuery}
                 onSearchChange={lambda v: str { searchQuery = v; }}
                 onSearch={handleSearch}
                 onClearSearch={lambda {
                     searchQuery = "";
                     handleSearch("");
                 }}
-                trendingTags={trendingTags}
+                {trendingTags}
                 onTrendClick={handleTrendClick}
-                toFollow={toFollow}
+                {toFollow}
                 onFollow={handleFollow}
                 onShowMore={lambda { navigate("explore"); }}
             />
-            <MobileNav
-                activeTab={activeTab}
-                notifCount={notifCount}
-                onNavigate={navigate}
-            />
+            <MobileNav {activeTab} {notifCount} onNavigate={navigate}/>
             <button className="lx-mobile-fab" onClick={lambda { navigate("feed"); }}>
                 <Feather size={22}/>
             </button>


### PR DESCRIPTION
## Summary

Adopts the `{name}` JSX attribute shorthand (#6085) across the example
client components. Bindings of the form `attr={attr}` -- where the
attribute name equals a bare variable of the same name -- collapse to
`{attr}`. This is pure sugar: each attribute is type-checked identically
to the explicit form, so there is **no behavior change**, only a
readability cleanup at the busy component call sites.

## Changes

| Area | Files |
|---|---|
| littleX | `frontend.cl.jac`, `AuthForm`, `Button`, `ChannelsTab`, `Composer`, `FeedTab`, `ProfileTab` |
| day_planner | `ShoppingPanel` (both `walkers/` and `auth/` trees) |

The big win is `frontend.cl.jac`, where the `<Sidebar>`, `<FeedTab>`,
`<ChannelsTab>`, `<ProfileTab>`, `<RightSidebar>` and `<MobileNav>` call
sites shed a column of repeated `name={name}` noise.

Non-matching bindings are intentionally left explicit, e.g.
`onNavigate={navigate}`, `task={t}`, `size={24}`, `style={{**...}}`,
`key={ing.name}`.

## Notes

Other recently-shipped slot features were evaluated and **not** applied
where they would regress behavior or fight existing conventions:

- `try/awaiting/except` lowering: the example fetches use plain
  non-suspending `sv import` calls, so the `awaiting` fallback would
  never fire -- the manual loading flags are the correct pattern here.
- `.style.css` scoped annexes: the few inline styles are one-off layout
  tweaks (or dynamically computed in `Button`); the examples
  consistently use a single global stylesheet.

## Validation

`jac check` on every touched file shows an **identical diagnostic
profile before and after** the edit (verified by stashing). chess and
mini_todo have no client/JSX modules and are untouched.