### PR TITLE
fix(type-checker): don't flag spread-filled params as duplicate keyword args

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6284.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6284.bugfix.md
@@ -1,0 +1,1 @@
+- **Spread arguments no longer trigger a false duplicate-argument error**: mixing a `*`/`**` spread with an explicit keyword for the same parameter (e.g. `greet(**defaults, name="x")` or `f(*args, c=3)`) no longer reports a spurious "Parameter 'X' already matched"; the spread still satisfies the required-parameter check.

--- a/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
@@ -254,6 +254,7 @@ impl ParamAssignmentTracker.get_unmatched_required_params -> list[types.Paramete
     for param in self.params {
         if (
             (param not in self.matched_params)
+            and (param not in self.spread_filled)
             and (param.default_value is None)
             and (
                 param.param_kind not in (types.ParamKind.VARARG, types.ParamKind.KWARG)
@@ -311,7 +312,7 @@ impl ParamAssignmentTracker.match_named_argument(
     }
 }
 
-"""Mark all positional parameters as matched."""
+"""Mark positional params as *possibly* filled by a `*args` spread."""
 impl ParamAssignmentTracker._mark_all_positional_params_as_matched -> None {
     for param in self.params {
         if (
@@ -321,13 +322,13 @@ impl ParamAssignmentTracker._mark_all_positional_params_as_matched -> None {
                 types.ParamKind.VARARG
             )
         ) {
-            self.matched_params.add(param);
+            self.spread_filled.add(param);
         }
     }
     self.curr_param_idx = -1;
 }
 
-"""Mark all named parameters as matched."""
+"""Mark named params as *possibly* filled by a `**kwargs` spread."""
 impl ParamAssignmentTracker._mark_all_named_params_as_matched -> None {
     for param in self.params {
         if (
@@ -337,7 +338,7 @@ impl ParamAssignmentTracker._mark_all_named_params_as_matched -> None {
                 types.ParamKind.KWARG
             )
         ) {
-            self.matched_params.add(param);
+            self.spread_filled.add(param);
         }
     }
 }
@@ -359,6 +360,10 @@ impl ParamAssignmentTracker.lookup_named_parameter(
             continue;
         }
         if (param.name == param_name) {
+            # A param in `matched_params` was bound by a real positional or
+            # keyword arg, so naming it again is a true duplicate. A param only
+            # in `spread_filled` (a `**`/`*` spread of unknown keys) is not — we
+            # cannot prove the spread set it, so the explicit keyword wins.
             if (param in self.matched_params) {
                 raise Exception(f"Parameter '{param.name}' already matched");
             }

--- a/jac/jaclang/compiler/type_system/type_utils.jac
+++ b/jac/jaclang/compiler/type_system/type_utils.jac
@@ -65,6 +65,12 @@ obj ParamAssignmentTracker {
     has params: list[types.Parameter],
         curr_param_idx: int = 0,
         matched_params: set[types.Parameter] = set(),
+        # Params *possibly* filled by a `*`/`**` spread of statically-unknown
+        # contents. Kept apart from `matched_params` (definite positional/keyword
+        # binds): a spread satisfies required-param checks but must NOT trigger a
+        # duplicate-argument error for a later explicit keyword, since we cannot
+        # prove the spread actually set that key.
+        spread_filled: set[types.Parameter] = set(),
         varargs: (types.Parameter | None) = None,
         kwargs: (types.Parameter | None) = None;
 

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_spread_with_kwarg.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_spread_with_kwarg.jac
@@ -1,0 +1,21 @@
+def make(a: int, b: int, c: int) -> None { }
+def greet(name: str, greeting: str) -> None { }
+
+with entry {
+    # A `*`/`**` spread of statically-unknown contents may supply a param, but
+    # we cannot prove it did -- so a later explicit keyword for that param is
+    # NOT a duplicate. None of the calls below should emit E1057.
+    nums = (1, 2);
+    make(*nums, c=3);  # *-spread covers a, b -- explicit c is not a duplicate
+
+    opts = {"greeting": "hello"};
+    greet(**opts, name="bob");  # **-spread covers greeting -- explicit name is fine
+
+    extra = {"b": 2};
+    make(1, **extra, c=3);  # positional a + **-spread + explicit c -- none duplicated
+
+    # Preserved behavior: a spread still satisfies the required-param check, so
+    # the params it may supply are not reported as missing.
+    full = {"a": 1, "b": 2, "c": 3};
+    make(**full);
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -5130,3 +5130,17 @@ test "duplicate_archetype_decl_is_hard_error" {
         1
     ].pretty_print()}";
 }
+
+test "spread_with_explicit_kwarg_no_false_positive" {
+    # Regression: a call that mixes a `*`/`**` spread with an explicit keyword
+    # argument must not emit E1057 "Parameter 'X' already matched". The spread
+    # contents are statically unknown, so the explicit keyword wins and the
+    # spread only satisfies the required-param check.
+    path = os.path.join(CHECKER_FIXTURES, "checker_spread_with_kwarg.jac");
+    program = JacProgram();
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+    assert len(program.errors_had) == 0 , f"Expected no errors for spread + explicit kwarg, got {len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(e.pretty_print() for e in program.errors_had);
+}


### PR DESCRIPTION
## Problem

`ParamAssignmentTracker` (the call-argument to parameter matcher used by the
type checker) recorded params *possibly* filled by a `*`/`**` spread into the
same `matched_params` set it uses to detect duplicate keyword arguments.

Because a spread of statically-unknown contents conservatively marks **every**
compatible parameter, any explicit keyword that named one of those params then
raised a false `E1057 "Parameter 'X' already matched"`. Valid calls were
rejected:

```jac
greet(**defaults, name="bob");   # E1057 on 'name' (false positive)
f(*args, c=3);                   # E1057 on 'c'    (false positive)
```

## Fix

Split the two concerns into two sets:

- `matched_params` -- params **definitely** bound by a concrete positional or
  keyword argument; drives duplicate detection.
- `spread_filled` (new) -- params that **might** be supplied by a `*`/`**`
  spread; drives only the required-parameter check.

So:

- `_mark_all_*_params_as_matched` now populate `spread_filled`.
- `get_unmatched_required_params` treats either set as satisfying a required
  param (a spread may supply it), preserving the existing behavior.
- `lookup_named_parameter` only reports a duplicate when the param is in
  `matched_params`, so an explicit keyword after a spread wins.

No change to genuine duplicate detection (two explicit binds of the same name),
unknown-keyword detection, or arity checks.

## Test

Adds `spread_with_explicit_kwarg_no_false_positive` to `test_checker_pass.jac`
with a `checker_spread_with_kwarg.jac` fixture. Verified it fails on the prior
code (3x E1057) and passes with the fix; the rest of the checker suite is
unaffected.

## Context

This is one of the underlying false positives surfaced by client (`.cl.jac`)
type-checking (related to #6262), but the bug and fix are general -- they apply
to any Jac code that overrides a `*`/`**` spread with an explicit keyword.
