### PR TITLE
refactor(ai-agent): polymorphic phases, tools as OSP edges, cohesive workspace

### DIFF
--- a/jac-byllm/tests/test_ai_agent.jac
+++ b/jac-byllm/tests/test_ai_agent.jac
@@ -60,9 +60,9 @@ def arm(proj: str, events: list, feedback: bool = True) -> CodeIntelligence {
         events.append(info);
     }
     ci.on_event = on_evt;
-    ai.agent.cwd = proj;
-    ai.agent.ci = ci;
-    ai.agent.ci_dirty = False;
+    ai.agent.ws.cwd = proj;
+    ai.agent.ws.ci = ci;
+    ai.agent.ws.ci_dirty = False;
     ai.agent.cfg.yolo_mode = True;
     ai.agent.cfg.show_stats = False;
     ai.agent.cfg.inline_feedback = feedback;
@@ -134,7 +134,7 @@ test "the inline_feedback opt-out suppresses feedback but still flags dirty" {
     out = ai.agent.files.write_file(bad, "def g() -> int { return \"nope\"; }\n");
     assert "compiler feedback" not in out , out;
     # With feedback off the project model is left dirty for the next query.
-    assert ai.agent.ci_dirty , "expected ci_dirty after a feedback-off write";
+    assert ai.agent.ws.ci_dirty , "expected ci_dirty after a feedback-off write";
 
     shutil.rmtree(proj, ignore_errors=True);
 }

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -43,10 +43,33 @@ obj AgentConfig {
         n_ctx: int = 0;
 }
 
+"""The session's view of the project on disk: the working directory and the
+shared CodeIntelligence handle (with its dirty flag), plus the operations over
+them. Path resolution, re-rooting on a `cd`, the lazily-refreshed code-intel
+handle, and the current project errors all live here as methods, so the
+file/process/semantic tools depend on this one cohesive object instead of a pile
+of module globals. Injected into those toolboxes by `AgentRuntime.postinit`.
+"""
+obj Workspace {
+    has cwd: str = "",
+        ci: any = None,
+        # Set on write; the next code-intel query rebuilds the project model.
+        ci_dirty: bool = False;
+
+    # Resolve a tool path against `cwd` (absolute paths pass through).
+    def resolve(path: str) -> str;
+    # Re-root the session (and its code intelligence) at a new working directory.
+    def set_cwd(new_dir: str);
+    # The shared CodeIntelligence, rebuilt lazily when a write marked it dirty.
+    def code_intel -> any;
+    # The project's current compiler errors (empty list if none / unavailable).
+    def project_errors -> list;
+}
+
 # ---------------------------------------------------------------------------
 # Toolboxes -- the agent's capabilities, grouped by domain. Each public method
 # is a byLLM tool (its `sem` becomes the tool's JSON-schema description); the
-# `TOOLS` registry below wires them to phases. Cross-cutting infra (path
+# `TOOL_SPECS` registry below wires them to phases. Cross-cutting infra (path
 # resolution, confirmation, code intelligence) lives in free functions and on
 # `AgentRuntime`, which the methods reach through the `agent` glob. The toolbox
 # objects are stateless: per-session state lives on `AgentRuntime`.
@@ -58,6 +81,11 @@ Paths resolve against the session working directory; writes are gated by
 successful write reports the compiler errors it introduced via `write_feedback`.
 """
 obj FileTools {
+    # Injected by AgentRuntime.postinit: the shared workspace (path resolution,
+    # code intelligence) and the session config (write feedback toggle).
+    has ws: Workspace = Workspace(),
+        cfg: AgentConfig = AgentConfig();
+
     def read_file(path: str) -> str;
     def write_file(path: str, content: str) -> str;
     def edit_file(path: str, old_text: str, new_text: str) -> str;
@@ -75,6 +103,12 @@ persists), are gated by `confirm`, and have their output truncated. `serve` /
 through `run_command` is redirected to `serve` because it would block.
 """
 obj ProcessTools {
+    # `ws` injected by AgentRuntime.postinit. `serve_proc` is this toolbox's own
+    # resource: the dev server `serve` launched, tracked so it can be polled then
+    # stopped.
+    has ws: Workspace = Workspace(),
+        serve_proc: any = None;
+
     def run_command(command: str) -> str;
     def jac_check(path: str) -> str;
     def start_app(entry_file: str) -> str;
@@ -93,6 +127,10 @@ project's archetypes, the walkers that visit a node, or a typed context slice --
 where grep would match comments and unrelated identifiers.
 """
 obj SemanticTools {
+    # Injected by AgentRuntime.postinit: the shared workspace, whose code_intel()
+    # answers every lookup.
+    has ws: Workspace = Workspace();
+
     def find_symbol(name: str) -> str;
     def find_uses(name: str) -> str;
     def project_map -> str;
@@ -111,11 +149,15 @@ obj GuideTools {
 """Browser tools: drive a headless browser over the Chrome DevTools Protocol.
 
 Built on the built-in `jac browse` engine (no npm/pip). Every call reconnects to
-one shared session (`agent.browse_session`), so they are all serialized. Reads
+one shared session (`self.session_id`), so they are all serialized. Reads
 (snapshot, get, eval) run unconfirmed; navigations and interactions are gated by
 `confirm`.
 """
 obj BrowseTools {
+    # This toolbox's own resource: the shared headless-browser session id; every
+    # browser call reconnects to it.
+    has session_id: str = "jac-ai";
+
     def browse_open(url: str) -> str;
     def browse_navigate(url: str) -> str;
     def browse_snapshot -> str;
@@ -271,29 +313,22 @@ toggles.
 """
 obj AgentRuntime {
     has cfg: AgentConfig = AgentConfig(),
-        # Logical working directory: every file tool resolves its `path` against
-        # this and `run_command` runs in it, so a `cd` the model issues in one
-        # shell command persists to the next call and to the file tools (a plain
-        # subprocess cwd does not survive between calls). Set by `run_agent`.
-        cwd: str = "",
-        # Shared CodeIntelligence the semantic tools query; set by `run_agent`.
-        ci: any = None,
-        # Set on write; the next semantic query rebuilds the project model.
-        ci_dirty: bool = False,
+        # The project on disk (cwd + code intelligence) and its operations. The
+        # file/process/semantic tools share this one object, wired to them in
+        # `postinit`.
+        ws: Workspace = Workspace(),
         # Durable cross-turn memory.
         ledger: Ledger | None = None,
         # The live walker, so the `note` tool can reach its ledger.
         active_session: AgentSession | None = None,
-        # The dev server `serve` launched, tracked so it can be polled then stopped.
-        serve_proc: any = None,
-        # Shared headless-browser session id; every browser call reconnects to it.
-        browse_session: str = "jac-ai",
         # Set by a file-writing tool; gates verify-and-continue.
         turn_wrote: bool = False,
         # Live structured event feed for the `--ui` web view; the terminal path
         # leaves it untouched (it stays empty and is never read).
         bus: AgentEventBus = AgentEventBus(),
-        # Toolboxes: the agent's capabilities, composed onto the runtime.
+        # Toolboxes: the agent's capabilities, composed onto the runtime. They own
+        # their own resources (proc the dev server, web the browser session) and
+        # take the shared workspace/config injected in `postinit`.
         files: FileTools = FileTools(),
         proc: ProcessTools = ProcessTools(),
         semantic: SemanticTools = SemanticTools(),
@@ -301,7 +336,7 @@ obj AgentRuntime {
         web: BrowseTools = BrowseTools(),
         # The live terminal view and turn-summary renderer.
         view: TurnRenderer = TurnRenderer(),
-        # The current phase's tools and conversation, set by `PhaseState.run`
+        # The current phase's tools and conversation, set by `PhaseState.step`
         # right before it calls `run_phase`. They live here -- not as `run_phase`
         # parameters -- because byLLM serializes a `by` function's parameters into
         # the prompt as text inputs; passing the conversation as a parameter would
@@ -311,30 +346,53 @@ obj AgentRuntime {
         phase_tools: list = [],
         phase_ctx: list = [];
 
+    # Inject the shared workspace/config into the toolboxes that need them, so a
+    # toolbox depends on its collaborators rather than reaching the module glob.
+    def postinit -> None;
     def note(text: str) -> str;
 }
 
 glob agent: AgentRuntime = AgentRuntime();
 
-# A tool's properties -- its stats category, whether it must be serialized, and
-# which phases may call it -- declared together on one descriptor instead of
-# spread across separate hand-kept lists. The `TOOLS` registry (built after the
-# tool functions, below) is the single source those lists are now derived from.
-obj ToolSpec {
-    has fn: any,
-        # "read" | "write" | "run"; drives the turn-stat breakdown (anything
-        # that is neither write nor run counts as a read).
-        category: str,
-        # Side-effecting: byLLM keeps any parallel batch containing it sequential.
-        serialize: bool = False,
-        # Subset of {"plan", "build", "qa"} -- the phases that expose this tool.
-        phases: set[str] = set();
+# Tools are modeled as a small graph: each capability is a `Tool` node that a
+# phase state is connected to by an `Exposes` edge (built in `build_pipeline`).
+# A state's `tools()` is then just its Exposes-neighbours -- no global lookup and
+# no stringly-typed phase match.
+enum ToolCat {
+    # Drives the turn-stat breakdown; anything that is neither Write nor Run
+    # counts as a read.
+    Read,
+    Write,
+    Run
 }
 
-def _resolve(path: str) -> str;
-def _set_session_cwd(new_dir: str);
+"""One capability the agent can call: a tool function plus its stats category and
+whether it must be serialized. Connected to the phase states that expose it by
+`Exposes` edges."""
+node Tool {
+    has fn: any,
+        category: ToolCat,
+        # Side-effecting: byLLM keeps any parallel batch containing it sequential.
+        serialize: bool = False;
+}
+
+"""Connects a phase state to a `Tool` it exposes."""
+edge Exposes {}
+
+# A tool's declaration row -- the function, its stats category, whether it must
+# be serialized, and the phase-state types that expose it -- on one descriptor
+# instead of spread across separate hand-kept lists. The `TOOL_SPECS` registry
+# (declared after the phase nodes, below) is the single source the stat groups,
+# the `Exposes` edges, and the serialize calls are all derived from.
+obj ToolSpec {
+    has fn: any,
+        category: ToolCat,
+        serialize: bool = False,
+        # The phase-state types that expose this tool (subset of {Plan,Build,QA}).
+        phases: set[type] = set();
+}
+
 def _project_root_of(start: str) -> str;
-def _phase_directive(label: str) -> str;
 def resolve_model_name(model_override: str = "") -> str;
 def _byllm_config -> any;
 def build_model(model_override: str = "", n_ctx: int = 0) -> Model;
@@ -345,7 +403,6 @@ glob agent_model = build_model();
 def truncate(text: str, limit: int = 12000) -> str;
 def confirm(action: str) -> bool;
 def _count_diags(diags: list) -> tuple[int, int];
-def code_intel -> any;
 
 # Flatten one conversation message (litellm dict or object) to a small JSON-safe
 # record (role + truncated content + tool-call summaries) for the token-usage
@@ -356,7 +413,7 @@ def _san_msg(m: any) -> dict;
 glob AGENT_RULES = """\
 You are Jac AI, a coding agent working inside the user's terminal in their Jac
 project. You read, write, and debug Jac code, and verify it really works. You
-move through states -- planning, building, QA -- and the state you are in tells
+move through states and the state you are in tells
 you what to do now; these are the habits that hold across all of them.
 
 Universal habits:
@@ -373,8 +430,8 @@ Universal habits:
   something a later state should check, call `note` -- notes stay visible to
   every later state and turn.
 
-You write JAC -- Python-flavored with braces -- never JavaScript, TypeScript, or
-React. A UI component is Jac (`def:pub Name(props) -> JsxElement { ... }`), not a
+You write only JAC -- Python-flavored with braces -- never JavaScript, TypeScript.
+A UI component is Jac (`def:pub Name(props) -> JsxElement { ... }`), not a
 React class or function. Before writing any UI code, call
 read_guide("jac-cl-components") and copy its shapes exactly.
 """;
@@ -469,155 +526,65 @@ sem request_needs_code_changes.objective = "The user's original request for this
 sem request_needs_code_changes.plan = "The plan and findings produced by the Plan phase so far.";
 
 
-# The single source of truth for the agent's tools. Each row pairs a tool
-# function with its properties; the stats categories, each PhaseState's tool
-# set (PhaseState.tools), and the serialize calls below are all derived from
-# this table, so adding a tool means adding one row here. Order is the order
-# tools are offered to the model within a phase.
-glob TOOLS: list[ToolSpec] = [
-         ToolSpec(
-             fn=agent.files.read_file, category="read", phases={"plan", "build", "qa"}
-         ),
-         ToolSpec(
-             fn=agent.files.write_file,
-             category="write",
-             serialize=True,
-             phases={"build"}
-         ),
-         ToolSpec(
-             fn=agent.files.edit_file,
-             category="write",
-             serialize=True,
-             phases={"build"}
-         ),
-         ToolSpec(fn=agent.files.list_dir, category="read", phases={"plan", "build"}),
-         ToolSpec(fn=agent.files.grep, category="read", phases={"plan", "build"}),
-         ToolSpec(
-             fn=agent.semantic.find_symbol, category="read", phases={"plan", "build"}
-         ),
-         ToolSpec(
-             fn=agent.semantic.find_uses, category="read", phases={"plan", "build"}
-         ),
-         ToolSpec(fn=agent.semantic.project_map, category="read", phases={"plan"}),
-         ToolSpec(fn=agent.semantic.find_walkers, category="read", phases={"plan"}),
-         ToolSpec(
-             fn=agent.semantic.context_slice, category="read", phases={"plan", "build"}
-         ),
-         ToolSpec(fn=agent.proc.jac_check, category="run", phases={"build", "qa"}),
-         ToolSpec(
-             fn=agent.proc.start_app, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(fn=agent.proc.serve, category="run", serialize=True, phases={"qa"}),
-         ToolSpec(
-             fn=agent.proc.stop_server, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.proc.run_command,
-             category="run",
-             serialize=True,
-             phases={"build", "qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_open, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_navigate, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_snapshot,
-             category="read",
-             serialize=True,
-             phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_click, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_type, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_fill, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_press, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_get, category="read", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_eval, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.web.browse_close, category="run", serialize=True, phases={"qa"}
-         ),
-         ToolSpec(
-             fn=agent.guides.search_guides, category="read", phases={"plan", "build"}
-         ),
-         ToolSpec(
-             fn=agent.guides.read_guide, category="read", phases={"plan", "build"}
-         ),
-         ToolSpec(
-             fn=agent.note,
-             category="read",
-             serialize=True,
-             phases={"plan", "build", "qa"}
-         )
-     ];
-
-# Tool-name groups for the turn-stat breakdown, derived from TOOLS; everything
-# not named here counts as a read.
-glob _WRITE_TOOLS: set[str] = {
-         str(t.fn.__name__)
-         for t in TOOLS
-         if t.category == "write"
-     },
-     _RUN_TOOLS: set[str] = {
-         str(t.fn.__name__)
-         for t in TOOLS
-         if t.category == "run"
-     };
-
-# Side-effecting tools must not run concurrently; serialize each one so byLLM
-# keeps any parallel batch that contains it sequential. Derived from TOOLS.
-with entry {
-    for t in TOOLS {
-        if t.serialize {
-            # Tools are toolbox methods: mark the underlying function so the flag
-            # survives (a bound method is a throwaway and rejects attributes).
-            mark_serialize(t.fn?.__func__ or t.fn);
-        }
-    }
-}
+# The `TOOL_SPECS` registry -- the single source of truth for the agent's tools
+# -- is declared below the phase nodes (so each row's `phases` can name the state
+# types directly), along with the stat-group and serialize derivations.
 
 # OSP agent: an AgentSession walker over a small state graph laid out as a
 # pipeline -- Plan --> Build --> QA, with QA looping back to Build/Plan or on to
 # Done. The legal transitions ARE the edges, so each state routes only among its
-# own successors: the shared `PhaseState.run` runs the phase, records a ledger
-# entry, then advances along the single out-edge, or lets the model pick when a
-# state has several (only QA does). Each state owns its prompt (`sem`) and tool
-# set (`tools()`).
+# own successors. Behavior is polymorphic, not branched on a label string: the
+# shared `step` runs the phase and records a ledger entry, `halt` is the common
+# stop guard, and each concrete state owns its own `run` ability -- so each owns
+# its routing (Plan's read-only fast path, Build's wrote-nothing nudge, QA's
+# model-picked edge) -- plus its `directive`, prompt (`sem`), and tool set
+# (`tools()`).
+"""A legal transition between phase states (Plan->Build->QA->Done). Distinct
+from `Exposes` so the routing traversals see only successor states, never the
+`Tool` nodes a state exposes."""
+edge Flow {}
+
 """A phase state: a self-contained step with its own prompt, tools, and context."""
 node PhaseState {
     has ctx: list = [],
+        # One-line role blurb the UI shows under the node. Lives here so tracing
+        # the real graph yields the label too -- no separate hardcoded list to
+        # keep in sync with the pipeline.
         desc: str = "";
 
-    # One-line role blurb the UI shows under the node. Lives here so tracing the
-    # real graph yields the label too -- no separate hardcoded list to keep in
-    # sync with the pipeline.
+    # The tools this state exposes (its `Exposes`-edge neighbours).
     def tools -> list;
-    can run with AgentSession entry;
+    # The imperative kickoff line for this phase; overridden per state.
+    def directive -> str;
+    # Shared phase body: run the LLM over this state's tools/ctx, fold the result
+    # into the walker's stats and ledger, and return the phase result. No `visit`
+    # -- routing is each concrete state's own `run` ability.
+    def step(visitor: AgentSession) -> dict;
+    # Common stop guard, called after `step`: True once the turn is cancelled or
+    # the step cap is hit (and it advances the step counter). Each `run` returns
+    # early on it before routing.
+    def halt(visitor: AgentSession) -> bool;
 }
 
 node Plan(PhaseState) {
     has desc: str = "Explore and decide the approach";
+
+    override def directive -> str;
+    can run with AgentSession entry;
 }
 
 node Build(PhaseState) {
     has desc: str = "Write and edit the code";
+
+    override def directive -> str;
+    can run with AgentSession entry;
 }
 
 node QA(PhaseState) {
     has desc: str = "Type-check, run, and verify";
+
+    override def directive -> str;
+    can run with AgentSession entry;
 }
 
 """The terminal state: the task is complete and verified."""
@@ -625,6 +592,147 @@ node Done {
     has desc: str = "Objective built and verified";
 
     can finish with AgentSession entry;
+}
+
+# The single source of truth for the agent's tools. Each row pairs a tool
+# function with its properties; the stat groups (_WRITE_TOOLS/_RUN_TOOLS), each
+# state's tool affordances (materialized as Exposes edges in build_pipeline), and
+# the serialize calls below are all derived from this table, so adding a tool
+# means adding one row here. Order is the order tools are offered to the model
+# within a phase. Declared after the phase nodes so each `phases` set can name
+# the state types directly.
+glob TOOL_SPECS: list[ToolSpec] = [
+         ToolSpec(
+             fn=agent.files.read_file, category=ToolCat.Read, phases={Plan, Build, QA}
+         ),
+         ToolSpec(
+             fn=agent.files.write_file,
+             category=ToolCat.Write,
+             serialize=True,
+             phases={Build}
+         ),
+         ToolSpec(
+             fn=agent.files.edit_file,
+             category=ToolCat.Write,
+             serialize=True,
+             phases={Build}
+         ),
+         ToolSpec(fn=agent.files.list_dir, category=ToolCat.Read, phases={Plan, Build}),
+         ToolSpec(fn=agent.files.grep, category=ToolCat.Read, phases={Plan, Build}),
+         ToolSpec(
+             fn=agent.semantic.find_symbol, category=ToolCat.Read, phases={Plan, Build}
+         ),
+         ToolSpec(
+             fn=agent.semantic.find_uses, category=ToolCat.Read, phases={Plan, Build}
+         ),
+         ToolSpec(fn=agent.semantic.project_map, category=ToolCat.Read, phases={Plan}),
+         ToolSpec(fn=agent.semantic.find_walkers, category=ToolCat.Read, phases={Plan}),
+         ToolSpec(
+             fn=agent.semantic.context_slice,
+             category=ToolCat.Read,
+             phases={Plan, Build}
+         ),
+         ToolSpec(fn=agent.proc.jac_check, category=ToolCat.Run, phases={Build, QA}),
+         ToolSpec(
+             fn=agent.proc.start_app, category=ToolCat.Run, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.proc.serve, category=ToolCat.Run, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.proc.stop_server,
+             category=ToolCat.Run,
+             serialize=True,
+             phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.proc.run_command,
+             category=ToolCat.Run,
+             serialize=True,
+             phases={Build, QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_open, category=ToolCat.Run, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_navigate,
+             category=ToolCat.Run,
+             serialize=True,
+             phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_snapshot,
+             category=ToolCat.Read,
+             serialize=True,
+             phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_click,
+             category=ToolCat.Run,
+             serialize=True,
+             phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_type, category=ToolCat.Run, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_fill, category=ToolCat.Run, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_press,
+             category=ToolCat.Run,
+             serialize=True,
+             phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_get, category=ToolCat.Read, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_eval, category=ToolCat.Run, serialize=True, phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.web.browse_close,
+             category=ToolCat.Run,
+             serialize=True,
+             phases={QA}
+         ),
+         ToolSpec(
+             fn=agent.guides.search_guides, category=ToolCat.Read, phases={Plan, Build}
+         ),
+         ToolSpec(
+             fn=agent.guides.read_guide, category=ToolCat.Read, phases={Plan, Build}
+         ),
+         ToolSpec(
+             fn=agent.note,
+             category=ToolCat.Read,
+             serialize=True,
+             phases={Plan, Build, QA}
+         )
+     ];
+
+# Tool-name groups for the turn-stat breakdown, derived from TOOL_SPECS;
+# everything not named here counts as a read.
+glob _WRITE_TOOLS: set[str] = {
+         str(t.fn.__name__)
+         for t in TOOL_SPECS
+         if t.category == ToolCat.Write
+     },
+     _RUN_TOOLS: set[str] = {
+         str(t.fn.__name__)
+         for t in TOOL_SPECS
+         if t.category == ToolCat.Run
+     };
+
+# Side-effecting tools must not run concurrently; serialize each one so byLLM
+# keeps any parallel batch that contains it sequential. Derived from TOOL_SPECS.
+with entry {
+    for t in TOOL_SPECS {
+        if t.serialize {
+            # Tools are toolbox methods: mark the underlying function so the flag
+            # survives (a bound method is a throwaway and rejects attributes).
+            mark_serialize(t.fn?.__func__ or t.fn);
+        }
+    }
 }
 
 def build_pipeline -> Plan;
@@ -646,7 +754,6 @@ walker AgentSession {
 
 
 def run_turn(message: str);
-def _project_errors -> list;
 def verify_and_continue(max_rounds: int = 3);
 def run_agent(req: object) -> int;
 

--- a/jac/jaclang/cli/impl/ai_agent.impl.jac
+++ b/jac/jaclang/cli/impl/ai_agent.impl.jac
@@ -33,19 +33,19 @@ import from jaclang.cli.browser_engine {
 # byLLM resolves config from `jac.toml` relative to its project dir. Use the
 # agent's working directory (the user's project) as the single source of truth,
 # not the process cwd -- under `jac ai --ui` the process runs in the bundled web
-# app's dir, so process cwd would read the wrong jac.toml. Empty `agent.cwd`
+# app's dir, so process cwd would read the wrong jac.toml. Empty `agent.ws.cwd`
 # (import time, before run_agent sets it) falls back to the default (cwd).
 """byLLM config rooted at the agent's working dir, not the process cwd.
 
 The single source of truth for which `jac.toml` supplies the model and byLLM
-settings: `agent.cwd` (the user's project). This matters under `jac ai --ui`,
+settings: `agent.ws.cwd` (the user's project). This matters under `jac ai --ui`,
 where the process runs in the bundled web app's directory -- resolving against
 process cwd there would read the wrong `jac.toml`. Falls back to the default
-(process cwd) only before `agent.cwd` is set (import time).
+(process cwd) only before `agent.ws.cwd` is set (import time).
 """
 impl _byllm_config -> any {
-    if agent.cwd {
-        return get_byllm_config(Path(agent.cwd));
+    if agent.ws.cwd {
+        return get_byllm_config(Path(agent.ws.cwd));
     }
     return get_byllm_config();
 }
@@ -179,19 +179,85 @@ impl _refresh_key_status -> None {
     agent.bus.model_name = name;
 }
 
-"""Resolve a tool path against the session working directory.
+"""Resolve a tool path against the workspace's working directory.
 
-Absolute paths pass through; relative paths are joined onto `agent.cwd` so
-every file tool agrees on what `main.jac` means, regardless of where `jac ai`
-was launched or which subfolder the model has `cd`'d into.
+Absolute paths pass through; relative paths are joined onto `cwd` so every file
+tool agrees on what `main.jac` means, regardless of where `jac ai` was launched
+or which subfolder the model has `cd`'d into.
 """
-impl _resolve(path: str) -> str {
+impl Workspace.resolve(path: str) -> str {
     p = path or ".";
     if os.path.isabs(p) {
         return os.path.normpath(p);
     }
-    base = agent.cwd or os.getcwd();
+    base = self.cwd or os.getcwd();
     return os.path.normpath(os.path.join(base, p));
+}
+
+"""Point the workspace (and its code intelligence) at a new working directory.
+
+Called when a `run_command` changes the shell's directory. Re-roots the shared
+CodeIntelligence at the new project root (the nearest ancestor holding a
+`jac.toml`, else the directory itself) so semantic queries and the health line
+reflect the project the model actually moved into -- e.g. a freshly scaffolded
+app subfolder -- not the launch directory.
+"""
+impl Workspace.set_cwd(new_dir: str) {
+    real = os.path.normpath(new_dir);
+    if not os.path.isdir(real) or real == self.cwd {
+        return;
+    }
+    prev_root = _project_root_of(self.cwd) if self.cwd else "";
+    self.cwd = real;
+    new_root = _project_root_of(real);
+    # Only rebuild code intelligence when the *project* changed -- a `cd` within
+    # the same project keeps the existing (warm) handle.
+    if self.ci is not None and new_root != prev_root {
+        try {
+            new_ci = CodeIntelligence(proj_dir=new_root, lazy=True);
+            new_ci.on_event = self.ci.on_event;
+            self.ci = new_ci;
+            self.ci_dirty = False;
+        } except Exception as e {
+            _ = e;
+        }
+    }
+}
+
+"""The shared CodeIntelligence, rebuilding it if a write happened since the last
+query.
+
+`write_file`/`edit_file` flag the project as dirty; the first query after a write
+recompiles so symbol lookups reflect what the agent just wrote.
+"""
+impl Workspace.code_intel -> any {
+    if self.ci is None {
+        return None;
+    }
+    if self.ci_dirty {
+        try {
+            self.ci.refresh();
+        } except Exception { }
+        self.ci_dirty = False;
+    }
+    return self.ci;
+}
+
+"""The project's current error diagnostics, or [] if no model is built yet."""
+impl Workspace.project_errors -> list {
+    ci = self.code_intel();
+    if ci is None or not ci.is_loaded() {
+        return [];
+    }
+    try {
+        return [
+            d
+            for d in ci.diagnostics()
+            if d.severity == "error"
+        ];
+    } except Exception {
+        return [];
+    }
 }
 
 """The project root for a directory: nearest ancestor with a `jac.toml`, else it."""
@@ -206,36 +272,6 @@ impl _project_root_of(start: str) -> str {
             return os.path.normpath(start);
         }
         cur = parent;
-    }
-}
-
-"""Point the session (and its code intelligence) at a new working directory.
-
-Called when a `run_command` changes the shell's directory. Re-roots the shared
-CodeIntelligence at the new project root (the nearest ancestor holding a
-`jac.toml`, else the directory itself) so semantic queries and the health line
-reflect the project the model actually moved into -- e.g. a freshly scaffolded
-app subfolder -- not the launch directory.
-"""
-impl _set_session_cwd(new_dir: str) {
-    real = os.path.normpath(new_dir);
-    if not os.path.isdir(real) or real == agent.cwd {
-        return;
-    }
-    prev_root = _project_root_of(agent.cwd) if agent.cwd else "";
-    agent.cwd = real;
-    new_root = _project_root_of(real);
-    # Only rebuild code intelligence when the *project* changed -- a `cd` within
-    # the same project keeps the existing (warm) handle.
-    if agent.ci is not None and new_root != prev_root {
-        try {
-            new_ci = CodeIntelligence(proj_dir=new_root, lazy=True);
-            new_ci.on_event = agent.ci.on_event;
-            agent.ci = new_ci;
-            agent.ci_dirty = False;
-        } except Exception as e {
-            _ = e;
-        }
     }
 }
 
@@ -286,23 +322,23 @@ type surfaces as a warning, not an error. Empty string when the edit
 introduced nothing (or no code intelligence is available).
 """
 impl FileTools.write_feedback(path: str) -> str {
-    if agent.ci is None or not agent.cfg.inline_feedback {
+    if self.ws.ci is None or not self.cfg.inline_feedback {
         # Feedback off: still flag dirty so the next semantic query refreshes.
-        if agent.ci is not None and not agent.cfg.inline_feedback {
-            agent.ci_dirty = True;
+        if self.ws.ci is not None and not self.cfg.inline_feedback {
+            self.ws.ci_dirty = True;
         }
         return "";
     }
     # Mark dirty up front so a failed refresh still rebuilds on the next query.
-    agent.ci_dirty = True;
+    self.ws.ci_dirty = True;
     try {
         # refresh_and_diff returns the diagnostics this edit caused (`path`
         # plus breakage in dependent modules).
-        diags: list = list(agent.ci.refresh_and_diff(path));
+        diags: list = list(self.ws.ci.refresh_and_diff(path));
     } except Exception {
         return "";
     }
-    agent.ci_dirty = False;
+    self.ws.ci_dirty = False;
     if not diags {
         return "";
     }
@@ -397,7 +433,7 @@ sem FileTools.read_file = "Read and return the full text of a file.";
 sem FileTools.read_file.path = "Path to the file to read, relative to the project.";
 impl FileTools.read_file(path: str) -> str {
     try {
-        return truncate(Path(_resolve(path)).read_text());
+        return truncate(Path(self.ws.resolve(path)).read_text());
     } except Exception as e {
         return f"ERROR reading {path}: {e}";
     }
@@ -415,7 +451,7 @@ impl FileTools.write_file(path: str, content: str) -> str {
         return "DENIED: the user declined this write.";
     }
     try {
-        rp = _resolve(path);
+        rp = self.ws.resolve(path);
         p = Path(rp);
         p.parent.mkdir(parents=True, exist_ok=True);
         p.write_text(content);
@@ -430,14 +466,14 @@ sem FileTools.edit_file.path = "Path of the file to edit.";
 sem FileTools.edit_file.old_text = "Exact text to find; must occur exactly once in the file.";
 sem FileTools.edit_file.new_text = "Text to replace it with.";
 impl FileTools.edit_file(path: str, old_text: str, new_text: str) -> str {
-    rp = _resolve(path);
+    rp = self.ws.resolve(path);
     if not os.path.isfile(rp) {
         # A new file has nothing to edit; steer the model to write_file rather
         # than letting it retry a doomed edit (the loop earlier sessions hit).
         return (
             f"ERROR: {path} does not exist, so there is nothing to edit. "
             "Create it with write_file(path, content) instead. (Paths resolve "
-            f"against the current directory {agent.cwd or os.getcwd()}.)"
+            f"against the current directory {self.ws.cwd or os.getcwd()}.)"
         );
     }
     try {
@@ -475,7 +511,7 @@ sem FileTools.list_dir = "List the entries of a directory (hidden entries exclud
 sem FileTools.list_dir.path = "Directory path; empty string means the current directory.";
 impl FileTools.list_dir(path: str) -> str {
     try {
-        target = Path(_resolve(path));
+        target = Path(self.ws.resolve(path));
         names: list[str] = [];
         for entry in sorted(target.iterdir()) {
             if entry.name.startswith(".") {
@@ -498,7 +534,7 @@ impl FileTools.grep(pattern: str, path: str) -> str {
     } except Exception as e {
         return f"ERROR: invalid regular expression: {e}";
     }
-    search_root = Path(_resolve(path));
+    search_root = Path(self.ws.resolve(path));
     if search_root.is_file() {
         files = [search_root];
     } elif search_root.is_dir() {
@@ -538,13 +574,13 @@ impl ProcessTools._proc_output(result: any) -> str {
 """Run a `jac` subcommand on a file and return its combined output."""
 impl ProcessTools.run_jac_cli(subcommand: str, path: str) -> str {
     try {
-        return agent.proc._proc_output(
+        return self._proc_output(
             subprocess.run(
                 [sys.executable, "-m", "jaclang", subcommand, path],
                 capture_output=True,
                 text=True,
                 timeout=120,
-                cwd=agent.cwd or None
+                cwd=self.ws.cwd or None
             )
         );
     } except Exception as e {
@@ -577,7 +613,7 @@ impl ProcessTools.run_command(command: str) -> str {
     if bin_dir {
         env["PATH"] = bin_dir + os.pathsep + env.get("PATH", "");
     }
-    work_dir = agent.cwd or os.getcwd();
+    work_dir = self.ws.cwd or os.getcwd();
     # Run the command, then echo the shell's final directory on its own line.
     # Because shell=True runs the whole thing in one shell, a `cd` inside
     # `command` changes that shell's cwd, and the trailing `pwd` captures it --
@@ -613,7 +649,7 @@ impl ProcessTools.run_command(command: str) -> str {
         }
     }
     if new_cwd and new_cwd != work_dir {
-        _set_session_cwd(new_cwd);
+        self.ws.set_cwd(new_cwd);
     }
     combined = ("\n".join(kept) + str(result.stderr or "")).strip();
     out = truncate(combined or f"(no output; exit code {result.returncode})");
@@ -628,18 +664,18 @@ impl ProcessTools.run_command(command: str) -> str {
 sem ProcessTools.jac_check = "Type-check and compile Jac code with `jac check`. Pass a single file, or a directory (`.` for the whole project) to check everything at once. Use this after writing or editing Jac code to confirm it is valid.";
 sem ProcessTools.jac_check.path = "File or directory to check; '.' or empty string checks the whole project.";
 impl ProcessTools.jac_check(path: str) -> str {
-    return agent.proc.run_jac_cli("check", path or ".");
+    return self.run_jac_cli("check", path or ".");
 }
 
 sem ProcessTools.start_app = "Start the app with `jac start` for ~12 seconds to confirm it boots, then stop it; returns the startup logs. Use this after building an app to catch errors that `jac check` cannot.";
 sem ProcessTools.start_app.entry_file = "Entry .jac file to start; empty string means 'main.jac'.";
 impl ProcessTools.start_app(entry_file: str) -> str {
     entry_path = entry_file or "main.jac";
-    abs_entry = _resolve(entry_path);
+    abs_entry = self.ws.resolve(entry_path);
     if not os.path.isfile(abs_entry) {
         return (
             f"ERROR: no such entry file '{entry_path}' (looked in "
-            f"{agent.cwd or os.getcwd()}). Use list_dir to find the app's "
+            f"{self.ws.cwd or os.getcwd()}). Use list_dir to find the app's "
             "main .jac file, then pass its path."
         );
     }
@@ -696,11 +732,11 @@ window.
 """
 impl ProcessTools.serve(entry_file: str) -> str {
     entry_path = entry_file or "main.jac";
-    abs_entry = _resolve(entry_path);
+    abs_entry = self.ws.resolve(entry_path);
     if not os.path.isfile(abs_entry) {
         return (
             f"ERROR: no such entry file '{entry_path}' (looked in "
-            f"{agent.cwd or os.getcwd()}). Use list_dir to find the app's "
+            f"{self.ws.cwd or os.getcwd()}). Use list_dir to find the app's "
             "main .jac file (the one with the `cl`/`sv` mount), then pass its path."
         );
     }
@@ -708,7 +744,7 @@ impl ProcessTools.serve(entry_file: str) -> str {
         return "DENIED: the user declined to start the server.";
     }
     # Drop any server we started earlier so we don't leak ports.
-    agent.proc._serve_shutdown();
+    self._serve_shutdown();
     work_dir = os.path.dirname(abs_entry) or ".";
     target = os.path.basename(abs_entry);
     log_path = "/tmp/jac_ai_serve.log";
@@ -716,7 +752,7 @@ impl ProcessTools.serve(entry_file: str) -> str {
         log_f = open(log_path, "w");
         # Own process group so _serve_shutdown can kill the server *and* the
         # vite/build children it spawns.
-        agent.serve_proc = subprocess.Popen(
+        self.serve_proc = subprocess.Popen(
             [sys.executable, "-m", "jaclang", "start", target],
             cwd=work_dir,
             stdout=log_f,
@@ -746,7 +782,7 @@ impl ProcessTools.serve(entry_file: str) -> str {
     deadline = time.time() + timeout;
     url = "";
     while time.time() < deadline {
-        if agent.serve_proc.poll() is not None {
+        if self.serve_proc.poll() is not None {
             break;  # server exited before becoming ready
         }
         try {
@@ -773,7 +809,7 @@ impl ProcessTools.serve(entry_file: str) -> str {
     } except Exception {
         tail = "(no log output)";
     }
-    agent.proc._serve_shutdown();
+    self._serve_shutdown();
     return (
         f"ERROR: the server did not become ready within {int(timeout)}s. "
         f"Last log lines:\n{tail}"
@@ -783,21 +819,21 @@ impl ProcessTools.serve(entry_file: str) -> str {
 sem ProcessTools.stop_server = "Stop the dev server started by serve. Call this when finished with browser QA.";
 """Stop the dev server started by `serve` (best-effort)."""
 impl ProcessTools.stop_server -> str {
-    agent.proc._serve_shutdown();
+    self._serve_shutdown();
     return "OK: dev server stopped.";
 }
 
 """Kill the `serve` dev server and its child processes if one is running."""
 impl ProcessTools._serve_shutdown{
-    if agent.serve_proc is not None {
+    if self.serve_proc is not None {
         try {
-            os.killpg(os.getpgid(int(agent.serve_proc.pid)), int(signal.SIGTERM));
+            os.killpg(os.getpgid(int(self.serve_proc.pid)), int(signal.SIGTERM));
         } except Exception {
             try {
-                agent.serve_proc.terminate();
+                self.serve_proc.terminate();
             } except Exception { }
         }
-        agent.serve_proc = None;
+        self.serve_proc = None;
     }
 }
 
@@ -845,28 +881,10 @@ impl GuideTools.read_guide(name: str) -> str {
     return truncate(guide.body, 16000);
 }
 
-"""Return the session's CodeIntelligence, rebuilding it if a write happened.
-
-`write_file`/`edit_file` flag the project as dirty; the first semantic query
-after a write recompiles so symbol lookups reflect what the agent just wrote.
-"""
-impl code_intel -> any {
-    if agent.ci is None {
-        return None;
-    }
-    if agent.ci_dirty {
-        try {
-            agent.ci.refresh();
-        } except Exception { }
-        agent.ci_dirty = False;
-    }
-    return agent.ci;
-}
-
 sem SemanticTools.find_symbol = "Look up a Jac symbol (node, walker, edge, obj, enum, ability, ...) by name via the compiler's symbol table. Returns its exact definition site, fields, abilities, base classes, and every place it is used. This is precise -- unlike grep it never matches a comment or an unrelated identifier. Prefer this over grep whenever you know the name of the thing you are looking for.";
 sem SemanticTools.find_symbol.name = "The symbol name to look up, e.g. 'User' or 'make_user'.";
 impl SemanticTools.find_symbol(name: str) -> str {
-    ci = code_intel();
+    ci = self.ws.code_intel();
     if ci is None {
         return "ERROR: code intelligence is unavailable in this session.";
     }
@@ -895,7 +913,7 @@ impl SemanticTools.find_symbol(name: str) -> str {
 sem SemanticTools.find_uses = "List every definition and use of a symbol across the whole project, computed from the compiler's def/use chains. Use this before renaming or changing a symbol to see exactly what it touches.";
 sem SemanticTools.find_uses.name = "The symbol name whose references to list.";
 impl SemanticTools.find_uses(name: str) -> str {
-    ci = code_intel();
+    ci = self.ws.code_intel();
     if ci is None {
         return "ERROR: code intelligence is unavailable in this session.";
     }
@@ -912,7 +930,7 @@ impl SemanticTools.find_uses(name: str) -> str {
 
 sem SemanticTools.project_map = "Show every node, walker, edge, and object archetype in the project with its location -- a structural overview built from the compiler, not a directory listing. Use this first to understand an unfamiliar project.";
 impl SemanticTools.project_map -> str {
-    ci = code_intel();
+    ci = self.ws.code_intel();
     if ci is None {
         return "ERROR: code intelligence is unavailable in this session.";
     }
@@ -930,7 +948,7 @@ impl SemanticTools.project_map -> str {
 sem SemanticTools.find_walkers = "Find every walker entry point that traverses a given node type -- an Object-Spatial query the compiler answers from walker entry signatures. Use this to see how a node is visited.";
 sem SemanticTools.find_walkers.node_type = "The node archetype name, e.g. 'User'.";
 impl SemanticTools.find_walkers(node_type: str) -> str {
-    ci = code_intel();
+    ci = self.ws.code_intel();
     if ci is None {
         return "ERROR: code intelligence is unavailable in this session.";
     }
@@ -948,7 +966,7 @@ impl SemanticTools.find_walkers(node_type: str) -> str {
 sem SemanticTools.context_slice = "Get a typed context slice for a symbol: its definition, the types it depends on, and where it is used -- a focused, compiler-accurate neighbourhood to read instead of opening whole files.";
 sem SemanticTools.context_slice.name = "The symbol to build a context slice around.";
 impl SemanticTools.context_slice(name: str) -> str {
-    ci = code_intel();
+    ci = self.ws.code_intel();
     if ci is None {
         return "ERROR: code intelligence is unavailable in this session.";
     }
@@ -979,39 +997,37 @@ impl BrowseTools._browse(confirm_msg: str, run: any, clip: bool = False) -> str 
         out = run();
         return truncate(str(out)) if clip else str(out);
     } except Exception as e {
-        return agent.web._browse_err(e);
+        return self._browse_err(e);
     }
 }
 
 sem BrowseTools.browse_open = "Launch a headless browser (or reuse the one already open) and navigate to a URL. Use this to QA a running web app, then read the page with browse_snapshot. An empty URL opens a blank page.";
 sem BrowseTools.browse_open.url = "URL to open, e.g. 'http://localhost:8000'. Empty string opens about:blank.";
 impl BrowseTools.browse_open(url: str) -> str {
-    return agent.web._browse(
+    return self._browse(
         f"open a browser at {url}" if url else "",
-        lambda : br_open(agent.browse_session, url or None)
+        lambda : br_open(self.session_id, url or None)
     );
 }
 
 sem BrowseTools.browse_navigate = "Navigate the open browser to a different URL and wait for it to load.";
 sem BrowseTools.browse_navigate.url = "The URL to navigate to.";
 impl BrowseTools.browse_navigate(url: str) -> str {
-    return agent.web._browse(
-        f"navigate the browser to {url}",
-        lambda : br_navigate(agent.browse_session, url)
+    return self._browse(
+        f"navigate the browser to {url}", lambda : br_navigate(self.session_id, url)
     );
 }
 
 sem BrowseTools.browse_snapshot = "Read the current page as an accessibility tree. Interactive elements are tagged with @e1/@e2 refs that you pass to browse_click, browse_type, and browse_fill. Call this after navigating, and again after any action that changes the page, to see the new state.";
 impl BrowseTools.browse_snapshot -> str {
-    return agent.web._browse("", lambda : br_snapshot(agent.browse_session), clip=True);
+    return self._browse("", lambda : br_snapshot(self.session_id), clip=True);
 }
 
 sem BrowseTools.browse_click = "Click an element with a real, trusted mouse event. Pass an @ref from browse_snapshot (e.g. '@e5') or a CSS selector (e.g. '#submit').";
 sem BrowseTools.browse_click.target = "An @ref from browse_snapshot, or a CSS selector.";
 impl BrowseTools.browse_click(target: str) -> str {
-    return agent.web._browse(
-        f"click {target} in the browser",
-        lambda : br_click(agent.browse_session, target)
+    return self._browse(
+        f"click {target} in the browser", lambda : br_click(self.session_id, target)
     );
 }
 
@@ -1019,9 +1035,9 @@ sem BrowseTools.browse_type = "Focus an element and type text into it as real ke
 sem BrowseTools.browse_type.target = "An @ref from browse_snapshot, or a CSS selector.";
 sem BrowseTools.browse_type.text = "The text to type.";
 impl BrowseTools.browse_type(target: str, text: str) -> str {
-    return agent.web._browse(
+    return self._browse(
         f"type into {target} in the browser",
-        lambda : br_type(agent.browse_session, target, text)
+        lambda : br_type(self.session_id, target, text)
     );
 }
 
@@ -1029,17 +1045,16 @@ sem BrowseTools.browse_fill = "Clear a field and set its value to the given text
 sem BrowseTools.browse_fill.target = "An @ref from browse_snapshot, or a CSS selector.";
 sem BrowseTools.browse_fill.text = "The text to set the field to.";
 impl BrowseTools.browse_fill(target: str, text: str) -> str {
-    return agent.web._browse(
-        f"fill {target} in the browser",
-        lambda : br_fill(agent.browse_session, target, text)
+    return self._browse(
+        f"fill {target} in the browser", lambda : br_fill(self.session_id, target, text)
     );
 }
 
 sem BrowseTools.browse_press = "Press a single key in the browser, e.g. 'Enter', 'Tab', 'Escape', or a chord like 'Ctrl+A'.";
 sem BrowseTools.browse_press.key = "The key or chord to press.";
 impl BrowseTools.browse_press(key: str) -> str {
-    return agent.web._browse(
-        f"press {key} in the browser", lambda : br_press(agent.browse_session, key)
+    return self._browse(
+        f"press {key} in the browser", lambda : br_press(self.session_id, key)
     );
 }
 
@@ -1047,30 +1062,30 @@ sem BrowseTools.browse_get = "Read a property of the current page: 'url', 'title
 sem BrowseTools.browse_get.what = "One of 'url', 'title', or 'text'.";
 sem BrowseTools.browse_get.selector = "CSS selector for 'text'; empty string for 'url' or 'title'.";
 impl BrowseTools.browse_get(what: str, selector: str) -> str {
-    return agent.web._browse(
-        "", lambda : br_get(agent.browse_session, what, selector or None), clip=True
+    return self._browse(
+        "", lambda : br_get(self.session_id, what, selector or None), clip=True
     );
 }
 
 sem BrowseTools.browse_eval = "Evaluate a JavaScript expression in the page and return its result. Use this to inspect page state or check for errors, e.g. \"document.querySelectorAll('.error').length\".";
 sem BrowseTools.browse_eval.expression = "A JavaScript expression to evaluate.";
 impl BrowseTools.browse_eval(expression: str) -> str {
-    return agent.web._browse(
+    return self._browse(
         f"run JavaScript in the browser: {expression}",
-        lambda : br_eval(agent.browse_session, expression),
+        lambda : br_eval(self.session_id, expression),
         clip=True
     );
 }
 
 sem BrowseTools.browse_close = "Close the browser and free its resources. Call this when finished with browser QA.";
 impl BrowseTools.browse_close -> str {
-    return agent.web._browse("", lambda : br_close(agent.browse_session));
+    return self._browse("", lambda : br_close(self.session_id));
 }
 
 """Close the agent's browser session if one was opened (best-effort)."""
 impl BrowseTools._browse_shutdown{
     try {
-        br_close(agent.browse_session);
+        br_close(self.session_id);
     } except Exception {
     # The browser may never have been opened this session; nothing to clean.
     }
@@ -1621,7 +1636,7 @@ the model is not yet built there is nothing the turn touched, so the stat is
 simply omitted.
 """
 impl TurnRenderer._format_health -> str {
-    ci = code_intel();
+    ci = agent.ws.code_intel();
     if ci is None or not ci.is_loaded() {
         return "";
     }
@@ -2060,6 +2075,17 @@ impl Prompt.for_phase(state_ty: type, objective: str, ledger: Ledger) -> str {
     );
 }
 
+"""Wire the shared workspace/config into the toolboxes that need them, so each
+depends on its injected collaborators rather than reaching the module glob. Runs
+once, when the `agent` singleton is constructed at import.
+"""
+impl AgentRuntime.postinit -> None {
+    self.files.ws = self.ws;
+    self.files.cfg = self.cfg;
+    self.proc.ws = self.ws;
+    self.semantic.ws = self.ws;
+}
+
 sem AgentRuntime.note = "Record a short note that stays visible to every later phase (Plan, Build, QA) and in later turns. Use it to flag a decision, an assumption, or something to verify.";
 sem AgentRuntime.note.text = "The note to remember.";
 """Record a note onto the active session's ledger (the `note` tool).
@@ -2077,22 +2103,12 @@ impl AgentRuntime.note(text: str) -> str {
     return "(no active session to note onto)";
 }
 
-# A state's tools are the TOOLS rows tagged with its phase, in registry order.
-# The phase is the node's class name lowercased (Plan -> "plan"), the same name
-# `run` uses as the phase label -- so Plan/Build/QA need no override.
-"""The tools this state exposes: the TOOLS rows tagged with its phase.
-
-Derived from the node's own class name (Plan/Build/QA -> plan/build/qa),
-so a state's allowed actions follow from its identity with no per-state
-override -- the same name `run` uses as the phase label.
-"""
+"""The tool functions this state exposes: its `Exposes`-edge neighbours, in the
+order build_pipeline connected them (the TOOL_SPECS registry order). A pure
+adjacency walk -- the state's affordances are graph structure, not a global
+lookup filtered by a phase-name string."""
 impl PhaseState.tools -> list {
-    phase = type(self).__name__.lower();
-    return [
-        t.fn
-        for t in TOOLS
-        if phase in t.phases
-    ];
+    return [t.fn for t in [self->:Exposes:->]];
 }
 
 sem Plan = "the PLANNING state: understand the request and the existing project before writing anything. Use project_map for an unfamiliar project, find_symbol / find_uses / context_slice to navigate by meaning, read_file to read what you will change, and the guides for unfamiliar Jac (read at least the one for the kind of code you will write -- e.g. jac-cl-components for a UI). Do not write or edit files here. Finish by stating a short, concrete plan: whether to scaffold (and which template -- client for a browser-only UI, fullstack for server/data, default for a script), the files to create or change, and what each is for.";
@@ -2101,53 +2117,25 @@ sem Build = "the BUILDING state: carry out the plan. For a new app, scaffold it 
 
 sem QA = "the QA state: verify the work end to end and fix what you find. Run `jac check .` (zero errors required). For a runnable app, start_app and confirm it boots cleanly. For a web or fullstack app, drive the built-in browser: call serve(entry) to start the dev server -- it waits until the server is actually ready and returns its URL (the first start is slow, as it installs client deps and builds the client). Then browse_open that URL, browse_snapshot to read the page, exercise the main flows with browse_click / browse_fill / browse_type / browse_press (snapshotting after each), check for errors with browse_eval, then browse_close and stop_server. If serve reports the server failed to start, read the log tail it returns and go back to Build to fix the cause -- do not conclude the app works until you have actually run and exercised it.";
 
-"""The imperative kickoff line for a phase, by state label (Plan/Build/QA).
+"""The imperative kickoff line for this phase: the turn's actual instruction.
 
-The phase `sem` describes the role; this is the turn's actual instruction. A
-weaker model tends to stop after merely exploring or describing a plan, so the
-Build line insists on writing code and the QA line insists on actually running
-the result -- finishing is not an option until the work exists and is verified.
+The phase `sem` describes the role; this is what kicks off the work. A weaker
+model tends to stop after merely exploring or describing a plan, so Build insists
+on writing code and QA insists on actually running the result -- finishing is not
+an option until the work exists and is verified. Overridden per concrete state;
+the base returns a generic fallback.
 """
-impl _phase_directive(label: str) -> str {
-    if label == "Plan" {
-        return (
-            "Investigate the request and the existing project, then state a "
-            "short, concrete plan. Do not write or edit files in this state."
-        );
-    }
-    if label == "Build" {
-        return (
-            "Build the requested feature NOW by writing real code: call "
-            "write_file to create each new file with its full contents, and "
-            "edit_file to change existing ones. Exploring or describing the "
-            "plan is NOT building -- keep working until every file the task "
-            "needs exists and the project compiles. After each write, read the "
-            "compiler feedback it returns and fix the errors before moving on. "
-            "Do not end this state with only reads."
-        );
-    }
-    if label == "QA" {
-        return (
-            "Verify the finished work end to end NOW. Run jac_check and require "
-            "zero errors. For a web or fullstack app, serve it and drive the "
-            "browser (browse_open, browse_snapshot, then click/type the real "
-            "controls) to confirm the REQUESTED feature actually works on the "
-            "page -- not just that the scaffold loads. If anything is missing, "
-            "wrong, or broken, go back to Build to fix it; choose Done only "
-            "after you have actually run and exercised the result."
-        );
-    }
-    return f"Carry out the {label} state now.";
+impl PhaseState.directive -> str {
+    return f"Carry out the {type(self).__name__} state now.";
 }
 
-sem run_phase.directive = "A short instruction kicking off the current phase.";
-impl PhaseState.run{
+"""Run this phase: the LLM works with the state's tools over its own ctx, then
+the result is folded into the walker's stats and ledger. Returns the phase
+result. No `visit` -- each concrete state's `run` ability owns routing.
+"""
+impl PhaseState.step(visitor: AgentSession) -> dict {
     agent.active_session = visitor;
     label = type(self).__name__;
-    # Stop pressed in the UI: halt the walker before entering another phase.
-    if agent.bus.cancel_requested {
-        return;
-    }
     console.print(f"\n  ● {label}", style="bold blue");
     # Move the walker on the live graph: the UI animates the edge from the
     # previous phase to this one.
@@ -2174,32 +2162,107 @@ impl PhaseState.run{
     agent.bus.open_convo(self.ctx);
     # Capture the phase's tool schemas (the API `tools` param) for this convo.
     agent.bus.set_convo_tools(agent.phase_tools);
-    result = agent.view.render_stream(run_phase(_phase_directive(label)));
+    result = agent.view.render_stream(run_phase(self.directive()));
     agent.bus.close_convo(self.ctx);
     visitor.stats.absorb(result);
     visitor.ledger.record(label, str(result.get("answer", "") or "(no summary)"));
     # Surface the new ledger entry to the UI panel right away (the next bus emit
     # would carry it anyway, but this lands it the instant the phase records).
     agent.bus.publish_ledger();
+    return result;
+}
+
+"""Common post-phase stop guard, called before routing: True once the turn is
+cancelled or the step cap is hit. Advances the step counter as a side effect."""
+impl PhaseState.halt(visitor: AgentSession) -> bool {
     # Stop pressed during the phase: halt here, don't route onward (and don't
     # make the QA route-selection LLM call).
     if agent.bus.cancel_requested {
-        return;
+        return True;
     }
-    # Route to the next state along this node's own out-edges.
+    # Safety valve: a runaway session halts at the cap rather than looping
+    # forever. The outer verify-and-continue still applies.
     visitor.steps += 1;
     if visitor.steps > visitor.max_steps {
-        # Safety valve: a runaway session halts here (no onward visit) rather
-        # than looping forever. The outer verify-and-continue still applies.
         console.print("\n  ● step cap reached -- stopping", style="yellow");
-    } elif label == "Build"
-    and int(result.get("n_write", 0) or 0) == 0
-    and visitor.build_nudges < 2 {
-        # Build that wrote nothing -- a weaker model often "describes" code (even
-        # pastes it into its answer) without ever calling write_file. Don't let
-        # that count as building: push back into Build with a blunt instruction
-        # to actually write the files. Bounded by build_nudges so a model that
-        # truly cannot produce a file falls through instead of looping.
+        return True;
+    }
+    return False;
+}
+
+impl Plan.directive -> str {
+    return (
+        "Investigate the request and the existing project, then state a "
+        "short, concrete plan. Do not write or edit files in this state."
+    );
+}
+
+impl Build.directive -> str {
+    return (
+        "Build the requested feature NOW by writing real code: call "
+        "write_file to create each new file with its full contents, and "
+        "edit_file to change existing ones. Exploring or describing the "
+        "plan is NOT building -- keep working until every file the task "
+        "needs exists and the project compiles. After each write, read the "
+        "compiler feedback it returns and fix the errors before moving on. "
+        "Do not end this state with only reads."
+    );
+}
+
+impl QA.directive -> str {
+    return (
+        "Verify the finished work end to end NOW. Run jac_check and require "
+        "zero errors. For a web or fullstack app, serve it and drive the "
+        "browser (browse_open, browse_snapshot, then click/type the real "
+        "controls) to confirm the REQUESTED feature actually works on the "
+        "page -- not just that the scaffold loads. If anything is missing, "
+        "wrong, or broken, go back to Build to fix it; choose Done only "
+        "after you have actually run and exercised the result."
+    );
+}
+
+sem run_phase.directive = "A short instruction kicking off the current phase.";
+# Plan routes via a read-only fast path: classify whether carrying out the
+# request needs any file created or edited. A pure question/inspection finishes
+# straight from Plan (skipping Build and its wrote-nothing nudge loop, and QA);
+# anything that touches code routes to Build, the default. Uses a typed bool
+# classifier with a Build-biased default -- robust where `visit [-->] by`'s LLM
+# edge filter can crash on a weak model's bad index.
+impl Plan.run with AgentSession entry {
+    # Stop pressed in the UI: halt the walker before entering another phase.
+    if agent.bus.cancel_requested {
+        return;
+    }
+    self.step(visitor);
+    if self.halt(visitor) {
+        return;
+    }
+    if request_needs_code_changes(visitor.objective, visitor.ledger.render()) {
+        visit [->:Flow:->][?:Build];
+    } else {
+        console.print(
+            "  ↳ read-only request -- answered in Plan, skipping Build/QA",
+            style="green"
+        );
+        visit [->:Flow:->][?:Done];
+    }
+}
+
+# Build advances to its single successor (QA), unless it wrote nothing -- a
+# weaker model often "describes" code (even pastes it into its answer) without
+# ever calling write_file. Don't let that count as building: push back into
+# Build with a blunt instruction to actually write the files. Bounded by
+# build_nudges so a model that truly cannot produce a file falls through to QA
+# instead of looping.
+impl Build.run with AgentSession entry {
+    if agent.bus.cancel_requested {
+        return;
+    }
+    result = self.step(visitor);
+    if self.halt(visitor) {
+        return;
+    }
+    if int(result.get("n_write", 0) or 0) == 0 and visitor.build_nudges < 2 {
         visitor.build_nudges += 1;
         self.ctx.append(
             {
@@ -2220,44 +2283,35 @@ impl PhaseState.run{
             style="yellow"
         );
         visit self;
-    } elif label == "Plan" {
-        # Read-only fast path: classify whether carrying out the request needs
-        # any file created or edited. A pure question/inspection finishes
-        # straight from Plan (skipping Build and its wrote-nothing nudge loop,
-        # and QA); anything that touches code routes to Build, the default. Uses
-        # a typed bool classifier with a Build-biased default -- robust where
-        # `visit [-->] by`'s LLM edge filter can crash on a weak model's bad
-        # index.
-        if request_needs_code_changes(visitor.objective, visitor.ledger.render()) {
-            visit [-->][?:Build];
-        } else {
-            console.print(
-                "  ↳ read-only request -- answered in Plan, skipping Build/QA",
-                style="green"
-            );
-            visit [-->][?:Done];
-        }
-    } elif len([-->]) == 1 {
-        # Single successor (Build -> QA): advance, no LLM call.
-        visit [-->];
-    } elif _project_errors() {
-        # Hard gate: the project does not compile, so finishing is not an option.
-        # Skip the model's choice and route straight back to Build to fix it --
-        # this is what stops QA from declaring Done on broken code.
-        n = len(_project_errors());
+    } else {
+        visit [->:Flow:->];
+    }
+}
+
+# QA either hard-gates back to Build (the project does not compile, so finishing
+# is not an option -- this is what stops QA from declaring Done on broken code)
+# or, when the project compiles, lets the model choose among its successors
+# (Build / Plan / Done), reading each candidate state's `sem`, the objective, and
+# the ledger. The choice is streamed via a stream_handler so the routing call's
+# reasoning reaches the live feed and its token usage the token-usage stream,
+# while `visit [-->] by` still constrains the choice to a real successor edge (no
+# free-text parsing, no manual default).
+impl QA.run with AgentSession entry {
+    if agent.bus.cancel_requested {
+        return;
+    }
+    self.step(visitor);
+    if self.halt(visitor) {
+        return;
+    }
+    if agent.ws.project_errors() {
+        n = len(agent.ws.project_errors());
         console.print(
             f"  ↳ project has {n} compile error(s) -- returning to Build",
             style="yellow"
         );
-        visit [-->][?:Build];
+        visit [->:Flow:->][?:Build];
     } else {
-        # Several successors (QA -> Build / Plan / Done) and the project
-        # compiles: let the model choose along this node's own out-edges,
-        # reading each candidate state's `sem`, the objective, and the ledger.
-        # Streamed via a stream_handler so the routing call's reasoning reaches
-        # the live feed and its token usage the token-usage stream, while
-        # `visit [-->] by` still constrains the choice to a real successor edge
-        # (no free-text parsing, no manual default).
         # byLLM builds the routing prompt internally, so seed the capture with a
         # synthetic input mirroring the incl_info -- enough for the detail view to
         # show what the routing call was deciding on.
@@ -2273,7 +2327,7 @@ impl PhaseState.run{
                 }
             ]
         );
-        visit [-->] by agent_model(
+        visit [->:Flow:->] by agent_model(
             stream=True,
             stream_handler=agent.view.route_stream_event,
             incl_info={
@@ -2345,15 +2399,28 @@ impl build_pipeline -> Plan {
     build = Build();
     qa = QA();
     done = Done();
-    plan ++> build;
+    plan +>: Flow :+> build;
     # Read-only fast path: a pure question or inspection that needs no file
     # changes finishes straight from Plan, so it never enters Build (and its
     # wrote-nothing nudge loop) or QA. Build remains the default Plan successor.
-    plan ++> done;
-    build ++> qa;
-    qa ++> build;
-    qa ++> plan;
-    qa ++> done;
+    plan +>: Flow :+> done;
+    build +>: Flow :+> qa;
+    qa +>: Flow :+> build;
+    qa +>: Flow :+> plan;
+    qa +>: Flow :+> done;
+    # Materialize each state's tool affordances as Exposes edges from the single
+    # TOOL_SPECS registry, in registry order (the order tools are offered to the
+    # model). Built fresh per pipeline, so edges never accumulate across turns;
+    # `tools()` then just reads its Exposes-neighbours.
+    for ph in [plan, build, qa] {
+        for spec in TOOL_SPECS {
+            if type(ph) in spec.phases {
+                ph +>: Exposes :+> Tool(
+                    fn=spec.fn, category=spec.category, serialize=spec.serialize
+                );
+            }
+        }
+    }
     return plan;
 }
 
@@ -2403,7 +2470,7 @@ impl run_turn(message: str) {
         n_err = 0;
         n_warn = 0;
         health_loaded = False;
-        ci = code_intel();
+        ci = agent.ws.code_intel();
         if ci is not None and ci.is_loaded() {
             try {
                 (n_err, n_warn) = _count_diags(list(ci.diagnostics()));
@@ -2431,23 +2498,6 @@ impl run_turn(message: str) {
     }
 }
 
-"""The project's current error diagnostics, or [] if no model is built yet."""
-impl _project_errors -> list {
-    ci = code_intel();
-    if ci is None or not ci.is_loaded() {
-        return [];
-    }
-    try {
-        return [
-            d
-            for d in ci.diagnostics()
-            if d.severity == "error"
-        ];
-    } except Exception {
-        return [];
-    }
-}
-
 """After a one-shot build, keep going until the project compiles.
 
 A weaker model often declares a multi-file task done while the project still
@@ -2464,7 +2514,7 @@ impl verify_and_continue(max_rounds: int = 3) {
     rnd = 0;
     prev_count = -1;
     while rnd < max_rounds {
-        errs = _project_errors();
+        errs = agent.ws.project_errors();
         if not errs {
             break;
         }
@@ -2514,7 +2564,7 @@ impl run_agent(req: object) -> int {
     r: any = req;
     # Seed the session working directory; every file tool and run_command
     # resolves against it, and a `cd` the model issues updates it.
-    agent.cwd = os.path.normpath(str(r?.cwd or os.getcwd()));
+    agent.ws.cwd = os.path.normpath(str(r?.cwd or os.getcwd()));
     # `--ui`: hand off to the bundled web app instead of the terminal REPL. The
     # child server re-imports this module and runs the agent itself, so nothing
     # else here (model build, banner, REPL) applies to the parent process.
@@ -2524,9 +2574,9 @@ impl run_agent(req: object) -> int {
     agent.cfg.yolo_mode = not r.safe;
     agent.cfg.verbose = not bool(r?.quiet);
     # Surface CI recompiles in the live view so the work behind writes/queries shows.
-    agent.ci = r.code_intel;
-    if agent.ci is not None {
-        agent.ci.on_event = agent.view._ci_event;
+    agent.ws.ci = r.code_intel;
+    if agent.ws.ci is not None {
+        agent.ws.ci.on_event = agent.view._ci_event;
     }
     initial_prompt = str(r.prompt);
     # Import-time `agent_model` covers jac.toml/default; rebuild only when a
@@ -2618,7 +2668,7 @@ impl run_agent(req: object) -> int {
 """Configure the agent for a UI session from the launcher's environment.
 
 Called once at the UI server's boot. Reads the user's project directory and
-model knobs from the `JAC_AI_UI_*` env vars the launcher set, points `agent.cwd`
+model knobs from the `JAC_AI_UI_*` env vars the launcher set, points `agent.ws.cwd`
 and a fresh `CodeIntelligence` at that project, builds the model, and forces
 yolo mode (the server has no terminal to confirm at). Idempotent.
 """
@@ -2626,7 +2676,7 @@ impl ui_configure -> None {
     global agent_model;
     # The launcher set these when it spawned this server process.
     proj = os.environ.get("JAC_AI_UI_PROJECT") or os.getcwd();
-    agent.cwd = os.path.normpath(proj);
+    agent.ws.cwd = os.path.normpath(proj);
     # No terminal here to confirm at, so writes/commands always run.
     agent.cfg.yolo_mode = True;
     agent.cfg.verbose = True;
@@ -2639,9 +2689,9 @@ impl ui_configure -> None {
     } except Exception { }
     # A project-rooted CodeIntelligence so the semantic tools work, lazily so
     # boot stays cheap. No on_event hook: its prints would only clutter the log.
-    agent.ci = CodeIntelligence(proj_dir=agent.cwd, lazy=True);
+    agent.ws.ci = CodeIntelligence(proj_dir=agent.ws.cwd, lazy=True);
     reset_session();
-    # `agent.cwd` is now set to the user's project, so build_model resolves the
+    # `agent.ws.cwd` is now set to the user's project, so build_model resolves the
     # model and byLLM config from their jac.toml (via `_byllm_config`), not this
     # child server's working directory (the bundled ai_ui dir).
     # Building the model can fail (missing API key, no local weights). Keep the
@@ -2652,12 +2702,12 @@ impl ui_configure -> None {
         agent_model = build_model(model_flag, n_ctx);
         agent.bus.emit(
             "system",
-            {"text": f"Connected to {agent.cwd} using {agent_model.model_name}."}
+            {"text": f"Connected to {agent.ws.cwd} using {agent_model.model_name}."}
         );
     } except Exception as e {
         agent.bus.emit(
             "error",
-            {"text": f"Connected to {agent.cwd}, but the model failed to load: {e}"}
+            {"text": f"Connected to {agent.ws.cwd}, but the model failed to load: {e}"}
         );
     }
     # Detect whether the chosen model still needs an API key. This rides along in
@@ -2909,7 +2959,10 @@ impl ui_graph -> dict {
                 "tools": tool_names
             }
         );
-        for succ in [nd-->] {
+        # Follow only Flow edges (the legal transitions) -- not the Exposes edges
+        # to this state's Tool nodes -- so the rendered graph is the phase
+        # pipeline, with tools carried per node in `tools` above.
+        for succ in [nd->:Flow:->] {
             edges.append({"source": nid, "target": type(succ).__name__});
             frontier.append(succ);
         }
@@ -3072,13 +3125,13 @@ impl _run_ui_server(r: any) -> int {
         return 1;
     }
     env = dict(os.environ);
-    env["JAC_AI_UI_PROJECT"] = agent.cwd;
+    env["JAC_AI_UI_PROJECT"] = agent.ws.cwd;
     env["JAC_AI_UI_MODEL"] = str(r?.model or "");
     env["JAC_AI_UI_NCTX"] = str(int(r?.n_ctx or 0));
     log_path = "/tmp/jac_ai_ui.log";
     console.print("");
     console.print("  Jac AI -- web UI", style="bold");
-    console.print(f"  project: {agent.cwd}", style="muted");
+    console.print(f"  project: {agent.ws.cwd}", style="muted");
     console.print("  building the client (first run installs deps)…", style="muted");
     proc: any = None;
     try {


### PR DESCRIPTION
## What & why

`cli/ai_agent.jac` (the engine behind `jac ai`) already models the agent as a `walker AgentSession` over a `Plan → Build → QA → Done` phase graph, but three patterns worked against that OOP/OSP ethos. This reworks them while **preserving behavior and the external contract** (`run_agent` + the 10 `ui_*` endpoints consumed by `ai_ui/server.jac`, plus the byLLM `by`-clause channel).

### 1. Polymorphic phase nodes (was: string dispatch)
`PhaseState.run` branched on `label == "Plan"/"Build"/"QA"` (~145 lines) to pick the directive and routing. Now `PhaseState` exposes a shared `step()` (phase body, no `visit`) and `halt()` (stop guard), and each concrete node owns its `run` ability + `directive()` override:
- **Plan** owns the read-only fast path,
- **Build** owns the wrote-nothing nudge,
- **QA** owns the compile-error gate + model-picked edge.

`_phase_directive` is removed.

### 2. Tools as OSP nodes/edges (was: stringly-typed join)
Adds `node Tool`, `edge Exposes`, and `enum ToolCat`. `build_pipeline` materializes per-phase `Exposes` edges from the `TOOL_SPECS` registry, and `PhaseState.tools()` becomes an adjacency walk `[t.fn for t in [self ->:Exposes:-> ]]` — eliminating the `phase in t.phases` string match keyed off `type(self).__name__.lower()`. Phase transitions are now a typed `edge Flow`, so routing and `ui_graph` traversals see successor states, never the `Tool` nodes a state exposes.

### 3. State cohesion + dependency injection (was: god-object + glob reach)
- New `obj Workspace` owns `cwd`/`ci`/`ci_dirty` and the operations over them (folds in the former free functions `_resolve`, `_set_session_cwd`, `code_intel`, `_project_errors`).
- `ProcessTools` owns `serve_proc`; `BrowseTools` owns `session_id`.
- `AgentRuntime.postinit` injects the shared `Workspace`/config into the toolboxes, so **no toolbox method reaches the module-level `agent` glob anymore**.

## Behavior preservation / verification
- `jac check` reports the **same diagnostics** as before (no new errors introduced).
- Per-phase tool sets are byte-identical to the old registry (Plan 11 / Build 13 / QA 17, same order); `_WRITE_TOOLS`/`_RUN_TOOLS` (2/13) unchanged.
- Pipeline topology and `ui_graph` output unchanged (Plan→[Build,Done], Build→[QA], QA→[Build,Done,Plan]).
- DI wiring verified at runtime: `files`/`proc`/`semantic` share one `Workspace`; file tools resolve/read/write through it.
- `ai_ui/server.jac` (the `ui_*` consumer) checks with an identical error count before/after.

## Note
Not yet exercised with a live `jac ai` turn (needs a model/key); the byLLM wiring of `run_phase` and the QA routing call is structurally unchanged — only how tools/directive/routing-edges are computed changed, and those are verified equivalent.