### PR TITLE
feat(native): allow `Callable = 0` (null fn-ptr) defaults in clib struct fields

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6574.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6574.feature.md
@@ -1,0 +1,1 @@
+- **Native: `Callable = 0` (NULL fn-ptr) defaults in clib struct fields**: In native (`.na.jac`) modules an integer may now initialize a `Callable[[...], ret]` slot — typically the literal `0` for a C NULL function pointer in clib vtable structs (CEF/libuv callback slots). Regular Jac modules keep rejecting the assignment (E1001).

--- a/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
+++ b/jac/jaclang/compiler/type_system/type_evaluator.impl/type_evaluator.impl.jac
@@ -3242,6 +3242,18 @@ impl TypeEvaluator.assign_type(
                 }
             }
         }
+        # int → function reference: in native code a function value is a
+        # 64-bit pointer, so an integer may initialize a Callable slot —
+        # typically the literal 0 for a C NULL function pointer in clib
+        # vtable struct fields (e.g. CEF/libuv callback slots). Mirrors the
+        # function → int rule below and is gated to native modules so
+        # regular Jac keeps its function/int distinction.
+        if isinstance(src_type, types.ClassType)
+        and src_type.is_class_instance()
+        and src_type.is_builtin("int")
+        and self._in_native_context() {
+            return True;
+        }
     }
     # Source is FunctionType assigned to a different type
     if isinstance(src_type, types.FunctionType) {

--- a/jac/tests/compiler/passes/main/fixtures/checker/checker_callable_null_default.jac
+++ b/jac/tests/compiler/passes/main/fixtures/checker/checker_callable_null_default.jac
@@ -1,0 +1,6 @@
+"""Regular (non-native) Jac keeps the int/Callable distinction: `= 0` is
+not a valid default for a Callable field outside `.na.jac` modules."""
+
+obj Op {
+    has fn: Callable[[int], int] = 0;  # <-- Error
+}

--- a/jac/tests/compiler/passes/main/test_checker_pass.jac
+++ b/jac/tests/compiler/passes/main/test_checker_pass.jac
@@ -5202,3 +5202,22 @@ test "circular_import_preserves_class_identity" {
         program.errors_had
     )} error(s):\n" + "\n---\n".join(e.pretty_print() for e in program.errors_had);
 }
+
+test "callable_null_default_rejected_outside_native" {
+    # Issue #6569 allows `Callable[[...], ret] = 0` (a C NULL function
+    # pointer) in native modules only. Regular Jac must keep rejecting it.
+    path = os.path.join(CHECKER_FIXTURES, "checker_callable_null_default.jac");
+    program = JacProgram();
+    mod = program.compile(path, options=NO_TC);
+    TypeCheckPass(ir_in=mod, prog=program);
+    assert len(program.errors_had) == 1 , "Expected exactly 1 error, got " + f"{len(
+        program.errors_had
+    )}:\n" + "\n---\n".join(e.pretty_print() for e in program.errors_had);
+    assert program.errors_had[0].code.code == "E1001";
+    assert_error_pretty_found(
+        """
+        has fn: Callable[[int], int] = 0;  # <-- Error
+    """,
+        program.errors_had[0].pretty_print()
+    );
+}

--- a/jac/tests/compiler/passes/native/fixtures/fnptr_null_default.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/fnptr_null_default.na.jac
@@ -1,0 +1,41 @@
+"""Null (`= 0`) defaults for `Callable` fields (issue #6569).
+
+C callback-based APIs (CEF, libuv) describe vtables as structs whose
+function-pointer slots default to NULL. In native code an integer zero
+must be accepted where a `Callable[[...], ret]` is expected and lower to
+a null C function pointer — both in clib vtable structs and plain native
+objects used as dispatch tables.
+"""
+
+import from "/usr/lib/libm.so.6" {
+    obj handler_vt {
+        has size: int = 0,
+            on_event: Callable[[int, int], None] = 0;
+    }
+    def sqrt(x: f64) -> f64;
+}
+
+obj Op {
+    has tag: int = 0,
+        fn: Callable[[int], int] = 0;
+}
+
+def op_default_is_null() -> int {
+    o = Op();
+    return o.fn;
+}
+
+def op_slot_reset_to_null(x: int) -> int {
+    o = Op(tag=1, fn=double);
+    o.fn = 0;
+    return o.fn;
+}
+
+def vt_default_is_null() -> int {
+    h = handler_vt(size=56);
+    return h.on_event;
+}
+
+def double(x: int) -> int {
+    return x * 2;
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -3008,6 +3008,21 @@ test "fnptr call_via_local stores and calls pointer" {
     assert call_via_local(mul_addr, 6, 7) == 42;
 }
 
+# --- Callable null (`= 0`) field defaults (issue #6569) ---
+test "callable field accepts int 0 default in native (issue #6569)" {
+    (eng, _) = compile_native("fnptr_null_default.na.jac");
+    op_default = get_func(eng, "op_default_is_null", ctypes.c_int64);
+    assert op_default() == 0;
+    vt_default = get_func(eng, "vt_default_is_null", ctypes.c_int64);
+    assert vt_default() == 0;
+}
+
+test "callable field slot resets to null via int 0 (issue #6569)" {
+    (eng, _) = compile_native("fnptr_null_default.na.jac");
+    reset = get_func(eng, "op_slot_reset_to_null", ctypes.c_int64, ctypes.c_int64);
+    assert reset(5) == 0;
+}
+
 # --- TestCrossModuleGlobInit ---
 test "cross module glob init compiles without errors" {
     # Importing a module with a glob list initializer must compile cleanly.


### PR DESCRIPTION
## Summary

Fixes #6569.

C libraries with callback-based APIs (CEF, libuv) use vtable structs whose function-pointer slots default to `NULL`. The type checker rejected `Callable = 0` with `E1001: Cannot assign int to Callable`, forcing those fields to be declared `int = 0` and losing the type information the compiler needs for C-ABI trampolines (#6570).

## What changed

- `type_evaluator.impl.jac`: `int` → `Callable` assignment is now permitted **in native (`.na.jac`) modules only**, as the symmetric counterpart of the existing `function → int` native rule (a function value is a 64-bit pointer in native code). Regular Jac modules keep rejecting it with E1001.
- No codegen change needed: the existing generic `int → pointer` (`inttoptr`) coercion already lowers `0` to a null C function pointer, for field defaults, constructor kwargs, and field re-assignment alike.

```jac
import from "libcef.so" {
    obj cef_life_span_handler_t {
        has size: int = 0,
            on_before_close: Callable[[int, int], None] = 0;  # now type-checks
    }
}
```

## Tests

- `fnptr_null_default.na.jac` fixture + 2 JIT execution tests: a defaulted `Callable` slot reads back as 0 (null fn ptr) in both a clib vtable struct and a plain native obj, and a slot can be reset to null via `= 0`.
- Negative checker test: the same shape in a regular `.jac` module still fails with exactly one E1001.

Targeted runs: the new tests, the `fnptr`/`clib`/`callable` native suites (22 tests), and the checker `callable` suite (7 tests) all pass.

## Stack

Part 1 of 3 for deleting `cef_shim.c` in jac-desktop: #6569 (this PR) → #6570 (C→Jac trampolines) → #6571 (flat vtable allocation).