### PR TITLE
refactor(littleX): use visit-else in social_graph setup_profile

### DIFF
--- a/jac/examples/littleX/social_graph.jac
+++ b/jac/examples/littleX/social_graph.jac
@@ -145,10 +145,9 @@ walker setup_profile {
         reports: list[ProfileView] = [];
 
     can run with Root entry {
-        existing = [-->[?:Profile]];
-        if existing {
-            visit existing;
-        } else {
+        # The `else` fires when `visit` enqueues nothing - i.e. no profile
+        # exists yet - so we create one and walk into it instead.
+        visit [-->[?:Profile]] else {
             fresh = here ++> Profile(created_at=_now());
             grant(fresh[0], level=ConnectPerm);
             visit fresh;


### PR DESCRIPTION
## What

Collapse the `if existing { visit existing } else { create }` guard in `setup_profile`'s `Root entry` ability into the native `visit ... else { ... }` form:

```jac
can run with Root entry {
    visit [-->[?:Profile]] else {
        fresh = here ++> Profile(created_at=_now());
        grant(fresh[0], level=ConnectPerm);
        visit fresh;
    }
}
```

## Why it's equivalent

A `visit` statement's `else` block runs exactly when the visit enqueues nothing. The chain:

- **Grammar** (`jac.spec`): `visit_stmt ::= "visit" (":" expression ":")? expression (else_stmt | ";")?`
- **Codegen** (`pyast_gen_pass`): lowers `visit X else {…}` to `if not visit(self, X): <else>`
- **Runtime** (`osp_kernel.osp_visit`): returns `True` only when it enqueues ≥1 target

At the first `Root entry` ability, `scope.ignores` is empty, so the visit's truthiness matches the old list-truthiness guard one-to-one. Behavior is unchanged; the version simply uses the object-spatial idiom directly. `jac check` passes.