### PR TITLE
fix(types): keep overload set for imported @overload functions

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6480.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6480.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: imported overloaded functions keep all overloads**: Calling an `@overload`-ed function imported with `import from mod { fn }` (e.g. SQLAlchemy's `create_engine`) no longer reports a spurious missing-parameter error for calls that match a later overload.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/evaluator_util_methods.impl.jac
@@ -856,7 +856,29 @@ impl TypeEvaluator._set_module_item_symbol_and_type(
     if node_.alias {
         node_.alias.sym = sym;
     }
-    node_.name.type = self.get_type_of_symbol(sym);
+    sym_type = self.get_type_of_symbol(sym);
+    # An imported @overload-ed function keeps only its primary signature here
+    # unless we gather the sibling overloads from its source scope (mirrors the
+    # module-attribute path, e.g. `math.floor`).
+    if isinstance(sym_type, types.FunctionType) and sym.parent_tab {
+        overloaded_fns: list[types.FunctionType] = [sym_type];
+        for overload_symbol in type_utils.collect_member_syms(
+            sym.parent_tab, sym.sym_name
+        ) {
+            if overload_symbol == sym {
+                continue;
+            }
+            overload_type = self.get_type_of_symbol(overload_symbol);
+            if isinstance(overload_type, types.FunctionType) {
+                overloaded_fns.append(overload_type);
+            }
+        }
+        if len(overloaded_fns) > 1 {
+            node_.name.type = types.OverloadedType(overloads=overloaded_fns);
+            return node_.name.type;
+        }
+    }
+    node_.name.type = sym_type;
     return node_.name.type;
 }
 

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_imported_overload.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_imported_overload.jac
@@ -1,0 +1,3 @@
+import from checker_imported_overload_lib { make }
+
+glob ref = make;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_imported_overload_lib.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_imported_overload_lib.jac
@@ -1,0 +1,7 @@
+import from typing { overload }
+
+@overload
+def make(url: str, *, strict: bool) -> int { }
+
+@overload
+def make(url: str) -> int { }

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -241,6 +241,27 @@ test "from_import" {
     );
 }
 
+"""An imported @overload-ed function keeps its full overload set; collapsing to
+the first signature wrongly rejected calls matching a later overload."""
+test "imported_overloaded_function_keeps_overloads" {
+    import jaclang.jac0core.unitree as uni;
+    import from jaclang.compiler.type_system.types { OverloadedType }
+
+    path = os.path.join(CHECKER_FIXTURES, "checker_imported_overload.jac");
+    program = JacProgram();
+    mod = program.compile(path, type_check=True);
+
+    item = [
+        mi
+        for mi in mod.get_all_sub_nodes(uni.ModuleItem)
+        if isinstance(mi.name, uni.Name) and mi.name.value == "make"
+    ][0];
+    assert isinstance(item.name.type, OverloadedType) , f"imported `make` should resolve to OverloadedType, got {type(
+        item.name.type
+    )}";
+    assert len(item.name.type.overloads) == 2;
+}
+
 test "call_expr" {
     path = os.path.join(CHECKER_FIXTURES, "checker_expr_call.jac");
     program = JacProgram();


### PR DESCRIPTION
## Summary

Resolving `import from mod { fn }` collapsed an overloaded function to its **first** signature: `_set_module_item_symbol_and_type` set the import item's type from the primary symbol only and never gathered the sibling `@overload`s.

A call matching a *later* overload then failed. Real-world repro (SQLAlchemy):

```jac
import from sqlalchemy { create_engine }
glob eng = create_engine("sqlite:///:memory:");  # E1050: missing required parameter 'future'
```

`create_engine`'s first `@overload` makes `future: Literal[True]` required, so the checker rejected the single-arg call instead of falling through to the `**kwargs` overload.

## Fix

In `_set_module_item_symbol_and_type`, when the imported symbol is a function, gather its sibling overloads from the symbol's source scope (`collect_member_syms(sym.parent_tab, ...)`) and build an `OverloadedType` — mirroring the existing module-attribute path (e.g. `math.floor`).

## Test

`imported_overloaded_function_keeps_overloads` compiles a two-file fixture and asserts the imported function resolves to `OverloadedType` (2 overloads). Red before the fix (bare `FunctionType`), green after.

Earlier broader regression (298 checker/import tests) passed with this change.

## Note

This fixes the `E1050` false positive in the SQLAlchemy repro. A second, larger false positive in the same file — `result.rowcount > 0` (E1110), where `@util.memoized_property` isn't unwrapped via the descriptor `__get__` protocol — is a separate, tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)