### PR TITLE
ci(jac-check): add label-triggered type-error breakdown report

### DIFF
--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 jobs:
@@ -44,3 +45,24 @@ jobs:
       - name: Run jac check (using .jacignore)
         run: |
           jac check . --ignore tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ') --nowarn
+
+      - name: Error-code breakdown (label "type-error-report")
+        if: contains(github.event.pull_request.labels.*.name, 'type-error-report')
+        run: |
+          set +e
+          echo "Scanning the whole codebase (no ignores) for an error-code breakdown..."
+          jac check . --nowarn > jac-check-full.log 2>&1
+
+          {
+            echo "## jac check error-code breakdown (whole codebase, no ignores)"
+            echo ""
+            echo "| Error code | Count |"
+            echo "| --- | ---: |"
+            grep -oE 'error\[E[0-9]+\]' jac-check-full.log \
+              | grep -oE 'E[0-9]+' \
+              | sort | uniq -c | sort -rn \
+              | awk '{ printf "| %s | %d |\n", $2, $1; total += $1 }
+                     END { printf "| **TOTAL** | **%d** |\n", total }'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 0


### PR DESCRIPTION
## What this does

Adds an optional, on-demand report to the Jac Type Check workflow. When a pull request carries the `type-error-report` label, the workflow runs an extra full-codebase `jac check` (with no ignores) and posts a per-error-code count
table to the run's Summary page.

The report is purely informational: the step always exits 0, so it never affects whether the job passes or fails. The existing gating `jac check` step (which uses `.jacignore`) is unchanged and remains the sole determinant of pass/fail.

## Why

The normal check suppresses a large set of files via `.jacignore`, so it is hard to see the real backlog of type errors across the codebase. This gives us an opt-in snapshot, grouped by error code, so we can see at a glance which diagnostics are most common and track them over time, without adding noise to every CI run.

## How it works

- The `pull_request` trigger now also fires on `labeled`, so adding the label re-runs the workflow on demand.
- The new "Error-code breakdown" step is gated on the `type-error-report` label, so it only runs when the label is present.
- It scans the whole repo, extracts every `error[E####]` code from the output, counts them, and writes a Markdown table to the run summary.

Example output on the run summary:

| Error code | Count |
| --- | ---: |
| E1053 | 124 |
| E1099 | 40 |
| E1030 | 23 |
| **TOTAL** | **187** |

## Notes

- The report's scan is intentionally unfiltered (no `.jacignore`), so its counts are higher than the gating step's and include test fixtures and intentional error files.
