### PR TITLE
fix(native): coerce sysconfig libpy to str for strict-Any param check

### DIFF
--- a/jac-desktop/jac_desktop/targets/impl/native_desktop_target.impl.jac
+++ b/jac-desktop/jac_desktop/targets/impl/native_desktop_target.impl.jac
@@ -210,7 +210,7 @@ impl NativeDesktopTarget.build(
     (out_dir / "oauth_broker.py").write_text(broker_res.stdout);
 
     # 5. Generate + compile the native host into the output dir.
-    libpy = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
+    libpy = str(sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0");
     host_src = _generate_host_source(
         libpy, win.title or app_name, win.width, win.height, str(app_name)
     );


### PR DESCRIPTION
## Problem
https://github.com/jaseci-labs/jaseci/actions/runs/27140011566/job/80102699258
The release build failed in `build (jac-desktop, …)` during `jac bundle --precompile`:

```
✖ Error: error[E1053]: Cannot assign Any | str to parameter 'libpy' of type str
  --> jac-desktop/jac_desktop/targets/impl/native_desktop_target.impl.jac:215:9
  213 |     libpy = sysconfig.get_config_var("INSTSONAME") or "libpython3.12.so.1.0";
```

## Root cause

`sysconfig.get_config_var(name: str)` is typed `-> Any` in the stdlib stub, so
`get_config_var("INSTSONAME") or "libpython3.12.so.1.0"` types as `Any | str`.
Passing that to `_generate_host_source`'s `libpy: str` parameter is rejected under
the **strict-Any gradual semantics** (#5859): hand-written Jac modules are *strict*
call sites, so an `Any` leaking across the Python boundary into a concretely-typed
parameter is flagged `E1053`.

This surfaced now because all four conditions coincide only here:
1. `get_config_var` returns `Any` (Python-boundary leak).
2. The call site is a strict Jac module (not Python-derived).
3. `_generate_host_source` declares `libpy: str` concretely.
4. The target generates `host.na.jac` and runs the native type-checker, whose
   diagnostics are **fatal** (#6049) — unlike ordinary `.jac` precompile errors,
   which are caught and counted. jac-desktop is the only plugin with native code.

## Fix

Wrap the expression in `str(...)`, collapsing the boundary `Any` to `str` (a
runtime no-op when it is already a string).

## Verification

In the build's resolution context (sibling deps resolvable, mirroring CI's
`JAC_PRECOMPILE_LOCAL_DEPS`):

| | result |
|---|---|
| before | `1 error` — `E1053 … parameter 'libpy'` at 215:9 (exactly CI's error) |
| after  | `1 passed`, 0 errors |

Full `jac bundle --precompile` of jac-desktop: exit 1 → exit 0.