### PR TITLE
feat(runtime): unify the @jac/runtime surface as a single contract

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6268.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6268.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `try`/`awaiting`/`except` JSX under bare-serve**: Bare-serve now provides the `JacAwaiting` and client error-boundary wrappers the compiler emits for these views, so a bare-serve app using them no longer fails with an unresolved `@jac/runtime` import.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6268.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6268.feature.md
@@ -1,0 +1,1 @@
+- **Bare-serve auto-caches reader endpoints**: The dependency-free bare-serve client runtime now caches reader walker and function calls, dedups concurrent identical requests, and invalidates on writes and auth changes, matching jac-client.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6268.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6268.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Single `@jac/runtime` surface contract**: The client runtime surface shared by bare-serve and jac-client is now declared in one place, so the compiler's import injection and the cross-runtime alignment check derive from a single source instead of separately maintained copies.

--- a/jac/jaclang/cli/commands/impl/eject.impl.jac
+++ b/jac/jaclang/cli/commands/impl/eject.impl.jac
@@ -426,10 +426,11 @@ function definition signature and skip the injection to avoid a circular
 import.
 """
 def _inject_runtime_imports(js_code: str) -> str {
+    import from jaclang.runtimelib.client_surface { prepended_runtime_import }
     if "function __jacJsx(" in js_code {
         return js_code;
     }
-    return 'import {__jacJsx, __jacSpawn} from "@jac/runtime";\n' + js_code;
+    return prepended_runtime_import() + '\n' + js_code;
 }
 
 

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -316,7 +316,6 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def _get_setter_name(var_name: str) -> str;
     def _has_import(name: str) -> bool;
     def _inject_runtime_import(name: str, nd: uni.UniNode) -> None;
-    def _inject_react_import(name: str, nd: uni.UniNode) -> None;
     def _ref_head_name(expr: (uni.UniNode | None)) -> (str | None);
     def _register_jac_runtime_import -> None;
     def _transform_to_useeffect(nd: uni.Ability) -> None;

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -3378,51 +3378,35 @@ impl EsastGenPass._register_jac_runtime_import -> None {
     }
 }
 
-"""Auto-inject a named import from @jac/runtime (e.g. useState, useEffect, __jacCallFunction)."""
+"""Auto-inject a named import for a runtime symbol (e.g. useState, useEffect,
+__jacCallFunction, useRef).
+
+The `client_surface` contract decides where each symbol resolves: `@jac/runtime`
+for everything both runtimes back, or `react` for primitives taken straight from
+React (e.g. `useRef`, which needs no `@jac/runtime` shim). Only `@jac/runtime`
+symbols register the runtime for inlining — `react` is an ordinary dependency."""
 impl EsastGenPass._inject_runtime_import(name: str, nd: uni.UniNode) -> None {
+    import from jaclang.runtimelib.client_surface { runtime_import_source }
     if name in self.injected_imports or self._has_import(name) {
         return;
     }
+    src = runtime_import_source(name);
     specifier = self.sync_loc(
         es.ImportSpecifier(
             imported=es.Identifier(name=name), local=es.Identifier(name=name)
         ),
         jac_node=nd
     );
-    source = self.sync_loc(
-        es.Literal(value='@jac/runtime', raw='"@jac/runtime"'), jac_node=nd
-    );
+    source = self.sync_loc(es.Literal(value=src, raw='"' + src + '"'), jac_node=nd);
     import_decl = self.sync_loc(
         es.ImportDeclaration(specifiers=[specifier], source=source), jac_node=nd
     );
     self.imports.append(import_decl);
     self.injected_imports.add(name);
-    # Register in client manifest so bundler knows to inline the runtime
-    self._register_jac_runtime_import();
-}
-
-"""Auto-inject a named import from `react` (e.g. useRef).
-
-Unlike `_inject_runtime_import`, this targets `react` directly: `useRef`
-is a plain React primitive with no reactivity, so it needs no `@jac/runtime`
-shim (which exists only to bridge `useState`/`useEffect` into Jac's reactive
-core). No `_register_jac_runtime_import` — react is an ordinary dependency."""
-impl EsastGenPass._inject_react_import(name: str, nd: uni.UniNode) -> None {
-    if name in self.injected_imports or self._has_import(name) {
-        return;
+    if src == '@jac/runtime' {
+        # Register in client manifest so bundler knows to inline the runtime.
+        self._register_jac_runtime_import();
     }
-    specifier = self.sync_loc(
-        es.ImportSpecifier(
-            imported=es.Identifier(name=name), local=es.Identifier(name=name)
-        ),
-        jac_node=nd
-    );
-    source = self.sync_loc(es.Literal(value='react', raw='"react"'), jac_node=nd);
-    import_decl = self.sync_loc(
-        es.ImportDeclaration(specifiers=[specifier], source=source), jac_node=nd
-    );
-    self.imports.append(import_decl);
-    self.injected_imports.add(name);
 }
 
 """Leftmost identifier of a call/subscript chain, or None.
@@ -3569,7 +3553,7 @@ impl EsastGenPass.exit_arch_has(nd: uni.ArchHas) -> None {
             if ref_typed and not ref_ctor {
                 self.emit(E2025, node_override=has_var);
             }
-            self._inject_react_import('useRef', nd);
+            self._inject_runtime_import('useRef', nd);
             # The field is constructed as `= Ref()` / `= Ref(initial)` — a
             # Jac-only ambient with no JS counterpart. So we don't emit the
             # `Ref(...)` call itself; we lift its sole argument (the seed for

--- a/jac/jaclang/runtimelib/client_runtime.cl.jac
+++ b/jac/jaclang/runtimelib/client_runtime.cl.jac
@@ -17,6 +17,18 @@ def __buildDom(nd: any) -> any;
 # Internal: Apply property to DOM element
 def __applyProp(element: any, key: str, value: any) -> None;
 # ============================================================================
+# View wrappers — compiler-emitted for `try`/`awaiting`/`except` JSX
+# ============================================================================
+# Synthesized by the view-lowering pass: `try { ... } awaiting { ... }` lowers
+# to `<JacAwaiting fallback={...}>{...}</JacAwaiting>`, and `except` arms add a
+# `<JacClientErrorBoundary fallback={...}>`. jac-client backs these with
+# `React.Suspense` and `react-error-boundary`; bare-serve has neither, so these
+# render their resolved children directly (no suspense, no error capture). They
+# exist so the same view code compiles and the emitted imports resolve in both
+# runtimes.
+def JacAwaiting(props: dict[str, any]) -> any;
+def JacClientErrorBoundary(props: dict[str, any]) -> any;
+# ============================================================================
 # Reactive State Management System
 # ============================================================================
 
@@ -145,6 +157,38 @@ async def __jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) ->
 def jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) -> any;
 # Function call function - calls server-side functions from client
 async def __jacCallFunction(function_name: str, args: dict[str, any] = {}) -> any;
+# ============================================================================
+# Auto-cache — compiler-driven caching for walker/function calls
+# ============================================================================
+# Reader endpoints are cached (LRU + TTL) and concurrent identical requests are
+# deduped; writer endpoints invalidate the readers they touch. Endpoint effects
+# are supplied by the compiler (serialized into `globalThis.__jacEndpointEffects__`
+# at module load, with a `__jac_init__` fallback), so an endpoint with no
+# metadata simply fetches directly. Runtime-agnostic — same logic backs
+# jac-client; bare-serve owns it natively with no npm dependency.
+
+# Read compiler-provided endpoint effects.
+def __getEndpointEffects -> dict[str, any];
+# Get or initialize cache state on globalThis.
+def __getCacheState -> dict[str, any];
+# Whether a cache entry is still within its TTL.
+def __isFresh(`entry: dict[str, any]) -> bool;
+# Get a cache entry and promote it in LRU order.
+def __cacheGet(key: str) -> any;
+# Store an entry with LRU eviction.
+def __cacheSet(key: str, data: any, ttl: int) -> None;
+# Evict the oldest cache entry.
+def __evictOldest -> None;
+# Whether two lists share any element.
+def __overlaps(list1: list[any], list2: list[any]) -> bool;
+# Invalidate all cache entries under an endpoint-key prefix.
+def __invalidateEndpoint(endpoint_key: str) -> None;
+# Raw walker fetch (POST /walker/<name>[/<nodeId>]) — no caching.
+async def __doWalkerFetch(`walker: str, nodeId: str, fields: dict[str, any]) -> any;
+# Raw function fetch (POST /function/<name>) — no caching.
+async def __doFuncFetch(function_name: str, args: dict[str, any]) -> any;
+# Cache-aware dispatch shared by __jacSpawn and __jacCallFunction.
+async def __cachedEndpointCall(endpoint_key: str, args_key: str, fetch_fn: any) -> any;
 # Authentication helpers
 def __normalizeIdentity(x: any) -> dict[str, any];
 def __normalizeCredential(x: any) -> dict[str, any];

--- a/jac/jaclang/runtimelib/client_surface.jac
+++ b/jac/jaclang/runtimelib/client_surface.jac
@@ -1,0 +1,270 @@
+"""Single source of truth for the `@jac/runtime` client surface contract.
+
+`@jac/runtime` is a virtual module backed by two runtimes: bare-serve's
+`jaclang/runtimelib/client_runtime.cl.jac` (zero npm deps, native JS) and
+jac-client's `jac_client/plugin/client_runtime.cl.jac` (React-backed). User
+`.cl.jac` code is portable between them only while their public surfaces stay
+aligned.
+
+This module declares that surface once. The pieces that used to hardcode their
+own copy of it now derive from here instead:
+
+  * the ECMAScript pass asks `runtime_import_source` where each emitted runtime
+    symbol is imported from, so the import source lives in one place;
+  * the `eject` and HMR bundle paths build their prepended JSX-runtime import
+    from `prepended_runtime_import`;
+  * the runtime-surface-alignment test derives its expectations from
+    `aligned_surface` / `production_surface` / `routing_surface` /
+    `compiler_emitted_surface`.
+
+Tiers
+  ALIGNED     Must be exported by BOTH runtimes — either user-facing (imported
+              via `import from "@jac/runtime"`) or emitted by the compiler.
+              Breaking alignment breaks cross-runtime portability.
+  PRODUCTION  jac-client only. Bare-serve omits these; they are irreducibly
+              tied to React / Zod / react-router, or — like `useRef` — imported
+              straight from `react` and so never resolved through the runtime.
+"""
+
+enum RuntimeTier { ALIGNED, PRODUCTION }
+
+"""One symbol on the `@jac/runtime` surface.
+
+`source` is the module the compiler imports the symbol from (`@jac/runtime` for
+everything the runtimes back, `react` for primitives taken straight from React).
+`emitted` marks symbols the compiler references by name in generated code (so
+both runtimes must provide them). `prepend` marks the bare global identifiers
+the compiler emits without an explicit import node — the bundle paths prepend a
+single import statement covering them.
+"""
+obj RuntimeSymbol {
+    has name: str,
+        tier: RuntimeTier,
+        category: str,
+        source: str = "@jac/runtime",
+        emitted: bool = False,
+        prepend: bool = False;
+}
+
+glob CLIENT_RUNTIME_SURFACE: list[RuntimeSymbol] = [
+         # ---- JSX factory (emitted as a bare global; prepended as a bundle import) -
+         RuntimeSymbol(
+             name="__jacJsx",
+             tier=RuntimeTier.ALIGNED,
+             category="jsx",
+             emitted=True,
+             prepend=True
+         ),
+         # ---- Walker / function calls ------------------------------------------
+         RuntimeSymbol(
+             name="__jacSpawn",
+             tier=RuntimeTier.ALIGNED,
+             category="walker",
+             emitted=True,
+             prepend=True
+         ),
+         RuntimeSymbol(name="jacSpawn", tier=RuntimeTier.ALIGNED, category="walker"),
+         RuntimeSymbol(
+             name="__jacCallFunction",
+             tier=RuntimeTier.ALIGNED,
+             category="walker",
+             emitted=True
+         ),
+         # ---- Reactive hooks (emitted for `has` fields / event abilities) ------
+         RuntimeSymbol(
+             name="useState", tier=RuntimeTier.ALIGNED, category="hooks", emitted=True
+         ),
+         RuntimeSymbol(
+             name="useEffect", tier=RuntimeTier.ALIGNED, category="hooks", emitted=True
+         ),
+         # `useRef` is imported straight from `react`, so it never resolves through
+         # the runtime: `Ref[T]` fields are a jac-client-only capability today.
+         RuntimeSymbol(
+             name="useRef",
+             tier=RuntimeTier.PRODUCTION,
+             category="hooks",
+             source="react",
+             emitted=True
+         ),
+         # ---- View wrappers (emitted for `try`/`awaiting`/`except` JSX) ---------
+         RuntimeSymbol(
+             name="JacAwaiting", tier=RuntimeTier.ALIGNED, category="view", emitted=True
+         ),
+         RuntimeSymbol(
+             name="JacClientErrorBoundary",
+             tier=RuntimeTier.ALIGNED,
+             category="view",
+             emitted=True
+         ),
+         # ---- Routing (React Router v6-shaped) ---------------------------------
+         RuntimeSymbol(name="Router", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="Routes", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="Route", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="Link", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="Navigate", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="Outlet", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(
+             name="useNavigate", tier=RuntimeTier.ALIGNED, category="routing"
+         ),
+         RuntimeSymbol(
+             name="useLocation", tier=RuntimeTier.ALIGNED, category="routing"
+         ),
+         RuntimeSymbol(name="useParams", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="useRouter", tier=RuntimeTier.ALIGNED, category="routing"),
+         RuntimeSymbol(name="navigate", tier=RuntimeTier.ALIGNED, category="routing"),
+         # ---- Auth -------------------------------------------------------------
+         RuntimeSymbol(name="jacSignup", tier=RuntimeTier.ALIGNED, category="auth"),
+         RuntimeSymbol(name="jacLogin", tier=RuntimeTier.ALIGNED, category="auth"),
+         RuntimeSymbol(name="jacLogout", tier=RuntimeTier.ALIGNED, category="auth"),
+         RuntimeSymbol(name="jacIsLoggedIn", tier=RuntimeTier.ALIGNED, category="auth"),
+         # ---- Browser storage shims --------------------------------------------
+         RuntimeSymbol(
+             name="__getLocalStorage", tier=RuntimeTier.ALIGNED, category="browser"
+         ),
+         RuntimeSymbol(
+             name="__setLocalStorage", tier=RuntimeTier.ALIGNED, category="browser"
+         ),
+         RuntimeSymbol(
+             name="__removeLocalStorage", tier=RuntimeTier.ALIGNED, category="browser"
+         ),
+         # ---- Auto-cache layer (runtime-agnostic; backed by both runtimes) -----
+         RuntimeSymbol(
+             name="__getEndpointEffects", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         RuntimeSymbol(
+             name="__getCacheState", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         RuntimeSymbol(name="__isFresh", tier=RuntimeTier.ALIGNED, category="cache"),
+         RuntimeSymbol(name="__cacheGet", tier=RuntimeTier.ALIGNED, category="cache"),
+         RuntimeSymbol(name="__cacheSet", tier=RuntimeTier.ALIGNED, category="cache"),
+         RuntimeSymbol(
+             name="__evictOldest", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         RuntimeSymbol(name="__overlaps", tier=RuntimeTier.ALIGNED, category="cache"),
+         RuntimeSymbol(
+             name="__invalidateEndpoint", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         RuntimeSymbol(
+             name="__cachedEndpointCall", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         RuntimeSymbol(
+             name="__doWalkerFetch", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         RuntimeSymbol(
+             name="__doFuncFetch", tier=RuntimeTier.ALIGNED, category="cache"
+         ),
+         # ---- Client error reporting -------------------------------------------
+         RuntimeSymbol(
+             name="__jacReportError", tier=RuntimeTier.ALIGNED, category="error"
+         ),
+         RuntimeSymbol(
+             name="__jacInstallErrorHandlers",
+             tier=RuntimeTier.ALIGNED,
+             category="error"
+         ),
+         RuntimeSymbol(
+             name="__jacReactErrorHandler", tier=RuntimeTier.ALIGNED, category="error"
+         ),
+         # ---- Production tier: jac-client only, React / Zod / react-router bound -
+         RuntimeSymbol(name="JacForm", tier=RuntimeTier.PRODUCTION, category="form"),
+         RuntimeSymbol(name="useJacForm", tier=RuntimeTier.PRODUCTION, category="form"),
+         RuntimeSymbol(name="JacSchema", tier=RuntimeTier.PRODUCTION, category="form"),
+         RuntimeSymbol(
+             name="__createJacSchema", tier=RuntimeTier.PRODUCTION, category="form"
+         ),
+         RuntimeSymbol(name="AuthGuard", tier=RuntimeTier.PRODUCTION, category="auth"),
+         RuntimeSymbol(
+             name="ErrorFallback", tier=RuntimeTier.PRODUCTION, category="error"
+         ),
+         RuntimeSymbol(
+             name="errorOverlay", tier=RuntimeTier.PRODUCTION, category="error"
+         ),
+         RuntimeSymbol(
+             name="__getApiBaseUrl", tier=RuntimeTier.PRODUCTION, category="browser"
+         )
+     ];
+
+"""The declared symbol for `name`, or `None` if it is not part of the surface."""
+def runtime_symbol(name: str) -> (RuntimeSymbol | None) {
+    for sym in CLIENT_RUNTIME_SURFACE {
+        if sym.name == name {
+            return sym;
+        }
+    }
+    return None;
+}
+
+"""Whether `name` is a declared `@jac/runtime` surface symbol."""
+def is_runtime_symbol(name: str) -> bool {
+    return runtime_symbol(name) is not None;
+}
+
+"""Module the compiler imports `name` from.
+
+Returns the declared source (`@jac/runtime`, or `react` for React primitives).
+Undeclared names fall back to `@jac/runtime` — the historical default — so an
+unforeseen emission never breaks a build; the alignment test is what guards
+against undeclared compiler emissions.
+"""
+def runtime_import_source(name: str) -> str {
+    sym = runtime_symbol(name);
+    if sym is not None {
+        return sym.source;
+    }
+    return "@jac/runtime";
+}
+
+# The export-surface helpers describe what the runtime *files* export, so they
+# exclude react-sourced symbols (e.g. `useRef`) — those resolve straight from
+# `react` via the compiler and are never exported by either runtime.
+def _exports_with_tier(tier: RuntimeTier) -> set[str] {
+    return {
+        sym.name
+        for sym in CLIENT_RUNTIME_SURFACE
+        if sym.tier == tier and sym.source == "@jac/runtime"
+    };
+}
+
+"""Names both runtimes must export (the portability contract)."""
+def aligned_surface -> set[str] {
+    return _exports_with_tier(RuntimeTier.ALIGNED);
+}
+
+"""Names only jac-client exports (bare-serve omits). Excludes react-sourced
+symbols like `useRef`, which the compiler takes straight from `react`."""
+def production_surface -> set[str] {
+    return _exports_with_tier(RuntimeTier.PRODUCTION);
+}
+
+"""The routing subset — must match exactly across runtimes."""
+def routing_surface -> set[str] {
+    return {
+        sym.name
+        for sym in CLIENT_RUNTIME_SURFACE
+        if sym.category == "routing"
+    };
+}
+
+"""Names the compiler emits that resolve through `@jac/runtime`.
+
+React-sourced emissions (e.g. `useRef`) are excluded — they never touch the
+runtime — so every name here must be exported by both runtimes.
+"""
+def compiler_emitted_surface -> set[str] {
+    return {
+        sym.name
+        for sym in CLIENT_RUNTIME_SURFACE
+        if sym.emitted and sym.source == "@jac/runtime"
+    };
+}
+
+"""The single import statement the bundle paths prepend for the bare global
+identifiers the compiler emits (`__jacJsx`, `__jacSpawn`)."""
+def prepended_runtime_import -> str {
+    names = [
+        sym.name
+        for sym in CLIENT_RUNTIME_SURFACE
+        if sym.prepend
+    ];
+    return 'import {' + ", ".join(names) + '} from "@jac/runtime";';
+}

--- a/jac/jaclang/runtimelib/impl/client_runtime.impl.jac
+++ b/jac/jaclang/runtimelib/impl/client_runtime.impl.jac
@@ -90,6 +90,24 @@ impl __applyProp(element: any, key: str, value: any) -> None {
     }
 }
 
+impl JacAwaiting(props: dict[str, any]) -> any {
+    # Bare-serve has no React Suspense; there is no async boundary here, so the
+    # resolved try-clause children render directly. `fallback` is unused — it
+    # only has meaning under jac-client's React.Suspense backing. Returning the
+    # children array lets `__buildDom` render them as a fragment (no wrapper
+    # node), matching React.Suspense's transparent output. The view-lowering
+    # pass always emits this wrapper with a children array, so it is present.
+    return props["children"];
+}
+
+impl JacClientErrorBoundary(props: dict[str, any]) -> any {
+    # Bare-serve has no React error boundary; children render directly. The
+    # `fallback` (except-clause content) is not shown on throw — errors
+    # propagate. Surface parity only; jac-client backs this with
+    # react-error-boundary.
+    return props["children"];
+}
+
 impl createSignal(initialValue: any) -> list[any] {
     signalId = len(__jacReactiveContext.signals);
     signalData = {"value": initialValue, "subscribers": []};
@@ -457,11 +475,131 @@ impl __jacGetPath -> str {
     return "/";
 }
 
-impl __jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) -> any {
+# ============================================================================
+# Auto-cache infrastructure
+# ============================================================================
+impl __getEndpointEffects -> dict[str, any] {
+    if not globalThis.__jacEndpointEffects__ {
+        initEl = None;
+        try {
+            initEl = document.getElementById("__jac_init__");
+        } except Exception as e {
+            console.warn("[bare-serve] Failed to find __jac_init__ element:", e);
+        }
+        if initEl {
+            try {
+                data = JSON.parse(initEl.textContent);
+                globalThis.__jacEndpointEffects__ = data["endpointEffects"] or {};
+            } except Exception as e {
+                console.warn(
+                    "[bare-serve] Failed to parse __jac_init__ data, using empty effects:",
+                    e
+                );
+                globalThis.__jacEndpointEffects__ = {};
+            }
+        } else {
+            globalThis.__jacEndpointEffects__ = {};
+        }
+    }
+    return globalThis.__jacEndpointEffects__;
+}
+
+impl __getCacheState -> dict[str, any] {
+    if not globalThis.__jacCacheState__ {
+        globalThis.__jacCacheState__ = {
+            "cache": {},
+            "order": [],
+            "pending": {},
+            "config": {"maxEntries": 500, "defaultTtlMs": 60000}
+        };
+    }
+    return globalThis.__jacCacheState__;
+}
+
+impl __isFresh(`entry: dict[str, any]) -> bool {
+    if not `entry {
+        return False;
+    }
+    age = Date.now() - `entry["timestamp"];
+    return age < `entry["ttl"];
+}
+
+impl __cacheGet(key: str) -> any {
+    state = __getCacheState();
+    entry = state["cache"][key];
+    if not entry {
+        return None;
+    }
+    # Move to end (most recently used)
+    idx = state["order"].indexOf(key);
+    if idx > -1 {
+        state["order"].splice(idx, 1);
+    }
+    state["order"].push(key);
+    return entry;
+}
+
+impl __cacheSet(key: str, data: any, ttl: int) -> None {
+    state = __getCacheState();
+    # Remove existing entry if present
+    if state["cache"][key] {
+        idx = state["order"].indexOf(key);
+        if idx > -1 {
+            state["order"].splice(idx, 1);
+        }
+    }
+    # Evict oldest while at capacity
+    while len(state["order"]) >= state["config"]["maxEntries"] {
+        __evictOldest();
+    }
+    state["cache"][key] = {"data": data, "timestamp": Date.now(), "ttl": ttl};
+    state["order"].push(key);
+}
+
+impl __evictOldest -> None {
+    state = __getCacheState();
+    if len(state["order"]) > 0 {
+        oldest = state["order"].shift();
+        if oldest and state["cache"][oldest] {
+            Reflect.deleteProperty(state["cache"], oldest);
+        }
+    }
+}
+
+impl __overlaps(list1: list[any], list2: list[any]) -> bool {
+    for item in list1 {
+        if list2.includes(item) {
+            return True;
+        }
+    }
+    return False;
+}
+
+impl __invalidateEndpoint(endpoint_key: str) -> None {
+    state = __getCacheState();
+    keys_to_delete = [];
+    for key in Object.keys(state["cache"]) {
+        if key.startsWith(endpoint_key) {
+            keys_to_delete.push(key);
+        }
+    }
+    for key in keys_to_delete {
+        Reflect.deleteProperty(state["cache"], key);
+        idx = state["order"].indexOf(key);
+        if idx > -1 {
+            state["order"].splice(idx, 1);
+        }
+    }
+}
+
+# ============================================================================
+# Raw fetch helpers (no caching)
+# ============================================================================
+impl __doWalkerFetch(`walker: str, nodeId: str, fields: dict[str, any]) -> any {
     token = __getLocalStorage("jac_token");
-    url = f"/walker/{left}";
-    if right != "" {
-        url = f"/walker/{left}/{right}";
+    url = f"/walker/{`walker}";
+    if nodeId != "" {
+        url = f"/walker/{`walker}/{nodeId}";
     }
     response = await fetch(
         url,
@@ -477,12 +615,74 @@ impl __jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) -> any 
     );
     if not response.ok {
         error_text = await response.json();
-        walker_name = f"{left}/{right}" if right else left;
+        walker_name = f"{`walker}/{nodeId}" if nodeId else `walker;
         raise Exception(f"Walker {walker_name} failed: {error_text}");
     }
     payload = await response.json();
     # Handle TransportResponse envelope format
     return payload["data"] if payload["data"] else payload;
+}
+
+# ============================================================================
+# Cache-aware dispatch shared by __jacSpawn and __jacCallFunction
+# ============================================================================
+impl __cachedEndpointCall(endpoint_key: str, args_key: str, fetch_fn: any) -> any {
+    effects = __getEndpointEffects();
+    info = effects[endpoint_key];
+    state = __getCacheState();
+    # Known READER — check cache first, then dedup concurrent identical calls.
+    if info and not info["is_writer"] {
+        cached = __cacheGet(args_key);
+        if cached and __isFresh(cached) {
+            return cached["data"];
+        }
+        if state["pending"][args_key] {
+            return await state["pending"][args_key];
+        }
+        fetch_promise = fetch_fn();
+        state["pending"][args_key] = fetch_promise;
+        try {
+            data = await fetch_promise;
+            __cacheSet(args_key, data, state["config"]["defaultTtlMs"]);
+            return data;
+        } finally {
+            Reflect.deleteProperty(state["pending"], args_key);
+        }
+    }
+    # Known WRITER — fetch, then invalidate readers it touches.
+    if info and info["is_writer"] {
+        data = await fetch_fn();
+        writer_touches = info["touches"];
+        for endpoint_name in Object.keys(effects) {
+            reader_info = effects[endpoint_name];
+            if reader_info and not reader_info["is_writer"] {
+                if writer_touches.includes("*")
+                or __overlaps(reader_info["touches"], writer_touches) {
+                    __invalidateEndpoint(endpoint_name);
+                }
+            }
+        }
+        return data;
+    }
+    # Unknown endpoint (no metadata) — direct fetch, no caching.
+    return await fetch_fn();
+}
+
+impl __jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) -> any {
+    # Auth walkers must never be cached.
+    if left == "login"
+    or left == "signup"
+    or left == "logout"
+    or left == "refresh_token" {
+        return await __doWalkerFetch(left, right, fields);
+    }
+    endpoint_key = f"walker:{left}";
+    args_key = f"{endpoint_key}:{right}:{JSON.stringify(fields)}";
+    return await __cachedEndpointCall(
+        endpoint_key,
+        args_key,
+        lambda -> any { return __doWalkerFetch(left, right, fields); }
+    );
 }
 
 impl jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) -> any {
@@ -492,7 +692,7 @@ impl jacSpawn(left: str, right: str = "", fields: dict[str, any] = {}) -> any {
     return __jacSpawn(left, right, fields);
 }
 
-impl __jacCallFunction(function_name: str, args: dict[str, any] = {}) -> any {
+impl __doFuncFetch(function_name: str, args: dict[str, any]) -> any {
     token = __getLocalStorage("jac_token");
     response = await fetch(
         f"/function/{function_name}",
@@ -519,6 +719,16 @@ impl __jacCallFunction(function_name: str, args: dict[str, any] = {}) -> any {
         }
     } except Exception { }
     return result;
+}
+
+impl __jacCallFunction(function_name: str, args: dict[str, any] = {}) -> any {
+    endpoint_key = f"func:{function_name}";
+    args_key = f"{endpoint_key}:{JSON.stringify(args)}";
+    return await __cachedEndpointCall(
+        endpoint_key,
+        args_key,
+        lambda -> any { return __doFuncFetch(function_name, args); }
+    );
 }
 
 def __normalizeIdentity(x: any) -> dict[str, any] {
@@ -570,6 +780,13 @@ impl jacSignup(
             }
         } except Exception { }
         if token {
+            # Signup auto-logs-in (sets the token) — an auth change, so drop
+            # all cached reader responses just like jacLogin/jacLogout.
+            state = __getCacheState();
+            for key in Object.keys(state["cache"]) {
+                Reflect.deleteProperty(state["cache"], key);
+            }
+            state["order"].splice(0, state["order"].length);
             __setLocalStorage("jac_token", token);
             return {"success": True, "token": token, "username": primary_username};
         }
@@ -620,6 +837,12 @@ impl jacLogin(
             }
         } except Exception { }
         if token {
+            # Auth change — drop all cached reader responses.
+            state = __getCacheState();
+            for key in Object.keys(state["cache"]) {
+                Reflect.deleteProperty(state["cache"], key);
+            }
+            state["order"].splice(0, state["order"].length);
             __setLocalStorage("jac_token", token);
             return True;
         }
@@ -628,6 +851,12 @@ impl jacLogin(
 }
 
 impl jacLogout -> None {
+    # Auth change — drop all cached reader responses.
+    state = __getCacheState();
+    for key in Object.keys(state["cache"]) {
+        Reflect.deleteProperty(state["cache"], key);
+    }
+    state["order"].splice(0, state["order"].length);
     __removeLocalStorage("jac_token");
 }
 

--- a/jac/jaclang/runtimelib/impl/hmr.impl.jac
+++ b/jac/jaclang/runtimelib/impl/hmr.impl.jac
@@ -211,7 +211,8 @@ impl HotReloader._recompile_client_code(
         }
 
         # Ensure __jacJsx import is present (required for client-side rendering)
-        jac_runtime_import = 'import {__jacJsx, __jacSpawn} from "@jac/runtime";';
+        import from jaclang.runtimelib.client_surface { prepended_runtime_import }
+        jac_runtime_import = prepended_runtime_import();
         if '__jacJsx' in js_code and jac_runtime_import not in js_code {
             js_code = jac_runtime_import + '\n' + js_code;
         }

--- a/jac/tests/runtimelib/test_runtime_surface_alignment.jac
+++ b/jac/tests/runtimelib/test_runtime_surface_alignment.jac
@@ -6,9 +6,15 @@ jac-client's `jac_client/plugin/client_runtime.cl.jac` (React + React Router).
 User code is portable between the two only if the public surface stays
 aligned — issue #5847 is what happens when it drifts.
 
-This test extracts top-level `def`/`glob` symbol names from both files and
-asserts that the routing/hooks/walker surface bare-serve advertises is also
-exported by jac-client. Skipped when jac-client isn't installed.
+The surface itself is declared once in `jaclang.runtimelib.client_surface`;
+this test extracts top-level `def`/`glob` symbol names from both files and
+asserts each runtime honors its slice of that contract:
+  * both runtimes export every ALIGNED symbol;
+  * bare-serve exports every symbol the compiler emits (so emitted imports
+    always resolve);
+  * jac-client exports every PRODUCTION (jac-client-only) symbol;
+  * the routing subset matches exactly.
+Skipped when jac-client isn't installed.
 """
 
 import os;
@@ -17,44 +23,12 @@ import pytest;
 import importlib;
 import from pathlib { Path }
 import jaclang;
-
-glob ALIGNED_SURFACE = {
-         # React Router v6-shaped routing. jac-client maps `Router` to
-         # ReactRouterBrowserRouter, so the same name covers both modes.
-         "Router",
-         "Routes",
-         "Route",
-         "Link",
-         "Navigate",
-         "Outlet",
-         "useNavigate",
-         "useLocation",
-         "useParams",
-         "useRouter",
-         "navigate",
-         # Hook aliases (different semantics across runtimes, but same names)
-         "useState",
-         "useEffect",
-         # JSX factory
-         "__jacJsx",
-         # Walker / function calls
-         "__jacSpawn",
-         "jacSpawn",
-         "__jacCallFunction",
-         # Auth
-         "jacSignup",
-         "jacLogin",
-         "jacLogout",
-         "jacIsLoggedIn",
-         # Browser API shims
-         "__getLocalStorage",
-         "__setLocalStorage",
-         "__removeLocalStorage",
-         # Error reporting
-         "__jacReportError",
-         "__jacInstallErrorHandlers",
-         "__jacReactErrorHandler"
-     };
+import from jaclang.runtimelib.client_surface {
+    aligned_surface,
+    production_surface,
+    routing_surface,
+    compiler_emitted_surface
+}
 
 def _bareserve_runtime_path -> str {
     runtimelib_dir = os.path.dirname(jaclang.runtimelib.__file__);
@@ -95,41 +69,46 @@ def _extract_symbols(path: str) -> set[str] {
     return names;
 }
 
-test "bare-serve and jac-client expose the aligned @jac/runtime surface" {
+test "bare-serve exposes the aligned and compiler-emitted @jac/runtime surface" {
     bareserve_syms = _extract_symbols(_bareserve_runtime_path());
-    missing_from_bareserve = ALIGNED_SURFACE - bareserve_syms;
+    missing_from_bareserve = aligned_surface() - bareserve_syms;
     assert not missing_from_bareserve , (
         f"Aligned surface missing from bare-serve runtime: "
         f"{sorted(missing_from_bareserve)}"
     );
+    # Every `@jac/runtime` symbol the compiler emits must exist in bare-serve,
+    # or apps using that construct emit an import bare-serve can't resolve.
+    emitted_missing = compiler_emitted_surface() - bareserve_syms;
+    assert not emitted_missing , (
+        f"Compiler-emitted runtime symbols missing from bare-serve: "
+        f"{sorted(emitted_missing)}"
+    );
+}
+
+test "jac-client and bare-serve honor the @jac/runtime contract" {
+    bareserve_syms = _extract_symbols(_bareserve_runtime_path());
     jac_client_path = _jac_client_runtime_path();
     if not jac_client_path {
         pytest.skip("jac-client plugin not installed");
     }
     jac_client_syms = _extract_symbols(jac_client_path);
-    missing_from_jac_client = ALIGNED_SURFACE - jac_client_syms;
+    missing_from_jac_client = aligned_surface() - jac_client_syms;
     assert not missing_from_jac_client , (
         f"Aligned surface missing from jac-client runtime: "
         f"{sorted(missing_from_jac_client)}"
     );
-    # Drift detector: anything bare-serve adds but jac-client lacks (or vice
-    # versa) within the routing/hooks subset means user code that compiles in
-    # one mode breaks in the other.
-    routing_subset = {
-        "Router",
-        "Routes",
-        "Route",
-        "Link",
-        "Navigate",
-        "Outlet",
-        "useNavigate",
-        "useLocation",
-        "useParams",
-        "useRouter",
-        "navigate"
-    };
-    bareserve_routing = bareserve_syms & routing_subset;
-    jac_client_routing = jac_client_syms & routing_subset;
+    # jac-client must provide every production-tier (jac-client-only) symbol.
+    production_missing = production_surface() - jac_client_syms;
+    assert not production_missing , (
+        f"Production surface missing from jac-client runtime: "
+        f"{sorted(production_missing)}"
+    );
+    # Drift detector: any routing symbol present in one runtime but not the
+    # other means user routing code that compiles in one mode breaks in the
+    # other.
+    routing = routing_surface();
+    bareserve_routing = bareserve_syms & routing;
+    jac_client_routing = jac_client_syms & routing;
     drift = bareserve_routing.symmetric_difference(jac_client_routing);
     assert not drift , f"Routing surface drift between runtimes: {sorted(drift)}";
 }


### PR DESCRIPTION
## Summary

The bare-serve core runtime (`jaclang/runtimelib/client_runtime.cl.jac`) and the jac-client plugin runtime both back the `@jac/runtime` virtual module, but the contract binding them was duplicated across four hand-synced places: the compiler's runtime-import injection, the eject/HMR import prepend, the cross-runtime alignment test, and the two runtime files. This PR makes that contract a single declared source of truth and closes the gaps it surfaced.

## What changed

- **New `client_surface.jac`**: declares every `@jac/runtime` symbol once, each with an `ALIGNED` (both runtimes must export) or `PRODUCTION` (jac-client only) tier and an import source. The compiler's injection, the eject/HMR import prepend, and the alignment test now all derive from it instead of carrying their own copy.
- **Auto-cache in bare-serve**: the runtime-agnostic cache layer (reader caching, concurrent-request dedup, writer-driven invalidation, cleared on auth change) now lives in the bare-serve runtime, consuming the endpoint-effects metadata the compiler already ships. This removes the largest behavioral divergence from jac-client while keeping bare-serve dependency-free.
- **Closed a latent gap**: the compiler emits `JacAwaiting` / `JacClientErrorBoundary` imports for `try`/`awaiting`/`except` JSX, but bare-serve did not export them, so such apps emitted an import that could not resolve. Added native passthrough wrappers, and the alignment test now enforces that every compiler-emitted symbol exists in bare-serve.
- **Compiler injection unified**: `_inject_runtime_import` resolves each symbol's source (`@jac/runtime` vs `react`) from the contract; the separate `_inject_react_import` is removed.

## Behavior change

Bare-serve reader endpoints are now cached (60s TTL) with writer-driven invalidation; previously every call re-fetched. This matches jac-client's existing behavior.

## Testing

- Runtime surface alignment: 2/2
- ECMAScript pass: 106/106
- eject + runtimelib suites: 351/351
- Core runtime compiles to valid JS (cache functions, view wrappers, correct async emission)
