### PR TITLE
feat(shadcn): add sonner toast + drop redundant cl markers from registry

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-super/6467.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jac-super/6467.feature.md
@@ -1,0 +1,1 @@
+- **Feature: sonner toast component**: The jac-shadcn registry now ships the sonner toast/notification component, installable with `jac add --shadcn sonner`. (jaseci-labs/jaseci#6467)

--- a/docs/docs/community/release_notes/unreleased/jac-super/6467.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jac-super/6467.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: registry components use the bare client form**: jac-shadcn components delivered by `jac add --shadcn` no longer carry redundant `cl` import and block markers. (jaseci-labs/jaseci#6467)

--- a/docs/docs/community/release_notes/unreleased/jaclang/6467.docs.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6467.docs.md
@@ -1,0 +1,1 @@
+- **Docs: sonner in the jac-shadcn component guide**: The bundled component-selection guide now lists the sonner toast component. (jaseci-labs/jaseci#6467)

--- a/jac-super/jac_super/shadcn/registry/components/ui/accordion.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/accordion.cl.jac
@@ -1,70 +1,68 @@
-cl import from "radix-ui" { Accordion as AccordionPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { ArrowDownIcon, ArrowUpIcon }
+import from "radix-ui" { Accordion as AccordionPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { ArrowDownIcon, ArrowUpIcon }
 
-cl {
-    def:pub Accordion(props: any) -> JsxElement {
-        return
-            <AccordionPrimitive.Root
+def:pub Accordion(props: any) -> JsxElement {
+    return
+        <AccordionPrimitive.Root
+            {**props}
+            data-slot="accordion"
+            className={cn("cn-accordion flex w-full flex-col", props["className"])}
+        />;
+}
+
+def:pub AccordionItem(props: any) -> JsxElement {
+    return
+        <AccordionPrimitive.Item
+            {**props}
+            data-slot="accordion-item"
+            className={cn("cn-accordion-item", props["className"])}
+        />;
+}
+
+def:pub AccordionTrigger(props: any) -> JsxElement {
+    return
+        <AccordionPrimitive.Header className="flex">
+            <AccordionPrimitive.Trigger
                 {**props}
-                data-slot="accordion"
-                className={cn("cn-accordion flex w-full flex-col", props["className"])}
-            />;
-    }
-
-    def:pub AccordionItem(props: any) -> JsxElement {
-        return
-            <AccordionPrimitive.Item
-                {**props}
-                data-slot="accordion-item"
-                className={cn("cn-accordion-item", props["className"])}
-            />;
-    }
-
-    def:pub AccordionTrigger(props: any) -> JsxElement {
-        return
-            <AccordionPrimitive.Header className="flex">
-                <AccordionPrimitive.Trigger
-                    {**props}
-                    data-slot="accordion-trigger"
-                    className={cn(
-                        "cn-accordion-trigger group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50",
-                        props["className"]
-                    )}
-                >
-                    {props["children"]}
-                    <HugeiconsIcon
-                        icon={ArrowDownIcon}
-                        strokeWidth={2}
-                        data-slot="accordion-trigger-icon"
-                        className="cn-accordion-trigger-icon pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
-                    />
-                    <HugeiconsIcon
-                        icon={ArrowUpIcon}
-                        strokeWidth={2}
-                        data-slot="accordion-trigger-icon"
-                        className="cn-accordion-trigger-icon pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
-                    />
-                </AccordionPrimitive.Trigger>
-            </AccordionPrimitive.Header>;
-    }
-
-    def:pub AccordionContent(props: any) -> JsxElement {
-        return
-            <AccordionPrimitive.Content
-                {**props}
-                data-slot="accordion-content"
-                className="cn-accordion-content overflow-hidden"
+                data-slot="accordion-trigger"
+                className={cn(
+                    "cn-accordion-trigger group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50",
+                    props["className"]
+                )}
             >
-                <div
-                    className={cn(
-                        "cn-accordion-content-inner h-(--radix-accordion-content-height) [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
-                        props["className"]
-                    )}
-                >
-                    {props["children"]}
-                </div>
-            </AccordionPrimitive.Content>;
-    }
+                {props["children"]}
+                <HugeiconsIcon
+                    icon={ArrowDownIcon}
+                    strokeWidth={2}
+                    data-slot="accordion-trigger-icon"
+                    className="cn-accordion-trigger-icon pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+                />
+                <HugeiconsIcon
+                    icon={ArrowUpIcon}
+                    strokeWidth={2}
+                    data-slot="accordion-trigger-icon"
+                    className="cn-accordion-trigger-icon pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+                />
+            </AccordionPrimitive.Trigger>
+        </AccordionPrimitive.Header>;
+}
+
+def:pub AccordionContent(props: any) -> JsxElement {
+    return
+        <AccordionPrimitive.Content
+            {**props}
+            data-slot="accordion-content"
+            className="cn-accordion-content overflow-hidden"
+        >
+            <div
+                className={cn(
+                    "cn-accordion-content-inner h-(--radix-accordion-content-height) [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+                    props["className"]
+                )}
+            >
+                {props["children"]}
+            </div>
+        </AccordionPrimitive.Content>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/alert-dialog.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/alert-dialog.cl.jac
@@ -1,136 +1,133 @@
-cl import from "radix-ui" { AlertDialog as AlertDialogPrimitive }
-cl import from ...lib.utils { cn }
-cl import from .button { Button }
+import from "radix-ui" { AlertDialog as AlertDialogPrimitive }
+import from ...lib.utils { cn }
+import from .button { Button }
 
-cl {
-    def:pub AlertDialog(props: any) -> JsxElement {
-        return <AlertDialogPrimitive.Root data-slot="alert-dialog" {**props}/>;
-    }
+def:pub AlertDialog(props: any) -> JsxElement {
+    return <AlertDialogPrimitive.Root data-slot="alert-dialog" {**props}/>;
+}
 
-    def:pub AlertDialogTrigger(props: any) -> JsxElement {
-        return
-            <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {**props}/>;
-    }
+def:pub AlertDialogTrigger(props: any) -> JsxElement {
+    return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {**props}/>;
+}
 
-    def:pub AlertDialogPortal(props: any) -> JsxElement {
-        return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {**props}/>;
-    }
+def:pub AlertDialogPortal(props: any) -> JsxElement {
+    return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {**props}/>;
+}
 
-    def:pub AlertDialogOverlay(props: any) -> JsxElement {
-        return
-            <AlertDialogPrimitive.Overlay
+def:pub AlertDialogOverlay(props: any) -> JsxElement {
+    return
+        <AlertDialogPrimitive.Overlay
+            {**props}
+            data-slot="alert-dialog-overlay"
+            className={cn(
+                "cn-alert-dialog-overlay data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub AlertDialogContent(props: any) -> JsxElement {
+    size = props["size"] or "default";
+    return
+        <AlertDialogPortal>
+            <AlertDialogOverlay/>
+            <AlertDialogPrimitive.Content
                 {**props}
-                data-slot="alert-dialog-overlay"
+                data-slot="alert-dialog-content"
+                data-size={size}
                 className={cn(
-                    "cn-alert-dialog-overlay data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+                    "cn-alert-dialog-content data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
                     props["className"]
                 )}
-            />;
-    }
+            />
+        </AlertDialogPortal>;
+}
 
-    def:pub AlertDialogContent(props: any) -> JsxElement {
-        size = props["size"] or "default";
-        return
-            <AlertDialogPortal>
-                <AlertDialogOverlay/>
-                <AlertDialogPrimitive.Content
-                    {**props}
-                    data-slot="alert-dialog-content"
-                    data-size={size}
-                    className={cn(
-                        "cn-alert-dialog-content data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
-                        props["className"]
-                    )}
-                />
-            </AlertDialogPortal>;
-    }
+def:pub AlertDialogHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="alert-dialog-header"
+            className={cn(
+                "cn-alert-dialog-header grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AlertDialogHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="alert-dialog-header"
-                className={cn(
-                    "cn-alert-dialog-header grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AlertDialogFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="alert-dialog-footer"
+            className={cn(
+                "cn-alert-dialog-footer bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AlertDialogFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="alert-dialog-footer"
-                className={cn(
-                    "cn-alert-dialog-footer bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AlertDialogMedia(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="alert-dialog-media"
+            className={cn(
+                "cn-alert-dialog-media bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AlertDialogMedia(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="alert-dialog-media"
-                className={cn(
-                    "cn-alert-dialog-media bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AlertDialogTitle(props: any) -> JsxElement {
+    return
+        <AlertDialogPrimitive.Title
+            {**props}
+            data-slot="alert-dialog-title"
+            className={cn(
+                "cn-alert-dialog-title text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AlertDialogTitle(props: any) -> JsxElement {
-        return
-            <AlertDialogPrimitive.Title
+def:pub AlertDialogDescription(props: any) -> JsxElement {
+    return
+        <AlertDialogPrimitive.Description
+            {**props}
+            data-slot="alert-dialog-description"
+            className={cn(
+                "cn-alert-dialog-description text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub AlertDialogAction(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    return
+        <Button variant={variant} size={size} asChild={True}>
+            <AlertDialogPrimitive.Action
                 {**props}
-                data-slot="alert-dialog-title"
-                className={cn(
-                    "cn-alert-dialog-title text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
-                    props["className"]
-                )}
-            />;
-    }
+                data-slot="alert-dialog-action"
+                className={cn("cn-alert-dialog-action", props["className"])}
+            />
+        </Button>;
+}
 
-    def:pub AlertDialogDescription(props: any) -> JsxElement {
-        return
-            <AlertDialogPrimitive.Description
+def:pub AlertDialogCancel(props: any) -> JsxElement {
+    variant = props["variant"] or "outline";
+    size = props["size"] or "default";
+    return
+        <Button variant={variant} size={size} asChild={True}>
+            <AlertDialogPrimitive.Cancel
                 {**props}
-                data-slot="alert-dialog-description"
-                className={cn(
-                    "cn-alert-dialog-description text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub AlertDialogAction(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        return
-            <Button variant={variant} size={size} asChild={True}>
-                <AlertDialogPrimitive.Action
-                    {**props}
-                    data-slot="alert-dialog-action"
-                    className={cn("cn-alert-dialog-action", props["className"])}
-                />
-            </Button>;
-    }
-
-    def:pub AlertDialogCancel(props: any) -> JsxElement {
-        variant = props["variant"] or "outline";
-        size = props["size"] or "default";
-        return
-            <Button variant={variant} size={size} asChild={True}>
-                <AlertDialogPrimitive.Cancel
-                    {**props}
-                    data-slot="alert-dialog-cancel"
-                    className={cn("cn-alert-dialog-cancel", props["className"])}
-                />
-            </Button>;
-    }
+                data-slot="alert-dialog-cancel"
+                className={cn("cn-alert-dialog-cancel", props["className"])}
+            />
+        </Button>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/alert.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/alert.cl.jac
@@ -1,5 +1,5 @@
-cl import from "class-variance-authority" { cva }
-cl import from ...lib.utils { cn }
+import from "class-variance-authority" { cva }
+import from ...lib.utils { cn }
 
 glob _alertVariants: any = cva(
          "cn-alert w-full relative group/alert",
@@ -14,51 +14,48 @@ glob _alertVariants: any = cva(
          }
      );
 
-cl {
-    def:pub Alert(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        variant = props["variant"] or "default";
-        variantsFn = _alertVariants;
-        computedClass = cn(
-            variantsFn.call(None, {"variant": variant, "className": props["className"]})
-        );
-        return
-            <div {**attrs} data-slot="alert" role="alert" className={computedClass}/>;
-    }
+def:pub Alert(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    variant = props["variant"] or "default";
+    variantsFn = _alertVariants;
+    computedClass = cn(
+        variantsFn.call(None, {"variant": variant, "className": props["className"]})
+    );
+    return <div {**attrs} data-slot="alert" role="alert" className={computedClass}/>;
+}
 
-    def:pub AlertTitle(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="alert-title"
-                className={cn(
-                    "cn-alert-title [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AlertTitle(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="alert-title"
+            className={cn(
+                "cn-alert-title [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AlertDescription(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="alert-description"
-                className={cn(
-                    "cn-alert-description [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AlertDescription(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="alert-description"
+            className={cn(
+                "cn-alert-description [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AlertAction(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="alert-action"
-                className={cn("cn-alert-action", props["className"])}
-            />;
-    }
+def:pub AlertAction(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="alert-action"
+            className={cn("cn-alert-action", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/aspect-ratio.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/aspect-ratio.cl.jac
@@ -1,7 +1,5 @@
-cl import from "radix-ui" { AspectRatio as AspectRatioPrimitive }
+import from "radix-ui" { AspectRatio as AspectRatioPrimitive }
 
-cl {
-    def:pub AspectRatio(props: any) -> JsxElement {
-        return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {**props}/>;
-    }
+def:pub AspectRatio(props: any) -> JsxElement {
+    return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {**props}/>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/avatar.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/avatar.cl.jac
@@ -1,84 +1,82 @@
-cl import from "radix-ui" { Avatar as AvatarPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Avatar as AvatarPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Avatar(props: any) -> JsxElement {
-        size = props["size"] or "default";
-        return
-            <AvatarPrimitive.Root
-                {**props}
-                data-slot="avatar"
-                data-size={size}
-                className={cn(
-                    "cn-avatar after:border-border group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Avatar(props: any) -> JsxElement {
+    size = props["size"] or "default";
+    return
+        <AvatarPrimitive.Root
+            {**props}
+            data-slot="avatar"
+            data-size={size}
+            className={cn(
+                "cn-avatar after:border-border group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AvatarImage(props: any) -> JsxElement {
-        return
-            <AvatarPrimitive.Image
-                {**props}
-                data-slot="avatar-image"
-                className={cn(
-                    "cn-avatar-image aspect-square size-full object-cover",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AvatarImage(props: any) -> JsxElement {
+    return
+        <AvatarPrimitive.Image
+            {**props}
+            data-slot="avatar-image"
+            className={cn(
+                "cn-avatar-image aspect-square size-full object-cover",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AvatarFallback(props: any) -> JsxElement {
-        return
-            <AvatarPrimitive.Fallback
-                {**props}
-                data-slot="avatar-fallback"
-                className={cn(
-                    "cn-avatar-fallback flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AvatarFallback(props: any) -> JsxElement {
+    return
+        <AvatarPrimitive.Fallback
+            {**props}
+            data-slot="avatar-fallback"
+            className={cn(
+                "cn-avatar-fallback flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AvatarBadge(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                {**attrs}
-                data-slot="avatar-badge"
-                className={cn(
-                    "cn-avatar-badge absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blend-color ring-2 select-none",
-                    "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
-                    "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
-                    "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AvatarBadge(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            data-slot="avatar-badge"
+            className={cn(
+                "cn-avatar-badge absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blend-color ring-2 select-none",
+                "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+                "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+                "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AvatarGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="avatar-group"
-                className={cn(
-                    "cn-avatar-group *:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AvatarGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="avatar-group"
+            className={cn(
+                "cn-avatar-group *:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub AvatarGroupCount(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="avatar-group-count"
-                className={cn(
-                    "cn-avatar-group-count ring-background relative flex shrink-0 items-center justify-center ring-2",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub AvatarGroupCount(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="avatar-group-count"
+            className={cn(
+                "cn-avatar-group-count ring-background relative flex shrink-0 items-center justify-center ring-2",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/badge.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/badge.cl.jac
@@ -1,6 +1,6 @@
-cl import from "class-variance-authority" { cva }
-cl import from "radix-ui" { Slot }
-cl import from ...lib.utils { cn }
+import from "class-variance-authority" { cva }
+import from "radix-ui" { Slot }
+import from ...lib.utils { cn }
 
 glob _badgeVariants: any = cva(
          "cn-badge h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
@@ -19,37 +19,33 @@ glob _badgeVariants: any = cva(
          }
      );
 
-cl {
-    def:pub Badge(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        variant = props["variant"] or "default";
-        asChild = props["asChild"] or False;
+def:pub Badge(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    variant = props["variant"] or "default";
+    asChild = props["asChild"] or False;
 
-        variantsFn = _badgeVariants;
-        computedClass = cn(
-            variantsFn.call(None, {"variant": variant}), props["className"]
-        );
+    variantsFn = _badgeVariants;
+    computedClass = cn(variantsFn.call(None, {"variant": variant}), props["className"]);
 
-        if asChild {
-            return
-                <Slot.Root
-                    {**props}
-                    data-slot="badge"
-                    data-variant={variant}
-                    className={computedClass}
-                />;
-        }
-
+    if asChild {
         return
-            <span
-                {**attrs}
+            <Slot.Root
+                {**props}
                 data-slot="badge"
                 data-variant={variant}
                 className={computedClass}
             />;
     }
 
-    def:pub badgeVariants -> any {
-        return _badgeVariants;
-    }
+    return
+        <span
+            {**attrs}
+            data-slot="badge"
+            data-variant={variant}
+            className={computedClass}
+        />;
+}
+
+def:pub badgeVariants -> any {
+    return _badgeVariants;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/breadcrumb.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/breadcrumb.cl.jac
@@ -1,114 +1,112 @@
-cl import from "radix-ui" { Slot }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" {
+import from "radix-ui" { Slot }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" {
     ArrowRight01Icon,
     MoreHorizontalCircle01Icon
 }
 
-cl {
-    def:pub Breadcrumb(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <nav
-                {**attrs}
-                aria-label="breadcrumb"
-                data-slot="breadcrumb"
-                className={cn("cn-breadcrumb", props["className"])}
-            />;
-    }
+def:pub Breadcrumb(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <nav
+            {**attrs}
+            aria-label="breadcrumb"
+            data-slot="breadcrumb"
+            className={cn("cn-breadcrumb", props["className"])}
+        />;
+}
 
-    def:pub BreadcrumbList(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <ol
-                {**attrs}
-                data-slot="breadcrumb-list"
-                className={cn(
-                    "cn-breadcrumb-list flex flex-wrap items-center wrap-break-word",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub BreadcrumbList(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <ol
+            {**attrs}
+            data-slot="breadcrumb-list"
+            className={cn(
+                "cn-breadcrumb-list flex flex-wrap items-center wrap-break-word",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub BreadcrumbItem(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <li
-                {**attrs}
-                data-slot="breadcrumb-item"
-                className={cn(
-                    "cn-breadcrumb-item inline-flex items-center", props["className"]
-                )}
-            />;
-    }
+def:pub BreadcrumbItem(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <li
+            {**attrs}
+            data-slot="breadcrumb-item"
+            className={cn(
+                "cn-breadcrumb-item inline-flex items-center", props["className"]
+            )}
+        />;
+}
 
-    def:pub BreadcrumbLink(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        asChild = props["asChild"] or False;
-        if asChild {
-            return
-                <Slot.Root
-                    {**props}
-                    data-slot="breadcrumb-link"
-                    className={cn("cn-breadcrumb-link", props["className"])}
-                />;
-        }
+def:pub BreadcrumbLink(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    asChild = props["asChild"] or False;
+    if asChild {
         return
-            <a
-                {**attrs}
+            <Slot.Root
+                {**props}
                 data-slot="breadcrumb-link"
                 className={cn("cn-breadcrumb-link", props["className"])}
             />;
     }
+    return
+        <a
+            {**attrs}
+            data-slot="breadcrumb-link"
+            className={cn("cn-breadcrumb-link", props["className"])}
+        />;
+}
 
-    def:pub BreadcrumbPage(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                {**attrs}
-                data-slot="breadcrumb-page"
-                role="link"
-                aria-disabled="true"
-                aria-current="page"
-                className={cn("cn-breadcrumb-page", props["className"])}
-            />;
-    }
+def:pub BreadcrumbPage(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            data-slot="breadcrumb-page"
+            role="link"
+            aria-disabled="true"
+            aria-current="page"
+            className={cn("cn-breadcrumb-page", props["className"])}
+        />;
+}
 
-    def:pub BreadcrumbSeparator(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <li
-                {**attrs}
-                data-slot="breadcrumb-separator"
-                role="presentation"
-                aria-hidden="true"
-                className={cn("cn-breadcrumb-separator", props["className"])}
-            >
-                {props["children"]
-                or <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    strokeWidth={2}
-                    className="cn-rtl-flip"
-                />}
-            </li>;
-    }
+def:pub BreadcrumbSeparator(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <li
+            {**attrs}
+            data-slot="breadcrumb-separator"
+            role="presentation"
+            aria-hidden="true"
+            className={cn("cn-breadcrumb-separator", props["className"])}
+        >
+            {props["children"]
+            or <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                strokeWidth={2}
+                className="cn-rtl-flip"
+            />}
+        </li>;
+}
 
-    def:pub BreadcrumbEllipsis(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                {**attrs}
-                data-slot="breadcrumb-ellipsis"
-                role="presentation"
-                aria-hidden="true"
-                className={cn(
-                    "cn-breadcrumb-ellipsis flex items-center justify-center",
-                    props["className"]
-                )}
-            >
-                <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={2}/>
-                <span className="sr-only">More</span>
-            </span>;
-    }
+def:pub BreadcrumbEllipsis(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            data-slot="breadcrumb-ellipsis"
+            role="presentation"
+            aria-hidden="true"
+            className={cn(
+                "cn-breadcrumb-ellipsis flex items-center justify-center",
+                props["className"]
+            )}
+        >
+            <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={2}/>
+            <span className="sr-only">More</span>
+        </span>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/button-group.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/button-group.cl.jac
@@ -1,7 +1,7 @@
-cl import from "class-variance-authority" { cva }
-cl import from "radix-ui" { Slot }
-cl import from ...lib.utils { cn }
-cl import from .separator { Separator }
+import from "class-variance-authority" { cva }
+import from "radix-ui" { Slot }
+import from ...lib.utils { cn }
+import from .separator { Separator }
 
 glob _buttonGroupVariants: any = cva(
          "cn-button-group flex w-fit items-stretch *:focus-visible:z-10 *:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
@@ -22,65 +22,63 @@ glob _buttonGroupVariants: any = cva(
          "children"
      ];
 
-cl {
-    def:pub ButtonGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        orientation = props["orientation"] or "horizontal";
-        computedClass = cn(
-            _buttonGroupVariants.call(
-                None, {"orientation": orientation, "className": props["className"]}
-            )
-        );
+def:pub ButtonGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    orientation = props["orientation"] or "horizontal";
+    computedClass = cn(
+        _buttonGroupVariants.call(
+            None, {"orientation": orientation, "className": props["className"]}
+        )
+    );
+    return
+        <div
+            role="group"
+            data-slot="button-group"
+            data-orientation={orientation}
+            className={computedClass}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
+
+def:pub ButtonGroupText(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    asChild = props["asChild"] or False;
+    computedClass = cn(
+        "cn-button-group-text flex items-center [&_svg]:pointer-events-none",
+        props["className"]
+    );
+    if asChild {
         return
-            <div
-                role="group"
-                data-slot="button-group"
-                data-orientation={orientation}
+            <Slot.Root
+                data-slot="button-group-text"
                 className={computedClass}
-                {**attrs}
+                {**props}
             >
                 {props["children"]}
-            </div>;
+            </Slot.Root>;
     }
+    return
+        <div data-slot="button-group-text" className={computedClass} {**attrs}>
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ButtonGroupText(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        asChild = props["asChild"] or False;
-        computedClass = cn(
-            "cn-button-group-text flex items-center [&_svg]:pointer-events-none",
-            props["className"]
-        );
-        if asChild {
-            return
-                <Slot.Root
-                    data-slot="button-group-text"
-                    className={computedClass}
-                    {**props}
-                >
-                    {props["children"]}
-                </Slot.Root>;
-        }
-        return
-            <div data-slot="button-group-text" className={computedClass} {**attrs}>
-                {props["children"]}
-            </div>;
-    }
+def:pub ButtonGroupSeparator(props: any) -> JsxElement {
+    orientation = props["orientation"] or "vertical";
+    return
+        <Separator
+            data-slot="button-group-separator"
+            orientation={orientation}
+            className={cn(
+                "cn-button-group-separator relative self-stretch data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+                props["className"]
+            )}
+            {**props}
+        />;
+}
 
-    def:pub ButtonGroupSeparator(props: any) -> JsxElement {
-        orientation = props["orientation"] or "vertical";
-        return
-            <Separator
-                data-slot="button-group-separator"
-                orientation={orientation}
-                className={cn(
-                    "cn-button-group-separator relative self-stretch data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
-                    props["className"]
-                )}
-                {**props}
-            />;
-    }
-
-    def:pub buttonGroupVariants -> any {
-        return _buttonGroupVariants;
-    }
+def:pub buttonGroupVariants -> any {
+    return _buttonGroupVariants;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/button.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/button.cl.jac
@@ -1,6 +1,6 @@
-cl import from "class-variance-authority" { cva }
-cl import from "radix-ui" { Slot }
-cl import from ...lib.utils { cn }
+import from "class-variance-authority" { cva }
+import from "radix-ui" { Slot }
+import from ...lib.utils { cn }
 
 glob _buttonVariants: any = cva(
          "cn-button focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
@@ -36,41 +36,27 @@ glob _buttonVariants: any = cva(
          "children"
      ];
 
-cl {
-    def:pub Button(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        asChild = props["asChild"] or False;
+def:pub Button(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    asChild = props["asChild"] or False;
 
-        restProps = {};
-        for key in Object.keys(props) {  # jac:ignore[W6001]
-            if key not in _buttonExcludeKeys {
-                restProps[key] = props[key];
-            }
+    restProps = {};
+    for key in Object.keys(props) {  # jac:ignore[W6001]
+        if key not in _buttonExcludeKeys {
+            restProps[key] = props[key];
         }
+    }
 
-        computedClass = cn(
-            _buttonVariants.call(
-                None,
-                {"variant": variant, "size": size, "className": props["className"]}
-            )
-        );
+    computedClass = cn(
+        _buttonVariants.call(
+            None, {"variant": variant, "size": size, "className": props["className"]}
+        )
+    );
 
-        if asChild {
-            return
-                <Slot.Root
-                    data-slot="button"
-                    data-variant={variant}
-                    data-size={size}
-                    className={computedClass}
-                    {**restProps}
-                >
-                    {props["children"]}
-                </Slot.Root>;
-        }
-
+    if asChild {
         return
-            <button
+            <Slot.Root
                 data-slot="button"
                 data-variant={variant}
                 data-size={size}
@@ -78,10 +64,21 @@ cl {
                 {**restProps}
             >
                 {props["children"]}
-            </button>;
+            </Slot.Root>;
     }
 
-    def:pub buttonVariants -> any {
-        return _buttonVariants;
-    }
+    return
+        <button
+            data-slot="button"
+            data-variant={variant}
+            data-size={size}
+            className={computedClass}
+            {**restProps}
+        >
+            {props["children"]}
+        </button>;
+}
+
+def:pub buttonVariants -> any {
+    return _buttonVariants;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/calendar.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/calendar.cl.jac
@@ -1,165 +1,160 @@
-cl import from "react-day-picker" { DayPicker, getDefaultClassNames }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" {
+import from "react-day-picker" { DayPicker, getDefaultClassNames }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" {
     ArrowLeftIcon,
     ArrowRightIcon,
     ArrowDownIcon
 }
-cl import from .button { Button, buttonVariants }
-cl import from ...lib.utils { cn }
+import from .button { Button, buttonVariants }
+import from ...lib.utils { cn }
 
-cl {
-    def CalendarChevron(props: any) -> JsxElement {
-        ori = props["orientation"];
-        icon = ArrowDownIcon;
-        if ori == "left" {
-            icon = ArrowLeftIcon;
-        } elif ori == "right" {
-            icon = ArrowRightIcon;
-        }
-        return
-            <HugeiconsIcon
-                icon={icon}
-                {**props}
-                className={cn("cn-rtl-flip size-4", props["className"])}
-                size={16}
-            />;
+def CalendarChevron(props: any) -> JsxElement {
+    ori = props["orientation"];
+    icon = ArrowDownIcon;
+    if ori == "left" {
+        icon = ArrowLeftIcon;
+    } elif ori == "right" {
+        icon = ArrowRightIcon;
     }
+    return
+        <HugeiconsIcon
+            icon={icon}
+            {**props}
+            className={cn("cn-rtl-flip size-4", props["className"])}
+            size={16}
+        />;
+}
 
-    def CalendarDayButton(props: any) -> JsxElement {
-        defaultClassNames2: any = getDefaultClassNames();
-        day = props["day"];
-        mm = props["modifiers"];
-        locale = props["locale"];
-        dateStr: str = "";
-        if day and day.date {
-            dateStr = str(day.date.toISOString().split("T")[0]);
-        }
-        isSelectedSingle = mm
-        and mm.selected
-        and not mm.range_start
-        and not mm.range_end
-        and not mm.range_middle;
-        return
-            <Button
-                {**props}
-                variant="ghost"
-                size="icon"
-                data-day={dateStr}
-                data-selected-single={isSelectedSingle}
-                data-range-start={mm.range_start if mm else False}
-                data-range-end={mm.range_end if mm else False}
-                data-range-middle={mm.range_middle if mm else False}
-                className={cn(
-                    "cn-calendar-day-button data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-muted data-[range-middle=true]:text-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground relative isolate z-10 flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 border-0 leading-none font-normal",
-                    defaultClassNames2.day,
-                    props["className"]
-                )}
-            />;
+def CalendarDayButton(props: any) -> JsxElement {
+    defaultClassNames2: any = getDefaultClassNames();
+    day = props["day"];
+    mm = props["modifiers"];
+    locale = props["locale"];
+    dateStr: str = "";
+    if day and day.date {
+        dateStr = str(day.date.toISOString().split("T")[0]);
     }
+    isSelectedSingle = mm
+    and mm.selected
+    and not mm.range_start
+    and not mm.range_end
+    and not mm.range_middle;
+    return
+        <Button
+            {**props}
+            variant="ghost"
+            size="icon"
+            data-day={dateStr}
+            data-selected-single={isSelectedSingle}
+            data-range-start={mm.range_start if mm else False}
+            data-range-end={mm.range_end if mm else False}
+            data-range-middle={mm.range_middle if mm else False}
+            className={cn(
+                "cn-calendar-day-button data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-muted data-[range-middle=true]:text-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground relative isolate z-10 flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 border-0 leading-none font-normal",
+                defaultClassNames2.day,
+                props["className"]
+            )}
+        />;
+}
 
-    def CalendarWeekNumber(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <td {**attrs}>
-                <div
-                    className="flex size-(--cell-size) items-center justify-center text-center"
-                >
-                    {props["children"]}
-                </div>
-            </td>;
-    }
-
-    def CalendarRoot(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
+def CalendarWeekNumber(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <td {**attrs}>
             <div
-                data-slot="calendar"
-                ref={props["rootRef"]}
-                {**attrs}
-                className={cn(props["className"])}
-            />;
-    }
+                className="flex size-(--cell-size) items-center justify-center text-center"
+            >
+                {props["children"]}
+            </div>
+        </td>;
+}
 
-    def:pub Calendar(props: any) -> JsxElement {
-        showOutsideDays = True
-            if props["showOutsideDays"] is None
-            else props["showOutsideDays"];
-        captionLayout = props["captionLayout"] or "label";
-        buttonVariant = props["buttonVariant"] or "ghost";
-        locale = props["locale"];
-        defaultClassNames: any = getDefaultClassNames();
-        variantsFn: any = buttonVariants();
-        btnClass = variantsFn.call(None, {"variant": buttonVariant});
-        captionIsLabel = captionLayout == "label";
-        captionLabelClass = "select-none font-medium text-sm"
-            if captionIsLabel
-            else "cn-calendar-caption-label rounded-(--cell-radius) flex items-center gap-1 text-sm select-none font-medium [&>svg]:text-muted-foreground [&>svg]:size-3.5";
-        dayPickerClassNames = {
-            root: cn("w-fit", defaultClassNames.root),
-            months: cn(
-                "flex gap-4 flex-col md:flex-row relative", defaultClassNames.months
-            ),
-            month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
-            nav: cn(
-                "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
-                defaultClassNames.nav
-            ),
-            button_previous: cn(
-                btnClass,
-                "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
-                defaultClassNames.button_previous
-            ),
-            button_next: cn(
-                btnClass,
-                "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
-                defaultClassNames.button_next
-            ),
-            month_caption: cn(
-                "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
-                defaultClassNames.month_caption
-            ),
-            caption_label: cn(captionLabelClass, defaultClassNames.caption_label),
-            table: "w-full border-collapse",
-            weekdays: cn("flex", defaultClassNames.weekdays),
-            weekday: cn(
-                "text-muted-foreground rounded-(--cell-radius) flex-1 font-normal text-[0.8rem] select-none",
-                defaultClassNames.weekday
-            ),
-            week: cn("flex w-full mt-2", defaultClassNames.week),
-            day: cn(
-                "relative w-full rounded-(--cell-radius) h-full p-0 text-center group/day aspect-square select-none",
-                defaultClassNames.day
-            ),
-            today: cn(
-                "bg-muted text-foreground rounded-(--cell-radius)",
-                defaultClassNames.today
-            ),
-            outside: cn("text-muted-foreground", defaultClassNames.outside),
-            disabled: cn(
-                "text-muted-foreground opacity-50", defaultClassNames.disabled
-            ),
-            hidden: cn("invisible", defaultClassNames.hidden)
-        };
-        dayButtonFn = lambda (p: any) -> any { return
-            <CalendarDayButton locale={locale} {**p}/>; };
-        calendarComponents = {
-            Root: CalendarRoot,
-            Chevron: CalendarChevron,
-            DayButton: dayButtonFn,
-            WeekNumber: CalendarWeekNumber
-        };
-        return
-            <DayPicker
-                showOutsideDays={showOutsideDays}
-                {**props}
-                className={cn(
-                    "cn-calendar bg-background group/calendar in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
-                    props["className"]
-                )}
-                captionLayout={captionLayout}
-                classNames={dayPickerClassNames}
-                components={calendarComponents}
-            />;
-    }
+def CalendarRoot(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="calendar"
+            ref={props["rootRef"]}
+            {**attrs}
+            className={cn(props["className"])}
+        />;
+}
+
+def:pub Calendar(props: any) -> JsxElement {
+    showOutsideDays = True
+        if props["showOutsideDays"] is None
+        else props["showOutsideDays"];
+    captionLayout = props["captionLayout"] or "label";
+    buttonVariant = props["buttonVariant"] or "ghost";
+    locale = props["locale"];
+    defaultClassNames: any = getDefaultClassNames();
+    variantsFn: any = buttonVariants();
+    btnClass = variantsFn.call(None, {"variant": buttonVariant});
+    captionIsLabel = captionLayout == "label";
+    captionLabelClass = "select-none font-medium text-sm"
+        if captionIsLabel
+        else "cn-calendar-caption-label rounded-(--cell-radius) flex items-center gap-1 text-sm select-none font-medium [&>svg]:text-muted-foreground [&>svg]:size-3.5";
+    dayPickerClassNames = {
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn(
+            "flex gap-4 flex-col md:flex-row relative", defaultClassNames.months
+        ),
+        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        nav: cn(
+            "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
+            defaultClassNames.nav
+        ),
+        button_previous: cn(
+            btnClass,
+            "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+            defaultClassNames.button_previous
+        ),
+        button_next: cn(
+            btnClass,
+            "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+            defaultClassNames.button_next
+        ),
+        month_caption: cn(
+            "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
+            defaultClassNames.month_caption
+        ),
+        caption_label: cn(captionLabelClass, defaultClassNames.caption_label),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+            "text-muted-foreground rounded-(--cell-radius) flex-1 font-normal text-[0.8rem] select-none",
+            defaultClassNames.weekday
+        ),
+        week: cn("flex w-full mt-2", defaultClassNames.week),
+        day: cn(
+            "relative w-full rounded-(--cell-radius) h-full p-0 text-center group/day aspect-square select-none",
+            defaultClassNames.day
+        ),
+        today: cn(
+            "bg-muted text-foreground rounded-(--cell-radius)", defaultClassNames.today
+        ),
+        outside: cn("text-muted-foreground", defaultClassNames.outside),
+        disabled: cn("text-muted-foreground opacity-50", defaultClassNames.disabled),
+        hidden: cn("invisible", defaultClassNames.hidden)
+    };
+    dayButtonFn = lambda (p: any) -> any { return
+        <CalendarDayButton locale={locale} {**p}/>; };
+    calendarComponents = {
+        Root: CalendarRoot,
+        Chevron: CalendarChevron,
+        DayButton: dayButtonFn,
+        WeekNumber: CalendarWeekNumber
+    };
+    return
+        <DayPicker
+            showOutsideDays={showOutsideDays}
+            {**props}
+            className={cn(
+                "cn-calendar bg-background group/calendar in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent",
+                props["className"]
+            )}
+            captionLayout={captionLayout}
+            classNames={dayPickerClassNames}
+            components={calendarComponents}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/card.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/card.cl.jac
@@ -1,96 +1,93 @@
-cl import from ...lib.utils { cn }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Card(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        size = props["size"] or "default";
-        return
-            <div
-                {**attrs}
-                data-slot="card"
-                data-size={size}
-                className={cn(
-                    "cn-card ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl pt-4 pb-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:pt-3 data-[size=sm]:pb-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Card(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    size = props["size"] or "default";
+    return
+        <div
+            {**attrs}
+            data-slot="card"
+            data-size={size}
+            className={cn(
+                "cn-card ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl pt-4 pb-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:pt-3 data-[size=sm]:pb-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub CardHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="card-header"
-                className={cn(
-                    "cn-card-header gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub CardHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="card-header"
+            className={cn(
+                "cn-card-header gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub CardTitle(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="card-title"
-                className={cn(
-                    "cn-card-title text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub CardTitle(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="card-title"
+            className={cn(
+                "cn-card-title text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub CardDescription(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="card-description"
-                className={cn(
-                    "cn-card-description text-muted-foreground text-sm",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub CardDescription(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="card-description"
+            className={cn(
+                "cn-card-description text-muted-foreground text-sm", props["className"]
+            )}
+        />;
+}
 
-    def:pub CardAction(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="card-action"
-                className={cn(
-                    "cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub CardAction(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="card-action"
+            className={cn(
+                "cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub CardContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="card-content"
-                className={cn(
-                    "cn-card-content px-4 group-data-[size=sm]/card:px-3",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub CardContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="card-content"
+            className={cn(
+                "cn-card-content px-4 group-data-[size=sm]/card:px-3",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub CardFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="card-footer"
-                className={cn(
-                    "cn-card-footer bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub CardFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="card-footer"
+            className={cn(
+                "cn-card-footer bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/carousel.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/carousel.cl.jac
@@ -1,135 +1,121 @@
-cl import from "embla-carousel-react" { default as useEmblaCarousel }
-cl import from react { createContext, useContext }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { ArrowLeft01Icon, ArrowRight01Icon }
-cl import from .button { Button }
-cl import from ...lib.utils { cn }
+import from "embla-carousel-react" { default as useEmblaCarousel }
+import from react { createContext, useContext }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { ArrowLeft01Icon, ArrowRight01Icon }
+import from .button { Button }
+import from ...lib.utils { cn }
 
 glob CarouselContext: any = createContext(None);
 
-cl {
-    def:pub Carousel(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        orientation = props["orientation"] or "horizontal";
-        axisOpt = "x" if orientation == "horizontal" else "y";
-        embla: any = useEmblaCarousel({"axis": axisOpt}, props["plugins"]);
-        carouselRef = embla[0];
-        api: any = embla[1];
-        scrollPrev = lambda -> any { api and api.scrollPrev(); };
-        scrollNext = lambda -> any { api and api.scrollNext(); };
-        ctxValue = {
-            "carouselRef": carouselRef,
-            "api": api,
-            "orientation": orientation,
-            "scrollPrev": scrollPrev,
-            "scrollNext": scrollNext
-        };
-        return
-            <CarouselContext.Provider value={ctxValue}>
-                <div
-                    {**attrs}
-                    data-slot="carousel"
-                    className={cn("relative", props["className"])}
-                    role="region"
-                    aria-roledescription="carousel"
-                >
-                    {props["children"]}
-                </div>
-            </CarouselContext.Provider>;
-    }
-
-    def:pub CarouselContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        ctx: any = useContext(CarouselContext);
-        carouselRef = ctx.carouselRef if ctx else None;
-        ori = ctx.orientation if ctx else "horizontal";
-        dirClass = "-ml-4" if ori == "horizontal" else "-mt-4 flex-col";
-        return
-            <div
-                ref={carouselRef}
-                className="overflow-hidden"
-                data-slot="carousel-content"
-            >
-                <div {**attrs} className={cn("flex", dirClass, props["className"])}/>
-            </div>;
-    }
-
-    def:pub CarouselItem(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        ctx: any = useContext(CarouselContext);
-        ori = ctx.orientation if ctx else "horizontal";
-        padClass = "pl-4" if ori == "horizontal" else "pt-4";
-        return
+def:pub Carousel(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    orientation = props["orientation"] or "horizontal";
+    axisOpt = "x" if orientation == "horizontal" else "y";
+    embla: any = useEmblaCarousel({"axis": axisOpt}, props["plugins"]);
+    carouselRef = embla[0];
+    api: any = embla[1];
+    scrollPrev = lambda -> any { api and api.scrollPrev(); };
+    scrollNext = lambda -> any { api and api.scrollNext(); };
+    ctxValue = {
+        "carouselRef": carouselRef,
+        "api": api,
+        "orientation": orientation,
+        "scrollPrev": scrollPrev,
+        "scrollNext": scrollNext
+    };
+    return
+        <CarouselContext.Provider value={ctxValue}>
             <div
                 {**attrs}
-                role="group"
-                aria-roledescription="slide"
-                data-slot="carousel-item"
-                className={cn(
-                    "min-w-0 shrink-0 grow-0 basis-full", padClass, props["className"]
-                )}
-            />;
-    }
-
-    def:pub CarouselPrevious(props: any) -> JsxElement {
-        ctx: any = useContext(CarouselContext);
-        ori = ctx.orientation if ctx else "horizontal";
-        scrollPrev = ctx.scrollPrev if ctx else None;
-        posClass = "top-1/2 -left-12 -translate-y-1/2"
-            if ori == "horizontal"
-            else "-top-12 left-1/2 -translate-x-1/2 rotate-90";
-        variant = props["variant"] or "outline";
-        size = props["size"] or "icon-sm";
-        return
-            <Button
-                {**props}
-                data-slot="carousel-previous"
-                variant={variant}
-                size={size}
-                className={cn(
-                    "cn-carousel-previous absolute touch-manipulation",
-                    posClass,
-                    props["className"]
-                )}
-                onClick={scrollPrev}
+                data-slot="carousel"
+                className={cn("relative", props["className"])}
+                role="region"
+                aria-roledescription="carousel"
             >
-                <HugeiconsIcon
-                    icon={ArrowLeft01Icon}
-                    className="cn-rtl-flip"
-                    size={16}
-                />
-                <span className="sr-only">Previous slide</span>
-            </Button>;
-    }
+                {props["children"]}
+            </div>
+        </CarouselContext.Provider>;
+}
 
-    def:pub CarouselNext(props: any) -> JsxElement {
-        ctx: any = useContext(CarouselContext);
-        ori = ctx.orientation if ctx else "horizontal";
-        scrollNext = ctx.scrollNext if ctx else None;
-        posClass = "top-1/2 -right-12 -translate-y-1/2"
-            if ori == "horizontal"
-            else "-bottom-12 left-1/2 -translate-x-1/2 rotate-90";
-        variant = props["variant"] or "outline";
-        size = props["size"] or "icon-sm";
-        return
-            <Button
-                {**props}
-                data-slot="carousel-next"
-                variant={variant}
-                size={size}
-                className={cn(
-                    "cn-carousel-next absolute touch-manipulation",
-                    posClass,
-                    props["className"]
-                )}
-                onClick={scrollNext}
-            >
-                <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    className="cn-rtl-flip"
-                    size={16}
-                />
-                <span className="sr-only">Next slide</span>
-            </Button>;
-    }
+def:pub CarouselContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    ctx: any = useContext(CarouselContext);
+    carouselRef = ctx.carouselRef if ctx else None;
+    ori = ctx.orientation if ctx else "horizontal";
+    dirClass = "-ml-4" if ori == "horizontal" else "-mt-4 flex-col";
+    return
+        <div ref={carouselRef} className="overflow-hidden" data-slot="carousel-content">
+            <div {**attrs} className={cn("flex", dirClass, props["className"])}/>
+        </div>;
+}
+
+def:pub CarouselItem(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    ctx: any = useContext(CarouselContext);
+    ori = ctx.orientation if ctx else "horizontal";
+    padClass = "pl-4" if ori == "horizontal" else "pt-4";
+    return
+        <div
+            {**attrs}
+            role="group"
+            aria-roledescription="slide"
+            data-slot="carousel-item"
+            className={cn(
+                "min-w-0 shrink-0 grow-0 basis-full", padClass, props["className"]
+            )}
+        />;
+}
+
+def:pub CarouselPrevious(props: any) -> JsxElement {
+    ctx: any = useContext(CarouselContext);
+    ori = ctx.orientation if ctx else "horizontal";
+    scrollPrev = ctx.scrollPrev if ctx else None;
+    posClass = "top-1/2 -left-12 -translate-y-1/2"
+        if ori == "horizontal"
+        else "-top-12 left-1/2 -translate-x-1/2 rotate-90";
+    variant = props["variant"] or "outline";
+    size = props["size"] or "icon-sm";
+    return
+        <Button
+            {**props}
+            data-slot="carousel-previous"
+            variant={variant}
+            size={size}
+            className={cn(
+                "cn-carousel-previous absolute touch-manipulation",
+                posClass,
+                props["className"]
+            )}
+            onClick={scrollPrev}
+        >
+            <HugeiconsIcon icon={ArrowLeft01Icon} className="cn-rtl-flip" size={16}/>
+            <span className="sr-only">Previous slide</span>
+        </Button>;
+}
+
+def:pub CarouselNext(props: any) -> JsxElement {
+    ctx: any = useContext(CarouselContext);
+    ori = ctx.orientation if ctx else "horizontal";
+    scrollNext = ctx.scrollNext if ctx else None;
+    posClass = "top-1/2 -right-12 -translate-y-1/2"
+        if ori == "horizontal"
+        else "-bottom-12 left-1/2 -translate-x-1/2 rotate-90";
+    variant = props["variant"] or "outline";
+    size = props["size"] or "icon-sm";
+    return
+        <Button
+            {**props}
+            data-slot="carousel-next"
+            variant={variant}
+            size={size}
+            className={cn(
+                "cn-carousel-next absolute touch-manipulation",
+                posClass,
+                props["className"]
+            )}
+            onClick={scrollNext}
+        >
+            <HugeiconsIcon icon={ArrowRight01Icon} className="cn-rtl-flip" size={16}/>
+            <span className="sr-only">Next slide</span>
+        </Button>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/chart.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/chart.cl.jac
@@ -1,165 +1,158 @@
-cl import from "recharts" {
+import from "recharts" {
     Tooltip as RechartsTooltip,
     Legend as RechartsLegend,
     ResponsiveContainer
 }
-cl import from react { createContext, useContext }
-cl import from ...lib.utils { cn }
+import from react { createContext, useContext }
+import from ...lib.utils { cn }
 
 glob ChartContext: any = createContext(None);
 
-cl {
-    def getPayloadConfig(config: any, payload: any, key: any) -> any {
-        if not config {
-            return None;
-        }
-        configLabelKey = key;
-        if payload and payload[key] and isinstance(payload[key], str) {
-            configLabelKey = payload[key];
-        }
-        cfg: dict[str, any] = {** config};
-        if configLabelKey in cfg {
-            return cfg[configLabelKey];
-        }
-        return cfg[key] if key in cfg else None;
+def getPayloadConfig(config: any, payload: any, key: any) -> any {
+    if not config {
+        return None;
     }
+    configLabelKey = key;
+    if payload and payload[key] and isinstance(payload[key], str) {
+        configLabelKey = payload[key];
+    }
+    cfg: dict[str, any] = {** config};
+    if configLabelKey in cfg {
+        return cfg[configLabelKey];
+    }
+    return cfg[key] if key in cfg else None;
+}
 
-    def buildChartStyle(config: any) -> any {
-        styleObj = {};
-        for k in Object.keys(config) {  # jac:ignore[W6001]
-            ic: any = config[k];
-            color = ic.color if ic else None;
-            if color {
-                styleObj["--color-" + str(k)] = color;
-            }
+def buildChartStyle(config: any) -> any {
+    styleObj = {};
+    for k in Object.keys(config) {  # jac:ignore[W6001]
+        ic: any = config[k];
+        color = ic.color if ic else None;
+        if color {
+            styleObj["--color-" + str(k)] = color;
         }
-        return styleObj;
     }
+    return styleObj;
+}
 
-    def:pub ChartContainer(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        config = props["config"] or {};
-        colorStyle = buildChartStyle(config);
-        ctxValue = {"config": config};
-        return
-            <ChartContext.Provider value={ctxValue}>
-                <div
-                    {**attrs}
-                    data-slot="chart"
-                    style={{** (props["style"] or {}), ** colorStyle}}
-                    className={cn(
-                        "cn-chart flex aspect-video justify-center text-xs",
-                        props["className"]
-                    )}
-                >
-                    <ResponsiveContainer>{props["children"]}</ResponsiveContainer>
-                </div>
-            </ChartContext.Provider>;
-    }
-
-    def:pub ChartTooltipContent(props: any) -> JsxElement {
-        active = props["active"];
-        payload = props["payload"];
-        hideIndicator = props["hideIndicator"] or False;
-        indicator = props["indicator"] or "dot";
-        ctx: any = useContext(ChartContext);
-        config = ctx.config if ctx else {};
-        filteredPayload: list[any] = [
-            item
-            for item in (payload or [])
-            if item.type != "none"
-        ];
-        hasItems = active and len(filteredPayload);
-        return
+def:pub ChartContainer(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    config = props["config"] or {};
+    colorStyle = buildChartStyle(config);
+    ctxValue = {"config": config};
+    return
+        <ChartContext.Provider value={ctxValue}>
             <div
+                {**attrs}
+                data-slot="chart"
+                style={{** (props["style"] or {}), ** colorStyle}}
                 className={cn(
-                    "cn-chart-tooltip grid min-w-32 items-start gap-1.5 px-2.5 py-1.5 text-xs shadow-xl",
+                    "cn-chart flex aspect-video justify-center text-xs",
                     props["className"]
                 )}
             >
-                {if hasItems {
-                    for item in filteredPayload {
-                        itemKey = props["nameKey"]
-                        or item.name
-                        or item.dataKey
-                        or "value";
-                        itemConfig = getPayloadConfig(config, item, itemKey);
-                        indicatorColor = props["color"]
-                        or (item.payload.fill if item.payload else None)
-                        or item.color;
-                        <div
-                            key={item.dataKey}
-                            className="flex w-full flex-wrap items-center gap-2"
-                        >
-                            {not hideIndicator
-                            and (
-                                <div
-                                    className={cn(
-                                        "shrink-0 rounded-[2px]",
-                                        "size-2.5" if indicator == "dot" else "w-1"
-                                    )}
-                                    style={{"backgroundColor": indicatorColor}}
-                                />
-                            )}
-                            <div className="flex flex-1 justify-between leading-none">
-                                <span className="text-muted-foreground">
-                                    {itemConfig and itemConfig.label or itemKey}
-                                </span>
-                                {item.value is not None
-                                and (
-                                    <span
-                                        className="font-mono font-medium tabular-nums text-foreground"
-                                    >
-                                        {item.value.toLocaleString()}
-                                    </span>
-                                )}
-                            </div>
-                        </div>
-                    }
-                }}
-            </div>;
-    }
+                <ResponsiveContainer>{props["children"]}</ResponsiveContainer>
+            </div>
+        </ChartContext.Provider>;
+}
 
-    def:pub ChartLegendContent(props: any) -> JsxElement {
-        payload = props["payload"];
-        hideIcon = props["hideIcon"] or False;
-        verticalAlign = props["verticalAlign"] or "bottom";
-        ctx: any = useContext(ChartContext);
-        config = ctx.config if ctx else {};
-        items: any = payload or [];
-        topClass = "pb-3" if verticalAlign == "top" else "";
-        return
-            <div
-                className={cn(
-                    "flex items-center justify-center gap-4",
-                    topClass,
-                    props["className"]
-                )}
-            >
-                {for item in items {
-                    k = props["nameKey"] or item.dataKey or "value";
-                    itemConfig = getPayloadConfig(config, item, k);
-                    <div key={item.value} className="flex items-center gap-1.5">
-                        {not hideIcon
+def:pub ChartTooltipContent(props: any) -> JsxElement {
+    active = props["active"];
+    payload = props["payload"];
+    hideIndicator = props["hideIndicator"] or False;
+    indicator = props["indicator"] or "dot";
+    ctx: any = useContext(ChartContext);
+    config = ctx.config if ctx else {};
+    filteredPayload: list[any] = [
+        item
+        for item in (payload or [])
+        if item.type != "none"
+    ];
+    hasItems = active and len(filteredPayload);
+    return
+        <div
+            className={cn(
+                "cn-chart-tooltip grid min-w-32 items-start gap-1.5 px-2.5 py-1.5 text-xs shadow-xl",
+                props["className"]
+            )}
+        >
+            {if hasItems {
+                for item in filteredPayload {
+                    itemKey = props["nameKey"] or item.name or item.dataKey or "value";
+                    itemConfig = getPayloadConfig(config, item, itemKey);
+                    indicatorColor = props["color"]
+                    or (item.payload.fill if item.payload else None)
+                    or item.color;
+                    <div
+                        key={item.dataKey}
+                        className="flex w-full flex-wrap items-center gap-2"
+                    >
+                        {not hideIndicator
                         and (
                             <div
-                                className="size-2 shrink-0 rounded-[2px]"
-                                style={{"backgroundColor": item.color}}
+                                className={cn(
+                                    "shrink-0 rounded-[2px]",
+                                    "size-2.5" if indicator == "dot" else "w-1"
+                                )}
+                                style={{"backgroundColor": indicatorColor}}
                             />
                         )}
-                        <span className="text-muted-foreground text-xs">
-                            {itemConfig and itemConfig.label or item.value}
-                        </span>
+                        <div className="flex flex-1 justify-between leading-none">
+                            <span className="text-muted-foreground">
+                                {itemConfig and itemConfig.label or itemKey}
+                            </span>
+                            {item.value is not None
+                            and (
+                                <span
+                                    className="font-mono font-medium tabular-nums text-foreground"
+                                >
+                                    {item.value.toLocaleString()}
+                                </span>
+                            )}
+                        </div>
                     </div>
-                }}
-            </div>;
-    }
+                }
+            }}
+        </div>;
+}
 
-    def:pub ChartTooltip(props: any) -> JsxElement {
-        return <RechartsTooltip {**props}/>;
-    }
+def:pub ChartLegendContent(props: any) -> JsxElement {
+    payload = props["payload"];
+    hideIcon = props["hideIcon"] or False;
+    verticalAlign = props["verticalAlign"] or "bottom";
+    ctx: any = useContext(ChartContext);
+    config = ctx.config if ctx else {};
+    items: any = payload or [];
+    topClass = "pb-3" if verticalAlign == "top" else "";
+    return
+        <div
+            className={cn(
+                "flex items-center justify-center gap-4", topClass, props["className"]
+            )}
+        >
+            {for item in items {
+                k = props["nameKey"] or item.dataKey or "value";
+                itemConfig = getPayloadConfig(config, item, k);
+                <div key={item.value} className="flex items-center gap-1.5">
+                    {not hideIcon
+                    and (
+                        <div
+                            className="size-2 shrink-0 rounded-[2px]"
+                            style={{"backgroundColor": item.color}}
+                        />
+                    )}
+                    <span className="text-muted-foreground text-xs">
+                        {itemConfig and itemConfig.label or item.value}
+                    </span>
+                </div>
+            }}
+        </div>;
+}
 
-    def:pub ChartLegend(props: any) -> JsxElement {
-        return <RechartsLegend {**props}/>;
-    }
+def:pub ChartTooltip(props: any) -> JsxElement {
+    return <RechartsTooltip {**props}/>;
+}
+
+def:pub ChartLegend(props: any) -> JsxElement {
+    return <RechartsLegend {**props}/>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/checkbox.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/checkbox.cl.jac
@@ -1,25 +1,23 @@
-cl import from "radix-ui" { Checkbox as CheckboxPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Tick02Icon }
+import from "radix-ui" { Checkbox as CheckboxPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Tick02Icon }
 
-cl {
-    def:pub Checkbox(props: any) -> JsxElement {
-        return
-            <CheckboxPrimitive.Root
-                {**props}
-                data-slot="checkbox"
-                className={cn(
-                    "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
-                    props["className"]
-                )}
+def:pub Checkbox(props: any) -> JsxElement {
+    return
+        <CheckboxPrimitive.Root
+            {**props}
+            data-slot="checkbox"
+            className={cn(
+                "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+                props["className"]
+            )}
+        >
+            <CheckboxPrimitive.Indicator
+                data-slot="checkbox-indicator"
+                className="cn-checkbox-indicator grid place-content-center text-current transition-none"
             >
-                <CheckboxPrimitive.Indicator
-                    data-slot="checkbox-indicator"
-                    className="cn-checkbox-indicator grid place-content-center text-current transition-none"
-                >
-                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                </CheckboxPrimitive.Indicator>
-            </CheckboxPrimitive.Root>;
-    }
+                <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+            </CheckboxPrimitive.Indicator>
+        </CheckboxPrimitive.Root>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/collapsible.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/collapsible.cl.jac
@@ -1,23 +1,21 @@
-cl import from "radix-ui" { Collapsible as CollapsiblePrimitive }
+import from "radix-ui" { Collapsible as CollapsiblePrimitive }
 
-cl {
-    def:pub Collapsible(props: any) -> JsxElement {
-        return <CollapsiblePrimitive.Root data-slot="collapsible" {**props}/>;
-    }
+def:pub Collapsible(props: any) -> JsxElement {
+    return <CollapsiblePrimitive.Root data-slot="collapsible" {**props}/>;
+}
 
-    def:pub CollapsibleTrigger(props: any) -> JsxElement {
-        return
-            <CollapsiblePrimitive.CollapsibleTrigger
-                data-slot="collapsible-trigger"
-                {**props}
-            />;
-    }
+def:pub CollapsibleTrigger(props: any) -> JsxElement {
+    return
+        <CollapsiblePrimitive.CollapsibleTrigger
+            data-slot="collapsible-trigger"
+            {**props}
+        />;
+}
 
-    def:pub CollapsibleContent(props: any) -> JsxElement {
-        return
-            <CollapsiblePrimitive.CollapsibleContent
-                data-slot="collapsible-content"
-                {**props}
-            />;
-    }
+def:pub CollapsibleContent(props: any) -> JsxElement {
+    return
+        <CollapsiblePrimitive.CollapsibleContent
+            data-slot="collapsible-content"
+            {**props}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/combobox.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/combobox.cl.jac
@@ -1,15 +1,15 @@
-cl import from "@base-ui/react" { Combobox as ComboboxPrimitive }
-cl import from react { useRef }
-cl import from ...lib.utils { cn }
-cl import from .button { Button }
-cl import from ".input-group" {
+import from "@base-ui/react" { Combobox as ComboboxPrimitive }
+import from react { useRef }
+import from ...lib.utils { cn }
+import from .button { Button }
+import from ".input-group" {
     InputGroup,
     InputGroupAddon,
     InputGroupButton,
     InputGroupInput
 }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { ArrowDownIcon, Cancel01Icon, Tick02Icon }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { ArrowDownIcon, Cancel01Icon, Tick02Icon }
 
 glob _comboboxInputExclude: list[str] = [
          "className",
@@ -19,260 +19,255 @@ glob _comboboxInputExclude: list[str] = [
          "showClear"
      ];
 
-cl {
-    def:pub Combobox(props: any) -> JsxElement {
-        return <ComboboxPrimitive.Root {**props}/>;
+def:pub Combobox(props: any) -> JsxElement {
+    return <ComboboxPrimitive.Root {**props}/>;
+}
+
+def:pub ComboboxValue(props: any) -> JsxElement {
+    return <ComboboxPrimitive.Value data-slot="combobox-value" {**props}/>;
+}
+
+def:pub ComboboxTrigger(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Trigger
+            {**props}
+            data-slot="combobox-trigger"
+            className={cn("[&_svg:not([class*='size-'])]:size-4", props["className"])}
+        >
+            {props["children"]}
+            <HugeiconsIcon
+                icon={ArrowDownIcon}
+                strokeWidth={2}
+                className="text-muted-foreground size-4 pointer-events-none"
+            />
+        </ComboboxPrimitive.Trigger>;
+}
+
+def:pub ComboboxClear(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Clear
+            {**props}
+            data-slot="combobox-clear"
+            render={<InputGroupButton variant="ghost" size="icon-xs"/>}
+            className={cn(props["className"])}
+        >
+            <HugeiconsIcon
+                icon={Cancel01Icon}
+                strokeWidth={2}
+                className="pointer-events-none"
+            />
+        </ComboboxPrimitive.Clear>;
+}
+
+def:pub ComboboxInput(props: any) -> JsxElement {
+    disabled = props["disabled"] or False;
+    showTrigger = props["showTrigger"];
+    if showTrigger is None {
+        showTrigger = True;
+    }
+    showClear = props["showClear"] or False;
+
+    inputProps = {};
+    for key in Object.keys(props) {  # jac:ignore[W6001]
+        if key not in _comboboxInputExclude {
+            inputProps[key] = props[key];
+        }
     }
 
-    def:pub ComboboxValue(props: any) -> JsxElement {
-        return <ComboboxPrimitive.Value data-slot="combobox-value" {**props}/>;
-    }
+    return
+        <InputGroup className={cn("w-auto", props["className"])}>
+            <ComboboxPrimitive.Input
+                render={<input
+                    data-slot="input-group-control"
+                    className="cn-input-group-input rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1 text-base md:text-sm placeholder:text-muted-foreground w-full min-w-0 outline-none px-2.5 py-1"
+                    disabled={disabled}
+                />}
+                {**inputProps}
+            />
+            <InputGroupAddon align="inline-end">
+                {showTrigger
+                and (
+                    <InputGroupButton
+                        size="icon-xs"
+                        variant="ghost"
+                        asChild={True}
+                        data-slot="input-group-button"
+                        className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
+                        disabled={disabled}
+                    >
+                        <ComboboxTrigger/>
+                    </InputGroupButton>
+                )}{showClear and <ComboboxClear disabled={disabled}/>}
+            </InputGroupAddon>
+            {props["children"]}
+        </InputGroup>;
+}
 
-    def:pub ComboboxTrigger(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Trigger
-                {**props}
-                data-slot="combobox-trigger"
-                className={cn(
-                    "[&_svg:not([class*='size-'])]:size-4", props["className"]
-                )}
+def:pub ComboboxContent(props: any) -> JsxElement {
+    side = props["side"] or "bottom";
+    sideOffset = props["sideOffset"] or 6;
+    align = props["align"] or "start";
+    alignOffset = props["alignOffset"] or 0;
+    anchor = props["anchor"];
+    return
+        <ComboboxPrimitive.Portal>
+            <ComboboxPrimitive.Positioner
+                side={side}
+                sideOffset={sideOffset}
+                align={align}
+                alignOffset={alignOffset}
+                anchor={anchor}
+                className="isolate z-50"
             >
-                {props["children"]}
-                <HugeiconsIcon
-                    icon={ArrowDownIcon}
-                    strokeWidth={2}
-                    className="text-muted-foreground size-4 pointer-events-none"
+                <ComboboxPrimitive.Popup
+                    {**props}
+                    data-slot="combobox-content"
+                    data-chips={Boolean(anchor)}
+                    className={cn(
+                        "cn-combobox-content bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 overflow-hidden rounded-lg shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)",
+                        props["className"]
+                    )}
                 />
-            </ComboboxPrimitive.Trigger>;
-    }
+            </ComboboxPrimitive.Positioner>
+        </ComboboxPrimitive.Portal>;
+}
 
-    def:pub ComboboxClear(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Clear
-                {**props}
-                data-slot="combobox-clear"
-                render={<InputGroupButton variant="ghost" size="icon-xs"/>}
-                className={cn(props["className"])}
+def:pub ComboboxList(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.List
+            {**props}
+            data-slot="combobox-list"
+            className={cn(
+                "cn-combobox-list no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 p-1 data-empty:p-0 overflow-y-auto overscroll-contain",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub ComboboxItem(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Item
+            {**props}
+            data-slot="combobox-item"
+            className={cn(
+                "cn-combobox-item data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+            <ComboboxPrimitive.ItemIndicator
+                render={<span
+                    className="pointer-events-none absolute right-2 flex size-4 items-center justify-center"
+                />}
             >
                 <HugeiconsIcon
-                    icon={Cancel01Icon}
+                    icon={Tick02Icon}
                     strokeWidth={2}
                     className="pointer-events-none"
                 />
-            </ComboboxPrimitive.Clear>;
+            </ComboboxPrimitive.ItemIndicator>
+        </ComboboxPrimitive.Item>;
+}
+
+def:pub ComboboxGroup(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Group
+            {**props}
+            data-slot="combobox-group"
+            className={cn(props["className"])}
+        />;
+}
+
+def:pub ComboboxLabel(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.GroupLabel
+            {**props}
+            data-slot="combobox-label"
+            className={cn(
+                "text-muted-foreground px-2 py-1.5 text-xs", props["className"]
+            )}
+        />;
+}
+
+def:pub ComboboxCollection(props: any) -> JsxElement {
+    return <ComboboxPrimitive.Collection data-slot="combobox-collection" {**props}/>;
+}
+
+def:pub ComboboxEmpty(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Empty
+            {**props}
+            data-slot="combobox-empty"
+            className={cn(
+                "cn-combobox-empty text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub ComboboxSeparator(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Separator
+            {**props}
+            data-slot="combobox-separator"
+            className={cn("bg-border -mx-1 my-1 h-px", props["className"])}
+        />;
+}
+
+def:pub ComboboxChips(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Chips
+            {**props}
+            data-slot="combobox-chips"
+            className={cn(
+                "dark:bg-input/30 border-input focus-within:border-ring focus-within:ring-ring/50 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive dark:has-aria-invalid:border-destructive/50 flex min-h-8 flex-wrap items-center gap-1 rounded-lg border bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:ring-3 has-aria-invalid:ring-3 has-data-[slot=combobox-chip]:px-1",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+        </ComboboxPrimitive.Chips>;
+}
+
+def:pub ComboboxChip(props: any) -> JsxElement {
+    showRemove = props["showRemove"];
+    if showRemove is None {
+        showRemove = True;
     }
-
-    def:pub ComboboxInput(props: any) -> JsxElement {
-        disabled = props["disabled"] or False;
-        showTrigger = props["showTrigger"];
-        if showTrigger is None {
-            showTrigger = True;
-        }
-        showClear = props["showClear"] or False;
-
-        inputProps = {};
-        for key in Object.keys(props) {  # jac:ignore[W6001]
-            if key not in _comboboxInputExclude {
-                inputProps[key] = props[key];
-            }
-        }
-
-        return
-            <InputGroup className={cn("w-auto", props["className"])}>
-                <ComboboxPrimitive.Input
-                    render={<input
-                        data-slot="input-group-control"
-                        className="cn-input-group-input rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1 text-base md:text-sm placeholder:text-muted-foreground w-full min-w-0 outline-none px-2.5 py-1"
-                        disabled={disabled}
-                    />}
-                    {**inputProps}
-                />
-                <InputGroupAddon align="inline-end">
-                    {showTrigger
-                    and (
-                        <InputGroupButton
-                            size="icon-xs"
-                            variant="ghost"
-                            asChild={True}
-                            data-slot="input-group-button"
-                            className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
-                            disabled={disabled}
-                        >
-                            <ComboboxTrigger/>
-                        </InputGroupButton>
-                    )}{showClear and <ComboboxClear disabled={disabled}/>}
-                </InputGroupAddon>
-                {props["children"]}
-            </InputGroup>;
-    }
-
-    def:pub ComboboxContent(props: any) -> JsxElement {
-        side = props["side"] or "bottom";
-        sideOffset = props["sideOffset"] or 6;
-        align = props["align"] or "start";
-        alignOffset = props["alignOffset"] or 0;
-        anchor = props["anchor"];
-        return
-            <ComboboxPrimitive.Portal>
-                <ComboboxPrimitive.Positioner
-                    side={side}
-                    sideOffset={sideOffset}
-                    align={align}
-                    alignOffset={alignOffset}
-                    anchor={anchor}
-                    className="isolate z-50"
-                >
-                    <ComboboxPrimitive.Popup
-                        {**props}
-                        data-slot="combobox-content"
-                        data-chips={Boolean(anchor)}
-                        className={cn(
-                            "cn-combobox-content bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 overflow-hidden rounded-lg shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)",
-                            props["className"]
-                        )}
-                    />
-                </ComboboxPrimitive.Positioner>
-            </ComboboxPrimitive.Portal>;
-    }
-
-    def:pub ComboboxList(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.List
-                {**props}
-                data-slot="combobox-list"
-                className={cn(
-                    "cn-combobox-list no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 p-1 data-empty:p-0 overflow-y-auto overscroll-contain",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub ComboboxItem(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Item
-                {**props}
-                data-slot="combobox-item"
-                className={cn(
-                    "cn-combobox-item data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-            >
-                {props["children"]}
-                <ComboboxPrimitive.ItemIndicator
-                    render={<span
-                        className="pointer-events-none absolute right-2 flex size-4 items-center justify-center"
-                    />}
+    return
+        <ComboboxPrimitive.Chip
+            {**props}
+            data-slot="combobox-chip"
+            className={cn(
+                "bg-muted text-foreground flex h-[calc(--spacing(5.25))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-data-[slot=combobox-chip-remove]:pr-0 has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50",
+                props["className"]
+            )}
+        >
+            {props["children"]}{showRemove
+            and (
+                <ComboboxPrimitive.ChipRemove
+                    render={<Button variant="ghost" size="icon-xs"/>}
+                    className="-ml-1 opacity-50 hover:opacity-100"
+                    data-slot="combobox-chip-remove"
                 >
                     <HugeiconsIcon
-                        icon={Tick02Icon}
+                        icon={Cancel01Icon}
                         strokeWidth={2}
                         className="pointer-events-none"
                     />
-                </ComboboxPrimitive.ItemIndicator>
-            </ComboboxPrimitive.Item>;
-    }
+                </ComboboxPrimitive.ChipRemove>
+            )}
+        </ComboboxPrimitive.Chip>;
+}
 
-    def:pub ComboboxGroup(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Group
-                {**props}
-                data-slot="combobox-group"
-                className={cn(props["className"])}
-            />;
-    }
+def:pub ComboboxChipsInput(props: any) -> JsxElement {
+    return
+        <ComboboxPrimitive.Input
+            {**props}
+            data-slot="combobox-chip-input"
+            className={cn("min-w-16 flex-1 outline-none", props["className"])}
+        />;
+}
 
-    def:pub ComboboxLabel(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.GroupLabel
-                {**props}
-                data-slot="combobox-label"
-                className={cn(
-                    "text-muted-foreground px-2 py-1.5 text-xs", props["className"]
-                )}
-            />;
-    }
-
-    def:pub ComboboxCollection(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Collection data-slot="combobox-collection" {**props}/>;
-    }
-
-    def:pub ComboboxEmpty(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Empty
-                {**props}
-                data-slot="combobox-empty"
-                className={cn(
-                    "cn-combobox-empty text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub ComboboxSeparator(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Separator
-                {**props}
-                data-slot="combobox-separator"
-                className={cn("bg-border -mx-1 my-1 h-px", props["className"])}
-            />;
-    }
-
-    def:pub ComboboxChips(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Chips
-                {**props}
-                data-slot="combobox-chips"
-                className={cn(
-                    "dark:bg-input/30 border-input focus-within:border-ring focus-within:ring-ring/50 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive dark:has-aria-invalid:border-destructive/50 flex min-h-8 flex-wrap items-center gap-1 rounded-lg border bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:ring-3 has-aria-invalid:ring-3 has-data-[slot=combobox-chip]:px-1",
-                    props["className"]
-                )}
-            >
-                {props["children"]}
-            </ComboboxPrimitive.Chips>;
-    }
-
-    def:pub ComboboxChip(props: any) -> JsxElement {
-        showRemove = props["showRemove"];
-        if showRemove is None {
-            showRemove = True;
-        }
-        return
-            <ComboboxPrimitive.Chip
-                {**props}
-                data-slot="combobox-chip"
-                className={cn(
-                    "bg-muted text-foreground flex h-[calc(--spacing(5.25))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-data-[slot=combobox-chip-remove]:pr-0 has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50",
-                    props["className"]
-                )}
-            >
-                {props["children"]}{showRemove
-                and (
-                    <ComboboxPrimitive.ChipRemove
-                        render={<Button variant="ghost" size="icon-xs"/>}
-                        className="-ml-1 opacity-50 hover:opacity-100"
-                        data-slot="combobox-chip-remove"
-                    >
-                        <HugeiconsIcon
-                            icon={Cancel01Icon}
-                            strokeWidth={2}
-                            className="pointer-events-none"
-                        />
-                    </ComboboxPrimitive.ChipRemove>
-                )}
-            </ComboboxPrimitive.Chip>;
-    }
-
-    def:pub ComboboxChipsInput(props: any) -> JsxElement {
-        return
-            <ComboboxPrimitive.Input
-                {**props}
-                data-slot="combobox-chip-input"
-                className={cn("min-w-16 flex-1 outline-none", props["className"])}
-            />;
-    }
-
-    def:pub useComboboxAnchor -> any {
-        return useRef(None);
-    }
+def:pub useComboboxAnchor -> any {
+    return useRef(None);
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/command.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/command.cl.jac
@@ -1,140 +1,136 @@
-cl import from "cmdk" { Command as CommandPrimitive }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { SearchIcon, Tick02Icon }
-cl import from .dialog {
+import from "cmdk" { Command as CommandPrimitive }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { SearchIcon, Tick02Icon }
+import from .dialog {
     Dialog,
     DialogContent,
     DialogDescription,
     DialogHeader,
     DialogTitle
 }
-cl import from ".input-group" { InputGroup, InputGroupAddon }
-cl import from ...lib.utils { cn }
+import from ".input-group" { InputGroup, InputGroupAddon }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Command(props: any) -> JsxElement {
-        return
-            <CommandPrimitive
-                data-slot="command"
+def:pub Command(props: any) -> JsxElement {
+    return
+        <CommandPrimitive
+            data-slot="command"
+            {**props}
+            className={cn(
+                "cn-command flex size-full flex-col overflow-hidden", props["className"]
+            )}
+        />;
+}
+
+def:pub CommandDialog(props: any) -> JsxElement {
+    title = props["title"] or "Command Palette";
+    description = props["description"] or "Search for a command to run...";
+    showCloseButton = props["showCloseButton"] or False;
+    return
+        <Dialog {**props}>
+            <DialogHeader className="sr-only">
+                <DialogTitle>{title}</DialogTitle>
+                <DialogDescription>{description}</DialogDescription>
+            </DialogHeader>
+            <DialogContent
                 {**props}
                 className={cn(
-                    "cn-command flex size-full flex-col overflow-hidden",
+                    "cn-command-dialog top-1/3 translate-y-0 overflow-hidden p-0",
                     props["className"]
                 )}
-            />;
-    }
-
-    def:pub CommandDialog(props: any) -> JsxElement {
-        title = props["title"] or "Command Palette";
-        description = props["description"] or "Search for a command to run...";
-        showCloseButton = props["showCloseButton"] or False;
-        return
-            <Dialog {**props}>
-                <DialogHeader className="sr-only">
-                    <DialogTitle>{title}</DialogTitle>
-                    <DialogDescription>{description}</DialogDescription>
-                </DialogHeader>
-                <DialogContent
-                    {**props}
-                    className={cn(
-                        "cn-command-dialog top-1/3 translate-y-0 overflow-hidden p-0",
-                        props["className"]
-                    )}
-                    showCloseButton={showCloseButton}
-                >
-                    {props["children"]}
-                </DialogContent>
-            </Dialog>;
-    }
-
-    def:pub CommandInput(props: any) -> JsxElement {
-        return
-            <div data-slot="command-input-wrapper" className="cn-command-input-wrapper">
-                <InputGroup className="cn-command-input-group">
-                    <CommandPrimitive.Input
-                        data-slot="command-input"
-                        {**props}
-                        className={cn(
-                            "cn-command-input outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-                            props["className"]
-                        )}
-                    />
-                    <InputGroupAddon>
-                        <HugeiconsIcon
-                            icon={SearchIcon}
-                            className="cn-command-input-icon"
-                            size={16}
-                        />
-                    </InputGroupAddon>
-                </InputGroup>
-            </div>;
-    }
-
-    def:pub CommandList(props: any) -> JsxElement {
-        return
-            <CommandPrimitive.List
-                data-slot="command-list"
-                {**props}
-                className={cn(
-                    "cn-command-list overflow-x-hidden overflow-y-auto",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub CommandEmpty(props: any) -> JsxElement {
-        return
-            <CommandPrimitive.Empty
-                data-slot="command-empty"
-                {**props}
-                className={cn("cn-command-empty", props["className"])}
-            />;
-    }
-
-    def:pub CommandGroup(props: any) -> JsxElement {
-        return
-            <CommandPrimitive.Group
-                data-slot="command-group"
-                {**props}
-                className={cn("cn-command-group", props["className"])}
-            />;
-    }
-
-    def:pub CommandSeparator(props: any) -> JsxElement {
-        return
-            <CommandPrimitive.Separator
-                data-slot="command-separator"
-                {**props}
-                className={cn("cn-command-separator", props["className"])}
-            />;
-    }
-
-    def:pub CommandItem(props: any) -> JsxElement {
-        return
-            <CommandPrimitive.Item
-                data-slot="command-item"
-                {**props}
-                className={cn(
-                    "cn-command-item group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
-                    props["className"]
-                )}
+                showCloseButton={showCloseButton}
             >
                 {props["children"]}
-                <HugeiconsIcon
-                    icon={Tick02Icon}
-                    className="cn-command-item-indicator ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100"
-                    size={16}
-                />
-            </CommandPrimitive.Item>;
-    }
+            </DialogContent>
+        </Dialog>;
+}
 
-    def:pub CommandShortcut(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                data-slot="command-shortcut"
-                {**attrs}
-                className={cn("cn-command-shortcut", props["className"])}
-            />;
-    }
+def:pub CommandInput(props: any) -> JsxElement {
+    return
+        <div data-slot="command-input-wrapper" className="cn-command-input-wrapper">
+            <InputGroup className="cn-command-input-group">
+                <CommandPrimitive.Input
+                    data-slot="command-input"
+                    {**props}
+                    className={cn(
+                        "cn-command-input outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+                        props["className"]
+                    )}
+                />
+                <InputGroupAddon>
+                    <HugeiconsIcon
+                        icon={SearchIcon}
+                        className="cn-command-input-icon"
+                        size={16}
+                    />
+                </InputGroupAddon>
+            </InputGroup>
+        </div>;
+}
+
+def:pub CommandList(props: any) -> JsxElement {
+    return
+        <CommandPrimitive.List
+            data-slot="command-list"
+            {**props}
+            className={cn(
+                "cn-command-list overflow-x-hidden overflow-y-auto", props["className"]
+            )}
+        />;
+}
+
+def:pub CommandEmpty(props: any) -> JsxElement {
+    return
+        <CommandPrimitive.Empty
+            data-slot="command-empty"
+            {**props}
+            className={cn("cn-command-empty", props["className"])}
+        />;
+}
+
+def:pub CommandGroup(props: any) -> JsxElement {
+    return
+        <CommandPrimitive.Group
+            data-slot="command-group"
+            {**props}
+            className={cn("cn-command-group", props["className"])}
+        />;
+}
+
+def:pub CommandSeparator(props: any) -> JsxElement {
+    return
+        <CommandPrimitive.Separator
+            data-slot="command-separator"
+            {**props}
+            className={cn("cn-command-separator", props["className"])}
+        />;
+}
+
+def:pub CommandItem(props: any) -> JsxElement {
+    return
+        <CommandPrimitive.Item
+            data-slot="command-item"
+            {**props}
+            className={cn(
+                "cn-command-item group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+            <HugeiconsIcon
+                icon={Tick02Icon}
+                className="cn-command-item-indicator ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100"
+                size={16}
+            />
+        </CommandPrimitive.Item>;
+}
+
+def:pub CommandShortcut(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            data-slot="command-shortcut"
+            {**attrs}
+            className={cn("cn-command-shortcut", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/context-menu.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/context-menu.cl.jac
@@ -1,172 +1,168 @@
-cl import from "radix-ui" { ContextMenu as ContextMenuPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Tick02Icon, ArrowRight01Icon }
+import from "radix-ui" { ContextMenu as ContextMenuPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Tick02Icon, ArrowRight01Icon }
 
-cl {
-    def:pub ContextMenu(props: any) -> JsxElement {
-        return <ContextMenuPrimitive.Root data-slot="context-menu" {**props}/>;
-    }
+def:pub ContextMenu(props: any) -> JsxElement {
+    return <ContextMenuPrimitive.Root data-slot="context-menu" {**props}/>;
+}
 
-    def:pub ContextMenuTrigger(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.Trigger
+def:pub ContextMenuTrigger(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.Trigger
+            {**props}
+            data-slot="context-menu-trigger"
+            className={cn("cn-context-menu-trigger select-none", props["className"])}
+        />;
+}
+
+def:pub ContextMenuGroup(props: any) -> JsxElement {
+    return <ContextMenuPrimitive.Group data-slot="context-menu-group" {**props}/>;
+}
+
+def:pub ContextMenuPortal(props: any) -> JsxElement {
+    return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {**props}/>;
+}
+
+def:pub ContextMenuSub(props: any) -> JsxElement {
+    return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {**props}/>;
+}
+
+def:pub ContextMenuRadioGroup(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.RadioGroup
+            data-slot="context-menu-radio-group"
+            {**props}
+        />;
+}
+
+def:pub ContextMenuContent(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.Portal>
+            <ContextMenuPrimitive.Content
                 {**props}
-                data-slot="context-menu-trigger"
+                data-slot="context-menu-content"
                 className={cn(
-                    "cn-context-menu-trigger select-none", props["className"]
-                )}
-            />;
-    }
-
-    def:pub ContextMenuGroup(props: any) -> JsxElement {
-        return <ContextMenuPrimitive.Group data-slot="context-menu-group" {**props}/>;
-    }
-
-    def:pub ContextMenuPortal(props: any) -> JsxElement {
-        return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {**props}/>;
-    }
-
-    def:pub ContextMenuSub(props: any) -> JsxElement {
-        return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {**props}/>;
-    }
-
-    def:pub ContextMenuRadioGroup(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.RadioGroup
-                data-slot="context-menu-radio-group"
-                {**props}
-            />;
-    }
-
-    def:pub ContextMenuContent(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.Portal>
-                <ContextMenuPrimitive.Content
-                    {**props}
-                    data-slot="context-menu-content"
-                    className={cn(
-                        "cn-context-menu-content cn-menu-target z-50 max-h-(--radix-context-menu-content-available-height) origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto",
-                        props["className"]
-                    )}
-                />
-            </ContextMenuPrimitive.Portal>;
-    }
-
-    def:pub ContextMenuItem(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        return
-            <ContextMenuPrimitive.Item
-                {**props}
-                data-slot="context-menu-item"
-                data-inset={props["inset"]}
-                data-variant={variant}
-                className={cn(
-                    "cn-context-menu-item group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                    "cn-context-menu-content cn-menu-target z-50 max-h-(--radix-context-menu-content-available-height) origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto",
                     props["className"]
                 )}
-            />;
-    }
+            />
+        </ContextMenuPrimitive.Portal>;
+}
 
-    def:pub ContextMenuSubTrigger(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.SubTrigger
-                {**props}
-                data-slot="context-menu-sub-trigger"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-context-menu-sub-trigger flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-            >
-                {props["children"]}
-                <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    strokeWidth={2}
-                    className="cn-rtl-flip ml-auto"
-                />
-            </ContextMenuPrimitive.SubTrigger>;
-    }
+def:pub ContextMenuItem(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    return
+        <ContextMenuPrimitive.Item
+            {**props}
+            data-slot="context-menu-item"
+            data-inset={props["inset"]}
+            data-variant={variant}
+            className={cn(
+                "cn-context-menu-item group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub ContextMenuSubContent(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.SubContent
-                {**props}
-                data-slot="context-menu-sub-content"
-                className={cn(
-                    "cn-context-menu-sub-content cn-menu-target z-50 origin-(--radix-context-menu-content-transform-origin) overflow-hidden",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub ContextMenuSubTrigger(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.SubTrigger
+            {**props}
+            data-slot="context-menu-sub-trigger"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-context-menu-sub-trigger flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+            <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                strokeWidth={2}
+                className="cn-rtl-flip ml-auto"
+            />
+        </ContextMenuPrimitive.SubTrigger>;
+}
 
-    def:pub ContextMenuCheckboxItem(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.CheckboxItem
-                {**props}
-                data-slot="context-menu-checkbox-item"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-context-menu-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-                checked={props["checked"]}
-            >
-                <span className="cn-context-menu-item-indicator pointer-events-none">
-                    <ContextMenuPrimitive.ItemIndicator>
-                        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                    </ContextMenuPrimitive.ItemIndicator>
-                </span>
-                {props["children"]}
-            </ContextMenuPrimitive.CheckboxItem>;
-    }
+def:pub ContextMenuSubContent(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.SubContent
+            {**props}
+            data-slot="context-menu-sub-content"
+            className={cn(
+                "cn-context-menu-sub-content cn-menu-target z-50 origin-(--radix-context-menu-content-transform-origin) overflow-hidden",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub ContextMenuRadioItem(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.RadioItem
-                {**props}
-                data-slot="context-menu-radio-item"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-context-menu-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-            >
-                <span className="cn-context-menu-item-indicator pointer-events-none">
-                    <ContextMenuPrimitive.ItemIndicator>
-                        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                    </ContextMenuPrimitive.ItemIndicator>
-                </span>
-                {props["children"]}
-            </ContextMenuPrimitive.RadioItem>;
-    }
+def:pub ContextMenuCheckboxItem(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.CheckboxItem
+            {**props}
+            data-slot="context-menu-checkbox-item"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-context-menu-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+            checked={props["checked"]}
+        >
+            <span className="cn-context-menu-item-indicator pointer-events-none">
+                <ContextMenuPrimitive.ItemIndicator>
+                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+                </ContextMenuPrimitive.ItemIndicator>
+            </span>
+            {props["children"]}
+        </ContextMenuPrimitive.CheckboxItem>;
+}
 
-    def:pub ContextMenuLabel(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.Label
-                {**props}
-                data-slot="context-menu-label"
-                data-inset={props["inset"]}
-                className={cn("cn-context-menu-label", props["className"])}
-            />;
-    }
+def:pub ContextMenuRadioItem(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.RadioItem
+            {**props}
+            data-slot="context-menu-radio-item"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-context-menu-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            <span className="cn-context-menu-item-indicator pointer-events-none">
+                <ContextMenuPrimitive.ItemIndicator>
+                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+                </ContextMenuPrimitive.ItemIndicator>
+            </span>
+            {props["children"]}
+        </ContextMenuPrimitive.RadioItem>;
+}
 
-    def:pub ContextMenuSeparator(props: any) -> JsxElement {
-        return
-            <ContextMenuPrimitive.Separator
-                {**props}
-                data-slot="context-menu-separator"
-                className={cn("cn-context-menu-separator", props["className"])}
-            />;
-    }
+def:pub ContextMenuLabel(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.Label
+            {**props}
+            data-slot="context-menu-label"
+            data-inset={props["inset"]}
+            className={cn("cn-context-menu-label", props["className"])}
+        />;
+}
 
-    def:pub ContextMenuShortcut(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                {**attrs}
-                data-slot="context-menu-shortcut"
-                className={cn("cn-context-menu-shortcut", props["className"])}
-            />;
-    }
+def:pub ContextMenuSeparator(props: any) -> JsxElement {
+    return
+        <ContextMenuPrimitive.Separator
+            {**props}
+            data-slot="context-menu-separator"
+            className={cn("cn-context-menu-separator", props["className"])}
+        />;
+}
+
+def:pub ContextMenuShortcut(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            data-slot="context-menu-shortcut"
+            className={cn("cn-context-menu-shortcut", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/dialog.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/dialog.cl.jac
@@ -1,128 +1,121 @@
-cl import from "radix-ui" { Dialog as DialogPrimitive }
-cl import from ...lib.utils { cn }
-cl import from .button { buttonVariants }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Cancel01Icon }
+import from "radix-ui" { Dialog as DialogPrimitive }
+import from ...lib.utils { cn }
+import from .button { buttonVariants }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Cancel01Icon }
 
-cl {
-    def:pub Dialog(props: any) -> JsxElement {
-        return <DialogPrimitive.Root data-slot="dialog" {**props}/>;
-    }
+def:pub Dialog(props: any) -> JsxElement {
+    return <DialogPrimitive.Root data-slot="dialog" {**props}/>;
+}
 
-    def:pub DialogTrigger(props: any) -> JsxElement {
-        return <DialogPrimitive.Trigger data-slot="dialog-trigger" {**props}/>;
-    }
+def:pub DialogTrigger(props: any) -> JsxElement {
+    return <DialogPrimitive.Trigger data-slot="dialog-trigger" {**props}/>;
+}
 
-    def:pub DialogPortal(props: any) -> JsxElement {
-        return <DialogPrimitive.Portal data-slot="dialog-portal" {**props}/>;
-    }
+def:pub DialogPortal(props: any) -> JsxElement {
+    return <DialogPrimitive.Portal data-slot="dialog-portal" {**props}/>;
+}
 
-    def:pub DialogClose(props: any) -> JsxElement {
-        return <DialogPrimitive.Close data-slot="dialog-close" {**props}/>;
-    }
+def:pub DialogClose(props: any) -> JsxElement {
+    return <DialogPrimitive.Close data-slot="dialog-close" {**props}/>;
+}
 
-    def:pub DialogOverlay(props: any) -> JsxElement {
-        return
-            <DialogPrimitive.Overlay
+def:pub DialogOverlay(props: any) -> JsxElement {
+    return
+        <DialogPrimitive.Overlay
+            {**props}
+            data-slot="dialog-overlay"
+            className={cn(
+                "cn-dialog-overlay data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub DialogContent(props: any) -> JsxElement {
+    # default to shown; only an explicit False hides the close button
+    showCloseButton = props["showCloseButton"] is not False;  # jac:ignore[W2075]
+    return
+        <DialogPortal>
+            <DialogOverlay/>
+            <DialogPrimitive.Content
                 {**props}
-                data-slot="dialog-overlay"
+                data-slot="dialog-content"
                 className={cn(
-                    "cn-dialog-overlay data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub DialogContent(props: any) -> JsxElement {
-        # default to shown; only an explicit False hides the close button
-        showCloseButton = props["showCloseButton"] is not False;  # jac:ignore[W2075]
-        return
-            <DialogPortal>
-                <DialogOverlay/>
-                <DialogPrimitive.Content
-                    {**props}
-                    data-slot="dialog-content"
-                    className={cn(
-                        "cn-dialog-content data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
-                        props["className"]
-                    )}
-                >
-                    {props["children"]}{showCloseButton
-                    and <DialogPrimitive.Close data-slot="dialog-close" asChild={True}>
-                        <button
-                            className={cn(
-                                buttonVariants().call(
-                                    None, {"variant": "ghost", "size": "icon-sm"}
-                                ),
-                                "cn-dialog-close"
-                            )}
-                        >
-                            <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2}/>
-                            <span className="sr-only">Close</span>
-                        </button>
-                    </DialogPrimitive.Close>}
-                </DialogPrimitive.Content>
-            </DialogPortal>;
-    }
-
-    def:pub DialogHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="dialog-header"
-                className={cn(
-                    "cn-dialog-header flex flex-col gap-2", props["className"]
-                )}
-            />;
-    }
-
-    def:pub DialogFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        showCloseButton = props["showCloseButton"] or False;
-        return
-            <div
-                {**attrs}
-                data-slot="dialog-footer"
-                className={cn(
-                    "cn-dialog-footer flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+                    "cn-dialog-content data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
                     props["className"]
                 )}
             >
                 {props["children"]}{showCloseButton
-                and <DialogPrimitive.Close asChild={True}>
+                and <DialogPrimitive.Close data-slot="dialog-close" asChild={True}>
                     <button
                         className={cn(
-                            buttonVariants().call(None, {"variant": "outline"})
+                            buttonVariants().call(
+                                None, {"variant": "ghost", "size": "icon-sm"}
+                            ),
+                            "cn-dialog-close"
                         )}
                     >
-                        Close
+                        <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2}/>
+                        <span className="sr-only">Close</span>
                     </button>
                 </DialogPrimitive.Close>}
-            </div>;
-    }
+            </DialogPrimitive.Content>
+        </DialogPortal>;
+}
 
-    def:pub DialogTitle(props: any) -> JsxElement {
-        return
-            <DialogPrimitive.Title
-                {**props}
-                data-slot="dialog-title"
-                className={cn(
-                    "cn-dialog-title text-base leading-none font-medium",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub DialogHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="dialog-header"
+            className={cn("cn-dialog-header flex flex-col gap-2", props["className"])}
+        />;
+}
 
-    def:pub DialogDescription(props: any) -> JsxElement {
-        return
-            <DialogPrimitive.Description
-                {**props}
-                data-slot="dialog-description"
-                className={cn(
-                    "cn-dialog-description text-muted-foreground text-sm",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub DialogFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    showCloseButton = props["showCloseButton"] or False;
+    return
+        <div
+            {**attrs}
+            data-slot="dialog-footer"
+            className={cn(
+                "cn-dialog-footer flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+                props["className"]
+            )}
+        >
+            {props["children"]}{showCloseButton
+            and <DialogPrimitive.Close asChild={True}>
+                <button
+                    className={cn(buttonVariants().call(None, {"variant": "outline"}))}
+                >
+                    Close
+                </button>
+            </DialogPrimitive.Close>}
+        </div>;
+}
+
+def:pub DialogTitle(props: any) -> JsxElement {
+    return
+        <DialogPrimitive.Title
+            {**props}
+            data-slot="dialog-title"
+            className={cn(
+                "cn-dialog-title text-base leading-none font-medium", props["className"]
+            )}
+        />;
+}
+
+def:pub DialogDescription(props: any) -> JsxElement {
+    return
+        <DialogPrimitive.Description
+            {**props}
+            data-slot="dialog-description"
+            className={cn(
+                "cn-dialog-description text-muted-foreground text-sm",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/drawer.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/drawer.cl.jac
@@ -1,94 +1,88 @@
-cl import from "vaul" { Drawer as DrawerPrimitive }
-cl import from ...lib.utils { cn }
+import from "vaul" { Drawer as DrawerPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Drawer(props: any) -> JsxElement {
-        return <DrawerPrimitive.Root data-slot="drawer" {**props}/>;
-    }
+def:pub Drawer(props: any) -> JsxElement {
+    return <DrawerPrimitive.Root data-slot="drawer" {**props}/>;
+}
 
-    def:pub DrawerTrigger(props: any) -> JsxElement {
-        return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {**props}/>;
-    }
+def:pub DrawerTrigger(props: any) -> JsxElement {
+    return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {**props}/>;
+}
 
-    def:pub DrawerPortal(props: any) -> JsxElement {
-        return <DrawerPrimitive.Portal data-slot="drawer-portal" {**props}/>;
-    }
+def:pub DrawerPortal(props: any) -> JsxElement {
+    return <DrawerPrimitive.Portal data-slot="drawer-portal" {**props}/>;
+}
 
-    def:pub DrawerClose(props: any) -> JsxElement {
-        return <DrawerPrimitive.Close data-slot="drawer-close" {**props}/>;
-    }
+def:pub DrawerClose(props: any) -> JsxElement {
+    return <DrawerPrimitive.Close data-slot="drawer-close" {**props}/>;
+}
 
-    def:pub DrawerOverlay(props: any) -> JsxElement {
-        return
+def:pub DrawerOverlay(props: any) -> JsxElement {
+    return
+        <DrawerPrimitive.Overlay
+            {**props}
+            data-slot="drawer-overlay"
+            className={cn("cn-drawer-overlay fixed inset-0 z-50", props["className"])}
+        />;
+}
+
+def:pub DrawerContent(props: any) -> JsxElement {
+    return
+        <DrawerPrimitive.Portal data-slot="drawer-portal">
             <DrawerPrimitive.Overlay
-                {**props}
                 data-slot="drawer-overlay"
+                className="cn-drawer-overlay fixed inset-0 z-50"
+            />
+            <DrawerPrimitive.Content
+                {**props}
+                data-slot="drawer-content"
                 className={cn(
-                    "cn-drawer-overlay fixed inset-0 z-50", props["className"]
+                    "cn-drawer-content group/drawer-content fixed z-50",
+                    props["className"]
                 )}
-            />;
-    }
-
-    def:pub DrawerContent(props: any) -> JsxElement {
-        return
-            <DrawerPrimitive.Portal data-slot="drawer-portal">
-                <DrawerPrimitive.Overlay
-                    data-slot="drawer-overlay"
-                    className="cn-drawer-overlay fixed inset-0 z-50"
+            >
+                <div
+                    className="cn-drawer-handle mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
                 />
-                <DrawerPrimitive.Content
-                    {**props}
-                    data-slot="drawer-content"
-                    className={cn(
-                        "cn-drawer-content group/drawer-content fixed z-50",
-                        props["className"]
-                    )}
-                >
-                    <div
-                        className="cn-drawer-handle mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
-                    />
-                    {props["children"]}
-                </DrawerPrimitive.Content>
-            </DrawerPrimitive.Portal>;
-    }
+                {props["children"]}
+            </DrawerPrimitive.Content>
+        </DrawerPrimitive.Portal>;
+}
 
-    def:pub DrawerHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="drawer-header"
-                className={cn("cn-drawer-header flex flex-col", props["className"])}
-            />;
-    }
+def:pub DrawerHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="drawer-header"
+            className={cn("cn-drawer-header flex flex-col", props["className"])}
+        />;
+}
 
-    def:pub DrawerFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="drawer-footer"
-                className={cn(
-                    "cn-drawer-footer mt-auto flex flex-col", props["className"]
-                )}
-            />;
-    }
+def:pub DrawerFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="drawer-footer"
+            className={cn("cn-drawer-footer mt-auto flex flex-col", props["className"])}
+        />;
+}
 
-    def:pub DrawerTitle(props: any) -> JsxElement {
-        return
-            <DrawerPrimitive.Title
-                {**props}
-                data-slot="drawer-title"
-                className={cn("cn-drawer-title", props["className"])}
-            />;
-    }
+def:pub DrawerTitle(props: any) -> JsxElement {
+    return
+        <DrawerPrimitive.Title
+            {**props}
+            data-slot="drawer-title"
+            className={cn("cn-drawer-title", props["className"])}
+        />;
+}
 
-    def:pub DrawerDescription(props: any) -> JsxElement {
-        return
-            <DrawerPrimitive.Description
-                {**props}
-                data-slot="drawer-description"
-                className={cn("cn-drawer-description", props["className"])}
-            />;
-    }
+def:pub DrawerDescription(props: any) -> JsxElement {
+    return
+        <DrawerPrimitive.Description
+            {**props}
+            data-slot="drawer-description"
+            className={cn("cn-drawer-description", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/dropdown-menu.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/dropdown-menu.cl.jac
@@ -1,189 +1,178 @@
-cl import from "radix-ui" { DropdownMenu as DropdownMenuPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Tick02Icon, ArrowRight01Icon }
+import from "radix-ui" { DropdownMenu as DropdownMenuPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Tick02Icon, ArrowRight01Icon }
 
-cl {
-    def:pub DropdownMenu(props: any) -> JsxElement {
-        return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {**props}/>;
-    }
+def:pub DropdownMenu(props: any) -> JsxElement {
+    return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {**props}/>;
+}
 
-    def:pub DropdownMenuPortal(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {**props}/>;
-    }
+def:pub DropdownMenuPortal(props: any) -> JsxElement {
+    return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {**props}/>;
+}
 
-    def:pub DropdownMenuTrigger(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.Trigger
-                data-slot="dropdown-menu-trigger"
+def:pub DropdownMenuTrigger(props: any) -> JsxElement {
+    return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {**props}/>;
+}
+
+def:pub DropdownMenuContent(props: any) -> JsxElement {
+    align = props["align"] or "start";
+    sideOffset = props["sideOffset"] or 4;
+    return
+        <DropdownMenuPrimitive.Portal>
+            <DropdownMenuPrimitive.Content
                 {**props}
-            />;
-    }
-
-    def:pub DropdownMenuContent(props: any) -> JsxElement {
-        align = props["align"] or "start";
-        sideOffset = props["sideOffset"] or 4;
-        return
-            <DropdownMenuPrimitive.Portal>
-                <DropdownMenuPrimitive.Content
-                    {**props}
-                    data-slot="dropdown-menu-content"
-                    sideOffset={sideOffset}
-                    align={align}
-                    className={cn(
-                        "cn-dropdown-menu-content cn-menu-target no-scrollbar data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
-                        props["className"]
-                    )}
-                />
-            </DropdownMenuPrimitive.Portal>;
-    }
-
-    def:pub DropdownMenuGroup(props: any) -> JsxElement {
-        return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {**props}/>;
-    }
-
-    def:pub DropdownMenuItem(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        return
-            <DropdownMenuPrimitive.Item
-                {**props}
-                data-slot="dropdown-menu-item"
-                data-inset={props["inset"]}
-                data-variant={variant}
+                data-slot="dropdown-menu-content"
+                sideOffset={sideOffset}
+                align={align}
                 className={cn(
-                    "cn-dropdown-menu-item focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                    "cn-dropdown-menu-content cn-menu-target no-scrollbar data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
                     props["className"]
                 )}
-            />;
-    }
+            />
+        </DropdownMenuPrimitive.Portal>;
+}
 
-    def:pub DropdownMenuCheckboxItem(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.CheckboxItem
-                {**props}
-                data-slot="dropdown-menu-checkbox-item"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-dropdown-menu-checkbox-item focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-                checked={props["checked"]}
-            >
-                <span
-                    className="absolute right-2 flex items-center justify-center pointer-events-none"
-                    data-slot="dropdown-menu-checkbox-item-indicator"
-                >
-                    <DropdownMenuPrimitive.ItemIndicator>
-                        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                    </DropdownMenuPrimitive.ItemIndicator>
-                </span>
-                {props["children"]}
-            </DropdownMenuPrimitive.CheckboxItem>;
-    }
+def:pub DropdownMenuGroup(props: any) -> JsxElement {
+    return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {**props}/>;
+}
 
-    def:pub DropdownMenuRadioGroup(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.RadioGroup
-                data-slot="dropdown-menu-radio-group"
-                {**props}
-            />;
-    }
+def:pub DropdownMenuItem(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    return
+        <DropdownMenuPrimitive.Item
+            {**props}
+            data-slot="dropdown-menu-item"
+            data-inset={props["inset"]}
+            data-variant={variant}
+            className={cn(
+                "cn-dropdown-menu-item focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub DropdownMenuRadioItem(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.RadioItem
-                {**props}
-                data-slot="dropdown-menu-radio-item"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-dropdown-menu-radio-item focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-            >
-                <span
-                    className="absolute right-2 flex items-center justify-center pointer-events-none"
-                    data-slot="dropdown-menu-radio-item-indicator"
-                >
-                    <DropdownMenuPrimitive.ItemIndicator>
-                        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                    </DropdownMenuPrimitive.ItemIndicator>
-                </span>
-                {props["children"]}
-            </DropdownMenuPrimitive.RadioItem>;
-    }
-
-    def:pub DropdownMenuLabel(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.Label
-                {**props}
-                data-slot="dropdown-menu-label"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-dropdown-menu-label text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub DropdownMenuSeparator(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.Separator
-                {**props}
-                data-slot="dropdown-menu-separator"
-                className={cn(
-                    "cn-dropdown-menu-separator bg-border -mx-1 my-1 h-px",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub DropdownMenuShortcut(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
+def:pub DropdownMenuCheckboxItem(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.CheckboxItem
+            {**props}
+            data-slot="dropdown-menu-checkbox-item"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-dropdown-menu-checkbox-item focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+            checked={props["checked"]}
+        >
             <span
-                {**attrs}
-                data-slot="dropdown-menu-shortcut"
-                className={cn(
-                    "cn-dropdown-menu-shortcut text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub DropdownMenuSub(props: any) -> JsxElement {
-        return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {**props}/>;
-    }
-
-    def:pub DropdownMenuSubTrigger(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.SubTrigger
-                {**props}
-                data-slot="dropdown-menu-sub-trigger"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-dropdown-menu-sub-trigger focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
+                className="absolute right-2 flex items-center justify-center pointer-events-none"
+                data-slot="dropdown-menu-checkbox-item-indicator"
             >
-                {props["children"]}
-                <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    strokeWidth={2}
-                    className="ml-auto"
-                />
-            </DropdownMenuPrimitive.SubTrigger>;
-    }
+                <DropdownMenuPrimitive.ItemIndicator>
+                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+                </DropdownMenuPrimitive.ItemIndicator>
+            </span>
+            {props["children"]}
+        </DropdownMenuPrimitive.CheckboxItem>;
+}
 
-    def:pub DropdownMenuSubContent(props: any) -> JsxElement {
-        return
-            <DropdownMenuPrimitive.SubContent
-                {**props}
-                data-slot="dropdown-menu-sub-content"
-                className={cn(
-                    "cn-dropdown-menu-sub-content data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 duration-100 z-50 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub DropdownMenuRadioGroup(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.RadioGroup
+            data-slot="dropdown-menu-radio-group"
+            {**props}
+        />;
+}
+
+def:pub DropdownMenuRadioItem(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.RadioItem
+            {**props}
+            data-slot="dropdown-menu-radio-item"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-dropdown-menu-radio-item focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            <span
+                className="absolute right-2 flex items-center justify-center pointer-events-none"
+                data-slot="dropdown-menu-radio-item-indicator"
+            >
+                <DropdownMenuPrimitive.ItemIndicator>
+                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+                </DropdownMenuPrimitive.ItemIndicator>
+            </span>
+            {props["children"]}
+        </DropdownMenuPrimitive.RadioItem>;
+}
+
+def:pub DropdownMenuLabel(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.Label
+            {**props}
+            data-slot="dropdown-menu-label"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-dropdown-menu-label text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub DropdownMenuSeparator(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.Separator
+            {**props}
+            data-slot="dropdown-menu-separator"
+            className={cn(
+                "cn-dropdown-menu-separator bg-border -mx-1 my-1 h-px",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub DropdownMenuShortcut(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            data-slot="dropdown-menu-shortcut"
+            className={cn(
+                "cn-dropdown-menu-shortcut text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub DropdownMenuSub(props: any) -> JsxElement {
+    return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {**props}/>;
+}
+
+def:pub DropdownMenuSubTrigger(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.SubTrigger
+            {**props}
+            data-slot="dropdown-menu-sub-trigger"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-dropdown-menu-sub-trigger focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+            <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} className="ml-auto"/>
+        </DropdownMenuPrimitive.SubTrigger>;
+}
+
+def:pub DropdownMenuSubContent(props: any) -> JsxElement {
+    return
+        <DropdownMenuPrimitive.SubContent
+            {**props}
+            data-slot="dropdown-menu-sub-content"
+            className={cn(
+                "cn-dropdown-menu-sub-content data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 duration-100 z-50 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/empty.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/empty.cl.jac
@@ -1,5 +1,5 @@
-cl import from "class-variance-authority" { cva }
-cl import from ...lib.utils { cn }
+import from "class-variance-authority" { cva }
+import from ...lib.utils { cn }
 
 glob _emptyMediaVariants: any = cva(
          "cn-empty-media flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
@@ -14,95 +14,93 @@ glob _emptyMediaVariants: any = cva(
          }
      );
 
-cl {
-    def:pub Empty(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="empty"
-                className={cn(
-                    "cn-empty flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub Empty(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="empty"
+            className={cn(
+                "cn-empty flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub EmptyHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="empty-header"
-                className={cn(
-                    "cn-empty-header flex max-w-sm flex-col items-center",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub EmptyHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="empty-header"
+            className={cn(
+                "cn-empty-header flex max-w-sm flex-col items-center",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub EmptyMedia(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        variant = props["variant"] or "default";
-        computedClass = cn(
-            _emptyMediaVariants.call(
-                None, {"variant": variant, "className": props["className"]}
-            )
-        );
-        return
-            <div
-                data-slot="empty-icon"
-                data-variant={variant}
-                className={computedClass}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub EmptyMedia(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    variant = props["variant"] or "default";
+    computedClass = cn(
+        _emptyMediaVariants.call(
+            None, {"variant": variant, "className": props["className"]}
+        )
+    );
+    return
+        <div
+            data-slot="empty-icon"
+            data-variant={variant}
+            className={computedClass}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub EmptyTitle(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="empty-title"
-                className={cn("cn-empty-title", props["className"])}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub EmptyTitle(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="empty-title"
+            className={cn("cn-empty-title", props["className"])}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub EmptyDescription(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="empty-description"
-                className={cn(
-                    "cn-empty-description text-muted-foreground [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub EmptyDescription(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="empty-description"
+            className={cn(
+                "cn-empty-description text-muted-foreground [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub EmptyContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="empty-content"
-                className={cn(
-                    "cn-empty-content flex w-full max-w-sm min-w-0 flex-col items-center text-balance",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub EmptyContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="empty-content"
+            className={cn(
+                "cn-empty-content flex w-full max-w-sm min-w-0 flex-col items-center text-balance",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/field.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/field.cl.jac
@@ -1,8 +1,8 @@
-cl import from react { useMemo }
-cl import from "class-variance-authority" { cva }
-cl import from ...lib.utils { cn }
-cl import from .label { Label }
-cl import from .separator { Separator }
+import from react { useMemo }
+import from "class-variance-authority" { cva }
+import from ...lib.utils { cn }
+import from .label { Label }
+import from .separator { Separator }
 
 glob _fieldVariants: any = cva(
          "cn-field data-[invalid=true]:text-destructive gap-2 group/field flex w-full",
@@ -18,194 +18,191 @@ glob _fieldVariants: any = cva(
          }
      );
 
-cl {
-    def:pub FieldSet(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <fieldset
-                {**attrs}
-                data-slot="field-set"
-                className={cn(
-                    "cn-field-set gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3 flex flex-col",
-                    props["className"]
-                )}
-            />;
+def:pub FieldSet(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <fieldset
+            {**attrs}
+            data-slot="field-set"
+            className={cn(
+                "cn-field-set gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3 flex flex-col",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub FieldLegend(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    variant = props["variant"] or "legend";
+    return
+        <legend
+            {**attrs}
+            data-slot="field-legend"
+            data-variant={variant}
+            className={cn(
+                "cn-field-legend mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub FieldGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="field-group"
+            className={cn(
+                "cn-field-group gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4 group/field-group @container/field-group flex w-full flex-col",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub Field(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    orientation = props["orientation"] or "vertical";
+    variantsFn = _fieldVariants;
+    return
+        <div
+            {**attrs}
+            role="group"
+            data-slot="field"
+            data-orientation={orientation}
+            className={cn(
+                variantsFn.call(None, {"orientation": orientation}), props["className"]
+            )}
+        />;
+}
+
+def:pub FieldContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="field-content"
+            className={cn(
+                "cn-field-content gap-0.5 group/field-content flex flex-1 flex-col leading-snug",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub FieldLabel(props: any) -> JsxElement {
+    return
+        <Label
+            {**props}
+            data-slot="field-label"
+            className={cn(
+                "cn-field-label has-data-checked:bg-primary/5 has-data-checked:border-primary/30 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 group/field-label peer/field-label flex w-fit leading-snug",
+                "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub FieldTitle(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="field-label"
+            className={cn(
+                "cn-field-title gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50 flex w-fit items-center leading-snug",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub FieldDescription(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <p
+            {**attrs}
+            data-slot="field-description"
+            className={cn(
+                "cn-field-description text-muted-foreground text-left text-sm [[data-variant=legend]+&]:-mt-1.5 leading-normal font-normal group-has-data-horizontal/field:text-balance",
+                "last:mt-0 nth-last-2:-mt-1",
+                "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub FieldSeparator(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="field-separator"
+            data-content={Boolean(props["children"])}
+            className={cn(
+                "cn-field-separator -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 relative",
+                props["className"]
+            )}
+        >
+            <Separator className="absolute inset-0 top-1/2"/>
+            {props["children"]
+            and (
+                <span
+                    className="text-muted-foreground px-2 bg-background relative mx-auto block w-fit"
+                    data-slot="field-separator-content"
+                >
+                    {props["children"]}
+                </span>
+            )}
+        </div>;
+}
+
+def:pub FieldError(props: any) -> any {
+    attrs: dict[str, any] = {** props};
+    children = props["children"];
+    errors = props["errors"];
+
+    content = useMemo(
+        lambda -> any {
+            if children {
+                return children;
+            }
+            errorList: list[any] = [e for e in (errors or [])];
+            if not len(errorList) {
+                return None;
+            }
+            uniqueMap = {};
+            for error in errorList {
+                uniqueMap[error and error.message] = error;
+            }
+            uniqueKeys = Object.keys(uniqueMap);  # jac:ignore[W6001]
+            uniqueErrors: list[any] = [uniqueMap[k] for k in uniqueKeys];
+            if len(uniqueErrors) == 1 {
+                return uniqueErrors[0] and uniqueErrors[0].message;
+            }
+            return
+                <ul className="ml-4 flex list-disc flex-col gap-1">
+                    {for (index, error) in enumerate(uniqueErrors) {
+                        if error and error.message {
+                            <li key={index}>{error.message}</li>;
+                        }
+                    }}
+                </ul>;
+        },
+        [children, errors]
+    );
+
+    if not content {
+        return None;
     }
 
-    def:pub FieldLegend(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        variant = props["variant"] or "legend";
-        return
-            <legend
-                {**attrs}
-                data-slot="field-legend"
-                data-variant={variant}
-                className={cn(
-                    "cn-field-legend mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub FieldGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="field-group"
-                className={cn(
-                    "cn-field-group gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4 group/field-group @container/field-group flex w-full flex-col",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub Field(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        orientation = props["orientation"] or "vertical";
-        variantsFn = _fieldVariants;
-        return
-            <div
-                {**attrs}
-                role="group"
-                data-slot="field"
-                data-orientation={orientation}
-                className={cn(
-                    variantsFn.call(None, {"orientation": orientation}),
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub FieldContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="field-content"
-                className={cn(
-                    "cn-field-content gap-0.5 group/field-content flex flex-1 flex-col leading-snug",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub FieldLabel(props: any) -> JsxElement {
-        return
-            <Label
-                {**props}
-                data-slot="field-label"
-                className={cn(
-                    "cn-field-label has-data-checked:bg-primary/5 has-data-checked:border-primary/30 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 group/field-label peer/field-label flex w-fit leading-snug",
-                    "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub FieldTitle(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="field-label"
-                className={cn(
-                    "cn-field-title gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50 flex w-fit items-center leading-snug",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub FieldDescription(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <p
-                {**attrs}
-                data-slot="field-description"
-                className={cn(
-                    "cn-field-description text-muted-foreground text-left text-sm [[data-variant=legend]+&]:-mt-1.5 leading-normal font-normal group-has-data-horizontal/field:text-balance",
-                    "last:mt-0 nth-last-2:-mt-1",
-                    "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub FieldSeparator(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="field-separator"
-                data-content={Boolean(props["children"])}
-                className={cn(
-                    "cn-field-separator -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 relative",
-                    props["className"]
-                )}
-            >
-                <Separator className="absolute inset-0 top-1/2"/>
-                {props["children"]
-                and (
-                    <span
-                        className="text-muted-foreground px-2 bg-background relative mx-auto block w-fit"
-                        data-slot="field-separator-content"
-                    >
-                        {props["children"]}
-                    </span>
-                )}
-            </div>;
-    }
-
-    def:pub FieldError(props: any) -> any {
-        attrs: dict[str, any] = {** props};
-        children = props["children"];
-        errors = props["errors"];
-
-        content = useMemo(
-            lambda -> any {
-                if children {
-                    return children;
-                }
-                errorList: list[any] = [e for e in (errors or [])];
-                if not len(errorList) {
-                    return None;
-                }
-                uniqueMap = {};
-                for error in errorList {
-                    uniqueMap[error and error.message] = error;
-                }
-                uniqueKeys = Object.keys(uniqueMap);  # jac:ignore[W6001]
-                uniqueErrors: list[any] = [uniqueMap[k] for k in uniqueKeys];
-                if len(uniqueErrors) == 1 {
-                    return uniqueErrors[0] and uniqueErrors[0].message;
-                }
-                return
-                    <ul className="ml-4 flex list-disc flex-col gap-1">
-                        {for (index, error) in enumerate(uniqueErrors) {
-                            if error and error.message {
-                                <li key={index}>{error.message}</li>;
-                            }
-                        }}
-                    </ul>;
-            },
-            [children, errors]
-        );
-
-        if not content {
-            return None;
-        }
-
-        return
-            <div
-                {**attrs}
-                role="alert"
-                data-slot="field-error"
-                className={cn(
-                    "cn-field-error text-destructive text-sm font-normal",
-                    props["className"]
-                )}
-            >
-                {content}
-            </div>;
-    }
+    return
+        <div
+            {**attrs}
+            role="alert"
+            data-slot="field-error"
+            className={cn(
+                "cn-field-error text-destructive text-sm font-normal",
+                props["className"]
+            )}
+        >
+            {content}
+        </div>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/hover-card.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/hover-card.cl.jac
@@ -1,30 +1,28 @@
-cl import from "radix-ui" { HoverCard as HoverCardPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { HoverCard as HoverCardPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub HoverCard(props: any) -> JsxElement {
-        return <HoverCardPrimitive.Root data-slot="hover-card" {**props}/>;
-    }
+def:pub HoverCard(props: any) -> JsxElement {
+    return <HoverCardPrimitive.Root data-slot="hover-card" {**props}/>;
+}
 
-    def:pub HoverCardTrigger(props: any) -> JsxElement {
-        return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {**props}/>;
-    }
+def:pub HoverCardTrigger(props: any) -> JsxElement {
+    return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {**props}/>;
+}
 
-    def:pub HoverCardContent(props: any) -> JsxElement {
-        align = props["align"] or "center";
-        sideOffset = props["sideOffset"] or 4;
-        return
-            <HoverCardPrimitive.Portal data-slot="hover-card-portal">
-                <HoverCardPrimitive.Content
-                    {**props}
-                    data-slot="hover-card-content"
-                    align={align}
-                    sideOffset={sideOffset}
-                    className={cn(
-                        "cn-hover-card-content z-50 origin-(--radix-hover-card-content-transform-origin) outline-hidden",
-                        props["className"]
-                    )}
-                />
-            </HoverCardPrimitive.Portal>;
-    }
+def:pub HoverCardContent(props: any) -> JsxElement {
+    align = props["align"] or "center";
+    sideOffset = props["sideOffset"] or 4;
+    return
+        <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+            <HoverCardPrimitive.Content
+                {**props}
+                data-slot="hover-card-content"
+                align={align}
+                sideOffset={sideOffset}
+                className={cn(
+                    "cn-hover-card-content z-50 origin-(--radix-hover-card-content-transform-origin) outline-hidden",
+                    props["className"]
+                )}
+            />
+        </HoverCardPrimitive.Portal>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/input-group.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/input-group.cl.jac
@@ -1,8 +1,8 @@
-cl import from "class-variance-authority" { cva }
-cl import from ...lib.utils { cn }
-cl import from .button { Button }
-cl import from .input { Input }
-cl import from .textarea { Textarea }
+import from "class-variance-authority" { cva }
+import from ...lib.utils { cn }
+import from .button { Button }
+import from .input { Input }
+import from .textarea { Textarea }
 
 glob _inputGroupAddonVariants: any = cva(
          "cn-input-group-addon text-muted-foreground h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4 flex cursor-text items-center justify-center select-none",
@@ -33,98 +33,96 @@ glob _inputGroupAddonVariants: any = cva(
          }
      );
 
-cl {
-    def:pub InputGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="input-group"
-                role="group"
-                className={cn(
-                    "cn-input-group border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-disabled:bg-input/50 dark:has-disabled:bg-input/80 h-8 rounded-lg border transition-colors in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
-                    props["className"]
-                )}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub InputGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="input-group"
+            role="group"
+            className={cn(
+                "cn-input-group border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-disabled:bg-input/50 dark:has-disabled:bg-input/80 h-8 rounded-lg border transition-colors in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub InputGroupAddon(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        align = props["align"] or "inline-start";
-        addonFn = _inputGroupAddonVariants;
-        return
-            <div
-                {**attrs}
-                role="group"
-                data-slot="input-group-addon"
-                data-align={align}
-                className={cn(addonFn.call(None, {"align": align}), props["className"])}
-                onClick={lambda (e: any) { if not e.target.closest("button") {
-                    inputEl = e.currentTarget.parentElement
-                    and e.currentTarget.parentElement.querySelector("input");
-                    if inputEl {
-                        inputEl.focus();
-                    }
-                }}}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub InputGroupAddon(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    align = props["align"] or "inline-start";
+    addonFn = _inputGroupAddonVariants;
+    return
+        <div
+            {**attrs}
+            role="group"
+            data-slot="input-group-addon"
+            data-align={align}
+            className={cn(addonFn.call(None, {"align": align}), props["className"])}
+            onClick={lambda (e: any) { if not e.target.closest("button") {
+                inputEl = e.currentTarget.parentElement
+                and e.currentTarget.parentElement.querySelector("input");
+                if inputEl {
+                    inputEl.focus();
+                }
+            }}}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub InputGroupButton(props: any) -> JsxElement {
-        type = props["type"] or "button";
-        variant = props["variant"] or "ghost";
-        size = props["size"] or "xs";
-        btnFn = _inputGroupButtonVariants;
-        return
-            <Button
-                {**props}
-                type={type}
-                data-size={size}
-                variant={variant}
-                className={cn(btnFn.call(None, {"size": size}), props["className"])}
-            >
-                {props["children"]}
-            </Button>;
-    }
+def:pub InputGroupButton(props: any) -> JsxElement {
+    type = props["type"] or "button";
+    variant = props["variant"] or "ghost";
+    size = props["size"] or "xs";
+    btnFn = _inputGroupButtonVariants;
+    return
+        <Button
+            {**props}
+            type={type}
+            data-size={size}
+            variant={variant}
+            className={cn(btnFn.call(None, {"size": size}), props["className"])}
+        >
+            {props["children"]}
+        </Button>;
+}
 
-    def:pub InputGroupText(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                {**attrs}
-                className={cn(
-                    "cn-input-group-text text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
-                    props["className"]
-                )}
-            >
-                {props["children"]}
-            </span>;
-    }
+def:pub InputGroupText(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            className={cn(
+                "cn-input-group-text text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+        </span>;
+}
 
-    def:pub InputGroupInput(props: any) -> JsxElement {
-        return
-            <Input
-                {**props}
-                data-slot="input-group-control"
-                className={cn(
-                    "cn-input-group-input rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub InputGroupInput(props: any) -> JsxElement {
+    return
+        <Input
+            {**props}
+            data-slot="input-group-control"
+            className={cn(
+                "cn-input-group-input rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub InputGroupTextarea(props: any) -> JsxElement {
-        return
-            <Textarea
-                {**props}
-                data-slot="input-group-control"
-                className={cn(
-                    "cn-input-group-textarea rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1 resize-none",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub InputGroupTextarea(props: any) -> JsxElement {
+    return
+        <Textarea
+            {**props}
+            data-slot="input-group-control"
+            className={cn(
+                "cn-input-group-textarea rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1 resize-none",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/input.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/input.cl.jac
@@ -1,16 +1,14 @@
-cl import from ...lib.utils { cn }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Input(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <input
-                {**attrs}
-                data-slot="input"
-                className={cn(
-                    "cn-input dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Input(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <input
+            {**attrs}
+            data-slot="input"
+            className={cn(
+                "cn-input dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/item.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/item.cl.jac
@@ -1,7 +1,7 @@
-cl import from "class-variance-authority" { cva }
-cl import from "radix-ui" { Slot }
-cl import from ...lib.utils { cn }
-cl import from .separator { Separator }
+import from "class-variance-authority" { cva }
+import from "radix-ui" { Slot }
+import from ...lib.utils { cn }
+import from .separator { Separator }
 
 glob _itemVariants: any = cva(
          "cn-item w-full group/item focus-visible:border-ring focus-visible:ring-ring/50 flex items-center flex-wrap outline-none transition-colors duration-100 focus-visible:ring-[3px]",
@@ -42,65 +42,52 @@ glob _itemVariants: any = cva(
          "children"
      ];
 
-cl {
-    def:pub ItemGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                role="list"
-                data-slot="item-group"
-                className={cn(
-                    "cn-item-group group/item-group flex w-full flex-col",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
+def:pub ItemGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            role="list"
+            data-slot="item-group"
+            className={cn(
+                "cn-item-group group/item-group flex w-full flex-col",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
+
+def:pub ItemSeparator(props: any) -> JsxElement {
+    return
+        <Separator
+            data-slot="item-separator"
+            orientation="horizontal"
+            className={cn("cn-item-separator", props["className"])}
+            {**props}
+        />;
+}
+
+def:pub Item(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    asChild = props["asChild"] or False;
+    computedClass = cn(
+        _itemVariants.call(
+            None, {"variant": variant, "size": size, "className": props["className"]}
+        )
+    );
+
+    restProps = {};
+    for key in Object.keys(props) {  # jac:ignore[W6001]
+        if key not in _itemExcludeKeys {
+            restProps[key] = props[key];
+        }
     }
 
-    def:pub ItemSeparator(props: any) -> JsxElement {
+    if asChild {
         return
-            <Separator
-                data-slot="item-separator"
-                orientation="horizontal"
-                className={cn("cn-item-separator", props["className"])}
-                {**props}
-            />;
-    }
-
-    def:pub Item(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        asChild = props["asChild"] or False;
-        computedClass = cn(
-            _itemVariants.call(
-                None,
-                {"variant": variant, "size": size, "className": props["className"]}
-            )
-        );
-
-        restProps = {};
-        for key in Object.keys(props) {  # jac:ignore[W6001]
-            if key not in _itemExcludeKeys {
-                restProps[key] = props[key];
-            }
-        }
-
-        if asChild {
-            return
-                <Slot.Root
-                    data-slot="item"
-                    data-variant={variant}
-                    data-size={size}
-                    className={computedClass}
-                    {**restProps}
-                >
-                    {props["children"]}
-                </Slot.Root>;
-        }
-        return
-            <div
+            <Slot.Root
                 data-slot="item"
                 data-variant={variant}
                 data-size={size}
@@ -108,116 +95,125 @@ cl {
                 {**restProps}
             >
                 {props["children"]}
-            </div>;
+            </Slot.Root>;
     }
+    return
+        <div
+            data-slot="item"
+            data-variant={variant}
+            data-size={size}
+            className={computedClass}
+            {**restProps}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ItemMedia(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        variant = props["variant"] or "default";
-        computedClass = cn(
-            _itemMediaVariants.call(
-                None, {"variant": variant, "className": props["className"]}
-            )
-        );
-        return
-            <div
-                data-slot="item-media"
-                data-variant={variant}
-                className={computedClass}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub ItemMedia(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    variant = props["variant"] or "default";
+    computedClass = cn(
+        _itemMediaVariants.call(
+            None, {"variant": variant, "className": props["className"]}
+        )
+    );
+    return
+        <div
+            data-slot="item-media"
+            data-variant={variant}
+            className={computedClass}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ItemContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="item-content"
-                className={cn(
-                    "cn-item-content flex flex-1 flex-col [&+[data-slot=item-content]]:flex-none",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub ItemContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="item-content"
+            className={cn(
+                "cn-item-content flex flex-1 flex-col [&+[data-slot=item-content]]:flex-none",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ItemTitle(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="item-title"
-                className={cn(
-                    "cn-item-title line-clamp-1 flex w-fit items-center",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub ItemTitle(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="item-title"
+            className={cn(
+                "cn-item-title line-clamp-1 flex w-fit items-center", props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ItemDescription(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <p
-                data-slot="item-description"
-                className={cn(
-                    "cn-item-description line-clamp-2 font-normal [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </p>;
-    }
+def:pub ItemDescription(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <p
+            data-slot="item-description"
+            className={cn(
+                "cn-item-description line-clamp-2 font-normal [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </p>;
+}
 
-    def:pub ItemActions(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="item-actions"
-                className={cn("cn-item-actions flex items-center", props["className"])}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub ItemActions(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="item-actions"
+            className={cn("cn-item-actions flex items-center", props["className"])}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ItemHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="item-header"
-                className={cn(
-                    "cn-item-header flex basis-full items-center justify-between",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub ItemHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="item-header"
+            className={cn(
+                "cn-item-header flex basis-full items-center justify-between",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub ItemFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="item-footer"
-                className={cn(
-                    "cn-item-footer flex basis-full items-center justify-between",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </div>;
-    }
+def:pub ItemFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="item-footer"
+            className={cn(
+                "cn-item-footer flex basis-full items-center justify-between",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </div>;
+}
 
-    def:pub itemVariants -> any {
-        return _itemVariants;
-    }
+def:pub itemVariants -> any {
+    return _itemVariants;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/kbd.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/kbd.cl.jac
@@ -1,32 +1,28 @@
-cl import from ...lib.utils { cn }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Kbd(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <kbd
-                data-slot="kbd"
-                className={cn(
-                    "cn-kbd pointer-events-none inline-flex items-center justify-center select-none",
-                    props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </kbd>;
-    }
+def:pub Kbd(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <kbd
+            data-slot="kbd"
+            className={cn(
+                "cn-kbd pointer-events-none inline-flex items-center justify-center select-none",
+                props["className"]
+            )}
+            {**attrs}
+        >
+            {props["children"]}
+        </kbd>;
+}
 
-    def:pub KbdGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <kbd
-                data-slot="kbd-group"
-                className={cn(
-                    "cn-kbd-group inline-flex items-center", props["className"]
-                )}
-                {**attrs}
-            >
-                {props["children"]}
-            </kbd>;
-    }
+def:pub KbdGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <kbd
+            data-slot="kbd-group"
+            className={cn("cn-kbd-group inline-flex items-center", props["className"])}
+            {**attrs}
+        >
+            {props["children"]}
+        </kbd>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/label.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/label.cl.jac
@@ -1,16 +1,14 @@
-cl import from "radix-ui" { Label as LabelPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Label as LabelPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Label(props: any) -> JsxElement {
-        return
-            <LabelPrimitive.Root
-                {**props}
-                data-slot="label"
-                className={cn(
-                    "cn-label gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Label(props: any) -> JsxElement {
+    return
+        <LabelPrimitive.Root
+            {**props}
+            data-slot="label"
+            className={cn(
+                "cn-label gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/menubar.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/menubar.cl.jac
@@ -1,190 +1,186 @@
-cl import from "radix-ui" { Menubar as MenubarPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Tick02Icon, ArrowRight01Icon }
+import from "radix-ui" { Menubar as MenubarPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Tick02Icon, ArrowRight01Icon }
 
-cl {
-    def:pub Menubar(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.Root
+def:pub Menubar(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.Root
+            {**props}
+            data-slot="menubar"
+            className={cn("cn-menubar flex items-center", props["className"])}
+        />;
+}
+
+def:pub MenubarMenu(props: any) -> JsxElement {
+    return <MenubarPrimitive.Menu data-slot="menubar-menu" {**props}/>;
+}
+
+def:pub MenubarGroup(props: any) -> JsxElement {
+    return <MenubarPrimitive.Group data-slot="menubar-group" {**props}/>;
+}
+
+def:pub MenubarPortal(props: any) -> JsxElement {
+    return <MenubarPrimitive.Portal data-slot="menubar-portal" {**props}/>;
+}
+
+def:pub MenubarRadioGroup(props: any) -> JsxElement {
+    return <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {**props}/>;
+}
+
+def:pub MenubarTrigger(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.Trigger
+            {**props}
+            data-slot="menubar-trigger"
+            className={cn(
+                "cn-menubar-trigger flex items-center outline-hidden select-none",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub MenubarContent(props: any) -> JsxElement {
+    align = props["align"] or "start";
+    alignOffset = props["alignOffset"] or -4;
+    sideOffset = props["sideOffset"] or 8;
+    return
+        <MenubarPrimitive.Portal>
+            <MenubarPrimitive.Content
                 {**props}
-                data-slot="menubar"
-                className={cn("cn-menubar flex items-center", props["className"])}
-            />;
-    }
-
-    def:pub MenubarMenu(props: any) -> JsxElement {
-        return <MenubarPrimitive.Menu data-slot="menubar-menu" {**props}/>;
-    }
-
-    def:pub MenubarGroup(props: any) -> JsxElement {
-        return <MenubarPrimitive.Group data-slot="menubar-group" {**props}/>;
-    }
-
-    def:pub MenubarPortal(props: any) -> JsxElement {
-        return <MenubarPrimitive.Portal data-slot="menubar-portal" {**props}/>;
-    }
-
-    def:pub MenubarRadioGroup(props: any) -> JsxElement {
-        return <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {**props}/>;
-    }
-
-    def:pub MenubarTrigger(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.Trigger
-                {**props}
-                data-slot="menubar-trigger"
+                data-slot="menubar-content"
+                align={align}
+                alignOffset={alignOffset}
+                sideOffset={sideOffset}
                 className={cn(
-                    "cn-menubar-trigger flex items-center outline-hidden select-none",
+                    "cn-menubar-content cn-menu-target z-50 origin-(--radix-menubar-content-transform-origin) overflow-hidden",
                     props["className"]
                 )}
-            />;
-    }
+            />
+        </MenubarPrimitive.Portal>;
+}
 
-    def:pub MenubarContent(props: any) -> JsxElement {
-        align = props["align"] or "start";
-        alignOffset = props["alignOffset"] or -4;
-        sideOffset = props["sideOffset"] or 8;
-        return
-            <MenubarPrimitive.Portal>
-                <MenubarPrimitive.Content
-                    {**props}
-                    data-slot="menubar-content"
-                    align={align}
-                    alignOffset={alignOffset}
-                    sideOffset={sideOffset}
-                    className={cn(
-                        "cn-menubar-content cn-menu-target z-50 origin-(--radix-menubar-content-transform-origin) overflow-hidden",
-                        props["className"]
-                    )}
-                />
-            </MenubarPrimitive.Portal>;
-    }
+def:pub MenubarItem(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    return
+        <MenubarPrimitive.Item
+            {**props}
+            data-slot="menubar-item"
+            data-inset={props["inset"]}
+            data-variant={variant}
+            className={cn(
+                "cn-menubar-item group/menubar-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub MenubarItem(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        return
-            <MenubarPrimitive.Item
-                {**props}
-                data-slot="menubar-item"
-                data-inset={props["inset"]}
-                data-variant={variant}
-                className={cn(
-                    "cn-menubar-item group/menubar-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub MenubarCheckboxItem(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.CheckboxItem
-                {**props}
-                data-slot="menubar-checkbox-item"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-menubar-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-                checked={props["checked"]}
-            >
-                <span
-                    className="cn-menubar-checkbox-item-indicator pointer-events-none absolute flex items-center justify-center"
-                >
-                    <MenubarPrimitive.ItemIndicator>
-                        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                    </MenubarPrimitive.ItemIndicator>
-                </span>
-                {props["children"]}
-            </MenubarPrimitive.CheckboxItem>;
-    }
-
-    def:pub MenubarRadioItem(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.RadioItem
-                {**props}
-                data-slot="menubar-radio-item"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-menubar-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
-            >
-                <span
-                    className="cn-menubar-radio-item-indicator pointer-events-none absolute flex items-center justify-center"
-                >
-                    <MenubarPrimitive.ItemIndicator>
-                        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
-                    </MenubarPrimitive.ItemIndicator>
-                </span>
-                {props["children"]}
-            </MenubarPrimitive.RadioItem>;
-    }
-
-    def:pub MenubarLabel(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.Label
-                {**props}
-                data-slot="menubar-label"
-                data-inset={props["inset"]}
-                className={cn("cn-menubar-label", props["className"])}
-            />;
-    }
-
-    def:pub MenubarSeparator(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.Separator
-                {**props}
-                data-slot="menubar-separator"
-                className={cn(
-                    "cn-menubar-separator -mx-1 my-1 h-px", props["className"]
-                )}
-            />;
-    }
-
-    def:pub MenubarShortcut(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
+def:pub MenubarCheckboxItem(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.CheckboxItem
+            {**props}
+            data-slot="menubar-checkbox-item"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-menubar-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+            checked={props["checked"]}
+        >
             <span
-                {**attrs}
-                data-slot="menubar-shortcut"
-                className={cn("cn-menubar-shortcut ml-auto", props["className"])}
-            />;
-    }
-
-    def:pub MenubarSub(props: any) -> JsxElement {
-        return <MenubarPrimitive.Sub data-slot="menubar-sub" {**props}/>;
-    }
-
-    def:pub MenubarSubTrigger(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.SubTrigger
-                {**props}
-                data-slot="menubar-sub-trigger"
-                data-inset={props["inset"]}
-                className={cn(
-                    "cn-menubar-sub-trigger flex cursor-default items-center outline-none select-none",
-                    props["className"]
-                )}
+                className="cn-menubar-checkbox-item-indicator pointer-events-none absolute flex items-center justify-center"
             >
-                {props["children"]}
-                <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    strokeWidth={2}
-                    className="cn-rtl-flip ml-auto size-4"
-                />
-            </MenubarPrimitive.SubTrigger>;
-    }
+                <MenubarPrimitive.ItemIndicator>
+                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+                </MenubarPrimitive.ItemIndicator>
+            </span>
+            {props["children"]}
+        </MenubarPrimitive.CheckboxItem>;
+}
 
-    def:pub MenubarSubContent(props: any) -> JsxElement {
-        return
-            <MenubarPrimitive.SubContent
-                {**props}
-                data-slot="menubar-sub-content"
-                className={cn(
-                    "cn-menubar-sub-content cn-menu-target z-50 origin-(--radix-menubar-content-transform-origin) overflow-hidden",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub MenubarRadioItem(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.RadioItem
+            {**props}
+            data-slot="menubar-radio-item"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-menubar-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            <span
+                className="cn-menubar-radio-item-indicator pointer-events-none absolute flex items-center justify-center"
+            >
+                <MenubarPrimitive.ItemIndicator>
+                    <HugeiconsIcon icon={Tick02Icon} strokeWidth={2}/>
+                </MenubarPrimitive.ItemIndicator>
+            </span>
+            {props["children"]}
+        </MenubarPrimitive.RadioItem>;
+}
+
+def:pub MenubarLabel(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.Label
+            {**props}
+            data-slot="menubar-label"
+            data-inset={props["inset"]}
+            className={cn("cn-menubar-label", props["className"])}
+        />;
+}
+
+def:pub MenubarSeparator(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.Separator
+            {**props}
+            data-slot="menubar-separator"
+            className={cn("cn-menubar-separator -mx-1 my-1 h-px", props["className"])}
+        />;
+}
+
+def:pub MenubarShortcut(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            data-slot="menubar-shortcut"
+            className={cn("cn-menubar-shortcut ml-auto", props["className"])}
+        />;
+}
+
+def:pub MenubarSub(props: any) -> JsxElement {
+    return <MenubarPrimitive.Sub data-slot="menubar-sub" {**props}/>;
+}
+
+def:pub MenubarSubTrigger(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.SubTrigger
+            {**props}
+            data-slot="menubar-sub-trigger"
+            data-inset={props["inset"]}
+            className={cn(
+                "cn-menubar-sub-trigger flex cursor-default items-center outline-none select-none",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+            <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                strokeWidth={2}
+                className="cn-rtl-flip ml-auto size-4"
+            />
+        </MenubarPrimitive.SubTrigger>;
+}
+
+def:pub MenubarSubContent(props: any) -> JsxElement {
+    return
+        <MenubarPrimitive.SubContent
+            {**props}
+            data-slot="menubar-sub-content"
+            className={cn(
+                "cn-menubar-sub-content cn-menu-target z-50 origin-(--radix-menubar-content-transform-origin) overflow-hidden",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/native-select.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/native-select.cl.jac
@@ -1,64 +1,60 @@
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { UnfoldMoreIcon }
-cl import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { UnfoldMoreIcon }
+import from ...lib.utils { cn }
 
 glob _nativeSelectExcludeKeys: list[str] = ["className", "size", "children"];
 
-cl {
-    def:pub NativeSelect(props: any) -> JsxElement {
-        size = props["size"] or "default";
+def:pub NativeSelect(props: any) -> JsxElement {
+    size = props["size"] or "default";
 
-        restProps = {};
-        for key in Object.keys(props) {  # jac:ignore[W6001]
-            if key not in _nativeSelectExcludeKeys {
-                restProps[key] = props[key];
-            }
+    restProps = {};
+    for key in Object.keys(props) {  # jac:ignore[W6001]
+        if key not in _nativeSelectExcludeKeys {
+            restProps[key] = props[key];
         }
+    }
 
-        return
-            <div
-                className={cn(
-                    "cn-native-select-wrapper group/native-select relative w-fit has-[select:disabled]:opacity-50",
-                    props["className"]
-                )}
-                data-slot="native-select-wrapper"
+    return
+        <div
+            className={cn(
+                "cn-native-select-wrapper group/native-select relative w-fit has-[select:disabled]:opacity-50",
+                props["className"]
+            )}
+            data-slot="native-select-wrapper"
+            data-size={size}
+        >
+            <select
+                data-slot="native-select"
                 data-size={size}
-            >
-                <select
-                    data-slot="native-select"
-                    data-size={size}
-                    className="cn-native-select outline-none disabled:pointer-events-none disabled:cursor-not-allowed"
-                    {**restProps}
-                >
-                    {props["children"]}
-                </select>
-                <HugeiconsIcon
-                    icon={UnfoldMoreIcon}
-                    className="cn-native-select-icon pointer-events-none absolute select-none"
-                    aria-hidden="true"
-                    data-slot="native-select-icon"
-                    size={16}
-                />
-            </div>;
-    }
-
-    def:pub NativeSelectOption(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <option data-slot="native-select-option" {**attrs}>
-                {props["children"]}
-            </option>;
-    }
-
-    def:pub NativeSelectOptGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <optgroup
-                data-slot="native-select-optgroup"
-                className={props["className"]}
-                {**attrs}
+                className="cn-native-select outline-none disabled:pointer-events-none disabled:cursor-not-allowed"
+                {**restProps}
             >
                 {props["children"]}
-            </optgroup>;
-    }
+            </select>
+            <HugeiconsIcon
+                icon={UnfoldMoreIcon}
+                className="cn-native-select-icon pointer-events-none absolute select-none"
+                aria-hidden="true"
+                data-slot="native-select-icon"
+                size={16}
+            />
+        </div>;
+}
+
+def:pub NativeSelectOption(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <option data-slot="native-select-option" {**attrs}>{props["children"]}</option>;
+}
+
+def:pub NativeSelectOptGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <optgroup
+            data-slot="native-select-optgroup"
+            className={props["className"]}
+            {**attrs}
+        >
+            {props["children"]}
+        </optgroup>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/navigation-menu.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/navigation-menu.cl.jac
@@ -1,129 +1,127 @@
-cl import from "class-variance-authority" { cva }
-cl import from "radix-ui" { NavigationMenu as NavigationMenuPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { ArrowDownIcon }
+import from "class-variance-authority" { cva }
+import from "radix-ui" { NavigationMenu as NavigationMenuPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { ArrowDownIcon }
 
 glob _navigationMenuTriggerStyle: any = cva(
          "cn-navigation-menu-trigger group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center disabled:pointer-events-none outline-none"
      );
 
-cl {
-    def:pub NavigationMenu(props: any) -> JsxElement {
-        viewport = props["viewport"];
-        if viewport is None {
-            viewport = True;
-        }
-        return
-            <NavigationMenuPrimitive.Root
+def:pub NavigationMenu(props: any) -> JsxElement {
+    viewport = props["viewport"];
+    if viewport is None {
+        viewport = True;
+    }
+    return
+        <NavigationMenuPrimitive.Root
+            {**props}
+            data-slot="navigation-menu"
+            data-viewport={viewport}
+            className={cn(
+                "cn-navigation-menu group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
+                props["className"]
+            )}
+        >
+            {props["children"]}{viewport and <NavigationMenuViewport/>}
+        </NavigationMenuPrimitive.Root>;
+}
+
+def:pub NavigationMenuList(props: any) -> JsxElement {
+    return
+        <NavigationMenuPrimitive.List
+            {**props}
+            data-slot="navigation-menu-list"
+            className={cn(
+                "cn-navigation-menu-list group flex flex-1 list-none items-center justify-center",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub NavigationMenuItem(props: any) -> JsxElement {
+    return
+        <NavigationMenuPrimitive.Item
+            {**props}
+            data-slot="navigation-menu-item"
+            className={cn("cn-navigation-menu-item relative", props["className"])}
+        />;
+}
+
+def:pub NavigationMenuTrigger(props: any) -> JsxElement {
+    triggerStyleFn = _navigationMenuTriggerStyle;
+    computedClass = cn(
+        triggerStyleFn.call(None, {"className": props["className"]}), "group"
+    );
+    return
+        <NavigationMenuPrimitive.Trigger
+            {**props}
+            data-slot="navigation-menu-trigger"
+            className={computedClass}
+        >
+            {props["children"]}
+            <HugeiconsIcon
+                icon={ArrowDownIcon}
+                strokeWidth={2}
+                className="cn-navigation-menu-trigger-icon"
+                aria-hidden="true"
+            />
+        </NavigationMenuPrimitive.Trigger>;
+}
+
+def:pub NavigationMenuContent(props: any) -> JsxElement {
+    return
+        <NavigationMenuPrimitive.Content
+            {**props}
+            data-slot="navigation-menu-content"
+            className={cn(
+                "cn-navigation-menu-content top-0 left-0 w-full group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden md:absolute md:w-auto",
+                props["className"]
+            )}
+        />;
+}
+
+def:pub NavigationMenuViewport(props: any) -> JsxElement {
+    return
+        <div
+            className="cn-navigation-menu-viewport-wrapper absolute top-full left-0 isolate z-50 flex justify-center"
+        >
+            <NavigationMenuPrimitive.Viewport
                 {**props}
-                data-slot="navigation-menu"
-                data-viewport={viewport}
+                data-slot="navigation-menu-viewport"
                 className={cn(
-                    "cn-navigation-menu group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
+                    "cn-navigation-menu-viewport origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden md:w-(--radix-navigation-menu-viewport-width)",
                     props["className"]
                 )}
-            >
-                {props["children"]}{viewport and <NavigationMenuViewport/>}
-            </NavigationMenuPrimitive.Root>;
-    }
+            />
+        </div>;
+}
 
-    def:pub NavigationMenuList(props: any) -> JsxElement {
-        return
-            <NavigationMenuPrimitive.List
-                {**props}
-                data-slot="navigation-menu-list"
-                className={cn(
-                    "cn-navigation-menu-list group flex flex-1 list-none items-center justify-center",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub NavigationMenuLink(props: any) -> JsxElement {
+    return
+        <NavigationMenuPrimitive.Link
+            {**props}
+            data-slot="navigation-menu-link"
+            className={cn("cn-navigation-menu-link", props["className"])}
+        />;
+}
 
-    def:pub NavigationMenuItem(props: any) -> JsxElement {
-        return
-            <NavigationMenuPrimitive.Item
-                {**props}
-                data-slot="navigation-menu-item"
-                className={cn("cn-navigation-menu-item relative", props["className"])}
-            />;
-    }
-
-    def:pub NavigationMenuTrigger(props: any) -> JsxElement {
-        triggerStyleFn = _navigationMenuTriggerStyle;
-        computedClass = cn(
-            triggerStyleFn.call(None, {"className": props["className"]}), "group"
-        );
-        return
-            <NavigationMenuPrimitive.Trigger
-                {**props}
-                data-slot="navigation-menu-trigger"
-                className={computedClass}
-            >
-                {props["children"]}
-                <HugeiconsIcon
-                    icon={ArrowDownIcon}
-                    strokeWidth={2}
-                    className="cn-navigation-menu-trigger-icon"
-                    aria-hidden="true"
-                />
-            </NavigationMenuPrimitive.Trigger>;
-    }
-
-    def:pub NavigationMenuContent(props: any) -> JsxElement {
-        return
-            <NavigationMenuPrimitive.Content
-                {**props}
-                data-slot="navigation-menu-content"
-                className={cn(
-                    "cn-navigation-menu-content top-0 left-0 w-full group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden md:absolute md:w-auto",
-                    props["className"]
-                )}
-            />;
-    }
-
-    def:pub NavigationMenuViewport(props: any) -> JsxElement {
-        return
+def:pub NavigationMenuIndicator(props: any) -> JsxElement {
+    return
+        <NavigationMenuPrimitive.Indicator
+            {**props}
+            data-slot="navigation-menu-indicator"
+            className={cn(
+                "cn-navigation-menu-indicator top-full z-1 flex h-1.5 items-end justify-center overflow-hidden",
+                props["className"]
+            )}
+        >
             <div
-                className="cn-navigation-menu-viewport-wrapper absolute top-full left-0 isolate z-50 flex justify-center"
-            >
-                <NavigationMenuPrimitive.Viewport
-                    {**props}
-                    data-slot="navigation-menu-viewport"
-                    className={cn(
-                        "cn-navigation-menu-viewport origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden md:w-(--radix-navigation-menu-viewport-width)",
-                        props["className"]
-                    )}
-                />
-            </div>;
-    }
+                className="cn-navigation-menu-indicator-arrow relative top-[60%] size-2 rotate-45"
+            />
+        </NavigationMenuPrimitive.Indicator>;
+}
 
-    def:pub NavigationMenuLink(props: any) -> JsxElement {
-        return
-            <NavigationMenuPrimitive.Link
-                {**props}
-                data-slot="navigation-menu-link"
-                className={cn("cn-navigation-menu-link", props["className"])}
-            />;
-    }
-
-    def:pub NavigationMenuIndicator(props: any) -> JsxElement {
-        return
-            <NavigationMenuPrimitive.Indicator
-                {**props}
-                data-slot="navigation-menu-indicator"
-                className={cn(
-                    "cn-navigation-menu-indicator top-full z-1 flex h-1.5 items-end justify-center overflow-hidden",
-                    props["className"]
-                )}
-            >
-                <div
-                    className="cn-navigation-menu-indicator-arrow relative top-[60%] size-2 rotate-45"
-                />
-            </NavigationMenuPrimitive.Indicator>;
-    }
-
-    def:pub navigationMenuTriggerStyle -> any {
-        return _navigationMenuTriggerStyle.call(None, {});
-    }
+def:pub navigationMenuTriggerStyle -> any {
+    return _navigationMenuTriggerStyle.call(None, {});
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/otp-input.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/otp-input.cl.jac
@@ -1,80 +1,76 @@
-cl import from "input-otp" { OTPInput, OTPInputContext }
-cl import from react { useContext }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { MinusSignIcon }
-cl import from ...lib.utils { cn }
+import from "input-otp" { OTPInput, OTPInputContext }
+import from react { useContext }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { MinusSignIcon }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub InputOTP(props: any) -> JsxElement {
-        return
-            <OTPInput
-                data-slot="input-otp"
-                {**props}
-                containerClassName={cn(
-                    "cn-input-otp flex items-center has-disabled:opacity-50",
-                    props["containerClassName"]
-                )}
-                spellCheck={false}
-                className={cn(
-                    "cn-input-otp-input disabled:cursor-not-allowed", props["className"]
-                )}
-            />;
-    }
+def:pub InputOTP(props: any) -> JsxElement {
+    return
+        <OTPInput
+            data-slot="input-otp"
+            {**props}
+            containerClassName={cn(
+                "cn-input-otp flex items-center has-disabled:opacity-50",
+                props["containerClassName"]
+            )}
+            spellCheck={false}
+            className={cn(
+                "cn-input-otp-input disabled:cursor-not-allowed", props["className"]
+            )}
+        />;
+}
 
-    def:pub InputOTPGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="input-otp-group"
-                {**attrs}
-                className={cn(
-                    "cn-input-otp-group flex items-center", props["className"]
-                )}
-            />;
-    }
+def:pub InputOTPGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="input-otp-group"
+            {**attrs}
+            className={cn("cn-input-otp-group flex items-center", props["className"])}
+        />;
+}
 
-    def:pub InputOTPSlot(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        index = props["index"];
-        ctx: any = useContext(OTPInputContext);
-        slotData: any = None;
-        if ctx and ctx.slots {
-            slotData = ctx.slots[index];
-        }
-        char = slotData.char if slotData else None;
-        hasFakeCaret = slotData.hasFakeCaret if slotData else False;
-        isActive = slotData.isActive if slotData else False;
-        return
-            <div
-                data-slot="input-otp-slot"
-                data-active={isActive}
-                {**attrs}
-                className={cn(
-                    "cn-input-otp-slot relative flex items-center justify-center data-[active=true]:z-10",
-                    props["className"]
-                )}
-            >
-                {char}{hasFakeCaret
-                and (
-                    <div
-                        className="cn-input-otp-caret pointer-events-none absolute inset-0 flex items-center justify-center"
-                    >
-                        <div className="cn-input-otp-caret-line"/>
-                    </div>
-                )}
-            </div>;
+def:pub InputOTPSlot(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    index = props["index"];
+    ctx: any = useContext(OTPInputContext);
+    slotData: any = None;
+    if ctx and ctx.slots {
+        slotData = ctx.slots[index];
     }
+    char = slotData.char if slotData else None;
+    hasFakeCaret = slotData.hasFakeCaret if slotData else False;
+    isActive = slotData.isActive if slotData else False;
+    return
+        <div
+            data-slot="input-otp-slot"
+            data-active={isActive}
+            {**attrs}
+            className={cn(
+                "cn-input-otp-slot relative flex items-center justify-center data-[active=true]:z-10",
+                props["className"]
+            )}
+        >
+            {char}{hasFakeCaret
+            and (
+                <div
+                    className="cn-input-otp-caret pointer-events-none absolute inset-0 flex items-center justify-center"
+                >
+                    <div className="cn-input-otp-caret-line"/>
+                </div>
+            )}
+        </div>;
+}
 
-    def:pub InputOTPSeparator(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="input-otp-separator"
-                {**attrs}
-                className="cn-input-otp-separator flex items-center"
-                role="separator"
-            >
-                <HugeiconsIcon icon={MinusSignIcon} size={16}/>
-            </div>;
-    }
+def:pub InputOTPSeparator(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="input-otp-separator"
+            {**attrs}
+            className="cn-input-otp-separator flex items-center"
+            role="separator"
+        >
+            <HugeiconsIcon icon={MinusSignIcon} size={16}/>
+        </div>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/pagination.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/pagination.cl.jac
@@ -1,121 +1,116 @@
-cl import from ...lib.utils { cn }
-cl import from ".button" { Button, buttonVariants }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" {
+import from ...lib.utils { cn }
+import from ".button" { Button, buttonVariants }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" {
     ArrowLeft01Icon,
     ArrowRight01Icon,
     MoreHorizontalCircle01Icon
 }
 
-cl {
-    def:pub Pagination(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <nav
-                {**attrs}
-                role="navigation"
-                aria-label="pagination"
-                data-slot="pagination"
-                className={cn(
-                    "cn-pagination mx-auto flex w-full justify-center",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Pagination(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <nav
+            {**attrs}
+            role="navigation"
+            aria-label="pagination"
+            data-slot="pagination"
+            className={cn(
+                "cn-pagination mx-auto flex w-full justify-center", props["className"]
+            )}
+        />;
+}
 
-    def:pub PaginationContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <ul
-                {**attrs}
-                data-slot="pagination-content"
-                className={cn(
-                    "cn-pagination-content flex items-center", props["className"]
-                )}
-            />;
-    }
+def:pub PaginationContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <ul
+            {**attrs}
+            data-slot="pagination-content"
+            className={cn(
+                "cn-pagination-content flex items-center", props["className"]
+            )}
+        />;
+}
 
-    def:pub PaginationItem(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return <li data-slot="pagination-item" {**attrs}/>;
-    }
+def:pub PaginationItem(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return <li data-slot="pagination-item" {**attrs}/>;
+}
 
-    def:pub PaginationLink(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        isActive = props["isActive"] or False;
-        size = props["size"] or "icon";
-        variantsFn: any = buttonVariants();
-        computedClass = cn(
-            variantsFn.call(
-                None, {"variant": isActive and "outline" or "ghost", "size": size}
-            ),
-            "cn-pagination-link",
-            props["className"]
-        );
-        return
-            <a
-                {**attrs}
-                aria-current={isActive and "page" or None}
-                data-slot="pagination-link"
-                data-active={isActive}
-                className={computedClass}
-            />;
-    }
+def:pub PaginationLink(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    isActive = props["isActive"] or False;
+    size = props["size"] or "icon";
+    variantsFn: any = buttonVariants();
+    computedClass = cn(
+        variantsFn.call(
+            None, {"variant": isActive and "outline" or "ghost", "size": size}
+        ),
+        "cn-pagination-link",
+        props["className"]
+    );
+    return
+        <a
+            {**attrs}
+            aria-current={isActive and "page" or None}
+            data-slot="pagination-link"
+            data-active={isActive}
+            className={computedClass}
+        />;
+}
 
-    def:pub PaginationPrevious(props: any) -> JsxElement {
-        text = props["text"] or "Previous";
-        return
-            <PaginationLink
-                {**props}
-                aria-label="Go to previous page"
-                size="default"
-                className={cn("cn-pagination-previous", props["className"])}
-            >
-                <HugeiconsIcon
-                    icon={ArrowLeft01Icon}
-                    strokeWidth={2}
-                    data-icon="inline-start"
-                    className="cn-rtl-flip"
-                />
-                <span className="cn-pagination-previous-text hidden sm:block">
-                    {text}
-                </span>
-            </PaginationLink>;
-    }
+def:pub PaginationPrevious(props: any) -> JsxElement {
+    text = props["text"] or "Previous";
+    return
+        <PaginationLink
+            {**props}
+            aria-label="Go to previous page"
+            size="default"
+            className={cn("cn-pagination-previous", props["className"])}
+        >
+            <HugeiconsIcon
+                icon={ArrowLeft01Icon}
+                strokeWidth={2}
+                data-icon="inline-start"
+                className="cn-rtl-flip"
+            />
+            <span className="cn-pagination-previous-text hidden sm:block">{text}</span>
+        </PaginationLink>;
+}
 
-    def:pub PaginationNext(props: any) -> JsxElement {
-        text = props["text"] or "Next";
-        return
-            <PaginationLink
-                {**props}
-                aria-label="Go to next page"
-                size="default"
-                className={cn("cn-pagination-next", props["className"])}
-            >
-                <span className="cn-pagination-next-text hidden sm:block">{text}</span>
-                <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    strokeWidth={2}
-                    data-icon="inline-end"
-                    className="cn-rtl-flip"
-                />
-            </PaginationLink>;
-    }
+def:pub PaginationNext(props: any) -> JsxElement {
+    text = props["text"] or "Next";
+    return
+        <PaginationLink
+            {**props}
+            aria-label="Go to next page"
+            size="default"
+            className={cn("cn-pagination-next", props["className"])}
+        >
+            <span className="cn-pagination-next-text hidden sm:block">{text}</span>
+            <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                strokeWidth={2}
+                data-icon="inline-end"
+                className="cn-rtl-flip"
+            />
+        </PaginationLink>;
+}
 
-    def:pub PaginationEllipsis(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <span
-                {**attrs}
-                aria-hidden={True}
-                data-slot="pagination-ellipsis"
-                className={cn(
-                    "cn-pagination-ellipsis flex items-center justify-center",
-                    props["className"]
-                )}
-            >
-                <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={2}/>
-                <span className="sr-only">More pages</span>
-            </span>;
-    }
+def:pub PaginationEllipsis(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <span
+            {**attrs}
+            aria-hidden={True}
+            data-slot="pagination-ellipsis"
+            className={cn(
+                "cn-pagination-ellipsis flex items-center justify-center",
+                props["className"]
+            )}
+        >
+            <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={2}/>
+            <span className="sr-only">More pages</span>
+        </span>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/popover.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/popover.cl.jac
@@ -1,64 +1,62 @@
-cl import from "radix-ui" { Popover as PopoverPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Popover as PopoverPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Popover(props: any) -> JsxElement {
-        return <PopoverPrimitive.Root data-slot="popover" {**props}/>;
-    }
+def:pub Popover(props: any) -> JsxElement {
+    return <PopoverPrimitive.Root data-slot="popover" {**props}/>;
+}
 
-    def:pub PopoverTrigger(props: any) -> JsxElement {
-        return <PopoverPrimitive.Trigger data-slot="popover-trigger" {**props}/>;
-    }
+def:pub PopoverTrigger(props: any) -> JsxElement {
+    return <PopoverPrimitive.Trigger data-slot="popover-trigger" {**props}/>;
+}
 
-    def:pub PopoverAnchor(props: any) -> JsxElement {
-        return <PopoverPrimitive.Anchor data-slot="popover-anchor" {**props}/>;
-    }
+def:pub PopoverAnchor(props: any) -> JsxElement {
+    return <PopoverPrimitive.Anchor data-slot="popover-anchor" {**props}/>;
+}
 
-    def:pub PopoverContent(props: any) -> JsxElement {
-        align = props["align"] or "center";
-        sideOffset = props["sideOffset"] or 4;
-        return
-            <PopoverPrimitive.Portal>
-                <PopoverPrimitive.Content
-                    {**props}
-                    data-slot="popover-content"
-                    align={align}
-                    sideOffset={sideOffset}
-                    className={cn(
-                        "cn-popover-content z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
-                        props["className"]
-                    )}
-                />
-            </PopoverPrimitive.Portal>;
-    }
+def:pub PopoverContent(props: any) -> JsxElement {
+    align = props["align"] or "center";
+    sideOffset = props["sideOffset"] or 4;
+    return
+        <PopoverPrimitive.Portal>
+            <PopoverPrimitive.Content
+                {**props}
+                data-slot="popover-content"
+                align={align}
+                sideOffset={sideOffset}
+                className={cn(
+                    "cn-popover-content z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
+                    props["className"]
+                )}
+            />
+        </PopoverPrimitive.Portal>;
+}
 
-    def:pub PopoverHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="popover-header"
-                className={cn("cn-popover-header", props["className"])}
-            />;
-    }
+def:pub PopoverHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="popover-header"
+            className={cn("cn-popover-header", props["className"])}
+        />;
+}
 
-    def:pub PopoverTitle(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="popover-title"
-                className={cn("cn-popover-title", props["className"])}
-            />;
-    }
+def:pub PopoverTitle(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="popover-title"
+            className={cn("cn-popover-title", props["className"])}
+        />;
+}
 
-    def:pub PopoverDescription(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <p
-                {**attrs}
-                data-slot="popover-description"
-                className={cn("cn-popover-description", props["className"])}
-            />;
-    }
+def:pub PopoverDescription(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <p
+            {**attrs}
+            data-slot="popover-description"
+            className={cn("cn-popover-description", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/progress.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/progress.cl.jac
@@ -1,24 +1,22 @@
-cl import from "radix-ui" { Progress as ProgressPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Progress as ProgressPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Progress(props: any) -> JsxElement {
-        value = props["value"] or 0;
-        translateX = 100 - value;
-        return
-            <ProgressPrimitive.Root
-                {**props}
-                data-slot="progress"
-                className={cn(
-                    "cn-progress relative flex w-full items-center overflow-x-hidden",
-                    props["className"]
-                )}
-            >
-                <ProgressPrimitive.Indicator
-                    data-slot="progress-indicator"
-                    className="cn-progress-indicator size-full flex-1 transition-all"
-                    style={{"transform": "translateX(-" + String(translateX) + "%)"}}
-                />
-            </ProgressPrimitive.Root>;
-    }
+def:pub Progress(props: any) -> JsxElement {
+    value = props["value"] or 0;
+    translateX = 100 - value;
+    return
+        <ProgressPrimitive.Root
+            {**props}
+            data-slot="progress"
+            className={cn(
+                "cn-progress relative flex w-full items-center overflow-x-hidden",
+                props["className"]
+            )}
+        >
+            <ProgressPrimitive.Indicator
+                data-slot="progress-indicator"
+                className="cn-progress-indicator size-full flex-1 transition-all"
+                style={{"transform": "translateX(-" + String(translateX) + "%)"}}
+            />
+        </ProgressPrimitive.Root>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/radio-group.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/radio-group.cl.jac
@@ -1,32 +1,30 @@
-cl import from "radix-ui" { RadioGroup as RadioGroupPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { RadioGroup as RadioGroupPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub RadioGroup(props: any) -> JsxElement {
-        return
-            <RadioGroupPrimitive.Root
-                {**props}
-                data-slot="radio-group"
-                className={cn("cn-radio-group w-full", props["className"])}
-            />;
-    }
+def:pub RadioGroup(props: any) -> JsxElement {
+    return
+        <RadioGroupPrimitive.Root
+            {**props}
+            data-slot="radio-group"
+            className={cn("cn-radio-group w-full", props["className"])}
+        />;
+}
 
-    def:pub RadioGroupItem(props: any) -> JsxElement {
-        return
-            <RadioGroupPrimitive.Item
-                {**props}
-                data-slot="radio-group-item"
-                className={cn(
-                    "cn-radio-group-item group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
-                    props["className"]
-                )}
+def:pub RadioGroupItem(props: any) -> JsxElement {
+    return
+        <RadioGroupPrimitive.Item
+            {**props}
+            data-slot="radio-group-item"
+            className={cn(
+                "cn-radio-group-item group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+                props["className"]
+            )}
+        >
+            <RadioGroupPrimitive.Indicator
+                data-slot="radio-group-indicator"
+                className="cn-radio-group-indicator"
             >
-                <RadioGroupPrimitive.Indicator
-                    data-slot="radio-group-indicator"
-                    className="cn-radio-group-indicator"
-                >
-                    <span className="cn-radio-group-indicator-icon"/>
-                </RadioGroupPrimitive.Indicator>
-            </RadioGroupPrimitive.Item>;
-    }
+                <span className="cn-radio-group-indicator-icon"/>
+            </RadioGroupPrimitive.Indicator>
+        </RadioGroupPrimitive.Item>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/resizable.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/resizable.cl.jac
@@ -1,36 +1,34 @@
-cl import from "react-resizable-panels" { PanelGroup, Panel, PanelResizeHandle }
-cl import from ...lib.utils { cn }
+import from "react-resizable-panels" { PanelGroup, Panel, PanelResizeHandle }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub ResizablePanelGroup(props: any) -> JsxElement {
-        return
-            <PanelGroup
-                {**props}
-                data-slot="resizable-panel-group"
-                className={cn(
-                    "cn-resizable-panel-group flex h-full w-full aria-[orientation=vertical]:flex-col",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub ResizablePanelGroup(props: any) -> JsxElement {
+    return
+        <PanelGroup
+            {**props}
+            data-slot="resizable-panel-group"
+            className={cn(
+                "cn-resizable-panel-group flex h-full w-full aria-[orientation=vertical]:flex-col",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub ResizablePanel(props: any) -> JsxElement {
-        return <Panel data-slot="resizable-panel" {**props}/>;
-    }
+def:pub ResizablePanel(props: any) -> JsxElement {
+    return <Panel data-slot="resizable-panel" {**props}/>;
+}
 
-    def:pub ResizableHandle(props: any) -> JsxElement {
-        withHandle = props["withHandle"] or False;
-        return
-            <PanelResizeHandle
-                {**props}
-                data-slot="resizable-handle"
-                className={cn(
-                    "cn-resizable-handle bg-border focus-visible:ring-ring ring-offset-background relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2",
-                    props["className"]
-                )}
-            >
-                {withHandle
-                and <div className="cn-resizable-handle-icon z-10 flex shrink-0"/>}
-            </PanelResizeHandle>;
-    }
+def:pub ResizableHandle(props: any) -> JsxElement {
+    withHandle = props["withHandle"] or False;
+    return
+        <PanelResizeHandle
+            {**props}
+            data-slot="resizable-handle"
+            className={cn(
+                "cn-resizable-handle bg-border focus-visible:ring-ring ring-offset-background relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2",
+                props["className"]
+            )}
+        >
+            {withHandle
+            and <div className="cn-resizable-handle-icon z-10 flex shrink-0"/>}
+        </PanelResizeHandle>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/scroll-area.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/scroll-area.cl.jac
@@ -1,52 +1,50 @@
-cl import from "radix-ui" { ScrollArea as ScrollAreaPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { ScrollArea as ScrollAreaPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub ScrollArea(props: any) -> JsxElement {
-        return
-            <ScrollAreaPrimitive.Root
-                {**props}
-                data-slot="scroll-area"
-                className={cn("cn-scroll-area relative", props["className"])}
+def:pub ScrollArea(props: any) -> JsxElement {
+    return
+        <ScrollAreaPrimitive.Root
+            {**props}
+            data-slot="scroll-area"
+            className={cn("cn-scroll-area relative", props["className"])}
+        >
+            <ScrollAreaPrimitive.Viewport
+                data-slot="scroll-area-viewport"
+                className="cn-scroll-area-viewport focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
             >
-                <ScrollAreaPrimitive.Viewport
-                    data-slot="scroll-area-viewport"
-                    className="cn-scroll-area-viewport focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
-                >
-                    {props["children"]}
-                </ScrollAreaPrimitive.Viewport>
-                <ScrollAreaPrimitive.ScrollAreaScrollbar
-                    data-slot="scroll-area-scrollbar"
-                    data-orientation="vertical"
-                    orientation="vertical"
-                    className="cn-scroll-area-scrollbar flex touch-none pt-px pb-px transition-colors select-none"
-                >
-                    <ScrollAreaPrimitive.ScrollAreaThumb
-                        data-slot="scroll-area-thumb"
-                        className="cn-scroll-area-thumb bg-border relative flex-1"
-                    />
-                </ScrollAreaPrimitive.ScrollAreaScrollbar>
-                <ScrollAreaPrimitive.Corner/>
-            </ScrollAreaPrimitive.Root>;
-    }
-
-    def:pub ScrollBar(props: any) -> JsxElement {
-        orientation = props["orientation"] or "vertical";
-        return
+                {props["children"]}
+            </ScrollAreaPrimitive.Viewport>
             <ScrollAreaPrimitive.ScrollAreaScrollbar
-                {**props}
                 data-slot="scroll-area-scrollbar"
-                data-orientation={orientation}
-                orientation={orientation}
-                className={cn(
-                    "cn-scroll-area-scrollbar flex touch-none pt-px pb-px transition-colors select-none",
-                    props["className"]
-                )}
+                data-orientation="vertical"
+                orientation="vertical"
+                className="cn-scroll-area-scrollbar flex touch-none pt-px pb-px transition-colors select-none"
             >
                 <ScrollAreaPrimitive.ScrollAreaThumb
                     data-slot="scroll-area-thumb"
                     className="cn-scroll-area-thumb bg-border relative flex-1"
                 />
-            </ScrollAreaPrimitive.ScrollAreaScrollbar>;
-    }
+            </ScrollAreaPrimitive.ScrollAreaScrollbar>
+            <ScrollAreaPrimitive.Corner/>
+        </ScrollAreaPrimitive.Root>;
+}
+
+def:pub ScrollBar(props: any) -> JsxElement {
+    orientation = props["orientation"] or "vertical";
+    return
+        <ScrollAreaPrimitive.ScrollAreaScrollbar
+            {**props}
+            data-slot="scroll-area-scrollbar"
+            data-orientation={orientation}
+            orientation={orientation}
+            className={cn(
+                "cn-scroll-area-scrollbar flex touch-none pt-px pb-px transition-colors select-none",
+                props["className"]
+            )}
+        >
+            <ScrollAreaPrimitive.ScrollAreaThumb
+                data-slot="scroll-area-thumb"
+                className="cn-scroll-area-thumb bg-border relative flex-1"
+            />
+        </ScrollAreaPrimitive.ScrollAreaScrollbar>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/select.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/select.cl.jac
@@ -1,168 +1,166 @@
-cl import from "radix-ui" { Select as SelectPrimitive }
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" {
+import from "radix-ui" { Select as SelectPrimitive }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" {
     UnfoldMoreIcon,
     Tick02Icon,
     ArrowUpIcon,
     ArrowDownIcon
 }
 
-cl {
-    def:pub Select(props: any) -> JsxElement {
-        return <SelectPrimitive.Root data-slot="select" {**props}/>;
-    }
+def:pub Select(props: any) -> JsxElement {
+    return <SelectPrimitive.Root data-slot="select" {**props}/>;
+}
 
-    def:pub SelectGroup(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.Group
-                {**props}
-                data-slot="select-group"
-                className={cn("cn-select-group scroll-my-1 p-1", props["className"])}
-            />;
-    }
+def:pub SelectGroup(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.Group
+            {**props}
+            data-slot="select-group"
+            className={cn("cn-select-group scroll-my-1 p-1", props["className"])}
+        />;
+}
 
-    def:pub SelectValue(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.Value
-                data-slot="select-value"
-                className={cn("cn-select-value", props["className"])}
-                {**props}
-            />;
-    }
+def:pub SelectValue(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.Value
+            data-slot="select-value"
+            className={cn("cn-select-value", props["className"])}
+            {**props}
+        />;
+}
 
-    def:pub SelectTrigger(props: any) -> JsxElement {
-        size = props["size"] or "default";
-        return
-            <SelectPrimitive.Trigger
+def:pub SelectTrigger(props: any) -> JsxElement {
+    size = props["size"] or "default";
+    return
+        <SelectPrimitive.Trigger
+            {**props}
+            data-slot="select-trigger"
+            data-size={size}
+            className={cn(
+                "cn-select-trigger border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+            <SelectPrimitive.Icon asChild={True}>
+                <HugeiconsIcon
+                    icon={UnfoldMoreIcon}
+                    strokeWidth={2}
+                    className="text-muted-foreground size-4 pointer-events-none"
+                />
+            </SelectPrimitive.Icon>
+        </SelectPrimitive.Trigger>;
+}
+
+def:pub SelectContent(props: any) -> JsxElement {
+    position = props["position"] or "item-aligned";
+    align = props["align"] or "center";
+    popperClass = "";
+    if position == "popper" {
+        popperClass = "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1";
+    }
+    return
+        <SelectPrimitive.Portal>
+            <SelectPrimitive.Content
                 {**props}
-                data-slot="select-trigger"
-                data-size={size}
+                data-slot="select-content"
+                data-align-trigger={position == "item-aligned"}
                 className={cn(
-                    "cn-select-trigger border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                    "cn-select-content bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
+                    popperClass,
                     props["className"]
                 )}
+                position={position}
+                align={align}
             >
-                {props["children"]}
-                <SelectPrimitive.Icon asChild={True}>
-                    <HugeiconsIcon
-                        icon={UnfoldMoreIcon}
-                        strokeWidth={2}
-                        className="text-muted-foreground size-4 pointer-events-none"
-                    />
-                </SelectPrimitive.Icon>
-            </SelectPrimitive.Trigger>;
-    }
-
-    def:pub SelectContent(props: any) -> JsxElement {
-        position = props["position"] or "item-aligned";
-        align = props["align"] or "center";
-        popperClass = "";
-        if position == "popper" {
-            popperClass = "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1";
-        }
-        return
-            <SelectPrimitive.Portal>
-                <SelectPrimitive.Content
-                    {**props}
-                    data-slot="select-content"
-                    data-align-trigger={position == "item-aligned"}
+                <SelectScrollUpButton/>
+                <SelectPrimitive.Viewport
+                    data-position={position}
                     className={cn(
-                        "cn-select-content bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
-                        popperClass,
-                        props["className"]
+                        "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)"
                     )}
-                    position={position}
-                    align={align}
                 >
-                    <SelectScrollUpButton/>
-                    <SelectPrimitive.Viewport
-                        data-position={position}
-                        className={cn(
-                            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)"
-                        )}
-                    >
-                        {props["children"]}
-                    </SelectPrimitive.Viewport>
-                    <SelectScrollDownButton/>
-                </SelectPrimitive.Content>
-            </SelectPrimitive.Portal>;
-    }
+                    {props["children"]}
+                </SelectPrimitive.Viewport>
+                <SelectScrollDownButton/>
+            </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>;
+}
 
-    def:pub SelectLabel(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.Label
-                {**props}
-                data-slot="select-label"
-                className={cn(
-                    "cn-select-label text-muted-foreground px-1.5 py-1 text-xs",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub SelectLabel(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.Label
+            {**props}
+            data-slot="select-label"
+            className={cn(
+                "cn-select-label text-muted-foreground px-1.5 py-1 text-xs",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub SelectItem(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.Item
-                {**props}
-                data-slot="select-item"
-                className={cn(
-                    "cn-select-item focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    props["className"]
-                )}
+def:pub SelectItem(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.Item
+            {**props}
+            data-slot="select-item"
+            className={cn(
+                "cn-select-item focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                props["className"]
+            )}
+        >
+            <span
+                className="pointer-events-none absolute right-2 flex size-4 items-center justify-center"
             >
-                <span
-                    className="pointer-events-none absolute right-2 flex size-4 items-center justify-center"
-                >
-                    <SelectPrimitive.ItemIndicator>
-                        <HugeiconsIcon
-                            icon={Tick02Icon}
-                            strokeWidth={2}
-                            className="pointer-events-none"
-                        />
-                    </SelectPrimitive.ItemIndicator>
-                </span>
-                <SelectPrimitive.ItemText>{props["children"]}</SelectPrimitive.ItemText>
-            </SelectPrimitive.Item>;
-    }
+                <SelectPrimitive.ItemIndicator>
+                    <HugeiconsIcon
+                        icon={Tick02Icon}
+                        strokeWidth={2}
+                        className="pointer-events-none"
+                    />
+                </SelectPrimitive.ItemIndicator>
+            </span>
+            <SelectPrimitive.ItemText>{props["children"]}</SelectPrimitive.ItemText>
+        </SelectPrimitive.Item>;
+}
 
-    def:pub SelectSeparator(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.Separator
-                {**props}
-                data-slot="select-separator"
-                className={cn(
-                    "cn-select-separator bg-border -mx-1 my-1 h-px pointer-events-none",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub SelectSeparator(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.Separator
+            {**props}
+            data-slot="select-separator"
+            className={cn(
+                "cn-select-separator bg-border -mx-1 my-1 h-px pointer-events-none",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub SelectScrollUpButton(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.ScrollUpButton
-                {**props}
-                data-slot="select-scroll-up-button"
-                className={cn(
-                    "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
-                    props["className"]
-                )}
-            >
-                <HugeiconsIcon icon={ArrowUpIcon} strokeWidth={2}/>
-            </SelectPrimitive.ScrollUpButton>;
-    }
+def:pub SelectScrollUpButton(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.ScrollUpButton
+            {**props}
+            data-slot="select-scroll-up-button"
+            className={cn(
+                "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
+                props["className"]
+            )}
+        >
+            <HugeiconsIcon icon={ArrowUpIcon} strokeWidth={2}/>
+        </SelectPrimitive.ScrollUpButton>;
+}
 
-    def:pub SelectScrollDownButton(props: any) -> JsxElement {
-        return
-            <SelectPrimitive.ScrollDownButton
-                {**props}
-                data-slot="select-scroll-down-button"
-                className={cn(
-                    "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
-                    props["className"]
-                )}
-            >
-                <HugeiconsIcon icon={ArrowDownIcon} strokeWidth={2}/>
-            </SelectPrimitive.ScrollDownButton>;
-    }
+def:pub SelectScrollDownButton(props: any) -> JsxElement {
+    return
+        <SelectPrimitive.ScrollDownButton
+            {**props}
+            data-slot="select-scroll-down-button"
+            className={cn(
+                "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
+                props["className"]
+            )}
+        >
+            <HugeiconsIcon icon={ArrowDownIcon} strokeWidth={2}/>
+        </SelectPrimitive.ScrollDownButton>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/separator.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/separator.cl.jac
@@ -1,23 +1,21 @@
-cl import from "radix-ui" { Separator as SeparatorPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Separator as SeparatorPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Separator(props: any) -> JsxElement {
-        orientation = props["orientation"] or "horizontal";
-        decorative = props["decorative"];
-        if decorative is None {
-            decorative = True;
-        }
-        return
-            <SeparatorPrimitive.Root
-                {**props}
-                data-slot="separator"
-                decorative={decorative}
-                orientation={orientation}
-                className={cn(
-                    "bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
-                    props["className"]
-                )}
-            />;
+def:pub Separator(props: any) -> JsxElement {
+    orientation = props["orientation"] or "horizontal";
+    decorative = props["decorative"];
+    if decorative is None {
+        decorative = True;
     }
+    return
+        <SeparatorPrimitive.Root
+            {**props}
+            data-slot="separator"
+            decorative={decorative}
+            orientation={orientation}
+            className={cn(
+                "bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/sheet.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/sheet.cl.jac
@@ -1,104 +1,94 @@
-cl import from "radix-ui" { Dialog as SheetPrimitive }
-cl import from ...lib.utils { cn }
-cl import from ".button" { Button }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Cancel01Icon }
+import from "radix-ui" { Dialog as SheetPrimitive }
+import from ...lib.utils { cn }
+import from ".button" { Button }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Cancel01Icon }
 
-cl {
-    def:pub Sheet(props: any) -> JsxElement {
-        return <SheetPrimitive.Root data-slot="sheet" {**props}/>;
+def:pub Sheet(props: any) -> JsxElement {
+    return <SheetPrimitive.Root data-slot="sheet" {**props}/>;
+}
+
+def:pub SheetTrigger(props: any) -> JsxElement {
+    return <SheetPrimitive.Trigger data-slot="sheet-trigger" {**props}/>;
+}
+
+def:pub SheetClose(props: any) -> JsxElement {
+    return <SheetPrimitive.Close data-slot="sheet-close" {**props}/>;
+}
+
+def:pub SheetPortal(props: any) -> JsxElement {
+    return <SheetPrimitive.Portal data-slot="sheet-portal" {**props}/>;
+}
+
+def:pub SheetOverlay(props: any) -> JsxElement {
+    return
+        <SheetPrimitive.Overlay
+            {**props}
+            data-slot="sheet-overlay"
+            className={cn("cn-sheet-overlay fixed inset-0 z-50", props["className"])}
+        />;
+}
+
+def:pub SheetContent(props: any) -> JsxElement {
+    side = props["side"] or "right";
+    showCloseButton = props["showCloseButton"];
+    if showCloseButton is None {
+        showCloseButton = True;
     }
-
-    def:pub SheetTrigger(props: any) -> JsxElement {
-        return <SheetPrimitive.Trigger data-slot="sheet-trigger" {**props}/>;
-    }
-
-    def:pub SheetClose(props: any) -> JsxElement {
-        return <SheetPrimitive.Close data-slot="sheet-close" {**props}/>;
-    }
-
-    def:pub SheetPortal(props: any) -> JsxElement {
-        return <SheetPrimitive.Portal data-slot="sheet-portal" {**props}/>;
-    }
-
-    def:pub SheetOverlay(props: any) -> JsxElement {
-        return
-            <SheetPrimitive.Overlay
+    return
+        <SheetPortal>
+            <SheetOverlay/>
+            <SheetPrimitive.Content
                 {**props}
-                data-slot="sheet-overlay"
-                className={cn(
-                    "cn-sheet-overlay fixed inset-0 z-50", props["className"]
-                )}
-            />;
-    }
+                data-slot="sheet-content"
+                data-side={side}
+                className={cn("cn-sheet-content", props["className"])}
+            >
+                {props["children"]}{showCloseButton
+                and <SheetPrimitive.Close data-slot="sheet-close" asChild={True}>
+                    <Button variant="ghost" className="cn-sheet-close" size="icon-sm">
+                        <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2}/>
+                        <span className="sr-only">Close</span>
+                    </Button>
+                </SheetPrimitive.Close>}
+            </SheetPrimitive.Content>
+        </SheetPortal>;
+}
 
-    def:pub SheetContent(props: any) -> JsxElement {
-        side = props["side"] or "right";
-        showCloseButton = props["showCloseButton"];
-        if showCloseButton is None {
-            showCloseButton = True;
-        }
-        return
-            <SheetPortal>
-                <SheetOverlay/>
-                <SheetPrimitive.Content
-                    {**props}
-                    data-slot="sheet-content"
-                    data-side={side}
-                    className={cn("cn-sheet-content", props["className"])}
-                >
-                    {props["children"]}{showCloseButton
-                    and <SheetPrimitive.Close data-slot="sheet-close" asChild={True}>
-                        <Button
-                            variant="ghost"
-                            className="cn-sheet-close"
-                            size="icon-sm"
-                        >
-                            <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2}/>
-                            <span className="sr-only">Close</span>
-                        </Button>
-                    </SheetPrimitive.Close>}
-                </SheetPrimitive.Content>
-            </SheetPortal>;
-    }
+def:pub SheetHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="sheet-header"
+            className={cn("cn-sheet-header flex flex-col", props["className"])}
+        />;
+}
 
-    def:pub SheetHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="sheet-header"
-                className={cn("cn-sheet-header flex flex-col", props["className"])}
-            />;
-    }
+def:pub SheetFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="sheet-footer"
+            className={cn("cn-sheet-footer mt-auto flex flex-col", props["className"])}
+        />;
+}
 
-    def:pub SheetFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="sheet-footer"
-                className={cn(
-                    "cn-sheet-footer mt-auto flex flex-col", props["className"]
-                )}
-            />;
-    }
+def:pub SheetTitle(props: any) -> JsxElement {
+    return
+        <SheetPrimitive.Title
+            {**props}
+            data-slot="sheet-title"
+            className={cn("cn-sheet-title", props["className"])}
+        />;
+}
 
-    def:pub SheetTitle(props: any) -> JsxElement {
-        return
-            <SheetPrimitive.Title
-                {**props}
-                data-slot="sheet-title"
-                className={cn("cn-sheet-title", props["className"])}
-            />;
-    }
-
-    def:pub SheetDescription(props: any) -> JsxElement {
-        return
-            <SheetPrimitive.Description
-                {**props}
-                data-slot="sheet-description"
-                className={cn("cn-sheet-description", props["className"])}
-            />;
-    }
+def:pub SheetDescription(props: any) -> JsxElement {
+    return
+        <SheetPrimitive.Description
+            {**props}
+            data-slot="sheet-description"
+            className={cn("cn-sheet-description", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/sidebar.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/sidebar.cl.jac
@@ -1,15 +1,15 @@
-cl import from react { useState, useEffect, useCallback, createContext, useContext }
-cl import from "class-variance-authority" { cva }
-cl import from "@radix-ui/react-slot" { Slot }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { SidebarLeftIcon }
-cl import from .button { Button }
-cl import from .input { Input }
-cl import from .separator { Separator }
-cl import from .sheet { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle }
-cl import from .skeleton { Skeleton }
-cl import from .tooltip { Tooltip, TooltipContent, TooltipTrigger }
-cl import from ...lib.utils { cn }
+import from react { useState, useEffect, useCallback, createContext, useContext }
+import from "class-variance-authority" { cva }
+import from "@radix-ui/react-slot" { Slot }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { SidebarLeftIcon }
+import from .button { Button }
+import from .input { Input }
+import from .separator { Separator }
+import from .sheet { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle }
+import from .skeleton { Skeleton }
+import from .tooltip { Tooltip, TooltipContent, TooltipTrigger }
+import from ...lib.utils { cn }
 
 glob SIDEBAR_COOKIE_NAME: str = "sidebar_state",
      SIDEBAR_COOKIE_MAX_AGE: int = 604800,
@@ -36,545 +36,536 @@ glob SIDEBAR_COOKIE_NAME: str = "sidebar_state",
          }
      );
 
-cl {
-    def useIsMobile -> any {
-        isMobileState = useState(False);
-        isMobile = isMobileState[0];
-        setIsMobile = isMobileState[1];
-        useEffect(
-            lambda -> any {
-                mql: any = window.matchMedia("(max-width: 767px)");
-                onChange = lambda -> any {
-                    setIsMobile(window.innerWidth < 768);
-                    return None;
-                };
-                mql.addEventListener("change", onChange);
+def useIsMobile -> any {
+    isMobileState = useState(False);
+    isMobile = isMobileState[0];
+    setIsMobile = isMobileState[1];
+    useEffect(
+        lambda -> any {
+            mql: any = window.matchMedia("(max-width: 767px)");
+            onChange = lambda -> any {
                 setIsMobile(window.innerWidth < 768);
-                return lambda -> any {
-                    mql.removeEventListener("change", onChange);
-                    return None;
-                };
-            },
-            []
-        );
-        return isMobile;
-    }
+                return None;
+            };
+            mql.addEventListener("change", onChange);
+            setIsMobile(window.innerWidth < 768);
+            return lambda -> any {
+                mql.removeEventListener("change", onChange);
+                return None;
+            };
+        },
+        []
+    );
+    return isMobile;
+}
 
-    def:pub useSidebar -> any {
-        ctx: any = useContext(SidebarContext);
-        return ctx;
-    }
+def:pub useSidebar -> any {
+    ctx: any = useContext(SidebarContext);
+    return ctx;
+}
 
-    def:pub SidebarProvider(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        defaultOpen = props["defaultOpen"] or True;
-        openProp = props["open"];
-        setOpenProp = props["onOpenChange"];
-        isMobile = useIsMobile();
-        openMobileState = useState(False);
-        openMobile = openMobileState[0];
-        setOpenMobile = openMobileState[1];
-        openState = useState(defaultOpen);
-        _open = openState[0];
-        _setOpen = openState[1];
-        open = openProp or _open;
-        setOpen = useCallback(
-            lambda (value: any) -> any {
-                nextState = value(open) if callable(value) else value;
-                if setOpenProp {
-                    setOpenProp(nextState);
-                } else {
-                    _setOpen(nextState);
-                }
-                document.cookie = f"{SIDEBAR_COOKIE_NAME}={nextState}; path=/; max-age={SIDEBAR_COOKIE_MAX_AGE}";  # jac:ignore[W6001]
-            },
-            [setOpenProp, open]
-        );
-        toggleSidebar = useCallback(
-            lambda -> any {
-                isMobile
-                and setOpenMobile(lambda (prev: any) -> any { return not prev; });
-                isMobile or setOpen(lambda (prev: any) -> any { return not prev; });
-            },
-            [isMobile, setOpen, setOpenMobile]
-        );
-        useEffect(
-            lambda -> any {
-                handleKeyDown = lambda (event: any) -> any { if event.key == SIDEBAR_KEYBOARD_SHORTCUT
-                and (event.metaKey or event.ctrlKey) {
-                    event.preventDefault();
-                    toggleSidebar();
-                }};
-                window.addEventListener("keydown", handleKeyDown);
-                return lambda -> any { window.removeEventListener(
-                    "keydown", handleKeyDown
-                ); };
-            },
-            [toggleSidebar]
-        );
-        state = "expanded" if open else "collapsed";
-        ctxValue = {
-            state: state,
-            open: open,
-            setOpen: setOpen,
-            isMobile: isMobile,
-            openMobile: openMobile,
-            setOpenMobile: setOpenMobile,
-            toggleSidebar: toggleSidebar
-        };
-        mergedStyle = {
-            "--sidebar-width": SIDEBAR_WIDTH,
-            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON
-        };
+def:pub SidebarProvider(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    defaultOpen = props["defaultOpen"] or True;
+    openProp = props["open"];
+    setOpenProp = props["onOpenChange"];
+    isMobile = useIsMobile();
+    openMobileState = useState(False);
+    openMobile = openMobileState[0];
+    setOpenMobile = openMobileState[1];
+    openState = useState(defaultOpen);
+    _open = openState[0];
+    _setOpen = openState[1];
+    open = openProp or _open;
+    setOpen = useCallback(
+        lambda (value: any) -> any {
+            nextState = value(open) if callable(value) else value;
+            if setOpenProp {
+                setOpenProp(nextState);
+            } else {
+                _setOpen(nextState);
+            }
+            document.cookie = f"{SIDEBAR_COOKIE_NAME}={nextState}; path=/; max-age={SIDEBAR_COOKIE_MAX_AGE}";  # jac:ignore[W6001]
+        },
+        [setOpenProp, open]
+    );
+    toggleSidebar = useCallback(
+        lambda -> any {
+            isMobile and setOpenMobile(lambda (prev: any) -> any { return not prev; });
+            isMobile or setOpen(lambda (prev: any) -> any { return not prev; });
+        },
+        [isMobile, setOpen, setOpenMobile]
+    );
+    useEffect(
+        lambda -> any {
+            handleKeyDown = lambda (event: any) -> any { if event.key == SIDEBAR_KEYBOARD_SHORTCUT
+            and (event.metaKey or event.ctrlKey) {
+                event.preventDefault();
+                toggleSidebar();
+            }};
+            window.addEventListener("keydown", handleKeyDown);
+            return lambda -> any { window.removeEventListener(
+                "keydown", handleKeyDown
+            ); };
+        },
+        [toggleSidebar]
+    );
+    state = "expanded" if open else "collapsed";
+    ctxValue = {
+        state: state,
+        open: open,
+        setOpen: setOpen,
+        isMobile: isMobile,
+        openMobile: openMobile,
+        setOpenMobile: setOpenMobile,
+        toggleSidebar: toggleSidebar
+    };
+    mergedStyle = {
+        "--sidebar-width": SIDEBAR_WIDTH,
+        "--sidebar-width-icon": SIDEBAR_WIDTH_ICON
+    };
+    return
+        <SidebarContext.Provider value={ctxValue}>
+            <div
+                data-slot="sidebar-wrapper"
+                style={mergedStyle}
+                className={cn(
+                    "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+                    props["className"]
+                )}
+                {**attrs}
+            >
+                {props["children"]}
+            </div>
+        </SidebarContext.Provider>;
+}
+
+def:pub Sidebar(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    side = props["side"] or "left";
+    variant = props["variant"] or "sidebar";
+    collapsible = props["collapsible"] or "offcanvas";
+    ctx: any = useContext(SidebarContext);
+    isMobile = ctx.isMobile if ctx else False;
+    state = ctx.state if ctx else "expanded";
+    openMobile = ctx.openMobile if ctx else False;
+    setOpenMobile = ctx.setOpenMobile if ctx else None;
+    isFloating = variant == "floating" or variant == "inset";
+    containerClass = "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+        if isFloating
+        else "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l";
+    if collapsible == "none" {
         return
-            <SidebarContext.Provider value={ctxValue}>
-                <div
-                    data-slot="sidebar-wrapper"
-                    style={mergedStyle}
-                    className={cn(
-                        "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
-                        props["className"]
-                    )}
-                    {**attrs}
-                >
-                    {props["children"]}
-                </div>
-            </SidebarContext.Provider>;
-    }
-
-    def:pub Sidebar(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        side = props["side"] or "left";
-        variant = props["variant"] or "sidebar";
-        collapsible = props["collapsible"] or "offcanvas";
-        ctx: any = useContext(SidebarContext);
-        isMobile = ctx.isMobile if ctx else False;
-        state = ctx.state if ctx else "expanded";
-        openMobile = ctx.openMobile if ctx else False;
-        setOpenMobile = ctx.setOpenMobile if ctx else None;
-        isFloating = variant == "floating" or variant == "inset";
-        containerClass = "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-            if isFloating
-            else "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l";
-        if collapsible == "none" {
-            return
-                <div
+            <div
+                data-slot="sidebar"
+                className={cn(
+                    "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+                    props["className"]
+                )}
+                {**attrs}
+            >
+                {props["children"]}
+            </div>;
+    } elif isMobile {
+        mobileStyle = {"--sidebar-width": SIDEBAR_WIDTH_MOBILE};
+        return
+            <Sheet open={openMobile} onOpenChange={setOpenMobile} {**props}>
+                <SheetContent
+                    dir={props["dir"]}
+                    data-sidebar="sidebar"
                     data-slot="sidebar"
-                    className={cn(
-                        "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
-                        props["className"]
-                    )}
-                    {**attrs}
+                    data-mobile="true"
+                    className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+                    style={mobileStyle}
+                    side={side}
                 >
-                    {props["children"]}
-                </div>;
-        } elif isMobile {
-            mobileStyle = {"--sidebar-width": SIDEBAR_WIDTH_MOBILE};
-            return
-                <Sheet open={openMobile} onOpenChange={setOpenMobile} {**props}>
-                    <SheetContent
-                        dir={props["dir"]}
-                        data-sidebar="sidebar"
-                        data-slot="sidebar"
-                        data-mobile="true"
-                        className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
-                        style={mobileStyle}
-                        side={side}
-                    >
-                        <SheetHeader className="sr-only">
-                            <SheetTitle>Sidebar</SheetTitle>
-                            <SheetDescription>
-                                Displays the mobile sidebar.
-                            </SheetDescription>
-                        </SheetHeader>
-                        <div className="flex h-full w-full flex-col">
-                            {props["children"]}
-                        </div>
-                    </SheetContent>
-                </Sheet>;
-        } else {
-            return
-                <div
-                    className="group peer text-sidebar-foreground hidden md:block"
-                    data-state={state}
-                    data-collapsible={collapsible if state == "collapsed" else ""}
-                    data-variant={variant}
-                    data-side={side}
-                    data-slot="sidebar"
-                >
-                    <div
-                        data-slot="sidebar-gap"
-                        className={cn(
-                            "cn-sidebar-gap relative w-(--sidebar-width) bg-transparent",
-                            "group-data-[collapsible=offcanvas]:w-0",
-                            "group-data-[side=right]:rotate-180",
-                            "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
-                                if isFloating
-                                else "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
-                        )}
-                    />
-                    <div
-                        data-slot="sidebar-container"
-                        data-side={side}
-                        className={cn(
-                            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
-                            containerClass,
-                            props["className"]
-                        )}
-                        {**attrs}
-                    >
-                        <div
-                            data-sidebar="sidebar"
-                            data-slot="sidebar-inner"
-                            className="cn-sidebar-inner flex size-full flex-col"
-                        >
-                            {props["children"]}
-                        </div>
+                    <SheetHeader className="sr-only">
+                        <SheetTitle>Sidebar</SheetTitle>
+                        <SheetDescription>
+                            Displays the mobile sidebar.
+                        </SheetDescription>
+                    </SheetHeader>
+                    <div className="flex h-full w-full flex-col">
+                        {props["children"]}
                     </div>
-                </div>;
-        }
-    }
-
-    def:pub SidebarTrigger(props: any) -> JsxElement {
-        ctx: any = useContext(SidebarContext);
-        toggleSidebar: any = ctx.toggleSidebar if ctx else None;
-        handleClick = lambda (event: any) -> any {
-            props["onClick"] and props["onClick"](event);
-            toggleSidebar and toggleSidebar();
-        };
+                </SheetContent>
+            </Sheet>;
+    } else {
         return
-            <Button
-                data-sidebar="trigger"
-                data-slot="sidebar-trigger"
-                variant="ghost"
-                size="icon-sm"
-                className={cn("cn-sidebar-trigger", props["className"])}
-                onClick={handleClick}
-                {**props}
+            <div
+                className="group peer text-sidebar-foreground hidden md:block"
+                data-state={state}
+                data-collapsible={collapsible if state == "collapsed" else ""}
+                data-variant={variant}
+                data-side={side}
+                data-slot="sidebar"
             >
-                <HugeiconsIcon
-                    icon={SidebarLeftIcon}
-                    className="cn-rtl-flip"
-                    size={16}
+                <div
+                    data-slot="sidebar-gap"
+                    className={cn(
+                        "cn-sidebar-gap relative w-(--sidebar-width) bg-transparent",
+                        "group-data-[collapsible=offcanvas]:w-0",
+                        "group-data-[side=right]:rotate-180",
+                        "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+                            if isFloating
+                            else "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+                    )}
                 />
-                <span className="sr-only">Toggle Sidebar</span>
-            </Button>;
-    }
-
-    def:pub SidebarRail(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        ctx: any = useContext(SidebarContext);
-        toggleSidebar: any = ctx.toggleSidebar if ctx else None;
-        return
-            <button
-                data-sidebar="rail"
-                data-slot="sidebar-rail"
-                aria-label="Toggle Sidebar"
-                tabIndex={-1}
-                onClick={toggleSidebar}
-                title="Toggle Sidebar"
-                className={cn(
-                    "cn-sidebar-rail absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex",
-                    props["className"]
-                )}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarInset(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <main
-                data-slot="sidebar-inset"
-                className={cn(
-                    "cn-sidebar-inset relative flex w-full flex-1 flex-col",
-                    props["className"]
-                )}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarInput(props: any) -> JsxElement {
-        return
-            <Input
-                data-slot="sidebar-input"
-                data-sidebar="input"
-                className={cn("cn-sidebar-input", props["className"])}
-                {**props}
-            />;
-    }
-
-    def:pub SidebarHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="sidebar-header"
-                data-sidebar="header"
-                className={cn("cn-sidebar-header flex flex-col", props["className"])}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="sidebar-footer"
-                data-sidebar="footer"
-                className={cn("cn-sidebar-footer flex flex-col", props["className"])}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarSeparator(props: any) -> JsxElement {
-        return
-            <Separator
-                data-slot="sidebar-separator"
-                data-sidebar="separator"
-                className={cn("cn-sidebar-separator w-auto", props["className"])}
-                {**props}
-            />;
-    }
-
-    def:pub SidebarContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="sidebar-content"
-                data-sidebar="content"
-                className={cn(
-                    "cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
-                    props["className"]
-                )}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarGroup(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="sidebar-group"
-                data-sidebar="group"
-                className={cn(
-                    "cn-sidebar-group relative flex w-full min-w-0 flex-col",
-                    props["className"]
-                )}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarGroupLabel(props: any) -> JsxElement {
-        asChild = props["asChild"] or False;
-        Comp = Slot if asChild else "div";
-        return
-            <Comp
-                data-slot="sidebar-group-label"
-                data-sidebar="group-label"
-                className={cn(
-                    "cn-sidebar-group-label flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
-                    props["className"]
-                )}
-                {**props}
-            />;
-    }
-
-    def:pub SidebarGroupAction(props: any) -> JsxElement {
-        asChild = props["asChild"] or False;
-        Comp = Slot if asChild else "button";
-        return
-            <Comp
-                data-slot="sidebar-group-action"
-                data-sidebar="group-action"
-                className={cn(
-                    "cn-sidebar-group-action flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden [&>svg]:shrink-0",
-                    props["className"]
-                )}
-                {**props}
-            />;
-    }
-
-    def:pub SidebarGroupContent(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="sidebar-group-content"
-                data-sidebar="group-content"
-                className={cn("cn-sidebar-group-content w-full", props["className"])}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarMenu(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <ul
-                data-slot="sidebar-menu"
-                data-sidebar="menu"
-                className={cn(
-                    "cn-sidebar-menu flex w-full min-w-0 flex-col", props["className"]
-                )}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarMenuItem(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <li
-                data-slot="sidebar-menu-item"
-                data-sidebar="menu-item"
-                className={cn("group/menu-item relative", props["className"])}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarMenuButton(props: any) -> JsxElement {
-        asChild = props["asChild"] or False;
-        isActive = props["isActive"] or False;
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        tooltip = props["tooltip"];
-        ctx: any = useContext(SidebarContext);
-        isMobile = ctx.isMobile if ctx else False;
-        state = ctx.state if ctx else "expanded";
-        Comp = Slot if asChild else "button";
-        btnClass = _sidebarMenuButtonVariants.call(
-            None, {variant: variant, size: size}
-        );
-        button = <Comp
-            data-slot="sidebar-menu-button"
-            data-sidebar="menu-button"
-            data-size={size}
-            data-active={isActive}
-            className={cn(btnClass, props["className"])}
-            {**props}
-        />;
-        if not tooltip {
-            return button;
-        }
-        tooltipProps = {"children": tooltip} if isinstance(tooltip, str) else tooltip;
-        isHidden = state != "collapsed" or isMobile;
-        return
-            <Tooltip>
-                <TooltipTrigger asChild={True}>{button}</TooltipTrigger>
-                <TooltipContent
-                    side="right"
-                    align="center"
-                    hidden={isHidden}
-                    {**tooltipProps}
-                />
-            </Tooltip>;
-    }
-
-    def:pub SidebarMenuAction(props: any) -> JsxElement {
-        asChild = props["asChild"] or False;
-        showOnHover = props["showOnHover"] or False;
-        Comp = Slot if asChild else "button";
-        hoverClass = "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 aria-expanded:opacity-100 md:opacity-0"
-            if showOnHover
-            else "";
-        return
-            <Comp
-                data-slot="sidebar-menu-action"
-                data-sidebar="menu-action"
-                className={cn(
-                    "cn-sidebar-menu-action flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden [&>svg]:shrink-0",
-                    hoverClass,
-                    props["className"]
-                )}
-                {**props}
-            />;
-    }
-
-    def:pub SidebarMenuBadge(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                data-slot="sidebar-menu-badge"
-                data-sidebar="menu-badge"
-                className={cn(
-                    "cn-sidebar-menu-badge flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden",
-                    props["className"]
-                )}
-                {**attrs}
-            />;
-    }
-
-    def:pub SidebarMenuSkeleton(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        showIcon = props["showIcon"] or False;
-        widthState = useState(
-            lambda -> any { return f"{int(
-                Math.random() * 40 + 50
-            )}%"; }  # jac:ignore[W6001]
-        );
-        width = widthState[0];
-        skeletonStyle = {"--skeleton-width": width};
-        return
-            <div
-                data-slot="sidebar-menu-skeleton"
-                data-sidebar="menu-skeleton"
-                className={cn(
-                    "cn-sidebar-menu-skeleton flex items-center", props["className"]
-                )}
-                {**attrs}
-            >
-                {showIcon
-                and (
-                    <Skeleton
-                        className="cn-sidebar-menu-skeleton-icon"
-                        data-sidebar="menu-skeleton-icon"
-                    />
-                )}
-                <Skeleton
-                    className="cn-sidebar-menu-skeleton-text max-w-(--skeleton-width) flex-1"
-                    data-sidebar="menu-skeleton-text"
-                    style={skeletonStyle}
-                />
+                <div
+                    data-slot="sidebar-container"
+                    data-side={side}
+                    className={cn(
+                        "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+                        containerClass,
+                        props["className"]
+                    )}
+                    {**attrs}
+                >
+                    <div
+                        data-sidebar="sidebar"
+                        data-slot="sidebar-inner"
+                        className="cn-sidebar-inner flex size-full flex-col"
+                    >
+                        {props["children"]}
+                    </div>
+                </div>
             </div>;
     }
+}
 
-    def:pub SidebarMenuSub(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <ul
-                data-slot="sidebar-menu-sub"
-                data-sidebar="menu-sub"
-                className={cn(
-                    "cn-sidebar-menu-sub flex min-w-0 flex-col", props["className"]
-                )}
-                {**attrs}
-            />;
-    }
+def:pub SidebarTrigger(props: any) -> JsxElement {
+    ctx: any = useContext(SidebarContext);
+    toggleSidebar: any = ctx.toggleSidebar if ctx else None;
+    handleClick = lambda (event: any) -> any {
+        props["onClick"] and props["onClick"](event);
+        toggleSidebar and toggleSidebar();
+    };
+    return
+        <Button
+            data-sidebar="trigger"
+            data-slot="sidebar-trigger"
+            variant="ghost"
+            size="icon-sm"
+            className={cn("cn-sidebar-trigger", props["className"])}
+            onClick={handleClick}
+            {**props}
+        >
+            <HugeiconsIcon icon={SidebarLeftIcon} className="cn-rtl-flip" size={16}/>
+            <span className="sr-only">Toggle Sidebar</span>
+        </Button>;
+}
 
-    def:pub SidebarMenuSubItem(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <li
-                data-slot="sidebar-menu-sub-item"
-                data-sidebar="menu-sub-item"
-                className={cn("group/menu-sub-item relative", props["className"])}
-                {**attrs}
-            />;
-    }
+def:pub SidebarRail(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    ctx: any = useContext(SidebarContext);
+    toggleSidebar: any = ctx.toggleSidebar if ctx else None;
+    return
+        <button
+            data-sidebar="rail"
+            data-slot="sidebar-rail"
+            aria-label="Toggle Sidebar"
+            tabIndex={-1}
+            onClick={toggleSidebar}
+            title="Toggle Sidebar"
+            className={cn(
+                "cn-sidebar-rail absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] sm:flex",
+                props["className"]
+            )}
+            {**attrs}
+        />;
+}
 
-    def:pub SidebarMenuSubButton(props: any) -> JsxElement {
-        asChild = props["asChild"] or False;
-        size = props["size"] or "md";
-        isActive = props["isActive"] or False;
-        Comp = Slot if asChild else "a";
-        return
-            <Comp
-                data-slot="sidebar-menu-sub-button"
-                data-sidebar="menu-sub-button"
-                data-size={size}
-                data-active={isActive}
-                className={cn(
-                    "cn-sidebar-menu-sub-button flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
-                    props["className"]
-                )}
-                {**props}
-            />;
+def:pub SidebarInset(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <main
+            data-slot="sidebar-inset"
+            className={cn(
+                "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+                props["className"]
+            )}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarInput(props: any) -> JsxElement {
+    return
+        <Input
+            data-slot="sidebar-input"
+            data-sidebar="input"
+            className={cn("cn-sidebar-input", props["className"])}
+            {**props}
+        />;
+}
+
+def:pub SidebarHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="sidebar-header"
+            data-sidebar="header"
+            className={cn("cn-sidebar-header flex flex-col", props["className"])}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="sidebar-footer"
+            data-sidebar="footer"
+            className={cn("cn-sidebar-footer flex flex-col", props["className"])}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarSeparator(props: any) -> JsxElement {
+    return
+        <Separator
+            data-slot="sidebar-separator"
+            data-sidebar="separator"
+            className={cn("cn-sidebar-separator w-auto", props["className"])}
+            {**props}
+        />;
+}
+
+def:pub SidebarContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="sidebar-content"
+            data-sidebar="content"
+            className={cn(
+                "cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+                props["className"]
+            )}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarGroup(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="sidebar-group"
+            data-sidebar="group"
+            className={cn(
+                "cn-sidebar-group relative flex w-full min-w-0 flex-col",
+                props["className"]
+            )}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarGroupLabel(props: any) -> JsxElement {
+    asChild = props["asChild"] or False;
+    Comp = Slot if asChild else "div";
+    return
+        <Comp
+            data-slot="sidebar-group-label"
+            data-sidebar="group-label"
+            className={cn(
+                "cn-sidebar-group-label flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+                props["className"]
+            )}
+            {**props}
+        />;
+}
+
+def:pub SidebarGroupAction(props: any) -> JsxElement {
+    asChild = props["asChild"] or False;
+    Comp = Slot if asChild else "button";
+    return
+        <Comp
+            data-slot="sidebar-group-action"
+            data-sidebar="group-action"
+            className={cn(
+                "cn-sidebar-group-action flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden [&>svg]:shrink-0",
+                props["className"]
+            )}
+            {**props}
+        />;
+}
+
+def:pub SidebarGroupContent(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="sidebar-group-content"
+            data-sidebar="group-content"
+            className={cn("cn-sidebar-group-content w-full", props["className"])}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarMenu(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <ul
+            data-slot="sidebar-menu"
+            data-sidebar="menu"
+            className={cn(
+                "cn-sidebar-menu flex w-full min-w-0 flex-col", props["className"]
+            )}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarMenuItem(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <li
+            data-slot="sidebar-menu-item"
+            data-sidebar="menu-item"
+            className={cn("group/menu-item relative", props["className"])}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarMenuButton(props: any) -> JsxElement {
+    asChild = props["asChild"] or False;
+    isActive = props["isActive"] or False;
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    tooltip = props["tooltip"];
+    ctx: any = useContext(SidebarContext);
+    isMobile = ctx.isMobile if ctx else False;
+    state = ctx.state if ctx else "expanded";
+    Comp = Slot if asChild else "button";
+    btnClass = _sidebarMenuButtonVariants.call(None, {variant: variant, size: size});
+    button = <Comp
+        data-slot="sidebar-menu-button"
+        data-sidebar="menu-button"
+        data-size={size}
+        data-active={isActive}
+        className={cn(btnClass, props["className"])}
+        {**props}
+    />;
+    if not tooltip {
+        return button;
     }
+    tooltipProps = {"children": tooltip} if isinstance(tooltip, str) else tooltip;
+    isHidden = state != "collapsed" or isMobile;
+    return
+        <Tooltip>
+            <TooltipTrigger asChild={True}>{button}</TooltipTrigger>
+            <TooltipContent
+                side="right"
+                align="center"
+                hidden={isHidden}
+                {**tooltipProps}
+            />
+        </Tooltip>;
+}
+
+def:pub SidebarMenuAction(props: any) -> JsxElement {
+    asChild = props["asChild"] or False;
+    showOnHover = props["showOnHover"] or False;
+    Comp = Slot if asChild else "button";
+    hoverClass = "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 aria-expanded:opacity-100 md:opacity-0"
+        if showOnHover
+        else "";
+    return
+        <Comp
+            data-slot="sidebar-menu-action"
+            data-sidebar="menu-action"
+            className={cn(
+                "cn-sidebar-menu-action flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden [&>svg]:shrink-0",
+                hoverClass,
+                props["className"]
+            )}
+            {**props}
+        />;
+}
+
+def:pub SidebarMenuBadge(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            data-slot="sidebar-menu-badge"
+            data-sidebar="menu-badge"
+            className={cn(
+                "cn-sidebar-menu-badge flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden",
+                props["className"]
+            )}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarMenuSkeleton(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    showIcon = props["showIcon"] or False;
+    widthState = useState(
+        lambda -> any { return f"{int(
+            Math.random() * 40 + 50
+        )}%"; }  # jac:ignore[W6001]
+    );
+    width = widthState[0];
+    skeletonStyle = {"--skeleton-width": width};
+    return
+        <div
+            data-slot="sidebar-menu-skeleton"
+            data-sidebar="menu-skeleton"
+            className={cn(
+                "cn-sidebar-menu-skeleton flex items-center", props["className"]
+            )}
+            {**attrs}
+        >
+            {showIcon
+            and (
+                <Skeleton
+                    className="cn-sidebar-menu-skeleton-icon"
+                    data-sidebar="menu-skeleton-icon"
+                />
+            )}
+            <Skeleton
+                className="cn-sidebar-menu-skeleton-text max-w-(--skeleton-width) flex-1"
+                data-sidebar="menu-skeleton-text"
+                style={skeletonStyle}
+            />
+        </div>;
+}
+
+def:pub SidebarMenuSub(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <ul
+            data-slot="sidebar-menu-sub"
+            data-sidebar="menu-sub"
+            className={cn(
+                "cn-sidebar-menu-sub flex min-w-0 flex-col", props["className"]
+            )}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarMenuSubItem(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <li
+            data-slot="sidebar-menu-sub-item"
+            data-sidebar="menu-sub-item"
+            className={cn("group/menu-sub-item relative", props["className"])}
+            {**attrs}
+        />;
+}
+
+def:pub SidebarMenuSubButton(props: any) -> JsxElement {
+    asChild = props["asChild"] or False;
+    size = props["size"] or "md";
+    isActive = props["isActive"] or False;
+    Comp = Slot if asChild else "a";
+    return
+        <Comp
+            data-slot="sidebar-menu-sub-button"
+            data-sidebar="menu-sub-button"
+            data-size={size}
+            data-active={isActive}
+            className={cn(
+                "cn-sidebar-menu-sub-button flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
+                props["className"]
+            )}
+            {**props}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/skeleton.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/skeleton.cl.jac
@@ -1,13 +1,11 @@
-cl import from ...lib.utils { cn }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Skeleton(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div
-                {**attrs}
-                data-slot="skeleton"
-                className={cn("cn-skeleton animate-pulse", props["className"])}
-            />;
-    }
+def:pub Skeleton(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div
+            {**attrs}
+            data-slot="skeleton"
+            className={cn("cn-skeleton animate-pulse", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/slider.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/slider.cl.jac
@@ -1,30 +1,28 @@
-cl import from "radix-ui" { Slider as SliderPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Slider as SliderPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Slider(props: any) -> JsxElement {
-        return
-            <SliderPrimitive.Root
-                {**props}
-                data-slot="slider"
-                className={cn(
-                    "cn-slider relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
-                    props["className"]
-                )}
+def:pub Slider(props: any) -> JsxElement {
+    return
+        <SliderPrimitive.Root
+            {**props}
+            data-slot="slider"
+            className={cn(
+                "cn-slider relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
+                props["className"]
+            )}
+        >
+            <SliderPrimitive.Track
+                data-slot="slider-track"
+                className="cn-slider-track relative grow overflow-hidden data-horizontal:w-full data-vertical:h-full"
             >
-                <SliderPrimitive.Track
-                    data-slot="slider-track"
-                    className="cn-slider-track relative grow overflow-hidden data-horizontal:w-full data-vertical:h-full"
-                >
-                    <SliderPrimitive.Range
-                        data-slot="slider-range"
-                        className="cn-slider-range absolute select-none data-horizontal:h-full data-vertical:w-full"
-                    />
-                </SliderPrimitive.Track>
-                <SliderPrimitive.Thumb
-                    data-slot="slider-thumb"
-                    className="cn-slider-thumb block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
+                <SliderPrimitive.Range
+                    data-slot="slider-range"
+                    className="cn-slider-range absolute select-none data-horizontal:h-full data-vertical:w-full"
                 />
-            </SliderPrimitive.Root>;
-    }
+            </SliderPrimitive.Track>
+            <SliderPrimitive.Thumb
+                data-slot="slider-thumb"
+                className="cn-slider-thumb block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
+            />
+        </SliderPrimitive.Root>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/sonner.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/sonner.cl.jac
@@ -1,20 +1,18 @@
-cl import from "sonner" { Toaster as SonnerPrimitive }
+import from "sonner" { Toaster as SonnerPrimitive }
 
-cl {
-    def:pub Toaster(props: any) -> JsxElement {
-        theme = props["theme"] or "system";
-        return
-            <SonnerPrimitive
-                theme={theme}
-                className="toaster group"
-                toastOptions={{"classNames": {"toast": "cn-toast"}}}
-                style={{
-                    "--normal-bg": "var(--popover)",
-                    "--normal-text": "var(--popover-foreground)",
-                    "--normal-border": "var(--border)",
-                    "--border-radius": "var(--radius)"
-                }}
-                {**props}
-            />;
-    }
+def:pub Toaster(props: any) -> JsxElement {
+    theme = props["theme"] or "system";
+    return
+        <SonnerPrimitive
+            theme={theme}
+            className="toaster group"
+            toastOptions={{"classNames": {"toast": "cn-toast"}}}
+            style={{
+                "--normal-bg": "var(--popover)",
+                "--normal-text": "var(--popover-foreground)",
+                "--normal-border": "var(--border)",
+                "--border-radius": "var(--radius)"
+            }}
+            {**props}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/sonner.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/sonner.cl.jac
@@ -1,0 +1,20 @@
+cl import from "sonner" { Toaster as SonnerPrimitive }
+
+cl {
+    def:pub Toaster(props: any) -> JsxElement {
+        theme = props["theme"] or "system";
+        return
+            <SonnerPrimitive
+                theme={theme}
+                className="toaster group"
+                toastOptions={{"classNames": {"toast": "cn-toast"}}}
+                style={{
+                    "--normal-bg": "var(--popover)",
+                    "--normal-text": "var(--popover-foreground)",
+                    "--normal-border": "var(--border)",
+                    "--border-radius": "var(--radius)"
+                }}
+                {**props}
+            />;
+    }
+}

--- a/jac-super/jac_super/shadcn/registry/components/ui/spinner.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/spinner.cl.jac
@@ -1,17 +1,15 @@
-cl import from ...lib.utils { cn }
-cl import from "@hugeicons/react" { HugeiconsIcon }
-cl import from "@hugeicons/core-free-icons" { Loading03Icon }
+import from ...lib.utils { cn }
+import from "@hugeicons/react" { HugeiconsIcon }
+import from "@hugeicons/core-free-icons" { Loading03Icon }
 
-cl {
-    def:pub Spinner(props: any) -> JsxElement {
-        return
-            <HugeiconsIcon
-                icon={Loading03Icon}
-                strokeWidth={2}
-                role="status"
-                aria-label="Loading"
-                {**props}
-                className={cn("size-4 animate-spin", props["className"])}
-            />;
-    }
+def:pub Spinner(props: any) -> JsxElement {
+    return
+        <HugeiconsIcon
+            icon={Loading03Icon}
+            strokeWidth={2}
+            role="status"
+            aria-label="Loading"
+            {**props}
+            className={cn("size-4 animate-spin", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/switch.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/switch.cl.jac
@@ -1,23 +1,21 @@
-cl import from "radix-ui" { Switch as SwitchPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Switch as SwitchPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Switch(props: any) -> JsxElement {
-        size = props["size"] or "default";
-        return
-            <SwitchPrimitive.Root
-                {**props}
-                data-slot="switch"
-                data-size={size}
-                className={cn(
-                    "cn-switch peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
-                    props["className"]
-                )}
-            >
-                <SwitchPrimitive.Thumb
-                    data-slot="switch-thumb"
-                    className="cn-switch-thumb pointer-events-none block ring-0 transition-transform"
-                />
-            </SwitchPrimitive.Root>;
-    }
+def:pub Switch(props: any) -> JsxElement {
+    size = props["size"] or "default";
+    return
+        <SwitchPrimitive.Root
+            {**props}
+            data-slot="switch"
+            data-size={size}
+            className={cn(
+                "cn-switch peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+                props["className"]
+            )}
+        >
+            <SwitchPrimitive.Thumb
+                data-slot="switch-thumb"
+                className="cn-switch-thumb pointer-events-none block ring-0 transition-transform"
+            />
+        </SwitchPrimitive.Root>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/table.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/table.cl.jac
@@ -1,85 +1,83 @@
-cl import from ...lib.utils { cn }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Table(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <div data-slot="table-container" className="cn-table-container">
-                <table
-                    {**attrs}
-                    data-slot="table"
-                    className={cn("cn-table", props["className"])}
-                />
-            </div>;
-    }
-
-    def:pub TableHeader(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <thead
+def:pub Table(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <div data-slot="table-container" className="cn-table-container">
+            <table
                 {**attrs}
-                data-slot="table-header"
-                className={cn("cn-table-header", props["className"])}
-            />;
-    }
+                data-slot="table"
+                className={cn("cn-table", props["className"])}
+            />
+        </div>;
+}
 
-    def:pub TableBody(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <tbody
-                {**attrs}
-                data-slot="table-body"
-                className={cn("cn-table-body", props["className"])}
-            />;
-    }
+def:pub TableHeader(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <thead
+            {**attrs}
+            data-slot="table-header"
+            className={cn("cn-table-header", props["className"])}
+        />;
+}
 
-    def:pub TableFooter(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <tfoot
-                {**attrs}
-                data-slot="table-footer"
-                className={cn("cn-table-footer", props["className"])}
-            />;
-    }
+def:pub TableBody(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <tbody
+            {**attrs}
+            data-slot="table-body"
+            className={cn("cn-table-body", props["className"])}
+        />;
+}
 
-    def:pub TableRow(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <tr
-                {**attrs}
-                data-slot="table-row"
-                className={cn("cn-table-row", props["className"])}
-            />;
-    }
+def:pub TableFooter(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <tfoot
+            {**attrs}
+            data-slot="table-footer"
+            className={cn("cn-table-footer", props["className"])}
+        />;
+}
 
-    def:pub TableHead(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <th
-                {**attrs}
-                data-slot="table-head"
-                className={cn("cn-table-head", props["className"])}
-            />;
-    }
+def:pub TableRow(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <tr
+            {**attrs}
+            data-slot="table-row"
+            className={cn("cn-table-row", props["className"])}
+        />;
+}
 
-    def:pub TableCell(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <td
-                {**attrs}
-                data-slot="table-cell"
-                className={cn("cn-table-cell", props["className"])}
-            />;
-    }
+def:pub TableHead(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <th
+            {**attrs}
+            data-slot="table-head"
+            className={cn("cn-table-head", props["className"])}
+        />;
+}
 
-    def:pub TableCaption(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <caption
-                {**attrs}
-                data-slot="table-caption"
-                className={cn("cn-table-caption", props["className"])}
-            />;
-    }
+def:pub TableCell(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <td
+            {**attrs}
+            data-slot="table-cell"
+            className={cn("cn-table-cell", props["className"])}
+        />;
+}
+
+def:pub TableCaption(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <caption
+            {**attrs}
+            data-slot="table-caption"
+            className={cn("cn-table-caption", props["className"])}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/tabs.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/tabs.cl.jac
@@ -1,6 +1,6 @@
-cl import from "radix-ui" { Tabs as TabsPrimitive }
-cl import from "class-variance-authority" { cva }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Tabs as TabsPrimitive }
+import from "class-variance-authority" { cva }
+import from ...lib.utils { cn }
 
 glob _tabsListVariants: any = cva(
          "cn-tabs-list group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col",
@@ -15,62 +15,56 @@ glob _tabsListVariants: any = cva(
          }
      );
 
-cl {
-    def:pub Tabs(props: any) -> JsxElement {
-        orientation = props["orientation"] or "horizontal";
-        return
-            <TabsPrimitive.Root
-                {**props}
-                data-slot="tabs"
-                data-orientation={orientation}
-                className={cn(
-                    "cn-tabs group/tabs flex data-horizontal:flex-col",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Tabs(props: any) -> JsxElement {
+    orientation = props["orientation"] or "horizontal";
+    return
+        <TabsPrimitive.Root
+            {**props}
+            data-slot="tabs"
+            data-orientation={orientation}
+            className={cn(
+                "cn-tabs group/tabs flex data-horizontal:flex-col", props["className"]
+            )}
+        />;
+}
 
-    def:pub TabsList(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        return
-            <TabsPrimitive.List
-                {**props}
-                data-slot="tabs-list"
-                data-variant={variant}
-                className={cn(
-                    _tabsListVariants.call(None, {"variant": variant}),
-                    props["className"]
-                )}
-            />;
-    }
+def:pub TabsList(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    return
+        <TabsPrimitive.List
+            {**props}
+            data-slot="tabs-list"
+            data-variant={variant}
+            className={cn(
+                _tabsListVariants.call(None, {"variant": variant}), props["className"]
+            )}
+        />;
+}
 
-    def:pub TabsTrigger(props: any) -> JsxElement {
-        return
-            <TabsPrimitive.Trigger
-                {**props}
-                data-slot="tabs-trigger"
-                className={cn(
-                    "cn-tabs-trigger focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-                    "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-                    "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
-                    "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub TabsTrigger(props: any) -> JsxElement {
+    return
+        <TabsPrimitive.Trigger
+            {**props}
+            data-slot="tabs-trigger"
+            className={cn(
+                "cn-tabs-trigger focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+                "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
+                "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+                props["className"]
+            )}
+        />;
+}
 
-    def:pub TabsContent(props: any) -> JsxElement {
-        return
-            <TabsPrimitive.Content
-                {**props}
-                data-slot="tabs-content"
-                className={cn(
-                    "cn-tabs-content flex-1 outline-none", props["className"]
-                )}
-            />;
-    }
+def:pub TabsContent(props: any) -> JsxElement {
+    return
+        <TabsPrimitive.Content
+            {**props}
+            data-slot="tabs-content"
+            className={cn("cn-tabs-content flex-1 outline-none", props["className"])}
+        />;
+}
 
-    def:pub tabsListVariants -> any {
-        return _tabsListVariants;
-    }
+def:pub tabsListVariants -> any {
+    return _tabsListVariants;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/textarea.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/textarea.cl.jac
@@ -1,16 +1,14 @@
-cl import from ...lib.utils { cn }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub Textarea(props: any) -> JsxElement {
-        attrs: dict[str, any] = {** props};
-        return
-            <textarea
-                {**attrs}
-                data-slot="textarea"
-                className={cn(
-                    "cn-textarea border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-3 aria-invalid:ring-3 md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
-                    props["className"]
-                )}
-            />;
-    }
+def:pub Textarea(props: any) -> JsxElement {
+    attrs: dict[str, any] = {** props};
+    return
+        <textarea
+            {**attrs}
+            data-slot="textarea"
+            className={cn(
+                "cn-textarea border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-3 aria-invalid:ring-3 md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
+                props["className"]
+            )}
+        />;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/toggle-group.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/toggle-group.cl.jac
@@ -1,49 +1,47 @@
-cl import from "radix-ui" { ToggleGroup as ToggleGroupPrimitive }
-cl import from ...lib.utils { cn }
-cl import from ".toggle" { toggleVariants }
+import from "radix-ui" { ToggleGroup as ToggleGroupPrimitive }
+import from ...lib.utils { cn }
+import from ".toggle" { toggleVariants }
 
-cl {
-    def:pub ToggleGroup(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        spacing = props["spacing"] or 0;
-        orientation = props["orientation"] or "horizontal";
+def:pub ToggleGroup(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    spacing = props["spacing"] or 0;
+    orientation = props["orientation"] or "horizontal";
 
-        return
-            <ToggleGroupPrimitive.Root
-                {**props}
-                data-slot="toggle-group"
-                data-variant={variant}
-                data-size={size}
-                data-spacing={spacing}
-                data-orientation={orientation}
-                className={cn(
-                    "cn-toggle-group group/toggle-group flex w-fit flex-row items-center data-vertical:flex-col data-vertical:items-stretch",
-                    props["className"]
-                )}
-            >
-                {props["children"]}
-            </ToggleGroupPrimitive.Root>;
-    }
+    return
+        <ToggleGroupPrimitive.Root
+            {**props}
+            data-slot="toggle-group"
+            data-variant={variant}
+            data-size={size}
+            data-spacing={spacing}
+            data-orientation={orientation}
+            className={cn(
+                "cn-toggle-group group/toggle-group flex w-fit flex-row items-center data-vertical:flex-col data-vertical:items-stretch",
+                props["className"]
+            )}
+        >
+            {props["children"]}
+        </ToggleGroupPrimitive.Root>;
+}
 
-    def:pub ToggleGroupItem(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        variantsFn: any = toggleVariants();
-        computedClass = cn(
-            "cn-toggle-group-item shrink-0 focus:z-10 focus-visible:z-10",
-            variantsFn.call(None, {"variant": variant, "size": size}),
-            props["className"]
-        );
-        return
-            <ToggleGroupPrimitive.Item
-                {**props}
-                data-slot="toggle-group-item"
-                data-variant={variant}
-                data-size={size}
-                className={computedClass}
-            >
-                {props["children"]}
-            </ToggleGroupPrimitive.Item>;
-    }
+def:pub ToggleGroupItem(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    variantsFn: any = toggleVariants();
+    computedClass = cn(
+        "cn-toggle-group-item shrink-0 focus:z-10 focus-visible:z-10",
+        variantsFn.call(None, {"variant": variant, "size": size}),
+        props["className"]
+    );
+    return
+        <ToggleGroupPrimitive.Item
+            {**props}
+            data-slot="toggle-group-item"
+            data-variant={variant}
+            data-size={size}
+            className={computedClass}
+        >
+            {props["children"]}
+        </ToggleGroupPrimitive.Item>;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/toggle.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/toggle.cl.jac
@@ -1,6 +1,6 @@
-cl import from "class-variance-authority" { cva }
-cl import from "radix-ui" { Toggle as TogglePrimitive }
-cl import from ...lib.utils { cn }
+import from "class-variance-authority" { cva }
+import from "radix-ui" { Toggle as TogglePrimitive }
+import from ...lib.utils { cn }
 
 glob _toggleVariants: any = cva(
          "cn-toggle group/toggle hover:bg-muted inline-flex items-center justify-center whitespace-nowrap outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
@@ -20,26 +20,19 @@ glob _toggleVariants: any = cva(
          }
      );
 
-cl {
-    def:pub Toggle(props: any) -> JsxElement {
-        variant = props["variant"] or "default";
-        size = props["size"] or "default";
-        variantsFn = _toggleVariants;
-        computedClass = cn(
-            variantsFn.call(
-                None,
-                {"variant": variant, "size": size, "className": props["className"]}
-            )
-        );
-        return
-            <TogglePrimitive.Root
-                {**props}
-                data-slot="toggle"
-                className={computedClass}
-            />;
-    }
+def:pub Toggle(props: any) -> JsxElement {
+    variant = props["variant"] or "default";
+    size = props["size"] or "default";
+    variantsFn = _toggleVariants;
+    computedClass = cn(
+        variantsFn.call(
+            None, {"variant": variant, "size": size, "className": props["className"]}
+        )
+    );
+    return
+        <TogglePrimitive.Root {**props} data-slot="toggle" className={computedClass}/>;
+}
 
-    def:pub toggleVariants -> any {
-        return _toggleVariants;
-    }
+def:pub toggleVariants -> any {
+    return _toggleVariants;
 }

--- a/jac-super/jac_super/shadcn/registry/components/ui/tooltip.cl.jac
+++ b/jac-super/jac_super/shadcn/registry/components/ui/tooltip.cl.jac
@@ -1,43 +1,41 @@
-cl import from "radix-ui" { Tooltip as TooltipPrimitive }
-cl import from ...lib.utils { cn }
+import from "radix-ui" { Tooltip as TooltipPrimitive }
+import from ...lib.utils { cn }
 
-cl {
-    def:pub TooltipProvider(props: any) -> JsxElement {
-        delayDuration = props["delayDuration"] or 0;
-        return
-            <TooltipPrimitive.Provider
+def:pub TooltipProvider(props: any) -> JsxElement {
+    delayDuration = props["delayDuration"] or 0;
+    return
+        <TooltipPrimitive.Provider
+            {**props}
+            data-slot="tooltip-provider"
+            delayDuration={delayDuration}
+        />;
+}
+
+def:pub Tooltip(props: any) -> JsxElement {
+    return <TooltipPrimitive.Root data-slot="tooltip" {**props}/>;
+}
+
+def:pub TooltipTrigger(props: any) -> JsxElement {
+    return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {**props}/>;
+}
+
+def:pub TooltipContent(props: any) -> JsxElement {
+    sideOffset = props["sideOffset"] or 0;
+    return
+        <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
                 {**props}
-                data-slot="tooltip-provider"
-                delayDuration={delayDuration}
-            />;
-    }
-
-    def:pub Tooltip(props: any) -> JsxElement {
-        return <TooltipPrimitive.Root data-slot="tooltip" {**props}/>;
-    }
-
-    def:pub TooltipTrigger(props: any) -> JsxElement {
-        return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {**props}/>;
-    }
-
-    def:pub TooltipContent(props: any) -> JsxElement {
-        sideOffset = props["sideOffset"] or 0;
-        return
-            <TooltipPrimitive.Portal>
-                <TooltipPrimitive.Content
-                    {**props}
-                    data-slot="tooltip-content"
-                    sideOffset={sideOffset}
-                    className={cn(
-                        "cn-tooltip-content bg-foreground text-background z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)",
-                        props["className"]
-                    )}
-                >
-                    {props["children"]}
-                    <TooltipPrimitive.Arrow
-                        className="cn-tooltip-arrow bg-foreground fill-foreground z-50 translate-y-[calc(-50%_-_2px)]"
-                    />
-                </TooltipPrimitive.Content>
-            </TooltipPrimitive.Portal>;
-    }
+                data-slot="tooltip-content"
+                sideOffset={sideOffset}
+                className={cn(
+                    "cn-tooltip-content bg-foreground text-background z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)",
+                    props["className"]
+                )}
+            >
+                {props["children"]}
+                <TooltipPrimitive.Arrow
+                    className="cn-tooltip-arrow bg-foreground fill-foreground z-50 translate-y-[calc(-50%_-_2px)]"
+                />
+            </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>;
 }

--- a/jac-super/jac_super/shadcn/registry/registry.json
+++ b/jac-super/jac_super/shadcn/registry/registry.json
@@ -420,6 +420,13 @@
         "@hugeicons/core-free-icons"
       ],
       "peerComponents": ["button", "input", "separator", "sheet", "skeleton", "tooltip"]
+    },
+    "sonner": {
+      "file": "sonner.cl.jac",
+      "npmDeps": [
+        "sonner"
+      ],
+      "peerComponents": []
     }
   },
   "sharedDeps": {

--- a/jac/jaclang/cli/skills/jac-shadcn-components.md
+++ b/jac/jaclang/cli/skills/jac-shadcn-components.md
@@ -97,6 +97,7 @@ Most filenames are the kebab-case of the component (`alert-dialog` → import `"
 | Loading spinner | `Spinner` |
 | Empty state | `Empty` |
 | Alert / banner | `Alert` + `AlertTitle` + `AlertDescription` |
+| Toast / notification | `Toaster` (mount once at app root); call `toast(...)` from `"sonner"` |
 | Progress bar | `Progress` |
 | Date picker | `Calendar` |
 | Slider | `Slider` |


### PR DESCRIPTION
## What

Two related changes to the bundled jac-shadcn registry, in separate commits:

1. **Add the `sonner` toast component** (closes the last gap with upstream shadcn-ui).
2. **Drop redundant `cl` markers** from all 54 registry components.

## 1. sonner toast component

- New `sonner.cl.jac` Toaster wrapper. Ports the upstream shadcn sonner component, drops the `next-themes` dependency, defaults `theme` to `"system"`, and stays overridable via props.
- Registered in `registry.json` with `npmDeps: ["sonner"]`.
- Toast colors are driven by the existing `--popover` / `--popover-foreground` / `--border` design tokens. The `cn-toast` style hook already ships in all five bundled styles (nova/vega/maia/lyra/mira), so no CSS changes are required.
- Adds a toast/notification row to the component-selection guide so it is discoverable during UI generation.

Usage (matches upstream shadcn):

```jac
import from .components.ui.sonner { Toaster }
import from "sonner" { toast }
```

Mount `<Toaster />` once at the app root, then call `toast(...)`.

## 2. Drop redundant cl markers

In a `.cl.jac` file the client context is implied by the file extension, so the explicit `cl import` prefix and `cl { ... }` block wrapper are redundant. The jac-client templates and example apps already use the bare form (plain `import`, top-level `def:pub`); the registry components were the outlier. This brings them in line.

## Testing

- `sonner` resolves cleanly through `jac add --shadcn sonner`; `cn-toast` lowers to the per-style class and the design tokens plus the `sonner` import survive resolution.
- For the cleanup: `jac2js` output is **byte-identical before and after** for every one of the 54 components, so the marker removal is a pure source cleanup with no behavior change. `jac format --check` is clean on all 54.
