### PR TITLE
docs(release): document the close/reopen + auto-merge step

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -129,8 +129,11 @@ jobs:
             --head "$BRANCH_NAME")
           echo "::notice::Release PR created: $PR_URL"
 
-          # Trigger CI workflows (GITHUB_TOKEN can trigger workflow_dispatch)
-          gh workflow run test-jaseci.yml --ref "$BRANCH_NAME"
-          gh workflow run jac-check.yml --ref "$BRANCH_NAME"
-          gh workflow run contribution-checks.yml --ref "$BRANCH_NAME"
-          echo "::notice::CI workflows triggered on $BRANCH_NAME"
+          # CI does NOT run here: the PR is authored by the GITHUB_TOKEN actor, and
+          # GitHub blocks workflows triggered by GITHUB_TOKEN from triggering further
+          # workflows (anti-recursion), so no pull_request checks attach. A maintainer
+          # must CLOSE AND REOPEN the PR so the reopen event comes from a real user;
+          # only then do the checks run and attach (enabling auto-merge). See
+          # CONTRIBUTING.md "Release Flow". Permanent fix: author the PR with a
+          # GitHub App / PAT token instead of GITHUB_TOKEN.
+          echo "::notice::Close & reopen this PR to run its checks, then enable auto-merge (see CONTRIBUTING.md)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,10 +150,11 @@ The docs site has three tiers with different expectations for contributors:
 Releasing new versions to PyPI is a two-step process using GitHub Actions.
 
 ```
-┌─────────────────────┐      ┌─────────────────────┐      ┌─────────────────────┐
-│  Create Release PR  │ ───▶ │   Merge to main     │ ───▶ │  Approve & Publish  │
-│  (manual trigger)   │      │   (triggers publish)│      │  (one-click)        │
-└─────────────────────┘      └─────────────────────┘      └─────────────────────┘
+┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
+│  Create Release PR  │ ─▶ │  Close & reopen PR  │ ─▶ │   Merge to main     │ ─▶ │  Approve & Publish  │
+│  (manual trigger)   │    │  (so CI runs) +     │    │  (auto-merge;       │    │  (one-click on the  │
+│                     │    │  enable auto-merge  │    │  triggers publish)  │    │  pypi environment)  │
+└─────────────────────┘    └─────────────────────┘    └─────────────────────┘    └─────────────────────┘
 ```
 
 ### Step 1: Create the Release PR
@@ -163,8 +164,10 @@ Releasing new versions to PyPI is a two-step process using GitHub Actions.
 3. For each package, select the version bump type (`skip`, `patch`, `minor`, or `major`):
    - `jaclang`, `jac-byllm`, `jac-client`, `jac-scale`, `jac-super`, `jac-mcp`, `jac-desktop`, `jaseci`
 4. Click **Run workflow**
-5. The workflow validates versions against PyPI, bumps them, creates a PR from a `release/*` branch, and triggers the CI workflows on it
-6. Wait for CI tests to pass, then **approve and merge** the PR to main
+5. The workflow validates versions against PyPI, bumps them, and creates a PR from a `release/*` branch
+6. **Close and reopen the PR** to make CI run. The PR is authored by `github-actions[bot]`, and GitHub does not run `pull_request` checks for PRs opened by the `GITHUB_TOKEN` actor (workflows triggered by `GITHUB_TOKEN` can't trigger further workflows, to prevent recursion). Closing and reopening makes the reopen event come from *you* (a real user), so the PR checks run and attach to the PR. _(Permanent fix: author the PR with a GitHub App / PAT token instead.)_
+7. Once the checks attach, enable **auto-merge** on the PR
+8. When CI passes, the PR auto-merges to `main` (or **approve and merge** it manually)
 
 ### Step 2: Approve Publishing
 
@@ -193,7 +196,8 @@ After the release PR is merged, the **Publish Release** workflow triggers automa
 
 | Issue | Solution |
 |-------|----------|
-| CI tests not running on release PR | The `Create Release PR` workflow triggers them automatically; if they're missing, manually re-run `test-jaseci.yml` / `jac-check.yml` on the `release/*` branch |
+| CI checks not running / not showing on the release PR | Expected: GitHub skips `pull_request` checks for PRs opened by the `github-actions[bot]` / `GITHUB_TOKEN` actor. **Close and reopen the PR** so the reopen event comes from a real user, and the checks then run and attach. (A GitHub App / PAT token authoring the PR would remove this step.) |
+| Auto-merge won't enable / PR won't merge | Auto-merge needs the PR's required status checks to be attached; do the close/reopen above first so the checks exist on the PR |
 | Publish workflow didn't trigger | Ensure the PR branch started with `release/` |
 | A tier failed to publish | Re-run the failed job from GitHub Actions; already-published packages are skipped (`skip-existing`) |
 | Need to re-publish after the release PR is merged | Manually trigger **Publish Release** (`workflow_dispatch`) and check the packages to publish |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ Releasing new versions to PyPI is a two-step process using GitHub Actions.
    - `jaclang`, `jac-byllm`, `jac-client`, `jac-scale`, `jac-super`, `jac-mcp`, `jac-desktop`, `jaseci`
 4. Click **Run workflow**
 5. The workflow validates versions against PyPI, bumps them, and creates a PR from a `release/*` branch
-6. **Close and reopen the PR** to make CI run. The PR is authored by `github-actions[bot]`, and GitHub does not run `pull_request` checks for PRs opened by the `GITHUB_TOKEN` actor (workflows triggered by `GITHUB_TOKEN` can't trigger further workflows, to prevent recursion). Closing and reopening makes the reopen event come from *you* (a real user), so the PR checks run and attach to the PR. _(Permanent fix: author the PR with a GitHub App / PAT token instead.)_
+6. **Close and reopen the PR** to make CI run. The PR is authored by `github-actions[bot]`, and GitHub does not run `pull_request` checks for PRs opened by the `GITHUB_TOKEN` actor (workflows triggered by `GITHUB_TOKEN` can't trigger further workflows, to prevent recursion). Closing and reopening makes the reopen event come from *you* (a real user), so the PR checks run and attach to the PR. *(Permanent fix: author the PR with a GitHub App / PAT token instead.)*
 7. Once the checks attach, enable **auto-merge** on the PR
 8. When CI passes, the PR auto-merges to `main` (or **approve and merge** it manually)
 


### PR DESCRIPTION
## Problem

The release docs (and a workflow comment) say CI is triggered automatically on the release PR — but it isn't. The `Create Release PR` workflow opens the PR as the `github-actions[bot]` / `GITHUB_TOKEN` actor, and GitHub blocks workflows triggered by `GITHUB_TOKEN` from triggering further workflows (anti-recursion). So no `pull_request` checks attach to the PR, and auto-merge can't proceed.

The **actual** working procedure — used on every release — is to **close and reopen the PR** so the reopen event comes from a real user; the checks then run and attach, and auto-merge can be enabled. This step was documented nowhere, and the existing text actively implied it was unnecessary.

(Confirmed behaviour; the pattern matches what pytest/pre-commit do for the same GitHub limitation.)

## Changes

- **CONTRIBUTING.md**
  - Step 1 now documents: close & reopen the PR (with the *why*), then enable auto-merge.
  - Flow diagram updated to 4 steps (adds the close/reopen + auto-merge stage).
  - Troubleshooting: corrected the "CI not running" row (it's expected; close/reopen fixes it) and added an "auto-merge won't enable" row.
- **.github/workflows/create-release-pr.yml**
  - Removed the three `gh workflow run …` calls. They fired detached `workflow_dispatch` runs that never attach as PR status checks — wasted CI minutes and reinforced the "CI auto-triggers" misconception.
  - Comment now states the `GITHUB_TOKEN` limitation and the close/reopen requirement plainly.

## Note

The permanent fix (out of scope here) is to author the release PR with a GitHub App / PAT token instead of `GITHUB_TOKEN`, which would let CI run automatically and remove the manual close/reopen entirely. Mentioned inline in both files.