### PR TITLE
Review hardening for the train-8 foreign/capability seams

### DIFF
--- a/jac/jaclang/compiler/passes/main/impl/capability_check_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/capability_check_pass.impl.jac
@@ -99,46 +99,48 @@ impl native_capability_violations(mod: uni.Module) -> list {
     import from jaclang.jac0core.passes.module_codegen_pass { ModuleCodegenPass }
     import from jaclang.jac0core.constant { CodeContext }
     out: list = [];
-    # Non-allowlisted Python imports in native context (issue #6357): the
-    # import would be dropped and member access would lower to garbage, so
-    # reject it loudly. Clib imports (`import from "lib" {...}`) and native
-    # module imports carry from_loc / clib_decls and are legal.
     _stdlib_help: (str | None) = None;
-    for stmt in ModuleCodegenPass.iter_context_stmts(mod) {
-        if not isinstance(stmt, uni.Import) or stmt.clib_decls or not stmt.items {
+    # One NATIVE-context iteration covers both violation families. NOTE:
+    # NATIVE_DISQUALIFIER_NODES is deliberately NOT swept here - it is the
+    # AUTO-PROMOTION eligibility table, conservatively broader than what
+    # explicit na {} / .na.jac code can lower (LambdaExpr and the OSP forms
+    # are auto-promote disqualifiers but natively supported).
+    # Genuinely-unsupported node kinds remain the emitter fallbacks' job
+    # until a dedicated explicit-native rejection table is derived from
+    # them.
+    for stmt in ModuleCodegenPass.iter_context_stmts(mod, CodeContext.NATIVE) {
+        # Non-allowlisted Python imports in native context (issue #6357):
+        # the import would be dropped and member access would lower to
+        # garbage, so reject it loudly. Clib imports
+        # (`import from "lib" {...}`) and native module imports carry
+        # from_loc / clib_decls and are legal.
+        if isinstance(stmt, uni.Import) {
+            if stmt.clib_decls or not stmt.items {
+                continue;
+            }
+            for item in stmt.items {
+                (mod_name, _ok) = classify_native_import(item);
+                if mod_name is not None and not _ok {
+                    if _stdlib_help is None {
+                        _supported_list = ", ".join(
+                            f"`import {m}`" for m in sorted(NATIVE_SUPPORTED_STDLIB)
+                        );
+                        _stdlib_help = (
+                            f"Native compilation supports these stdlib imports: "
+                            f"{_supported_list}; C-library imports "
+                            f"(`import from \"lib\" {{...}}`); and other native "
+                            f"(.na.jac) modules (`import from mod {{...}}`). Move "
+                            f"Python-dependent code to a @sv/Python context."
+                        );
+                    }
+                    out.append((item, "Python module import", mod_name, _stdlib_help));
+                }
+            }
             continue;
         }
-        for item in stmt.items {
-            (mod_name, _ok) = classify_native_import(item);
-            if mod_name is not None
-            and not _ok
-            and stmt.code_context == CodeContext.NATIVE {
-                if _stdlib_help is None {
-                    _supported_list = ", ".join(
-                        f"`import {m}`" for m in sorted(NATIVE_SUPPORTED_STDLIB)
-                    );
-                    _stdlib_help = (
-                        f"Native compilation supports these stdlib imports: "
-                        f"{_supported_list}; C-library imports "
-                        f"(`import from \"lib\" {{...}}`); and other native "
-                        f"(.na.jac) modules (`import from mod {{...}}`). Move "
-                        f"Python-dependent code to a @sv/Python context."
-                    );
-                }
-                out.append((item, "Python module import", mod_name, _stdlib_help));
-            }
-        }
-    }
-    # Structural match patterns anywhere in native-context statements.
-    # Flagged subtrees are not descended into, so one construct yields one
-    # violation, not a cascade. NOTE: NATIVE_DISQUALIFIER_NODES is
-    # deliberately NOT swept here - it is the AUTO-PROMOTION eligibility
-    # table, conservatively broader than what explicit na {} / .na.jac code
-    # can lower (LambdaExpr and the OSP forms are auto-promote
-    # disqualifiers but natively supported). Genuinely-unsupported node
-    # kinds remain the emitter fallbacks' job until a dedicated
-    # explicit-native rejection table is derived from them.
-    for stmt in ModuleCodegenPass.iter_context_stmts(mod, CodeContext.NATIVE) {
+        # Structural match patterns anywhere in the statement subtree.
+        # Flagged subtrees are not descended into, so one construct yields
+        # one violation, not a cascade.
         work: list = [stmt];
         while work {
             nd = work.pop();

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -98,7 +98,10 @@ impl NaIRGenPass._declare_clib_ability(nd: uni.Ability) -> None {
         # The declared signature names come from the foreign declaration
         # model (collect_foreign_fns) - the central owner of WHAT was
         # declared at the C boundary - not from re-walking the annotation
-        # AST here.
+        # AST here. A function absent from the model is one the collector
+        # skipped (unnamed declaration), which cannot name a foreign struct
+        # in its signature - so falling through to the legacy scalar path
+        # below is the correct (and only) outcome, same as a plan of None.
         _fdecl = self._foreign_fns().get(name);
         if _fdecl is not None {
             plan = classify_foreign_fn(

--- a/jac/jaclang/compiler/targets/foreign.jac
+++ b/jac/jaclang/compiler/targets/foreign.jac
@@ -34,7 +34,13 @@ glob FOREIGN_SCALARS: dict[str, tuple] = {
 
 """Collect clib struct declarations from the given modules: name ->
 ordered list of (field_name, declared_type_name). Field types are the
-declaration-surface names (the C boundary is declared, not inferred)."""
+declaration-surface names (the C boundary is declared, not inferred).
+
+Duplicate names across modules are last-writer-wins: C symbol and struct
+names are unique per link unit, so duplicate declarations of the same
+name must describe the same C entity (the same contract a C compiler
+applies to redeclarations) - the model does not arbitrate conflicting
+redeclarations."""
 def collect_foreign_structs(modules: list) -> dict {
     out: dict = {};
     for mod in modules {
@@ -90,7 +96,9 @@ def declared_type_name(type_expr: (uni.UniNode | None)) -> (str | None) {
 {"params": ordered (param_name, declared_type_name) pairs,
  "ret": declared return type name | None}. Like collect_foreign_structs,
 this owns WHAT the user declared at the C boundary; backends own only
-how those names materialize as LLVM types."""
+how those names materialize as LLVM types. The same last-writer-wins
+duplicate-name contract applies: C function symbols are unique per link
+unit, so redeclarations must agree."""
 def collect_foreign_fns(modules: list) -> dict {
     out: dict = {};
     for mod in modules {


### PR DESCRIPTION
Follow-up to #6616, addressing its three review threads (the commit landed on the train-8 branch moments after the merge, so it rides separately).

- `native_capability_violations`: both violation families (non-allowlisted Python imports, structural match patterns) now ride one `CodeContext.NATIVE`-filtered iteration instead of an all-context loop with an inline context check next to a filtered loop - same outcomes, symmetric intent.
- `_declare_clib_ability`: the legacy fallthrough for a function absent from the foreign declaration model is documented as an invariant - the collector only skips unnamed declarations, which cannot name a foreign struct in their signature, so the legacy scalar path is the correct (and only) outcome, identical to a `None` plan.
- `collect_foreign_structs` / `collect_foreign_fns`: the last-writer-wins duplicate-name behavior is documented as the C link-unit contract (redeclarations of one symbol must describe the same C entity; the model does not arbitrate conflicting redeclarations).

Comment/structure only - no behavior change on any gated path. Gates: native feature guardrail suite, transitive clib fixture, clib scalar smoke, ABI fixture emitted IR byte-identical.