### PR TITLE
fix(jac-scale): annotate SqliteIdentityStorage engine/table fields with real types

### DIFF
--- a/jac-scale/jac_scale/identity_storage.jac
+++ b/jac-scale/jac_scale/identity_storage.jac
@@ -18,6 +18,7 @@ import logging;
 import from datetime { datetime, UTC }
 import from sqlalchemy {
     create_engine,
+    Engine,
     MetaData,
     Table,
     Column,
@@ -122,10 +123,10 @@ obj MongoIdentityStorage(IdentityStorage) {
 """SQLite-backed identity storage."""
 obj SqliteIdentityStorage(IdentityStorage) {
     has db_path: str,
-        _engine: any by postinit,
-        _table: any by postinit,
-        _identity_lookups: any by postinit,
-        _sso_lookups: any by postinit;
+        _engine: Engine by postinit,
+        _table: Table by postinit,
+        _identity_lookups: Table by postinit,
+        _sso_lookups: Table by postinit;
 
     def postinit -> None;
     # Abstract primitives


### PR DESCRIPTION
### Type check errors down from 
61 errors, 9 warnings   **------->**  42 errors, 63 warnings

## What

`SqliteIdentityStorage` annotated its SQLAlchemy fields as `any`:

```jac
_engine: any by postinit,
_table: any by postinit,
_identity_lookups: any by postinit,
_sso_lookups: any by postinit;
```

This replaces them with their concrete types:

- `_engine: any` → `Engine`
- `_table` / `_identity_lookups` / `_sso_lookups: any` → `Table`

(`Engine` is added to the existing `sqlalchemy` import; `Table` was already imported.)


## Remaining diagnostics

After this change, the residual `with`-statement diagnostics come from `Engine.begin()` / `Engine.connect()` being `@contextmanager` methods, which the type checker does not yet model — that is addressed separately in #6260. This PR is a prerequisite for that fix to benefit this file, since a context manager cannot be resolved off an `any`-typed receiver.
