### PR TITLE
perf(jac-scale): bake Jac toolchain into K8s e2e runtime image (build once, not per-pod)

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -311,7 +311,20 @@ jobs:
           wait: 120s
           config: /tmp/kind-config.yaml
 
+      # Bake the Jac toolchain (apt deps + Bun + editable installs) into a
+      # single image ONCE, then load it into the kind node. The deploy tests
+      # set install_jaseci=False against this image so each app pod skips the
+      # apt/Bun/clone/pip build that otherwise runs from scratch in every pod
+      # on every deploy. Tag is non-':latest' so the default imagePullPolicy
+      # (IfNotPresent) uses the loaded image instead of pulling from a registry.
+      - name: Build and load Jac runtime image
+        run: |
+          docker build -f jac-scale/scripts/Dockerfile.allinone.citest -t jac-runtime:citest .
+          kind load docker-image jac-runtime:citest --name jaseci-test
+
       - name: Run K8 tests
+        env:
+          JAC_RUNTIME_IMAGE: jac-runtime:citest
         run: |
           pytest  -s -x jac-scale/jac_scale/tests/test_k8s_utils.jac
           pytest  -s -x jac-scale/jac_scale/tests/test_deploy_k8s.jac

--- a/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
@@ -183,6 +183,19 @@ obj KubernetesTarget(DeploymentTarget) {
         config = self.k8s_config;
         commands = [];
 
+        # When the base image is pre-provisioned with the Jac toolchain
+        # (apt deps, Bun, and an installed jaclang/jac-scale/jac-client/...),
+        # skip the expensive from-scratch runtime build and only install the
+        # app's own dependencies and launch it. This is how CI keeps the K8s
+        # e2e tests fast: the toolchain is baked once into the image instead
+        # of being rebuilt inside every pod on every deploy.
+        if not config.install_jaseci {
+            commands.append(f"cd {config.app_mount_path}");
+            commands.append('jac install');
+            commands.append(f"jac start {app_config.file_name}");
+            return ['bash', '-c', ' && '.join(commands)];
+        }
+
         # Base setup
         commands.append('export DEBIAN_FRONTEND=noninteractive');
         # Disable apt sandbox: CAP_SETUID/CAP_SETGID are dropped in the container

--- a/jac-scale/jac_scale/tests/test_deploy_k8s.jac
+++ b/jac-scale/jac_scale/tests/test_deploy_k8s.jac
@@ -226,6 +226,17 @@ test "deploy all in one" {
     target_config["mongodb_dashboard"] = True;
     target_config["loki_enabled"] = True;
 
+    # CI bakes the Jac toolchain into a prebuilt image and loads it into the
+    # kind node (see .github/workflows/test-jaseci.yml). When that image is
+    # present, deploy against it with install_jaseci=False so each pod skips
+    # the apt/Bun/clone/pip build. Falls back to the from-scratch runtime
+    # build for local runs where the image isn't available.
+    runtime_image = os.environ.get("JAC_RUNTIME_IMAGE");
+    if runtime_image {
+        target_config["python_image"] = runtime_image;
+        target_config["install_jaseci"] = False;
+    }
+
     (repo_url, branch, commit) = _get_git_config();
     assert repo_url , "repo_url must be a non-empty string";
     assert branch , "branch must be a non-empty string";
@@ -1817,6 +1828,13 @@ test "early exit" {
     target_config["app_name"] = app_name;
     target_config["namespace"] = namespace;
     target_config["ingress_node_port"] = 30081;
+
+    # Reuse the CI-baked toolchain image when present (see "deploy all in one").
+    runtime_image = os.environ.get("JAC_RUNTIME_IMAGE");
+    if runtime_image {
+        target_config["python_image"] = runtime_image;
+        target_config["install_jaseci"] = False;
+    }
 
     logger = UtilityFactory.create_logger("standard");
 

--- a/jac-scale/scripts/Dockerfile.allinone.citest
+++ b/jac-scale/scripts/Dockerfile.allinone.citest
@@ -1,0 +1,54 @@
+# CI-only runtime image for the all-in-one Kubernetes e2e tests
+# (jac-scale/jac_scale/tests/test_deploy_k8s.jac).
+#
+# It bakes the full Jac toolchain (apt deps + Bun + editable installs of the
+# PR's jac / jac-scale / jac-client / jac-byllm / jac-mcp) ONCE so each app pod
+# can deploy with install_jaseci=False and skip the apt/Bun/clone/pip build
+# that otherwise reruns from scratch inside every pod on every deploy.
+#
+# This is deliberately separate from Dockerfile.microservice.exp: the
+# microservice path bakes a fixed app into the image, whereas the all-in-one
+# tests mount app code via a PVC at runtime and build a React frontend with
+# `jac install`, so this image must carry Bun and the full `--extras all` set
+# but must NOT bake an app.
+#
+# Build context = repo root.
+
+FROM python:3.12-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Disable the apt sandbox: CAP_SETUID/CAP_SETGID are dropped in the deploy
+# security context, and dropping the trixie-updates/-security suites avoids
+# apt-get hanging on Release files that don't exist yet on Debian testing.
+RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/00sandbox \
+    && sed -i '/trixie-updates\|trixie-security/d' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true \
+    && sed -i -E '/^Suites:/ s/[[:space:]]+trixie-updates//g' /etc/apt/sources.list.d/*.sources 2>/dev/null || true \
+    && apt-get -o Acquire::Retries=1 -o Acquire::http::Timeout=20 update || true \
+    && apt-get install -y --no-install-recommends git curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# See Dockerfile.microservice for the safe.directory rationale.
+RUN git config --system --add safe.directory '*'
+
+# Bun is required for jac-client frontend builds at app deploy time.
+RUN curl -fsSL https://bun.sh/install | bash
+ENV BUN_INSTALL="/root/.bun"
+ENV PATH="/root/.bun/bin:${PATH}"
+
+RUN pip install --no-cache-dir --upgrade pip
+
+WORKDIR /opt/jaseci
+COPY jac ./jac
+COPY jac-scale ./jac-scale
+COPY jac-client ./jac-client
+COPY jac-byllm ./jac-byllm
+COPY jac-mcp ./jac-mcp
+RUN pip install --no-cache-dir pluggy \
+    && pip install --no-cache-dir -e ./jac \
+    && jac install -e ./jac-scale --extras all \
+    && jac install -e ./jac-client \
+    && jac install -e ./jac-byllm \
+    && jac install -e ./jac-mcp
+
+RUN jac --version


### PR DESCRIPTION
## What

The `test-scale-k8s` CI job runs two live deploys against a kind cluster — `deploy all in one` and `early exit` — and **each app pod rebuilt the entire Jac toolchain from scratch at startup**: `apt-get`, Bun, a full `git clone` of the repo + submodules, and editable installs of `jac`/`jac-scale`/`jac-client`/`jac-byllm`/`jac-mcp`. That cycle ran inside every pod on every deploy and sat on the pod-readiness critical path, racing the startup/liveness probes.

This bakes the cycle **once** into a prebuilt image and reuses it for both deploys.

## Changes

- **Honor the (previously dead) `install_jaseci` flag** in `_build_runtime_setup_command`: when `false`, skip the apt/Bun/clone/pip preamble and only run `jac install` + `jac start` against a base image that already carries the toolchain. The flag was defined and plumbed through `from_dict`/`to_dict` but never read.
- **Add `jac-scale/scripts/Dockerfile.allinone.citest`**, which bakes apt deps + Bun + the PR's editable installs once. Kept separate from `Dockerfile.microservice.exp` because the all-in-one path mounts app code via a PVC and builds a React frontend at runtime, so it needs Bun and the full `--extras all` set and must not bake an app.
- **CI** builds that image and `kind load`s it. The non-`:latest` tag keeps the default `imagePullPolicy: IfNotPresent`, so the loaded image is used without a registry pull. The deploy tests opt in via `JAC_RUNTIME_IMAGE`.
- **Tests** use the baked image only when `JAC_RUNTIME_IMAGE` is set, so local runs fall back to the from-scratch build unchanged.

## Why it's safe

The `install_jaseci` flag only changes the container's startup command, not the deploy phases. Deploy-phase counts are untouched (`details == 13` / `12`), so all existing assertions hold and `early exit` still crashes at `jac start app_err.jac`.

## Net effect

The heavy toolchain build runs once at image-build time instead of twice inside pods, and is lifted off the pod-readiness critical path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/jaseci-labs/codesmith/jaseci/pr/6218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782490202&installation_id=136081925&pr_number=6218&repository=jaseci-labs%2Fjaseci&return_to=https%3A%2F%2Fgithub.com%2Fjaseci-labs%2Fjaseci%2Fpull%2F6218&signature=405ba47c937d7630df9c932ab4883e6def2f8d3e5df97d45044381e1546b8a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->