### PR TITLE
feat(runtime): surface the shared public root as root.shared

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/6554.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/6554.feature.md
@@ -1,0 +1,1 @@
+- **`root.shared` resolves in jac-scale deployments**: The server maps the guest account to its root at startup so walkers can address the public graph via `root.shared`. (jaseci-labs/jaseci#6554)

--- a/docs/docs/community/release_notes/unreleased/jaclang/6554.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6554.feature.md
@@ -1,0 +1,1 @@
+- **`root.shared` addresses the public graph**: Any walker can read and extend the deployment's shared root - the graph unauthenticated requests run on - directly via `root.shared`, with commons-by-default access (readable and attachable by every user) in place of `allroots()` scans and app-managed arming grants. (jaseci-labs/jaseci#6554)

--- a/docs/docs/reference/language/osp.md
+++ b/docs/docs/reference/language/osp.md
@@ -789,6 +789,39 @@ with entry {
 }
 ```
 
+### 6 The Shared Root (`root.shared`)
+
+Every served deployment has one public graph alongside the per-user roots: the **shared root**, the root that every unauthenticated request runs on. `root.shared` resolves to it from any request context, so a walker can read or extend the public graph directly - no `allroots()` fan-out, no passing root ids around:
+
+```jac
+node Post { has text: str; }
+edge Posted {}
+
+walker:pub publish {
+    has text: str;
+
+    can run with Root entry {
+        # Lands on the public graph whoever the caller is.
+        fresh = root.shared +>: Posted() :+> Post(text=self.text);
+        grant(fresh[0], level=ReadPerm);   # author opens the post to readers
+    }
+}
+
+walker:pub read_feed {
+    can run with Root entry {
+        report [p.text for p in [root.shared-->[?:Post]]];
+    }
+}
+```
+
+**Default policy.** The shared root is a commons: its access level is floored at `ConnectPerm`, so every user - authenticated or anonymous - can read it and attach nodes to it without any arming grant. The floor reflects reality rather than weakening security: anonymous requests already act as the shared root's owner through any public endpoint, so withholding access from authenticated users protects nothing.
+
+**Ownership stays the boundary.** Nodes a user hangs on the shared graph remain owned by that user and closed until the author grants. The conventional levels: `ConnectPerm` on container nodes others should build under, `ReadPerm` on leaf contributions others should only see. Anonymous-created content is collectively owned by the anonymous identity and is readable by everyone through the floor.
+
+**Lockdown.** An app can lower the commons explicitly - for example `grant(root.shared, level=ReadPerm)` from an anonymous or system context makes it read-only. Any explicitly set level other than `NoPerm` is respected; only the never-granted state is floored back to `ConnectPerm`.
+
+Outside a server (CLI runs, scripts, tests without a server) there are no separate users, so `root.shared` is the current root itself: `jid(root.shared) == jid(root)`.
+
 ---
 
 ## Graph Traversal

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -635,6 +635,8 @@ Roles are stored in the user document and included in JWT claims. The admin user
 - System accounts (role `system`)
 - The guest account (identity `__guest__`)
 
+The guest account's root is the deployment's public graph - every unauthenticated request runs on it, and Jac code addresses it from any request as `root.shared` (see [The Shared Root](../language/osp.md#6-the-shared-root-rootshared)).
+
 Roles are managed via the admin portal API or programmatically through the `UserManager`:
 
 ```bash

--- a/jac-scale/jac_scale/impl/serve.core.impl.jac
+++ b/jac-scale/jac_scale/impl/serve.core.impl.jac
@@ -300,6 +300,12 @@ impl JacAPIServerCore.start(
         }
     }
     self.user_manager.create_internal_user(Con.GUEST.value, '__no_password__');
+    # Back `root.shared`: map the guest user (created above) to its root id.
+    _um = self.user_manager;
+    def _shared_root_id -> (str | None) {
+        return _um.get_root_id(Con.GUEST.value);
+    }
+    Jac.set_shared_root_resolver(_shared_root_id);
     self.setup_emailer();
     self._setup_scheduler();
     self._setup_events();

--- a/jac/jaclang/compiler/type_system/jac_builtins.pyi
+++ b/jac/jaclang/compiler/type_system/jac_builtins.pyi
@@ -97,7 +97,13 @@ class Walker:
     reports: list[Any]
 
 class Obj: ...
-class Root(Node): ...
+
+class Root(Node):
+    # The deployment's shared root: the root every unauthenticated
+    # request runs on. Normal permission checks still apply to its graph.
+    @property
+    def shared(self) -> Root: ...
+
 class GenericEdge(Edge): ...
 
 class JsxElement:

--- a/jac/jaclang/jac0core/archetype.jac
+++ b/jac/jaclang/jac0core/archetype.jac
@@ -229,6 +229,17 @@ obj Root(NodeArchetype) {
     @cached_property
     def __jac__ -> NodeAnchor;
 
+    """Dynamic-attribute hook backing `root.shared` — the deployment's
+    shared root: the root every unauthenticated request runs on. Lets any
+    walker address the public graph without an `allroots()` scan; normal
+    permission checks still apply. In single-user contexts (CLI, scripts)
+    this is the current root itself. Deliberately NOT a property: the
+    serializer walks `dir()` for non-callable attributes, so a property
+    would be evaluated (and recursed into) during persistence and leak a
+    computed `shared` field into every serialized Root.
+    """
+    def __getattr__(name: str) -> Root;
+
     def __repr__ -> str;
 }
 

--- a/jac/jaclang/jac0core/impl/archetype.impl.jac
+++ b/jac/jaclang/jac0core/impl/archetype.impl.jac
@@ -352,6 +352,17 @@ impl Root.__jac__ -> NodeAnchor {
     return NodeAnchor(archetype=self, persistent=True, edges=[]);
 }
 
+"""Resolve `root.shared` (the deployment's shared root) on attribute miss."""
+impl Root.__getattr__(name: str) -> Root {
+    if name == 'shared' {
+        # Lazy import: archetype loads before the runtime during bootstrap.
+        import from jaclang.jac0core.runtime { JacRuntime }
+        import from typing { cast }
+        return cast(Root, JacRuntime.get_shared_root());
+    }
+    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'");
+}
+
 """Override repr for archetype."""
 impl Root.__repr__ -> str {
     return f"{self.__class__.__name__}()";

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -2491,6 +2491,53 @@ impl JacRuntime.get_program(cls: any) -> JacProgram {
     return cls.program;
 }
 
+"""Return the deployment's shared root (resolver-backed, context-root fallback)."""
+impl JacRuntime.get_shared_root -> Root {
+    resolver = _shared_root_resolver[0];
+    if resolver is None {
+        return JacRuntimeInterface.get_context().get_root();
+    }
+    root_id = _shared_root_resolver[1];
+    if not isinstance(root_id, str) {
+        root_id = resolver();
+        if not isinstance(root_id, str) {
+            raise RuntimeError(
+                "Shared root unavailable: the registered shared-root resolver "
+                "returned no root id."
+            );
+        }
+        _shared_root_resolver[1] = root_id;
+    }
+    shared = JacRuntimeInterface.get_object(root_id);
+    if not isinstance(shared, Root) {
+        raise RuntimeError(
+            f"Shared root unavailable: id {root_id} did not resolve to a Root node."
+        );
+    }
+    # Default policy: the shared root is a commons - readable and attachable
+    # (CONNECT) by every user, since anonymous requests already act as its
+    # owner through any public endpoint. The grant is floored lazily on
+    # access so pre-existing deployments pick it up too; persistence
+    # write-through lands the first time an owner-context request touches
+    # it, and until then the in-memory floor keeps each request correct.
+    # An app may lower the level explicitly (e.g. ReadPerm for a read-only
+    # commons) - any level other than NO_ACCESS is respected. Only the
+    # never-granted state is floored: a root owned by the anonymous public
+    # cannot be meaningfully closed.
+    if shared.__jac__.access.all == AccessLevel.NO_ACCESS {
+        JacRuntimeInterface.perm_grant(shared, AccessLevel.CONNECT);
+    }
+    return shared;
+}
+
+"""Register (or clear) the shared-root resolver and drop the cached id."""
+impl JacRuntime.set_shared_root_resolver(
+    resolver: (Callable[([], (str | None))] | None)
+) -> None {
+    _shared_root_resolver[0] = resolver;
+    _shared_root_resolver[1] = None;
+}
+
 """Return the seed base path for new contexts."""
 impl JacRuntime.get_base_path_dir -> (str | None) {
     return _default_base_path_dir[0];

--- a/jac/jaclang/jac0core/runtime.jac
+++ b/jac/jaclang/jac0core/runtime.jac
@@ -86,7 +86,14 @@ glob plugin_manager = plugin.PluginManager('jac'),
      # poison a live ctx. Live behavior always follows the ctx; these
      # values are only consulted during ctx construction.
      _default_base_path_dir: list = [os.getcwd()],
-     _default_full_target_path: list = [None];
+     _default_full_target_path: list = [None],
+     # Shared-root resolver seed. Slot 0 holds the callable an API server
+     # registers at startup to map the internal guest user to its root id;
+     # slot 1 caches the resolved id (root ids are stable per deployment).
+     # When no resolver is registered (CLI, scripts, embedders) `root.shared`
+     # falls back to the current context's root — in those single-user
+     # contexts the caller IS the shared graph's owner.
+     _shared_root_resolver: list = [None, None];
 
 """Jac Access Validation Specs."""
 class JacAccessValidation {
@@ -1115,6 +1122,29 @@ class JacRuntime(JacRuntimeInterface) {
         Mutates only the seed — already-constructed contexts are unaffected.
         """
     static def set_full_target_path(target_path: (str | None)) -> None;
+
+    """Return the deployment's shared root — the root every unauthenticated
+    request runs on (surfaced in Jac as `root.shared`). Resolution goes
+    through the resolver an API server registered at startup; when none is
+    registered (CLI, scripts, embedders) the current context's root is
+    returned, since single-user contexts have no separate shared graph.
+
+    Default policy: the shared root is a commons — its `access.all` is
+    floored to CONNECT on access, so every user can read it and attach to
+    it without app-side arming. Nodes users hang on the shared graph stay
+    owned by their author and closed until the author grants. Apps may
+    lower the root's level explicitly (any level other than NO_ACCESS is
+    respected, e.g. ReadPerm for a read-only commons).
+    """
+    static def get_shared_root -> Root;
+
+    """Register (or clear, with None) the callable that maps the internal
+    guest user to its root id (the shared root). API servers call this at
+    startup; replacing the resolver invalidates the cached id.
+    """
+    static def set_shared_root_resolver(
+        resolver: (Callable[([], (str | None))] | None)
+    ) -> None;
 
     """Install the process-global execution context for CLI and other
     non-server callers. Server request paths use `push_request_context`

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -1581,6 +1581,16 @@ impl ExecutionHandler.spawn_walker(
 impl JacAPIServer.postinit -> None {
     import from jaclang.runtimelib.scheduler { Scheduler }
     self.user_manager = Jac.get_user_manager(base_path=self.base_path);
+    # Back `root.shared`: map the internal guest user to its root id, creating
+    # the guest account on first use (request paths create it lazily too).
+    _um = self.user_manager;
+    def _shared_root_id -> (str | None) {
+        if not _um.user_exists(Con.GUEST.value) {
+            _um.create_user(Con.GUEST.value, '__no_password__');
+        }
+        return _um.get_root_id(Con.GUEST.value);
+    }
+    Jac.set_shared_root_resolver(_shared_root_id);
     self.introspector = ModuleIntrospector(self.module_name, self.base_path);
     self.execution_manager = ExecutionManager(
         base_path=self.base_path, user_manager=self.user_manager

--- a/jac/tests/runtimelib/fixtures/serve_shared_root.jac
+++ b/jac/tests/runtimelib/fixtures/serve_shared_root.jac
@@ -1,0 +1,52 @@
+"""Fixture exercising the shared root surfaced as `root.shared`.
+
+The shared root is the root every unauthenticated request runs on, and the
+runtime floors its access at ConnectPerm: any user can read the public
+graph and attach to it with no app-side arming. Nodes a user hangs there
+stay owned by that user - the author opens them (ReadPerm) for everyone.
+"""
+
+node Note {
+    has text: str = "";
+}
+
+edge HasNote {}
+
+walker:pub whereami {
+    can run with Root entry {
+        report jid(here);
+        report jid(root.shared);
+    }
+}
+
+walker:pub leave_note {
+    has text: str = "";
+
+    can run with Root entry {
+        # Connect denial no-ops with an empty result (plus a diagnostic) -
+        # guard so a denied write reports cleanly instead of crashing.
+        fresh = root.shared +>: HasNote() :+> Note(text=self.text);
+        if fresh {
+            # The note is owned by its author; open it to all readers.
+            grant(fresh[0], level=ReadPerm);
+        }
+        report jid(root.shared);
+    }
+}
+
+walker:pub read_notes {
+    can run with Root entry {
+        report sorted([n.text for n in [root.shared-->[?:Note]]]);
+        report jid(root.shared);
+    }
+}
+
+# Lock the commons down to read-only. Run anonymously: the caller IS the
+# shared root's owner, so the lowered level persists - and because it is
+# an explicit non-NO_ACCESS level, the runtime's CONNECT floor respects it.
+walker:pub make_readonly {
+    can run with Root entry {
+        grant(root.shared, level=ReadPerm);
+        report "locked";
+    }
+}

--- a/jac/tests/runtimelib/test_shared_root.jac
+++ b/jac/tests/runtimelib/test_shared_root.jac
@@ -1,0 +1,141 @@
+"""Tests for the shared root surfaced as `root.shared`.
+
+Under a server, `root.shared` resolves through the resolver the server
+registers at startup, mapping the internal guest user to its root — so any
+request, authenticated or not, can address the shared public graph without
+an `allroots()` scan. The runtime floors the shared root's access at
+ConnectPerm (it is a commons), so no app-side arming grant is needed.
+Outside a server there are no separate users, so `root.shared` falls back
+to the current context's root.
+"""
+
+import from pathlib { Path }
+import from tempfile { TemporaryDirectory }
+import from jaclang { JacRuntime as Jac }
+import from jaclang.runtimelib.testing { JacTestClient }
+
+glob FIXTURES = str(Path(__file__).parent / "fixtures");
+
+
+def make_shared_client(base_path: str) -> JacTestClient {
+    return JacTestClient.from_file(
+        str((Path(FIXTURES) / "serve_shared_root.jac").resolve()), base_path=base_path
+    );
+}
+
+
+test "root.shared falls back to the current root outside a server" {
+    # Earlier tests in this process may have registered a server resolver;
+    # this test pins the bare-context fallback.
+    Jac.set_shared_root_resolver(None);
+    assert jid(root.shared) == jid(root);
+}
+
+
+test "anonymous requests all run on the one shared root" {
+    with TemporaryDirectory() as tmpdir {
+        client = make_shared_client(tmpdir);
+        first = client.post("/walker/whereami", json={});
+        assert first.ok;
+        second = client.post("/walker/whereami", json={});
+        assert second.ok;
+        # `here` (the request root) and `root.shared` agree, and both
+        # anonymous requests landed on the same root.
+        (here_id, shared_id) = first.data["reports"];
+        assert here_id == shared_id , "anonymous request root is not root.shared";
+        assert second.data["reports"][0] == here_id , "shared root not stable across requests";
+        client.close();
+        Jac.set_shared_root_resolver(None);
+    }
+}
+
+
+test "a logged-in user can write the commons before any anonymous request" {
+    # The default-CONNECT floor closes the bootstrap race: with NO app-side
+    # arming grant and NO prior anonymous traffic, the very first request -
+    # from an authenticated user - can attach to the shared graph.
+    with TemporaryDirectory() as tmpdir {
+        client = make_shared_client(tmpdir);
+        client.register_user("alice", "secret123");
+        alice_note = client.post("/walker/leave_note", json={"text": "first-write"});
+        assert alice_note.ok;
+        alice_read = client.post("/walker/read_notes", json={});
+        assert alice_read.ok;
+        assert alice_read.data["reports"][0] == ["first-write"] , "authenticated-first write to the commons failed";
+        # The note landed on the shared root, not on alice's own root.
+        client.clear_auth();
+        anon_read = client.post("/walker/read_notes", json={});
+        assert anon_read.ok;
+        assert anon_read.data["reports"][0] == ["first-write"] , "anonymous reader cannot see the commons";
+        client.close();
+        # Reopen over the same store: anchors now deserialize from L3 with
+        # their hashes stamped, so access checks are fully enforced (the
+        # in-process working set treats hash==0 anchors as creator-writable).
+        # A SECOND user attaching must succeed purely via the floored grant.
+        client2 = make_shared_client(tmpdir);
+        client2.register_user("carol", "secret123");
+        carol_note = client2.post("/walker/leave_note", json={"text": "second-write"});
+        assert carol_note.ok;
+        carol_read = client2.post("/walker/read_notes", json={});
+        assert carol_read.ok;
+        assert carol_read.data["reports"][0] == ["first-write", "second-write"] , "floored CONNECT grant not honored after reload";
+        client2.close();
+        Jac.set_shared_root_resolver(None);
+    }
+}
+
+
+test "guest and logged-in users share the shared-root graph" {
+    with TemporaryDirectory() as tmpdir {
+        client = make_shared_client(tmpdir);
+        # Anonymous note lands on the shared root - no arming grant needed.
+        anon_note = client.post("/walker/leave_note", json={"text": "from-guest"});
+        assert anon_note.ok;
+        shared_root_id = anon_note.data["reports"][0];
+        # Alice (authenticated, her own root) writes to the SAME shared graph.
+        client.register_user("alice", "secret123");
+        alice_note = client.post("/walker/leave_note", json={"text": "from-alice"});
+        assert alice_note.ok;
+        assert alice_note.data["reports"][0] == shared_root_id , "alice's root.shared is not the shared root";
+        # Alice reads back both notes through root.shared.
+        alice_read = client.post("/walker/read_notes", json={});
+        assert alice_read.ok;
+        assert alice_read.data["reports"][0] == ["from-alice", "from-guest"];
+        # Anonymous readers see both notes too.
+        client.clear_auth();
+        anon_read = client.post("/walker/read_notes", json={});
+        assert anon_read.ok;
+        assert anon_read.data["reports"][0] == ["from-alice", "from-guest"];
+        client.close();
+        Jac.set_shared_root_resolver(None);
+    }
+}
+
+
+test "an explicitly lowered shared-root level is respected" {
+    # Apps may lock the commons down to read-only: a non-NO_ACCESS level set
+    # explicitly must NOT be re-floored back to CONNECT.
+    with TemporaryDirectory() as tmpdir {
+        client = make_shared_client(tmpdir);
+        # Seed one note, then lower the commons to read-only as its owner.
+        seed = client.post("/walker/leave_note", json={"text": "seeded"});
+        assert seed.ok;
+        lowered = client.post("/walker/make_readonly", json={});
+        assert lowered.ok;
+        client.close();
+        # Reopen so anchors deserialize from L3 with hashes stamped and the
+        # READ level is actually enforced (in-process hash==0 anchors are
+        # treated as creator-writable, bypassing checks).
+        client2 = make_shared_client(tmpdir);
+        client2.register_user("bob", "secret123");
+        bob_read = client2.post("/walker/read_notes", json={});
+        assert bob_read.ok;
+        assert bob_read.data["reports"][0] == ["seeded"] , "read-only commons not readable";
+        bob_note = client2.post("/walker/leave_note", json={"text": "blocked"});
+        assert bob_note.ok , "write-denied request should still 200 (silent no-op + warning)";
+        bob_recheck = client2.post("/walker/read_notes", json={});
+        assert bob_recheck.data["reports"][0] == ["seeded"] , "read-only commons accepted a write";
+        client2.close();
+        Jac.set_shared_root_resolver(None);
+    }
+}


### PR DESCRIPTION
## Summary

Every served deployment has one public graph - the root all unauthenticated requests run on. This PR surfaces it to Jac code as `root.shared`, resolvable from any request context, so walkers can read and extend the public graph without an `allroots()` fan-out or app-managed root ids.

```jac
walker:pub publish {
    has text: str;
    can run with Root entry {
        fresh = root.shared +>: Posted() :+> Post(text=self.text);
        grant(fresh[0], level=ReadPerm);
    }
}
```

## Design

- **Resolution.** Both servers (bare-serve and jac-scale) register a resolver at startup that maps the internal guest user to its root id; `JacRuntime.get_shared_root()` caches the id and derefs through the active context. Outside a server (CLI, scripts) `root.shared` falls back to the current context's root, since single-user contexts have no separate shared graph.
- **Commons-by-default.** The shared root's access level is floored at `ConnectPerm` on resolution: every user, authenticated or anonymous, can read it and attach to it with no arming grant. This is not a security relaxation - anonymous requests already act as the shared root's owner through any public endpoint, so withholding access from authenticated users protects nothing while creating a bootstrap race (an authenticated-first write would fail until anonymous traffic armed a grant). Explicitly lowered levels are respected (e.g. `grant(root.shared, level=ReadPerm)` for a read-only commons); only the never-granted state is floored.
- **Ownership stays the boundary.** Nodes users hang on the shared graph remain owned by their author and closed until the author grants (convention: `ConnectPerm` on containers, `ReadPerm` on leaf contributions).
- **`Root.__getattr__`, not a property.** The serializer walks `dir()` for non-callable attributes, so a property would be evaluated (and recursed into) during persistence and leak a computed field into every serialized Root.
- The type checker picks up the surface from `jac_builtins.pyi` (the `root` keyword's class is prefetched from that stub).

## Tests

`jac/tests/runtimelib/test_shared_root.jac` (5 tests):

- CLI fallback: `jid(root.shared) == jid(root)` outside a server
- Anonymous requests all land on one stable shared root
- Authenticated-first write succeeds with no prior anonymous traffic (the bootstrap race), and a second user attaches after server reload purely via the floored grant (checks fully enforced against deserialized anchors)
- Anonymous and logged-in users write and read the same shared graph
- An explicitly lowered (read-only) level is respected: reads succeed, writes are denied and not re-floored

Docs: new "The Shared Root" section in `reference/language/osp.md`, cross-referenced from the jac-scale guest-account docs.

Validated end-to-end in a live `jac start` app: a logged-in user and anonymous visitors sign and read one shared guestbook, with `explore_graph`/stats walking the single shared graph.