### PR TITLE
fix(test): skip hidden and __pycache__ dirs during jac test discovery

### DIFF
--- a/jac/examples/littleX/test_littlex.jac
+++ b/jac/examples/littleX/test_littlex.jac
@@ -9,9 +9,8 @@ Run with:  jac test test_littlex.jac
 
 import os;
 import pytest;
-import from typing { Any }
 import from tempfile { mkdtemp }
-import from jaclang.runtimelib.testing { JacTestClient }
+import from jaclang.runtimelib.testing { JacTestClient, TestResponse }
 
 glob SERVER = os.path.join(os.path.dirname(__file__), "server.jac");
 
@@ -27,16 +26,16 @@ def login_as(client: JacTestClient, username: str, password: str) {
 }
 
 """Return the walker's report list from a response."""
-def reports_of(response: Any) -> list {
+def reports_of(response: TestResponse) -> list {
     data = response.data;
     if data and "reports" in data {
-        return data["reports"];
+        return list(data["reports"]);
     }
     return [];
 }
 
 """Return the first reported value (or None if the walker reported nothing)."""
-def first_report(response: Any) -> Any {
+def first_report(response: TestResponse) -> any {
     reports = reports_of(response);
     return reports[0] if reports else None;
 }
@@ -96,7 +95,7 @@ test "create tweet shows up in the feed" {
     assert tweet["is_mine"] == True;
 
     feed = first_report(client.post("/walker/load_feed", json={}));
-    assert len(feed) == 1;
+    assert len(list(feed)) == 1;
     assert feed[0]["content"] == "hello world";
 
     client.close();
@@ -115,7 +114,7 @@ test "like and comment on a tweet" {
         client.post("/walker/like_tweet", json={"tweet_id": tweet_id})
     );
     assert liked["liked"] == True;
-    assert "alice" in liked["likes"];
+    assert "alice" in list(liked["likes"]);
 
     unliked = first_report(
         client.post("/walker/like_tweet", json={"tweet_id": tweet_id})
@@ -130,7 +129,7 @@ test "like and comment on a tweet" {
     assert commented["success"] == True;
 
     profile = first_report(client.post("/walker/get_profile", json={}));
-    assert len(profile["tweets"][0]["comments"]) == 1;
+    assert len(list(profile["tweets"][0]["comments"])) == 1;
 
     client.close();
 }
@@ -149,7 +148,7 @@ test "delete a tweet removes it from the feed" {
     assert deleted["success"] == True;
 
     feed = first_report(client.post("/walker/load_feed", json={}));
-    assert len(feed) == 0;
+    assert len(list(feed)) == 0;
 
     client.close();
 }
@@ -162,7 +161,7 @@ test "search filters the feed by content" {
     client.post("/walker/create_tweet", json={"content": "python is fine"});
 
     hits = first_report(client.post("/walker/load_feed", json={"search_query": "jac"}));
-    assert len(hits) == 1;
+    assert len(list(hits)) == 1;
     assert hits[0]["content"] == "jac is great";
 
     client.close();
@@ -203,12 +202,12 @@ test "follow and unfollow another user" {
     assert first_report(followed)["success"] == True;
 
     after_follow = first_report(client.post("/walker/get_profile", json={}));
-    assert len(after_follow["following"]) == 1;
+    assert len(list(after_follow["following"])) == 1;
     assert after_follow["following"][0]["username"] == "bob";
 
     client.post("/walker/unfollow_user", json={"target_id": bob_id});
     after_unfollow = first_report(client.post("/walker/get_profile", json={}));
-    assert len(after_unfollow["following"]) == 0;
+    assert len(list(after_unfollow["following"])) == 0;
 
     client.close();
 }
@@ -285,14 +284,14 @@ test "channel create, join, post and detail" {
     assert joined["success"] == True;
 
     listing = first_report(client.post("/walker/get_channels", json={}));
-    assert len(listing) == 1;
+    assert len(list(listing)) == 1;
     assert listing[0]["member_count"] == 2;
 
     detail = first_report(
         client.post("/walker/get_channel_detail", json={"channel_id": channel_id})
     );
     assert detail["is_member"] == True;
-    assert len(detail["posts"]) == 1;
+    assert len(list(detail["posts"])) == 1;
     assert detail["posts"][0]["content"] == "welcome to the channel";
 
     client.close();

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -1009,7 +1009,17 @@ impl JacBasics.run_test(
     }
     if (filter or directory) {
         current_dir = directory or os.getcwd();
-        for (root_dir, _, files) in os.walk(current_dir, topdown=True) {
+        for (root_dir, dirs, files) in os.walk(current_dir, topdown=True) {
+            # Prune hidden / build-cache / pycache directories in place so the
+            # walk never descends into them — e.g. the per-project ".jac" build
+            # cache, which holds generated artifacts that are not test sources.
+            # Mutating the list in place is required: os.walk in topdown mode
+            # only honors pruning of the same list object it yields.
+            dirs[:] = [
+                d
+                for d in dirs
+                if not (d.startswith('.') or d == '__pycache__')
+            ];
             files = [
                 file
                 for file in files

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -485,6 +485,43 @@ test "run test with directory filter" {
     assert "circle_pure.impl" not in stdout;
 }
 
+test "discovery prunes hidden and pycache dirs" {
+    tmp_dir = tempfile.mkdtemp();
+    try {
+        os.makedirs(os.path.join(tmp_dir, ".jac"));
+        os.makedirs(os.path.join(tmp_dir, "__pycache__"));
+        # A real, top-level test that must be discovered and pass.
+        Path(os.path.join(tmp_dir, "good_test.jac")).write_text(
+            'test "good_one" {\n    assert True;\n}\n'
+        );
+        # Failing tests planted inside the build-cache (".jac") and pycache
+        # dirs. The discovery walk must prune these, so they never run.
+        Path(os.path.join(tmp_dir, ".jac", "skip_test.jac")).write_text(
+            'test "pruned_cache" {\n    assert False;\n}\n'
+        );
+        Path(os.path.join(tmp_dir, "__pycache__", "skip_test.jac")).write_text(
+            'test "pruned_pyc" {\n    assert False;\n}\n'
+        );
+        process = subprocess.Popen(
+            ["jac", "test", "-d", tmp_dir],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        );
+        (stdout, stderr) = process.communicate();
+        combined = stdout + stderr;
+        # Top-level test is discovered and runs to a pass.
+        assert "good_test.jac" in combined;
+        assert "Passed successfully." in combined;
+        # Hidden / pycache dirs are pruned: their failing tests never run.
+        assert "skip_test.jac" not in combined;
+        assert "FAILED" not in combined;
+        assert process.returncode == 0;
+    } finally {
+        shutil.rmtree(tmp_dir, ignore_errors=True);
+    }
+}
+
 test "run test with filter maxfail" {
     process = subprocess.Popen(
         ["jac", "test", "-f", "*run_test.jac", "-m", "3"],


### PR DESCRIPTION
## Problem

`jac test` directory discovery ran `os.walk()` without pruning any
directories, so it descended into the per-project `.jac` build cache
(generated artifacts, a full `node_modules` tree, JIR caches, compiled
JS) as well as any other hidden or `__pycache__` directories. In a built
project this meant walking thousands of irrelevant files, and any
test-like file generated under those trees could be picked up and run.

## Fix

Prune the `dirs` list in place during the topdown walk so those subtrees
are never visited. The predicate (skip any directory starting with `.` or
named `__pycache__`) matches the convention already used elsewhere for
bytecode precompilation discovery. Mutating the list in place is required:
`os.walk` in topdown mode only honors pruning of the same list object it
yields.

## Test

Adds a regression test that creates a temp directory with a passing
top-level test plus failing tests planted inside `.jac/` and
`__pycache__/`, then runs `jac test -d <dir>` and asserts only the
top-level test is discovered and runs. Verified that reverting the fix
makes the planted tests run and the suite fail, so the test genuinely
guards the behavior.

## Also included

A small typing tweak in the littleX example test helpers, replacing
`typing.Any` annotations with the concrete `TestResponse` type.