### PR TITLE
fix(formatter): space and wrap set literals and assign comprehensions

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6188.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6188.bugfix.md
@@ -1,0 +1,1 @@
+- **Formatter spacing for set literals and assign comprehensions**: `jac format` now puts a space after commas in set literals and assign comprehensions, and wraps long set literals one element per line, matching how lists, tuples, and dicts are formatted.

--- a/jac-byllm/byllm/local_runtime.jac
+++ b/jac-byllm/byllm/local_runtime.jac
@@ -226,7 +226,21 @@ local models need is injected by `BaseLLM.make_model_params`
 just this one, so it does not need to be re-applied here.
 """
 def filter_params(params: dict) -> dict {
-    accepted: set[str] = {"messages","tools","tool_choice","response_format","stop","max_tokens","temperature","top_p","top_k","presence_penalty","frequency_penalty","repeat_penalty","seed"};
+    accepted: set[str] = {
+        "messages",
+        "tools",
+        "tool_choice",
+        "response_format",
+        "stop",
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "presence_penalty",
+        "frequency_penalty",
+        "repeat_penalty",
+        "seed"
+    };
     out: dict = {};
     for (k, v) in params.items() {
         if k in accepted and v is not None {

--- a/jac-client/jac_client/plugin/src/asset_processor.jac
+++ b/jac-client/jac_client/plugin/src/asset_processor.jac
@@ -7,7 +7,28 @@ import from jaclang.project.config { get_config }
 """Handles copying of asset files (CSS, images, fonts, etc.) between directories."""
 class AssetProcessor {
     with entry {
-        ASSET_EXTENSIONS = {'.css','.scss','.sass','.less','.svg','.png','.jpg','.jpeg','.gif','.webp','.ico','.woff','.woff2','.ttf','.eot','.otf','.mp4','.webm','.mp3','.wav'};
+        ASSET_EXTENSIONS = {
+            '.css',
+            '.scss',
+            '.sass',
+            '.less',
+            '.svg',
+            '.png',
+            '.jpg',
+            '.jpeg',
+            '.gif',
+            '.webp',
+            '.ico',
+            '.woff',
+            '.woff2',
+            '.ttf',
+            '.eot',
+            '.otf',
+            '.mp4',
+            '.webm',
+            '.mp3',
+            '.wav'
+        };
     }
 
     def copy_assets(

--- a/jac-client/jac_client/plugin/src/impl/asset_processor.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/asset_processor.impl.jac
@@ -55,7 +55,7 @@ impl AssetProcessor.copy_typescript_files(
         return;
     }
     dest_dir.mkdir(parents=True, exist_ok=True);
-    ts_extensions = {'.ts','.tsx'};
+    ts_extensions = {'.ts', '.tsx'};
     def copy_recursive(
         source: Path, destination: Path, base: (Path | None) = None
     ) -> None {

--- a/jac-client/jac_client/plugin/src/impl/compiler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/compiler.impl.jac
@@ -369,7 +369,7 @@ impl ViteCompiler.compile_dependencies_recursively(
             );
         } elif (path_obj.suffix == '.js') {
             self._copy_js_file(path_obj, source_root);
-        } elif (path_obj.suffix in {'.ts','.tsx'}) {
+        } elif (path_obj.suffix in {'.ts', '.tsx'}) {
             self._copy_ts_file(path_obj, source_root);
         } elif path_obj.is_file() {
             self._copy_asset_file(path_obj, source_root);

--- a/jac-client/jac_client/plugin/src/impl/config_loader.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/config_loader.impl.jac
@@ -37,7 +37,7 @@ glob CORE_RUNTIME_DEPS: dict[str, str] = {
          "@types/react-dom": "^18.2.0"
      },
      # Legacy meta-package names (for migration)
-     LEGACY_META_PACKAGES = {"jac-client-node","@jac-client/dev-deps"};
+     LEGACY_META_PACKAGES = {"jac-client-node", "@jac-client/dev-deps"};
 
 # ============================================================================
 # DEPENDENCY MANAGEMENT HELPERS

--- a/jac-client/jac_client/plugin/src/impl/diagnostics.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/diagnostics.impl.jac
@@ -135,8 +135,22 @@ impl BaseDetector.find_importing_file(
 # ============== MissingDependencyDetector ==============
 
 # Core runtime dependencies (auto-injected by jac-client)
-glob CORE_DEPS = {"react","react-dom","react-router-dom","react-error-boundary","react-hook-form","zod","@hookform/resolvers"},
-     DEV_DEPS = {"vite","@vitejs/plugin-react","typescript","@types/react","@types/react-dom"};
+glob CORE_DEPS = {
+         "react",
+         "react-dom",
+         "react-router-dom",
+         "react-error-boundary",
+         "react-hook-form",
+         "zod",
+         "@hookform/resolvers"
+     },
+     DEV_DEPS = {
+         "vite",
+         "@vitejs/plugin-react",
+         "typescript",
+         "@types/react",
+         "@types/react-dom"
+     };
 
 impl MissingDependencyDetector.detect(
     self: MissingDependencyDetector, ctx: BuildContext

--- a/jac-client/jac_client/plugin/src/impl/import_processor.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/import_processor.impl.jac
@@ -3,7 +3,7 @@
 impl ImportProcessor.should_process_import(
     self: ImportProcessor, import_path: Path
 ) -> bool {
-    return (import_path.suffix in {'.jac','.js'});
+    return (import_path.suffix in {'.jac', '.js'});
 }
 
 """Process client imports for Vite bundling."""

--- a/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
+++ b/jac-client/jac_client/plugin/src/impl/vite_bundler.impl.jac
@@ -85,7 +85,13 @@ impl ViteBundler.create_package_json(
     };
     for (key, value) in package_config.items() {
         if (
-            key not in {'name','version','description','dependencies','devDependencies'}
+            key not in {
+                'name',
+                'version',
+                'description',
+                'dependencies',
+                'devDependencies'
+            }
         ) {
             package_data[key] = value;
         }
@@ -1028,7 +1034,7 @@ impl ViteBundler.create_npmrc(self: ViteBundler) -> Optional[Path] {
     npmrc_path = configs_dir / '.npmrc';
     lines: list[str] = [];
     # Process global settings: { "registry" = "...", "always-auth" = true }
-    known_keys = {'scoped_registries','auth','settings'};
+    known_keys = {'scoped_registries', 'auth', 'settings'};
     settings = npm_config.get('settings', {});
     for (key, value) in settings.items() {
         if isinstance(value, bool) {

--- a/jac-client/jac_client/tests/test_form.jac
+++ b/jac-client/jac_client/tests/test_form.jac
@@ -49,7 +49,7 @@ def _setup_form_project(
     for entry in os.listdir(form_handling_path) {
         src = os.path.join(form_handling_path, entry);
         dst = os.path.join(project_path, entry);
-        if entry in {"node_modules","build","dist",".pytest_cache",".jac"} {
+        if entry in {"node_modules", "build", "dist", ".pytest_cache", ".jac"} {
             continue;
         }
         if os.path.isdir(src) {

--- a/jac-client/jac_client/tests/test_it.jac
+++ b/jac-client/jac_client/tests/test_it.jac
@@ -140,7 +140,13 @@ test "all in one app endpoints" {
             for entry in os.listdir(all_in_one_path) {
                 src = os.path.join(all_in_one_path, entry);
                 dst = os.path.join(project_path, entry);
-                if entry in {"node_modules","build","dist",".pytest_cache",".jac"} {
+                if entry in {
+                    "node_modules",
+                    "build",
+                    "dist",
+                    ".pytest_cache",
+                    ".jac"
+                } {
                     continue;
                 }
                 if os.path.isdir(src) {
@@ -1026,7 +1032,13 @@ test "configurable api base url in bundle" {
             for entry in os.listdir(all_in_one_path) {
                 src = os.path.join(all_in_one_path, entry);
                 dst = os.path.join(project_path, entry);
-                if entry in {"node_modules","build","dist",".pytest_cache",".jac"} {
+                if entry in {
+                    "node_modules",
+                    "build",
+                    "dist",
+                    ".pytest_cache",
+                    ".jac"
+                } {
                     continue;
                 }
                 if os.path.isdir(src) {
@@ -1209,7 +1221,7 @@ def _setup_all_in_one_project(temp_dir: str, app_name: str) -> str {
     for entry in os.listdir(all_in_one_path) {
         src = os.path.join(all_in_one_path, entry);
         dst = os.path.join(project_path, entry);
-        if entry in {"node_modules","build","dist",".pytest_cache",".jac"} {
+        if entry in {"node_modules", "build", "dist", ".pytest_cache", ".jac"} {
             continue;
         }
         if os.path.isdir(src) {

--- a/jac-scale/jac_scale/impl/identity_storage.impl.jac
+++ b/jac-scale/jac_scale/impl/identity_storage.impl.jac
@@ -29,7 +29,7 @@ impl IdentityStorage.create_user(
     type_counts: dict[str, int] = {};
     for identity in identities {
         id_type = identity.get('type', '');
-        if id_type not in {'username','email'} {
+        if id_type not in {'username', 'email'} {
             return {
                 'error': f"Invalid identity type: {id_type}. Only 'username' and 'email' are allowed",
                 'code': 'VALIDATION_ERROR'

--- a/jac-scale/jac_scale/impl/identity_storage.sqlite.impl.jac
+++ b/jac-scale/jac_scale/impl/identity_storage.sqlite.impl.jac
@@ -164,7 +164,12 @@ impl SqliteIdentityStorage.delete_user(user_id: str) -> bool {
 impl SqliteIdentityStorage._update_fields(
     user_id: str, fields: dict[str, any]
 ) -> bool {
-    allowed = {c.name for c in self._table.columns} - {'user_id','created_at','identities','credentials'};
+    allowed = {c.name for c in self._table.columns} - {
+        'user_id',
+        'created_at',
+        'identities',
+        'credentials'
+    };
     safe_fields = {
         k: v
         for (k, v) in fields.items()

--- a/jac-scale/jac_scale/impl/memory_hierarchy.mongo.impl.jac
+++ b/jac-scale/jac_scale/impl/memory_hierarchy.mongo.impl.jac
@@ -532,7 +532,7 @@ The planner combines these with the topology_index narrowing automatically
 — see `jaclang.runtimelib.planner` for the strategy chooser.
 """
 impl MongoBackend.capabilities -> set[str] {
-    return {'type_pushdown','field_pushdown','id_in','slice'};
+    return {'type_pushdown', 'field_pushdown', 'id_in', 'slice'};
 }
 
 

--- a/jac-scale/jac_scale/impl/serve.static.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.static.impl.jac
@@ -254,7 +254,30 @@ impl JacAPIServerStatic.render_base_route_callback(
 """Serve root-level assets like /img.png, /icons/logo.svg, etc.
 Falls back to SPA HTML for extensionless paths when base_route_app is configured."""
 impl JacAPIServerStatic.serve_root_asset(file_path: str) -> Response {
-    allowed_extensions = {'.png','.jpg','.jpeg','.gif','.webp','.svg','.ico','.woff','.woff2','.ttf','.otf','.eot','.mp4','.webm','.mp3','.wav','.css','.js','.json','.pdf','.txt','.xml'};
+    allowed_extensions = {
+        '.png',
+        '.jpg',
+        '.jpeg',
+        '.gif',
+        '.webp',
+        '.svg',
+        '.ico',
+        '.woff',
+        '.woff2',
+        '.ttf',
+        '.otf',
+        '.eot',
+        '.mp4',
+        '.webm',
+        '.mp3',
+        '.wav',
+        '.css',
+        '.js',
+        '.json',
+        '.pdf',
+        '.txt',
+        '.xml'
+    };
     file_ext = Path(file_path).suffix.lower();
     import from jaclang.project.config { get_config }
     config = get_config();

--- a/jac-scale/jac_scale/microservices/gateway.jac
+++ b/jac-scale/jac_scale/microservices/gateway.jac
@@ -25,7 +25,12 @@ import from jac_scale.microservices.runtime.util {
 import from jac_scale.admin.admin_portal { JacAPIServerAdmin }
 
 glob logger = logging.getLogger(__name__),
-     HOP_BY_HOP_HEADERS: set[str] = {"host","transfer-encoding","connection","keep-alive"};
+     HOP_BY_HOP_HEADERS: set[str] = {
+         "host",
+         "transfer-encoding",
+         "connection",
+         "keep-alive"
+     };
 
 """API Gateway that routes requests to microservices by path prefix.
 

--- a/jac-scale/jac_scale/microservices/gateway_internals/drain.jac
+++ b/jac-scale/jac_scale/microservices/gateway_internals/drain.jac
@@ -9,7 +9,7 @@ import from threading { Lock as _DrainLock }
 
 glob logger = logging.getLogger(__name__),
      # Liveness must stay 200 mid-drain; readiness has its own draining handler.
-     _DRAIN_EXEMPT_PATHS: set[str] = {"/healthz/live","/healthz/ready"};
+     _DRAIN_EXEMPT_PATHS: set[str] = {"/healthz/live", "/healthz/ready"};
 
 
 # Pre-set: inflight=0 so wait_for_zero returns True immediately.

--- a/jac-scale/jac_scale/microservices/gateway_internals/middleware/ws_forward.jac
+++ b/jac-scale/jac_scale/microservices/gateway_internals/middleware/ws_forward.jac
@@ -9,7 +9,18 @@ import aiohttp;
 import asyncio;
 
 glob _logger = logging.getLogger(__name__),
-     _WS_HOP_BY_HOP: set[str] = {"host","connection","upgrade","sec-websocket-key","sec-websocket-version","sec-websocket-extensions","sec-websocket-protocol","sec-websocket-accept","transfer-encoding","keep-alive"};
+     _WS_HOP_BY_HOP: set[str] = {
+         "host",
+         "connection",
+         "upgrade",
+         "sec-websocket-key",
+         "sec-websocket-version",
+         "sec-websocket-extensions",
+         "sec-websocket-protocol",
+         "sec-websocket-accept",
+         "transfer-encoding",
+         "keep-alive"
+     };
 
 
 def _to_ws_scheme(url: str) -> str {

--- a/jac-scale/jac_scale/microservices/impl/gateway.impl.jac
+++ b/jac-scale/jac_scale/microservices/impl/gateway.impl.jac
@@ -293,7 +293,7 @@ glob _BUILTIN_PREFIXES: tuple = (
          "/jobs/",
          "/graph/"
      ),
-     _BUILTIN_EXACT: set[str] = {"/user","/graph"};
+     _BUILTIN_EXACT: set[str] = {"/user", "/graph"};
 
 """Copy incoming request headers, dropping hop-by-hop headers.
 

--- a/jac-scale/jac_scale/microservices/impl/http_forward.jac
+++ b/jac-scale/jac_scale/microservices/impl/http_forward.jac
@@ -10,7 +10,7 @@ import aiohttp;
 import from fastapi.responses { Response, StreamingResponse }
 
 glob _logger = logging.getLogger(__name__),
-     _HOP_BY_HOP: set[str] = {"host","transfer-encoding","connection","keep-alive"};
+     _HOP_BY_HOP: set[str] = {"host", "transfer-encoding", "connection", "keep-alive"};
 
 
 """Buffered forward. Returns (status, headers, body) or None on transport error."""

--- a/jac-scale/jac_scale/microservices/setup.jac
+++ b/jac-scale/jac_scale/microservices/setup.jac
@@ -19,7 +19,15 @@ import from jaclang.cli.console { console }
 """Scan the project for .jac files, excluding build artifacts."""
 def scan_jac_files(project_root: str = ".") -> list[str] {
     base_dir = Path(project_root);
-    exclude_dirs: set[str] = {".jac","__pycache__","node_modules",".git","dist","build","__jac_gen__"};
+    exclude_dirs: set[str] = {
+        ".jac",
+        "__pycache__",
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        "__jac_gen__"
+    };
     jac_files: list[str] = [];
 
     for f in base_dir.rglob("*.jac") {

--- a/jac-scale/jac_scale/tests/test_config_loader.jac
+++ b/jac-scale/jac_scale/tests/test_config_loader.jac
@@ -50,7 +50,19 @@ test "get_microservices_config preserves all sections (regression guard)" {
         }
     };
     out = cfg.get_microservices_config();
-    expected_keys: set[str] = {"enabled","gateway_port","gateway_host","drain_timeout_seconds","http_forward_timeout","routes","services","rate_limit","cors","client","ingress"};
+    expected_keys: set[str] = {
+        "enabled",
+        "gateway_port",
+        "gateway_host",
+        "drain_timeout_seconds",
+        "http_forward_timeout",
+        "routes",
+        "services",
+        "rate_limit",
+        "cors",
+        "client",
+        "ingress"
+    };
     missing = expected_keys - set(out.keys());
     assert not missing , f"missing keys: {missing}";
 }

--- a/jac-scale/jac_scale/tests/test_memory_hierarchy.jac
+++ b/jac-scale/jac_scale/tests/test_memory_hierarchy.jac
@@ -67,7 +67,7 @@ def _reset_mongo -> None {
     if "mongo_client" not in _shared {
         return;
     }
-    system_dbs = {"admin","config","local"};
+    system_dbs = {"admin", "config", "local"};
     for db_name in _shared["mongo_client"].list_database_names() {
         if db_name not in system_dbs {
             _shared["mongo_client"].drop_database(db_name);

--- a/jac-scale/jac_scale/tests/test_persistence_race.jac
+++ b/jac-scale/jac_scale/tests/test_persistence_race.jac
@@ -182,7 +182,7 @@ test "concurrent writes to same root must not lose edges (race condition proof)"
                 server.wait(timeout=2);
             }
         }
-        system_dbs = {"admin","config","local"};
+        system_dbs = {"admin", "config", "local"};
         for db_name in mongo_client.list_database_names() {
             if db_name not in system_dbs {
                 mongo_client.drop_database(db_name);

--- a/jac-scale/jac_scale/tests/test_restspec.jac
+++ b/jac-scale/jac_scale/tests/test_restspec.jac
@@ -400,7 +400,7 @@ test "custom obj body - walker flows" {
         user_schema = schemas["UserBody"];
         assert user_schema["properties"]["name"]["type"] == "string"
         and user_schema["properties"]["age"]["type"] == "integer"
-        and set(user_schema["required"]) == {"name","age"};
+        and set(user_schema["required"]) == {"name", "age"};
         body_ref = spec["paths"]["/walker/CreateUser"]["post"]["requestBody"]["content"][
             "application/json"
         ]["schema"]["$ref"];

--- a/jac-scale/jac_scale/tests/test_topology_slice_pushdown.jac
+++ b/jac-scale/jac_scale/tests/test_topology_slice_pushdown.jac
@@ -71,7 +71,7 @@ def _get_redis_url -> str {
 def _reset_dbs {
     if "mongo_client" in _shared {
         for db_name in _shared["mongo_client"].list_database_names() {
-            if db_name not in {"admin","config","local"} {
+            if db_name not in {"admin", "config", "local"} {
                 _shared["mongo_client"].drop_database(db_name);
             }
         }

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -73,8 +73,20 @@ glob yolo_mode: bool = True,
 
 # Tool names grouped for the turn-stat breakdown: tools that mutate files,
 # and tools that execute code or shell commands. Everything else is a read.
-glob _WRITE_TOOLS: set[str] = {"write_file","edit_file"},
-     _RUN_TOOLS: set[str] = {"run_command","jac_check","start_app","browse_open","browse_navigate","browse_click","browse_type","browse_fill","browse_press","browse_eval","browse_close"},
+glob _WRITE_TOOLS: set[str] = {"write_file", "edit_file"},
+     _RUN_TOOLS: set[str] = {
+         "run_command",
+         "jac_check",
+         "start_app",
+         "browse_open",
+         "browse_navigate",
+         "browse_click",
+         "browse_type",
+         "browse_fill",
+         "browse_press",
+         "browse_eval",
+         "browse_close"
+     },
      # Set True by `run_turn` when the turn issued a file-writing tool call, so
      # the one-shot verify-and-continue guard only kicks in when code changed.
      _turn_wrote: bool = False;

--- a/jac/jaclang/cli/browser_engine.jac
+++ b/jac/jaclang/cli/browser_engine.jac
@@ -35,7 +35,22 @@ glob OP_TEXT: int = 0x1,
      OP_PONG: int = 0xA;
 
 """Accessibility roles worth assigning a @ref to in a snapshot."""
-glob INTERACTIVE_ROLES: set = {"button","link","textbox","checkbox","radio","combobox","menuitem","tab","switch","searchbox","slider","option","menuitemcheckbox",};
+glob INTERACTIVE_ROLES: set = {
+         "button",
+         "link",
+         "textbox",
+         "checkbox",
+         "radio",
+         "combobox",
+         "menuitem",
+         "tab",
+         "switch",
+         "searchbox",
+         "slider",
+         "option",
+         "menuitemcheckbox",
+
+     };
 
 """Virtual key codes for the named keys `press` understands."""
 glob KEY_CODES: dict = {

--- a/jac/jaclang/cli/commands/impl/eject.impl.jac
+++ b/jac/jaclang/cli/commands/impl/eject.impl.jac
@@ -32,7 +32,18 @@ glob _SV_SUFFIX: str = ".sv.jac",
      _IMPL_SUFFIX: str = ".impl.jac",
      _TEST_SUFFIX: str = ".test.jac",
      # Directories never traversed when collecting source files.
-     _SKIP_DIRS: set = {".jac",".git",".venv","venv","node_modules","__pycache__",".mypy_cache",".pytest_cache","dist","build"};
+     _SKIP_DIRS: set = {
+         ".jac",
+         ".git",
+         ".venv",
+         "venv",
+         "node_modules",
+         "__pycache__",
+         ".mypy_cache",
+         ".pytest_cache",
+         "dist",
+         "build"
+     };
 
 
 """Resolve the output directory for `jac eject`.

--- a/jac/jaclang/compiler/code_intel.jac
+++ b/jac/jaclang/compiler/code_intel.jac
@@ -26,7 +26,18 @@ import from jaclang.jac0core.program { JacProgram }
 import from jaclang.jac0core.passes { Alert }
 
 # Directories never worth compiling -- generated output, vendored deps, VCS.
-glob _SKIP_DIRS: set[str] = {"__pycache__","__jac_gen__",".git",".venv","venv","node_modules","build","dist",".mypy_cache",".pytest_cache"},
+glob _SKIP_DIRS: set[str] = {
+         "__pycache__",
+         "__jac_gen__",
+         ".git",
+         ".venv",
+         "venv",
+         "node_modules",
+         "build",
+         "dist",
+         ".mypy_cache",
+         ".pytest_cache"
+     },
      # Archetype keyword -> readable kind. Falls back to the raw token value.
      _ARCH_KIND: dict[str, str] = {
          "node": "node",

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -141,7 +141,16 @@ glob _T = TypeVar('_T', bound=es.Node),
      # type of the receiver cannot be proven (issue #5508 / #5453), the
      # codegen routes these calls through `_jac.poly.<method>(target, ...)`,
      # which dispatches to the native JS operation at runtime.
-     POLYMORPHIC_METHODS: set[str] = {"lower","upper","strip","lstrip","rstrip","append","extend","pop"},
+     POLYMORPHIC_METHODS: set[str] = {
+         "lower",
+         "upper",
+         "strip",
+         "lstrip",
+         "rstrip",
+         "append",
+         "extend",
+         "pop"
+     },
      LiteralValue = str | bool | int | float | None;
 
 """Name of the synthesized children accumulator local for a JSX `{...}`

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -2625,7 +2625,43 @@ impl EsastGenPass.exit_assert_stmt(nd: uni.AssertStmt) -> None {
 }
 
 # Known exception types that map to _jac.exc.X in generated JS.
-glob _KNOWN_EXCEPTIONS: set[str] = {'BaseException','Exception','ArithmeticError','ZeroDivisionError','OverflowError','FloatingPointError','LookupError','IndexError','KeyError','ValueError','TypeError','AttributeError','RuntimeError','NotImplementedError','RecursionError','OSError','FileNotFoundError','FileExistsError','PermissionError','TimeoutError','IsADirectoryError','NotADirectoryError','AssertionError','ImportError','ModuleNotFoundError','NameError','UnboundLocalError','StopIteration','StopAsyncIteration','EOFError','MemoryError','ReferenceError','KeyboardInterrupt','SystemExit','GeneratorExit'};
+glob _KNOWN_EXCEPTIONS: set[str] = {
+         'BaseException',
+         'Exception',
+         'ArithmeticError',
+         'ZeroDivisionError',
+         'OverflowError',
+         'FloatingPointError',
+         'LookupError',
+         'IndexError',
+         'KeyError',
+         'ValueError',
+         'TypeError',
+         'AttributeError',
+         'RuntimeError',
+         'NotImplementedError',
+         'RecursionError',
+         'OSError',
+         'FileNotFoundError',
+         'FileExistsError',
+         'PermissionError',
+         'TimeoutError',
+         'IsADirectoryError',
+         'NotADirectoryError',
+         'AssertionError',
+         'ImportError',
+         'ModuleNotFoundError',
+         'NameError',
+         'UnboundLocalError',
+         'StopIteration',
+         'StopAsyncIteration',
+         'EOFError',
+         'MemoryError',
+         'ReferenceError',
+         'KeyboardInterrupt',
+         'SystemExit',
+         'GeneratorExit'
+     };
 
 """Process raise statement.
 

--- a/jac/jaclang/compiler/passes/ecmascript/impl/scoped_styles.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/scoped_styles.impl.jac
@@ -1,6 +1,12 @@
 """Implementation for scoped-style annex support."""
 
-glob _GROUPING_AT_RULES: set[str] = {'media','supports','container','layer','scope'};
+glob _GROUPING_AT_RULES: set[str] = {
+         'media',
+         'supports',
+         'container',
+         'layer',
+         'scope'
+     };
 
 impl ScopedStyleSheet.postinit -> None {
     self.scoped_css = scope_stylesheet(

--- a/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
@@ -523,7 +523,7 @@ impl LayoutPass._is_layout_compatible_type(
         if isinstance(type_node.target, uni.Name) {
             target_name = type_node.target.value;
         }
-        if target_name in {"list","dict","set","frozenset","tuple"} {
+        if target_name in {"list", "dict", "set", "frozenset", "tuple"} {
             # Validate element types
             if type_node?.right and type_node.right?.slices {
                 for sl in type_node.right.slices {

--- a/jac/jaclang/compiler/passes/main/layout_pass.jac
+++ b/jac/jaclang/compiler/passes/main/layout_pass.jac
@@ -20,7 +20,24 @@ obj fields must resolve to one of these, another obj, an enum, a typed
 collection (list[T], dict[K,V], set[T]) where element types are also
 layout-compatible, or a callable with explicit signature (function pointer).
 """
-glob LAYOUT_COMPATIBLE_PRIMITIVES: set[str] = {"int","float","bool","str","bytes","i8","u8","i16","u16","i32","u32","i64","u64","f32","f64",};
+glob LAYOUT_COMPATIBLE_PRIMITIVES: set[str] = {
+         "int",
+         "float",
+         "bool",
+         "str",
+         "bytes",
+         "i8",
+         "u8",
+         "i16",
+         "u16",
+         "i32",
+         "u32",
+         "i64",
+         "u64",
+         "f32",
+         "f64",
+
+     };
 
 """Per-field layout descriptor."""
 obj FieldInfo {

--- a/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
@@ -217,7 +217,7 @@ impl ArchConfig.from_e_machine(e_machine: int) -> (ArchConfig | None) {
             jump_slot_rtype=R_X86_64_JUMP_SLOT,
             copy_rtype=R_X86_64_COPY,
             glob_dat_rtype=R_X86_64_GLOB_DAT,
-            gotpcrel_rtypes={R_X86_64_GOTPCREL,R_X86_64_REX_GOTPCRELX}
+            gotpcrel_rtypes={R_X86_64_GOTPCREL, R_X86_64_REX_GOTPCRELX}
         );
     } elif e_machine == EM_AARCH64 {
         return ArchConfig(
@@ -233,7 +233,7 @@ impl ArchConfig.from_e_machine(e_machine: int) -> (ArchConfig | None) {
             jump_slot_rtype=R_AARCH64_JUMP_SLOT,
             copy_rtype=R_AARCH64_COPY,
             glob_dat_rtype=R_AARCH64_GLOB_DAT,
-            gotpcrel_rtypes={R_AARCH64_ADR_GOT_PAGE,R_AARCH64_LD64_GOT_LO12_NC}
+            gotpcrel_rtypes={R_AARCH64_ADR_GOT_PAGE, R_AARCH64_LD64_GOT_LO12_NC}
         );
     }
     return None;
@@ -639,7 +639,7 @@ impl ElfLinker.build_executable -> bytes {
     }
 
     # Identify external symbols
-    known_data_syms = {"stdin","stdout","stderr","environ"};
+    known_data_syms = {"stdin", "stdout", "stderr", "environ"};
     extern_func_syms: list[str] = [];
     extern_data_syms: list[str] = [];
     local_sym_map: dict[str, tuple[str, int]] = {};

--- a/jac/jaclang/compiler/passes/native/impl/macho_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/macho_linker.impl.jac
@@ -553,7 +553,13 @@ impl MachOLinker.build_executable -> bytes {
     # ── Classify symbols ─────────────────────────────────────────
     extern_func_syms: list[str] = [];
     extern_data_syms: list[str] = [];
-    known_data_syms: set = {"__stdinp","__stdoutp","__stderrp","environ","_environ"};
+    known_data_syms: set = {
+        "__stdinp",
+        "__stdoutp",
+        "__stderrp",
+        "environ",
+        "_environ"
+    };
     local_sym_map: dict[str, tuple[str, int]] = {};
     sym_idx_map: dict[int, tuple[str, int]] = {};
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -995,7 +995,7 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
                 } elif uni?.BuiltinType and isinstance(_redecl_tag, uni.BuiltinType) {
                     bare_redecl = _redecl_tag.value;
                 }
-                _skip_redecl = bare_redecl in {"list","dict","set","frozenset"};
+                _skip_redecl = bare_redecl in {"list", "dict", "set", "frozenset"};
                 if not _skip_redecl {
                     _declared_type = self._resolve_jac_type(_redecl_tag);
                     if _declared_type is not None
@@ -1606,7 +1606,7 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
                     bare_name = tag_node.value;
                 }
                 infer_from_val = (
-                    bare_name in {"list","dict","set","frozenset"}
+                    bare_name in {"list", "dict", "set", "frozenset"}
                     and isinstance(value.type, ir.PointerType)
                 );
                 if infer_from_val {

--- a/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/tool/doc_ir_gen_pass.jac
@@ -51,6 +51,10 @@ obj DocIRGenPass(UniPass) {
     ) -> doc.DocType;
 
     def format_comprehension(parts: list[doc.DocType]) -> doc.DocType;
+    """Lay out a comma-delimited literal (list/set/tuple): flat with a space
+    after each comma, or one element per line when it must break."""
+    def format_comma_collection(nd: uni.UniNode) -> doc.DocType;
+
     def is_one_line(nd: uni.UniNode) -> bool;
     def has_gap(prev_kid: uni.UniNode, curr_kid: uni.UniNode) -> bool;
     def add_body_stmt_with_spacing(

--- a/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
@@ -795,10 +795,13 @@ impl DocIRGenPass.exit_py_inline_code(nd: uni.PyInlineCode) -> None {
 impl DocIRGenPass.exit_assign_compr(nd: uni.AssignCompr) -> None {
     parts: list[doc.DocType] = [];
     for i in nd.kid {
-        parts.append(i.gen.doc_ir);
+        if isinstance(i, uni.Token) and i.name == Tok.COMMA {
+            parts.append(doc.Text(", "));
+        } else {
+            parts.append(self.remove_all_spaces(i.gen.doc_ir));
+        }
     }
-    compact_doc = self.remove_all_spaces(self.concat(parts));
-    nd.gen.doc_ir = self.group(compact_doc);
+    nd.gen.doc_ir = self.group(self.concat(parts));
 }
 
 """Generate DocIR for filter comprehensions."""
@@ -1600,11 +1603,49 @@ impl DocIRGenPass.exit_with_stmt(nd: uni.WithStmt) -> None {
 
 """Generate DocIR for set values."""
 impl DocIRGenPass.exit_set_val(nd: uni.SetVal) -> None {
-    parts: list[doc.DocType] = [];
+    nd.gen.doc_ir = self.format_comma_collection(nd);
+}
+
+"""Lay out a comma-delimited literal: flat with a space after each comma, or,
+when the group breaks, one element per line wrapped in an indented block. Shared
+by list, set, and tuple literals so their comma handling cannot drift apart."""
+impl DocIRGenPass.format_comma_collection(nd: uni.UniNode) -> doc.DocType {
+    flat_parts: list[doc.DocType] = [];
     for i in nd.kid {
-        parts.append(i.gen.doc_ir);
+        if (isinstance(i, uni.Token) and (i.name == Tok.COMMA)) {
+            flat_parts.append(i.gen.doc_ir);
+            flat_parts.append(self.space());
+        } else {
+            flat_parts.append(i.gen.doc_ir);
+        }
     }
-    nd.gen.doc_ir = self.group(self.concat(parts, ast_node=nd), ast_node=nd);
+    not_broke = self.concat(flat_parts, ast_node=nd);
+    broken_parts: list[doc.DocType] = [];
+    for i in nd.kid {
+        if (isinstance(i, uni.Token) and (i.name == Tok.COMMA)) {
+            broken_parts.append(i.gen.doc_ir);
+            broken_parts.append(self.hard_line());
+        } else {
+            broken_parts.append(i.gen.doc_ir);
+        }
+    }
+    if (len(broken_parts) >= 3) {
+        broke = self.concat(
+            [
+                broken_parts[0],
+                self.indent(
+                    self.concat([self.hard_line(), *broken_parts[1:-1]], ast_node=nd),
+                    ast_node=nd
+                ),
+                self.hard_line(),
+                broken_parts[-1]
+            ],
+            ast_node=nd
+        );
+    } else {
+        broke = self.concat(broken_parts, ast_node=nd);
+    }
+    return self.group(self.if_break(broke, not_broke), ast_node=nd);
 }
 
 """Generate DocIR for multiline strings."""
@@ -1620,38 +1661,7 @@ impl DocIRGenPass.exit_multi_string(nd: uni.MultiString) -> None {
 
 """Generate DocIR for tuple values."""
 impl DocIRGenPass.exit_tuple_val(nd: uni.TupleVal) -> None {
-    parts: list[doc.DocType] = [];
-    for i in nd.kid {
-        if (isinstance(i, uni.Token) and (i.name == Tok.COMMA)) {
-            parts.append(i.gen.doc_ir);
-            parts.append(self.space());
-        } else {
-            parts.append(i.gen.doc_ir);
-        }
-    }
-    not_broke = self.concat(parts);
-    parts = [];
-    for i in nd.kid {
-        if (isinstance(i, uni.Token) and (i.name == Tok.COMMA)) {
-            parts.append(i.gen.doc_ir);
-            parts.append(self.hard_line());
-        } else {
-            parts.append(i.gen.doc_ir);
-        }
-    }
-    if (len(parts) >= 3) {
-        broke = self.concat(
-            [
-                parts[0],
-                self.indent(self.concat([self.hard_line(), *parts[1:-1]])),
-                self.hard_line(),
-                parts[-1]
-            ]
-        );
-    } else {
-        broke = self.concat(parts);
-    }
-    nd.gen.doc_ir = self.group(self.if_break(broke, not_broke));
+    nd.gen.doc_ir = self.format_comma_collection(nd);
 }
 
 """Generate DocIR for finally statements."""
@@ -1865,42 +1875,7 @@ impl DocIRGenPass.exit_dict_val(nd: uni.DictVal) -> None {
 
 """Generate DocIR for list values."""
 impl DocIRGenPass.exit_list_val(nd: uni.ListVal) -> None {
-    parts: list[doc.DocType] = [];
-    for i in nd.kid {
-        if (isinstance(i, uni.Token) and (i.name == Tok.COMMA)) {
-            parts.append(i.gen.doc_ir);
-            parts.append(self.space());
-        } else {
-            parts.append(i.gen.doc_ir);
-        }
-    }
-    not_broke = self.concat(parts, ast_node=nd);
-    parts = [];
-    for i in nd.kid {
-        if (isinstance(i, uni.Token) and (i.name == Tok.COMMA)) {
-            parts.append(i.gen.doc_ir);
-            parts.append(self.hard_line());
-        } else {
-            parts.append(i.gen.doc_ir);
-        }
-    }
-    if (len(parts) >= 3) {
-        broke = self.concat(
-            [
-                parts[0],
-                self.indent(
-                    self.concat([self.hard_line(), *parts[1:-1]], ast_node=nd),
-                    ast_node=nd
-                ),
-                self.hard_line(),
-                parts[-1]
-            ],
-            ast_node=nd
-        );
-    } else {
-        broke = self.concat(parts, ast_node=nd);
-    }
-    nd.gen.doc_ir = self.group(self.if_break(broke, not_broke), ast_node=nd);
+    nd.gen.doc_ir = self.format_comma_collection(nd);
 }
 
 """Generate DocIR for atom trailers."""

--- a/jac/jaclang/compiler/tests/test_code_intel.jac
+++ b/jac/jaclang/compiler/tests/test_code_intel.jac
@@ -143,7 +143,7 @@ test "nodes_visited_by lists a walker's targets" {
 test "archetypes filters by kind" {
     ci = fresh();
     nodes = {a.name for a in ci.archetypes("node")};
-    assert nodes == {"User","Post"} , nodes;
+    assert nodes == {"User", "Post"} , nodes;
     walkers = {a.name for a in ci.archetypes("walker")};
     assert walkers == {"Crawler"} , walkers;
     shutil.rmtree(ci.proj_dir, ignore_errors=True);

--- a/jac/jaclang/compiler/type_registry.jac
+++ b/jac/jaclang/compiler/type_registry.jac
@@ -172,37 +172,81 @@ glob JAC_TYPE_REGISTRY = JacTypeRegistry(
          },
          _builtin_names=frozenset(
              {
-             # I/O
-             "print","input",
-             # Aggregation
-             "len","abs","round","min","max","sum",
-             # Iteration
-             "sorted","reversed","enumerate","zip","map","filter","any","all",
-             # Type checking
-             "isinstance","issubclass","type","callable",
-             # Identity / hashing
-             "id","hash","jid",
-             # Portable constructor (server: Cls(*args); cl: Reflect.construct)
-             "new",
-             # JSX raw-HTML opt-in (returns a marker recognised by __jacJsx)
-             "unsafe_html",
-             # Representation
-             "repr","format","ascii",
-             # Char/ord conversion
-             "chr","ord",
-             # Number formatting
-             "hex","oct","bin",
-             # Arithmetic
-             "pow","divmod",
-             # Iteration protocol
-             "iter","next",
-             # Attribute access
-             "getattr","setattr","hasattr","delattr",
-             # Introspection
-             "vars","dir",
-             # File I/O
-             "open",
-             # Type conversions
-             "str","int","float","bool","list","dict","set","tuple","frozenset","bytes","complex","range","slice","bytearray",}
+                 # I/O
+                 "print",
+                 "input",
+                 # Aggregation
+                 "len",
+                 "abs",
+                 "round",
+                 "min",
+                 "max",
+                 "sum",
+                 # Iteration
+                 "sorted",
+                 "reversed",
+                 "enumerate",
+                 "zip",
+                 "map",
+                 "filter",
+                 "any",
+                 "all",
+                 # Type checking
+                 "isinstance",
+                 "issubclass",
+                 "type",
+                 "callable",
+                 # Identity / hashing
+                 "id",
+                 "hash",
+                 "jid",
+                 # Portable constructor (server: Cls(*args); cl: Reflect.construct)
+                 "new",
+                 # JSX raw-HTML opt-in (returns a marker recognised by __jacJsx)
+                 "unsafe_html",
+                 # Representation
+                 "repr",
+                 "format",
+                 "ascii",
+                 # Char/ord conversion
+                 "chr",
+                 "ord",
+                 # Number formatting
+                 "hex",
+                 "oct",
+                 "bin",
+                 # Arithmetic
+                 "pow",
+                 "divmod",
+                 # Iteration protocol
+                 "iter",
+                 "next",
+                 # Attribute access
+                 "getattr",
+                 "setattr",
+                 "hasattr",
+                 "delattr",
+                 # Introspection
+                 "vars",
+                 "dir",
+                 # File I/O
+                 "open",
+                 # Type conversions
+                 "str",
+                 "int",
+                 "float",
+                 "bool",
+                 "list",
+                 "dict",
+                 "set",
+                 "tuple",
+                 "frozenset",
+                 "bytes",
+                 "complex",
+                 "range",
+                 "slice",
+                 "bytearray",
+
+             }
          )
      );

--- a/jac/jaclang/compiler/type_system/enum_utils.jac
+++ b/jac/jaclang/compiler/type_system/enum_utils.jac
@@ -8,7 +8,17 @@ import from . { types }
 import type from .type_evaluator { TypeEvaluator, PrefetchedTypes }
 
 # Names that are excluded from enum membership
-glob ENUM_RESERVED_NAMES: set[str] = {'name','value','_name_','_value_','_ignore_','_order_','__order__','_missing_','_generate_next_value_'};
+glob ENUM_RESERVED_NAMES: set[str] = {
+         'name',
+         'value',
+         '_name_',
+         '_value_',
+         '_ignore_',
+         '_order_',
+         '__order__',
+         '_missing_',
+         '_generate_next_value_'
+     };
 
 """Check if a name should be excluded from enum membership."""
 def is_excluded_enum_member_name(name: str) -> bool;

--- a/jac/jaclang/compiler/type_system/operations.jac
+++ b/jac/jaclang/compiler/type_system/operations.jac
@@ -43,7 +43,15 @@ glob BINARY_OPERATOR_MAP: dict[str, tuple[str, str]] = {
          Tok.GT: ('__gt__', '__lt__'),
          Tok.GTE: ('__ge__', '__le__')
      },
-     ARITHMETIC_OPERATORS: set[str] = {Tok.PLUS,Tok.MINUS,Tok.STAR_MUL,Tok.DIV,Tok.FLOOR_DIV,Tok.MOD,Tok.STAR_POW},
+     ARITHMETIC_OPERATORS: set[str] = {
+         Tok.PLUS,
+         Tok.MINUS,
+         Tok.STAR_MUL,
+         Tok.DIV,
+         Tok.FLOOR_DIV,
+         Tok.MOD,
+         Tok.STAR_POW
+     },
      INT_LIKE_WIDTHS: dict[str, int] = {
          "i8": 8,
          "u8": 8,
@@ -54,7 +62,7 @@ glob BINARY_OPERATOR_MAP: dict[str, tuple[str, str]] = {
          "i64": 64,
          "u64": 64
      },
-     FLOAT_LIKE_NAMES: set[str] = {"f32","f64"},
+     FLOAT_LIKE_NAMES: set[str] = {"f32", "f64"},
      AUG_OPERATOR_MAP: dict[str, str] = {
          Tok.ADD_EQ: '__iadd__',
          Tok.SUB_EQ: '__isub__',

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/jsx_type_check.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/jsx_type_check.impl.jac
@@ -8,7 +8,7 @@ Validates that JSX element attributes match the expected types from:
 # Reserved JSX attributes consumed by the framework reconciler, never forwarded
 # to the component as props.  Must be accepted on any element/component without
 # being declared in its parameter list (mirrors React/Preact behaviour).
-glob _JSX_RESERVED_ATTRS: set[str] = {"key","ref"};
+glob _JSX_RESERVED_ATTRS: set[str] = {"key", "ref"};
 
 
 """Resolve a JsxElementName to the FunctionType of the component it references."""

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -1165,7 +1165,20 @@ impl TypeEvaluator._get_type_of_expression_core(
                     }
                     # Unbounded TypeVar - only universal object attributes are allowed
                     # Pyright: treats unbounded TypeVars as "object*"
-                    universal_attrs = {"__class__","__doc__","__dict__","__module__","__sizeof__","__str__","__repr__","__hash__","__eq__","__ne__","__init__","__new__"};
+                    universal_attrs = {
+                        "__class__",
+                        "__doc__",
+                        "__dict__",
+                        "__module__",
+                        "__sizeof__",
+                        "__str__",
+                        "__repr__",
+                        "__hash__",
+                        "__eq__",
+                        "__ne__",
+                        "__init__",
+                        "__new__"
+                    };
                     if attr_name in universal_attrs {
                         # Look up on object class
                         if self.prefetch.object_class {

--- a/jac/jaclang/jac0core/bccache.jac
+++ b/jac/jaclang/jac0core/bccache.jac
@@ -202,7 +202,7 @@ def discover_base_file(annex_path: str) -> (str | None) {
             if parent.endswith(folder_suffix) {
                 candidates.append((src.parent.parent, parent[:-len(folder_suffix)]));
             }
-            if (parent in {'impl','test'}) {
+            if (parent in {'impl', 'test'}) {
                 candidates.append((src.parent.parent, base_name));
             }
             for (directory, name) in candidates {

--- a/jac/jaclang/jac0core/gen_jir_registry.jac
+++ b/jac/jaclang/jac0core/gen_jir_registry.jac
@@ -26,7 +26,7 @@ glob MANUAL_FIELDS: dict[str, list] = {
      # body field from AstImplNeedingNode[T] is (Sequence | ImplDef | None), must be NODE_LIST
      # TODO: Remove this override by specifying T in unitree.jac, e.g.:
      #   obj Archetype(..., AstImplNeedingNode[Sequence[ArchBlockStmt] | ImplDef], ...)
-     BODY_NODE_LIST_CLASSES: set = {"Archetype","Ability","Enum"},
+     BODY_NODE_LIST_CLASSES: set = {"Archetype", "Ability", "Enum"},
      FIELD_KINDS: dict[str, int] = {
          "STRING": 0,
          "INT": 1,
@@ -42,8 +42,8 @@ glob MANUAL_FIELDS: dict[str, list] = {
          "OPT_NODE_LIST": 11,
 
      },
-     ENUM_TYPES: set = {"SymbolType","SymbolAccess","EdgeDir","CodeContext"},
-     SKIP_PARAMS: set = {"self","kid","parent"};
+     ENUM_TYPES: set = {"SymbolType", "SymbolAccess", "EdgeDir", "CodeContext"},
+     SKIP_PARAMS: set = {"self", "kid", "parent"};
 
 """Map a type annotation string to a FieldKind int."""
 def classify_type(ann_str: str) -> int {

--- a/jac/jaclang/jac0core/modresolver.jac
+++ b/jac/jaclang/jac0core/modresolver.jac
@@ -278,10 +278,10 @@ def resolve_module(target: str, base_path: str) -> tuple[(str, str)] {
         } except (ImportError, AttributeError, ValueError) {
             spec = None;
         }
-        if (spec and spec.origin and (spec.origin not in {'built-in','frozen'})) {
+        if (spec and spec.origin and (spec.origin not in {'built-in', 'frozen'})) {
             origin = os.path.normpath(spec.origin);
             ext = os.path.splitext(origin)[1].lower();
-            if (ext in {'.jac','.pyi','.py','.js','.ts','.jsx','.tsx'}) {
+            if (ext in {'.jac', '.pyi', '.py', '.js', '.ts', '.jsx', '.tsx'}) {
                 if (ext == '.jac') {
                     return (origin, 'jac');
                 }
@@ -291,7 +291,7 @@ def resolve_module(target: str, base_path: str) -> tuple[(str, str)] {
                 if (ext == '.py') {
                     return (origin, 'py');
                 }
-                if (ext in {'.js','.ts','.jsx','.tsx'}) {
+                if (ext in {'.js', '.ts', '.jsx', '.tsx'}) {
                     return (origin, 'js');
                 }
                 return (origin, 'other');

--- a/jac/jaclang/jac0core/passes/impl/ast_validation_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/ast_validation_pass.impl.jac
@@ -156,7 +156,7 @@ impl ASTValidationPass.enter_assignment(
 ) -> None {
     # root and super compile to function calls (e.g. Jac.root()) which
     # cannot appear on the left side of an assignment in Python.
-    non_assignable = {Tok.KW_ROOT,Tok.KW_SUPER};
+    non_assignable = {Tok.KW_ROOT, Tok.KW_SUPER};
     for target in nd.target {
         ref_node: (uni.SpecialVarRef | None) = None;
         if isinstance(target, uni.SpecialVarRef) {

--- a/jac/jaclang/jac0core/passes/impl/interop_analysis_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/interop_analysis_pass.impl.jac
@@ -576,7 +576,23 @@ impl InteropAnalysisPass._extract_all_subscript_types(
 impl InteropAnalysisPass._extract_all_type_names(
     self: InteropAnalysisPass, expr: (uni.UniNode | None)
 ) -> list[str] {
-    prims = {'str','int','float','bool','None','Any','list','dict','tuple','set','frozenset','bytes','object','type','JsxElement'};
+    prims = {
+        'str',
+        'int',
+        'float',
+        'bool',
+        'None',
+        'Any',
+        'list',
+        'dict',
+        'tuple',
+        'set',
+        'frozenset',
+        'bytes',
+        'object',
+        'type',
+        'JsxElement'
+    };
     if expr is None {
         return [];
     }
@@ -619,7 +635,23 @@ impl InteropAnalysisPass._extract_all_type_names(
 impl InteropAnalysisPass._collect_boundary_type(
     self: InteropAnalysisPass, type_name: str, source_mod: (uni.Module | None)
 ) -> None {
-    prims = {'str','int','float','bool','None','Any','list','dict','tuple','set','frozenset','bytes','object','type','JsxElement'};
+    prims = {
+        'str',
+        'int',
+        'float',
+        'bool',
+        'None',
+        'Any',
+        'list',
+        'dict',
+        'tuple',
+        'set',
+        'frozenset',
+        'bytes',
+        'object',
+        'type',
+        'JsxElement'
+    };
     if type_name in prims {
         return;
     }

--- a/jac/jaclang/project/impl/dependencies.impl.jac
+++ b/jac/jaclang/project/impl/dependencies.impl.jac
@@ -281,7 +281,7 @@ impl DependencyInstaller.list_installed -> list[str] {
     try {
         packages_data = json.loads(stdout);
         # Filter out venv infrastructure packages
-        infrastructure = {"pip","setuptools","wheel"};
+        infrastructure = {"pip", "setuptools", "wheel"};
         return sorted(
             [
                 pkg["name"]

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -136,7 +136,7 @@ def _is_legacy_schema(conn: sqlite3.Connection) -> bool {
         return False;
     }
     cols = {row[1] for row in rows};
-    return cols == {'id','data'};
+    return cols == {'id', 'data'};
 }
 
 """Create the anchors + quarantine + schema_meta tables (new schema)."""

--- a/jac/jaclang/runtimelib/impl/planner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/planner.impl.jac
@@ -66,7 +66,7 @@ def _filter_has_predicates(filt: any) -> bool {
     } except (TypeError, AttributeError, ValueError) {
         return True;
     }
-    return bool(opcodes & {'LOAD_ATTR','COMPARE_OP','CONTAINS_OP','IS_OP'});
+    return bool(opcodes & {'LOAD_ATTR', 'COMPARE_OP', 'CONTAINS_OP', 'IS_OP'});
 }
 
 

--- a/jac/jaclang/runtimelib/impl/serializer.impl.jac
+++ b/jac/jaclang/runtimelib/impl/serializer.impl.jac
@@ -278,7 +278,7 @@ impl Serializer._deserialize_value(val: object) -> object {
         return [Serializer._deserialize_value(v) for v in val];
     }
     if isinstance(val, dict) {
-        if '$ref' in val and val.keys() <= {'$ref','$type'} {
+        if '$ref' in val and val.keys() <= {'$ref', '$type'} {
             return Serializer._deserialize_jac_ref(val);
         }
         return Serializer.deserialize(val)

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -1481,7 +1481,27 @@ impl JacAPIServer.create_handler -> type[BaseHTTPRequestHandler] {
                 and (
                     Path(path).suffix in (
                         custom_asset_extensions
-                        or {'.png','.jpg','.jpeg','.gif','.webp','.svg','.ico','.woff','.woff2','.ttf','.otf','.eot','.mp4','.webm','.mp3','.wav','.css','.js','.json'}
+                        or {
+                            '.png',
+                            '.jpg',
+                            '.jpeg',
+                            '.gif',
+                            '.webp',
+                            '.svg',
+                            '.ico',
+                            '.woff',
+                            '.woff2',
+                            '.ttf',
+                            '.otf',
+                            '.eot',
+                            '.mp4',
+                            '.webm',
+                            '.mp3',
+                            '.wav',
+                            '.css',
+                            '.js',
+                            '.json'
+                        }
                     )
                 )
             );

--- a/jac/tests/compiler/passes/main/test_decl_impl_match_pass.jac
+++ b/jac/tests/compiler/passes/main/test_decl_impl_match_pass.jac
@@ -310,7 +310,7 @@ test "standalone def/obj/node/walker in .impl.jac get symbol resolution" {
 
     # Collect every Load-context read in the annex whose target is a local
     # assignment (msg / local_label / v / n) and assert each has a resolved sym.
-    resolvable = {"msg","local_label","v","n"};
+    resolvable = {"msg", "local_label", "v", "n"};
     reads_checked = 0;
     for nm in impl_mod.get_all_sub_nodes(uni.Name, brute_force=True) {
         if nm.value not in resolvable {

--- a/jac/tests/compiler/passes/main/test_layout_pass.jac
+++ b/jac/tests/compiler/passes/main/test_layout_pass.jac
@@ -34,7 +34,23 @@ def get_registry(fixture: str) -> LayoutRegistry {
 
 # ── LAYOUT_COMPATIBLE_PRIMITIVES ──────────────────────────────
 test "LAYOUT_COMPATIBLE_PRIMITIVES contains all expected types" {
-    expected = {"int","float","bool","str","bytes","i8","u8","i16","u16","i32","u32","i64","u64","f32","f64"};
+    expected = {
+        "int",
+        "float",
+        "bool",
+        "str",
+        "bytes",
+        "i8",
+        "u8",
+        "i16",
+        "u16",
+        "i32",
+        "u32",
+        "i64",
+        "u64",
+        "f32",
+        "f64"
+    };
     assert LAYOUT_COMPATIBLE_PRIMITIVES == expected;
 }
 

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -890,8 +890,16 @@ glob MUST_REJECT_NEW: dict[str, str] = {
          "E0058_continue_no_loop": "with entry { continue; }"
      };
 
-glob IMPLEMENTED_REJECT: set[str] = {"E0062_nonlocal_module","E0071_bare_except_first","E0075_dup_base"},
-     IMPLEMENTED_VALIDATE: set[str] = {"E0055_yield_in_entry","E0058_break_no_loop","E0058_continue_no_loop"};
+glob IMPLEMENTED_REJECT: set[str] = {
+         "E0062_nonlocal_module",
+         "E0071_bare_except_first",
+         "E0075_dup_base"
+     },
+     IMPLEMENTED_VALIDATE: set[str] = {
+         "E0055_yield_in_entry",
+         "E0058_break_no_loop",
+         "E0058_continue_no_loop"
+     };
 
 def reject_test(name_snippet: tuple) {
     (name, snippet) = name_snippet;

--- a/jac/tests/compiler/passes/main/test_sym_tab_build_pass.jac
+++ b/jac/tests/compiler/passes/main/test_sym_tab_build_pass.jac
@@ -65,12 +65,12 @@ test "compr unpacking variables" {
     mod = JacProgram().compile(file_path);
     test_cases = [
         (0, {"x"}, uni.ListCompr),
-        (1, {"a","b","rest"}, uni.ListCompr),
-        (2, {"a","b","c","d"}, uni.ListCompr),
-        (3, {"a","b"}, uni.SetCompr),
-        (4, {"k","v"}, uni.DictCompr),
-        (5, {"a","b"}, uni.GenCompr),
-        (6, {"row","name","val"}, uni.ListCompr)
+        (1, {"a", "b", "rest"}, uni.ListCompr),
+        (2, {"a", "b", "c", "d"}, uni.ListCompr),
+        (3, {"a", "b"}, uni.SetCompr),
+        (4, {"k", "v"}, uni.DictCompr),
+        (5, {"a", "b"}, uni.GenCompr),
+        (6, {"row", "name", "val"}, uni.ListCompr)
     ];
     for (scope_idx, expected_vars, expected_type) in test_cases {
         scope = mod.sym_tab.kid_scope[scope_idx];

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2516,7 +2516,17 @@ test "layout exports all expected functions" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
     layout = ir.gen.native_layout;
     assert layout is not None;
-    expected = {"add","mul","negate","identity","make_all_fields","get_all_fields_x","get_all_fields_flag","make_maybe_point","get_maybe_x"};
+    expected = {
+        "add",
+        "mul",
+        "negate",
+        "identity",
+        "make_all_fields",
+        "get_all_fields_x",
+        "get_all_fields_flag",
+        "make_maybe_point",
+        "get_maybe_x"
+    };
     assert expected == set(layout.functions.keys());
 }
 

--- a/jac/tests/compiler/passes/tool/test_grammar_extract_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_grammar_extract_pass.jac
@@ -168,7 +168,18 @@ test "known rule names" {
     assert not prog.errors_had;
     extracted = GrammarExtractPass(ir_in=mod, prog=prog);
     rule_names = {r.name for r in extracted.rules};
-    expected = {"if_stmt","while_stmt","expression","bitwise_or","bitwise_xor","bitwise_and","arithmetic","term","power","factor"};
+    expected = {
+        "if_stmt",
+        "while_stmt",
+        "expression",
+        "bitwise_or",
+        "bitwise_xor",
+        "bitwise_and",
+        "arithmetic",
+        "term",
+        "power",
+        "factor"
+    };
     missing = expected - rule_names;
     assert len(missing) == 0 , f"Missing rules: {missing}";
 }

--- a/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
@@ -685,9 +685,7 @@ test "long set literal wraps one element per line like a list" {
         f"long set literal must break across lines, got:\n{formatted}"
     );
     # No two elements may share a line once broken.
-    assert not any(
-        ('"alpha"' in ln) and ('"bravo"' in ln) for ln in lines
-    ) , (
+    assert not any(('"alpha"' in ln) and ('"bravo"' in ln) for ln in lines) , (
         f"broken set must place one element per line, got:\n{formatted}"
     );
     # Idempotency

--- a/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
@@ -653,6 +653,64 @@ test "genai ability with kwargs preserves by and arguments" {
     assert formatted == prog2.mod.main.gen.jac , "genai kwargs formatting is not idempotent";
 }
 
+"""Regression: set literals must space after commas like lists, tuples, and
+dicts. `exit_set_val` blindly concatenated its kids, so `{1,2,3}` round-tripped
+crammed while `[1,2,3]`/`(1,2,3)`/`{1: 2,3: 4}` all gained the comma space."""
+test "set literal spaces after commas like other collections" {
+    source = "glob a = {1,2,3};\n";
+    prog = JacProgram.jac_str_formatter(source_str=source, file_path="<test>.jac");
+    assert not prog.errors_had , f"formatter errors: {prog.errors_had}";
+    formatted = prog.mod.main.gen.jac;
+    assert "{1, 2, 3}" in formatted , (
+        f"set literal must space after commas like lists/dicts, got:\n{repr(formatted)}"
+    );
+    # Idempotency
+    prog2 = JacProgram.jac_str_formatter(source_str=formatted, file_path="<test>.jac");
+    assert formatted == prog2.mod.main.gen.jac , "set comma spacing is not idempotent";
+}
+
+"""Regression: a set literal wider than the print width must break one element
+per line, exactly like a list. `exit_set_val` had no broken layout at all, so
+long sets stayed on a single overlong line."""
+test "long set literal wraps one element per line like a list" {
+    source = (
+        'glob a = {"alpha","bravo","charlie","delta","echo","foxtrot",'
+        '"golf","hotel","india","juliet","kilo","lima"};\n'
+    );
+    prog = JacProgram.jac_str_formatter(source_str=source, file_path="<test>.jac");
+    assert not prog.errors_had , f"formatter errors: {prog.errors_had}";
+    formatted = prog.mod.main.gen.jac;
+    lines = formatted.splitlines();
+    assert len(lines) > 3 , (
+        f"long set literal must break across lines, got:\n{formatted}"
+    );
+    # No two elements may share a line once broken.
+    assert not any(
+        ('"alpha"' in ln) and ('"bravo"' in ln) for ln in lines
+    ) , (
+        f"broken set must place one element per line, got:\n{formatted}"
+    );
+    # Idempotency
+    prog2 = JacProgram.jac_str_formatter(source_str=formatted, file_path="<test>.jac");
+    assert formatted == prog2.mod.main.gen.jac , "long set wrapping is not idempotent";
+}
+
+"""Regression: assign comprehensions must space after commas the same way
+filter comprehensions do. `exit_assign_compr` stripped every space, so
+`(=foo=1,bar=2)` round-tripped crammed while `(?foo>1,bar<2)` got the space."""
+test "assign comprehension spaces after commas like filter comprehension" {
+    source = "with entry { x = (a)(=foo=1,bar=2); }\n";
+    prog = JacProgram.jac_str_formatter(source_str=source, file_path="<test>.jac");
+    assert not prog.errors_had , f"formatter errors: {prog.errors_had}";
+    formatted = prog.mod.main.gen.jac;
+    assert "=foo=1, bar=2" in formatted , (
+        f"assign comprehension must space after commas, got:\n{repr(formatted)}"
+    );
+    # Idempotency
+    prog2 = JacProgram.jac_str_formatter(source_str=formatted, file_path="<test>.jac");
+    assert formatted == prog2.mod.main.gen.jac , "assign-compr spacing is not idempotent";
+}
+
 """Regression: jac_str_formatter must populate errors_had on syntax error
 so that the LSP returns the original source instead of an empty string."""
 test "syntax error preserves original source" {

--- a/jac/tests/compiler/test_new_builtin.jac
+++ b/jac/tests/compiler/test_new_builtin.jac
@@ -181,7 +181,7 @@ test "server: new with builtin types works end-to-end" {
     import from jaclang.runtimelib.builtin { new }
     assert new(list, [1, 2, 3]) == [1, 2, 3];
     assert new(dict, {"a": 1}) == {"a": 1};
-    assert new(set, [1, 2, 2, 3]) == {1,2,3};
+    assert new(set, [1, 2, 2, 3]) == {1, 2, 3};
 }
 
 

--- a/jac/tests/compiler/test_type_registry.jac
+++ b/jac/tests/compiler/test_type_registry.jac
@@ -5,7 +5,30 @@ import from jaclang.compiler.type_registry { JAC_TYPE_REGISTRY, JacTypeEntry }
 # ── Primitive type names ──────────────────────────────────────
 test "registry contains all 22 expected primitive types" {
     names = JAC_TYPE_REGISTRY.primitive_names();
-    expected = {"int","float","bool","complex","str","bytes","list","dict","set","frozenset","tuple","range","i8","u8","i16","u16","i32","u32","i64","u64","f32","f64"};
+    expected = {
+        "int",
+        "float",
+        "bool",
+        "complex",
+        "str",
+        "bytes",
+        "list",
+        "dict",
+        "set",
+        "frozenset",
+        "tuple",
+        "range",
+        "i8",
+        "u8",
+        "i16",
+        "u16",
+        "i32",
+        "u32",
+        "i64",
+        "u64",
+        "f32",
+        "f64"
+    };
     assert names == expected;
 }
 
@@ -88,13 +111,47 @@ test "types without LLVM representation are excluded from na_type_entries" {
 # ── Builtin function names ───────────────────────────────────
 test "builtin_names contains core builtins" {
     builtins = JAC_TYPE_REGISTRY.builtin_names();
-    core = {"print","len","range","int","str","float","bool","list","dict","set","tuple","isinstance","type","abs","round","min","max","sum"};
+    core = {
+        "print",
+        "len",
+        "range",
+        "int",
+        "str",
+        "float",
+        "bool",
+        "list",
+        "dict",
+        "set",
+        "tuple",
+        "isinstance",
+        "type",
+        "abs",
+        "round",
+        "min",
+        "max",
+        "sum"
+    };
     assert core.issubset(builtins);
 }
 
 test "builtin_names contains type conversions" {
     builtins = JAC_TYPE_REGISTRY.builtin_names();
-    conversions = {"str","int","float","bool","list","dict","set","tuple","frozenset","bytes","complex","range","slice","bytearray"};
+    conversions = {
+        "str",
+        "int",
+        "float",
+        "bool",
+        "list",
+        "dict",
+        "set",
+        "tuple",
+        "frozenset",
+        "bytes",
+        "complex",
+        "range",
+        "slice",
+        "bytearray"
+    };
     assert conversions.issubset(builtins);
 }
 

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -522,8 +522,8 @@ test "run specific test only" {
 test "graph coverage" {
     graph_params = set(inspect.signature(tools.dot).parameters.keys());
     printgraph_params = set(inspect.signature(printgraph).parameters.keys());
-    printgraph_params = printgraph_params - {"nd","file","edge_type"};
-    printgraph_params.update({"initial","saveto","connection","session"});
+    printgraph_params = printgraph_params - {"nd", "file", "edge_type"};
+    printgraph_params.update({"initial", "saveto", "connection", "session"});
     assert printgraph_params.issubset(graph_params);
     assert len(printgraph_params) + 2 == len(graph_params);
 }

--- a/jac/tests/runtimelib/test_jaseci.jac
+++ b/jac/tests/runtimelib/test_jaseci.jac
@@ -355,7 +355,7 @@ test "get edge" {
             ) for n_id in node_ids
         ];
         assert len(node_objs) == 2;
-        assert {no["archetype"].tag for no in node_objs} == {"first","second"};
+        assert {no["archetype"].tag for no in node_objs} == {"first", "second"};
     } finally {
         Jac.set_base_path(_orig_base);
         shutil.rmtree(_tmpdir, ignore_errors=True);

--- a/jac/tests/runtimelib/test_runtime_surface_alignment.jac
+++ b/jac/tests/runtimelib/test_runtime_surface_alignment.jac
@@ -19,21 +19,42 @@ import from pathlib { Path }
 import jaclang;
 
 glob ALIGNED_SURFACE = {
-     # React Router v6-shaped routing. jac-client maps `Router` to
-     # ReactRouterBrowserRouter, so the same name covers both modes.
-     "Router","Routes","Route","Link","Navigate","Outlet","useNavigate","useLocation","useParams","useRouter","navigate",
-     # Hook aliases (different semantics across runtimes, but same names)
-     "useState","useEffect",
-     # JSX factory
-     "__jacJsx",
-     # Walker / function calls
-     "__jacSpawn","jacSpawn","__jacCallFunction",
-     # Auth
-     "jacSignup","jacLogin","jacLogout","jacIsLoggedIn",
-     # Browser API shims
-     "__getLocalStorage","__setLocalStorage","__removeLocalStorage",
-     # Error reporting
-     "__jacReportError","__jacInstallErrorHandlers","__jacReactErrorHandler"};
+         # React Router v6-shaped routing. jac-client maps `Router` to
+         # ReactRouterBrowserRouter, so the same name covers both modes.
+         "Router",
+         "Routes",
+         "Route",
+         "Link",
+         "Navigate",
+         "Outlet",
+         "useNavigate",
+         "useLocation",
+         "useParams",
+         "useRouter",
+         "navigate",
+         # Hook aliases (different semantics across runtimes, but same names)
+         "useState",
+         "useEffect",
+         # JSX factory
+         "__jacJsx",
+         # Walker / function calls
+         "__jacSpawn",
+         "jacSpawn",
+         "__jacCallFunction",
+         # Auth
+         "jacSignup",
+         "jacLogin",
+         "jacLogout",
+         "jacIsLoggedIn",
+         # Browser API shims
+         "__getLocalStorage",
+         "__setLocalStorage",
+         "__removeLocalStorage",
+         # Error reporting
+         "__jacReportError",
+         "__jacInstallErrorHandlers",
+         "__jacReactErrorHandler"
+     };
 
 def _bareserve_runtime_path -> str {
     runtimelib_dir = os.path.dirname(jaclang.runtimelib.__file__);
@@ -94,7 +115,19 @@ test "bare-serve and jac-client expose the aligned @jac/runtime surface" {
     # Drift detector: anything bare-serve adds but jac-client lacks (or vice
     # versa) within the routing/hooks subset means user code that compiles in
     # one mode breaks in the other.
-    routing_subset = {"Router","Routes","Route","Link","Navigate","Outlet","useNavigate","useLocation","useParams","useRouter","navigate"};
+    routing_subset = {
+        "Router",
+        "Routes",
+        "Route",
+        "Link",
+        "Navigate",
+        "Outlet",
+        "useNavigate",
+        "useLocation",
+        "useParams",
+        "useRouter",
+        "navigate"
+    };
     bareserve_routing = bareserve_syms & routing_subset;
     jac_client_routing = jac_client_syms & routing_subset;
     drift = bareserve_routing.symmetric_difference(jac_client_routing);

--- a/jac/tests/runtimelib/test_topology_index.jac
+++ b/jac/tests/runtimelib/test_topology_index.jac
@@ -134,7 +134,9 @@ test "deep chain" {
     idx.add_edge(r, a, "E1");
     idx.add_edge(a, b, "E2");
     idx.add_edge(b, c, "E3");
-    assert idx.resolve_chain({r}, [("E1", "A", 2), ("E2", "B", 2), ("E3", "C", 2)]) == {c};
+    assert idx.resolve_chain({r}, [("E1", "A", 2), ("E2", "B", 2), ("E3", "C", 2)]) == {
+        c
+    };
 }
 
 test "multi hop selective" {
@@ -168,7 +170,7 @@ test "cross root ids" {
     idx.add_node(uuid4(), "Root");
     idx.add_node(n1, "A");
     idx.add_node(n2, "B", owner_root=foreign);
-    cross = idx.get_cross_root_ids({n1,n2});
+    cross = idx.get_cross_root_ids({n1, n2});
     assert cross[foreign] == {n2};
     assert n1 not in cross.get(foreign, set());
 }
@@ -185,7 +187,7 @@ test "subtype query returns instances of all descendants" {
     idx.add_edge(r, post, "Authored");
     idx.add_edge(r, article, "Authored");
     # Query by parent type — both subtypes match.
-    assert idx.resolve_chain({r}, [(None, "BaseContent", 2)]) == {post,article};
+    assert idx.resolve_chain({r}, [(None, "BaseContent", 2)]) == {post, article};
     # Query by concrete subtype — only that subtype matches.
     assert idx.resolve_chain({r}, [(None, "PostNode", 2)]) == {post};
 }
@@ -286,7 +288,9 @@ test "v1 blob migrates to v2 on decode and warms up MRO via mutation" {
 
     # Re-encoding the migrated index produces a v2 blob that round-trips.
     re_decoded = TopologyIndex.decode(idx.encode());
-    assert re_decoded.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == {new_child};
+    assert re_decoded.resolve_chain({root_id}, [(None, "BaseContent", 2)]) == {
+        new_child
+    };
 }
 
 # ── Compact-encoding fidelity ────────────────────────────────────────


### PR DESCRIPTION
## Problem

The Jac formatter left two comma-delimited forms crammed while every sibling form was spaced correctly:

- **Set literals** — `{1,2,3}` round-tripped with no space after commas and never wrapped when too long, unlike `[1,2,3]`, `(1,2,3)`, and `{1: 2, 3: 4}`. `exit_set_val` blindly concatenated its kids with no comma handling and no broken layout.
- **Assign comprehensions** — `(=foo=1,bar=2)` stripped all spaces, diverging from filter comprehensions `(?foo>1, bar<2)` which already space after commas.

Both still exited successfully, so the bad output went unnoticed.

## Fix

The root cause was drift: list, set, and tuple literals carried three near-identical hand-maintained copies of the same comma-layout logic, and the set copy had rotted. This extracts a single `format_comma_collection` helper that all three literals call, so their comma handling can no longer diverge. Assign comprehensions are aligned with the existing filter-comprehension comma handling.

## Tests

Adds three regression tests (written failing-first):

- set literal spaces after commas like other collections
- long set literal wraps one element per line like a list
- assign comprehension spaces after commas like filter comprehension

The full tool-pass suite (including the AST round-trip / idempotency guards) passes.