### PR TITLE
fix(compiler): rename reserved `root` param in jac0core modules to fix precompile

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6384.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6384.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `root` parameter name no longer breaks bytecode precompile**: Three `jac0core` modules used the reserved keyword `root` as a parameter name, which raised an `Empty py_ast on ParamVar` internal compiler error and left those modules out of the shipped precompiled bytecode (degrading cold start). The bindings were renamed to `root_node`.

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -617,12 +617,12 @@ impl JacBasics.acommit(anchor: Anchor | Archetype | None = None) -> None {
 }
 
 """Purge current or target graph."""
-impl JacBasics.reset_graph(root: (Root | None) = None) -> int {
+impl JacBasics.reset_graph(root_node: (Root | None) = None) -> int {
     import pickle;
     import sqlite3;
     ctx = JacRuntimeInterface.get_context();
     mem = ctx.mem;
-    ranchor = root.__jac__ if root else ctx.user_root;
+    ranchor = root_node.__jac__ if root_node else ctx.user_root;
     deleted_count = 0;
     deleted_ids: set[UUID] = `set();
     persistence = mem.l3;

--- a/jac/jaclang/jac0core/impl/unitree.impl.jac
+++ b/jac/jaclang/jac0core/impl/unitree.impl.jac
@@ -596,7 +596,7 @@ impl UniScopeNode.update_py_ctx_for_def(nd: AstSymbolNode) -> None {
 
 """Pretty print."""
 impl UniScopeNode.sym_pp(depth: (int | None) = None) -> str {
-    return print_symtab_tree(root=self, depth=depth);
+    return print_symtab_tree(root_node=self, depth=depth);
 }
 
 """Generate dot graph for sym table."""

--- a/jac/jaclang/jac0core/passes/decl_impl_match_pass.jac
+++ b/jac/jaclang/jac0core/passes/decl_impl_match_pass.jac
@@ -75,7 +75,7 @@ declarations in the main module.
 
     """Resolve unresolved Name and AtomTrailer symbols in a subtree."""
     def _resolve_symbols_in_subtree(
-        self: DeclImplMatchPass, root: uni.UniNode
+        self: DeclImplMatchPass, root_node: uni.UniNode
     ) -> None;
 
     """Populate self-member symbols from impl body to archetype's symbol table.

--- a/jac/jaclang/jac0core/passes/impl/decl_impl_match_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/decl_impl_match_pass.impl.jac
@@ -295,9 +295,9 @@ to do so on one node is a degraded-info outcome, not a correctness
 hazard for the others.
 """
 impl DeclImplMatchPass._resolve_symbols_in_subtree(
-    self: DeclImplMatchPass, root: uni.UniNode
+    self: DeclImplMatchPass, root_node: uni.UniNode
 ) -> None {
-    for name_node in root.get_all_sub_nodes(uni.Name) {
+    for name_node in root_node.get_all_sub_nodes(uni.Name) {
         if name_node.sym is not None {
             continue;
         }
@@ -310,7 +310,7 @@ impl DeclImplMatchPass._resolve_symbols_in_subtree(
             } except ValueError { }
         }
     }
-    for trailer_node in root.get_all_sub_nodes(uni.AtomTrailer) {
+    for trailer_node in root_node.get_all_sub_nodes(uni.AtomTrailer) {
         chain = trailer_node.as_attr_list;
         if chain and chain[0].sym is None and trailer_node.sym_tab {
             try {

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -320,7 +320,7 @@ class JacBasics {
     static async def acommit(anchor: Anchor | Archetype | None = None) -> None;
 
     """Purge current or target graph."""
-    static def reset_graph(root: (Root | None) = None) -> int;
+    static def reset_graph(root_node: (Root | None) = None) -> int;
 
     """Get object given id."""
     static def get_object(id: str) -> (Archetype | None);

--- a/jac/jaclang/jac0core/treeprinter.jac
+++ b/jac/jaclang/jac0core/treeprinter.jac
@@ -129,7 +129,9 @@ glob id_bag: dict = {},
      };
 
 """Recursively generate ast tree in dot format."""
-def printgraph_ast_tree(root: UniNode, dot_lines: (list[str] | None) = None) -> str {
+def printgraph_ast_tree(
+    root_node: UniNode, dot_lines: (list[str] | None) = None
+) -> str {
     starting_call = False;
     if (dot_lines is None) {
         starting_call = True;
@@ -173,9 +175,9 @@ def printgraph_ast_tree(root: UniNode, dot_lines: (list[str] | None) = None) -> 
         label = f"{label} {shape} {style} {fillcolor}".strip();
         return f"[label={label}]";
     }
-    dot_lines.append(f"{gen_node_id(root)} {gen_node_parameters(root)};");
-    for i in root.kid {
-        dot_lines.append(f"{gen_node_id(root)}  -> {gen_node_id(i)};");
+    dot_lines.append(f"{gen_node_id(root_node)} {gen_node_parameters(root_node)};");
+    for i in root_node.kid {
+        dot_lines.append(f"{gen_node_id(root_node)}  -> {gen_node_id(i)};");
         printgraph_ast_tree(i, dot_lines);
     }
     if starting_call {
@@ -186,7 +188,7 @@ def printgraph_ast_tree(root: UniNode, dot_lines: (list[str] | None) = None) -> 
 
 """Recursively print ast tree."""
 def print_ast_tree(
-    root: (UniNode | ast3.AST),
+    root_node: (UniNode | ast3.AST),
     marker: str = '+-- ',
     level_markers: (list[bool] | None) = None,
     output_file: (str | None) = None,
@@ -296,7 +298,7 @@ def print_ast_tree(
         return '-:- - -:-';
     }
     if (
-        (root is None)
+        (root_node is None)
         or ((max_depth is not None) and (len((level_markers or [])) >= max_depth))
     ) {
         return '';
@@ -311,20 +313,20 @@ def print_ast_tree(
         [connection_str if draw else empty_str for draw in level_markers[:-1]]
     );
     markers += marker if (level > 0) else '';
-    if isinstance(root, uni.UniNode) {
-        tree_str = f"{root.loc}	{markers}{__node_repr_in_tree(root)}\n";
+    if isinstance(root_node, uni.UniNode) {
+        tree_str = f"{root_node.loc}	{markers}{__node_repr_in_tree(root_node)}\n";
         if (
-            isinstance(root, uni.Module)
-            and root.is_raised_from_py
+            isinstance(root_node, uni.Module)
+            and root_node.is_raised_from_py
             and not print_py_raise
         ) {
             kids: list[UniNode] = [
                 x
-                for x in root.get_all_sub_nodes(uni.Module)
+                for x in root_node.get_all_sub_nodes(uni.Module)
                 if x.is_raised_from_py
             ];
         } else {
-            kids = root.kid;
+            kids = root_node.kid;
         }
         for (i, child) in enumerate(kids) {
             is_last = i == (len(kids) - 1);
@@ -332,12 +334,12 @@ def print_ast_tree(
                 child, marker, [*level_markers, not is_last], output_file, max_depth
             );
         }
-    } elif isinstance(root, ast3.AST) {
-        tree_str = f"{get_location_info(root)}	{markers}{__node_repr_in_py_tree(
-            root
+    } elif isinstance(root_node, ast3.AST) {
+        tree_str = f"{get_location_info(root_node)}	{markers}{__node_repr_in_py_tree(
+            root_node
         )}\n";
-        for (i_a, child_a) in enumerate(ast3.iter_child_nodes(root)) {
-            is_last = i_a == (len(`list(ast3.iter_child_nodes(root))) - 1);
+        for (i_a, child_a) in enumerate(ast3.iter_child_nodes(root_node)) {
+            is_last = i_a == (len(`list(ast3.iter_child_nodes(root_node))) - 1);
             tree_str += print_ast_tree(
                 child_a, marker, [*level_markers, not is_last], output_file, max_depth
             );
@@ -370,12 +372,12 @@ class SymbolTree {
 def _build_symbol_tree_common(
     nd: UniScopeNode, parent_node: (SymbolTree | None) = None
 ) -> SymbolTree {
-    root = SymbolTree(
+    root_node = SymbolTree(
         node_name=f"SymTable::{nd.__class__.__name__}({nd.scope_name})",
         parent=parent_node
     );
-    symbols = SymbolTree(node_name='Symbols', parent=root);
-    children = SymbolTree(node_name='Sub Tables', parent=root);
+    symbols = SymbolTree(node_name='Symbols', parent=root_node);
+    children = SymbolTree(node_name='Sub Tables', parent=root_node);
     syms_to_iterate = `set(nd.names_in_scope.values());
     for sym in syms_to_iterate {
         symbol_node = SymbolTree(node_name=f"{sym.sym_name}", parent=symbols);
@@ -407,31 +409,31 @@ def _build_symbol_tree_common(
         }
         _build_symbol_tree_common(k, children);
     }
-    return root;
+    return root_node;
 }
 
 """Recursively print symbol table tree."""
 def print_symtab_tree(
-    root: UniScopeNode,
+    root_node: UniScopeNode,
     marker: str = '+-- ',
     level_markers: (list[bool] | None) = None,
     output_file: (str | None) = None,
     depth: (int | None) = None
 ) -> str {
     return get_symtab_tree_str(
-        _build_symbol_tree_common(root), marker, level_markers, output_file, depth
+        _build_symbol_tree_common(root_node), marker, level_markers, output_file, depth
     );
 }
 
 """Recursively print symbol table tree."""
 def get_symtab_tree_str(
-    root: SymbolTree,
+    root_node: SymbolTree,
     marker: str = '+-- ',
     level_markers: (list[bool] | None) = None,
     output_file: (str | None) = None,
     depth: (int | None) = None
 ) -> str {
-    if ((root is None) or (depth == 0) or (root.name in dir(builtins))) {
+    if ((root_node is None) or (depth == 0) or (root_node.name in dir(builtins))) {
         return '';
     }
     level_markers = level_markers or [];
@@ -445,7 +447,7 @@ def get_symtab_tree_str(
             if level_markers
             else ''
     );
-    line = f"{markers}{root.name}\n";
+    line = f"{markers}{root_node.name}\n";
     if output_file {
         with open(output_file, 'a+') as f {
             f.write(line);
@@ -456,10 +458,10 @@ def get_symtab_tree_str(
             get_symtab_tree_str(
                 child,
                 marker,
-                (level_markers + [(i < (len(root.kid) - 1))]),
+                (level_markers + [(i < (len(root_node.kid) - 1))]),
                 output_file,
                 None if (depth is None) else (depth - 1)
-            ) for (i, child) in enumerate(root.kid)
+            ) for (i, child) in enumerate(root_node.kid)
         )
     );
 }


### PR DESCRIPTION
## What

Three `jac0core` modules used `root` as a parameter name:

- `jac0core/treeprinter.jac` (`printgraph_ast_tree`, `print_ast_tree`, and the symbol-tree helpers `_build_symbol_tree_common` / `print_symtab_tree` / `get_symtab_tree_str`)
- `jac0core/impl/runtime.impl.jac` (`JacBasics.reset_graph`)
- `jac0core/passes/impl/decl_impl_match_pass.impl.jac` (`DeclImplMatchPass._resolve_symbols_in_subtree`)

This PR renames those bindings to `root_node` and updates the one keyword-arg caller (`UniScopeNode.sym_pp`).

## Why

Since #5724 restored `root` as a reserved `SpecialVarRef` keyword, a parameter named `root` parses to a `SpecialVarRef` rather than a plain `Name`. `PyastGenPass.exit_param_var` only emits a py_ast when the param name is an `ast3.Name`, so the `ParamVar` is left with an empty py_ast and raises the internal compiler error:

```
Internal Compiler Error: Pass PyastGenPass - Empty py_ast on ParamVar
```

The bytecode precompile (`jac run jac/jaclang/utils/precompile_bytecode.jac ./jac`) tolerates the ICE and exits 0 reporting "5 failed", so the affected modules shipped **without** bytecode. On a cold start they then have to be recompiled from source, which is the fragility behind the flaky `timeout 5 jac --version` cold-start CI step ("Verify cold start with precompiled bytecode" in `test-jaseci.yml`).

## How

`root` is a reserved keyword and cannot be used as a binding (param, loop target, local var): as an expression it lowers to `Jac.root()`, and assignment is rejected with E0024. So the fix is to stop using the keyword as an identifier in these modules. Renamed every such binding (and its in-body references) to `root_node`.

## Result / tests

- Precompile is now **191/193** (was 188/193); the only remaining items are the 2 intentional SKIPs (`archetype.jac`, `modresolver.jac`), no ICEs.
- `jac --version` cold start, the AST/symtab tree printers, and `Jac.reset_graph` all work.
- 606 passed across `tests/runtimelib` + `tests/language`.
- `tests/compiler` failure set is identical before and after this change (verified against a clean checkout), so no regressions are introduced.