### PR TITLE
fix(native): explicit iteration-kind dispatch with ICE on unknown kind

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6580.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6580.bugfix.md
@@ -1,0 +1,1 @@
+- **Native for-loop dispatch hardening**: the unified for-loop skeleton's element fetch now dispatches explicitly per iteration kind and raises an E9002 internal-contract error on an unknown kind, instead of silently falling through to key-fetch semantics. (jaseci-labs/jaseci#6542)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -1885,7 +1885,7 @@ impl NaIRGenPass._codegen_for_indexed(
             if char_str is not None {
                 self.builder.store(char_str, allocas[0]);
             }
-        } else {
+        } elif kind in ("list", "dict") {
             fetch_fn = helpers["get"] if kind == "list" else helpers["get_key"];
             elem_val = self.builder.call(
                 fetch_fn, [collection_val, body_idx], name="for.elem"
@@ -1903,6 +1903,16 @@ impl NaIRGenPass._codegen_for_indexed(
                 self._emit_rc_retain(elem_val, op="for_elem", loc=_rc_loc);
             }
             self.builder.store(elem_val, allocas[0]);
+        } else {
+            # Internal contract: every iteration form must be dispatched
+            # explicitly - an unknown kind means a dispatcher bug, never a
+            # user error.
+            self.emit(
+                E9002,
+                node_override=nd,
+                details=f"unknown for-loop iteration kind '{kind}'"
+            );
+            return;
         }
     }
     _for_saved = set(self.local_vars.keys());


### PR DESCRIPTION
Follow-up to #6577, addressing the review finding that the unified for-loop skeleton's element fetch silently fell through to `helpers["get_key"]` for any unrecognised `kind` string. The list/dict branch is now explicit, and an unknown kind emits an E9002 internal-contract error instead of producing wrong element semantics with no diagnostic.

Validated on fresh builds (`JAC_REBUILD=1`): chess plays to checkmate leak-clean under `JAC_RC_DEBUG_CODEGEN=1`; the five-form for-matrix smoke (range / list / dict-keys / dict-items / string, break/continue, reused loop variables) passes.