### PR TITLE
feat(examples): Zig twin of raylib shooter + FPS benchmark mode

### DIFF
--- a/jac/examples/raylib_shooter/.gitignore
+++ b/jac/examples/raylib_shooter/.gitignore
@@ -1,13 +1,20 @@
 # Downloaded raylib release + extraction cache
 .build/
 
-# Shared library staged by demo.sh
+# Shared library staged by demo.sh (incl. versioned SONAME symlinks)
 libraylib.so
+libraylib.so.*
 libraylib*.dylib
 
 # Compiled native binaries
 /shooter
+/shooter_zig
+/shooter_zig.o
 /smoke
+
+# Benchmark scratch files (switch written by demo.sh, result by the binaries)
+.bench_seconds
+.bench_result
 
 # Jac native IR cache
 .jac_ir/

--- a/jac/examples/raylib_shooter/README.md
+++ b/jac/examples/raylib_shooter/README.md
@@ -36,17 +36,80 @@ resolves no matter where the binary is launched from.
 ## Run it
 
 ```bash
-./demo.sh
+./demo.sh         # default: benchmark BOTH builds (8s each), print avg/max FPS
+./demo.sh --jac   # build & play only the Jac-native shooter, interactively
+./demo.sh --zig   # build & play only the Zig shooter, interactively
 ```
 
 `demo.sh` will:
 
 1. detect your platform/architecture,
 2. download the matching precompiled raylib release from GitHub,
-3. stage its shared library under the platform's natural name (`libraylib.so` on
-   Linux, `libraylib.dylib` on macOS),
-4. compile `shooter.na.jac` with `jac nacompile`, and
-5. launch the resulting `./shooter` binary.
+3. stage its shared library beside the script (`libraylib.so` on Linux,
+   `libraylib.dylib` on macOS),
+4. build the shooter(s) it needs:
+   - `shooter.na.jac` with `jac nacompile` (no C compiler, no `cc`/`ld`),
+     producing `./shooter`;
+   - `shooter.zig` with the Zig toolchain against the staged library, producing
+     `./shooter_zig`. If `zig` is not already on your `PATH`, the script
+     downloads the matching single-archive Zig distribution into `.build/` and
+     uses it from there - nothing is installed system-wide;
+5. run them: the default **benchmarks** both (see below); `--jac` / `--zig` launch
+   one interactively.
+
+### Benchmark mode (default)
+
+With no flag, `demo.sh` runs each build for 8 seconds and prints a table:
+
+```
+====== raylib cube shooter benchmark (8s each, uncapped) ======
+  build        avg FPS        max FPS       frames
+  Jac            461.7          719.9         3694
+  Zig            470.5          719.1         3764
+===============================================================
+```
+
+(Numbers above are from a WSLg + Mesa `llvmpipe` software-rendering box; yours
+will differ. The two builds track each other closely - they link the same
+precompiled raylib and do identical per-frame work.)
+
+How it works without changing how the demos _play_: a binary can't report FPS to
+the shell on its own (raylib paints the counter onto the framebuffer, not
+stdout), so each shooter has a small, **dormant** benchmark path. `demo.sh`
+writes the requested duration into a sibling `.bench_seconds` file before
+launching; each binary reads that file with raylib's own cross-platform helpers
+(`FileExists` / `LoadFileText` / `TextToInteger`), and when present it times
+itself with raylib's `GetTime`, then writes a `BENCH_RESULT avg max frames
+seconds` line to a sibling `.bench_result` file (via raylib's `SaveFileText`) and
+exits; `demo.sh` reads that back and cleans both files up. When `.bench_seconds`
+is absent - every `--jac` / `--zig` run, or a bare `./shooter` - that path is
+skipped entirely and the game loop runs until you close the window, exactly as
+before. (The result travels through a file rather than stdout because the demos
+go through raylib's own I/O - no `print`, no libc - so the Jac and Zig twins stay
+byte-for-byte parallel.)
+
+### The Zig twin
+
+`shooter.zig` is a faithful Zig port of `shooter.na.jac`. Like the Jac version,
+it **binds raylib by declaring its entry points directly** - here as `extern
+fn`, the moral equivalent of Jac's `import from raylib { def ... }` block - so it
+needs **no C headers**; the symbols resolve straight out of the precompiled
+shared library:
+
+```zig
+extern fn InitWindow(width: c_int, height: c_int, title: [*:0]const u8) void;
+extern fn rlVertex3f(x: f32, y: f32, z: f32) void;
+extern fn rlColor4ub(r: u8, g: u8, b: u8, a: u8) void;
+// ...
+```
+
+It renders through the same scalar `rlgl` immediate-mode API, so the two builds
+are pixel-identical on screen. It exists as the conventional-toolchain baseline:
+same precompiled library, but linked the ordinary way (with a
+`$ORIGIN`/`@loader_path` runpath so it, too, finds the sibling library). One
+wrinkle the Jac backend sidesteps: a conventional linker records raylib's
+**SONAME** (`libraylib.so.600`) rather than the plain `libraylib.so`, so the
+`--zig` path stages the release's full versioned symlink set beside the binary.
 
 ### Controls
 
@@ -72,12 +135,17 @@ The current frame rate is shown top-left. The loop runs **uncapped** (no
 | File             | Purpose                                                                |
 | ---------------- | ---------------------------------------------------------------------- |
 | `shooter.na.jac` | the whole demo: raylib FFI bindings, wrappers, and the game + render loop |
-| `demo.sh`        | platform detection, download, link, run                                |
+| `shooter.zig`    | faithful Zig twin of the demo, built with `./demo.sh --zig`            |
+| `demo.sh`        | platform detection, download, build, benchmark (default) or run one    |
 
 ## Requirements
 
-- The `jac` CLI (`pip install jaclang`, or the repo's `.venv`).
-- `curl` and `tar` (used by `demo.sh`).
+- The `jac` CLI (`pip install jaclang`, or the repo's `.venv`) - for the Jac build
+  (i.e. the default benchmark and `--jac`).
+- A `zig` toolchain - for the Zig build (the default benchmark and `--zig`).
+  `demo.sh` downloads one into `.build/` automatically if you don't already have
+  it on your `PATH` (nothing system-wide).
+- `curl` and `tar` (used by `demo.sh`; the Zig archive is `.tar.xz`).
 - A GPU/desktop with OpenGL 3.3+ and a window system. On Linux that means
   `libGL`/`libX11` (raylib's own transitive dependencies); software rendering
   (Mesa `llvmpipe`) works too.

--- a/jac/examples/raylib_shooter/demo.sh
+++ b/jac/examples/raylib_shooter/demo.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 #
-# Build & run the Jac-native raylib shooter.
+# Build & run the raylib cube shooter.
 #
-#   1. detect the platform / architecture
-#   2. download the matching *precompiled* raylib release from GitHub
-#   3. stage its shared library under the platform's natural name
-#      (libraylib.so on Linux, libraylib.dylib on macOS) next to this script
-#   4. compile shooter.na.jac into a standalone native binary (`jac nacompile`)
-#   5. run it
+#   default   benchmark BOTH builds: run each for a fixed number of seconds,
+#             then print the average and max FPS side by side
+#   --jac     build & run only the Jac-native shooter (shooter.na.jac), interactive
+#   --zig     build & run only the Zig shooter (shooter.zig), interactive
+#
+# Either way the script:
+#   1. detects the platform / architecture
+#   2. downloads the matching *precompiled* raylib release from GitHub
+#   3. stages its shared library beside this script
+#   4. builds the requested shooter(s)
+#   5. runs / benchmarks them
 #
 # shooter.na.jac links against raylib by its *logical* name -
 # `import from raylib { ... }` (no path, no extension). The native backend picks
@@ -16,9 +21,41 @@
 # a $ORIGIN / @loader_path runpath so the binary finds the sibling library
 # regardless of the directory it is launched from.
 #
+# shooter.zig is a faithful Zig twin of the same demo: it declares the same
+# raylib entry points as `extern fn` (the moral equivalent of Jac's import
+# block) and renders through the same scalar rlgl API, so the two builds can be
+# compared side by side.
+#
+# Benchmark switch: this script writes the requested duration into a sibling
+# `.bench_seconds` file before launching and deletes it afterwards. Each binary
+# reads that file with raylib's own cross-platform helpers (FileExists /
+# LoadFileText / TextToInteger); when it is absent the binaries run interactively
+# exactly as before. Nothing in the demos changes for normal play.
+#
 set -euo pipefail
 
+# ── 0. Parse args ───────────────────────────────────────────────────────────
+MODE="bench"   # bench | jac | zig
+for arg in "$@"; do
+  case "$arg" in
+    --jac)        MODE="jac" ;;
+    --zig)        MODE="zig" ;;
+    --bench)      MODE="bench" ;;
+    -h|--help)
+      echo "Usage: ${0##*/} [--jac | --zig | --bench]"
+      echo "  (default)  benchmark both builds for ${BENCH_SECONDS:-8}s each and print avg/max FPS"
+      echo "  --jac      build & run only the Jac-native shooter, interactively"
+      echo "  --zig      build & run only the Zig shooter, interactively"
+      echo "  --bench    explicit form of the default benchmark mode"
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg (try --help)" >&2; exit 1 ;;
+  esac
+done
+
 RAYLIB_VERSION="6.0"
+ZIG_VERSION="0.13.0"
+BENCH_SECONDS=8
 BASE_URL="https://github.com/raysan5/raylib/releases/download/${RAYLIB_VERSION}"
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -65,7 +102,7 @@ else
   echo ">> using cached $tarball"
 fi
 
-# ── 3. Extract and stage the shared library under its natural name ──────────
+# ── 3. Extract and stage the shared library beside this script ──────────────
 extract_dir="$BUILD_DIR/extracted"
 rm -rf "$extract_dir"; mkdir -p "$extract_dir"
 tar xzf "$tarball" -C "$extract_dir"
@@ -76,23 +113,178 @@ if [ -z "$lib_file" ]; then
   echo "Could not locate $lib_glob inside the raylib release." >&2
   exit 1
 fi
-cp -f "$lib_file" "$HERE/$stage_name"
-echo ">> staged   : $(basename "$lib_file") -> ./$stage_name"
+lib_src_dir="$(dirname "$lib_file")"
 
-# ── 4. Locate the jac CLI and compile ───────────────────────────────────────
-if command -v jac >/dev/null 2>&1; then
-  JAC="jac"
-elif [ -x "$HERE/../../../.venv/bin/jac" ]; then
-  JAC="$HERE/../../../.venv/bin/jac"   # in-repo virtualenv fallback
+# Stage the release's full symlinked library set. The Jac backend records the
+# plain logical name `libraylib.so`, but a conventional linker (the Zig build)
+# records the library's SONAME / install-name - a versioned name like
+# `libraylib.so.600` (Linux) or `@rpath/libraylib.500.dylib` (macOS). Copying the
+# real object plus its version symlinks (preserved with `cp -P`) satisfies both:
+# whatever name a binary records resolves beside it via the runpath.
+if [ "$os" = "Darwin" ]; then
+  cp -P "$lib_src_dir"/libraylib*.dylib "$HERE/" 2>/dev/null || true
 else
-  echo "Could not find the 'jac' CLI on PATH or in ../../../.venv." >&2
-  echo "Install jaclang (pip install jaclang) or activate the repo venv." >&2
-  exit 1
+  cp -P "$lib_src_dir"/libraylib.so* "$HERE/" 2>/dev/null || true
 fi
+echo ">> staged   : raylib shared library set -> ./ (via $stage_name)"
 
-echo ">> compiling: $JAC nacompile shooter.na.jac"
-"$JAC" nacompile shooter.na.jac
+# ── 4. Build helpers ────────────────────────────────────────────────────────
 
-# ── 5. Run (the $ORIGIN runpath finds ./$stage_name beside the binary) ──────
-echo ">> launching ./shooter   -   arrows = aim, WASD = move, space = fire, Esc = quit"
-exec ./shooter
+# Compile shooter.na.jac -> ./shooter with the jac CLI.
+build_jac() {
+  local JAC
+  if command -v jac >/dev/null 2>&1; then
+    JAC="jac"
+  elif [ -x "$HERE/../../../.venv/bin/jac" ]; then
+    JAC="$HERE/../../../.venv/bin/jac"   # in-repo virtualenv fallback
+  else
+    echo "Could not find the 'jac' CLI on PATH or in ../../../.venv." >&2
+    echo "Install jaclang (pip install jaclang) or activate the repo venv." >&2
+    exit 1
+  fi
+  echo ">> compiling: $JAC nacompile shooter.na.jac"
+  "$JAC" nacompile shooter.na.jac
+}
+
+# Locate a Zig toolchain, downloading the single-archive distribution into
+# .build/ if `zig` is not already on PATH. Echoes the resolved zig path.
+ensure_zig() {
+  if command -v zig >/dev/null 2>&1; then
+    echo "zig"
+    return 0
+  fi
+  # Map this platform onto Zig's download asset (zig-<os>-<arch>-<ver>).
+  local zig_arch zig_os
+  case "$arch" in
+    x86_64|amd64)  zig_arch="x86_64" ;;
+    aarch64|arm64) zig_arch="aarch64" ;;
+    *) echo "No prebuilt Zig auto-download for architecture: $arch" >&2
+       echo "Install Zig manually (https://ziglang.org/download) and re-run." >&2
+       exit 1 ;;
+  esac
+  case "$os" in
+    Linux)  zig_os="linux" ;;
+    Darwin) zig_os="macos" ;;
+  esac
+
+  local zig_asset zig_url zig_tarball zig_root
+  zig_asset="zig-${zig_os}-${zig_arch}-${ZIG_VERSION}.tar.xz"
+  zig_url="https://ziglang.org/download/${ZIG_VERSION}/${zig_asset}"
+  zig_tarball="$BUILD_DIR/$zig_asset"
+  zig_root="$BUILD_DIR/zig-${zig_os}-${zig_arch}-${ZIG_VERSION}"
+
+  if [ ! -x "$zig_root/zig" ]; then
+    if [ ! -f "$zig_tarball" ]; then
+      echo ">> fetching Zig $ZIG_VERSION  ($zig_url)" >&2
+      curl -fL --retry 3 -o "$zig_tarball" "$zig_url" >&2
+    else
+      echo ">> using cached $zig_tarball" >&2
+    fi
+    echo ">> unpacking $(basename "$zig_tarball") -> .build/" >&2
+    tar xf "$zig_tarball" -C "$BUILD_DIR" >&2
+  fi
+  if [ ! -x "$zig_root/zig" ]; then
+    echo "Zig toolchain not found at $zig_root/zig after unpack." >&2
+    exit 1
+  fi
+  echo "$zig_root/zig"
+}
+
+# Compile shooter.zig -> ./shooter_zig against the staged sibling library.
+build_zig() {
+  local ZIG rpath_value
+  ZIG="$(ensure_zig)"
+  echo ">> zig      : $ZIG"
+
+  # Bake an $ORIGIN/@loader_path runpath so ./shooter_zig finds the staged
+  # library regardless of the directory it is launched from. shooter.zig
+  # declares raylib's symbols as `extern fn`, so no headers are needed.
+  if [ "$os" = "Darwin" ]; then
+    rpath_value="@loader_path"
+  else
+    rpath_value="\$ORIGIN"
+  fi
+
+  echo ">> compiling: zig build-exe shooter.zig -> ./shooter_zig"
+  "$ZIG" build-exe shooter.zig \
+    -O ReleaseFast \
+    -lc \
+    -L"$HERE" -lraylib \
+    -rpath "$rpath_value" \
+    -femit-bin=shooter_zig
+  rm -f "$HERE/shooter_zig.o"   # zig leaves the intermediate object behind
+}
+
+# Run one binary in benchmark mode for $BENCH_SECONDS and echo its result line
+# ("BENCH_RESULT avg max frames seconds") to stdout, or nothing on failure.
+# $1 = binary (e.g. ./shooter), $2 = label (for diagnostics).
+#
+# The binary can't print FPS to the shell on its own (raylib paints the counter
+# onto the framebuffer, and the Jac lint rules disallow print()), so it writes
+# the result to a sibling `.bench_result` file via raylib's SaveFileText; we read
+# that back here. The duration is handed over the same way, via `.bench_seconds`.
+run_bench() {
+  local bin="$1" label="$2" rc line
+  rm -f "$HERE/.bench_result"
+  printf '%s' "$BENCH_SECONDS" > "$HERE/.bench_seconds"
+  set +e
+  # Cap the run in case a binary hangs or has no display to draw to (the binary
+  # normally self-exits after $BENCH_SECONDS via raylib's clock).
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$((BENCH_SECONDS + 15))" "$bin" >/dev/null 2>&1
+  else
+    "$bin" >/dev/null 2>&1
+  fi
+  rc=$?
+  set -e
+  rm -f "$HERE/.bench_seconds"
+  if [ ! -f "$HERE/.bench_result" ]; then
+    echo "!! $label: no FPS result (exit $rc) - is a display/GPU available?" >&2
+    return 1
+  fi
+  line="$(cat "$HERE/.bench_result")"
+  rm -f "$HERE/.bench_result"
+  echo "$line"
+}
+
+# Print one row of the benchmark table. $1 = label, $2 = result line (may be empty).
+print_bench_row() {
+  local label="$1" line="$2" avg max frames
+  if [ -z "$line" ]; then
+    printf '  %-5s %14s %14s %12s\n' "$label" "n/a" "n/a" "n/a"
+    return
+  fi
+  # shellcheck disable=SC2034
+  read -r _tag avg max frames _secs <<<"$line"
+  printf '  %-5s %14.1f %14.1f %12s\n' "$label" "$avg" "$max" "$frames"
+}
+
+# ── 5. Dispatch ─────────────────────────────────────────────────────────────
+case "$MODE" in
+  jac)
+    build_jac
+    rm -f "$HERE/.bench_seconds"   # ensure interactive (no time limit)
+    echo ">> launching ./shooter   -   arrows = aim, WASD = move, space = fire, Esc = quit"
+    exec ./shooter
+    ;;
+  zig)
+    build_zig
+    rm -f "$HERE/.bench_seconds"
+    echo ">> launching ./shooter_zig   -   arrows = aim, WASD = move, space = fire, Esc = quit"
+    exec ./shooter_zig
+    ;;
+  bench)
+    build_jac
+    build_zig
+    echo ">> benchmarking each build for ${BENCH_SECONDS}s (a window opens for each) ..."
+    jac_line="$(run_bench ./shooter Jac || true)"
+    zig_line="$(run_bench ./shooter_zig Zig || true)"
+
+    printf '\n'
+    printf '====== raylib cube shooter benchmark (%ss each, uncapped) ======\n' "$BENCH_SECONDS"
+    printf '  %-5s %14s %14s %12s\n' "build" "avg FPS" "max FPS" "frames"
+    print_bench_row "Jac" "$jac_line"
+    print_bench_row "Zig" "$zig_line"
+    printf '===============================================================\n'
+    ;;
+esac

--- a/jac/examples/raylib_shooter/shooter.na.jac
+++ b/jac/examples/raylib_shooter/shooter.na.jac
@@ -42,7 +42,11 @@ import from raylib {
         x: f32, y: f32, z: f32
     ) -> None;  def rlColor4ub(r: u8, g: u8, b: u8, a: u8) -> None;  def rlEnableDepthTest -> None;  def rlDisableDepthTest -> None;  def rlSetLineWidth(
         width: f32
-    ) -> None;  def EndMode3D -> None;
+    ) -> None;  def EndMode3D -> None;  def GetTime -> f64;  def FileExists(
+        fileName: str
+    ) -> bool;  def LoadFileText(fileName: str) -> str;  def TextToInteger(
+        text: str
+    ) -> i32;  def SaveFileText(fileName: str, text: str) -> bool;
 }
 
 glob RL_MODELVIEW: int = 0x1700,
@@ -257,6 +261,46 @@ def draw_floor(half: int, step: float) {
     rlEnd();
 }
 
+
+"""Seconds elapsed since the window opened (raylib's own clock)."""
+def clock -> float {
+    return GetTime();
+}
+
+"""Benchmark duration in seconds, or 0 for normal (interactive) play.
+
+`demo.sh` writes the requested duration into a sibling `.bench_seconds` file
+before launching, then deletes it; when that file is absent (every interactive
+run, or a bare `./shooter`) this returns 0 and the game loop runs until the
+window is closed. The whole benchmark path is dormant unless the file exists.
+The value is read with raylib's own cross-platform file helpers, so no libc
+binding is needed."""
+def bench_seconds -> float {
+    if FileExists(".bench_seconds") {
+        return float(TextToInteger(LoadFileText(".bench_seconds")));
+    }
+    return 0.0;
+}
+
+"""Hand the benchmark result back to demo.sh.
+
+raylib paints its FPS counter onto the framebuffer, never stdout, and this
+repo's Jac lint rules disallow `print`, so the result is written to a sibling
+`.bench_result` file via raylib's SaveFileText. Fields are positional:
+avg_fps max_fps frames seconds."""
+def write_bench_result(
+    avg_fps: float, peak_fps: float, frame_count: int, seconds: float
+) {
+    SaveFileText(
+        ".bench_result", f"BENCH_RESULT {avg_fps} {peak_fps} {frame_count} {seconds}"
+    );
+}
+
+"""Benchmark accumulators. `bench` is the requested duration (0 = interactive),
+resolved once at startup; `frames`/`max_fps` are tallied across the run."""
+glob bench: float = bench_seconds(),
+     frames: int = 0,
+     max_fps: float = 0.0;
 
 glob KEY_W: int = 87,
      KEY_A: int = 65,
@@ -513,6 +557,14 @@ with entry {
         step = dt();
         world_t += step;
 
+        frames += 1;
+        if step > 0.0 {
+            inst = 1.0 / step;
+            if inst > max_fps {
+                max_fps = inst;
+            }
+        }
+
         handle_input(step);
         fire_cd -= step;
         if key_held(KEY_SPACE) and fire_cd <= 0.0 {
@@ -553,6 +605,19 @@ with entry {
         end_camera(960.0, 600.0);
         draw_fps(10, 10);
         end_frame();
+
+        if bench > 0.0 and clock() >= bench {
+            break;
+        }
+    }
+
+    if bench > 0.0 {
+        elapsed = clock();
+        avg_fps = 0.0;
+        if elapsed > 0.0 {
+            avg_fps = float(frames) / elapsed;
+        }
+        write_bench_result(avg_fps, max_fps, frames, elapsed);
     }
 
     close_window();

--- a/jac/examples/raylib_shooter/shooter.zig
+++ b/jac/examples/raylib_shooter/shooter.zig
@@ -1,0 +1,557 @@
+// Jac Cube Shooter - the Zig twin of shooter.na.jac.
+//
+// A faithful Zig port of the Jac-native shooter, kept deliberately close so the
+// two can be compared side by side. Like the Jac version, it binds raylib by
+// declaring its entry points directly - here as `extern fn`, the moral
+// equivalent of Jac's `import from raylib { def ... }` block - so no C headers
+// are needed; the symbols resolve out of the precompiled libraylib shared
+// library at link/load time. Rendering goes through the same scalar `rlgl`
+// immediate-mode API (rlVertex3f / rlColor4ub / rlTranslatef / ...) rather than
+// raylib's by-value Vector3/Camera3D API, so the on-screen result is identical.
+//
+// Build/run via `./demo.sh --zig` (which fetches a Zig toolchain if you don't
+// already have one).
+//
+// Controls: mouse / arrows aim (click or Tab to capture the cursor for
+// mouse-look), WASD move, Space fire, Tab release / re-capture cursor, Esc quit.
+
+const std = @import("std");
+
+// ── raylib bindings (resolved from libraylib at link time) ──────────────────
+// `extern fn` uses the C calling convention by default, so these line up with
+// raylib's C ABI without any per-declaration annotation.
+extern fn InitWindow(width: c_int, height: c_int, title: [*:0]const u8) void;
+extern fn WindowShouldClose() bool;
+extern fn CloseWindow() void;
+extern fn BeginDrawing() void;
+extern fn EndDrawing() void;
+extern fn EndMode3D() void;
+extern fn DrawFPS(pos_x: c_int, pos_y: c_int) void;
+extern fn GetFrameTime() f32;
+extern fn IsKeyDown(key: c_int) bool;
+extern fn IsKeyPressed(key: c_int) bool;
+extern fn GetMouseX() c_int;
+extern fn GetMouseY() c_int;
+extern fn IsMouseButtonPressed(button: c_int) bool;
+extern fn DisableCursor() void;
+extern fn EnableCursor() void;
+extern fn rlClearColor(r: u8, g: u8, b: u8, a: u8) void;
+extern fn rlClearScreenBuffers() void;
+extern fn rlEnableDepthTest() void;
+extern fn rlMatrixMode(mode: c_int) void;
+extern fn rlLoadIdentity() void;
+extern fn rlPushMatrix() void;
+extern fn rlPopMatrix() void;
+extern fn rlTranslatef(x: f32, y: f32, z: f32) void;
+extern fn rlRotatef(angle: f32, x: f32, y: f32, z: f32) void;
+extern fn rlFrustum(left: f64, right: f64, bottom: f64, top: f64, znear: f64, zfar: f64) void;
+extern fn rlOrtho(left: f64, right: f64, bottom: f64, top: f64, znear: f64, zfar: f64) void;
+extern fn rlBegin(mode: c_int) void;
+extern fn rlEnd() void;
+extern fn rlVertex3f(x: f32, y: f32, z: f32) void;
+extern fn rlColor4ub(r: u8, g: u8, b: u8, a: u8) void;
+extern fn rlSetLineWidth(width: f32) void;
+extern fn GetTime() f64;
+extern fn FileExists(fileName: [*:0]const u8) bool;
+extern fn LoadFileText(fileName: [*:0]const u8) [*:0]const u8;
+extern fn TextToInteger(text: [*:0]const u8) c_int;
+extern fn SaveFileText(fileName: [*:0]const u8, text: [*:0]const u8) bool;
+
+// raylib's GL matrix-mode and primitive constants (mirrors the Jac globals).
+const RL_MODELVIEW: c_int = 0x1700;
+const RL_PROJECTION: c_int = 0x1701;
+const RL_LINES: c_int = 0x0001;
+const RL_TRIANGLES: c_int = 0x0004;
+
+// Saturating-ish channel cast: shade values are clamped to 0..255 by _shade.
+inline fn u8c(v: i32) u8 {
+    return @intCast(v);
+}
+
+// ── thin wrappers, 1:1 with the Jac source ──────────────────────────────────
+
+/// Open a window. No frame-rate cap is set, so the loop runs as fast as the
+/// hardware allows (call SetTargetFPS yourself if you want to limit it).
+fn open_window(width: c_int, height: c_int, title: [*:0]const u8) void {
+    InitWindow(width, height, title);
+}
+
+/// True once the user closes the window or presses ESC.
+fn should_close() bool {
+    return WindowShouldClose();
+}
+
+/// Tear the window down.
+fn close_window() void {
+    CloseWindow();
+}
+
+/// Seconds elapsed during the previous frame (for frame-rate-independent motion).
+fn dt() f64 {
+    return GetFrameTime();
+}
+
+/// Held-this-frame test for a raylib key code.
+fn key_held(code: c_int) bool {
+    return IsKeyDown(code);
+}
+
+/// Pressed-this-frame (edge) test for a raylib key code.
+fn key_tapped(code: c_int) bool {
+    return IsKeyPressed(code);
+}
+
+/// Current mouse X in pixels (as a float - matches the Jac float(GetMouseX())).
+fn mouse_x() f64 {
+    return @floatFromInt(GetMouseX());
+}
+
+/// Current mouse Y in pixels (as a float).
+fn mouse_y() f64 {
+    return @floatFromInt(GetMouseY());
+}
+
+/// Pressed-this-frame test for a mouse button (0 = left).
+fn mouse_pressed(button: c_int) bool {
+    return IsMouseButtonPressed(button);
+}
+
+/// Hide and lock the cursor for FPS-style relative mouse-look.
+fn lock_mouse() void {
+    DisableCursor();
+}
+
+/// Show and release the cursor.
+fn unlock_mouse() void {
+    EnableCursor();
+}
+
+/// Begin a frame: clear color+depth to (r,g,b) and turn on depth testing.
+fn begin_frame(r: i32, g: i32, b: i32) void {
+    BeginDrawing();
+    rlClearColor(u8c(r), u8c(g), u8c(b), 255);
+    rlClearScreenBuffers();
+    rlEnableDepthTest();
+}
+
+/// Present the frame.
+fn end_frame() void {
+    EndDrawing();
+}
+
+/// End the 3D pass and switch to a pixel-space 2D overlay mode.
+fn end_camera(width: f64, height: f64) void {
+    EndMode3D();
+    rlMatrixMode(RL_PROJECTION);
+    rlLoadIdentity();
+    rlOrtho(0.0, width, height, 0.0, -1.0, 1.0);
+    rlMatrixMode(RL_MODELVIEW);
+    rlLoadIdentity();
+}
+
+/// Draw raylib's built-in FPS counter at (x, y) as a 2D overlay.
+fn draw_fps(x: c_int, y: c_int) void {
+    DrawFPS(x, y);
+}
+
+/// Install a perspective camera at (px,py,pz) looking with yaw/pitch (degrees).
+fn set_camera(cpx: f32, cpy: f32, cpz: f32, yaw_deg: f32, pitch_deg: f32, aspect: f32) void {
+    const near: f64 = 0.05;
+    const far_plane: f64 = 400.0;
+    const top: f64 = near * 0.57735026;
+    const right: f64 = top * @as(f64, aspect);
+    rlMatrixMode(RL_PROJECTION);
+    rlLoadIdentity();
+    rlFrustum(-right, right, -top, top, near, far_plane);
+    rlMatrixMode(RL_MODELVIEW);
+    rlLoadIdentity();
+    rlRotatef(-pitch_deg, 1.0, 0.0, 0.0);
+    rlRotatef(-yaw_deg, 0.0, 1.0, 0.0);
+    rlTranslatef(-cpx, -cpy, -cpz);
+}
+
+/// Emit one quad (corners 0->1->2->3, CCW) as two triangles.
+fn _quad(p0: f32, p1: f32, p2: f32, p3: f32, p4: f32, p5: f32, p6: f32, p7: f32, p8: f32, p9: f32, p10: f32, p11: f32) void {
+    rlVertex3f(p0, p1, p2);
+    rlVertex3f(p3, p4, p5);
+    rlVertex3f(p6, p7, p8);
+    rlVertex3f(p0, p1, p2);
+    rlVertex3f(p6, p7, p8);
+    rlVertex3f(p9, p10, p11);
+}
+
+/// Scale a 0-255 channel by a percentage (cheap face shading).
+fn _shade(c: i32, pct: i32) i32 {
+    const v = @divTrunc(c * pct, 100);
+    return if (v < 255) v else 255;
+}
+
+/// Draw an axis-aligned colored box centered at (cx,cy,cz) with size (sx,sy,sz).
+fn draw_box(cx: f32, cy: f32, cz: f32, sx: f32, sy: f32, sz: f32, r: i32, g: i32, b: i32) void {
+    const hx = sx * 0.5;
+    const hy = sy * 0.5;
+    const hz = sz * 0.5;
+    rlPushMatrix();
+    rlTranslatef(cx, cy, cz);
+    rlBegin(RL_TRIANGLES);
+
+    rlColor4ub(u8c(_shade(r, 100)), u8c(_shade(g, 100)), u8c(_shade(b, 100)), 255);
+    _quad(-hx, hy, hz, hx, hy, hz, hx, hy, -hz, -hx, hy, -hz);
+    rlColor4ub(u8c(_shade(r, 85)), u8c(_shade(g, 85)), u8c(_shade(b, 85)), 255);
+    _quad(-hx, -hy, hz, hx, -hy, hz, hx, hy, hz, -hx, hy, hz);
+    _quad(hx, -hy, -hz, -hx, -hy, -hz, -hx, hy, -hz, hx, hy, -hz);
+    rlColor4ub(u8c(_shade(r, 70)), u8c(_shade(g, 70)), u8c(_shade(b, 70)), 255);
+    _quad(hx, -hy, hz, hx, -hy, -hz, hx, hy, -hz, hx, hy, hz);
+    _quad(-hx, -hy, -hz, -hx, -hy, hz, -hx, hy, hz, -hx, hy, -hz);
+    rlColor4ub(u8c(_shade(r, 45)), u8c(_shade(g, 45)), u8c(_shade(b, 45)), 255);
+    _quad(-hx, -hy, -hz, hx, -hy, -hz, hx, -hy, hz, -hx, -hy, hz);
+
+    rlEnd();
+    rlPopMatrix();
+}
+
+/// Draw a flat floor grid of half*2 lines per axis, spaced step apart, on y=0.
+fn draw_floor(half: i32, step: f32) void {
+    const ext = @as(f32, @floatFromInt(half)) * step;
+    rlSetLineWidth(1.0);
+    rlBegin(RL_LINES);
+    rlColor4ub(55, 60, 75, 255);
+    var i: i32 = -half;
+    while (i <= half) : (i += 1) {
+        const f = @as(f32, @floatFromInt(i)) * step;
+        rlVertex3f(f, 0.0, -ext);
+        rlVertex3f(f, 0.0, ext);
+        rlVertex3f(-ext, 0.0, f);
+        rlVertex3f(ext, 0.0, f);
+    }
+    rlEnd();
+}
+
+/// Benchmark duration in seconds, or 0 for normal (interactive) play.
+///
+/// `demo.sh` writes the requested duration into a sibling `.bench_seconds` file
+/// before launching, then deletes it; when that file is absent (every
+/// interactive run, or a bare `./shooter_zig`) this returns 0 and the game loop
+/// runs until the window is closed. The whole benchmark path is dormant unless
+/// the file exists. Read with raylib's own cross-platform file helpers, exactly
+/// as the Jac twin does.
+fn bench_seconds() f64 {
+    if (FileExists(".bench_seconds")) {
+        return @floatFromInt(TextToInteger(LoadFileText(".bench_seconds")));
+    }
+    return 0.0;
+}
+
+/// Hand the benchmark result back to demo.sh. Written to a sibling
+/// `.bench_result` file via raylib's SaveFileText (not stdout), exactly as the
+/// Jac twin does, so demo.sh reads both builds the same way. Fields are
+/// positional: avg_fps max_fps frames seconds.
+fn write_bench_result(avg_fps: f64, max_fps: f64, frames: i64, seconds: f64) void {
+    var buf: [192]u8 = undefined;
+    const s = std.fmt.bufPrintZ(&buf, "BENCH_RESULT {d:.6} {d:.6} {d} {d:.6}", .{ avg_fps, max_fps, frames, seconds }) catch return;
+    _ = SaveFileText(".bench_result", s.ptr);
+}
+
+// ── key codes & game state (mirrors the Jac globals) ─────────────────────────
+
+const KEY_W: c_int = 87;
+const KEY_A: c_int = 65;
+const KEY_S: c_int = 83;
+const KEY_D: c_int = 68;
+const KEY_SPACE: c_int = 32;
+const KEY_RIGHT: c_int = 262;
+const KEY_LEFT: c_int = 263;
+const KEY_DOWN: c_int = 264;
+const KEY_UP: c_int = 265;
+const KEY_TAB: c_int = 258;
+const MOUSE_LEFT: c_int = 0;
+const DEG2RAD: f64 = 0.017453292519943295;
+
+var px: f64 = 0.0;
+var py: f64 = 2.0;
+var pz: f64 = 12.0;
+var yaw: f64 = 0.0;
+var pitch: f64 = 0.0;
+var fire_cd: f64 = 0.0;
+var world_t: f64 = 0.0;
+var score: i32 = 0;
+var rng: i64 = 987654321;
+var prev_mx: f64 = 0.0;
+var prev_my: f64 = 0.0;
+var mouse_warmup: i32 = 12;
+var mouse_sens: f64 = 0.12;
+var mouse_captured: bool = false;
+
+const Target = struct {
+    x: f64,
+    y: f64,
+    z: f64,
+    base_y: f64,
+    phase: f64,
+    alive: bool,
+};
+
+const Bullet = struct {
+    x: f64,
+    y: f64,
+    z: f64,
+    vx: f64,
+    vy: f64,
+    vz: f64,
+    life: f64,
+};
+
+/// cos via range-reduced Taylor series (good to ~1e-4 on the reduced range).
+fn jcos(a_in: f64) f64 {
+    const twopi = 6.283185307179586;
+    const pi = 3.141592653589793;
+    var a = a_in;
+    while (a > pi) {
+        a -= twopi;
+    }
+    while (a < -pi) {
+        a += twopi;
+    }
+    const x2 = a * a;
+    const x4 = x2 * x2;
+    const x6 = x4 * x2;
+    const x8 = x4 * x4;
+    const x10 = x8 * x2;
+    const x12 = x8 * x4;
+    return 1.0 - x2 / 2.0 + x4 / 24.0 - x6 / 720.0 + x8 / 40320.0 - x10 / 3628800.0 + x12 / 479001600.0;
+}
+
+/// sin(a) = cos(a - pi/2).
+fn jsin(a: f64) f64 {
+    return jcos(a - 1.5707963267948796);
+}
+
+/// Uniform pseudo-random float in [0, 1) via a 31-bit LCG.
+fn rand01() f64 {
+    rng = @rem(rng * 1103515245 + 12345, 2147483648);
+    return @as(f64, @floatFromInt(rng)) / 2147483648.0;
+}
+
+/// Random float in [lo, hi).
+fn rand_range(lo: f64, hi: f64) f64 {
+    return lo + rand01() * (hi - lo);
+}
+
+/// (Re)place a target somewhere in the arena in front of the player.
+fn respawn(t: *Target) void {
+    t.x = rand_range(-14.0, 14.0);
+    t.base_y = rand_range(1.0, 5.0);
+    t.z = rand_range(-16.0, 2.0);
+    t.phase = rand_range(0.0, 6.28);
+    t.y = t.base_y;
+    t.alive = true;
+}
+
+/// Fire a bullet from the eye along the current aim, reusing a dead pool slot.
+fn fire(bullets: []Bullet) void {
+    const yaw_r = yaw * DEG2RAD;
+    const pitch_r = pitch * DEG2RAD;
+    const cp = jcos(pitch_r);
+    const dx = -jsin(yaw_r) * cp;
+    const dy = jsin(pitch_r);
+    const dz = -jcos(yaw_r) * cp;
+    const speed = 40.0;
+    for (bullets) |*b| {
+        if (b.life <= 0.0) {
+            b.x = px;
+            b.y = py;
+            b.z = pz;
+            b.vx = dx * speed;
+            b.vy = dy * speed;
+            b.vz = dz * speed;
+            b.life = 2.0;
+            return;
+        }
+    }
+}
+
+/// Advance bullets, resolve hits against targets, and tally score.
+fn update_bullets(bullets: []Bullet, targets: []Target, step: f64) void {
+    for (bullets) |*b| {
+        if (b.life > 0.0) {
+            b.x += b.vx * step;
+            b.y += b.vy * step;
+            b.z += b.vz * step;
+            b.life -= step;
+            for (targets) |*t| {
+                if (t.alive) {
+                    const ddx = b.x - t.x;
+                    const ddy = b.y - t.y;
+                    const ddz = b.z - t.z;
+                    if (ddx * ddx + ddy * ddy + ddz * ddz < 1.4) {
+                        t.alive = false;
+                        b.life = 0.0;
+                        score += 1;
+                        respawn(t);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Read keyboard + mouse and update camera orientation + position this frame.
+fn handle_input(step: f64) void {
+    const turn = 90.0 * step;
+
+    if (key_tapped(KEY_TAB)) {
+        if (mouse_captured) {
+            unlock_mouse();
+            mouse_captured = false;
+        } else {
+            lock_mouse();
+            mouse_captured = true;
+            mouse_warmup = 8;
+        }
+    }
+    if (!mouse_captured and mouse_pressed(MOUSE_LEFT)) {
+        lock_mouse();
+        mouse_captured = true;
+        mouse_warmup = 8;
+    }
+
+    if (key_held(KEY_LEFT)) {
+        yaw += turn;
+    }
+    if (key_held(KEY_RIGHT)) {
+        yaw -= turn;
+    }
+    if (key_held(KEY_UP)) {
+        pitch += turn;
+    }
+    if (key_held(KEY_DOWN)) {
+        pitch -= turn;
+    }
+
+    if (mouse_captured) {
+        const mx = mouse_x();
+        const my = mouse_y();
+        if (mouse_warmup > 0) {
+            mouse_warmup -= 1;
+        } else {
+            const ddx = mx - prev_mx;
+            const ddy = my - prev_my;
+            if (ddx < 150.0 and ddx > -150.0 and ddy < 150.0 and ddy > -150.0) {
+                yaw -= ddx * mouse_sens;
+                pitch -= ddy * mouse_sens;
+            }
+        }
+        prev_mx = mx;
+        prev_my = my;
+    }
+
+    if (pitch > 85.0) {
+        pitch = 85.0;
+    }
+    if (pitch < -85.0) {
+        pitch = -85.0;
+    }
+
+    const yaw_r = yaw * DEG2RAD;
+    const fwd_x = -jsin(yaw_r);
+    const fwd_z = -jcos(yaw_r);
+    const rgt_x = jcos(yaw_r);
+    const rgt_z = -jsin(yaw_r);
+    const move = 8.0 * step;
+    if (key_held(KEY_W)) {
+        px += fwd_x * move;
+        pz += fwd_z * move;
+    }
+    if (key_held(KEY_S)) {
+        px -= fwd_x * move;
+        pz -= fwd_z * move;
+    }
+    if (key_held(KEY_D)) {
+        px += rgt_x * move;
+        pz += rgt_z * move;
+    }
+    if (key_held(KEY_A)) {
+        px -= rgt_x * move;
+        pz -= rgt_z * move;
+    }
+}
+
+const NUM_TARGETS = 7;
+const NUM_BULLETS = 24;
+
+pub fn main() void {
+    var targets: [NUM_TARGETS]Target = undefined;
+    var bullets: [NUM_BULLETS]Bullet = undefined;
+
+    open_window(960, 600, "Jac Cube Shooter (Zig)");
+
+    for (&targets) |*t| {
+        t.* = Target{ .x = 0.0, .y = 0.0, .z = 0.0, .base_y = 0.0, .phase = 0.0, .alive = false };
+        respawn(t);
+    }
+
+    for (&bullets) |*b| {
+        b.* = Bullet{ .x = 0.0, .y = 0.0, .z = 0.0, .vx = 0.0, .vy = 0.0, .vz = 0.0, .life = 0.0 };
+    }
+
+    const bench = bench_seconds();
+    var frames: i64 = 0;
+    var max_fps: f64 = 0.0;
+
+    while (!should_close()) {
+        const step = dt();
+        world_t += step;
+
+        frames += 1;
+        if (step > 0.0) {
+            const inst = 1.0 / step;
+            if (inst > max_fps) {
+                max_fps = inst;
+            }
+        }
+
+        handle_input(step);
+        fire_cd -= step;
+        if (key_held(KEY_SPACE) and fire_cd <= 0.0) {
+            fire(&bullets);
+            fire_cd = 0.14;
+        }
+        update_bullets(&bullets, &targets, step);
+
+        for (&targets) |*t| {
+            t.y = t.base_y + 0.4 * jsin(world_t * 1.5 + t.phase);
+        }
+
+        begin_frame(15, 18, 28);
+        set_camera(@floatCast(px), @floatCast(py), @floatCast(pz), @floatCast(yaw), @floatCast(pitch), 1.6);
+        draw_floor(20, 1.5);
+
+        for (&targets) |*t| {
+            if (t.alive) {
+                draw_box(@floatCast(t.x), @floatCast(t.y), @floatCast(t.z), 1.4, 1.4, 1.4, 235, 80, 60);
+            }
+        }
+
+        for (&bullets) |*b| {
+            if (b.life > 0.0) {
+                draw_box(@floatCast(b.x), @floatCast(b.y), @floatCast(b.z), 0.22, 0.22, 0.22, 250, 220, 90);
+            }
+        }
+
+        end_camera(960.0, 600.0);
+        draw_fps(10, 10);
+        end_frame();
+
+        if (bench > 0.0 and GetTime() >= bench) {
+            break;
+        }
+    }
+
+    if (bench > 0.0) {
+        const elapsed = GetTime();
+        const avg_fps = if (elapsed > 0.0) @as(f64, @floatFromInt(frames)) / elapsed else 0.0;
+        write_bench_result(avg_fps, max_fps, frames, elapsed);
+    }
+
+    close_window();
+}


### PR DESCRIPTION
## What

Extends the `raylib_shooter` example so the precompiled-raylib demo can be run two ways and compared head to head.

- **`shooter.zig`** — a faithful Zig port of `shooter.na.jac`. Like the Jac version it binds raylib by declaring its entry points directly (here as `extern fn`, the analog of Jac's `import from raylib { def ... }` block), so it needs no C headers; it renders through the same scalar `rlgl` API and is pixel-identical on screen. It's the conventional-toolchain baseline next to the no-cc/ld Jac build.
- **`demo.sh`** now has three modes:
  - **default** — benchmark *both* builds for 8s each and print avg/max FPS;
  - **`--jac`** — build & run only the Jac shooter, interactively;
  - **`--zig`** — build & run only the Zig shooter, interactively.

## Notes

- The `--zig` path **auto-downloads a single-archive Zig toolchain** into `.build/` when `zig` isn't on `PATH` (nothing installed system-wide), and stages the release's full versioned symlink set so the SONAME a conventional linker records (e.g. `libraylib.so.600`) resolves beside the binary via the runpath. The Jac backend sidesteps this by recording the plain logical name.
- **Benchmark instrumentation is dormant for normal play.** `demo.sh` writes the duration to a sibling `.bench_seconds` file before launching; each binary reads it with raylib's own cross-platform helpers (`FileExists`/`LoadFileText`/`TextToInteger`), times itself with `GetTime`, and writes a `BENCH_RESULT` line to `.bench_result` via raylib's `SaveFileText`, which `demo.sh` reads back. Both twins use raylib's own I/O (no `print`, no libc) so they stay parallel. When `.bench_seconds` is absent — every `--jac`/`--zig` run, or a bare `./shooter` — that path is skipped and behavior is unchanged.

## Testing

Built and ran end to end on Linux x86_64 (WSLg + Mesa `llvmpipe`). Both builds link the same precompiled raylib and do identical per-frame work, so they track each other closely:

```
====== raylib cube shooter benchmark (8s each, uncapped) ======
  build        avg FPS        max FPS       frames
  Jac            552.3          778.2         4419
  Zig            525.0          763.6         4201
===============================================================
```

Also verified: `--jac` and `--zig` interactive launches behave exactly as the original demo; `jac nacompile shooter.na.jac` compiles clean and the result file is actually written; `jaclang format --lintfix` is at a stable fixpoint on the Jac source.