### PR TITLE
fix(type-system): resolve real type errors in operations.jac

### DIFF
--- a/jac/jaclang/compiler/type_system/operations.jac
+++ b/jac/jaclang/compiler/type_system/operations.jac
@@ -140,14 +140,20 @@ def get_numeric_promotion_type(
         return None;
     }
 
+    float_class = evaluator.prefetch.float_class;
+    int_class = evaluator.prefetch.int_class;
+    if float_class is None or int_class is None {
+        return None;
+    }
+
     # Division always returns float
     if op == Tok.DIV {
-        return evaluator._convert_to_instance(evaluator.prefetch.float_class);
+        return evaluator._convert_to_instance(float_class);
     }
 
     # If either operand is float-like, result is float
     if left_is_float or right_is_float {
-        return evaluator._convert_to_instance(evaluator.prefetch.float_class);
+        return evaluator._convert_to_instance(float_class);
     }
 
     # Both are int-like: promote to the wider type
@@ -158,7 +164,7 @@ def get_numeric_promotion_type(
 
     # If either is plain int, result is int (int is the widest integer)
     if not left_fw or not right_fw {
-        return evaluator._convert_to_instance(evaluator.prefetch.int_class);
+        return evaluator._convert_to_instance(int_class);
     }
 
     # Both are fixed-width: pick the wider one
@@ -275,8 +281,9 @@ def get_type_of_binary_operation(
                 return True;
             }
             # Although None is not a valid class, it can be used as a class in the type annotation.
-            if isinstance(ty, jtypes.ClassType) {
-                return ty.shared == evaluator.prefetch.none_type_class.shared;
+            none_type_class = evaluator.prefetch.none_type_class;
+            if isinstance(ty, jtypes.ClassType) and none_type_class is not None {
+                return ty.shared == none_type_class.shared;
             }
             return False;
         }
@@ -322,8 +329,9 @@ def get_type_of_binary_operation(
                 return True;
             }
             # Although None is not a valid class, it can be used as a class in the type annotation.
-            if isinstance(ty, jtypes.ClassType) {
-                return ty.shared == evaluator.prefetch.none_type_class.shared;
+            none_type_class = evaluator.prefetch.none_type_class;
+            if isinstance(ty, jtypes.ClassType) and none_type_class is not None {
+                return ty.shared == none_type_class.shared;
             }
             return False;
         }
@@ -479,8 +487,9 @@ def get_type_of_binary_operation(
                     and (assign_compr := expr.op.conn_assign)
                 ) {
                     for assign in assign_compr.assigns {
-                        if (assign.key is not None) {
-                            edge_inst_type = evaluator._convert_to_instance(conn_type);
+                        edge_inst_type = evaluator._convert_to_instance(conn_type);
+                        if (assign.key is not None)
+                        and isinstance(edge_inst_type, jtypes.ClassType) {
                             if (
                                 member := evaluator._lookup_object_member(
                                     edge_inst_type, assign.key.sym_name
@@ -625,7 +634,6 @@ def get_type_of_binary_operation(
     if isinstance(expr.op, uni.Token) and expr.op.name == Tok.WALRUS_EQ {
         # Walrus operator: (x := expr) assigns right to left and returns right's type
         if isinstance(expr.left, uni.Name) and expr.left.sym {
-            expr.left.sym.type = right_type;
             expr.left.type = right_type;
         }
         return right_type;


### PR DESCRIPTION
## What

Fixes seven type-checker errors and one warning reported by `jac check` on `jac/jaclang/compiler/type_system/operations.jac`. All were genuine bugs in the file, not false positives — the type checker was correct in every case.

## Fixes

- **Unguarded `None` on prefetched classes** (`get_numeric_promotion_type`): `prefetch.float_class` / `prefetch.int_class` are typed `ClassType | None` but were passed straight into `_convert_to_instance(jtype: TypeBase)`. Added an early `None` guard that returns `None` (consistent with the function's existing `TypeBase | None` contract and the two `return None` guards already above it).
- **Unguarded `.shared` on `none_type_class`** (both `is_annotation_type` helpers): `none_type_class` is `ClassType | None`, so `.shared` could be accessed on `None`. Added `and none_type_class is not None` to the guard, returning `False` when unavailable.
- **`TypeBase` passed where `ClassType` required**: `_convert_to_instance` returns `TypeBase`, but `_lookup_object_member` requires a `ClassType`. Hoisted the conversion and narrowed with `isinstance(edge_inst_type, jtypes.ClassType)`.
- **Write to non-existent attribute** (walrus case): `expr.left.sym.type = right_type` — `Symbol` has no `.type` field (only `sym_type`, an enum). Removed it; the walrus target's type is already set on the next line via `expr.left.type` (a real `Expr.type` field). This also clears the `W1051` fallout warning.

The `None` guards follow the module's established convention of graceful degradation (cf. lines around `bool_class is not None` / `if evaluator.prefetch and evaluator.prefetch.list_class`) rather than asserting, since this is a type checker that must not crash on broken/incomplete environments.

## Testing

`jac check jac/jaclang/compiler/type_system/operations.jac` now **passes** (previously 7 errors, 1 warning). `pre-commit` (jac-format + all hooks) passes.