### PR TITLE
fix(type-checker): bind `with ... as` to the enter-method result; async-aware with check

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6293.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6293.bugfix.md
@@ -1,0 +1,1 @@
+- `with cm() as x` now types `x` as the value the context manager yields (its `__enter__` result) instead of the context manager itself, and `async with` is checked against the async `__aenter__`/`__aexit__` protocol. Using the bound variable inside the block no longer raises spurious type errors.

--- a/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/type_checker_pass.impl.jac
@@ -1161,44 +1161,59 @@ impl TypeCheckPass.exit_raise_stmt(self: TypeCheckPass, nd: uni.RaiseStmt) -> No
 """Bind alias types from context manager BEFORE visiting body."""
 impl TypeCheckPass.enter_with_stmt(self: TypeCheckPass, nd: uni.WithStmt) -> None {
     import from jaclang.compiler.type_system { types }
+    enter_method = "__aenter__" if nd.is_async else "__enter__";
     for item in nd.exprs {
         ctx_item: uni.ExprAsItem = item;
         expr_type = self.evaluator.get_type_of_expression(ctx_item.expr);
-        # Bind alias type - context managers typically return self from __enter__
-        if ctx_item.alias is not None
-        and not isinstance(expr_type, types.UnknownType) {
-            if isinstance(ctx_item.alias, uni.Name) {
-                ctx_item.alias.type = expr_type;
+        if ctx_item.alias is None
+        or not isinstance(ctx_item.alias, uni.Name)
+        or isinstance(expr_type, types.UnknownType) {
+            continue;
+        }
+        # `as x` binds the enter method's return, not the manager itself
+        # (`async with` awaits __aenter__). Fall back to the manager when the
+        # protocol can't be resolved.
+        enter_ret = self.evaluator.get_type_of_magic_method_call(
+            expr_type, enter_method, [], ctx_item.expr
+        );
+        if enter_ret is not None {
+            if nd.is_async {
+                enter_ret = self.evaluator._unwrap_awaitable_type(
+                    enter_ret, ctx_item.expr
+                );
             }
+            ctx_item.alias.type = enter_ret;
+        } else {
+            ctx_item.alias.type = expr_type;
         }
     }
 }
 
-"""Type-check with statements — verify context manager protocol."""
+"""Type-check with statements: verify the (async) context manager protocol."""
 impl TypeCheckPass.exit_with_stmt(self: TypeCheckPass, nd: uni.WithStmt) -> None {
     import from jaclang.compiler.type_system { types }
+    enter_method = "__aenter__" if nd.is_async else "__enter__";
+    exit_method = "__aexit__" if nd.is_async else "__exit__";
     for item in nd.exprs {
         ctx_item: uni.ExprAsItem = item;
         expr_type = self.evaluator.get_type_of_expression(ctx_item.expr);
         if not isinstance(expr_type, types.UnknownType) {
             enter_result = self.evaluator.get_type_of_magic_method_call(
-                expr_type, "__enter__", [], ctx_item.expr
+                expr_type, enter_method, [], ctx_item.expr
             );
             if enter_result is None {
                 self.emit(E1091, node_override=nd, type=str(expr_type));
             }
-            # Check __exit__ method exists (required for context manager protocol).
-            # Use direct member lookup instead of magic method call because
-            # __exit__ takes 3 params (exc_type, exc_val, exc_tb) that we
-            # don't have at this point — magic method call would fail on
-            # argument matching even when __exit__ exists.
+            # Direct member lookup, not a magic method call: __exit__/__aexit__
+            # take 3 args (exc_type, exc_val, exc_tb) we don't have here, so a
+            # call would fail arg-matching even when the method exists.
             if isinstance(expr_type, types.ClassType) {
                 has_exit = (
                     self.evaluator._lookup_class_member(
-                        expr_type, "__exit__"
+                        expr_type, exit_method
                     ) is not None
                     or self.evaluator._lookup_object_member(
-                        expr_type, "__exit__"
+                        expr_type, exit_method
                     ) is not None
                 );
                 if not has_exit and not expr_type.is_any_type() {

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_async_with_as_binding.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_async_with_as_binding.jac
@@ -1,0 +1,24 @@
+"""Fixture: `async with cm() as x` checks the async protocol and binds x.
+
+Expected: 0 errors. The checker verifies __aenter__/__aexit__ and binds the
+alias to the awaited __aenter__ result (int).
+"""
+
+import from contextlib { asynccontextmanager }
+import from typing { AsyncIterator }
+
+obj Lock {
+    @asynccontextmanager
+    async def acquire -> AsyncIterator[int];
+}
+
+impl Lock.acquire -> AsyncIterator[int] {
+    yield 1;
+}
+
+async def use_it {
+    lock = Lock();
+    async with lock.acquire() as x {
+        y = x + 1;
+    }
+}

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_with_as_enter_binding.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_with_as_enter_binding.jac
@@ -1,0 +1,24 @@
+"""Fixture: `with cm() as x` binds x to __enter__'s result.
+
+Expected: 0 errors. The alias is typed as the yielded value (str), not the
+context manager, so string concatenation typechecks.
+"""
+
+import from contextlib { contextmanager }
+import from typing { Iterator }
+
+obj Lock {
+    @contextmanager
+    def acquire -> Iterator[str];
+}
+
+impl Lock.acquire -> Iterator[str] {
+    yield "x";
+}
+
+def use_it {
+    lock = Lock();
+    with lock.acquire() as s {
+        t = s + "y";
+    }
+}

--- a/jac/tests/compiler/passes/main/test_checker_bugs.jac
+++ b/jac/tests/compiler/passes/main/test_checker_bugs.jac
@@ -29,6 +29,7 @@ Bug index:
   #DLOC-1 - Decorated class inside function body parsed as Ability instead of Archetype
   #STUB-VGUARD - Module-level version-guarded stub symbols (e.g. datetime.UTC) resolve as Unknown
   #HOGEN-1 - TypeVars not bound through function-typed args; blocks generic decorator-application
+  #WITHAS-1 - `with cm() as x` bound x to the manager not __enter__'s result; async with used sync protocol
 """
 
 import os;
@@ -861,5 +862,26 @@ test "bug_hogen_1_plain_method_in_with_still_errors" {
     assert e1091 == 1 and e1092 == 1 , (
         "Bug #HOGEN-1 guard: a plain (non-context-manager) method in `with` "
         f"must still produce E1091 + E1092. Got E1091={e1091}, E1092={e1092}."
+    );
+}
+
+# Bug #WITHAS-1: `with cm() as x` bound x to the context manager rather than
+# __enter__'s result, and `async with` was checked against the sync protocol.
+# The alias now binds through __enter__/__aenter__ (awaited for async), and the
+# protocol check picks the methods by the `async with` flag.
+test "bug_withas_1_as_binds_enter_result" {
+    program = compile_and_check("checker_with_as_enter_binding.jac");
+    assert program.errors_had == [] , (
+        "Bug #WITHAS-1: `with cm() as x` must bind x to __enter__'s return "
+        f"type. Got errors: {[str(e) for e in program.errors_had]}"
+    );
+}
+
+test "bug_withas_1_async_with_as_binds_and_checks" {
+    program = compile_and_check("checker_async_with_as_binding.jac");
+    assert program.errors_had == [] , (
+        "Bug #WITHAS-1: `async with cm() as x` must verify the async protocol "
+        "and bind x to the awaited __aenter__ result. "
+        f"Got errors: {[str(e) for e in program.errors_had]}"
     );
 }


### PR DESCRIPTION

<img width="1594" height="852" alt="image" src="https://github.com/user-attachments/assets/693d1fac-68c4-4340-ad98-900f7a37085d" />


## What

Follow-up to #6292. Two related `with`-statement type-checking fixes:

1. **`as` target binds the enter result, not the manager.** `with cm() as x` typed `x` as the context manager itself. It now binds `x` to what `__enter__` returns (for `async with`, the awaited `__aenter__` result). For a `@contextmanager` that yields a value, `x` is now that value; for managers whose `__enter__` returns `self` (e.g. `open()`, locks) the binding is unchanged. Falls back to the manager type if the protocol can't be resolved.

2. **`async with` uses the async protocol.** The protocol check now verifies `__aenter__`/`__aexit__` for `async with` (it previously always checked the sync `__enter__`/`__exit__`), so async context managers no longer raise false E1091/E1092.

## Why

Building on #6292 (which made `@contextmanager` methods type as context managers), the natural next gap was that `with cm() as x: use(x)` still raised spurious errors because `x` was the manager, not the yielded value. This completes correct `with`/`async with as` typing.

## Verified

- `with cm() as x` binds `x` to the yielded type (sync) / awaited `__aenter__` result (async); no spurious errors on `x` usage.
- `with open(...) as f` (manager whose `__enter__` returns self) is unchanged — Bug #23 regression test still passes.
- Plain (non-context-manager) methods in `with` still correctly error (E1091/E1092).
- New regression tests (`bug_withas_1_*`); no behavioral regressions in the checker / language suites.

## Out of scope

A `@contextmanager` method annotated `-> None` (relying on `yield`) leaves the yielded type unbound and additionally trips a pre-existing E1093 yield-type-mismatch on `main`; precise inference of an unannotated generator's yield type is a separate concern.