### PR TITLE
docs(reference): document test blocks in the native codespace

### DIFF
--- a/docs/docs/reference/language/native-pathway.md
+++ b/docs/docs/reference/language/native-pathway.md
@@ -50,6 +50,7 @@ Native compilation is ideal for:
 | **C interop (out)** | `jac nacompile --shared` exports `:pub` symbols as a `.so`/`.dylib`/`.dll` |
 | **Std library** | `import math` / `time` / `sys` / `os` / `random` (Python-congruent subset) |
 | **Memory model** | Automatic reference counting |
+| **Testing** | `test "description" { }` blocks compile native and run via `jac test` |
 
 ---
 
@@ -774,6 +775,36 @@ Native Jac uses **automatic reference counting** for memory management. Heap-all
 
 !!! warning "Current Status"
     Deep release of nested structures is currently disabled to prevent use-after-free in complex ownership scenarios. This means certain long-running native programs may leak memory. Programs with bounded allocation are unaffected. Proper ownership tracking is a planned improvement.
+
+---
+
+## Testing
+
+`test` blocks in native context compile to native code and run through `jac test` -- the same harness used everywhere else in Jac. A test in a `.na.jac` module, or inside an inline `na { }` block, executes inside the module's JIT engine with full native semantics: the same integer, float, string, and object behavior as the code it exercises.
+
+```jac
+# vectors.na.jac
+
+def dot(x1: float, y1: float, x2: float, y2: float) -> float {
+    return x1 * x2 + y1 * y2;
+}
+
+test "dot product" {
+    assert dot(1.0, 0.0, 0.0, 1.0) == 0.0;
+    assert dot(2.0, 3.0, 4.0, 5.0) == 23.0;
+}
+```
+
+```bash
+jac test vectors.na.jac
+```
+
+Each native test runs under an implicit exception handler: a failing `assert` -- or any uncaught runtime raise (`IndexError`, `ZeroDivisionError`, ...) -- fails that one test and reports through the standard pass/fail pipeline. The failure message carries the assert site as `file:line`. All `jac test` options (`-t` name filtering, directory discovery, `--maxfail`, `--xit`) behave identically for native tests, and a mixed module can hold Python and native tests side by side -- each runs in its own codespace.
+
+Assert messages in native tests are limited to string literals: `assert cond, "message"` includes the literal in the failure report, while a dynamic message such as an f-string is not evaluated (the report falls back to the assert location).
+
+!!! warning "Process isolation"
+    Native tests run in-process via the JIT. A test that crashes the process outright -- for example a segfault through a bad C-interop pointer -- takes the test runner down with it, unlike an assert failure, which is caught and reported.
 
 ---
 

--- a/docs/docs/reference/testing.md
+++ b/docs/docs/reference/testing.md
@@ -186,6 +186,20 @@ jac test main.jac -t calculator_add -v
 
 ---
 
+## Tests and Codespaces
+
+A `test` block runs in the codespace its surrounding context compiles to, so tests exercise the same semantics as the code beside them:
+
+| Context | Where the test runs |
+|---------|---------------------|
+| `.jac` / `.sv.jac` | Python runtime (unittest) |
+| `.na.jac` or inline `na { }` block | Native code via the LLVM JIT |
+| `test_*.cl.jac` / `*.test.cl.jac` | JavaScript runtime via bun |
+
+All of them report through the same `jac test` pass/fail pipeline, and the CLI options above apply uniformly. A test in a `.na.jac` module compiles to native code and runs with native semantics -- a failing `assert` reports the failing source location (`file:line`). See [Native Compilation -- Testing](language/native-pathway.md#testing) for native-specific details and limitations.
+
+---
+
 ## Test Output
 
 ### Success
@@ -726,3 +740,4 @@ test "calculation no message" {
 ## Related Resources
 
 - [CLI Reference](cli/index.md)
+- [Native Compilation -- Testing](language/native-pathway.md#testing)


### PR DESCRIPTION
## Summary

Documents the native `test` block support that landed in #6599. The two reference pages that cover this area had no mention of it: the native-pathway reference (991 lines, zero occurrences of testing) and the testing reference (no mention of codespaces).

## Changes

**`reference/language/native-pathway.md`**
- New **Testing** section placed with the other workflow topics (between Memory Management and Debugging): a runnable `.na.jac` example, the implicit-exception-handler failure semantics, `file:line` failure locations, the literal-only limitation on assert messages, uniform `jac test` CLI behavior, and an in-process crash caveat (a segfaulting test takes the runner down, unlike an assert failure).
- **Testing** row added to the Quick Reference table.

**`reference/testing.md`**
- New **Tests and Codespaces** section mapping each file context to where its tests execute (Python / native JIT / bun), with a cross-link to the native-pathway section, plus a Related Resources link.

## Validation

Both doc examples were run verbatim against current main: the `vectors.na.jac` example passes under `jac test` (a first draft used `by` as a parameter name, which is a Jac keyword — caught by running it), and the mixed-module claim (Python and native tests side by side in one file) was verified with a scratch module. Confirmed `with entry { }` is NOT required for `jac test` on a `.na.jac`, so the example stays minimal. The mkdocs build failure on `community/release_notes/jaclang.md` is pre-existing and unrelated (html.parser error on that page's existing content); the two edited pages build without warnings.