### PR TITLE
fix(server): replace any-typed fields with real types to clear type-check errors

### DIFF
--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -2427,7 +2427,9 @@ impl JacAPIServer.start(
     configured_root = config.serve.base_route_app if config else "";
     base_route_app = self.introspector.resolve_root_app(configured_root);
     if self.server is None {
-        raise RuntimeError("Cannot start server: no socket was bound (test mode, port=0)");
+        raise RuntimeError(
+            "Cannot start server: no socket was bound (test mode, port=0)"
+        );
     }
     with self.server as httpd {
         console.print(f"Jac API Server running on http://0.0.0.0:{self.port}");

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -50,13 +50,20 @@ impl UserManager._ensure_connection -> None {
     }
 }
 
+impl UserManager.conn -> sqlite3.Connection {
+    if self._conn is None {
+        raise RuntimeError("SQLite connection is not initialized; call _ensure_connection() first");
+    }
+    return self._conn;
+}
+
 """Create a new user with their own root node. Returns dict with user data or error."""
 impl UserManager.create_user(username: str, password: str) -> dict[str, str] {
     import from jaclang.jac0core.constructs { Root }
     self._ensure_connection();
     with self._lock {
         # Check if user already exists
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT 1 FROM users WHERE username = ?", (username, )
         );
         if cursor.fetchone() {
@@ -71,11 +78,11 @@ impl UserManager.create_user(username: str, password: str) -> dict[str, str] {
         root_id = root_anchor.id.hex;
         token = secrets.token_urlsafe(32);
         password_hash = hashlib.sha256(password.encode()).hexdigest();
-        self._conn.execute(
+        self.conn.execute(
             "INSERT INTO users (username, password_hash, token, root_id) VALUES (?, ?, ?, ?)",
             (username, password_hash, token, root_id)
         );
-        self._conn.commit();
+        self.conn.commit();
         return {'username': username, 'token': token, 'root_id': root_id};
     }
 }
@@ -87,7 +94,7 @@ impl UserManager.authenticate(
     self._ensure_connection();
     password_hash = hashlib.sha256(password.encode()).hexdigest();
     with self._lock {
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT token, root_id FROM users WHERE username = ? AND password_hash = ?",
             (username, password_hash)
         );
@@ -103,7 +110,7 @@ impl UserManager.authenticate(
 impl UserManager.validate_token(token: str) -> (str | None) {
     self._ensure_connection();
     with self._lock {
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT username FROM users WHERE token = ?", (token, )
         );
         row = cursor.fetchone();
@@ -115,7 +122,7 @@ impl UserManager.validate_token(token: str) -> (str | None) {
 impl UserManager.get_root_id(username: str) -> (str | None) {
     self._ensure_connection();
     with self._lock {
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT root_id FROM users WHERE username = ?", (username, )
         );
         row = cursor.fetchone();
@@ -132,7 +139,7 @@ impl UserManager.aget_root_id(username: str) -> (str | None) {
 impl UserManager.get_user(username: str) -> (dict[(str, str)] | None) {
     self._ensure_connection();
     with self._lock {
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT token, root_id FROM users WHERE username = ?", (username, )
         );
         row = cursor.fetchone();
@@ -147,7 +154,7 @@ impl UserManager.get_user(username: str) -> (dict[(str, str)] | None) {
 impl UserManager.user_exists(username: str) -> bool {
     self._ensure_connection();
     with self._lock {
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT 1 FROM users WHERE username = ?", (username, )
         );
         return cursor.fetchone() is not None;
@@ -162,23 +169,23 @@ impl UserManager.update_username(
     self._ensure_connection();
     with self._lock {
         # Check if new username already exists
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT 1 FROM users WHERE username = ? ", (new_username, )
         );
         if cursor.fetchone() {
             return {'error': 'Username already taken'};
         }
         # Update username
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "UPDATE users SET username = ? WHERE username = ?",
             (new_username, current_username)
         );
-        self._conn.commit();
+        self.conn.commit();
         if cursor.rowcount == 0 {
             return {'error': 'User not found'};
         }
         # Get updated user data
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT token, root_id FROM users WHERE username = ?", (new_username, )
         );
         row = cursor.fetchone();
@@ -195,7 +202,7 @@ impl UserManager.update_password(
     with self._lock {
         # Verify current password
         current_password_hash = hashlib.sha256(current_password.encode()).hexdigest();
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "SELECT 1 FROM users WHERE username = ?  AND password_hash = ?",
             (username, current_password_hash)
         );
@@ -204,11 +211,11 @@ impl UserManager.update_password(
         }
         # Update password
         new_password_hash = hashlib.sha256(new_password.encode()).hexdigest();
-        cursor = self._conn.execute(
+        cursor = self.conn.execute(
             "UPDATE users SET password_hash = ? WHERE username = ?",
             (new_password_hash, username)
         );
-        self._conn.commit();
+        self.conn.commit();
         return {'username': username, 'message': 'Password updated successfully'};
     }
 }
@@ -2418,6 +2425,9 @@ impl JacAPIServer.start(
     cl_route_prefix = config.serve.cl_route_prefix if config else "cl";
     configured_root = config.serve.base_route_app if config else "";
     base_route_app = self.introspector.resolve_root_app(configured_root);
+    if self.server is None {
+        raise RuntimeError("Cannot start server: no socket was bound (test mode, port=0)");
+    }
     with self.server as httpd {
         console.print(f"Jac API Server running on http://0.0.0.0:{self.port}");
         console.print(f"Module: {self.module_name}");

--- a/jac/jaclang/runtimelib/impl/server.impl.jac
+++ b/jac/jaclang/runtimelib/impl/server.impl.jac
@@ -50,20 +50,14 @@ impl UserManager._ensure_connection -> None {
     }
 }
 
-impl UserManager.conn -> sqlite3.Connection {
-    if self._conn is None {
-        raise RuntimeError("SQLite connection is not initialized; call _ensure_connection() first");
-    }
-    return self._conn;
-}
-
 """Create a new user with their own root node. Returns dict with user data or error."""
 impl UserManager.create_user(username: str, password: str) -> dict[str, str] {
     import from jaclang.jac0core.constructs { Root }
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
         # Check if user already exists
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT 1 FROM users WHERE username = ?", (username, )
         );
         if cursor.fetchone() {
@@ -78,11 +72,11 @@ impl UserManager.create_user(username: str, password: str) -> dict[str, str] {
         root_id = root_anchor.id.hex;
         token = secrets.token_urlsafe(32);
         password_hash = hashlib.sha256(password.encode()).hexdigest();
-        self.conn.execute(
+        self._conn.execute(
             "INSERT INTO users (username, password_hash, token, root_id) VALUES (?, ?, ?, ?)",
             (username, password_hash, token, root_id)
         );
-        self.conn.commit();
+        self._conn.commit();
         return {'username': username, 'token': token, 'root_id': root_id};
     }
 }
@@ -92,9 +86,10 @@ impl UserManager.authenticate(
     username: str, password: str
 ) -> (dict[(str, str)] | None) {
     self._ensure_connection();
+    assert self._conn is not None;
     password_hash = hashlib.sha256(password.encode()).hexdigest();
     with self._lock {
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT token, root_id FROM users WHERE username = ? AND password_hash = ?",
             (username, password_hash)
         );
@@ -109,8 +104,9 @@ impl UserManager.authenticate(
 """Validate token and return username."""
 impl UserManager.validate_token(token: str) -> (str | None) {
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT username FROM users WHERE token = ?", (token, )
         );
         row = cursor.fetchone();
@@ -121,8 +117,9 @@ impl UserManager.validate_token(token: str) -> (str | None) {
 """Get user's root node ID."""
 impl UserManager.get_root_id(username: str) -> (str | None) {
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT root_id FROM users WHERE username = ?", (username, )
         );
         row = cursor.fetchone();
@@ -138,8 +135,9 @@ impl UserManager.aget_root_id(username: str) -> (str | None) {
 """Get user data by username."""
 impl UserManager.get_user(username: str) -> (dict[(str, str)] | None) {
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT token, root_id FROM users WHERE username = ?", (username, )
         );
         row = cursor.fetchone();
@@ -153,8 +151,9 @@ impl UserManager.get_user(username: str) -> (dict[(str, str)] | None) {
 """Check if a user exists."""
 impl UserManager.user_exists(username: str) -> bool {
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT 1 FROM users WHERE username = ?", (username, )
         );
         return cursor.fetchone() is not None;
@@ -167,25 +166,26 @@ impl UserManager.update_username(
 ) -> dict[str, str] {
     import hashlib;
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
         # Check if new username already exists
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT 1 FROM users WHERE username = ? ", (new_username, )
         );
         if cursor.fetchone() {
             return {'error': 'Username already taken'};
         }
         # Update username
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "UPDATE users SET username = ? WHERE username = ?",
             (new_username, current_username)
         );
-        self.conn.commit();
+        self._conn.commit();
         if cursor.rowcount == 0 {
             return {'error': 'User not found'};
         }
         # Get updated user data
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT token, root_id FROM users WHERE username = ?", (new_username, )
         );
         row = cursor.fetchone();
@@ -199,10 +199,11 @@ impl UserManager.update_password(
 ) -> dict[str, str] {
     import hashlib;
     self._ensure_connection();
+    assert self._conn is not None;
     with self._lock {
         # Verify current password
         current_password_hash = hashlib.sha256(current_password.encode()).hexdigest();
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "SELECT 1 FROM users WHERE username = ?  AND password_hash = ?",
             (username, current_password_hash)
         );
@@ -211,11 +212,11 @@ impl UserManager.update_password(
         }
         # Update password
         new_password_hash = hashlib.sha256(new_password.encode()).hexdigest();
-        cursor = self.conn.execute(
+        cursor = self._conn.execute(
             "UPDATE users SET password_hash = ? WHERE username = ?",
             (new_password_hash, username)
         );
-        self.conn.commit();
+        self._conn.commit();
         return {'username': username, 'message': 'Password updated successfully'};
     }
 }

--- a/jac/jaclang/runtimelib/server.jac
+++ b/jac/jaclang/runtimelib/server.jac
@@ -7,6 +7,8 @@ import inspect;
 import json;
 import os;
 import secrets;
+import sqlite3;
+import threading;
 import from collections.abc { Callable }
 import from contextlib { suppress }
 import from http.server { BaseHTTPRequestHandler, HTTPServer }
@@ -24,7 +26,6 @@ import from urllib.parse { parse_qs, urlparse }
 import from jaclang.runtimelib.client_bundle { ClientBundleError }
 import from jaclang.runtimelib.context { CallState, ExecutionContext }
 import from jaclang.runtimelib.transport {
-    BaseTransport,
     TransportRequest,
     TransportResponse,
     HTTPTransport,
@@ -69,11 +70,20 @@ driver (aiosqlite) or per-thread connection pool would obviate this.
 obj UserManager {
     has base_path: str,
         _db_path: str by postinit,
-        _conn: any by postinit,
-        _lock: any by postinit;
+        _conn: (sqlite3.Connection | None) by postinit,
+        _lock: threading.RLock by postinit;
 
     def postinit -> None;
     def _ensure_connection -> None;
+
+    """The live SQLite connection, asserting it has been opened.
+
+    Call `_ensure_connection()` before touching this. Centralizes the
+    non-None narrowing so call sites can use `self.conn` directly.
+    """
+    @property
+    def conn -> sqlite3.Connection;
+
     def create_user(username: str, password: str) -> dict[str, str];
     def authenticate(username: str, password: str) -> (dict[(str, str)] | None);
     def validate_token(token: str) -> (str | None);
@@ -271,8 +281,7 @@ obj JacAPIServer {
         auth_handler: AuthHandler by postinit,
         introspection_handler: IntrospectionHandler by postinit,
         execution_handler: ExecutionHandler by postinit,
-        transport: BaseTransport by postinit,
-        server: any by postinit,
+        server: (HTTPServer | None) by postinit,
         scheduler: Scheduler by postinit;
 
     obj RestSpecs {

--- a/jac/jaclang/runtimelib/server.jac
+++ b/jac/jaclang/runtimelib/server.jac
@@ -75,15 +75,6 @@ obj UserManager {
 
     def postinit -> None;
     def _ensure_connection -> None;
-
-    """The live SQLite connection, asserting it has been opened.
-
-    Call `_ensure_connection()` before touching this. Centralizes the
-    non-None narrowing so call sites can use `self.conn` directly.
-    """
-    @property
-    def conn -> sqlite3.Connection;
-
     def create_user(username: str, password: str) -> dict[str, str];
     def authenticate(username: str, password: str) -> (dict[(str, str)] | None);
     def validate_token(token: str) -> (str | None);


### PR DESCRIPTION
## Summary

`UserManager` and `JacAPIServer` in `server.jac` declared several fields as `any`, which masked real issues and produced type-checker errors. This types them properly.

- `_lock: any` and `server: any` failed the `with`-statement check (E1091/E1092 — `Any` has no `__enter__`/`__exit__`).
- `_conn: any` was masking 24 null-safety access sites.
- `transport: BaseTransport by postinit` was declared but never assigned in `postinit` (E1095) and never read anywhere — dead since it was introduced 6 months ago.

## Changes

- Type the fields: `_lock: threading.RLock`, `_conn: sqlite3.Connection | None`, `server: HTTPServer | None`; add module imports for `sqlite3`/`threading`.
- After each `_ensure_connection()`, add `assert self._conn is not None;` to narrow `sqlite3.Connection | None` → `sqlite3.Connection` for the checker. `_conn` stays private (no new public surface; avoids the W3043 `@property`→native-getter lint).
- Guard `start()` against a `None` server (test mode, `port=0`) before the `with`, which also narrows the type for the context manager.
- Remove the dead `transport` field and its now-unused `BaseTransport` import.

## Impact

- `jac check jac/jaclang/runtimelib/server.jac` errors: **159 → 136**. Specifically resolves all E1091/E1092 and the E1095 flagged in the IDE.
- No behavior change for the live server; the new guards/asserts only fire on paths that were already invalid (using a connection before `_ensure_connection()`, or starting a never-bound test-mode server).

## Testing

- `jac test tests/runtimelib/test_serve.jac` — all 11 tests pass.