### PR TITLE
test(native): guard owned-temporary release across consumption seams

### DIFF
--- a/jac/tests/compiler/passes/native/fixtures/perf_owned_temps.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/perf_owned_temps.na.jac
@@ -1,0 +1,60 @@
+"""P-06: Owned-temporary release across value-consumption seams (#6464).
+
+Each loop iteration produces several heap temporaries that are consumed by a
+`for`-loop, a comprehension, an `in` test, `set.add`, and a function-call
+argument. The native RC code-gen must release each consumed temporary; if any
+seam forgets, the temporary leaks and peak RSS grows without bound even with GC
+enabled (the bug fixed in #6464). With GC on every temporary is reclaimed and
+RSS stays flat, so this fixture's GC-vs-no-GC delta guards against a regression
+of those releases.
+
+Timing and RSS are measured externally by the gc test via /usr/bin/time.
+"""
+
+def gen(n: int) -> list[int] {
+    out: list[int] = [];
+    i = 0;
+    while i < n {
+        out.append(i);
+        i = i + 1;
+    }
+    return out;
+}
+
+def take(xs: list[int]) -> int {
+    return len(xs);
+}
+
+def attacks(n: int) -> set[tuple[int, int]] {
+    s: set[tuple[int, int]] = set();
+    i = 0;
+    while i < n {
+        s.add((i, i));
+        i = i + 1;
+    }
+    return s;
+}
+
+with entry {
+    total: int = 0;
+    k: int = 0;
+    while k < 100000 {
+        # 1. for-loop over a call-returned temporary list
+        for v in gen(16) {
+            total = total + v;
+        }
+        # 2. set comprehension over a call-returned temporary list
+        sq: set[int] = {v for v in gen(16)};
+        total = total + len(sq);
+        # 3. membership test against a call-returned temporary set (+ tuple key);
+        #    attacks() also exercises set.add of value tuples
+        if (3, 3) in attacks(16) {
+            total = total + 1;
+        }
+        # 4. owned-temporary (list literal + call result) passed as a call argument
+        total = total + take(gen(16));
+        total = total + take([0, 1, 2, 3, 4, 5, 6, 7]);
+        k = k + 1;
+    }
+    print("OK owned_temps total =", total);
+}

--- a/jac/tests/compiler/passes/native/test_native_gc.jac
+++ b/jac/tests/compiler/passes/native/test_native_gc.jac
@@ -189,3 +189,13 @@ test "gc reduces rss for chess" {
     );
     print(f"[chess] gc={gc} KB  nogc={nogc} KB  saved={nogc - gc} KB");
 }
+
+test "gc reclaims owned temporaries across consumption seams" {
+    # Regression guard for #6464: each iteration produces heap temporaries that
+    # are consumed by a for-loop, a comprehension, an `in` test, set.add, and
+    # call arguments. If any seam fails to release its temporary the leak
+    # survives even with GC on, so the GC-vs-no-GC delta collapses. With the
+    # releases in place GC keeps RSS flat while no-GC balloons.
+    (gc, nogc) = _measure_gc_savings("perf_owned_temps.na.jac", min_savings_kb=10240);
+    print(f"[owned_temps] gc={gc} KB  nogc={nogc} KB  saved={nogc - gc} KB");
+}


### PR DESCRIPTION
## What

Adds a regression test for the native-backend reference-counting leaks fixed in #6464 (owned temporaries not released at value-consumption seams).

- New fixture `tests/compiler/passes/native/fixtures/perf_owned_temps.na.jac` — a tight loop that, every iteration, produces heap temporaries consumed by each fixed seam:
  - a `for`-loop over a call-returned list,
  - a set comprehension over a call-returned list,
  - an `in` test against a call-returned set (plus a tuple key),
  - `set.add` of value tuples,
  - owned temporaries (a list literal and a call result) passed as call arguments.
- New test in `test_native_gc.jac` that runs it through the existing `_measure_gc_savings` harness (GC on vs `JAC_NO_GC=1`).

## Why this guards the fix

If any seam stops releasing its temporary, the leak survives **even with GC enabled**, so the GC-vs-no-GC delta collapses below the threshold and the assertion fails.

The existing gc suite did **not** catch these leaks: its `chess.na.jac` fixture runs interactively (stdin closed, so the engine displays one position and exits) and barely allocates, so `[chess]` gc RSS was identical with and without the #6464 fix. This fixture exercises the seams under load instead.

Measured locally:

```
[owned_temps] gc=1792 KB  nogc=272128 KB  saved=270336 KB
```

~266 MB leaked without GC, ~1.8 MB flat with it. Verified that reverting the #6464 releases makes GC-on balloon and the test fail.

Test-only change (no `jac/jaclang/` sources touched).