### PR TITLE
fix(release): use stdlib tomllib in release_utils so parse-release doesn't crash

### DIFF
--- a/scripts/release_utils.jac
+++ b/scripts/release_utils.jac
@@ -7,7 +7,7 @@ All release-related scripts import from here to ensure consistency.
 import from __future__ { annotations }
 import os;
 import re;
-import tomlkit;
+import tomllib;
 import urllib.error;
 import urllib.request;
 import from pathlib { Path }
@@ -126,7 +126,7 @@ def get_current_version(repo_root: Path, pkg_dir: str) -> str {
     manifest = jac_toml
         if jac_toml.exists()
         else repo_root / pkg_dir / "pyproject.toml";
-    data = tomlkit.loads(manifest.read_text());
+    data = tomllib.loads(manifest.read_text());
     return str(data["project"]["version"]);
 }
 


### PR DESCRIPTION
## Problem — release is currently blocked

Every **Publish Release** run now fails immediately in the `parse-release` job:

```
✖ Error: No module named 'tomlkit'
   10 | import tomlkit;
  at <module> .../scripts/release_utils.jac:10
  at <module> .../scripts/parse_release.jac:19
Error: Process completed with exit code 1.
```

`parse-release` is the first job, so this **blocks the entire release** before any package is built or published.

## Root cause

The manual-publish-trigger change added `get_current_version()` to `release_utils.jac`, which imported `tomlkit`. But the `parse-release` job in `publish-release.yml` only installs jaclang (`pip install -e ./jac`) — it does **not** `pip install tomlkit`. (The `create-release-pr.yml` workflow does install tomlkit, which is why this wasn't caught there.) So as soon as `parse_release.jac` imports `release_utils`, the `tomlkit` import crashes.

## Fix

`get_current_version()` only does a **read-only** parse of one field. Switch it from `tomlkit` to stdlib **`tomllib`** (always present on Python 3.11+), so `release_utils` imports cleanly in any job regardless of that job's extra deps.

`release.jac` still uses `tomlkit` for its read-modify-write of manifests (it needs format-preserving `dumps`) and installs tomlkit itself — so it is unaffected. This change only touches the read path.

## Testing
- `parse_release.jac --packages "jaclang jac-client jac-scale jac-super jac-mcp jac-byllm"` → correct tier-sorted matrix with versions read from manifests (0.15.6 / 0.3.20 / 0.2.22 / 0.1.18 / 0.1.19 / 0.6.12), exit 0.
- `tomllib` confirmed stdlib (no install needed).
- No `tomlkit` references remain in `release_utils.jac`; neither `parse_release.jac` nor `validate_release.jac` imports tomlkit directly.
- Type-checker error count unchanged (4 → 4); pre-commit passes.

## Impact
This unblocks the in-progress release. Merge, then re-run **Publish Release**.