### PR TITLE
ci: add skip-k8s label gate to K8s e2e jobs

### DIFF
--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   real-e2e:
     name: microk8s real-app smoke
-    # Runs by default. Add the 'skip-k8s' label to a PR to skip it.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   real-e2e:
     name: microk8s real-app smoke
+    # Runs by default. Add the 'skip-k8s' label to a PR to skip it.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -271,6 +271,8 @@ jobs:
         pytest -x -vv -s jac-scale/jac_scale/tests/test_scheduling.jac
 
   test-scale-k8s:
+    # Runs by default. Add the 'skip-k8s' label to a PR to skip it.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code


### PR DESCRIPTION
Adds a label-based skip switch for the two K8s CI jobs.

- **Default:** both jobs run on every PR/push (unchanged behavior).
- **Skip:** add the \`skip-k8s\` label to a PR and they are skipped.

Gated jobs:
- \`test-scale-k8s\` in \`test-jaseci.yml\`
- \`real-e2e\` in \`k8s-microservice-real-e2e.yml\`

Both use:
\`\`\`yaml
if: \${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
\`\`\`

Note: labels are evaluated at trigger time — to skip an in-flight PR, add the label then re-trigger (push a commit). On direct pushes to main there's no PR context, so the jobs run as before.