### PR TITLE
Simplify hash computation in Serializer

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6388.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6388.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: includes topology changes in the hash computation**: Previously the graph topology changes are removed from hash generation. Therefore, the topology changes are not persisted properly in MongoDB. Now we include the topology in the hash computation.

--- a/jac-scale/jac_scale/tests/test_topology_scale.jac
+++ b/jac-scale/jac_scale/tests/test_topology_scale.jac
@@ -7,7 +7,9 @@ edge queries work after reload without rebuilding.
 """
 
 import os;
+import sys;
 import shutil;
+import subprocess;
 import from tempfile { mkdtemp }
 import from uuid { UUID }
 import from jaclang.jac0core.runtime { JacRuntime }
@@ -219,6 +221,166 @@ test "topology index survives sqlite persistence round-trip" {
     } finally {
         JacRuntime.set_base_path(orig_base);
         set_config(JacConfig());
+        shutil.rmtree(tmpdir, ignore_errors=True);
+    }
+}
+
+"""Regression (#6388): a topology-only change must alter the dirty-check hash.
+
+`Serializer._compute_hash` is the gate the jac-scale backends use to decide
+whether an anchor is dirty and needs persisting (`MongoBackend.sync` and
+`ScaleTieredMemory.commit`). The topology index lives on the root anchor as
+`topology_index_data` and is updated by `on_edge_created` for edges anywhere in
+the subtree — without touching the root's own edges or archetype fields. If the
+hash ignores `topology_index_data`, such a change is invisible to the gate, the
+root is judged clean, and the updated index is never written to MongoDB.
+
+This fails when `_compute_hash` strips `topology_index_data` before hashing.
+"""
+test "topology-only change is detected by _compute_hash dirty gate" {
+    tmpdir = mkdtemp();
+    orig_base = JacRuntime.get_base_path_dir();
+    try {
+        cfg = JacConfig();
+        cfg.run.topology_index = True;
+        set_config(cfg);
+        JacRuntime.set_base_path(tmpdir);
+        ctx = ExecutionContext();
+        JacRuntime.set_context(ctx);
+
+        r = root;
+
+        # Build an initial graph so the root carries a populated topology index.
+        p0 = Person(name="p0", age=20);
+        r +>: Knows :+> p0;
+        for i in range(1, 4) {
+            r +>: Knows :+> Person(name=f"p{i}", age=20 + i);
+        }
+
+        root_anchor = r.__jac__;
+        idx_before = root_anchor.get_topology_index();
+        assert len(idx_before) > 0 , "Root should carry a topology index";
+
+        # Snapshot the dirty-gate hash and the raw index blob for the baseline.
+        baseline_hash = Serializer._compute_hash(root_anchor);
+        topo_before = root_anchor.topology_index_data;
+        root_edges_before = [e.id for e in root_anchor.edges];
+
+        # A topology-only mutation: connect an edge *deeper* in the subtree
+        # (p0 -> Person). on_edge_created updates the root's topology index, but
+        # the root's own edge list and archetype fields are untouched.
+        p0 +>: Knows :+> Person(name="deep", age=99);
+
+        topo_after = root_anchor.topology_index_data;
+        root_edges_after = [e.id for e in root_anchor.edges];
+
+        # Preconditions: the index blob changed, but nothing else on the root did.
+        assert topo_after != topo_before , (
+            "Precondition: deep edge must update the root's topology_index_data"
+        );
+        assert root_edges_after == root_edges_before , (
+            "Precondition: a deep edge must not change the root's own edge list"
+        );
+
+        # The fix: that topology change must be visible to the dirty gate.
+        after_hash = Serializer._compute_hash(root_anchor);
+        assert after_hash != baseline_hash , (
+            "topology_index_data must participate in _compute_hash; otherwise a "
+            "topology change leaves the root judged clean and the updated index "
+            "is never persisted (#6388)"
+        );
+
+        ctx.close();
+    } finally {
+        JacRuntime.set_base_path(orig_base);
+        set_config(JacConfig());
+        shutil.rmtree(tmpdir, ignore_errors=True);
+    }
+}
+
+# Standalone script run as separate OS processes (one per phase), so each phase
+# reloads the graph from SQLite with zero in-memory carry-over — a true
+# persistence round-trip across a "restart". `build` and `deep` each auto-commit
+# on exit; `check` reads the reloaded index. A deep edge (p0 -> deep) updates the
+# root's topology index without touching the root's own edges/archetype, which
+# is exactly the topology-only change the SQLite dirty gate must catch.
+glob TOPO_REGRESS_SCRIPT: str = "import os;\n"
+     "\n"
+     "node Person { has name: str = \"\"; }\n"
+     "edge Knows {}\n"
+     "\n"
+     "with entry {\n"
+     "    phase = os.environ.get(\"PHASE\", \"\");\n"
+     "    r = root;\n"
+     "    if phase == \"build\" {\n"
+     "        r +>: Knows :+> Person(name=\"p0\");\n"
+     "    } elif phase == \"deep\" {\n"
+     "        p0 = [r ->: Knows :-> [?:Person]][0];\n"
+     "        p0 +>: Knows :+> Person(name=\"deep\");\n"
+     "        print(\"DEEP_NODES=\" + str(len(r.__jac__.get_topology_index().node_table)));\n"
+     "    } elif phase == \"check\" {\n"
+     "        print(\"CHECK_NODES=\" + str(len(r.__jac__.get_topology_index().node_table)));\n"
+     "    }\n"
+     "}\n";
+
+"""Run one phase of the regression script in a fresh `jac run` subprocess."""
+def _topo_run_phase(workdir: str, phase: str) -> str {
+    env = dict(os.environ);
+    env["JAC_TOPOLOGY_INDEX"] = "1";
+    env["PHASE"] = phase;
+    result = subprocess.run(
+        [sys.executable, "-m", "jaclang", "run", "regress.jac"],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600
+    );
+    return result.stdout;
+}
+
+"""Pull an integer marker (e.g. `DEEP_NODES=3`) out of captured stdout."""
+def _topo_marker(out: str, prefix: str) -> int {
+    for line in out.splitlines() {
+        stripped = line.strip();
+        if stripped.startswith(prefix) {
+            return int(stripped[len(prefix):]);
+        }
+    }
+    return -1;
+}
+
+"""Regression (#6388 sibling, SQLite): a topology-only change to an
+already-persisted root must survive a process restart. SqliteMemory.sync keys
+its dirty check off edge/access/archetype-field changes and never consults the
+whole-anchor hash, so without persisting `topology_index_data` explicitly the
+updated index is dropped and the reloaded index is stale. Process-isolated so
+the result cannot be masked by in-memory carry-over.
+
+Fails (check < deep) if SqliteMemory.sync does not persist topology_index_data.
+"""
+test "sqlite persists topology-only change across a process restart" {
+    tmpdir = mkdtemp();
+    try {
+        script_path = os.path.join(tmpdir, "regress.jac");
+        with open(script_path, "w") as f {
+            f.write(TOPO_REGRESS_SCRIPT);
+        }
+        _topo_run_phase(tmpdir, "build");
+        deep_out = _topo_run_phase(tmpdir, "deep");
+        check_out = _topo_run_phase(tmpdir, "check");
+        deep_nodes = _topo_marker(deep_out, "DEEP_NODES=");
+        check_nodes = _topo_marker(check_out, "CHECK_NODES=");
+        assert deep_nodes >= 3 , (
+            "Precondition: deep edge should grow the in-memory index to >=3 "
+            f"nodes, got {deep_nodes}. deep stdout:\n{deep_out}"
+        );
+        assert check_nodes == deep_nodes , (
+            "Topology-only change was not persisted across the restart: "
+            f"reloaded index has {check_nodes} nodes, expected {deep_nodes}. "
+            f"check stdout:\n{check_out}"
+        );
+    } finally {
         shutil.rmtree(tmpdir, ignore_errors=True);
     }
 }

--- a/jac/jaclang/runtimelib/impl/memory.impl.jac
+++ b/jac/jaclang/runtimelib/impl/memory.impl.jac
@@ -1086,6 +1086,24 @@ impl SqliteMemory.sync -> None {
                         }
                         changed = True;
                     }
+                    # Topology index is a derived adjacency cache on root
+                    # NodeAnchors, updated by edges *anywhere* in the subtree —
+                    # so a deep edge change leaves this root's own edges and
+                    # archetype fields untouched while the index blob still
+                    # changes. It is not an archetype field, so neither the
+                    # edge merge above nor the field-hash dirty check below
+                    # catches it; without this the update is silently dropped
+                    # on persist. Gate on CONNECT access, like edges, since the
+                    # index reflects connectivity.
+                    if (
+                        isinstance(stored_anchor, NodeAnchor)
+                        and isinstance(anchor, NodeAnchor)
+                        and anchor.topology_index_data != stored_anchor.topology_index_data
+                        and Jac.check_connect_access(anchor)
+                    ) {
+                        stored_anchor.topology_index_data = anchor.topology_index_data;
+                        changed = True;
+                    }
                     # Handle access/archetype updates (WRITE access)
                     access_changed = _canonical_json(stored_anchor.access) != _canonical_json(
                         anchor.access

--- a/jac/jaclang/runtimelib/impl/serializer.impl.jac
+++ b/jac/jaclang/runtimelib/impl/serializer.impl.jac
@@ -760,12 +760,6 @@ impl Serializer._compute_hash(anchor: Anchor) -> int {
     import from json { dumps }
     try {
         data = Serializer.serialize(anchor, include_type=True);
-        # Exclude topology_index_data from hash — it's a derived cache,
-        # not user-mutable state. Including it would double the cost of
-        # every serialize round-trip for large graphs.
-        if isinstance(data, dict) {
-            data.pop('topology_index_data', None);
-        }
         return hash(dumps(data, sort_keys=True));
     } except Exception {
         return 0;


### PR DESCRIPTION
## Summary

The topology index (`topology_index_data`, a derived adjacency cache stored on root node anchors) was not persisted when it was the only thing that changed on a root. Both persistence backends decide whether to write an anchor using a dirty check, and neither accounted for `topology_index_data`:

- **jac-scale Mongo** (`MongoBackend.sync`, `ScaleTieredMemory.commit`) gate on `Serializer._compute_hash`, which explicitly stripped `topology_index_data` before hashing. A topology-only change left the hash unchanged, so the root was judged clean and never written.
- **jaclang SQLite** (`SqliteMemory.sync`) keys its dirty check off edge-list, access, and archetype-field changes only. `topology_index_data` is an anchor field (not an archetype field, edge, or access entry), so a topology-only change tripped none of those gates.

Because the index is updated by edges anywhere in the subtree (via `on_edge_created`), a deep edge mutation changes a root's index without touching the root's own edges or archetype fields. The result: graphs reloaded from either backend came back with a stale topology index, and queries routed through it returned incorrect results.

## Changes

- **Serializer**: stop excluding `topology_index_data` from `_compute_hash`, so the Mongo dirty gate detects topology-only changes.
- **SqliteMemory.sync**: persist `topology_index_data` when the in-memory value diverges from the stored copy, gated on connect access (consistent with the edge merge). The merged row is built from the stored anchor, so the value is copied onto it rather than only flagged.
- **Tests** (`test_topology_scale.jac`):
  - A `_compute_hash` dirty-gate test: a topology-only change must alter the hash. Guards the Serializer change; fails if the exclusion returns.
  - A SQLite persistence test: process-isolated (`jac run` across separate processes sharing one DB) so the reload is a true round-trip with no in-memory carry-over, asserting the reloaded index reflects a topology-only change.

## Test plan

- [x] `jac test jac-scale/jac_scale/tests/test_topology_scale.jac` (5 tests) passes; both regression tests fail without their respective fixes.
- [x] `jac test jac-scale/jac_scale/tests/test_memory_hierarchy.jac` (20 tests) passes as the SQLite dirty-path regression guard.
