### PR TITLE
fix(precompile): skip .jac cache dirs so jac-scale release build doesn't crash

### DIFF
--- a/jac/jaclang/utils/precompile_bytecode.jac
+++ b/jac/jaclang/utils/precompile_bytecode.jac
@@ -85,7 +85,22 @@ def find_jac_files(package_dir: str) -> list[str] {
     result: list[str] = [];
     pkg = Path(package_dir);
     for jac_file in sorted(pkg.rglob("*.jac")) {
-        rel = str(jac_file.relative_to(pkg));
+        # rglob("*.jac") also matches directories named ".jac" (jaclang's
+        # per-project build cache, e.g. created by a nested `jac build`).
+        # Only real files can be hashed.
+        if not jac_file.is_file() {
+            continue;
+        }
+        rel_path = jac_file.relative_to(pkg);
+        rel = str(rel_path);
+        # Skip anything under a hidden/cache directory (".jac", "__pycache__",
+        # ".git", ...). Checking only rel.startswith(".") misses these when the
+        # dot-component is nested, e.g. "admin/ui/.jac/...".
+        if any(
+            part.startswith(".") or part == "__pycache__" for part in rel_path.parts
+        ) {
+            continue;
+        }
         # Skip test files, impl files, and hidden files
         if (
             ".test." in rel


### PR DESCRIPTION
## Problem

The **Publish Release** run for `jaclang 0.15.6 / jac-client 0.3.20 / jac-scale 0.2.22 / ...` failed in the **jac-scale** build job during `jac bundle --precompile`:

```
✖ Error: FAIL: admin/ui/.jac - Could not read file .../jac-scale/jac_scale/admin/ui/.jac:
  [Errno 21] Is a directory: '.../jac_scale/admin/ui/.jac'
...
✖ Error: Precompilation incomplete — 3/3 version(s) failed: cpython-312, cpython-313, cpython-314
```

## Root cause

`jac-scale`'s `extra_build_cmd` runs `scripts/build_admin_ui.jac`, which does `jac build main.jac` with `cwd=jac_scale/admin/ui/`. That nested build creates jaclang's per-project cache directory **`jac_scale/admin/ui/.jac/`**.

The precompiler's `find_jac_files()` then collects sources with `pkg.rglob("*.jac")` — and `rglob` matches **directories** named `.jac` too, not just files. The only hidden-path guard was `rel.startswith(".")`, which misses a dot-dir nested below the package root (`admin/ui/.jac`). So the `.jac` cache dir slipped through, and `file_hash()` called `open()` on a directory → `[Errno 21] Is a directory` → all three Python precompile passes failed → release aborted.

(The wheel source-collector in `publish/sources.jac` already excludes `.jac` via `EXCLUDED_DIRS`; this standalone precompile script just didn't have the equivalent guard.)

## Fix

In `find_jac_files()`:
1. Skip entries that aren't real files (`is_file()`) — directly prevents hashing a `.jac` directory.
2. Skip any path containing a dotted component or `__pycache__` anywhere in its parts (e.g. `admin/ui/.jac/...`, `.git/...`), not just paths that *start* with `.`.

## Testing

Reproduced locally by creating `jac_scale/admin/ui/.jac/client/c.jac` (mimicking the CI cache dir):
- **Before:** `[Errno 21] Is a directory` crash.
- **After:** `Found 7 .jac files` / `Done! Compiled 7/7 modules (0 failed)` — the `.jac` cache dir and its contents are excluded.

No new type-checker errors (the 6 pre-existing `str | NoneType` errors in the file are unchanged). pre-commit (incl. jac-format) passes.