### PR TITLE
chore(jac-desktop): roll version back to 0.1.1 so the release lands 0.2.0

### DIFF
--- a/docs/docs/community/release_notes/jac-desktop.md
+++ b/docs/docs/community/release_notes/jac-desktop.md
@@ -1,27 +1,6 @@
 # jac-desktop Release Notes
 
-## jac-desktop 0.2.0 (Latest Release)
-
-### Breaking: PyTauri/PyInstaller replaced by a Jac-native desktop host
-
-The desktop target is now **Jac-native**: `jac build --client desktop` builds your
-`cl` bundle and compiles a single native host (`jac nacompile`) that embeds the OS
-webview to render it - no Rust toolchain, no PyInstaller sidecar, no separate
-process. Output is one self-contained binary under `.jac/client/desktop/`.
-
-- **Removed**: the PyTauri shell, the PyInstaller sidecar, the `jac desktop plugin`
-  CLI (Tauri plugin catalog), and the `pytauri-wheel`/`anyio`/`pyinstaller`
-  dependencies. There is no longer a `jac setup desktop` step or `src-pytauri/`
-  scaffold.
-- **Added**: the native webview binding + build tooling under
-  `jac_desktop/native/webview/`, with a dependency-free test suite. The host
-  embeds CPython to serve the bundle on loopback (and to host `sv` in-process).
-- **Config**: `[plugins.desktop]` keeps app identity + `[plugins.desktop.window]`
-  geometry; the Tauri-plugin / sidecar config fields are gone.
-
-See [issue #6436](https://github.com/jaseci-labs/jaseci/issues/6436).
-
-## jac-desktop 0.1.1
+## jac-desktop 0.1.1 (Latest Release)
 
 ### New Features
 

--- a/docs/docs/community/release_notes/unreleased/jac-desktop/6455.breaking.md
+++ b/docs/docs/community/release_notes/unreleased/jac-desktop/6455.breaking.md
@@ -1,0 +1,5 @@
+- **PyTauri/PyInstaller replaced by a Jac-native desktop host**: The desktop target is now Jac-native. `jac build --client desktop` builds your `cl` bundle and compiles a single native host (`jac nacompile`) that embeds the OS webview to render it - no Rust toolchain, no PyInstaller sidecar, no separate process. Output is one self-contained binary under `.jac/client/desktop/`.
+- **Removed**: the PyTauri shell, the PyInstaller sidecar, the `jac desktop plugin` CLI (Tauri plugin catalog), and the `pytauri-wheel`/`anyio`/`pyinstaller` dependencies. There is no longer a `jac setup desktop` step or `src-pytauri/` scaffold.
+- **Added**: the native webview binding + build tooling under `jac_desktop/native/webview/`, with a dependency-free test suite. The host embeds CPython to serve the bundle on loopback (and to host `sv` in-process).
+- **Config**: `[plugins.desktop]` keeps app identity + `[plugins.desktop.window]` geometry; the Tauri-plugin / sidecar config fields are gone.
+- See [issue #6436](https://github.com/jaseci-labs/jaseci/issues/6436).

--- a/jac-desktop/jac.toml
+++ b/jac-desktop/jac.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jac-desktop"
-version = "0.2.0"
+version = "0.1.1"
 description = "Jac-native desktop target: one nacompile'd binary + the OS webview."
 authors = [{ name = "Jason Mars", email = "jason@mars.ninja" }]
 maintainers = [{ name = "Jason Mars", email = "jason@mars.ninja" }]


### PR DESCRIPTION
## Why

jac-desktop's `jac.toml` was set to **0.2.0** (the Jac-native rewrite), but **0.2.0 was never published to PyPI** — only `0.1.0` and `0.1.1` are live. If we run a `patch` release from here, jac-desktop bumps `0.2.0 → 0.2.1` and **0.2.0 is skipped on PyPI entirely**.

0.2.0 is the milestone release (full PyTauri → Jac-native rewrite) and should ship under that exact number.

## Change

Roll `jac-desktop/jac.toml` version back to **0.1.1** (the last published version). Then in the upcoming release, give jac-desktop a **minor** bump:

```
0.1.1 --minor--> 0.2.0   ✅ (validated: 0.2.0 is free on PyPI)
0.1.1 --patch--> 0.1.2   (what we're avoiding)
```

So jac-desktop publishes the rewrite as **0.2.0** while the other 7 packages take their normal `patch`.

## No other changes needed
- **Release notes** already have `## jac-desktop 0.2.0 (Latest Release)` → `0.1.1` → `0.1.0`, which stays correct (the release tooling won't touch notes since there are no unreleased fragments).
- **jaseci-package** already pins `jac-desktop>=0.1.1` (it was never moved to 0.2.0 either), satisfied by the upcoming 0.2.0.

## After this merges
Run **Create Release PR** with: jac-desktop = **minor**, everything else = **patch**.