### PR TITLE
fix(compiler): reject glob-in-function at run time and harden E0063 scope check

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6238.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6238.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `glob` outside module scope is now rejected before execution**: `glob` used inside a function, a `with entry` block, or a `test` block emits `E0063` and now blocks code generation, so `jac run` exits without executing the invalid module instead of running it. `glob` remains valid at module level and inside `cl`/`sv`/`na` codespace blocks.

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -438,6 +438,11 @@ obj JacCompiler {
         cancel_token: (Event | None) = None
     ) -> None;
 
+    """Count codegen-blocking errors attributed to a specific module file."""
+    static def _count_module_blocking_errors(
+        target_program: JacProgram, mod_path: str
+    ) -> int;
+
     static def _prepare_tool_program(
         source_str: str,
         file_path: str,

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -26,7 +26,14 @@ obj DiagnosticInfo {
         category: Category,
         message_template: str,
         help_text: str | None = None,
-        url_slug: str | None = None;
+        url_slug: str | None = None,
+        # When True, this error blocks Python code generation for the module
+        # it is reported in, so the invalid construct cannot be executed.
+        # Most structural errors are reported but non-fatal (the codebase
+        # generates code through them, e.g. E0076 duplicate method); set this
+        # only for constructs that would otherwise compile to valid-but-wrong
+        # Python and silently run (e.g. E0063 glob inside a function).
+        blocks_codegen: bool = False;
 
     def format_message(**kwargs: object) -> str {
         try {
@@ -44,7 +51,8 @@ def _reg(
     severity: Severity,
     category: Category,
     template: str,
-    help_text: str | None = None
+    help_text: str | None = None,
+    blocks_codegen: bool = False
 ) -> DiagnosticInfo {
     info = DiagnosticInfo(
         code=code,
@@ -52,7 +60,8 @@ def _reg(
         category=category,
         message_template=template,
         help_text=help_text,
-        url_slug=code.lower()
+        url_slug=code.lower(),
+        blocks_codegen=blocks_codegen
     );
     DIAGNOSTICS[code] = info;
     return info;
@@ -60,9 +69,13 @@ def _reg(
 
 # Shorthand aliases
 def _err(
-    code: str, cat: Category, tmpl: str, help: str | None = None
+    code: str,
+    cat: Category,
+    tmpl: str,
+    help: str | None = None,
+    blocks_codegen: bool = False
 ) -> DiagnosticInfo {
-    return _reg(code, Severity.ERROR, cat, tmpl, help);
+    return _reg(code, Severity.ERROR, cat, tmpl, help, blocks_codegen);
 }
 
 def _warn(
@@ -217,7 +230,8 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "E0063",
          Category.SYNTAX,
          "'glob' is only valid at module level",
-         help="Move the glob declaration to the top of the file, outside any function or code block."
+         help="Move the glob declaration to the top of the file, outside any function or code block.",
+         blocks_codegen=True
      ),
      E0065 = _err("E0065", Category.SYNTAX, "Duplicate keyword argument '{name}'"),
      E0066 = _err(

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -229,7 +229,7 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
      E0063 = _err(
          "E0063",
          Category.SYNTAX,
-         "'glob' is only valid at module level",
+         "'glob' is only valid at module level, perhaps you mean global",
          help="Move the glob declaration to the top of the file, outside any function or code block.",
          blocks_codegen=True
      ),

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -635,6 +635,14 @@ impl JacCompiler.compile(
         keep_str, file_path, actual_program, cancel_token=options.cancel_token
     );
     had_parse_errors = len(actual_program.errors_had) > had_parse_errors;
+    # Count codegen-blocking errors attributed to *this* module only. The IR
+    # schedule below recursively compiles imported modules into the same
+    # program; filtering by file path keeps a nested module's diagnostics from
+    # poisoning this module's codegen gate.
+    cur_mod_path = os.path.normpath(file_path);
+    blocking_errs_pre_ir = self._count_module_blocking_errors(
+        actual_program, cur_mod_path
+    );
     if options.symtab_ir_only {
         self.run_schedule(
             mod=mod_targ,
@@ -650,6 +658,15 @@ impl JacCompiler.compile(
             cancel_token=options.cancel_token
         );
     }
+    # Diagnostics flagged blocks_codegen (e.g. E0063 glob inside a function)
+    # must prevent code generation just like parse errors, otherwise an
+    # invalid construct that happens to compile to valid Python would silently
+    # execute. Structural errors not flagged blocking (e.g. E0076 duplicate
+    # method) stay non-fatal, matching the codebase's lenient codegen policy.
+    blocking_errs_post_ir = self._count_module_blocking_errors(
+        actual_program, cur_mod_path
+    );
+    had_blocking_errors = blocking_errs_post_ir > blocking_errs_pre_ir;
     # Native-compiled modules consume the central type checker's results:
     # NaIRGenPass lowers Expr.type (via _lower_type) instead of running a
     # parallel AST type resolver. Run the type-check schedule for any .na.jac
@@ -719,7 +736,7 @@ impl JacCompiler.compile(
             cancel_token=options.cancel_token
         );
     }
-    if (not had_parse_errors and not options.no_cgen) {
+    if (not had_parse_errors and not had_blocking_errors and not options.no_cgen) {
         # Re-pin _compile_options to *our* options before codegen runs.
         # Earlier schedules may have invoked nested compile()s (e.g.
         # TypeCheckPass loading an imported module to resolve a symbol),
@@ -765,6 +782,26 @@ impl JacCompiler.run_schedule(
         }
         current_pass(ir_in=mod, prog=target_program, cancel_token=cancel_token);
     }
+}
+
+impl JacCompiler._count_module_blocking_errors(
+    target_program: JacProgram, mod_path: str
+) -> int {
+    count = 0;
+    for e in target_program.errors_had {
+        if e.code is None or not e.code.blocks_codegen {
+            continue;
+        }
+        try {
+            e_path = os.path.normpath(e.loc.mod_path);
+        } except Exception {
+            continue;
+        }
+        if e_path == mod_path {
+            count += 1;
+        }
+    }
+    return count;
 }
 
 """Parse a Jac file/string and optionally load annexes for tooling passes.

--- a/jac/jaclang/jac0core/passes/impl/ast_validation_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/ast_validation_pass.impl.jac
@@ -235,9 +235,14 @@ impl ASTValidationPass.enter_non_local_stmt(
 impl ASTValidationPass.enter_global_vars(
     self: ASTValidationPass, nd: uni.GlobalVars
 ) -> None {
-    if nd.find_parent_of_type(uni.ModuleCode) is not None
-    or nd.find_parent_of_type(uni.Ability) is not None
-    or nd.find_parent_of_type(uni.ImplDef) is not None {
+    # glob is a declaration: it is valid directly under the module or a
+    # codespace block (cl/sv/na), but never inside a function body, impl,
+    # archetype, or an executable code block ('with entry', loops, test, etc.).
+    # Whitelisting valid parents rejects unknown containers by default, which
+    # is safer than blacklisting (a new executable block type can't slip glob
+    # through).
+    valid_parents = (uni.Module, uni.ClientBlock, uni.ServerBlock, uni.NativeBlock);
+    if not isinstance(nd.parent, valid_parents) {
         self.emit(E0063, node_override=nd);
     }
 }

--- a/jac/tests/compiler/passes/main/test_new_diagnostics.jac
+++ b/jac/tests/compiler/passes/main/test_new_diagnostics.jac
@@ -426,12 +426,33 @@ test "E0063: glob in statement position is always rejected" {
         "with entry { glob a = }",
         "with entry { glob a }",
         "with entry { glob }",
-        "def foo() -> int { glob a = 1; return a; }"
+        "def foo() -> int { glob a = 1; return a; }",
+        "test \"t\" { glob sneaky = 1; assert True; }"
     ];
     for src in sources {
         (has_err, _) = parse_and_validate(src);
         assert has_err , f"Expected error for: {src}";
     }
+}
+
+test "E0063: glob inside a codespace block is valid" {
+    # glob is a declaration, so it is allowed directly under cl/sv/na blocks.
+    for src in ["cl { glob counter: int = 0; }", "sv { glob token = \"x\"; }"] {
+        (has_err, _) = parse_and_validate(src);
+        assert not has_err , f"Unexpected error for: {src}";
+    }
+}
+
+test "E0063: glob inside a function produces no runnable bytecode" {
+    # Detected by ASTValidationPass (not the parser), and the structural
+    # error must block codegen so the invalid module cannot silently execute.
+    prog = JacProgram();
+    mod = prog.compile(
+        file_path="/tmp/test_e0063_gate.jac",
+        use_str="def foo() -> int { glob a = 1; return a; }"
+    );
+    assert has_diagnostic_code(prog, "E0063");
+    assert not mod.gen.py_bytecode;
 }
 
 # ══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Follow-up to #5953. That PR moved `glob`-scope detection into `ASTValidationPass` and gives a clear `E0063` message, but two gaps remain:

- **`jac run` still executes glob-in-function code.** `E0063` is reported with a non-zero exit, but code generation is gated only on *parse* errors. Since `glob` now parses permissively into a `GlobalVars` node, a glob inside a function compiles to valid-but-wrong Python and silently runs — the exact "silent execution" the original issue (#5849) set out to fix.
- **The scope check has a false negative.** `enter_global_vars` used an ancestor blacklist (`ModuleCode`/`Ability`/`ImplDef`), which misses `glob` inside a `test { ... }` block and silently re-allows `glob` in any executable container added in the future.

## What changed

- Add a per-diagnostic `blocks_codegen` policy field to `DiagnosticInfo` (threaded through `_reg`/`_err`); mark `E0063` as blocking.
- Gate code generation in `JacCompiler.compile()` on blocking errors **attributed to the current module's file**. Per-file attribution prevents a nested import's diagnostics from poisoning the parent module's gate. Structural errors that are intentionally non-fatal (e.g. `E0076` duplicate method) stay lenient, so the self-hosted bootstrap is unaffected.
- Replace the blacklist in `enter_global_vars` with a **whitelist** of valid direct parents: `Module` plus the `cl`/`sv`/`na` codespace blocks. Unknown/executable containers are rejected by default.

## Behavior

| input | before this PR | after |
| --- | --- | --- |
| `glob` at module level | runs | runs |
| `glob` inside `cl`/`sv`/`na` block | runs | runs |
| `glob` inside a function | reports E0063 **but still runs** | reports E0063, **does not run** (exit 1) |
| `glob` inside `with entry { }` | reports E0063 but still runs | reports E0063, does not run |
| `glob` inside `test { }` | not detected | reports E0063, does not run |

## Test plan

- [x] `tests/compiler/passes/main/test_new_diagnostics.jac` — added codegen-gate, codespace-block-valid, and test-block reject cases
- [x] `jac run` on glob-in-function exits 1 without executing; module-level and `cl {}` glob run normally
- [x] grammar-extract, esast, and micro suite (E0076-tolerant fixtures) remain green
- [ ] full compiler + language suite