### PR TITLE
fix(native): link OSP kernel when an imported module uses spawn/visit

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6671.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6671.bugfix.md
@@ -1,0 +1,1 @@
+- **Native OSP: kernel links when an imported module does the spawn/visit** (issue #6669): a layered native binary whose Object-Spatial `spawn`/`visit` lives in an imported module rather than the thin entry now links the OSP kernel and runs, instead of building cleanly but failing at load with `undefined symbol: __jac_glob_init_osp_kernel`.

--- a/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
@@ -148,9 +148,19 @@ impl NativeCompilePass.transform(ir_in: uni.Module) -> uni.Module {
         }
 
         # Link the portable OSP kernel's IR when this program uses Object-Spatial
-        # spawn (issue #6146). NaIRGenPass marks it via native_transitive_sources.
-        if (manifest is not None)
-        and ("osp_kernel" in manifest.native_transitive_sources) {
+        # spawn/visit (issue #6146). NaIRGenPass marks DIRECT use on the entry
+        # module via native_transitive_sources. But a thin entry that only
+        # delegates -- doing no OSP itself while an imported module does the
+        # spawn -- carries no such mark, yet the imported IR (already linked into
+        # `mod` above) still references the kernel's glob-init. Link the kernel
+        # whenever ANY linked module needs it: the dangling `__jac_glob_init_osp_kernel`
+        # declaration in the merged IR is the ground truth (issue #6669).
+        _needs_osp_kernel = (manifest is not None)
+        and ("osp_kernel" in manifest.native_transitive_sources);
+        if (not _needs_osp_kernel) and self._references_undefined_osp_kernel(mod) {
+            _needs_osp_kernel = True;
+        }
+        if _needs_osp_kernel {
             self._link_osp_kernel(mod);
             module.gen.llvm_ir = mod;
         }
@@ -863,6 +873,26 @@ def _compile_osp_kernel_ir -> (str | None) {
         _OSP_KERNEL_IR_CACHE.append(ir_str);
     }
     return ir_str;
+}
+
+"""True when the merged module references the OSP kernel's glob-init symbol
+without defining it. Any OSP-using module emits an `__osp_ensure_init` that calls
+`__jac_glob_init_osp_kernel`; the kernel that DEFINES that symbol is only linked
+by `_link_osp_kernel`. So a dangling declaration in `main_mod` -- after all
+imported modules are linked in -- means an imported (non-entry) module pulled in
+OSP and the kernel still needs linking, even though the entry module's manifest
+never marked it (issue #6669)."""
+impl NativeCompilePass._references_undefined_osp_kernel(main_mod: object) -> bool {
+    try {
+        for _fn in main_mod.functions {
+            if _fn.name == "__jac_glob_init_osp_kernel" and _fn.is_declaration {
+                return True;
+            }
+        }
+    } except Exception {
+        return False;
+    }
+    return False;
 }
 
 """Compile + link the portable OSP kernel's IR into an OSP program's module.

--- a/jac/jaclang/compiler/passes/native/na_compile_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_compile_pass.jac
@@ -28,4 +28,7 @@ obj NativeCompilePass(Transform) {
     ) -> None;
     # Link the portable OSP kernel's IR into an OSP program (issue #6146)
     def _link_osp_kernel(main_mod: object) -> None;
+    # True when the linked IR references the OSP kernel but no module defines it
+    # -- e.g. the spawn/visit lives in an imported module (issue #6669)
+    def _references_undefined_osp_kernel(main_mod: object) -> bool;
 }

--- a/jac/tests/compiler/passes/native/fixtures/osp_kernel_transitive_lib.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_kernel_transitive_lib.na.jac
@@ -1,0 +1,26 @@
+"""Issue #6669 fixture (imported half): the Object-Spatial spawn lives HERE, in
+an imported (non-entry) module. The entry module that imports `run_it` uses no
+OSP of its own, so the OSP kernel's glob-init (`__jac_glob_init_osp_kernel`) is
+referenced only transitively through this module. NativeCompilePass must still
+link the kernel; otherwise the binary builds cleanly but fails at load with
+`undefined symbol: __jac_glob_init_osp_kernel`.
+
+Expected: `run_it()` -> 7 (walker accumulates `here.tag` over one spawn)."""
+
+node N {
+    has tag: int = 0;
+}
+
+walker WA {
+    has n: int = 0;
+
+    can a with N entry {
+        self.n += here.tag;
+    }
+}
+
+def run_it() -> int {
+    a = N(tag=7);
+    r = a spawn WA();
+    return r.n;
+}

--- a/jac/tests/compiler/passes/native/fixtures/osp_kernel_transitive_main.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_kernel_transitive_main.na.jac
@@ -1,0 +1,10 @@
+"""Issue #6669 fixture (entry half): a thin entry that uses NO Object-Spatial
+construct itself -- it only delegates to an imported module whose `run_it` does
+the `spawn`. Compiled via `jac nacompile`, the binary must link the OSP kernel
+(pulled in transitively through the import) and print `7`."""
+
+import from osp_kernel_transitive_lib { run_it }
+
+with entry {
+    print(run_it());
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2446,6 +2446,38 @@ test "sys argv via nacompile" {
     }
 }
 
+test "native osp kernel links transitively through an imported module (issue #6669)" {
+    # A thin entry that uses no OSP itself but imports a module whose `run_it`
+    # does the `spawn`. The kernel's glob-init is referenced only transitively,
+    # so the entry module's manifest carries no `osp_kernel` mark. The link gate
+    # must still pull the kernel in. Before the fix the binary built cleanly but
+    # failed at load with: undefined symbol: __jac_glob_init_osp_kernel.
+    import tempfile;
+    fixture = str(os.path.join(FIXTURES, "osp_kernel_transitive_main.na.jac"));
+    with tempfile.TemporaryDirectory() as tmpdir {
+        out_bin = os.path.join(tmpdir, "osp_kernel_transitive");
+        comp = subprocess.run(
+            [sys.executable, "-m", "jaclang", "nacompile", fixture, "-o", out_bin],
+            capture_output=True,
+            text=True,
+            timeout=120
+        );
+        assert comp.returncode == 0 , (
+            f"nacompile failed: exit={comp.returncode}\n"
+            f"stderr: {comp.stderr[-500:] if comp.stderr else '(empty)'}"
+        );
+        assert os.path.exists(out_bin) , f"Binary not created at {out_bin}";
+        result = subprocess.run([out_bin], capture_output=True, text=True, timeout=10);
+        assert result.returncode == 0 , (
+            f"Native binary crashed at load: exit={result.returncode}\n"
+            f"stderr: {result.stderr[-500:] if result.stderr else '(empty)'}"
+        );
+        assert result.stdout.strip() == "7" , (
+            f"Expected '7', got stdout={result.stdout!r} stderr={result.stderr!r}"
+        );
+    }
+}
+
 # --- TestNativeAArch64Linker ---
 test "aarch64 standalone binary runs (issue #6366)" {
     # Cross-compile a trivial program to aarch64 via the in-house ELF linker


### PR DESCRIPTION
## Summary

Fixes #6669. The native OSP kernel was linked only when the **entry** module's manifest marked `osp_kernel` in `native_transitive_sources` — i.e. only when the entry module itself used Object-Spatial `spawn`/`visit`. A thin entry that does no OSP but imports a module which does the `spawn` carried no such mark, so `NativeCompilePass` skipped the kernel link while the imported IR (already linked into the program) still referenced `__jac_glob_init_osp_kernel`. The binary built with zero errors but failed at load:

```
./qp: symbol lookup error: ./qp: undefined symbol: __jac_glob_init_osp_kernel
```

This is the normal shape of a layered app: a thin entry that delegates, with all `spawn`s living in imported modules.

## Fix

Link the kernel whenever **any** linked module needs it, not only when the entry module does. After imported modules are merged into the program IR, a dangling (undefined) `__jac_glob_init_osp_kernel` declaration in the merged module is the ground truth that the kernel must be linked — every OSP-using module emits an `__osp_ensure_init` that calls that symbol, and only `_link_osp_kernel` ever defines it. The existing entry-module manifest check is kept as the fast path; the IR-based check is the completeness fallback that covers the imported/transitive case (and is robust to import depth and cache hits).

## Test

`osp_kernel_transitive_main.na.jac` (thin entry, no OSP) + `osp_kernel_transitive_lib.na.jac` (the `spawn` lives here) are compiled via `jac nacompile` and the binary is run; it must print `7`. Before the fix the binary built cleanly but crashed at load with the undefined-symbol error.