### PR TITLE
fix(type-checker): substitute glob-form TypeVars at free-function call sites

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6257.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6257.bugfix.md
@@ -1,0 +1,1 @@
+- **Generic free functions now narrow to the argument's actual type**: calling `identity(d)` where `d` is a subclass returns the subclass, so accessing subclass-only members no longer raises a spurious "cannot access attribute" against the bound.

--- a/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
@@ -593,6 +593,12 @@ impl apply_solved_type_vars(
             and ty.name in solution {
                 is_declared_class_param = True;
             }
+            # Free-function path: no class context → per-call solution is authoritative.
+            if not is_declared_class_param
+            and class_type is None
+            and ty.name in solution {
+                is_declared_class_param = True;
+            }
         }
         if not is_declared_class_param {
             return ty;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_typevar_glob_free_func.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_bug_typevar_glob_free_func.jac
@@ -1,0 +1,21 @@
+import from typing { TypeVar }
+
+obj Base {
+    has tag: str = "base";
+}
+
+obj Derived(Base) {
+    has derived_attr: str = "extra";
+}
+
+glob T = TypeVar('T', bound=Base);
+
+def identity(x: T) -> T {
+    return x;
+}
+
+glob d = Derived();
+
+with entry {
+    print(identity(d).derived_attr);
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -485,6 +485,14 @@ test "bug_tvar5_module_typevar_shadowed_by_class_param" {
     assert 23 not in error_lines , f"Line 23 should NOT error, got {error_lines}.";
 }
 
+# Bug #TVAR-6: glob-form TypeVar not solved at free-function call sites.
+test "bug_tvar6_glob_typevar_in_free_function" {
+    program = compile_and_check("checker_bug_typevar_glob_free_func.jac");
+    assert len(program.errors_had) == 0 , f"Bug #TVAR-6: Expected 0 errors but got {len(
+        program.errors_had
+    )}: {[e.msg for e in program.errors_had]}.";
+}
+
 # =========================================================================
 # Bug #IMPL-1: `has` var reassigned in impl body shadows the parent type
 #


### PR DESCRIPTION
## Summary

`glob T = TypeVar('T', bound=Base)` used in a free function signature was not solved at the call site, so the return type stayed as the raw TypeVar and downstream attribute access fell back on the bound. A subclass-only member like `Derived.derived_attr` then surfaced as a spurious `E1031 Cannot access attribute "..." for type "Base"`.

Minimal repro (now passes):

```jac
import from typing { TypeVar }
obj Base { has tag: str = \"base\"; }
obj Derived(Base) { has derived_attr: str = \"extra\"; }
glob T = TypeVar('T', bound=Base);
def identity(x: T) -> T { return x; }
with entry {
    d = Derived();
    print(identity(d).derived_attr);  # was: E1031 on Base
}
```
## Root cause

`apply_solved_type_vars` (commit 034cb89e, #TVAR-5) was hardened to stop module-level TypeVars from being clobbered by inherited class type params in a **class** context. The guard requires \`is_class_type_param\` OR \`bound is None\` to substitute, which is correct inside a class.

The free-function path goes through `FunctionType.specialize_func_type_vars` and calls `apply_solved_type_vars(ty, solution)` with **`class_type=None`** and a per-call `solution` produced by `_collect_type_var_bindings`. That solution is authoritative for this call, but the guard refused to substitute a bounded, non-class TypeVar — silently dropping the binding.

## Fix

In `apply_solved_type_vars`, when `class_type is None` and `ty.name` is in `solution`, allow substitution. The class-context misbinding guard is unchanged for class contexts.

The change is 10 lines and additive — it doesn't touch any existing condition.

## Test plan

- [x] New fixture: \`checker_bug_typevar_glob_free_func.jac\`
- [x] New regression test: \`bug_tvar6_glob_typevar_in_free_function\` in \`test_checker_bugs.jac\`
- [x] Existing #TVAR-5 class-context regression guard (\`bug_tvar5_module_typevar_shadowed_by_class_param\`) still passes
- [x] \`test_checker_bugs\` 35/35 pass
- [x] \`test_checker_gaps\` 18/18 pass
- [x] \`test_checker_pass\` 216/216 pass
- [x] \`test_typevar\` 9/9 pass
- [x] \`test_checker_production\` 10/10 pass
- [x] \`test_checker_shortcomings\` 9/9 pass