### PR TITLE
fix(cache): repair malformed .jac_ir/ ignore line from #6709

### DIFF
--- a/jac/.gitignore
+++ b/jac/.gitignore
@@ -12,7 +12,8 @@ venv
 .jac/
 *.jir
 *.jbc
-.jac_ir/        # legacy native IR cache (superseded by .jac/cache/native)
+# legacy native IR cache (superseded by .jac/cache/native)
+.jac_ir/
 
 # Distribution / packaging
 .Python

--- a/jac/examples/raylib_shooter/.gitignore
+++ b/jac/examples/raylib_shooter/.gitignore
@@ -20,5 +20,6 @@ libraylib*.dylib
 .jac/
 *.jir
 *.jbc
-.jac_ir/        # legacy native IR cache (superseded by .jac/cache/native)
+# legacy native IR cache (superseded by .jac/cache/native)
+.jac_ir/
 __pycache__/


### PR DESCRIPTION
## Summary

A follow-up to #6709. The legacy-cache ignore line that PR added carried a trailing **inline comment**:

```
.jac_ir/        # legacy native IR cache (superseded by .jac/cache/native)
```

`.gitignore` does not support inline comments — `#` only begins a comment at the *start* of a line. Mid-line, the whole thing is treated as one literal pattern (`.jac_ir/␠␠␠# legacy…`) that matches nothing, so `git check-ignore` reported `NOT IGNORED`.

#6709 stopped *writing* `.jac_ir/` siblings (native artifacts now route through `get_native_cache_dir()` → `.jac/cache/native/`), but pre-existing **stale** `.jac_ir/` dirs left by older builds were no longer ignored and started surfacing as untracked noise in `git status`.

## Fix

Move the comment onto its own line so the `.jac_ir/` pattern is honored again, in both affected files:

- `jac/.gitignore`
- `jac/examples/raylib_shooter/.gitignore`

(`jac-desktop/jac_desktop/native/webview/.gitignore` was already correct — no inline comment.)

## Validation

```
$ git check-ignore -v jac/.jac_ir/x
jac/.gitignore:16:.jac_ir/	jac/.jac_ir/x
$ git check-ignore -v jac/examples/raylib_shooter/.jac_ir/x
jac/examples/raylib_shooter/.gitignore:24:.jac_ir/	jac/examples/raylib_shooter/.jac_ir/x
```

Both now match; the stale dirs no longer appear in `git status`.
