### PR TITLE
fix(type-system): render Jac's lowercase `any` in diagnostics

### DIFF
--- a/jac/jaclang/cli/skills/jac-types.md
+++ b/jac/jaclang/cli/skills/jac-types.md
@@ -101,7 +101,7 @@ def run_callback(cb: any, payload: str) {   # cb: an opaque function reference
 - **Every `def` parameter needs a type** (E0052). `def foo(x) -> int` is invalid - must be `def foo(x: int) -> int`.
 - **A `def` that returns a value needs a return type** (E1003). A `def` with no `return` infers `None` - **do not** annotate it `-> None`, that triggers W3037 (`unnecessary-none-return`). Write `def save(x: int) { ... }`, not `def save(x: int) -> None { ... }`.
 - **`has name;`** without a type is a parse error. Always `has name: type;`.
-- `list`, `dict`, `set` without type args default to `list[Any]` (W1036) - add args when you know the element type: `list[str]`, `dict[str, int]`.
+- `list`, `dict`, `set` without type args default to `list[any]` (W1036) - add args when you know the element type: `list[str]`, `dict[str, int]`.
 - Use **`T | None`** for optional references. NOT `Optional[T]` (Python stdlib, not idiomatic). Always check `is None` before dereferencing.
 - **The gradual / escape-hatch type is lowercase `any`** - Jac-native, no import needed, type-checks cleanly. Do **NOT** `import from typing { Any }` - that triggers `W1104` (the compiler explicitly tells you to use the `any` keyword instead). Capitalized `Any` is not the keyword: a bare `x: Any` warns `W2001` ("Name 'Any' may be undefined").
 - **Event-handler params take the event type, not `any`.** In a `.cl.jac` handler, `e: any` leaves `e.target.value` an untyped `any` that then fails when stored in typed state - annotate the real event type (`e: ChangeEvent`, `e: MouseEvent`, ...). See `jac-cl-components`.

--- a/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
@@ -2447,7 +2447,7 @@ TODO: this is ad-hoc, need to do proper type inference.
 """
 impl JacAutoLintPass._infer_type_from_usestate_value(value: (uni.Expr | None)) -> str {
     if value is None {
-        return "Any";
+        return "any";
     }
     if isinstance(value, (uni.String, uni.MultiString)) {
         return "str";
@@ -2470,7 +2470,7 @@ impl JacAutoLintPass._infer_type_from_usestate_value(value: (uni.Expr | None)) -
     if isinstance(value, uni.DictVal) {
         return "dict";
     }
-    return "Any";
+    return "any";
 }
 
 """Create an ArchHas (has declaration) node from useState info.

--- a/jac/jaclang/compiler/type_system/impl/types.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/types.impl.jac
@@ -37,7 +37,7 @@ impl NeverType.__str__ -> str {
 
 """Return a string representation of the any type."""
 impl AnyType.__str__ -> str {
-    return "<Any>";
+    return "<any>";
 }
 
 """Return a string representation of the module type."""

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -367,7 +367,7 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "W1036",
          Category.TYPE,
          "Generic type \"{type}\" used without type arguments, defaulting to"
-         " \"{type}[Any]\"; consider adding explicit type arguments"
+         " \"{type}[any]\"; consider adding explicit type arguments"
      ),
      # Explicit `any` annotation warning
      W1037 = _warn(
@@ -609,7 +609,7 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
      W1102 = _warn(
          "W1102",
          Category.IMPORT,
-         "Imported name '{name}' from foreign-source module '{module}' typed as Any"
+         "Imported name '{name}' from foreign-source module '{module}' typed as any"
      ),
      W1103 = _warn(
          "W1103",

--- a/jac/tests/compiler/test_types_str.jac
+++ b/jac/tests/compiler/test_types_str.jac
@@ -23,7 +23,7 @@ test "all type str methods" {
 
     # AnyType
     any_type = types.AnyType();
-    assert str(any_type) == "<Any>";
+    assert str(any_type) == "<any>";
 
     # TypeVarType
     type_var = types.TypeVarType();
@@ -59,11 +59,11 @@ test "all type str methods" {
     func2 = types.FunctionType(
         func_name="add", parameters=[param1, param2], return_type=types.AnyType()
     );
-    assert str(func2) == "<function add(x: <Any>, y: <Any>) -> <Any>>";
+    assert str(func2) == "<function add(x: <any>, y: <any>) -> <any>>";
 
     # FunctionType - return type only
     func3 = types.FunctionType(func_name="get_value", return_type=types.AnyType());
-    assert str(func3) == "<function get_value() -> <Any>>";
+    assert str(func3) == "<function get_value() -> <any>>";
 
     # FunctionType - anonymous
     func4 = types.FunctionType();
@@ -87,13 +87,13 @@ test "all type str methods" {
     int_type = types.AnyType();
     str_type = types.AnyType();
     union2 = types.UnionType(types=[int_type, str_type]);
-    assert str(union2) == "<Any> | <Any>";
+    assert str(union2) == "<any> | <any>";
 
     # UnionType - different types
     union3 = types.UnionType(
         types=[types.UnknownType(), types.NeverType(), types.AnyType()]
     );
-    assert str(union3) == "<Unknown> | <Never> | <Any>";
+    assert str(union3) == "<Unknown> | <Never> | <any>";
 
     # ClassType
     mock_module = MagicMock(spec=Module);


### PR DESCRIPTION
## What

Diagnostics printed Python's `Any` instead of Jac's lowercase `any`, which the codebase has standardized on.

## Changes

- `AnyType.__str__` now returns `<any>` instead of `<Any>`. This is the source for how the any-type prints in every type-checker diagnostic (assignability errors, reveal-type / hover, union members, function signatures).
- Diagnostic templates W1036 (`{type}[any]`) and W1102 (`typed as any`) use lowercase `any`.
- `_infer_type_from_usestate_value` fallback now emits `any` (its docstring already states it should fall back to `any`).
- Updated `test_types_str` expectations and the `jac-types` skill doc to match.

Left untouched: references that genuinely mean Python's `typing.Any` (W1104 guidance text, `get_typing_class("Any")`, `== "Any"` symbol checks, and the codegen that emits Python `Any`).

## Testing

- `jac test jac/tests/compiler/test_types_str.jac` -> OK
- `jac test jac/tests/compiler/passes/main/test_checker_pass.jac` -> Ran 216 tests, OK