### PR TITLE
feat(native): run test blocks natively in the na codespace

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6599.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6599.feature.md
@@ -1,0 +1,1 @@
+- **`test` blocks run natively in the na codespace**: a `test` in a `.na.jac` module or inline `na {}` block compiles to native code, executes via the JIT under `jac test`, and reports through the standard test pipeline with source-located assertion failures. (jaseci-labs/jaseci#6599)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -138,6 +138,8 @@ impl NaIRGenPass.transform(ir_in: uni.Module) -> uni.Module {
             self._codegen_ability(stmt);
         } elif isinstance(stmt, uni.ModuleCode) {
             self._codegen_entry(stmt);
+        } elif isinstance(stmt, uni.Test) {
+            self._codegen_test(stmt);
         }
     }
     # Store LLVM module on AST
@@ -226,7 +228,8 @@ impl NaIRGenPass._export_native_layout -> None {
         NativeFieldInfo,
         NativeEnumLayout,
         NativeFuncLayout,
-        NativeTupleLayout
+        NativeTupleLayout,
+        NativeTestLayout
     }
     layout = NativeModuleLayout();
     # Structs
@@ -365,6 +368,12 @@ impl NaIRGenPass._export_native_layout -> None {
     # List element types
     for (ename, ltype) in self.list_types.items() {
         layout.list_elem_types[f"List.{ename}"] = ename;
+    }
+    # Test blocks
+    for (tname, tsymbol, tdesc, tline) in self.native_tests {
+        layout.tests.append(
+            NativeTestLayout(name=tname, symbol=tsymbol, description=tdesc, line=tline)
+        );
     }
     self.ir_in.gen.native_layout = layout;
 }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -382,6 +382,89 @@ impl NaIRGenPass._codegen_ability(nd: uni.Ability) -> None {
     self._builder = None;
 }
 
+"""Lower a test block to a zero-argument native function.
+
+The function returns i8*: null means the test passed, a non-null pointer is
+a static failure message. The body runs under an implicit exception handler
+(the same setjmp/longjmp machinery as try/except) so a failing assert or any
+uncaught runtime raise fails THIS test instead of hitting the no-handler
+abort() path and killing the host test runner.
+"""
+impl NaIRGenPass._codegen_test(nd: uni.Test) -> None {
+    import from jaclang.jac0core.codeinfo { native_test_symbol }
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    if self._exc_raise_fn is None {
+        self._declare_exception_runtime();
+    }
+    test_name = nd.name.sym_name;
+    line = nd.loc.first_line if nd.loc else 0;
+    symbol = native_test_symbol(test_name, line);
+    fnty = ir.FunctionType(i8p, []);
+    func = ir.Function(self.llvm_module, fnty, name=symbol);
+    # Locals must survive the setjmp/longjmp round trip (same rationale as
+    # _codegen_try): without optnone, mem2reg promotes them to registers and
+    # values written between setjmp and the raise are lost.
+    func.attributes.add("optnone");
+    func.attributes.add("noinline");
+    entry_bb = func.append_basic_block(name="entry");
+    body_bb = func.append_basic_block(name="test.body");
+    success_bb = func.append_basic_block(name="test.success");
+    fail_bb = func.append_basic_block(name="test.fail");
+    self._builder = ir.IRBuilder(entry_bb);
+    self.local_vars = {};
+    saved_param_vars = self.param_vars;
+    self.param_vars = set();
+    self._attach_di_subprogram(func, symbol, line);
+    # ── entry: install the implicit handler ──
+    exc_state = self.builder.alloca(self._exc_state_type, name="exc.state");
+    self.builder.call(self._exc_push_fn, [exc_state]);
+    env_ptr = self.builder.gep(
+        exc_state, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="env.ptr"
+    );
+    env_i8p = self.builder.bitcast(env_ptr, i8p, name="env.i8p");
+    setjmp_fn = self.extern_funcs["setjmp"];
+    setjmp_result = self.builder.call(setjmp_fn, [env_i8p], name="setjmp.result");
+    is_exception = self.builder.icmp_signed(
+        "!=", setjmp_result, ir.Constant(i32, 0), name="is.exception"
+    );
+    self.builder.cbranch(is_exception, fail_bb, body_bb);
+    # ── test.body ──
+    self.builder.position_at_end(body_bb);
+    self._codegen_body(nd.body);
+    if not self.builder.block.is_terminated {
+        self.builder.branch(success_bb);
+    }
+    # ── test.success: pop handler, release locals, return null (pass) ──
+    self.builder.position_at_end(success_bb);
+    self.builder.call(self._exc_pop_fn, []);
+    _tc_loc = f"{self.ir_in.loc.mod_path}:{nd.loc.last_line if nd.loc else 0}";
+    self._emit_scope_cleanup(skip_var=None, loc=_tc_loc);
+    self.builder.ret(ir.Constant(i8p, None));
+    # ── test.fail: pop handler, return the exception message (fail) ──
+    # Locals are deliberately not released here: the longjmp skipped an
+    # unknown suffix of the body, so slot states can't be trusted. Leaking
+    # on a failing test is acceptable in a test-runner process.
+    self.builder.position_at_end(fail_bb);
+    self.builder.call(self._exc_pop_fn, []);
+    exc_obj_ptr = self.builder.gep(
+        exc_state, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="exc.obj.ptr"
+    );
+    exc_msg = self.builder.load(exc_obj_ptr, name="exc.msg");
+    self.builder.ret(exc_msg);
+    self._finalize_di_locations(func, line);
+    self.param_vars = saved_param_vars;
+    self._builder = None;
+    desc = nd.description.lit_value if nd.description else "";
+    self.native_tests.append((test_name, symbol, desc, line));
+    self.has_native_code = True;
+    # Mark the node native so PyastGenPass.exit_test emits the host-side shim
+    # instead of a Python lowering of the body. Top-level tests in a .na.jac
+    # are already coerced; this matters for tests inside inline na {} blocks,
+    # whose code_context still carries the SERVER default.
+    nd.code_context = CodeContext.NATIVE;
+}
+
 """Generate a nested function definition (a `def` inside another function).
 
 The inner function is lifted to a uniquely-named private LLVM function and

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -104,7 +104,18 @@ impl NaIRGenPass._codegen_stmt(nd: uni.UniNode) -> None {
             cond_bool = self._to_bool(cond);
             # assert fires when condition is FALSE
             is_false = self.builder.not_(cond_bool, name="assert.fail");
-            self._emit_runtime_raise(is_false, "AssertionError", "assertion failed");
+            # Stamp the source location (and any literal message) into the
+            # raise so the failure points at the assert site; messages are
+            # deduplicated globals, so unique strings cost one constant each.
+            _a_path = self.ir_in.loc.mod_path if self.ir_in.loc else "";
+            _a_line = nd.loc.first_line if nd.loc else 0;
+            _a_text = "assertion failed";
+            if isinstance(nd.error_msg, uni.String) {
+                _a_text = nd.error_msg.lit_value;
+            }
+            self._emit_runtime_raise(
+                is_false, "AssertionError", f"{_a_text} at {_a_path}:{_a_line}"
+            );
         }
     } elif isinstance(nd, uni.DeleteStmt) {
         # del d[k]  →  d.remove(k)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -101,6 +101,9 @@ obj NaIRGenPass(ModuleCodegenPass) {
         local_vars: dict[str, ir.AllocaInstr] = {},
         param_vars: set[str] = set(),
         has_native_code: bool = False,
+        # Test blocks lowered to native functions: (name, symbol, description,
+        # line) tuples, exported as NativeTestLayout entries in the layout.
+        native_tests: list = [],
         _fmt_strings: dict[str, ir.GlobalVariable] = {},
         # External function cache (Phase 0)
         extern_funcs: dict[str, ir.Function] = {},
@@ -290,6 +293,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
     # Ability (function definition) - manual codegen
     def _codegen_ability(nd: uni.Ability) -> None;
     def _codegen_nested_ability(nd: uni.Ability) -> None;
+    # Test block - lowered to a zero-arg native fn returning i8* (null = pass)
+    def _codegen_test(nd: uni.Test) -> None;
     # Body / statement codegen
     def _codegen_body(stmts: (list | tuple)) -> None;
     def _codegen_stmt(nd: uni.UniNode) -> None;

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -96,6 +96,30 @@ obj NativeFuncLayout {
         ret_enum_type: (str | None) = None;
 }
 
+"""Layout info for a native test block.
+
+A `test` block in native context lowers to a zero-argument native function
+returning `i8*`: null means the test passed, a non-null pointer is a static
+failure message (the uncaught exception's message).
+"""
+obj NativeTestLayout {
+    has name: str,
+        symbol: str,
+        description: str = "",
+        line: int = 0;
+}
+
+"""Native symbol name for a test block.
+
+Single naming contract shared by NaIRGenPass (which defines the function)
+and PyastGenPass (whose host-side shim looks the address up by name). The
+line number keeps symbols unique when two descriptions derive the same
+identifier.
+"""
+def native_test_symbol(name: str, line: int) -> str {
+    return f"__jac_test_{name}_{line}";
+}
+
 """Resolve a module name to a .na.jac file path.
 
 Shared resolver used by both BoundaryAnalysisPass and NaIRGenPass to
@@ -141,7 +165,8 @@ obj NativeModuleLayout {
         functions: dict[(str, NativeFuncLayout)] = field(default_factory=`dict),
         methods: dict[(str, NativeFuncLayout)] = field(default_factory=`dict),
         list_elem_types: dict[(str, str)] = field(default_factory=`dict),
-        tuples: dict[(str, NativeTupleLayout)] = field(default_factory=`dict);
+        tuples: dict[(str, NativeTupleLayout)] = field(default_factory=`dict),
+        tests: list[NativeTestLayout] = field(default_factory=`list);
 }
 
 """Metadata for a type (obj, node, enum) that crosses a codespace boundary.

--- a/jac/jaclang/jac0core/impl/runtime.impl.jac
+++ b/jac/jaclang/jac0core/impl/runtime.impl.jac
@@ -994,6 +994,11 @@ impl JacBasics.run_test(
             mod_name = mod_name[:-4];
             if mod_name.endswith('.test') {
                 mod_name = mod_name[:-5];
+            } elif mod_name.endswith('.na') or mod_name.endswith('.sv') {
+                # Compound codespace suffix: foo.na.jac imports as module
+                # 'foo' (the importer resolves the stem back to the file);
+                # leaving the '.na' makes jac_import read it as a package path.
+                mod_name = mod_name[:-3];
             }
             JacTestCheck.reset();
             JacRuntimeInterface.jac_import(target=mod_name, base_path=base);
@@ -1053,8 +1058,13 @@ impl JacBasics.run_test(
                         f"\n\n\t\t* Inside {root_dir}/{file} *"
                     );
                     JacTestCheck.reset();
+                    mod_target = file[:-4];
+                    if mod_target.endswith('.na') or mod_target.endswith('.sv') {
+                        # Compound codespace suffix (see single-file branch).
+                        mod_target = mod_target[:-3];
+                    }
                     JacRuntimeInterface.jac_import(
-                        target=file[:-4], base_path=root_dir
+                        target=mod_target, base_path=root_dir
                     );
                     JacTestCheck.run_test(
                         xit, maxfail, verbose, os.path.abspath(file), func_name

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -153,28 +153,42 @@ ctypes.
         """
 impl PyastGenPass._gen_native_interop_stubs(nd: uni.NativeBlock) -> None {
     manifest = self.ir_in.gen.interop_manifest;
-    if (not manifest or not manifest.bindings) {
-        return;
-    }
-    import from jaclang.jac0core.interop_bridge { JAC_TO_CTYPES_STR }
     parts: list[str] = [];
-    for binding in manifest.native_exports {
-        params = ', '.join(binding.param_names);
-        ret_ct = JAC_TO_CTYPES_STR.get(binding.ret_type, 'ctypes.c_int64');
-        arg_cts = ', '.join(
-            JAC_TO_CTYPES_STR.get(pt, 'ctypes.c_int64') for pt in binding.param_types
-        );
-        parts.append(
-            f"def {binding.name}({params}):\n" + f"    import ctypes\n" + f"    _addr = __jac_native_engine__" + f".get_function_address('{binding.name}')\n" + f"    _fn = ctypes.CFUNCTYPE({ret_ct}, {arg_cts})(_addr)\n" + f"    return _fn({params})"
-        );
+    if (manifest and manifest.bindings) {
+        import from jaclang.jac0core.interop_bridge { JAC_TO_CTYPES_STR }
+        for binding in manifest.native_exports {
+            params = ', '.join(binding.param_names);
+            ret_ct = JAC_TO_CTYPES_STR.get(binding.ret_type, 'ctypes.c_int64');
+            arg_cts = ', '.join(
+                JAC_TO_CTYPES_STR.get(pt, 'ctypes.c_int64')
+                for pt in binding.param_types
+            );
+            parts.append(
+                f"def {binding.name}({params}):\n" + f"    import ctypes\n" + f"    _addr = __jac_native_engine__" + f".get_function_address('{binding.name}')\n" + f"    _fn = ctypes.CFUNCTYPE({ret_ct}, {arg_cts})(_addr)\n" + f"    return _fn({params})"
+            );
+        }
+        for binding in manifest.native_imports {
+            parts.append(
+                f"__jac_interop_py_funcs__['{binding.name}'] = {binding.name}"
+            );
+        }
     }
-    for binding in manifest.native_imports {
-        parts.append(f"__jac_interop_py_funcs__['{binding.name}'] = {binding.name}");
-    }
+    out: list = [];
     if parts {
         src = '\n'.join(parts);
         parsed = ast3.parse(src);
-        nd.gen.py_ast = `list(parsed.body);
+        out.extend(parsed.body);
+    }
+    # Test blocks inside this na block: the block's children are pruned from
+    # normal traversal, so their host-side shims are emitted here instead.
+    for stmt in nd.body {
+        if isinstance(stmt, uni.Test) {
+            self.exit_test(stmt);
+            out.extend(stmt.gen.py_ast);
+        }
+    }
+    if out {
+        nd.gen.py_ast = out;
     }
 }
 
@@ -967,6 +981,16 @@ impl PyastGenPass.exit_global_vars(nd: uni.GlobalVars) -> None {
 
 impl PyastGenPass.exit_test(nd: uni.Test) -> None {
     test_name = nd.name.sym_name;
+    # A natively-lowered test keeps native semantics: its body lives in the
+    # LLVM module and the Python side is only a shim that invokes it.
+    if nd.code_context == CodeContext.NATIVE {
+        body_stmts = self._native_test_shim_stmts(nd);
+    } else {
+        body_stmts = [
+            cast(ast3.stmt, stmt)
+            for stmt in self.resolve_stmt_block(nd.body, doc=nd.doc)
+        ];
+    }
     func = self.sync(
         ast3.FunctionDef(
             name=test_name,
@@ -981,10 +1005,7 @@ impl PyastGenPass.exit_test(nd: uni.Test) -> None {
                     defaults=[]
                 )
             ),
-            body=[
-                cast(ast3.stmt, stmt)
-                for stmt in self.resolve_stmt_block(nd.body, doc=nd.doc)
-            ],
+            body=body_stmts,
             decorator_list=[cast(ast3.expr, self.py_ast_val(i)) for i in nd.decorators]
                 if nd.decorators
                 else [],
@@ -1031,6 +1052,27 @@ impl PyastGenPass.exit_test(nd: uni.Test) -> None {
         );
     }
     nd.gen.py_ast = [func];
+}
+
+impl PyastGenPass._native_test_shim_stmts(nd: uni.Test) -> list {
+    import from jaclang.jac0core.codeinfo { native_test_symbol }
+    test_name = nd.name.sym_name;
+    line = nd.loc.first_line if nd.loc else 0;
+    symbol = native_test_symbol(test_name, line);
+    src_lines = [
+        "import ctypes as _jac_ctypes",
+        "_jac_engine = globals().get('__jac_native_engine__')",
+        "if _jac_engine is None:",
+        "    raise RuntimeError('native engine unavailable for " + test_name + "')",
+        "_jac_addr = _jac_engine.get_function_address('" + symbol + "')",
+        "if _jac_addr == 0:",
+        "    raise RuntimeError('native test symbol missing: " + symbol + "')",
+        "_jac_msg = _jac_ctypes.CFUNCTYPE(_jac_ctypes.c_char_p)(_jac_addr)()",
+        "if _jac_msg is not None:",
+        "    raise AssertionError(_jac_msg.decode('utf-8', 'replace'))"
+    ];
+    parsed = ast3.parse('\n'.join(src_lines));
+    return `list(parsed.body);
 }
 
 impl PyastGenPass.exit_module_code(nd: uni.ModuleCode) -> None {

--- a/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
+++ b/jac/jaclang/jac0core/passes/pyast_gen_pass.jac
@@ -142,6 +142,15 @@ ctypes.
         """
     def _gen_native_interop_stubs(nd: uni.NativeBlock) -> None;
 
+    """Build shim body statements for a natively-lowered test block.
+
+        The shim calls the test's native function through the module's JIT
+        engine and re-raises its failure message as an AssertionError, so
+        native tests report through the same unittest pipeline as Python
+        tests.
+        """
+    def _native_test_shim_stmts(nd: uni.Test) -> list;
+
     """Generate Python HTTP client stubs for sv-to-sv microservice imports.
 
         For each function imported via an sv import from another server module,

--- a/jac/tests/compiler/passes/native/fixtures/test_blocks.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/test_blocks.na.jac
@@ -1,0 +1,26 @@
+"""Fixture: test blocks in a pure .na.jac module (one passing, one failing)."""
+
+def add(a: int, b: int) -> int {
+    return a + b;
+}
+
+def scale(x: int) -> int {
+    return x * GAIN;
+}
+
+glob GAIN: int = 3;
+
+test "add works" {
+    assert add(2, 3) == 5;
+    assert add(-1, 1) == 0;
+}
+
+test "globals visible in tests" {
+    assert scale(4) == 12;
+}
+
+test "deliberate failure" {
+    assert add(2, 2) == 5;
+}
+
+with entry {}

--- a/jac/tests/compiler/passes/native/fixtures/test_blocks_inline.jac
+++ b/jac/tests/compiler/passes/native/fixtures/test_blocks_inline.jac
@@ -1,0 +1,17 @@
+"""Fixture: test blocks inside an inline na {} block of a regular module."""
+
+na {
+    def double(x: int) -> int {
+        return x * 2;
+    }
+
+    test "inline double works" {
+        assert double(21) == 42;
+    }
+
+    test "inline deliberate failure" {
+        assert double(2) == 5;
+    }
+}
+
+with entry {}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -4099,3 +4099,90 @@ test "tuple-trigger union gives `here` a usable field layout (issue #6470)" {
     fn(ctypes.cast(self_buf, ctypes.c_void_p), ctypes.cast(here_buf2, ctypes.c_void_p));
     assert self_buf[3] == 12;
 }
+
+# --- TestNativeTestBlocks ---
+test "native test blocks compile to pass/fail functions" {
+    (eng, ir) = compile_native("test_blocks.na.jac");
+    layout = ir.gen.native_layout;
+    assert layout is not None;
+    tests = layout.tests;
+    assert len(tests) == 3 , f"expected 3 test entries in layout, got {len(tests)}";
+    by_name = {t.name: t for t in tests};
+    assert set(by_name.keys()) == {
+        "test_add_works",
+        "test_globals_visible_in_tests",
+        "test_deliberate_failure"
+    };
+    assert by_name["test_add_works"].description == "add works";
+    # Globals must be initialized before tests touch them.
+    glob_init = get_func(eng, "__jac_glob_init", None);
+    glob_init();
+    # Convention: null (None) = pass, static message pointer = fail.
+    passing = get_func(eng, by_name["test_add_works"].symbol, ctypes.c_char_p);
+    assert passing() is None , "passing test returned a failure message";
+    uses_glob = get_func(
+        eng, by_name["test_globals_visible_in_tests"].symbol, ctypes.c_char_p
+    );
+    assert uses_glob() is None , "test reading module globals failed";
+    failing = get_func(eng, by_name["test_deliberate_failure"].symbol, ctypes.c_char_p);
+    msg = failing();
+    assert msg is not None , "failing assert did not produce a message";
+    text = msg.decode("utf-8");
+    assert "assertion failed" in text;
+    # The failing assert sits on line 23 of the fixture; the message must
+    # carry the source location so the host report can point at it.
+    assert "test_blocks.na.jac:23" in text , f"no source location in: {text}";
+}
+
+test "a failing native test must not abort the host process" {
+    # The implicit per-test handler is what stands between a failing assert
+    # and the no-handler abort() path -- calling the failing test twice in
+    # one process proves the handler is popped/re-armed correctly too.
+    (eng, ir) = compile_native("test_blocks.na.jac");
+    by_name = {t.name: t for t in ir.gen.native_layout.tests};
+    failing = get_func(eng, by_name["test_deliberate_failure"].symbol, ctypes.c_char_p);
+    assert failing() is not None;
+    assert failing() is not None;
+}
+
+test "jac test runs .na.jac test blocks end to end" {
+    fixture = os.path.join(FIXTURES, "test_blocks.na.jac");
+    result = subprocess.run(
+        [sys.executable, "-m", "jaclang", "test", fixture],
+        capture_output=True,
+        text=True,
+        timeout=300
+    );
+    output = result.stdout + result.stderr;
+    assert "Ran 3 tests" in output , (
+        f"expected 3 tests to run.\nstdout: {result.stdout[-800:]}\n"
+        f"stderr: {result.stderr[-800:]}"
+    );
+    assert "FAILED (failures=1)" in output , (
+        f"expected exactly the deliberate failure.\noutput tail: {output[-800:]}"
+    );
+    assert "test_blocks.na.jac:23" in output , (
+        f"failure report must point at the failing assert.\noutput tail: {output[-800:]}"
+    );
+    assert result.returncode != 0 , "jac test must exit non-zero on failure";
+}
+
+test "jac test runs test blocks inside inline na blocks (no false green)" {
+    fixture = os.path.join(FIXTURES, "test_blocks_inline.jac");
+    result = subprocess.run(
+        [sys.executable, "-m", "jaclang", "test", fixture],
+        capture_output=True,
+        text=True,
+        timeout=300
+    );
+    output = result.stdout + result.stderr;
+    assert "NO TESTS RAN" not in output , "inline na-block tests were silently dropped";
+    assert "Ran 2 tests" in output , (
+        f"expected 2 tests to run.\nstdout: {result.stdout[-800:]}\n"
+        f"stderr: {result.stderr[-800:]}"
+    );
+    assert "FAILED (failures=1)" in output , (
+        f"expected exactly the deliberate failure.\noutput tail: {output[-800:]}"
+    );
+    assert result.returncode != 0 , "jac test must exit non-zero on failure";
+}


### PR DESCRIPTION
## Summary

`test` blocks in native context now run as native code. Previously a `test` in a `.na.jac` module lowered (accidentally) to a Python body over FFI stubs and `jac test foo.na.jac` crashed outright on a dotted-import bug, while a `test` inside an inline `na {}` block was silently dropped — `jac test` reported `NO TESTS RAN ... Passed successfully` for a file whose only test was a failing assert.

## Semantics

A native-context `test` compiles to a zero-argument native function returning `i8*` (null = pass, static message pointer = fail). The body executes with full native semantics in the module's JIT engine, wrapped in an implicit exception handler built on the existing setjmp/longjmp machinery — a failing `assert` or any uncaught runtime raise fails that one test instead of hitting the no-handler `abort()` path and killing the runner. Native assert failures carry the assert site (`file:line`) plus any literal message.

## Wiring (reuses existing infrastructure)

- **NaIRGenPass** gains `_codegen_test`: same function-codegen conventions as `_codegen_ability`, same handler mechanics as `_codegen_try`. Lowered tests are recorded on a new `NativeModuleLayout.tests` inventory (`codeinfo.jac`), with the symbol naming contract (`native_test_symbol`) shared between passes.
- **PyastGenPass.exit_test** emits a `jac_test`-decorated shim for native tests — it calls the native function through `__jac_native_engine__` (the same pattern as the existing interop stubs) and re-raises the message as `AssertionError`, so native tests report through the standard unittest pipeline: file mode, directory discovery, `-t` filtering, and `maxfail` all behave identically to Python tests. Tests inside inline `na {}` blocks get their shims at the NativeBlock stub position (the block's children are pruned from normal traversal).
- **`run_test` dispatch fix**: compound codespace suffixes (`foo.na.jac`, `foo.sv.jac`) were stripped to `foo.na`/`foo.sv` and treated as dotted package paths by `jac_import` → `ModuleNotFoundError`. Both the single-file branch and the directory walk now strip the full suffix.

## Tests

- `fixtures/test_blocks.na.jac` + `fixtures/test_blocks_inline.jac` (each with a deliberate failure)
- 4 new tests in `test_native_gen_pass.jac`: layout inventory + pass/fail convention + source-located messages; failing test must not abort the host (called twice to prove the handler re-arms); `jac test` end-to-end on a `.na.jac`; `jac test` end-to-end on inline `na {}` blocks (kills the false green)

## Validation

- Native gen pass suite: 409 tests OK (includes the 4 new)
- Native lexer/marshal suite: OK
- Unified prim equivalence suite (Python/ES/NA): 54 tests OK
- `jac test` CLI suite: failure set identical to `main` baseline (pre-existing environment failures only)
- Manual: plain `.jac` test path unchanged; `jac run` still ignores tests; the original `jac test foo.na.jac` crash repro now runs and reports correctly

Known limitation (inherent to in-process JIT): a segfaulting native test still kills the runner process; subprocess isolation is possible follow-up work.