### PR TITLE
docs(native): correct stale "struct-by-value FFI unsupported" guidance (#6679)

### DIFF
--- a/jac/examples/raylib_shooter/README.md
+++ b/jac/examples/raylib_shooter/README.md
@@ -157,17 +157,23 @@ The current frame rate is shown top-left. The loop runs **uncapped** (no
 
 No C compiler or system linker is required to build the Jac side.
 
-## How the 3D works (and a caveat)
+## How the 3D works (a deliberate scalar pipeline)
 
 raylib's headline 3D API passes small math structs **by value** -
 `DrawCube(Vector3 position, …)`, `BeginMode3D(Camera3D camera)`. The Jac native
-backend does not yet implement the full C struct-by-value ABI for multi-field
-float structs, so those entry points can't be called correctly today.
+backend lowers struct-by-value calls to the platform C ABI (System V AMD64
+eightbyte classification / AArch64 AAPCS), so those entry points _can_ be bound
+directly: declare the C struct as an `obj` in the `import from` block and call
+the by-value API.
 
-This demo therefore builds its 3D pipeline on raylib's lower-level **`rlgl`
+This demo nonetheless builds its 3D pipeline on raylib's lower-level **`rlgl`
 immediate-mode API**, which is entirely scalar (`rlVertex3f`, `rlColor4ub`,
-`rlTranslatef`, `rlRotatef`, `rlFrustum`, …) and so crosses the FFI boundary
-cleanly. The camera is a hand-built `rlFrustum` projection plus an
+`rlTranslatef`, `rlRotatef`, `rlFrustum`, …) - a deliberate choice, not a
+workaround. Two reasons: the `shooter.zig` twin binds the same scalar `rlgl`
+entry points, so the Jac and Zig builds stay line-for-line comparable and
+pixel-identical; and the WebGL/DOM `raylib_shim` behind the `web/` build emulates
+exactly this scalar `rlgl` surface, so one unchanged game source targets native
+_and_ the browser. The camera is a hand-built `rlFrustum` projection plus an
 `rlRotatef`/`rlTranslatef` view transform; cubes are drawn the same way raylib
 draws its own - `rlPushMatrix` + per-vertex emission. Every FFI call in the
 bindings is scalar - even the screen clear goes through `rlClearColor`'s four

--- a/jac/examples/raylib_shooter/shooter.na.jac
+++ b/jac/examples/raylib_shooter/shooter.na.jac
@@ -11,11 +11,14 @@ an extern symbol the native linker resolves out of the shared library at load ti
 `$ORIGIN`/`@loader_path` runpath the binary finds a sibling library regardless of
 the launch directory. The linker is pure Python, so no cc/ld is needed.
 
-Only scalar / small-struct entry points are bound. The 3D pipeline uses raylib's
-scalar rlgl immediate-mode API (rlVertex3f / rlColor4ub / rlTranslatef / ...)
-rather than the higher-level DrawCube(Vector3) / BeginMode3D(Camera3D) API, which
-passes multi-field float structs by value - something the native backend does not
-yet lower to the platform C ABI.
+The 3D pipeline deliberately uses raylib's scalar rlgl immediate-mode API
+(rlVertex3f / rlColor4ub / rlTranslatef / ...) rather than the higher-level
+DrawCube(Vector3) / BeginMode3D(Camera3D) by-value-struct API. The native backend
+*does* lower struct-by-value calls to the platform C ABI (declare the C struct as
+an obj in the import block), so the by-value entry points would work; the scalar
+rlgl surface is chosen here so the shooter.zig twin stays line-for-line comparable
+and the WebGL raylib_shim behind web/ - which emulates the same scalar rlgl API -
+can run this one source unchanged in the browser.
 
 Controls: mouse / arrows aim (click or Tab to capture the cursor for mouse-look),
 WASD move, Space fire, Tab release / re-capture cursor, Esc quit.

--- a/jac/jaclang/cli/skills/jac-native.md
+++ b/jac/jaclang/cli/skills/jac-native.md
@@ -139,11 +139,32 @@ import from raylib {                                  # logical name, like a lin
 }
 ```
 
+Pass and return C structs **by value** by declaring them as `obj` inside the same block - the backend lowers them to the platform C struct ABI, so a library's natural by-value API works directly (no scalar workaround needed):
+
+```jac
+import from raylib {                                  # same sibling-library resolution as above
+    obj Color   { has r: u8, g: u8, b: u8, a: u8; }            # 4B  -> packed into an i32
+    obj Vector3 { has x: f32, y: f32, z: f32; }               # 12B -> <2 x float>, float
+    obj Camera3D { has position: Vector3, target: Vector3, up: Vector3,
+                       fovy: f32, projection: i32; }          # 44B -> MEMORY class (byval)
+
+    def GetColor(hexValue: u32) -> Color;                     # struct returned by value
+    def ColorToInt(color: Color) -> i32;                      # struct passed by value
+    def DrawCube(position: Vector3, w: f32, h: f32, l: f32, color: Color) -> None;
+    def BeginMode3D(camera: Camera3D) -> None;                # 44B struct, passed byval
+}
+
+with entry {
+    print(ColorToInt(GetColor(0xFF0000FF)));   # a Color round-trips by value across the FFI
+    DrawCube(Vector3(x=0.0, y=1.0, z=0.0), 2.0, 2.0, 2.0, Color(r=255, g=0, b=0, a=255));
+}
+```
+
 - The plain logical name already finds a **sibling** library: every binary gets RUNPATH `$ORIGIN` (`@loader_path` on macOS) plus a bare DT_NEEDED (`libraylib.so`), so the loader checks the binary's own directory first, then `LD_LIBRARY_PATH`/system paths (verified with `readelf -d`). Ship the `.so` next to the binary and it runs from any cwd - the shooter flagship stages `libraylib.so` beside `./shooter` exactly this way.
 - `import from .raylib` (leading dot) **pins** sibling-only resolution: DT_NEEDED becomes `$ORIGIN/libraylib.so`, so a system-installed copy is never used as a fallback. `import from vendor.raylib` -> `$ORIGIN/vendor/...`.
 - A literal string (`import from "/usr/lib/libm.so.6" { def sqrt(x: f64) -> f64; }`) is only for pinning an exact path or versioned soname - no prefix/extension rewriting.
 - Fixed-width types (`i32`, `u8`, `f32`, `f64`, `c_void`) are needed ONLY inside the `import from` declaration to match the C ABI. Everywhere else use standard `int`/`float`/`str`; the compiler coerces at the call site.
-- **Keep FFI calls scalar.** Passing or returning a multi-field struct *by value* (a 3-float `Vector3`, a `Camera3D`, a `Color`) does not reliably round-trip yet - bind the library's scalar entry points instead (e.g. raylib's `rlVertex3f`/`rlColor4ub`/`rlClearColor` rather than `DrawCube(Vector3,...)`/`ClearBackground(Color)`). An int return read straight into `float(...)` is a known safe workaround for some bindings.
+- **Structs cross by value.** Declare each C struct as an `obj` of fixed-width fields (nested `obj` structs allowed) inside the `import from` block and call the by-value entry points directly: the compiler classifies each struct per the platform C ABI (System V AMD64 eightbytes on x86_64, AArch64 AAPCS) and emits the matching `byval`/`sret`/register coercion, so a `Color`/`Vector3`/`Camera3D` passed or returned by value round-trips correctly - including >16-byte MEMORY-class aggregates like the 44-byte `Camera3D`. Targets outside x86_64 SysV / AArch64 AAPCS fall back to the legacy path; binding a library's scalar entry points (raylib's `rlVertex3f`/`rlColor4ub`) is still a valid lower-level style, just no longer required.
 - No `cc`/`ld` step: each declared symbol becomes an extern Jac's own linker records (DT_NEEDED / LC_LOAD_DYLIB) and the OS loader resolves at run time.
 
 ## Debugging


### PR DESCRIPTION
Closes #6679.

## Problem

The native-FFI docs and the `jac-native` skill stated that passing/returning a
multi-field C struct **by value** across the native FFI does not round-trip, and
steered users to bind scalar entry points instead. That is no longer true: the
native backend implements the platform C struct ABI (System V AMD64 eightbyte
classification / AArch64 AAPCS, with `byval`/`sret`/register coercion), so
by-value struct args and returns work directly.

## Changes

- **`jac/jaclang/cli/skills/jac-native.md`** (the authoritative guidance LLMs
  read): replaced the "keep FFI calls scalar" gotcha with an accurate
  by-value-struct note documenting the supported scope, plus a runnable example
  that declares the C structs as `obj` inside the `import from` block. The
  example passes the `test_guide` "every ```jac example checks clean" gate.
- **`jac/examples/raylib_shooter/README.md`** + **`shooter.na.jac`** docstring:
  reframed the scalar `rlgl` pipeline as a *deliberate* choice — line-for-line
  parity with the `shooter.zig` twin and reuse by the WebGL `raylib_shim` behind
  `web/` — rather than a workaround for a missing feature.

### Intentionally not changed

`demo.sh`, `web/README.md`, and `web/main.jac` were left as-is. Their scalar-`rlgl`
descriptions are accurate for their contexts: the web build is wasm + a
hand-written WebGL shim that only implements the scalar `rlgl` surface, so the
native SysV/AAPCS struct ABI does not apply there, and `demo.sh:26` merely
describes the Zig-twin parity. Rewording them to claim by-value works would be
incorrect for the web/wasm target.

## Validation

Built a real C shared library exporting raylib-shaped struct-by-value functions
and bound it from Jac with the structs declared as `obj`. `jac nacompile` + run
round-trips every System V eightbyte class:

```
ColorToInt(1,0,0,0) = 16777216     # 4B  INTEGER  (by-value arg)
GetColor(0x12345678) -> 18 52 86 120  # by-value struct return
Vector3Scale((1,2,3),10) -> 10 20 30  # 12B SSE eightbytes (arg + return)
Camera3DFovy -> 45                 # 44B MEMORY class (byval) + sret return
```

The in-tree native ABI tests (`tests/compiler/passes/native/test_native_gen_pass.jac`,
which already pins the `clib_sysv_abi.na.jac` fixture's `byval`/`sret` lowering)
and the guide-example check both pass.