### PR TITLE
fix(release): skip Python 3.14 precompile for jac-desktop

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -146,13 +146,20 @@ jobs:
           python-version: "3.12"
 
       # Set up additional Python versions needed for precompile (both plugins and jaclang itself).
-      - name: Set up Python 3.13 and 3.14 (for precompile)
+      - name: Set up Python 3.13 (for precompile)
         if: matrix.precompile == true
         uses: actions/setup-python@v5
         with:
-          python-version: |
-            3.13
-            3.14
+          python-version: "3.13"
+
+      # Python 3.14 is set up for precompile EXCEPT for jac-desktop, whose
+      # pytauri-wheel dependency has no cp314 wheel yet; precompiling for 3.14
+      # there forces a from-source Rust build of the Tauri runtime that fails.
+      - name: Set up Python 3.14 (for precompile)
+        if: matrix.precompile == true && matrix.name != 'jac-desktop'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
 
       # Install jaclang for plugin builds (jac bundle) and for any extra build commands.
       # jaclang itself uses python -m build, so it doesn't need this step.

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -16,13 +16,17 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python 3.12, 3.13, 3.14
+      # jac-desktop depends on pytauri-wheel, which only ships wheels up to
+      # cp313 (no Python 3.14 wheel yet). Precompiling for 3.14 would force a
+      # from-source Rust build of the whole Tauri runtime, which fails the
+      # release. Pin to the versions pytauri-wheel actually supports;
+      # jac-desktop requires >=3.12.
+      - name: Set up Python 3.12, 3.13
         uses: actions/setup-python@v5
         with:
           python-version: |
             3.12
             3.13
-            3.14
 
       - name: Install jaclang and twine
         run: |


### PR DESCRIPTION
Fixes the jac-desktop release failure described in #6373.

## Problem
`release-desktop.yml` runs `jac bundle --precompile` for Python 3.12, 3.13, and 3.14. jac-desktop depends on **pytauri-wheel**, which ships wheels only for **cp39–cp313 (no cp314)**. So precompiling for 3.14 makes pip build pytauri-wheel from Rust source, which needs system GTK/GLib/WebKitGTK dev libraries that aren't on the runner:

```
The system library `glib-2.0` required by crate `glib-sys` was not found.
The system library `gobject-2.0` required by crate `gobject-sys` was not found.
```

The precompiler treats any failed version as fatal, so the single 3.14 failure aborts the whole release before `twine upload`. (3.12/3.13 succeed because they use prebuilt wheels.)

## Why drop 3.14 rather than install the GTK libs
3.14 bytecode is unusable anyway: with no cp314 pytauri-wheel, **end users can't install jac-desktop on 3.14** either (their pip hits the same source-build wall). Installing the GTK + Rust toolchain in CI would only turn the run green while shipping an artifact nobody can install. See #6373 for the full analysis. Revisit when pytauri-wheel publishes a cp314 wheel — at which point no GTK/source build is needed.

## Changes
- **release-desktop.yml**: set up only Python 3.12 + 3.13.
- **publish-release.yml**: split the combined 3.13/3.14 setup into two steps; 3.14 is skipped only for jac-desktop (`matrix.name != 'jac-desktop'`). All other packages still precompile for 3.14 unchanged.

## Effect
- jac-desktop precompiles for 3.12 + 3.13 only → all built versions use prebuilt pytauri-wheel → no GTK source build → release succeeds.
- No behavior change for any other package.

Refs #6373