### PR TITLE
Add pluggable autoscaler framework with KEDA support in jac-scale

### DIFF
--- a/jac-scale/jac_scale/tests/test_autoscaler_factory.jac
+++ b/jac-scale/jac_scale/tests/test_autoscaler_factory.jac
@@ -1,0 +1,55 @@
+"""Unit tests for autoscaler factory + engine selection behavior."""
+
+import unittest.mock;
+
+import from jac_scale.factories.autoscaler_factory { AutoscalerFactory }
+import from jac_scale.abstractions.models.autoscaler { AutoscalerSpec, Trigger }
+
+
+test "autoscaler factory defaults to hpa engine" {
+    autoscaler = AutoscalerFactory.create(None, {"namespace": "default"});
+    assert autoscaler is not None;
+    assert autoscaler.__class__.__name__ == "HPAAutoscaler";
+}
+
+
+test "autoscaler factory creates hpa engine by name" {
+    autoscaler = AutoscalerFactory.create("hpa", {"namespace": "default"});
+    assert autoscaler is not None;
+    assert autoscaler.__class__.__name__ == "HPAAutoscaler";
+}
+
+
+test "autoscaler factory creates keda engine by name" {
+    autoscaler = AutoscalerFactory.create("keda", {"namespace": "default"});
+    assert autoscaler is not None;
+    assert autoscaler.__class__.__name__ == "KEDAAutoscaler";
+}
+
+
+test "autoscaler factory raises for unknown engine" {
+    raised = False;
+    try {
+        AutoscalerFactory.create("nope", {"namespace": "default"});
+    } except ValueError as e {
+        raised = True;
+        assert "Unsupported autoscaler engine" in str(e);
+    }
+    assert raised , "Expected ValueError for unknown autoscaler engine";
+}
+
+
+test "hpa with non-resource trigger auto-promotes to keda and logs once" {
+    logger = unittest.mock.MagicMock();
+    spec = AutoscalerSpec(
+        target_name="orders",
+        namespace="default",
+        triggers=[Trigger(type="redis", metadata={"listName": "jobs"})]
+    );
+    autoscaler = AutoscalerFactory.create(
+        "hpa", {"namespace": "default"}, logger, spec
+    );
+    assert autoscaler.__class__.__name__ == "KEDAAutoscaler";
+    logger.info.assert_called_once();
+    assert "auto-promot" in str(logger.info.call_args).lower();
+}

--- a/jac-scale/jac_scale/tests/test_config_loader.jac
+++ b/jac-scale/jac_scale/tests/test_config_loader.jac
@@ -3,6 +3,7 @@ tests stub get_microservices_config; this catches bugs in the loader
 itself - e.g. when the ingress block was dropped from the return dict)."""
 
 import from jac_scale.config_loader { JacScaleConfig }
+import from jac_scale.plugin_config { JacScalePluginConfig }
 
 
 test "get_microservices_config returns ingress block" {
@@ -53,4 +54,94 @@ test "get_microservices_config preserves all sections (regression guard)" {
     expected_keys: set[str] = {"enabled","gateway_port","gateway_host","drain_timeout_seconds","http_forward_timeout","routes","services","rate_limit","cors","client","ingress"};
     missing = expected_keys - set(out.keys());
     assert not missing , f"missing keys: {missing}";
+}
+
+
+test "get_kubernetes_config parses autoscaler keys" {
+    cfg = JacScaleConfig();
+    cfg._config = {
+        "kubernetes": {
+            "autoscaler_engine": "keda",
+            "idle_replicas": 0,
+            "autoscaler_polling_interval": 15,
+            "autoscaler_cooldown": 120,
+            "autoscaler_initial_cooldown": 45,
+            "extra_triggers": [
+                {
+                    "type": "prometheus",
+                    "metadata": {"metricName": "http_rps", "threshold": "5"}
+                }
+            ]
+        }
+    };
+    out = cfg.get_kubernetes_config();
+    assert out["autoscaler_engine"] == "keda";
+    assert out["idle_replicas"] == 0;
+    assert out["autoscaler_polling_interval"] == 15;
+    assert out["autoscaler_cooldown"] == 120;
+    assert out["autoscaler_initial_cooldown"] == 45;
+    assert out["extra_triggers"][0]["type"] == "prometheus";
+}
+
+
+test "get_kubernetes_config autoscaler defaults are stable when absent" {
+    cfg = JacScaleConfig();
+    cfg._config = {"kubernetes": {}};
+    out = cfg.get_kubernetes_config();
+    assert out.get("autoscaler_engine", "hpa") == "hpa";
+    assert out.get("idle_replicas") is None;
+    assert out.get("autoscaler_polling_interval", 30) == 30;
+    assert out.get("autoscaler_cooldown", 300) == 300;
+    assert out.get("autoscaler_initial_cooldown", 0) == 0;
+    assert out.get("extra_triggers", []) == [];
+}
+
+
+test "get_microservices_config parses autoscaler engine and triggers" {
+    cfg = JacScaleConfig();
+    cfg._config = {
+        "microservices": {
+            "enabled": True,
+            "autoscaler_engine": "keda",
+            "services": {
+                "llm_worker": {
+                    "triggers": [
+                        {
+                            "type": "redis",
+                            "metadata": {
+                                "address": "redis:6379",
+                                "listName": "jobs",
+                                "listLength": "5"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    };
+    out = cfg.get_microservices_config();
+    assert out["autoscaler_engine"] == "keda";
+    assert out["services"]["llm_worker"]["triggers"][0]["type"] == "redis";
+}
+
+
+test "plugin config schema includes kubernetes autoscaler keys" {
+    schema = JacScalePluginConfig.get_config_schema();
+    k8s = schema["options"]["kubernetes"]["nested"];
+    assert "autoscaler_engine" in k8s;
+    assert "idle_replicas" in k8s;
+    assert "autoscaler_polling_interval" in k8s;
+    assert "autoscaler_cooldown" in k8s;
+    assert "autoscaler_initial_cooldown" in k8s;
+    assert "extra_triggers" in k8s;
+}
+
+
+test "plugin config schema includes microservices autoscaler keys" {
+    schema = JacScalePluginConfig.get_config_schema();
+    ms = schema["options"]["microservices"]["nested"];
+    assert "autoscaler_engine" in ms;
+    # Service-level triggers are nested under services.* and documented in description.
+    assert "services" in ms;
+    assert "trigger" in ms["services"]["description"].lower();
 }

--- a/jac-scale/jac_scale/tests/test_deploy_k8s.jac
+++ b/jac-scale/jac_scale/tests/test_deploy_k8s.jac
@@ -2253,3 +2253,94 @@ test "redis ACL is secret mounted not in configmap and creds validated" {
     assert provider._build_connection_string('admin', 'pw', 'h') == 'redis://admin:pw@h:6379/0';
     assert secret_sd['connection-string'] == provider.get_connection_string();
 }
+
+
+test "monolith deploy routes autoscaler through factory" {
+    target_config = {
+        "app_name": "autoscale-app",
+        "namespace": "default",
+        "autoscaler_engine": "keda"
+    };
+    logger = unittest.mock.MagicMock();
+    fake_target = DeploymentTargetFactory.create("kubernetes", target_config, logger);
+
+    fake_autoscaler = unittest.mock.MagicMock();
+    fake_autoscaler.preflight.return_value = [];
+    with unittest.mock.patch(
+        "jac_scale.targets.kubernetes.kubernetes_target.AutoscalerFactory.create",
+        return_value=fake_autoscaler
+    ) {
+        with unittest.mock.patch.object(
+            fake_target,
+            "_deploy_application",
+            return_value=DeploymentResult(success=True, message="ok", details={})
+        ) {
+            app_cfg = AppConfig(code_folder=".", file_name="main.jac", build=False);
+            try {
+                fake_target.deploy(app_cfg);
+            } except Exception {
+                # TDD guard: deploy may still fail until autoscaler refactor lands.
+                0;
+            }
+        }
+    }
+    assert fake_autoscaler.preflight.called or fake_autoscaler.apply.called;
+}
+
+
+test "monolith destroy routes autoscaler destroy through factory" {
+    target_config = {
+        "app_name": "autoscale-app",
+        "namespace": "default",
+        "autoscaler_engine": "keda"
+    };
+    logger = unittest.mock.MagicMock();
+    target = DeploymentTargetFactory.create("kubernetes", target_config, logger);
+    fake_autoscaler = unittest.mock.MagicMock();
+    with unittest.mock.patch(
+        "jac_scale.targets.kubernetes.kubernetes_target.AutoscalerFactory.create",
+        return_value=fake_autoscaler
+    ) {
+        try {
+            target.destroy("autoscale-app", "application");
+        } except Exception {
+            0;
+        }
+    }
+    assert fake_autoscaler.destroy.called;
+}
+
+
+test "keda missing crd warns and skips autoscaler apply without failing deploy" {
+    target_config = {
+        "app_name": "autoscale-app",
+        "namespace": "default",
+        "autoscaler_engine": "keda"
+    };
+    logger = unittest.mock.MagicMock();
+    target = DeploymentTargetFactory.create("kubernetes", target_config, logger);
+    fake_autoscaler = unittest.mock.MagicMock();
+    fake_autoscaler.preflight.return_value = [
+        "KEDA CRD missing. Install: kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/v2.16.0/keda-2.16.0.yaml"
+    ];
+    with unittest.mock.patch(
+        "jac_scale.targets.kubernetes.kubernetes_target.AutoscalerFactory.create",
+        return_value=fake_autoscaler
+    ) {
+        with unittest.mock.patch.object(
+            target,
+            "_deploy_application",
+            return_value=DeploymentResult(success=True, message="ok", details={})
+        ) {
+            app_cfg = AppConfig(code_folder=".", file_name="main.jac", build=False);
+            try {
+                result = target.deploy(app_cfg);
+                assert result.success is True;
+            } except Exception {
+                0;
+            }
+        }
+    }
+    fake_autoscaler.apply.assert_not_called();
+    assert logger.warn.called or logger.info.called;
+}

--- a/jac-scale/jac_scale/tests/test_plan.jac
+++ b/jac-scale/jac_scale/tests/test_plan.jac
@@ -425,3 +425,56 @@ test "has_errors: True iff any diagnostic has severity='error'" {
         ]
     ) is True;
 }
+
+
+test "render smoke: hpa engine output still renders hpa summary" {
+    bundle: dict[str, Any] = {
+        "deployments": {"api": _dep(image="api:v1")},
+        "services": {"api": {}},
+        "hpas": {
+            "api": {
+                "spec": {
+                    "minReplicas": 1,
+                    "maxReplicas": 3,
+                    "metrics": [
+                        {
+                            "resource": {
+                                "name": "cpu",
+                                "target": {"averageUtilization": 70}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    };
+    (out, _) = _run_plan(
+        bundle,
+        ms_cfg_pair=({"autoscaler_engine": "hpa", "routes": {"api": "/api"}}, {})
+    );
+    assert "HPA: 1 -> 3 @ 70% CPU" in out;
+}
+
+
+test "render smoke: keda engine output includes ScaledObject section" {
+    bundle: dict[str, Any] = {
+        "deployments": {"worker": _dep(image="worker:v1")},
+        "services": {"worker": {}},
+        "scaled_objects": {
+            "worker": {
+                "apiVersion": "keda.sh/v1alpha1",
+                "kind": "ScaledObject",
+                "metadata": {"name": "worker-scaledobject"},
+                "spec": {
+                    "scaleTargetRef": {"name": "worker-deployment"},
+                    "triggers": [{"type": "redis", "metadata": {"listName": "jobs"}}]
+                }
+            }
+        }
+    };
+    (out, _) = _run_plan(
+        bundle,
+        ms_cfg_pair=({"autoscaler_engine": "keda", "routes": {"worker": "/w"}}, {})
+    );
+    assert "keda" in out.lower() or "scaledobject" in out.lower();
+}


### PR DESCRIPTION
## Summary

This PR proposes adding **KEDA** support to `jac-scale` through a **pluggable Autoscaler abstraction**, while keeping the current HPA behavior as the default.

The goal is to support CPU/memory autoscaling and event/metric-driven autoscaling (Redis, Prometheus, Kafka, etc.) through a single engine selection surface in `jac.toml`.

## Status

Implementation is **not yet completed**. This PR description captures the intended architecture, behavior decisions, and acceptance criteria for review before final code lands.

## Motivation

`jac-scale` currently hard-codes CPU-oriented HPA behavior in monolith and microservice flows. That is limiting for common workloads (LLM workers, queue consumers, HTTP rate-driven services) where non-CPU signals are better scaling inputs.

KEDA enables these signals with a standard Kubernetes operator/CRD model and supports scale-to-zero behavior.

## Proposed Design

### Layer 1: Autoscaler interface

Add `jac-scale/jac_scale/abstractions/autoscaler.jac` with an engine contract:
- `build_manifests(spec)`
- `apply(spec)`
- `destroy(target_name, namespace)`
- `preflight()` (returns warnings; does not hard-fail deploy)

### Layer 2: Engine-agnostic autoscaler models

Add `jac-scale/jac_scale/abstractions/models/autoscaler.jac`:
- `AutoscalerSpec`
- `Trigger`
- `TriggerAuth`
- `FallbackSpec`

These models define scaling policy independently of implementation.

### Layer 3: Built-in engines + factory

- `jac-scale/jac_scale/abstractions/autoscalers/hpa_autoscaler.jac`
  - CPU/memory-only path via `autoscaling/v2` HPA.
- `jac-scale/jac_scale/abstractions/autoscalers/keda_autoscaler.jac`
  - Generic trigger path via KEDA `ScaledObject` + optional `TriggerAuthentication`.
  - Includes CRD preflight checks.
- `jac-scale/jac_scale/factories/autoscaler_factory.jac`
  - Registry-based creation.
  - Built-in engines: `hpa` (default), `keda`.

## User-Facing Surface

### `jac.toml` additions (Kubernetes)

Planned additions:
- `autoscaler_engine` (default: `hpa`)
- `idle_replicas`
- `autoscaler_polling_interval`
- `autoscaler_cooldown`
- `autoscaler_initial_cooldown`
- `extra_triggers` (pass-through KEDA trigger dicts)

### CLI behavior

No new CLI flags. `jac start ... --scale` reads engine from config; `--destroy` also cleans up autoscaler resources created by the selected engine.

### Microservice behavior

Existing HPA config remains valid. KEDA trigger support is added as a sibling config path under microservices service config.

## Locked Behavior Decisions

- Default engine remains `hpa` for backward compatibility.
- If engine is `hpa` but non-resource triggers are provided, auto-promote to `keda` with a clear one-time `logger.info` notice.
- If KEDA CRDs are missing, warn-and-skip autoscaler apply; deployment continues.
- Trigger config uses pass-through KEDA shape to avoid translation-layer drift.
- Monolith and microservice paths are refactored together (no partial migration state).

## Monolith and Microservice Wiring

Planned integration points:
- Monolith: `kubernetes_target.deploy()` / `destroy()` route autoscaling through `AutoscalerFactory`.
- Microservice: manifest builder and target apply loop route autoscaling through the same abstraction and engine selection model.

## Tests and Validation (Planned)

- Unit/integration tests for:
  - factory registration/selection/defaults
  - config loader + schema coverage for new keys
  - auto-promotion logging path (one-time assertion)
  - missing-CRD warning path (one-time assertion)
  - monolith/microservice autoscaler apply + destroy behavior
- E2E target:
  - deploy with `engine="keda"` and trigger config
  - verify `ScaledObject` exists
  - verify scaling behavior under synthetic load

## Operational Notes

KEDA operator installation remains a cluster-admin concern; `jac-scale` will not auto-install KEDA.

Expected install one-liner in warnings/docs:

```bash
kubectl apply --server-side -f \
  https://github.com/kedacore/keda/releases/download/v2.16.0/keda-2.16.0.yaml
```

## Interaction with `--scale --build`

Autoscaler behavior is orthogonal to image build path. Both `--scale` and `--scale --build` target the same Deployment, but cold-start UX differs when scale-to-zero is enabled.

## Acceptance Criteria

- Autoscaler interface and models added under `jac-scale/jac_scale/abstractions/`.
- `HPAAutoscaler` and `KEDAAutoscaler` implemented with `apply`, `destroy`, and `preflight` behavior.
- `AutoscalerFactory` implemented with `hpa` and `keda` defaults.
- Monolith deploy/destroy path routed through autoscaler factory.
- Microservice manifest/apply path routed through autoscaler factory.
- New config keys exposed and documented in plugin config schema.
- Auto-promotion path logs a clear one-time message and is tested.
- Missing-CRD path logs install guidance and is tested.
- E2E KEDA path verifies resource creation and scaling behavior.
- Release note entry added via unreleased fragment workflow.

## Out of Scope (Follow-ups)

- KEDA `ScaledJob` support.
- KEDA HTTP add-on integration.
- jac-scale-managed Helm/Flux install automation for KEDA.