### PR TITLE
WIP: native deslop - consume centralized analysis (#6386)

### DIFF
--- a/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
@@ -410,6 +410,48 @@ impl LayoutRegistry.is_subclass(child: str, parent: str) -> bool {
     return parent in mro;
 }
 
+"""All fields (inherited + own, in layout order) of a class, or []."""
+impl LayoutRegistry.get_fields(class_name: str) -> list[FieldInfo] {
+    layout = self.layouts.get(class_name);
+    if layout is None {
+        return [];
+    }
+    return layout.fields;
+}
+
+"""All vtable method slots of a class, or []."""
+impl LayoutRegistry.get_methods(class_name: str) -> list[MethodSlot] {
+    layout = self.layouts.get(class_name);
+    if layout is None {
+        return [];
+    }
+    return layout.methods;
+}
+
+"""The FieldInfo for one field, or None if the class/field is unknown."""
+impl LayoutRegistry.get_field_info(
+    class_name: str, field_name: str
+) -> (FieldInfo | None) {
+    layout = self.layouts.get(class_name);
+    if layout is None {
+        return None;
+    }
+    idx = layout.field_index.get(field_name);
+    if idx is None {
+        return None;
+    }
+    return layout.fields[idx];
+}
+
+"""Per-ancestor starting field index for a class, or {}."""
+impl LayoutRegistry.get_parent_field_start(class_name: str) -> dict[str, int] {
+    layout = self.layouts.get(class_name);
+    if layout is None {
+        return {};
+    }
+    return layout.parent_field_start;
+}
+
 """Check if ancestor is reachable via primary parent chain from child."""
 impl LayoutRegistry.is_primary_ancestor(child: str, ancestor: str) -> bool {
     current = child;

--- a/jac/jaclang/compiler/passes/main/layout_pass.jac
+++ b/jac/jaclang/compiler/passes/main/layout_pass.jac
@@ -101,6 +101,12 @@ obj LayoutRegistry {
     def get_method_slot(class_name: str, method_name: str) -> (int | None);
     def is_subclass(child: str, parent: str) -> bool;
     def is_primary_ancestor(child: str, ancestor: str) -> bool;
+    # Read accessors over already-computed layout data so backends consume the
+    # registry instead of rebuilding parallel field/vtable tables (#6386).
+    def get_fields(class_name: str) -> list[FieldInfo];
+    def get_methods(class_name: str) -> list[MethodSlot];
+    def get_field_info(class_name: str, field_name: str) -> (FieldInfo | None);
+    def get_parent_field_start(class_name: str) -> dict[str, int];
 }
 
 """Layout analysis pass.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -135,6 +135,14 @@ impl NaIRGenPass._codegen_expr(nd: (uni.UniNode | None)) -> (ir.Value | None) {
     # allocations without needing a loc parameter threaded through.
     if _result is not None {
         _result.jac_loc = _jac_loc;
+        # Stamp the central semantic type (TypeBase from TypeCheckPass) onto
+        # the produced value, mirroring the is_owned marker. This makes the
+        # value self-describing so downstream type dispatch can read
+        # `_type_of(val)` instead of re-deriving the type from the lowered
+        # LLVM shape or scanning name-keyed shadow tables (#6386).
+        if isinstance(nd, uni.Expr) and nd?.type is not None {
+            _result.jac_type = nd.type;
+        }
     }
     return _result;
 }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -1391,19 +1391,8 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
     return None;
 }
 
-"""Infer dict type info from an LLVM value. Returns (key_type_name, val_type_name) or None."""
+"""Infer dict (key_spec, val_spec) from a value's central type (#6386)."""
 impl NaIRGenPass._infer_dict_type(val: ir.Value) -> (tuple | None) {
-    if not isinstance(val.type, ir.PointerType) {
-        return None;
-    }
-    for (dict_key, dtype) in self.dict_types.items() {
-        if val.type == dtype.as_pointer() {
-            parts = dict_key.split(":");
-            if len(parts) == 2 {
-                return (parts[0], parts[1]);
-            }
-        }
-    }
-    return None;
+    return self._dict_specs_of_type(self._type_of(val));
 }
 # ─── Phase 1: Boolean Expressions (short-circuit) ────────────

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -184,16 +184,12 @@ impl NaIRGenPass._register_archetypes(module: uni.Module) -> None {
             }
         }
     }
-    # Pass 3.5: Build vtable layouts (topological order via MRO)
-    for topo_name in topo_order {
-        if topo_name in self.has_vtable {
-            self._build_vtable(topo_name);
-        }
-    }
     # Pass 3.6: Compute non-overridden methods for devirtualization
     # A method M on class C is "non-overridden" if NO child class has its own C.M.
     # For these methods, we can emit direct calls instead of vtable dispatch.
-    for (base_name, layout) in self.vtable_layouts.items() {
+    # Vtable slot names come from LayoutRegistry via _vtable_method_names (#6386).
+    for base_name in self.has_vtable {
+        layout = self._vtable_method_names(base_name);
         non_overridden: set[str] = set();
         for method_name in layout {
             # Find the class that defines this method (walk MRO)
@@ -351,13 +347,11 @@ impl NaIRGenPass._codegen_archetype(nd: uni.Archetype) -> None {
     import from jaclang.compiler.passes.main.layout_pass { get_layout_registry }
     layout_reg = get_layout_registry(self.ir_in, self.prog);
     _fields = layout_reg.get_fields(arch_name);
-    _pfs = layout_reg.get_parent_field_start(arch_name);
     if not _fields {
         _owner = nd.find_parent_of_type(uni.Module);
         if _owner is not None and _owner is not self.ir_in {
             _owner_reg = get_layout_registry(_owner, self.prog);
             _fields = _owner_reg.get_fields(arch_name);
-            _pfs = _owner_reg.get_parent_field_start(arch_name);
         }
     }
     for fi in _fields {
@@ -387,16 +381,6 @@ impl NaIRGenPass._codegen_archetype(nd: uni.Archetype) -> None {
                 self.struct_field_enum_type[arch_name][fi.name] = ftag_name;
             }
         }
-    }
-    # Per-ancestor field-region start: registry is vtable-agnostic, so shift by
-    # the implicit vtable slot to match native indices.
-    _pfs = layout_reg.get_parent_field_start(arch_name);
-    if _pfs {
-        _adj: dict[(str, int)] = {};
-        for (_anc, _i) in _pfs.items() {
-            _adj[_anc] = _i + vtable_off;
-        }
-        self.parent_field_start[arch_name] = _adj;
     }
     # Define the struct body (always call set_body, even with empty field_types,
     # to make the struct type non-opaque so GEP operations work)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -330,7 +330,9 @@ impl NaIRGenPass._codegen_archetype(nd: uni.Archetype) -> None {
         return;
     }
     needs_vtable = arch_name in self.has_vtable;
-    # Collect fields
+    # Implicit vtable pointer occupies native slot 0; LayoutRegistry indexes
+    # fields 0-based *excluding* that slot, so native_index = fi.index + off.
+    vtable_off = 1 if needs_vtable else 0;
     field_types: list[ir.Type] = [];
     field_index_map: dict[(str, int)] = {};
     field_type_map: dict[(str, ir.Type)] = {};
@@ -339,90 +341,62 @@ impl NaIRGenPass._codegen_archetype(nd: uni.Archetype) -> None {
     if needs_vtable {
         field_types.append(ir.IntType(8).as_pointer().as_pointer());
     }
-    # Flatten fields from all ancestors in MRO order (diamond dedup by name)
-    mro = self.mro_order.get(arch_name, [arch_name]);
-    seen_fields: set[str] = set();
-    for ancestor_name in mro[1:] {
-        if ancestor_name not in self.struct_field_indices {
-            continue;
+    # Consume the centralized field layout (already flattened in MRO order and
+    # diamond-deduped by LayoutPass) instead of re-walking the hierarchy and
+    # re-implementing diamond dedup / index assignment here (#6386, Category C).
+    # _codegen_archetype runs for local archetypes (this module's registry) AND
+    # for imported ones via the cross-module import path (core.impl). An imported
+    # archetype's layout lives in its *defining* module's registry, so resolve
+    # against that module rather than re-deriving the layout here.
+    import from jaclang.compiler.passes.main.layout_pass { get_layout_registry }
+    layout_reg = get_layout_registry(self.ir_in, self.prog);
+    _fields = layout_reg.get_fields(arch_name);
+    _pfs = layout_reg.get_parent_field_start(arch_name);
+    if not _fields {
+        _owner = nd.find_parent_of_type(uni.Module);
+        if _owner is not None and _owner is not self.ir_in {
+            _owner_reg = get_layout_registry(_owner, self.prog);
+            _fields = _owner_reg.get_fields(arch_name);
+            _pfs = _owner_reg.get_parent_field_start(arch_name);
         }
-        ancestor_indices = self.struct_field_indices[ancestor_name];
-        ancestor_types = self.struct_field_types.get(ancestor_name, {});
-        ancestor_defaults = self.struct_field_defaults.get(ancestor_name, {});
-        # Record start index for this ancestor's region
-        if arch_name not in self.parent_field_start {
-            self.parent_field_start[arch_name] = {};
+    }
+    for fi in _fields {
+        ftype = (
+            self._resolve_jac_type(fi.type_node)
+                if fi.type_node is not None
+                else ir.IntType(64)
+        );
+        # fields come in index order, so a plain append lands each at its slot.
+        field_types.append(ftype);
+        field_index_map[fi.name] = fi.index + vtable_off;
+        field_type_map[fi.name] = ftype;
+        if fi.default_expr is not None {
+            field_default_map[fi.name] = fi.default_expr;
         }
-        self.parent_field_start[arch_name][ancestor_name] = len(field_types);
-        # Build reverse map: index → field name, then iterate in order
-        idx_to_name: dict[(int, str)] = {};
-        for (fname, pidx) in ancestor_indices.items() {
-            idx_to_name[pidx] = fname;
-        }
-        sorted_idxs = sorted(idx_to_name.keys());
-        for pidx in sorted_idxs {
-            fname = idx_to_name[pidx];
-            if fname in seen_fields {
-                continue;  # Diamond dedup: skip fields already present
+        if fi.type_node is not None {
+            if arch_name not in self.field_type_node {
+                self.field_type_node[arch_name] = {};
             }
-            seen_fields.add(fname);
-            ftype = ancestor_types.get(fname, ir.IntType(64));
-            new_idx = len(field_types);
-            field_types.append(ftype);
-            field_index_map[fname] = new_idx;
-            field_type_map[fname] = ftype;
-            if fname in ancestor_defaults {
-                field_default_map[fname] = ancestor_defaults[fname];
-            }
-            # Propagate Jac-level type AST from ancestor
-            if ancestor_name in self.field_type_node
-            and fname in self.field_type_node[ancestor_name] {
-                if arch_name not in self.field_type_node {
-                    self.field_type_node[arch_name] = {};
+            self.field_type_node[arch_name][fi.name] = fi.type_node;
+            # Track enum-typed fields (stored as their i64 ordinal).
+            ftag_name = self._get_name(fi.type_node);
+            if ftag_name is not None and ftag_name in self.enum_types {
+                if arch_name not in self.struct_field_enum_type {
+                    self.struct_field_enum_type[arch_name] = {};
                 }
-                self.field_type_node[arch_name][fname] = self.field_type_node[
-                    ancestor_name
-                ][fname];
+                self.struct_field_enum_type[arch_name][fi.name] = ftag_name;
             }
         }
     }
-    # Add own fields from ArchHas nodes
-    if (nd).body is not None {
-        for stmt in (nd).body {
-            if isinstance(stmt, uni.ArchHas) {
-                for var in stmt.vars {
-                    fname = var.name.value if var.name else "field";
-                    if fname in seen_fields {
-                        continue;  # Skip fields already inherited
-                    }
-                    seen_fields.add(fname);
-                    ftype = ir.IntType(64);
-                    if var.type_tag and var.type_tag.tag {
-                        ftype = self._resolve_jac_type(var.type_tag.tag);
-                        # Track Jac-level type AST for nested type resolution
-                        if arch_name not in self.field_type_node {
-                            self.field_type_node[arch_name] = {};
-                        }
-                        self.field_type_node[arch_name][fname] = var.type_tag.tag;
-                        # Track enum-typed fields
-                        ftag_name = self._get_name(var.type_tag.tag);
-                        if ftag_name is not None and ftag_name in self.enum_types {
-                            if arch_name not in self.struct_field_enum_type {
-                                self.struct_field_enum_type[arch_name] = {};
-                            }
-                            self.struct_field_enum_type[arch_name][fname] = ftag_name;
-                        }
-                    }
-                    new_idx = len(field_types);
-                    field_types.append(ftype);
-                    field_index_map[fname] = new_idx;
-                    field_type_map[fname] = ftype;
-                    if var.value is not None {
-                        field_default_map[fname] = var.value;
-                    }
-                }
-            }
+    # Per-ancestor field-region start: registry is vtable-agnostic, so shift by
+    # the implicit vtable slot to match native indices.
+    _pfs = layout_reg.get_parent_field_start(arch_name);
+    if _pfs {
+        _adj: dict[(str, int)] = {};
+        for (_anc, _i) in _pfs.items() {
+            _adj[_anc] = _i + vtable_off;
         }
+        self.parent_field_start[arch_name] = _adj;
     }
     # Define the struct body (always call set_body, even with empty field_types,
     # to make the struct type non-opaque so GEP operations work)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -216,6 +216,41 @@ impl NaIRGenPass._lower_function_type(t: any) -> ir.Type {
     return ir.FunctionType(ret_type, param_types).as_pointer();
 }
 
+"""Read the central semantic type stamped onto a produced ir.Value.
+
+_codegen_expr stamps `val.jac_type = nd.type` (the central TypeBase) on every
+value it produces, mirroring the is_owned marker. This reads it back so type
+dispatch can consume the central analysis instead of re-deriving the type from
+the lowered LLVM shape or scanning name-keyed shadow tables (#6386). Returns
+None for values produced outside _codegen_expr (e.g. raw helper temporaries).
+"""
+impl NaIRGenPass._type_of(val: (ir.Value | None)) -> (any | None) {
+    if val is None {
+        return None;
+    }
+    return val?.jac_type;
+}
+
+"""Lower a type-bearing AST node's central type to an LLVM type, or fail loudly.
+
+This is the canonical "consume the central type checker" accessor for places
+that previously coerced a missing/unresolved type to i64 (Category B in #6386).
+A genuinely-absent type is a compile error (E5091), not a silent guess.
+"""
+impl NaIRGenPass._require_type(type_src: (uni.UniNode | None), what: str) -> ir.Type {
+    if isinstance(type_src, uni.Expr) and type_src?.type is not None {
+        lowered = self._lower_type(type_src.type);
+        if lowered is not None {
+            return lowered;
+        }
+    }
+    # No central type to consume: emit a hard diagnostic instead of i64. The
+    # returned type only lets codegen unwind without a secondary crash -- the
+    # emitted error has already marked the module as failed.
+    self.emit(E5091, node_override=type_src, what=what);
+    return ir.IntType(64);
+}
+
 """Resolve a Jac type expression to an LLVM type.
 
 An annotation Expr carries a `.type` (TypeBase) populated by TypeCheckPass;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -98,12 +98,7 @@ impl NaIRGenPass._lower_class_type(t: any) -> (ir.Type | None) {
             }
             elem_llvm = _e;
         }
-        spec = "i64";
-        if isinstance(elem_llvm, ir.DoubleType) {
-            spec = "f64";
-        } elif isinstance(elem_llvm, ir.PointerType) {
-            spec = "ptr";
-        }
+        spec = self._list_spec_of_llvm(elem_llvm);
         self._emit_list_helpers(spec, elem_llvm);
         return self.list_types[spec].as_pointer();
     }
@@ -120,27 +115,7 @@ impl NaIRGenPass._lower_class_type(t: any) -> (ir.Type | None) {
             k_llvm = _k;
             v_llvm = _v;
         }
-        # Key spec: i64 / f64 / ptr / tuple{size}.
-        k_spec = "i64";
-        k_size = 0;
-        if isinstance(k_llvm, ir.DoubleType) {
-            k_spec = "f64";
-        } elif isinstance(k_llvm, ir.PointerType) {
-            k_spec = "ptr";
-            if isinstance(k_llvm.pointee, ir.LiteralStructType) {
-                k_size = self._get_struct_size(k_llvm.pointee);
-                k_spec = f"tuple{k_size}";
-            }
-        }
-        # Value spec: i64 / f64 / ptr / jacval.
-        v_spec = "i64";
-        if isinstance(v_llvm, ir.DoubleType) {
-            v_spec = "f64";
-        } elif isinstance(v_llvm, ir.PointerType) {
-            v_spec = "ptr";
-        } elif self?.jacval_type and v_llvm == self.jacval_type {
-            v_spec = "jacval";
-        }
+        (k_spec, v_spec, k_size) = self._dict_specs_of_llvm(k_llvm, v_llvm);
         self._emit_dict_helpers(k_spec, v_spec, k_llvm, v_llvm, k_size);
         return self.dict_types[f"{k_spec}:{v_spec}"].as_pointer();
     }
@@ -1658,30 +1633,189 @@ impl NaIRGenPass._emit_comparison(
 }
 
 # ─── Phase 1: Enums ──────────────────────────────────────────
-"""Infer the struct type name from an LLVM value's type."""
-impl NaIRGenPass._infer_type_name(val: ir.Value) -> (str | None) {
-    if not isinstance(val.type, ir.PointerType) {
+"""Struct/archetype name carried by a central type, peeling `T | None`, or None.
+
+Consumes the central TypeBase (ClassType, or a UnionType whose non-None member
+is a class) and returns the archetype name iff it is a known native struct.
+This replaces the LLVM-shape reverse-scan of struct_types (#6386).
+"""
+impl NaIRGenPass._struct_name_of_type(t: any) -> (str | None) {
+    if t is None {
         return None;
     }
-    for (sname, stype) in self.struct_types.items() {
-        if val.type == stype.as_pointer() {
-            return sname;
+    try {
+        import from jaclang.compiler.type_system.types {
+            ClassType as _CT,
+            UnionType as _UT
         }
+    } except ImportError {
+        return None;
+    }
+    if isinstance(t, _UT) {
+        for m in (t.types or []) {
+            if isinstance(m, _CT) and m.shared.class_name in ("NoneType", "None") {
+                continue;
+            }
+            _r = self._struct_name_of_type(m);
+            if _r is not None {
+                return _r;
+            }
+        }
+        return None;
+    }
+    if isinstance(t, _CT) and t.shared.class_name in self.struct_types {
+        return t.shared.class_name;
     }
     return None;
 }
 
-"""Infer the list element type name from an LLVM value's type."""
-impl NaIRGenPass._infer_list_elem_type(val: ir.Value) -> (str | None) {
-    if not isinstance(val.type, ir.PointerType) {
-        return None;
+"""Infer the struct type name of a value from its central type (#6386).
+
+Consumes the `jac_type` stamp (the central `Expr.type`) instead of reverse-
+scanning struct_types for an LLVM pointer-shape match. The old scan was a lossy
+proxy -- it could not see through `T | None`, conflated distinct structs with
+the same lowered shape, and only worked for stamped pointer values.
+"""
+impl NaIRGenPass._infer_type_name(val: ir.Value) -> (str | None) {
+    return self._struct_name_of_type(self._type_of(val));
+}
+
+"""Map a list element's LLVM type to its list_types spec key (i64/f64/ptr).
+
+Single source for the spec selection consumed by both _lower_class_type (at
+list-helper emit time) and _list_elem_spec_of_type (at inference time) (#6386).
+"""
+impl NaIRGenPass._list_spec_of_llvm(elem_llvm: ir.Type) -> str {
+    if isinstance(elem_llvm, ir.DoubleType) {
+        return "f64";
     }
-    for (ename, ltype) in self.list_types.items() {
-        if val.type == ltype.as_pointer() {
-            return ename;
+    if isinstance(elem_llvm, ir.PointerType) {
+        return "ptr";
+    }
+    return "i64";
+}
+
+"""Map dict key/value LLVM types to (key_spec, val_spec, key_size).
+
+Single source for the dict spec selection consumed by both _lower_class_type
+and _dict_specs_of_type (#6386). key_spec is i64/f64/ptr/tuple{N}; val_spec is
+i64/f64/ptr/jacval.
+"""
+impl NaIRGenPass._dict_specs_of_llvm(k_llvm: ir.Type, v_llvm: ir.Type) -> tuple {
+    k_spec = "i64";
+    k_size = 0;
+    if isinstance(k_llvm, ir.DoubleType) {
+        k_spec = "f64";
+    } elif isinstance(k_llvm, ir.PointerType) {
+        k_spec = "ptr";
+        if isinstance(k_llvm.pointee, ir.LiteralStructType) {
+            k_size = self._get_struct_size(k_llvm.pointee);
+            k_spec = f"tuple{k_size}";
         }
     }
-    return None;
+    v_spec = "i64";
+    if isinstance(v_llvm, ir.DoubleType) {
+        v_spec = "f64";
+    } elif isinstance(v_llvm, ir.PointerType) {
+        v_spec = "ptr";
+    } elif self?.jacval_type and v_llvm == self.jacval_type {
+        v_spec = "jacval";
+    }
+    return (k_spec, v_spec, k_size);
+}
+
+"""Non-None member of a `T | None` union, or the type itself; None-safe (#6386)."""
+impl NaIRGenPass._peel_optional(t: any) -> any {
+    if t is None {
+        return None;
+    }
+    try {
+        import from jaclang.compiler.type_system.types {
+            ClassType as _CT,
+            UnionType as _UT
+        }
+    } except ImportError {
+        return t;
+    }
+    if isinstance(t, _UT) {
+        for m in (t.types or []) {
+            if isinstance(m, _CT) and m.shared.class_name in ("NoneType", "None") {
+                continue;
+            }
+            return m;
+        }
+        return None;
+    }
+    return t;
+}
+
+"""list[T] element spec (i64/f64/ptr) from a central type, or None (#6386).
+
+Mirrors the spec selection in _lower_class_type so it keys self.list_types the
+same way the list was created, replacing the LLVM-shape reverse-scan.
+"""
+impl NaIRGenPass._list_elem_spec_of_type(t: any) -> (str | None) {
+    pt = self._peel_optional(t);
+    if pt is None {
+        return None;
+    }
+    try {
+        import from jaclang.compiler.type_system.types { ClassType as _CT }
+    } except ImportError {
+        return None;
+    }
+    if not (isinstance(pt, _CT) and pt.shared.class_name == "list") {
+        return None;
+    }
+    elem_llvm: ir.Type = ir.IntType(64);
+    ta = pt.private.type_args or [];
+    if ta {
+        _e = self._lower_type(ta[0]);
+        if _e is None {
+            return None;
+        }
+        elem_llvm = _e;
+    }
+    return self._list_spec_of_llvm(elem_llvm);
+}
+
+"""(key_spec, val_spec) of a dict[K,V] central type, or None (#6386).
+
+Mirrors the key/value spec selection in _lower_class_type so it keys
+self.dict_types the same way the dict was created.
+"""
+impl NaIRGenPass._dict_specs_of_type(t: any) -> (tuple | None) {
+    pt = self._peel_optional(t);
+    if pt is None {
+        return None;
+    }
+    try {
+        import from jaclang.compiler.type_system.types { ClassType as _CT }
+    } except ImportError {
+        return None;
+    }
+    if not (isinstance(pt, _CT) and pt.shared.class_name == "dict") {
+        return None;
+    }
+    k_llvm: ir.Type = ir.IntType(64);
+    v_llvm: ir.Type = ir.IntType(64);
+    ta = pt.private.type_args or [];
+    if len(ta) >= 2 {
+        _k = self._lower_type(ta[0]);
+        _v = self._lower_type(ta[1]);
+        if _k is None or _v is None {
+            return None;
+        }
+        k_llvm = _k;
+        v_llvm = _v;
+    }
+    (k_spec, v_spec, _ks) = self._dict_specs_of_llvm(k_llvm, v_llvm);
+    return (k_spec, v_spec);
+}
+
+"""Infer the list element spec from a value's central type (#6386)."""
+impl NaIRGenPass._infer_list_elem_type(val: ir.Value) -> (str | None) {
+    return self._list_elem_spec_of_type(self._type_of(val));
 }
 
 """Peel one layer from a list type annotation: list[T] → (T_node, T_llvm_type, T_elem_type_name).

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/vtable.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/vtable.impl.jac
@@ -1,34 +1,39 @@
 """Virtual table (vtable) support for inheritance with C3 MRO."""
-"""Build vtable layout for a class (merge from all MRO ancestors + own methods)."""
-impl NaIRGenPass._build_vtable(arch_name: str) -> None {
-    # Consume the centralized vtable slot assignment (merged from MRO ancestors
-    # + own methods, in canonical order) instead of re-deriving it from a
-    # string-prefix scan of method_funcs (#6386, Category C).
+"""Vtable method-slot names for a class, in slot order, from LayoutRegistry.
+
+Consumes the centralized vtable slot assignment directly instead of caching it
+in a vtable_layouts shadow dict (#6386, Category C). Imported archetypes resolve
+against their defining module's registry.
+"""
+impl NaIRGenPass._vtable_method_names(arch_name: str) -> list[str] {
     import from jaclang.compiler.passes.main.layout_pass { get_layout_registry }
-    layout_reg = get_layout_registry(self.ir_in, self.prog);
-    _methods = layout_reg.get_methods(arch_name);
-    if not _methods {
-        # Imported archetype: vtable slot order lives in its defining module.
+    methods = get_layout_registry(self.ir_in, self.prog).get_methods(arch_name);
+    if not methods {
         _arch = self.arch_ast_map.get(arch_name);
         _owner = _arch.find_parent_of_type(uni.Module) if _arch is not None else None;
         if _owner is not None and _owner is not self.ir_in {
-            _methods = get_layout_registry(_owner, self.prog).get_methods(arch_name);
+            methods = get_layout_registry(_owner, self.prog).get_methods(arch_name);
         }
     }
-    layout: list[str] = [];
-    index_map: dict[(str, int)] = {};
-    for mslot in _methods {
-        layout.append(mslot.name);
-        index_map[mslot.name] = mslot.index;
+    return [m.name for m in methods];
+}
+
+"""Vtable slot index of a method on a class, or None (#6386)."""
+impl NaIRGenPass._vtable_method_index(
+    arch_name: str, method_name: str
+) -> (int | None) {
+    for (i, n) in enumerate(self._vtable_method_names(arch_name)) {
+        if n == method_name {
+            return i;
+        }
     }
-    self.vtable_layouts[arch_name] = layout;
-    self.vtable_method_indices[arch_name] = index_map;
+    return None;
 }
 
 """Emit a vtable global constant for a class."""
 impl NaIRGenPass._emit_vtable_global(arch_name: str) -> None {
-    layout = self.vtable_layouts.get(arch_name);
-    if layout is None or not layout {
+    layout = self._vtable_method_names(arch_name);
+    if not layout {
         return;
     }
     i8_ptr = ir.IntType(8).as_pointer();
@@ -66,8 +71,8 @@ Devirtualizes to direct call when the method is never overridden by any subclass
 impl NaIRGenPass._codegen_virtual_call(
     obj_val: ir.Value, method_name: str, args: list[ir.Value], obj_type_name: str
 ) -> (ir.Value | None) {
-    indices = self.vtable_method_indices.get(obj_type_name);
-    if indices is None or method_name not in indices {
+    method_idx = self._vtable_method_index(obj_type_name, method_name);
+    if method_idx is None {
         return None;
     }
     # Find the resolved function (walk MRO)
@@ -99,7 +104,6 @@ impl NaIRGenPass._codegen_virtual_call(
         return self.builder.call(func, coerced, name=f"call.{method_name}");
     }
     # Full vtable dispatch for overridden methods
-    method_idx = indices[method_name];
     i32 = ir.IntType(32);
     i8_ptr = ir.IntType(8).as_pointer();
     # Load vtable pointer from field 0
@@ -130,7 +134,7 @@ impl NaIRGenPass._generate_inherited_method_wrappers -> None {
         # Collect all methods from ancestors via MRO
         seen_methods: set[str] = set();
         for ancestor_name in mro[1:] {
-            ancestor_layout = self.vtable_layouts.get(ancestor_name, []);
+            ancestor_layout = self._vtable_method_names(ancestor_name);
             for method_name in ancestor_layout {
                 if method_name in seen_methods {
                     continue;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/vtable.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/vtable.impl.jac
@@ -1,35 +1,28 @@
 """Virtual table (vtable) support for inheritance with C3 MRO."""
 """Build vtable layout for a class (merge from all MRO ancestors + own methods)."""
 impl NaIRGenPass._build_vtable(arch_name: str) -> None {
-    layout: list[str] = [];
-    seen_methods: set[str] = set();
-    # Merge method slots from all ancestors in MRO order
-    mro = self.mro_order.get(arch_name, [arch_name]);
-    for ancestor_name in mro[1:] {
-        ancestor_layout = self.vtable_layouts.get(ancestor_name, []);
-        for method_name in ancestor_layout {
-            if method_name not in seen_methods {
-                layout.append(method_name);
-                seen_methods.add(method_name);
-            }
+    # Consume the centralized vtable slot assignment (merged from MRO ancestors
+    # + own methods, in canonical order) instead of re-deriving it from a
+    # string-prefix scan of method_funcs (#6386, Category C).
+    import from jaclang.compiler.passes.main.layout_pass { get_layout_registry }
+    layout_reg = get_layout_registry(self.ir_in, self.prog);
+    _methods = layout_reg.get_methods(arch_name);
+    if not _methods {
+        # Imported archetype: vtable slot order lives in its defining module.
+        _arch = self.arch_ast_map.get(arch_name);
+        _owner = _arch.find_parent_of_type(uni.Module) if _arch is not None else None;
+        if _owner is not None and _owner is not self.ir_in {
+            _methods = get_layout_registry(_owner, self.prog).get_methods(arch_name);
         }
     }
-    # Add own methods (those forward-declared with this class name)
-    prefix = f"{arch_name}.";
-    for full_name in self.method_funcs {
-        if full_name.startswith(prefix) {
-            method_name = full_name[len(prefix):];
-            if method_name not in seen_methods {
-                layout.append(method_name);
-                seen_methods.add(method_name);
-            }
-        }
+    layout: list[str] = [];
+    index_map: dict[(str, int)] = {};
+    for mslot in _methods {
+        layout.append(mslot.name);
+        index_map[mslot.name] = mslot.index;
     }
     self.vtable_layouts[arch_name] = layout;
-    self.vtable_method_indices[arch_name] = {};
-    for (i, name) in enumerate(layout) {
-        self.vtable_method_indices[arch_name][name] = i;
-    }
+    self.vtable_method_indices[arch_name] = index_map;
 }
 
 """Emit a vtable global constant for a class."""

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -439,6 +439,12 @@ obj NaIRGenPass(ModuleCodegenPass) {
 
     def _generate_inherited_method_wrappers -> None;
     # Phase 6: Complex Chains and Type Inference
+    def _struct_name_of_type(t: any) -> (str | None);
+    def _peel_optional(t: any) -> any;
+    def _list_spec_of_llvm(elem_llvm: ir.Type) -> str;
+    def _dict_specs_of_llvm(k_llvm: ir.Type, v_llvm: ir.Type) -> tuple;
+    def _list_elem_spec_of_type(t: any) -> (str | None);
+    def _dict_specs_of_type(t: any) -> (tuple | None);
     def _infer_type_name(val: ir.Value) -> (str | None);
     def _infer_list_elem_type(val: ir.Value) -> (str | None);
     def _peel_list_type(type_node: (object | None)) -> tuple;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -107,11 +107,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
         class_hierarchy: dict[str, str] = {},
         class_parents: dict[str, list[str]] = {},
         mro_order: dict[str, list[str]] = {},
-        parent_field_start: dict[str, dict[str, int]] = {},
         arch_ast_map: dict[str, object] = {},
         has_vtable: dict[str, bool] = {},
-        vtable_layouts: dict[str, list[str]] = {},
-        vtable_method_indices: dict[str, dict] = {},
         vtable_globals: dict[str, ir.GlobalVariable] = {},
         _non_overridden_methods: dict[str, set[str]] = {},
         # Tuple support (Phase 9)
@@ -431,7 +428,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
         target_val: ir.Value, index_val: ir.Value, value: ir.Value, elem_type_name: str
     ) -> None;
     # Phase 5: Inheritance, Vtables, and C3 MRO
-    def _build_vtable(arch_name: str) -> None;
+    def _vtable_method_names(arch_name: str) -> list[str];
+    def _vtable_method_index(arch_name: str, method_name: str) -> (int | None);
     def _emit_vtable_global(arch_name: str) -> None;
     def _codegen_virtual_call(
         obj_val: ir.Value, method_name: str, args: list[ir.Value], obj_type_name: str

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -12,7 +12,7 @@ import from llvmlite { ir }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes.module_codegen_pass { ModuleCodegenPass }
 import from jaclang.jac0core.constant { CodeContext, Tokens as Tok }
-import from jaclang.jac0core.diagnostics { E5026, E5060, E5090 }
+import from jaclang.jac0core.diagnostics { E5026, E5060, E5090, E5091 }
 
 # ── Sentinel refcount value for static (immortal) strings.
 # INT64_MAX = 0x7FFFFFFFFFFFFFFF — never reaches 0 even if accidentally decremented.
@@ -261,6 +261,13 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _lower_type(t: any) -> (ir.Type | None);
     def _lower_class_type(t: any) -> (ir.Type | None);
     def _lower_function_type(t: any) -> ir.Type;
+    # Read the central semantic type (TypeBase) stamped onto a produced
+    # ir.Value by _codegen_expr, or None. Mirrors _is_owned (#6386).
+    def _type_of(val: (ir.Value | None)) -> (any | None);
+    # Canonical "consume the central type or fail loudly" accessor. Lowers a
+    # type-bearing AST node's Expr.type to an ir.Type; emits E5091 (never a
+    # silent i64) when the central checker left it unresolved (#6386).
+    def _require_type(type_src: (uni.UniNode | None), what: str) -> ir.Type;
     def _resolve_type_str(type_name: str) -> ir.Type;
     def _get_name(nd: (uni.UniNode | None)) -> (str | None);
     def _to_bool(val: ir.Value) -> ir.Value;

--- a/jac/jaclang/jac0core/diagnostics.jac
+++ b/jac/jaclang/jac0core/diagnostics.jac
@@ -1129,6 +1129,12 @@ glob E0001 = _err("E0001", Category.SYNTAX, "Expected '{expected}', got '{got}'"
          "Native pathway does not yet support {kind} '{name}'",
          help="This Jac construct is supported on the @sv/Python pathway but is not implemented in the .na.jac native compiler yet. Move the code to a non-native context, or extend NaIRGenPass to handle this node type."
      ),
+     E5091 = _err(
+         "E5091",
+         Category.CODEGEN,
+         "Cannot determine the native type of {what}; the central type checker left it unresolved",
+         help="Native codegen consumes the central type checker's result rather than guessing. Add an explicit type annotation so TypeCheckPass can resolve it, or extend NaIRGenPass._lower_type to handle this type category. (Previously this was silently coerced to i64, which could miscompile -- see #6386.)"
+     ),
      # Language server
      E5070 = _err("E5070", Category.CODEGEN, "Error during type check: {error}"),
      E5071 = _err("E5071", Category.CODEGEN, "Error during formatting: {error}"),

--- a/jac/tests/compiler/passes/native/fixtures/na_float_arg.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/na_float_arg.na.jac
@@ -1,0 +1,12 @@
+"""Regression lock: a cross-module native call must marshal a float argument by
+its real (central) parameter type, not a synthesized all-i64 signature (#6386).
+
+Expected outputs (used by test_native_gen_pass.jac):
+  test_cross_module_float()  -> 7.0   (scale(3.5) == 3.5 * 2.0)
+"""
+
+import from na_float_arg_lib { scale }
+
+def test_cross_module_float() -> float {
+    return scale(3.5);
+}

--- a/jac/tests/compiler/passes/native/fixtures/na_float_arg_lib.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/na_float_arg_lib.na.jac
@@ -1,0 +1,11 @@
+"""Library module exporting a function with a float parameter.
+
+Used by na_float_arg.na.jac to lock in correct cross-module marshalling of a
+non-i64 argument. Guards against the #6386 Category-B path in calls.impl that
+synthesized an absent callee signature as all-i64 by arg count -- a float
+passed that way would be reinterpreted as an integer bit pattern.
+"""
+
+def:pub scale(x: float) -> float {
+    return x * 2.0;
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -623,6 +623,15 @@ test "cross-module chained method calls" {
     assert f() == 12;
 }
 
+# Regression lock for #6386 Category B: a cross-module callee whose signature is
+# resolved from central analysis must marshal a float argument as a double, not
+# as a synthesized all-i64 signature (which would reinterpret the bit pattern).
+test "cross-module float argument marshalled correctly" {
+    (eng, _) = compile_native("na_float_arg.na.jac");
+    f = get_func(eng, "test_cross_module_float", ctypes.c_double);
+    assert f() == 7.0;
+}
+
 # --- TestNativeBuiltins ---
 test "builtins char at" {
     (eng, _) = compile_native("builtins.na.jac");


### PR DESCRIPTION
## WORK IN PROGRESS

Tracking issue: **#6386** — *Native backend re-derives type/layout/symbol info instead of consuming centralized analysis.*

Incrementally replaces the native backend's parallel, hand-built model of type/layout/symbol information with consumption of the existing centralized analyses (`Expr.type`, `LayoutRegistry`, `.sym`). Landed in small, individually-verified steps.

### Landed so far

**Phase 1 - consumption primitives (no behavior change)**
- `_codegen_expr` stamps `val.jac_type` (the central `TypeBase` from `TypeCheckPass`) onto every produced value, mirroring the existing `is_owned` marker; `_type_of(val)` reads it back. This is the mechanism for replacing LLVM-shape probing / shadow-table scans with reads of the central type, without threading `Expr` through ~130 call sites.
- `_require_type(src, what)` - the canonical "consume the central type or fail loudly" accessor - plus diagnostic **E5091**, replacing silent `i64` coercion of a missing type.
- Regression-lock fixture/test for cross-module `float` argument marshalling.
- Emitted IR is byte-identical across the single-module native fixtures.

**Phase 2 - layout consolidation (Category C)**
- New read accessors on `LayoutRegistry`: `get_fields` / `get_methods` / `get_field_info` / `get_parent_field_start`.
- `_codegen_archetype` consumes `get_fields()` instead of re-walking the MRO + re-implementing diamond dedup + sequential field indexing (~85 lines removed). Handles the implicit vtable slot (registry is 0-based excluding it, so `native_index = field.index + vtable_off`).
- `_build_vtable` consumes `get_methods()` instead of a string-prefix scan of `method_funcs`.
- Imported archetypes (cross-module import path) resolve their layout from their **defining** module's registry via `find_parent_of_type(Module)`.

### Verification
- Native suite on a **clean module cache**: this branch is **386/386 green**, up from **383/385** at HEAD - the owning-module layout resolution fixes the two pre-existing cross-module struct round-trip failures (`test_third_module_struct_*`).
- Single-module fixtures: emitted IR byte-identical to the prior hand-derivation.
- Note: the suite is cache-fragile - `~/.cache/jac/jir/modules` keys compiled user-module IR by user-source hash, so editing *compiler* files can serve stale cross-module dependency IR. All gating here clears the module cache first.

### Context
- The two *concrete* miscompiles named in #6386 (`def foo {}` drop; cross-module `float` arg) are already fixed upstream (parser #6385; interop manifest `param_types`). #6386 is therefore now a **structural deslop** - consume central analysis, delete shadow state, convert latent fallbacks to diagnostics - gated by the native suite.

### Still TODO (tracked)
- Repoint the remaining ~80 readers of the layout shadow dicts onto the registry, then delete `struct_field_*` / `parent_field_start` / `vtable_*` / `method_ast_sigs`.
- Phase 3A: value-type dispatch via `jac_type` (+ complete `_lower_type` for `EnumMemberType` etc.); delete `_infer_*` and `var_*_type` tables.
- Phase 3D: name resolution via `.sym`.
- Phase 3E: semantic predicates (replace `signature is None`, hardcoded builtin tables, enum/union shape checks).
- Phase 3B: convert remaining `i64`/`None` masking fallbacks to E5091 diagnostics.
