### PR TITLE
ci(test-client): install WebKitGTK runtime for desktop dev test

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -90,6 +90,14 @@ jobs:
         pip install playwright
         pip install pyinstaller
 
+    - name: Install desktop runtime libraries
+      run: |
+        # jac-desktop's pytauri shell loads a native extension that links
+        # libwebkit2gtk-4.1.so.0; install the WebKitGTK runtime so the
+        # "desktop dev mode" test can launch the pytauri process.
+        sudo apt-get update
+        sudo apt-get install -y libwebkit2gtk-4.1-0 libjavascriptcoregtk-4.1-0 libsoup-3.0-0
+
     - name: Install Playwright browsers
       run: playwright install chromium --with-deps
 


### PR DESCRIPTION
## Problem

The `test-client` job fails on the `desktop dev mode starts vite server` test ([example run](https://github.com/jaseci-labs/jaseci/actions/runs/26910503054/job/79386927436)). The surface error is misleading:

```
TimeoutError: Timed out waiting for 127.0.0.1:5173
```

The real cause is in the captured stderr:

```
ImportError: libwebkit2gtk-4.1.so.0: cannot open shared object file: No such file or directory
```

### Chain of events
1. The test runs `jac start main.jac --client desktop --dev --port 5173`.
2. Vite starts successfully (`✔ Vite dev server ready` / `http://localhost:5173`).
3. The dev orchestrator then launches the pytauri shell (`python app.py`).
4. `app.py` imports `pytauri`, whose native extension links against `libwebkit2gtk-4.1.so.0` — **not installed** on the `blacksmith-4vcpu-ubuntu-2404` runner → `ImportError`.
5. The pytauri shell crashes, so the orchestrator tears everything down, including the Vite server it had just started.
6. `wait_for_port("127.0.0.1", 5173)` then times out after 90s, failing the suite (`pytest -x` → exit code 2).

This is the only desktop test that actually launches the pytauri runtime, which is why it's the only one that hits the missing library.

## Fix

Add a step to install the WebKitGTK 4.1 runtime (Ubuntu 24.04 package names) before the client/desktop suite runs, so the pytauri process can start. `libwebkit2gtk-4.1-0` pulls the rest transitively; `libjavascriptcoregtk-4.1-0` and `libsoup-3.0-0` are listed explicitly for clarity.
