### PR TITLE
docs(fullstack): document ref-forwarding components (follow-up to #6520)

### DIFF
--- a/docs/docs/tutorials/fullstack/npm-and-libraries.md
+++ b/docs/docs/tutorials/fullstack/npm-and-libraries.md
@@ -395,7 +395,7 @@ glob _buttonVariants: any = cva(
     }
 );
 
-def:pub Button(props: any) -> JsxElement {
+def:pub Button(props: any, ref: Ref[HTMLButtonElement]) -> JsxElement {
     variant = props.variant or "default";
     size = props.size or "default";
     computedClass = cn(
@@ -403,11 +403,13 @@ def:pub Button(props: any) -> JsxElement {
         props.className
     );
 
-    return <button className={computedClass} {**props}>
+    return <button ref={ref} className={computedClass} {**props}>
         {props.children}
     </button>;
 }
 ```
+
+The trailing `ref: Ref[HTMLButtonElement]` parameter is what lets this `Button` be used as a radix `asChild` trigger (`DropdownMenuTrigger`, `Tooltip.Trigger`, ...). It forwards the anchor ref radix needs for positioning down to the real `<button>`; without it the trigger would silently never open. See [forwarding a ref into your component](state.md#forwarding-a-ref-into-your-component) for the details.
 
 Required dependencies:
 
@@ -418,31 +420,33 @@ Required dependencies:
 
 ### Wrapping Radix UI Primitives
 
-shadcn components wrap Radix UI primitives. Here's a Dialog example in Jac:
+shadcn components wrap Radix UI primitives. Each wrapper that renders a DOM node **forwards a ref** to it (via a trailing `ref: Ref` parameter) so the primitive stays a valid `asChild` / positioning target -- exactly as upstream shadcn does with `React.forwardRef`. The exception is a wrapper around a context-only primitive like `Dialog.Root`, which renders no element and takes no ref. Here's a Dialog example in Jac:
 
 ```jac
 # components/ui/dialog.cl.jac
 import from "radix-ui" { Dialog as DialogPrimitive }
 import from ...lib.utils { cn }
 
+# Root is a context provider -- it renders no DOM node, so it takes no ref.
 def:pub Dialog(props: any) -> JsxElement {
     return <DialogPrimitive.Root {**props}>
         {props.children}
     </DialogPrimitive.Root>;
 }
 
-def:pub DialogTrigger(props: any) -> JsxElement {
-    return <DialogPrimitive.Trigger {**props}>
+def:pub DialogTrigger(props: any, ref: Ref[HTMLButtonElement]) -> JsxElement {
+    return <DialogPrimitive.Trigger ref={ref} {**props}>
         {props.children}
     </DialogPrimitive.Trigger>;
 }
 
-def:pub DialogContent(props: any) -> JsxElement {
+def:pub DialogContent(props: any, ref: Ref[HTMLElement]) -> JsxElement {
     return <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
             className={cn("fixed inset-0 z-50 bg-black/50", props.overlayClassName)}
         />
         <DialogPrimitive.Content
+            ref={ref}
             className={cn(
                 "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
                 "w-full max-w-lg rounded-lg bg-background p-6 shadow-lg",
@@ -454,6 +458,8 @@ def:pub DialogContent(props: any) -> JsxElement {
     </DialogPrimitive.Portal>;
 }
 ```
+
+Forwarding the ref on `DialogTrigger` is what lets `<DialogTrigger asChild>` wrap your own `Button` and still open: radix attaches the anchor ref through the trigger down to the host node. See [forwarding a ref into your component](state.md#forwarding-a-ref-into-your-component) for how the trailing `ref: Ref` parameter lowers to `forwardRef`.
 
 Required dependencies:
 

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -291,8 +291,8 @@ The example above uses a ref *inside* a component. The other direction -- lettin
 
 ```jac
 cl {
-    def:pub FancyInput(props: dict[str, any], ref: Ref[HTMLInputElement]) -> JsxElement {
-        return <input ref={ref} class="fancy" {**props} />;
+    def:pub FancyInput(props: any, ref: Ref[HTMLInputElement]) -> JsxElement {
+        return <input ref={ref} className="fancy" {**props} />;
     }
 }
 ```

--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -285,6 +285,32 @@ cl {
 
 The field must be constructed (`= Ref()` / `= Ref(initial)`); a bare `has r: Ref[T];` is rejected ([E2025](../../reference/diagnostics.md)) because, like every other `has`-field, it needs a value. `.current` is typed `T | None`, so null-check it before use.
 
+### Forwarding a ref into your component
+
+The example above uses a ref *inside* a component. The other direction -- letting a **parent** attach a ref to a component *you* wrote -- requires the component to **forward** that ref to a real DOM node. A component opts in by declaring a trailing parameter typed `Ref`, a 1:1 match with React's `forwardRef((props, ref) => ...)` render signature:
+
+```jac
+cl {
+    def:pub FancyInput(props: dict[str, any], ref: Ref[HTMLInputElement]) -> JsxElement {
+        return <input ref={ref} class="fancy" {**props} />;
+    }
+}
+```
+
+This lowers to `const FancyInput = forwardRef(function FancyInput(props, ref) { ... })`, so a parent can point its own ref at the component and reach the underlying `<input>`:
+
+```jac
+has inputRef: Ref[HTMLInputElement] = Ref();
+# ...
+<FancyInput ref={inputRef} placeholder="Type here" />
+```
+
+- Only the **last** parameter qualifies, and it must be typed `Ref` (or `Ref[T]`). Named props before it destructure as usual; `ref` stays the trailing positional argument and is never folded into the props bundle.
+- `forwardRef` is auto-imported from React; you do not import it yourself.
+- A component that declares no `ref` parameter compiles exactly as before -- this is opt-in and zero-cost.
+
+Forwarding is what makes a component usable as a [radix](npm-and-libraries.md) `asChild` trigger -- `DropdownMenuTrigger`, `Tooltip.Trigger`, `Popover.Trigger`, and friends attach a ref to their child to use as a positioning anchor, so a component that cannot forward a ref leaves that anchor null and the menu/popover silently never opens.
+
 ---
 
 ## useContext - Global State


### PR DESCRIPTION
## Summary

Documentation follow-up to #6520 / #6522 (client components can now forward refs via the `forwardRef` lowering). Documents the **producer** side of refs and applies it to the radix wrapper examples, so the tutorials stop teaching the now-fixed non-forwarding pattern.

## Changes

**`state.md` — "Refs with `Ref[T]`"**
Adds a **"Forwarding a ref into your component"** subsection. The section previously covered only the consumer side (holding a ref to a DOM node *inside* your component); this adds the producer side: a trailing `ref: Ref` parameter lowers to `forwardRef(function C(props, ref) {...})`, the opt-in/zero-cost rule, and why it's what makes a component a valid radix `asChild` trigger.

**`npm-and-libraries.md` — shadcn examples**
The canonical `Button` and the Dialog wrappers were authored as plain `def:pub X(props: any)` with no ref forwarding — the exact pattern #6520 fixed. Updated so each wrapper that renders a DOM node forwards its ref, matching upstream shadcn's `React.forwardRef`:

- `Button` -> trailing `ref: Ref[HTMLButtonElement]`, `<button ref={ref} ...>`
- `DialogTrigger` -> `ref: Ref[HTMLButtonElement]`, forwarded to `DialogPrimitive.Trigger`
- `DialogContent` -> `ref: Ref[HTMLElement]`, forwarded to `DialogPrimitive.Content`
- `Dialog` (a context-only `Root` wrapper) renders no DOM node and correctly takes **no** ref — called out explicitly so the asymmetry reads as intentional.

Both spots cross-link to the new state.md section.

## Verification

- The `FancyInput` producer example and the wrapper pattern (`<Comp ref={ref} {**props}>`) were compiled and confirmed to lower to `forwardRef(function C(props, ref) {...})` with the ref threaded through.
- markdownlint + ban-em-dashes pre-commit hooks pass; the cross-link anchor (`state.md#forwarding-a-ref-into-your-component`) resolves to the new header.
- Docs-only change: no release-note fragment required (the check maps only code folders) and no protected release-note files touched.
