### PR TITLE
refactor(test): remove check; tests use assert exclusively

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6251.breaking.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6251.breaking.md
@@ -1,0 +1,1 @@
+- **Breaking: `check` removed in favor of `assert`**: Test assertions are written with `assert` on every backend; a failing test assertion now raises a plain `AssertionError`.

--- a/jac/jaclang/jac0core/constant.jac
+++ b/jac/jaclang/jac0core/constant.jac
@@ -95,7 +95,6 @@ class Constants(StrEnum) {
         ROOT = 'root';
         VISITOR = 'visitor';
         GUEST = '__guest__';
-        JAC_CHECK = '_check';
         SUPER_ROOT_UUID = '00000000-0000-0000-0000-000000000000';
     }
 

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -1326,7 +1326,7 @@ impl JacBasics.jac_test(description: str = "") -> Callable {
         file_path = getfile(test_fun);
         func_name = test_fun.__name__;
         def test_deco {
-            test_fun(JacTestCheck());
+            test_fun();
         }
         test_deco.__name__ = test_fun.__name__;
         JacTestCheck.add_test(

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -975,9 +975,7 @@ impl PyastGenPass.exit_test(nd: uni.Test) -> None {
             args=self.sync(
                 ast3.arguments(
                     posonlyargs=[],
-                    args=[
-                        self.sync(ast3.arg(arg=Con.JAC_CHECK.value, annotation=None))
-                    ],
+                    args=[],
                     kwonlyargs=[],
                     vararg=None,
                     kwarg=None,
@@ -2176,128 +2174,16 @@ impl PyastGenPass.exit_raise_stmt(nd: uni.RaiseStmt) -> None {
 }
 
 impl PyastGenPass.exit_assert_stmt(nd: uni.AssertStmt) -> None {
-    if isinstance(nd.parent, uni.Test) {
-        self.assert_helper(nd);
-    } else {
-        nd.gen.py_ast = [
-            self.sync(
-                ast3.Assert(
-                    `test=cast(ast3.expr, self.py_ast_val(nd.condition)),
-                    msg=cast(ast3.expr, self.py_ast_val(nd.error_msg))
-                        if nd.error_msg
-                        else None
-                )
+    nd.gen.py_ast = [
+        self.sync(
+            ast3.Assert(
+                `test=cast(ast3.expr, self.py_ast_val(nd.condition)),
+                msg=cast(ast3.expr, self.py_ast_val(nd.error_msg))
+                    if nd.error_msg
+                    else None
             )
-        ];
-    }
-}
-
-"""Sub objects.
-
-        target: ExprType,
-        """
-impl PyastGenPass.assert_helper(nd: uni.AssertStmt) -> None {
-    @dataclass
-    class CheckNodeIsinstanceCallResult {
-        with entry {
-            isit: bool = False;
-            inst: (ast3.AST | None) = None;
-            clss: (ast3.AST | None) = None;
-        }
-    }
-    def check_node_isinstance_call(nd: uni.FuncCall) -> CheckNodeIsinstanceCallResult {
-        if not (
-            (len(nd.params) == 2)
-            and isinstance(nd.params[0], uni.Expr)
-            and isinstance(nd.params[1], uni.Expr)
-        ) {
-            return CheckNodeIsinstanceCallResult();
-        }
-        func = self.py_ast_val(nd.target);
-        if not (isinstance(func, ast3.Name) and (func.id == 'isinstance')) {
-            return CheckNodeIsinstanceCallResult();
-        }
-        return CheckNodeIsinstanceCallResult(
-            True, self.py_ast_val(nd.params[0]), self.py_ast_val(nd.params[1])
-        );
-    }
-    assert_func_name = 'assertTrue';
-    assert_args_list = nd.condition.gen.py_ast;
-    if (
-        isinstance(nd.condition, uni.CompareExpr)
-        and isinstance(self.py_ast_val(nd.condition), ast3.Compare)
-        and (len(nd.condition.ops) == 1)
-    ) {
-        expr: uni.CompareExpr = nd.condition;
-        opty: uni.Token = expr.ops[0];
-        optype2fn = {
-            Tok.EE.name: 'assertEqual',
-            Tok.NE.name: 'assertNotEqual',
-            Tok.LT.name: 'assertLess',
-            Tok.LTE.name: 'assertLessEqual',
-            Tok.GT.name: 'assertGreater',
-            Tok.GTE.name: 'assertGreaterEqual',
-            Tok.KW_IN.name: 'assertIn',
-            Tok.KW_NIN.name: 'assertNotIn',
-            Tok.KW_IS.name: 'assertIs',
-            Tok.KW_ISN.name: 'assertIsNot'
-        };
-        if (opty.name in optype2fn) {
-            assert_func_name = optype2fn[opty.name];
-            assert_args_list = [
-                self.py_ast_val(expr.left),
-                self.py_ast_val(expr.rights[0])
-            ];
-            if ((opty.name == Tok.KW_IS) and isinstance(expr.rights[0], uni.Null)) {
-                assert_func_name = 'assertIsNone';
-                assert_args_list.pop();
-            } elif (
-                (opty.name == Tok.KW_ISN) and isinstance(expr.rights[0], uni.Null)
-            ) {
-                assert_func_name = 'assertIsNotNone';
-                assert_args_list.pop();
-            }
-        }
-    } elif (
-        isinstance(nd.condition, uni.FuncCall)
-        and isinstance(self.py_ast_val(nd.condition), ast3.Call)
-    ) {
-        res = check_node_isinstance_call(nd.condition);
-        if res.isit {
-            assert isinstance(res.inst, ast3.AST);
-            assert isinstance(res.clss, ast3.AST);
-            assert_func_name = 'assertIsInstance';
-            assert_args_list = [res.inst, res.clss];
-        }
-    } elif (
-        isinstance(nd.condition, uni.UnaryExpr)
-        and isinstance(nd.condition, uni.UnaryExpr)
-        and isinstance(nd.condition.operand, uni.FuncCall)
-        and isinstance(nd.condition.operand, uni.UnaryExpr)
-    ) {
-        res = check_node_isinstance_call(nd.condition.operand);
-        if res.isit {
-            assert isinstance(res.inst, ast3.AST);
-            assert isinstance(res.clss, ast3.AST);
-            assert_func_name = 'assertIsNotInstance';
-            assert_args_list = [res.inst, res.clss];
-        }
-    }
-    assert_func_expr: ast3.Attribute = self.sync(
-        ast3.Attribute(
-            value=self.sync(ast3.Name(id=Con.JAC_CHECK.value, ctx=ast3.Load())),
-            attr=assert_func_name,
-            ctx=ast3.Load()
         )
-    );
-    assert_call_expr: ast3.Call = self.sync(
-        ast3.Call(
-            func=assert_func_expr,
-            args=[cast(ast3.expr, arg) for arg in assert_args_list],
-            keywords=[]
-        )
-    );
-    nd.gen.py_ast = [self.sync(ast3.Expr(assert_call_expr))];
+    ];
 }
 
 impl PyastGenPass.exit_ctrl_stmt(nd: uni.CtrlStmt) -> None {

--- a/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
+++ b/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
@@ -351,12 +351,6 @@ variables
     def exit_expr_as_item(nd: uni.ExprAsItem) -> None;
     def exit_raise_stmt(nd: uni.RaiseStmt) -> None;
     def exit_assert_stmt(nd: uni.AssertStmt) -> None;
-    """Sub objects.
-
-        target: ExprType,
-        """
-    def assert_helper(nd: uni.AssertStmt) -> None;
-
     def exit_ctrl_stmt(nd: uni.CtrlStmt) -> None;
     def exit_delete_stmt(nd: uni.DeleteStmt) -> None;
     def exit_report_stmt(nd: uni.ReportStmt) -> None;

--- a/jac/jaclang/runtimelib/impl/test.impl.jac
+++ b/jac/jaclang/runtimelib/impl/test.impl.jac
@@ -1,10 +1,5 @@
 import from jaclang.cli.console { console }
 
-"""Make convenient check.Equal(...) etc."""
-impl JacTestCheck.__getattr__(name: str) -> object {
-    return getattr(JacTestCheck.test_case, name);
-}
-
 """Create a new test."""
 impl JacTestCheck.add_test(
     filepath: str, func_name: str, test_func: Callable, display_name: str = ""
@@ -80,7 +75,6 @@ impl JacTestCheck.run_test(
 
 """Clear the test suite."""
 impl JacTestCheck.reset -> None {
-    JacTestCheck.test_case = unittest.TestCase();
     JacTestCheck.test_suite = unittest.TestSuite();
     JacTestCheck.test_suite_path = {};
 }

--- a/jac/jaclang/runtimelib/test.jac
+++ b/jac/jaclang/runtimelib/test.jac
@@ -24,7 +24,6 @@ obj JacTextTestRunner(unittest.TextTestRunner) {
 """Jac Testing and Checking."""
 obj JacTestCheck {
     with entry {
-        test_case = unittest.TestCase();
         test_suite = unittest.TestSuite();
     }
 
@@ -55,8 +54,6 @@ obj JacTestCheck {
     static def add_test(
         filepath: str, func_name: str, test_func: Callable, display_name: str = ""
     ) -> None;
-
-    def __getattr__(name: str) -> object;
 }
 
 """Register one test per parameter (like pytest.mark.parametrize)."""


### PR DESCRIPTION
## Summary
- Removes `check`, the `unittest.TestCase` proxy the compiler injected into every test block as the `_check` parameter. It rewrote `assert x == y` inside a test into `_check.assertEqual(x, y)`, so `assert` behaved differently inside tests than everywhere else.
- Tests now use plain `assert` on every backend; assertion semantics are identical inside and outside test blocks.
- Drops the `JAC_CHECK` constant, the `assert_helper` lowering (and its decl), `jac_test`'s `_check` argument, and `JacTestCheck`'s assertion proxy (`__getattr__` + the shared `unittest.TestCase`). The test registry/runner is unchanged.

## Behavior change
- A failing `assert` inside a test now raises a bare `AssertionError` under the unittest runner instead of an `assertEqual`-style value diff.
- Custom assert messages (`assert x == y, "msg"`) are now honored inside tests; previously they were dropped.

## Test plan
- [x] `jac test jac/tests/compiler/passes/main/test_checker_pass.jac` — 215 tests pass
- [x] `==`, `in`, `isinstance` asserts pass; a failing assert is reported with its message
- [ ] CI green