### PR TITLE
fix(jac-desktop): give the dev-mode CI test a virtual display (xvfb)

### DIFF
--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   jac-check:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   real-e2e:
     name: microk8s real-app smoke
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -100,9 +100,11 @@ jobs:
       run: |
         # jac-desktop's pytauri shell loads a native extension that links
         # libwebkit2gtk-4.1.so.0; install the WebKitGTK runtime so the
-        # "desktop dev mode" test can launch the pytauri process.
+        # "desktop dev mode" test can launch the pytauri process. xvfb gives
+        # the GTK window a virtual display so it initializes on the headless
+        # runner instead of panicking in gtk::rt::init.
         sudo apt-get update
-        sudo apt-get install -y libwebkit2gtk-4.1-0 libjavascriptcoregtk-4.1-0 libsoup-3.0-0
+        sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libjavascriptcoregtk-4.1-0 libsoup-3.0-0
 
     - name: Install Playwright browsers
       run: playwright install chromium --with-deps
@@ -112,7 +114,9 @@ jobs:
         echo "TEST_ENV=true" >> $GITHUB_ENV
 
     - name: Run all client tests (including E2E in parallel)
-      run: pytest -x jac-client jac-desktop -n auto
+      # xvfb-run provides a virtual X display so the desktop dev-mode test can
+      # launch the pytauri GTK window; -a auto-picks a free server number.
+      run: xvfb-run -a pytest -x jac-client jac-desktop -n auto
 
     - name: Re-run auth roundtrip e2e against jac-scale backend
       run: |

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test-core-compiler:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -35,6 +36,7 @@ jobs:
       run: pytest -x jac/tests/compiler -n auto
 
   test-core-runtime:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -66,6 +68,12 @@ jobs:
 
   test-client:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # TEMP(fix/desktop-dev-test-headless-display): run 10x in parallel to flush
+    # out flakiness in the headless desktop dev-mode test before merge.
+    strategy:
+      fail-fast: false
+      matrix:
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
     - name: Check out code
       uses: actions/checkout@v5
@@ -124,6 +132,7 @@ jobs:
         pytest -x -vv jac-client/jac_client/tests/test_e2e.jac -k "jacSignup"
 
   test-packages-and-docs:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -170,6 +179,7 @@ jobs:
       run: pytest docs/tests/e2e/test_code_blocks.jac -v
 
   test-mcp:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -194,6 +204,7 @@ jobs:
       run: pytest -x jac-mcp -n auto
 
   test-scale:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -298,7 +309,7 @@ jobs:
 
   test-scale-k8s:
     # Runs by default. Add the 'skip-k8s' label to a PR to skip it.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check out code
@@ -347,6 +358,7 @@ jobs:
           pytest  -s -x jac-scale/jac_scale/tests/test_deploy_k8s.jac
 
   test-pypi-build:
+    if: false  # TEMP(fix/desktop-dev-test-headless-display): disabled to iterate on test-client
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code

--- a/jac-desktop/jac_desktop/tests/_helpers.jac
+++ b/jac-desktop/jac_desktop/tests/_helpers.jac
@@ -79,9 +79,20 @@ def get_env_with_bun -> dict[str, str] {
 glob get_env_with_npm = get_env_with_bun;
 
 """Block until a TCP port is accepting connections or timeout."""
-def wait_for_port(host: str, port: int, timeout: float = 60.0) -> None {
+def wait_for_port(
+    host: str,
+    port: int,
+    timeout: float = 60.0,
+    process: (subprocess.Popen | None) = None
+) -> None {
     deadline = time.time() + timeout;
     while time.time() < deadline {
+        if process is not None and process.poll() is not None {
+            raise RuntimeError(
+                f"Process exited (code {process.returncode}) before {host}:{port} "
+                f"opened; the dev shell crashed instead of timing out"
+            );
+        }
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock {
             sock.settimeout(0.5);
             try {

--- a/jac-desktop/jac_desktop/tests/test_it_desktop.jac
+++ b/jac-desktop/jac_desktop/tests/test_it_desktop.jac
@@ -361,7 +361,7 @@ test "desktop dev mode starts vite server" {
                 cwd=project_dir,
                 env=env,
             );
-            wait_for_port("127.0.0.1", vite_port, timeout=90.0);
+            wait_for_port("127.0.0.1", vite_port, timeout=90.0, process=dev_process);
             with urlopen(f"http://127.0.0.1:{vite_port}/", timeout=10) as resp {
                 assert resp.status == 200 , "Dev server should return 200";
             }


### PR DESCRIPTION
## Problem

The `test-client` job's `"desktop dev mode starts vite server"` test fails on the headless CI runner with:

```
thread '<unnamed>' panicked ... Failed to initialize GTK
pyo3_runtime.PanicException: Failed to initialize gtk backend!
TimeoutError: Timed out waiting for 127.0.0.1:5173
```

`jac start --dev` launches the Vite dev server **and** the PyTauri shell (`app.py`), which opens a GTK window. The runner installs the WebKitGTK libs but has **no display**, so `gtk::rt::init` panics, the shell dies, Vite never comes up, and the test fails with a misleading port timeout. It is unrelated to whatever PR happens to trigger it — it fails on `main` too.

## Fix

Give the GTK window a real virtual display instead of skipping the test, so the dev-mode pipeline is still exercised end to end:

- Install `xvfb` and run the client suite under `xvfb-run -a`.
- Make `wait_for_port` process-aware: when the watched process exits before the port opens it now raises with the exit code instead of blocking the full timeout and reporting a generic `TimeoutError` — so future crashes name the real cause.

## ⚠️ Temporary CI gating in this PR — REVERT BEFORE MERGE

To iterate quickly on the headless fix, this branch also contains a commit that:
- gates every job except `test-client` with `if: false` in `test-jaseci.yml`
- disables `jac-check.yml` and `k8s-microservice-real-e2e.yml`
- runs `test-client` **10× in parallel** to flush out flakiness

**The `ci: TEMP disable all jobs except test-client` commit must be reverted before this merges.**