### PR TITLE
docs: prefer `cl { }` / `sv { }` / `na { }` blocks over `to X:` headers

### DIFF
--- a/docs/docs/internals/jac_import_patterns.md
+++ b/docs/docs/internals/jac_import_patterns.md
@@ -106,11 +106,11 @@ Path aliases let you define short prefixes (like `@components`) that map to proj
 Then use them in imports:
 
 ```jac
-to cl:
-
-import from "@components/Button" { Button }
-import from "@utils/format" { formatDate }
-import from "@shared" { constants }
+cl {
+    import from "@components/Button" { Button }
+    import from "@utils/format" { formatDate }
+    import from "@shared" { constants }
+}
 ```
 
 Aliases are resolved by:
@@ -172,41 +172,41 @@ All patterns tested and verified in:
 ### Full Feature Demo
 
 ```jac
-to cl:
+cl {
+    # Named imports
+    import from react { useEffect, useRef }
+    import from lodash { map as mapArray, filter }
 
-# Named imports
-import from react { useEffect, useRef }
-import from lodash { map as mapArray, filter }
+    # Default imports
+    import from react { default as React }
+    import from axios { default as axios }
 
-# Default imports
-import from react { default as React }
-import from axios { default as axios }
+    # Namespace imports
+    import from "date-fns" { * as DateFns }
+    import from .utils { * as Utils }
 
-# Namespace imports
-import from "date-fns" { * as DateFns }
-import from .utils { * as Utils }
+    # String literal imports (for hyphenated packages)
+    import from "react-dom" { render, hydrate }
+    import from "styled-components" { default as styled }
+    import from "react-router-dom" { BrowserRouter, Route }
 
-# String literal imports (for hyphenated packages)
-import from "react-dom" { render, hydrate }
-import from "styled-components" { default as styled }
-import from "react-router-dom" { BrowserRouter, Route }
+    # Mixed imports
+    import from react { default as React, useEffect }
 
-# Mixed imports
-import from react { default as React, useEffect }
+    # Relative paths
+    import from .components.Button { default as Button }
+    import from ..lib.helpers { formatDate }
+    import from ...config.constants { API_URL }
 
-# Relative paths
-import from .components.Button { default as Button }
-import from ..lib.helpers { formatDate }
-import from ...config.constants { API_URL }
+    def MyComponent() {
+        # Reactive state - auto-generates useState
+        has count: int = 0;
 
-def MyComponent() {
-    # Reactive state - auto-generates useState
-    has count: int = 0;
+        now = DateFns.format(Date.now());
+        axios.get(API_URL);
 
-    now = DateFns.format(Date.now());
-    axios.get(API_URL);
-
-    return count;
+        return count;
+    }
 }
 ```
 

--- a/docs/docs/quick-guide/import-anything.md
+++ b/docs/docs/quick-guide/import-anything.md
@@ -139,51 +139,51 @@ include math_helpers;
 Client code compiles to JavaScript, so the import list maps directly onto ECMAScript `import` declarations -- giving you **the entire npm ecosystem**. Client imports must live in the client codespace (`to cl:`, a `cl` prefix, a `cl { }` block, or a `.cl.jac` file).
 
 ```jac
-to cl:
+cl {
+    # Named imports -- the most common form
+    import from react { useState, useEffect }
 
-# Named imports -- the most common form
-import from react { useState, useEffect }
+    # Named imports with aliases
+    import from lodash { map as mapArray, filter }
 
-# Named imports with aliases
-import from lodash { map as mapArray, filter }
+    # Default import -- "default as Name". Requires the client codespace,
+    # because Python has no concept of a default export.
+    import from react { default as React }
 
-# Default import -- "default as Name". Requires the client codespace,
-# because Python has no concept of a default export.
-import from react { default as React }
+    # Namespace import -- "* as Name"
+    import from react { * as React }
 
-# Namespace import -- "* as Name"
-import from react { * as React }
-
-# Mixed: default + named in one statement (default listed first)
-import from react { default as React, useRef }
+    # Mixed: default + named in one statement (default listed first)
+    import from react { default as React, useRef }
+}
 ```
 
 npm package names often contain hyphens or `@scope/` prefixes that are not valid Jac identifiers. Quote them as **string literals** -- this works for every import form:
 
 ```jac
-to cl:
+cl {
+    import from "react-dom" { render, hydrate }
+    import from "react-router-dom" { BrowserRouter, Route }
+    import from "styled-components" { default as styled }
+    import from "date-fns" { * as DateFns }
 
-import from "react-dom" { render, hydrate }
-import from "react-router-dom" { BrowserRouter, Route }
-import from "styled-components" { default as styled }
-import from "date-fns" { * as DateFns }
-
-# @jac/runtime -- built-in client runtime helpers
-import from "@jac/runtime" { Link, useNavigate, JacForm }
+    # @jac/runtime -- built-in client runtime helpers
+    import from "@jac/runtime" { Link, useNavigate, JacForm }
+}
 ```
 
 Relative client modules and configured path aliases:
 
 ```jac
-to cl:
+cl {
+    # Relative imports between .jac client modules
+    import from .components.Button { default as Button }
+    import from ..lib.helpers { formatDate }
 
-# Relative imports between .jac client modules
-import from .components.Button { default as Button }
-import from ..lib.helpers { formatDate }
-
-# Path aliases -- prefixes defined in jac.toml under [plugins.client.paths]
-import from "@components/Button" { default as Button }
-import from "@shared" { constants }
+    # Path aliases -- prefixes defined in jac.toml under [plugins.client.paths]
+    import from "@components/Button" { default as Button }
+    import from "@shared" { constants }
+}
 ```
 
 A path alias is declared once in `jac.toml`:
@@ -199,17 +199,17 @@ A path alias is declared once in `jac.toml`:
 Some imports bind no names -- they exist purely for their side effects. **Stylesheets are the most common case:** importing a `.css` or `.scss` file applies its styles to the bundle. Drop the `{ items }` list entirely and import the path as a bare string literal:
 
 ```jac
-to cl:
+cl {
+    # Stylesheets -- applied to the bundle, no names bound
+    import "./styles.css";
+    import "./theme.scss";
 
-# Stylesheets -- applied to the bundle, no names bound
-import "./styles.css";
-import "./theme.scss";
+    # A font package whose CSS you want applied globally
+    import "@fontsource/roboto/400.css";
 
-# A font package whose CSS you want applied globally
-import "@fontsource/roboto/400.css";
-
-# A polyfill or any import-for-its-effects-only package
-import "core-js/stable";
+    # A polyfill or any import-for-its-effects-only package
+    import "core-js/stable";
+}
 ```
 
 Each lowers to a side-effect-only ECMAScript import -- `import "./styles.css";` stays `import "./styles.css";` in the generated JavaScript. Asset files (`.css`, `.scss`, `.sass`, `.less`, `.svg`, images, fonts) are detected by the client bundler and emitted into the built `styles.css` / asset output automatically.
@@ -221,41 +221,41 @@ Each lowers to a side-effect-only ECMAScript import -- `import "./styles.css";` 
 Native code compiles to machine code through LLVM. It has no Python interpreter, so PyPI packages are unavailable -- instead, the native codespace can call into **any C-ABI shared library** and import other native Jac modules.
 
 ```jac
-to na:
+na {
+    # Import from another native Jac module
+    import from math_utils { square, cube }
 
-# Import from another native Jac module
-import from math_utils { square, cube }
-
-# A small slice of the standard library is available natively
-import sys;   # sys.argv, sys.exit()
+    # A small slice of the standard library is available natively
+    import sys;   # sys.argv, sys.exit()
+}
 ```
 
 The headline native feature is **C library interop**. Point `import from` at a shared library path and declare the foreign functions you need right inside the braces -- the compiler generates the C-ABI bridge:
 
 ```jac
-to na:
+na {
+    # Pull a math function out of libm
+    import from "/usr/lib/libm.so.6" {
+        def sqrt(x: f64) -> f64;
+    }
 
-# Pull a math function out of libm
-import from "/usr/lib/libm.so.6" {
-    def sqrt(x: f64) -> f64;
-}
-
-# C signatures use fixed-width types -- carry those types through code
-# that feeds values into the C call.
-def hypotenuse(a: f64, b: f64) -> f64 {
-    return sqrt(a * a + b * b);
+    # C signatures use fixed-width types -- carry those types through code
+    # that feeds values into the C call.
+    def hypotenuse(a: f64, b: f64) -> f64 {
+        return sqrt(a * a + b * b);
+    }
 }
 ```
 
 The same mechanism works for any third-party C library, and a C `import from` block can declare structs (as `obj`) alongside functions:
 
 ```jac
-to na:
-
-import from "libgeometry.so" {
-    obj Point { has x: f64; has y: f64; }
-    def make_point(x: f64, y: f64) -> Point;
-    def distance(a: Point, b: Point) -> f64;
+na {
+    import from "libgeometry.so" {
+        obj Point { has x: f64; has y: f64; }
+        def make_point(x: f64, y: f64) -> Point;
+        def distance(a: Point, b: Point) -> f64;
+    }
 }
 ```
 
@@ -269,22 +269,22 @@ import from "libgeometry.so" {
 A single file can mix all three codespaces, and imports can reach *across* the boundary. The most important cross-codespace import is **`sv import` inside client code**: it pulls a server walker or `def:pub` function into the client, and the compiler rewrites the call into an HTTP request automatically.
 
 ```jac
-to cl:
+cl {
+    # Import a server walker into client code -- calls become HTTP requests.
+    sv import from .main { create_task }
 
-# Import a server walker into client code -- calls become HTTP requests.
-sv import from .main { create_task }
+    import from react { useState }
 
-import from react { useState }
-
-def TaskForm() -> JsxElement {
-    has title: str = "";
-    return <button onClick={lambda e: ChangeEvent {
-        create_task(title=title);
-    }}>Add</button>;
+    def TaskForm() -> JsxElement {
+        has title: str = "";
+        return <button onClick={lambda e: ChangeEvent {
+            create_task(title=title);
+        }}>Add</button>;
+    }
 }
 ```
 
-Server and native code interoperate the same way -- a native `to na:` function can be called directly from server code in the same file, with the compiler generating the interop stubs:
+Server and native code interoperate the same way -- a native function (in a `na { }` block) can be called directly from server code in the same file, with the compiler generating the interop stubs:
 
 ```jac
 """One file, three codespaces."""
@@ -296,14 +296,12 @@ def now_iso() -> str {
     return datetime.now().isoformat();
 }
 
-to na:
-
-def fib(n: int) -> int {
-    if n <= 1 { return n; }
-    return fib(n - 1) + fib(n - 2);
+na {
+    def fib(n: int) -> int {
+        if n <= 1 { return n; }
+        return fib(n - 1) + fib(n - 2);
+    }
 }
-
-to sv:
 
 with entry {
     print(now_iso());

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -142,9 +142,9 @@ Jac introduces **codespaces** -- regions of code that target different execution
 
 | Codespace | Target | Ecosystem | Syntax |
 |-----------|--------|-----------|--------|
-| **Server** | Python runtime | PyPI (`numpy`, `pandas`, `fastapi`) | `to sv:` or `.sv.jac` |
-| **Client** | Browser/JavaScript | npm (`react`, `tailwind`, `@mui`) | `to cl:` or `.cl.jac` |
-| **Native** | Compiled binary | C ABI | `to na:` or `.na.jac` |
+| **Server** | Python runtime | PyPI (`numpy`, `pandas`, `fastapi`) | `sv { }` or `.sv.jac` |
+| **Client** | Browser/JavaScript | npm (`react`, `tailwind`, `@mui`) | `cl { }` or `.cl.jac` |
+| **Native** | Compiled binary | C ABI | `na { }` or `.na.jac` |
 
 Server definitions are visible to client sections. When the client calls a server function, the compiler generates the HTTP request, serialization, and routing automatically. You write one language; the compiler produces the interop layer.
 

--- a/docs/docs/quick-guide/jac-vs-traditional-stack.md
+++ b/docs/docs/quick-guide/jac-vs-traditional-stack.md
@@ -1,6 +1,6 @@
 # Jac vs Traditional Stack: A Side-by-Side Comparison
 
-A traditional full-stack web application requires separate projects, frameworks, and glue code -- a Python backend, a React frontend, an ORM, API route definitions, and serialization logic. In Jac, you write all of this in a single file: nodes are your data model, walkers are your API endpoints, and a `to cl:` section (or `.cl.jac` file) holds your UI components. This comparison builds the same Todo app both ways so you can see the difference.
+A traditional full-stack web application requires separate projects, frameworks, and glue code -- a Python backend, a React frontend, an ORM, API route definitions, and serialization logic. In Jac, you write all of this in a single file: nodes are your data model, walkers are your API endpoints, and a `cl { }` block (or `.cl.jac` file) holds your UI components. This comparison builds the same Todo app both ways so you can see the difference.
 
 ---
 

--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -1298,81 +1298,81 @@ cl import from react { useState }
 # Client Components (JSX)
 # ============================================================
 
-to cl:
+cl {
+    def:pub Counter() -> JsxElement {
+        # `has` in client components becomes React useState
+        has count: int = 0;
 
-def:pub Counter() -> JsxElement {
-    # `has` in client components becomes React useState
-    has count: int = 0;
+        return <div>
+            <p>Count: {count}</p>
+            <button onClick={lambda -> None { count = count + 1; }}>
+                Increment
+            </button>
+        </div>;
+    }
 
-    return <div>
-        <p>Count: {count}</p>
-        <button onClick={lambda -> None { count = count + 1; }}>
-            Increment
-        </button>
-    </div>;
+    # JSX `{...}` slots accept statement-form control flow as children.
+    # Inside the slot, JSX statements push into the enclosing element's
+    # children list; `skip;` ends the slot with whatever was emitted.
+    def:pub Greeting(name: str) -> JsxElement {
+        return <div>
+            {if name == "" {
+                <p>(no name given)</p>
+                skip;                     # skip; = slot early-exit guard
+            }}
+            <h1>Hello, {name}!</h1>
+        </div>;
+    }
+
+    # Raw HTML opt-in (the name is the security review hint):
+    #   <div>{unsafe_html(trusted_html_blob)}</div>
+
+    # JSX syntax reference:
+    # <div>text</div>               HTML elements
+    # <Component prop="val" />      Component with props
+    # {expression}                  Expression slot (one value)
+    # {if .. for ..}                Statement slot (control flow as children)
+    # {#* comment *#}               JSX comment (renders nothing)
+    # {unsafe_html(x)}              Raw HTML opt-in (escapes off)
+    # <@expr />                     Dynamic tag (resolves expr at runtime)
+    # <div {**props}>               Spread props ({...props} also works but warns W0063)
+    # <Box {title} {count} />       Attribute shorthand ({title} -> title={title})
+    # <div className="cls">         Class name (not "class")
+    # <div style={{"color": "red"}} Inline styles
+    #   (classes declared in a same-base-name <Comp>.style.css are auto-scoped)
+    # <@expr>...</@expr>            Dynamic tag (tag chosen by expression)
 }
-
-# JSX `{...}` slots accept statement-form control flow as children.
-# Inside the slot, JSX statements push into the enclosing element's
-# children list; `skip;` ends the slot with whatever was emitted.
-def:pub Greeting(name: str) -> JsxElement {
-    return <div>
-        {if name == "" {
-            <p>(no name given)</p>
-            skip;                     # skip; = slot early-exit guard
-        }}
-        <h1>Hello, {name}!</h1>
-    </div>;
-}
-
-# Raw HTML opt-in (the name is the security review hint):
-#   <div>{unsafe_html(trusted_html_blob)}</div>
-
-# JSX syntax reference:
-# <div>text</div>               HTML elements
-# <Component prop="val" />      Component with props
-# {expression}                  Expression slot (one value)
-# {if .. for ..}                Statement slot (control flow as children)
-# {#* comment *#}               JSX comment (renders nothing)
-# {unsafe_html(x)}              Raw HTML opt-in (escapes off)
-# <@expr />                     Dynamic tag (resolves expr at runtime)
-# <div {**props}>               Spread props ({...props} also works but warns W0063)
-# <Box {title} {count} />       Attribute shorthand ({title} -> title={title})
-# <div className="cls">         Class name (not "class")
-# <div style={{"color": "red"}} Inline styles
-#   (classes declared in a same-base-name <Comp>.style.css are auto-scoped)
-# <@expr>...</@expr>            Dynamic tag (tag chosen by expression)
 
 
 # ============================================================
 # Client State & Lifecycle
 # ============================================================
 
-to cl:
+cl {
+    def:pub DataView() -> JsxElement {
+        has data: list = [];
+        has loading: bool = True;
 
-def:pub DataView() -> JsxElement {
-    has data: list = [];
-    has loading: bool = True;
+        # Mount effect (runs once on component mount)
+        async can with entry {
+            data = await fetch("/api/data").then(
+                lambda r: any -> any { return r.json(); }
+            );
+            loading = False;
+        }
 
-    # Mount effect (runs once on component mount)
-    async can with entry {
-        data = await fetch("/api/data").then(
-            lambda r: any -> any { return r.json(); }
-        );
-        loading = False;
+        # Dependency effect (runs when userId changes)
+        # async can with [userId] entry { ... }
+
+        # Multiple dependencies
+        # can with (a, b) entry { ... }
+
+        # Cleanup on unmount
+        # can with exit { unsubscribe(); }
+
+        if loading { return <p>Loading...</p>; }
+        return <div>{data}</div>;
     }
-
-    # Dependency effect (runs when userId changes)
-    # async can with [userId] entry { ... }
-
-    # Multiple dependencies
-    # can with (a, b) entry { ... }
-
-    # Cleanup on unmount
-    # can with exit { unsubscribe(); }
-
-    if loading { return <p>Loading...</p>; }
-    return <div>{data}</div>;
 }
 
 
@@ -1383,26 +1383,26 @@ def:pub DataView() -> JsxElement {
 # Import server walkers in client code
 sv import from ...main { AddTodo, GetTodos }
 
-to cl:
+cl {
+    def:pub TodoApp() -> JsxElement {
+        has todos: list = [];
 
-def:pub TodoApp() -> JsxElement {
-    has todos: list = [];
-
-    async can with entry {
-        result = root spawn GetTodos();
-        if result.reports {
-            todos = result.reports[0];
+        async can with entry {
+            result = root spawn GetTodos();
+            if result.reports {
+                todos = result.reports[0];
+            }
         }
-    }
 
-    async def add_todo(text: str) -> None {
-        result = root spawn AddTodo(title=text);
-        if result.reports {
-            todos = todos + [result.reports[0]];
+        async def add_todo(text: str) -> None {
+            result = root spawn AddTodo(title=text);
+            if result.reports {
+                todos = todos + [result.reports[0]];
+            }
         }
-    }
 
-    return <div>...</div>;
+        return <div>...</div>;
+    }
 }
 
 
@@ -1416,15 +1416,17 @@ def:pub TodoApp() -> JsxElement {
 # pages/(auth)/layout.jac  -> route group  (no URL segment)
 # pages/layout.jac         -> root layout
 
-# Page files export a `page` function under a `to cl:` section:
-# to cl:
-# def:pub page() -> JsxElement { ... }
+# Page files export a `page` function inside a `cl { }` block:
+# cl {
+#     def:pub page() -> JsxElement { ... }
+# }
 
 # Layout files use <Outlet /> for child routes:
 # cl import from "@jac/runtime" { Outlet }
-# to cl:
-# def:pub layout() -> JsxElement {
-#     return <><nav>...</nav><Outlet /></>;
+# cl {
+#     def:pub layout() -> JsxElement {
+#         return <><nav>...</nav><Outlet /></>;
+#     }
 # }
 
 

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -494,10 +494,10 @@ Define global variables that are replaced at compile time in client code via the
 These values are inlined by Vite during bundling. String values must be double-quoted (JSON-encoded). In client code, access them directly:
 
 ```jac
-to cl:
-
-def:pub Footer() -> JsxElement {
-    return <p>Version: {globalThis.BUILD_VERSION}</p>;
+cl {
+    def:pub Footer() -> JsxElement {
+        return <p>Version: {globalThis.BUILD_VERSION}</p>;
+    }
 }
 ```
 

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -295,11 +295,11 @@ VITE_API_URL=https://api.example.com
 Then access in client code:
 
 ```jac
-to cl:
-
-def:pub app() -> JsxElement {
-    api_url = import.meta.env.VITE_API_URL;
-    return <div>{api_url}</div>;
+cl {
+    def:pub app() -> JsxElement {
+        api_url = import.meta.env.VITE_API_URL;
+        return <div>{api_url}</div>;
+    }
 }
 ```
 
@@ -310,12 +310,12 @@ def:pub app() -> JsxElement {
 ### npm Packages
 
 ```jac
-to cl:
-
-import from react { useState, useEffect, useCallback }
-import from "@tanstack/react-query" { useQuery, useMutation }
-import from lodash { debounce, throttle }
-import from axios { default as axios }
+cl {
+    import from react { useState, useEffect, useCallback }
+    import from "@tanstack/react-query" { useQuery, useMutation }
+    import from lodash { debounce, throttle }
+    import from axios { default as axios }
+}
 ```
 
 ### TypeScript Configuration
@@ -334,26 +334,26 @@ exclude = ["node_modules"]
 ### Browser APIs
 
 ```jac
-to cl:
+cl {
+    def:pub app() -> JsxElement {
+        # Window
+        width = window.innerWidth;
 
-def:pub app() -> JsxElement {
-    # Window
-    width = window.innerWidth;
+        # LocalStorage
+        window.localStorage.setItem("key", "value");
+        value = window.localStorage.getItem("key");
 
-    # LocalStorage
-    window.localStorage.setItem("key", "value");
-    value = window.localStorage.getItem("key");
+        # Document
+        element = document.getElementById("my-id");
 
-    # Document
-    element = document.getElementById("my-id");
+        return <div>{width}</div>;
+    }
 
-    return <div>{width}</div>;
-}
-
-# Fetch
-async def load_data() -> None {
-    response = await fetch("/api/data");
-    data = await response.json();
+    # Fetch
+    async def load_data() -> None {
+        response = await fetch("/api/data");
+        data = await response.json();
+    }
 }
 ```
 

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -2045,8 +2045,6 @@ Native and Python codespaces can call each other within the same module:
 
 ```jac
 # main.jac (Python/server codespace)
-to sv:
-
 def process_data(data: list) -> list {
     # Python code with full PyPI access
     return sorted(data);

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -972,11 +972,11 @@ impl CircleService.describe -> str {
 
 #### Native Variant Files (`.na.jac`)
 
-Native variant files compile to LLVM IR and execute via JIT (MCJIT). Code in `.na.jac` files runs as native machine code, bypassing the Python runtime entirely. This is useful for performance-critical code and for calling C libraries directly. The same functionality is available in `to na:` sections (or `na` statement prefixes) within regular `.jac` files.
+Native variant files compile to LLVM IR and execute via JIT (MCJIT). Code in `.na.jac` files runs as native machine code, bypassing the Python runtime entirely. This is useful for performance-critical code and for calling C libraries directly. The same functionality is available in `na { }` blocks (or `na` statement prefixes) within regular `.jac` files.
 
 **C Library Imports:**
 
-Native code can import C shared libraries using the `import from` syntax with a library path and extern function declarations, either at the top level of a `.na.jac` file or under a `to na:` section in a regular `.jac` file:
+Native code can import C shared libraries using the `import from` syntax with a library path and extern function declarations, either at the top level of a `.na.jac` file or inside a `na { }` block in a regular `.jac` file:
 
 <!-- jac-skip -->
 ```jac

--- a/docs/docs/reference/language/native-pathway.md
+++ b/docs/docs/reference/language/native-pathway.md
@@ -6,7 +6,7 @@
 
 - [Overview](#overview) - What native compilation is and when to use it
 - [Quick Reference](#quick-reference) - At-a-glance summary of capabilities
-- [Native Sections in Jac Applications](#native-sections-in-jac-applications) - Mixing `to na:` sections into Python-backed Jac code
+- [Native Sections in Jac Applications](#native-sections-in-jac-applications) - Mixing native sections into Python-backed Jac code
 - [Python-Native Interop](#python-native-interop) - How the two codespaces communicate
 - [Standalone Native Binaries](#standalone-native-binaries) - Compiling `.na.jac` files to executables
 - [Type System](#type-system) - Native type mappings and fixed-width types
@@ -24,7 +24,7 @@
 
 Jac's native codespace compiles code to **machine-code via LLVM** -- the same Jac syntax, but running as native instructions instead of on the Python runtime. You can use it in two ways:
 
-1. **Inline native sections** -- drop native-compiled functions into any Jac application alongside Python-backed code using a `to na:` section header (or `na` statement prefix). The compiler generates the interop layer automatically.
+1. **Inline native sections** -- drop native-compiled functions into any Jac application alongside Python-backed code using a `na { }` block (or `to na:` section header / `na` statement prefix). The compiler generates the interop layer automatically.
 2. **Standalone `.na.jac` files** -- compile an entire program to a self-contained binary with `jac nacompile`. No Python runtime, no external compiler, no external linker -- the entire toolchain from source to executable runs within Jac itself.
 
 Native compilation is ideal for:
@@ -39,7 +39,7 @@ Native compilation is ideal for:
 
 | Aspect | Details |
 |--------|---------|
-| **Inline section** | `to na:` section header (or `na` prefix) in any `.jac` file |
+| **Inline section** | `na { }` block (or `to na:` header / `na` prefix) in any `.jac` file |
 | **Dedicated file** | `.na.jac` extension |
 | **Entry point** | `with entry { }` (standalone binaries only) |
 | **CLI command** | `jac nacompile <file> [-o output]` |
@@ -71,23 +71,21 @@ def process_data(items: list[dict]) -> list[dict] {
     return [item for item in items if item["active"]];
 }
 
-to na:
-
-# Native codespace -- compiles to machine code
-def compute_checksum(data: list[int]) -> int {
-    has result: int = 0;
-    for val in data {
-        result = (result * 31 + val) % 1000000007;
+na {
+    # Native codespace -- compiles to machine code
+    def compute_checksum(data: list[int]) -> int {
+        has result: int = 0;
+        for val in data {
+            result = (result * 31 + val) % 1000000007;
+        }
+        return result;
     }
-    return result;
-}
 
-def fibonacci(n: int) -> int {
-    if n <= 1 { return n; }
-    return fibonacci(n - 1) + fibonacci(n - 2);
+    def fibonacci(n: int) -> int {
+        if n <= 1 { return n; }
+        return fibonacci(n - 1) + fibonacci(n - 2);
+    }
 }
-
-to sv:
 
 with entry {
     # Call both Python and native functions seamlessly
@@ -123,15 +121,13 @@ def py_double(x: int) -> int {
     return x * 2;
 }
 
-to na:
-
-# Native function that calls the Python function
-def native_add_one_to_doubled(x: int) -> int {
-    has doubled: int = py_double(x);
-    return doubled + 1;
+na {
+    # Native function that calls the Python function
+    def native_add_one_to_doubled(x: int) -> int {
+        has doubled: int = py_double(x);
+        return doubled + 1;
+    }
 }
-
-to sv:
 
 with entry {
     print(native_add_one_to_doubled(5));  # prints 11
@@ -589,7 +585,7 @@ The following Jac features are **not yet available** in the native codespace:
 | PyPI imports | No Python ecosystem in native binaries |
 
 !!! tip
-    If you need a feature from the list above, keep that code in the Python codespace and use `to na:` sections only for the performance-critical parts. The compiler handles the interop automatically.
+    If you need a feature from the list above, keep that code in the Python codespace and use `na { }` blocks only for the performance-critical parts. The compiler handles the interop automatically.
 
 ---
 
@@ -712,18 +708,16 @@ def serialize(data: dict) -> str {
     return dumps(data);
 }
 
-to na:
-
-# Native side -- compiled to machine code
-def sum_squares(n: int) -> int {
-    has total: int = 0;
-    for i in range(n) {
-        total += i * i;
+na {
+    # Native side -- compiled to machine code
+    def sum_squares(n: int) -> int {
+        has total: int = 0;
+        for i in range(n) {
+            total += i * i;
+        }
+        return total;
     }
-    return total;
 }
-
-to sv:
 
 with entry {
     result = sum_squares(1000);

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1,6 +1,6 @@
 # jac-client Reference
 
-jac-client adds client-side compilation to Jac so you can write React-style UI components using `to cl:` section headers (or `.cl.jac` files). The compiler separates your code automatically -- server-side logic compiles to Python, while client-side components compile to JavaScript with React as the rendering engine.
+jac-client adds client-side compilation to Jac so you can write React-style UI components using `cl { }` blocks (or `.cl.jac` files). The compiler separates your code automatically -- server-side logic compiles to Python, while client-side components compile to JavaScript with React as the rendering engine.
 
 You also get project scaffolding (`jac create --use client`), npm dependency management, a Vite-powered dev server with HMR, and automatic HTTP bridge generation so your client components can call server walkers without manual API wiring. This reference covers installation, project structure, the module system, component authoring, and build configuration.
 
@@ -41,7 +41,7 @@ a `.css` file anywhere in the project and import it from your Jac code.
 
 ### The `.cl.jac` Convention
 
-Files ending in `.cl.jac` are automatically treated as client-side code -- no `to cl:` header needed:
+Files ending in `.cl.jac` are automatically treated as client-side code -- no `cl { }` block needed:
 
 ```jac
 # components/Header.cl.jac -- automatically client-side
@@ -50,7 +50,7 @@ def:pub Header() -> JsxElement {
 }
 ```
 
-This is equivalent to starting a regular `.jac` file with a `to cl:` section header.
+This is equivalent to wrapping a regular `.jac` file's contents in a `cl { }` block.
 
 ---
 
@@ -119,8 +119,6 @@ walker:priv InternalProcess { }
 ### Server Sections
 
 ```jac
-to sv:
-
 # Server-only section
 node User {
     has email: str;
@@ -178,25 +176,25 @@ def:pub create_task(title: str) -> Task {
 }
 
 # Client: receives hydrated Task instances
-to cl:
+cl {
+    sv import from .main { get_tasks, create_task }
 
-sv import from .main { get_tasks, create_task }
+    def:pub app -> JsxElement {
+        has tasks: list = [];
 
-def:pub app -> JsxElement {
-    has tasks: list = [];
+        async can with entry {
+            tasks = await get_tasks();  # list of Task objects
+        }
 
-    async can with entry {
-        tasks = await get_tasks();  # list of Task objects
+        async def addTask(title: str) -> None {
+            task = await create_task(title);  # a Task object
+            tasks = tasks + [task];
+        }
+
+        return <div>
+            {[<span key={t.title}>{t.title} - {t.done}</span> for t in tasks]}
+        </div>;
     }
-
-    async def addTask(title: str) -> None {
-        task = await create_task(title);  # a Task object
-        tasks = tasks + [task];
-    }
-
-    return <div>
-        {[<span key={t.title}>{t.title} - {t.done}</span> for t in tasks]}
-    </div>;
 }
 ```
 
@@ -290,10 +288,10 @@ cl def:pub app -> JsxElement {
 The entry `app()` function must be exported with `:pub`:
 
 ```jac
-to cl:
-
-def:pub app() -> JsxElement {  # :pub required
-    return <App />;
+cl {
+    def:pub app() -> JsxElement {  # :pub required
+        return <App />;
+    }
 }
 ```
 
@@ -308,46 +306,46 @@ every JSX call site per attribute. `children` is the special prop that holds
 the JSX nested between a component's tags:
 
 ```jac
-to cl:
-
-def:pub Button(
-    className: str = "",
-    onClick: MouseEventHandler = None,
-    children: any = None
-) -> JsxElement {
-    return <button className={className} onClick={onClick}>
-        {children}
-    </button>;
+cl {
+    def:pub Button(
+        className: str = "",
+        onClick: MouseEventHandler = None,
+        children: any = None
+    ) -> JsxElement {
+        return <button className={className} onClick={onClick}>
+            {children}
+        </button>;
+    }
 }
 ```
 
 ### Using Props
 
 ```jac
-to cl:
-
-def:pub Card(title: str, description: str = "", children: any = None) -> JsxElement {
-    return <div className="card">
-        <h2>{title}</h2>
-        <p>{description}</p>
-        {children}
-    </div>;
+cl {
+    def:pub Card(title: str, description: str = "", children: any = None) -> JsxElement {
+        return <div className="card">
+            <h2>{title}</h2>
+            <p>{description}</p>
+            {children}
+        </div>;
+    }
 }
 ```
 
 ### Composition
 
 ```jac
-to cl:
-
-def:pub app() -> JsxElement {
-    return <div>
-        <Card title="Welcome" description="Hello!">
-            <Button onClick={lambda -> None { print("clicked"); }}>
-                Click Me
-            </Button>
-        </Card>
-    </div>;
+cl {
+    def:pub app() -> JsxElement {
+        return <div>
+            <Card title="Welcome" description="Hello!">
+                <Button onClick={lambda -> None { print("clicked"); }}>
+                    Click Me
+                </Button>
+            </Card>
+        </div>;
+    }
 }
 ```
 
@@ -360,17 +358,17 @@ def:pub app() -> JsxElement {
 Inside client-tagged code (a `cl { }` block, a `.cl.jac` file, or a `to cl:` section), `has` creates reactive state:
 
 ```jac
-to cl:
+cl {
+    def:pub Counter() -> JsxElement {
+        has count: int = 0;  # Compiles to useState(0)
 
-def:pub Counter() -> JsxElement {
-    has count: int = 0;  # Compiles to useState(0)
-
-    return <div>
-        <p>Count: {count}</p>
-        <button onClick={lambda -> None { count = count + 1; }}>
-            Increment
-        </button>
-    </div>;
+        return <div>
+            <p>Count: {count}</p>
+            <button onClick={lambda -> None { count = count + 1; }}>
+                Increment
+            </button>
+        </div>;
+    }
 }
 ```
 
@@ -384,19 +382,19 @@ def:pub Counter() -> JsxElement {
 ### Complex State
 
 ```jac
-to cl:
+cl {
+    def:pub Form() -> JsxElement {
+        has name: str = "";
+        has items: list = [];
+        has data: dict = {"key": "value"};
 
-def:pub Form() -> JsxElement {
-    has name: str = "";
-    has items: list = [];
-    has data: dict = {"key": "value"};
+        # Create new references for lists/objects
+        def add_item(item: str) -> None {
+            items = items + [item];  # Concatenate to new list
+        }
 
-    # Create new references for lists/objects
-    def add_item(item: str) -> None {
-        items = items + [item];  # Concatenate to new list
+        return <div>Form</div>;
     }
-
-    return <div>Form</div>;
 }
 ```
 
@@ -429,40 +427,40 @@ Similar to how `has` variables automatically generate `useState`, the `can with 
 | `can with (a, b) entry { ... }` | `useEffect(() => { ... }, [a, b])` |
 
 ```jac
-to cl:
+cl {
+    def:pub DataLoader() -> JsxElement {
+        has data: list = [];
+        has loading: bool = True;
 
-def:pub DataLoader() -> JsxElement {
-    has data: list = [];
-    has loading: bool = True;
+        # Run once on mount (async with IIFE wrapping)
+        async can with entry {
+            data = await fetch_data();
+            loading = False;
+        }
 
-    # Run once on mount (async with IIFE wrapping)
-    async can with entry {
-        data = await fetch_data();
-        loading = False;
+        # Cleanup on unmount
+        can with exit {
+            cleanup_subscriptions();
+        }
+
+        return <div>...</div>;
     }
 
-    # Cleanup on unmount
-    can with exit {
-        cleanup_subscriptions();
+    def:pub UserProfile(userId: str) -> JsxElement {
+        has user: dict = {};
+
+        # Re-run when userId changes (dependency array)
+        async can with [userId] entry {
+            user = await fetch_user(userId);
+        }
+
+        # Multiple dependencies using tuple syntax
+        async can with (userId, refresh) entry {
+            user = await fetch_user(userId);
+        }
+
+        return <div>{user.name}</div>;
     }
-
-    return <div>...</div>;
-}
-
-def:pub UserProfile(userId: str) -> JsxElement {
-    has user: dict = {};
-
-    # Re-run when userId changes (dependency array)
-    async can with [userId] entry {
-        user = await fetch_user(userId);
-    }
-
-    # Multiple dependencies using tuple syntax
-    async can with (userId, refresh) entry {
-        user = await fetch_user(userId);
-    }
-
-    return <div>{user.name}</div>;
 }
 ```
 
@@ -471,48 +469,48 @@ def:pub UserProfile(userId: str) -> JsxElement {
 You can also use `useEffect` manually by importing it from React:
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    def:pub DataLoader() -> JsxElement {
+        has data: list = [];
+        has loading: bool = True;
 
-def:pub DataLoader() -> JsxElement {
-    has data: list = [];
-    has loading: bool = True;
+        # Run once on mount
+        useEffect(lambda -> None {
+            fetch_data();
+        }, []);
 
-    # Run once on mount
-    useEffect(lambda -> None {
-        fetch_data();
-    }, []);
+        # Run when dependency changes
+        useEffect(lambda -> None {
+            refresh_data();
+        }, [some_dep]);
 
-    # Run when dependency changes
-    useEffect(lambda -> None {
-        refresh_data();
-    }, [some_dep]);
-
-    return <div>...</div>;
+        return <div>...</div>;
+    }
 }
 ```
 
 ### useContext
 
 ```jac
-to cl:
+cl {
+    import from react { createContext, useContext }
 
-import from react { createContext, useContext }
+    glob AppContext = createContext(None);
 
-glob AppContext = createContext(None);
+    def:pub AppProvider(children: any = None) -> JsxElement {
+        has theme: str = "light";
 
-def:pub AppProvider(children: any = None) -> JsxElement {
-    has theme: str = "light";
+        return <AppContext.Provider value={{"theme": theme}}>
+            {children}
+        </AppContext.Provider>;
+    }
 
-    return <AppContext.Provider value={{"theme": theme}}>
-        {children}
-    </AppContext.Provider>;
-}
-
-def:pub ThemedComponent() -> JsxElement {
-    ctx = useContext(AppContext);
-    return <div className={ctx.theme}>Content</div>;
+    def:pub ThemedComponent() -> JsxElement {
+        ctx = useContext(AppContext);
+        return <div className={ctx.theme}>Content</div>;
+    }
 }
 ```
 
@@ -521,33 +519,33 @@ def:pub ThemedComponent() -> JsxElement {
 Create reusable state logic by defining functions that use `has`:
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    def use_local_storage(key: str, initial_value: any) -> tuple {
+        has value: any = initial_value;
 
-def use_local_storage(key: str, initial_value: any) -> tuple {
-    has value: any = initial_value;
+        useEffect(lambda -> None {
+            stored = localStorage.getItem(key);
+            if stored {
+                value = JSON.parse(stored);
+            }
+        }, []);
 
-    useEffect(lambda -> None {
-        stored = localStorage.getItem(key);
-        if stored {
-            value = JSON.parse(stored);
-        }
-    }, []);
+        useEffect(lambda -> None {
+            localStorage.setItem(key, JSON.stringify(value));
+        }, [value]);
 
-    useEffect(lambda -> None {
-        localStorage.setItem(key, JSON.stringify(value));
-    }, [value]);
+        return (value, lambda v: any -> None { value = v; });
+    }
 
-    return (value, lambda v: any -> None { value = v; });
-}
-
-def:pub Settings() -> JsxElement {
-    (theme, set_theme) = use_local_storage("theme", "light");
-    return <div>
-        <p>Current: {theme}</p>
-        <button onClick={lambda -> None { set_theme("dark"); }}>Dark</button>
-    </div>;
+    def:pub Settings() -> JsxElement {
+        (theme, set_theme) = use_local_storage("theme", "light");
+        return <div>
+            <p>Current: {theme}</p>
+            <button onClick={lambda -> None { set_theme("dark"); }}>Dark</button>
+        </div>;
+    }
 }
 ```
 
@@ -563,28 +561,28 @@ Use native Jac `spawn` syntax to call walkers from client code. First, import yo
 # Import walkers from backend
 sv import from ...main { get_tasks, create_task }
 
-to cl:
+cl {
+    def:pub TaskList() -> JsxElement {
+        has tasks: list = [];
+        has loading: bool = True;
 
-def:pub TaskList() -> JsxElement {
-    has tasks: list = [];
-    has loading: bool = True;
-
-    # Fetch data on component mount
-    async can with entry {
-        result = root spawn get_tasks();
-        if result.reports and result.reports.length > 0 {
-            tasks = result.reports[0];
+        # Fetch data on component mount
+        async can with entry {
+            result = root spawn get_tasks();
+            if result.reports and result.reports.length > 0 {
+                tasks = result.reports[0];
+            }
+            loading = False;
         }
-        loading = False;
-    }
 
-    if loading {
-        return <p>Loading...</p>;
-    }
+        if loading {
+            return <p>Loading...</p>;
+        }
 
-    return <ul>
-        {[<li key={task["id"]}>{task["title"]}</li> for task in tasks]}
-    </ul>;
+        return <ul>
+            {[<li key={task["id"]}>{task["title"]}</li> for task in tasks]}
+        </ul>;
+    }
 }
 ```
 
@@ -615,39 +613,39 @@ The spawn call returns a result object with:
 ```jac
 sv import from ...main { add_task, toggle_task, delete_task }
 
-to cl:
+cl {
+    def:pub TaskManager() -> JsxElement {
+        has tasks: list = [];
 
-def:pub TaskManager() -> JsxElement {
-    has tasks: list = [];
-
-    # Create
-    async def handle_add(title: str) -> None {
-        result = root spawn add_task(title=title);
-        if result.reports and result.reports.length > 0 {
-            tasks = tasks + [result.reports[0]];
+        # Create
+        async def handle_add(title: str) -> None {
+            result = root spawn add_task(title=title);
+            if result.reports and result.reports.length > 0 {
+                tasks = tasks + [result.reports[0]];
+            }
         }
-    }
 
-    # Update
-    async def handle_toggle(task_id: str) -> None {
-        result = root spawn toggle_task(task_id=task_id);
-        if result.reports and result.reports[0]["success"] {
-            tasks = [
-                {**t, "completed": not t["completed"]} if t["id"] == task_id else t
-                for t in tasks
-            ];
+        # Update
+        async def handle_toggle(task_id: str) -> None {
+            result = root spawn toggle_task(task_id=task_id);
+            if result.reports and result.reports[0]["success"] {
+                tasks = [
+                    {**t, "completed": not t["completed"]} if t["id"] == task_id else t
+                    for t in tasks
+                ];
+            }
         }
-    }
 
-    # Delete
-    async def handle_delete(task_id: str) -> None {
-        result = root spawn delete_task(task_id=task_id);
-        if result.reports and result.reports[0]["success"] {
-            tasks = [t for t in tasks if t["id"] != task_id];
+        # Delete
+        async def handle_delete(task_id: str) -> None {
+            result = root spawn delete_task(task_id=task_id);
+            if result.reports and result.reports[0]["success"] {
+                tasks = [t for t in tasks if t["id"] != task_id];
+            }
         }
-    }
 
-    return <div>...</div>;
+        return <div>...</div>;
+    }
 }
 ```
 
@@ -656,34 +654,34 @@ def:pub TaskManager() -> JsxElement {
 Wrap spawn calls in try/catch and track loading/error state:
 
 ```jac
-to cl:
+cl {
+    def:pub SafeDataView() -> JsxElement {
+        has data: any = None;
+        has loading: bool = True;
+        has error: str = "";
 
-def:pub SafeDataView() -> JsxElement {
-    has data: any = None;
-    has loading: bool = True;
-    has error: str = "";
-
-    async can with entry {
-        loading = True;
-        try {
-            result = root spawn get_data();
-            if result.reports and result.reports.length > 0 {
-                data = result.reports[0];
+        async can with entry {
+            loading = True;
+            try {
+                result = root spawn get_data();
+                if result.reports and result.reports.length > 0 {
+                    data = result.reports[0];
+                }
+            } except Exception as e {
+                error = f"Failed to load: {e}";
             }
-        } except Exception as e {
-            error = f"Failed to load: {e}";
+            loading = False;
         }
-        loading = False;
-    }
 
-    if loading { return <p>Loading...</p>; }
-    if error {
-        return <div>
-            <p>{error}</p>
-            <button onClick={lambda -> None { location.reload(); }}>Retry</button>
-        </div>;
+        if loading { return <p>Loading...</p>; }
+        if error {
+            return <div>
+                <p>{error}</p>
+                <button onClick={lambda -> None { location.reload(); }}>Retry</button>
+            </div>;
+        }
+        return <div>{JSON.stringify(data)}</div>;
     }
-    return <div>{JSON.stringify(data)}</div>;
 }
 ```
 
@@ -692,30 +690,30 @@ def:pub SafeDataView() -> JsxElement {
 Use `setInterval` with effect cleanup for periodic data refresh:
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    def:pub LiveData() -> JsxElement {
+        has data: any = None;
 
-def:pub LiveData() -> JsxElement {
-    has data: any = None;
-
-    async def fetch_data() -> None {
-        result = root spawn get_live_data();
-        if result.reports and result.reports.length > 0 {
-            data = result.reports[0];
+        async def fetch_data() -> None {
+            result = root spawn get_live_data();
+            if result.reports and result.reports.length > 0 {
+                data = result.reports[0];
+            }
         }
+
+        async can with entry { await fetch_data(); }
+
+        # The outer lambda must NOT be annotated `-> None` -- a cleanup effect
+        # returns a function, so `-> None` would be a type error.
+        useEffect(lambda {
+            interval = setInterval(lambda { fetch_data(); }, 5000);
+            return lambda { clearInterval(interval); };
+        }, []);
+
+        return <div>{data and <p>Last updated: {data["timestamp"]}</p>}</div>;
     }
-
-    async can with entry { await fetch_data(); }
-
-    # The outer lambda must NOT be annotated `-> None` -- a cleanup effect
-    # returns a function, so `-> None` would be a type error.
-    useEffect(lambda {
-        interval = setInterval(lambda { fetch_data(); }, 5000);
-        return lambda { clearInterval(interval); };
-    }, []);
-
-    return <div>{data and <p>Last updated: {data["timestamp"]}</p>}</div>;
 }
 ```
 
@@ -762,14 +760,14 @@ Each page file exports a `page` function:
 # pages/users/[id].jac
 cl import from "@jac/runtime" { useParams, Link }
 
-to cl:
-
-def:pub page() -> JsxElement {
-    params = useParams();
-    return <div>
-        <Link to="/users">Back</Link>
-        <h1>User {params["id"]}</h1>
-    </div>;
+cl {
+    def:pub page() -> JsxElement {
+        params = useParams();
+        return <div>
+            <Link to="/users">Back</Link>
+            <h1>User {params["id"]}</h1>
+        </div>;
+    }
 }
 ```
 
@@ -779,12 +777,12 @@ def:pub page() -> JsxElement {
 # pages/(auth)/layout.jac -- protects all pages in this group
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
-to cl:
-
-def:pub layout() -> JsxElement {
-    return <AuthGuard redirect="/login">
-        <Outlet />
-    </AuthGuard>;
+cl {
+    def:pub layout() -> JsxElement {
+        return <AuthGuard redirect="/login">
+            <Outlet />
+        </AuthGuard>;
+    }
 }
 ```
 
@@ -795,20 +793,20 @@ For manual routing, import components from `@jac/runtime`:
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-to cl:
+cl {
+    def:pub app() -> JsxElement {
+        return <Router>
+            <nav>
+                <Link to="/">Home</Link>
+                <Link to="/about">About</Link>
+            </nav>
 
-def:pub app() -> JsxElement {
-    return <Router>
-        <nav>
-            <Link to="/">Home</Link>
-            <Link to="/about">About</Link>
-        </nav>
-
-        <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/about" element={<About />} />
-        </Routes>
-    </Router>;
+            <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/about" element={<About />} />
+            </Routes>
+        </Router>;
+    }
 }
 ```
 
@@ -817,16 +815,16 @@ def:pub app() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { useParams }
 
-to cl:
+cl {
+    def:pub UserProfile() -> JsxElement {
+        params = useParams();
+        user_id = params["id"];
 
-def:pub UserProfile() -> JsxElement {
-    params = useParams();
-    user_id = params["id"];
+        return <div>User: {user_id}</div>;
+    }
 
-    return <div>User: {user_id}</div>;
+    # Route: /user/:id
 }
-
-# Route: /user/:id
 ```
 
 ### Programmatic Navigation
@@ -834,21 +832,21 @@ def:pub UserProfile() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { useNavigate }
 
-to cl:
+cl {
+    def:pub LoginForm() -> JsxElement {
+        navigate = useNavigate();
 
-def:pub LoginForm() -> JsxElement {
-    navigate = useNavigate();
-
-    async def handle_login() -> None {
-        success = await do_login();
-        if success {
-            navigate("/dashboard");
+        async def handle_login() -> None {
+            success = await do_login();
+            if success {
+                navigate("/dashboard");
+            }
         }
-    }
 
-    return <button onClick={lambda -> None { handle_login(); }}>
-        Login
-    </button>;
+        return <button onClick={lambda -> None { handle_login(); }}>
+            Login
+        </button>;
+    }
 }
 ```
 
@@ -857,26 +855,26 @@ def:pub LoginForm() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { Outlet }
 
-to cl:
+cl {
+    # pages/layout.jac -- root layout wrapping all pages
+    def:pub layout() -> JsxElement {
+        return <>
+            <nav>...</nav>
+            <main><Outlet /></main>
+            <footer>...</footer>
+        </>;
+    }
 
-# pages/layout.jac -- root layout wrapping all pages
-def:pub layout() -> JsxElement {
-    return <>
-        <nav>...</nav>
-        <main><Outlet /></main>
-        <footer>...</footer>
-    </>;
-}
-
-# pages/dashboard/layout.jac -- nested dashboard layout
-def:pub DashboardLayout() -> JsxElement {
-    # Child routes render where Outlet is placed
-    return <div>
-        <Sidebar />
-        <main>
-            <Outlet />
-        </main>
-    </div>;
+    # pages/dashboard/layout.jac -- nested dashboard layout
+    def:pub DashboardLayout() -> JsxElement {
+        # Child routes render where Outlet is placed
+        return <div>
+            <Sidebar />
+            <main>
+                <Outlet />
+            </main>
+        </div>;
+    }
 }
 ```
 
@@ -921,27 +919,27 @@ jac-client provides built-in authentication functions via `@jac/runtime`.
 ```jac
 cl import from "@jac/runtime" { jacLogin, useNavigate }
 
-to cl:
+cl {
+    def:pub LoginForm() -> JsxElement {
+        has username: str = "";
+        has password: str = "";
+        has error: str = "";
 
-def:pub LoginForm() -> JsxElement {
-    has username: str = "";
-    has password: str = "";
-    has error: str = "";
+        navigate = useNavigate();
 
-    navigate = useNavigate();
-
-    async def handleLogin(e: FormEvent) -> None {
-        e.preventDefault();
-        # jacLogin returns bool (True = success, False = failure)
-        success = await jacLogin(username, password);
-        if success {
-            navigate("/dashboard");
-        } else {
-            error = "Invalid credentials";
+        async def handleLogin(e: FormEvent) -> None {
+            e.preventDefault();
+            # jacLogin returns bool (True = success, False = failure)
+            success = await jacLogin(username, password);
+            if success {
+                navigate("/dashboard");
+            } else {
+                error = "Invalid credentials";
+            }
         }
-    }
 
-    return <form onSubmit={handleLogin}>...</form>;
+        return <form onSubmit={handleLogin}>...</form>;
+    }
 }
 ```
 
@@ -950,16 +948,16 @@ def:pub LoginForm() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { jacSignup }
 
-to cl:
-
-async def handleSignup() -> None {
-    # jacSignup returns dict with success key
-    result = await jacSignup(username, password);
-    if result["success"] {
-        # User registered and logged in
-        navigate("/dashboard");
-    } else {
-        error = result["error"] or "Signup failed";
+cl {
+    async def handleSignup() -> None {
+        # jacSignup returns dict with success key
+        result = await jacSignup(username, password);
+        if result["success"] {
+            # User registered and logged in
+            navigate("/dashboard");
+        } else {
+            error = result["error"] or "Signup failed";
+        }
     }
 }
 ```
@@ -969,23 +967,23 @@ async def handleSignup() -> None {
 ```jac
 cl import from "@jac/runtime" { jacLogout, jacIsLoggedIn }
 
-to cl:
+cl {
+    def:pub NavBar() -> JsxElement {
+        isLoggedIn = jacIsLoggedIn();
 
-def:pub NavBar() -> JsxElement {
-    isLoggedIn = jacIsLoggedIn();
+        def handleLogout() -> None {
+            jacLogout();
+            # Redirect to login
+        }
 
-    def handleLogout() -> None {
-        jacLogout();
-        # Redirect to login
+        return <nav>
+            {isLoggedIn and (
+                <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
+            ) or (
+                <a href="/login">Login</a>
+            )}
+        </nav>;
     }
-
-    return <nav>
-        {isLoggedIn and (
-            <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
-        ) or (
-            <a href="/login">Login</a>
-        )}
-    </nav>;
 }
 ```
 
@@ -1028,13 +1026,13 @@ Use `AuthGuard` to protect routes in file-based routing:
 ```jac
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
-to cl:
-
-# pages/(auth)/layout.jac
-def:pub layout() -> JsxElement {
-    return <AuthGuard redirect="/login">
-        <Outlet />
-    </AuthGuard>;
+cl {
+    # pages/(auth)/layout.jac
+    def:pub layout() -> JsxElement {
+        return <AuthGuard redirect="/login">
+            <Outlet />
+        </AuthGuard>;
+    }
 }
 ```
 
@@ -1045,24 +1043,24 @@ def:pub layout() -> JsxElement {
 ### Inline Styles
 
 ```jac
-to cl:
-
-def:pub StyledComponent() -> JsxElement {
-    return <div style={{"color": "blue", "padding": "10px"}}>
-        Styled content
-    </div>;
+cl {
+    def:pub StyledComponent() -> JsxElement {
+        return <div style={{"color": "blue", "padding": "10px"}}>
+            Styled content
+        </div>;
+    }
 }
 ```
 
 ### CSS Classes
 
 ```jac
-to cl:
-
-def:pub Card() -> JsxElement {
-    return <div className="card card-primary">
-        Content
-    </div>;
+cl {
+    def:pub Card() -> JsxElement {
+        return <div className="card card-primary">
+            Content
+        </div>;
+    }
 }
 ```
 
@@ -1077,9 +1075,9 @@ def:pub Card() -> JsxElement {
 ```
 
 ```jac
-to cl:
-
-import "./styles/main.css";
+cl {
+    import "./styles/main.css";
+}
 ```
 
 ### Scoped CSS (`.style.css` annexes)
@@ -1151,26 +1149,26 @@ Key points:
 ### cn() Utility (Tailwind/shadcn)
 
 ```jac
-to cl:
+cl {
+    # cn() from local lib/utils.ts (shadcn/ui pattern)
+    import from "../lib/utils" { cn }
 
-# cn() from local lib/utils.ts (shadcn/ui pattern)
-import from "../lib/utils" { cn }
+    def:pub StylingExamples() -> JsxElement {
+        has condition: bool = True;
+        has hasError: bool = False;
+        has isSuccess: bool = True;
 
-def:pub StylingExamples() -> JsxElement {
-    has condition: bool = True;
-    has hasError: bool = False;
-    has isSuccess: bool = True;
+        className = cn(
+            "base-class",
+            condition and "active",
+            {"error": hasError, "success": isSuccess}
+        );
 
-    className = cn(
-        "base-class",
-        condition and "active",
-        {"error": hasError, "success": isSuccess}
-    );
-
-    return <div>
-        <div className="p-4 bg-blue-500 text-white">Tailwind</div>
-        <div className={className}>Dynamic</div>
-    </div>;
+        return <div>
+            <div className="p-4 bg-blue-500 text-white">Tailwind</div>
+            <div className={className}>Dynamic</div>
+        </div>;
+    }
 }
 ```
 
@@ -1192,23 +1190,23 @@ def:pub StylingExamples() -> JsxElement {
 ### JSX Syntax Reference
 
 ```jac
-to cl:
+cl {
+    def:pub JsxExamples() -> JsxElement {
+        has variable: str = "text";
+        has condition: bool = True;
+        has items: list = [];
+        has props: dict = {};
 
-def:pub JsxExamples() -> JsxElement {
-    has variable: str = "text";
-    has condition: bool = True;
-    has items: list = [];
-    has props: dict = {};
+        return <div>
+            <input type="text" value={variable} />
 
-    return <div>
-        <input type="text" value={variable} />
+            {condition and <div>Shown if true</div>}
 
-        {condition and <div>Shown if true</div>}
+            {items}
 
-        {items}
-
-        <button {**props} {variable}>Click</button>
-    </div>;
+            <button {**props} {variable}>Click</button>
+        </div>;
+    }
 }
 ```
 
@@ -1219,34 +1217,34 @@ Two brace forms appear in attribute position. `{**props}` is a **spread** -- it 
 A `try` slot whose body needs to wait on async work can name its loading state with an `awaiting` clause. The cl lowering wraps the slot in `<JacAwaiting fallback={...}>{...}</JacAwaiting>` from `@jac/runtime` -- a `React.Suspense` shim -- so the `awaiting` body renders during the dispatched-but-not-joined window and the `try` body takes over once it settles. On `sv` and `na` targets the `awaiting` body is dropped with a `W2020` warning until the streaming-SSR and native-thread lowerings land.
 
 ```jac
-to cl:
-
-def:pub Profile(user_id: int) -> JsxElement {
-    return <article>
-        {try {
-            <ResolvedProfile id={user_id}/>
-        } awaiting {
-            <p>Loading profile…</p>
-        }}
-    </article>;
+cl {
+    def:pub Profile(user_id: int) -> JsxElement {
+        return <article>
+            {try {
+                <ResolvedProfile id={user_id}/>
+            } awaiting {
+                <p>Loading profile…</p>
+            }}
+        </article>;
+    }
 }
 ```
 
 Add an `except` arm to name the error state. On the cl target the slot then lowers to a `<JacClientErrorBoundary fallback={...}>` (auto-imported from `@jac/runtime`, where it re-exports [`react-error-boundary`'s `ErrorBoundary`](#jacclienterrorboundary)) **wrapping** the `<JacAwaiting>` node, so a throw in the resolved `try` body -- including from data the suspense shim awaited -- is caught and the `except` body renders in its place:
 
 ```jac
-to cl:
-
-def:pub Profile(user_id: int) -> JsxElement {
-    return <article>
-        {try {
-            <ResolvedProfile id={user_id}/>
-        } awaiting {
-            <p>Loading profile…</p>
-        } except Exception {
-            <p>Could not load profile.</p>
-        }}
-    </article>;
+cl {
+    def:pub Profile(user_id: int) -> JsxElement {
+        return <article>
+            {try {
+                <ResolvedProfile id={user_id}/>
+            } awaiting {
+                <p>Loading profile…</p>
+            } except Exception {
+                <p>Could not load profile.</p>
+            }}
+        </article>;
+    }
 }
 ```
 
@@ -1257,14 +1255,14 @@ Because a JS error boundary catches every error regardless of declared type, per
 Use Jac's block-comment syntax wrapped in a JSX expression slot -- `{#* ... *#}` -- to leave a note inside a JSX tree. The comment renders nothing and is preserved verbatim by `jac format`:
 
 ```jac
-to cl:
-
-def:pub App() -> JsxElement {
-    return <div>
-        <h1>Hello</h1>
-        {#* TODO: replace with a custom Button component *#}
-        <button>Click me</button>
-    </div>;
+cl {
+    def:pub App() -> JsxElement {
+        return <div>
+            <h1>Hello</h1>
+            {#* TODO: replace with a custom Button component *#}
+            <button>Click me</button>
+        </div>;
+    }
 }
 ```
 
@@ -1295,12 +1293,12 @@ export const Button: React.FC<ButtonProps> = ({ label, onClick }) => {
 ```
 
 ```jac
-to cl:
+cl {
+    import from "./components/Button" { Button }
 
-import from "./components/Button" { Button }
-
-def:pub app() -> JsxElement {
-    return <Button label="Click" onClick={lambda -> None { }} />;
+    def:pub app() -> JsxElement {
+        return <Button label="Click" onClick={lambda -> None { }} />;
+    }
 }
 ```
 
@@ -1396,11 +1394,11 @@ The `[plugins.client.paths]` section lets you define custom import path aliases.
 With the above config, you can use aliases in your `.cl.jac` or `cl {}` code:
 
 ```jac
-to cl:
-
-import from "@components/Button" { Button }
-import from "@utils/format" { formatDate }
-import from "@shared" { constants }
+cl {
+    import from "@components/Button" { Button }
+    import from "@utils/format" { formatDate }
+    import from "@shared" { constants }
+}
 ```
 
 | Feature | How It's Applied |
@@ -1444,14 +1442,14 @@ tailwindcss = "^4.0.0"
 Then import Tailwind in your entry CSS and use `className=` in components:
 
 ```jac
-to cl:
+cl {
+    import "./assets/main.css";  # contains: @import "tailwindcss";
 
-import "./assets/main.css";  # contains: @import "tailwindcss";
-
-def:pub app() -> JsxElement {
-    return <div className="min-h-screen bg-gray-100 p-8">
-        <h1 className="text-3xl font-bold">Hello</h1>
-    </div>;
+    def:pub app() -> JsxElement {
+        return <div className="min-h-screen bg-gray-100 p-8">
+            <h1 className="text-3xl font-bold">Hello</h1>
+        </div>;
+    }
 }
 ```
 
@@ -2063,18 +2061,18 @@ For advanced use cases, import the PWA runtime module:
 ```jac
 cl import from "@jac/pwa" { usePwaInstall, PwaInstallButton }
 
-to cl:
+cl {
+    def:pub CustomInstallUI() -> JsxElement {
+        (canInstall, triggerInstall) = usePwaInstall();
 
-def:pub CustomInstallUI() -> JsxElement {
-    (canInstall, triggerInstall) = usePwaInstall();
-
-    return <div>
-        {canInstall and (
-            <button onClick={lambda -> None { triggerInstall(); }}>
-                Get the App
-            </button>
-        )}
-    </div>;
+        return <div>
+            {canInstall and (
+                <button onClick={lambda -> None { triggerInstall(); }}>
+                    Get the App
+                </button>
+            )}
+        </div>;
+    }
 }
 ```
 
@@ -2145,10 +2143,10 @@ Define global variables that are replaced at compile time using the `[plugins.cl
 These values are inlined by Vite during bundling. String values must be double-quoted (JSON-encoded). Access them in client code:
 
 ```jac
-to cl:
-
-def:pub Footer() -> JsxElement {
-    return <p>Version: {globalThis.BUILD_VERSION}</p>;
+cl {
+    def:pub Footer() -> JsxElement {
+        return <p>Version: {globalThis.BUILD_VERSION}</p>;
+    }
 }
 ```
 
@@ -2191,23 +2189,23 @@ In dev mode, API routes are automatically proxied:
 Jac provides ambient DOM types (`ChangeEvent`, `KeyboardEvent`, `MouseEvent`, `FormEvent`, etc.) that are available without import. Use these for type-safe event handling:
 
 ```jac
-to cl:
+cl {
+    def:pub Form() -> JsxElement {
+        has value: str = "";
 
-def:pub Form() -> JsxElement {
-    has value: str = "";
-
-    return <div>
-        <input
-            value={value}
-            onChange={lambda e: ChangeEvent { value = e.target.value; }}
-            onKeyPress={lambda e: KeyboardEvent {
-                if e.key == "Enter" { submit(); }
-            }}
-        />
-        <button onClick={lambda -> None { submit(); }}>
-            Submit
-        </button>
-    </div>;
+        return <div>
+            <input
+                value={value}
+                onChange={lambda e: ChangeEvent { value = e.target.value; }}
+                onKeyPress={lambda e: KeyboardEvent {
+                    if e.key == "Enter" { submit(); }
+                }}
+            />
+            <button onClick={lambda -> None { submit(); }}>
+                Submit
+            </button>
+        </div>;
+    }
 }
 ```
 
@@ -2254,32 +2252,32 @@ The following event and element types are available in all Jac modules without a
 **Usage examples:**
 
 ```jac
-to cl:
+cl {
+    def:pub TypedForm() -> JsxElement {
+        has text: str = "";
+        has checked: bool = False;
 
-def:pub TypedForm() -> JsxElement {
-    has text: str = "";
-    has checked: bool = False;
-
-    return <div>
-        <input
-            value={text}
-            onChange={lambda e: ChangeEvent { text = e.target.value; }}
-            onKeyDown={lambda e: KeyboardEvent {
-                if e.key == "Enter" and not e.shiftKey { submit(); }
-            }}
-        />
-        <input
-            type="checkbox"
-            checked={checked}
-            onChange={lambda e: ChangeEvent { checked = e.target.checked; }}
-        />
-        <form onSubmit={lambda e: FormEvent {
-            e.preventDefault();
-            handleSubmit();
-        }}>
-            <button type="submit">Submit</button>
-        </form>
-    </div>;
+        return <div>
+            <input
+                value={text}
+                onChange={lambda e: ChangeEvent { text = e.target.value; }}
+                onKeyDown={lambda e: KeyboardEvent {
+                    if e.key == "Enter" and not e.shiftKey { submit(); }
+                }}
+            />
+            <input
+                type="checkbox"
+                checked={checked}
+                onChange={lambda e: ChangeEvent { checked = e.target.checked; }}
+            />
+            <form onSubmit={lambda e: FormEvent {
+                e.preventDefault();
+                handleSubmit();
+            }}>
+                <button type="submit">Submit</button>
+            </form>
+        </div>;
+    }
 }
 ```
 
@@ -2299,24 +2297,24 @@ def:pub TypedForm() -> JsxElement {
 ## Conditional Rendering
 
 ```jac
-to cl:
+cl {
+    def:pub ConditionalComponent() -> JsxElement {
+        has show: bool = False;
+        has items: list = [];
 
-def:pub ConditionalComponent() -> JsxElement {
-    has show: bool = False;
-    has items: list = [];
+        if show {
+            content = <p>Visible</p>;
+        } else {
+            content = <p>Hidden</p>;
+        }
+        return <div>
+            {content}
 
-    if show {
-        content = <p>Visible</p>;
-    } else {
-        content = <p>Hidden</p>;
+            {show and <p>Only when true</p>}
+
+            {[<li key={item["id"]}>{item["name"]}</li> for item in items]}
+        </div>;
     }
-    return <div>
-        {content}
-
-        {show and <p>Only when true</p>}
-
-        {[<li key={item["id"]}>{item["name"]}</li> for item in items]}
-    </div>;
 }
 ```
 
@@ -2335,12 +2333,12 @@ Import and wrap `JacClientErrorBoundary` around any subtree where you want to ca
 ```jac
 cl import from "@jac/runtime" { JacClientErrorBoundary }
 
-to cl:
-
-def:pub app() -> JsxElement {
-    return <JacClientErrorBoundary fallback={<div>Oops! Something went wrong.</div>}>
-        <MainAppComponents />
-    </JacClientErrorBoundary>;
+cl {
+    def:pub app() -> JsxElement {
+        return <JacClientErrorBoundary fallback={<div>Oops! Something went wrong.</div>}>
+            <MainAppComponents />
+        </JacClientErrorBoundary>;
+    }
 }
 ```
 
@@ -2363,12 +2361,12 @@ By default, jac-client internally wraps your entire application with `JacClientE
 ### Example with Custom Fallback
 
 ```jac
-to cl:
-
-def:pub App() -> JsxElement {
-    return <JacClientErrorBoundary fallback={<div className="error">Component failed to load</div>}>
-        <ExpensiveWidget />
-    </JacClientErrorBoundary>;
+cl {
+    def:pub App() -> JsxElement {
+        return <JacClientErrorBoundary fallback={<div className="error">Component failed to load</div>}>
+            <ExpensiveWidget />
+        </JacClientErrorBoundary>;
+    }
 }
 ```
 
@@ -2377,16 +2375,16 @@ def:pub App() -> JsxElement {
 You can nest multiple error boundaries for fine-grained error isolation:
 
 ```jac
-to cl:
-
-def:pub App() -> JsxElement {
-    return <JacClientErrorBoundary fallback={<div>App error</div>}>
-        <Header />
-        <JacClientErrorBoundary fallback={<div>Content error</div>}>
-            <MainContent />
-        </JacClientErrorBoundary>
-        <Footer />
-    </JacClientErrorBoundary>;
+cl {
+    def:pub App() -> JsxElement {
+        return <JacClientErrorBoundary fallback={<div>App error</div>}>
+            <Header />
+            <JacClientErrorBoundary fallback={<div>Content error</div>}>
+                <MainContent />
+            </JacClientErrorBoundary>
+            <Footer />
+        </JacClientErrorBoundary>;
+    }
 }
 ```
 
@@ -2451,24 +2449,24 @@ Jac does not have a JavaScript-style `new` keyword. Use the `new(...)` ambient b
 
 <!-- jac-skip -->
 ```jac
-to cl:
+cl {
+    # WebSocket
+    ws = new(WebSocket, url);
 
-# WebSocket
-ws = new(WebSocket, url);
+    # URL
+    url = new(URL, String(baseUrl));
 
-# URL
-url = new(URL, String(baseUrl));
+    # Date
+    now = new(Date);
 
-# Date
-now = new(Date);
+    # Promise
+    p = new(Promise, lambda(resolve: any, reject: any) {
+        resolve.call(None, "done");
+    });
 
-# Promise
-p = new(Promise, lambda(resolve: any, reject: any) {
-    resolve.call(None, "done");
-});
-
-# CustomEvent
-evt = new(CustomEvent, "my-event", {"detail": data});
+    # CustomEvent
+    evt = new(CustomEvent, "my-event", {"detail": data});
+}
 ```
 
 `new(Cls, ...args)` is portable: it works in any codespace. On the server it is a thin wrapper for `Cls(*args)`; in `cl` blocks the compiler rewrites the call into `Reflect.construct(Cls, [args])` so it can drive JS class constructors that require `new`.
@@ -2479,12 +2477,12 @@ When passing callbacks to be invoked later, use `.call(None, ...)`:
 
 <!-- jac-skip -->
 ```jac
-to cl:
-
-handler = myCallback;
-ws.onmessage = lambda(e: any) {
-    handler.call(None, JSON.parse(e.data));
-};
+cl {
+    handler = myCallback;
+    ws.onmessage = lambda(e: any) {
+        handler.call(None, JSON.parse(e.data));
+    };
+}
 ```
 
 ### Module-Level State
@@ -2492,10 +2490,10 @@ ws.onmessage = lambda(e: any) {
 Use `glob` for state shared across a module:
 
 ```jac
-to cl:
-
-glob initialized: bool = False;
-glob cache: any = None;
+cl {
+    glob initialized: bool = False;
+    glob cache: any = None;
+}
 ```
 
 For more patterns, see the [Advanced Patterns & JS Interop tutorial](../../tutorials/fullstack/advanced-patterns.md).

--- a/docs/docs/tutorials/fullstack/auth.md
+++ b/docs/docs/tutorials/fullstack/auth.md
@@ -41,66 +41,66 @@ cl import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn }
 ```jac
 cl import from "@jac/runtime" { jacLogin, jacSignup, jacLogout, jacIsLoggedIn, useNavigate }
 
-to cl:
+cl {
+    def:pub LoginPage() -> JsxElement {
+        has username: str = "";
+        has password: str = "";
+        has error: str = "";
+        has loading: bool = False;
 
-def:pub LoginPage() -> JsxElement {
-    has username: str = "";
-    has password: str = "";
-    has error: str = "";
-    has loading: bool = False;
+        navigate = useNavigate();
 
-    navigate = useNavigate();
+        async def handleLogin(e: FormEvent) -> None {
+            e.preventDefault();
+            error = "";
 
-    async def handleLogin(e: FormEvent) -> None {
-        e.preventDefault();
-        error = "";
+            if not username or not password {
+                error = "Please fill in all fields";
+                return;
+            }
 
-        if not username or not password {
-            error = "Please fill in all fields";
-            return;
+            loading = True;
+            success = await jacLogin(username, password);
+            loading = False;
+
+            if success {
+                navigate("/");
+            } else {
+                error = "Invalid credentials";
+            }
         }
 
-        loading = True;
-        success = await jacLogin(username, password);
-        loading = False;
+        return <div style={{"maxWidth": "400px", "margin": "0 auto", "padding": "2rem"}}>
+            <h2>Login</h2>
+            <form onSubmit={handleLogin}>
+                {error and <div style={{"color": "red", "marginBottom": "1rem"}}>{error}</div>}
 
-        if success {
-            navigate("/");
-        } else {
-            error = "Invalid credentials";
-        }
+                <input
+                    type="text"
+                    value={username}
+                    onChange={lambda e: ChangeEvent { username = e.target.value; }}
+                    placeholder="Username"
+                    style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
+                />
+
+                <input
+                    type="password"
+                    value={password}
+                    onChange={lambda e: ChangeEvent { password = e.target.value; }}
+                    placeholder="Password"
+                    style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
+                />
+
+                <button
+                    type="submit"
+                    disabled={loading}
+                    style={{"width": "100%", "padding": "0.5rem"}}
+                >
+                    {loading and "Logging in..." or "Login"}
+                </button>
+            </form>
+        </div>;
     }
-
-    return <div style={{"maxWidth": "400px", "margin": "0 auto", "padding": "2rem"}}>
-        <h2>Login</h2>
-        <form onSubmit={handleLogin}>
-            {error and <div style={{"color": "red", "marginBottom": "1rem"}}>{error}</div>}
-
-            <input
-                type="text"
-                value={username}
-                onChange={lambda e: ChangeEvent { username = e.target.value; }}
-                placeholder="Username"
-                style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
-            />
-
-            <input
-                type="password"
-                value={password}
-                onChange={lambda e: ChangeEvent { password = e.target.value; }}
-                placeholder="Password"
-                style={{"width": "100%", "padding": "0.5rem", "marginBottom": "1rem"}}
-            />
-
-            <button
-                type="submit"
-                disabled={loading}
-                style={{"width": "100%", "padding": "0.5rem"}}
-            >
-                {loading and "Logging in..." or "Login"}
-            </button>
-        </form>
-    </div>;
 }
 ```
 
@@ -115,17 +115,17 @@ Authenticates a user and stores the JWT token.
 ```jac
 cl import from "@jac/runtime" { jacLogin }
 
-to cl:
+cl {
+    async def handleLogin() -> None {
+        # jacLogin returns bool (True = success, False = failure)
+        success = await jacLogin(username, password);
 
-async def handleLogin() -> None {
-    # jacLogin returns bool (True = success, False = failure)
-    success = await jacLogin(username, password);
-
-    if success {
-        # User is now logged in, token stored automatically
-        navigate("/dashboard");
-    } else {
-        error = "Invalid credentials";
+        if success {
+            # User is now logged in, token stored automatically
+            navigate("/dashboard");
+        } else {
+            error = "Invalid credentials";
+        }
     }
 }
 ```
@@ -137,17 +137,17 @@ Registers a new user account.
 ```jac
 cl import from "@jac/runtime" { jacSignup }
 
-to cl:
+cl {
+    async def handleSignup() -> None {
+        # jacSignup returns dict with success key
+        result = await jacSignup(username, password);
 
-async def handleSignup() -> None {
-    # jacSignup returns dict with success key
-    result = await jacSignup(username, password);
-
-    if result["success"] {
-        # User registered and logged in
-        navigate("/dashboard");
-    } else {
-        error = result["error"] or "Signup failed";
+        if result["success"] {
+            # User registered and logged in
+            navigate("/dashboard");
+        } else {
+            error = result["error"] or "Signup failed";
+        }
     }
 }
 ```
@@ -159,12 +159,12 @@ Clears the authentication token.
 ```jac
 cl import from "@jac/runtime" { jacLogout }
 
-to cl:
-
-def handleLogout() -> None {
-    jacLogout();
-    # User is now logged out
-    navigate("/login");
+cl {
+    def handleLogout() -> None {
+        jacLogout();
+        # User is now logged out
+        navigate("/login");
+    }
 }
 ```
 
@@ -175,18 +175,18 @@ Checks if user is currently authenticated.
 ```jac
 cl import from "@jac/runtime" { jacIsLoggedIn }
 
-to cl:
+cl {
+    def:pub NavBar() -> JsxElement {
+        isLoggedIn = jacIsLoggedIn();
 
-def:pub NavBar() -> JsxElement {
-    isLoggedIn = jacIsLoggedIn();
-
-    return <nav>
-        {isLoggedIn and (
-            <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
-        ) or (
-            <a href="/login">Login</a>
-        )}
-    </nav>;
+        return <nav>
+            {isLoggedIn and (
+                <button onClick={lambda -> None { handleLogout(); }}>Logout</button>
+            ) or (
+                <a href="/login">Login</a>
+            )}
+        </nav>;
+    }
 }
 ```
 
@@ -207,238 +207,238 @@ cl import from "@jac/runtime" {
     useNavigate
 }
 
-to cl:
+cl {
+    # === Login Page ===
+    def:pub LoginPage() -> JsxElement {
+        has username: str = "";
+        has password: str = "";
+        has error: str = "";
+        has loading: bool = False;
 
-# === Login Page ===
-def:pub LoginPage() -> JsxElement {
-    has username: str = "";
-    has password: str = "";
-    has error: str = "";
-    has loading: bool = False;
+        navigate = useNavigate();
 
-    navigate = useNavigate();
-
-    # Check if already logged in
-    can with entry {
-        if jacIsLoggedIn() {
-            navigate("/");
+        # Check if already logged in
+        can with entry {
+            if jacIsLoggedIn() {
+                navigate("/");
+            }
         }
+
+        async def handleLogin(e: FormEvent) -> None {
+            e.preventDefault();
+            error = "";
+
+            if not username.trim() or not password {
+                error = "Please fill in all fields";
+                return;
+            }
+
+            loading = True;
+            success = await jacLogin(username, password);
+            loading = False;
+
+            if success {
+                navigate("/");
+            } else {
+                error = "Invalid username or password";
+            }
+        }
+
+        return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
+            <h2>Login</h2>
+            <form onSubmit={handleLogin}>
+                {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
+
+                <div style={{"marginBottom": "1rem"}}>
+                    <input
+                        type="text"
+                        value={username}
+                        onChange={lambda e: ChangeEvent { username = e.target.value; }}
+                        placeholder="Username"
+                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                    />
+                </div>
+
+                <div style={{"marginBottom": "1rem"}}>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={lambda e: ChangeEvent { password = e.target.value; }}
+                        placeholder="Password"
+                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={loading}
+                    style={{
+                        "width": "100%",
+                        "padding": "0.75rem",
+                        "background": "#3b82f6",
+                        "color": "white",
+                        "border": "none",
+                        "borderRadius": "4px",
+                        "cursor": "pointer"
+                    }}
+                >
+                    {loading and "Logging in..." or "Login"}
+                </button>
+
+                <p style={{"textAlign": "center", "marginTop": "1rem"}}>
+                    Need an account? <Link to="/signup">Sign up</Link>
+                </p>
+            </form>
+        </div>;
     }
 
-    async def handleLogin(e: FormEvent) -> None {
-        e.preventDefault();
-        error = "";
+    # === Signup Page ===
+    def:pub SignupPage() -> JsxElement {
+        has username: str = "";
+        has password: str = "";
+        has confirmPassword: str = "";
+        has error: str = "";
+        has loading: bool = False;
 
-        if not username.trim() or not password {
-            error = "Please fill in all fields";
-            return;
+        navigate = useNavigate();
+
+        async def handleSignup(e: FormEvent) -> None {
+            e.preventDefault();
+            error = "";
+
+            if not username.trim() or not password {
+                error = "Please fill in all fields";
+                return;
+            }
+
+            if password != confirmPassword {
+                error = "Passwords don't match";
+                return;
+            }
+
+            if password.length < 6 {
+                error = "Password must be at least 6 characters";
+                return;
+            }
+
+            loading = True;
+            result = await jacSignup(username, password);
+            loading = False;
+
+            if result["success"] {
+                navigate("/");
+            } else {
+                error = result["error"] or "Signup failed";
+            }
         }
 
-        loading = True;
-        success = await jacLogin(username, password);
-        loading = False;
+        return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
+            <h2>Create Account</h2>
+            <form onSubmit={handleSignup}>
+                {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
 
-        if success {
-            navigate("/");
-        } else {
-            error = "Invalid username or password";
-        }
+                <div style={{"marginBottom": "1rem"}}>
+                    <input
+                        type="text"
+                        value={username}
+                        onChange={lambda e: ChangeEvent { username = e.target.value; }}
+                        placeholder="Username"
+                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                    />
+                </div>
+
+                <div style={{"marginBottom": "1rem"}}>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={lambda e: ChangeEvent { password = e.target.value; }}
+                        placeholder="Password"
+                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                    />
+                </div>
+
+                <div style={{"marginBottom": "1rem"}}>
+                    <input
+                        type="password"
+                        value={confirmPassword}
+                        onChange={lambda e: ChangeEvent { confirmPassword = e.target.value; }}
+                        placeholder="Confirm Password"
+                        style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={loading}
+                    style={{
+                        "width": "100%",
+                        "padding": "0.75rem",
+                        "background": "#10b981",
+                        "color": "white",
+                        "border": "none",
+                        "borderRadius": "4px",
+                        "cursor": "pointer"
+                    }}
+                >
+                    {loading and "Creating account..." or "Sign Up"}
+                </button>
+
+                <p style={{"textAlign": "center", "marginTop": "1rem"}}>
+                    Already have an account? <Link to="/login">Login</Link>
+                </p>
+            </form>
+        </div>;
     }
 
-    return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
-        <h2>Login</h2>
-        <form onSubmit={handleLogin}>
-            {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
+    # === Protected Dashboard ===
+    def:pub Dashboard() -> JsxElement {
+        navigate = useNavigate();
 
-            <div style={{"marginBottom": "1rem"}}>
-                <input
-                    type="text"
-                    value={username}
-                    onChange={lambda e: ChangeEvent { username = e.target.value; }}
-                    placeholder="Username"
-                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                />
-            </div>
-
-            <div style={{"marginBottom": "1rem"}}>
-                <input
-                    type="password"
-                    value={password}
-                    onChange={lambda e: ChangeEvent { password = e.target.value; }}
-                    placeholder="Password"
-                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                />
-            </div>
-
-            <button
-                type="submit"
-                disabled={loading}
-                style={{
-                    "width": "100%",
-                    "padding": "0.75rem",
-                    "background": "#3b82f6",
-                    "color": "white",
-                    "border": "none",
-                    "borderRadius": "4px",
-                    "cursor": "pointer"
-                }}
-            >
-                {loading and "Logging in..." or "Login"}
-            </button>
-
-            <p style={{"textAlign": "center", "marginTop": "1rem"}}>
-                Need an account? <Link to="/signup">Sign up</Link>
-            </p>
-        </form>
-    </div>;
-}
-
-# === Signup Page ===
-def:pub SignupPage() -> JsxElement {
-    has username: str = "";
-    has password: str = "";
-    has confirmPassword: str = "";
-    has error: str = "";
-    has loading: bool = False;
-
-    navigate = useNavigate();
-
-    async def handleSignup(e: FormEvent) -> None {
-        e.preventDefault();
-        error = "";
-
-        if not username.trim() or not password {
-            error = "Please fill in all fields";
-            return;
+        # Redirect if not logged in
+        can with entry {
+            if not jacIsLoggedIn() {
+                navigate("/login");
+            }
         }
 
-        if password != confirmPassword {
-            error = "Passwords don't match";
-            return;
-        }
-
-        if password.length < 6 {
-            error = "Password must be at least 6 characters";
-            return;
-        }
-
-        loading = True;
-        result = await jacSignup(username, password);
-        loading = False;
-
-        if result["success"] {
-            navigate("/");
-        } else {
-            error = result["error"] or "Signup failed";
-        }
-    }
-
-    return <div style={{"maxWidth": "400px", "margin": "2rem auto", "padding": "2rem"}}>
-        <h2>Create Account</h2>
-        <form onSubmit={handleSignup}>
-            {error and <div style={{"color": "#dc2626", "marginBottom": "1rem"}}>{error}</div>}
-
-            <div style={{"marginBottom": "1rem"}}>
-                <input
-                    type="text"
-                    value={username}
-                    onChange={lambda e: ChangeEvent { username = e.target.value; }}
-                    placeholder="Username"
-                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                />
-            </div>
-
-            <div style={{"marginBottom": "1rem"}}>
-                <input
-                    type="password"
-                    value={password}
-                    onChange={lambda e: ChangeEvent { password = e.target.value; }}
-                    placeholder="Password"
-                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                />
-            </div>
-
-            <div style={{"marginBottom": "1rem"}}>
-                <input
-                    type="password"
-                    value={confirmPassword}
-                    onChange={lambda e: ChangeEvent { confirmPassword = e.target.value; }}
-                    placeholder="Confirm Password"
-                    style={{"width": "100%", "padding": "0.75rem", "border": "1px solid #ddd", "borderRadius": "4px"}}
-                />
-            </div>
-
-            <button
-                type="submit"
-                disabled={loading}
-                style={{
-                    "width": "100%",
-                    "padding": "0.75rem",
-                    "background": "#10b981",
-                    "color": "white",
-                    "border": "none",
-                    "borderRadius": "4px",
-                    "cursor": "pointer"
-                }}
-            >
-                {loading and "Creating account..." or "Sign Up"}
-            </button>
-
-            <p style={{"textAlign": "center", "marginTop": "1rem"}}>
-                Already have an account? <Link to="/login">Login</Link>
-            </p>
-        </form>
-    </div>;
-}
-
-# === Protected Dashboard ===
-def:pub Dashboard() -> JsxElement {
-    navigate = useNavigate();
-
-    # Redirect if not logged in
-    can with entry {
-        if not jacIsLoggedIn() {
+        def handleLogout() -> None {
+            jacLogout();
             navigate("/login");
         }
+
+        if not jacIsLoggedIn() {
+            return <p>Redirecting...</p>;
+        }
+
+        return <div style={{"padding": "2rem"}}>
+            <h1>Dashboard</h1>
+            <p>Welcome! You are logged in.</p>
+            <button
+                onClick={lambda -> None { handleLogout(); }}
+                style={{
+                    "padding": "0.5rem 1rem",
+                    "background": "#ef4444",
+                    "color": "white",
+                    "border": "none",
+                    "borderRadius": "4px",
+                    "cursor": "pointer"
+                }}
+            >
+                Logout
+            </button>
+        </div>;
     }
 
-    def handleLogout() -> None {
-        jacLogout();
-        navigate("/login");
+    # === Main App ===
+    def:pub app() -> JsxElement {
+        return <Router>
+            <Routes>
+                <Route path="/" element={<Dashboard />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/signup" element={<SignupPage />} />
+            </Routes>
+        </Router>;
     }
-
-    if not jacIsLoggedIn() {
-        return <p>Redirecting...</p>;
-    }
-
-    return <div style={{"padding": "2rem"}}>
-        <h1>Dashboard</h1>
-        <p>Welcome! You are logged in.</p>
-        <button
-            onClick={lambda -> None { handleLogout(); }}
-            style={{
-                "padding": "0.5rem 1rem",
-                "background": "#ef4444",
-                "color": "white",
-                "border": "none",
-                "borderRadius": "4px",
-                "cursor": "pointer"
-            }}
-        >
-            Logout
-        </button>
-    </div>;
-}
-
-# === Main App ===
-def:pub app() -> JsxElement {
-    return <Router>
-        <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/signup" element={<SignupPage />} />
-        </Routes>
-    </Router>;
 }
 ```
 
@@ -452,12 +452,12 @@ For file-based routing, use the built-in `AuthGuard` component:
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
 # pages/(auth)/layout.jac - Protects all routes in (auth) group
-to cl:
-
-def:pub layout() -> JsxElement {
-    return <AuthGuard redirect="/login">
-        <Outlet />
-    </AuthGuard>;
+cl {
+    def:pub layout() -> JsxElement {
+        return <AuthGuard redirect="/login">
+            <Outlet />
+        </AuthGuard>;
+    }
 }
 ```
 
@@ -476,54 +476,54 @@ For complex apps that need shared auth state across components:
 ```jac
 cl import from "@jac/runtime" { jacIsLoggedIn, jacLogin, jacLogout }
 
-to cl:
+cl {
+    import from react { createContext, useContext }
 
-import from react { createContext, useContext }
+    glob AuthContext = createContext(None);
 
-glob AuthContext = createContext(None);
+    # Auth Provider component -- `children` holds the nested JSX
+    def:pub AuthProvider(children: any = None) -> JsxElement {
+        has user: any = None;
+        has loading: bool = True;
 
-# Auth Provider component -- `children` holds the nested JSX
-def:pub AuthProvider(children: any = None) -> JsxElement {
-    has user: any = None;
-    has loading: bool = True;
-
-    can with entry {
-        # Check auth status on mount
-        if jacIsLoggedIn() {
-            # Optionally fetch user data from backend
-            user = {"authenticated": True};
+        can with entry {
+            # Check auth status on mount
+            if jacIsLoggedIn() {
+                # Optionally fetch user data from backend
+                user = {"authenticated": True};
+            }
+            loading = False;
         }
-        loading = False;
-    }
 
-    async def login(username: str, password: str) -> bool {
-        success = await jacLogin(username, password);
-        if success {
-            user = {"authenticated": True};
+        async def login(username: str, password: str) -> bool {
+            success = await jacLogin(username, password);
+            if success {
+                user = {"authenticated": True};
+            }
+            return success;
         }
-        return success;
+
+        def logout() -> None {
+            jacLogout();
+            user = None;
+        }
+
+        value = {
+            "user": user,
+            "loading": loading,
+            "isAuthenticated": user != None,
+            "login": login,
+            "logout": logout
+        };
+
+        return <AuthContext.Provider value={value}>
+            {children}
+        </AuthContext.Provider>;
     }
 
-    def logout() -> None {
-        jacLogout();
-        user = None;
+    def useAuth() -> dict {
+        return useContext(AuthContext);
     }
-
-    value = {
-        "user": user,
-        "loading": loading,
-        "isAuthenticated": user != None,
-        "login": login,
-        "logout": logout
-    };
-
-    return <AuthContext.Provider value={value}>
-        {children}
-    </AuthContext.Provider>;
-}
-
-def useAuth() -> dict {
-    return useContext(AuthContext);
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/backend.md
+++ b/docs/docs/tutorials/fullstack/backend.md
@@ -20,7 +20,7 @@ This tutorial shows how to call backend functions from the frontend, use walkers
 In Jac full-stack apps, the compiler handles the client-server boundary for you. Here's the mental model:
 
 1. **Backend** = Functions or walkers that process data and return results
-2. **Frontend** = Components in `to cl:` sections (or `.cl.jac` files)
+2. **Frontend** = Components in `cl { }` blocks (or `.cl.jac` files)
 3. **Connection** = Direct function calls (`await func()`) or walker spawning (`root spawn Walker()`)
 
 ```mermaid
@@ -122,43 +122,43 @@ Use `root spawn walker_name()` to call walkers from client code:
 # Import walkers from your main module
 sv import from ...main { get_tasks, add_task, toggle_task }
 
-to cl:
+cl {
+    def:pub TaskList() -> JsxElement {
+        has tasks: list = [];
+        has loading: bool = True;
+        has error: str = "";
 
-def:pub TaskList() -> JsxElement {
-    has tasks: list = [];
-    has loading: bool = True;
-    has error: str = "";
-
-    # Fetch data on component mount
-    async can with entry {
-        await load_tasks();
-    }
-
-    async def load_tasks() -> None {
-        loading = True;
-        error = "";
-        try {
-            result = root spawn get_tasks();
-            if result.reports and result.reports.length > 0 {
-                tasks = result.reports[0];
-            }
-        } except Exception as e {
-            error = f"Failed to load: {e}";
+        # Fetch data on component mount
+        async can with entry {
+            await load_tasks();
         }
-        loading = False;
-    }
 
-    if loading {
-        return <p>Loading tasks...</p>;
-    }
+        async def load_tasks() -> None {
+            loading = True;
+            error = "";
+            try {
+                result = root spawn get_tasks();
+                if result.reports and result.reports.length > 0 {
+                    tasks = result.reports[0];
+                }
+            } except Exception as e {
+                error = f"Failed to load: {e}";
+            }
+            loading = False;
+        }
 
-    if error {
-        return <p className="error">Error: {error}</p>;
-    }
+        if loading {
+            return <p>Loading tasks...</p>;
+        }
 
-    return <ul>
-        {[<li key={jid(task)}>{task.title}</li> for task in tasks]}
-    </ul>;
+        if error {
+            return <p className="error">Error: {error}</p>;
+        }
+
+        return <ul>
+            {[<li key={jid(task)}>{task.title}</li> for task in tasks]}
+        </ul>;
+    }
 }
 ```
 
@@ -176,91 +176,91 @@ def:pub TaskList() -> JsxElement {
 ```jac
 sv import from ...main { get_tasks, add_task, toggle_task, delete_task }
 
-to cl:
+cl {
+    def:pub TaskManager() -> JsxElement {
+        has tasks: list = [];
+        has new_title: str = "";
+        has loading: bool = True;
 
-def:pub TaskManager() -> JsxElement {
-    has tasks: list = [];
-    has new_title: str = "";
-    has loading: bool = True;
-
-    # Load tasks on mount
-    async can with entry {
-        await load_tasks();
-    }
-
-    async def load_tasks() -> None {
-        loading = True;
-        result = root spawn get_tasks();
-        if result.reports and result.reports.length > 0 {
-            tasks = result.reports[0];
+        # Load tasks on mount
+        async can with entry {
+            await load_tasks();
         }
-        loading = False;
-    }
 
-    # Add new task
-    async def handle_add() -> None {
-        if new_title.trim() {
-            result = root spawn add_task(title=new_title.trim());
+        async def load_tasks() -> None {
+            loading = True;
+            result = root spawn get_tasks();
             if result.reports and result.reports.length > 0 {
-                tasks = tasks + [result.reports[0]];
+                tasks = result.reports[0];
             }
-            new_title = "";
+            loading = False;
         }
-    }
 
-    # Toggle task completion
-    async def handle_toggle(task_id: str) -> None {
-        result = root spawn toggle_task(task_id=task_id);
-        if result.reports and result.reports.length > 0 {
-            updated = result.reports[0];
-            tasks = [updated if jid(t) == task_id else t for t in tasks];
+        # Add new task
+        async def handle_add() -> None {
+            if new_title.trim() {
+                result = root spawn add_task(title=new_title.trim());
+                if result.reports and result.reports.length > 0 {
+                    tasks = tasks + [result.reports[0]];
+                }
+                new_title = "";
+            }
         }
-    }
 
-    # Delete task
-    async def handle_delete(task_id: str) -> None {
-        result = root spawn delete_task(task_id=task_id);
-        if result.reports and result.reports.length > 0 {
-            tasks = [t for t in tasks if jid(t) != task_id];
+        # Toggle task completion
+        async def handle_toggle(task_id: str) -> None {
+            result = root spawn toggle_task(task_id=task_id);
+            if result.reports and result.reports.length > 0 {
+                updated = result.reports[0];
+                tasks = [updated if jid(t) == task_id else t for t in tasks];
+            }
         }
+
+        # Delete task
+        async def handle_delete(task_id: str) -> None {
+            result = root spawn delete_task(task_id=task_id);
+            if result.reports and result.reports.length > 0 {
+                tasks = [t for t in tasks if jid(t) != task_id];
+            }
+        }
+
+        return <div>
+            <div className="add-task">
+                <input
+                    value={new_title}
+                    onChange={lambda e: ChangeEvent { new_title = e.target.value; }}
+                    onKeyDown={lambda e: KeyboardEvent {
+                        if e.key == "Enter" { handle_add(); }
+                    }}
+                    placeholder="New task..."
+                />
+                <button onClick={lambda -> None { handle_add(); }}>
+                    Add
+                </button>
+            </div>
+
+            {loading and <p>Loading...</p>}
+
+            <ul className="task-list">
+                {[
+                    <li key={jid(task)}>
+                        <input
+                            type="checkbox"
+                            checked={task.completed}
+                            onChange={lambda -> None { handle_toggle(jid(task)); }}
+                        />
+                        <span className={task.completed and "completed"}>
+                            {task.title}
+                        </span>
+                        <button onClick={lambda -> None { handle_delete(jid(task)); }}>
+                            Delete
+                        </button>
+                    </li>
+                    for task in tasks
+                ]}
+            </ul>
+        </div>;
     }
-
-    return <div>
-        <div className="add-task">
-            <input
-                value={new_title}
-                onChange={lambda e: ChangeEvent { new_title = e.target.value; }}
-                onKeyDown={lambda e: KeyboardEvent {
-                    if e.key == "Enter" { handle_add(); }
-                }}
-                placeholder="New task..."
-            />
-            <button onClick={lambda -> None { handle_add(); }}>
-                Add
-            </button>
-        </div>
-
-        {loading and <p>Loading...</p>}
-
-        <ul className="task-list">
-            {[
-                <li key={jid(task)}>
-                    <input
-                        type="checkbox"
-                        checked={task.completed}
-                        onChange={lambda -> None { handle_toggle(jid(task)); }}
-                    />
-                    <span className={task.completed and "completed"}>
-                        {task.title}
-                    </span>
-                    <button onClick={lambda -> None { handle_delete(jid(task)); }}>
-                        Delete
-                    </button>
-                </li>
-                for task in tasks
-            ]}
-        </ul>
-    </div>;
 }
 ```
 
@@ -273,89 +273,89 @@ def:pub TaskManager() -> JsxElement {
 ```jac
 sv import from ...main { submit_data }
 
-to cl:
+cl {
+    def:pub SafeSubmit() -> JsxElement {
+        has error_msg: str = "";
+        has submitting: bool = False;
 
-def:pub SafeSubmit() -> JsxElement {
-    has error_msg: str = "";
-    has submitting: bool = False;
+        async def handle_submit(data: dict) -> None {
+            submitting = True;
+            error_msg = "";
 
-    async def handle_submit(data: dict) -> None {
-        submitting = True;
-        error_msg = "";
-
-        try {
-            result = root spawn submit_data(payload=data);
-            if result.reports and result.reports.length > 0 {
-                response = result.reports[0];
-                if not response["success"] {
-                    error_msg = response["error"];
+            try {
+                result = root spawn submit_data(payload=data);
+                if result.reports and result.reports.length > 0 {
+                    response = result.reports[0];
+                    if not response["success"] {
+                        error_msg = response["error"];
+                    }
                 }
+            } except Exception as e {
+                error_msg = f"Network error: {e}";
             }
-        } except Exception as e {
-            error_msg = f"Network error: {e}";
+
+            submitting = False;
         }
 
-        submitting = False;
+        return <div>
+            {error_msg and <div className="error">{error_msg}</div>}
+            <button
+                onClick={lambda -> None { handle_submit({"key": "value"}); }}
+                disabled={submitting}
+            >
+                {("Submitting..." if submitting else "Submit")}
+            </button>
+        </div>;
     }
-
-    return <div>
-        {error_msg and <div className="error">{error_msg}</div>}
-        <button
-            onClick={lambda -> None { handle_submit({"key": "value"}); }}
-            disabled={submitting}
-        >
-            {("Submitting..." if submitting else "Submit")}
-        </button>
-    </div>;
 }
 ```
 
 ### Loading States Pattern
 
 ```jac
-to cl:
+cl {
+    def:pub DataView() -> JsxElement {
+        has data: any = None;
+        has loading: bool = True;
+        has error: str = "";
 
-def:pub DataView() -> JsxElement {
-    has data: any = None;
-    has loading: bool = True;
-    has error: str = "";
-
-    async can with entry {
-        await fetch_data();
-    }
-
-    async def fetch_data() -> None {
-        loading = True;
-        try {
-            result = root spawn get_data();
-            if result.reports and result.reports.length > 0 {
-                data = result.reports[0];
-            }
-        } except Exception as e {
-            error = f"Failed to load: {e}";
+        async can with entry {
+            await fetch_data();
         }
-        loading = False;
-    }
 
-    if loading {
-        return <div className="skeleton">
-            <div className="skeleton-line"></div>
-            <div className="skeleton-line"></div>
+        async def fetch_data() -> None {
+            loading = True;
+            try {
+                result = root spawn get_data();
+                if result.reports and result.reports.length > 0 {
+                    data = result.reports[0];
+                }
+            } except Exception as e {
+                error = f"Failed to load: {e}";
+            }
+            loading = False;
+        }
+
+        if loading {
+            return <div className="skeleton">
+                <div className="skeleton-line"></div>
+                <div className="skeleton-line"></div>
+            </div>;
+        }
+
+        if error {
+            return <div className="error">
+                <p>{error}</p>
+                <button onClick={lambda -> None { fetch_data(); }}>
+                    Retry
+                </button>
+            </div>;
+        }
+
+        return <div className="data">
+            {JSON.stringify(data)}
         </div>;
     }
-
-    if error {
-        return <div className="error">
-            <p>{error}</p>
-            <button onClick={lambda -> None { fetch_data(); }}>
-                Retry
-            </button>
-        </div>;
-    }
-
-    return <div className="data">
-        {JSON.stringify(data)}
-    </div>;
 }
 ```
 
@@ -366,38 +366,38 @@ def:pub DataView() -> JsxElement {
 ### Polling Pattern
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    def:pub LiveData() -> JsxElement {
+        has data: any = None;
+        has loading: bool = True;
 
-def:pub LiveData() -> JsxElement {
-    has data: any = None;
-    has loading: bool = True;
-
-    async def fetch_data() -> None {
-        result = root spawn get_live_data();
-        if result.reports and result.reports.length > 0 {
-            data = result.reports[0];
+        async def fetch_data() -> None {
+            result = root spawn get_live_data();
+            if result.reports and result.reports.length > 0 {
+                data = result.reports[0];
+            }
+            loading = False;
         }
-        loading = False;
+
+        # Initial fetch
+        async can with entry {
+            await fetch_data();
+        }
+
+        # Poll every 5 seconds. The outer lambda must NOT be annotated `-> None`:
+        # a cleanup effect returns a function, so `-> None` would be a type error.
+        useEffect(lambda {
+            interval = setInterval(lambda { fetch_data(); }, 5000);
+            return lambda { clearInterval(interval); };
+        }, []);
+
+        return <div>
+            {loading and <p>Loading...</p>}
+            {data and <p>Last updated: {data["timestamp"]}</p>}
+        </div>;
     }
-
-    # Initial fetch
-    async can with entry {
-        await fetch_data();
-    }
-
-    # Poll every 5 seconds. The outer lambda must NOT be annotated `-> None`:
-    # a cleanup effect returns a function, so `-> None` would be a type error.
-    useEffect(lambda {
-        interval = setInterval(lambda { fetch_data(); }, 5000);
-        return lambda { clearInterval(interval); };
-    }, []);
-
-    return <div>
-        {loading and <p>Loading...</p>}
-        {data and <p>Last updated: {data["timestamp"]}</p>}
-    </div>;
 }
 ```
 
@@ -446,72 +446,72 @@ walker:pub toggle_task {
 }
 
 # === Frontend: UI ===
-to cl:
+cl {
+    def:pub app() -> JsxElement {
+        has tasks: list = [];
+        has input_text: str = "";
+        has loading: bool = True;
 
-def:pub app() -> JsxElement {
-    has tasks: list = [];
-    has input_text: str = "";
-    has loading: bool = True;
-
-    # Load tasks on mount
-    async can with entry {
-        result = root spawn get_tasks();
-        if result.reports {
-            tasks = result.reports;
-        }
-        loading = False;
-    }
-
-    async def add() -> None {
-        if input_text.trim() {
-            result = root spawn add_task(title=input_text.trim());
-            if result.reports and result.reports.length > 0 {
-                tasks = tasks + [result.reports[0]];
+        # Load tasks on mount
+        async can with entry {
+            result = root spawn get_tasks();
+            if result.reports {
+                tasks = result.reports;
             }
-            input_text = "";
+            loading = False;
         }
-    }
 
-    async def toggle(task_id: str) -> None {
-        result = root spawn toggle_task(task_id=task_id);
-        if result.reports and result.reports.length > 0 {
-            updated = result.reports[0];
-            tasks = [updated if jid(t) == task_id else t for t in tasks];
+        async def add() -> None {
+            if input_text.trim() {
+                result = root spawn add_task(title=input_text.trim());
+                if result.reports and result.reports.length > 0 {
+                    tasks = tasks + [result.reports[0]];
+                }
+                input_text = "";
+            }
         }
+
+        async def toggle(task_id: str) -> None {
+            result = root spawn toggle_task(task_id=task_id);
+            if result.reports and result.reports.length > 0 {
+                updated = result.reports[0];
+                tasks = [updated if jid(t) == task_id else t for t in tasks];
+            }
+        }
+
+        return <div className="app">
+            <h1>My Tasks</h1>
+
+            <div className="input-row">
+                <input
+                    value={input_text}
+                    onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
+                    onKeyDown={lambda e: KeyboardEvent {
+                        if e.key == "Enter" { add(); }
+                    }}
+                    placeholder="Add a task..."
+                />
+                <button onClick={lambda -> None { add(); }}>Add</button>
+            </div>
+
+            {loading and <p>Loading...</p>}
+
+            {not loading and (
+                <ul>
+                    {[
+                        <li
+                            key={jid(t)}
+                            style={{"textDecoration": t.completed and "line-through"}}
+                            onClick={lambda -> None { toggle(jid(t)); }}
+                        >
+                            {t.title}
+                        </li>
+                        for t in tasks
+                    ]}
+                </ul>
+            )}
+        </div>;
     }
-
-    return <div className="app">
-        <h1>My Tasks</h1>
-
-        <div className="input-row">
-            <input
-                value={input_text}
-                onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
-                onKeyDown={lambda e: KeyboardEvent {
-                    if e.key == "Enter" { add(); }
-                }}
-                placeholder="Add a task..."
-            />
-            <button onClick={lambda -> None { add(); }}>Add</button>
-        </div>
-
-        {loading and <p>Loading...</p>}
-
-        {not loading and (
-            <ul>
-                {[
-                    <li
-                        key={jid(t)}
-                        style={{"textDecoration": t.completed and "line-through"}}
-                        onClick={lambda -> None { toggle(jid(t)); }}
-                    >
-                        {t.title}
-                    </li>
-                    for t in tasks
-                ]}
-            </ul>
-        )}
-    </div>;
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/components.md
+++ b/docs/docs/tutorials/fullstack/components.md
@@ -1,6 +1,6 @@
 # React-Style Components
 
-Jac's client-side code uses JSX syntax (the same HTML-in-code approach popularized by React) to build UI components. Components are functions declared in client-side code -- a `.cl.jac` file or a `to cl:` section -- that return `JsxElement` values. Each prop is a named parameter -- the type-checker validates every JSX call site per attribute -- and components compose just like in React, with conditional rendering, list mapping, and event handling.
+Jac's client-side code uses JSX syntax (the same HTML-in-code approach popularized by React) to build UI components. Components are functions declared in client-side code -- a `.cl.jac` file or a `cl { }` block -- that return `JsxElement` values. Each prop is a named parameter -- the type-checker validates every JSX call site per attribute -- and components compose just like in React, with conditional rendering, list mapping, and event handling.
 
 The key difference from a standard React setup: there's no separate JavaScript project, no webpack configuration, and no build toolchain to manage. You write components in Jac syntax, the compiler generates optimized JavaScript, and the dev server bundles and serves it automatically.
 
@@ -14,17 +14,17 @@ The key difference from a standard React setup: there's no separate JavaScript p
 ## Basic Component
 
 ```jac
-to cl:
+cl {
+    def:pub Greeting(name: str) -> JsxElement {
+        return <h1>Hello, {name}!</h1>;
+    }
 
-def:pub Greeting(name: str) -> JsxElement {
-    return <h1>Hello, {name}!</h1>;
-}
-
-def:pub app() -> JsxElement {
-    return <div>
-        <Greeting name="Alice" />
-        <Greeting name="Bob" />
-    </div>;
+    def:pub app() -> JsxElement {
+        return <div>
+            <Greeting name="Alice" />
+            <Greeting name="Bob" />
+        </div>;
+    }
 }
 ```
 
@@ -44,20 +44,20 @@ Declare **every prop as its own named, typed parameter**. The type-checker keys 
 `children` -- the JSX nested between a component's tags -- is just a regular parameter named `children`. It is not special-cased: React's reconciler fills it in and the compiler destructures it like any other prop. (The only genuinely reserved attribute names are `key` and `ref`.)
 
 ```jac
-to cl:
+cl {
+    def:pub Card(title: str, description: str = "", children: any = None) -> JsxElement {
+        return <div className="card">
+            <h2>{title}</h2>
+            <p>{description}</p>
+            {children}
+        </div>;
+    }
 
-def:pub Card(title: str, description: str = "", children: any = None) -> JsxElement {
-    return <div className="card">
-        <h2>{title}</h2>
-        <p>{description}</p>
-        {children}
-    </div>;
-}
-
-def:pub app() -> JsxElement {
-    return <Card title="Welcome" description="Hello!">
-        <p>This is the card content.</p>
-    </Card>;
+    def:pub app() -> JsxElement {
+        return <Card title="Welcome" description="Hello!">
+            <p>This is the card content.</p>
+        </Card>;
+    }
 }
 ```
 
@@ -75,11 +75,11 @@ There is no `ReactNode`-style union type in Jac, and a children value can be an 
 `props` is a Jac keyword that names the call-site argument object as a whole, the same way `self` names the receiver. A component declared with a single parameter literally named `props` receives the object verbatim instead of having each prop destructured into its own local:
 
 ```jac
-to cl:
-
-# jac:ignore[W5015]
-def:pub PassThrough(props: dict) -> JsxElement {
-    return <Inner {**props} />;
+cl {
+    # jac:ignore[W5015]
+    def:pub PassThrough(props: dict) -> JsxElement {
+        return <Inner {**props} />;
+    }
 }
 ```
 
@@ -94,15 +94,15 @@ This shape is useful for higher-order components, wrappers, and forwarding helpe
 ### HTML Elements
 
 ```jac
-to cl:
-
-def:pub MyComponent() -> JsxElement {
-    return <div className="container">
-        <h1>Title</h1>
-        <p>Paragraph text</p>
-        <a href="/about">Link</a>
-        <img src="/logo.png" alt="Logo" />
-    </div>;
+cl {
+    def:pub MyComponent() -> JsxElement {
+        return <div className="container">
+            <h1>Title</h1>
+            <p>Paragraph text</p>
+            <a href="/about">Link</a>
+            <img src="/logo.png" alt="Logo" />
+        </div>;
+    }
 }
 ```
 
@@ -111,17 +111,17 @@ def:pub MyComponent() -> JsxElement {
 ### JavaScript Expressions
 
 ```jac
-to cl:
+cl {
+    def:pub MyComponent() -> JsxElement {
+        name = "World";
+        items = [1, 2, 3];
 
-def:pub MyComponent() -> JsxElement {
-    name = "World";
-    items = [1, 2, 3];
-
-    return <div>
-        <p>Hello, {name}!</p>
-        <p>Sum: {1 + 2 + 3}</p>
-        <p>Items: {len(items)}</p>
-    </div>;
+        return <div>
+            <p>Hello, {name}!</p>
+            <p>Sum: {1 + 2 + 3}</p>
+            <p>Items: {len(items)}</p>
+        </div>;
+    }
 }
 ```
 
@@ -134,37 +134,37 @@ Use `{ }` to embed any Jac expression.
 ### Ternary Operator
 
 ```jac
-to cl:
-
-def:pub Status(active: bool) -> JsxElement {
-    return <span>
-        {("Active" if active else "Inactive")}
-    </span>;
+cl {
+    def:pub Status(active: bool) -> JsxElement {
+        return <span>
+            {("Active" if active else "Inactive")}
+        </span>;
+    }
 }
 ```
 
 ### Logical AND
 
 ```jac
-to cl:
-
-def:pub Notification(count: int) -> JsxElement {
-    return <div>
-        {count > 0 and <span>You have {count} messages</span>}
-    </div>;
+cl {
+    def:pub Notification(count: int) -> JsxElement {
+        return <div>
+            {count > 0 and <span>You have {count} messages</span>}
+        </div>;
+    }
 }
 ```
 
 ### If Statement
 
 ```jac
-to cl:
-
-def:pub UserGreeting(isLoggedIn: bool) -> JsxElement {
-    if isLoggedIn {
-        return <h1>Welcome back!</h1>;
+cl {
+    def:pub UserGreeting(isLoggedIn: bool) -> JsxElement {
+        if isLoggedIn {
+            return <h1>Welcome back!</h1>;
+        }
+        return <h1>Please sign in</h1>;
     }
-    return <h1>Please sign in</h1>;
 }
 ```
 
@@ -173,22 +173,22 @@ def:pub UserGreeting(isLoggedIn: bool) -> JsxElement {
 ## Lists and Iteration
 
 ```jac
-to cl:
+cl {
+    def:pub TodoList(items: list[dict[str, any]]) -> JsxElement {
+        return <ul>
+            {[<li key={item["id"]}>{item["text"]}</li> for item in items]}
+        </ul>;
+    }
 
-def:pub TodoList(items: list[dict[str, any]]) -> JsxElement {
-    return <ul>
-        {[<li key={item["id"]}>{item["text"]}</li> for item in items]}
-    </ul>;
-}
+    def:pub app() -> JsxElement {
+        todos = [
+            {"id": 1, "text": "Learn Jac"},
+            {"id": 2, "text": "Build app"},
+            {"id": 3, "text": "Deploy"}
+        ];
 
-def:pub app() -> JsxElement {
-    todos = [
-        {"id": 1, "text": "Learn Jac"},
-        {"id": 2, "text": "Build app"},
-        {"id": 3, "text": "Deploy"}
-    ];
-
-    return <TodoList items={todos} />;
+        return <TodoList items={todos} />;
+    }
 }
 ```
 
@@ -201,62 +201,62 @@ def:pub app() -> JsxElement {
 ### Click Events
 
 ```jac
-to cl:
+cl {
+    def:pub Button() -> JsxElement {
+        def handle_click() -> None {
+            print("Button clicked!");
+        }
 
-def:pub Button() -> JsxElement {
-    def handle_click() -> None {
-        print("Button clicked!");
+        return <button onClick={lambda -> None { handle_click(); }}>
+            Click me
+        </button>;
     }
-
-    return <button onClick={lambda -> None { handle_click(); }}>
-        Click me
-    </button>;
 }
 ```
 
 ### Input Events
 
 ```jac
-to cl:
+cl {
+    def:pub SearchBox() -> JsxElement {
+        has query: str = "";
 
-def:pub SearchBox() -> JsxElement {
-    has query: str = "";
-
-    return <input
-        type="text"
-        value={query}
-        onChange={lambda e: ChangeEvent { query = e.target.value; }}
-        placeholder="Search..."
-    />;
+        return <input
+            type="text"
+            value={query}
+            onChange={lambda e: ChangeEvent { query = e.target.value; }}
+            placeholder="Search..."
+        />;
+    }
 }
 ```
 
 ### Form Submit
 
 ```jac
-to cl:
+cl {
+    def:pub LoginForm() -> JsxElement {
+        has username: str = "";
+        has password: str = "";
 
-def:pub LoginForm() -> JsxElement {
-    has username: str = "";
-    has password: str = "";
+        def handle_submit(e: FormEvent) -> None {
+            e.preventDefault();
+            print(f"Login: {username}");
+        }
 
-    def handle_submit(e: FormEvent) -> None {
-        e.preventDefault();
-        print(f"Login: {username}");
+        return <form onSubmit={lambda e: FormEvent { handle_submit(e); }}>
+            <input
+                value={username}
+                onChange={lambda e: ChangeEvent { username = e.target.value; }}
+            />
+            <input
+                type="password"
+                value={password}
+                onChange={lambda e: ChangeEvent { password = e.target.value; }}
+            />
+            <button type="submit">Login</button>
+        </form>;
     }
-
-    return <form onSubmit={lambda e: FormEvent { handle_submit(e); }}>
-        <input
-            value={username}
-            onChange={lambda e: ChangeEvent { username = e.target.value; }}
-        />
-        <input
-            type="password"
-            value={password}
-            onChange={lambda e: ChangeEvent { password = e.target.value; }}
-        />
-        <button type="submit">Login</button>
-    </form>;
 }
 ```
 
@@ -267,52 +267,52 @@ def:pub LoginForm() -> JsxElement {
 ### Children
 
 ```jac
-to cl:
+cl {
+    def:pub Card(title: str, children: any = None) -> JsxElement {
+        return <div className="card">
+            <div className="card-header">{title}</div>
+            <div className="card-body">{children}</div>
+        </div>;
+    }
 
-def:pub Card(title: str, children: any = None) -> JsxElement {
-    return <div className="card">
-        <div className="card-header">{title}</div>
-        <div className="card-body">{children}</div>
-    </div>;
-}
-
-def:pub app() -> JsxElement {
-    return <Card title="Welcome">
-        <p>This is the card content.</p>
-        <button>Action</button>
-    </Card>;
+    def:pub app() -> JsxElement {
+        return <Card title="Welcome">
+            <p>This is the card content.</p>
+            <button>Action</button>
+        </Card>;
+    }
 }
 ```
 
 ### Nested Components
 
 ```jac
-to cl:
+cl {
+    def:pub Header() -> JsxElement {
+        return <header>
+            <h1>My App</h1>
+            <Nav />
+        </header>;
+    }
 
-def:pub Header() -> JsxElement {
-    return <header>
-        <h1>My App</h1>
-        <Nav />
-    </header>;
-}
+    def:pub Nav() -> JsxElement {
+        return <nav>
+            <a href="/">Home</a>
+            <a href="/about">About</a>
+        </nav>;
+    }
 
-def:pub Nav() -> JsxElement {
-    return <nav>
-        <a href="/">Home</a>
-        <a href="/about">About</a>
-    </nav>;
-}
+    def:pub Footer() -> JsxElement {
+        return <footer>© 2024</footer>;
+    }
 
-def:pub Footer() -> JsxElement {
-    return <footer>© 2024</footer>;
-}
-
-def:pub app() -> JsxElement {
-    return <div>
-        <Header />
-        <main>Content here</main>
-        <Footer />
-    </div>;
+    def:pub app() -> JsxElement {
+        return <div>
+            <Header />
+            <main>Content here</main>
+            <Footer />
+        </div>;
+    }
 }
 ```
 
@@ -328,17 +328,17 @@ A component is just `def:pub Name(...) -> JsxElement { return <jsx>; }`. The int
 The two forms share the same `{...}` syntax -- the compiler decides which shape applies from the body's first token.
 
 ```jac
-to cl:
-
-def:pub Greeting(name: str) -> JsxElement {
-    return <div class="card">
-        {if name == "" {
-            <p>Hello, stranger</p>
-        } else {
-            <h1>Hello, {name}</h1>
-            <p>Welcome back.</p>
-        }}
-    </div>;
+cl {
+    def:pub Greeting(name: str) -> JsxElement {
+        return <div class="card">
+            {if name == "" {
+                <p>Hello, stranger</p>
+            } else {
+                <h1>Hello, {name}</h1>
+                <p>Welcome back.</p>
+            }}
+        </div>;
+    }
 }
 ```
 
@@ -354,19 +354,19 @@ def:pub Greeting(name: str) -> JsxElement {
 `for it in items { <Row item={it} /> }` inside a slot lowers to a `JS` `for` loop that pushes each `<Row>` to the element's children -- not a comprehension over a `.map()`. Same shape for the `for x = 0 to n by 1 { ... }` form and for `while`.
 
 ```jac
-to cl:
-
-def:pub ItemList(items: list[str]) -> JsxElement {
-    return <>
-        {if len(items) == 0 {
-            <p class="empty">Nothing here.</p>
-            skip;
-        }}
-        <h2>Items</h2>
-        {for (i, item) in enumerate(items) {
-            <li key={i}>{item}</li>
-        }}
-    </>;
+cl {
+    def:pub ItemList(items: list[str]) -> JsxElement {
+        return <>
+            {if len(items) == 0 {
+                <p class="empty">Nothing here.</p>
+                skip;
+            }}
+            <h2>Items</h2>
+            {for (i, item) in enumerate(items) {
+                <li key={i}>{item}</li>
+            }}
+        </>;
+    }
 }
 ```
 
@@ -377,16 +377,16 @@ Loop slots that emit keyless JSX get a warning -- `W2019` for a `while` loop and
 A `def:pub -> JsxElement` body can declare `has`-fields and nested `def` handlers exactly like a regular component. `has`-fields keep the auto-`useState` wiring -- assigning to one rewrites to the generated setter:
 
 ```jac
-to cl:
+cl {
+    def:pub Counter() -> JsxElement {
+        has count: int = 0;
 
-def:pub Counter() -> JsxElement {
-    has count: int = 0;
+        def bump {
+            count = count + 1;
+        }
 
-    def bump {
-        count = count + 1;
+        return <button onClick={bump}>Count: {count}</button>;
     }
-
-    return <button onClick={bump}>Count: {count}</button>;
 }
 ```
 
@@ -410,17 +410,17 @@ Don't confuse this with the slot-guard form above: in a slot, `skip;` yields the
 `<@expr />` chooses its element tag from an expression instead of a fixed name. The expression can be an identifier, a dotted access, or a brace-wrapped expression `<@{expr}>`, and resolves to a host-tag string, another component, or a `str | type` value:
 
 ```jac
-to cl:
+cl {
+    def:pub Box(as_: str, children: any = None) -> JsxElement {
+        return <@as_ className="box">{children}</@as_>;
+    }
 
-def:pub Box(as_: str, children: any = None) -> JsxElement {
-    return <@as_ className="box">{children}</@as_>;
-}
-
-def:pub Demo() -> JsxElement {
-    return <>
-        <Box as_="article">Inside an article element</Box>
-        <Box as_="section">Inside a section element</Box>
-    </>;
+    def:pub Demo() -> JsxElement {
+        return <>
+            <Box as_="article">Inside an article element</Box>
+            <Box as_="section">Inside a section element</Box>
+        </>;
+    }
 }
 ```
 
@@ -431,24 +431,24 @@ Use `as_`, not `as` -- `as` is reserved in Jac for import aliases.
 A `try` slot can take an `awaiting` clause that names what to render while the work inside is still in flight. The cl-target compiler wraps the slot in a `<JacAwaiting>` element from `@jac/runtime` -- a thin shim over `React.Suspense` -- so the `awaiting` body renders during the dispatched-but-not-joined window and the `try` body's content takes over once the underlying async work settles.
 
 ```jac
-to cl:
+cl {
+    def:pub UserCardSkeleton() -> JsxElement {
+        return <div class="card skeleton"><p>Loading user…</p></div>;
+    }
 
-def:pub UserCardSkeleton() -> JsxElement {
-    return <div class="card skeleton"><p>Loading user…</p></div>;
-}
+    def:pub UserCardView(user: User) -> JsxElement {
+        return <div class="card"><h2>{user.name}</h2><p>{user.bio}</p></div>;
+    }
 
-def:pub UserCardView(user: User) -> JsxElement {
-    return <div class="card"><h2>{user.name}</h2><p>{user.bio}</p></div>;
-}
-
-def:pub UserPanel(user: User) -> JsxElement {
-    return <section class="panel">
-        {try {
-            <UserCardView user={user}/>
-        } awaiting {
-            <UserCardSkeleton/>
-        }}
-    </section>;
+    def:pub UserPanel(user: User) -> JsxElement {
+        return <section class="panel">
+            {try {
+                <UserCardView user={user}/>
+            } awaiting {
+                <UserCardSkeleton/>
+            }}
+        </section>;
+    }
 }
 ```
 
@@ -457,18 +457,18 @@ The `try` body needs a Suspense-aware data primitive (today: a `use(promise)` ca
 Add an `except` arm to name the error state alongside the loading state. The slot then lowers to a `<JacClientErrorBoundary fallback={...}>` **wrapping** the `<JacAwaiting>` node, so a throw anywhere in the resolved `try` body is caught and the `except` body renders instead:
 
 ```jac
-to cl:
-
-def:pub UserPanel(user: User) -> JsxElement {
-    return <section class="panel">
-        {try {
-            <UserCardView user={user}/>
-        } awaiting {
-            <UserCardSkeleton/>
-        } except Exception {
-            <div class="card error">Couldn't load this user.</div>
-        }}
-    </section>;
+cl {
+    def:pub UserPanel(user: User) -> JsxElement {
+        return <section class="panel">
+            {try {
+                <UserCardView user={user}/>
+            } awaiting {
+                <UserCardSkeleton/>
+            } except Exception {
+                <div class="card error">Couldn't load this user.</div>
+            }}
+        </section>;
+    }
 }
 ```
 
@@ -486,13 +486,13 @@ def:pub UserPanel(user: User) -> JsxElement {
 By default `{value}` is rendered as escaped text. The `unsafe_html(x)` ambient builtin returns a sentinel that the client runtime renders as raw HTML (via `dangerouslySetInnerHTML` on React, `innerHTML` on bare-serve). Use it only with content you trust -- the name is the security review hint at the call site:
 
 ```jac
-to cl:
-
-def:pub Comment(c: dict) -> JsxElement {
-    return <article>
-        <h3>{c["author"]}</h3>
-        <div class="body">{unsafe_html(c["trusted_html"])}</div>
-    </article>;
+cl {
+    def:pub Comment(c: dict) -> JsxElement {
+        return <article>
+            <h3>{c["author"]}</h3>
+            <div class="body">{unsafe_html(c["trusted_html"])}</div>
+        </article>;
+    }
 }
 ```
 
@@ -503,7 +503,7 @@ def:pub Comment(c: dict) -> JsxElement {
 ### Header.cl.jac
 
 ```jac
-# No `to cl:` header needed for .cl.jac files
+# No `cl { }` block needed for .cl.jac files
 
 def:pub Header(title: str) -> JsxElement {
     return <header>
@@ -515,15 +515,15 @@ def:pub Header(title: str) -> JsxElement {
 ### main.jac
 
 ```jac
-to cl:
+cl {
+    import from "./Header.cl.jac" { Header }
 
-import from "./Header.cl.jac" { Header }
-
-def:pub app() -> JsxElement {
-    return <div>
-        <Header title="My App" />
-        <main>Content</main>
-    </div>;
+    def:pub app() -> JsxElement {
+        return <div>
+            <Header title="My App" />
+            <main>Content</main>
+        </div>;
+    }
 }
 ```
 
@@ -549,15 +549,15 @@ export function Button({ label, onClick }: ButtonProps) {
 ### main.jac
 
 ```jac
-to cl:
+cl {
+    import from "./Button.tsx" { Button }
 
-import from "./Button.tsx" { Button }
-
-def:pub app() -> JsxElement {
-    return <Button
-        label="Click me"
-        onClick={lambda -> None { print("Clicked!"); }}
-    />;
+    def:pub app() -> JsxElement {
+        return <Button
+            label="Click me"
+            onClick={lambda -> None { print("Clicked!"); }}
+        />;
+    }
 }
 ```
 
@@ -568,31 +568,31 @@ def:pub app() -> JsxElement {
 ### Inline Styles
 
 ```jac
-to cl:
-
-def:pub StyledBox() -> JsxElement {
-    return <div style={{
-        "backgroundColor": "#f0f0f0",
-        "padding": "20px",
-        "borderRadius": "8px",
-        "boxShadow": "0 2px 4px rgba(0,0,0,0.1)"
-    }}>
-        Styled content
-    </div>;
+cl {
+    def:pub StyledBox() -> JsxElement {
+        return <div style={{
+            "backgroundColor": "#f0f0f0",
+            "padding": "20px",
+            "borderRadius": "8px",
+            "boxShadow": "0 2px 4px rgba(0,0,0,0.1)"
+        }}>
+            Styled content
+        </div>;
+    }
 }
 ```
 
 ### CSS Classes
 
 ```jac
-to cl:
+cl {
+    import "./styles.css";
 
-import "./styles.css";
-
-def:pub app() -> JsxElement {
-    return <div className="container">
-        <h1 className="title">Hello</h1>
-    </div>;
+    def:pub app() -> JsxElement {
+        return <div className="container">
+            <h1 className="title">Hello</h1>
+        </div>;
+    }
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/npm-and-libraries.md
+++ b/docs/docs/tutorials/fullstack/npm-and-libraries.md
@@ -326,12 +326,12 @@ This resolves the chosen style's `.cl.jac` components into `components/ui/`, ins
 ```jac
 cl import from "./components/ui/button" { Button }
 
-to cl:
-
-def:pub MyPage() -> JsxElement {
-    return <div>
-        <Button variant="outline">Click me</Button>
-    </div>;
+cl {
+    def:pub MyPage() -> JsxElement {
+        return <div>
+            <Button variant="outline">Click me</Button>
+        </div>;
+    }
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -15,7 +15,7 @@ When your application grows beyond a single view, you need routing -- the abilit
     If your app is a single-page application (like the [AI Day Planner tutorial](../first-app/build-ai-day-planner.md)), you don't need routing -- a single `def:pub app -> JsxElement` entry point is sufficient. Add routing when your app needs multiple distinct pages (e.g., dashboard, settings, profile).
 
 !!! tip "Browser APIs in client code"
-    Inside client-side code (a `.cl.jac` file or a `to cl:` section), standard JavaScript browser APIs like `URLSearchParams`, `parseInt`, `setInterval`, `clearInterval`, `localStorage`, and `JSON` are available since client code compiles to JavaScript.
+    Inside client-side code (a `.cl.jac` file or a `cl { }` block), standard JavaScript browser APIs like `URLSearchParams`, `parseInt`, `setInterval`, `clearInterval`, `localStorage`, and `JSON` are available since client code compiles to JavaScript.
 
 !!! note "Reading route params"
     `useParams()` returns a `dict`. Read parameters with subscript access -- `params["id"]`, `params["slug"]` -- not dotted attribute access. Dotted access (`params.id`) fails `jac check` with `error[E1030]: Type "dict" has no attribute "id"`.
@@ -72,13 +72,13 @@ Each page file exports a `page` function:
 
 ```jac
 # pages/about.jac
-to cl:
-
-def:pub page() -> JsxElement {
-    return <div>
-        <h1>About Us</h1>
-        <p>Learn more about our company.</p>
-    </div>;
+cl {
+    def:pub page() -> JsxElement {
+        return <div>
+            <h1>About Us</h1>
+            <p>Learn more about our company.</p>
+        </div>;
+    }
 }
 ```
 
@@ -90,32 +90,32 @@ Use square brackets for dynamic URL segments:
 # pages/users/[id].jac
 cl import from "@jac/runtime" { Link, useParams }
 
-to cl:
+cl {
+    def:pub page() -> JsxElement {
+        params = useParams();
+        userId = params["id"];
 
-def:pub page() -> JsxElement {
-    params = useParams();
-    userId = params["id"];
+        # Mock data lookup
+        users = {
+            "1": {"name": "Alice", "role": "Admin"},
+            "2": {"name": "Bob", "role": "Developer"}
+        };
 
-    # Mock data lookup
-    users = {
-        "1": {"name": "Alice", "role": "Admin"},
-        "2": {"name": "Bob", "role": "Developer"}
-    };
+        user = users[userId];
 
-    user = users[userId];
+        if not user {
+            return <div>
+                <h1>User Not Found</h1>
+                <Link to="/users">Back to Users</Link>
+            </div>;
+        }
 
-    if not user {
         return <div>
-            <h1>User Not Found</h1>
-            <Link to="/users">Back to Users</Link>
+            <Link to="/users">← Back</Link>
+            <h1>User: {user["name"]}</h1>
+            <p>Role: {user["role"]}</p>
         </div>;
     }
-
-    return <div>
-        <Link to="/users">← Back</Link>
-        <h1>User: {user["name"]}</h1>
-        <p>Role: {user["role"]}</p>
-    </div>;
 }
 ```
 
@@ -125,17 +125,17 @@ def:pub page() -> JsxElement {
 # pages/posts/[slug].jac
 cl import from "@jac/runtime" { Link, useParams }
 
-to cl:
+cl {
+    def:pub page() -> JsxElement {
+        params = useParams();
+        slug = params["slug"];  # e.g., "getting-started-with-jac"
 
-def:pub page() -> JsxElement {
-    params = useParams();
-    slug = params["slug"];  # e.g., "getting-started-with-jac"
-
-    return <article>
-        <Link to="/posts">← All Posts</Link>
-        <h1>Blog Post</h1>
-        <p>Slug: {slug}</p>
-    </article>;
+        return <article>
+            <Link to="/posts">← All Posts</Link>
+            <h1>Blog Post</h1>
+            <p>Slug: {slug}</p>
+        </article>;
+    }
 }
 ```
 
@@ -147,14 +147,14 @@ Use `[...param]` for catch-all routes (404 pages, docs, etc.):
 # pages/[...notFound].jac
 cl import from "@jac/runtime" { Link }
 
-to cl:
-
-def:pub page() -> JsxElement {
-    return <div style={{"textAlign": "center", "padding": "2rem"}}>
-        <h1>404 - Page Not Found</h1>
-        <p>The page you are looking for does not exist.</p>
-        <Link to="/">Back to Home</Link>
-    </div>;
+cl {
+    def:pub page() -> JsxElement {
+        return <div style={{"textAlign": "center", "padding": "2rem"}}>
+            <h1>404 - Page Not Found</h1>
+            <p>The page you are looking for does not exist.</p>
+            <Link to="/">Back to Home</Link>
+        </div>;
+    }
 }
 ```
 
@@ -188,16 +188,16 @@ Create `layout.jac` to wrap pages with shared UI:
 cl import from "@jac/runtime" { Outlet }
 cl import from ..components.navigation { Navigation }
 
-to cl:
-
-def:pub layout() -> JsxElement {
-    return <>
-        <Navigation />
-        <main style={{"maxWidth": "960px", "margin": "0 auto"}}>
-            <Outlet />  # Child routes render here
-        </main>
-        <footer>Footer content</footer>
-    </>;
+cl {
+    def:pub layout() -> JsxElement {
+        return <>
+            <Navigation />
+            <main style={{"maxWidth": "960px", "margin": "0 auto"}}>
+                <Outlet />  # Child routes render here
+            </main>
+            <footer>Footer content</footer>
+        </>;
+    }
 }
 ```
 
@@ -220,16 +220,16 @@ For explicit route configuration, import from `@jac/runtime`:
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-to cl:
-
-def:pub app() -> JsxElement {
-    return <Router>
-        <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/contact" element={<Contact />} />
-        </Routes>
-    </Router>;
+cl {
+    def:pub app() -> JsxElement {
+        return <Router>
+            <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/about" element={<About />} />
+                <Route path="/contact" element={<Contact />} />
+            </Routes>
+        </Router>;
+    }
 }
 ```
 
@@ -242,59 +242,59 @@ def:pub app() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-to cl:
+cl {
+    def:pub Home() -> JsxElement {
+        return <div>
+            <h1>Home Page</h1>
+            <p>Welcome to our site!</p>
+        </div>;
+    }
 
-def:pub Home() -> JsxElement {
-    return <div>
-        <h1>Home Page</h1>
-        <p>Welcome to our site!</p>
-    </div>;
-}
+    def:pub About() -> JsxElement {
+        return <div>
+            <h1>About Us</h1>
+            <p>Learn more about our company.</p>
+        </div>;
+    }
 
-def:pub About() -> JsxElement {
-    return <div>
-        <h1>About Us</h1>
-        <p>Learn more about our company.</p>
-    </div>;
-}
+    def:pub Contact() -> JsxElement {
+        return <div>
+            <h1>Contact</h1>
+            <p>Get in touch with us.</p>
+        </div>;
+    }
 
-def:pub Contact() -> JsxElement {
-    return <div>
-        <h1>Contact</h1>
-        <p>Get in touch with us.</p>
-    </div>;
-}
+    def:pub app() -> JsxElement {
+        return <Router>
+            <nav>
+                <Link to="/">Home</Link>
+                <Link to="/about">About</Link>
+                <Link to="/contact">Contact</Link>
+            </nav>
 
-def:pub app() -> JsxElement {
-    return <Router>
-        <nav>
-            <Link to="/">Home</Link>
-            <Link to="/about">About</Link>
-            <Link to="/contact">Contact</Link>
-        </nav>
-
-        <main>
-            <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/about" element={<About />} />
-                <Route path="/contact" element={<Contact />} />
-            </Routes>
-        </main>
-    </Router>;
+            <main>
+                <Routes>
+                    <Route path="/" element={<Home />} />
+                    <Route path="/about" element={<About />} />
+                    <Route path="/contact" element={<Contact />} />
+                </Routes>
+            </main>
+        </Router>;
+    }
 }
 ```
 
 ### Link vs Anchor
 
 ```jac
-to cl:
-
-# Use Link for internal navigation, anchor for external
-def:pub NavExample() -> JsxElement {
-    return <div>
-        <Link to="/about">About</Link>
-        <a href="https://example.com">External Site</a>
-    </div>;
+cl {
+    # Use Link for internal navigation, anchor for external
+    def:pub NavExample() -> JsxElement {
+        return <div>
+            <Link to="/about">About</Link>
+            <a href="https://example.com">External Site</a>
+        </div>;
+    }
 }
 ```
 
@@ -316,16 +316,16 @@ pages/users/[id].jac  # Matches /users/:id
 # pages/users/[id].jac
 cl import from "@jac/runtime" { useParams }
 
-to cl:
+cl {
+    def:pub page() -> JsxElement {
+        params = useParams();
+        user_id = params["id"];
 
-def:pub page() -> JsxElement {
-    params = useParams();
-    user_id = params["id"];
-
-    return <div>
-        <h1>User Profile</h1>
-        <p>Viewing user: {user_id}</p>
-    </div>;
+        return <div>
+            <h1>User Profile</h1>
+            <p>Viewing user: {user_id}</p>
+        </div>;
+    }
 }
 ```
 
@@ -334,24 +334,24 @@ def:pub page() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, useParams }
 
-to cl:
+cl {
+    def:pub UserProfile() -> JsxElement {
+        params = useParams();
+        user_id = params["id"];
 
-def:pub UserProfile() -> JsxElement {
-    params = useParams();
-    user_id = params["id"];
+        return <div>
+            <h1>User Profile</h1>
+            <p>Viewing user: {user_id}</p>
+        </div>;
+    }
 
-    return <div>
-        <h1>User Profile</h1>
-        <p>Viewing user: {user_id}</p>
-    </div>;
-}
-
-def:pub app() -> JsxElement {
-    return <Router>
-        <Routes>
-            <Route path="/user/:id" element={<UserProfile />} />
-        </Routes>
-    </Router>;
+    def:pub app() -> JsxElement {
+        return <Router>
+            <Routes>
+                <Route path="/user/:id" element={<UserProfile />} />
+            </Routes>
+        </Router>;
+    }
 }
 ```
 
@@ -360,20 +360,20 @@ def:pub app() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { useParams }
 
-to cl:
+cl {
+    def:pub BlogPost() -> JsxElement {
+        params = useParams();
 
-def:pub BlogPost() -> JsxElement {
-    params = useParams();
+        return <div>
+            <p>Category: {params["category"]}</p>
+            <p>Post ID: {params["postId"]}</p>
+        </div>;
+    }
 
-    return <div>
-        <p>Category: {params["category"]}</p>
-        <p>Post ID: {params["postId"]}</p>
-    </div>;
+    # Route: /blog/:category/:postId
+    # URL: /blog/tech/123
+    # params = {"category": "tech", "postId": "123"}
 }
-
-# Route: /blog/:category/:postId
-# URL: /blog/tech/123
-# params = {"category": "tech", "postId": "123"}
 ```
 
 ---
@@ -399,20 +399,20 @@ pages/
 # pages/dashboard/layout.jac
 cl import from "@jac/runtime" { Outlet, Link }
 
-to cl:
+cl {
+    def:pub layout() -> JsxElement {
+        return <div className="dashboard">
+            <aside>
+                <Link to="/dashboard">Overview</Link>
+                <Link to="/dashboard/settings">Settings</Link>
+                <Link to="/dashboard/profile">Profile</Link>
+            </aside>
 
-def:pub layout() -> JsxElement {
-    return <div className="dashboard">
-        <aside>
-            <Link to="/dashboard">Overview</Link>
-            <Link to="/dashboard/settings">Settings</Link>
-            <Link to="/dashboard/profile">Profile</Link>
-        </aside>
-
-        <main>
-            <Outlet />
-        </main>
-    </div>;
+            <main>
+                <Outlet />
+            </main>
+        </div>;
+    }
 }
 ```
 
@@ -421,44 +421,44 @@ def:pub layout() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Outlet, Link }
 
-to cl:
+cl {
+    def:pub DashboardLayout() -> JsxElement {
+        return <div className="dashboard">
+            <aside>
+                <Link to="/dashboard">Overview</Link>
+                <Link to="/dashboard/settings">Settings</Link>
+                <Link to="/dashboard/profile">Profile</Link>
+            </aside>
 
-def:pub DashboardLayout() -> JsxElement {
-    return <div className="dashboard">
-        <aside>
-            <Link to="/dashboard">Overview</Link>
-            <Link to="/dashboard/settings">Settings</Link>
-            <Link to="/dashboard/profile">Profile</Link>
-        </aside>
+            <main>
+                <Outlet />
+            </main>
+        </div>;
+    }
 
-        <main>
-            <Outlet />
-        </main>
-    </div>;
-}
+    def:pub DashboardHome() -> JsxElement {
+        return <h2>Dashboard Overview</h2>;
+    }
 
-def:pub DashboardHome() -> JsxElement {
-    return <h2>Dashboard Overview</h2>;
-}
+    def:pub DashboardSettings() -> JsxElement {
+        return <h2>Settings</h2>;
+    }
 
-def:pub DashboardSettings() -> JsxElement {
-    return <h2>Settings</h2>;
-}
+    def:pub DashboardProfile() -> JsxElement {
+        return <h2>Profile</h2>;
+    }
 
-def:pub DashboardProfile() -> JsxElement {
-    return <h2>Profile</h2>;
-}
-
-def:pub app() -> JsxElement {
-    return <Router>
-        <Routes>
-            <Route path="/dashboard" element={<DashboardLayout />}>
-                <Route index element={<DashboardHome />} />
-                <Route path="settings" element={<DashboardSettings />} />
-                <Route path="profile" element={<DashboardProfile />} />
-            </Route>
-        </Routes>
-    </Router>;
+    def:pub app() -> JsxElement {
+        return <Router>
+            <Routes>
+                <Route path="/dashboard" element={<DashboardLayout />}>
+                    <Route index element={<DashboardHome />} />
+                    <Route path="settings" element={<DashboardSettings />} />
+                    <Route path="profile" element={<DashboardProfile />} />
+                </Route>
+            </Routes>
+        </Router>;
+    }
 }
 ```
 
@@ -471,32 +471,32 @@ def:pub app() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { useNavigate }
 
-to cl:
+cl {
+    def:pub LoginForm() -> JsxElement {
+        has email: str = "";
+        has password: str = "";
 
-def:pub LoginForm() -> JsxElement {
-    has email: str = "";
-    has password: str = "";
+        navigate = useNavigate();
 
-    navigate = useNavigate();
+        async def handle_login() -> None {
+            success = await do_login(email, password);
 
-    async def handle_login() -> None {
-        success = await do_login(email, password);
-
-        if success {
-            # Redirect to dashboard
-            navigate("/dashboard");
+            if success {
+                # Redirect to dashboard
+                navigate("/dashboard");
+            }
         }
-    }
 
-    return <form>
-        <input
-            value={email}
-            onChange={lambda e: ChangeEvent { email = e.target.value; }}
-        />
-        <button onClick={lambda -> None { handle_login(); }}>
-            Login
-        </button>
-    </form>;
+        return <form>
+            <input
+                value={email}
+                onChange={lambda e: ChangeEvent { email = e.target.value; }}
+            />
+            <button onClick={lambda -> None { handle_login(); }}>
+                Login
+            </button>
+        </form>;
+    }
 }
 ```
 
@@ -505,28 +505,28 @@ def:pub LoginForm() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { useNavigate }
 
-to cl:
+cl {
+    def:pub NavExample() -> JsxElement {
+        navigate = useNavigate();
 
-def:pub NavExample() -> JsxElement {
-    navigate = useNavigate();
+        return <div>
+            <button onClick={lambda -> None { navigate("/home"); }}>
+                Go Home
+            </button>
 
-    return <div>
-        <button onClick={lambda -> None { navigate("/home"); }}>
-            Go Home
-        </button>
+            <button onClick={lambda -> None { navigate("/login", {"replace": True}); }}>
+                Login (replace)
+            </button>
 
-        <button onClick={lambda -> None { navigate("/login", {"replace": True}); }}>
-            Login (replace)
-        </button>
+            <button onClick={lambda -> None { navigate(-1); }}>
+                Back
+            </button>
 
-        <button onClick={lambda -> None { navigate(-1); }}>
-            Back
-        </button>
-
-        <button onClick={lambda -> None { navigate(1); }}>
-            Forward
-        </button>
-    </div>;
+            <button onClick={lambda -> None { navigate(1); }}>
+                Forward
+            </button>
+        </div>;
+    }
 }
 ```
 
@@ -542,12 +542,12 @@ For file-based routing, use the built-in `AuthGuard` component in a layout file:
 # pages/(protected)/layout.jac
 cl import from "@jac/runtime" { AuthGuard, Outlet }
 
-to cl:
-
-def:pub layout() -> JsxElement {
-    return <AuthGuard redirect="/login">
-        <Outlet />
-    </AuthGuard>;
+cl {
+    def:pub layout() -> JsxElement {
+        return <AuthGuard redirect="/login">
+            <Outlet />
+        </AuthGuard>;
+    }
 }
 ```
 
@@ -558,23 +558,23 @@ Any pages in the `(protected)` group will require authentication.
 ```jac
 cl import from "@jac/runtime" { useNavigate, jacIsLoggedIn }
 
-to cl:
+cl {
+    def:pub ProtectedRoute(children: any = None) -> JsxElement {
+        navigate = useNavigate();
+        isAuthenticated = jacIsLoggedIn();
 
-def:pub ProtectedRoute(children: any = None) -> JsxElement {
-    navigate = useNavigate();
-    isAuthenticated = jacIsLoggedIn();
-
-    can with entry {
-        if not isAuthenticated {
-            navigate("/login", {"replace": True});
+        can with entry {
+            if not isAuthenticated {
+                navigate("/login", {"replace": True});
+            }
         }
-    }
 
-    if not isAuthenticated {
-        return <div>Redirecting...</div>;
-    }
+        if not isAuthenticated {
+            return <div>Redirecting...</div>;
+        }
 
-    return <div>{children}</div>;
+        return <div>{children}</div>;
+    }
 }
 ```
 
@@ -589,39 +589,39 @@ Access query parameters using `useLocation` and standard URL parsing:
 ```jac
 cl import from "@jac/runtime" { useLocation, useNavigate }
 
-to cl:
+cl {
+    def:pub SearchResults() -> JsxElement {
+        location = useLocation();
+        navigate = useNavigate();
 
-def:pub SearchResults() -> JsxElement {
-    location = useLocation();
-    navigate = useNavigate();
+        # Parse query parameters from location.search
+        searchParams = URLSearchParams(location.search);
+        query = searchParams.get("q") or "";
+        page = int(searchParams.get("page") or "1");
 
-    # Parse query parameters from location.search
-    searchParams = URLSearchParams(location.search);
-    query = searchParams.get("q") or "";
-    page = int(searchParams.get("page") or "1");
+        def updatePage(newPage: int) -> None {
+            navigate(f"/search?q={query}&page={newPage}");
+        }
 
-    def updatePage(newPage: int) -> None {
-        navigate(f"/search?q={query}&page={newPage}");
+        return <div>
+            <h2>Results for: {query}</h2>
+            <p>Page: {page}</p>
+
+            <button
+                onClick={lambda -> None { updatePage(page - 1); }}
+                disabled={page <= 1}
+            >
+                Previous
+            </button>
+
+            <button onClick={lambda -> None { updatePage(page + 1); }}>
+                Next
+            </button>
+        </div>;
     }
 
-    return <div>
-        <h2>Results for: {query}</h2>
-        <p>Page: {page}</p>
-
-        <button
-            onClick={lambda -> None { updatePage(page - 1); }}
-            disabled={page <= 1}
-        >
-            Previous
-        </button>
-
-        <button onClick={lambda -> None { updatePage(page + 1); }}>
-            Next
-        </button>
-    </div>;
+    # URL: /search?q=hello&page=2
 }
-
-# URL: /search?q=hello&page=2
 ```
 
 ---
@@ -631,24 +631,24 @@ def:pub SearchResults() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link }
 
-to cl:
+cl {
+    def:pub NotFound() -> JsxElement {
+        return <div className="error-page">
+            <h1>404</h1>
+            <p>Page not found</p>
+            <Link to="/">Go Home</Link>
+        </div>;
+    }
 
-def:pub NotFound() -> JsxElement {
-    return <div className="error-page">
-        <h1>404</h1>
-        <p>Page not found</p>
-        <Link to="/">Go Home</Link>
-    </div>;
-}
-
-def:pub app() -> JsxElement {
-    return <Router>
-        <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/about" element={<About />} />
-            <Route path="*" element={<NotFound />} />
-        </Routes>
-    </Router>;
+    def:pub app() -> JsxElement {
+        return <Router>
+            <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/about" element={<About />} />
+                <Route path="*" element={<NotFound />} />
+            </Routes>
+        </Router>;
+    }
 }
 ```
 
@@ -661,30 +661,30 @@ Use `useLocation` with `Link` to create active link styling:
 ```jac
 cl import from "@jac/runtime" { Link, useLocation }
 
-to cl:
+cl {
+    def:pub Navigation() -> JsxElement {
+        location = useLocation();
 
-def:pub Navigation() -> JsxElement {
-    location = useLocation();
+        def isActive(path: str) -> bool {
+            return location.pathname == path;
+        }
 
-    def isActive(path: str) -> bool {
-        return location.pathname == path;
+        return <nav>
+            <Link
+                to="/"
+                className={"nav-link " + ("active" if isActive("/") else "")}
+            >
+                Home
+            </Link>
+
+            <Link
+                to="/about"
+                className={"nav-link " + ("active" if isActive("/about") else "")}
+            >
+                About
+            </Link>
+        </nav>;
     }
-
-    return <nav>
-        <Link
-            to="/"
-            className={"nav-link " + ("active" if isActive("/") else "")}
-        >
-            Home
-        </Link>
-
-        <Link
-            to="/about"
-            className={"nav-link " + ("active" if isActive("/about") else "")}
-        >
-            About
-        </Link>
-    </nav>;
 }
 ```
 
@@ -708,101 +708,101 @@ def:pub Navigation() -> JsxElement {
 ```jac
 cl import from "@jac/runtime" { Router, Routes, Route, Link, Outlet, useParams, useNavigate }
 
-to cl:
+cl {
+    # Layout
+    def:pub Layout() -> JsxElement {
+        return <div className="app">
+            <header>
+                <nav>
+                    <Link to="/">Home</Link>
+                    <Link to="/products">Products</Link>
+                    <Link to="/about">About</Link>
+                </nav>
+            </header>
 
-# Layout
-def:pub Layout() -> JsxElement {
-    return <div className="app">
-        <header>
-            <nav>
-                <Link to="/">Home</Link>
-                <Link to="/products">Products</Link>
-                <Link to="/about">About</Link>
-            </nav>
-        </header>
+            <main>
+                <Outlet />
+            </main>
 
-        <main>
-            <Outlet />
-        </main>
+            <footer>
+                <p>© 2024 My App</p>
+            </footer>
+        </div>;
+    }
 
-        <footer>
-            <p>© 2024 My App</p>
-        </footer>
-    </div>;
-}
+    # Pages
+    def:pub Home() -> JsxElement {
+        return <div>
+            <h1>Welcome!</h1>
+            <Link to="/products">Browse Products</Link>
+        </div>;
+    }
 
-# Pages
-def:pub Home() -> JsxElement {
-    return <div>
-        <h1>Welcome!</h1>
-        <Link to="/products">Browse Products</Link>
-    </div>;
-}
+    def:pub Products() -> JsxElement {
+        products = [
+            {"id": 1, "name": "Widget A"},
+            {"id": 2, "name": "Widget B"},
+            {"id": 3, "name": "Widget C"}
+        ];
 
-def:pub Products() -> JsxElement {
-    products = [
-        {"id": 1, "name": "Widget A"},
-        {"id": 2, "name": "Widget B"},
-        {"id": 3, "name": "Widget C"}
-    ];
+        return <div>
+            <h1>Products</h1>
+            <ul>
+                {[
+                    <li key={p["id"]}>
+                        <Link to={f"/products/{p['id']}"}>
+                            {p["name"]}
+                        </Link>
+                    </li>
+                    for p in products
+                ]}
+            </ul>
+        </div>;
+    }
 
-    return <div>
-        <h1>Products</h1>
-        <ul>
-            {[
-                <li key={p["id"]}>
-                    <Link to={f"/products/{p['id']}"}>
-                        {p["name"]}
-                    </Link>
-                </li>
-                for p in products
-            ]}
-        </ul>
-    </div>;
-}
+    def:pub ProductDetail() -> JsxElement {
+        params = useParams();
+        navigate = useNavigate();
 
-def:pub ProductDetail() -> JsxElement {
-    params = useParams();
-    navigate = useNavigate();
+        product_id = params["id"];
 
-    product_id = params["id"];
+        return <div>
+            <button onClick={lambda -> None { navigate(-1); }}>
+                ← Back
+            </button>
+            <h1>Product {product_id}</h1>
+            <p>Details about product {product_id}</p>
+        </div>;
+    }
 
-    return <div>
-        <button onClick={lambda -> None { navigate(-1); }}>
-            ← Back
-        </button>
-        <h1>Product {product_id}</h1>
-        <p>Details about product {product_id}</p>
-    </div>;
-}
+    def:pub About() -> JsxElement {
+        return <div>
+            <h1>About Us</h1>
+            <p>We make great products.</p>
+        </div>;
+    }
 
-def:pub About() -> JsxElement {
-    return <div>
-        <h1>About Us</h1>
-        <p>We make great products.</p>
-    </div>;
-}
+    def:pub NotFound() -> JsxElement {
+        return <div>
+            <h1>404 - Not Found</h1>
+            <Link to="/">Go Home</Link>
+        </div>;
+    }
 
-def:pub NotFound() -> JsxElement {
-    return <div>
-        <h1>404 - Not Found</h1>
-        <Link to="/">Go Home</Link>
-    </div>;
-}
-
-# App
-def:pub app() -> JsxElement {
-    return <Router>
-        <Routes>
-            <Route path="/" element={<Layout />}>
-                <Route index element={<Home />} />
-                <Route path="products" element={<Products />} />
-                <Route path="products/:id" element={<ProductDetail />} />
-                <Route path="about" element={<About />} />
-                <Route path="*" element={<NotFound />} />
-            </Route>
-        </Routes>
-    </Router>;
+    # App
+    def:pub app() -> JsxElement {
+        return <Router>
+            <Routes>
+                <Route path="/" element={<Layout />}>
+                    <Route index element={<Home />} />
+                    <Route path="products" element={<Products />} />
+                    <Route path="products/:id" element={<ProductDetail />} />
+                    <Route path="about" element={<About />} />
+                    <Route path="*" element={<NotFound />} />
+                </Route>
+            </Routes>
+        </Router>;
+    }
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -1,6 +1,6 @@
 # Full-Stack Project Setup
 
-Jac's `jac-client` plugin lets you build full-stack web applications where the frontend (React-style JSX components) and backend (walkers, functions, graph operations) live in the same codebase -- even the same file. The compiler separates client and server code automatically: client-side code -- a `.cl.jac` file or anything under a `to cl:` section header -- compiles to JavaScript and runs in the browser, while everything else compiles to Python and runs on the server.
+Jac's `jac-client` plugin lets you build full-stack web applications where the frontend (React-style JSX components) and backend (walkers, functions, graph operations) live in the same codebase -- even the same file. The compiler separates client and server code automatically: client-side code -- a `.cl.jac` file or anything inside a `cl { }` block -- compiles to JavaScript and runs in the browser, while everything else compiles to Python and runs on the server.
 
 This means no separate frontend repository, no REST API boilerplate, and no manual data serialization. When a client component calls a server function, the compiler generates the HTTP layer for you. Hot Module Replacement (HMR) is built in, so changes to both frontend and backend code reflect instantly during development.
 
@@ -59,14 +59,14 @@ walker:pub get_todos {
 }
 
 # Frontend code (client section)
-to cl:
+cl {
+    def:pub app() -> JsxElement {
+        has message: str = "Hello from Jac!";
 
-def:pub app() -> JsxElement {
-    has message: str = "Hello from Jac!";
-
-    return <div>
-        <h1>{message}</h1>
-    </div>;
+        return <div>
+            <h1>{message}</h1>
+        </div>;
+    }
 }
 ```
 
@@ -132,9 +132,9 @@ Open http://localhost:8000/cl/app
 
 ---
 
-## Understanding `to cl:`
+## Understanding `cl { }`
 
-The `to cl:` section header marks frontend (client) code -- everything below it, until the next `to X:` header or end of file, compiles to JavaScript/React:
+A `cl { }` block marks frontend (client) code -- everything inside the braces compiles to JavaScript/React, while everything outside stays on the server:
 
 ```jac
 # This is backend code (runs on server)
@@ -143,16 +143,16 @@ walker api_endpoint {
 }
 
 # This is frontend code (runs in browser)
-to cl:
-
-def:pub MyComponent() -> JsxElement {
-    return <div>I run in the browser</div>;
+cl {
+    def:pub MyComponent() -> JsxElement {
+        return <div>I run in the browser</div>;
+    }
 }
 ```
 
 **Key rules:**
 
-- Code under `to cl:` (or in a `.cl.jac` file) compiles to JavaScript/React
+- Code inside a `cl { }` block (or in a `.cl.jac` file) compiles to JavaScript/React
 - `def:pub` exports functions (like React components)
 - `app()` is the required entry point
 
@@ -172,10 +172,10 @@ walker get_user {
 }
 
 # Frontend
-to cl:
-
-def:pub app() -> JsxElement {
-    return <div>App</div>;
+cl {
+    def:pub app() -> JsxElement {
+        return <div>App</div>;
+    }
 }
 ```
 
@@ -194,7 +194,7 @@ myapp/
     └── About.cl.jac   # Frontend page
 ```
 
-**Note:** `.cl.jac` files are automatically client-side (no `to cl:` header needed).
+**Note:** `.cl.jac` files are automatically client-side (no `cl { }` block needed).
 
 ---
 
@@ -215,15 +215,15 @@ walker get_user {
 
 ```jac
 # main.jac
-to cl:
+cl {
+    import from "./components/Header.cl.jac" { Header }
 
-import from "./components/Header.cl.jac" { Header }
-
-def:pub app() -> JsxElement {
-    return <div>
-        <Header />
-        <main>Content</main>
-    </div>;
+    def:pub app() -> JsxElement {
+        return <div>
+            <Header />
+            <main>Content</main>
+        </div>;
+    }
 }
 ```
 
@@ -256,13 +256,13 @@ Then use in frontend:
     npm packages bundle correctly at build time, but the static checker has no `.d.ts`-like stubs for them yet, so `jac check` reports their attributes as Unknown. The code below runs as written under `jac start`.
 
 ```jac
-to cl:
+cl {
+    import lodash;
 
-import lodash;
-
-def:pub app() -> JsxElement {
-    items = lodash.sortBy(["c", "a", "b"]);
-    return <ul>{[<li>{i}</li> for i in items]}</ul>;
+    def:pub app() -> JsxElement {
+        items = lodash.sortBy(["c", "a", "b"]);
+        return <ul>{[<li>{i}</li> for i in items]}</ul>;
+    }
 }
 ```
 
@@ -301,18 +301,18 @@ watchdog = ">=3.0.0"
 Create this minimal `main.jac`:
 
 ```jac
-to cl:
+cl {
+    def:pub app() -> JsxElement {
+        has count: int = 0;
 
-def:pub app() -> JsxElement {
-    has count: int = 0;
-
-    return <div style={{"textAlign": "center", "marginTop": "50px"}}>
-        <h1>Jac Full-Stack</h1>
-        <p>Count: {count}</p>
-        <button onClick={lambda -> None { count = count + 1; }}>
-            Increment
-        </button>
-    </div>;
+        return <div style={{"textAlign": "center", "marginTop": "50px"}}>
+            <h1>Jac Full-Stack</h1>
+            <p>Count: {count}</p>
+            <button onClick={lambda -> None { count = count + 1; }}>
+                Increment
+            </button>
+        </div>;
+    }
 }
 ```
 

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -16,20 +16,20 @@ This tutorial covers declaring reactive state, handling user input, sharing stat
 
 ## Reactive State with `has`
 
-Inside client-side code (a `.cl.jac` file or a `to cl:` section), `has` creates reactive state (like React's `useState`). Declaring `has count: int = 0;` inside a component function creates a stateful variable that persists across re-renders and triggers a UI update whenever its value changes:
+Inside client-side code (a `.cl.jac` file or a `cl { }` block), `has` creates reactive state (like React's `useState`). Declaring `has count: int = 0;` inside a component function creates a stateful variable that persists across re-renders and triggers a UI update whenever its value changes:
 
 ```jac
-to cl:
+cl {
+    def:pub Counter() -> JsxElement {
+        has count: int = 0;  # Reactive state
 
-def:pub Counter() -> JsxElement {
-    has count: int = 0;  # Reactive state
-
-    return <div>
-        <p>Count: {count}</p>
-        <button onClick={lambda -> None { count = count + 1; }}>
-            Increment
-        </button>
-    </div>;
+        return <div>
+            <p>Count: {count}</p>
+            <button onClick={lambda -> None { count = count + 1; }}>
+                Increment
+            </button>
+        </div>;
+    }
 }
 ```
 
@@ -44,40 +44,40 @@ def:pub Counter() -> JsxElement {
 ## Multiple State Variables
 
 ```jac
-to cl:
+cl {
+    def:pub Form() -> JsxElement {
+        has name: str = "";
+        has email: str = "";
+        has submitted: bool = False;
 
-def:pub Form() -> JsxElement {
-    has name: str = "";
-    has email: str = "";
-    has submitted: bool = False;
+        def handle_submit() -> None {
+            print(f"Submitting: {name}, {email}");
+            submitted = True;
+        }
 
-    def handle_submit() -> None {
-        print(f"Submitting: {name}, {email}");
-        submitted = True;
+        if submitted {
+            return <p>Thanks, {name}!</p>;
+        }
+
+        return <form>
+            <input
+                value={name}
+                onChange={lambda e: ChangeEvent { name = e.target.value; }}
+                placeholder="Name"
+            />
+            <input
+                value={email}
+                onChange={lambda e: ChangeEvent { email = e.target.value; }}
+                placeholder="Email"
+            />
+            <button
+                type="button"
+                onClick={lambda -> None { handle_submit(); }}
+            >
+                Submit
+            </button>
+        </form>;
     }
-
-    if submitted {
-        return <p>Thanks, {name}!</p>;
-    }
-
-    return <form>
-        <input
-            value={name}
-            onChange={lambda e: ChangeEvent { name = e.target.value; }}
-            placeholder="Name"
-        />
-        <input
-            value={email}
-            onChange={lambda e: ChangeEvent { email = e.target.value; }}
-            placeholder="Email"
-        />
-        <button
-            type="button"
-            onClick={lambda -> None { handle_submit(); }}
-        >
-            Submit
-        </button>
-    </form>;
 }
 ```
 
@@ -86,42 +86,42 @@ def:pub Form() -> JsxElement {
 ## Complex State (Objects/Lists)
 
 ```jac
-to cl:
+cl {
+    def:pub TodoApp() -> JsxElement {
+        has todos: list = [];
+        has input_text: str = "";
 
-def:pub TodoApp() -> JsxElement {
-    has todos: list = [];
-    has input_text: str = "";
-
-    def add_todo() -> None {
-        if input_text {
-            todos = todos + [{"id": len(todos), "text": input_text}];
-            input_text = "";
+        def add_todo() -> None {
+            if input_text {
+                todos = todos + [{"id": len(todos), "text": input_text}];
+                input_text = "";
+            }
         }
+
+        def remove_todo(id: int) -> None {
+            todos = [t for t in todos if t["id"] != id];
+        }
+
+        return <div>
+            <input
+                value={input_text}
+                onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
+            />
+            <button onClick={lambda -> None { add_todo(); }}>Add</button>
+
+            <ul>
+                {[
+                    <li key={todo["id"]}>
+                        {todo["text"]}
+                        <button onClick={lambda -> None { remove_todo(todo["id"]); }}>
+                            X
+                        </button>
+                    </li>
+                    for todo in todos
+                ]}
+            </ul>
+        </div>;
     }
-
-    def remove_todo(id: int) -> None {
-        todos = [t for t in todos if t["id"] != id];
-    }
-
-    return <div>
-        <input
-            value={input_text}
-            onChange={lambda e: ChangeEvent { input_text = e.target.value; }}
-        />
-        <button onClick={lambda -> None { add_todo(); }}>Add</button>
-
-        <ul>
-            {[
-                <li key={todo["id"]}>
-                    {todo["text"]}
-                    <button onClick={lambda -> None { remove_todo(todo["id"]); }}>
-                        X
-                    </button>
-                </li>
-                for todo in todos
-            ]}
-        </ul>
-    </div>;
 }
 ```
 
@@ -139,26 +139,26 @@ def:pub TodoApp() -> JsxElement {
 Similar to how `has` automatically generates `useState`, you can use `can with entry` and `can with exit` to automatically generate `useEffect` hooks:
 
 ```jac
-to cl:
+cl {
+    def:pub DataFetcher() -> JsxElement {
+        has data: list = [];
+        has loading: bool = True;
 
-def:pub DataFetcher() -> JsxElement {
-    has data: list = [];
-    has loading: bool = True;
+        # Run once on mount - async effects are wrapped in IIFE automatically
+        async can with entry {
+            result = await some_async_operation();
+            data = result;
+            loading = False;
+        }
 
-    # Run once on mount - async effects are wrapped in IIFE automatically
-    async can with entry {
-        result = await some_async_operation();
-        data = result;
-        loading = False;
+        if loading {
+            return <p>Loading...</p>;
+        }
+
+        return <ul>
+            {[<li key={item.id}>{item.name}</li> for item in data]}
+        </ul>;
     }
-
-    if loading {
-        return <p>Loading...</p>;
-    }
-
-    return <ul>
-        {[<li key={item.id}>{item.name}</li> for item in data]}
-    </ul>;
 }
 ```
 
@@ -167,28 +167,28 @@ def:pub DataFetcher() -> JsxElement {
 Use list syntax `[dep1, dep2]` to specify dependencies (similar to React's dependency arrays):
 
 ```jac
-to cl:
+cl {
+    def:pub SearchResults() -> JsxElement {
+        has query: str = "";
+        has results: list = [];
 
-def:pub SearchResults() -> JsxElement {
-    has query: str = "";
-    has results: list = [];
-
-    # Run when query changes
-    async can with [query] entry {
-        if query {
-            results = await search_api(query);
+        # Run when query changes
+        async can with [query] entry {
+            if query {
+                results = await search_api(query);
+            }
         }
-    }
 
-    return <div>
-        <input
-            value={query}
-            onChange={lambda e: ChangeEvent { query = e.target.value; }}
-        />
-        <ul>
-            {[<li>{r}</li> for r in results]}
-        </ul>
-    </div>;
+        return <div>
+            <input
+                value={query}
+                onChange={lambda e: ChangeEvent { query = e.target.value; }}
+            />
+            <ul>
+                {[<li>{r}</li> for r in results]}
+            </ul>
+        </div>;
+    }
 }
 ```
 
@@ -197,21 +197,21 @@ def:pub SearchResults() -> JsxElement {
 `can with exit` generates a standalone cleanup `useEffect` -- use it for teardown that does **not** depend on a handle created at mount:
 
 ```jac
-to cl:
+cl {
+    def:pub Subscriber() -> JsxElement {
+        has events: list = [];
 
-def:pub Subscriber() -> JsxElement {
-    has events: list = [];
+        can with entry {
+            subscribe_to_events();
+        }
 
-    can with entry {
-        subscribe_to_events();
+        # Cleanup on unmount
+        can with exit {
+            cleanup_subscriptions();
+        }
+
+        return <p>{len(events)} events</p>;
     }
-
-    # Cleanup on unmount
-    can with exit {
-        cleanup_subscriptions();
-    }
-
-    return <p>{len(events)} events</p>;
 }
 ```
 
@@ -219,20 +219,20 @@ def:pub Subscriber() -> JsxElement {
     `can with entry` and `can with exit` compile to *separate* `useEffect` closures, so a variable created in `entry` is not visible from `exit`. When setup produces a handle that cleanup needs -- an interval id, a subscription, an event listener -- do the setup and teardown in a **single** `useEffect` whose callback *returns* the cleanup function:
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    def:pub Timer() -> JsxElement {
+        has seconds: int = 0;
 
-def:pub Timer() -> JsxElement {
-    has seconds: int = 0;
+        useEffect(lambda {
+            intervalId = setInterval(lambda { seconds = seconds + 1; }, 1000);
+            # The returned function is the cleanup -- it runs on unmount
+            return lambda { clearInterval(intervalId); };
+        }, []);
 
-    useEffect(lambda {
-        intervalId = setInterval(lambda { seconds = seconds + 1; }, 1000);
-        # The returned function is the cleanup -- it runs on unmount
-        return lambda { clearInterval(intervalId); };
-    }, []);
-
-    return <p>Seconds: {seconds}</p>;
+        return <p>Seconds: {seconds}</p>;
+    }
 }
 ```
 
@@ -241,18 +241,18 @@ def:pub Timer() -> JsxElement {
 The `can with entry/exit` syntax above is the idiomatic approach and should be preferred. However, you can also use `useEffect` manually by importing from React -- this is useful for complex patterns involving `useRef` or `useCallback`:
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    def:pub DataFetcher() -> JsxElement {
+        has data: list = [];
 
-def:pub DataFetcher() -> JsxElement {
-    has data: list = [];
+        useEffect(lambda -> None {
+            fetch_data();
+        }, []);
 
-    useEffect(lambda -> None {
-        fetch_data();
-    }, []);
-
-    return <div>...</div>;
+        return <div>...</div>;
+    }
 }
 ```
 
@@ -263,19 +263,19 @@ def:pub DataFetcher() -> JsxElement {
 Just as `has` declares reactive state (`useState`) and `can with entry` declares effects (`useEffect`), a `has`-field typed `Ref[T]` declares a **ref** -- a mutable container that persists across renders but, unlike state, does **not** trigger a re-render when its `.current` changes. It compiles to React's `useRef`:
 
 ```jac
-to cl:
+cl {
+    def:pub FocusableInput() -> JsxElement {
+        has inputRef: Ref[HTMLInputElement] = Ref();  # -> const inputRef = useRef(null)
 
-def:pub FocusableInput() -> JsxElement {
-    has inputRef: Ref[HTMLInputElement] = Ref();  # -> const inputRef = useRef(null)
+        def focus() -> None {
+            if inputRef.current { inputRef.current.focus(); }
+        }
 
-    def focus() -> None {
-        if inputRef.current { inputRef.current.focus(); }
+        return <div>
+            <input ref={inputRef} type="text" />
+            <button onClick={lambda -> None { focus(); }}>Focus</button>
+        </div>;
     }
-
-    return <div>
-        <input ref={inputRef} type="text" />
-        <button onClick={lambda -> None { focus(); }}>Focus</button>
-    </div>;
 }
 ```
 
@@ -292,55 +292,55 @@ The field must be constructed (`= Ref()` / `= Ref(initial)`); a bare `has r: Ref
 ### Creating Context
 
 ```jac
-to cl:
+cl {
+    import from react { createContext, useContext }
 
-import from react { createContext, useContext }
+    # Create context
+    glob AppContext = createContext(None);
 
-# Create context
-glob AppContext = createContext(None);
+    # Provider component -- `children` is the nested JSX passed between its tags
+    def:pub AppProvider(children: any = None) -> JsxElement {
+        has user: any = None;
+        has theme: str = "light";
 
-# Provider component -- `children` is the nested JSX passed between its tags
-def:pub AppProvider(children: any = None) -> JsxElement {
-    has user: any = None;
-    has theme: str = "light";
+        value = {
+            "user": user,
+            "theme": theme,
+            "setUser": lambda u: any -> None { user = u; },
+            "setTheme": lambda t: str -> None { theme = t; }
+        };
 
-    value = {
-        "user": user,
-        "theme": theme,
-        "setUser": lambda u: any -> None { user = u; },
-        "setTheme": lambda t: str -> None { theme = t; }
-    };
-
-    return <AppContext.Provider value={value}>
-        {children}
-    </AppContext.Provider>;
-}
-
-# Consumer component
-def:pub UserDisplay() -> JsxElement {
-    ctx = useContext(AppContext);
-
-    if ctx.user {
-        return <p>Welcome, {ctx.user.name}!</p>;
+        return <AppContext.Provider value={value}>
+            {children}
+        </AppContext.Provider>;
     }
-    return <p>Not logged in</p>;
-}
 
-def:pub ThemeToggle() -> JsxElement {
-    ctx = useContext(AppContext);
+    # Consumer component
+    def:pub UserDisplay() -> JsxElement {
+        ctx = useContext(AppContext);
 
-    return <button onClick={lambda -> None {
-        ctx.setTheme("dark" if ctx.theme == "light" else "light");
-    }}>
-        Toggle Theme ({ctx.theme})
-    </button>;
-}
+        if ctx.user {
+            return <p>Welcome, {ctx.user.name}!</p>;
+        }
+        return <p>Not logged in</p>;
+    }
 
-def:pub app() -> JsxElement {
-    return <AppProvider>
-        <UserDisplay />
-        <ThemeToggle />
-    </AppProvider>;
+    def:pub ThemeToggle() -> JsxElement {
+        ctx = useContext(AppContext);
+
+        return <button onClick={lambda -> None {
+            ctx.setTheme("dark" if ctx.theme == "light" else "light");
+        }}>
+            Toggle Theme ({ctx.theme})
+        </button>;
+    }
+
+    def:pub app() -> JsxElement {
+        return <AppProvider>
+            <UserDisplay />
+            <ThemeToggle />
+        </AppProvider>;
+    }
 }
 ```
 
@@ -351,42 +351,42 @@ def:pub app() -> JsxElement {
 Create reusable state logic:
 
 ```jac
-to cl:
+cl {
+    import from react { useEffect }
 
-import from react { useEffect }
+    # Custom hook
+    def use_local_storage(key: str, initial_value: any) -> tuple {
+        has value: any = initial_value;
 
-# Custom hook
-def use_local_storage(key: str, initial_value: any) -> tuple {
-    has value: any = initial_value;
+        # Load from localStorage on mount
+        useEffect(lambda -> None {
+            stored = localStorage.getItem(key);
+            if stored {
+                value = JSON.parse(stored);
+            }
+        }, []);
 
-    # Load from localStorage on mount
-    useEffect(lambda -> None {
-        stored = localStorage.getItem(key);
-        if stored {
-            value = JSON.parse(stored);
-        }
-    }, []);
+        # Save to localStorage when value changes
+        useEffect(lambda -> None {
+            localStorage.setItem(key, JSON.stringify(value));
+        }, [value]);
 
-    # Save to localStorage when value changes
-    useEffect(lambda -> None {
-        localStorage.setItem(key, JSON.stringify(value));
-    }, [value]);
+        return (value, lambda v: any -> None { value = v; });
+    }
 
-    return (value, lambda v: any -> None { value = v; });
-}
+    def:pub Settings() -> JsxElement {
+        (theme, set_theme) = use_local_storage("theme", "light");
 
-def:pub Settings() -> JsxElement {
-    (theme, set_theme) = use_local_storage("theme", "light");
-
-    return <div>
-        <p>Current theme: {theme}</p>
-        <button onClick={lambda -> None { set_theme("dark"); }}>
-            Dark
-        </button>
-        <button onClick={lambda -> None { set_theme("light"); }}>
-            Light
-        </button>
-    </div>;
+        return <div>
+            <p>Current theme: {theme}</p>
+            <button onClick={lambda -> None { set_theme("dark"); }}>
+                Dark
+            </button>
+            <button onClick={lambda -> None { set_theme("light"); }}>
+                Light
+            </button>
+        </div>;
+    }
 }
 ```
 
@@ -397,71 +397,71 @@ def:pub Settings() -> JsxElement {
 ### Loading State Pattern
 
 ```jac
-to cl:
+cl {
+    def:pub DataComponent() -> JsxElement {
+        has data: any = None;
+        has loading: bool = True;
+        has error: str = "";
 
-def:pub DataComponent() -> JsxElement {
-    has data: any = None;
-    has loading: bool = True;
-    has error: str = "";
+        # ... fetch data ...
 
-    # ... fetch data ...
+        if loading {
+            return <div className="spinner">Loading...</div>;
+        }
 
-    if loading {
-        return <div className="spinner">Loading...</div>;
+        if error {
+            return <div className="error">{error}</div>;
+        }
+
+        return <div>{data}</div>;
     }
-
-    if error {
-        return <div className="error">{error}</div>;
-    }
-
-    return <div>{data}</div>;
 }
 ```
 
 ### Form State Pattern
 
 ```jac
-to cl:
+cl {
+    def:pub ContactForm() -> JsxElement {
+        has form_data: dict = {
+            "name": "",
+            "email": "",
+            "message": ""
+        };
+        has errors: dict = {};
+        has submitting: bool = False;
 
-def:pub ContactForm() -> JsxElement {
-    has form_data: dict = {
-        "name": "",
-        "email": "",
-        "message": ""
-    };
-    has errors: dict = {};
-    has submitting: bool = False;
-
-    def update_field(field: str, value: str) -> None {
-        form_data = {**form_data, field: value};
-    }
-
-    def validate() -> bool {
-        new_errors = {};
-        if not form_data["name"] {
-            new_errors["name"] = "Name is required";
+        def update_field(field: str, value: str) -> None {
+            form_data = {**form_data, field: value};
         }
-        if "@" not in form_data["email"] {
-            new_errors["email"] = "Invalid email";
-        }
-        errors = new_errors;
-        return len(new_errors) == 0;
-    }
 
-    def handle_submit() -> None {
-        if validate() {
-            submitting = True;
-            # ... submit form ...
+        def validate() -> bool {
+            new_errors = {};
+            if not form_data["name"] {
+                new_errors["name"] = "Name is required";
+            }
+            if "@" not in form_data["email"] {
+                new_errors["email"] = "Invalid email";
+            }
+            errors = new_errors;
+            return len(new_errors) == 0;
         }
-    }
 
-    return <form>
-        <input
-            value={form_data["name"]}
-            onChange={lambda e: ChangeEvent { update_field("name", e.target.value); }}
-        />
-        {errors.get("name") and <span className="error">{errors["name"]}</span>}
-    </form>;
+        def handle_submit() -> None {
+            if validate() {
+                submitting = True;
+                # ... submit form ...
+            }
+        }
+
+        return <form>
+            <input
+                value={form_data["name"]}
+                onChange={lambda e: ChangeEvent { update_field("name", e.target.value); }}
+            />
+            {errors.get("name") and <span className="error">{errors["name"]}</span>}
+        </form>;
+    }
 }
 ```
 

--- a/docs/docs/tutorials/native/chess.md
+++ b/docs/docs/tutorials/native/chess.md
@@ -1,6 +1,6 @@
 # Build a Chess Engine
 
-> **Prerequisites:** Familiarity with [Native Compilation](../../reference/language/native-pathway.md) basics -- `to na:` sections (or `.na.jac` files) and `with entry {}`.
+> **Prerequisites:** Familiarity with [Native Compilation](../../reference/language/native-pathway.md) basics -- `na { }` blocks (or `.na.jac` files) and `with entry {}`.
 
 In this tutorial you will explore a fully playable chess engine written in idiomatic Jac, run it on the native compilation pathway, and compile it to a standalone binary. Along the way you will learn:
 


### PR DESCRIPTION
## Summary

Switches the default codespace convention throughout the docs from the `to cl:` / `to sv:` / `to na:` **section-header** form to the `cl { }` / `sv { }` / `na { }` **braced-block** form. Both forms remain valid in the language; this change just makes the block form the default the docs present.

## What changed

- **Code examples** across the full-stack tutorials and the reference are wrapped in `cl { }` / `na { }` blocks (with re-indentation).
- **Server code** — the default codespace — is left at top level rather than wrapped in `sv { }`, so `to sv:` headers that only switched back to the default are simply dropped.
- **Prose and headings** now lead with the block form (e.g. "Understanding `cl { }`", "a `.cl.jac` file or a `cl { }` block").

## What was intentionally left in header form

The header form is still documented where it is the subject being taught, since both forms are valid:

- The dedicated **"Section Headers"** subsections in the codespace reference (`primitives.md`) and the `jac-client` reference — both already present blocks first.
- The "ways to tag a codespace" enumeration in `import-anything.md` and the "Section header — an alternative to a block" demo in the syntax cheat sheet.
- Reference tables that enumerate every form (header / prefix / block / file).

Release notes (historical records) were not touched.

## Notes

- 19 files changed; all converted Jac code blocks remain brace-balanced, and `cl { }` / `na { }` block snippets were validated against the compiler.
- The day-planner tutorial is not included here — its Part 6 formally teaches the section-header mechanism, so its examples stay in header form.