### PR TITLE
feat(examples): add self-screenshot protocol to the Zig shooter twin

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6573.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6573.feature.md
@@ -1,0 +1,1 @@
+- **Zig shooter twin gains the self-screenshot protocol**: The raylib shooter example's Zig baseline honors the same dormant `.screenshot` capture file as the Jac build, so tooling can screenshot both engines' real runs. (jaseci-labs/jaseci#6573)

--- a/jac/examples/raylib_shooter/shooter.zig
+++ b/jac/examples/raylib_shooter/shooter.zig
@@ -56,6 +56,7 @@ extern fn FileExists(fileName: [*:0]const u8) bool;
 extern fn LoadFileText(fileName: [*:0]const u8) [*:0]const u8;
 extern fn TextToInteger(text: [*:0]const u8) c_int;
 extern fn SaveFileText(fileName: [*:0]const u8, text: [*:0]const u8) bool;
+extern fn TakeScreenshot(fileName: [*:0]const u8) void;
 
 // raylib's GL matrix-mode and primitive constants (mirrors the Jac globals).
 const RL_MODELVIEW: c_int = 0x1700;
@@ -240,6 +241,19 @@ fn bench_seconds() f64 {
         return @floatFromInt(TextToInteger(LoadFileText(".bench_seconds")));
     }
     return 0.0;
+}
+
+/// Screenshot warmup frame, or 0 for none. `capture.jac` writes the frame
+/// number to capture into a sibling `.screenshot` file before launching; when
+/// that file is absent this returns 0 and the self-screenshot path stays
+/// dormant (every normal run), exactly as the Jac twin does. raylib's
+/// `TakeScreenshot` reads the GL framebuffer directly - no window grab needed.
+fn shot_frames() i64 {
+    if (FileExists(".screenshot")) {
+        const n: i64 = @intCast(TextToInteger(LoadFileText(".screenshot")));
+        return if (n > 0) n else 60;
+    }
+    return 0;
 }
 
 /// Hand the benchmark result back to demo.sh. Written to a sibling
@@ -495,6 +509,7 @@ pub fn main() void {
     }
 
     const bench = bench_seconds();
+    const shot = shot_frames();
     var frames: i64 = 0;
     var max_fps: f64 = 0.0;
 
@@ -541,6 +556,13 @@ pub fn main() void {
         end_camera(960.0, 600.0);
         draw_fps(10, 10);
         end_frame();
+
+        // Self-screenshot path (dormant unless `.screenshot` exists): grab the
+        // presented frame after EndDrawing, then exit.
+        if (shot > 0 and frames >= shot) {
+            TakeScreenshot("shooter_shot.png");
+            break;
+        }
 
         if (bench > 0.0 and GetTime() >= bench) {
             break;


### PR DESCRIPTION
## Summary

The Jac raylib shooter has a dormant self-capture path: a sibling `.screenshot` file holds a warmup frame count; the binary renders to that frame, calls raylib's `TakeScreenshot` (which reads the GL framebuffer directly - no external window grab), writes `shooter_shot.png`, and exits. The Zig twin had no equivalent, so capture tooling could screenshot the Jac engine's real run but not the Zig baseline's.

This mirrors the exact protocol in `shooter.zig` (+22 lines): a `shot_frames()` reader for the `.screenshot` file, defaulting to frame 60, and a post-`EndDrawing` capture-and-exit in the main loop. Dormant unless the file exists - identical in spirit and mechanics to the existing `.bench_seconds` benchmark path, and to the Jac twin line for line.

## Validation

Rebuilt with the pinned toolchain (`zig build-exe -O ReleaseFast -lc -lraylib`) and drove both binaries through the same capture flow: each renders the identical scene and writes a real 960x600 frame of the running game (FPS counter live, cubes and grid rendered). Normal interactive runs and benchmark runs are unaffected.