### PR TITLE
feat(cli): `jac ai --ui` web mode with live phase-graph visualizer

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6202.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6202.feature.md
@@ -1,0 +1,1 @@
+- **`jac ai --ui` web mode with live phase-graph visualizer**: The coding agent can now run in a web UI that streams the agent's Plan/Build/QA progress in real time, with a live phase graph, activity feed, conversation view, and stats bar.

--- a/jac/jaclang/cli/agent_api.jac
+++ b/jac/jaclang/cli/agent_api.jac
@@ -24,6 +24,9 @@ obj AgentRequest {
         # Compact output: suppress the live reasoning stream, per-step/tool
         # timings, and step detail, leaving just tool calls and the answer.
         quiet: bool = False,
+        # Open the agent in a web UI (a bundled Jac fullstack app) instead of the
+        # terminal REPL, with a live cytoscape visualizer of the phase walker.
+        ui: bool = False,
         cwd: str = "",
         code_intel: CodeIntelligence | None = None;
 }
@@ -39,7 +42,8 @@ def build_agent_request(
     model: str = "",
     n_ctx: int = 0,
     safe: bool = False,
-    quiet: bool = False
+    quiet: bool = False,
+    ui: bool = False
 ) -> AgentRequest {
     cwd = os.getcwd();
     return AgentRequest(
@@ -48,6 +52,7 @@ def build_agent_request(
         n_ctx=n_ctx,
         safe=safe,
         quiet=quiet,
+        ui=ui,
         cwd=cwd,
         code_intel=CodeIntelligence(proj_dir=cwd, lazy=True)
         # Lazy: the agent's structural tools (`project_map`, walkers) load from

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -269,6 +269,50 @@ obj TurnRenderer {
     def render_stream(event_stream: any) -> dict;
 }
 
+"""A live, in-process feed of structured agent events for the `--ui` web view.
+
+The terminal renderer prints to stdout; this bus tees the same milestones --
+phase transitions, tool calls and results, reasoning prose, the answer, and turn
+stats -- as structured records so the bundled web UI can render them and animate
+the phase-graph walker in real time. It lives on `AgentRuntime`, is appended to
+from the background turn thread, and read by the `ui_poll` endpoint, so every
+mutation takes `_lk`. `events` is a bounded ring (the UI replaces its log
+wholesale each poll, so no cursor is needed); `active` / `status` / `path` carry
+the current walker position for the graph.
+"""
+obj AgentEventBus {
+    has events: list[dict] = [],
+        # True only in a `--ui` session; the terminal path leaves it False so the
+        # emit points are no-ops and the bus stays empty and unread.
+        active_feed: bool = False,
+        # "idle" | "running" | "done" -- drives the UI status pill and graph glow.
+        status: str = "idle",
+        # The phase node the walker currently occupies (Plan/Build/QA/Done).
+        active: str = "",
+        # Phase nodes in visit order this turn; the UI animates the edge between
+        # each consecutive pair to show the walker moving.
+        path: list[str] = [],
+        _next_id: int = 1,
+        # Keep the feed bounded so a long session does not grow without limit.
+        _cap: int = 400;
+
+    """Append one event (kind + fields), stamping a monotonic id; thread-safe."""
+    def emit(kind: str, fields: dict) -> None;
+
+    """Mark the walker as entering a phase: set active, extend the path, emit."""
+    def enter(phase: str) -> None;
+
+    """Set the run status ("idle" | "running" | "done") and emit a status event."""
+    def set_status(s: str) -> None;
+
+    """Reset the per-turn graph state (active node and path) for a fresh walk."""
+    def begin_turn -> None;
+
+    """A JSON-ready snapshot the `ui_poll` endpoint returns each tick."""
+    def snapshot -> dict;
+}
+
+
 """All mutable per-session state for one `jac ai` run, gathered in one object.
 
 This is the single composition root: the working directory, the shared
@@ -300,6 +344,9 @@ obj AgentRuntime {
         browse_session: str = "jac-ai",
         # Set by a file-writing tool; gates verify-and-continue.
         turn_wrote: bool = False,
+        # Live structured event feed for the `--ui` web view; the terminal path
+        # leaves it untouched (it stays empty and is never read).
+        bus: AgentEventBus = AgentEventBus(),
         # Toolboxes: the agent's capabilities, composed onto the runtime.
         files: FileTools = FileTools(),
         proc: ProcessTools = ProcessTools(),
@@ -372,6 +419,16 @@ default_model` in jac.toml, then the bundled local model so the command works
 with no API key. Records the winning source in `agent.cfg.model_source`.
 """
 def resolve_model_name(model_override: str = "") -> str;
+
+"""byLLM config rooted at the agent's working dir, not the process cwd.
+
+The single source of truth for which `jac.toml` supplies the model and byLLM
+settings: `agent.cwd` (the user's project). This matters under `jac ai --ui`,
+where the process runs in the bundled web app's directory -- resolving against
+process cwd there would read the wrong `jac.toml`. Falls back to the default
+(process cwd) only before `agent.cwd` is set (import time).
+"""
+def _byllm_config -> any;
 
 """Build the agent's LLM, supporting any byLLM-compatible model.
 
@@ -726,5 +783,59 @@ flags, the working directory, and a shared `CodeIntelligence` handle the
 semantic tools query. With a non-empty `prompt`, runs a single turn and exits;
 otherwise starts an interactive read-eval-print loop. Always returns 0 -- a
 failed turn reports its error but does not abort the session.
+
+When `req.ui` is set, hands off to `_run_ui_server`: launches the bundled Jac
+web app as a subprocess and opens it in the browser instead of the REPL.
 """
 def run_agent(req: object) -> int;
+
+
+# ---------------------------------------------------------------------------
+# Web UI bridge. The bundled `ai_ui` fullstack app (served in a child `jac
+# start` process) imports these functions as its server endpoints' backend.
+# That child process re-imports this module, so its `agent` glob -- and the
+# `agent.bus` the turn thread writes to -- is the same object `ui_poll` reads.
+# ---------------------------------------------------------------------------
+"""Configure the agent for a UI session from the launcher's environment.
+
+Called once at the UI server's boot. Reads the user's project directory and
+model knobs from the `JAC_AI_UI_*` env vars the launcher set, points `agent.cwd`
+and a fresh `CodeIntelligence` at that project, builds the model, and forces
+yolo mode (the server has no terminal to confirm at). Idempotent.
+"""
+def ui_configure -> None;
+
+"""Start one agent turn for `prompt` on a background thread; never blocks.
+
+Returns False (and does nothing) if a turn is already running, so the UI can
+disable its input while busy. The turn writes its milestones to `agent.bus`,
+which `ui_poll` drains.
+"""
+def ui_send(prompt: str) -> bool;
+
+"""The current event feed and walker state -- the UI's per-tick poll payload.
+
+Returns `agent.bus.snapshot()`: the bounded event log plus `status`, the
+`active` phase node, and the `path` walked this turn.
+"""
+def ui_poll -> dict;
+
+"""The static phase graph (nodes + edges) the UI renders in cytoscape, with state.
+
+Nodes are Plan/Build/QA/Done; edges are the legal transitions the walker may
+take. Returned once on mount; live position comes from `ui_poll`.
+"""
+def ui_graph -> dict;
+
+"""Clear the cross-turn ledger and the event feed for a fresh UI session."""
+def ui_reset -> None;
+
+"""Launch the bundled web UI for `jac ai --ui` and block until the user quits.
+
+Spawns `jac start` on the bundled `ai_ui` Jac app as a child process -- passing
+the user's project directory and model flags through `JAC_AI_UI_*` env vars --
+polls its log for the ready URL, opens the browser there, and waits. Ctrl-C
+shuts the child down. Returns 0 on a clean exit, 1 if the client plugin is
+missing or the server never came up.
+"""
+def _run_ui_server(r: any) -> int;

--- a/jac/jaclang/cli/ai_ui/components/ActivityFeed.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/ActivityFeed.cl.jac
@@ -1,0 +1,53 @@
+"""Live activity log: every tool call, result, reasoning chunk, and phase move.
+
+The raw event stream the agent emits, rendered terminal-style. Auto-scrolls to
+the newest event as the feed grows so the latest action stays in view.
+"""
+
+import from react { useRef, useEffect }
+sv import from ..server { UiEvent }
+
+def:pub ActivityFeed(events: list[UiEvent]) -> JsxElement {
+    endRef: any = useRef(None);
+    # Stick to the bottom as new events arrive. A useEffect callback must return
+    # a cleanup function or nothing -- never an explicit None, which compiles to
+    # `return null` and is then invoked as a (non-)function on teardown.
+    useEffect(
+        lambda { if endRef.current {
+            endRef.current.scrollIntoView({"block": "end"});
+        }},
+        [len(events)]
+    );
+    rows = [
+        e
+        for e in events
+        if e.kind == "tool"
+        or e.kind == "tool_result"
+        or e.kind == "phase"
+        or e.kind == "reasoning"
+        or e.kind == "error"
+    ];
+    return
+        <div className="pane">
+            <div className="pane-head">Activity</div>
+            <div className="pane-body">
+                {<div className="empty">No activity yet.</div>
+                    if len(rows) == 0
+                    else <div className="feed">
+                        {[
+                            <div className={"evt " + e.kind} key={e.id}>
+                                <span className="tag">
+                                    {("→ " + e.node)
+                                        if e.kind == "phase"
+                                        else (e.name if e.kind == "tool" else e.kind)}
+                                </span>
+                                <span className="body">
+                                    {e.node if e.kind == "phase" else e.text}
+                                </span>
+                            </div> for e in rows
+                        ]}
+                        <div ref={endRef}/>
+                    </div>}
+            </div>
+        </div>;
+}

--- a/jac/jaclang/cli/ai_ui/components/Conversation.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/Conversation.cl.jac
@@ -1,0 +1,89 @@
+"""Chat panel: the user's prompts, the agent's answers, and the composer.
+
+Derives its message list from the shared event feed (the `user`, `answer`,
+`system`, and `error` events), so it stays in sync with everything else the
+poll loop drives. The composer sends on Enter (Shift+Enter for a newline) and
+is disabled while a turn is running.
+"""
+
+import from .ui.Button { Button }
+import from .ui.Badge { Badge }
+sv import from ..server { UiEvent }
+
+def:pub Conversation(
+    events: list[UiEvent],
+    status: str,
+    draft: str,
+    onDraftChange: Callable[[str], None],
+    onSend: Callable[[], None]
+) -> JsxElement {
+    msgs = [
+        e
+        for e in events
+        if e.kind == "user"
+        or e.kind == "answer"
+        or e.kind == "system"
+        or e.kind == "error"
+    ];
+    running = status == "running";
+    return
+        <div className="pane">
+            <div className="pane-head">
+                Conversation
+                <span className="spacer"/>
+                {<Badge label="working" variant="amber" pulse={True}/>
+                    if running
+                    else (
+                        <Badge label="done" variant="green"/>
+                            if status == "done"
+                            else <Badge label="idle"/>
+                    )}
+            </div>
+            <div className="pane-body">
+                {<div className="empty">
+                    Ask the agent to build or change something in your project. Watch it move through Plan, Build, and QA on the right.
+                </div>
+                    if len(msgs) == 0
+                    else <div className="chat-list">
+                        {[
+                            <div
+                                className={"msg user"
+                                    if m.kind == "user"
+                                    else (
+                                        "msg system"
+                                            if (m.kind == "system" or m.kind == "error")
+                                            else "msg agent"
+                                    )}
+                                key={m.id}
+                            >
+                                <span className="who">
+                                    {"you"
+                                        if m.kind == "user"
+                                        else ("jac ai" if m.kind == "answer" else "")}
+                                </span>
+                                <div className="bubble">{m.text}</div>
+                            </div> for m in msgs
+                        ]}
+                    </div>}
+            </div>
+            <div className="composer">
+                <textarea
+                    className="input"
+                    placeholder="Describe a change, e.g. 'add a dark-mode toggle'…"
+                    value={draft}
+                    disabled={running}
+                    onChange={lambda e: ChangeEvent { onDraftChange(e.target.value); }}
+                    onKeyDown={lambda e: KeyboardEvent { if e.key == "Enter"
+                    and not e.shiftKey {
+                        e.preventDefault();
+                        onSend();
+                    }}}
+                />
+                <Button
+                    label="Send"
+                    onClick={onSend}
+                    disabled={running or len(draft.strip()) == 0}
+                />
+            </div>
+        </div>;
+}

--- a/jac/jaclang/cli/ai_ui/components/PhaseGraph.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/PhaseGraph.cl.jac
@@ -1,0 +1,175 @@
+"""Live phase-graph visualizer for the agent walker, rendered with cytoscape.
+
+Draws the Plan -> Build -> QA -> Done pipeline (with QA's loop-back edges) once
+on mount, then reflects the walker's live position: the `active` node glows and
+pulses, every node along `path` is marked visited, and each traversed edge
+lights up -- so you watch the agent move through its own object-spatial graph in
+real time as `active`/`path` update from the poll loop.
+"""
+
+import from react { useRef, useEffect }
+cl import from "cytoscape" { default as cytoscape }
+sv import from ..server { GraphNode, GraphEdge }
+
+def:pub PhaseGraph(
+    nodes: list[GraphNode],
+    edges: list[GraphEdge],
+    active: str,
+    path: list[str],
+    status: str
+) -> JsxElement {
+    containerRef: any = useRef(None);
+    cyRef: any = useRef(None);
+
+    # Build the graph once the nodes have loaded. The body is wrapped in the
+    # positive guard rather than early-returning None: a useEffect callback must
+    # return a cleanup function or nothing, never null (null is then invoked as
+    # a cleanup and throws).
+    useEffect(
+        lambda { if containerRef.current and len(nodes) > 0 and not cyRef.current {
+            positions = {
+                "Plan": {"x": 170, "y": 60},
+                "Build": {"x": 170, "y": 190},
+                "QA": {"x": 170, "y": 320},
+                "Done": {"x": 170, "y": 450}
+            };
+            els: list = [];
+            for n in nodes {
+                els.append(
+                    {
+                        "data": {"id": n.id, "label": n.label, "desc": n.desc},
+                        "position": positions.get(n.id, {"x": 170, "y": 60})
+                    }
+                );
+            }
+            for e in edges {
+                els.append(
+                    {
+                        "data": {
+                            "id": e.source + "->" + e.target,
+                            "source": e.source,
+                            "target": e.target
+                        }
+                    }
+                );
+            }
+            cy = cytoscape(
+                {
+                    "container": containerRef.current,
+                    "elements": els,
+                    "layout": {"name": "preset", "fit": True, "padding": 36},
+                    "userZoomingEnabled": False,
+                    "userPanningEnabled": False,
+                    "boxSelectionEnabled": False,
+                    "autoungrabify": True,
+                    "style": [
+                        {
+                            "selector": "node",
+                            "style": {
+                                "label": "data(label)",
+                                "text-valign": "center",
+                                "text-halign": "center",
+                                "color": "#cdd0d6",
+                                "font-size": 15,
+                                "font-weight": 600,
+                                "width": 92,
+                                "height": 56,
+                                "shape": "round-rectangle",
+                                "background-color": "#181a1d",
+                                "border-width": 1.5,
+                                "border-color": "#33363b",
+                                "transition-property": "background-color, border-color, border-width",
+                                "transition-duration": 250
+                            }
+                        },
+                        {
+                            "selector": "node.visited",
+                            "style": {"border-color": "#4f46e5", "color": "#e7e7ea"}
+                        },
+                        {
+                            "selector": "node.active",
+                            "style": {
+                                "background-color": "#312e81",
+                                "border-color": "#818cf8",
+                                "border-width": 3.5,
+                                "color": "#ffffff"
+                            }
+                        },
+                        {
+                            "selector": "edge",
+                            "style": {
+                                "width": 2,
+                                "line-color": "#33363b",
+                                "target-arrow-color": "#33363b",
+                                "target-arrow-shape": "triangle",
+                                "curve-style": "bezier",
+                                "control-point-step-size": 60,
+                                "transition-property": "line-color, target-arrow-color, width",
+                                "transition-duration": 250
+                            }
+                        },
+                        {
+                            "selector": "edge.flow",
+                            "style": {
+                                "width": 3.5,
+                                "line-color": "#6366f1",
+                                "target-arrow-color": "#6366f1"
+                            }
+                        }
+                    ]
+                }
+            );
+            cyRef.current = cy;
+            # Re-fit after layout settles, in case the pane sized late.
+            window.setTimeout(
+                lambda { if cyRef.current {
+                    cyRef.current.resize();
+                    cyRef.current.fit(cyRef.current.elements(), 36);
+                }},
+                80
+            );
+        }},
+        [nodes]
+    );
+
+    # Reflect the live walker position. Recreated each render, so it reads the
+    # current `path`; rerun whenever the active node or run status changes.
+    useEffect(
+        lambda {
+            cy = cyRef.current;
+            if cy {
+                cy.nodes().removeClass("active visited");
+                cy.edges().removeClass("flow");
+                i = 0;
+                while i < len(path) {
+                    cy.getElementById(path[i]).addClass("visited");
+                    if i > 0 {
+                        cy.getElementById(path[i - 1] + "->" + path[i]).addClass(
+                            "flow"
+                        );
+                    }
+                    i += 1;
+                }
+                if active {
+                    cy.getElementById(active).addClass("active");
+                }
+            }
+        },
+        [active, status]
+    );
+
+    return
+        <div className="graph-wrap">
+            <div className="cy" ref={containerRef}/>
+            <div className="graph-legend">
+                <span className="legend-item">
+                    <span className="legend-swatch" style={{"background": "#818cf8"}}/>
+                    active
+                </span>
+                <span className="legend-item">
+                    <span className="legend-swatch" style={{"background": "#4f46e5"}}/>
+                    visited
+                </span>
+            </div>
+        </div>;
+}

--- a/jac/jaclang/cli/ai_ui/components/StatsBar.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/StatsBar.cl.jac
@@ -1,0 +1,21 @@
+"""Footer stats bar: the latest turn's tool/file tallies and the run status."""
+
+sv import from ..server { UiEvent }
+
+def:pub StatsBar(events: list[UiEvent], active: str) -> JsxElement {
+    latest = "";
+    for e in events {
+        if e.kind == "stats" {
+            latest = e.text;
+        }
+    }
+    return
+        <div className="stats">
+            <span className="stat">
+                phase:
+                <b>{active or "—"}</b>
+            </span>
+            <span className="spacer"/>
+            <span className="stat">{latest or "no turns yet"}</span>
+        </div>;
+}

--- a/jac/jaclang/cli/ai_ui/components/ui/Badge.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/ui/Badge.cl.jac
@@ -1,0 +1,10 @@
+"""Badge primitive -- a small status pill, optionally with a live pulse dot."""
+
+def:pub Badge(label: str, variant: str = "", pulse: bool = False) -> JsxElement {
+    cls = "badge" if not variant else ("badge " + variant);
+    dot_cls = "pulse-dot live" if pulse else "pulse-dot";
+    return
+        <span className={cls}>
+            {<span className={dot_cls}/> if pulse else None}{label}
+        </span>;
+}

--- a/jac/jaclang/cli/ai_ui/components/ui/Button.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/ui/Button.cl.jac
@@ -1,0 +1,12 @@
+"""Button primitive -- shadcn-style, driven by global.css `.btn` classes."""
+
+def:pub Button(
+    label: str,
+    onClick: Callable[[], None],
+    variant: str = "primary",
+    disabled: bool = False
+) -> JsxElement {
+    cls = "btn" if variant == "primary" else "btn ghost";
+    return
+        <button className={cls} {onClick} {disabled}>{label}</button>;
+}

--- a/jac/jaclang/cli/ai_ui/frontend.cl.jac
+++ b/jac/jaclang/cli/ai_ui/frontend.cl.jac
@@ -1,0 +1,109 @@
+"""Jac AI web UI -- top-level app: state, the poll loop, and the layout.
+
+Fetches the phase graph once on mount, then polls the agent's event bus on a
+timer (the bus is the source of truth for the conversation, the activity log,
+the live walker position, and turn stats). The poll replaces all state wholesale
+each tick, so the cytoscape graph and the chat stay in lockstep with the agent.
+"""
+
+import from react { useEffect }
+sv import from .server { agent_poll, agent_send, agent_graph, agent_reset }
+sv import from .server { UiEvent, PollResult, GraphNode, GraphEdge, GraphData }
+import from .components.PhaseGraph { PhaseGraph }
+import from .components.Conversation { Conversation }
+import from .components.ActivityFeed { ActivityFeed }
+import from .components.StatsBar { StatsBar }
+import "./global.css";
+
+def:pub app -> JsxElement {
+    has events: list[UiEvent] = [],
+        status: str = "idle",
+        active: str = "",
+        path: list[str] = [],
+        nodes: list[GraphNode] = [],
+        edges: list[GraphEdge] = [],
+        draft: str = "";
+
+    # Pull the latest event feed and walker position from the server. The RPC
+    # stub is async, so the call must be awaited -- an un-awaited call leaves a
+    # Promise in `res` and every field reads back undefined.
+    async def refresh {
+        res = await agent_poll();
+        events = res.events;
+        status = res.status;
+        active = res.active;
+        path = res.path;
+    }
+
+    # Kick off one turn; the poll loop then reflects its progress.
+    async def send -> None {
+        text = draft.strip();
+        if not text {
+            return;
+        }
+        draft = "";
+        await agent_send(text);
+    }
+
+    async def reset {
+        await agent_reset();
+        events = [];
+        active = "";
+        path = [];
+    }
+
+    # First paint: load the static phase graph and the current state.
+    async can with entry {
+        g = await agent_graph();
+        nodes = g.nodes;
+        edges = g.edges;
+        events = g.state.events;
+        status = g.state.status;
+        active = g.state.active;
+        path = g.state.path;
+    }
+
+    # Poll the bus on a timer; clean up the interval on unmount.
+    useEffect(
+        lambda -> any {
+            handle = window.setInterval(lambda { refresh(); }, 800);
+            return lambda { window.clearInterval(handle); };
+        },
+        []
+    );
+
+    return
+        <div className="app">
+            <div className="topbar">
+                <span className="brand">
+                    jac
+                    <span className="dot">●</span>
+                    ai
+                </span>
+                <span className="meta">agent control room</span>
+                <span className="spacer"/>
+                <button className="btn ghost" onClick={lambda { reset(); }}>
+                    New session
+                </button>
+            </div>
+            <div className="workspace">
+                <div className="col left">
+                    <Conversation
+                        {events}
+                        {status}
+                        {draft}
+                        onDraftChange={lambda v: str { draft = v; }}
+                        onSend={send}
+                    />
+                </div>
+                <div className="col right">
+                    <div className="pane">
+                        <div className="pane-head">Phase graph</div>
+                        <PhaseGraph {nodes} {edges} {active} {path} {status}/>
+                    </div>
+                    <ActivityFeed {events}/>
+                </div>
+            </div>
+            <StatsBar {events} {active}/>
+        </div>;
+}

--- a/jac/jaclang/cli/ai_ui/global.css
+++ b/jac/jaclang/cli/ai_ui/global.css
@@ -1,0 +1,439 @@
+/* Jac AI web UI -- self-contained shadcn-inspired dark theme.
+   No Tailwind: the core CLI bundles this app and must build with only the base
+   jac-client toolchain, so styling is plain CSS classes keyed off a small set
+   of design tokens. */
+
+:root {
+    --bg: #0a0a0b;
+    --panel: #121214;
+    --panel-2: #181a1d;
+    --border: #26282c;
+    --fg: #e7e7ea;
+    --muted: #8a8d93;
+    --primary: #6366f1;
+    --primary-fg: #ffffff;
+    --accent: #22d3ee;
+    --green: #34d399;
+    --amber: #fbbf24;
+    --red: #f87171;
+    --radius: 12px;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+    height: 100%;
+    margin: 0;
+}
+
+body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #2c2f34;
+    border-radius: 8px;
+    border: 2px solid var(--panel);
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #3a3e44;
+}
+
+/* ---- App shell -------------------------------------------------------- */
+.app {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+.topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+}
+
+.brand {
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    font-size: 15px;
+}
+
+.brand .dot {
+    color: var(--primary);
+}
+
+.topbar .meta {
+    color: var(--muted);
+    font-size: 12.5px;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.spacer {
+    flex: 1;
+}
+
+.workspace {
+    display: grid;
+    grid-template-columns: minmax(360px, 1.1fr) minmax(420px, 1fr);
+    flex: 1;
+    min-height: 0;
+}
+
+.col {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+}
+
+.col.left {
+    border-right: 1px solid var(--border);
+}
+
+.col.right {
+    display: grid;
+    grid-template-rows: minmax(220px, 0.9fr) 1.1fr;
+    min-height: 0;
+}
+
+.pane {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    background: var(--bg);
+}
+
+.pane + .pane {
+    border-top: 1px solid var(--border);
+}
+
+.pane-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+}
+
+.pane-body {
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
+}
+
+/* ---- Primitives (shadcn-ish) ----------------------------------------- */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 36px;
+    padding: 0 14px;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    background: var(--primary);
+    color: var(--primary-fg);
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: filter 0.15s ease, opacity 0.15s ease;
+}
+
+.btn:hover {
+    filter: brightness(1.08);
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn.ghost {
+    background: transparent;
+    border-color: var(--border);
+    color: var(--fg);
+}
+
+.btn.ghost:hover {
+    background: var(--panel-2);
+    filter: none;
+}
+
+.input {
+    width: 100%;
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    color: var(--fg);
+    border-radius: 10px;
+    padding: 10px 12px;
+    font: inherit;
+    resize: none;
+    outline: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.input:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 9px;
+    border-radius: 999px;
+    font-size: 11.5px;
+    font-weight: 600;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+    color: var(--muted);
+}
+
+.badge.green {
+    color: var(--green);
+    border-color: rgba(52, 211, 153, 0.35);
+    background: rgba(52, 211, 153, 0.08);
+}
+
+.badge.amber {
+    color: var(--amber);
+    border-color: rgba(251, 191, 36, 0.35);
+    background: rgba(251, 191, 36, 0.08);
+}
+
+.badge.indigo {
+    color: #a5b4fc;
+    border-color: rgba(99, 102, 241, 0.4);
+    background: rgba(99, 102, 241, 0.1);
+}
+
+.pulse-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.pulse-dot.live {
+    animation: pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.35; transform: scale(0.7); }
+}
+
+/* ---- Chat ------------------------------------------------------------- */
+.chat-list {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 18px;
+}
+
+.msg {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-width: 92%;
+}
+
+.msg.user {
+    align-self: flex-end;
+    align-items: flex-end;
+}
+
+.msg .who {
+    font-size: 11px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.bubble {
+    padding: 10px 13px;
+    border-radius: 13px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.msg.user .bubble {
+    background: var(--primary);
+    color: var(--primary-fg);
+    border-bottom-right-radius: 4px;
+}
+
+.msg.agent .bubble {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-bottom-left-radius: 4px;
+}
+
+.msg.system .bubble {
+    background: transparent;
+    border: 1px dashed var(--border);
+    color: var(--muted);
+    font-size: 12.5px;
+}
+
+.composer {
+    display: flex;
+    gap: 10px;
+    padding: 14px;
+    border-top: 1px solid var(--border);
+    background: var(--panel);
+    align-items: flex-end;
+}
+
+.composer .input {
+    min-height: 42px;
+    max-height: 140px;
+}
+
+.empty {
+    color: var(--muted);
+    text-align: center;
+    padding: 40px 24px;
+    font-size: 13px;
+}
+
+/* ---- Event feed ------------------------------------------------------- */
+.feed {
+    display: flex;
+    flex-direction: column;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 12.5px;
+}
+
+.evt {
+    display: flex;
+    gap: 9px;
+    padding: 7px 16px;
+    border-bottom: 1px solid rgba(38, 40, 44, 0.5);
+    align-items: baseline;
+}
+
+.evt .tag {
+    flex-shrink: 0;
+    width: 66px;
+    color: var(--muted);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding-top: 1px;
+}
+
+.evt .body {
+    flex: 1;
+    min-width: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--fg);
+}
+
+.evt.tool .body {
+    color: var(--accent);
+}
+
+.evt.tool_result .body {
+    color: var(--muted);
+}
+
+.evt.phase .body {
+    color: #a5b4fc;
+    font-weight: 600;
+}
+
+.evt.error .body {
+    color: var(--red);
+}
+
+.evt.reasoning .body {
+    color: var(--muted);
+    font-style: italic;
+}
+
+/* ---- Graph ------------------------------------------------------------ */
+.graph-wrap {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+}
+
+.cy {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.graph-legend {
+    position: absolute;
+    bottom: 10px;
+    left: 12px;
+    display: flex;
+    gap: 14px;
+    font-size: 11px;
+    color: var(--muted);
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+}
+
+/* ---- Stats bar -------------------------------------------------------- */
+.stats {
+    display: flex;
+    gap: 18px;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border);
+    background: var(--panel);
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.stat b {
+    color: var(--fg);
+    font-weight: 600;
+}

--- a/jac/jaclang/cli/ai_ui/jac.toml
+++ b/jac/jaclang/cli/ai_ui/jac.toml
@@ -1,0 +1,32 @@
+[project]
+name = "jac-ai-ui"
+version = "0.1.0"
+description = "Web UI for the jac ai coding agent"
+entry-point = "main.jac"
+
+[dependencies.npm]
+react = "^18.2.0"
+react-dom = "^18.2.0"
+cytoscape = "^3.30.0"
+react-router-dom = "^6.22.0"
+react-error-boundary = "^5.0.0"
+react-hook-form = "^7.71.0"
+zod = "^4.3.6"
+"@hookform/resolvers" = "^5.2.2"
+
+[dependencies.npm.dev]
+vite = "^6.4.1"
+"@vitejs/plugin-react" = "^4.2.1"
+typescript = "^5.3.3"
+"@types/react" = "^18.2.0"
+"@types/react-dom" = "^18.2.0"
+
+[serve]
+base_route_app = "app"
+
+[plugins.client.app_meta_data]
+title = "Jac AI"
+description = "Watch the jac ai agent plan, build, and QA in real time"
+keywords = "jac ai agent visualizer"
+author = "Jaseci Labs"
+theme_color = "#6366f1"

--- a/jac/jaclang/cli/ai_ui/main.jac
+++ b/jac/jaclang/cli/ai_ui/main.jac
@@ -1,0 +1,18 @@
+"""Jac AI web UI -- entry point combining the agent backend and the frontend.
+
+Server is the default context, so the endpoint + type imports sit plainly at the
+top (this is what registers them, and how the access-extraction pass sees their
+`def:pub` visibility); the client app is opened under the `to cl:` section.
+"""
+
+import from server { agent_poll, agent_send, agent_graph, agent_reset }
+import from server { UiEvent, PollResult, GraphNode, GraphEdge, GraphData }
+
+to cl:
+
+import from .frontend { app as ClientApp }
+
+def:pub app -> JsxElement {
+    return
+        <ClientApp/>;
+}

--- a/jac/jaclang/cli/ai_ui/server.jac
+++ b/jac/jaclang/cli/ai_ui/server.jac
@@ -1,0 +1,120 @@
+"""Server endpoints for the `jac ai --ui` web app.
+
+Thin RPC surface over the agent's in-process event bus. This server runs in the
+child `jac start` process the `--ui` launcher spawned; it re-imports the core
+agent module, so its `agent` glob -- and the `agent.bus` the turn thread writes
+to -- is the very object these endpoints read. `ui_configure()` runs once at
+boot to point the agent at the user's project (passed via env by the launcher).
+"""
+
+import from jaclang.cli.ai_agent { ui_configure, ui_send, ui_poll, ui_graph, ui_reset }
+
+# Point the agent at the user's project and build its model. Runs once when the
+# server process imports this module at boot.
+with entry {
+    ui_configure();
+}
+
+"""One structured agent event for the UI feed (a flattened bus record).
+
+`kind` is one of: system, user, reasoning, tool, tool_result, answer, phase,
+status, stats, error. Only the fields a kind uses are populated; the rest stay
+empty so the client can read any field unconditionally.
+"""
+obj UiEvent {
+    has id: int = 0,
+        kind: str = "",
+        text: str = "",
+        name: str = "",
+        node: str = "";
+}
+
+"""The per-tick poll payload: the event feed plus the live walker position."""
+obj PollResult {
+    has events: list[UiEvent] = [],
+        status: str = "idle",
+        active: str = "",
+        path: list[str] = [];
+}
+
+"""A phase node in the agent's state graph (Plan/Build/QA/Done)."""
+obj GraphNode {
+    has id: str = "",
+        label: str = "",
+        desc: str = "";
+}
+
+"""A legal transition between two phase nodes."""
+obj GraphEdge {
+    has source: str = "",
+        target: str = "";
+}
+
+"""The full phase graph plus the current walker state, for first paint."""
+obj GraphData {
+    has nodes: list[GraphNode] = [],
+        edges: list[GraphEdge] = [],
+        state: PollResult = PollResult();
+}
+
+"""Map a raw bus snapshot dict into a typed PollResult for the client."""
+def _to_poll(snap: dict) -> PollResult {
+    evs: list[UiEvent] = [];
+    for e in snap.get("events", []) {
+        evs.append(
+            UiEvent(
+                id=int(e.get("id", 0)),
+                kind=str(e.get("kind", "")),
+                text=str(e.get("text", "")),
+                name=str(e.get("name", "")),
+                node=str(e.get("node", ""))
+            )
+        );
+    }
+    return PollResult(
+        events=evs,
+        status=str(snap.get("status", "idle")),
+        active=str(snap.get("active", "")),
+        path=[str(p) for p in snap.get("path", [])]
+    );
+}
+
+"""Current event feed and walker state -- the client polls this on a timer."""
+def:pub agent_poll -> PollResult {
+    return _to_poll(ui_poll());
+}
+
+"""Kick off one agent turn for `prompt`; returns False if one is already running."""
+def:pub agent_send(prompt: str) -> bool {
+    return ui_send(prompt);
+}
+
+"""The phase graph (nodes + edges) plus current state, for the visualizer's mount."""
+def:pub agent_graph -> GraphData {
+    g = ui_graph();
+    nodes: list[GraphNode] = [];
+    for n in g.get("nodes", []) {
+        nodes.append(
+            GraphNode(
+                id=str(n.get("id", "")),
+                label=str(n.get("label", "")),
+                desc=str(n.get("desc", ""))
+            )
+        );
+    }
+    edges: list[GraphEdge] = [];
+    for ed in g.get("edges", []) {
+        edges.append(
+            GraphEdge(
+                source=str(ed.get("source", "")), target=str(ed.get("target", ""))
+            )
+        );
+    }
+    return GraphData(nodes=nodes, edges=edges, state=_to_poll(g.get("state", {})));
+}
+
+"""Clear the conversation, ledger, and event feed for a fresh session."""
+def:pub agent_reset -> bool {
+    ui_reset();
+    return True;
+}

--- a/jac/jaclang/cli/commands/ai.jac
+++ b/jac/jaclang/cli/commands/ai.jac
@@ -57,6 +57,13 @@ glob registry = get_registry();
             help="Compact output: hide live reasoning, timings, and step detail",
             short="q"
         ),
+        Arg.create(
+            "ui",
+            kind=ArgKind.FLAG,
+            typ=bool,
+            default=False,
+            help="Open the agent in a web UI with a live phase-graph visualizer"
+        ),
 
     ],
     examples=[
@@ -70,6 +77,7 @@ glob registry = get_registry();
             "jac ai -q \"fix the build\"",
             "Compact output -- just tool calls and the answer"
         ),
+        ("jac ai --ui", "Open a web UI with a live agent phase-graph visualizer"),
 
     ],
     group="general"
@@ -79,5 +87,6 @@ def ai(
     model: str = "",
     n_ctx: int = 0,
     safe: bool = False,
-    quiet: bool = False
+    quiet: bool = False,
+    ui: bool = False
 ) -> int;

--- a/jac/jaclang/cli/commands/impl/ai.impl.jac
+++ b/jac/jaclang/cli/commands/impl/ai.impl.jac
@@ -13,10 +13,11 @@ impl ai(
     model: str = "",
     n_ctx: int = 0,
     safe: bool = False,
-    quiet: bool = False
+    quiet: bool = False,
+    ui: bool = False
 ) -> int {
     import from jaclang.cli.agent_api { build_agent_request }
     import from jaclang.jac0core.runtime { JacRuntime as Jac }
-    req = build_agent_request(prompt, model, n_ctx, safe, quiet);
+    req = build_agent_request(prompt, model, n_ctx, safe, quiet, ui);
     return Jac.run_ai_agent(req);
 }

--- a/jac/jaclang/cli/impl/ai_agent.impl.jac
+++ b/jac/jaclang/cli/impl/ai_agent.impl.jac
@@ -6,6 +6,8 @@ import sys;
 import time;
 import signal;
 import subprocess;
+import threading;
+import webbrowser;
 import from pathlib { Path }
 
 import from byllm.lib { Model, IterationAction }
@@ -28,6 +30,18 @@ import from jaclang.cli.browser_engine {
 }
 
 
+# byLLM resolves config from `jac.toml` relative to its project dir. Use the
+# agent's working directory (the user's project) as the single source of truth,
+# not the process cwd -- under `jac ai --ui` the process runs in the bundled web
+# app's dir, so process cwd would read the wrong jac.toml. Empty `agent.cwd`
+# (import time, before run_agent sets it) falls back to the default (cwd).
+impl _byllm_config -> any {
+    if agent.cwd {
+        return get_byllm_config(Path(agent.cwd));
+    }
+    return get_byllm_config();
+}
+
 impl resolve_model_name(model_override: str = "") -> str {
     flag = model_override.strip();
     if flag {
@@ -38,7 +52,7 @@ impl resolve_model_name(model_override: str = "") -> str {
     # `default_model` is not mistaken for a choice.
     toml_model = "";
     try {
-        raw = get_byllm_config().get_jac_config().get_plugin_config("byllm");
+        raw = _byllm_config().get_jac_config().get_plugin_config("byllm");
         model_section = raw.get("model", {});
         if isinstance(model_section, dict) {
             toml_model = str(model_section.get("default_model", "")).strip();
@@ -65,7 +79,7 @@ impl build_model(model_override: str = "", n_ctx: int = 0) -> Model {
     agent.cfg.temperature = 0.3 if is_local else None;
     if is_local {
         try {
-            cfg = dict(get_byllm_config().get_local_config());
+            cfg = dict(_byllm_config().get_local_config());
         } except Exception {
             cfg = {};
         }
@@ -931,6 +945,54 @@ impl reset_session{
     agent.ledger = Ledger();
 }
 
+# ---------------------------------------------------------------------------
+# Event bus -- structured milestones for the `--ui` web view.
+# ---------------------------------------------------------------------------
+impl AgentEventBus.emit(kind: str, fields: dict) -> None {
+    if not self.active_feed {
+        return;
+    }
+    # No lock: the only writer is the single turn thread and the only reader is
+    # the poll endpoint; under the GIL the list append and the slice-reassign
+    # below are each atomic, and `snapshot` copies in one atomic step.
+    ev = {"id": self._next_id, "kind": kind};
+    ev.update(fields);
+    self._next_id += 1;
+    self.events.append(ev);
+    # Bounded ring: the UI replaces its whole log each poll, so dropping the
+    # oldest events just trims scrollback, never breaks continuity.
+    if len(self.events) > self._cap {
+        self.events = self.events[-self._cap:];
+    }
+}
+
+impl AgentEventBus.enter(phase: str) -> None {
+    self.active = phase;
+    self.path.append(phase);
+    self.emit("phase", {"node": phase});
+}
+
+impl AgentEventBus.set_status(s: str) -> None {
+    self.status = s;
+    self.emit("status", {"status": s});
+}
+
+impl AgentEventBus.begin_turn -> None {
+    self.active = "";
+    self.path = [];
+}
+
+impl AgentEventBus.snapshot -> dict {
+    # Copy in one step so the returned lists are stable even if the turn thread
+    # emits concurrently (atomic under the GIL).
+    return {
+        "events": list(self.events),
+        "status": self.status,
+        "active": self.active,
+        "path": list(self.path)
+    };
+}
+
 impl _progress_guard(ctx: any) -> str {
     import json;
     counts: dict[str, int] = {};
@@ -1254,6 +1316,7 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
         }
         (result, ms) = (pend_result["result"], pend_result["ms"]);
         pend_result = None;
+        agent.bus.emit("tool_result", {"text": truncate(str(result), 600)});
         lines = agent.view._result_snippet(result, 3 if agent.cfg.verbose else 1);
         tail = f"   {agent.view._fmt_ms(ms)}"
             if (agent.cfg.verbose and ms is not None)
@@ -1288,6 +1351,7 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
                     out.write(cleaned);
                     out.flush();
                     streamed = True;
+                    agent.bus.emit("reasoning", {"text": cleaned});
                 }
                 # Generating but no prose yet (streaming as JSON): show a
                 # ticking activity line so a slow model is not silent.
@@ -1336,6 +1400,9 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
                 console.print(
                     f"  ⏺ {agent.view.fmt_tool_call(tool, args)}{gen}", style="cyan"
                 );
+                agent.bus.emit(
+                    "tool", {"name": tool, "text": agent.view.fmt_tool_call(tool, args)}
+                );
                 last_llm_ms = 0.0;
                 last_llm_tokens = 0;
                 thought_raw = "";
@@ -1376,6 +1443,9 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
             import traceback;
             traceback.print_exc();
         }
+    }
+    if answer.strip() {
+        agent.bus.emit("answer", {"text": answer.strip()});
     }
     return {
         "n_read": n_read,
@@ -1491,6 +1561,9 @@ impl PhaseState.run{
     agent.active_session = visitor;
     label = type(self).__name__;
     console.print(f"\n  ● {label}", style="bold blue");
+    # Move the walker on the live graph: the UI animates the edge from the
+    # previous phase to this one.
+    agent.bus.enter(label);
     # Refresh the system message with the latest ledger; keep this node's prior
     # working messages (its memory).
     sysmsg = {
@@ -1573,6 +1646,7 @@ sem Done = "the DONE state: choose this only when the objective is fully built A
 impl Done.finish{
     # No onward visit: the walker's queue empties here and the session ends.
     console.print("\n  ● Done", style="bold green");
+    agent.bus.enter("Done");
 }
 
 impl AgentSession.begin{
@@ -1610,6 +1684,17 @@ impl run_turn(message: str) {
             time.time() - started, st.n_read, st.n_write, st.n_run, st.files, st.usage
         );
     }
+    st2 = session.stats;
+    elapsed = time.time() - started;
+    agent.bus.emit(
+        "stats",
+        {
+            "text": (
+                f"{elapsed:.1f}s  ·  {st2.n_read} reads  ·  "
+                f"{st2.n_write} writes  ·  {st2.n_run} runs  ·  {len(st2.files)} files"
+            )
+        }
+    );
 }
 
 impl _project_errors -> list {
@@ -1675,6 +1760,12 @@ impl run_agent(req: object) -> int {
     # Seed the session working directory; every file tool and run_command
     # resolves against it, and a `cd` the model issues updates it.
     agent.cwd = os.path.normpath(str(getattr(r, "cwd", "") or os.getcwd()));
+    # `--ui`: hand off to the bundled web app instead of the terminal REPL. The
+    # child server re-imports this module and runs the agent itself, so nothing
+    # else here (model build, banner, REPL) applies to the parent process.
+    if bool(getattr(r, "ui", False)) {
+        return _run_ui_server(r);
+    }
     agent.cfg.yolo_mode = not r.safe;
     agent.cfg.verbose = not bool(getattr(r, "quiet", False));
     # Surface CI recompiles in the live view so the work behind writes/queries shows.
@@ -1762,6 +1853,215 @@ impl run_agent(req: object) -> int {
 
     agent.web._browse_shutdown();
     agent.proc._serve_shutdown();
+    console.print("Bye.");
+    return 0;
+}
+
+# ---------------------------------------------------------------------------
+# Web UI bridge -- backend the bundled `ai_ui` server endpoints call.
+# ---------------------------------------------------------------------------
+impl ui_configure -> None {
+    global agent_model;
+    # The launcher set these when it spawned this server process.
+    proj = os.environ.get("JAC_AI_UI_PROJECT") or os.getcwd();
+    agent.cwd = os.path.normpath(proj);
+    # No terminal here to confirm at, so writes/commands always run.
+    agent.cfg.yolo_mode = True;
+    agent.cfg.verbose = True;
+    agent.cfg.show_stats = True;
+    agent.bus.active_feed = True;
+    model_flag = os.environ.get("JAC_AI_UI_MODEL") or "";
+    n_ctx = 0;
+    try {
+        n_ctx = int(os.environ.get("JAC_AI_UI_NCTX") or "0");
+    } except Exception { }
+    # A project-rooted CodeIntelligence so the semantic tools work, lazily so
+    # boot stays cheap. No on_event hook: its prints would only clutter the log.
+    agent.ci = CodeIntelligence(proj_dir=agent.cwd, lazy=True);
+    reset_session();
+    # `agent.cwd` is now set to the user's project, so build_model resolves the
+    # model and byLLM config from their jac.toml (via `_byllm_config`), not this
+    # child server's working directory (the bundled ai_ui dir).
+    # Building the model can fail (missing API key, no local weights). Keep the
+    # server up regardless: the UI still loads and reports the problem in the
+    # feed, rather than the whole web app failing to boot.
+    try {
+        agent_model = build_model(model_flag, n_ctx);
+        agent.bus.emit(
+            "system",
+            {"text": f"Connected to {agent.cwd} using {agent_model.model_name}."}
+        );
+    } except Exception as e {
+        agent.bus.emit(
+            "error",
+            {"text": f"Connected to {agent.cwd}, but the model failed to load: {e}"}
+        );
+    }
+}
+
+def _ui_turn_worker(prompt: str) {
+    try {
+        run_turn(prompt);
+        verify_and_continue();
+    } except Exception as e {
+        agent.bus.emit("error", {"text": f"agent error: {e}"});
+    }
+    # The walker leaves `active` on its final node (Done, or wherever it
+    # stopped); fall back to idle so the status pill stops pulsing.
+    if agent.bus.status != "done" {
+        agent.bus.set_status("idle");
+    }
+}
+
+impl ui_send(prompt: str) -> bool {
+    text = prompt.strip();
+    if not text {
+        return False;
+    }
+    if agent.bus.status == "running" {
+        return False;  # one turn at a time
+    }
+    agent.bus.begin_turn();
+    agent.bus.emit("user", {"text": text});
+    agent.bus.set_status("running");
+    threading.Thread(target=_ui_turn_worker, args=(text, ), daemon=True).start();
+    return True;
+}
+
+impl ui_poll -> dict {
+    return agent.bus.snapshot();
+}
+
+impl ui_graph -> dict {
+    # The phase pipeline the AgentSession walker traverses. Nodes carry a short
+    # role blurb for the UI; edges are the legal transitions (QA fans out).
+    return {
+        "nodes": [
+            {"id": "Plan", "label": "Plan", "desc": "Explore and decide the approach"},
+            {"id": "Build", "label": "Build", "desc": "Write and edit the code"},
+            {"id": "QA", "label": "QA", "desc": "Type-check, run, and verify"},
+            {"id": "Done", "label": "Done", "desc": "Objective built and verified"}
+        ],
+        "edges": [
+            {"source": "Plan", "target": "Build"},
+            {"source": "Build", "target": "QA"},
+            {"source": "QA", "target": "Build"},
+            {"source": "QA", "target": "Plan"},
+            {"source": "QA", "target": "Done"}
+        ],
+        "state": agent.bus.snapshot()
+    };
+}
+
+impl ui_reset -> None {
+    reset_session();
+    agent.bus.events = [];
+    agent.bus.begin_turn();
+    agent.bus.set_status("idle");
+}
+
+impl _run_ui_server(r: any) -> int {
+    import jaclang;
+    import from importlib.util { find_spec }
+    if find_spec("jac_client") is None {
+        console.error(
+            "`jac ai --ui` needs the jac-client plugin, which is not installed.",
+            hint="Install it with:  pip install jac-client"
+        );
+        return 1;
+    }
+    pkg_file = jaclang.__file__;
+    if pkg_file is None {
+        console.error("jaclang package location is unavailable");
+        return 1;
+    }
+    ui_dir = str(Path(pkg_file).parent / "cli" / "ai_ui");
+    entry = os.path.join(ui_dir, "main.jac");
+    if not os.path.exists(entry) {
+        console.error(f"bundled UI app not found at {entry}");
+        return 1;
+    }
+    env = dict(os.environ);
+    env["JAC_AI_UI_PROJECT"] = agent.cwd;
+    env["JAC_AI_UI_MODEL"] = str(getattr(r, "model", "") or "");
+    env["JAC_AI_UI_NCTX"] = str(int(getattr(r, "n_ctx", 0) or 0));
+    log_path = "/tmp/jac_ai_ui.log";
+    console.print("");
+    console.print("  Jac AI -- web UI", style="bold");
+    console.print(f"  project: {agent.cwd}", style="muted");
+    console.print("  building the client (first run installs deps)…", style="muted");
+    proc: any = None;
+    try {
+        log_f = open(log_path, "w");
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "jaclang", "start", "main.jac"],
+            cwd=ui_dir,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            start_new_session=True
+        );
+    } except Exception as e {
+        console.error(f"failed to launch the UI server: {e}");
+        return 1;
+    }
+    url_re = re.compile(
+        "https?://(?:localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0)(?::\\d+)?\\S*"
+    );
+    timeout = 180.0;
+    try {
+        raw = os.environ.get("JAC_AI_UI_TIMEOUT");
+        if raw {
+            timeout = float(raw);
+        }
+    } except Exception { }
+    deadline = time.time() + timeout;
+    url = "";
+    while time.time() < deadline {
+        if proc.poll() is not None {
+            break;
+        }
+        try {
+            log_text = Path(log_path).read_text();
+        } except Exception {
+            log_text = "";
+        }
+        m = url_re.search(log_text);
+        if m {
+            url = m.group(0).rstrip("/");
+            break;
+        }
+        time.sleep(1.0);
+    }
+    if not url {
+        tail = "";
+        try {
+            tail = "\n".join(Path(log_path).read_text().splitlines()[-25:]);
+        } except Exception {
+            tail = "(no log output)";
+        }
+        try {
+            os.killpg(os.getpgid(int(proc.pid)), int(signal.SIGTERM));
+        } except Exception { }
+        console.error(f"the UI server did not come up within {int(timeout)}s.\n{tail}");
+        return 1;
+    }
+    console.success(f"  UI ready at {url}");
+    console.print(f"  logs: {log_path}", style="muted");
+    console.print("  press Ctrl-C to stop", style="muted");
+    console.print("");
+    try {
+        webbrowser.open(url);
+    } except Exception { }
+    try {
+        proc.wait();
+    } except KeyboardInterrupt {
+        console.print("\n  stopping the UI server…", style="muted");
+    }
+    try {
+        os.killpg(os.getpgid(int(proc.pid)), int(signal.SIGTERM));
+    } except Exception { }
     console.print("Bye.");
     return 0;
 }


### PR DESCRIPTION
## Summary

Adds a `--ui` flag to `jac ai` that opens the coding agent in a **web UI** instead of the terminal REPL — a control room for watching the agent work:

- **Conversation** — send prompts, see the agent's streamed answers.
- **Phase graph (cytoscape)** — a live visualizer of the `AgentSession` walker moving through its own object-spatial graph **Plan → Build → QA → Done** (with QA's loop-back edges). The active node glows; visited nodes and traversed edges light up in real time as the agent works.
- **Activity feed** — every phase transition, tool call/result, and reasoning chunk, streamed live.
- **Stats bar** — per-turn tool/file tallies and the current phase.

```
jac ai --ui
```

## How it works

- The `--ui` flag is plumbed through the `ai` command, `ai.impl`, and the `AgentRequest` contract.
- An `AgentEventBus` on `AgentRuntime` tees structured milestones from the existing render path (phase moves, tool calls/results, reasoning, answers, stats), gated by an `active_feed` flag so the terminal path stays a no-op.
- UI bridge functions (`ui_configure` / `ui_send` / `ui_poll` / `ui_graph` / `ui_reset`) back the web endpoints. A `--ui` branch in `run_agent` launches a bundled Jac fullstack app via `jac start`, opens the browser, and blocks until quit. It requires the `jac-client` plugin (detected, with an install hint — same pattern as byLLM).
- The bundled app lives under `jaclang/cli/ai_ui/`: server endpoints over the event bus, plus a self-contained shadcn-styled client (no Tailwind toolchain) with cytoscape via npm. The client polls the bus every 800ms and re-renders the graph + feed.

## Notes

- **byLLM config resolves from the user's project, not the process cwd.** The `--ui` child server runs in the bundled app's directory (so `jac start` builds the right client), which has no `[plugins.byllm.model]`. Config resolution is centralized on `agent.cwd`, so the server reads the user's `jac.toml` model / api_key / base_url. The terminal path is unaffected.
- Build artifacts (`.jac/`, `node_modules`) are covered by the existing `.gitignore`; only source ships.

## Testing

- `jac ai --help` shows the new flag; `ai_agent.jac` type-checks at the existing baseline (no net-new errors).
- Verified end to end in a headless browser: endpoints return 200, the cytoscape graph renders, and on sending a prompt the activity feed and graph track the walker (Plan → Build → QA) in real time with zero console errors.