### PR TITLE
chore: disable Greptile attribution footer

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "hideFooter": true
+}


### PR DESCRIPTION
Adds a `greptile.json` at the repo root with `hideFooter: true` so Greptile's review comments no longer include the attribution/footer line.

The setting is picked up automatically from the repo root on the next PR review.