### PR TITLE
fix(ai-ui): keep rank-skipping PhaseGraph edges visible

### DIFF
--- a/jac.toml
+++ b/jac.toml
@@ -12,6 +12,6 @@ exclude = [
 ]
 
 [plugins.byllm.model]
-default_model = "anthropic/claude-opus-4-7"
+default_model = "anthropic/claude-sonnet-4-6"
 #default_model = "ollama/gemma4:31b"
 #default_model = "ollama/qwen3-coder"

--- a/jac/jaclang/cli/ai_ui/components/PhaseGraph.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/PhaseGraph.cl.jac
@@ -31,17 +31,29 @@ def:pub PhaseGraph(
     useEffect(
         lambda { if containerRef.current and len(nodes) > 0 and not cyRef.current {
             els: list = [];
-            for n in nodes {
+            # Rank each node by its position in the (BFS-ordered) node list so an
+            # edge spanning more than one rank can be told apart from an adjacent
+            # one below.
+            ranks: dict[str, int] = {};
+            for (i, n) in enumerate(nodes) {
                 els.append({"data": {"id": n.id, "label": n.label, "desc": n.desc}});
+                ranks[n.id] = i;
             }
             for e in edges {
+                # A bidirectional pair between adjacent nodes (Build <-> QA) fans
+                # out on its own, but an edge that skips a rank (QA -> Plan jumps
+                # over Build) drawn straight runs behind the intervening node and
+                # vanishes. Tag it so its style bows it out to the side instead.
+                gap = ranks[e.source] - ranks[e.target];
+                cls = "skip" if (gap > 1 or gap < -1) else "";
                 els.append(
                     {
                         "data": {
                             "id": e.source + "->" + e.target,
                             "source": e.source,
                             "target": e.target
-                        }
+                        },
+                        "classes": cls
                     }
                 );
             }
@@ -114,6 +126,17 @@ def:pub PhaseGraph(
                                 "control-point-step-size": 60,
                                 "transition-property": "line-color, target-arrow-color, width",
                                 "transition-duration": 250
+                            }
+                        },
+                        {
+                            # A rank-skipping edge bows out to the side so it
+                            # clears the node it would otherwise run straight
+                            # behind, instead of bezier's straight default.
+                            "selector": "edge.skip",
+                            "style": {
+                                "curve-style": "unbundled-bezier",
+                                "control-point-distances": [130],
+                                "control-point-weights": [0.5]
                             }
                         },
                         {


### PR DESCRIPTION
## Summary
- In the `jac ai --ui` phase graph, an edge that skips a rank (e.g. `QA -> Plan` jumping over `Build`) was drawn straight behind the intervening node and effectively disappeared.
- Rank each node by its position in the BFS-ordered node list, tag any edge that spans more than one rank, and style it as an unbundled bezier that bows out to the side so it stays visible. Adjacent bidirectional pairs are unaffected.
- Switch the default byLLM model in `jac.toml` to `anthropic/claude-sonnet-4-6`.

## Test plan
- [ ] Run `jac ai --ui`, trigger a flow that produces a back/skip edge, and confirm the rank-skipping edge bows out and renders rather than vanishing behind a node.
- [ ] Confirm adjacent bidirectional edges still fan out as before.