### PR TITLE
fix(console): use semantic Span roles so Rich theme styles match ANSI

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-super/6496.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-super/6496.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Rich console theme roles match the ANSI backend**: jac-super's Rich renderer now applies semantic roles (`highlight`, `muted`, etc.) from Span styles instead of raw color names, so styled CLI chrome renders correctly when jac-super is installed.

--- a/docs/docs/community/release_notes/unreleased/jaclang/6496.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6496.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: console `cyan`/`dim` Span roles render unstyled under jac-super**: Facade and Rich renderer now use semantic roles `highlight` and `muted` instead of raw color names, so styled chrome matches across ANSI and Rich backends.

--- a/jac-super/jac_super/plugin/impl/console.impl.jac
+++ b/jac-super/jac_super/plugin/impl/console.impl.jac
@@ -139,7 +139,7 @@ obj RichRenderer(ConsoleRenderer) {
         }
     }
 
-    """Header: title (and version) in cyan, no rule (Rich house style)."""
+    """Header: title (and version) in highlight role, no rule (Rich house style)."""
     def header(title: str, version: (str | None) = None) {
         if version {
             self.emit([Span(f"{title} v{version}", 'highlight')]);

--- a/jac-super/jac_super/plugin/impl/console.impl.jac
+++ b/jac-super/jac_super/plugin/impl/console.impl.jac
@@ -142,9 +142,9 @@ obj RichRenderer(ConsoleRenderer) {
     """Header: title (and version) in cyan, no rule (Rich house style)."""
     def header(title: str, version: (str | None) = None) {
         if version {
-            self.emit([Span(f"{title} v{version}", 'cyan')]);
+            self.emit([Span(f"{title} v{version}", 'highlight')]);
         } else {
-            self.emit([Span(title, 'cyan')]);
+            self.emit([Span(title, 'highlight')]);
         }
     }
 

--- a/jac/jaclang/cli/impl/console.impl.jac
+++ b/jac/jaclang/cli/impl/console.impl.jac
@@ -39,8 +39,6 @@ glob _ANSI_ROLES: dict = {
          'highlight': CYAN,
          'url': BRIGHT_BLUE + UNDERLINE,
          'time': GREEN,
-         'cyan': CYAN,
-         'dim': DIM,
          'bright_white': BRIGHT_WHITE
      };
 
@@ -222,7 +220,7 @@ impl ConsoleRenderer.urls(items: list, symbol: str = '') -> None {
         self.emit(
             [
                 Span("  ", None),
-                Span(sym, 'cyan'),
+                Span(sym, 'highlight'),
                 Span("  ", None),
                 Span(padded_label, 'muted'),
                 Span(" ", None),
@@ -237,7 +235,7 @@ impl ConsoleRenderer.next_steps(steps: list[str], title: str = 'Next Steps') -> 
     self.emit([Span("", None)]);
     self.emit([Span(f"{title}:", 'bright_white')]);
     for (i, step) in enumerate(steps, 1) {
-        self.emit([Span(f"  {i}.", 'cyan'), Span(f" {step}", None)]);
+        self.emit([Span(f"  {i}.", 'highlight'), Span(f" {step}", None)]);
     }
     self.emit([Span("", None)]);
 }
@@ -261,19 +259,19 @@ impl ConsoleRenderer.table(
     header_spans: list[Span] = [];
     for (idx, (h, w)) in enumerate(zip(headers, col_widths)) {
         if idx > 0 {
-            header_spans.append(Span(" | ", 'dim'));
+            header_spans.append(Span(" | ", 'muted'));
         }
         header_spans.append(Span(h.ljust(w), 'bright_white'));
     }
     self.emit(header_spans);
     sep_len = sum(col_widths) + (len(col_widths) - 1) * 3;
-    self.emit([Span('-' * sep_len, 'dim')]);
+    self.emit([Span('-' * sep_len, 'muted')]);
     # Data rows: cells emitted verbatim, only the separators styled.
     for row in rows {
         row_spans: list[Span] = [];
         for (i, cell) in enumerate(row) {
             if i > 0 {
-                row_spans.append(Span(" | ", 'dim'));
+                row_spans.append(Span(" | ", 'muted'));
             }
             width = col_widths[i] if i < len(col_widths) else 0;
             row_spans.append(Span(str(cell).ljust(width), None));


### PR DESCRIPTION
## Summary

Small follow-up to the console facade/renderer refactor (#6201).

`cyan` and `dim` were used as `Span` style roles in facade chrome (`print_urls`, `print_next_steps`, `print_table`) and the Rich header. The ANSI backend mapped them in `_ANSI_ROLES`, but jac-super's `JAC_THEME` had no entries for those names, so the spans rendered **unstyled** under the default Rich console.

This PR replaces them with semantic roles both renderers already support:

- `cyan` → `highlight`
- `dim` → `muted`

Also removes `cyan` / `dim` from `_ANSI_ROLES` so the leak cannot recur. They remain in `_ANSI_STYLE_TOKENS` for legacy `print(style="bold cyan")` call sites.

## Files

- `jac/jaclang/cli/impl/console.impl.jac`
- `jac-super/jac_super/plugin/impl/console.impl.jac`
- `docs/docs/community/release_notes/unreleased/jaclang/6496.bugfix.md`

## Test plan

- [ ] `jac test jac/tests/language/test_console.jac`
- [ ] `jac test jac-super/tests/test_console_conformance.jac`
- [ ] `jac test jac-super/tests/test_console_capability.jac`
- [ ] `jac test jac-super/tests/test_console_renderer.jac`

## Related

- #6201 (shipped refactor)
- #6499 (remaining ANSI per-stream color bug, separate scope)