### PR TITLE
feat(osp): ospchess -- Object-Spatial chess e2e for native traversal (#6146)

### DIFF
--- a/jac/examples/chess/ospchess.jac
+++ b/jac/examples/chess/ospchess.jac
@@ -1,0 +1,136 @@
+"""ospchess -- Object-Spatial chess move-network analysis (issue #6146).
+
+The chess board as a graph: 64 `Square` nodes wired with two typed edge
+networks (`Knight`: 336 directed moves, `King`: 420), analyzed by walkers
+instead of loops over arrays:
+
+  * `Census`  measures a square's knight mobility with a typed edge ref
+              (`len([->:Knight:->])`) -- corner 2, edge 3, center 8;
+  * `Reach`   runs a visit-once DFS over the knight network, proving the
+              knight graph is connected (all 64 squares from a1);
+  * `Hunt`    DFS-walks the king network from a1 hunting h8, `report`ing each
+              new square and `disengage`-ing on arrival; the collected
+              reports come back on `w.reports` at the spawn boundary.
+
+The same program compiles on the server (py/sv) and native (LLVM) backends
+through the portable osp_kernel -- the cross-backend equivalence fixture
+`osp_chess.jac` in the compiler test suite asserts both produce identical
+results. Squares are coded `rank * 8 + file` (a1 = 0, h8 = 63).
+
+Run with: jac run ospchess.jac
+"""
+
+node Square {
+    has code: int;
+}
+
+edge Knight {}
+edge King {}
+
+walker Census {
+    has deg: int = 0;
+
+    can measure with Square entry {
+        self.deg = len([->:Knight:->]);
+    }
+}
+
+walker Reach {
+    has seen: list = [];
+
+    can step with Square entry {
+        if here.code not in self.seen {
+            self.seen.append(here.code);
+            visit [->:Knight:->];
+        }
+    }
+}
+
+walker Hunt {
+    has target: int = 63,
+        found: int = 0,
+        seen: list = [];
+
+    can step with Square entry {
+        if here.code not in self.seen {
+            self.seen.append(here.code);
+            report here.code;
+            if here.code == self.target {
+                self.found = 1;
+                disengage;
+            }
+            visit [->:King:->];
+        }
+    }
+}
+
+def build_board -> list {
+    squares: list = [];
+    for code in range(64) {
+        squares.append(Square(code=code));
+    }
+    drs: list = [1, 2, 2, 1, -1, -2, -2, -1];
+    dfs: list = [2, 1, -1, -2, -2, -1, 1, 2];
+    krs: list = [1, 1, 1, 0, 0, -1, -1, -1];
+    kfs: list = [-1, 0, 1, -1, 1, -1, 0, 1];
+    for r in range(8) {
+        for f in range(8) {
+            src = squares[r * 8 + f];
+            for i in range(8) {
+                nr = r + drs[i];
+                nf = f + dfs[i];
+                if nr >= 0 and nr < 8 and nf >= 0 and nf < 8 {
+                    src +>:Knight():+> squares[nr * 8 + nf];
+                }
+                kr = r + krs[i];
+                kf = f + kfs[i];
+                if kr >= 0 and kr < 8 and kf >= 0 and kf < 8 {
+                    src +>:King():+> squares[kr * 8 + kf];
+                }
+            }
+        }
+    }
+    return squares;
+}
+
+glob squares = build_board(),
+     a1 = squares[0],
+     b1 = squares[1],
+     d4 = squares[27],
+     c1 = Census();
+
+with entry {
+    c1 spawn a1;
+}
+
+glob c2 = Census();
+
+with entry {
+    c2 spawn b1;
+}
+
+glob c3 = Census();
+
+with entry {
+    c3 spawn d4;
+    print(f"knight mobility: a1={c1.deg} b1={c2.deg} d4={c3.deg}");
+}
+
+glob r = Reach();
+
+with entry {
+    r spawn a1;
+    print(f"knight network reaches {len(r.seen)}/64 squares from a1");
+}
+
+glob h = Hunt();
+
+with entry {
+    h spawn a1;
+}
+
+glob hr = h.reports;
+
+with entry {
+    print(f"king walk found h8: {h.found == 1}, after visiting {len(hr)} squares");
+}

--- a/jac/jaclang/compiler/tests/fixtures/osp_chess.jac
+++ b/jac/jaclang/compiler/tests/fixtures/osp_chess.jac
@@ -1,0 +1,236 @@
+"""Cross-backend OSP end-to-end fixture: ospchess (issue #6146 Phase 5).
+
+Object-Spatial chess move-network analysis -- the e2e that exercises the whole
+OSP stack at once, at a scale the micro-fixtures don't: a full 8x8 board of 64
+`Square` nodes wired with TWO typed edge networks (`Knight`: 336 directed
+moves, `King`: 420), then three walkers over it:
+
+  * `Census`  -- per-square knight mobility via `len([->:Knight:->])`
+                 (a1 corner = 2, b1 edge = 3, d4 center = 8);
+  * `Reach`   -- visit-once DFS over the knight network from a1; the knight
+                 graph is connected, so it reaches all 64 squares. The first
+                 visited squares pin the kernel's deterministic DFS order;
+  * `Hunt`    -- DFS over the king network from a1 (code 0) hunting h8 (63),
+                 `report`ing each new square and `disengage`-ing on arrival;
+                 reports are delivered onto `w.reports` at the spawn boundary.
+
+Squares are coded `rank * 8 + file` (a1 = 0, h8 = 63). All compared values are
+portable ints / int lists -- never backend identity.
+
+Backend status: py and na agree on every value (graph build at scale, typed
+edge refs, visit-once guards, report delivery, disengage), so na is enforced.
+cl stays unrequired: its spawn lowering only recognizes a target that is a node
+constructor or a variable bound to one, so spawning at a square held in a list
+(`a1 = squares[0]; w spawn a1;`) lowers to `null` (tracked upstream). Flip to
+`require=["na", "cl"]` when that lands.
+"""
+
+node Square { has code: int; }
+
+edge Knight {}
+edge King {}
+
+walker Census {
+    has deg: int = 0;
+    can measure with Square entry {
+        self.deg = len([->:Knight:->]);
+    }
+}
+
+walker Reach {
+    has seen: list = [];
+    can step with Square entry {
+        if here.code not in self.seen {
+            self.seen.append(here.code);
+            visit [->:Knight:->];
+        }
+    }
+}
+
+walker Hunt {
+    has target: int = 63, found: int = 0;
+    has seen: list = [];
+    can step with Square entry {
+        if here.code not in self.seen {
+            self.seen.append(here.code);
+            report here.code;
+            if here.code == self.target {
+                self.found = 1;
+                disengage;
+            }
+            visit [->:King:->];
+        }
+    }
+}
+
+def build_board_py() -> list {
+    squares: list = [];
+    for code in range(64) {
+        squares.append(Square(code=code));
+    }
+    drs: list = [1, 2, 2, 1, -1, -2, -2, -1];
+    dfs: list = [2, 1, -1, -2, -2, -1, 1, 2];
+    krs: list = [1, 1, 1, 0, 0, -1, -1, -1];
+    kfs: list = [-1, 0, 1, -1, 1, -1, 0, 1];
+    for r in range(8) {
+        for f in range(8) {
+            src = squares[r * 8 + f];
+            for i in range(8) {
+                nr = r + drs[i];
+                nf = f + dfs[i];
+                if nr >= 0 and nr < 8 and nf >= 0 and nf < 8 {
+                    src +>: Knight() :+> squares[nr * 8 + nf];
+                }
+                kr = r + krs[i];
+                kf = f + kfs[i];
+                if kr >= 0 and kr < 8 and kf >= 0 and kf < 8 {
+                    src +>: King() :+> squares[kr * 8 + kf];
+                }
+            }
+        }
+    }
+    return squares;
+}
+
+def ospchess_py() -> dict[str, any] {
+    squares = build_board_py();
+    a1 = squares[0];
+    b1 = squares[1];
+    d4 = squares[27];
+    c1 = Census();
+    c1 spawn a1;
+    c2 = Census();
+    c2 spawn b1;
+    c3 = Census();
+    c3 spawn d4;
+    r = Reach();
+    r spawn a1;
+    rs = r.seen;
+    h = Hunt();
+    h spawn a1;
+    hr = h.reports;
+    return {
+        "deg_a1": c1.deg,
+        "deg_b1": c2.deg,
+        "deg_d4": c3.deg,
+        "reach": len(rs),
+        "first": rs[:8],
+        "found": h.found,
+        "hunt_len": len(hr),
+        "hunt_last": hr[len(hr) - 1]
+    };
+}
+
+na {
+    def build_board_na() -> list {
+        squares: list = [];
+        for code in range(64) {
+            squares.append(Square(code=code));
+        }
+        drs: list = [1, 2, 2, 1, -1, -2, -2, -1];
+        dfs: list = [2, 1, -1, -2, -2, -1, 1, 2];
+        krs: list = [1, 1, 1, 0, 0, -1, -1, -1];
+        kfs: list = [-1, 0, 1, -1, 1, -1, 0, 1];
+        for r in range(8) {
+            for f in range(8) {
+                src = squares[r * 8 + f];
+                for i in range(8) {
+                    nr = r + drs[i];
+                    nf = f + dfs[i];
+                    if nr >= 0 and nr < 8 and nf >= 0 and nf < 8 {
+                        src +>: Knight() :+> squares[nr * 8 + nf];
+                    }
+                    kr = r + krs[i];
+                    kf = f + kfs[i];
+                    if kr >= 0 and kr < 8 and kf >= 0 and kf < 8 {
+                        src +>: King() :+> squares[kr * 8 + kf];
+                    }
+                }
+            }
+        }
+        return squares;
+    }
+
+    def ospchess_na() -> dict[str, any] {
+        squares = build_board_na();
+        c1 = Census();
+        c1 spawn squares[0];
+        c2 = Census();
+        c2 spawn squares[1];
+        c3 = Census();
+        c3 spawn squares[27];
+        r = Reach();
+        r spawn squares[0];
+        rs = r.seen;
+        h = Hunt();
+        h spawn squares[0];
+        hr = h.reports;
+        return {
+            "deg_a1": c1.deg,
+            "deg_b1": c2.deg,
+            "deg_d4": c3.deg,
+            "reach": len(rs),
+            "first": rs[:8],
+            "found": h.found,
+            "hunt_len": len(hr),
+            "hunt_last": hr[len(hr) - 1]
+        };
+    }
+}
+
+cl {
+    def build_board_cl() -> list {
+        squares: list = [];
+        for code in range(64) {
+            squares.append(Square(code=code));
+        }
+        drs: list = [1, 2, 2, 1, -1, -2, -2, -1];
+        dfs: list = [2, 1, -1, -2, -2, -1, 1, 2];
+        krs: list = [1, 1, 1, 0, 0, -1, -1, -1];
+        kfs: list = [-1, 0, 1, -1, 1, -1, 0, 1];
+        for r in range(8) {
+            for f in range(8) {
+                src = squares[r * 8 + f];
+                for i in range(8) {
+                    nr = r + drs[i];
+                    nf = f + dfs[i];
+                    if nr >= 0 and nr < 8 and nf >= 0 and nf < 8 {
+                        src +>: Knight() :+> squares[nr * 8 + nf];
+                    }
+                    kr = r + krs[i];
+                    kf = f + kfs[i];
+                    if kr >= 0 and kr < 8 and kf >= 0 and kf < 8 {
+                        src +>: King() :+> squares[kr * 8 + kf];
+                    }
+                }
+            }
+        }
+        return squares;
+    }
+
+    def ospchess_cl() -> dict[str, any] {
+        squares = build_board_cl();
+        c1 = Census();
+        c1 spawn squares[0];
+        c2 = Census();
+        c2 spawn squares[1];
+        c3 = Census();
+        c3 spawn squares[27];
+        r = Reach();
+        r spawn squares[0];
+        rs = r.seen;
+        h = Hunt();
+        h spawn squares[0];
+        hr = h.reports;
+        return {
+            "deg_a1": c1.deg,
+            "deg_b1": c2.deg,
+            "deg_d4": c3.deg,
+            "reach": len(rs),
+            "first": rs[:8],
+            "found": h.found,
+            "hunt_len": len(hr),
+            "hunt_last": hr[len(hr) - 1]
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/test_osp_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_osp_equivalence.jac
@@ -156,3 +156,19 @@ test "osp edge typed: `[->:Road:->]` follows only the typed edge" {
         require=["na", "cl"]
     );
 }
+
+test "ospchess e2e: 64-square board, typed move networks, census/reach/hunt walkers" {
+    assert run_py_fixture("osp_chess", "ospchess_py") == {
+        "deg_a1": 2,
+        "deg_b1": 3,
+        "deg_d4": 8,
+        "reach": 64,
+        "first": [0, 10, 17, 20, 27, 25, 16, 4],
+        "found": 1,
+        "hunt_len": 57,
+        "hunt_last": 63
+    };
+    run_with_both(
+        "osp_chess.jac", "ospchess_py", "ospchess_cl", "ospchess_na", require=["na"]
+    );
+}


### PR DESCRIPTION
## Summary

Phase 5 of #6146: **ospchess** — the Object-Spatial chess end-to-end that exercises the whole native OSP stack at once, at a scale the micro-fixtures don't.

The chess board as a graph: 64 `Square` nodes wired with two typed edge networks (`Knight`: 336 directed moves, `King`: 420), analyzed by three walkers:

- **`Census`** — per-square knight mobility via a typed edge ref (`len([->:Knight:->])`): corner 2, edge 3, center 8
- **`Reach`** — visit-once DFS over the knight network, proving it reaches all 64 squares from a1 (and pinning the kernel's deterministic DFS order)
- **`Hunt`** — king-network DFS from a1 hunting h8, `report`ing each new square and `disengage`-ing on arrival; reports read back off `w.reports`

Together that covers graph build at scale (~760 edge records), typed edge refs, visit-once guards, deterministic traversal order, report delivery, and disengage — in one program.

## What's in it

- **`jac/jaclang/compiler/tests/fixtures/osp_chess.jac`** — the cross-backend equivalence fixture. py and na agree on every value; enforced `require=["na"]` in `test_osp_equivalence.jac` with the py reference pinned (`deg 2/3/8`, `reach 64`, `first [0,10,17,20,27,25,16,4]`, `hunt_len 57`, `hunt_last 63`).
- **`jac/examples/chess/ospchess.jac`** — the runnable example (`jac run ospchess.jac`), same program with a printing entry.

## cl status

cl stays unrequired: its local spawn lowering only recognizes a target that is a node **constructor** or a variable bound to one, so spawning at a square held in a list (`a1 = squares[0]; w spawn a1;`) lowers to `null` — every spawn in the fixture no-ops. Tracked in a separate issue; the fixture's cl variant is ready to flip to `require=["na", "cl"]` once that lands.

## Tests

OSP equivalence suite: 11/11 (the new e2e included).
