### PR TITLE
feat(jaclang): resolve Literal[None] and negative-int annotations

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6334.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6334.feature.md
@@ -1,0 +1,1 @@
+- **Feature: `Literal[None]` and negative-int literal annotations**: `Literal[None]` resolves to `NoneType` and negative integer literals such as `Literal[-1, -2]` resolve correctly, where both previously widened to an unresolved type.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -90,12 +90,16 @@ impl TypeEvaluator._build_field_params(
 
 """Build a literal-typed instance from a `Literal[...]` argument expression.
 
-Maps a str/int/bool literal node to its base class cloned with the literal
-value. Returns None for unsupported argument forms.
+Maps a str/int/bool/None literal node (including negated int literals) to its
+type. Returns None for unsupported argument forms.
 """
 impl TypeEvaluator._literal_type_from_expr(val: uni.Expr) -> types.TypeBase | None {
     if not self.prefetch {
         return None;
+    }
+    # `Literal[None]` resolves to NoneType, not a literal-valued class.
+    if isinstance(val, uni.Null) and self.prefetch.none_type_class {
+        return self._convert_to_instance(self.prefetch.none_type_class);
     }
     base: types.ClassType | None = None;
     value: str | int | bool | None = None;
@@ -107,6 +111,14 @@ impl TypeEvaluator._literal_type_from_expr(val: uni.Expr) -> types.TypeBase | No
     } elif isinstance(val, uni.Int) {
         base = self.prefetch.int_class;
         value = val.lit_value;
+    } elif (
+        isinstance(val, uni.UnaryExpr)
+        and val.op.name == Tok.MINUS
+        and isinstance(val.operand, uni.Int)
+    ) {
+        # Negative int literals parse as unary minus over an Int.
+        base = self.prefetch.int_class;
+        value = -val.operand.lit_value;
     } elif isinstance(val, uni.String) and isinstance(val.lit_value, str) {
         base = self.prefetch.str_class;
         value = val.lit_value;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_literal_annotation.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_literal_annotation.jac
@@ -46,6 +46,15 @@ def ok_assign -> str {
     return f"{x}{n}{flag}";
 }
 
+# Literal[None] resolves to NoneType; negative ints resolve too.
+def ok_none(x: Literal[None]) -> None {
+    return x;
+}
+
+def ok_negative(n: Literal[-1, -2]) -> int {
+    return n;
+}
+
 # --- Invalid: each line is one error ---
 def bad_arg -> str {
     return take_mode('x');


### PR DESCRIPTION
## What

Extends `Literal[...]` annotation resolution (follow-up to #6333) to two cases it didn't cover:

- `Literal[None]` resolves to `NoneType`.
- Negative integer literals like `Literal[-1, -2]` resolve to `int` (they parse as unary-minus over an `Int` node, which the resolver now unwraps).

Both previously widened to an unresolved type. This matches the existing positive-int behaviour, where a `Literal[int]` annotation resolves to `int`.

## Scope

This is the annotation (producer) side only. Integer/bool literal *value* discrimination on calls (e.g. rejecting `f(5)` against `Literal[1, 2]`) is a separate, larger change: it requires int/bool literal *expressions* to carry their value, which `get_type_of_int` does not do today (it returns plain `int`). Out of scope here; worth a follow-up.

Other Pyright-supported forms still unhandled (bytes, enum members) remain follow-ups.

## Testing

Extends the `checker_literal_annotation.jac` fixture with `Literal[None]` and negative-int cases (both valid, resolve cleanly). The `gap 55` test still asserts exactly three errors. Full checker suite (`pass`, `bugs`, `production`, `shortcomings`, `typevar`, `gaps`) green with zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)