### PR TITLE
fix(native): apply R_AARCH64_MOVW_UABS relocations in ELF linker (#6366)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6369.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6369.bugfix.md
@@ -1,0 +1,1 @@
+- `jac nacompile` now produces working standalone aarch64 binaries instead of ones that crash at startup.

--- a/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
@@ -107,7 +107,18 @@ glob R_AARCH64_PREL32 = 261,
      R_AARCH64_COPY = 1024,
      R_AARCH64_GLOB_DAT = 1025,
      R_AARCH64_JUMP_SLOT = 1026,
-     R_AARCH64_ABS64 = 257;
+     R_AARCH64_ABS64 = 257,
+     # MOVZ/MOVK absolute-address materialization. A 64-bit address is built
+     # across four instructions; each reloc patches one 16-bit slice into the
+     # imm16 field. G0/G1/G2/G3 carry address bits [15:0]/[31:16]/[47:32]/[63:48].
+     # The _NC ("no check") variants suppress the per-group overflow check.
+     R_AARCH64_MOVW_UABS_G0 = 263,
+     R_AARCH64_MOVW_UABS_G0_NC = 264,
+     R_AARCH64_MOVW_UABS_G1 = 265,
+     R_AARCH64_MOVW_UABS_G1_NC = 266,
+     R_AARCH64_MOVW_UABS_G2 = 267,
+     R_AARCH64_MOVW_UABS_G2_NC = 268,
+     R_AARCH64_MOVW_UABS_G3 = 269;
 
 
 # ── Helper: build ELF hash table ────────────────────────────────
@@ -415,6 +426,25 @@ def _aarch64_apply_reloc(
     } elif rtype == R_AARCH64_ABS64 {
         val = sym_addr + addend;
         struct.pack_into("<Q", patch_buf, patch_off, val & 0xFFFFFFFFFFFFFFFF);
+        return True;
+    } elif rtype == R_AARCH64_MOVW_UABS_G0
+    or rtype == R_AARCH64_MOVW_UABS_G0_NC
+    or rtype == R_AARCH64_MOVW_UABS_G1
+    or rtype == R_AARCH64_MOVW_UABS_G1_NC
+    or rtype == R_AARCH64_MOVW_UABS_G2
+    or rtype == R_AARCH64_MOVW_UABS_G2_NC
+    or rtype == R_AARCH64_MOVW_UABS_G3 {
+        # Patch one 16-bit slice of the absolute address (S + A) into the
+        # MOVZ/MOVK imm16 field at bits [20:5]. The reloc type selects the
+        # group: G0/G1/G2/G3 -> address bits [15:0]/[31:16]/[47:32]/[63:48].
+        # Each {G,G_NC} pair is two consecutive codes, so dividing the offset
+        # from G0 by two yields the group index.
+        val = sym_addr + addend;
+        group = (rtype - R_AARCH64_MOVW_UABS_G0) // 2;
+        imm16 = (val >> (group * 16)) & 0xFFFF;
+        insn = struct.unpack_from("<I", patch_buf, patch_off)[0];
+        insn = (insn & 0xFFE0001F) | (imm16 << 5);
+        struct.pack_into("<I", patch_buf, patch_off, insn);
         return True;
     }
     return False;
@@ -945,20 +975,33 @@ impl ElfLinker.build_executable -> bytes {
             rodata_vaddr,
             data_vaddr
         );
-        if _pt is not None {
-            (patch_buf, sec_blob_off, patch_base_vaddr) = _pt;
-        } else {
-            patch_buf = code_bytes;
-            sec_blob_off = 0;
-            patch_base_vaddr = text_vaddr;
+        if _pt is None {
+            # The relocation targets a section we do not place in the loadable
+            # image (e.g. metadata like .eh_frame, whose relocations are also
+            # filtered while parsing). There is nothing in the output to patch,
+            # so skip it. The previous fallback wrote into .text at this offset,
+            # which would corrupt code if such a relocation were ever applied.
+            continue;
         }
+        (patch_buf, sec_blob_off, patch_base_vaddr) = _pt;
         patch_off = sec_blob_off + rela.offset;
         patch_vaddr = patch_base_vaddr + patch_off;
 
-        # Apply via architecture-specific handler
-        arch.apply_reloc(
+        # Apply via architecture-specific handler. Every relocation that reaches
+        # here targets an emitted (loadable) section, so an unhandled type would
+        # leave the reference pointing at NULL. Fail loudly instead of emitting a
+        # binary that segfaults at process entry (the failure mode of #6366).
+        applied = arch.apply_reloc(
             rela.rtype, patch_buf, patch_off, sym_addr, rela.addend, patch_vaddr
         );
+        if not applied {
+            raise ValueError(
+                f"ELF linker: no handler for relocation type {rela.rtype} "
+                f"(symbol '{rela.sym_name}', section '{rela.target_sec}', "
+                f"e_machine {arch.e_machine}). Refusing to emit a binary with "
+                f"an unrelocated reference."
+            );
+        }
     }
 
     # ── Find entry point ──────────────────────────────────────────

--- a/jac/tests/compiler/passes/native/fixtures/aarch64_global_roundtrip.jac
+++ b/jac/tests/compiler/passes/native/fixtures/aarch64_global_roundtrip.jac
@@ -1,0 +1,17 @@
+"""aarch64 ELF linker round-trip fixture (regression for issue #6366).
+
+`total` is a module-level global, so storing and reloading it emits a
+movz/movk absolute-address chain relocated by R_AARCH64_MOVW_UABS_G0..G3.
+If the in-house linker drops those relocations the address stays NULL and
+the binary segfaults at entry. The exit code carries the computed value so
+the test confirms the global actually round-trips, not merely that the
+process avoided a crash.
+"""
+import sys;
+
+def add(a: int, b: int) -> int { return a + b; }
+
+with entry {
+    total = add(40, 2);
+    sys.exit(total);
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2248,6 +2248,102 @@ test "sys argv via nacompile" {
     }
 }
 
+# --- TestNativeAArch64Linker ---
+test "aarch64 standalone binary runs (issue #6366)" {
+    # Cross-compile a trivial program to aarch64 via the in-house ELF linker
+    # and run it under qemu-user. Guards the linker's absolute-address
+    # relocations (R_AARCH64_MOVW_UABS_G0..G3): without them every global /
+    # .rodata reference materializes to NULL and the binary segfaults at entry.
+    import shutil;
+    import tempfile;
+    qemu = shutil.which("qemu-aarch64-static") or shutil.which("qemu-aarch64");
+    ld_prefix = "/usr/aarch64-linux-gnu";
+    loader = os.path.join(ld_prefix, "lib", "ld-linux-aarch64.so.1");
+    if not qemu or not os.path.exists(loader) {
+        import pytest;
+        pytest.skip("aarch64 qemu-user + cross libc not installed");
+    }
+    fixture = str(os.path.join(FIXTURES, "aarch64_global_roundtrip.jac"));
+    with tempfile.TemporaryDirectory() as tmpdir {
+        out_bin = os.path.join(tmpdir, "a64_roundtrip");
+        # Step 1: cross-compile for aarch64.
+        comp_env = dict(os.environ);
+        comp_env["JAC_NATIVE_TARGET"] = "aarch64-unknown-linux-gnu";
+        comp = subprocess.run(
+            [sys.executable, "-m", "jaclang", "nacompile", fixture, "-o", out_bin],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=comp_env
+        );
+        assert comp.returncode == 0 , (
+            f"aarch64 nacompile failed: exit={comp.returncode}\n"
+            f"stderr: {comp.stderr[-500:] if comp.stderr else '(empty)'}"
+        );
+        assert os.path.exists(out_bin) , f"Binary not created at {out_bin}";
+        # Step 2: run under qemu-user. total = add(40, 2) = 42, surfaced via
+        # sys.exit. A dropped MOVW_UABS reloc stores to NULL -> SIGSEGV
+        # (returncode -11 / 139) instead of the expected 42.
+        run_env = dict(os.environ);
+        run_env["QEMU_LD_PREFIX"] = ld_prefix;
+        result = subprocess.run(
+            [qemu, out_bin], capture_output=True, text=True, timeout=30, env=run_env
+        );
+        assert result.returncode == 42 , (
+            f"Expected exit 42, got {result.returncode} "
+            f"(SIGSEGV/-11/139 == dropped R_AARCH64_MOVW_UABS relocations).\n"
+            f"stderr: {result.stderr[-500:] if result.stderr else '(empty)'}"
+        );
+    }
+}
+
+test "elf linker rejects unhandled relocation (issue #6366 guard)" {
+    # Defense-in-depth: the linker must refuse to emit a binary when a
+    # relocation targeting an emitted section has no handler, rather than
+    # silently leaving the reference pointing at NULL (the #6366 failure mode).
+    # Pure link-time check -- no execution, so it runs without qemu.
+    import llvmlite.binding as llvm;
+    import from jaclang.compiler.passes.native.elf_linker { ElfLinker }
+    llvm.initialize_all_targets();
+    llvm.initialize_all_asmprinters();
+    # A function that loads a module global forces an address-materialization
+    # relocation into .text against the global.
+    ir = "target triple = \"aarch64-unknown-linux-gnu\"\n" + "@g = global i64 0\n" + "define i64 @f() {\n  %v = load i64, i64* @g\n  ret i64 %v\n}\n";
+    mod = llvm.parse_assembly(ir);
+    tm = llvm.Target.from_triple("aarch64-unknown-linux-gnu").create_target_machine(
+        opt=2
+    );
+    obj_bytes = tm.emit_object(mod);
+    linker = ElfLinker(
+        obj_data=obj_bytes,
+        sections=[],
+        symbols=[],
+        relocations=[],
+        needed_libs=["libc.so.6"]
+    );
+    assert linker.parse_object() , "parse_object failed on aarch64 object";
+    assert len(linker.relocations) > 0 , "expected at least one relocation";
+    # Corrupt a relocation that patches the emitted code section to an unknown
+    # type; the linker must raise instead of emitting an unrelocated binary.
+    target = None;
+    for r in linker.relocations {
+        if r.target_sec and "text" in r.target_sec {
+            target = r;
+            break;
+        }
+    }
+    assert target is not None , "no .text relocation found to corrupt";
+    target.rtype = 9999;
+    raised = False;
+    try {
+        linker.build_executable();
+    } except ValueError as e {
+        raised = True;
+        assert "relocation type" in str(e) , f"unexpected message: {e}";
+    }
+    assert raised , "linker silently accepted an unhandled relocation";
+}
+
 # --- TestNativeListBugs ---
 test "list_bugs pop local removes element" {
     (eng, _) = compile_native("list_bugs.na.jac");


### PR DESCRIPTION
## **Description**

Fixes #6366.

`jac nacompile` advertised aarch64 support but produced binaries that segfaulted at process entry, even for a trivial program with no C-FFI.

### Root cause
LLVM materializes absolute global / `.rodata` addresses on aarch64 with a `movz`/`movk` chain relocated by `R_AARCH64_MOVW_UABS_G0..G3`. The in-house ELF linker had no handler for those relocation types, so the `imm16` fields were left zero and every global access dereferenced `0x0` — a `SIGSEGV` at `si_addr=NULL` on the first global store in `main`. x86_64 was unaffected because it uses `R_X86_64_64` (a single `movabs`), which the linker already handles.

### Changes
- Add `R_AARCH64_MOVW_UABS_G0..G3` handling to the aarch64 relocation applier (patches the 16-bit slice into the `MOVZ`/`MOVK` `imm16` field).
- Harden the relocation loop: an unhandled relocation targeting an emitted (loadable) section now fails the link with a clear error instead of silently emitting a broken binary; relocations whose target section is not part of the loadable image are skipped (the previous fallback patched `.text`).

### Tests
- `aarch64 standalone binary runs (#6366)`: cross-compiles a trivial program and runs it under `qemu-user`, asserting it exits cleanly (skips when qemu-user / a cross libc are unavailable).
- `elf linker rejects unhandled relocation (#6366 guard)`: qemu-free check that an unhandled relocation into an emitted section is rejected at link time.

Round-trip test verified red (SIGSEGV) to green; the native suite passes.
