### PR TITLE
fix(native): materialize imported OSP archetypes used only in an impl annex

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6717.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6717.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Native OSP archetypes wired only from an impl annex now compile**: A native module that imports a node/edge/walker and connects or spawns it only from a companion `.impl.jac` file no longer fails to compile (`E5090 ... not materialized`) or crash at runtime; impl-annex usage is now recognized the same as inline usage.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/osp.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/osp.impl.jac
@@ -234,9 +234,29 @@ impl NaIRGenPass._register_imported_osp_archetypes(imported_mod: uni.Module) -> 
 (`++>`), a `spawn`, a `visit`, or an edge ref (`[-->]`) — anywhere in its
 native-context statements. Distinct from declaring OSP archetypes: usage is
 what requires the kernel + adjacency at runtime. Same work-stack sweep idiom
-as `native_capability_violations`."""
+as `native_capability_violations`.
+
+A head decl's body that lives in an impl annex (`.na.impl.jac`) or a variant
+file is held in a SEPARATE module reachable through `mod.impl_mod` /
+`mod.variant_mod`, never through the head module's `kid` tree (DeclImplMatchPass
+sets `decl.body = <ImplDef from the annex module>`, it does not splice the annex
+statements into the head). So an OSP construct that lives ONLY in an impl annex
+— e.g. a `build_arena` whose body wires a `spawn`/connect — is invisible to a
+head-only `kid` sweep, leaving the module mis-classified as a non-OSP user; any
+OSP archetype it imports then never gets a stable type-tag and the connect/spawn
+fails with E5090 ("not materialized") or mis-codegens to a runtime SIGSEGV.
+Scan the annex/variant modules too — mirrors `module_native_compat`."""
 impl NaIRGenPass._module_uses_osp(module: uni.Module) -> bool {
-    for stmt in ModuleCodegenPass.iter_context_stmts(module, CodeContext.NATIVE) {
+    roots: list = list(
+        ModuleCodegenPass.iter_context_stmts(module, CodeContext.NATIVE)
+    );
+    # Impl annexes (`.na.impl.jac`) and variant bodies are wholly native context;
+    # take their top-level statements (the ImplDefs) directly — `iter_context_stmts`
+    # keys on per-statement context tags the annex ImplDefs do not carry.
+    for annex in list(module.impl_mod) + list(module.variant_mod) {
+        roots.extend(annex.body);
+    }
+    for stmt in roots {
         work: list = [stmt];
         while work {
             nd = work.pop();

--- a/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_builder.na.impl.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_builder.na.impl.jac
@@ -1,0 +1,11 @@
+"""Impl annex for the builder. The `++>` connect on the imported `Area` lives
+HERE, in a separate module hung off the head decl's `body` (an ImplDef), not its
+`kid`. Before the fix, `_module_uses_osp` swept only the head module's kid tree,
+classified this module as a non-OSP user, and never materialized the imported
+`Hub`/`Area` type-tags into its native compile -- so the `++>` failed with
+E5090 ('not materialized') / mis-codegen SIGSEGV."""
+
+impl build(hub: Hub) {
+    hub ++> Area(tag=1);
+    hub ++> Area(tag=2);
+}

--- a/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_builder.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_builder.na.jac
@@ -1,0 +1,10 @@
+"""Regression fixture (builder head half). Imports OSP archetypes from
+`osp_xmod_annexbuild_lib` and declares `build` BODYLESS; the body — the only
+place this module touches an OSP construct (`++>`) — lives in the impl annex
+`osp_xmod_annexbuild_builder.na.impl.jac`. The whole point of the regression:
+the OSP construct is reachable only through `mod.impl_mod`, never the head
+module's `kid` tree."""
+
+import from osp_xmod_annexbuild_lib { Hub, Area }
+
+def build(hub: Hub);

--- a/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_lib.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_lib.na.jac
@@ -1,0 +1,18 @@
+"""Regression fixture (OSP library half, issue: impl-annex OSP usage). Declares
+the graph archetypes and the walker. Imported by both the builder module (which
+wires the graph from an IMPL ANNEX) and the entry module (which spawns)."""
+
+node Hub {}
+node Area { has tag: int = 0; }
+
+walker Pass {
+    has seen: int = 0;
+
+    can start with Hub entry {
+        visit [here -->[?:Area]];
+    }
+
+    can at_area with Area entry {
+        self.seen += here.tag;
+    }
+}

--- a/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_main.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_xmod_annexbuild_main.na.jac
@@ -1,0 +1,17 @@
+"""Regression fixture (entry half). Builds the graph through the imported
+`build` (whose body is an impl annex that wires imported OSP nodes), then spawns
+`Pass` in THIS module. Prints `before after seen`; the fix prints `2 2 3` (graph
+built, walker sums area tags 1+2). Before the fix the builder module failed to
+compile (E5090 on the annexed `++>`) / mis-codegen."""
+
+import from osp_xmod_annexbuild_lib { Hub, Area, Pass }
+import from osp_xmod_annexbuild_builder { build }
+
+with entry {
+    hub = Hub();
+    build(hub);
+    before = len([hub -->[?:Area]]);
+    w = hub spawn Pass();
+    after = len([hub -->[?:Area]]);
+    print(before, after, w.seen);
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -2646,6 +2646,48 @@ test "native osp node constructed in a non-OSP module carries its dispatch tag (
     }
 }
 
+test "native osp construct living only in an impl annex materializes imported archetypes" {
+    # A builder module IMPORTS OSP archetypes (`Hub`/`Area`) from another native
+    # module and wires them (`++>`) from an IMPL ANNEX (`.na.impl.jac`), not its
+    # head file. DeclImplMatchPass attaches an annex body via `decl.body =
+    # <ImplDef from the annex module>`, never splicing it into the head decl's
+    # `kid`, so the OSP construct is reachable only through `mod.impl_mod`.
+    # `_module_uses_osp` swept just the head module's `iter_context_stmts` + kid
+    # tree, classified the builder as a non-OSP user, and never gave the imported
+    # archetypes their stable type-tag -- the annexed `++>` then failed with
+    # E5090 ("not materialized") at nacompile (or mis-codegen SIGSEGV in a fuller
+    # graph). The byte-identical program with `build`'s body INLINE in the head
+    # file always compiled. Fixed: prints `2 2 3` (graph built, walker sums 1+2).
+    import tempfile;
+    fixture = str(os.path.join(FIXTURES, "osp_xmod_annexbuild_main.na.jac"));
+    with tempfile.TemporaryDirectory() as tmpdir {
+        out_bin = os.path.join(tmpdir, "osp_xmod_annexbuild");
+        comp = subprocess.run(
+            [sys.executable, "-m", "jaclang", "nacompile", fixture, "-o", out_bin],
+            capture_output=True,
+            text=True,
+            timeout=120
+        );
+        assert comp.returncode == 0 , (
+            f"nacompile failed (annexed OSP construct not materialized): "
+            f"exit={comp.returncode}\n"
+            f"stderr: {comp.stderr[-500:] if comp.stderr else '(empty)'}"
+        );
+        assert os.path.exists(out_bin) , f"Binary not created at {out_bin}";
+        result = subprocess.run([out_bin], capture_output=True, text=True, timeout=10);
+        assert result.returncode == 0 , (
+            f"Native binary crashed (imported archetype tag not materialized): "
+            f"exit={result.returncode}\n"
+            f"stderr: {result.stderr[-500:] if result.stderr else '(empty)'}"
+        );
+        # before=2 (graph built via annexed `build`), after=2 (survives spawn),
+        # seen=1+2=3 (walker reaches both Area nodes and sums their tags).
+        assert result.stdout.strip() == "2 2 3" , (
+            f"Expected '2 2 3', got stdout={result.stdout!r} stderr={result.stderr!r}"
+        );
+    }
+}
+
 # --- TestNativeAArch64Linker ---
 test "aarch64 standalone binary runs (issue #6366)" {
     # Cross-compile a trivial program to aarch64 via the in-house ELF linker


### PR DESCRIPTION
## Problem

A native module that imports an OSP archetype (node/edge/walker) from another `.na.jac` module and then **wires or spawns it only from a companion impl-annex file** (`.na.impl.jac`) fails to compile with `error[E5090] ... was not materialized into this native compile`, or — in a larger compile graph — mis-codegens to a runtime `SIGSEGV` during walker traversal. The byte-identical program with the same body written **inline in the head file** compiles and runs fine.

This bites the standard impl-annex idiom (declaration surface in `mod.na.jac`, bodies in `impl/mod.na.impl.jac`): e.g. a `build_arena(world)` whose body constructs an imported `Player` node and connects it with `+>:`/`++>`, where the walker is later spawned from a different module.

## Root cause

`NaIRGenPass._module_uses_osp` is the gate that decides whether a native module participates in OSP — when true, every walker/node/edge gets its stable type-tag and the OSP kernel is loaded. It swept only the **head** module's `iter_context_stmts(...)` and recursed through `nd.kid`.

But `DeclImplMatchPass` attaches an impl-annex body via `decl.body = <ImplDef from the annex module>`; it never splices the annex statements into the head decl's `kid`. Impl-annex and variant bodies are reachable only through `mod.impl_mod` / `mod.variant_mod` (as `module_native_compat` already does). So an OSP construct (`spawn` / connect / `visit` / edge-ref) living only in an impl annex was invisible to the gate: the module was classified as a non-OSP user, the imported archetype never received a type-tag, and the annexed connect/spawn hit E5090 / bad codegen.

## Fix

Scan the impl-annex and variant modules' top-level statements alongside the head module's native-context statements. Conservative: a module with no annex behaves exactly as before, and only a real OSP construct flips the gate.

## Test

Adds a cross-module regression fixture set — a library declaring the archetypes, a builder that wires an imported node from its impl annex, and an entry module that spawns the walker — plus a test that `nacompile`s and runs it (expects `2 2 3`). The test fails with E5090 without the fix and passes with it. Full native gen-pass suite remains green.