### PR TITLE
fix(format): typed connect operators format compactly

### DIFF
--- a/docs/docs/assets/examples/object_spatial/family_relationship_graph.jac
+++ b/docs/docs/assets/examples/object_spatial/family_relationship_graph.jac
@@ -15,9 +15,9 @@ glob parent = root ++> Person(name="John", age=45),
 
 # Now, let's create the relationships between them
 with entry {
-    parent +>: FamilyRelation(relationship_type="parent") :+> child1;
-    parent +>: FamilyRelation(relationship_type="parent") :+> child2;
-    child1 +>: FamilyRelation(relationship_type="sibling") :+> child2;
+    parent +>:FamilyRelation(relationship_type="parent"):+> child1;
+    parent +>:FamilyRelation(relationship_type="parent"):+> child2;
+    child1 +>:FamilyRelation(relationship_type="sibling"):+> child2;
 }
 
 # You can now ask questions about these relationships

--- a/docs/docs/assets/examples/object_spatial/finding_common_interests.jac
+++ b/docs/docs/assets/examples/object_spatial/finding_common_interests.jac
@@ -50,9 +50,9 @@ glob alice = root ++> Person(
 
 # Create friendships with metadata
 with entry {
-    alice +>: FriendsWith(since="2020-01-15", closeness=8) :+> bob;
-    alice +>: FriendsWith(since="2021-06-10", closeness=9) :+> charlie;
-    bob +>: FriendsWith(since="2020-12-03", closeness=7) :+> charlie;
+    alice +>:FriendsWith(since="2020-01-15", closeness=8):+> bob;
+    alice +>:FriendsWith(since="2021-06-10", closeness=9):+> charlie;
+    bob +>:FriendsWith(since="2020-12-03", closeness=7):+> charlie;
 
     print("=== Friend Network Analysis ===");
 }

--- a/docs/docs/assets/examples/object_spatial/greeting_friends_walker.jac
+++ b/docs/docs/assets/examples/object_spatial/greeting_friends_walker.jac
@@ -24,8 +24,8 @@ glob alice = root ++> Person(name="Alice"),
 
 # Connect friends
 with entry {
-    alice +>: FriendsWith :+> bob +>: FriendsWith :+> charlie;
-    alice +>: FriendsWith :+> charlie;  # Alice also friends with Charlie
+    alice +>:FriendsWith:+> bob +>:FriendsWith:+> charlie;
+    alice +>:FriendsWith:+> charlie;  # Alice also friends with Charlie
 
     # Start the walker on the 'alice' node to greet everyone
     alice[0] spawn GreetFriends();

--- a/docs/docs/assets/examples/object_spatial/object_spatial_references.jac
+++ b/docs/docs/assets/examples/object_spatial/object_spatial_references.jac
@@ -17,8 +17,8 @@ impl Creator.create{
     for i = 0 to i < 3 by i += 1 {
         end ++> (end := node_a(val=i));
     }
-    end +>: connector : value=i :+> (end := node_a(val=i + 10));
-    root <+: connector : value=i :<+ (end := node_a(val=i + 10));
+    end +>:connector:value=i:+> (end := node_a(val=i + 10));
+    root <+:connector:value=i:<+ (end := node_a(val=i + 10));
     visit [-->];
 }
 

--- a/docs/docs/community/release_notes/unreleased/jaclang/6523.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6523.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: typed connect operators format compactly**: `jac format` now renders typed connect operators such as `+>:Edge:+>` and `+>:Edge:weight=5:+>` without spaces around the inner colons, matching the existing traversal (`->:Edge:->`) and disconnect (`del ->:Edge:->`) forms.

--- a/docs/docs/examples/chapter_10_school.jac
+++ b/docs/docs/examples/chapter_10_school.jac
@@ -118,9 +118,9 @@ walker StudentAnalyzer {
 glob science_lab = root ++> Classroom(
          room_number="Lab-A", capacity=24, has_projector=True
      ),
-     dr_smith = science_lab +>: Teaches(
+     dr_smith = science_lab +>:Teaches(
          start_date="2024-08-01", schedule="TR 10:00-11:30"
-     ) :+> Teacher(
+     ):+> Teacher(
          name="Dr. Smith",
          subject="Chemistry",
          years_experience=12,
@@ -134,9 +134,9 @@ glob science_lab = root ++> Classroom(
 
 with entry {
     for (name, age, grade, id) in students {
-        student = science_lab +>: EnrolledIn(
+        student = science_lab +>:EnrolledIn(
             enrollment_date="2024-08-15", attendance_rate=92.0
-        ) :+> Student(name=name, age=age, grade_level=grade, student_id=id);
+        ):+> Student(name=name, age=age, grade_level=grade, student_id=id);
 
         print(f"Enrolled {student[0].name} in {science_lab[0].room_number}");
     }

--- a/jac-client/jac_client/examples/little-x/main.jac
+++ b/jac-client/jac_client/examples/little-x/main.jac
@@ -19,7 +19,7 @@ node Profile {
 
     can follow with follow_request entry {
         current_profile = [root-->[?:Profile]];
-        current_profile[0] +>: Follow() :+> self;
+        current_profile[0] +>:Follow():+> self;
         report self;
     }
 
@@ -57,7 +57,7 @@ node Tweet {
 
     can like_tweet with like_tweet entry {
         current_profile = [root-->[?:Profile]];
-        self +>: Like() :+> current_profile[0];
+        self +>:Like():+> current_profile[0];
         report self;
     }
 
@@ -70,9 +70,7 @@ node Tweet {
 
     can comment with comment_tweet entry {
         current_profile = [root-->[?:Profile]];
-        comment_node = current_profile[0] +>: Post() :+> Comment(
-            content=visitor.content
-        );
+        comment_node = current_profile[0] +>:Post():+> Comment(content=visitor.content);
         grant(comment_node[0], level=ConnectPerm);
         self ++> comment_node[0];
         report comment_node[0];
@@ -159,7 +157,7 @@ walker create_tweet(visit_profile) {
     has content: str;
 
     can tweet with Profile entry {
-        tweet_node = here +>: Post() :+> Tweet(content=self.content, embedding=[]);
+        tweet_node = here +>:Post():+> Tweet(content=self.content, embedding=[]);
         grant(tweet_node[0], level=ConnectPerm);
         report tweet_node;
     }

--- a/jac-scale/jac_scale/tests/test_topology_scale.jac
+++ b/jac-scale/jac_scale/tests/test_topology_scale.jac
@@ -46,10 +46,10 @@ test "topology_index_data survives Serializer round-trip" {
         r = root;
 
         for i in range(5) {
-            r +>: Knows :+> Person(name=f"person_{i}", age=20 + i);
+            r +>:Knows:+> Person(name=f"person_{i}", age=20 + i);
         }
         for i in range(3) {
-            r +>: LivesIn :+> City(name=f"city_{i}");
+            r +>:LivesIn:+> City(name=f"city_{i}");
         }
 
         # Verify index was built
@@ -105,10 +105,10 @@ test "topology index resolve_chain works after Serializer round-trip" {
         r = root;
 
         for i in range(10) {
-            r +>: Knows :+> Person(name=f"p{i}", age=i);
+            r +>:Knows:+> Person(name=f"p{i}", age=i);
         }
         for i in range(5) {
-            r +>: LivesIn :+> City(name=f"c{i}");
+            r +>:LivesIn:+> City(name=f"c{i}");
         }
 
         root_id = r.__jac__.id;
@@ -156,10 +156,10 @@ test "topology index survives sqlite persistence round-trip" {
         r = root;
 
         for i in range(5) {
-            r +>: Knows :+> Person(name=f"person_{i}", age=20 + i);
+            r +>:Knows:+> Person(name=f"person_{i}", age=20 + i);
         }
         for i in range(3) {
-            r +>: LivesIn :+> City(name=f"city_{i}");
+            r +>:LivesIn:+> City(name=f"city_{i}");
         }
 
         # Verify queries work before persistence
@@ -252,9 +252,9 @@ test "topology-only change is detected by _compute_hash dirty gate" {
 
         # Build an initial graph so the root carries a populated topology index.
         p0 = Person(name="p0", age=20);
-        r +>: Knows :+> p0;
+        r +>:Knows:+> p0;
         for i in range(1, 4) {
-            r +>: Knows :+> Person(name=f"p{i}", age=20 + i);
+            r +>:Knows:+> Person(name=f"p{i}", age=20 + i);
         }
 
         root_anchor = r.__jac__;
@@ -269,7 +269,7 @@ test "topology-only change is detected by _compute_hash dirty gate" {
         # A topology-only mutation: connect an edge *deeper* in the subtree
         # (p0 -> Person). on_edge_created updates the root's topology index, but
         # the root's own edge list and archetype fields are untouched.
-        p0 +>: Knows :+> Person(name="deep", age=99);
+        p0 +>:Knows:+> Person(name="deep", age=99);
 
         topo_after = root_anchor.topology_index_data;
         root_edges_after = [e.id for e in root_anchor.edges];

--- a/jac/examples/littleX/social_graph.jac
+++ b/jac/examples/littleX/social_graph.jac
@@ -300,7 +300,7 @@ walker create_tweet {
     }
 
     can make with Profile entry {
-        new = here +>: Post() :+> Tweet(
+        new = here +>:Post():+> Tweet(
             content=self.content, author_username=here.username, created_at=_now()
         );
         grant(new[0], level=WritePerm);
@@ -317,7 +317,7 @@ walker create_channel {
     }
 
     can make with Profile entry {
-        new = here +>: Member() :+> Channel(
+        new = here +>:Member():+> Channel(
             name=self.name,
             description=self.description,
             creator_username=here.username,
@@ -347,7 +347,7 @@ walker follow_user(find_profile) {
     can act with Profile entry {
         if jid(here) == self.target_id {
             me = [root-->[?:Profile]][0];
-            me +>: Follow() :+> here;
+            me +>:Follow():+> here;
             report {"success": True};
             disengage;
         }
@@ -451,7 +451,7 @@ walker join_channel(find_channel) {
         if jid(here) == self.channel_id {
             me = [root-->[?:Profile]][0];
             if not [edge me->:Member:->here] {
-                me +>: Member() :+> here;
+                me +>:Member():+> here;
             }
             report {"success": True};
             disengage;
@@ -491,7 +491,7 @@ walker create_channel_tweet(find_channel) {
         if jid(here) == self.channel_id {
             me = [root-->[?:Profile]][0];
             if [edge me->:Member:->here] {
-                new = here +>: ChannelPost() :+> Tweet(
+                new = here +>:ChannelPost():+> Tweet(
                     content=self.content, author_username=me.username, created_at=_now()
                 );
                 grant(new[0], level=WritePerm);

--- a/jac/jaclang/cli/impl/ai_agent.impl.jac
+++ b/jac/jaclang/cli/impl/ai_agent.impl.jac
@@ -2429,15 +2429,15 @@ impl build_pipeline -> Plan {
     build = Build();
     qa = QA();
     done = Done();
-    plan +>: Flow :+> build;
+    plan +>:Flow:+> build;
     # Read-only fast path: a pure question or inspection that needs no file
     # changes finishes straight from Plan, so it never enters Build (and its
     # wrote-nothing nudge loop) or QA. Build remains the default Plan successor.
-    plan +>: Flow :+> done;
-    build +>: Flow :+> qa;
-    qa +>: Flow :+> build;
-    qa +>: Flow :+> plan;
-    qa +>: Flow :+> done;
+    plan +>:Flow:+> done;
+    build +>:Flow:+> qa;
+    qa +>:Flow:+> build;
+    qa +>:Flow:+> plan;
+    qa +>:Flow:+> done;
     # Materialize each state's tool affordances as Exposes edges from the single
     # TOOL_SPECS registry, in registry order (the order tools are offered to the
     # model). Built fresh per pipeline, so edges never accumulate across turns;
@@ -2445,7 +2445,7 @@ impl build_pipeline -> Plan {
     for ph in [plan, build, qa] {
         for spec in TOOL_SPECS {
             if type(ph) in spec.phases {
-                ph +>: Exposes :+> Tool(
+                ph +>:Exposes:+> Tool(
                     fn=spec.fn, category=spec.category, serialize=spec.serialize
                 );
             }

--- a/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/doc_ir_gen_pass.impl.jac
@@ -992,7 +992,11 @@ impl DocIRGenPass.exit_disconnect_op(nd: uni.DisconnectOp) -> None {
 
 """Generate DocIR for connect operator."""
 impl DocIRGenPass.exit_connect_op(nd: uni.ConnectOp) -> None {
-    self._assign_space_group(nd);
+    # Format the operator body compactly (no inner spaces) so a typed
+    # connect reads `+>:Edge:+>` / `+>:Edge:weight=5:+>`, matching the
+    # traversal edge-op ref (`->:Edge:->`) and disconnect (`del ->:Edge:->`)
+    # forms. Spacing around the operands is added by the enclosing BinaryExpr.
+    self._assign_group_concat(nd);
 }
 
 """Generate DocIR for visit statements."""

--- a/jac/tests/compiler/passes/tool/fixtures/connect_op_fmt.jac
+++ b/jac/tests/compiler/passes/tool/fixtures/connect_op_fmt.jac
@@ -1,0 +1,23 @@
+"""Connect-operator formatting: compact, consistent with traversal/disconnect."""
+node N {
+    has v: int = 0;
+}
+
+edge E {
+    has w: int = 0;
+}
+
+walker build {
+    can run with `root entry {
+        a = root +>:E:+> N(v=1);
+        b = a[0] +>:E:w=5:+> N(v=2);
+        c = a[0] +>:E:w=1, v=2:+> N(v=3);
+        d = a[0] <+:E:<+ N(v=4);
+        e = a[0] <+:E:+> N(v=5);
+        f = a[0] ++> N(v=6);
+        g = a[0] <++ N(v=7);
+        h = a[0] <++> N(v=8);
+        targets = [a[0]->:E:w>0:->];
+        a[0] del ->:E:-> N(v=1);
+    }
+}

--- a/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_format_pass.jac
@@ -100,6 +100,13 @@ test "tagbreak" {
     compare_files(os.path.join(FIXTURES, "tagbreak.jac"));
 }
 
+test "connect op compact fmt" {
+    # Typed connect operators (`+>:E:+>`, `<+:E:<+`, `+>:E:w=5:+>`) format
+    # compactly, matching the traversal edge-op (`->:E:->`) and disconnect
+    # (`del ->:E:->`) forms; no spaces are inserted around the inner colons.
+    compare_files(os.path.join(FIXTURES, "connect_op_fmt.jac"));
+}
+
 test "has fmt" {
     compare_files(os.path.join(FIXTURES, "has_frmt.jac"));
 }

--- a/jac/tests/runtimelib/test_topology_e2e.jac
+++ b/jac/tests/runtimelib/test_topology_e2e.jac
@@ -45,10 +45,10 @@ test "index type-filtered query returns correct results" {
         r = root;
 
         for i in range(10) {
-            r +>: EdgeX :+> TypeA(val=i);
+            r +>:EdgeX:+> TypeA(val=i);
         }
         for i in range(90) {
-            r +>: EdgeX :+> TypeB(val=i);
+            r +>:EdgeX:+> TypeB(val=i);
         }
 
         # Type-filtered: only TypeA via EdgeX
@@ -74,10 +74,10 @@ test "index results match non-indexed results in same context" {
     try {
         r = root;
         for i in range(20) {
-            r +>: EdgeX :+> TypeA(val=i);
+            r +>:EdgeX:+> TypeA(val=i);
         }
         for i in range(80) {
-            r +>: EdgeX :+> TypeB(val=i);
+            r +>:EdgeX:+> TypeB(val=i);
         }
 
         # With index (default): type-filtered
@@ -105,7 +105,7 @@ test "index returns empty for non-matching edge type" {
     try {
         r = root;
         for i in range(10) {
-            r +>: EdgeX :+> TypeA(val=i);
+            r +>:EdgeX:+> TypeA(val=i);
         }
 
         # EdgeY not in graph — should be empty
@@ -126,10 +126,10 @@ test "post-hoc filter fused with edge-op produces same results" {
     try {
         r = root;
         for i in range(10) {
-            r +>: EdgeX :+> TypeA(val=i);
+            r +>:EdgeX:+> TypeA(val=i);
         }
         for i in range(90) {
-            r +>: EdgeX :+> TypeB(val=i);
+            r +>:EdgeX:+> TypeB(val=i);
         }
 
         # Inline filter (already optimized)
@@ -157,12 +157,12 @@ test "nested post-hoc filter as origin of outer edge-op" {
         # root -> TypeA via EdgeX, TypeA -> TypeB via EdgeY
         for i in range(5) {
             a = TypeA(val=i);
-            r +>: EdgeX :+> a;
-            a +>: EdgeY :+> TypeB(val=i * 10);
+            r +>:EdgeX:+> a;
+            a +>:EdgeY:+> TypeB(val=i * 10);
         }
         # root -> TypeB via EdgeX (decoys)
         for i in range(20) {
-            r +>: EdgeX :+> TypeB(val=100 + i);
+            r +>:EdgeX:+> TypeB(val=100 + i);
         }
 
         # Inline multi-hop: get TypeB behind TypeA
@@ -196,7 +196,7 @@ test "planner bypasses index when no hop is filtered" {
     try {
         r = root;
         for i in range(10) {
-            r +>: EdgeX :+> TypeA(val=i);
+            r +>:EdgeX:+> TypeA(val=i);
         }
 
         # Fully unfiltered single-hop chain → planner must return None so
@@ -279,8 +279,8 @@ test "planner bails when a hop has predicates beyond type" {
         r = root;
         for i in range(10) {
             a = TypeA(val=i);
-            r +>: EdgeX :+> a;
-            a +>: EdgeY :+> TypeB(val=i * 10);
+            r +>:EdgeX:+> a;
+            a +>:EdgeY:+> TypeB(val=i * 10);
         }
 
         # `n.val > 5` introduces LOAD_ATTR + COMPARE_OP — the planner's
@@ -336,10 +336,10 @@ test "parent-type filter returns all subtype instances" {
     try {
         r = root;
         for i in range(5) {
-            r +>: EdgeX :+> PostNode(val=i);
+            r +>:EdgeX:+> PostNode(val=i);
         }
         for i in range(5) {
-            r +>: EdgeX :+> ArticleNode(val=100 + i);
+            r +>:EdgeX:+> ArticleNode(val=100 + i);
         }
 
         # Parent-type filter: must return ALL 10 (5 PostNode + 5 ArticleNode).
@@ -380,7 +380,7 @@ test "index built on root with null root field" {
     JacRuntime.set_context(ctx);
     try {
         r = root;
-        r +>: EdgeX :+> TypeA(val=42);
+        r +>:EdgeX:+> TypeA(val=42);
 
         idx = r.__jac__.get_topology_index();
         assert len(idx) > 0 , "Index should have edges";
@@ -412,9 +412,9 @@ test "typed-edge filter compares against edge attributes apply at runtime" {
         r = root;
         # Three nodes connected via Weighted edges with weights 1, 5, 10.
         # Predicate `weight>=5` should keep weights 5 and 10 (vals 20, 30).
-        r +>: Weighted(weight=1) :+> TypeA(val=10);
-        r +>: Weighted(weight=5) :+> TypeA(val=20);
-        r +>: Weighted(weight=10) :+> TypeA(val=30);
+        r +>:Weighted(weight=1):+> TypeA(val=10);
+        r +>:Weighted(weight=5):+> TypeA(val=20);
+        r +>:Weighted(weight=10):+> TypeA(val=30);
 
         heavy = sorted([n.val for n in [r->:Weighted:weight>=5:->]]);
         assert heavy == [20, 30] , (
@@ -450,8 +450,8 @@ test "non-final node predicate in multi-hop chain applies at runtime" {
         # `[r->:EdgeX:->[?:TypeA, val>=5]->:EdgeY:->[?:TypeB]]` should
         # only follow the v>=5 chains, yielding TypeB vals [50, 100].
         for v in [1, 5, 10] {
-            mid = r +>: EdgeX :+> TypeA(val=v);
-            mid[0] +>: EdgeY :+> TypeB(val=v * 10);
+            mid = r +>:EdgeX:+> TypeA(val=v);
+            mid[0] +>:EdgeY:+> TypeB(val=v * 10);
         }
 
         leaves = sorted(


### PR DESCRIPTION
## Problem

`jac format` rendered typed **connect** operators with spaces around the inner colons, e.g. `here +>: OnDay() :+> Day(...)` and (worse) `+>: Edge : weight=5 :+>` with a free-floating `:` before the attributes. That is inconsistent with every other edge-operator form, which already formats **compactly**:

- traversal edge-op ref: `[->:Edge:->]`, `[->:Edge:weight>5:->]`
- disconnect: `del ->:Edge:-> b`

Only `ConnectOp` was the outlier, because `exit_connect_op` joined its child tokens with spaces (`_assign_space_group`) while `exit_edge_op_ref` concatenates them (`_assign_group_concat`).

## Fix

Route `ConnectOp` through the same compact `_assign_group_concat` helper the traversal edge-op ref already uses. The operator body now has no inner spaces:

```
here +>:OnDay():+> Day(date=today)
n1   <+:Edge:<+ n2
here +>:Edge:weight=5:+> n2
```

Spacing around the operands is unchanged (it comes from the enclosing `BinaryExpr`), so `a +>:E:+> b` keeps its outer spaces.

## Repo reformat

CI's `jac-check.yml` runs `jac format --check` over the whole tree, so the new canonical form is applied to the existing spaced-style call sites: the docs OSP examples, `littleX/social_graph.jac`, the `jac-scale`/`runtimelib` topology tests, the littleX client example, and the `jac ai` agent module. All changes are whitespace-only inside connect operators (one call collapsed onto a single line because the shorter operator now fits).

## Tests

- New golden fixture `connect_op_fmt.jac` covering forward/backward/bidirectional connects, attribute forms, plain arrows, and the traversal/disconnect forms for contrast.
- New `test "connect op compact fmt"` (`compare_files`) — fails on the old spaced output, passes on the compact output.

_Note: this PR mechanically reformats example files across several packages, so it carries the `skip-release-notes-check` label; the user-facing change is captured by the jaclang release-note fragment._
