### PR TITLE
feat(ai-ui): per-call token-usage stream and collapsible tool outputs

### DIFF
--- a/docs/docs/community/release_notes/unreleased/byllm/6235.feature.md
+++ b/docs/docs/community/release_notes/unreleased/byllm/6235.feature.md
@@ -1,0 +1,1 @@
+- **Per-call token usage in streamed responses**: Streaming completions now report input-token and prompt-cache counts for each model call, not only the per-turn total.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6235.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6235.feature.md
@@ -1,0 +1,1 @@
+- **`jac ai --ui` shows per-call token usage and collapsible tool outputs**: The web UI replaces the raw token firehose with a live per-call token-usage stream (tokens in/out, cache, latency, and phase), and renders each tool's output as a collapsible, scrollable dropdown.

--- a/jac-byllm/byllm/llm.impl/basellm.impl.jac
+++ b/jac-byllm/byllm/llm.impl/basellm.impl.jac
@@ -35,6 +35,38 @@ def _mark_message_for_caching(msg: dict) {
 }
 
 
+"""Read an int usage field from a litellm usage dict-or-object, 0 if absent.
+
+For `cache_read_input_tokens`, falls back to the `prompt_tokens_details.cached_tokens`
+alias some providers nest it under.
+"""
+def _usage_int(usage: any, key: str) -> int {
+    if usage is None {
+        return 0;
+    }
+    val = usage.get(key) if isinstance(usage, dict) else getattr(usage, key, None);
+    if val is None and key == "cache_read_input_tokens" {
+        ptd = (
+            usage.get("prompt_tokens_details")
+                if isinstance(usage, dict)
+                else usage?.prompt_tokens_details
+        );
+        if ptd is not None {
+            val = (
+                ptd.get("cached_tokens")
+                    if isinstance(ptd, dict)
+                    else ptd?.cached_tokens
+            );
+        }
+    }
+    try {
+        return int(val or 0);
+    } except Exception {
+        return 0;
+    }
+}
+
+
 """Mark cache breakpoints for Anthropic: last system, last non-system, last tool."""
 def _apply_prompt_caching(messages: list, tools: list | None) {
     last_sys_idx = -1;
@@ -428,6 +460,33 @@ impl BaseLLM._invoke_with_handler(mt_run: MTRuntime, on_event: Callable) -> obje
             }
         } finally {
             mt_run.write_back_conversation();
+        }
+        # This branch streams only content tokens (no ReAct loop), so it never
+        # emits the per-call `llm_timing` the loop does. Surface this call's usage
+        # to the handler too, so structured/routing calls report tokens + cache.
+        if self._usage_history {
+            u = self._usage_history[-1];
+            try {
+                on_event(
+                    StreamEvent(
+                        event_type="llm_timing",
+                        data={
+                            "duration_ms": 0.0,
+                            "iteration": 0,
+                            "completion_tokens": _usage_int(u, "completion_tokens"),
+                            "prompt_tokens": _usage_int(u, "prompt_tokens"),
+                            "cache_read_input_tokens": _usage_int(
+                                u, "cache_read_input_tokens"
+                            ),
+                            "cache_creation_input_tokens": _usage_int(
+                                u, "cache_creation_input_tokens"
+                            )
+                        }
+                    )
+                );
+            } except Exception as e {
+                logger.debug(f"stream_handler raised: {e}");
+            }
         }
         return mt_run.parse_response(accumulated);
     }
@@ -1561,7 +1620,14 @@ impl BaseLLM._invoke_streaming(
                 data={
                     "duration_ms": _llm_ms,
                     "iteration": iter_count,
-                    "completion_tokens": _completion_tokens
+                    "completion_tokens": _completion_tokens,
+                    "prompt_tokens": _usage_int(usage, "prompt_tokens"),
+                    "cache_read_input_tokens": _usage_int(
+                        usage, "cache_read_input_tokens"
+                    ),
+                    "cache_creation_input_tokens": _usage_int(
+                        usage, "cache_creation_input_tokens"
+                    )
                 }
             );
 

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -165,6 +165,7 @@ obj TurnRenderer {
     def _ci_event(info: any);
     def render_stream(event_stream: any) -> dict;
     def route_stream_event(event: any) -> None;
+    def _emit_call_usage(data: any, phase: str) -> None;
 }
 
 """A live, in-process feed of structured agent events for the `--ui` web view.
@@ -225,7 +226,6 @@ obj AgentEventBus {
     def unsubscribe(q: any) -> None;
     def publish(ev: dict) -> None;
     def publish_full -> None;
-    def feed_token(token: str) -> None;
     def ledger_view -> dict;
     def publish_ledger -> None;
     def _state -> dict;
@@ -415,7 +415,11 @@ def run_phase(directive: str, tools: list, ctx: list) -> str by agent_model(
     max_tokens=8192,
     parallelize=True,
     max_react_iterations=60,
-    on_iteration=_progress_guard
+    on_iteration=_progress_guard,
+    max_tool_result_length=4000
+    # Carry up to ~4000 chars of each tool result into the stream event so the
+    # UI's collapsible tool-output dropdown can show more than a tiny preview.
+    # Display-only: full results still reach model history regardless.
 );
 
 

--- a/jac/jaclang/cli/ai_ui/components/ActivityFeed.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/ActivityFeed.cl.jac
@@ -1,17 +1,21 @@
 """Live activity log: tool calls, results, phase moves, and reasoning.
 
-Consecutive reasoning ("thinking") tokens fold into one collapsible dropdown
-that streams its text in as the model generates it; everything else renders as
-a terminal-style row. Auto-scrolls to the newest entry.
+Each tool call folds into a collapsible row -- the header (tool name + call)
+always shows, and its output is a dropdown that is closed by default and
+scrolls within itself when expanded. Consecutive reasoning ("thinking") tokens
+fold into one dropdown that is open by default and streams in live. Everything
+else renders as a terminal-style row. Auto-scrolls to the newest entry.
 """
 
 import from react { useRef, useEffect }
 sv import from ..server { UiEvent }
 
 def:pub ActivityFeed(events: list[UiEvent], status: str) -> JsxElement {
-    # Block ids the user has explicitly collapsed. Thinking blocks are open by
-    # default so the tokens are visible as they stream.
-    has collapsed: list[int] = [];
+    # Thinking blocks the user has collapsed (open by default). Tool outputs are
+    # the opposite -- closed by default -- so they are tracked separately as the
+    # ids the user has explicitly expanded.
+    has collapsed: list[int] = [],
+        expandedTools: list[int] = [];
     endRef: any = useRef(None);
     useEffect(
         lambda { if endRef.current {
@@ -32,9 +36,23 @@ def:pub ActivityFeed(events: list[UiEvent], status: str) -> JsxElement {
         }
     }
 
-    # Fold consecutive reasoning events into one block; keep the rest as rows.
+    def toggleTool(bid: int) {
+        if bid in expandedTools {
+            expandedTools = [
+                x
+                for x in expandedTools
+                if x != bid
+            ];
+        } else {
+            expandedTools = expandedTools + [bid];
+        }
+    }
+
+    # Fold the event stream into rows: consecutive reasoning into one think
+    # block; each tool call into a tool row that its following tool_result fills.
     rows: list = [];
     block: any = None;
+    toolRow: any = None;
     for e in events {
         if e.kind == "reasoning" {
             if block is None {
@@ -42,12 +60,24 @@ def:pub ActivityFeed(events: list[UiEvent], status: str) -> JsxElement {
                 rows.append({"type": "think", "id": e.id, "block": block});
             }
             block["text"] = block["text"] + e.text;
-        } elif (
-            e.kind == "tool"
-            or e.kind == "tool_result"
-            or e.kind == "phase"
-            or e.kind == "error"
-        ) {
+        } elif e.kind == "tool" {
+            block = None;
+            toolRow = {
+                "id": e.id,
+                "name": e.name,
+                "call": e.text,
+                "result": "",
+                "done": False
+            };
+            rows.append({"type": "tool", "id": e.id, "row": toolRow});
+        } elif e.kind == "tool_result" {
+            block = None;
+            # Attach the output to the tool call it belongs to (the most recent).
+            if toolRow is not None {
+                toolRow["result"] = e.text;
+                toolRow["done"] = True;
+            }
+        } elif e.kind == "phase" or e.kind == "error" {
             block = None;
             rows.append({"type": "evt", "ev": e});
         }
@@ -91,25 +121,56 @@ def:pub ActivityFeed(events: list[UiEvent], status: str) -> JsxElement {
                                         else None}
                                 </div>
                                     if r["type"] == "think"
-                                    else <div
-                                        className={"evt " + r["ev"].kind}
-                                        key={r["ev"].id}
-                                    >
-                                        <span className="tag">
-                                            {("→ " + r["ev"].node)
-                                                if r["ev"].kind == "phase"
-                                                else (
-                                                    r["ev"].name
-                                                        if r["ev"].kind == "tool"
-                                                        else r["ev"].kind
-                                                )}
-                                        </span>
-                                        <span className="body">
-                                            {r["ev"].node
-                                                if r["ev"].kind == "phase"
-                                                else r["ev"].text}
-                                        </span>
-                                    </div>
+                                    else (
+                                        <div className="evt tool toolrow" key={r["id"]}>
+                                            <button
+                                                className="tool-head"
+                                                onClick={lambda { toggleTool(
+                                                    r["id"]
+                                                ); }}
+                                            >
+                                                <span className="chev">
+                                                    {"▾"
+                                                        if r["id"] in expandedTools
+                                                        else "▸"}
+                                                </span>
+                                                <span className="tag">
+                                                    {r["row"]["name"]}
+                                                </span>
+                                                <span className="body">
+                                                    {r["row"]["call"]}
+                                                </span>
+                                                {<span className="think-dot live"/>
+                                                    if not r["row"]["done"]
+                                                    else <span className="think-count">
+                                                        {str(len(r["row"]["result"])) + " chars"}
+                                                    </span>}
+                                            </button>
+                                            {<div className="tool-body">
+                                                {r["row"]["result"]
+                                                    if r["row"]["result"]
+                                                    else "(no output)"}
+                                            </div>
+                                                if r["id"] in expandedTools
+                                                else None}
+                                        </div>
+                                            if r["type"] == "tool"
+                                            else <div
+                                                className={"evt " + r["ev"].kind}
+                                                key={r["ev"].id}
+                                            >
+                                                <span className="tag">
+                                                    {("→ " + r["ev"].node)
+                                                        if r["ev"].kind == "phase"
+                                                        else r["ev"].kind}
+                                                </span>
+                                                <span className="body">
+                                                    {r["ev"].node
+                                                        if r["ev"].kind == "phase"
+                                                        else r["ev"].text}
+                                                </span>
+                                            </div>
+                                    )
                             ) for r in rows
                         ]}
                         <div ref={endRef}/>

--- a/jac/jaclang/cli/ai_ui/components/TokenStream.cl.jac
+++ b/jac/jaclang/cli/ai_ui/components/TokenStream.cl.jac
@@ -1,30 +1,90 @@
-"""Live token firehose: every reasoning/answer token the model emits, raw and
-in order, as it streams. A monospace ticker (a section of the bottom pane) that
-auto-scrolls so the newest token stays in view.
+"""Live token-usage stream: one row per model call, newest last, showing the
+tokens that went into and came out of each call -- input (with a magnitude bar
+so an oversized prompt stands out), output, cache read/created, and latency,
+tagged by the phase it belongs to (or "route" for the routing decision). Makes
+context-size spikes and cache (re)use visible as the agent works.
 """
 
 import from react { useRef, useEffect }
+sv import from ..server { UiEvent }
 
-def:pub TokenStream(text: str, live: bool) -> JsxElement {
+"""Compact a token count: 66711 -> "66k", 940 -> "940"."""
+def _k(n: int) -> str {
+    return (str(n // 1000) + "k") if n >= 1000 else str(n);
+}
+
+def:pub TokenStream(events: list[UiEvent], live: bool) -> JsxElement {
     endRef: any = useRef(None);
+    calls = [
+        e
+        for e in events
+        if e.kind == "call"
+    ];
+    # Scale the input bars against the largest call this turn so the worst
+    # offender (e.g. the routing call) fills the row.
+    maxIn = 1;
+    for e in calls {
+        if e.tokens_in > maxIn {
+            maxIn = e.tokens_in;
+        }
+    }
     useEffect(
         lambda { if endRef.current {
             endRef.current.scrollIntoView({"block": "end"});
         }},
-        [len(text)]
+        [len(calls)]
     );
     return
         <div className="bp-section tokenstream">
             <div className="pane-head">
-                token stream
+                token usage
                 <span className="spacer"/>
                 {<span className="think-dot live"/> if live else <span/>}
             </div>
-            <div className="bp-body tokenstream-body">
-                {text
-                    if len(text) > 0
-                    else "tokens appear here as the model generates…"}
-                <span ref={endRef}/>
+            <div className="bp-body tokusage-body">
+                {<div className="empty">
+                    per-call tokens appear here as the model runs…
+                </div>
+                    if len(calls) == 0
+                    else <div className="tokfeed">
+                        {[
+                            (
+                                <div className="tokrow" key={e.id}>
+                                    <span className={"tok-chip tok-" + e.node}>
+                                        {e.node}
+                                    </span>
+                                    <div className="tok-inwrap">
+                                        <div
+                                            className="tokbar"
+                                            style={{
+                                                "width": str(
+                                                    int(e.tokens_in * 100 / maxIn)
+                                                ) + "%"
+                                            }}
+                                        />
+                                        <span className="tok-in">
+                                            {_k(e.tokens_in) + " in"}
+                                        </span>
+                                    </div>
+                                    <span className="tok-out">
+                                        {_k(e.tokens_out) + " out"}
+                                    </span>
+                                    <span
+                                        className="tok-cache"
+                                        title="cache read / created"
+                                    >
+                                        {"⟳" + _k(e.cache_read) + " +" + _k(
+                                            e.cache_create
+                                        )}
+                                    </span>
+                                    <span className="tok-ms">
+                                        {(str(int(e.ms)) + "ms") if e.ms > 0 else ""}
+                                    </span>
+                                </div>
+                            ) for e in calls
+                        ]}
+                        <div ref={endRef}/>
+                    </div>}
             </div>
         </div>;
 }

--- a/jac/jaclang/cli/ai_ui/frontend.cl.jac
+++ b/jac/jaclang/cli/ai_ui/frontend.cl.jac
@@ -32,8 +32,6 @@ def:pub app -> JsxElement {
         # Server-shaped TurnStatsView; the server constructs it, so the client
         # only ever holds a plain object (never instantiate the sv type here).
         stats: any = {"has_run": False},
-        # Raw firehose of every streamed token, concatenated (capped).
-        tokens: str = "",
         # The durable session ledger ({changes, notes}); refreshed whenever a
         # ledger message arrives so the bottom-pane panel mirrors it live.
         ledger: any = {"changes": [], "notes": []},
@@ -71,10 +69,8 @@ def:pub app -> JsxElement {
     doc: any = document;
     # The live event list is kept in a ref so the stream handler (captured once
     # by the effect) always upserts against the current list, not a stale render
-    # closure -- otherwise each delta would rebuild from an empty `events`. Same
-    # reason for the token firehose buffer.
+    # closure -- otherwise each delta would rebuild from an empty `events`.
     eventsRef: any = useRef([]);
-    tokensRef: any = useRef("");
     # Held in a ref for the same reason as events: ledger messages are sparse, so
     # the handler must read the latest value, not a stale render closure.
     ledgerRef: any = useRef({"changes": [], "notes": []});
@@ -111,16 +107,6 @@ def:pub app -> JsxElement {
             }
             eventsRef.current = out;
             events = out;
-        }
-        # Firehose: append the raw token (delta msgs carry it; empty otherwise),
-        # capped to the most recent stretch.
-        if msg.token {
-            nt = tokensRef.current + msg.token;
-            if len(nt) > 4000 {
-                nt = nt[len(nt) - 4000:];
-            }
-            tokensRef.current = nt;
-            tokens = nt;
         }
         # Ledger messages are sparse (only when a phase records or a note lands);
         # apply whenever present, otherwise keep the last value.
@@ -258,8 +244,6 @@ def:pub app -> JsxElement {
         active = "";
         path = [];
         stats = {"has_run": False};
-        tokensRef.current = "";
-        tokens = "";
         ledgerRef.current = {"changes": [], "notes": []};
         ledger = {"changes": [], "notes": []};
         selected = "";
@@ -383,7 +367,7 @@ def:pub app -> JsxElement {
                 ); }}
             />
             <div className="bottompane" style={{"height": str(bottomH) + "px"}}>
-                <TokenStream text={tokens} live={status == "running"}/>
+                <TokenStream events={events} live={status == "running"}/>
                 <LedgerPane {ledger}/>
                 <PhaseInspector {nodes} {selected}/>
             </div>

--- a/jac/jaclang/cli/ai_ui/global.css
+++ b/jac/jaclang/cli/ai_ui/global.css
@@ -504,6 +504,69 @@ body.resizing {
     overflow-y: auto;
 }
 
+/* ---- Tool dropdown (call header + collapsible scrollable output) ------ */
+.toolrow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 0;
+}
+
+.tool-head {
+    display: flex;
+    align-items: baseline;
+    gap: 9px;
+    width: 100%;
+    padding: 7px 16px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+}
+
+.tool-head:hover {
+    background: var(--panel-2);
+}
+
+.tool-head .chev {
+    width: 10px;
+    color: #6b7077;
+    flex-shrink: 0;
+    align-self: center;
+}
+
+.tool-head .tag {
+    flex-shrink: 0;
+    width: 96px;
+    color: var(--accent);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.tool-head .body {
+    flex: 1;
+    min-width: 0;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tool-body {
+    padding: 4px 16px 10px 34px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--muted);
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 11.5px;
+    line-height: 1.45;
+    max-height: 260px;
+    overflow-y: auto;
+    border-top: 1px solid rgba(38, 40, 44, 0.4);
+}
+
 /* ---- Graph ------------------------------------------------------------ */
 .graph-wrap {
     position: relative;
@@ -587,14 +650,92 @@ body.resizing {
     min-height: 0;
 }
 
-.tokenstream-body {
-    padding: 8px 14px 10px;
+/* ---- Token-usage stream (one row per model call) --------------------- */
+.tokusage-body {
+    padding: 2px 0 8px;
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-    font-size: 11.5px;
-    line-height: 1.45;
-    color: #9aa0a8;
-    white-space: pre-wrap;
-    word-break: break-word;
+    font-size: 11px;
+}
+
+.tokfeed {
+    display: flex;
+    flex-direction: column;
+}
+
+.tokrow {
+    display: grid;
+    grid-template-columns: 48px minmax(60px, 1fr) auto auto auto;
+    gap: 10px;
+    align-items: center;
+    padding: 4px 12px;
+    border-bottom: 1px solid rgba(38, 40, 44, 0.5);
+    font-variant-numeric: tabular-nums;
+}
+
+.tok-chip {
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 1px 4px;
+    border-radius: 4px;
+    text-align: center;
+    background: var(--panel-2);
+    color: var(--muted);
+}
+
+.tok-chip.tok-Plan {
+    color: #a5b4fc;
+}
+
+.tok-chip.tok-Build {
+    color: var(--green);
+}
+
+.tok-chip.tok-QA {
+    color: var(--amber);
+}
+
+.tok-chip.tok-route {
+    color: var(--accent);
+    background: rgba(34, 211, 238, 0.12);
+}
+
+.tok-inwrap {
+    position: relative;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    height: 16px;
+}
+
+.tokbar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    min-width: 2px;
+    background: rgba(248, 113, 113, 0.22);
+    border-radius: 3px;
+}
+
+.tok-in {
+    position: relative;
+    padding-left: 6px;
+    color: var(--fg);
+}
+
+.tok-out {
+    color: var(--green);
+}
+
+.tok-cache {
+    color: #6b7077;
+}
+
+.tok-ms {
+    color: var(--muted);
+    min-width: 46px;
+    text-align: right;
 }
 
 /* ---- Ledger panel ----------------------------------------------------- */

--- a/jac/jaclang/cli/ai_ui/server.jac
+++ b/jac/jaclang/cli/ai_ui/server.jac
@@ -37,7 +37,14 @@ obj UiEvent {
         kind: str = "",
         text: str = "",
         name: str = "",
-        node: str = "";
+        node: str = "",
+        # Populated only for `call` events (one per model call): the token usage
+        # the token-usage stream renders. Zero on every other kind.
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        cache_read: int = 0,
+        cache_create: int = 0,
+        ms: float = 0.0;
 }
 
 """The latest turn's summary stats -- the same set the CLI prints after a turn.
@@ -131,7 +138,12 @@ def _to_poll(snap: dict) -> PollResult {
                 kind=str(e.get("kind", "")),
                 text=str(e.get("text", "")),
                 name=str(e.get("name", "")),
-                node=str(e.get("node", ""))
+                node=str(e.get("node", "")),
+                tokens_in=int(e.get("tokens_in", 0) or 0),
+                tokens_out=int(e.get("tokens_out", 0) or 0),
+                cache_read=int(e.get("cache_read", 0) or 0),
+                cache_create=int(e.get("cache_create", 0) or 0),
+                ms=float(e.get("ms", 0.0) or 0.0)
             )
         );
     }

--- a/jac/jaclang/cli/impl/ai_agent.impl.jac
+++ b/jac/jaclang/cli/impl/ai_agent.impl.jac
@@ -1137,7 +1137,6 @@ impl AgentEventBus.emit_stream(kind: str, token: str) -> None {
     ) {
         self.events[-1]["text"] = str(self.events[-1].get("text", "")) + token;
         # Re-push the grown event so the client sees the cleaned text grow live.
-        # The firehose is fed separately from the raw stream (see feed_token).
         self.publish(self.events[-1]);
     } else {
         ev = {"id": self._next_id, "kind": kind, "text": token, "streaming": True};
@@ -1147,25 +1146,6 @@ impl AgentEventBus.emit_stream(kind: str, token: str) -> None {
             self.events = self.events[-self._cap:];
         }
         self.publish(ev);
-    }
-}
-
-"""Push one raw model token to the live firehose, without touching the event
-log. Fed from the unsplit stream, so it includes the tokens that form tool
-calls -- which the cleaned reasoning view deliberately hides.
-"""
-impl AgentEventBus.feed_token(token: str) -> None {
-    if not self.active_feed or not self._subscribers {
-        return;
-    }
-    # Token-only message (no `ev`): the client appends it to the firehose and
-    # refreshes top-level state, but the event log is untouched.
-    msg = self._state();
-    msg["token"] = token;
-    for q in list(self._subscribers) {
-        try {
-            q.put_nowait(msg);
-        } except Exception { }
     }
 }
 
@@ -1232,7 +1212,7 @@ impl AgentEventBus.publish_ledger -> None {
         return;
     }
     # A ledger-only message: no `ev`/`token`, so the client refreshes its ledger
-    # panel and top-level state without touching the event log or firehose.
+    # panel and top-level state without touching the event log.
     msg = self._state();
     msg["ledger"] = self.ledger_view();
     for q in list(self._subscribers) {
@@ -1629,6 +1609,34 @@ impl TurnRenderer._ci_event(info: any) {
     );
 }
 
+"""Emit one per-model-call usage record to the UI bus from a byLLM `llm_timing`
+event's data, tagged with the phase it belongs to ("Plan"/"Build"/"QA", or
+"route" for the routing call). Drives the live token-usage stream in `--ui`;
+a no-op on the terminal path (the bus is inactive there)."""
+impl TurnRenderer._emit_call_usage(data: any, phase: str) -> None {
+    if not agent.bus.active_feed {
+        return;
+    }
+    d = data if isinstance(data, dict) else {};
+    tin = int(d.get("prompt_tokens", 0) or 0);
+    tout = int(d.get("completion_tokens", 0) or 0);
+    # Skip empty records (a backend that returned no streamed usage).
+    if tin == 0 and tout == 0 {
+        return;
+    }
+    agent.bus.emit(
+        "call",
+        {
+            "node": phase,
+            "tokens_in": tin,
+            "tokens_out": tout,
+            "cache_read": int(d.get("cache_read_input_tokens", 0) or 0),
+            "cache_create": int(d.get("cache_creation_input_tokens", 0) or 0),
+            "ms": float(d.get("duration_ms", 0) or 0)
+        }
+    );
+}
+
 """Consume one byLLM phase event stream, rendering it live.
 
 A phase ability calls this with the stream returned by the `run_phase` byLLM
@@ -1679,7 +1687,7 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
         }
         (result, ms) = (pend_result["result"], pend_result["ms"]);
         pend_result = None;
-        agent.bus.emit("tool_result", {"text": truncate(str(result), 600)});
+        agent.bus.emit("tool_result", {"text": truncate(str(result), 4000)});
         lines = agent.view._result_snippet(result, 3 if agent.cfg.verbose else 1);
         tail = f"   {agent.view._fmt_ms(ms)}"
             if (agent.cfg.verbose and ms is not None)
@@ -1706,9 +1714,6 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
                 if not tok {
                     continue;
                 }
-                # Raw firehose: every generated token, including the ones that
-                # form tool calls (which the cleaned reasoning below hides).
-                agent.bus.feed_token(tok);
                 if step_t0 == 0.0 {
                     step_t0 = time.time();
                 }
@@ -1740,15 +1745,13 @@ impl TurnRenderer.render_stream(event_stream: any) -> dict {
                 out.write(tok);
                 out.flush();
                 streamed = True;
-                # Stream the answer into the conversation token-by-token, and
-                # the raw token into the firehose.
+                # Stream the answer into the conversation token-by-token.
                 agent.bus.emit_stream("answer", tok);
-                if tok {
-                    agent.bus.feed_token(tok);
-                }
             } elif kind == "llm_timing" {
                 last_llm_ms = float(data.get("duration_ms", 0) or 0);
                 last_llm_tokens = int(data.get("completion_tokens", 0) or 0);
+                # Feed the live per-call token-usage stream (--ui only).
+                agent.view._emit_call_usage(data, agent.bus.active);
             } elif kind == "tool_call" {
                 clear_think();
                 end_line();
@@ -2042,9 +2045,10 @@ impl PhaseState.run{
         # Several successors (QA -> Build / Plan / Done) and the project
         # compiles: let the model choose along this node's own out-edges,
         # reading each candidate state's `sem`, the objective, and the ledger.
-        # Streamed via a stream_handler so the routing call's tokens reach the
-        # live firehose, while `visit [-->] by` still constrains the choice to a
-        # real successor edge (no free-text parsing, no manual default).
+        # Streamed via a stream_handler so the routing call's reasoning reaches
+        # the live feed and its token usage the token-usage stream, while
+        # `visit [-->] by` still constrains the choice to a real successor edge
+        # (no free-text parsing, no manual default).
         visit [-->] by agent_model(
             stream=True,
             stream_handler=agent.view.route_stream_event,
@@ -2061,25 +2065,30 @@ impl PhaseState.run{
 """Forward one byLLM StreamEvent from a `visit [-->] by model` routing call.
 
 Passed as the `stream_handler` to the QA routing model so the structured
-edge selection still streams: every raw token is teed to the live firehose
-and any clean reasoning prose is shown in the feed, while `visit [-->] by`
-keeps the choice constrained to a real successor edge. Lighter than
-`render_stream` -- routing is one cheap call, not a phase, so it skips the
-tool and turn-stat bookkeeping.
+edge selection still streams: clean reasoning prose is shown in the feed and
+the call's synthetic `llm_timing` feeds the token-usage stream (tagged
+"route"), while `visit [-->] by` keeps the choice constrained to a real
+successor edge. Lighter than `render_stream` -- routing is one cheap call,
+not a phase, so it skips the tool and turn-stat bookkeeping.
 """
 impl TurnRenderer.route_stream_event(event: any) -> None {
     # Stop pressed in the UI: drop further routing tokens immediately.
     if agent.bus.cancel_requested {
         return;
     }
+    # The routing call runs outside the ReAct loop, so byLLM emits one synthetic
+    # `llm_timing` carrying this call's usage -- feed it to the token-usage stream
+    # tagged "route" so the expensive routing decision is visible.
+    if event.event_type == "llm_timing" {
+        self._emit_call_usage(event.data, "route");
+        return;
+    }
     tok = str(event.data.get("content", "")) if event.data else "";
     if not tok {
         return;
     }
-    # Every routing token is raw model output -- the structured choice JSON, or
-    # reasoning a backend streams ahead of it. Tee it all to the firehose; show
-    # only clean reasoning prose (`thought`) in the live reasoning feed.
-    agent.bus.feed_token(tok);
+    # Routing tokens are the structured choice JSON, or reasoning a backend
+    # streams ahead of it; show only clean reasoning prose in the live feed.
     if event.event_type == "thought" {
         cleaned = self._strip_control(tok);
         if cleaned {


### PR DESCRIPTION
## Summary

- Replace the raw token firehose in `jac ai --ui` with a **per-model-call token-usage stream** — one row per LLM call showing tokens in/out, cache read/created, latency, and the phase it belongs to (or `route` for the routing decision).
- Make activity-log **tool outputs collapsible dropdowns** — the call header always shows, the output is closed by default and scrolls within itself when expanded. Raise the displayed tool-result cap from 500 to 4000 chars (display only; full results still reach model history).
- byLLM now reports per-call input + cache counters on its `llm_timing` event, and emits one for the structured/handler path too, so the routing call's usage is captured.

## Why

Relates to #6231. The agent's token hotspots — the routing call that serializes each candidate node's full `ctx`, the cache-busting phase-finish calls, and per-phase cache reuse — were invisible in the UI. The per-call stream surfaces them directly: e.g. the QA→Done routing call shows as a ~100k-token `in` spike with zero cache reuse, and phase starts visibly reset cache reads to 0.

## Test plan

- [ ] `jac ai --ui`, run a build: the bottom pane shows one row per model call (in / out / cache / latency); the `route` row shows the large tokens-in spike; phase entries reset cache_read to 0.
- [ ] Activity-log tool entries are collapsed by default; clicking expands them; long outputs scroll within the dropdown.
- [ ] Terminal `jac ai` (non-UI) still renders normally (the per-call emit is a no-op when the UI bus is inactive).