### PR TITLE
fix(types): collect overloads at definition scope across re-exports

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6481.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6481.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: overloaded functions imported through re-exports resolve correctly**: Calling an `@overload`-ed function imported via a re-export chain (e.g. SQLAlchemy's `create_engine`) no longer reports a spurious missing-parameter error for calls that match a later overload.

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/imported.impl.jac
@@ -562,3 +562,26 @@ impl TypeEvaluator.get_type_of_symbol(symbol: uni.Symbol) -> TypeBase {
     }
     return types.UnknownType();
 }
+
+"""Follow an imported symbol's re-export chain to its defining symbol.
+
+A `from pkg import f` symbol's decl is the imported `Name`, whose own `.sym`
+points at the next re-export hop (e.g. `pkg/__init__` → `pkg/sub` → the
+`def`). Walk that chain until a non-import decl (the definition) so callers
+collect overloads in the definition scope rather than a re-export scope."""
+impl TypeEvaluator.resolve_to_definition_symbol(symbol: uni.Symbol) -> uni.Symbol {
+    visited: set[int] = set();
+    cur = symbol;
+    while id(cur) not in visited {
+        visited.add(id(cur));
+        if not (cur.imported and cur.decl) {
+            break;
+        }
+        node_ = cur.decl.name_of;
+        if not (isinstance(node_, uni.Name) and node_.sym and node_.sym is not cur) {
+            break;
+        }
+        cur = node_.sym;
+    }
+    return cur;
+}

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -2019,24 +2019,24 @@ impl TypeEvaluator._get_type_of_expression_core(
                     if isinstance(symbol_type, types.FunctionType) {
                         overloaded_ty: types.OverloadedType | None = None;
                         overloaded_fns: list[types.FunctionType] = [symbol_type];
-                        # Find the scope where the symbol is defined to check for overloads
-                        symbol_scope: uni.UniScopeNode | None = symbol.parent_tab;
-                        if symbol_scope is None {
-                            # If parent_tab is None, try to find the scope from the declaration
-                            if symbol.decl
-                            and symbol.decl.find_parent_of_type(uni.UniScopeNode) {
-                                symbol_scope = symbol.decl.find_parent_of_type(
-                                    uni.UniScopeNode
-                                );
-                            }
+                        # Collect sibling overloads at the symbol's definition
+                        # scope. Follow re-export chains (e.g. an `@overload`-ed
+                        # function imported through several `__init__` layers, as
+                        # SQLAlchemy's `create_engine`) so the overloads at the
+                        # `def` site are found, not the lone re-export.
+                        def_sym = self.resolve_to_definition_symbol(symbol);
+                        symbol_scope: uni.UniScopeNode | None = def_sym.parent_tab;
+                        if symbol_scope is None and def_sym.decl {
+                            symbol_scope = def_sym.decl.find_parent_of_type(
+                                uni.UniScopeNode
+                            );
                         }
-                        # Check if there are overloads in the symbol's scope
                         if symbol_scope {
                             all_syms = type_utils.collect_member_syms(
-                                symbol_scope, expr.value
+                                symbol_scope, def_sym.sym_name
                             );
                             for overload_symbol in all_syms {
-                                if overload_symbol == symbol {
+                                if overload_symbol == def_sym {
                                     continue;
                                 }
                                 overload_type = self.get_type_of_symbol(

--- a/jac/jaclang/compiler/type_system/type_evaluator.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.jac
@@ -303,6 +303,9 @@ obj TypeEvaluator {
     def pop_symbol_resolution(symbol: uni.Symbol) -> bool;
     # Pyright equivalent function name = getEffectiveTypeOfSymbol.
     def get_type_of_symbol(symbol: uni.Symbol) -> TypeBase;
+    # Follow an imported symbol's re-export chain to its defining symbol, so
+    # overload collection happens at the definition scope, not a re-export one.
+    def resolve_to_definition_symbol(symbol: uni.Symbol) -> uni.Symbol;
     # Widen literal types (e.g. Literal["x"] -> str) for the *declared* type
     # of an unannotated variable, inferred from its first binding.
     def _widen_literal_for_declaration(ty: TypeBase) -> TypeBase;

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_imported_overload.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_imported_overload.jac
@@ -1,0 +1,3 @@
+import from checker_overload_reexport { make }
+
+glob x = make("a");

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_overload_defs.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_overload_defs.jac
@@ -1,0 +1,7 @@
+import from typing { overload }
+
+@overload
+def make(url: str, *, strict: bool) -> int { }
+
+@overload
+def make(url: str) -> int { }

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_overload_reexport.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_overload_reexport.jac
@@ -1,0 +1,1 @@
+import from checker_overload_defs { make }

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -241,6 +241,20 @@ test "from_import" {
     );
 }
 
+"""Calling an @overload-ed function imported through a re-export chain matches
+the later overload. Overloads must be gathered at the definition scope, not the
+single-symbol re-export scope (regression: SQLAlchemy `create_engine`)."""
+test "imported_overloaded_function_call_resolves" {
+    path = os.path.join(CHECKER_FIXTURES, "checker_imported_overload.jac");
+    program = JacProgram();
+    program.compile(path, type_check=True);
+    assert program.errors_had == [] , (
+        "make(\"a\") matches the no-strict overload; expected no errors, got: " + str(
+            [e.pretty_print() for e in program.errors_had]
+        )
+    );
+}
+
 test "call_expr" {
     path = os.path.join(CHECKER_FIXTURES, "checker_expr_call.jac");
     program = JacProgram();


### PR DESCRIPTION
## Summary

Calling an `@overload`-ed function imported through a **re-export chain** reported a spurious `E1050: Not all required parameters were provided`.

Real-world repro (SQLAlchemy):

```jac
import from sqlalchemy { create_engine }
glob eng = create_engine("sqlite:///:memory:");  # E1050: missing required parameter 'future'
```

`create_engine` is re-exported through several `__init__` layers from `engine/create.py`, where it has three `@overload`s (the first makes `future` required). The checker collapsed it to that first signature and rejected the single-arg call.

## Root cause

The Name-expression overload collection gathered siblings from `symbol.parent_tab`. For a re-exported symbol that scope is the `__init__` re-export site, which holds only the **single** re-export symbol — not the definition scope (`engine/create.py`) where the overloads actually live. So no overloads were collected.

## Fix

Add `resolve_to_definition_symbol`, which follows an imported symbol's re-export chain (`decl.name_of.sym` hop by hop) to the defining symbol. Overload collection then runs in the **definition** scope, under the definition's name.

## Test

`imported_overloaded_function_call_resolves` uses a three-file re-export chain (`defs -> reexport -> caller`) and asserts a call matching a later overload type-checks clean. Red before the fix (E1050), green after.

## Note

This supersedes #6480, which targeted the import-item path and did **not** actually fix the bug (the call site resolves overloads via a different path). #6480 is closed.

A second false positive in the same SQLAlchemy snippet — `result.rowcount > 0` (E1110), where `@util.memoized_property` is not unwrapped via the descriptor `__get__` protocol — is a separate, larger, tracked follow-up.