### PR TITLE
feat(type-checker): infer TypeVars through function-typed args; apply decorators generically

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6260.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6260.feature.md
@@ -1,0 +1,1 @@
+- Type variables are now inferred through function-typed arguments, so a generic like `apply(f: Callable[[], T]) -> T` resolves `T` from the function you pass in. This also lets `@contextmanager` / `@asynccontextmanager` methods be recognized as context managers, removing the false "cannot be used in 'with' statement" errors on `with` blocks that use them.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/construct_types.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/construct_types.impl.jac
@@ -314,7 +314,43 @@ impl TypeEvaluator.get_type_of_ability(node_: uni.Ability) -> TypeBase {
         type_params=func_type_params,
         is_async=node_.is_async,
     );
+    func_type = self._apply_function_decorators(node_, func_type);
     node_.name_spec.type = func_type;
+    return func_type;
+}
+
+"""Type an ability by applying its callable->callable decorators (e.g. contextmanager).
+
+Binds the decorator's TypeVars from `func_type` and adopts its result, with no
+per-decorator name special-casing. property/classmethod/etc. are ClassType, not
+matched here, and keep their own handling.
+"""
+impl TypeEvaluator._apply_function_decorators(
+    node_: uni.Ability, func_type: types.FunctionType
+) -> types.FunctionType {
+    import from jaclang.compiler.type_system.type_utils { apply_solved_type_vars }
+    if not node_.decorators {
+        return func_type;
+    }
+    for decorator in node_.decorators {
+        decorator_type = self.get_type_of_expression(decorator);
+        if not isinstance(decorator_type, types.FunctionType) {
+            continue;
+        }
+        params = decorator_type.parameters or [];
+        # Only callable->callable decorators: take one function, return one.
+        if len(params) != 1
+        or not isinstance(params[0].param_type, types.FunctionType)
+        or not isinstance(decorator_type.return_type, types.FunctionType) {
+            continue;
+        }
+        bindings: dict[str, TypeBase] = {};
+        self.assign_type_to_type_var(params[0].param_type, func_type, bindings);
+        decorated = apply_solved_type_vars(decorator_type.return_type, bindings);
+        if isinstance(decorated, types.FunctionType) {
+            func_type = decorated;
+        }
+    }
     return func_type;
 }
 

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -450,6 +450,18 @@ impl TypeEvaluator._get_declared_return_type(
             );
         }
     }
+    # Body checks (return/yield) want the undecorated return type: a decorator
+    # like @contextmanager rewrites the cached type, but the body still
+    # returns/yields per its signature. (Same as the cached type when undecorated.)
+    if (
+        isinstance(scope, uni.Ability)
+        and isinstance(scope.signature, uni.FuncSignature)
+        and isinstance(scope.signature.return_type, uni.Expr)
+    ) {
+        return self._convert_to_instance(
+            self.get_type_of_expression(scope.signature.return_type)
+        );
+    }
     # Ability path — resolve via get_type_of_ability (handles both annotated
     # and unannotated cases; unannotated defaults to NoneType).
     fn_type_base = self.get_type_of_ability(scope);

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/parameter_type_check.impl.jac
@@ -768,6 +768,29 @@ impl TypeEvaluator.assign_type_to_type_var(
         return True;
     }
 
+    # Callable param: bind TypeVars structurally. Params contravariant
+    # (arg<-param), return covariant (param<-arg).
+    if isinstance(param_type, types.FunctionType)
+    and isinstance(arg_type, types.FunctionType) {
+        param_params = param_type.parameters or [];
+        arg_params = arg_type.parameters or [];
+        for (i, pp) in enumerate(param_params) {
+            if i < len(arg_params)
+            and pp.param_type is not None
+            and arg_params[i].param_type is not None {
+                self.assign_type_to_type_var(
+                    arg_params[i].param_type, pp.param_type, bindings
+                );
+            }
+        }
+        if param_type.return_type is not None and arg_type.return_type is not None {
+            self.assign_type_to_type_var(
+                param_type.return_type, arg_type.return_type, bindings
+            );
+        }
+        return True;
+    }
+
     if (
         isinstance(param_type, types.ClassType)
         and isinstance(arg_type, types.ClassType)

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -346,6 +346,11 @@ obj TypeEvaluator {
     def get_type_of_class(node_: uni.Archetype) -> types.ClassType;
     def get_type_of_enum(node_: uni.Enum) -> types.ClassType;
     def get_type_of_ability(node_: uni.Ability) -> TypeBase;
+    # Apply function-shaped decorators (e.g. contextmanager) to an ability's type.
+    def _apply_function_decorators(
+        node_: uni.Ability, func_type: types.FunctionType
+    ) -> types.FunctionType;
+
     def get_type_of_string(nd: uni.String | uni.MultiString) -> TypeBase;
     def get_type_of_int(nd: uni.Int) -> TypeBase;
     def get_type_of_float(nd: uni.Float) -> TypeBase;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_contextmanager_generic_apply.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_contextmanager_generic_apply.jac
@@ -1,0 +1,25 @@
+"""Fixture: @contextmanager on an annotated generator method, used in `with`.
+
+Expected: 0 errors. Generic decorator-application types the method as a
+context manager (no decorator-name special-casing), so the with statement
+finds the enter/exit protocol.
+"""
+
+import from contextlib { contextmanager }
+import from typing { Iterator }
+
+obj Lock {
+    @contextmanager
+    def acquire -> Iterator[int];
+}
+
+impl Lock.acquire -> Iterator[int] {
+    yield 1;
+}
+
+def use_it {
+    lock = Lock();
+    with lock.acquire() {
+        print("inside");
+    }
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_higher_order_typevar.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_higher_order_typevar.jac
@@ -1,0 +1,22 @@
+"""Fixture: a TypeVar is bound through a function-typed argument.
+
+Expected: 0 errors. `apply` returns T inferred from the passed callable's
+return type, so `n + 1` typechecks as int arithmetic.
+"""
+
+import from typing { Callable, TypeVar }
+
+glob T = TypeVar("T");
+
+def apply(f: Callable[[], T]) -> T {
+    return f();
+}
+
+def make_int() -> int {
+    return 5;
+}
+
+def use_it {
+    n = apply(make_int);
+    m = n + 1;
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_with_plain_method_errors.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_with_plain_method_errors.jac
@@ -1,0 +1,18 @@
+"""Fixture: a plain (non-context-manager) method used in `with`.
+
+Expected: E1091 + E1092. Generic decorator-application must not silence
+errors for methods that are not context managers.
+"""
+
+obj NotCM {
+    def get -> None;
+}
+
+impl NotCM.get -> None { }
+
+def use_it {
+    x = NotCM();
+    with x.get() {
+        print("fail");
+    }
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -28,6 +28,7 @@ Bug index:
   #DSTR-1  - Docstring before declaration inside function body triggers W0060 instead of attaching
   #DLOC-1 - Decorated class inside function body parsed as Ability instead of Archetype
   #STUB-VGUARD - Module-level version-guarded stub symbols (e.g. datetime.UTC) resolve as Unknown
+  #HOGEN-1 - TypeVars not bound through function-typed args; blocks generic decorator-application
 """
 
 import os;
@@ -819,5 +820,46 @@ test "bug_narrow_any_symbol_isinstance" {
         "Bug #NARROW-ANY: isinstance must narrow an Any-typed symbol, so "
         "accessing a member of the narrowed type does not error. "
         f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+# Bug #HOGEN-1: TypeVars were not bound through function-typed arguments, so
+# `apply(f: Callable[[], T]) -> T` returned an unbound T. Fixing the binder
+# also enables generic decorator-application (e.g. @contextmanager) with no
+# name special-casing.
+test "bug_hogen_1_typevar_bound_through_callable_arg" {
+    program = compile_and_check("checker_higher_order_typevar.jac");
+    assert program.errors_had == [] , (
+        "Bug #HOGEN-1: a TypeVar passed through a Callable argument must bind "
+        "to the callable's return type. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+test "bug_hogen_1_contextmanager_generic_apply" {
+    program = compile_and_check("checker_contextmanager_generic_apply.jac");
+    assert program.errors_had == [] , (
+        "Bug #HOGEN-1: an annotated-generator @contextmanager method must type "
+        "as a context manager via generic decorator-application, so `with` "
+        "produces no errors. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+test "bug_hogen_1_plain_method_in_with_still_errors" {
+    program = compile_and_check("checker_with_plain_method_errors.jac");
+    e1091 = sum(
+        1
+        for e in program.errors_had
+        if e.code and e.code.code == "E1091"
+    );
+    e1092 = sum(
+        1
+        for e in program.errors_had
+        if e.code and e.code.code == "E1092"
+    );
+    assert e1091 == 1 and e1092 == 1 , (
+        "Bug #HOGEN-1 guard: a plain (non-context-manager) method in `with` "
+        f"must still produce E1091 + E1092. Got E1091={e1091}, E1092={e1092}."
     );
 }


### PR DESCRIPTION
## What

Two related type-checker improvements:

1. **TypeVar inference through function-typed arguments.** `assign_type_to_type_var` gained a `FunctionType` branch that binds TypeVars structurally (parameters contravariant, return type covariant). A generic like `apply(f: Callable[[], T]) -> T` now resolves `T` from the function you pass in. Previously `T` stayed unbound.

2. **Generic decorator-application.** Building on (1), an ability decorated with a callable→callable decorator (e.g. `@contextmanager` / `@asynccontextmanager`) is now typed by *applying the decorator's signature* — binding the decorator's TypeVars from the ability's type and adopting the result — rather than matching the decorator by name. This removes the false *"cannot be used in 'with' statement"* (E1091/E1092) errors on `with`/`async with` blocks that use such methods, with **no per-decorator special-casing**.

Body `return`/`yield` checks read the *undecorated* return type, so the decorator transform doesn't leak into the body's own contract.

## Why this approach

This mirrors how Pyright handles decorators: it does not name-match `contextmanager`; it applies the decorator's stub signature (`getTypeOfDecorator` → `assignFunction`). The missing piece in Jac was the function-vs-function TypeVar binding, which this PR adds. The fix is general — it benefits any higher-order generic, not just context managers.

## Verified

- False E1091/E1092 gone for both annotated (`-> Iterator[T]`) and `-> None` + `yield` context managers.
- Plain (non-context-manager) methods in `with` still correctly error.
- New regression tests (`bug_hogen_1_*`) pass; no behavioral regressions in the checker suite.

## Known follow-up (out of scope here)

`with cm() as x:` currently types `x` as the context manager rather than `__enter__`'s result, so `x` usage may raise E1055. Precise `as`-binding through `__enter__` and binding the generator yield TypeVar are left for a separate change.