### PR TITLE
fix(cfg): back-edge loop-body branch tails to the loop header

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6269.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6269.bugfix.md
@@ -1,0 +1,1 @@
+- **Loop bodies now correctly loop back in the control-flow graph**: the end of a `for`/`while` body now returns to the loop header instead of falling through to the code after the loop, fixing spurious type-narrowing and unreachable-code results inside loops.

--- a/jac/jaclang/compiler/passes/main/cfg_build_pass.jac
+++ b/jac/jaclang/compiler/passes/main/cfg_build_pass.jac
@@ -22,6 +22,10 @@ obj CFGBuildPass(UniPass) {
     def link_bbs(source: uni.UniCFGNode, target: uni.UniCFGNode) -> None;
     def _link_sequential(body: Sequence[uni.CodeBlockStmt]) -> None;
     def _connect_tails(parent: uni.UniNode, target: uni.UniCFGNode) -> None;
+    def _link_body_tails_to_header(
+        nd: uni.WhileStmt | uni.InForStmt | uni.IterForStmt
+    ) -> None;
+
     def _is_terminal(nd: uni.UniNode) -> bool;
     def _find_parent_of_types(
         nd: uni.UniNode, types: tuple[type[uni.UniCFGNode], ...]

--- a/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/cfg_build_pass.impl.jac
@@ -342,6 +342,14 @@ impl CFGBuildPass._connect_tails(parent: uni.UniNode, target: uni.UniCFGNode) ->
             # Scope boundary -- don't recurse into nested scopes
             continue;
         }
+        if isinstance(k, (uni.WhileStmt, uni.InForStmt, uni.IterForStmt)) {
+            # Loop boundary -- body tails back-edge to the loop header (wired by
+            # the loop's exit handler), so don't sweep them to the successor.
+            if not k.bb_out and not self._is_terminal(k) {
+                self.link_bbs(k, target);
+            }
+            continue;
+        }
         if isinstance(k, uni.UniCFGNode) {
             if not k.bb_out and not self._is_terminal(k) {
                 # Unconnected tail -- link to target
@@ -745,23 +753,32 @@ impl CFGBuildPass.exit_while_stmt(nd: uni.WhileStmt) -> None {
         }
     }
 
-    if nd.body {
-        self._link_sequential(nd.body);
-        # Back-edge: last body stmt -> loop header
-        if not self._is_terminal(nd.body[-1]) {
-            self.link_bbs(nd.body[-1], nd);
-        }
+    self._link_body_tails_to_header(nd);
+}
+
+"""Back-edge every unconnected body tail to the loop header, including branch
+tails inside the body (e.g. the true arm of an if-without-else)."""
+impl CFGBuildPass._link_body_tails_to_header(
+    nd: uni.WhileStmt | uni.InForStmt | uni.IterForStmt
+) -> None {
+    if not nd.body {
+        return;
+    }
+    self._link_sequential(nd.body);
+    if not self._is_terminal(nd.body[-1]) {
+        self.link_bbs(nd.body[-1], nd);
+    }
+    # Scope to body stmts so else_body / successor never joins the cycle.
+    for stmt in nd.body {
+        self._connect_tails(stmt, nd);
     }
 }
 
 """InForStmt: body + back-edge + else_body."""
 impl CFGBuildPass.exit_in_for_stmt(nd: uni.InForStmt) -> None {
+    self._link_body_tails_to_header(nd);
     if nd.body {
         self.link_bbs(nd, nd.body[0]);
-        self._link_sequential(nd.body);
-        if not self._is_terminal(nd.body[-1]) {
-            self.link_bbs(nd.body[-1], nd);
-        }
     }
     if nd.else_body and isinstance(nd.else_body, uni.ElseStmt) and nd.else_body.body {
         self.link_bbs(nd, nd.else_body.body[0]);
@@ -770,12 +787,9 @@ impl CFGBuildPass.exit_in_for_stmt(nd: uni.InForStmt) -> None {
 
 """IterForStmt: body + back-edge + else_body."""
 impl CFGBuildPass.exit_iter_for_stmt(nd: uni.IterForStmt) -> None {
+    self._link_body_tails_to_header(nd);
     if nd.body {
         self.link_bbs(nd, nd.body[0]);
-        self._link_sequential(nd.body);
-        if not self._is_terminal(nd.body[-1]) {
-            self.link_bbs(nd.body[-1], nd);
-        }
     }
     if nd.else_body and isinstance(nd.else_body, uni.ElseStmt) and nd.else_body.body {
         self.link_bbs(nd, nd.else_body.body[0]);

--- a/jac/tests/compiler/passes/main/fixtures/cfg_loop_if_backedge.jac
+++ b/jac/tests/compiler/passes/main/fixtures/cfg_loop_if_backedge.jac
@@ -1,0 +1,9 @@
+def use(items: list) -> str {
+    tag = "";
+    for item in items {
+        if item == "x" {
+            tag = item;
+        }
+    }
+    return tag;
+}

--- a/jac/tests/compiler/passes/main/test_cfg_build_pass.jac
+++ b/jac/tests/compiler/passes/main/test_cfg_build_pass.jac
@@ -70,6 +70,16 @@ test "cfg for loop with break continue and else" {
     assert dot == expected_dot;
 }
 
+test "cfg loop body if tail back-edges to header" {
+    dot = cfg_dot_from_file(
+        file_name=os.path.join(FIXTURES, "cfg_loop_if_backedge.jac")
+    );
+    expected_dot = (
+        "digraph G {\n" + '  0 [label="BB0\\ndef use( items : list ) -> str\\ntag = \\"\\" ;", shape=box];\n' + '  1 [label="BB1\\nfor item in items", shape=box];\n' + '  2 [label="BB2\\nif item == \\"x\\"", shape=box];\n' + '  3 [label="BB3\\ntag = item ;", shape=box];\n' + '  4 [label="BB4\\nreturn tag ;", shape=box];\n' + "  0 -> 1;\n" + "  1 -> 2;\n" + "  1 -> 4;\n" + '  2 -> 3 [label="T"];\n' + "  2 -> 1;\n" + "  3 -> 1;\n" + "}\n"
+    );
+    assert dot == expected_dot;
+}
+
 test "cfg try except finally" {
     dot = cfg_dot_from_file(file_name=os.path.join(FIXTURES, "cfg_try_except.jac"));
     expected_dot = (


### PR DESCRIPTION
## What

A loop body whose last statement is an `if`-without-else left the true arm's tail unconnected. `_connect_tails` then swept that tail out to the loop's **successor** instead of the **header**, so the CFG modelled the loop as "run the body once, then fall through" — the body-tail back-edge was missing.

Example — `for item in items { if item == "x" { tag = item; } }` produced `BB(tag=item) -> BB(after-loop)` where it should produce `BB(tag=item) -> BB(loop-header)`.

## Fix

- Loop exit handlers now sweep **all** body-internal branch tails back to the loop header (not just `body[-1]`), scoped to body statements so the loop's `else_body`/successor is never pulled into the cycle.
- `_connect_tails` stops at loop boundaries when sweeping tails toward an enclosing successor.

```jac
obj Foo {
    has label: str = '';
}

def use(items: list) -> str {
    tag: (str | None) = None;
    for item in items {
        if isinstance(item, Foo) {
            tag = item.label;
        }
    }
    if tag is not None {
        return tag;
    }
    return '';
}
```
<img width="1571" height="841" alt="image" src="https://github.com/user-attachments/assets/7d446503-389d-42e0-bfc9-e3269342641e" />
