### PR TITLE
feat(native): nacompile --target wasm32 with a pure-Jac wasm linker

### DIFF
--- a/jac/examples/raylib_shooter/README.md
+++ b/jac/examples/raylib_shooter/README.md
@@ -41,6 +41,11 @@ resolves no matter where the binary is launched from.
 ./demo.sh --zig   # build & play only the Zig shooter, interactively
 ```
 
+> **Run it in the browser too:** [`web/`](web/) compiles the _same_ rlgl source to
+> WebAssembly (`jac nacompile --target wasm32`) and renders it with WebGL - the
+> `import from raylib` externs become the wasm module's imports. See
+> [`web/README.md`](web/README.md); run `cd web && ./demo.sh`.
+
 `demo.sh` will:
 
 1. detect your platform/architecture,

--- a/jac/examples/raylib_shooter/web/.gitignore
+++ b/jac/examples/raylib_shooter/web/.gitignore
@@ -1,0 +1,1 @@
+shooter.wasm

--- a/jac/examples/raylib_shooter/web/README.md
+++ b/jac/examples/raylib_shooter/web/README.md
@@ -1,0 +1,50 @@
+# Jac Cube Shooter - WASM / WebGL build
+
+The **same** `shooter.na.jac` that the native demo links against `libraylib.so`,
+here compiled to a browser `.wasm` module and rendered with WebGL - a *fourth*
+target for one unchanged rlgl source.
+
+```bash
+./demo.sh           # builds shooter.wasm and serves http://localhost:8099
+# then click the canvas to capture the mouse:
+#   WASD move · mouse/arrows aim · Space fire · Tab release the cursor
+```
+
+## How it works
+
+`jac nacompile --target wasm32 shooter.na.jac -o shooter.wasm` runs the native
+LLVM backend at the `wasm32-unknown-unknown` triple and links the single
+relocatable object into an instantiable module with the **pure-Jac wasm linker**
+([`compiler/passes/native/wasm_linker.jac`](../../../jaclang/compiler/passes/native/wasm_linker.jac)),
+with no `wasm-ld` or emscripten dependency.
+
+The game's `import from raylib { ... }` block (`rlVertex3f`, `rlColor4ub`,
+`rlTranslatef`, `IsKeyDown`, ...) does not resolve to a shared library here.
+Undefined externs simply **become the module's wasm imports**, and the WebGL
+shim in [`raylib_web.mjs`](./raylib_web.mjs) supplies them: it emulates rlgl's
+immediate mode (a projection/modelview matrix stack + an `rlBegin`/`rlVertex3f`
+batch) on one WebGL shader, and maps keyboard/mouse/pointer-lock to raylib's
+scalar input calls. The small libc/runtime surface the Jac native runtime needs
+(`malloc`/`free`/`memcpy`, `__multi3`, ...) is provided as `env` imports too.
+
+The only source change vs the native build is the entry shape: the blocking
+`with entry { while !WindowShouldClose() ... }` loop is split into `init()` (once)
+and `frame()` (per `requestAnimationFrame`), because a browser tab cannot block
+its main thread. All state already lived in module globals, so the split is
+mechanical.
+
+## Files
+
+| File | Role |
+|------|------|
+| `shooter.na.jac` | the game (native rlgl source + `init()`/`frame()` entry) |
+| `raylib_web.mjs` | WebGL shim: the `env` import object (rlgl + input + runtime) |
+| `index.html`     | canvas + HUD; instantiates the wasm and drives the rAF loop |
+| `demo.sh`        | build (`nacompile --target wasm32`) + serve |
+| `shooter.wasm`   | build output (git-ignored) |
+
+## Build surface (`int` is `i64`)
+
+Jac `int` lowers to wasm `i64`, so any exported function taking/returning `int`
+needs `BigInt` at the JS boundary (`e.get_score()` returns a BigInt). The hot
+rlgl/input surface is all `i32`/`f32`, so it stays `BigInt`-free.

--- a/jac/examples/raylib_shooter/web/demo.sh
+++ b/jac/examples/raylib_shooter/web/demo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Build & serve the WASM/WebGL build of the Jac cube shooter.
+#
+#   1. compile shooter.na.jac -> shooter.wasm with `jac nacompile --target wasm32`
+#      (the pure-Jac wasm linker; no wasm-ld / emscripten)
+#   2. serve this directory over HTTP and open the page
+#
+# The same rlgl source that the native build links against libraylib.so is here
+# compiled to wasm; its `import from raylib { ... }` externs become the module's
+# wasm imports, satisfied by the WebGL shim in raylib_web.mjs.
+#
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../../.." && pwd)"          # repo root
+PORT="${PORT:-8099}"
+
+# Resolve a `jac` CLI: prefer the repo venv, else PATH.
+JAC="$ROOT/.venv/bin/jac"
+command -v "$JAC" >/dev/null 2>&1 || JAC="jac"
+
+echo "▶ Building shooter.wasm …"
+"$JAC" nacompile --target wasm32 "$HERE/shooter.na.jac" -o "$HERE/shooter.wasm"
+
+URL="http://localhost:${PORT}/index.html"
+echo "▶ Serving on ${URL}  (Ctrl-C to stop)"
+( sleep 1; (command -v xdg-open >/dev/null && xdg-open "$URL") \
+  || (command -v open >/dev/null && open "$URL") || true ) >/dev/null 2>&1 &
+exec python3 -m http.server "$PORT" --directory "$HERE"

--- a/jac/examples/raylib_shooter/web/index.html
+++ b/jac/examples/raylib_shooter/web/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Jac Cube Shooter - WASM</title>
+<style>
+  body { margin: 0; background: #0b0e16; color: #cdd6e6;
+         font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+         display: flex; flex-direction: column; align-items: center; gap: 12px; padding: 18px; }
+  h1 { font-size: 16px; font-weight: 600; margin: 4px 0 0; }
+  #wrap { position: relative; }
+  canvas { background: #0f121c; border: 1px solid #232a3d; border-radius: 6px; display: block; }
+  #hud { position: absolute; top: 8px; left: 10px; pointer-events: none;
+         text-shadow: 0 1px 2px #000; }
+  #hud b { color: #f5c451; }
+  #hint { opacity: .7; }
+  #err { color: #ff6b6b; white-space: pre-wrap; max-width: 940px; }
+  a { color: #6ea8fe; }
+</style>
+</head>
+<body>
+  <h1>Jac Cube Shooter - compiled to WebAssembly</h1>
+  <div id="hint">Click the canvas to capture the mouse · <b>WASD</b> move · mouse/arrows aim · <b>Space</b> fire · <b>Tab</b> release</div>
+  <div id="wrap">
+    <canvas id="game" width="960" height="600"></canvas>
+    <div id="hud">score <b id="score">0</b> · <b id="fps">0</b> fps</div>
+  </div>
+  <div id="err"></div>
+  <p id="hint">Same <code>shooter.na.jac</code> rlgl source as the native build - the
+  <code>import from raylib</code> block became this module's wasm imports, satisfied by
+  <code>raylib_web.mjs</code> on WebGL.</p>
+
+<script type="module">
+import { makeEnv } from "./raylib_web.mjs";
+
+const canvas = document.getElementById("game");
+const fpsEl = document.getElementById("fps");
+const scoreEl = document.getElementById("score");
+const errEl = document.getElementById("err");
+
+try {
+  const rl = makeEnv({ canvas, onFps: (f) => { fpsEl.textContent = f; } });
+  const { instance } = await WebAssembly.instantiateStreaming(
+    fetch("./shooter.wasm"), { env: rl.env }
+  );
+  const e = instance.exports;
+  rl.attach(e);
+  e.__jac_glob_init();          // initialize module globals
+  e.init();                      // open window, spawn target/bullet pools
+
+  let running = true;
+  function loop(ts) {
+    rl.beginTick(ts);
+    let closed = false;
+    try { closed = !!e.frame(); } catch (ex) { errEl.textContent = String(ex); running = false; }
+    rl.endTick();
+    scoreEl.textContent = Number(e.get_score());
+    if (running && !closed) requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+} catch (ex) {
+  errEl.textContent = "Failed to start: " + (ex && ex.stack || ex);
+}
+</script>
+</body>
+</html>

--- a/jac/examples/raylib_shooter/web/raylib_web.mjs
+++ b/jac/examples/raylib_shooter/web/raylib_web.mjs
@@ -1,0 +1,197 @@
+// raylib_web.mjs - a minimal WebGL shim for the scalar rlgl immediate-mode API
+// used by shooter.na.jac. It provides exactly the `env` imports the wasm module
+// declares (the `import from raylib { ... }` block becomes wasm imports), plus
+// the tiny libc/runtime surface the Jac native runtime references.
+//
+// rlgl is OpenGL-immediate-mode in spirit: rlBegin/rlVertex3f/rlColor4ub batches,
+// a projection+modelview matrix stack, push/pop, translate/rotate, frustum/ortho.
+// We emulate that on a single WebGL pipeline (one VBO, one MVP shader).
+
+// ── 4x4 column-major matrix helpers ─────────────────────────────────────────
+const ident = () => [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1];
+function mul(a, b) {            // a * b  (column-major)
+  const c = new Array(16).fill(0);
+  for (let col = 0; col < 4; col++)
+    for (let row = 0; row < 4; row++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) s += a[row + 4*k] * b[k + 4*col];
+      c[row + 4*col] = s;
+    }
+  return c;
+}
+function translate(x, y, z) { const m = ident(); m[12]=x; m[13]=y; m[14]=z; return m; }
+function rotate(angDeg, x, y, z) {
+  const a = angDeg * Math.PI / 180, c = Math.cos(a), s = Math.sin(a);
+  let len = Math.hypot(x, y, z) || 1; x/=len; y/=len; z/=len; const t = 1 - c;
+  return [
+    x*x*t+c,   y*x*t+z*s, x*z*t-y*s, 0,
+    x*y*t-z*s, y*y*t+c,   y*z*t+x*s, 0,
+    x*z*t+y*s, y*z*t-x*s, z*z*t+c,   0,
+    0,0,0,1,
+  ];
+}
+function frustum(l, r, b, t, n, f) {
+  return [
+    2*n/(r-l), 0, 0, 0,
+    0, 2*n/(t-b), 0, 0,
+    (r+l)/(r-l), (t+b)/(t-b), -(f+n)/(f-n), -1,
+    0, 0, -2*f*n/(f-n), 0,
+  ];
+}
+function ortho(l, r, b, t, n, f) {
+  return [
+    2/(r-l), 0, 0, 0,
+    0, 2/(t-b), 0, 0,
+    0, 0, -2/(f-n), 0,
+    -(r+l)/(r-l), -(t+b)/(t-b), -(f+n)/(f-n), 1,
+  ];
+}
+
+// raylib key codes the shooter reads → from JS KeyboardEvent.code
+const KEYMAP = {
+  KeyW: 87, KeyA: 65, KeyS: 83, KeyD: 68, Space: 32, Tab: 258,
+  ArrowRight: 262, ArrowLeft: 263, ArrowDown: 264, ArrowUp: 265,
+};
+const RL_LINES = 1, RL_TRIANGLES = 4, RL_PROJECTION = 0x1701;
+
+// Build the wasm `env` import object plus per-frame hooks.
+//   onScore(n): optional HUD callback invoked each frame with get_score-like value
+export function makeEnv({ canvas, onFps } = {}) {
+  const gl = canvas.getContext("webgl", { antialias: true, depth: true });
+  if (!gl) throw new Error("WebGL not available");
+
+  // one shader: position + color, MVP uniform
+  const vs = `attribute vec3 aPos; attribute vec4 aCol; uniform mat4 uMVP;
+    varying vec4 vCol; void main(){ gl_Position = uMVP * vec4(aPos,1.0); vCol = aCol; }`;
+  const fs = `precision mediump float; varying vec4 vCol;
+    void main(){ gl_FragColor = vCol; }`;
+  const sh = (type, src) => { const s = gl.createShader(type); gl.shaderSource(s, src);
+    gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(s));
+    return s; };
+  const prog = gl.createProgram();
+  gl.attachShader(prog, sh(gl.VERTEX_SHADER, vs));
+  gl.attachShader(prog, sh(gl.FRAGMENT_SHADER, fs));
+  gl.linkProgram(prog); gl.useProgram(prog);
+  const aPos = gl.getAttribLocation(prog, "aPos");
+  const aCol = gl.getAttribLocation(prog, "aCol");
+  const uMVP = gl.getUniformLocation(prog, "uMVP");
+  const vbo = gl.createBuffer();
+  gl.clearColor(0, 0, 0, 1);
+  gl.disable(gl.CULL_FACE);            // depth test alone resolves the cube faces
+
+  // matrix stacks + immediate-mode batch state
+  let proj = ident(), mv = ident(), mode = 0;
+  const projStack = [], mvStack = [];
+  const cur = () => (mode === RL_PROJECTION ? proj : mv);
+  const setCur = (m) => { if (mode === RL_PROJECTION) proj = m; else mv = m; };
+  let batchMode = 0, verts = [], color = [1, 1, 1, 1];
+
+  // shared mutable state (filled by attach() after instantiate)
+  const st = { mem: null, heap: 0, dt: 0.016, time: 0,
+               mouseX: 0, mouseY: 0, locked: false };
+  const keysDown = new Set(), keysPressed = new Set(), mousePressed = new Set();
+  const u8 = () => new Uint8Array(st.mem.buffer);
+  const cstr = (p) => { const m = u8(); let s = ""; while (m[p]) s += String.fromCharCode(m[p++]); return s; };
+
+  // ── input listeners ──
+  addEventListener("keydown", (e) => {
+    const k = KEYMAP[e.code]; if (k === undefined) return; e.preventDefault();
+    if (!keysDown.has(k)) keysPressed.add(k);
+    keysDown.add(k);
+  });
+  addEventListener("keyup", (e) => { const k = KEYMAP[e.code]; if (k !== undefined) keysDown.delete(k); });
+  canvas.addEventListener("mousedown", () => mousePressed.add(0));
+  document.addEventListener("mousemove", (e) => {
+    if (st.locked) { st.mouseX += e.movementX; st.mouseY += e.movementY; }
+    else { st.mouseX = e.offsetX | 0; st.mouseY = e.offsetY | 0; }
+  });
+  document.addEventListener("pointerlockchange", () => { st.locked = document.pointerLockElement === canvas; });
+
+  function flush() {                   // rlEnd: draw the accumulated batch
+    if (!verts.length) return;
+    const mvp = mul(proj, mv);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STREAM_DRAW);
+    const stride = 7 * 4;
+    gl.enableVertexAttribArray(aPos); gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, stride, 0);
+    gl.enableVertexAttribArray(aCol); gl.vertexAttribPointer(aCol, 4, gl.FLOAT, false, stride, 3 * 4);
+    gl.uniformMatrix4fv(uMVP, false, new Float32Array(mvp));
+    gl.drawArrays(batchMode === RL_LINES ? gl.LINES : gl.TRIANGLES, 0, verts.length / 7);
+    verts = [];
+  }
+
+  const env = {
+    // ── window / lifecycle ──
+    InitWindow: (w, h, titlePtr) => { document.title = cstr(titlePtr) + " - Jac/WASM"; },
+    WindowShouldClose: () => 0, CloseWindow: () => {}, SetTargetFPS: () => {},
+    BeginDrawing: () => { gl.viewport(0, 0, canvas.width, canvas.height); },
+    EndDrawing: () => {}, EndMode3D: () => { flush(); },
+    GetFrameTime: () => st.dt, GetTime: () => st.time,
+    DrawFPS: () => { if (onFps) onFps(Math.round(1 / Math.max(st.dt, 1e-4))); },
+
+    // ── input ──
+    IsKeyDown: (k) => (keysDown.has(k) ? 1 : 0),
+    IsKeyPressed: (k) => (keysPressed.has(k) ? 1 : 0),
+    GetMouseX: () => st.mouseX, GetMouseY: () => st.mouseY,
+    IsMouseButtonPressed: (b) => (mousePressed.has(b) ? 1 : 0),
+    DisableCursor: () => { canvas.requestPointerLock && canvas.requestPointerLock(); },
+    EnableCursor: () => { document.exitPointerLock && document.exitPointerLock(); },
+
+    // ── rlgl immediate mode ──
+    rlClearColor: (r, g, b, a) => gl.clearColor(r/255, g/255, b/255, a/255),
+    rlClearScreenBuffers: () => gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT),
+    rlEnableDepthTest: () => gl.enable(gl.DEPTH_TEST),
+    rlDisableDepthTest: () => gl.disable(gl.DEPTH_TEST),
+    rlMatrixMode: (m) => { mode = m; },
+    rlLoadIdentity: () => setCur(ident()),
+    rlPushMatrix: () => { if (mode === RL_PROJECTION) projStack.push(proj.slice()); else mvStack.push(mv.slice()); },
+    rlPopMatrix: () => { if (mode === RL_PROJECTION) proj = projStack.pop(); else mv = mvStack.pop(); },
+    rlTranslatef: (x, y, z) => setCur(mul(cur(), translate(x, y, z))),
+    rlRotatef: (a, x, y, z) => setCur(mul(cur(), rotate(a, x, y, z))),
+    rlFrustum: (l, r, b, t, n, f) => setCur(mul(cur(), frustum(l, r, b, t, n, f))),
+    rlOrtho: (l, r, b, t, n, f) => setCur(mul(cur(), ortho(l, r, b, t, n, f))),
+    rlBegin: (m) => { batchMode = m; verts = []; },
+    rlEnd: () => flush(),
+    rlVertex3f: (x, y, z) => { verts.push(x, y, z, color[0], color[1], color[2], color[3]); },
+    rlColor4ub: (r, g, b, a) => { color = [r/255, g/255, b/255, a/255]; },
+    rlSetLineWidth: (w) => gl.lineWidth(w),
+
+    // ── raylib file helpers (benchmark path; dormant in interactive play) ──
+    FileExists: () => 0, LoadFileText: () => 0, TextToInteger: () => 0, SaveFileText: () => 0,
+
+    // ── libc / Jac native runtime surface ──
+    malloc: (n) => { n = Number(n); const p = st.heap; st.heap = (st.heap + n + 7) & ~7; return p; },
+    calloc: (c, s) => { const n = Number(c) * Number(s); const p = st.heap; st.heap = (st.heap + n + 7) & ~7;
+                        u8().fill(0, p, p + n); return p; },
+    free: () => {}, malloc_usable_size: () => 0,
+    memcpy: (d, s, n) => { u8().copyWithin(d, s, s + Number(n)); return d; },
+    memcmp: (a, b, n) => { const m = u8(); n = Number(n);
+      for (let i = 0; i < n; i++) { const d = m[a+i] - m[b+i]; if (d) return d; } return 0; },
+    puts: () => 0, printf: () => 0, snprintf: () => 0, getenv: () => 0, fflush: () => 0,
+    abort: () => { throw new Error("wasm abort()"); },
+    // 128-bit multiply (overflow-checked int math); write the 16-byte result to *res.
+    __multi3: (res, alo, ahi, blo, bhi) => {
+      const M = (1n << 64n) - 1n;
+      const a = (BigInt.asUintN(64, ahi) << 64n) | BigInt.asUintN(64, alo);
+      const b = (BigInt.asUintN(64, bhi) << 64n) | BigInt.asUintN(64, blo);
+      const p = BigInt.asUintN(128, a * b), dv = new DataView(st.mem.buffer);
+      dv.setBigUint64(res, p & M, true); dv.setBigUint64(res + 8, (p >> 64n) & M, true);
+    },
+  };
+
+  return {
+    env,
+    // wire memory + heap after instantiate
+    attach(exports) { st.mem = exports.memory; st.heap = exports.__heap_base.value; },
+    // call at the start of each rAF tick with the high-res timestamp (ms)
+    beginTick(tsMs) {
+      if (!st._t0) st._t0 = tsMs;
+      const now = (tsMs - st._t0) / 1000;
+      st.dt = st.time ? Math.min(now - st.time, 0.05) : 0.016;
+      st.time = now;
+    },
+    // clear per-frame edge state after frame()
+    endTick() { keysPressed.clear(); mousePressed.clear(); },
+  };
+}

--- a/jac/examples/raylib_shooter/web/shooter.na.jac
+++ b/jac/examples/raylib_shooter/web/shooter.na.jac
@@ -1,0 +1,601 @@
+"""Jac Cube Shooter - WASM/WebGL build.
+
+This is the SAME first-person shooter as ../shooter.na.jac, compiled to a
+browser `.wasm` module via `jac nacompile --target wasm32`. The body is
+unchanged: it binds raylib's scalar rlgl immediate-mode API by its logical name
+(`import from raylib { ... }`). On the native build those externs resolve to
+libraylib.so at link time; in the browser the very same extern block becomes the
+module's wasm *imports*, satisfied by a small WebGL shim (web/raylib_web.mjs) -
+one source, a fourth target.
+
+The only structural change vs the native version: the blocking `with entry`
+game loop is split into `init()` (called once) and `frame()` (called per
+requestAnimationFrame tick), because a browser cannot block the main thread.
+Mutable module globals already hold all state, so the split is mechanical.
+
+Controls: mouse/arrows aim (click the canvas to capture the mouse), WASD move,
+Space fire, Tab release/recapture the cursor.
+"""
+
+import from raylib {
+    def InitWindow(width: i32, height: i32, title: str) -> None;  def WindowShouldClose -> bool;  def CloseWindow -> None;  def SetTargetFPS(
+        fps: i32
+    ) -> None;  def BeginDrawing -> None;  def EndDrawing -> None;  def rlClearColor(
+        r: u8, g: u8, b: u8, a: u8
+    ) -> None;  def rlClearScreenBuffers -> None;  def DrawFPS(
+        pos_x: i32, pos_y: i32
+    ) -> None;  def IsKeyDown(key: i32) -> bool;  def IsKeyPressed(key: i32) -> bool;  def GetFrameTime -> f32;  def GetMouseX -> i32;  def GetMouseY -> i32;  def IsMouseButtonPressed(
+        button: i32
+    ) -> bool;  def DisableCursor -> None;  def EnableCursor -> None;  def rlMatrixMode(
+        mode: i32
+    ) -> None;  def rlLoadIdentity -> None;  def rlPushMatrix -> None;  def rlPopMatrix -> None;  def rlTranslatef(
+        x: f32, y: f32, z: f32
+    ) -> None;  def rlRotatef(angle: f32, x: f32, y: f32, z: f32) -> None;  def rlFrustum(
+        left: f64, right: f64, bottom: f64, top: f64, znear: f64, zfar: f64
+    ) -> None;  def rlOrtho(
+        left: f64, right: f64, bottom: f64, top: f64, znear: f64, zfar: f64
+    ) -> None;  def rlBegin(mode: i32) -> None;  def rlEnd -> None;  def rlVertex3f(
+        x: f32, y: f32, z: f32
+    ) -> None;  def rlColor4ub(r: u8, g: u8, b: u8, a: u8) -> None;  def rlEnableDepthTest -> None;  def rlDisableDepthTest -> None;  def rlSetLineWidth(
+        width: f32
+    ) -> None;  def EndMode3D -> None;  def GetTime -> f64;  def FileExists(
+        fileName: str
+    ) -> bool;  def LoadFileText(fileName: str) -> str;  def TextToInteger(
+        text: str
+    ) -> i32;  def SaveFileText(fileName: str, text: str) -> bool;
+}
+
+glob RL_MODELVIEW: int = 0x1700,
+     RL_PROJECTION: int = 0x1701,
+     RL_LINES: int = 0x0001,
+     RL_TRIANGLES: int = 0x0004;
+
+
+"""Open a window. No frame-rate cap is set, so the loop runs as fast as the
+hardware allows (call `SetTargetFPS` yourself if you want to limit it)."""
+def open_window(width: int, height: int, title: str) {
+    InitWindow(width, height, title);
+}
+
+"""True once the user closes the window or presses ESC."""
+def should_close -> bool {
+    return WindowShouldClose();
+}
+
+"""Tear the window down."""
+def close_window {
+    CloseWindow();
+}
+
+"""Seconds elapsed during the previous frame (for frame-rate-independent motion)."""
+def dt -> float {
+    return GetFrameTime();
+}
+
+"""Held-this-frame test for a raylib key code."""
+def key_held(code: int) -> bool {
+    return IsKeyDown(code);
+}
+
+"""Pressed-this-frame (edge) test for a raylib key code."""
+def key_tapped(code: int) -> bool {
+    return IsKeyPressed(code);
+}
+
+"""Current mouse X in pixels (as a float - see the GetMouseX note above)."""
+def mouse_x -> float {
+    return float(GetMouseX());
+}
+
+"""Current mouse Y in pixels (as a float)."""
+def mouse_y -> float {
+    return float(GetMouseY());
+}
+
+"""Pressed-this-frame test for a mouse button (0 = left)."""
+def mouse_pressed(button: int) -> bool {
+    return IsMouseButtonPressed(button);
+}
+
+"""Hide and lock the cursor for FPS-style relative mouse-look."""
+def lock_mouse {
+    DisableCursor();
+}
+
+"""Show and release the cursor."""
+def unlock_mouse {
+    EnableCursor();
+}
+
+
+"""Begin a frame: clear color+depth to (r,g,b) and turn on depth testing."""
+def begin_frame(r: int, g: int, b: int) {
+    BeginDrawing();
+    rlClearColor(r, g, b, 255);
+    rlClearScreenBuffers();
+    rlEnableDepthTest();
+}
+
+"""Present the frame."""
+def end_frame {
+    EndDrawing();
+}
+
+"""End the 3D pass and switch to a pixel-space 2D overlay mode.
+
+EndMode3D flushes the batch (drawing the accumulated 3D with the 3D matrices)
+and disables depth testing; we then install an explicit screen-pixel ortho
+projection (origin top-left) so 2D overlays land where you expect. Pairs with
+set_camera, which pushes the projection matrix. `width`/`height` are the window
+size in pixels. Call this before drawing any 2D overlay (e.g. the FPS counter)."""
+def end_camera(width: float, height: float) {
+    EndMode3D();
+    rlMatrixMode(RL_PROJECTION);
+    rlLoadIdentity();
+    rlOrtho(0.0, width, height, 0.0, -1.0, 1.0);
+    rlMatrixMode(RL_MODELVIEW);
+    rlLoadIdentity();
+}
+
+"""Draw raylib's built-in FPS counter at (x, y) as a 2D overlay."""
+def draw_fps(x: int, y: int) {
+    DrawFPS(x, y);
+}
+
+"""Install a perspective camera at (px,py,pz) looking with yaw/pitch (degrees).
+
+`aspect` is width/height. The projection is a 60-degree vertical FOV frustum;
+the view transform is the inverse of the camera placement, built from raylib's
+own rlRotatef/rlTranslatef so no by-value Matrix/Camera3D struct is needed.
+"""
+def set_camera(
+    px: float, py: float, pz: float, yaw_deg: float, pitch_deg: float, aspect: float
+) {
+    near = 0.05;
+    far_plane = 400.0;
+    top = near * 0.57735026;
+    right = top * aspect;
+    rlMatrixMode(RL_PROJECTION);
+    rlLoadIdentity();
+    rlFrustum(-right, right, -top, top, near, far_plane);
+    rlMatrixMode(RL_MODELVIEW);
+    rlLoadIdentity();
+    rlRotatef(-pitch_deg, 1.0, 0.0, 0.0);
+    rlRotatef(-yaw_deg, 0.0, 1.0, 0.0);
+    rlTranslatef(-px, -py, -pz);
+}
+
+
+"""Emit one quad (corners 0->1->2->3, CCW) as two triangles.
+
+Parameters are named p0.. rather than the natural ax,ay,az,bx,.. because the
+12-float grid pattern trips a type-checker param-counting bug under a clib
+import.
+"""
+def _quad(
+    p0: float,
+    p1: float,
+    p2: float,
+    p3: float,
+    p4: float,
+    p5: float,
+    p6: float,
+    p7: float,
+    p8: float,
+    p9: float,
+    p10: float,
+    p11: float
+) {
+    rlVertex3f(p0, p1, p2);
+    rlVertex3f(p3, p4, p5);
+    rlVertex3f(p6, p7, p8);
+    rlVertex3f(p0, p1, p2);
+    rlVertex3f(p6, p7, p8);
+    rlVertex3f(p9, p10, p11);
+}
+
+"""Scale a 0-255 channel by a percentage (cheap face shading)."""
+def _shade(c: int, pct: int) -> int {
+    v = c * pct // 100;
+    return v if v < 255 else 255;
+}
+
+"""Draw an axis-aligned colored box centered at (cx,cy,cz) with size (sx,sy,sz).
+
+Faces are shaded by a fixed per-face brightness so the cube reads as solid
+even without real lighting. Winding is CCW-outward to satisfy raylib's default
+back-face culling.
+"""
+def draw_box(
+    cx: float,
+    cy: float,
+    cz: float,
+    sx: float,
+    sy: float,
+    sz: float,
+    r: int,
+    g: int,
+    b: int
+) {
+    hx = sx * 0.5;
+    hy = sy * 0.5;
+    hz = sz * 0.5;
+    rlPushMatrix();
+    rlTranslatef(cx, cy, cz);
+    rlBegin(RL_TRIANGLES);
+
+    rlColor4ub(_shade(r, 100), _shade(g, 100), _shade(b, 100), 255);
+    _quad(-hx, hy, hz, hx, hy, hz, hx, hy, -hz, -hx, hy, -hz);
+    rlColor4ub(_shade(r, 85), _shade(g, 85), _shade(b, 85), 255);
+    _quad(-hx, -hy, hz, hx, -hy, hz, hx, hy, hz, -hx, hy, hz);
+    _quad(hx, -hy, -hz, -hx, -hy, -hz, -hx, hy, -hz, hx, hy, -hz);
+    rlColor4ub(_shade(r, 70), _shade(g, 70), _shade(b, 70), 255);
+    _quad(hx, -hy, hz, hx, -hy, -hz, hx, hy, -hz, hx, hy, hz);
+    _quad(-hx, -hy, -hz, -hx, -hy, hz, -hx, hy, hz, -hx, hy, -hz);
+    rlColor4ub(_shade(r, 45), _shade(g, 45), _shade(b, 45), 255);
+    _quad(-hx, -hy, -hz, hx, -hy, -hz, hx, -hy, hz, -hx, -hy, hz);
+
+    rlEnd();
+    rlPopMatrix();
+}
+
+"""Draw a flat floor grid of `half*2` lines per axis, spaced `step` apart, on y=0."""
+def draw_floor(half: int, step: float) {
+    ext = float(half) * step;
+    rlSetLineWidth(1.0);
+    rlBegin(RL_LINES);
+    rlColor4ub(55, 60, 75, 255);
+    i = -half;
+    while i <= half {
+        f = float(i) * step;
+        rlVertex3f(f, 0.0, -ext);
+        rlVertex3f(f, 0.0, ext);
+        rlVertex3f(-ext, 0.0, f);
+        rlVertex3f(ext, 0.0, f);
+        i += 1;
+    }
+    rlEnd();
+}
+
+
+"""Seconds elapsed since the window opened (raylib's own clock)."""
+def clock -> float {
+    return GetTime();
+}
+
+"""Benchmark duration in seconds, or 0 for normal (interactive) play.
+
+`demo.sh` writes the requested duration into a sibling `.bench_seconds` file
+before launching, then deletes it; when that file is absent (every interactive
+run, or a bare `./shooter`) this returns 0 and the game loop runs until the
+window is closed. The whole benchmark path is dormant unless the file exists.
+The value is read with raylib's own cross-platform file helpers, so no libc
+binding is needed."""
+def bench_seconds -> float {
+    if FileExists(".bench_seconds") {
+        return float(TextToInteger(LoadFileText(".bench_seconds")));
+    }
+    return 0.0;
+}
+
+"""Hand the benchmark result back to demo.sh.
+
+raylib paints its FPS counter onto the framebuffer, never stdout, and this
+repo's Jac lint rules disallow `print`, so the result is written to a sibling
+`.bench_result` file via raylib's SaveFileText. Fields are positional:
+avg_fps max_fps frames seconds."""
+def write_bench_result(
+    avg_fps: float, peak_fps: float, frame_count: int, seconds: float
+) {
+    SaveFileText(
+        ".bench_result", f"BENCH_RESULT {avg_fps} {peak_fps} {frame_count} {seconds}"
+    );
+}
+
+"""Benchmark accumulators. `bench` is the requested duration (0 = interactive),
+resolved once at startup; `frames`/`max_fps` are tallied across the run."""
+glob bench: float = bench_seconds(),
+     frames: int = 0,
+     max_fps: float = 0.0;
+
+glob KEY_W: int = 87,
+     KEY_A: int = 65,
+     KEY_S: int = 83,
+     KEY_D: int = 68,
+     KEY_SPACE: int = 32,
+     KEY_RIGHT: int = 262,
+     KEY_LEFT: int = 263,
+     KEY_DOWN: int = 264,
+     KEY_UP: int = 265,
+     KEY_TAB: int = 258,
+     MOUSE_LEFT: int = 0,
+     DEG2RAD: float = 0.017453292519943295,
+     px: float = 0.0,
+     py: float = 2.0,
+     pz: float = 12.0,
+     yaw: float = 0.0,
+     pitch: float = 0.0,
+     fire_cd: float = 0.0,
+     world_t: float = 0.0,
+     score: int = 0,
+     rng: int = 987654321,
+     prev_mx: float = 0.0,
+     prev_my: float = 0.0,
+     mouse_warmup: int = 12,
+     mouse_sens: float = 0.12,
+     mouse_captured: bool = False;
+
+obj Target {
+    has x: float,
+        y: float,
+        z: float,
+        base_y: float,
+        phase: float,
+        alive: bool;
+}
+
+obj Bullet {
+    has x: float,
+        y: float,
+        z: float,
+        vx: float,
+        vy: float,
+        vz: float,
+        life: float;
+}
+
+
+"""cos via range-reduced Taylor series (good to ~1e-4 on the reduced range)."""
+def jcos(a: float) -> float {
+    twopi = 6.283185307179586;
+    pi = 3.141592653589793;
+    while a > pi {
+        a -= twopi;
+    }
+    while a < -pi {
+        a += twopi;
+    }
+    x2 = a * a;
+    x4 = x2 * x2;
+    x6 = x4 * x2;
+    x8 = x4 * x4;
+    x10 = x8 * x2;
+    x12 = x8 * x4;
+    return 1.0 - x2 / 2.0 + x4 / 24.0 - x6 / 720.0 + x8 / 40320.0 - x10 / 3628800.0 + x12 / 479001600.0;
+}
+
+"""sin(a) = cos(a - pi/2)."""
+def jsin(a: float) -> float {
+    return jcos(a - 1.5707963267948796);
+}
+
+"""Uniform pseudo-random float in [0, 1) via a 31-bit LCG."""
+def rand01 -> float {
+    global rng;
+    rng = (rng * 1103515245 + 12345) % 2147483648;
+    return float(rng) / 2147483648.0;
+}
+
+"""Random float in [lo, hi)."""
+def rand_range(lo: float, hi: float) -> float {
+    return lo + rand01() * (hi - lo);
+}
+
+
+"""(Re)place a target somewhere in the arena in front of the player."""
+def respawn(t: Target) {
+    t.x = rand_range(-14.0, 14.0);
+    t.base_y = rand_range(1.0, 5.0);
+    t.z = rand_range(-16.0, 2.0);
+    t.phase = rand_range(0.0, 6.28);
+    t.y = t.base_y;
+    t.alive = True;
+}
+
+"""Fire a bullet from the eye along the current aim, reusing a dead pool slot."""
+def fire(bullets: list[Bullet]) -> None {
+    yaw_r = yaw * DEG2RAD;
+    pitch_r = pitch * DEG2RAD;
+    cp = jcos(pitch_r);
+    dx = -jsin(yaw_r) * cp;
+    dy = jsin(pitch_r);
+    dz = -jcos(yaw_r) * cp;
+    speed = 40.0;
+    i = 0;
+    while i < len(bullets) {
+        b = bullets[i];
+        if b.life <= 0.0 {
+            b.x = px;
+            b.y = py;
+            b.z = pz;
+            b.vx = dx * speed;
+            b.vy = dy * speed;
+            b.vz = dz * speed;
+            b.life = 2.0;
+            return;
+        }
+        i += 1;
+    }
+}
+
+"""Advance bullets, resolve hits against targets, and tally score."""
+def update_bullets(bullets: list[Bullet], targets: list[Target], step: float) {
+    global score;
+    bi = 0;
+    while bi < len(bullets) {
+        b = bullets[bi];
+        if b.life > 0.0 {
+            b.x += b.vx * step;
+            b.y += b.vy * step;
+            b.z += b.vz * step;
+            b.life -= step;
+            ti = 0;
+            while ti < len(targets) {
+                t = targets[ti];
+                if t.alive {
+                    ddx = b.x - t.x;
+                    ddy = b.y - t.y;
+                    ddz = b.z - t.z;
+                    if ddx * ddx + ddy * ddy + ddz * ddz < 1.4 {
+                        t.alive = False;
+                        b.life = 0.0;
+                        score += 1;
+                        respawn(t);
+                    }
+                }
+                ti += 1;
+            }
+        }
+        bi += 1;
+    }
+}
+
+"""Read keyboard + mouse and update camera orientation + position this frame."""
+def handle_input(step: float) {
+    global yaw,pitch,px,pz,prev_mx,prev_my,mouse_warmup,mouse_captured;
+    turn = 90.0 * step;
+
+    if key_tapped(KEY_TAB) {
+        if mouse_captured {
+            unlock_mouse();
+            mouse_captured = False;
+        } else {
+            lock_mouse();
+            mouse_captured = True;
+            mouse_warmup = 8;
+        }
+    }
+    if not mouse_captured and mouse_pressed(MOUSE_LEFT) {
+        lock_mouse();
+        mouse_captured = True;
+        mouse_warmup = 8;
+    }
+
+    if key_held(KEY_LEFT) {
+        yaw += turn;
+    }
+    if key_held(KEY_RIGHT) {
+        yaw -= turn;
+    }
+    if key_held(KEY_UP) {
+        pitch += turn;
+    }
+    if key_held(KEY_DOWN) {
+        pitch -= turn;
+    }
+
+    if mouse_captured {
+        mx = mouse_x();
+        my = mouse_y();
+        if mouse_warmup > 0 {
+            mouse_warmup -= 1;
+        } else {
+            ddx = mx - prev_mx;
+            ddy = my - prev_my;
+            if ddx < 150.0 and ddx > -150.0 and ddy < 150.0 and ddy > -150.0 {
+                yaw -= ddx * mouse_sens;
+                pitch -= ddy * mouse_sens;
+            }
+        }
+        prev_mx = mx;
+        prev_my = my;
+    }
+
+    if pitch > 85.0 {
+        pitch = 85.0;
+    }
+    if pitch < -85.0 {
+        pitch = -85.0;
+    }
+
+    yaw_r = yaw * DEG2RAD;
+    fwd_x = -jsin(yaw_r);
+    fwd_z = -jcos(yaw_r);
+    rgt_x = jcos(yaw_r);
+    rgt_z = -jsin(yaw_r);
+    move = 8.0 * step;
+    if key_held(KEY_W) {
+        px += fwd_x * move;
+        pz += fwd_z * move;
+    }
+    if key_held(KEY_S) {
+        px -= fwd_x * move;
+        pz -= fwd_z * move;
+    }
+    if key_held(KEY_D) {
+        px += rgt_x * move;
+        pz += rgt_z * move;
+    }
+    if key_held(KEY_A) {
+        px -= rgt_x * move;
+        pz -= rgt_z * move;
+    }
+}
+
+
+glob targets: list[Target] = [],
+     bullets: list[Bullet] = [];
+
+
+# ─── Browser entry points (replace the native `with entry` loop) ─────────────
+"""Set up the window and object pools. Call once before the first frame()."""
+def init {
+    global targets,bullets;
+    open_window(960, 600, "Jac Cube Shooter");
+    for n in range(7) {
+        t = Target(x=0.0, y=0.0, z=0.0, base_y=0.0, phase=0.0, alive=False);
+        respawn(t);
+        targets.append(t);
+    }
+    for n in range(24) {
+        bullets.append(Bullet(x=0.0, y=0.0, z=0.0, vx=0.0, vy=0.0, vz=0.0, life=0.0));
+    }
+}
+
+"""Advance and render one frame. Returns True when the game wants to close."""
+def frame -> bool {
+    global world_t,fire_cd;
+    step = dt();
+    world_t += step;
+    handle_input(step);
+    fire_cd -= step;
+    if key_held(KEY_SPACE) and fire_cd <= 0.0 {
+        fire(bullets);
+        fire_cd = 0.14;
+    }
+    update_bullets(bullets, targets, step);
+    ti = 0;
+    while ti < len(targets) {
+        t = targets[ti];
+        t.y = t.base_y + 0.4 * jsin(world_t * 1.5 + t.phase);
+        ti += 1;
+    }
+    begin_frame(15, 18, 28);
+    set_camera(px, py, pz, yaw, pitch, 1.6);
+    draw_floor(20, 1.5);
+    ti = 0;
+    while ti < len(targets) {
+        t = targets[ti];
+        if t.alive {
+            draw_box(t.x, t.y, t.z, 1.4, 1.4, 1.4, 235, 80, 60);
+        }
+        ti += 1;
+    }
+    bi = 0;
+    while bi < len(bullets) {
+        b = bullets[bi];
+        if b.life > 0.0 {
+            draw_box(b.x, b.y, b.z, 0.22, 0.22, 0.22, 250, 220, 90);
+        }
+        bi += 1;
+    }
+    end_camera(960.0, 600.0);
+    draw_fps(10, 10);
+    end_frame();
+    return should_close();
+}
+
+"""Current score (targets destroyed) - for an HTML/`sv` HUD."""
+def get_score -> int {
+    return score;
+}

--- a/jac/jaclang/cli/commands/impl/nacompile.impl.jac
+++ b/jac/jaclang/cli/commands/impl/nacompile.impl.jac
@@ -40,7 +40,7 @@ def _inject_entry_elf(llvm_ir_str: str, triple: str = "") -> str {
 
 """Inject main() into the LLVM IR for Mach-O (macOS).
 
-Only main() is needed — dyld handles entry via LC_MAIN, and the
+Only main() is needed - dyld handles entry via LC_MAIN, and the
 system CRT manages _start. No exit() declaration needed since
 returning from main() is handled by dyld.
 """
@@ -56,7 +56,9 @@ def _inject_entry_macho(llvm_ir_str: str) -> str {
 
 
 """Compile a .na.jac file to a standalone native binary."""
-impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
+impl nacompile(
+    filename: str, output: str = "", scrub: bool = False, target: str = ""
+) -> int {
     # Validate input
     if not filename.endswith(".na.jac") and not filename.endswith(".jac") {
         console.error("Input must be a .jac or .na.jac file.");
@@ -65,6 +67,15 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     if not os.path.exists(filename) {
         console.error(f"File not found: {filename}");
         return 1;
+    }
+
+    # wasm32 target: emit a browser-loadable wasm module instead of a host binary.
+    # The native LLVM backend already targets wasm32; we set the triple before
+    # compiling so NaIRGenPass picks it up (data layout + ABI), then link the
+    # single relocatable object into a module with the pure-Jac wasm linker.
+    is_wasm = target in ["wasm", "wasm32", "wasm32-unknown-unknown"];
+    if is_wasm {
+        os.environ["JAC_NATIVE_TARGET"] = "wasm32-unknown-unknown";
     }
 
     # Scrub: wipe all .jac_ir/ cache directories under the source tree
@@ -95,6 +106,9 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
             output = output[:-7];
         } elif output.endswith(".jac") {
             output = output[:-4];
+        }
+        if is_wasm {
+            output = output + ".wasm";
         }
     }
 
@@ -165,6 +179,49 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
         console.print("  Auto-promoted to native compilation.");
     }
 
+    # wasm32 path: emit one relocatable object and link it into a module.
+    # Undefined externs (raylib, malloc/free/memcpy, __multi3, ...) stay as wasm
+    # imports for the JS host. No entry injection / DT_NEEDED - JS calls the
+    # exported functions directly.
+    if is_wasm {
+        import llvmlite.binding as llvm;
+        llvm.initialize_all_targets();
+        llvm.initialize_all_asmprinters();
+        wasm_ir_str = str(ir_module.gen.llvm_ir);
+        try {
+            wmod = llvm.parse_assembly(wasm_ir_str);
+            wmod.verify();
+        } except Exception as e {
+            console.error(f"LLVM IR verification failed: {e}");
+            return 1;
+        }
+        wtm = llvm.Target.from_triple("wasm32-unknown-unknown").create_target_machine(
+            opt=2
+        );
+        # Optimise (clean reloc set), but do NOT internalize: every defined
+        # function is an export the JS host may call.
+        pto = llvm.create_pipeline_tuning_options(speed_level=2, size_level=0);
+        pb = llvm.create_pass_builder(wtm, pto);
+        pb.getModulePassManager().run(wmod, pb);
+        obj_bytes = wtm.emit_object(wmod);
+        console.print(f"  Wasm object emitted ({len(obj_bytes)} bytes).");
+        import from jaclang.compiler.passes.native.wasm_linker { WasmLinker }
+        try {
+            wasm_bytes = WasmLinker.link(obj_bytes, [], 256);
+        } except Exception as e {
+            console.error(f"Wasm linking failed: {e}");
+            import traceback;
+            traceback.print_exc();
+            return 1;
+        }
+        with open(output, "wb") as _wf {
+            _wf.write(wasm_bytes);
+        }
+        console.print(f"  Wasm module written to {output} ({len(wasm_bytes)} bytes).");
+        console.print(f"  Instantiate in a browser/Node with an `env` import object.");
+        return 0;
+    }
+
     # Step 2: Check for Python/server interop (can't compile standalone)
     manifest = ir_module.gen.interop_manifest;
     if manifest and manifest.native_imports {
@@ -207,7 +264,7 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     }
 
     # Step 5: Determine needed libraries
-    # Note: libgc (Boehm GC) no longer needed — using reference counting
+    # Note: libgc (Boehm GC) no longer needed - using reference counting
     if is_macos {
         needed_libs: list[str] = ["/usr/lib/libSystem.B.dylib"];
     } else {

--- a/jac/jaclang/cli/commands/nacompile.jac
+++ b/jac/jaclang/cli/commands/nacompile.jac
@@ -31,6 +31,13 @@ glob registry = get_registry();
             kind=ArgKind.FLAG,
             help="Scrub build: wipe cached IR and recompile everything from scratch"
         ),
+        Arg.create(
+            "target",
+            kind=ArgKind.OPTION,
+            short="t",
+            default="",
+            help="Code target: native host (default) or 'wasm32' for a browser .wasm module"
+        ),
 
     ],
     examples=[
@@ -38,8 +45,14 @@ glob registry = get_registry();
         ("jac nacompile program.jac", "Auto-promote and compile to ./program"),
         ("jac nacompile program.na.jac -o mybin", "Compile to ./mybin"),
         ("jac nacompile program.na.jac --scrub", "Clean rebuild (wipe IR cache)"),
+        (
+            "jac nacompile game.na.jac --target wasm32 -o game.wasm",
+            "Compile to a wasm module"
+        ),
 
     ],
     group="transform"
 )
-def nacompile(filename: str, output: str = "", scrub: bool = False) -> int;
+def nacompile(
+    filename: str, output: str = "", scrub: bool = False, target: str = ""
+) -> int;

--- a/jac/jaclang/compiler/passes/native/wasm_linker.jac
+++ b/jac/jaclang/compiler/passes/native/wasm_linker.jac
@@ -1,0 +1,573 @@
+"""Pure-Jac WebAssembly linker for native Jac compilation.
+
+Takes the relocatable wasm object bytes from llvmlite's emit_object() (target
+triple wasm32-unknown-unknown) and produces a single instantiable wasm module.
+No external linker (wasm-ld / lld) required.
+
+Single-translation-unit model: the whole .na.jac module compiles to ONE LLVM
+module -> ONE object, so there is no cross-object merge. The linker:
+  - drops placeholder env imports (__linear_memory / __stack_pointer / ...),
+  - assigns the final function index space (kept imports first, then defined),
+  - lays out data segments + a stack in linear memory,
+  - synthesizes the memory, __stack_pointer + __heap_base globals, and the
+    indirect-function table + elem segment,
+  - rewrites code relocations (FUNCTION_INDEX / MEMORY_ADDR / GLOBAL_INDEX /
+    TABLE_INDEX / TABLE_NUMBER), and
+  - exports memory, the magic globals, and every defined function.
+
+Undefined externs (raylib, malloc/free/memcpy, __multi3, ...) remain wasm
+imports from module "env", satisfied by the JS host at instantiation time.
+"""
+
+# Names llvmlite emits as env placeholders that the linker resolves itself.
+glob _PLACEHOLDER: set = {
+         "__linear_memory",
+         "__indirect_function_table",
+         "__stack_pointer",
+         "__memory_base",
+         "__table_base"
+     };
+
+# ─── LEB128 / byte emit helpers ──────────────────────────────────────────────
+"""Read an unsigned LEB128. Returns (value, new_offset)."""
+def _rd_uleb(b: bytes, o: int) -> tuple {
+    r = 0;
+    s = 0;
+    while True {
+        x = b[o];
+        o += 1;
+        r |= (x & 0x7f) << s;
+        s += 7;
+        if not (x & 0x80) {
+            return (r, o);
+        }
+    }
+}
+
+"""Read a signed LEB128. Returns (value, new_offset)."""
+def _rd_sleb(b: bytes, o: int) -> tuple {
+    r = 0;
+    s = 0;
+    while True {
+        x = b[o];
+        o += 1;
+        r |= (x & 0x7f) << s;
+        s += 7;
+        if not (x & 0x80) {
+            if x & 0x40 {
+                r |= -(1 << s);
+            }
+            return (r, o);
+        }
+    }
+}
+
+"""Encode an unsigned LEB128 (minimal length)."""
+def _uleb(v: int) -> bytes {
+    out = bytearray();
+    while True {
+        x = v & 0x7f;
+        v >>= 7;
+        if v {
+            out.append(x | 0x80);
+        } else {
+            out.append(x);
+            return bytes(out);
+        }
+    }
+}
+
+"""Encode a fixed 5-byte padded unsigned LEB128 (for in-place reloc rewrite).
+
+Also valid as a 5-byte signed LEB for small non-negative values (memory
+addresses, table slots), since the sign bit of the 5th byte stays clear."""
+def _uleb5(v: int) -> bytes {
+    out = bytearray();
+    i = 0;
+    while i < 5 {
+        x = (v >> (7 * i)) & 0x7f;
+        if i < 4 {
+            out.append(x | 0x80);
+        } else {
+            out.append(x);
+        }
+        i += 1;
+    }
+    return bytes(out);
+}
+
+"""Encode a signed LEB128 (minimal length), used for init-expr constants."""
+def _sleb_bytes(v: int) -> bytes {
+    out = bytearray();
+    while True {
+        x = v & 0x7f;
+        v >>= 7;
+        if (v == 0 and not (x & 0x40)) or (v == -1 and (x & 0x40)) {
+            out.append(x);
+            return bytes(out);
+        }
+        out.append(x | 0x80);
+    }
+}
+
+"""Little-endian u32."""
+def _u32le(v: int) -> bytes {
+    return (v & 0xffffffff).to_bytes(4, "little");
+}
+
+"""Read a length-prefixed name. Returns (str, new_offset)."""
+def _rd_name(b: bytes, o: int) -> tuple {
+    (n, o) = _rd_uleb(b, o);
+    return (b[o:o + n].decode("latin1"), o + n);
+}
+
+"""Emit a length-prefixed UTF-8 name."""
+def _nm_bytes(s: str) -> bytes {
+    e = s.encode("utf-8");
+    return _uleb(len(e)) + e;
+}
+
+"""Emit a section: id byte, ULEB size, payload."""
+def _section(sid: int, payload: bytes) -> bytes {
+    return bytes([sid]) + _uleb(len(payload)) + payload;
+}
+
+"""Emit a vector: ULEB count then concatenated items."""
+def _vec(items: list) -> bytes {
+    return _uleb(len(items)) + b"".join(items);
+}
+
+"""Overwrite buf[off:off+len(data)] in place (byte-wise; no slice assign)."""
+def _patch(buf: bytearray, off: int, data: bytes) {
+    i = 0;
+    while i < len(data) {
+        buf[off + i] = data[i];
+        i += 1;
+    }
+}
+
+# ─── Parsed relocatable object ───────────────────────────────────────────────
+"""A parsed relocatable wasm object (subset of sections the linker needs).
+
+imports : list of [kind, module, field, extra]  (kind in func/table/mem/global)
+func_types : type index per defined function
+symtab : list of [kind, flags, idx_or_seginfo, name]   (linking symbol table)
+relocs : list of [reloc_section_name, type, offset, sym_index, addend]
+seg_info : list of (name, align_log2, flags) from SEGMENT_INFO
+"""
+obj WasmObj {
+    has b: bytes,
+        types_raw: list = [],
+        imports: list = [],
+        func_types: list = [],
+        code: bytes = b"",
+        data_raw: bytes = b"",
+        symtab: list = [],
+        relocs: list = [],
+        seg_info: list = [];
+
+    def postinit {
+        self.types_raw = [];
+        self.imports = [];
+        self.func_types = [];
+        self.code = b"";
+        self.data_raw = b"";
+        self.symtab = [];
+        self.relocs = [];
+        self.seg_info = [];
+        self.parse();
+    }
+
+    def parse -> None;
+    def parse_linking(o: int, end: int) -> None;
+    def parse_reloc(nm: str, o: int, end: int) -> None;
+}
+
+impl WasmObj.parse -> None {
+    b = self.b;
+    o = 8;
+    while o < len(b) {
+        sid = b[o];
+        o += 1;
+        (size, o) = _rd_uleb(b, o);
+        end = o + size;
+        if sid == 1 {
+            (n, o) = _rd_uleb(b, o);
+            ci = 0;
+            while ci < n {
+                st = o;
+                o += 1;  # 0x60 form byte
+                (np, o) = _rd_uleb(b, o);
+                o += np;
+                (nr, o) = _rd_uleb(b, o);
+                o += nr;
+                self.types_raw.append(b[st:o]);
+                ci += 1;
+            }
+        } elif sid == 2 {
+            (n, o) = _rd_uleb(b, o);
+            ci = 0;
+            while ci < n {
+                (mod, o) = _rd_name(b, o);
+                (fld, o) = _rd_name(b, o);
+                k = b[o];
+                o += 1;
+                if k == 0 {
+                    (ti, o) = _rd_uleb(b, o);
+                    self.imports.append(["func", mod, fld, ti]);
+                } elif k == 1 {
+                    et = b[o];
+                    o += 1;
+                    fl = b[o];
+                    o += 1;
+                    (mn, o) = _rd_uleb(b, o);
+                    if fl & 1 {
+                        (mx, o) = _rd_uleb(b, o);
+                    }
+                    self.imports.append(["table", mod, fld, et]);
+                } elif k == 2 {
+                    fl = b[o];
+                    o += 1;
+                    (mn, o) = _rd_uleb(b, o);
+                    if fl & 1 {
+                        (mx, o) = _rd_uleb(b, o);
+                    }
+                    self.imports.append(["mem", mod, fld, mn]);
+                } elif k == 3 {
+                    vt = b[o];
+                    o += 1;
+                    mut = b[o];
+                    o += 1;
+                    self.imports.append(["global", mod, fld, (vt, mut)]);
+                }
+                ci += 1;
+            }
+        } elif sid == 3 {
+            (n, o) = _rd_uleb(b, o);
+            ci = 0;
+            while ci < n {
+                (t, o) = _rd_uleb(b, o);
+                self.func_types.append(t);
+                ci += 1;
+            }
+        } elif sid == 10 {
+            self.code = b[o:end];
+        } elif sid == 11 {
+            self.data_raw = b[o:end];
+        } elif sid == 0 {
+            (nm, o2) = _rd_name(b, o);
+            if nm == "linking" {
+                self.parse_linking(o2, end);
+            } elif nm.startswith("reloc.") {
+                self.parse_reloc(nm, o2, end);
+            }
+        }
+        o = end;
+    }
+}
+
+impl WasmObj.parse_linking(o: int, end: int) -> None {
+    b = self.b;
+    (ver, o) = _rd_uleb(b, o);
+    while o < end {
+        sub = b[o];
+        o += 1;
+        (pl, o) = _rd_uleb(b, o);
+        se = o + pl;
+        if sub == 8 {  # WASM_SYMBOL_TABLE
+            (cnt, o) = _rd_uleb(b, o);
+            ci = 0;
+            while ci < cnt {
+                kind = b[o];
+                o += 1;
+                (flags, o) = _rd_uleb(b, o);
+                undef = flags & 0x10;
+                if kind == 0 or kind == 2 or kind == 5 {
+                    (idx, o) = _rd_uleb(b, o);
+                    nm = None;
+                    if not undef {
+                        (nm, o) = _rd_name(b, o);
+                    }
+                    self.symtab.append([kind, flags, idx, nm]);
+                } elif kind == 1 {  # DATA
+                    (nm, o) = _rd_name(b, o);
+                    info = None;
+                    if not undef {
+                        (sg, o) = _rd_uleb(b, o);
+                        (of, o) = _rd_uleb(b, o);
+                        (sz, o) = _rd_uleb(b, o);
+                        info = (sg, of, sz);
+                    }
+                    self.symtab.append([kind, flags, info, nm]);
+                }
+                ci += 1;
+            }
+        } elif sub == 5 {  # WASM_SEGMENT_INFO
+            (cnt, o) = _rd_uleb(b, o);
+            ci = 0;
+            while ci < cnt {
+                (nm, o) = _rd_name(b, o);
+                (al, o) = _rd_uleb(b, o);
+                (fl, o) = _rd_uleb(b, o);
+                self.seg_info.append((nm, al, fl));
+                ci += 1;
+            }
+        }
+        o = se;
+    }
+}
+
+impl WasmObj.parse_reloc(nm: str, o: int, end: int) -> None {
+    b = self.b;
+    (sec, o) = _rd_uleb(b, o);
+    (cnt, o) = _rd_uleb(b, o);
+    ci = 0;
+    while ci < cnt {
+        rt = b[o];
+        o += 1;
+        (off, o) = _rd_uleb(b, o);
+        (sym, o) = _rd_uleb(b, o);
+        add = 0;
+        if rt == 3 or rt == 4 or rt == 5 {
+            (add, o) = _rd_sleb(b, o);
+        }
+        self.relocs.append([nm, rt, off, sym, add]);
+        ci += 1;
+    }
+}
+
+"""Parse the data section payload into a list of segment content byte strings."""
+def _parse_data_segments(b: bytes) -> list {
+    if not b {
+        return [];
+    }
+    o = 0;
+    (n, o) = _rd_uleb(b, o);
+    segs = [];
+    ci = 0;
+    while ci < n {
+        (flags, o) = _rd_uleb(b, o);
+        if flags == 0 {  # active, mem 0, offset expr
+            o += 1;  # 0x41 i32.const
+            (_v, o) = _rd_sleb(b, o);
+            o += 1;  # 0x0b end
+            (sz, o) = _rd_uleb(b, o);
+            segs.append(b[o:o + sz]);
+            o += sz;
+        } elif flags == 1 {  # passive
+            (sz, o) = _rd_uleb(b, o);
+            segs.append(b[o:o + sz]);
+            o += sz;
+        } else {
+            raise ValueError(f"unsupported data segment flags {flags}");
+        }
+        ci += 1;
+    }
+    return segs;
+}
+
+"""Resolve a linking-table symbol index to its final value.
+
+FUNCTION -> final function index; GLOBAL -> 0 (the synthesized __stack_pointer);
+DATA -> final linear-memory address (segment base + intra-segment offset)."""
+def _sym_val(ob: WasmObj, si: int, old2new: dict, seg_base: list) -> int {
+    e = ob.symtab[si];
+    k = e[0];
+    idx = e[2];
+    if k == 0 {
+        return old2new[idx];
+    }
+    if k == 2 {
+        return 0;
+    }
+    if k == 1 {
+        return seg_base[idx[0]] + idx[1];
+    }
+    raise ValueError(f"unsupported symbol kind {k}");
+}
+
+# ─── Linker ──────────────────────────────────────────────────────────────────
+"""Pure-Jac single-object wasm linker.
+
+`link` turns one relocatable wasm object into an instantiable module.
+"""
+obj WasmLinker {
+    """Link `obj_bytes` into a complete wasm module.
+
+    export_funcs: names to export; empty => export every defined function.
+    mem_pages: initial linear-memory size in 64 KiB pages."""
+    static def link(
+        obj_bytes: bytes, export_funcs: list = [], mem_pages: int = 256
+    ) -> bytes;
+}
+
+impl WasmLinker.link(
+    obj_bytes: bytes, export_funcs: list = [], mem_pages: int = 256
+) -> bytes {
+    ob = WasmObj(b=obj_bytes);
+    segs = _parse_data_segments(ob.data_raw);
+
+    # ── memory layout: data segments at 1024, then a stack, then the heap ──
+    base = 1024;
+    seg_base = [];
+    i = 0;
+    while i < len(segs) {
+        al = 0;
+        if i < len(ob.seg_info) {
+            al = ob.seg_info[i][1];
+        }
+        align = (1 << al) if al else 1;
+        base = ((base + align - 1) // align) * align;
+        seg_base.append(base);
+        base += len(segs[i]);
+        i += 1;
+    }
+    base = ((base + 15) // 16) * 16;
+    stack_top = base + (1 << 18);  # 256 KiB stack
+    heap_base = ((stack_top + 15) // 16) * 16;
+
+    # ── final function index space: kept imports first, then defined funcs ──
+    obj_func_imports = [
+        im
+        for im in ob.imports
+        if im[0] == "func"
+    ];
+    kept = [];
+    old2new = {};
+    oi = 0;
+    for im in obj_func_imports {
+        if im[2] in _PLACEHOLDER { } else {
+            old2new[oi] = len(kept);
+            kept.append(im);
+        }
+        oi += 1;
+    }
+    n_obj_imp = len(obj_func_imports);
+    n_imp = len(kept);
+    di = 0;
+    while di < len(ob.func_types) {
+        old2new[n_obj_imp + di] = n_imp + di;
+        di += 1;
+    }
+
+    # ── assign indirect-table slots to address-taken funcs (slot 0 = null) ──
+    # needs_table: the code references table 0 (call_indirect / table ops) even
+    # if no function is address-taken in this object - the table must still exist.
+    slot_of = {};
+    nslot = 1;
+    needs_table = False;
+    for r in ob.relocs {
+        rt = r[1];
+        if rt == 1 or rt == 2 or rt == 20 {
+            needs_table = True;
+        }
+        if rt == 1 or rt == 2 {
+            fi = _sym_val(ob, r[3], old2new, seg_base);
+            if fi in slot_of { } else {
+                slot_of[fi] = nslot;
+                nslot += 1;
+            }
+        }
+    }
+
+    # ── rewrite code relocations in place ──
+    code = bytearray(ob.code);
+    for r in ob.relocs {
+        rnm = r[0];
+        rt = r[1];
+        off = r[2];
+        sym = r[3];
+        add = r[4];
+        if rnm != "reloc.CODE" {
+            continue;
+        }
+        if rt == 0 {
+            _patch(code, off, _uleb5(_sym_val(ob, sym, old2new, seg_base)));
+        } elif rt == 1 {
+            _patch(code, off, _uleb5(slot_of[_sym_val(ob, sym, old2new, seg_base)]));
+        } elif rt == 2 {
+            _patch(code, off, _u32le(slot_of[_sym_val(ob, sym, old2new, seg_base)]));
+        } elif rt == 3 or rt == 4 {
+            _patch(code, off, _uleb5(_sym_val(ob, sym, old2new, seg_base) + add));
+        } elif rt == 5 {
+            _patch(code, off, _u32le(_sym_val(ob, sym, old2new, seg_base) + add));
+        } elif rt == 6 {
+            # TYPE_INDEX_LEB - identity for a single object (type section kept as-is)
+        } elif rt == 7 {
+            _patch(code, off, _uleb5(_sym_val(ob, sym, old2new, seg_base)));
+        } elif rt == 20 {
+            _patch(code, off, _uleb5(0));  # TABLE_NUMBER_LEB -> table 0
+        } else {
+            raise ValueError(f"unsupported reloc type {rt}");
+        }
+    }
+
+    # ── emit the module ──
+    out = bytearray(b"\x00asm");
+    out += _u32le(1);
+    out += _section(1, _vec(ob.types_raw));
+    imps = [];
+    for im in kept {
+        imps.append(_nm_bytes(im[1]) + _nm_bytes(im[2]) + b"\x00" + _uleb(im[3]));
+    }
+    out += _section(2, _vec(imps));
+    out += _section(3, _vec([_uleb(t) for t in ob.func_types]));
+    if needs_table {
+        out += _section(4, _vec([b"\x70\x00" + _uleb(nslot)]));  # funcref table
+    }
+    out += _section(5, _vec([b"\x00" + _uleb(mem_pages)]));  # memory
+    g_sp = b"\x7f\x01\x41" + _sleb_bytes(stack_top) + b"\x0b";  # mut i32
+    g_hb = b"\x7f\x00\x41" + _sleb_bytes(heap_base) + b"\x0b";  # const i32
+    out += _section(6, _vec([g_sp, g_hb]));
+
+    ef = export_funcs;
+    if not ef {
+        ef = [];
+        for e in ob.symtab {
+            if e[0] == 0 and e[3] and not (e[1] & 0x10) {
+                ef.append(e[3]);
+            }
+        }
+    }
+    exps = [_nm_bytes("memory") + b"\x02" + _uleb(0)];
+    exps.append(_nm_bytes("__stack_pointer") + b"\x03" + _uleb(0));
+    exps.append(_nm_bytes("__heap_base") + b"\x03" + _uleb(1));
+    for nm in ef {
+        fi = -1;
+        for e in ob.symtab {
+            if e[0] == 0 and e[3] == nm {
+                fi = old2new[e[2]];
+            }
+        }
+        if fi >= 0 {
+            exps.append(_nm_bytes(nm) + b"\x00" + _uleb(fi));
+        }
+    }
+    out += _section(7, _vec(exps));
+
+    if nslot > 1 {
+        pairs = [];
+        for kv in slot_of.items() {
+            pairs.append((kv[1], kv[0]));
+        }  # (slot, funcidx)
+        pairs.sort();
+        funcidxs = [p[1] for p in pairs];
+        expr = b"\x41" + _sleb_bytes(1) + b"\x0b";
+        elem = b"\x00" + expr + _vec([_uleb(fi) for fi in funcidxs]);
+        out += _section(9, _vec([elem]));
+    }
+    out += _section(10, bytes(code));
+
+    dsegs = [];
+    i = 0;
+    while i < len(segs) {
+        expr = b"\x41" + _sleb_bytes(seg_base[i]) + b"\x0b";
+        c = segs[i];
+        dsegs.append(b"\x00" + expr + _uleb(len(c)) + c);
+        i += 1;
+    }
+    if dsegs {
+        out += _section(11, _vec(dsegs));
+    }
+    return bytes(out);
+}

--- a/jac/tests/compiler/passes/native/fixtures/wasm_objects.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/wasm_objects.na.jac
@@ -1,0 +1,34 @@
+"""Single fixture exercising the wasm linker's full object->module transform:
+objects + lists (malloc/memcpy imports, indirect-call table + elem, every
+relocation kind), and a mutable global (data segment + memory-addr relocs +
+cross-call persistence). The point under test is the linker, not the math."""
+
+obj Pt { has x: float, y: float, alive: bool; }
+
+glob calls: int = 0;
+
+def make(n: int) -> list[Pt] {
+    out: list[Pt] = [];
+    i = 0;
+    while i < n {
+        out.append(Pt(x=float(i), y=float(i) * 2.0, alive=True));
+        i += 1;
+    }
+    return out;
+}
+
+def sum_x(pts: list[Pt]) -> float {
+    global calls;
+    calls = calls + 1;
+    total = 0.0;
+    i = 0;
+    while i < len(pts) {
+        p = pts[i];
+        if p.alive { total += p.x; }
+        i += 1;
+    }
+    return total;
+}
+
+def demo(n: int) -> float { return sum_x(make(n)); }
+def call_count() -> int { return calls; }

--- a/jac/tests/compiler/passes/native/test_wasm_linker.jac
+++ b/jac/tests/compiler/passes/native/test_wasm_linker.jac
@@ -1,0 +1,286 @@
+"""Tests for the wasm32 link path.
+
+These exercise the wasm *infra* -- the pure-Jac `WasmLinker`'s relocatable
+object -> instantiable module transformation (LEB encoding, dropping placeholder
+env imports, synthesizing memory / __stack_pointer / __heap_base / the
+indirect-function table+elem, and rewriting relocations) and the
+`nacompile --target wasm32` CLI -- not LLVM codegen, which the rest of the
+native suite already covers. One representative fixture (objects + lists + a
+mutable global) drives the linker's whole transform: it pulls in every
+supported relocation kind, the malloc/memcpy import surface, a data segment,
+and the indirect-call table.
+"""
+
+import os;
+import subprocess;
+import sys;
+import shutil;
+import tempfile;
+import from pathlib { Path }
+import jaclang;
+import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.compile_options { CompileOptions }
+import from jaclang.compiler.passes.native.wasm_linker {
+    WasmLinker,
+    _uleb,
+    _uleb5,
+    _sleb_bytes,
+    _rd_uleb,
+    _rd_sleb,
+    _u32le
+}
+import llvmlite.binding as llvm;
+
+glob FIXTURES = str(
+         Path(jaclang.__file__).parent.parent / "tests" / "compiler" / "passes" / "native" / "fixtures"
+     ),
+     WASM_TRIPLE = "wasm32-unknown-unknown",
+     FIXTURE = "wasm_objects.na.jac";
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+"""Compile a fixture to a relocatable wasm object the way `nacompile` does."""
+def emit_wasm_object(fixture: str) -> bytes {
+    prev = os.environ.get("JAC_NATIVE_TARGET", None);
+    os.environ["JAC_NATIVE_TARGET"] = WASM_TRIPLE;
+    try {
+        prog = JacProgram();
+        ir = prog.compile(
+            file_path=os.path.join(FIXTURES, fixture),
+            options=CompileOptions(aot_mode=True, type_check=False)
+        );
+        assert not prog.errors_had , f"compile errors: {[
+            str(e) for e in prog.errors_had
+        ]}";
+        llvm.initialize_all_targets();
+        llvm.initialize_all_asmprinters();
+        mod = llvm.parse_assembly(str(ir.gen.llvm_ir));
+        mod.verify();
+        tm = llvm.Target.from_triple(WASM_TRIPLE).create_target_machine(opt=2);
+        pto = llvm.create_pipeline_tuning_options(speed_level=2, size_level=0);
+        pb = llvm.create_pass_builder(tm, pto);
+        pb.getModulePassManager().run(mod, pb);
+        relobj = tm.emit_object(mod);
+    } finally {
+        if prev is None {
+            os.environ.pop("JAC_NATIVE_TARGET", None);
+        } else {
+            os.environ["JAC_NATIVE_TARGET"] = prev;
+        }
+    }
+    return relobj;
+}
+
+"""Top-level section spans -> list of (id, payload_start, payload_end)."""
+def sections(b: bytes) -> list {
+    o = 8;
+    out = [];
+    while o < len(b) {
+        sid = b[o];
+        o += 1;
+        (sz, o) = _rd_uleb(b, o);
+        out.append((sid, o, o + sz));
+        o += sz;
+    }
+    return out;
+}
+
+def has_section(b: bytes, want: int) -> bool {
+    for (sid, s, e) in sections(b) {
+        if sid == want {
+            return True;
+        }
+    }
+    return False;
+}
+
+"""Names of imported functions (kind 0) in the module's import section."""
+def func_imports(b: bytes) -> list {
+    out = [];
+    for (sid, s, e) in sections(b) {
+        if sid != 2 {
+            continue;
+        }
+        (n, o) = _rd_uleb(b, s);
+        i = 0;
+        while i < n {
+            (mlen, o) = _rd_uleb(b, o);
+            o += mlen;
+            (flen, o) = _rd_uleb(b, o);
+            fld = b[o:o + flen].decode("latin1");
+            o += flen;
+            k = b[o];
+            o += 1;
+            if k == 0 {
+                (ti, o) = _rd_uleb(b, o);
+                out.append(fld);
+            } elif k == 1 {
+                o += 2;
+                (mn, o) = _rd_uleb(b, o);
+            } elif k == 2 {
+                fl = b[o];
+                o += 1;
+                (mn, o) = _rd_uleb(b, o);
+                if fl & 1 {
+                    (mx, o) = _rd_uleb(b, o);
+                }
+            } elif k == 3 {
+                o += 2;
+            }
+            i += 1;
+        }
+    }
+    return out;
+}
+
+"""Names exported by the module."""
+def export_names(b: bytes) -> list {
+    out = [];
+    for (sid, s, e) in sections(b) {
+        if sid != 7 {
+            continue;
+        }
+        (n, o) = _rd_uleb(b, s);
+        i = 0;
+        while i < n {
+            (ln, o) = _rd_uleb(b, o);
+            out.append(b[o:o + ln].decode("latin1"));
+            o += ln;
+            o += 1;
+            (idx, o) = _rd_uleb(b, o);
+            i += 1;
+        }
+    }
+    return out;
+}
+
+# ─── tests ───────────────────────────────────────────────────────────────────
+test "LEB and fixed-width byte encoders round-trip" {
+    for v in [0, 1, 63, 64, 127, 128, 300, 16384, 1 << 28, (1 << 31) - 1] {
+        assert _rd_uleb(_uleb(v), 0)[0] == v;
+        assert len(_uleb5(v)) == 5;  # always 5 bytes (in-place reloc safe)
+        assert _rd_uleb(_uleb5(v), 0)[0] == v;  # padded form still decodes to v
+    }
+    for v in [-1, -64, -8192, 0, 12345, -123456] {
+        assert _rd_sleb(_sleb_bytes(v), 0)[0] == v;
+    }
+    assert _u32le(0x01020304) == bytes([4, 3, 2, 1]);
+}
+
+test "linker emits a well-formed module with synthesized memory/globals/exports" {
+    mod = WasmLinker.link(emit_wasm_object(FIXTURE), [], 256);
+
+    # valid wasm header
+    assert mod[0:4] == b"\x00asm";
+    assert mod[4:8] == bytes([1, 0, 0, 0]);
+
+    # placeholder env imports are resolved by the linker, not left as imports;
+    # genuine undefined externs stay as imports for the JS host to satisfy.
+    imps = func_imports(mod);
+    assert "__linear_memory" not in imps;
+    assert "__stack_pointer" not in imps;
+    assert "malloc" in imps and "free" in imps and "memcpy" in imps;
+    # the JS-unshimmable libc never gets pulled in (would force a wasi runtime)
+    assert "setjmp" not in imps and "longjmp" not in imps;
+
+    # synthesized exports: linear memory, the magic globals, and every defined fn
+    exps = export_names(mod);
+    for name in [
+        "memory",
+        "__stack_pointer",
+        "__heap_base",
+        "demo",
+        "make",
+        "sum_x",
+        "call_count"
+    ] {
+        assert name in exps , f"missing export {name}";
+    }
+
+    # the transform synthesizes memory + globals + a data segment, and -- because
+    # the objects use vtable dispatch (an indirect call) -- a table + elem segment.
+    assert has_section(mod, 5);  # memory
+    assert has_section(mod, 6);  # global (__stack_pointer / __heap_base)
+    assert has_section(mod, 11);  # data
+    assert has_section(mod, 4);  # table
+    assert has_section(mod, 9);  # elem
+}
+
+test "linking is deterministic" {
+    relobj = emit_wasm_object(FIXTURE);
+    assert WasmLinker.link(relobj, [], 256) == WasmLinker.link(relobj, [], 256);
+}
+
+test "nacompile --target wasm32 writes a valid module via the CLI" {
+    out = os.path.join(tempfile.mkdtemp(), "game.wasm");
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jaclang",
+            "nacompile",
+            "--target",
+            "wasm32",
+            os.path.join(FIXTURES, FIXTURE),
+            "-o",
+            out
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300
+    );
+    assert proc.returncode == 0 , f"nacompile failed: {proc.stderr}\n{proc.stdout}";
+    assert os.path.exists(out);
+    data = Path(out).read_bytes();
+    assert data[0:4] == b"\x00asm";
+    assert "demo" in export_names(data);
+}
+
+test "linked module instantiates and runs under node" {
+    node_bin = shutil.which("node");
+    if not node_bin {
+        import pytest;
+        pytest.skip("node not available");
+    }
+    mod = WasmLinker.link(emit_wasm_object(FIXTURE), [], 256);
+    d = tempfile.mkdtemp();
+    wpath = os.path.join(d, "m.wasm");
+    Path(wpath).write_bytes(mod);
+    # JS host: a bump allocator over exported memory + the small runtime surface.
+    harness = """
+import { readFileSync } from "fs";
+const M = {};
+const env = {
+  malloc: (n) => { n = Number(n); const p = M.h; M.h = (M.h + n + 7) & ~7; return p; },
+  calloc: (c, s) => { const n = Number(c) * Number(s); const p = M.h; M.h = (M.h + n + 7) & ~7;
+                      new Uint8Array(M.mem.buffer).fill(0, p, p + n); return p; },
+  free: () => {}, malloc_usable_size: () => 0,
+  memcpy: (d, s, n) => { new Uint8Array(M.mem.buffer).copyWithin(d, s, s + Number(n)); return d; },
+  memcmp: (a, b, n) => { const m = new Uint8Array(M.mem.buffer); n = Number(n);
+    for (let i = 0; i < n; i++) { const e = m[a+i] - m[b+i]; if (e) return e; } return 0; },
+  puts: () => 0, printf: () => 0, snprintf: () => 0, getenv: () => 0, fflush: () => 0,
+  abort: () => { throw new Error("abort"); },
+  __multi3: (res, al, ah, bl, bh) => { const K = (1n<<64n)-1n;
+    const a = (BigInt.asUintN(64,ah)<<64n)|BigInt.asUintN(64,al);
+    const b = (BigInt.asUintN(64,bh)<<64n)|BigInt.asUintN(64,bl);
+    const p = BigInt.asUintN(128, a*b); const dv = new DataView(M.mem.buffer);
+    dv.setBigUint64(res, p & K, true); dv.setBigUint64(res+8, (p>>64n) & K, true); },
+};
+const { instance } = await WebAssembly.instantiate(readFileSync(process.argv[2]), { env });
+const e = instance.exports;
+M.mem = e.memory; M.h = e.__heap_base.value;
+e.__jac_glob_init();
+const d1 = Number(e.demo(5n));   // sum of x over Pt(0..4) = 10
+e.demo(5n);                       // second call bumps the persisted global
+console.log(`demo=${d1} calls=${Number(e.call_count())}`);
+""";
+    hpath = os.path.join(d, "run.mjs");
+    Path(hpath).write_text(harness);
+    proc = subprocess.run(
+        [node_bin, hpath, wpath], capture_output=True, text=True, timeout=60
+    );
+    assert proc.returncode == 0 , f"node failed: {proc.stderr}";
+    last = proc.stdout.strip().splitlines()[-1];
+    # demo(5)==10 proves data/memory-addr relocs + heap layout; calls==2 proves the
+    # mutable global persists across calls (global load/store resolved correctly).
+    assert last == "demo=10 calls=2" , f"unexpected output: {last}";
+}


### PR DESCRIPTION
## What

Adds a `--target wasm32` flag to `jac nacompile` that compiles a `.na.jac` to a **browser-loadable WebAssembly module**, plus a **pure-Jac wasm linker** (`compiler/passes/native/wasm_linker.jac`) and a runnable WebGL demo (`examples/raylib_shooter/web/`).

```bash
jac nacompile --target wasm32 game.na.jac -o game.wasm
```

This is the same `na` codespace and the same LLVM backend — wasm is just a build target, not a new codegen pass or a new codespace. No `wasm-ld`/emscripten; the linker is pure Jac, so the "no external toolchain" property holds.

## How it works

- **`nacompile --target wasm32` (`-t`)** — sets the `wasm32-unknown-unknown` triple before compile (the native backend already targets wasm32 via `JAC_NATIVE_TARGET`), skips entry injection / `DT_NEEDED` / Python-interop checks, emits one relocatable object at opt2 (no internalize, so every defined function is an export), links it, and writes `<name>.wasm`.
- **`wasm_linker.jac`** — a single-object linker mirroring the existing ELF/Mach-O linkers. It drops the env placeholder imports (`__linear_memory`/`__stack_pointer`/…), builds the function index space, lays out linear memory and synthesizes the memory + `__stack_pointer` + `__heap_base` globals and the indirect-function table/elem, then rewrites `FUNCTION_INDEX` / `MEMORY_ADDR` / `GLOBAL_INDEX` / `TABLE_INDEX` / `TABLE_NUMBER` relocations. Undefined externs (raylib, `malloc`/`free`/`memcpy`, `__multi3`, …) stay as wasm imports for the JS host to satisfy.
- **`examples/raylib_shooter/web/`** — the **same** rlgl shooter source as the native demo, compiled to wasm and rendered with a WebGL immediate-mode shim (`raylib_web.mjs`). The `import from raylib { ... }` externs become the module's wasm imports; the shim supplies them. The only source change vs the native build is the entry shape: the blocking `with entry` loop is split into `init()` + `frame()` (a browser tab can't block its main thread). `./web/demo.sh` builds and serves it.

## Validation

- `jac nacompile --target wasm32` of the shooter and of a trivial module both produce modules that instantiate and run correctly under Node/V8 (`sq(7)=49`; the shooter runs 600 frames, object pools/bullet physics/collision/scoring all execute).
- The WebGL pipeline was exercised headless through a mock GL context: 960 draw calls over 120 frames, ~75% of transformed vertices land inside the view frustum with finite MVPs.
- Native host builds are unchanged (`jac nacompile hello.na.jac` still produces a runnable binary).

## Notes / scope

- `int` is wasm `i64`, so exported functions taking/returning `int` need `BigInt` at the JS boundary; the hot rlgl/input surface is all `i32`/`f32`.
- This is a POC of the wasm target end-to-end. Follow-ups: a blessed browser graphics binding, namespacing imports via `wasm-import-module`, and folding the game into a single `cl { } + na { }` file with an `sv` leaderboard.