### PR TITLE
refactor(littleX): replace `any` annotations with precise types

### DIFF
--- a/jac/examples/littleX/components/AuthForm.cl.jac
+++ b/jac/examples/littleX/components/AuthForm.cl.jac
@@ -6,10 +6,10 @@ def:pub AuthForm(
     password: str,
     error: str,
     loading: bool,
-    onUsernameChange: any,
-    onPasswordChange: any,
-    onSubmit: any,
-    onToggleMode: any,
+    onUsernameChange: Callable[[ChangeEvent], None],
+    onPasswordChange: Callable[[ChangeEvent], None],
+    onSubmit: Callable[[FormEvent], None],
+    onToggleMode: Callable[[], None],
 ) -> JsxElement {
     return
         <div className="lx-auth-root">

--- a/jac/examples/littleX/components/Button.cl.jac
+++ b/jac/examples/littleX/components/Button.cl.jac
@@ -1,7 +1,10 @@
 """Button component for the Jac client application."""
 
 def:pub Button(
-    label: str, onClick: any, variant: str = "primary", disabled: bool = False
+    label: str,
+    onClick: Callable[[], None],
+    variant: str = "primary",
+    disabled: bool = False
 ) -> JsxElement {
     base_styles = {
         "padding": "0.75rem 1.5rem",

--- a/jac/examples/littleX/components/ChannelsTab.cl.jac
+++ b/jac/examples/littleX/components/ChannelsTab.cl.jac
@@ -12,28 +12,21 @@ def:pub ChannelsTab(
     channelPosts: list[TweetView],
     profileAvatar: str,
     profileUsername: str,
-    onCreateChannel: any,
-    onJoinChannel: any,
-    onLeaveChannel: any,
-    onSelectChannel: any,
-    onChannelPost: any,
-    onBackToChannels: any,
-    onLike: any,
-    onComment: any,
-    onDelete: any,
-    onRepost: any,
+    onCreateChannel: Callable[[str, str], None],
+    onJoinChannel: Callable[[str], None],
+    onLeaveChannel: Callable[[str], None],
+    onSelectChannel: Callable[[str], None],
+    onChannelPost: Callable[[str], None],
+    onBackToChannels: Callable[[], None],
+    onLike: Callable[[str], None],
+    onComment: Callable[[str, str], None],
+    onDelete: Callable[[str], None],
+    onRepost: Callable[[str, str, str], None],
 ) -> JsxElement {
     has showCreateChannel: bool = False,
         newChannelName: str = "",
         newChannelDescription: str = "",
         channelComposerText: str = "";
-
-    createFn = onCreateChannel;
-    joinFn = onJoinChannel;
-    leaveFn = onLeaveChannel;
-    selectFn = onSelectChannel;
-    postFn = onChannelPost;
-    backFn = onBackToChannels;
 
     return
         <div>
@@ -66,8 +59,7 @@ def:pub ChannelsTab(
                                 className="lx-post-btn"
                                 disabled={not newChannelName.strip()}
                                 onClick={lambda {
-                                    createFn.call(
-                                        None,
+                                    onCreateChannel(
                                         newChannelName.strip(),
                                         newChannelDescription.strip()
                                     );
@@ -106,7 +98,7 @@ def:pub ChannelsTab(
                     <div
                         className="lx-channel-item"
                         key={ch.id}
-                        onClick={lambda { selectFn.call(None, ch.id); }}
+                        onClick={lambda { onSelectChannel(ch.id); }}
                     >
                         <div className="lx-channel-icon">
                             <Hash size={20}/>
@@ -138,7 +130,7 @@ def:pub ChannelsTab(
                 <div className="lx-channel-header">
                     <button
                         className="lx-edit-profile-btn"
-                        onClick={lambda { backFn.call(None); }}
+                        onClick={lambda { onBackToChannels(); }}
                         style={{
                             "display": "flex",
                             "alignItems": "center",
@@ -170,7 +162,7 @@ def:pub ChannelsTab(
                             <button
                                 className="lx-edit-profile-btn"
                                 onClick={lambda { if selectedChannel {
-                                    leaveFn.call(None, selectedChannel.id);
+                                    onLeaveChannel(selectedChannel.id);
                                 }}}
                             >
                                 Leave
@@ -179,7 +171,7 @@ def:pub ChannelsTab(
                             <button
                                 className="lx-follow-btn"
                                 onClick={lambda { if selectedChannel {
-                                    joinFn.call(None, selectedChannel.id);
+                                    onJoinChannel(selectedChannel.id);
                                 }}}
                             >
                                 Join
@@ -195,7 +187,7 @@ def:pub ChannelsTab(
                         value={channelComposerText}
                         onChange={lambda v: str { channelComposerText = v; }}
                         onPost={lambda {
-                            postFn.call(None, channelComposerText);
+                            onChannelPost(channelComposerText);
                             channelComposerText = "";
                         }}
                         rows={2}

--- a/jac/examples/littleX/components/Composer.cl.jac
+++ b/jac/examples/littleX/components/Composer.cl.jac
@@ -5,15 +5,12 @@ def:pub Composer(
     avatarAlt: str,
     placeholder: str,
     value: str,
-    onChange: any,
-    onPost: any,
+    onChange: Callable[[str], None],
+    onPost: Callable[[], None],
     rows: int = 3,
     buttonLabel: str = "Post",
     showCharRing: bool = False,
 ) -> JsxElement {
-    changeFn = onChange;
-    postFn = onPost;
-
     charsLeft = 280 - len(value);
     ring_progress = min(1.0, (280 - charsLeft) / 280.0);
     ring_offset = str(62.83 * (1.0 - ring_progress));
@@ -34,9 +31,7 @@ def:pub Composer(
                     className="lx-composer-textarea"
                     {placeholder}
                     {value}
-                    onChange={lambda e: ChangeEvent { changeFn.call(
-                        None, e.target.value
-                    ); }}
+                    onChange={lambda e: ChangeEvent { onChange(e.target.value); }}
                     {rows}
                 />
                 <div className="lx-composer-footer">
@@ -75,7 +70,7 @@ def:pub Composer(
                     <button
                         className="lx-post-btn"
                         disabled={not value.strip() or over_limit}
-                        onClick={lambda { postFn.call(None); }}
+                        onClick={lambda { onPost(); }}
                     >
                         {buttonLabel}
                     </button>

--- a/jac/examples/littleX/components/ExploreTab.cl.jac
+++ b/jac/examples/littleX/components/ExploreTab.cl.jac
@@ -6,12 +6,9 @@ def:pub ExploreTab(
     allProfiles: list[UserView],
     followingIds: list[str],
     myProfileId: str,
-    onFollow: any,
-    onUnfollow: any,
+    onFollow: Callable[[str], None],
+    onUnfollow: Callable[[str], None],
 ) -> JsxElement {
-    followFn = onFollow;
-    unfollowFn = onUnfollow;
-
     return
         <div>
             {if not allProfiles {
@@ -41,14 +38,14 @@ def:pub ExploreTab(
                     {if u.id in followingIds {
                         <button
                             className="lx-unfollow-btn"
-                            onClick={lambda { unfollowFn.call(None, u.id); }}
+                            onClick={lambda { onUnfollow(u.id); }}
                         >
                             Following
                         </button>
                     } elif u.id != myProfileId {
                         <button
                             className="lx-follow-btn"
-                            onClick={lambda { followFn.call(None, u.id); }}
+                            onClick={lambda { onFollow(u.id); }}
                         >
                             Follow
                         </button>

--- a/jac/examples/littleX/components/FeedTab.cl.jac
+++ b/jac/examples/littleX/components/FeedTab.cl.jac
@@ -7,18 +7,18 @@ import from .WelcomeBanner { WelcomeBanner }
 
 def:pub FeedTab(
     showWelcome: bool,
-    onDismissWelcome: any,
+    onDismissWelcome: Callable[[], None],
     profileAvatar: str,
     profileUsername: str,
     composerText: str,
-    onComposerChange: any,
-    onPost: any,
+    onComposerChange: Callable[[str], None],
+    onPost: Callable[[], None],
     feedLoading: bool,
     tweets: list[TweetView],
-    onLike: any,
-    onComment: any,
-    onDelete: any,
-    onRepost: any,
+    onLike: Callable[[str], None],
+    onComment: Callable[[str, str], None],
+    onDelete: Callable[[str], None],
+    onRepost: Callable[[str, str, str], None],
 ) -> JsxElement {
     return
         <div>

--- a/jac/examples/littleX/components/MobileNav.cl.jac
+++ b/jac/examples/littleX/components/MobileNav.cl.jac
@@ -2,16 +2,16 @@
 
 import from "lucide-react" { Home, Compass, Hash, User }
 
-def:pub MobileNav(activeTab: str, notifCount: int, onNavigate: any) -> JsxElement {
-    navFn = onNavigate;
-
+def:pub MobileNav(
+    activeTab: str, notifCount: int, onNavigate: Callable[[str], None]
+) -> JsxElement {
     return
         <nav className="lx-mobile-nav">
             <div
                 className={"lx-mobile-nav-item" + (
                     " lx-mobile-nav-item-active" if activeTab == "feed" else ""
                 )}
-                onClick={lambda { navFn.call(None, "feed"); }}
+                onClick={lambda { onNavigate("feed"); }}
             >
                 <Home size={24}/>
             </div>
@@ -19,7 +19,7 @@ def:pub MobileNav(activeTab: str, notifCount: int, onNavigate: any) -> JsxElemen
                 className={"lx-mobile-nav-item" + (
                     " lx-mobile-nav-item-active" if activeTab == "explore" else ""
                 )}
-                onClick={lambda { navFn.call(None, "explore"); }}
+                onClick={lambda { onNavigate("explore"); }}
             >
                 <Compass size={24}/>
             </div>
@@ -27,7 +27,7 @@ def:pub MobileNav(activeTab: str, notifCount: int, onNavigate: any) -> JsxElemen
                 className={"lx-mobile-nav-item" + (
                     " lx-mobile-nav-item-active" if activeTab == "channels" else ""
                 )}
-                onClick={lambda { navFn.call(None, "channels"); }}
+                onClick={lambda { onNavigate("channels"); }}
             >
                 <Hash size={24}/>
             </div>
@@ -35,7 +35,7 @@ def:pub MobileNav(activeTab: str, notifCount: int, onNavigate: any) -> JsxElemen
                 className={"lx-mobile-nav-item" + (
                     " lx-mobile-nav-item-active" if activeTab == "profile" else ""
                 )}
-                onClick={lambda { navFn.call(None, "profile"); }}
+                onClick={lambda { onNavigate("profile"); }}
             >
                 <User size={24}/>
                 {if notifCount > 0 {

--- a/jac/examples/littleX/components/ProfileTab.cl.jac
+++ b/jac/examples/littleX/components/ProfileTab.cl.jac
@@ -10,18 +10,14 @@ def:pub ProfileTab(
     profileUsername: str,
     editingBio: bool,
     bioText: str,
-    onBioChange: any,
-    onSaveBio: any,
-    onCancelEditBio: any,
-    onLike: any,
-    onComment: any,
-    onDelete: any,
-    onRepost: any,
+    onBioChange: Callable[[str], None],
+    onSaveBio: Callable[[], None],
+    onCancelEditBio: Callable[[], None],
+    onLike: Callable[[str], None],
+    onComment: Callable[[str, str], None],
+    onDelete: Callable[[str], None],
+    onRepost: Callable[[str, str, str], None],
 ) -> JsxElement {
-    bioChangeFn = onBioChange;
-    saveBioFn = onSaveBio;
-    cancelFn = onCancelEditBio;
-
     followingCount = len(myProfile.following)
         if myProfile and myProfile.following
         else 0;
@@ -51,20 +47,20 @@ def:pub ProfileTab(
                             rows={3}
                             placeholder="Write your bio..."
                             value={bioText}
-                            onChange={lambda e: ChangeEvent { bioChangeFn.call(
-                                None, e.target.value
+                            onChange={lambda e: ChangeEvent { onBioChange(
+                                e.target.value
                             ); }}
                         />
                         <div style={{"display": "flex", "gap": "0.5rem"}}>
                             <button
                                 className="lx-bio-save-btn"
-                                onClick={lambda { saveBioFn.call(None); }}
+                                onClick={lambda { onSaveBio(); }}
                             >
                                 Save
                             </button>
                             <button
                                 className="lx-edit-profile-btn"
-                                onClick={lambda { cancelFn.call(None); }}
+                                onClick={lambda { onCancelEditBio(); }}
                             >
                                 Cancel
                             </button>

--- a/jac/examples/littleX/components/RightSidebar.cl.jac
+++ b/jac/examples/littleX/components/RightSidebar.cl.jac
@@ -5,22 +5,15 @@ sv import from ..server { UserView, TrendingTag }
 
 def:pub RightSidebar(
     searchQuery: str,
-    onSearchChange: any,
-    onSearch: any,
-    onClearSearch: any,
+    onSearchChange: Callable[[str], None],
+    onSearch: Callable[[str], None],
+    onClearSearch: Callable[[], None],
     trendingTags: list[TrendingTag],
-    onTrendClick: any,
+    onTrendClick: Callable[[str], None],
     toFollow: list[UserView],
-    onFollow: any,
-    onShowMore: any,
+    onFollow: Callable[[str], None],
+    onShowMore: Callable[[], None],
 ) -> JsxElement {
-    searchChangeFn = onSearchChange;
-    searchFn = onSearch;
-    clearFn = onClearSearch;
-    trendFn = onTrendClick;
-    followFn = onFollow;
-    showMoreFn = onShowMore;
-
     return
         <aside className="lx-sidebar-right">
             <div className="lx-sidebar-right-inner">
@@ -32,25 +25,25 @@ def:pub RightSidebar(
                         className="lx-search-input"
                         placeholder="Search Little-X"
                         value={searchQuery}
-                        onChange={lambda e: ChangeEvent { searchChangeFn.call(
-                            None, e.target.value
+                        onChange={lambda e: ChangeEvent { onSearchChange(
+                            e.target.value
                         ); }}
                         onKeyDown={lambda e: KeyboardEvent { if e.key == "Enter" {
-                            searchFn.call(None, e.target.value);
+                            onSearch(searchQuery);
                         }}}
                     />
                     {if searchQuery {
                         <button
                             className="lx-search-clear"
                             title="Clear search"
-                            onClick={lambda { clearFn.call(None); }}
+                            onClick={lambda { onClearSearch(); }}
                         >
                             <X size={16}/>
                         </button>
                     }}
                     <button
                         className="lx-search-btn"
-                        onClick={lambda { searchFn.call(None, searchQuery); }}
+                        onClick={lambda { onSearch(searchQuery); }}
                     >
                         Search
                     </button>
@@ -62,7 +55,7 @@ def:pub RightSidebar(
                             <div
                                 className="lx-trend-item"
                                 key={t.tag}
-                                onClick={lambda { trendFn.call(None, t.tag); }}
+                                onClick={lambda { onTrendClick(t.tag); }}
                             >
                                 <span className="lx-trend-tag">{t.tag}</span>
                                 <span className="lx-trend-count">
@@ -100,7 +93,7 @@ def:pub RightSidebar(
                                 </div>
                                 <button
                                     className="lx-follow-btn"
-                                    onClick={lambda { followFn.call(None, u.id); }}
+                                    onClick={lambda { onFollow(u.id); }}
                                 >
                                     Follow
                                 </button>
@@ -109,7 +102,7 @@ def:pub RightSidebar(
                         {if len(toFollow) > 5 {
                             <div
                                 className="lx-widget-show-more"
-                                onClick={lambda { showMoreFn.call(None); }}
+                                onClick={lambda { onShowMore(); }}
                             >
                                 Show more
                             </div>

--- a/jac/examples/littleX/components/Sidebar.cl.jac
+++ b/jac/examples/littleX/components/Sidebar.cl.jac
@@ -8,12 +8,9 @@ def:pub Sidebar(
     profileUsername: str,
     profileAvatar: str,
     notifCount: int,
-    onNavigate: any,
-    onLogout: any,
+    onNavigate: Callable[[str], None],
+    onLogout: Callable[[], None],
 ) -> JsxElement {
-    navFn = onNavigate;
-    logoutFn = onLogout;
-
     return
         <aside className="lx-sidebar-left">
             <div className="lx-brand">
@@ -29,7 +26,7 @@ def:pub Sidebar(
                     className={"lx-nav-item" + (
                         " lx-nav-item-active" if activeTab == "feed" else ""
                     )}
-                    onClick={lambda { navFn.call(None, "feed"); }}
+                    onClick={lambda { onNavigate("feed"); }}
                 >
                     <Home size={22}/>
                     <span>Home</span>
@@ -38,7 +35,7 @@ def:pub Sidebar(
                     className={"lx-nav-item" + (
                         " lx-nav-item-active" if activeTab == "explore" else ""
                     )}
-                    onClick={lambda { navFn.call(None, "explore"); }}
+                    onClick={lambda { onNavigate("explore"); }}
                 >
                     <Compass size={22}/>
                     <span>Explore</span>
@@ -47,7 +44,7 @@ def:pub Sidebar(
                     className={"lx-nav-item" + (
                         " lx-nav-item-active" if activeTab == "channels" else ""
                     )}
-                    onClick={lambda { navFn.call(None, "channels"); }}
+                    onClick={lambda { onNavigate("channels"); }}
                 >
                     <Hash size={22}/>
                     <span>Channels</span>
@@ -56,7 +53,7 @@ def:pub Sidebar(
                     className={"lx-nav-item" + (
                         " lx-nav-item-active" if activeTab == "profile" else ""
                     )}
-                    onClick={lambda { navFn.call(None, "profile"); }}
+                    onClick={lambda { onNavigate("profile"); }}
                 >
                     <User size={22}/>
                     <span>Profile</span>
@@ -65,10 +62,7 @@ def:pub Sidebar(
                     }}
                 </div>
             </nav>
-            <button
-                className="lx-compose-btn"
-                onClick={lambda { navFn.call(None, "feed"); }}
-            >
+            <button className="lx-compose-btn" onClick={lambda { onNavigate("feed"); }}>
                 <Feather size={18}/>
                 <span>Post</span>
             </button>
@@ -81,10 +75,7 @@ def:pub Sidebar(
                         {"@" + displayUsername}
                     </div>
                 </div>
-                <button
-                    className="lx-logout-icon-btn"
-                    onClick={lambda { logoutFn.call(None); }}
-                >
+                <button className="lx-logout-icon-btn" onClick={lambda { onLogout(); }}>
                     <LogOut size={18}/>
                 </button>
             </div>

--- a/jac/examples/littleX/components/TweetCard.cl.jac
+++ b/jac/examples/littleX/components/TweetCard.cl.jac
@@ -6,18 +6,13 @@ sv import from ..server { TweetView }
 def:pub TweetCard(
     tweet: TweetView,
     myUsername: str,
-    onLike: any,
-    onComment: any,
-    onDelete: any,
-    onRepost: any,
+    onLike: Callable[[str], None],
+    onComment: Callable[[str, str], None],
+    onDelete: Callable[[str], None],
+    onRepost: Callable[[str, str, str], None],
 ) -> JsxElement {
     has showComments: bool = False,
         commentText: str = "";
-
-    likeFn = onLike;
-    commentFn = onComment;
-    deleteFn = onDelete;
-    repostFn = onRepost;
 
     is_liked = myUsername in tweet.likes;
     like_count = str(len(tweet.likes));
@@ -74,8 +69,8 @@ def:pub TweetCard(
                     </button>
                     <button
                         className="lx-act-btn lx-act-repost"
-                        onClick={lambda { repostFn.call(
-                            None, tweet.id, tweet.content, tweet.author_username
+                        onClick={lambda { onRepost(
+                            tweet.id, tweet.content, tweet.author_username
                         ); }}
                         title="Repost"
                     >
@@ -85,7 +80,7 @@ def:pub TweetCard(
                         className={"lx-act-btn lx-act-liked"
                             if is_liked
                             else "lx-act-btn lx-act-like"}
-                        onClick={lambda { likeFn.call(None, tweet.id); }}
+                        onClick={lambda { onLike(tweet.id); }}
                     >
                         <Heart size={16}/>
                         <span>{like_count}</span>
@@ -96,7 +91,7 @@ def:pub TweetCard(
                             onClick={lambda { if confirm(
                                 "Delete this post? This cannot be undone."
                             ) {
-                                deleteFn.call(None, tweet.id);
+                                onDelete(tweet.id);
                             }}}
                         >
                             <Trash2 size={16}/>
@@ -132,14 +127,14 @@ def:pub TweetCard(
                                 onChange={lambda e: ChangeEvent { commentText = e.target.value; }}
                                 onKeyDown={lambda e: KeyboardEvent { if e.key == "Enter"
                                 and commentText.strip() {
-                                    commentFn.call(None, tweet.id, commentText);
+                                    onComment(tweet.id, commentText);
                                     commentText = "";
                                 }}}
                             />
                             <button
                                 className="lx-comment-submit"
                                 onClick={lambda { if commentText.strip() {
-                                    commentFn.call(None, tweet.id, commentText);
+                                    onComment(tweet.id, commentText);
                                     commentText = "";
                                 }}}
                             >

--- a/jac/examples/littleX/components/WelcomeBanner.cl.jac
+++ b/jac/examples/littleX/components/WelcomeBanner.cl.jac
@@ -1,8 +1,6 @@
 """First-run welcome banner for Little X."""
 
-def:pub WelcomeBanner(onDismiss: any) -> JsxElement {
-    dismissFn = onDismiss;
-
+def:pub WelcomeBanner(onDismiss: Callable[[], None]) -> JsxElement {
     return
         <div className="lx-welcome-banner">
             <div className="lx-welcome-content">
@@ -19,10 +17,7 @@ def:pub WelcomeBanner(onDismiss: any) -> JsxElement {
                     </span>
                 </div>
             </div>
-            <button
-                className="lx-welcome-dismiss"
-                onClick={lambda { dismissFn.call(None); }}
-            >
+            <button className="lx-welcome-dismiss" onClick={lambda { onDismiss(); }}>
                 {"Got it"}
             </button>
         </div>;

--- a/jac/examples/littleX/frontend.cl.jac
+++ b/jac/examples/littleX/frontend.cl.jac
@@ -134,9 +134,9 @@ def:pub app -> JsxElement {
         else profileUsername;
     profileAvatar = "https://i.pravatar.cc/150?u=fake@" + profileUsername;
     myProfileId = myProfile.id if myProfile else "";
-    followingIds = [f.id for f in myProfile.following]
-        if myProfile and myProfile.following
-        else [];
+    followingIds = [
+        f.id for f in (myProfile.following if myProfile and myProfile.following else [])
+    ];
     toFollow = [
         u
         for u in allProfiles

--- a/jac/examples/littleX/frontend.impl.jac
+++ b/jac/examples/littleX/frontend.impl.jac
@@ -37,19 +37,15 @@ impl app.handleLogin -> None {
         return;
     }
     authLoading = True;
-    result: any = await jacLogin(authUsername, authPassword);
+    result: bool = await jacLogin(authUsername, authPassword);
     authLoading = False;
-    if result and (result["ok"] or result == True) {
+    if result {
         localStorage.setItem("lx_username", authUsername);
         isLoggedIn = True;
         authPassword = "";
         authError = "";
     } else {
-        authError = str(
-            result["error"]["message"]
-                if result and result["error"] and result["error"]["message"]
-                else "Invalid username or password"
-        );
+        authError = "Invalid username or password";
     }
 }
 
@@ -64,13 +60,13 @@ impl app.handleSignup -> None {
         return;
     }
     authLoading = True;
-    result: any = await jacSignup(authUsername, authPassword);
-    if result["ok"] or result["success"] {
+    result: dict[str, any] = await jacSignup(authUsername, authPassword);
+    if result["success"] {
         # jacSignup only registers the account; establish a session by
         # logging in so the first walker calls aren't rejected with 401.
-        loginResult: any = await jacLogin(authUsername, authPassword);
+        loginResult: bool = await jacLogin(authUsername, authPassword);
         authLoading = False;
-        if loginResult and (loginResult["ok"] or loginResult == True) {
+        if loginResult {
             localStorage.setItem("lx_username", authUsername);
             isLoggedIn = True;
             authPassword = "";
@@ -81,11 +77,7 @@ impl app.handleSignup -> None {
         }
     } else {
         authLoading = False;
-        authError = str(
-            result["error"]["message"]
-                if result["error"] and result["error"]["message"]
-                else (result["error"] if result["error"] else "Signup failed")
-        );
+        authError = str(result["error"] if result["error"] else "Signup failed");
     }
 }
 


### PR DESCRIPTION
## What

Replaces every loose `any` annotation in the `littleX` example with its proper type.

### Callback props (all 12 component files)
- `onX: any` props are now precise `Callable[[...], None]` types derived from the parent handler signatures in `frontend.cl.jac`, e.g. `onLike: Callable[[str], None]`, `onComment: Callable[[str, str], None]`, `onRepost: Callable[[str, str, str], None]`, `onSubmit: Callable[[FormEvent], None]`.
- Since `Callable` has no `.call` member, the `fn.call(None, args)` JS-style invocations are converted to direct `fn(args)` calls (matching the `day_planner` example), and the redundant `xFn = onX` alias locals are dropped.

### Auth result vars (`frontend.impl.jac`)
Tightened to the real runtime contracts — `jacLogin -> bool`, `jacSignup -> dict[str, any]`. The correct types exposed dead/incorrect access patterns the loose `any` had masked:
- indexing the `bool` login result (`result["ok"]`, `result == True`),
- a non-existent `"ok"` key on the signup dict,
- `string["message"]` on the signup error string.

### Narrowing issues surfaced by the tighter types
- `KeyboardEvent.target` has no `.value` (unlike `ChangeEvent.target`); the Enter handler now uses the controlled `searchQuery` value.
- The `followingIds` comprehension was reworked into a form the checker can narrow (see note below).

## Note for reviewers

The `followingIds` change works around a checker gap filed as #6132: flow narrowing from an enclosing `if` is not propagated into a comprehension's iterable expression. Once that is fixed, the guard can move back to a plain `if` block.

## Test

`jac check` passes on `main.jac`, `server.jac`, `frontend.cl.jac`, and `frontend.impl.jac`. Behavior is unchanged.
