### PR TITLE
fix(docs): repair invalid Jac block and de-flake code-block e2e tests

### DIFF
--- a/docs/docs/tutorials/fullstack/state.md
+++ b/docs/docs/tutorials/fullstack/state.md
@@ -300,9 +300,12 @@ cl {
 This lowers to `const FancyInput = forwardRef(function FancyInput(props, ref) { ... })`, so a parent can point its own ref at the component and reach the underlying `<input>`:
 
 ```jac
-has inputRef: Ref[HTMLInputElement] = Ref();
-# ...
-<FancyInput ref={inputRef} placeholder="Type here" />
+cl {
+    def:pub ParentForm() -> JsxElement {
+        has inputRef: Ref[HTMLInputElement] = Ref();
+        return <FancyInput ref={inputRef} placeholder="Type here" />;
+    }
+}
 ```
 
 - Only the **last** parameter qualifies, and it must be typed `Ref` (or `Ref[T]`). Named props before it destructure as usual; `ref` stays the trailing positional argument and is never folded into the props bundle.

--- a/docs/tests/e2e/test_code_blocks.jac
+++ b/docs/tests/e2e/test_code_blocks.jac
@@ -240,8 +240,9 @@ test "execution: run produces output" {
         page.wait_for_selector(
             "#block-plain .jcb-output-wrap", state="visible", timeout=PYODIDE_TIMEOUT
         );
+        # jcb-running clears when run-code.js finishes; non-empty output races the warm-up banner.
         page.wait_for_function(
-            "document.querySelector('#block-plain .code-output')?.textContent?.trim().length > 0",
+            "!document.querySelector('#block-plain').classList.contains('jcb-running')",
             timeout=PYODIDE_TIMEOUT
         );
         output = page.text_content("#block-plain .code-output");
@@ -267,7 +268,7 @@ test "execution: syntax error shows error" {
     def check(page: any, resp: any) {
         _click_run(page, "#block-error");
         page.wait_for_function(
-            "document.querySelector('#block-error .code-output')?.textContent?.trim().length > 0",
+            "!document.querySelector('#block-error').classList.contains('jcb-running')",
             timeout=PYODIDE_TIMEOUT
         );
         output = page.text_content("#block-error .code-output");


### PR DESCRIPTION
## Why

Two unrelated failures are currently red on `main`:

1. **Contribution Checks → Validate Jac code block syntax** — a doc code block fails `jac check --parse_only` (853 passed, 1 failed).
2. **Run tests for jaseci → Run E2E code block tests** — two Playwright tests fail, both reading `Compiling jaclang/runtimelib/context.jac...` instead of the expected output.

## What

**Docs block** — The ref-forwarding usage snippet in the fullstack *state* tutorial was a bare fragment (a top-level `has` plus a bare JSX tag) that doesn't parse standalone. Rewrapped it as a valid `cl` component with the ref as a real `has` attribute, so it parses and reads as complete, copyable code.

**E2E flake** — The two execution tests waited for `.code-output` to become non-empty, then read it. On the first run the Jac runtime streams a one-time compiler warm-up banner *before* the program output, so the assertion captured the banner. They now wait for the `jcb-running` class to clear — the execution-complete signal set in `run-code.js`'s `finally` — before reading output, which is independent of warm-up timing.

## Verification

- Doc validator: `15 passed, 0 failed` on the edited file (was 1 failed).
- E2E: ran the execution suite locally against a cold Pyodide + Jac compile (the warm-up path) — `5 passed` including both previously-failing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)