### PR TITLE
Centralize compiler analysis facts

### DIFF
--- a/docs/docs/internals/compiler_architecture.md
+++ b/docs/docs/internals/compiler_architecture.md
@@ -15,6 +15,19 @@ A single `.jac` file can mix all three codespaces. The compiler routes each
 declaration to the correct backend, synthesises the interop bridges at the
 boundary, and emits the appropriate artefact per codespace.
 
+The architecture is governed by a simple ownership rule:
+
+| Layer | Owns | Must not own |
+|-------|------|--------------|
+| **Frontend analysis** | Jac language truth: parsed structure, symbols, scopes, semantic resolution, type facts, control-flow facts, meaning-typed IR, and portability diagnostics | Target syntax, runtime helper shape, or ABI-specific emission details |
+| **Boundary analysis** | Cross-codespace contracts: caller/callee context, route shape, parameter and return wire types, access requirements, endpoint effects, and provider metadata | Python/JavaScript/LLVM stub syntax |
+| **Target lowering** | Representation facts needed by exactly one backend, such as Python import requirements, JSX accumulator state, LLVM layout/ABI plans, and ownership lowering | Facts another backend would need to answer the same Jac semantic question |
+| **Emission** | Concrete Python AST, ESTree, LLVM IR, bytecode, JavaScript, native objects, and runtime stubs | Rediscovery of names, types, access, or cross-codespace contracts |
+
+As a review heuristic: if two backends need the same fact, that fact belongs
+in a shared analysis pass or manifest. If only one backend needs it because of
+the representation it emits, it can stay target-local.
+
 This document is the architectural map of how that pipeline is wired
 together. It is intended for compiler contributors. For language-level
 behaviour see [Primitives & Codespace Semantics](../reference/language/primitives.md);
@@ -112,7 +125,7 @@ graph TD
 
     FRONTEND --> FE1 --> FE2 --> FE3 --> FE4 --> FE5 --> FE6 --> FE7 --> FE8
     FE8 --> TYPECK["Type Check<br/>TypeCheckPass / StaticAnalysisPass / PortabilityCheckPass"]
-    TYPECK --> INTEROP["InteropAnalysisPass<br/>(boundary discovery)"]
+    TYPECK --> INTEROP["BoundaryAnalysisPass<br/>(boundary discovery)"]
     INTEROP --> SV[PyastGenPass + PyBytecodeGenPass]
     INTEROP --> CL[EsastGenPass]
     INTEROP --> NA[NaIRGenPass + NativeCompilePass]
@@ -203,9 +216,34 @@ instead of recursing forever.
 
 ---
 
-## Stage 4: Boundary Discovery -- `InteropAnalysisPass`
+## Shared Analysis Facts
 
-[`InteropAnalysisPass`](https://github.com/Jaseci-Labs/jaseci/blob/main/jac/jaclang/jac0core/passes/interop_analysis_pass.jac)
+All module-wide facts that survive across stages are anchored on
+[`CodeGenTarget.analysis`](https://github.com/Jaseci-Labs/jaseci/blob/main/jac/jaclang/jac0core/codeinfo.jac),
+a `ModuleAnalysis` object. This is the preferred home for facts that describe
+what a Jac module means independent of any one emitted artifact.
+
+`ModuleAnalysis` currently gathers the existing shared manifests:
+
+| Fact | Producer | Consumers |
+|------|----------|-----------|
+| `interop_manifest` | `BoundaryAnalysisPass` and native import registration | Python, client, native codegen, native cache loading, serve/runtime integration |
+| `client_manifest` | `EsastGenPass` | client bundling and runtime registration |
+| `native_layout` | `NaIRGenPass` today; intended to move toward a native layout analysis pass | native marshalling, native compile/cache paths, Python/native bridge code |
+| `native_compat` | `UniTreeEnrichPass` | auto-native promotion decisions |
+| `layout_registry` | `LayoutPass` | Shared archetype field layout, C3 MRO, vtable structure, and backend layout queries |
+
+Consumers read shared facts from `module.gen.analysis` directly, or through a
+small read-only helper such as `get_layout_registry(...)` when the fact has a
+domain-specific API. New shared facts should be added to `ModuleAnalysis`
+first; avoid adding compatibility accessors unless an external API genuinely
+depends on them.
+
+---
+
+## Stage 4: Boundary Discovery -- `BoundaryAnalysisPass`
+
+[`BoundaryAnalysisPass`](https://github.com/Jaseci-Labs/jaseci/blob/main/jac/jaclang/jac0core/passes/boundary_analysis_pass.jac)
 runs once *before* code generation. It walks every call site and records:
 
 1. The `CodeContext` of the **caller** and **callee** (SERVER / CLIENT / NATIVE).
@@ -306,7 +344,7 @@ Linking is also self-contained -- no external linker is invoked:
 The native backend supplies its own memory management: a 32-byte
 allocation header with reference counts (see `HDR_*` globals in
 `na_ir_gen_pass.jac`). Cross-codespace calls between Python and native
-flow through the interop bridge generated from `InteropAnalysisPass`.
+flow through the interop bridge generated from `BoundaryAnalysisPass`.
 
 ---
 
@@ -367,7 +405,7 @@ user-facing reference, [Primitives & Codespace Semantics](../reference/language/
 
 ## Cross-Codespace Interop
 
-`InteropAnalysisPass` discovers boundaries; the backends close them.
+`BoundaryAnalysisPass` discovers boundaries; the backends close them.
 
 | Direction | Bridge | Generated by |
 |-----------|--------|--------------|
@@ -375,7 +413,7 @@ user-facing reference, [Primitives & Codespace Semantics](../reference/language/
 | `sv → cl` | None at runtime -- the client mounts its own DOM. The server only ships the bootstrap payload | `PyastGenPass` emits the static-file route for the bundle |
 | `sv → na` | ctypes call into the native shared object | `PyastGenPass` emits a `ctypes.CFUNCTYPE` stub; `NaIRGenPass` exposes the function with C ABI |
 | `na → sv` | C-callable thunk that re-enters CPython via the limited API | Generated alongside the `sv → na` stub |
-| `na → na` | Direct symbol reference resolved by the in-tree linker | `InteropAnalysisPass` records the import; `NativeCompilePass` emits the relocation |
+| `na → na` | Direct symbol reference resolved by the in-tree linker | `BoundaryAnalysisPass` records the import; `NativeCompilePass` emits the relocation |
 | `sv → sv` (microservice) | HTTP between processes when an `sv import` resolves to a different deployment | `PyastGenPass` emits an `httpx` call; the manifest is consumed by `jac-scale` |
 
 Boundary types are serialised through the schemas in

--- a/docs/docs/internals/compiler_architecture.md
+++ b/docs/docs/internals/compiler_architecture.md
@@ -231,6 +231,9 @@ what a Jac module means independent of any one emitted artifact.
 | `client_manifest` | `EsastGenPass` | client bundling and runtime registration |
 | `native_layout` | `NaIRGenPass` today; intended to move toward a native layout analysis pass | native marshalling, native compile/cache paths, Python/native bridge code |
 | `native_compat` | `UniTreeEnrichPass` | auto-native promotion decisions |
+| `code_contexts` | `UniTreeEnrichPass` / `ModuleCodegenPass` | flattened top-level declarations per codespace and shared archetype indexes |
+| `symbols` | `UniTreeEnrichPass` / `ModuleCodegenPass` | reusable module symbol indexes, currently archetypes by name |
+| `native_clibs` | `NaIRGenPass` native import lowering | native compile/cache paths and nacompile linker inputs |
 | `layout_registry` | `LayoutPass` | Shared archetype field layout, C3 MRO, vtable structure, and backend layout queries |
 
 Consumers read shared facts from `module.gen.analysis` directly, or through a

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -157,7 +157,9 @@ impl run(
                     na_program._auto_promote_target = full_path;
                     ir_mod = na_program.compile(file_path=full_path);
                     if (
-                        ir_mod and ir_mod.gen.native_compat and ir_mod.gen.native_engine
+                        ir_mod
+                        and ir_mod.gen.analysis.native_compat
+                        and ir_mod.gen.native_engine
                     ) {
                         # Auto-promoted native module: execute via JIT
                         import ctypes;

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -158,7 +158,7 @@ impl run(
                     ir_mod = na_program.compile(file_path=full_path);
                     if (
                         ir_mod
-                        and ir_mod.gen.analysis.native_compat
+                        and ir_mod.gen.analysis.native_compat.is_compatible
                         and ir_mod.gen.native_engine
                     ) {
                         # Auto-promoted native module: execute via JIT

--- a/jac/jaclang/cli/commands/impl/nacompile.impl.jac
+++ b/jac/jaclang/cli/commands/impl/nacompile.impl.jac
@@ -143,7 +143,7 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     }
 
     if ir_module is None or ir_module.gen.llvm_ir is None {
-        if auto_promote and not (ir_module and ir_module.gen.native_compat) {
+        if auto_promote and not (ir_module and ir_module.gen.analysis.native_compat) {
             console.error(
                 "This .jac file is not compatible with native compilation.\n"
                 "  It may use walkers, nodes, edges, async, lambdas, or other\n"
@@ -166,7 +166,7 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     }
 
     # Step 2: Check for Python/server interop (can't compile standalone)
-    manifest = ir_module.gen.interop_manifest;
+    manifest = ir_module.gen.analysis.interop_manifest;
     if manifest and manifest.native_imports {
         console.error(
             "Cannot compile to standalone binary: "

--- a/jac/jaclang/cli/commands/impl/nacompile.impl.jac
+++ b/jac/jaclang/cli/commands/impl/nacompile.impl.jac
@@ -143,7 +143,8 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     }
 
     if ir_module is None or ir_module.gen.llvm_ir is None {
-        if auto_promote and not (ir_module and ir_module.gen.analysis.native_compat) {
+        if auto_promote
+        and not (ir_module and ir_module.gen.analysis.native_compat.is_compatible) {
             console.error(
                 "This .jac file is not compatible with native compilation.\n"
                 "  It may use walkers, nodes, edges, async, lambdas, or other\n"
@@ -217,8 +218,8 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     # Add C shared libraries discovered during compilation (e.g. libuv.so.1)
     # These come from `import from "/path/to/lib.so" { ... }` declarations
     # in the compiled module and its transitive dependencies.
-    # _clib_paths is accumulated by _compile_and_link_native_imports.
-    clib_paths = ir_module.gen._clib_paths;
+    # Native C library paths are accumulated by _compile_and_link_native_imports.
+    clib_paths = ir_module.gen.analysis.native_clibs.paths;
     # Maps a raw clib path to the soname actually recorded in needed_libs, so
     # the per-symbol library attribution below lines up with the linker's
     # LC_LOAD_DYLIB ordinals.
@@ -253,7 +254,7 @@ impl nacompile(filename: str, output: str = "", scrub: bool = False) -> int {
     # dylib ordinals (e.g. "InitWindow" -> "libraylib.dylib"). On ELF this is
     # unused (the loader searches all DT_NEEDED libs flatly).
     symbol_lib_map: dict[str, str] = {};
-    for (_sym, _raw) in ir_module.gen._clib_symbol_lib.items() {
+    for (_sym, _raw) in ir_module.gen.analysis.native_clibs.symbol_lib.items() {
         symbol_lib_map[_sym] = _lib_norm.get(_raw, _raw);
     }
 

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -1019,7 +1019,7 @@ impl EsastGenPass._resolve_call_ability(nd: uni.FuncCall) -> (uni.Ability | None
         # sv-imported name: read the source ability off the cross-boundary
         # binding that BoundaryAnalysisPass already resolved (no independent
         # import re-resolution here).
-        manifest = self.ir_in.gen.interop_manifest;
+        manifest = self.ir_in.gen.analysis.interop_manifest;
         binding = manifest.bindings.get(nd.target.sym_name) if manifest else None;
         if binding and isinstance(binding.ast_node, uni.Ability) {
             return binding.ast_node;
@@ -1576,10 +1576,10 @@ impl EsastGenPass._try_lower_server_rpc_call(
         ability_node
     );
     inline_ret_type: str = self._extract_return_type(
-        ability_node, func_name, self.ir_in.gen.interop_manifest
+        ability_node, func_name, self.ir_in.gen.analysis.interop_manifest
     );
-    inline_boundary = self.ir_in.gen.interop_manifest.boundary_types
-        if self.ir_in.gen.interop_manifest
+    inline_boundary = self.ir_in.gen.analysis.interop_manifest.boundary_types
+        if self.ir_in.gen.analysis.interop_manifest
         else {};
     (spread_arg, spread_read_source) = self._make_kwargs_spread_context(props, nd);
     use_kwargs_temp = spread_read_source is not None;
@@ -5192,12 +5192,12 @@ impl EsastGenPass._generate_sv_import_stubs(nd: uni.Import) -> None {
                 param_names = self._param_names_from_ability(ability_node);
                 param_type_map = self._param_type_map_from_ability(ability_node);
                 ret_type_name = self._extract_return_type(
-                    ability_node, func_name, nd.gen.interop_manifest
+                    ability_node, func_name, nd.gen.analysis.interop_manifest
                 );
                 # Carry the source module's precomputed effect (from
                 # BoundaryAnalysisPass) into this client bundle's manifest so the
                 # sv-imported endpoint self-registers with the right effects.
-                src_effect = source_mod.gen.interop_manifest.endpoint_effects.get(
+                src_effect = source_mod.gen.analysis.interop_manifest.endpoint_effects.get(
                     f"func:{func_name}"
                 );
                 if src_effect is not None {
@@ -5207,8 +5207,8 @@ impl EsastGenPass._generate_sv_import_stubs(nd: uni.Import) -> None {
                 }
             }
         }
-        boundary_types = nd.gen.interop_manifest.boundary_types
-            if nd.gen.interop_manifest
+        boundary_types = nd.gen.analysis.interop_manifest.boundary_types
+            if nd.gen.analysis.interop_manifest
             else {};
         # Build JS function parameters
         js_params: list[es.Pattern] = [];
@@ -5291,19 +5291,21 @@ impl EsastGenPass.exit_sub_tag(nd: uni.SubTag[uni.T]) -> None {
 
 """Recursively populate client manifest from module declarations."""
 impl EsastGenPass._populate_client_manifest(nd: uni.Module) -> None {
-    for item in nd.gen.client_manifest.exports {
+    for item in nd.gen.analysis.client_manifest.exports {
         self.client_manifest.exports.append(item);
     }
-    for item in nd.gen.client_manifest.globals {
+    for item in nd.gen.analysis.client_manifest.globals {
         self.client_manifest.globals.append(item);
     }
-    for (import_key, resolved_path) in nd.gen.client_manifest.imports.items() {
+    for (import_key, resolved_path) in nd.gen.analysis.client_manifest.imports.items() {
         self.client_manifest.imports[import_key] = resolved_path;
     }
-    for sub_mod in nd.gen.client_manifest.params {
-        self.client_manifest.params[sub_mod] = nd.gen.client_manifest.params[sub_mod];
+    for sub_mod in nd.gen.analysis.client_manifest.params {
+        self.client_manifest.params[sub_mod] = nd.gen.analysis.client_manifest.params[
+            sub_mod
+        ];
     }
-    for (ename, eeffect) in nd.gen.interop_manifest.endpoint_effects.items() {
+    for (ename, eeffect) in nd.gen.analysis.interop_manifest.endpoint_effects.items() {
         self.client_manifest.endpoint_effects[ename] = eeffect;
     }
 }
@@ -5318,7 +5320,7 @@ impl EsastGenPass.populate_client_manifest(nd: uni.Module) -> None {
 """Emit JS class stubs for types crossing the SV/CL boundary."""
 impl EsastGenPass._emit_boundary_type_stubs(nd: uni.Module) -> list[es.Statement] {
     import from jaclang.jac0core.codeinfo { BoundaryTypeInfo }
-    manifest = nd.gen.interop_manifest;
+    manifest = nd.gen.analysis.interop_manifest;
     if not manifest.boundary_types {
         return [];
     }
@@ -6168,7 +6170,7 @@ impl EsastGenPass.exit_module(nd: uni.Module) -> None {
     program = self.sync_loc(es.Program(body=body, sourceType='module'), jac_node=nd);
     nd.gen.es_ast = program;
     nd.gen.js = es_to_js(nd.gen.es_ast);
-    nd.gen.client_manifest = self.client_manifest;
+    nd.gen.analysis.client_manifest = self.client_manifest;
 }
 
 """Construct a block statement from a Jac scope node."""
@@ -6343,8 +6345,8 @@ impl EsastGenPass._build_spawn_arg_object(
             }
         }
     }
-    boundary_types = self.ir_in.gen.interop_manifest.boundary_types
-        if self.ir_in.gen.interop_manifest
+    boundary_types = self.ir_in.gen.analysis.interop_manifest.boundary_types
+        if self.ir_in.gen.analysis.interop_manifest
         else {};
     properties: list[(es.Property | es.SpreadElement)] = [];
     positional_index = 0;
@@ -6732,11 +6734,11 @@ impl EsastGenPass.before_pass -> None {
     self.child_passes = self._init_child_passes(EsastGenPass);
     self.client_manifest = ClientManifest();
     # Endpoint effects are computed by BoundaryAnalysisPass (front-end) into
-    # mod.gen.interop_manifest. Seed the fresh accumulator from it so the
+    # mod.gen.analysis.interop_manifest. Seed the fresh accumulator from it so the
     # registration emit and cross-module merge carry them through; this pass
     # no longer classifies effects itself.
     self.client_manifest.endpoint_effects = dict(
-        self.ir_in.gen.interop_manifest.endpoint_effects
+        self.ir_in.gen.analysis.interop_manifest.endpoint_effects
     );
     # Module-level (shared) archetypes referenced by client code. They live in
     # SERVER context (their default) but client code uses them, so they must be

--- a/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
@@ -14,7 +14,7 @@ impl LayoutPass.transform(ir_in: uni.Module) -> uni.Module {
     # Step 1: Collect all archetypes
     arch_map = self._collect_archetypes(module);
     if not arch_map {
-        module.gen.layout_registry = self.registry;
+        module.gen.analysis.layout_registry = self.registry;
         return ir_in;
     }
     # Step 2: Build hierarchy (parents + MRO)
@@ -41,8 +41,7 @@ impl LayoutPass.transform(ir_in: uni.Module) -> uni.Module {
             self._validate_obj_fields(arch_map[name], arch_map);
         }
     }
-    # Store registry on module (using setattr to avoid modifying CodeGenTarget)
-    module.gen.layout_registry = self.registry;
+    module.gen.analysis.layout_registry = self.registry;
     return ir_in;
 }
 

--- a/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/layout_pass.impl.jac
@@ -1,8 +1,8 @@
 """Layout pass implementation — computes class hierarchy, C3 MRO,
 field layout, and vtable structure for all archetypes."""
 import jaclang.jac0core.unitree as uni;
-import from jaclang.jac0core.passes { UniPass }
 import from jaclang.jac0core.constant { Tokens as Tok }
+import from jaclang.jac0core.passes.module_codegen_pass { ModuleCodegenPass }
 
 impl LayoutPass.postinit -> None {
     self.registry = LayoutRegistry();
@@ -47,18 +47,11 @@ impl LayoutPass.transform(ir_in: uni.Module) -> uni.Module {
 
 """Collect all Archetype nodes from the module, deduplicating forward declarations."""
 impl LayoutPass._collect_archetypes(module: uni.Module) -> dict[str, uni.Archetype] {
-    arch_map: dict[str, uni.Archetype] = {};
-    for nd in UniPass.get_all_sub_nodes(module, uni.Archetype, brute_force=True) {
-        aname = nd.name.value if nd.name else None;
-        if aname is None {
-            continue;
-        }
-        # Full definition overrides forward declaration
-        if aname not in arch_map or nd.body is not None {
-            arch_map[aname] = nd;
-        }
+    symbols = module.gen.analysis.symbols;
+    if not symbols.archetypes_by_name and module.body {
+        ModuleCodegenPass.index_code_contexts(module);
     }
-    return arch_map;
+    return symbols.archetypes_by_name;
 }
 
 """Extract parent names from base_classes and compute C3 MRO for all archetypes."""

--- a/jac/jaclang/compiler/passes/main/impl/unitree_enrich_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/unitree_enrich_pass.impl.jac
@@ -96,5 +96,7 @@ impl UniTreeEnrichPass.enter_module_code(nd: uni.ModuleCode) -> None {
 }
 
 impl UniTreeEnrichPass.exit_module(nd: uni.Module) -> None {
-    nd.gen.native_compat = not self._native_has_disqualifier and self._native_has_entry;
+    nd.gen.analysis.native_compat = (
+        not self._native_has_disqualifier and self._native_has_entry
+    );
 }

--- a/jac/jaclang/compiler/passes/main/impl/unitree_enrich_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/unitree_enrich_pass.impl.jac
@@ -1,8 +1,14 @@
 """Implementation of UniTreeEnrichPass."""
 
 impl UniTreeEnrichPass.before_pass -> None {
-    self._native_has_disqualifier: bool = False;
-    self._native_has_entry: bool = False;
+    self.ir_in.gen.analysis.native_compat = NativeCompatFacts();
+}
+
+impl UniTreeEnrichPass._mark_native_disqualifier(reason: str) -> None {
+    compat = self.ir_in.gen.analysis.native_compat;
+    if reason not in compat.disqualifiers {
+        compat.disqualifiers.append(reason);
+    }
 }
 
 
@@ -26,77 +32,76 @@ impl UniTreeEnrichPass.enter_name(nd: uni.Name) -> None {
 
 
 impl UniTreeEnrichPass.enter_archetype(nd: uni.Archetype) -> None {
-    if not self._native_has_disqualifier {
-        arch_val = nd.arch_type.value if nd.arch_type else "";
-        if arch_val in ("node", "edge", "walker") {
-            self._native_has_disqualifier = True;
-        }
+    arch_val = nd.arch_type.value if nd.arch_type else "";
+    if arch_val in ("node", "edge", "walker") {
+        self._mark_native_disqualifier(f"archetype:{arch_val}");
     }
 }
 
 impl UniTreeEnrichPass.enter_ability(nd: uni.Ability) -> None {
-    if not self._native_has_disqualifier {
-        if nd.is_async or isinstance(nd.signature, uni.EventSignature) {
-            self._native_has_disqualifier = True;
-        }
+    if nd.is_async {
+        self._mark_native_disqualifier("async ability");
+    }
+    if isinstance(nd.signature, uni.EventSignature) {
+        self._mark_native_disqualifier("event ability");
     }
 }
 
 impl UniTreeEnrichPass.enter_visit_stmt(nd: uni.VisitStmt) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("visit statement");
 }
 
 impl UniTreeEnrichPass.enter_disengage_stmt(nd: uni.DisengageStmt) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("disengage statement");
 }
 
 impl UniTreeEnrichPass.enter_report_stmt(nd: uni.ReportStmt) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("report statement");
 }
 
 impl UniTreeEnrichPass.enter_yield_expr(nd: uni.YieldExpr) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("yield expression");
 }
 
 impl UniTreeEnrichPass.enter_edge_op_ref(nd: uni.EdgeOpRef) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("edge operation");
 }
 
 impl UniTreeEnrichPass.enter_disconnect_op(nd: uni.DisconnectOp) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("disconnect operation");
 }
 
 impl UniTreeEnrichPass.enter_typed_ctx_block(nd: uni.TypedCtxBlock) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("typed context block");
 }
 
 impl UniTreeEnrichPass.enter_lambda_expr(nd: uni.LambdaExpr) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("lambda expression");
 }
 
 impl UniTreeEnrichPass.enter_py_inline_code(nd: uni.PyInlineCode) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("Python inline code");
 }
 
 impl UniTreeEnrichPass.enter_client_block(nd: uni.ClientBlock) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("client block");
 }
 
 impl UniTreeEnrichPass.enter_server_block(nd: uni.ServerBlock) -> None {
-    self._native_has_disqualifier = True;
+    self._mark_native_disqualifier("server block");
 }
 
 impl UniTreeEnrichPass.enter_module_code(nd: uni.ModuleCode) -> None {
     for k in nd.kid {
         if isinstance(k, uni.Token) and k.value == "entry" {
-            self._native_has_entry = True;
+            self.ir_in.gen.analysis.native_compat.has_entry = True;
             break;
         }
     }
 }
 
 impl UniTreeEnrichPass.exit_module(nd: uni.Module) -> None {
-    nd.gen.analysis.native_compat = (
-        not self._native_has_disqualifier and self._native_has_entry
-    );
+    self.index_code_contexts(nd);
+    compat = nd.gen.analysis.native_compat;
+    compat.is_compatible = not compat.disqualifiers and compat.has_entry;
 }

--- a/jac/jaclang/compiler/passes/main/layout_pass.jac
+++ b/jac/jaclang/compiler/passes/main/layout_pass.jac
@@ -72,19 +72,9 @@ obj ArchetypeLayout {
         parent_field_start: dict[str, int] = {};
 }
 
-"""Get or compute the layout registry for a module.
-
-Backends call this lazily instead of LayoutPass being in the schedule.
-Avoids re-entrancy issues with the self-hosting compiler bootstrap.
-"""
+"""Return the layout registry produced by LayoutPass."""
 def get_layout_registry(module: uni.Module, prog: any = None) -> LayoutRegistry {
-    reg = module.gen.layout_registry;
-    if reg is not None {
-        return reg;
-    }
-    # Compute lazily
-    pass_inst = LayoutPass(ir_in=module, prog=prog);
-    return module.gen.layout_registry or LayoutRegistry();
+    return module.gen.analysis.layout_registry or LayoutRegistry();
 }
 
 """Module-level layout registry."""

--- a/jac/jaclang/compiler/passes/main/unitree_enrich_pass.jac
+++ b/jac/jaclang/compiler/passes/main/unitree_enrich_pass.jac
@@ -1,6 +1,6 @@
 """Pre-computes backend-neutral analysis on AST nodes so codegen passes
 are pure code generation. Populates Name.js_decl_kind and
-Module.gen.native_compat."""
+Module.gen.analysis.native_compat."""
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.passes { UniPass }
 

--- a/jac/jaclang/compiler/passes/main/unitree_enrich_pass.jac
+++ b/jac/jaclang/compiler/passes/main/unitree_enrich_pass.jac
@@ -1,12 +1,14 @@
 """Pre-computes backend-neutral analysis on AST nodes so codegen passes
 are pure code generation. Populates Name.js_decl_kind and
-Module.gen.analysis.native_compat."""
+Module.gen.analysis codegen facts."""
 import jaclang.jac0core.unitree as uni;
+import from jaclang.jac0core.codeinfo { NativeCompatFacts }
 import from jaclang.jac0core.passes { UniPass }
 
 """Pre-compute backend hints on every Name node."""
 obj UniTreeEnrichPass(UniPass) {
     def before_pass -> None;
+    def _mark_native_disqualifier(reason: str) -> None;
     def enter_name(nd: uni.Name) -> None;
     def enter_archetype(nd: uni.Archetype) -> None;
     def enter_ability(nd: uni.Ability) -> None;

--- a/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
@@ -125,7 +125,7 @@ impl NativeCompilePass.transform(ir_in: uni.Module) -> uni.Module {
 
         # Register Python function callbacks before creating engine
         # so MCJIT can resolve them during code generation (sv↔na interop)
-        manifest = module.gen.interop_manifest;
+        manifest = module.gen.analysis.interop_manifest;
         native_imports = manifest.native_imports;
         if native_imports {
             import from jaclang.jac0core.interop_bridge { register_py_callbacks }
@@ -359,7 +359,7 @@ impl NativeCompilePass._compile_and_link_native_imports(
     # Names the main module imports from other native modules — used to tell
     # owned definitions apart from transitively-carried ones.
     _main_imported_names: set = set();
-    _main_manifest = module.gen.interop_manifest;
+    _main_manifest = module.gen.analysis.interop_manifest;
     if _main_manifest is not None {
         for _imp_b in _main_manifest.native_cross_module_imports {
             _main_imported_names.add(_imp_b.name);
@@ -553,7 +553,7 @@ impl NativeCompilePass._compile_and_link_native_imports(
             dep_clib_paths = imported_ir.gen._clib_paths or [];
             # Collect transitive dep paths for cache metadata
             dep_transitive_paths: list = [];
-            dep_manifest = imported_ir.gen.interop_manifest;
+            dep_manifest = imported_ir.gen.analysis.interop_manifest;
             if dep_manifest is not None {
                 dep_base = os.path.dirname(full_path);
                 for dep_binding in dep_manifest.native_cross_module_imports {
@@ -786,7 +786,9 @@ impl NativeCompilePass._compile_and_link_native_imports(
             }
 
             linked_modules[real_path] = mod_info;
-            module.gen.interop_manifest.native_module_imports[source_mod_path] = mod_info;
+            module.gen.analysis.interop_manifest.native_module_imports[
+                source_mod_path
+            ] = mod_info;
         } except Exception as e {
             self.emit(E5025, path=full_path, error=str(e));
         }

--- a/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
@@ -37,7 +37,7 @@ impl NativeCompilePass.transform(ir_in: uni.Module) -> uni.Module {
         # Note: libgc (Boehm GC) no longer needed — using reference counting
         # Load C shared libraries from import from "lib" { ... } declarations
         import os;
-        clib_paths = module.gen._clib_paths;
+        clib_paths = module.gen.analysis.native_clibs.paths;
         if clib_paths {
             for lib_path in clib_paths {
                 try {
@@ -550,7 +550,7 @@ impl NativeCompilePass._compile_and_link_native_imports(
                 continue;
             }
             imported_llvm_str_raw = str(imported_ir.gen.llvm_ir);
-            dep_clib_paths = imported_ir.gen._clib_paths or [];
+            dep_clib_paths = imported_ir.gen.analysis.native_clibs.paths or [];
             # Collect transitive dep paths for cache metadata
             dep_transitive_paths: list = [];
             dep_manifest = imported_ir.gen.analysis.interop_manifest;
@@ -612,8 +612,8 @@ impl NativeCompilePass._compile_and_link_native_imports(
             # Propagate dep C-lib paths back to the main module so that
             # nacompile (AOT) can discover all needed shared libraries.
             for dep_lib_path in dep_clib_paths {
-                if dep_lib_path not in module.gen._clib_paths {
-                    module.gen._clib_paths.append(dep_lib_path);
+                if dep_lib_path not in module.gen.analysis.native_clibs.paths {
+                    module.gen.analysis.native_clibs.paths.append(dep_lib_path);
                 }
                 try {
                     if os.path.exists(dep_lib_path) {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
@@ -596,7 +596,7 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
     func = self.func_symtab.get(func_name);
     if func is None {
         # Check interop manifest for cross-boundary functions callable from native
-        manifest = self.ir_in.gen.interop_manifest;
+        manifest = self.ir_in.gen.analysis.interop_manifest;
         binding = manifest.bindings.get(func_name);
         if binding is not None {
             if binding.source_context.value == "server" {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -100,7 +100,7 @@ impl NaIRGenPass.postinit -> None {
 """Forward-declare, codegen native abilities/entries, and store the LLVM module."""
 impl NaIRGenPass.transform(ir_in: uni.Module) -> uni.Module {
     # Auto-promote a compatible .jac module to native context when requested
-    if (self.prog._auto_promote_native and self.ir_in.gen.native_compat) {
+    if (self.prog._auto_promote_native and self.ir_in.gen.analysis.native_compat) {
         mod_path = self.ir_in.loc.mod_path if self.ir_in.loc else "";
         main_target = self.prog._auto_promote_target;
         if (
@@ -380,7 +380,7 @@ impl NaIRGenPass._export_native_layout -> None {
     for (ename, ltype) in self.list_types.items() {
         layout.list_elem_types[f"List.{ename}"] = ename;
     }
-    self.ir_in.gen.native_layout = layout;
+    self.ir_in.gen.analysis.native_layout = layout;
 }
 
 """Extract struct hints from a tuple return type AST node.
@@ -457,10 +457,10 @@ impl NaIRGenPass._register_imported_struct_types -> None {
     import from jaclang.jac0core.codeinfo { resolve_native_module }
     # ── DFS work queue: collect ALL transitive .na.jac imports ───────────────
     # Uses the shared resolve_native_module() from codeinfo to resolve paths,
-    # ensuring consistency with InteropAnalysisPass.
+    # ensuring consistency with BoundaryAnalysisPass.
     processed_modules: set[str] = set();
     imported_mods: list = [];  # list of (source_module_str, module_ast)
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
 
     # Seed work queue with entry module's import statements.
     entry_base = os.path.dirname(os.path.abspath(self.ir_in.loc.mod_path))

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -100,7 +100,10 @@ impl NaIRGenPass.postinit -> None {
 """Forward-declare, codegen native abilities/entries, and store the LLVM module."""
 impl NaIRGenPass.transform(ir_in: uni.Module) -> uni.Module {
     # Auto-promote a compatible .jac module to native context when requested
-    if (self.prog._auto_promote_native and self.ir_in.gen.analysis.native_compat) {
+    if (
+        self.prog._auto_promote_native
+        and self.ir_in.gen.analysis.native_compat.is_compatible
+    ) {
         mod_path = self.ir_in.loc.mod_path if self.ir_in.loc else "";
         main_target = self.prog._auto_promote_target;
         if (
@@ -111,6 +114,7 @@ impl NaIRGenPass.transform(ir_in: uni.Module) -> uni.Module {
         ) {
             import from jaclang.jac0core.compiler { _coerce_native_module }
             _coerce_native_module(self.ir_in);
+            ModuleCodegenPass.index_code_contexts(self.ir_in);
         }
     }
     # Emit reference counting helper functions (must be first)
@@ -945,10 +949,10 @@ impl NaIRGenPass._process_clib_imports(module: uni.Module) -> None {
                 }
             }
         }
-        # Store clib paths on module gen for compile pass
+        # Store durable clib facts on module analysis for compile/link passes.
         if self._clib_paths {
-            module.gen._clib_paths = self._clib_paths;
-            module.gen._clib_symbol_lib = self._clib_symbol_lib;
+            module.gen.analysis.native_clibs.paths = self._clib_paths;
+            module.gen.analysis.native_clibs.symbol_lib = self._clib_symbol_lib;
             self.has_native_code = True;
         }
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -638,7 +638,7 @@ impl NaIRGenPass._codegen_entry(nd: uni.ModuleCode) -> None {
     # _register_imported_struct_types (DFS over all import trees) on the
     # shared InteropManifest, and contains the same source_module strings
     # that na_compile_pass uses when renaming __jac_glob_init.
-    _manifest = self.ir_in.gen.interop_manifest if (self.ir_in?.gen) else None;
+    _manifest = self.ir_in.gen.analysis.interop_manifest if (self.ir_in?.gen) else None;
     _all_na_sources = _manifest.native_transitive_sources if _manifest else [];
     _seen_init_mods: set = set();
     for _source_mod in _all_na_sources {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -45,6 +45,10 @@ impl NaIRGenPass._register_archetypes(module: uni.Module) -> None {
     # na-block archetypes plus shared module-level archetypes referenced by
     # native code; names are already de-duplicated by _native_archetypes.
     archetypes: list[uni.Archetype] = self._native_archetypes(module);
+    if not archetypes {
+        self._forward_declare_functions(module);
+        return;
+    }
     arch_map: dict[(str, uni.Archetype)] = {};
     for arch in archetypes {
         arch_map[arch.name.value if arch.name else "unknown"] = arch;
@@ -56,9 +60,17 @@ impl NaIRGenPass._register_archetypes(module: uni.Module) -> None {
         self.struct_types[arch_name] = struct_type;
         self.has_native_code = True;
     }
-    # Pass 1.5 + 1.7: Read class hierarchy and MRO from centralized LayoutRegistry
-    import from jaclang.compiler.passes.main.layout_pass { get_layout_registry }
-    layout_reg = get_layout_registry(self.ir_in, self.prog);
+    # Pass 1.5 + 1.7: Read class hierarchy and MRO from centralized LayoutRegistry.
+    layout_reg = self.ir_in.gen.analysis.layout_registry;
+    if layout_reg is None {
+        self.emit(
+            E5090,
+            node_override=module,
+            kind="native layout",
+            name="missing LayoutRegistry",
+        );
+        return;
+    }
     for arch in archetypes {
         arch_name = arch.name.value if arch.name else "unknown";
         self.arch_ast_map[arch_name] = arch;

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -218,6 +218,22 @@ obj InteropManifest {
     has server_exports_to_server: list[InteropBinding] { getter; }
 }
 
+"""Shared analysis facts for a compiled module.
+
+This object is the stable home for facts that describe what a Jac module
+means across codespaces. Backend emitters should consume these facts rather
+than rediscovering language-level contracts during target-specific lowering.
+
+New shared analysis data should be added here first.
+"""
+obj ModuleAnalysis {
+    has interop_manifest: InteropManifest = field(default_factory=InteropManifest),
+        client_manifest: ClientManifest = field(default_factory=ClientManifest),
+        native_layout: (NativeModuleLayout | None) = None,
+        native_compat: bool = False,
+        layout_registry: any = None;
+}
+
 """Code generation target."""
 obj CodeGenTarget {
     has py: str = '',
@@ -225,19 +241,15 @@ obj CodeGenTarget {
         _doc_ir: (Doc | None) = None,
         js: str = '',
         css: str = '',
-        client_manifest: ClientManifest = field(default_factory=ClientManifest),
+        analysis: ModuleAnalysis = field(default_factory=ModuleAnalysis),
         py_ast: list = field(default_factory=`list),
         py_bytecode: (bytes | None) = None,
         es_ast: EsNode | Sequence[EsNode] | SliceInfo | IndexInfo | None = None,
         llvm_ir: (ModuleRef | None) = None,
         native_engine: (ExecutionEngine | None) = None,
         native_bitcode: (bytes | None) = None,
-        interop_manifest: InteropManifest = field(default_factory=InteropManifest),
         interop_py_funcs: dict[(str, Any)] = field(default_factory=`dict),
         _interop_callbacks: list[any] = field(default_factory=`list),
-        native_layout: (NativeModuleLayout | None) = None,
-        native_compat: bool = False,
-        layout_registry: any = None,
         # Paths to C shared libraries discovered during native compilation.
         # Set by NaIRGenPass._process_clib_imports, consumed by NativeCompilePass
         # and nacompile CLI for transitive .so loading and AOT linking.

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -6,6 +6,7 @@ import from typing { Any }
 import type from jaclang.compiler.passes.ecmascript.estree { IndexInfo, SliceInfo }
 import type from jaclang.compiler.passes.ecmascript.estree { Node as EsNode }
 import type from jaclang.compiler.passes.tool.doc_ir { Doc }
+import type from jaclang.jac0core.constant { CodeContext }
 import type from jaclang.jac0core.unitree { Source, Token }
 import type from llvmlite.binding { ModuleRef, ExecutionEngine }
 
@@ -226,11 +227,43 @@ than rediscovering language-level contracts during target-specific lowering.
 
 New shared analysis data should be added here first.
 """
+obj ModuleCodeContextFacts {
+    has all_stmts: list = field(default_factory=`list),
+        stmts_by_context: dict[(CodeContext, list)] = field(default_factory=`dict),
+        shared_archetypes_by_context: dict[(CodeContext, list)] = field(
+            default_factory=`dict
+        );
+}
+
+"""Module-wide symbol indexes that multiple analysis/codegen stages reuse."""
+obj ModuleSymbolFacts {
+    has archetypes_by_name: dict[(str, any)] = field(default_factory=`dict),
+        top_level_archetypes_by_name: dict[(str, any)] = field(default_factory=`dict);
+}
+
+"""C library linking facts discovered while lowering native imports."""
+obj NativeClibFacts {
+    has paths: list[str] = field(default_factory=`list),
+        symbol_lib: dict[(str, str)] = field(default_factory=`dict);
+}
+
+"""Native auto-promotion compatibility facts for a module."""
+obj NativeCompatFacts {
+    has is_compatible: bool = False,
+        has_entry: bool = False,
+        disqualifiers: list[str] = field(default_factory=`list);
+}
+
 obj ModuleAnalysis {
     has interop_manifest: InteropManifest = field(default_factory=InteropManifest),
         client_manifest: ClientManifest = field(default_factory=ClientManifest),
         native_layout: (NativeModuleLayout | None) = None,
-        native_compat: bool = False,
+        native_compat: NativeCompatFacts = field(default_factory=NativeCompatFacts),
+        code_contexts: ModuleCodeContextFacts = field(
+            default_factory=ModuleCodeContextFacts
+        ),
+        symbols: ModuleSymbolFacts = field(default_factory=ModuleSymbolFacts),
+        native_clibs: NativeClibFacts = field(default_factory=NativeClibFacts),
         layout_registry: any = None;
 }
 
@@ -249,15 +282,7 @@ obj CodeGenTarget {
         native_engine: (ExecutionEngine | None) = None,
         native_bitcode: (bytes | None) = None,
         interop_py_funcs: dict[(str, Any)] = field(default_factory=`dict),
-        _interop_callbacks: list[any] = field(default_factory=`list),
-        # Paths to C shared libraries discovered during native compilation.
-        # Set by NaIRGenPass._process_clib_imports, consumed by NativeCompilePass
-        # and nacompile CLI for transitive .so loading and AOT linking.
-        _clib_paths: list[str] = field(default_factory=`list),
-        # Maps each clib function's C name to the library it was imported from
-        # (e.g. "InitWindow" -> "libraylib.dylib"). Set by the same pass and
-        # consumed by the nacompile CLI to drive Mach-O two-level dylib ordinals.
-        _clib_symbol_lib: dict[(str, str)] = field(default_factory=`dict);
+        _interop_callbacks: list[any] = field(default_factory=`list);
 
     has doc_ir: Doc { getter; setter(value: Doc); }
 }

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -80,6 +80,7 @@ def get_ir_gen_sched -> list[type[Transform[uni.Module, uni.Module]]] {
     _ir_sched_loading = True;
     try {
         import from jaclang.compiler.passes.main.cfg_build_pass { CFGBuildPass }
+        import from jaclang.compiler.passes.main.layout_pass { LayoutPass }
         import from jaclang.compiler.passes.main.mtir_gen_pass { MTIRGenPass }
         import from jaclang.compiler.passes.main.sem_def_match_pass { SemDefMatchPass }
         import from jaclang.compiler.passes.main.unitree_enrich_pass {
@@ -87,7 +88,6 @@ def get_ir_gen_sched -> list[type[Transform[uni.Module, uni.Module]]] {
         }
         # Pre-compile shared analysis modules so codegen passes can import them
         import jaclang.compiler.symbol_utils;
-        import jaclang.compiler.passes.main.layout_pass;
         # JSX `{...}` slot bodies are NOT desugared here: the surface AST is
         # kept faithful through analysis (ASTValidationPass enforces the slot
         # body rules) and the accumulator-IIFE lowering happens at cl codegen
@@ -101,7 +101,8 @@ def get_ir_gen_sched -> list[type[Transform[uni.Module, uni.Module]]] {
             SemDefMatchPass,
             CFGBuildPass,
             MTIRGenPass,
-            UniTreeEnrichPass
+            UniTreeEnrichPass,
+            LayoutPass
         ];
     } except ImportError {
         return [

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -297,7 +297,7 @@ impl JacCompiler._load_native_from_cache(
         if cached_interop {
             import from jaclang.jac0core.interop_bridge { register_py_callbacks }
             manifest = self._deserialize_interop_table(cached_interop);
-            gen.interop_manifest = manifest;
+            gen.analysis.interop_manifest = manifest;
             if manifest.native_imports {
                 register_py_callbacks(manifest, py_func_table, callbacks_list);
             }
@@ -378,7 +378,7 @@ impl JacCompiler._load_native_from_bitcode(
             );
             manifest.bindings[name] = binding;
         }
-        gen.interop_manifest = manifest;
+        gen.analysis.interop_manifest = manifest;
         if manifest.native_imports {
             register_py_callbacks(manifest, py_func_table, callbacks_list);
         }
@@ -515,7 +515,7 @@ impl JacCompiler._get_precompiled_jir_bytecode(full_target: str) -> (bytes | Non
 
 """Build a JSON-serializable interop dict from a compiled module."""
 impl JacCompiler._build_interop_dict(result: uni.Module) -> dict {
-    manifest = result.gen.interop_manifest;
+    manifest = result.gen.analysis.interop_manifest;
     if manifest is None {
         return {};
     }
@@ -723,7 +723,7 @@ impl JacCompiler.compile(
             not is_native_mod
             and actual_program._auto_promote_native
             and mod_targ?.gen
-            and mod_targ.gen.native_compat
+            and mod_targ.gen.analysis.native_compat
         ) {
             is_native_mod = True;
         }
@@ -852,8 +852,8 @@ impl JacCompiler.compile(
                 cb_has_facts = (
                     cb_mod is not None
                     and cb_mod.gen
-                    and cb_mod.gen.interop_manifest
-                    and bool(cb_mod.gen.interop_manifest.bindings)
+                    and cb_mod.gen.analysis.interop_manifest
+                    and bool(cb_mod.gen.analysis.interop_manifest.bindings)
                 );
                 if not cb_has_facts {
                     try {

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -112,11 +112,11 @@ impl JacCompiler.get_native_layout(
     actual_program = self._resolve_program(full_target, target_program);
     if (full_target in actual_program._native_cache) {
         gen = actual_program._native_cache[full_target];
-        return gen?.native_layout;
+        return gen?.analysis.native_layout;
     }
     if (full_target in actual_program.mod.hub) {
         mod = actual_program.mod.hub[full_target];
-        return mod.gen?.native_layout;
+        return mod.gen?.analysis.native_layout;
     }
     return None;
 }
@@ -723,7 +723,7 @@ impl JacCompiler.compile(
             not is_native_mod
             and actual_program._auto_promote_native
             and mod_targ?.gen
-            and mod_targ.gen.analysis.native_compat
+            and mod_targ.gen.analysis.native_compat.is_compatible
         ) {
             is_native_mod = True;
         }

--- a/jac/jaclang/jac0core/native_accel.jac
+++ b/jac/jaclang/jac0core/native_accel.jac
@@ -60,13 +60,13 @@ def accelerate_module(mod_name: str, na_file: str) -> int {
             return -1;
         }
         engine = ir.gen.native_engine;
-        layout = ir.gen.native_layout;
+        layout = ir.gen.analysis.native_layout;
         if engine is None or layout is None {
             return 0;
         }
         # Initialize the module's (and its native imports') globals before any
         # wrapper can be called — otherwise reads of native globals segfault.
-        init_native_globals(engine, ir.gen.interop_manifest);
+        init_native_globals(engine, ir.gen.analysis.interop_manifest);
         count = install_native_wrappers(module, engine, layout);
         if count > 0 {
             # Keep engine alive on the module to prevent GC

--- a/jac/jaclang/jac0core/native_marshal.jac
+++ b/jac/jaclang/jac0core/native_marshal.jac
@@ -413,7 +413,7 @@ segfaults if the globals were never initialized. The codegen emits a
 `__jac_glob_init` for the module's own globals and a renamed
 `__jac_glob_init_<safe_name>` for each imported native module; imported
 modules must be initialized before the importer. `manifest` is the compiled
-module's InteropManifest (ir.gen.interop_manifest); its
+module's InteropManifest (ir.gen.analysis.interop_manifest); its
 `native_transitive_sources` lists the imported native modules in dependency
 order.
 """

--- a/jac/jaclang/jac0core/passes/impl/boundary_analysis_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/boundary_analysis_pass.impl.jac
@@ -126,7 +126,7 @@ impl BoundaryAnalysisPass.enter_import(
                 }
             }
             if (native_path and nd.items) {
-                manifest = self.ir_in.gen.interop_manifest;
+                manifest = self.ir_in.gen.analysis.interop_manifest;
                 for item in nd.items {
                     if isinstance(item, uni.ModuleItem) {
                         func_name = getattr(item.name, 'value', str(item.name));
@@ -225,7 +225,7 @@ impl BoundaryAnalysisPass._register_sv_import(
             self._collect_pub_walkers(source_mod, source_walkers);
         } except Exception { }
     }
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
     for item in nd.items {
         if not isinstance(item, uni.ModuleItem) {
             continue;
@@ -464,7 +464,7 @@ impl BoundaryAnalysisPass.enter_ability(
         and nd.access.tag.name == Tok.KW_PUB
         and isinstance(nd.name_ref, uni.Name)
     ) {
-        self.ir_in.gen.interop_manifest.endpoint_effects[
+        self.ir_in.gen.analysis.interop_manifest.endpoint_effects[
             f"func:{nd.name_ref.sym_name}"
         ] = self._classify(self._resolved_body(nd));
     }
@@ -484,7 +484,7 @@ impl BoundaryAnalysisPass.enter_func_call(
         return;
     }
     caller_ctx = self._get_context(nd);
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
     if (func_name in self._imported_native_funcs) {
         (source_module, import_ctx) = self._imported_native_funcs[func_name];
         if (caller_ctx == InteropContext.NATIVE) {
@@ -700,7 +700,7 @@ impl BoundaryAnalysisPass._collect_boundary_type(
     if type_name in prims {
         return;
     }
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
     if type_name in manifest.boundary_types {
         return;
     }
@@ -843,7 +843,7 @@ impl BoundaryAnalysisPass._collect_boundary_type(
 """After all nodes visited, collect boundary types from SV->CL bindings
 and server-side archetypes that may cross the boundary."""
 impl BoundaryAnalysisPass.after_pass(self: BoundaryAnalysisPass) -> None {
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
     # Collect types from explicit SV->CL function bindings
     for binding in manifest.server_exports_to_client {
         if binding.ast_node and isinstance(binding.ast_node, uni.Ability) {
@@ -957,9 +957,9 @@ impl BoundaryAnalysisPass.enter_archetype(
     if not isinstance(nd.name, uni.Name) {
         return;
     }
-    self.ir_in.gen.interop_manifest.endpoint_effects[f"walker:{nd.name.sym_name}"] = (
-        self._classify(self._resolved_body(nd))
-    );
+    self.ir_in.gen.analysis.interop_manifest.endpoint_effects[
+        f"walker:{nd.name.sym_name}"
+    ] = self._classify(self._resolved_body(nd));
 }
 
 """Run the effect scan over a flat statement body, returning the manifest entry.

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -152,7 +152,7 @@ ctypes.
           in the interop callback table.
         """
 impl PyastGenPass._gen_native_interop_stubs(nd: uni.NativeBlock) -> None {
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
     if (not manifest or not manifest.bindings) {
         return;
     }
@@ -180,7 +180,7 @@ impl PyastGenPass._gen_native_interop_stubs(nd: uni.NativeBlock) -> None {
 
 """Generate Python HTTP client stubs for sv-to-sv microservice imports."""
 impl PyastGenPass._generate_sv_to_sv_stubs(nd: uni.Import) -> bool {
-    manifest = self.ir_in.gen.interop_manifest;
+    manifest = self.ir_in.gen.analysis.interop_manifest;
     if (not manifest) {
         return False;
     }

--- a/jac/jaclang/jac0core/passes/module_codegen_pass.jac
+++ b/jac/jaclang/jac0core/passes/module_codegen_pass.jac
@@ -29,6 +29,63 @@ obj ModuleCodegenPass(Transform[uni.Module, uni.Module]) {
         return None;
     }
 
+    """Populate module-level code-context indexes once for all codegen passes."""
+    static def index_code_contexts(module: uni.Module) {
+        facts = module.gen.analysis.code_contexts;
+        facts.all_stmts = [];
+        facts.stmts_by_context = {
+            CodeContext.SERVER: [],
+            CodeContext.CLIENT: [],
+            CodeContext.NATIVE: []
+        };
+        for stmt in module.body {
+            if isinstance(stmt, uni.NativeBlock) {
+                facts.all_stmts.extend(stmt.body);
+                facts.stmts_by_context[CodeContext.NATIVE].extend(stmt.body);
+            } elif isinstance(stmt, uni.ClientBlock) {
+                facts.all_stmts.extend(stmt.body);
+                facts.stmts_by_context[CodeContext.CLIENT].extend(stmt.body);
+            } elif isinstance(stmt, uni.ServerBlock) {
+                facts.all_stmts.extend(stmt.body);
+                facts.stmts_by_context[CodeContext.SERVER].extend(stmt.body);
+            } else {
+                facts.all_stmts.append(stmt);
+                if isinstance(stmt, uni.ContextAwareNode) {
+                    facts.stmts_by_context[stmt.code_context].append(stmt);
+                } else {
+                    # Undecorated top-level nodes default to SERVER context.
+                    facts.stmts_by_context[CodeContext.SERVER].append(stmt);
+                }
+            }
+        }
+        symbols = module.gen.analysis.symbols;
+        symbols.archetypes_by_name = {};
+        symbols.top_level_archetypes_by_name = {};
+        for arch in module.get_all_sub_nodes(uni.Archetype, brute_force=True) {
+            aname = arch.name.value if arch.name else None;
+            if aname is None {
+                continue;
+            }
+            if aname not in symbols.archetypes_by_name or arch.body is not None {
+                symbols.archetypes_by_name[aname] = arch;
+            }
+            if isinstance(arch.parent, uni.Module) {
+                if aname not in symbols.top_level_archetypes_by_name
+                or arch.body is not None {
+                    symbols.top_level_archetypes_by_name[aname] = arch;
+                }
+            }
+        }
+        facts.shared_archetypes_by_context = {};
+        for ctx in [CodeContext.SERVER, CodeContext.CLIENT, CodeContext.NATIVE] {
+            facts.shared_archetypes_by_context[ctx] = (
+                ModuleCodegenPass._shared_archetypes_from_index(
+                    module, ctx, symbols.top_level_archetypes_by_name
+                )
+            );
+        }
+    }
+
     """Iterate top-level statements for a given context.
 
     Unwraps NativeBlock/ClientBlock/ServerBlock and yields their
@@ -38,34 +95,14 @@ obj ModuleCodegenPass(Transform[uni.Module, uni.Module]) {
     static def iter_context_stmts(
         module: uni.Module, ctx: (CodeContext | None) = None
     ) -> list[uni.ElementStmt] {
-        result: list[uni.ElementStmt] = [];
-        for stmt in module.body {
-            if isinstance(stmt, uni.NativeBlock) {
-                if (ctx is None or ctx == CodeContext.NATIVE) {
-                    result.extend(stmt.body);
-                }
-            } elif isinstance(stmt, uni.ClientBlock) {
-                if (ctx is None or ctx == CodeContext.CLIENT) {
-                    result.extend(stmt.body);
-                }
-            } elif isinstance(stmt, uni.ServerBlock) {
-                if (ctx is None or ctx == CodeContext.SERVER) {
-                    result.extend(stmt.body);
-                }
-            } elif ctx is None {
-                result.append(stmt);
-            } elif (
-                isinstance(stmt, uni.ContextAwareNode) and stmt.code_context == ctx
-            ) {
-                result.append(stmt);
-            } elif (
-                not isinstance(stmt, uni.ContextAwareNode) and ctx == CodeContext.SERVER
-            ) {
-                # Undecorated top-level nodes default to SERVER context
-                result.append(stmt);
-            }
+        facts = module.gen.analysis.code_contexts;
+        if not facts.all_stmts and module.body {
+            ModuleCodegenPass.index_code_contexts(module);
         }
-        return result;
+        if ctx is None {
+            return facts.all_stmts;
+        }
+        return facts.stmts_by_context.get(ctx, []);
     }
 
     """Names of archetypes referenced anywhere under `nd` (constructors, type
@@ -97,15 +134,16 @@ obj ModuleCodegenPass(Transform[uni.Module, uni.Module]) {
     static def shared_archetypes_for_context(
         module: uni.Module, ctx: CodeContext
     ) -> list[uni.Archetype] {
-        shared: dict[(str, uni.Archetype)] = {};
-        for arch in module.get_all_sub_nodes(uni.Archetype, brute_force=True) {
-            if (arch.name is not None) and isinstance(arch.parent, uni.Module) {
-                shared[arch.name.value] = arch;
-            }
+        facts = module.gen.analysis.code_contexts;
+        if ctx not in facts.shared_archetypes_by_context {
+            ModuleCodegenPass.index_code_contexts(module);
         }
-        if not shared {
-            return [];
-        }
+        return facts.shared_archetypes_by_context.get(ctx, []);
+    }
+
+    static def _shared_archetypes_from_index(
+        module: uni.Module, ctx: CodeContext, shared: dict[(str, uni.Archetype)]
+    ) -> list[uni.Archetype] {
         worklist: list[str] = [];
         for stmt in ModuleCodegenPass.iter_context_stmts(module, ctx) {
             worklist.extend(ModuleCodegenPass.archetype_refs(stmt));

--- a/jac/jaclang/publish/impl/dts.impl.jac
+++ b/jac/jaclang/publish/impl/dts.impl.jac
@@ -100,7 +100,7 @@ def _global_decl(assign: any, wanted: any) -> str {
 }
 
 impl dts_for_module(mod: Module) -> str {
-    manifest = mod.gen.client_manifest if (mod and mod.gen) else None;
+    manifest = mod.gen.analysis.client_manifest if (mod and mod.gen) else None;
     exports: set = set(manifest.exports) if manifest else set();
     globals_set: set = set(manifest.globals) if manifest else set();
     if not exports and not globals_set {

--- a/jac/jaclang/publish/impl/npm_sources.impl.jac
+++ b/jac/jaclang/publish/impl/npm_sources.impl.jac
@@ -115,7 +115,7 @@ def _package_dirs(config: JacConfig, proj_root: Path) -> list[Path] {
 }
 
 def _crosses_server_boundary(mod: any) -> bool {
-    im = mod.gen.interop_manifest if mod and mod.gen else None;
+    im = mod.gen.analysis.interop_manifest if mod and mod.gen else None;
     if im is None {
         return False;
     }

--- a/jac/jaclang/runtimelib/cl_test_runner.jac
+++ b/jac/jaclang/runtimelib/cl_test_runner.jac
@@ -6,7 +6,7 @@ runtime invoked those functions, so client tests were dead code.
 
 This module closes that gap. Given a `.cl.jac` file it:
 
-1. compiles it and reads the cl tests recorded in `mod.gen.client_manifest`,
+1. compiles it and reads the cl tests recorded in `mod.gen.analysis.client_manifest`,
 2. emits a single-file harness (the emitted module JS + a runner epilogue that
    calls each test, catching the thrown `Error` as a failure),
 3. resolves `@jac/runtime` and injects the API base URL / a `localStorage`

--- a/jac/jaclang/runtimelib/client/impl/jac_to_js.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/jac_to_js.impl.jac
@@ -26,6 +26,6 @@ impl JacToJSCompiler.compile_module(
     module_path: Path
 ) -> tuple[str, (ModuleType | None), (ClientManifest | None)] {
     (module_js, mod) = self._compile_to_js(module_path);
-    manifest = mod.gen.client_manifest if mod else None;
+    manifest = mod.gen.analysis.client_manifest if mod else None;
     return (module_js, mod, manifest);
 }

--- a/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
+++ b/jac/jaclang/runtimelib/impl/cl_test_runner.impl.jac
@@ -21,7 +21,7 @@ impl compile_cl_module(filepath: str) -> tuple[str, list, dict] {
         errs = "\n".join([str(e) for e in prog.errors_had]);
         raise RuntimeError(f"Failed to compile {filepath}:\n{errs}");
     }
-    manifest = mod.gen.client_manifest;
+    manifest = mod.gen.analysis.client_manifest;
     tests = list(getattr(manifest, "tests", []) or []);
     imports = dict(getattr(manifest, "imports", {}) or {});
     return (mod.gen.js, tests, imports);

--- a/jac/jaclang/runtimelib/impl/client_bundle.impl.jac
+++ b/jac/jaclang/runtimelib/impl/client_bundle.impl.jac
@@ -51,7 +51,7 @@ impl ClientBundleBuilder.build(
     if not mod {
         (_, mod) = self._compile_to_js(source_path);
     }
-    manifest = mod.gen.client_manifest if mod else None;
+    manifest = mod.gen.analysis.client_manifest if mod else None;
     bundle_paths = [source_path];
     if (manifest and manifest.imports) {
         for import_path in manifest.imports.values() {

--- a/jac/jaclang/runtimelib/impl/hmr.impl.jac
+++ b/jac/jaclang/runtimelib/impl/hmr.impl.jac
@@ -218,7 +218,7 @@ impl HotReloader._recompile_client_code(
         }
 
         # Recursively compile missing dependencies BEFORE writing this file's JS to ensure all dependencies are up to date
-        manifest = mod.gen.client_manifest if mod else None;
+        manifest = mod.gen.analysis.client_manifest if mod else None;
         if manifest and manifest.imports {
             for (import_key, import_path) in manifest.imports.items() {
                 if import_key.startswith('@jac/') {

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -567,11 +567,13 @@ impl ModuleIntrospector._load_manifest -> None {
         if not mod {
             mod = Jac.program.compile(mod_path);
         }
-        if mod and mod.gen.client_manifest and not mod.gen.client_manifest.exports {
+        if mod
+        and mod.gen.analysis.client_manifest
+        and not mod.gen.analysis.client_manifest.exports {
             _ensure_js_generated(mod, Jac.program);
         }
-        if (mod and mod.gen.client_manifest) {
-            manifest = mod.gen.client_manifest;
+        if (mod and mod.gen.analysis.client_manifest) {
+            manifest = mod.gen.analysis.client_manifest;
             base = {
                 'exports': manifest.exports,
                 'globals': manifest.globals,
@@ -593,8 +595,8 @@ impl ModuleIntrospector._load_manifest -> None {
     # span `find_module` uses.
     for hub in Jac.program._search_hubs() {
         for hub_mod in hub.values() {
-            if hub_mod and hub_mod.gen.interop_manifest {
-                for (ekey, eeff) in hub_mod.gen.interop_manifest.endpoint_effects.items() {
+            if hub_mod and hub_mod.gen.analysis.interop_manifest {
+                for (ekey, eeff) in hub_mod.gen.analysis.interop_manifest.endpoint_effects.items() {
                     aggregated[ekey] = eeff;
                 }
             }
@@ -657,10 +659,10 @@ impl ModuleIntrospector._extract_access_levels -> None {
         }
     }
     for src_mod in sources {
-        if not (src_mod and src_mod.gen and src_mod.gen.interop_manifest) {
+        if not (src_mod and src_mod.gen and src_mod.gen.analysis.interop_manifest) {
             continue;
         }
-        man = src_mod.gen.interop_manifest;
+        man = src_mod.gen.analysis.interop_manifest;
         for (name, auth) in man.func_access.items() {
             if name not in self._function_access {
                 self._function_access[name] = auth;
@@ -728,7 +730,7 @@ impl ModuleIntrospector._collect_cross_boundary_endpoints -> None {
     # `find_module` already uses to resolve across the two programs.
     for hub in Jac.program._search_hubs() {
         for mod in hub.values() {
-            man = mod.gen.interop_manifest if (mod and mod.gen) else None;
+            man = mod.gen.analysis.interop_manifest if (mod and mod.gen) else None;
             if not man {
                 continue;
             }

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -1472,10 +1472,10 @@ test "py interop native function has stub in python" {
 }
 
 test "py interop interop manifest built" {
-    # InteropAnalysisPass should detect cross-boundary calls.
+    # BoundaryAnalysisPass should detect cross-boundary calls.
     prog = JacProgram();
     ir = prog.compile(str(os.path.join(FIXTURES, "na_py_interop.jac")));
-    manifest = ir.gen.interop_manifest;
+    manifest = ir.gen.analysis.interop_manifest;
     assert manifest is not None;
     # py_double: defined in SERVER, called from NATIVE
     assert "py_double" in manifest.bindings;
@@ -1547,7 +1547,7 @@ test "multi module module level na import" {
     assert ir is not None;
     assert not prog.errors_had , f"Errors: {prog.errors_had}";
     # triple should be in manifest as a cross-module import
-    manifest = ir.gen.interop_manifest;
+    manifest = ir.gen.analysis.interop_manifest;
     assert "triple" in manifest.bindings;
     assert manifest.bindings["triple"].source_module == "na_math_utils.na";
 }
@@ -1558,7 +1558,7 @@ test "multi module na scoped import" {
     ir = prog.compile(str(os.path.join(FIXTURES, "na_py_interop_multi.jac")));
     assert not prog.errors_had , f"Errors: {prog.errors_had}";
     # The na-scoped import should be tracked in manifest
-    manifest = ir.gen.interop_manifest;
+    manifest = ir.gen.analysis.interop_manifest;
     # add_ten should be recognized as a NATIVE->NATIVE binding
     assert "add_ten" in manifest.bindings;
     assert manifest.bindings["add_ten"].source_module == "na_transformers.na";
@@ -2185,7 +2185,9 @@ def compile_auto_native(file_path: str) -> tuple[uni.Module, JacProgram] {
 test "auto promote chess.jac detects native compatible" {
     (ir, _) = compile_auto_native(CHESS_JAC);
     assert ir is not None;
-    assert ir.gen.native_compat , ("chess.jac should be auto-promoted to native");
+    assert ir.gen.analysis.native_compat , (
+        "chess.jac should be auto-promoted to native"
+    );
     assert ir.gen.native_engine is not None , (
         "Auto-promoted chess.jac should have a native engine"
     );
@@ -2727,7 +2729,7 @@ test "jir bitcode cache round-trip" {
 # --- CType struct contract: layout metadata and field types ---
 test "struct layout exports correct field types" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None , "Native layout should be exported";
     assert "AllFields" in layout.structs , "AllFields struct should be in layout";
     af = layout.structs["AllFields"];
@@ -2741,7 +2743,7 @@ test "struct layout exports correct field types" {
 
 test "struct layout tracks field indices correctly" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     af = layout.structs["AllFields"];
     indices = [f.index for f in af.fields];
@@ -2751,7 +2753,7 @@ test "struct layout tracks field indices correctly" {
 
 test "optional field compiles to pointer type" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert "MaybePoint" in layout.structs;
     mp = layout.structs["MaybePoint"];
@@ -2806,7 +2808,7 @@ test "maybe_point struct round-trip" {
 
 test "NativeFieldInfo func_ptr defaults to False" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     af = layout.structs["AllFields"];
     for f in af.fields {
@@ -2818,7 +2820,7 @@ test "NativeFieldInfo func_ptr defaults to False" {
 
 test "function layout exports param and return types" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert "add" in layout.functions;
     add_layout = layout.functions["add"];
@@ -2828,7 +2830,7 @@ test "function layout exports param and return types" {
 
 test "layout exports all expected functions" {
     (eng, ir) = compile_native("func_ptr_fields.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     expected = {
         "add",

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -1775,8 +1775,8 @@ test "clib import produces extern declares" {
     # Native Jac function should be 'define' (has body)
     assert 'define double @"hypotenuse"' in llvm_ir_str;
     # Library path should be stored for the compile pass
-    assert ir.gen._clib_paths is not None;
-    assert "/usr/lib/libm.so.6" in ir.gen._clib_paths;
+    assert ir.gen.analysis.native_clibs.paths is not None;
+    assert "/usr/lib/libm.so.6" in ir.gen.analysis.native_clibs.paths;
 }
 
 test "clib import inside na block" {
@@ -1791,8 +1791,8 @@ test "clib import inside na block" {
     # Native Jac function should be 'define'
     assert 'define double @"round_up"' in llvm_ir_str;
     # Library path should be stored
-    assert ir.gen._clib_paths is not None;
-    assert "/usr/lib/libm.so.6" in ir.gen._clib_paths;
+    assert ir.gen.analysis.native_clibs.paths is not None;
+    assert "/usr/lib/libm.so.6" in ir.gen.analysis.native_clibs.paths;
 }
 
 test "clib extensionless logical import produces extern declares (issue #6387)" {
@@ -1806,8 +1806,8 @@ test "clib extensionless logical import produces extern declares (issue #6387)" 
     assert 'declare void @"InitWindow"(i32' in s , "InitWindow not externed";
     assert 'declare void @"CloseWindow"()' in s , "CloseWindow not externed";
     assert 'define void @"open_then_close"' in s , "wrapper not defined";
-    assert ir.gen._clib_paths is not None;
-    assert len(ir.gen._clib_paths) == 1 , f"unexpected clib paths: {ir.gen._clib_paths}";
+    assert ir.gen.analysis.native_clibs.paths is not None;
+    assert len(ir.gen.analysis.native_clibs.paths) == 1 , f"unexpected clib paths: {ir.gen.analysis.native_clibs.paths}";
     # Managed inertness: the bare-name `raylib` must NOT be resolved as a managed
     # module, so the type-checker emits no W1100 "module not found" for it. (A
     # W5021 "C library not found" at JIT time is expected here and unrelated --
@@ -1842,7 +1842,7 @@ test "clib extensionless import resolves per platform (issue #6387)" {
             prog = JacProgram();
             ir = prog.compile(_fix, options=CompileOptions(type_check=False));
             assert not prog.errors_had , f"{tgt}: {prog.errors_had}";
-            assert list(ir.gen._clib_paths) == [want] , f"{tgt}: got {ir.gen._clib_paths}, want [{want}]";
+            assert list(ir.gen.analysis.native_clibs.paths) == [want] , f"{tgt}: got {ir.gen.analysis.native_clibs.paths}, want [{want}]";
         }
     } finally {
         if _saved is None {
@@ -1864,10 +1864,14 @@ test "clib dotted logical import maps to origin-relative subdir (issue #6387)" {
     try {
         _os.environ["JAC_NATIVE_TARGET"] = "x86_64-unknown-linux-gnu";
         ir = JacProgram().compile(_fix, options=CompileOptions(type_check=False));
-        assert list(ir.gen._clib_paths) == ["$ORIGIN/libs/libraylib.so"] , f"ELF: {ir.gen._clib_paths}";
+        assert list(ir.gen.analysis.native_clibs.paths) == [
+            "$ORIGIN/libs/libraylib.so"
+        ] , f"ELF: {ir.gen.analysis.native_clibs.paths}";
         _os.environ["JAC_NATIVE_TARGET"] = "arm64-apple-darwin";
         ir2 = JacProgram().compile(_fix, options=CompileOptions(type_check=False));
-        assert list(ir2.gen._clib_paths) == ["@loader_path/libs/libraylib.dylib"] , f"Mach-O: {ir2.gen._clib_paths}";
+        assert list(ir2.gen.analysis.native_clibs.paths) == [
+            "@loader_path/libs/libraylib.dylib"
+        ] , f"Mach-O: {ir2.gen.analysis.native_clibs.paths}";
     } finally {
         if _saved is None {
             del _os.environ["JAC_NATIVE_TARGET"];
@@ -2185,7 +2189,7 @@ def compile_auto_native(file_path: str) -> tuple[uni.Module, JacProgram] {
 test "auto promote chess.jac detects native compatible" {
     (ir, _) = compile_auto_native(CHESS_JAC);
     assert ir is not None;
-    assert ir.gen.analysis.native_compat , (
+    assert ir.gen.analysis.native_compat.is_compatible , (
         "chess.jac should be auto-promoted to native"
     );
     assert ir.gen.native_engine is not None , (
@@ -3123,7 +3127,7 @@ test "transitive glob init: push through mid updates deep glob list" {
 # When module A imports module B which in turn imports a .so (e.g. libm), the
 # .so was only loaded during B's compilation. When A linked B's bitcode, MCJIT
 # could not resolve the extern symbols from B's clib import, causing a segfault.
-# Fix: _compile_and_link_native_imports now propagates dep._clib_paths back to
+# Fix: _compile_and_link_native_imports now propagates dep native clib paths to
 # the main module and calls llvm.load_library_permanently for each entry.
 test "transitive clib: compiles without errors when dep imports a .so" {
     prog = JacProgram();
@@ -3132,14 +3136,14 @@ test "transitive clib: compiles without errors when dep imports a .so" {
     assert ir.gen.native_engine is not None , "No native engine created";
 }
 
-test "transitive clib: _clib_paths of dep module propagated to entry module" {
-    # The entry's _clib_paths must include libm even though only the lib module
+test "transitive clib: dep native clib paths propagated to entry module" {
+    # The entry's native clib paths must include libm even though only the lib module
     # directly imports it.
     prog = JacProgram();
     ir = prog.compile(str(os.path.join(FIXTURES, "fix_clib_transitive_entry.na.jac")));
     assert not prog.errors_had , f"Errors: {prog.errors_had}";
-    clib_paths = ir.gen._clib_paths;
-    assert clib_paths , "_clib_paths not set on entry module IR";
+    clib_paths = ir.gen.analysis.native_clibs.paths;
+    assert clib_paths , "native clib paths not set on entry module IR";
     assert any("/libm" in p or "libm" in p for p in clib_paths) , f"libm not found in transitive _clib_paths: {clib_paths}";
 }
 

--- a/jac/tests/compiler/passes/native/test_native_lexer.jac
+++ b/jac/tests/compiler/passes/native/test_native_lexer.jac
@@ -48,7 +48,7 @@ test "native lexer compiles" {
 test "native layout exported for lexer" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None , "No native_layout on CodeGenTarget";
     assert len(layout.structs) > 0 , "No structs in layout";
     assert len(layout.enums) > 0 , "No enums in layout";
@@ -58,7 +58,7 @@ test "native layout exported for lexer" {
 test "native layout struct fields correct" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert "SourceLoc" in layout.structs , "SourceLoc struct missing";
     loc = layout.structs["SourceLoc"];
@@ -70,7 +70,7 @@ test "native layout struct fields correct" {
 test "native layout enum members correct" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert len(layout.enums) > 0 , "No enums in layout";
     for (ename, elayout) in layout.enums.items() {
@@ -81,7 +81,7 @@ test "native layout enum members correct" {
 test "native layout functions have types" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     for (fname, flayout) in layout.functions.items() {
         assert flayout.ret_type , f"Function {fname} has no ret_type";
@@ -96,7 +96,7 @@ test "auto-marshal arithmetic add" {
         wrap_native_function
     }
     (eng, ir) = compile_fixture("arithmetic.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     ct_classes = build_ctypes_classes(layout);
     enum_maps = build_enum_maps(layout, {});
@@ -116,7 +116,7 @@ test "auto-marshal arithmetic float_add" {
         wrap_native_function
     }
     (eng, ir) = compile_fixture("arithmetic.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     ct_classes = build_ctypes_classes(layout);
     enum_maps = build_enum_maps(layout, {});
@@ -132,7 +132,7 @@ test "auto-marshal install_native_wrappers" {
     import types;
     import from jaclang.jac0core.native_marshal { install_native_wrappers }
     (eng, ir) = compile_fixture("arithmetic.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
 
     # Create a mock module with Python functions
@@ -156,7 +156,7 @@ test "auto-marshal install_native_wrappers" {
 # --- String enum auto-marshalling ---
 test "native layout for string enums" {
     (eng, ir) = compile_fixture("string_enums.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert "Color" in layout.enums , "Color enum not in layout";
     color_layout = layout.enums["Color"];
@@ -174,7 +174,7 @@ test "auto-marshal string enum functions" {
         wrap_native_function
     }
     (eng, ir) = compile_fixture("string_enums.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     ct_classes = build_ctypes_classes(layout);
     enum_maps = build_enum_maps(layout, {});
@@ -193,7 +193,7 @@ test "auto-marshal string enum functions" {
 test "native layout tuple metadata for tokenize" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert len(layout.tuples) > 0 , "No tuples in layout";
     # tokenize function should have ret_tuple_layout
@@ -222,7 +222,7 @@ test "auto-marshal tuple with struct list" {
         wrap_native_function
     }
     (eng, ir) = compile_fixture("tuple_structs.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     ct_classes = build_ctypes_classes(layout);
     enum_maps = build_enum_maps(layout, {});
@@ -263,7 +263,7 @@ test "auto-marshal struct with string field" {
         wrap_native_function
     }
     (eng, ir) = compile_fixture("tuple_structs.na.jac");
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert layout is not None;
     assert eng is not None;
     ct_classes = build_ctypes_classes(layout);
@@ -297,7 +297,7 @@ test "native tokenize returns correct tokens" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
     eng = ir.gen.native_engine;
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert eng is not None;
     assert layout is not None;
 
@@ -350,7 +350,7 @@ test "native tokenize matches python lexer" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
     eng = ir.gen.native_engine;
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert eng is not None;
     assert layout is not None;
     tokens_glob_addr = eng.get_function_address("__jac_glob_init_tokens_na");
@@ -404,7 +404,7 @@ test "native tokenize matches python lexer for fstrings" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
     eng = ir.gen.native_engine;
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert eng is not None;
     assert layout is not None;
     tokens_glob_addr = eng.get_function_address("__jac_glob_init_tokens_na");
@@ -459,7 +459,7 @@ test "native tokenize matches python lexer for unicode (byte offsets)" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
     eng = ir.gen.native_engine;
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert eng is not None and layout is not None;
     for g in ["__jac_glob_init_tokens_na", "__jac_glob_init"] {
         addr = eng.get_function_address(g);
@@ -530,7 +530,7 @@ test "native tokenize error count matches python for illegal chars" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
     eng = ir.gen.native_engine;
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert eng is not None and layout is not None;
     for g in ["__jac_glob_init_tokens_na", "__jac_glob_init"] {
         addr = eng.get_function_address(g);
@@ -570,7 +570,7 @@ test "native tokenize performance" {
     prog = JacProgram();
     ir = prog.compile(file_path=NA_LEXER_PATH);
     eng = ir.gen.native_engine;
-    layout = ir.gen.native_layout;
+    layout = ir.gen.analysis.native_layout;
     assert eng is not None;
     assert layout is not None;
     tokens_glob_addr = eng.get_function_address("__jac_glob_init_tokens_na");

--- a/jac/tests/compiler/test_client_codegen.jac
+++ b/jac/tests/compiler/test_client_codegen.jac
@@ -44,18 +44,18 @@ test "compilation skips python stubs" {
     assert "__jac_client__" not in mod.gen.py;
     assert "class ButtonProps" not in mod.gen.py;
 
-    # Manifest data should be in mod.gen.client_manifest
+    # Manifest data should be in mod.gen.analysis.client_manifest
     assert "__jac_client_manifest__" not in mod.gen.py;
-    manifest = mod.gen.client_manifest;
+    manifest = mod.gen.analysis.client_manifest;
     assert manifest , "Client manifest should be available in mod.gen";
     assert "component" in manifest.exports;
     assert "ButtonProps" in manifest.exports;
     assert "API_URL" in manifest.globals;
 
-    assert "component" in mod.gen.client_manifest.exports;
-    assert "ButtonProps" in mod.gen.client_manifest.exports;
-    assert "API_URL" in mod.gen.client_manifest.globals;
-    assert mod.gen.client_manifest.params.get("component", []) == [];
+    assert "component" in mod.gen.analysis.client_manifest.exports;
+    assert "ButtonProps" in mod.gen.analysis.client_manifest.exports;
+    assert "API_URL" in mod.gen.analysis.client_manifest.globals;
+    assert mod.gen.analysis.client_manifest.params.get("component", []) == [];
 }
 
 # Consolidated: typeof conversion + spawn operator (share one JacProgram)
@@ -114,7 +114,7 @@ test "def pub and endpoint effects" {
     # --- endpoint effects classifies walkers and functions ---
     effects_code = '"""Test auto endpoint effects."""\n\nnode Todo {\n    has title: str,\n        done: bool = False;\n}\n\nwalker get_todos {\n    can visit_root with Root entry {\n        report [-->];\n    }\n}\n\nwalker create_todo {\n    has title: str;\n    can do_create with Root entry {\n        here ++> Todo(title=self.title);\n    }\n}\n\ndef:pub get_stats() -> dict {\n    return {"count": 10};\n}\n\ndef:pub reset_data() -> dict {\n    items = [];\n    del items;\n    return {};\n}\n\ncl {\n    def:pub app() {\n        todos = root spawn get_todos();\n        root spawn create_todo(title="test");\n        stats = await get_stats();\n        result = await reset_data();\n    }\n}\n';
     mod2 = compile_inline(effects_code, prog);
-    effects = mod2.gen.client_manifest.endpoint_effects;
+    effects = mod2.gen.analysis.client_manifest.endpoint_effects;
     # Walker reader: no write operations in body
     assert "walker:get_todos" in effects , "get_todos should be in endpoint_effects";
     assert not effects["walker:get_todos"]["is_writer"] , "get_todos should be classified as reader";
@@ -143,7 +143,7 @@ test "endpoint effects follow helper calls" {
     # client cache is never invalidated after the mutation.
     code = '"""Interprocedural endpoint effect analysis."""\n\nnode Item {\n    has title: str,\n        tags: list = [];\n}\n\ndef _add_tag(it: Item, label: str) -> None {\n    it.tags = it.tags + [label];\n}\n\nwalker tag_item {\n    has label: str;\n    can do_tag with Root entry {\n        for it in [-->[?:Item]] {\n            _add_tag(it, self.label);\n        }\n    }\n}\n\ndef:pub mark_item(label: str) -> dict {\n    items = [];\n    for it in items {\n        _add_tag(it, label);\n    }\n    return {};\n}\n\ncl {\n    def:pub app() {\n        root spawn tag_item(label="x");\n        result = await mark_item("y");\n    }\n}\n';
     mod = compile_inline(code, prog);
-    effects = mod.gen.client_manifest.endpoint_effects;
+    effects = mod.gen.analysis.client_manifest.endpoint_effects;
 
     # The walker mutates Item.tags only inside the `_add_tag` helper.
     assert "walker:tag_item" in effects , "tag_item should be in endpoint_effects";

--- a/jac/tests/compiler/test_typed_interop.jac
+++ b/jac/tests/compiler/test_typed_interop.jac
@@ -110,7 +110,7 @@ test "inline cl block with defpub generates stubs" {
 test "endpoint effects classify readers and writers" {
     code = '"""Test."""\n\nnode Item { has name: str; }\n\nwalker read_items {\n    can visit_root with Root entry { report [-->]; }\n}\n\nwalker add_item {\n    has name: str;\n    can do_add with Root entry { here ++> Item(name=self.name); }\n}\n\ndef:pub get_count() -> int { return 0; }\n\ndef:pub delete_all() -> None { items = []; del items; }\n\ncl {\n    def:pub app() {\n        root spawn read_items();\n        root spawn add_item(name="x");\n        c = await get_count();\n        await delete_all();\n    }\n}\n';
     mod = compile_inline(code);
-    effects = mod.gen.client_manifest.endpoint_effects;
+    effects = mod.gen.analysis.client_manifest.endpoint_effects;
     assert "walker:read_items" in effects;
     assert not effects["walker:read_items"]["is_writer"];
     assert "walker:add_item" in effects;
@@ -124,7 +124,7 @@ test "endpoint effects classify readers and writers" {
 # Client manifest tracks exports from typed return fixture
 test "client manifest tracks exports" {
     mod = compile_fixture("typed_return_obj.jac");
-    manifest = mod.gen.client_manifest;
+    manifest = mod.gen.analysis.client_manifest;
     assert "app" in manifest.exports;
 }
 
@@ -227,7 +227,7 @@ test "serialization: bidirectional round trip" {
 # InteropManifest should collect boundary types with param + return types
 test "manifest: boundary types with params and returns" {
     mod = compile_fixture("typed_bidirectional.jac");
-    manifest = mod.gen.interop_manifest;
+    manifest = mod.gen.analysis.interop_manifest;
     exports = manifest.server_exports_to_client;
     func_names = [b.name for b in exports];
     assert "place_order" in func_names;
@@ -243,7 +243,7 @@ test "manifest: boundary types with params and returns" {
 # Nested types (Person -> Address) should be transitively collected
 test "manifest: nested types transitively collected" {
     mod = compile_fixture("typed_return_nested.jac");
-    manifest = mod.gen.interop_manifest;
+    manifest = mod.gen.analysis.interop_manifest;
     exports = manifest.server_exports_to_client;
     func_names = [b.name for b in exports];
     assert "get_person" in func_names;
@@ -325,7 +325,7 @@ test "gap: list return wraps call site with map and __from_wire" {
     mod = compile_fixture("typed_return_obj.jac");
     js = mod.gen.js;
     # The manifest knows the return type
-    exports = mod.gen.interop_manifest.server_exports_to_client;
+    exports = mod.gen.analysis.interop_manifest.server_exports_to_client;
     for b in exports {
         if b.name == "get_todos" {
             assert b.ret_type == "list[Todo]" , f"Manifest should have list[Todo] return type, got: {b.ret_type}";
@@ -368,7 +368,7 @@ test "gap: union return type wraps call site" {
 # get_metrics_map returns dict[str, Metric] — values should be hydrated
 test "gap: dict return type preserves generic in manifest" {
     mod = compile_fixture("typed_dict_return.jac");
-    exports = mod.gen.interop_manifest.server_exports_to_client;
+    exports = mod.gen.analysis.interop_manifest.server_exports_to_client;
     for b in exports {
         if b.name == "get_metrics_map" {
             assert "Metric" in b.ret_type , f"Manifest should preserve dict[str, Metric] return type, got: {b.ret_type}";
@@ -399,7 +399,7 @@ test "gap: dict return type wraps values with __from_wire" {
 # ---------------------------------------------------------------------------
 test "gap: nested_types field populated in manifest" {
     mod = compile_fixture("typed_return_nested.jac");
-    bt = mod.gen.interop_manifest.boundary_types;
+    bt = mod.gen.analysis.interop_manifest.boundary_types;
     assert "Person" in bt , "Person should be a boundary type";
     assert "Address" in bt , "Address should be a boundary type";
     # nested_types tracks transitive dependencies

--- a/jac/tests/runtimelib/test_client_bundle.jac
+++ b/jac/tests/runtimelib/test_client_bundle.jac
@@ -19,7 +19,7 @@ test "base builder compiles a client module to JS and extracts its manifest surf
     source_path = Path(module.__file__.replace(".py", ".jac")).resolve();
     (js, mod) = builder._compile_to_js(source_path);
     assert js;  # ES output was generated
-    manifest = mod.gen.client_manifest if mod else None;
+    manifest = mod.gen.analysis.client_manifest if mod else None;
     exports = builder._extract_client_exports(manifest);
     assert isinstance(exports, list);
     globals_map = builder._extract_client_globals(manifest, module);


### PR DESCRIPTION
## Summary

Centralizes shared compiler analysis facts under `CodeGenTarget.analysis` and removes the old top-level `gen.*` homes for cross-stage facts.

This PR:
- Adds `ModuleAnalysis` as the shared container for manifests, native layout, native compatibility, and layout registry facts.
- Migrates consumers from `gen.interop_manifest`, `gen.client_manifest`, `gen.native_layout`, `gen.native_compat`, and `gen.layout_registry` to `gen.analysis.*`.
- Removes the temporary compatibility accessor layer for migrated facts.
- Makes `get_layout_registry(...)` a read-only helper over centrally scheduled `LayoutPass` output.
- Stops native codegen from lazily producing shared layout analysis, while preserving function-only native module handling.
- Updates the compiler architecture docs with the ownership rule and current shared fact inventory.

## Why

The migration should reduce responsibility count rather than add another facade. After this change, module-wide shared facts have one authoritative home and backend code consumes them instead of rediscovering or manufacturing them on demand.

Tracks #6417.

## Validation

- `.venv/bin/python -m pytest jac/tests/compiler/passes/main/test_layout_pass.jac jac/tests/compiler/test_client_codegen.jac jac/tests/compiler/test_typed_interop.jac jac/tests/runtimelib/test_client_bundle.jac -q`
- `.venv/bin/python -m pytest jac/tests/compiler/passes/native/test_native_lexer.jac -q`
- `.venv/bin/python -m pytest jac/tests/compiler/passes/native/test_native_gen_pass.jac -k "auto and promote and detects" -q`
- native fixture smoke for `arithmetic.na.jac`
- central analysis smoke confirming old top-level analysis attrs are gone
- `git diff --check`
- stale-reference search for old `gen.*` analysis paths