### PR TITLE
perf(runtime): remove per-write dirty tracking from Archetype.__setattr__

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6277.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6277.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Native-speed archetype field writes**: Removed the per-write `__setattr__` dirty-field tracking on archetypes, which was redundant with the value-hash diff the memory backends already use to detect changes, restoring C-level attribute stores across the runtime.

--- a/jac/jaclang/jac0core/archetype.jac
+++ b/jac/jaclang/jac0core/archetype.jac
@@ -160,7 +160,6 @@ obj Archetype {
     def __jac__ -> Anchor;
 
     def __init_subclass__(cls: any, **kwargs: object) -> None;
-    def __setattr__(name: str, value: any) -> None;
     def postinit -> None;
     def __repr__ -> str;
     def __jac_access__ -> (AccessLevel | str | int | None);

--- a/jac/jaclang/jac0core/impl/archetype.impl.jac
+++ b/jac/jaclang/jac0core/impl/archetype.impl.jac
@@ -328,23 +328,8 @@ impl Archetype.__init_subclass__(cls: any, **kwargs: object) -> None {
     }
 }
 
-"""Set attribute on archetype and track dirty fields after initialization."""
-impl Archetype.__setattr__(name: str, value: any) -> None {
-    object.__setattr__(self, name, value);
-    if self.__dict__.get('__jac_initialized__', False) and not name.startswith('_') {
-        dirty: set[str] = self.__dict__.get('__jac_dirty_fields__');
-        if not isinstance(dirty, set) {
-            dirty = set();
-            object.__setattr__(self, '__jac_dirty_fields__', dirty);
-        }
-        dirty.add(name);
-    }
-}
-
-"""Mark archetype as initialized so subsequent field changes are tracked as dirty."""
-impl Archetype.postinit -> None {
-    object.__setattr__(self, '__jac_initialized__', True);
-}
+"""No-op base post-init; exists so subclass `super.postinit()` calls resolve."""
+impl Archetype.postinit -> None { }
 
 """Override repr for archetype."""
 impl Archetype.__repr__ -> str {

--- a/jac/jaclang/runtimelib/impl/serializer.impl.jac
+++ b/jac/jaclang/runtimelib/impl/serializer.impl.jac
@@ -726,7 +726,6 @@ impl Serializer._deserialize_archetype(
             );
         }
 
-        arch.__dict__['__jac_initialized__'] = True;
         setattr(arch, '__jac__', anchor);
         return arch;
     } except Exception as e {


### PR DESCRIPTION
## What

Removes the `Archetype.__setattr__` override that recorded dirty field names on every attribute write for incremental persistence.

## Why

`__setattr__` is defined on the base `Archetype`, so every node / edge / walker / object, and every compiler AST node (which is also an archetype), routed every `self.x = y` through a Python-level method doing `object.__setattr__` plus `dict.get` lookups instead of a C-level store. On a move-generation benchmark this was the dominant cost (~23M calls over 5 games), and it also taxes compilation, since AST nodes are archetypes.

The dirty set is consumed by the memory save path, which already derives dirty fields by diffing per-field value hashes (snapshotted on load and after each save). That value-diff is the more complete detector: it also catches in-place mutation (`list.append`, `dict[k]=v`) that the setattr tracker never saw. So this leans persistence on the value-diff.

`__jac_initialized__` was read only by the removed override, so it is no longer written: `Archetype.postinit` becomes a no-op base (kept so `super.postinit()` chains resolve) and the deserializer no longer sets it.

## Impact

Chess move-gen benchmark (`-b 5`, wall clock): 5.5s to 2.4s. Steady-state per-game compute overhead versus an equivalent plain-dataclass implementation dropped from ~20% to ~5%.

## Things to verify

- SQLite backend unions `setattr_dirty | hash_dirty` and always computes the hash-diff, so it degrades cleanly to value-diff only.
- jac-scale (Mongo backend) also reads `__jac_dirty_fields__` and unions it with its own hash-diff. With this change `setattr_dirty` is always empty there, so it relies on the hash-diff alone. Its inline comment asserts both are needed, so the Mongo suite is the key thing to watch. The only real gap in value-diff is a 64-bit hash collision; hardening the field digest to a content hash would close it if needed.

## Tests

Local jaclang runtimelib persistence / topology / OSP suites pass: persistence migration (plus e2e cross-context reload), layer3 e2e, topology e2e and index, osp kernel, storage, reactive signals, auth models, context isolation. jac-scale Mongo suite not run locally (needs Mongo); relying on CI.
