### PR TITLE
fix(type-checker): statically evaluate TYPE_CHECKING when loading Python modules

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6304.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6304.bugfix.md
@@ -1,0 +1,1 @@
+- The type checker now evaluates `if TYPE_CHECKING:` blocks as taken (and `if not TYPE_CHECKING:` as skipped), so types and aliases that libraries declare only for type checkers resolve correctly. Imports guarded by `if TYPE_CHECKING:` are now usable in annotations instead of resolving to `Unknown`.

--- a/jac/jaclang/jac0core/helpers.jac
+++ b/jac/jaclang/jac0core/helpers.jac
@@ -666,6 +666,24 @@ def _is_version_info_access(expr: 'uni.Expr') -> bool {
     );
 }
 
+"""Check if expr references `TYPE_CHECKING` (bare or `typing.TYPE_CHECKING`)."""
+def _is_type_checking_ref(expr: 'uni.Expr') -> bool {
+    import jaclang.jac0core.unitree as uni;
+
+    if isinstance(expr, uni.AtomUnit) {
+        expr = expr.value;
+    }
+    if isinstance(expr, uni.Name) {
+        return expr.value == "TYPE_CHECKING";
+    }
+    if isinstance(expr, uni.AtomTrailer) and expr.is_attr {
+        return (
+            isinstance(expr.right, uni.Name) and expr.right.value == "TYPE_CHECKING"
+        );
+    }
+    return False;
+}
+
 """Extract (major, minor) tuple from a TupleVal node."""
 def _extract_version_tuple(expr: 'uni.Expr') -> tuple[int, int] | None {
     import jaclang.jac0core.unitree as uni;
@@ -683,19 +701,30 @@ def _extract_version_tuple(expr: 'uni.Expr') -> tuple[int, int] | None {
     return (major.lit_value, minor.lit_value);
 }
 
-"""Evaluate a sys.version_info conditional expression.
+"""Statically evaluate a stub conditional.
 
-Handles `sys.version_info >= (3, 10)` style expressions.
-Returns True/False if recognized, None otherwise.
+Handles `TYPE_CHECKING` / `not TYPE_CHECKING` (a type checker treats it as
+True, per PEP 484) and `sys.version_info >= (3, 10)` comparisons. Returns
+True/False if recognized, None otherwise.
 """
 def evaluate_version_condition(condition: 'uni.Expr') -> bool | None {
     import sys;
     import operator;
     import jaclang.jac0core.unitree as uni;
+    import from jaclang.jac0core.constant { Tokens as Tok }
 
     cond = condition;
     if isinstance(cond, uni.AtomUnit) {
         cond = cond.value;
+    }
+    # TYPE_CHECKING is True for a static checker; `not TYPE_CHECKING` is False.
+    if _is_type_checking_ref(cond) {
+        return True;
+    }
+    if isinstance(cond, uni.UnaryExpr)
+    and cond.op.name == Tok.NOT
+    and _is_type_checking_ref(cond.operand) {
+        return False;
     }
     if not isinstance(cond, uni.CompareExpr) {
         return None;

--- a/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/sym_tab_build_pass.impl.jac
@@ -480,8 +480,9 @@ impl SymTabBuildPass.enter_if_stmt(self: SymTabBuildPass, nd: uni.IfStmt) -> Non
     # Pyright: evaluateStaticBoolLikeExpression for sys.version_info conditionals
     eval_result = evaluate_version_condition(nd.condition);
 
-    if eval_result is None {
-        # Not a version conditional - normal processing with scope
+    # Flatten static-guard declarations into module/class scope only. Pragmatic:
+    # TODO generalize static guards uniformly across SymTab + CFG (follow-up).
+    if eval_result is None or nd.find_parent_of_type(uni.Ability) is not None {
         self.push_scope_and_link(nd);
         return;
     }

--- a/jac/tests/compiler/passes/main/test_checker_gaps.jac
+++ b/jac/tests/compiler/passes/main/test_checker_gaps.jac
@@ -445,35 +445,17 @@ test "gap 48 type checker self check" {
 }
 
 # =========================================================================
-# Gap #49: TYPE_CHECKING forward-reference string annotations
+# Gap #49 (resolved): TYPE_CHECKING-guarded imports in string annotations.
 #
-# Types imported under `if TYPE_CHECKING` guard should be resolvable
-# when used as string annotations in function signatures. The checker
-# should treat these imports as available for type analysis even though
-# they don't execute at runtime.
-#
-# Currently, string annotations like 'Path' (where Path is imported
-# under TYPE_CHECKING) may resolve to Literal["Path"] or Unknown instead
-# of the actual pathlib.Path class, causing false "has no attribute"
-# errors and preventing type error detection on return values.
-#
-# Impact: `def foo() -> 'Path'` where Path is TYPE_CHECKING-imported
-#         produces Unknown/Literal return type. `p = foo(); p.name`
-#         either errors falsely or misses real type mismatches.
+# Types imported under `if TYPE_CHECKING` now resolve in annotations: the
+# checker evaluates the guard as True (PEP 484), so `Path` resolves to
+# pathlib.Path rather than Literal["Path"]/Unknown.
 # =========================================================================
 test "gap 49 type checking forward ref" {
     program = compile_and_check("checker_gap_fwd_ref.jac");
 
-    # Expected: exactly 2 errors:
-    #   1. bad1: int = get_name(p)   (str not assignable to int)
-    #   2. bad2: int = p.stem        (str not assignable to int)
-    #
-    # No errors for: p.name (Path.name is str), get_name(p) (returns str),
-    # accept_path(p) (returns str) — all valid when 'Path' resolves.
-    #
-    # Actual (gap): 'Path' from TYPE_CHECKING import may resolve to
-    # Literal["Path"] or Unknown, so p has wrong type and either
-    # false positives or missed errors occur.
+    # Exactly the 2 intended mismatches remain: bad1 (int = str return) and
+    # bad2 (int = p.stem). p.name / get_name(p) / accept_path(p) all resolve.
     assert len(program.errors_had) == 2 , "Gap #49: TYPE_CHECKING forward ref. "
     f"Expected exactly 2 type errors but got {len(program.errors_had)}. "
     "String annotations referencing TYPE_CHECKING-guarded imports should "


### PR DESCRIPTION
## What

The type checker now statically evaluates `if TYPE_CHECKING:` as taken and `if not TYPE_CHECKING:` as skipped when loading Python modules, per PEP 484. The condition evaluator recognizes bare `TYPE_CHECKING`, `typing.TYPE_CHECKING`, and their negation, reusing the existing `evaluate_version_condition` / `_flatten_version_conditionals` pipeline that already handles `sys.version_info` guards.

## Why

Libraries routinely declare types and aliases only for type checkers behind `if TYPE_CHECKING:` (and provide a runtime fallback under `if not TYPE_CHECKING:`). Jac ignored the guard and took the runtime branch, so those names resolved to `Unknown` (or the wrong runtime type). This mirrors how Pyright treats `TYPE_CHECKING` (`staticExpressions.ts`).

**Resolves Gap #49:** types imported under `if TYPE_CHECKING:` now resolve in annotations. The `checker_gap_fwd_ref.jac` fixture previously could not resolve a `TYPE_CHECKING`-guarded `Path`; it now resolves correctly, leaving only the two intended `str`/`int` mismatch errors.

## Tests

- `checker_gap_fwd_ref.jac` (Gap #49 fixture) resolves the guarded import; the gap test now reflects the fixed behavior.
- No regressions: `test_checker_bugs` (41) and `test_language` (93) pass.

## Out of scope

This does not fully resolve SQLAlchemy-style descriptor attributes (e.g. `CursorResult.rowcount`), which additionally require retaining a generic descriptor's type parameter through inheritance and recognizing descriptor-producing decorators. Those are tracked as separate follow-ups.