### PR TITLE
fix(native): load an imported module's C library into the JIT (jac run) (#6687)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6687.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6687.bugfix.md
@@ -1,0 +1,1 @@
+- **Native: `jac run` loads C shared libraries declared in imported modules** (#6687): a native program whose FFI lives behind a logical (`$ORIGIN`-relative) C-library import in an imported module no longer segfaults under `jac run` (in-process JIT) -- the library is now loaded so its symbols resolve, matching the `jac nacompile` standalone binary that already ran fine.

--- a/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/na_compile_pass.impl.jac
@@ -41,60 +41,7 @@ impl NativeCompilePass.transform(ir_in: uni.Module) -> uni.Module {
         if clib_paths {
             for lib_path in clib_paths {
                 try {
-                    # A logical import (issue #6387) may carry a loader token
-                    # ($ORIGIN/@loader_path) meant for the AOT binary; at JIT
-                    # time there is no output binary, so strip it and resolve
-                    # the remainder relative to the current directory.
-                    probe = lib_path;
-                    if probe.startswith("$ORIGIN/") {
-                        probe = probe[8:];
-                    } elif probe.startswith("@loader_path/") {
-                        probe = probe[13:];
-                    }
-                    base = os.path.basename(probe);
-                    loaded = False;
-                    # 1. An explicit/relative/sibling file that exists on disk.
-                    #    Pass the ABSOLUTE path: dlopen only loads a named file
-                    #    when the string contains a slash; a bare "libfoo.so" is
-                    #    treated as a soname and searched on the system path
-                    #    instead of the cwd-relative file we just found.
-                    for cand in [lib_path, probe, os.path.join(".", base)] {
-                        if cand and os.path.exists(cand) {
-                            llvm.load_library_permanently(os.path.abspath(cand));
-                            loaded = True;
-                            break;
-                        }
-                    }
-                    # 2. dlopen by soname (searches LD_LIBRARY_PATH + ldcache).
-                    if not loaded {
-                        try {
-                            llvm.load_library_permanently(base);
-                            loaded = True;
-                        } except Exception {
-                            loaded = False;
-                        }
-                    }
-                    # 3. find_library on the bare stem (handles versioned
-                    #    sonames, e.g. libraylib.so -> libraylib.so.5).
-                    if not loaded {
-                        stem = base;
-                        if stem.startswith("lib") {
-                            stem = stem[3:];
-                        }
-                        for _ext in [".so", ".dylib", ".dll"] {
-                            _i = stem.find(_ext);
-                            if _i != -1 {
-                                stem = stem[:_i];
-                            }
-                        }
-                        found = ctypes.util.find_library(stem)
-                        or ctypes.util.find_library(probe);
-                        if found {
-                            llvm.load_library_permanently(found);
-                            loaded = True;
-                        }
-                    }
-                    if not loaded {
+                    if not self._jit_load_clib(lib_path) {
                         self.emit(W5021, path=lib_path);
                     }
                 } except Exception as lib_err {
@@ -321,6 +268,62 @@ impl NativeCompilePass.transform(ir_in: uni.Module) -> uni.Module {
         self.emit(E5020, error=str(e));
     }
     return ir_in;
+}
+
+"""Load a C shared library so MCJIT can resolve its symbols at JIT time.
+
+A logical import (issue #6387) may carry a loader token (`$ORIGIN` /
+`@loader_path`) meant for the AOT binary's DT_NEEDED; at JIT time there is no
+output binary, so strip it and resolve the remainder relative to the current
+directory, then fall back to soname / `find_library` lookup. Shared by the
+top-level module's own clibs and the transitive clibs an imported module pulls
+in (issue #6687: an imported module's `$ORIGIN/...` clib was never loaded into
+the JIT, so its FFI symbols resolved to NULL and the program SIGSEGV'd -- while
+the AOT binary, whose loader honors `$ORIGIN`, ran fine). Returns True when the
+library was loaded."""
+impl NativeCompilePass._jit_load_clib(lib_path: str) -> bool {
+    import os;
+    import ctypes.util;
+    probe = lib_path;
+    if probe.startswith("$ORIGIN/") {
+        probe = probe[8:];
+    } elif probe.startswith("@loader_path/") {
+        probe = probe[13:];
+    }
+    base = os.path.basename(probe);
+    # 1. An explicit/relative/sibling file that exists on disk. Pass the
+    #    ABSOLUTE path: dlopen only loads a named file when the string contains
+    #    a slash; a bare "libfoo.so" is treated as a soname and searched on the
+    #    system path instead of the cwd-relative file we just found.
+    for cand in [lib_path, probe, os.path.join(".", base)] {
+        if cand and os.path.exists(cand) {
+            llvm.load_library_permanently(os.path.abspath(cand));
+            return True;
+        }
+    }
+    # 2. dlopen by soname (searches LD_LIBRARY_PATH + ldcache).
+    try {
+        llvm.load_library_permanently(base);
+        return True;
+    } except Exception { }
+    # 3. find_library on the bare stem (handles versioned sonames, e.g.
+    #    libraylib.so -> libraylib.so.5).
+    stem = base;
+    if stem.startswith("lib") {
+        stem = stem[3:];
+    }
+    for _ext in [".so", ".dylib", ".dll"] {
+        _i = stem.find(_ext);
+        if _i != -1 {
+            stem = stem[:_i];
+        }
+    }
+    found = ctypes.util.find_library(stem) or ctypes.util.find_library(probe);
+    if found {
+        llvm.load_library_permanently(found);
+        return True;
+    }
+    return False;
 }
 
 """Link imported .na.jac modules at IR level (before JIT compilation)."""
@@ -632,8 +635,7 @@ impl NativeCompilePass._compile_and_link_native_imports(
         # Load any .so libraries required by this imported module so that
         # MCJIT can resolve their external symbols at JIT compilation time.
         # Without this, transitive `import from "lib.so" { ... }` in a dep
-        # module causes an unresolved-symbol segfault at runtime.
-        import ctypes.util as _ctu;
+        # module causes an unresolved-symbol segfault at runtime (issue #6687).
         # dep_clib_paths is set by both cache-hit and cache-miss paths above.
         if dep_clib_paths {
             # Propagate dep C-lib paths back to the main module so that
@@ -642,15 +644,13 @@ impl NativeCompilePass._compile_and_link_native_imports(
                 if dep_lib_path not in module.gen._clib_paths {
                     module.gen._clib_paths.append(dep_lib_path);
                 }
+                # Use the same robust loader as the top-level module's clibs:
+                # it strips the AOT-only `$ORIGIN`/`@loader_path` token a
+                # logical import carries, which a bare `os.path.exists` /
+                # `find_library` check could not resolve -- leaving the library
+                # unloaded and its FFI symbols NULL under `jac run` (#6687).
                 try {
-                    if os.path.exists(dep_lib_path) {
-                        llvm.load_library_permanently(dep_lib_path);
-                    } else {
-                        found_lib = _ctu.find_library(dep_lib_path);
-                        if found_lib {
-                            llvm.load_library_permanently(found_lib);
-                        }
-                    }
+                    self._jit_load_clib(dep_lib_path);
                 } except Exception { }
             }
         }

--- a/jac/jaclang/compiler/passes/native/na_compile_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_compile_pass.jac
@@ -26,6 +26,10 @@ obj NativeCompilePass(Transform) {
     def _compile_and_link_native_imports(
         module: uni.Module, main_mod: object, imports: list, target_machine: object
     ) -> None;
+    # Load a C shared library into the process so MCJIT can resolve its
+    # symbols at JIT time, stripping any AOT-only `$ORIGIN`/`@loader_path`
+    # loader token first. Returns True when the library was loaded.
+    def _jit_load_clib(lib_path: str) -> bool;
     # Link the portable OSP kernel's IR into an OSP program (issue #6146)
     def _link_osp_kernel(main_mod: object) -> None;
     # True when the linked IR references the OSP kernel but no module defines it

--- a/jac/tests/compiler/passes/native/fixtures/clib_jit_xmod.c
+++ b/jac/tests/compiler/passes/native/fixtures/clib_jit_xmod.c
@@ -1,0 +1,5 @@
+/* Issue #6687 fixture: a tiny C shared library the test compiles at runtime.
+   Imported (via a dotted logical native import that carries an $ORIGIN loader
+   token) by clib_jit_xmod_lib.na.jac, which is in turn imported by
+   clib_jit_xmod_main.na.jac. */
+long jac6687_triple(long x) { return x * 3; }

--- a/jac/tests/compiler/passes/native/fixtures/clib_jit_xmod_lib.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/clib_jit_xmod_lib.na.jac
@@ -1,0 +1,16 @@
+"""Issue #6687 fixture (imported half): a library module whose FFI lives behind
+a dotted logical native import. The dotted form maps to an `$ORIGIN`-relative
+path (`$ORIGIN/libs/libclibjit6687.so`) -- the AOT binary's loader honors that
+token, but under `jac run` (in-process MCJIT) it must be stripped and resolved
+relative to the cwd. Because this clib is pulled in TRANSITIVELY (the entry
+module imports `compute`, not the library directly), it is loaded through the
+imported-dependency clib path, which did not strip the token -- so the library
+was never loaded into the JIT and `jac6687_triple` resolved to NULL, SIGSEGV."""
+
+import from libs.clibjit6687 {
+    def jac6687_triple(x: i64) -> i64;
+}
+
+def compute(x: i64) -> i64 {
+    return jac6687_triple(x);
+}

--- a/jac/tests/compiler/passes/native/fixtures/clib_jit_xmod_main.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/clib_jit_xmod_main.na.jac
@@ -1,0 +1,11 @@
+"""Issue #6687 fixture (entry half): runs under `jac run` (in-process MCJIT).
+The entry calls into an imported module whose FFI is backed by a transitively
+declared `$ORIGIN`-relative C shared library. Before the fix the JIT never
+loaded that library, so the FFI call jumped to NULL and the process SIGSEGV'd;
+the byte-identical program built with `jac nacompile` ran fine. Prints `21`."""
+
+import from clib_jit_xmod_lib { compute }
+
+with entry {
+    print(compute(7));
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2051,6 +2051,67 @@ test "clib System V AMD64 ABI lowering" {
     assert "clib.cabi.arg" in s , "nested struct packed to C layout for byval";
 }
 
+test "jac run loads a transitive imported-module clib (issue #6687)" {
+    # `jac run` JIT-executes a native module in-process via MCJIT. A C shared
+    # library declared in an IMPORTED module through a dotted logical import
+    # carries an `$ORIGIN`-relative path; the imported-dependency clib loader
+    # did not strip that loader token, so the library was never loaded into the
+    # JIT and its FFI symbols resolved to NULL -- the process SIGSEGV'd after a
+    # clean compile, while the byte-identical `jac nacompile` binary ran fine.
+    # The library must now be loaded so the cross-module FFI call returns 21.
+    import platform;
+    import shutil;
+    import tempfile;
+    if "x86_64" not in platform.machine() and "AMD64" not in platform.machine() {
+        import pytest;
+        pytest.skip("x86_64-only shared-library build");
+    }
+    cc = shutil.which("cc") or shutil.which("gcc");
+    if not cc {
+        import pytest;
+        pytest.skip("no C compiler available to build the test shared library");
+    }
+    with tempfile.TemporaryDirectory() as tmpdir {
+        os.makedirs(os.path.join(tmpdir, "libs"));
+        # Build libs/libclibjit6687.so from the C fixture.
+        so_path = os.path.join(tmpdir, "libs", "libclibjit6687.so");
+        build = subprocess.run(
+            [
+                cc,
+                "-shared",
+                "-fPIC",
+                "-o",
+                so_path,
+                str(os.path.join(FIXTURES, "clib_jit_xmod.c"))
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60
+        );
+        assert build.returncode == 0 , f"cc failed: {build.stderr}";
+        # The `$ORIGIN` token strips to the cwd at JIT time, so the .na.jac
+        # fixtures and the lib subdir must sit together in the run directory.
+        for _f in ["clib_jit_xmod_lib.na.jac", "clib_jit_xmod_main.na.jac"] {
+            shutil.copy(os.path.join(FIXTURES, _f), os.path.join(tmpdir, _f));
+        }
+        result = subprocess.run(
+            [sys.executable, "-m", "jaclang", "run", "clib_jit_xmod_main.na.jac"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=tmpdir
+        );
+        assert result.returncode == 0 , (
+            f"`jac run` crashed (transitive clib unresolved): "
+            f"exit={result.returncode}\n"
+            f"stderr: {result.stderr[-500:] if result.stderr else '(empty)'}"
+        );
+        assert result.stdout.strip() == "21" , (
+            f"Expected '21', got stdout={result.stdout!r} stderr={result.stderr!r}"
+        );
+    }
+}
+
 test "clib AArch64 AAPCS ABI lowering" {
     # Cross-targets aarch64 (works from any host) and asserts the emitted
     # foreign-call ABI matches what clang produces under AAPCS (Phase 2 of #6353).


### PR DESCRIPTION
## Summary

Fixes #6687. `jac run <file>.na.jac` JIT-executes a native module in-process via MCJIT. When the program's FFI lives behind a **logical** C-library import (issue #6387, e.g. `import from vendor.raylib { ... }`, which lowers to an `$ORIGIN/...` path) declared in an **imported** module, `jac run` segfaulted after a clean compile -- while the byte-identical `jac nacompile` standalone binary ran fine.

## Root cause

MCJIT resolves a program's FFI symbols from libraries loaded with `load_library_permanently`. There were two clib-loading paths in `NativeCompilePass`:

- The **top-level** module's own clibs went through a robust loader that strips the AOT-only `$ORIGIN` / `@loader_path` token (there is no output binary at JIT time) and resolves the remainder against the cwd, with soname / `find_library` fallbacks.
- The clibs an **imported** module pulls in transitively went through a second, weaker loader that did a bare `os.path.exists(dep_lib_path)` / `find_library(dep_lib_path)` on the raw path. For a logical import that path is `$ORIGIN/vendor/libraylib.so`, which exists nowhere as a literal file and is not a valid soname -- so the dependency's library was **never loaded into the JIT**, its FFI symbols resolved to NULL, and the first call jumped to address 0.

`jac nacompile` was unaffected because the AOT binary records `$ORIGIN/...` as a DT_NEEDED runpath the dynamic loader resolves at load time. This is why the divergence was JIT-only and only surfaced with a multi-module program whose render/FFI code lived in an imported module.

## Fix

Factor the top-level loader into `NativeCompilePass._jit_load_clib(lib_path)` and use it for **both** the entry module's clibs and the transitive imports' clibs, so an imported module's `$ORIGIN`-relative library is loaded exactly the same way.

Verified on the [quakepassion](https://github.com/marsninja/quakepassion) `na-conversion` engine: `jac run main.na.jac` (headless smoke) now renders all three screenshots and exits 0, matching `jac nacompile main.na.jac && ./qp`.

## Test

`clib_jit_xmod_{main,lib}.na.jac` + `clib_jit_xmod.c`: the test compiles a tiny C shared library, then runs (under `jac run`) an entry module that calls into an imported module whose FFI is backed by a dotted-logical (`$ORIGIN/libs/...`) import of that library. The program SIGSEGV'd (exit 139) before the fix and prints `21` after. Skips when no C compiler / non-x86_64. Targeted native clib/cross-module/OSP suite: 39/39 pass.