### PR TITLE
fix(type-checker): narrow isinstance/None guards on Any-typed symbols

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6271.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6271.bugfix.md
@@ -1,0 +1,1 @@
+- **`isinstance` now narrows values typed `Any`**: a guard like `if isinstance(x, Foo)` on an `Any`-typed value (e.g. an item from a bare `list`) now narrows `x` to `Foo`, so accessing the type's members no longer reports a spurious error.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -3882,7 +3882,8 @@ impl TypeEvaluator.get_narrowed_type(
     }
     symbol_type = self.get_type_of_symbol(symbol);
     if not isinstance(
-        symbol_type, (types.UnionType, types.ClassType, types.UnknownType)
+        symbol_type,
+        (types.UnionType, types.ClassType, types.UnknownType, types.AnyType)
     ) {
         return None;
     }

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_narrow_anytype_isinstance.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_narrow_anytype_isinstance.jac
@@ -1,0 +1,12 @@
+obj Foo {
+    has label: str = "";
+}
+
+def use(items: list) -> str {
+    for item in items {
+        if isinstance(item, Foo) {
+            return item.label;
+        }
+    }
+    return "";
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -808,3 +808,16 @@ test "bug_stub_vguard_module_level_symbol_resolves" {
         f"Got W1051 warnings: {[str(w) for w in unresolved]}"
     );
 }
+
+# Bug #NARROW-ANY: isinstance on a symbol typed Any (e.g. the element of a
+# bare `list`) did not narrow because get_narrowed_type's guard accepted only
+# Union/Class/Unknown, so `item.label` after `isinstance(item, Foo)` stayed
+# Unknown and raised E1001/E1002.
+test "bug_narrow_any_symbol_isinstance" {
+    program = compile_and_check("checker_narrow_anytype_isinstance.jac");
+    assert program.errors_had == [] , (
+        "Bug #NARROW-ANY: isinstance must narrow an Any-typed symbol, so "
+        "accessing a member of the narrowed type does not error. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}


### PR DESCRIPTION
## What

`isinstance(x, T)` (and `is not None`) did not narrow a symbol whose type is `Any`. The element of a bare `list` annotation defaults to `list[Any]`, so iterating it gives an `Any`-typed loop variable; an `isinstance` guard on it left the variable as `Any`, and member access on the (supposedly narrowed) value resolved to `<Unknown>`, raising spurious `E1001`/`E1002`.

```jac
def use(items: list) -> str {      # list[Any]
    for item in items {
        if isinstance(item, Foo) {
            return item.label;      # was: Cannot return <Unknown>, expected str
        }
    }
    return "";
}
```

## Root cause

`get_narrowed_type` guards on the symbol's type and only proceeded for `UnionType | ClassType | UnknownType` — `AnyType` was rejected, so the CFG narrowing walk never ran. (Writing `list[any]` worked because that element is the any-*class* `ClassType`, which passed the guard; bare `list` yields `AnyType`, which did not.)

## Fix

Admit `AnyType` to the guard. Positive isinstance narrowing already falls back to the guard's target type, so an `Any` base narrows to `T` exactly like the any-class form.