### PR TITLE
refactor(client): debloat bun handling to a single resolver

### DIFF
--- a/jac-client/jac_client/plugin/plugin_config.jac
+++ b/jac-client/jac_client/plugin/plugin_config.jac
@@ -184,11 +184,11 @@ def _load_template(template_name: str) -> dict[str, any] | None {
 def _post_create_client(project_path: Path, project_name: str) -> None {
     import from jaclang.runtimelib.client.vite_bundler { ViteBundler }
     import from jaclang.cli.console { console }
-    import from jaclang.runtimelib.client { ensure_bun_available }
+    import from jaclang.runtimelib.client { get_bun }
 
-    # First, ensure Bun is installed (prompt to install if not)
+    # First, ensure Bun is installed (auto-installs to .jac/bin if missing)
     console.print();
-    if not ensure_bun_available() {
+    if get_bun() is None {
         console.warning("Bun is required for client development");
         console.print("  After installing Bun, run: jac add --cl\n", style="muted");
         return;
@@ -361,10 +361,10 @@ def _npm_remove_handler(config: JacConfig, package_name: str, is_dev: bool = Fal
 """Regenerate package.json from jac.toml and run bun install."""
 def _regenerate_and_install(project_dir: Path) {
     import from jaclang.runtimelib.client.vite_bundler { ViteBundler }
-    import from jaclang.runtimelib.client { ensure_bun_available }
+    import from jaclang.runtimelib.client { get_bun }
 
-    # Ensure Bun is installed before proceeding (prompt to install if not)
-    if not ensure_bun_available() {
+    # Ensure Bun is installed before proceeding (auto-installs to .jac/bin if missing)
+    if get_bun() is None {
         raise RuntimeError(
             "Bun is required. Install manually: https://bun.sh"
         ) from None;

--- a/jac-client/jac_client/plugin/src/targets/mobile/common.jac
+++ b/jac-client/jac_client/plugin/src/targets/mobile/common.jac
@@ -5,6 +5,7 @@ import subprocess;
 import from pathlib { Path }
 import from typing { Optional }
 import from jaclang.cli.console { console }
+import from jaclang.runtimelib.client { get_bun }
 
 # ==============================================================================
 # Constants
@@ -163,7 +164,9 @@ def _run_install_cmd(project_dir: Path, packages: list[str], dev: bool = False) 
         }
         cmd.extend(packages);
     } else {
-        cmd = ["bun", "add"];
+        # Fall back to bun (auto-installs to .jac/bin if not on PATH).
+        bun = get_bun();
+        cmd = [bun or "bun", "add"];
         if dev {
             cmd.append("--dev");
         }

--- a/jac-client/jac_client/plugin/src/targets/mobile/deps.jac
+++ b/jac-client/jac_client/plugin/src/targets/mobile/deps.jac
@@ -4,6 +4,7 @@ import shutil;
 import platform as platform_mod;
 import from pathlib { Path }
 import from jaclang.cli.console { console }
+import from jaclang.runtimelib.client { get_bun }
 import from jac_client.plugin.src.targets.mobile.common {
     SUBPROCESS_TIMEOUT_SHORT,
     _check_command_available,
@@ -202,7 +203,14 @@ def _check_and_report_dependencies(plat: str = "android") {
     if node_ok {
         console.print(f"  ✔ Node.js found: {node_ver}", style="success");
     } else {
-        (bun_ok, bun_ver) = _check_command_available(["bun", "--version"]);
+        # Resolve via get_bun so the project-local .jac/bin copy counts too
+        # (auto-installs if neither node nor bun is present anywhere).
+        bun = get_bun();
+        if bun {
+            (bun_ok, bun_ver) = _check_command_available([bun, "--version"]);
+        } else {
+            (bun_ok, bun_ver) = (False, None);
+        }
         if bun_ok {
             console.print(f"  ✔ Bun found: {bun_ver}", style="success");
         } else {

--- a/jac-client/jac_client/tests/test_cli.jac
+++ b/jac-client/jac_client/tests/test_cli.jac
@@ -1047,8 +1047,7 @@ test "vite build prompts for missing client deps" {
         # Mock input to accept, and mock bun/vite so we don't need real installs.
         with unittest.mock.patch("builtins.input", return_value="Y") {
             with unittest.mock.patch(
-                "jaclang.runtimelib.client.bun_installer.ensure_bun_available",
-                return_value=True
+                "jaclang.runtimelib.client.bun_installer.get_bun", return_value="bun"
             ) {
                 with unittest.mock.patch("subprocess.run") as mock_subprocess {
                     # bun install returns success, vite build returns failure

--- a/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/kubernetes_target.jac
@@ -1,5 +1,6 @@
 """Kubernetes deployment target implementation."""
 import from typing { Any }
+import from jaclang.runtimelib.client { BUN_VERSION }
 import from jac_scale.abstractions.deployment_target { DeploymentTarget }
 import from jac_scale.abstractions.config.app_config { AppConfig }
 import from jac_scale.abstractions.models.deployment_result { DeploymentResult }
@@ -219,8 +220,12 @@ obj KubernetesTarget(DeploymentTarget) {
         }
         commands.append(f"apt-get install -y {' '.join(base_packages)}");
 
-        # Install Bun (required for jac-client frontend builds)
-        commands.append('curl -fsSL https://bun.sh/install | bash');
+        # Install Bun (required for jac-client frontend builds), pinned to the
+        # same version jac auto-installs locally (BUN_VERSION is the single
+        # source of truth in jaclang.runtimelib.client.bun_installer).
+        commands.append(
+            f'curl -fsSL https://bun.sh/install | bash -s "bun-v{BUN_VERSION}"'
+        );
         commands.append('export BUN_INSTALL="$HOME/.bun"');
         commands.append('export PATH="$BUN_INSTALL/bin:$PATH"');
 

--- a/jac/jaclang/runtimelib/client/__init__.jac
+++ b/jac/jaclang/runtimelib/client/__init__.jac
@@ -1,6 +1,6 @@
 """Core client build plumbing: bun toolchain, Vite bundler, config, npm install, jac->js bridge."""
 
-import from .bun_installer { get_bun, ensure_bun_available, prompt_install_bun }
+import from .bun_installer { get_bun, BUN_VERSION }
 import from .client_deps { ensure_client_deps }
 import from .asset_processor { AssetProcessor }
 import from .config_loader { JacClientConfig }
@@ -14,8 +14,7 @@ import from .vite_client_bundle { ViteClientBundleBuilder, make_client_bundle_bu
 
 glob __all__ = [
          'get_bun',
-         'ensure_bun_available',
-         'prompt_install_bun',
+         'BUN_VERSION',
          'ensure_client_deps',
          'AssetProcessor',
          'JacClientConfig',

--- a/jac/jaclang/runtimelib/client/bun_installer.jac
+++ b/jac/jaclang/runtimelib/client/bun_installer.jac
@@ -4,26 +4,19 @@ Provides functions to resolve the bun binary path, auto-installing
 a project-local copy to .jac/bin/ if bun is not on the system PATH.
 """
 
-"""Resolve the path to the bun binary.
+# Canonical pinned bun version. Single source of truth across the project
+# (also reused by deployment targets that pre-install bun in container images).
+# Bump this when a new bun release is validated.
+glob BUN_VERSION = "1.3.11";
+
+"""Resolve the path to the bun binary, auto-installing if needed.
 
 Resolution order:
   1. System PATH (use the user's global bun if present)
   2. .jac/bin/bun (project-local, managed by jac)
   3. Auto-download to .jac/bin/ (silent, no prompt)
 
+On success the resolved directory is prepended to PATH.
 Returns the absolute path as a string, or None if unavailable.
 """
 def get_bun -> str | None;
-
-"""Check if bun is available (legacy entry point).
-
-Delegates to get_bun() and ensures the resolved path is on PATH.
-Returns True if bun is available, False otherwise.
-"""
-def ensure_bun_available -> bool;
-
-"""Prompt user to install Bun (legacy, now auto-installs).
-
-Kept for backward compatibility. Delegates to ensure_bun_available().
-"""
-def prompt_install_bun -> bool;

--- a/jac/jaclang/runtimelib/client/impl/bun_installer.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/bun_installer.impl.jac
@@ -19,11 +19,10 @@ import from pathlib { Path }
 import from jaclang.cli.console { console }
 import from jaclang.project.config { get_config }
 
-# Pin the bun version jac-client ships with.
-# Bump this when a new bun release is validated.
-glob BUN_VERSION = "1.3.11",
-     # Map (system, machine) to bun release asset name.
-     _PLATFORM_MAP: dict[str, dict[str, str]] = {
+# Map (system, machine) to bun release asset name.
+# (BUN_VERSION is defined in the bun_installer.jac interface — the single
+#  source of truth shared with deployment targets.)
+glob _PLATFORM_MAP: dict[str, dict[str, str]] = {
          "Darwin": {
              "arm64": "bun-darwin-aarch64",
              "aarch64": "bun-darwin-aarch64",
@@ -154,80 +153,61 @@ def _download_bun(bin_dir: Path) -> Path | None {
 }
 
 
-"""Resolve the path to the bun binary.
+"""Resolve the path to the bun binary, auto-installing if needed.
 
 Resolution order:
   1. System PATH
   2. .jac/bin/bun (project-local, check version)
   3. Auto-download to .jac/bin/
 
+On success the resolved directory is prepended to PATH so subprocesses
+that resolve via PATH (e.g. shell=True) can find bun too.
 Returns the absolute path to bun, or None if unavailable.
 """
 impl get_bun -> str | None {
     is_windows = platform.system() == "Windows";
     bun_name = "bun.exe" if is_windows else "bun";
 
+    bun_path: str | None = None;
+
     # 1. System PATH
     system_bun = shutil.which("bun");
     if system_bun {
-        return system_bun;
-    }
-
-    # 2. .jac/bin/bun (may already be downloaded)
-    bin_dir = _get_jac_bin_dir();
-    local_bun = bin_dir / bun_name;
-
-    if local_bun.exists() {
-        # Check if version matches (upgrade if stale)
-        version_file = bin_dir / ".bun-version";
-        if version_file.exists() and version_file.read_text().strip() == BUN_VERSION {
-            return str(local_bun);
+        bun_path = system_bun;
+    } else {
+        bin_dir = _get_jac_bin_dir();
+        local_bun = bin_dir / bun_name;
+        # 2. .jac/bin/bun (may already be downloaded)
+        if local_bun.exists() {
+            # Check if version matches (upgrade if stale)
+            version_file = bin_dir / ".bun-version";
+            if version_file.exists()
+            and version_file.read_text().strip() == BUN_VERSION {
+                bun_path = str(local_bun);
+            } else {
+                # Version mismatch - re-download
+                console.warning(f"Upgrading Bun to v{BUN_VERSION}...", emoji=False);
+                local_bun.unlink(missing_ok=True);
+            }
         }
-        # Version mismatch - re-download
-        console.warning(f"Upgrading Bun to v{BUN_VERSION}...", emoji=False);
-        local_bun.unlink(missing_ok=True);
+        # 3. Auto-download
+        if bun_path is None {
+            result = _download_bun(bin_dir);
+            if result {
+                bun_path = str(result);
+            }
+        }
     }
 
-    # 3. Auto-download
-    result = _download_bun(bin_dir);
-    if result {
-        return str(result);
-    }
-
-    return None;
-}
-
-
-"""Check if bun is available, add to PATH if needed, or prompt to install.
-
-Legacy entry point - now delegates to get_bun().
-Returns True if bun is available, False otherwise.
-"""
-impl ensure_bun_available -> bool {
-    bun_path = get_bun();
     if bun_path is None {
-        console.error(
-            "Bun is required but could not be installed automatically.", emoji=False
-        );
-        console.print("  Install manually: https://bun.sh\n");
-        return False;
+        return None;
     }
 
-    # Ensure the directory containing bun is on PATH for subprocess calls
-    # that use shell=True or rely on PATH resolution.
+    # Ensure bun's directory is on PATH for subprocesses that resolve via PATH.
     bun_dir = str(Path(bun_path).parent);
     current_path = os.environ.get("PATH", "");
     if bun_dir not in current_path.split(os.pathsep) {
         os.environ["PATH"] = f"{bun_dir}{os.pathsep}{current_path}";
     }
-    return True;
-}
-
-
-"""Prompt user to install Bun and install if confirmed.
-
-Kept for backward compatibility but no longer prompts - auto-installs.
-"""
-impl prompt_install_bun -> bool {
-    return ensure_bun_available();
+    return bun_path;
 }

--- a/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
@@ -1161,9 +1161,9 @@ impl ViteBundler.start_dev_server(
     import sys;
     import time;
     import threading;
-    import from jaclang.runtimelib.client { ensure_bun_available }
+    import from jaclang.runtimelib.client { get_bun }
     # Ensure bun is available before starting dev server
-    if not ensure_bun_available() {
+    if get_bun() is None {
         raise ClientBundleError(
             'Bun is required for dev server. Install manually: https://bun.sh'
         ) from None;


### PR DESCRIPTION
## Summary

The bun installer core was already clean (system PATH → `.jac/bin/bun` → silent auto-download, version-pinned). The bloat was all *around* it: a redundant API, call sites that bypassed the resolver, and a divergent install path. This collapses everything to one mechanism — **if bun isn't detected, auto-install a pinned copy to `.jac/bin/`** — without rewriting the working core.

## Changes

- **One entry point.** Folded the `PATH`-prepend side-effect into `get_bun()` and removed the legacy `ensure_bun_available()` and `prompt_install_bun()` wrappers. All call sites now use `get_bun()` directly; each kept its own failure message.
- **No more bypasses.** The two hardcoded `["bun", ...]` call sites (mobile `common.jac` / `deps.jac`) now route through `get_bun()`, so the `.jac/bin` fallback is actually honored instead of only working when bun is on the system PATH.
- **Single source of truth for the version.** `BUN_VERSION` moved to the interface and is exported. The kubernetes target now pins its `curl … | bash` install to the same `BUN_VERSION` instead of pulling an unpinned upstream bun, so the local and in-cluster installs can't drift.
- Removed a stale duplicate copy of the installer under the obsolete `plugin/utils/` build path (was untracked).

## Verification

- Core module imports cleanly; `BUN_VERSION` exported; both removed functions confirmed gone.
- No new type errors introduced by any edit (verified against the pre-change tree — pre-existing strict-checker noise is unchanged).
- Test suite shows an identical pass/fail profile to the baseline (the 8 failures are pre-existing environmental issues unrelated to bun); the test that mocked the old API now passes against `get_bun`.