### PR TITLE
fix(skills): remove CSS reset invite and add Tailwind v4 no-reset guardrail

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6315.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6315.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: CSS reset conflict with Tailwind v4 in JacCoder-generated projects**: Removed the "resets" wording from `jac-fullstack-patterns` and added an explicit no-reset rule (with a plain-CSS-only exception) to both skill files.

--- a/jac/jaclang/cli/skills/jac-cl-styling.md
+++ b/jac/jaclang/cli/skills/jac-cl-styling.md
@@ -38,6 +38,7 @@ Rules:
 - **Only declared classes are rewritten.** Undeclared tokens (Tailwind utilities, shadcn classes) pass through untouched, so you can mix scoped + utility classes in one `className`.
 - **`:global(...)`** keeps a selector unscoped -- use it for resets, element selectors, or targeting third-party classes.
 - **Scoped vs global:** use `.style.css` for component-specific classes; use a plain shared `import "./global.css";` (or Tailwind) for app-wide styles.
+- **Tailwind projects: no `*` reset in `global.css`.** After `@import "tailwindcss";`, add only `:root` variable blocks and `@theme inline` registrations. A `* { margin: 0; padding: 0; box-sizing: border-box }` reset conflicts with Preflight and collapses spacing utilities. Plain-CSS-only projects (no `@import "tailwindcss"`) may still use resets.
 
 ## Conditional Classes
 

--- a/jac/jaclang/cli/skills/jac-fullstack-patterns.md
+++ b/jac/jaclang/cli/skills/jac-fullstack-patterns.md
@@ -32,7 +32,8 @@ cl {
 - **Import obj/node TYPES alongside functions** in both places. Missing types → server `NameError` at runtime or lost typed attribute access on the client.
 - **Call server endpoints with POSITIONAL args, not kwargs.** `save_profile(name, email)` works; `save_profile(name=name, email=email)` sends empty body → `422 Field required`.
 - **Client entry is `def:pub app()`** - lowercase `app`. Not `App()`, `ClientApp()`. Runtime mounts the literal name.
-- **Global vs scoped CSS:** import app-wide CSS once in `main.jac`'s `cl { }` block (`import ".styles.global.css";` for themes, resets, Tailwind). For component-specific classes, add a same-basename `Comp.style.css` beside the `.cl.jac` -- it auto-scopes and needs no import. See `jac-cl-styling`.
+- **Global vs scoped CSS:** import app-wide CSS once in `main.jac`'s `cl { }` block (`import ".styles.global.css";` for the Tailwind import and custom CSS variables). For component-specific classes, add a same-basename `Comp.style.css` beside the `.cl.jac` -- it auto-scopes and needs no import. See `jac-cl-styling`.
+- **No CSS reset in Tailwind projects.** `@import "tailwindcss"` includes Preflight which handles baseline normalization. Adding `* { margin: 0; padding: 0; box-sizing: border-box }` overrides Preflight and breaks all spacing utilities (`p-4`, `m-2`, `gap-6`). Plain-CSS-only projects (no Tailwind import) may still use resets.
 - **Start with `jac start --dev main.jac`** (background for hot reload). NOT `jac serve` (deprecated).
 - **HMR only reloads client (`.cl.jac`) files. Server (`.sv.jac`) changes need a full restart.** `def:pub`/`def:priv` endpoints + `glob` declarations evaluate once at server boot - editing a `.sv.jac` does not invalidate cached endpoints. `pkill -f "jac start"` then `jac start --dev main.jac` to pick up changes.
 - **Don't wrap the client entry in `with entry { ... }`.** Runtime mounts `def:pub app` directly.


### PR DESCRIPTION
## Problem

Two skill files were causing JacCoder to generate a `* { margin: 0; padding: 0; box-sizing: border-box }` reset block inside
`global.css` for Tailwind projects. This reset overrides Tailwind v4's built-in Preflight normalization and silently breaks every spacing utility (`p-4`, `m-2`, `gap-6`, `mx-auto`) — layouts collapse and cards stretch full-bleed.

The model was generating the reset from training-data muscle memory, and the skill docs were actively reinforcing that reflex in two ways:

1. `jac-fullstack-patterns.md` described `global.css` as being for "themes, **resets**, Tailwind" — the word "resets" directly invited the behaviour.
2. Neither skill file said anything about the incompatibility between a universal CSS reset and Tailwind v4 Preflight.

## Why context-aware

Plain-CSS-only projects (like `little-x`, which has no `@import "tailwindcss"`) legitimately use CSS resets. The new rule text in both files explicitly preserves that: *"Plain-CSS-only projects (no Tailwind import) may still use resets."*