### PR TITLE
fix(jir): preserve None vs empty list in HasVar.accessors 

### DIFF
--- a/jac/jaclang/jac0core/impl/jir_passes.impl.jac
+++ b/jac/jaclang/jac0core/impl/jir_passes.impl.jac
@@ -323,6 +323,17 @@ impl JirWriter._write_field(
             _write_varint(buf, 1);
             _write_varint(buf, self._get_node_id(val));
         }
+    } elif kind == FieldKind.OPT_NODE_LIST {
+        if val is None {
+            buf.append(0);
+        } else {
+            buf.append(1);
+            items = list(val) if isinstance(val, (list, tuple)) else [val];
+            _write_varint(buf, len(items));
+            for item in items {
+                _write_varint(buf, self._get_node_id(item));
+            }
+        }
     } elif kind == FieldKind.OPT_NODE_REF {
         if val is None {
             buf.append(0);
@@ -734,6 +745,25 @@ impl JirReader._read_node(data: (bytes | memoryview), pos: int, idx: int) -> int
                 }
             }
             nd[fname] = items;
+        } elif kind == FieldKind.OPT_NODE_LIST {
+            flag = data[pos];
+            pos += 1;
+            if flag == 0 {
+                nd[fname] = None;
+            } else {
+                (count, pos) = _read_varint(data, pos);
+                items = [];
+                for _ in range(count) {
+                    (nid, pos) = _read_varint(data, pos);
+                    if nid < _SN {
+                        n = nodes[nid];
+                        if n is not None {
+                            items.append(n);
+                        }
+                    }
+                }
+                nd[fname] = items;
+            }
         } elif kind == FieldKind.OPT_NODE_REF {
             flag = data[pos];
             pos += 1;

--- a/jac/jaclang/jac0core/jir_registry.jac
+++ b/jac/jaclang/jac0core/jir_registry.jac
@@ -22,6 +22,7 @@ class FieldKind(IntEnum) {
         OPT_BOOL = 8;
         OPT_INT = 9;
         SKIP = 10;
+        OPT_NODE_LIST = 11;
     }
 }
 
@@ -766,7 +767,7 @@ glob NODE_SPECS: tuple = (
                  FieldDesc(name="name", kind=4),
                  FieldDesc(name="value", kind=6),
                  FieldDesc(name="defer", kind=2),
-                 FieldDesc(name="accessors", kind=5)
+                 FieldDesc(name="accessors", kind=11)
              )
          ),
          NodeSpec(

--- a/jac/tests/compiler/passes/main/fixtures/checker/jir_has_assign.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/jir_has_assign.jac
@@ -1,0 +1,8 @@
+import from jir_has_assign_module { Container }
+
+with entry {
+    c = Container();
+    c.value = 42;
+    c.name = "hello";
+    c.items = [1, 2, 3];
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/jir_has_assign_module.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/jir_has_assign_module.jac
@@ -1,0 +1,5 @@
+obj Container {
+    has value: int = 0,
+        name: str = '',
+        items: list = [];
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -5022,3 +5022,14 @@ test "duplicate_archetype_decl_is_hard_error" {
         1
     ].pretty_print()}";
 }
+
+test "jir_plain_has_field_assign" {
+    program = JacProgram();
+    mod = program.compile(
+        os.path.join(CHECKER_FIXTURES, "jir_has_assign.jac"), options=NO_TC
+    );
+    TypeCheckPass(ir_in=mod, prog=program);
+    assert len(program.errors_had) == 0 , "Expected 0 errors, got " + f"{len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(err.pretty_print() for err in program.errors_had);
+}


### PR DESCRIPTION
## Summary

Running `jac check` on `pyast_gen_pass.jac` produced **250 total errors — 147 of which were false-positive E1005** (`Cannot assign to read-only property`) on plain `has` fields of objects imported from other modules. This PR fixes the root cause in the JIR serializer and brings that count to **0 false positives**.

---

## The Bug

### Error code and location
**E1005** — emitted in `type_checker_pass.impl.jac` when `get_property_write_type()` classifies an assignment target as `READ_ONLY`.

### Root cause: JIR round-trip corrupts `HasVar.accessors`

The `HasVar` AST node has a field `accessors: (Sequence[Ability] | None) = None`.

- For a **plain `has` field** (e.g. `has value: int = 0`), the parser sets `accessors = None`.
- For a **native property** with getter/setter syntax (`{ get; set; }`), the parser sets `accessors` to a list of `Ability` nodes.

The type checker uses this to distinguish writable fields from read-only ones:

```jac
if has_var.accessors is not None {
    // check if a setter exists — if not, READ_ONLY
}
// if None → plain has field → WRITABLE
```

When a module is **imported**, its compiled AST is serialized to JIR (binary cache) and then deserialized. The old `FieldKind.NODE_LIST` (kind=5) had no way to represent `None` — it only wrote a count:

```
Serializer:  None  → count=0
Serializer:  []    → count=0   ← identical, information lost

Deserializer: count=0 → []     ← always returns [], never None
```

After the round-trip: `accessors = []` (not `None`).

The type checker then hits `[] is not None` → **True**, enters the accessor loop, finds no setter, and classifies the field as **READ_ONLY** → **E1005** false positive.

This only triggers on **imported** symbols because JIR is only used as the cross-module transport layer. Same-file symbols never go through JIR, so `None` stays `None`.

---

## The Fix

Added `FieldKind.OPT_NODE_LIST = 11` — a new kind that uses the same flag-byte pattern as the existing `OPT_NODE_REF` (kind=6):

- `0` → `None`
- `1` → count + node IDs follow

Changed `HasVar.accessors` registration from `kind=5` (NODE_LIST) to `kind=11` (OPT_NODE_LIST) in `jir_registry.jac`.

Added serializer and deserializer branches for `OPT_NODE_LIST` in `jir_passes.impl.jac`.

### Files changed
| File | Change |
|------|--------|
| `jac/jaclang/jac0core/jir_registry.jac` | Add `OPT_NODE_LIST = 11` to `FieldKind`; change `HasVar.accessors` from `kind=5` to `kind=11` |
| `jac/jaclang/jac0core/impl/jir_passes.impl.jac` | Add `OPT_NODE_LIST` branch in both serializer (`_write_field`) and deserializer (`_read_node`) |
| `jac/tests/compiler/passes/main/test_checker_pass.jac` | Add regression test `"jir_plain_has_field_assign"` |
| `jac/tests/compiler/passes/main/fixtures/checker/jir_has_assign.jac` | Regression test fixture — imports `Container` and assigns to all plain `has` fields |
| `jac/tests/compiler/passes/main/fixtures/checker/jir_has_assign_module.jac` | Regression test fixture — defines `obj Container` with 3 plain `has` fields |

---

## Impact

| | Before | After |
|--|--------|-------|
| E1005 on `pyast_gen_pass.jac` | **147 false positives** | **0** |
| Total errors on `pyast_gen_pass.jac` | 250 | 103 (all remaining are genuine) |