### PR TITLE
Analysis centralization train 6: JIR-semantics decision gate (measured: NO) + CLIB call classification

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6588.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6588.refactor.md
@@ -1,0 +1,1 @@
+- **Analysis centralization (train 6)**: the JIR-carries-semantics question is measured and decided (semantic annotations stay recompute-on-load; warm cache hits already skip analysis entirely, with numbers recorded in the architecture spec); foreign calls now classify centrally as `CallKind.CLIB` - the seam the Phase 8 marshalling plan builds on. (jaseci-labs/jaseci#6542)

--- a/docs/docs/internals/compiler_architecture.md
+++ b/docs/docs/internals/compiler_architecture.md
@@ -476,6 +476,20 @@ rm -rf ~/.cache/jac/jir/modules/
 
 ---
 
+### The JIR-carries-semantics decision (Phase 10 gate)
+
+Measured 2026-06-11 on the chess fixture (3 runs each): warm cache-hit
+runs ~4.9s with the analysis pipeline fully skipped (bytecode and LLVM
+sections load directly); cold compiles ~182s with inference vs ~76s
+with inference disabled - inference is ~59% of a cold compile and ~0%
+of a warm one. Decision: semantic annotations (`Expr.type`,
+`callee_decl`, ownership facts) stay **recompute-on-load**; serializing
+them as JIR TLV sections would not improve warm compiles (already
+analysis-free) and cannot help the changed module on a miss (its
+analysis must run regardless). The actionable cost is typeshed stub
+processing inside cold-compile inference - an incremental-checking
+workstream, not a cache-format one.
+
 ## Key Files
 
 A short index, organised by the role each file plays in the pipeline.

--- a/jac/jaclang/compiler/symbol_utils.jac
+++ b/jac/jaclang/compiler/symbol_utils.jac
@@ -91,10 +91,20 @@ def classify_call(nd: uni.FuncCall) -> CallKind {
     }
     # (2) A resolved user symbol shadows any builtin/class name.
     sym = resolve_expr_symbol(nd.target);
-    # (2a) A symbol declared inside a C-library import block is a foreign
-    # call - the Phase 8 CallInfo seam (kind == CLIB) that the foreign
-    # marshalling plan hangs off.
-    if sym is not None and sym.decl is not None {
+    # (2a) A FUNCTION declared inside a C-library import block is a
+    # foreign call - the Phase 8 CallInfo seam (kind == CLIB) that the
+    # foreign marshalling plan hangs off. A clib-declared struct's
+    # constructor call is still an INSTANTIATION (the struct is laid out
+    # and allocated locally; only functions cross the C boundary).
+    if sym is not None
+    and sym.decl is not None
+    and sym.sym_type not in (
+        SymbolType.OBJECT_ARCH,
+        SymbolType.NODE_ARCH,
+        SymbolType.EDGE_ARCH,
+        SymbolType.WALKER_ARCH,
+        SymbolType.ENUM_ARCH
+    ) {
         _imp = sym.decl.find_parent_of_type(uni.Import);
         if _imp is not None and _imp.clib_decls {
             return CallKind.CLIB;

--- a/jac/jaclang/compiler/symbol_utils.jac
+++ b/jac/jaclang/compiler/symbol_utils.jac
@@ -19,6 +19,7 @@ enum CallKind {
     METHOD = "method",  # obj.method(...)
     INSTANTIATION = "instantiation",  # Foo(...) where Foo is a class/archetype
     BUILTIN = "builtin",  # len(...)/print(...): registry builtin, unshadowed
+    CLIB = "clib",  # foreign function declared by a C-library import block
     FUNCTION = "function"  # free function / ability / indirect / unknown
 }
 
@@ -90,6 +91,15 @@ def classify_call(nd: uni.FuncCall) -> CallKind {
     }
     # (2) A resolved user symbol shadows any builtin/class name.
     sym = resolve_expr_symbol(nd.target);
+    # (2a) A symbol declared inside a C-library import block is a foreign
+    # call - the Phase 8 CallInfo seam (kind == CLIB) that the foreign
+    # marshalling plan hangs off.
+    if sym is not None and sym.decl is not None {
+        _imp = sym.decl.find_parent_of_type(uni.Import);
+        if _imp is not None and _imp.clib_decls {
+            return CallKind.CLIB;
+        }
+    }
     if sym is not None and _is_user_symbol(sym) {
         if sym.sym_type in (
             SymbolType.OBJECT_ARCH,


### PR DESCRIPTION
Train 6 of #6542 - two focused deliverables.

## Phase 10 decision gate: JIR-carries-semantics - measured, decided NO

| Configuration | Time (3 runs) |
|---|---|
| Warm run (JIR cache hit) | 4.88-4.91s |
| Cold compile, inference ON | 180.3-185.7s |
| Cold compile, inference OFF | 75.3-75.9s |

Warm-cache compiles already skip the analysis pipeline entirely (bytecode + LLVM TLV sections load directly), so the plan's condition for serializing semantic annotations - analysis dominating warm compiles - is false (~0%). Inference is ~59% of COLD compiles, but serialization cannot help there (the changed module's analysis must run; the dominant cost is typeshed stub processing - an incremental-checking lever, not a cache-format one). **Decision: `Expr.type`, `callee_decl`, and the ownership facts stay recompute-on-load**, recorded with the numbers in `docs/internals/compiler_architecture.md` and on #6542.

## Phase 8 seam: foreign calls classify as CLIB

`classify_call` returns the new `CallKind.CLIB` for symbols declared inside a C-library import block - the central fact the foreign marshalling plan hangs off. Every existing `call_kind` consumer compares specific kinds with fall-through, so CLIB calls dispatch exactly as before (audited all 8 comparison sites); a libm smoke (sqrt/fabs through the foreign path) validates the lowering, and chess/purity/ABI/ES-golden/OSP gates are green.