### PR TITLE
fix(ecmascript): interpret string escape sequences in jac2js codegen (#6476)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6479.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6479.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: jac2js interprets string escape sequences**: The ECMAScript (`cl`) target now decodes string-literal escapes (`\n`, `\t`, `\xNN`, quotes, backslashes, and implicit concatenation) via the shared `lit_value` decoder, matching the Python (`sv`) target instead of emitting the backslash verbatim (#6476).

--- a/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/esast_gen_pass.jac
@@ -559,6 +559,7 @@ obj EsastGenPass(BaseAstGenPass[es.Statement]) {
     def exit_float(nd: uni.Float) -> None;
     def exit_multi_string(nd: uni.MultiString) -> None;
     def exit_string(nd: uni.String) -> None;
+    def _str_literal(nd: uni.String) -> es.Literal;
     def exit_formatted_value(nd: uni.FormattedValue) -> None;
     def exit_f_string(nd: uni.FString) -> None;
     def exit_if_else_expr(nd: uni.IfElseExpr) -> None;

--- a/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/ecmascript/impl/esast_gen_pass.impl.jac
@@ -342,20 +342,32 @@ impl EsastGenPass.exit_formatted_value(nd: uni.FormattedValue) -> None {
     nd.gen.es_ast = expr;
 }
 
+"""Build a JS string literal from a Jac String node, decoding escapes.
+
+`nd.lit_value` interprets escape sequences (\n, \t, \xNN, ...) and honors raw/
+byte prefixes exactly like the Python/sv target and `_literal_value`, so every
+backend agrees on what the same source token *means* (#6476 item 1). json.dumps
+then re-encodes that decoded value as a JS string literal -- JSON string syntax
+is a subset of ECMAScript string syntax, so the emitted `raw` is always valid JS
+and round-trips control characters, quotes, and backslashes correctly.
+"""
+impl EsastGenPass._str_literal(nd: uni.String) -> es.Literal {
+    decoded = nd.lit_value;
+    if isinstance(decoded, str) {
+        return self.sync_loc(
+            es.Literal(value=decoded, raw=json.dumps(decoded)), jac_node=nd
+        );
+    }
+    # Byte-string literals (b"...") have no JS string equivalent; fall back to
+    # the raw source token (out-of-scope, pre-existing behavior unchanged).
+    raw_token = nd.value;
+    fallback_raw = json.dumps(raw_token) if isinstance(raw_token, str) else None;
+    return self.sync_loc(es.Literal(value=raw_token, raw=fallback_raw), jac_node=nd);
+}
+
 """Process string literal."""
 impl EsastGenPass.exit_string(nd: uni.String) -> None {
-    value = nd.value;
-    if value.startswith(('"""', "'''")) {
-        value = value[3:-3];
-    } elif value.startswith(('"', "'")) {
-        value = value[1:-1];
-    }
-    raw_value = nd.value;
-    if isinstance(value, str) {
-        raw_value = json.dumps(value);
-    }
-    str_lit = self.sync_loc(es.Literal(value=value, raw=raw_value), jac_node=nd);
-    nd.gen.es_ast = str_lit;
+    nd.gen.es_ast = self._str_literal(nd);
 }
 
 """Process multi-string literal."""
@@ -370,16 +382,7 @@ impl EsastGenPass.exit_multi_string(nd: uni.MultiString) -> None {
         if string_node.gen.es_ast {
             nd.gen.es_ast = string_node.gen.es_ast;
         } elif isinstance(string_node, uni.String) {
-            value = string_node.value;
-            if value.startswith(('"""', "'''")) {
-                value = value[3:-3];
-            } elif value.startswith(('"', "'")) {
-                value = value[1:-1];
-            }
-            str_lit = self.sync_loc(
-                es.Literal(value=value, raw=string_node.value), jac_node=string_node
-            );
-            nd.gen.es_ast = str_lit;
+            nd.gen.es_ast = self._str_literal(string_node);
         } else {
             nd.gen.es_ast = self.sync_loc(es.Literal(value=''), jac_node=nd);
         }
@@ -390,19 +393,7 @@ impl EsastGenPass.exit_multi_string(nd: uni.MultiString) -> None {
         if string_node.gen.es_ast {
             parts.append(string_node.gen.es_ast);
         } elif isinstance(string_node, uni.String) {
-            value = string_node.value;
-            if value.startswith(('"""', "'''")) {
-                value = value[3:-3];
-            } elif value.startswith(('"', "'")) {
-                value = value[1:-1];
-            }
-            raw_val = json.dumps(value)
-                if isinstance(value, str)
-                else string_node.value;
-            str_lit = self.sync_loc(
-                es.Literal(value=value, raw=raw_val), jac_node=string_node
-            );
-            parts.append(str_lit);
+            parts.append(self._str_literal(string_node));
         }
     }
     if not parts {

--- a/jac/jaclang/compiler/tests/fixtures/cl_string_escapes.jac
+++ b/jac/jaclang/compiler/tests/fixtures/cl_string_escapes.jac
@@ -1,0 +1,55 @@
+"""String escape-sequence cross-backend equivalence fixture.
+
+Regression guard for #6476 item 1: the ECMAScript (cl) target used to emit
+string-literal escape sequences verbatim (e.g. `\n` stayed a backslash + 'n')
+instead of interpreting them the way the Python (sv) reference does, so the same
+literal meant different things per backend. Every backend must decode escapes
+identically, so the returned strings compare equal across sv / cl / na.
+"""
+
+# Shared escape-sequence literals, expressed once per backend body so the only
+# variable under test is how each emitter lowers the *same* source token.
+def escapes_py() -> dict {
+    return {
+        "newline": "x\ny",
+        "tab": "a\tb",
+        "carriage": "a\rb",
+        "backslash": "c:\\path",
+        "dquote": "say \"hi\"",
+        "squote": 'it\'s',
+        "hex": "esc\x1b[0m",
+        "unicode": "café",
+        "mixed": "line1\nline2\tend\\done",
+        "concat": "a\nb" "c\td",
+    };
+}
+
+cl def escapes_cl() -> dict {
+    return {
+        "newline": "x\ny",
+        "tab": "a\tb",
+        "carriage": "a\rb",
+        "backslash": "c:\\path",
+        "dquote": "say \"hi\"",
+        "squote": 'it\'s',
+        "hex": "esc\x1b[0m",
+        "unicode": "café",
+        "mixed": "line1\nline2\tend\\done",
+        "concat": "a\nb" "c\td",
+    };
+}
+
+na {
+    def escapes_na() -> dict[str, any] {
+        return {
+            "newline": "x\ny",
+            "tab": "a\tb",
+            "carriage": "a\rb",
+            "backslash": "c:\\path",
+            "dquote": "say \"hi\"",
+            "squote": 'it\'s',
+            "mixed": "line1\nline2\tend\\done",
+            "concat": "a\nb" "c\td",
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -45,6 +45,17 @@ test "str" {
     run_with_both("prim_str.jac", "str_py", "str_cl", "str_na");
 }
 
+# --- String literal escape sequences (#6476 item 1), cl required ---
+test "string escapes" {
+    run_with_both(
+        "cl_string_escapes.jac",
+        "escapes_py",
+        "escapes_cl",
+        "escapes_na",
+        require=["cl"]
+    );
+}
+
 # --- String Types (BytesEmitter) ---
 test "bytes search" {
     run_with_both(


### PR DESCRIPTION
## Summary

Fixes **item 1 of #6476**: the `cl`/ECMAScript (jac2js) target dropped string-literal escape sequences. Escapes such as `\n`, `\t`, `\xNN`, escaped quotes, and backslashes were emitted **verbatim** (the backslash itself was escaped) instead of being interpreted, so the same literal meant different things on the `cl` backend vs. the Python/`sv` backend, and strings rendered with a literal `\n` in the browser.

### Before
```jac
cl def f() -> dict { return {"a": "x\ny", "b": "c:\\path", "q": "say \"hi\""}; }
```
```js
// jac2js output (buggy)
return {"a": "x\\ny", "b": "c:\\\\path", "q": "say \\\"hi\\\""};
```

### After
```js
return {"a": "x\ny", "b": "c:\\path", "q": "say \"hi\""};  // matches the sv target
```

## Root cause

`exit_string` / `exit_multi_string` in the ECMAScript pass rebuilt each string by manually stripping quotes off the **raw source token** (`nd.value`) — leaving escape sequences un-interpreted — and then `json.dumps`'d that, which re-escaped the backslash. The logic was duplicated across three sites and was also wrong for raw (`r"..."`) strings.

## Fix

Route all three string-literal lowering sites through a single `_str_literal` helper that reuses the existing `String.lit_value` decoder — the same one the `sv` target and `_literal_value` already use, which correctly handles regular / raw / byte / triple-quoted strings and every escape form. `json.dumps` of the *decoded* value yields valid JS (JSON string syntax is a subset of ECMAScript). Net result is less code and one source of truth. F-strings were already correct (template literals interpret escapes natively) and are unchanged.

## Tests

Added a clean cross-backend fixture (`cl_string_escapes.jac`) and a `require=["cl"]` equivalence test in `test_prim_equivalence.jac`, reusing the existing `xbackend_equiv` harness (compile to JS, run in Node, compare against the Python reference). The test fails on `main` and passes with this change.

- New "string escapes" test: passes (failed before the fix).
- Full cross-backend suites: 54/54 (`test_prim_equivalence`) + 10/10 (`test_shared_types_equivalence`, `test_osp_equivalence`).
- No new `jac check` diagnostics on the edited pass (179/119 identical to baseline).
- `jac jac2js` verified correct end-to-end.
