### PR TITLE
test(osp): cross-backend OSP equivalence fixtures (Phase 2 of #6146)

### DIFF
--- a/jac/jaclang/compiler/tests/fixtures/osp_disengage.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_disengage.jac
@@ -1,0 +1,32 @@
+"""Cross-backend OSP equivalence fixture: `disengage` early-exit.
+
+The walker steps along a chain `1 -> 2 -> 3 -> 4 -> 5`, recording each value,
+and `disengage`s at `3`. `disengage` halts the walk after the in-flight ability
+returns, so the partial visit-set `[1, 2, 3]` is captured and nodes 4/5 are
+never entered.
+
+Backend status: `disengage` is E5090 on na and unwired on cl (also needs
+visit/edges), so py-only today.
+"""
+
+node N { has val: int; }
+
+walker Stop {
+    has seen: list = [];
+    can step with N entry {
+        self.seen.append(here.val);
+        if here.val == 3 {
+            disengage;
+        } else {
+            visit [-->];
+        }
+    }
+}
+
+def disengage_py() -> dict[str, any] {
+    n1 = N(val=1); n2 = N(val=2); n3 = N(val=3); n4 = N(val=4); n5 = N(val=5);
+    n1 ++> n2; n2 ++> n3; n3 ++> n4; n4 ++> n5;
+    w = Stop();
+    w spawn n1;
+    return {"seen": w.seen};
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_edge_typed.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_edge_typed.jac
@@ -1,0 +1,32 @@
+"""Cross-backend OSP equivalence fixture: typed / filtered edge references.
+
+The graph mixes edge types: `a -Road-> b`, `a -Rail-> c`, `b -Road-> d`. The
+walker follows ONLY `Road` edges via the typed edge ref `[->:Road:->]`, so it
+reaches `a, b, d` and never crosses the `Rail` edge to `c`. This pins typed
+edge filtering against the untyped `[-->]` (which would also reach `c`).
+
+Backend status: edge connect/ref are E5090 on na and unwired on cl, so py-only
+today.
+"""
+
+node City { has val: int; }
+edge Road {}
+edge Rail {}
+
+walker Router {
+    has seen: list = [];
+    can step with City entry {
+        self.seen.append(here.val);
+        visit [->:Road:->];
+    }
+}
+
+def edge_typed_py() -> dict[str, any] {
+    a = City(val=1); b = City(val=2); c = City(val=3); d = City(val=4);
+    a +>: Road() :+> b;
+    a +>: Rail() :+> c;
+    b +>: Road() :+> d;
+    w = Router();
+    w spawn a;
+    return {"seen": w.seen};
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_exit_ordering.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_exit_ordering.jac
@@ -1,0 +1,40 @@
+"""Cross-backend OSP equivalence fixture: entry/exit interleaving over a tree.
+
+Each location logs `+val` on entry and `-val` on exit. A parent's entry fires
+before its children and its exit fires after them, so the log is
+`[1, 2, 3, -3, -2, -1]` for `root(1) -> {a(2), b(3)}`.
+
+Note the sibling ordering: `a`'s exit (`-2`) lands AFTER `b`'s entire visit
+(`3`, `-3`), not between `a`'s entry and `b`'s. This is a property of the
+kernel's single shared `next` queue -- enqueued siblings are drained within the
+first sibling's recursion, so later siblings nest under earlier ones rather than
+being independent subtrees. This fixture pins that exact behavior so every
+backend reproduces it (and so a future "independent siblings" reconciliation is
+a visible, intentional change here).
+
+Backend status: exit abilities compile on na but do NOT fire (the inline spawn
+stopgap is entry-only), and this also needs `visit`/edges; cl is unwired. So
+py-only today -- add backend variants when exit firing + visit/edge lowering
+land.
+"""
+
+node N { has val: int; }
+
+walker Ex {
+    has log: list = [];
+    can enter with N entry {
+        self.log.append(here.val);
+        visit [-->];
+    }
+    can leave with N exit {
+        self.log.append(0 - here.val);
+    }
+}
+
+def exit_ordering_py() -> dict[str, any] {
+    root_n = N(val=1); a = N(val=2); b = N(val=3);
+    root_n ++> a; root_n ++> b;
+    w = Ex();
+    w spawn root_n;
+    return {"order": w.log};
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_multi_walker.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_multi_walker.jac
@@ -1,0 +1,40 @@
+"""Cross-backend OSP equivalence fixture: independent walkers don't share state.
+
+Two `Acc` walkers spawn against their own `Item`s; each accumulates only its own
+visits (`a` spawns twice -> 10, `b` once -> 100). This pins per-walker state
+isolation: the kernel's `WalkScope` is per-spawn, so interleaved spawns never
+cross-contaminate.
+
+Entry-only (no visit/edges), so na participates today via the inline spawn
+path. cl OSP is still unwired (spawn lowers to an unbound `__jacSpawn`), so it
+is skipped automatically until Phase 3.
+"""
+
+node Item { has val: int; }
+
+walker Acc {
+    has total: int = 0;
+    can grab with Item entry {
+        self.total = self.total + here.val;
+    }
+}
+
+def multi_walker_py() -> dict[str, any] {
+    a = Acc();
+    b = Acc();
+    a spawn Item(val=5);
+    b spawn Item(val=100);
+    a spawn Item(val=5);
+    return {"a": a.total, "b": b.total};
+}
+
+na {
+    def multi_walker_na() -> dict[str, any] {
+        a = Acc();
+        b = Acc();
+        a spawn Item(val=5);
+        b spawn Item(val=100);
+        a spawn Item(val=5);
+        return {"a": a.total, "b": b.total};
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_nested_spawn.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_nested_spawn.jac
@@ -1,0 +1,44 @@
+"""Cross-backend OSP equivalence fixture: an ability spawns a second walker.
+
+The `Outer` walker's entry ability spawns an `Inner` walker on a derived node,
+then folds the inner walker's result back into its own state
+(`Outer.sum = Inner.got = here.val * 2`). This pins that a nested spawn runs to
+completion with its own isolated scope and the outer walk resumes correctly.
+
+Entry-only (no visit/edges/report), so na participates today via the inline
+spawn path. cl OSP is still unwired, so it is skipped automatically until
+Phase 3. The report-aggregation half of nested spawning is covered py-side by
+`osp_report` until `report` lowering lands on na/cl.
+"""
+
+node Item { has val: int; }
+
+walker Inner {
+    has got: int = 0;
+    can grab with Item entry {
+        self.got = here.val;
+    }
+}
+
+walker Outer {
+    has sum: int = 0;
+    can run with Item entry {
+        inner = Inner();
+        inner spawn Item(val=here.val * 2);
+        self.sum = self.sum + inner.got;
+    }
+}
+
+def nested_spawn_py() -> dict[str, any] {
+    o = Outer();
+    o spawn Item(val=4);
+    return {"sum": o.sum};
+}
+
+na {
+    def nested_spawn_na() -> dict[str, any] {
+        o = Outer();
+        o spawn Item(val=4);
+        return {"sum": o.sum};
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_report.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_report.jac
@@ -1,0 +1,26 @@
+"""Cross-backend OSP equivalence fixture: `report` collection across the walk.
+
+The walker `report`s each location's value as it traverses a chain
+`10 -> 20 -> 30`; the collected reports `[10, 20, 30]` are delivered at the
+spawn boundary and read back off the walker.
+
+Backend status: `report` is E5090 on na and unwired on cl (also needs
+visit/edges), so py-only today.
+"""
+
+node N { has val: int; }
+
+walker Rep {
+    can step with N entry {
+        report here.val;
+        visit [-->];
+    }
+}
+
+def report_py() -> dict[str, any] {
+    n1 = N(val=10); n2 = N(val=20); n3 = N(val=30);
+    n1 ++> n2; n2 ++> n3;
+    w = Rep();
+    w spawn n1;
+    return {"reports": w.reports};
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_subtype_dispatch.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_subtype_dispatch.jac
@@ -1,0 +1,34 @@
+"""Cross-backend OSP equivalence fixture: subtype + union/tuple trigger dispatch.
+
+`with Base entry` must fire on a `Sub` instance (subtype-aware dispatch), and a
+tuple trigger `with (Sub, Other) entry` fires on either member. Spawning the
+same walker on `Sub(5)` then `Other(7)`:
+  - `on_base` (trigger `Base`) fires only on `Sub`        -> base = 5
+  - `on_either` (trigger `(Sub, Other)`) fires on both    -> either = 12
+
+Backend status: na dispatch keys on the exact type tag (no `is_a`), so it
+silently MISSES the subtype/tuple firing and returns base=0 -- a real native
+gap. py-only until native dispatch gains subtype matching; cl is unwired.
+"""
+
+node Base { has val: int; }
+node Sub(Base) {}
+node Other { has val: int; }
+
+walker W {
+    has base: int = 0;
+    has either: int = 0;
+    can on_base with Base entry {
+        self.base = self.base + here.val;
+    }
+    can on_either with (Sub, Other) entry {
+        self.either = self.either + here.val;
+    }
+}
+
+def subtype_dispatch_py() -> dict[str, any] {
+    w = W();
+    w spawn Sub(val=5);
+    w spawn Other(val=7);
+    return {"base": w.base, "either": w.either};
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_visit_order.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_visit_order.jac
@@ -1,0 +1,77 @@
+"""Cross-backend OSP equivalence fixture: `visit`-driven traversal order over
+four graph shapes (linear chain, diamond, fan-out, cycle).
+
+The portable kernel is DFS-recursive and does NOT auto-track visited locations
+(visit-once is opt-in), so a diamond double-visits its shared sink and a cycle
+would loop forever unless the walker guards itself. `chain`/`diamond`/`fanout`
+use the unguarded `Tracer`; `cycle` uses `GuardedTracer`, which only recurses
+into unseen nodes -- the canonical user-managed visit-once pattern.
+
+Backend status: `visit` and edge connect/ref (`++>`, `[-->]`) are E5090 on na
+and unwired on cl, so this runs py-only today. When visit/edge lowering lands,
+add `na {}` / `cl {}` entry variants and flip `require=` in the test.
+"""
+
+node Pos { has val: int; }
+
+walker Tracer {
+    has seen: list = [];
+    can step with Pos entry {
+        self.seen.append(here.val);
+        visit [-->];
+    }
+}
+
+walker GuardedTracer {
+    has seen: list = [];
+    can step with Pos entry {
+        if here.val not in self.seen {
+            self.seen.append(here.val);
+            visit [-->];
+        }
+    }
+}
+
+def _chain() -> list {
+    n1 = Pos(val=1); n2 = Pos(val=2); n3 = Pos(val=3); n4 = Pos(val=4);
+    n1 ++> n2; n2 ++> n3; n3 ++> n4;
+    w = Tracer();
+    w spawn n1;
+    return w.seen;
+}
+
+def _diamond() -> list {
+    # a -> b, a -> c, b -> d, c -> d : shared sink `d` is visited via both paths.
+    a = Pos(val=1); b = Pos(val=2); c = Pos(val=3); d = Pos(val=4);
+    a ++> b; a ++> c; b ++> d; c ++> d;
+    w = Tracer();
+    w spawn a;
+    return w.seen;
+}
+
+def _fanout() -> list {
+    root_n = Pos(val=1);
+    c1 = Pos(val=2); c2 = Pos(val=3); c3 = Pos(val=4);
+    root_n ++> c1; root_n ++> c2; root_n ++> c3;
+    w = Tracer();
+    w spawn root_n;
+    return w.seen;
+}
+
+def _cycle() -> list {
+    # 1 -> 2 -> 3 -> 1 : the guard stops the walk re-entering `1`.
+    n1 = Pos(val=1); n2 = Pos(val=2); n3 = Pos(val=3);
+    n1 ++> n2; n2 ++> n3; n3 ++> n1;
+    w = GuardedTracer();
+    w spawn n1;
+    return w.seen;
+}
+
+def visit_order_py() -> dict[str, any] {
+    return {
+        "chain": _chain(),
+        "diamond": _diamond(),
+        "fanout": _fanout(),
+        "cycle": _cycle()
+    };
+}

--- a/jac/jaclang/compiler/tests/test_osp_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_osp_equivalence.jac
@@ -3,21 +3,119 @@
 One OSP program per fixture, run on every backend that supports it, with the
 results compared (intersection semantics: a backend that returns {} or fails to
 compile is silently skipped). This is the executable check on the OSP kernel's
-core promise — the same `spawn`/ability dispatch behaves identically whether the
-program is run by the server runtime (py) or compiled natively (na).
+core promise -- the same `spawn`/`visit`/ability dispatch behaves identically
+whether the program is run by the server runtime (py) or compiled natively (na)
+or to JS (cl).
 
-Reuses the cross-backend harness from `test_prim_equivalence`. Comparisons use
-only portable logical data (walker state, report values as int lists), never
-backend-specific identity (anchor ids / uuids / pointers).
+Each test does two things:
+  1. Pins the canonical sv (py) semantics with a concrete `run_py_fixture`
+     assertion, so the kernel's behavior is a hard regression guard even while
+     only one backend runs the fixture.
+  2. Enforces cross-backend equivalence via `run_with_both`, with `require=`
+     naming the backends that MUST match today. As na/cl OSP lowering lands, a
+     fixture's `na {}` / `cl {}` entry variant is added and its backend is moved
+     into `require=` -- turning "support landed" into an enforced regression.
 
-Scope today: native OSP is entry-only (no `visit`/edge-ref yet) and cl OSP
-codegen is not wired, so fixtures stay on the entry-dispatch subset and cl is
-skipped automatically. Richer traversals (visit order, exit abilities, DFS
-ordering) get added as each backend's support lands.
+Comparisons use only portable logical data (walker state, report values as int
+lists), never backend-specific identity (anchor ids / uuids / pointers).
+
+Backend support today (see each fixture's docstring for specifics):
+  - na: entry-only spawn, EXACT-type dispatch. No visit / edges / report /
+    disengage; exit abilities compile but do not fire; no subtype dispatch.
+    So only the entry-only fixtures (`osp_acc`, `osp_multi_walker`,
+    `osp_nested_spawn`) carry `require=["na"]`.
+  - cl: OSP entirely unwired (spawn lowers to an unbound `__jacSpawn`), so cl is
+    skipped on every fixture for now.
 """
 
-import from jaclang.compiler.tests.xbackend_equiv { run_with_both }
+import from jaclang.compiler.tests.xbackend_equiv { run_with_both, run_py_fixture }
 
+# ---------------------------------------------------------------------------
+# Entry-only subset -- na participates today (require=["na"]).
+# ---------------------------------------------------------------------------
 test "osp acc: typed entry ability accumulates walker state across spawns" {
+    assert run_py_fixture("osp_acc", "acc_py") == {"total": 42};
     run_with_both("osp_acc.jac", "acc_py", "acc_cl", "acc_na", require=["na"]);
+}
+
+test "osp multi-walker: independent walkers do not share state" {
+    assert run_py_fixture("osp_multi_walker", "multi_walker_py") == {"a": 10, "b": 100};
+    run_with_both(
+        "osp_multi_walker.jac",
+        "multi_walker_py",
+        "multi_walker_cl",
+        "multi_walker_na",
+        require=["na"]
+    );
+}
+
+test "osp nested spawn: an ability spawns a second walker and folds its result" {
+    assert run_py_fixture("osp_nested_spawn", "nested_spawn_py") == {"sum": 8};
+    run_with_both(
+        "osp_nested_spawn.jac",
+        "nested_spawn_py",
+        "nested_spawn_cl",
+        "nested_spawn_na",
+        require=["na"]
+    );
+}
+
+# ---------------------------------------------------------------------------
+# Traversal subset -- py-only today (na: visit/edges/report/disengage E5090,
+# exit abilities don't fire, no subtype dispatch; cl unwired). These pin the
+# canonical sv semantics now and flip to cross-backend the moment na/cl gain
+# the matching lowering (add the codespace variant + require=).
+# ---------------------------------------------------------------------------
+test "osp visit order: chain / diamond / fan-out / cycle DFS traversal" {
+    assert run_py_fixture("osp_visit_order", "visit_order_py") == {
+        "chain": [1, 2, 3, 4],
+        "diamond": [1, 2, 3, 4, 4],
+        "fanout": [1, 2, 3, 4],
+        "cycle": [1, 2, 3]
+    };
+    run_with_both(
+        "osp_visit_order.jac", "visit_order_py", "visit_order_cl", "visit_order_na"
+    );
+}
+
+test "osp exit ordering: entry-before-children, exit-after (shared-queue nesting)" {
+    assert run_py_fixture("osp_exit_ordering", "exit_ordering_py") == {
+        "order": [1, 2, 3, -3, -2, -1]
+    };
+    run_with_both(
+        "osp_exit_ordering.jac",
+        "exit_ordering_py",
+        "exit_ordering_cl",
+        "exit_ordering_na"
+    );
+}
+
+test "osp subtype dispatch: `with Base entry` fires on Sub; tuple trigger" {
+    assert run_py_fixture("osp_subtype_dispatch", "subtype_dispatch_py") == {
+        "base": 5,
+        "either": 12
+    };
+    run_with_both(
+        "osp_subtype_dispatch.jac",
+        "subtype_dispatch_py",
+        "subtype_dispatch_cl",
+        "subtype_dispatch_na"
+    );
+}
+
+test "osp disengage: early-exit captures the partial visit set" {
+    assert run_py_fixture("osp_disengage", "disengage_py") == {"seen": [1, 2, 3]};
+    run_with_both("osp_disengage.jac", "disengage_py", "disengage_cl", "disengage_na");
+}
+
+test "osp report: per-walker reports survive the spawn boundary" {
+    assert run_py_fixture("osp_report", "report_py") == {"reports": [10, 20, 30]};
+    run_with_both("osp_report.jac", "report_py", "report_cl", "report_na");
+}
+
+test "osp edge typed: `[->:Road:->]` follows only the typed edge" {
+    assert run_py_fixture("osp_edge_typed", "edge_typed_py") == {"seen": [1, 2, 4]};
+    run_with_both(
+        "osp_edge_typed.jac", "edge_typed_py", "edge_typed_cl", "edge_typed_na"
+    );
 }


### PR DESCRIPTION
## Summary

Phase 2 of the OSP kernel roadmap in #6146: the systematic cross-backend
Object-Spatial equivalence fixtures. One source program per behavior, run
through every backend that supports it and compared against the canonical
**sv (py)** reference.

Each test does two things:
1. **Pins the canonical sv semantics** with a concrete `run_py_fixture`
   assertion, so the kernel's behavior is a hard regression guard even while
   only one backend runs the fixture.
2. **Enforces cross-backend equivalence** via `run_with_both`, with `require=`
   naming the backends that must match today. As na/cl OSP lowering lands, a
   fixture's `na {}` / `cl {}` entry variant is added and its backend moves into
   `require=`, turning "support landed" into an enforced regression.

Reuses the existing harness (`xbackend_equiv.jac`); no harness changes.

## Fixtures

| Fixture | Behavior pinned | Backends |
|---|---|---|
| `osp_visit_order` | chain `[1,2,3,4]`, diamond `[1,2,3,4,4]` (double-visit), fan-out, guarded cycle `[1,2,3]` | py |
| `osp_exit_ordering` | entry-before-children, exit-after `[1,2,3,-3,-2,-1]` | py |
| `osp_subtype_dispatch` | `with Base entry` on `Sub` + tuple trigger | py |
| `osp_disengage` | early-exit partial set `[1,2,3]` | py |
| `osp_report` | reports survive spawn boundary `[10,20,30]` | py |
| `osp_edge_typed` | `[->:Road:->]` follows only the typed edge `[1,2,4]` | py |
| `osp_multi_walker` | independent walker state | **py + na** |
| `osp_nested_spawn` | ability spawns a second walker | **py + na** |

All 9 tests (incl. the existing `osp_acc`) pass. `test_prim_equivalence`
(shares the harness) unaffected.

## Backend status surfaced by these fixtures

Only the entry-only fixtures carry `require=["na"]`. The traversal subset is
py-only today because:

- **na** (inline spawn stopgap): entry-only, EXACT-type dispatch. `visit` /
  edges / `report` / `disengage` are E5090; **exit abilities compile but do not
  fire**; **subtype/tuple dispatch silently misses** (`with Base entry` on a
  `Sub` returns 0). These map to Phase 4.
- **cl**: OSP entirely unwired (`spawn` lowers to an unbound `__jacSpawn`),
  skipped on every fixture. That is Phase 3.

When that lowering lands, each fixture gains its `na {}` / `cl {}` variant and a
`require=` flip — no other churn.

## Notes for the roadmap

Two items in the issue's *Current state / Gated* section are now inaccurate and
worth correcting:
- Exit abilities are **not** rejected with E5090 on na; they compile and
  silently no-op (a silent wrong answer, not a hard gate).
- The kernel is no longer "BFS, visit-once" — post-#6286 it is DFS with opt-in
  visit-once, so it **revisits** the shared sink (diamond `[1,2,3,4,4]`),
  matching legacy sv. The diamond divergence listed as pending appears resolved.

One behavior not in the plan: the kernel's single shared `next` queue makes a
parent's exit fire **after** its later siblings (`osp_exit_ordering` pins
`[1,2,3,-3,-2,-1]`, not `[1,2,-2,3,-3,-1]`) — siblings nest under the first
rather than being independent subtrees. Pinned here so any future
"independent siblings" reconciliation is a visible, intentional change.