### PR TITLE
feat(release): add manual workflow_dispatch trigger to publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,45 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  # Manual re-publish: if the auto-trigger run failed partway (e.g. a build
+  # error after the release/* PR was already merged), re-fire publishing for
+  # selected packages. Versions are read from each package's manifest on the
+  # current ref — no need to re-merge a release/* PR. Tier ordering and the
+  # "already on PyPI" skip still apply, so re-running is safe.
+  workflow_dispatch:
+    inputs:
+      jaclang:
+        description: "Publish jaclang"
+        type: boolean
+        default: false
+      jac-byllm:
+        description: "Publish jac-byllm (byllm)"
+        type: boolean
+        default: false
+      jac-client:
+        description: "Publish jac-client"
+        type: boolean
+        default: false
+      jac-scale:
+        description: "Publish jac-scale"
+        type: boolean
+        default: false
+      jac-super:
+        description: "Publish jac-super"
+        type: boolean
+        default: false
+      jac-mcp:
+        description: "Publish jac-mcp"
+        type: boolean
+        default: false
+      jac-desktop:
+        description: "Publish jac-desktop"
+        type: boolean
+        default: false
+      jaseci:
+        description: "Publish jaseci meta-package"
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -13,9 +52,12 @@ jobs:
   # ============================================================================
   parse-release:
     if: |
-      github.repository == 'Jaseci-Labs/jaseci' &&
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+      github.repository == 'Jaseci-Labs/jaseci' && (
+        github.event_name == 'workflow_dispatch' || (
+          github.event.pull_request.merged == true &&
+          startsWith(github.event.pull_request.head.ref, 'release/')
+        )
+      )
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     permissions:
@@ -41,9 +83,25 @@ jobs:
       - name: Parse release info
         id: parse
         env:
+          EVENT_NAME: ${{ github.event_name }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          # Collect the checked packages (empty string when unchecked).
+          IN_JACLANG: ${{ inputs.jaclang && 'jaclang' || '' }}
+          IN_BYLLM: ${{ inputs['jac-byllm'] && 'jac-byllm' || '' }}
+          IN_CLIENT: ${{ inputs['jac-client'] && 'jac-client' || '' }}
+          IN_SCALE: ${{ inputs['jac-scale'] && 'jac-scale' || '' }}
+          IN_SUPER: ${{ inputs['jac-super'] && 'jac-super' || '' }}
+          IN_MCP: ${{ inputs['jac-mcp'] && 'jac-mcp' || '' }}
+          IN_DESKTOP: ${{ inputs['jac-desktop'] && 'jac-desktop' || '' }}
+          IN_JASECI: ${{ inputs.jaseci && 'jaseci' || '' }}
         run: |
-          jac run scripts/parse_release.jac --pr-title "$PR_TITLE"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PACKAGES="$IN_JACLANG $IN_BYLLM $IN_CLIENT $IN_SCALE $IN_SUPER $IN_MCP $IN_DESKTOP $IN_JASECI"
+            echo "Manual dispatch - selected packages: $PACKAGES"
+            jac run scripts/parse_release.jac --packages "$PACKAGES"
+          else
+            jac run scripts/parse_release.jac --pr-title "$PR_TITLE"
+          fi
 
   # ============================================================================
   # Approval gate - ONE click to approve all publishing
@@ -276,6 +334,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+          # Idempotent re-runs: a manual re-publish (or rerun after a partial
+          # failure) skips versions already on PyPI instead of erroring.
+          skip-existing: true
 
   wait-tier1:
     needs: [parse-release, publish-tier1]
@@ -334,6 +395,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+          # Idempotent re-runs: a manual re-publish (or rerun after a partial
+          # failure) skips versions already on PyPI instead of erroring.
+          skip-existing: true
 
   wait-tier2:
     needs: [parse-release, publish-tier2]
@@ -392,6 +456,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+          # Idempotent re-runs: a manual re-publish (or rerun after a partial
+          # failure) skips versions already on PyPI instead of erroring.
+          skip-existing: true
 
   wait-tier3:
     needs: [parse-release, publish-tier3]

--- a/scripts/parse_release.jac
+++ b/scripts/parse_release.jac
@@ -15,37 +15,71 @@ import argparse;
 import json;
 import re;
 import sys;
-import from release_utils { PACKAGES, set_output }
+import from pathlib { Path }
+import from release_utils { PACKAGES, get_current_version, set_output }
+"""Build a release dict for one known package at a given version."""
+def release_entry(pkg_name_lower: str, version: str) -> dict {
+    pkg_info = PACKAGES[pkg_name_lower];
+    return {
+        "name": pkg_name_lower,
+        "dir": pkg_info.dir,
+        "pypi": pkg_info.pypi,
+        "tier": pkg_info.tier,
+        "version": version,
+        "submodules": pkg_info.submodules,
+        "precompile": pkg_info.precompile,
+        "extra_build_cmd": pkg_info.extra_build_cmd,
+        "needs_nodejs": pkg_info.needs_nodejs,
+        "extra_build_deps": pkg_info.extra_build_deps
+    };
+}
 """Match patterns like 'jaclang 1.2.3' or 'jac-client 2.0.0'."""
 def parse_from_title(pr_title: str) -> list[dict] {
     releases = [];
     for (pkg_name, version) in re.findall(r"([\w-]+)\s+(\d+\.\d+\.\d+)", pr_title) {
         pkg_name_lower = pkg_name.lower();
         if (pkg_name_lower in PACKAGES) {
-            pkg_info = PACKAGES[pkg_name_lower];
-            releases.append(
-                {
-                    "name": pkg_name_lower,
-                    "dir": pkg_info.dir,
-                    "pypi": pkg_info.pypi,
-                    "tier": pkg_info.tier,
-                    "version": version,
-                    "submodules": pkg_info.submodules,
-                    "precompile": pkg_info.precompile,
-                    "extra_build_cmd": pkg_info.extra_build_cmd,
-                    "needs_nodejs": pkg_info.needs_nodejs,
-                    "extra_build_deps": pkg_info.extra_build_deps
-                }
-            );
+            releases.append(release_entry(pkg_name_lower, version));
         }
+    }
+    return releases;
+}
+"""Build releases for an explicit package list, reading versions from manifests.
+
+    Used by the manual (workflow_dispatch) re-publish path: the caller selects
+    which packages to publish and the version is read straight from each
+    package's jac.toml (or pyproject.toml for jaclang). Lets a release be
+    re-fired after a partial CI failure without re-merging a release/* PR.
+    """
+def parse_from_packages(pkg_names: list[str]) -> list[dict] {
+    repo_root = Path(__file__).resolve().parent.parent;
+    releases = [];
+    for raw in pkg_names {
+        pkg_name_lower = raw.strip().lower();
+        if pkg_name_lower not in PACKAGES {
+            print(f"Warning: unknown package '{raw}' - skipping");
+            continue;
+        }
+        version = get_current_version(repo_root, PACKAGES[pkg_name_lower].dir);
+        releases.append(release_entry(pkg_name_lower, version));
     }
     return releases;
 }
 def main() -> int {
     parser = argparse.ArgumentParser();
-    parser.add_argument("--pr-title", required=True);
+    parser.add_argument("--pr-title", `default="");
+    parser.add_argument(
+        "--packages",
+        `default="",
+        help="Comma/space separated package names; versions read from manifests"
+    );
     args = parser.parse_args();
-    releases = parse_from_title(args.pr_title);
+    if args.packages {
+        pkg_list = [p for p in re.split(r"[,\s]+", args.packages) if p];
+        releases = parse_from_packages(pkg_list);
+    } else {
+        releases = parse_from_title(args.pr_title);
+    }
     if not releases {
         print("No packages found to release");
         set_output("has_releases", "false");

--- a/scripts/release_utils.jac
+++ b/scripts/release_utils.jac
@@ -7,6 +7,7 @@ All release-related scripts import from here to ensure consistency.
 import from __future__ { annotations }
 import os;
 import re;
+import tomlkit;
 import urllib.error;
 import urllib.request;
 import from pathlib { Path }
@@ -115,6 +116,20 @@ with entry {
         }
     }
 }
+"""Read the current version from a package's manifest.
+
+    Prefers jac.toml; falls back to pyproject.toml for packages (e.g. jac/)
+    that cannot migrate because they bootstrap the jac toolchain itself.
+    """
+def get_current_version(repo_root: Path, pkg_dir: str) -> str {
+    jac_toml = repo_root / pkg_dir / "jac.toml";
+    manifest = jac_toml
+        if jac_toml.exists()
+        else repo_root / pkg_dir / "pyproject.toml";
+    data = tomlkit.loads(manifest.read_text());
+    return str(data["project"]["version"]);
+}
+
 """Compute the next semantic version based on bump type.
 
     Given a version like "1.2.3" and bump type:

--- a/scripts/validate_release.jac
+++ b/scripts/validate_release.jac
@@ -9,21 +9,7 @@ import from __future__ { annotations }
 import argparse;
 import sys;
 import from pathlib { Path }
-import tomlkit;
-import from release_utils { PACKAGES, bump_version, check_pypi }
-"""Read the current version from a package's manifest.
-
-Prefers jac.toml; falls back to pyproject.toml for packages (e.g. jac/)
-that cannot migrate because they bootstrap the jac toolchain itself.
-"""
-def get_current_version(repo_root: Path, pkg_dir: str) -> str {
-    jac_toml = repo_root / pkg_dir / "jac.toml";
-    manifest = jac_toml
-        if jac_toml.exists()
-        else repo_root / pkg_dir / "pyproject.toml";
-    data = tomlkit.loads(manifest.read_text());
-    return str(data["project"]["version"]);
-}
+import from release_utils { PACKAGES, bump_version, check_pypi, get_current_version }
 
 def main -> int {
     parser = argparse.ArgumentParser();


### PR DESCRIPTION
## Problem

`publish-release.yml` only triggers on **merging a `release/*` PR** (`pull_request: closed`). When a release run fails partway — e.g. the recent jac-scale build crash that aborted the whole run *after* the `release/*` PR was already merged — there is no clean way to re-fire publishing. The triggering PR is gone, so the only options were re-merging an artificial PR or hand-running per-package `release-*.yml` workflows (which bypass the approval gate and tier ordering).

## Solution

Add a manual `workflow_dispatch` escape hatch that reuses the **entire existing pipeline** (approval gate, tiered publish, PyPI waits, tag push, GitHub release) — only the *entry point* changes.

### How it works
- `workflow_dispatch` exposes a **boolean per package** (jaclang, jac-byllm, jac-client, jac-scale, jac-super, jac-mcp, jac-desktop, jaseci).
- The `parse-release` job now branches on `github.event_name`:
  - **PR merge** → existing `--pr-title` path (unchanged).
  - **manual dispatch** → new `--packages` path: reads each selected package's **current version from its manifest** (`jac.toml`, or `pyproject.toml` for jaclang) and builds the *same* matrix the title path produces.
- Because both paths emit identical `has_releases` / `matrix` / `release_summary` outputs, **every downstream job is untouched** — tier ordering, approval, tag push, and GitHub release all just work.

### Idempotent re-runs
Added `skip-existing: true` to all three PyPI publish steps. Previously `gh-action-pypi-publish` would **error** if a version already existed, so re-running after a *partial* success (some tiers published, a later one failed) would fail on the already-uploaded packages. Now re-runs cleanly skip what's already on PyPI — which is exactly what makes the manual trigger safe.

### Refactor (no behavior change)
- `parse_release.jac`: add `parse_from_packages()` + `--packages` arg; extract shared `release_entry()`.
- `release_utils.jac`: add shared `get_current_version()` (previously duplicated).
- `validate_release.jac`: use the shared helper; drop now-dead `tomlkit` import.

## Usage

After a partial failure (or any time you need to re-publish): **Actions → Publish Release → Run workflow** from `main`, check the packages to publish, run. The approval gate and tier waits still apply. Versions come from the merged manifests on `main`, so there's nothing to type and no way to typo a version.

## Testing
- `parse_release.jac --packages "jaclang jac-scale jaseci"` → correct tier-sorted matrix reading versions 0.15.6 / 0.2.22 / 2.3.20 from manifests.
- `parse_release.jac --pr-title "..."` → unchanged output (regression check).
- `validate_release.jac` → still works via the shared `get_current_version`.
- Type-checker: my changes introduce **0** new errors and net-reduce them (parse_release 11→7, validate_release 10→2, release_utils 4→4).
- pre-commit on changed files passes (jac-format excludes `scripts/` by config; em-dash hook is markdown-only).

## Notes
- The `jac-desktop` checkbox is included for forward-compat; it parses as "unknown package, skipping" until #6346 (which registers jac-desktop in `PACKAGES`) merges, then works automatically.
- Branch is off current `main`, which already includes the precompile `.jac`-cache fix (#6351).