### PR TITLE
fix(types): type document root elements as HTMLElement so .classList resolves

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6489.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6489.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: DOM member access off `document.documentElement`/`body`/`head` in client code**: Reaching members like `.classList` off `document`'s root elements in `.cl.jac` code now type-checks instead of failing with `E1030: Type "object" has no attribute "classList"`. (jaseci-labs/jaseci#6489)

--- a/jac/jaclang/compiler/type_system/js_globals.pyi
+++ b/jac/jaclang/compiler/type_system/js_globals.pyi
@@ -20,7 +20,14 @@ sessionStorage) live in dom_types.pyi; this file is disjoint from it.
 """
 
 from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    # HTMLElement lives in dom_types.pyi, whose names the TypeEvaluator merges
+    # into builtins, so `_Document`'s element members below resolve it
+    # ambiently at check time. This guarded import is for static analysers
+    # (e.g. Pylance) only -- it is never executed by the stub loader.
+    from dom_types import HTMLElement
 
 _T = TypeVar("_T")
 
@@ -490,9 +497,15 @@ class _Document:
     title: str
     cookie: str
     readyState: str
-    body: object
-    head: object
-    documentElement: object
+    # Always-present root elements. Typed as the real HTMLElement (from
+    # dom_types.pyi, merged into builtins) rather than the bare `object`
+    # placeholder so member access like `.classList`/`.style` resolves.
+    # The query methods below stay `object`: they can return null and their
+    # callers want element-subtype members (e.g. `.value`), so a single
+    # HTMLElement type would neither type-check correctly nor stay null-safe.
+    body: HTMLElement
+    head: HTMLElement
+    documentElement: HTMLElement
     activeElement: object
     def getElementById(self, element_id: str) -> object: ...
     def querySelector(self, selectors: str) -> object: ...

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_js_globals_client.cl.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_js_globals_client.cl.jac
@@ -21,3 +21,17 @@ def parse_and_format(raw: str) -> int {
     n = parseInt(raw, 10);
     return int(n);
 }
+
+# Mirrors the this_is_jac frontend.cl.jac:61 failure: `document`'s
+# always-present root elements (documentElement/body/head) must carry the
+# real HTMLElement type so `.classList` (and other element members) resolve
+# instead of erroring E1030 off the bare `object` placeholder.
+def toggle_dark(dark: bool) -> bool {
+    if dark {
+        document.documentElement.classList.add("dark");
+    } else {
+        document.documentElement.classList.remove("dark");
+    }
+    document.body.classList.toggle("ready");
+    return document.head.classList.contains("loaded");
+}


### PR DESCRIPTION
## What

`_Document.documentElement` / `body` / `head` were typed as the bare `object` placeholder in `js_globals.pyi`, so client (`.cl.jac`) code accessing `.classList` (or any other `HTMLElement` member) off them failed type-checking with:

```
error[E1030]: Type "object" has no attribute "classList"
  document.documentElement.classList.add("dark");
```

even though this is valid browser JS. The correct `HTMLElement` type (with `classList: DOMTokenList`) already exists in `dom_types.pyi`, but `_Document`'s element accessors never referenced it.

## Change

- Type the three always-present, never-null root-element accessors (`documentElement`, `body`, `head`) as the real `HTMLElement` (resolved ambiently via the dom_types→builtins merge).
- The nullable query methods (`getElementById`, `querySelector`, ...) deliberately stay `object`: they can return null and their callers want element-subtype members like `.value`, so a single `HTMLElement` type would neither type-check those nor stay null-safe.
- A `TYPE_CHECKING`-guarded import keeps static analyzers (pyright/Pylance) resolving `HTMLElement` without the stub loader executing it.
- Adds regression coverage (`.classList` add/remove/toggle/contains on all three accessors) to the existing zero-diagnostics `checker_js_globals_client.cl.jac` fixture.

## Verification

- Server-context gating preserved (JS globals still stay Unknown in server `.jac`).
- pyright on the stub: 0 errors.
- 218 main checker-pass tests + 3 js_globals checker tests pass.