### PR TITLE
refactor(native-linker): centralize relocation patch-site resolution

### DIFF
--- a/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/elf_linker.impl.jac
@@ -12,7 +12,7 @@ import from jaclang.compiler.passes.native.linker_common {
     _build_strtab,
     _append_to_blob,
     _resolve_seg_vaddr,
-    _find_patch_target,
+    _resolve_patch_site,
     _find_entry_vaddr
 }
 
@@ -1018,8 +1018,9 @@ impl ElfLinker.build_executable -> bytes {
             }
         }
 
-        # Determine target buffer and base vaddr
-        _pt = _find_patch_target(
+        # Determine target buffer, in-buffer offset, and final vaddr.
+        site = _resolve_patch_site(
+            rela.offset,
             rela.target_sec,
             code_sections,
             rodata_sections,
@@ -1031,7 +1032,7 @@ impl ElfLinker.build_executable -> bytes {
             rodata_vaddr,
             data_vaddr
         );
-        if _pt is None {
+        if site is None {
             # The relocation targets a section we do not place in the loadable
             # image (e.g. metadata like .eh_frame, whose relocations are also
             # filtered while parsing). There is nothing in the output to patch,
@@ -1039,9 +1040,7 @@ impl ElfLinker.build_executable -> bytes {
             # which would corrupt code if such a relocation were ever applied.
             continue;
         }
-        (patch_buf, sec_blob_off, patch_base_vaddr) = _pt;
-        patch_off = sec_blob_off + rela.offset;
-        patch_vaddr = patch_base_vaddr + patch_off;
+        (patch_buf, patch_off, patch_vaddr) = site;
 
         # Apply via architecture-specific handler. Every relocation that reaches
         # here targets an emitted (loadable) section, so an unhandled type would
@@ -1863,7 +1862,8 @@ impl ElfLinker.build_shared_object -> bytes {
         if rela.rtype == arch.abs64_rtype and rela.target_sec in data_sections {
             continue;
         }
-        _pt = _find_patch_target(
+        site = _resolve_patch_site(
+            rela.offset,
             rela.target_sec,
             code_sections,
             rodata_sections,
@@ -1875,12 +1875,10 @@ impl ElfLinker.build_shared_object -> bytes {
             rodata_vaddr,
             data_vaddr
         );
-        if _pt is None {
+        if site is None {
             continue;
         }
-        (patch_buf, sec_blob_off, patch_base_vaddr) = _pt;
-        patch_off = sec_blob_off + rela.offset;
-        patch_vaddr = patch_base_vaddr + patch_off;
+        (patch_buf, patch_off, patch_vaddr) = site;
         sym_addr = 0;
         if rela.rtype in arch.gotpcrel_rtypes {
             # GOT-directed: resolve to the GOT slot holding the target address.

--- a/jac/jaclang/compiler/passes/native/impl/linker_common.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/linker_common.impl.jac
@@ -57,7 +57,22 @@ impl _resolve_seg_vaddr(
 }
 
 
-impl _find_patch_target(
+"""Resolve a relocation's patch site. Locates the output blob holding
+`target_sec` and returns (patch_buf, patch_off, patch_vaddr): the buffer to
+write into, the byte offset of the fixup within that buffer, and the final
+virtual address of the fixup. Returns None when `target_sec` is not placed in
+the loadable image (e.g. metadata like .eh_frame), so the caller skips it.
+
+A section sits at `sec_off` within its segment's blob, and that blob loads at
+`<seg>_vaddr`; the fixup is `reloc_offset` bytes into the section. So both the
+buffer offset and the vaddr are `sec_off + reloc_offset` past the segment base.
+This is the arithmetic every ELF/Mach-O relocation loop (executable and
+shared-object) used to inline by hand — centralized here so the two cannot
+drift. (ELF previously added `sec_off` a second time to the vaddr, which only
+agreed with the correct value while a segment held a single section, i.e.
+`sec_off == 0`; this unifies on the correct form.)"""
+impl _resolve_patch_site(
+    reloc_offset: int,
     target_sec: str,
     code_sections: dict[str, tuple[int, int]],
     rodata_sections: dict[str, tuple[int, int]],
@@ -70,14 +85,26 @@ impl _find_patch_target(
     data_vaddr: int
 ) -> tuple[bytearray, int, int] | None {
     if target_sec in code_sections {
-        off = code_sections[target_sec][0];
-        return (code_bytes, off, code_vaddr + off);
+        sec_off = code_sections[target_sec][0];
+        return (
+            code_bytes,
+            sec_off + reloc_offset,
+            code_vaddr + sec_off + reloc_offset
+        );
     } elif target_sec in rodata_sections {
-        off = rodata_sections[target_sec][0];
-        return (rodata_bytes, off, rodata_vaddr + off);
+        sec_off = rodata_sections[target_sec][0];
+        return (
+            rodata_bytes,
+            sec_off + reloc_offset,
+            rodata_vaddr + sec_off + reloc_offset
+        );
     } elif target_sec in data_sections {
-        off = data_sections[target_sec][0];
-        return (data_bytes, off, data_vaddr + off);
+        sec_off = data_sections[target_sec][0];
+        return (
+            data_bytes,
+            sec_off + reloc_offset,
+            data_vaddr + sec_off + reloc_offset
+        );
     }
     return None;
 }

--- a/jac/jaclang/compiler/passes/native/impl/macho_linker.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/macho_linker.impl.jac
@@ -14,7 +14,7 @@ import from jaclang.compiler.passes.native.linker_common {
     _build_strtab,
     _append_to_blob,
     _resolve_seg_vaddr,
-    _find_patch_target,
+    _resolve_patch_site,
     _find_entry_vaddr
 }
 
@@ -1162,8 +1162,9 @@ impl MachOLinker.build_executable -> bytes {
             }
         }
 
-        # Determine patch buffer
-        _pt = _find_patch_target(
+        # Determine patch buffer, in-buffer offset, and final vaddr.
+        site = _resolve_patch_site(
+            rel.address,
             rel.target_sec,
             code_sections,
             rodata_sections,
@@ -1175,13 +1176,10 @@ impl MachOLinker.build_executable -> bytes {
             const_sec_vaddr,
             data_sec_vaddr
         );
-        if _pt is None {
+        if site is None {
             continue;
         }
-        (patch_buf, sec_off_in_blob, patch_base_vaddr) = _pt;
-
-        patch_off = sec_off_in_blob + rel.address;
-        patch_vaddr = patch_base_vaddr + rel.address;
+        (patch_buf, patch_off, patch_vaddr) = site;
 
         if is_arm64 {
             _arm64_apply_reloc(
@@ -2115,7 +2113,8 @@ impl MachOLinker.build_shared_object -> bytes {
                 );
             }
         }
-        _pt = _find_patch_target(
+        site = _resolve_patch_site(
+            rel.address,
             rel.target_sec,
             code_sections,
             rodata_sections,
@@ -2127,12 +2126,10 @@ impl MachOLinker.build_shared_object -> bytes {
             const_sec_vaddr,
             data_sec_vaddr
         );
-        if _pt is None {
+        if site is None {
             continue;
         }
-        (patch_buf, sec_off_in_blob, patch_base_vaddr) = _pt;
-        patch_off = sec_off_in_blob + rel.address;
-        patch_vaddr = patch_base_vaddr + rel.address;
+        (patch_buf, patch_off, patch_vaddr) = site;
         if is_arm64 {
             _arm64_apply_reloc(
                 rel.rtype, patch_buf, patch_off, sym_addr, rel.addend, patch_vaddr

--- a/jac/jaclang/compiler/passes/native/linker_common.jac
+++ b/jac/jaclang/compiler/passes/native/linker_common.jac
@@ -1,8 +1,8 @@
 """Common utilities shared between ELF and Mach-O linkers.
 
 Extracts duplicated patterns: alignment, string table building,
-section blob collection, virtual address resolution, patch target
-dispatch, and entry point lookup.
+section blob collection, virtual address resolution, relocation
+patch-site resolution, and entry point lookup.
 """
 
 def _align(value: int, alignment: int) -> int;
@@ -19,7 +19,8 @@ def _resolve_seg_vaddr(
     seg: str, seg_off: int, code_vaddr: int, rodata_vaddr: int, data_vaddr: int
 ) -> int;
 
-def _find_patch_target(
+def _resolve_patch_site(
+    reloc_offset: int,
     target_sec: str,
     code_sections: dict[str, tuple[int, int]],
     rodata_sections: dict[str, tuple[int, int]],

--- a/jac/tests/compiler/passes/native/fixtures/exec_smoke.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/exec_smoke.na.jac
@@ -1,0 +1,22 @@
+"""Executable smoke fixture for the direct ELF/Mach-O linker tests.
+
+The `with entry` block becomes `jac_entry` — the symbol the injected `main()`
+calls — and drives the build_executable() relocation path end-to-end:
+  - `print` lowers to `printf`, reached through the PLT (external-func reloc),
+  - the format string + "JAC_EXEC_OK " live in rodata (PC-relative reloc),
+  - `add2` is an intra-image call (local relocation).
+
+Output is exactly "JAC_EXEC_OK 42" (print emits no trailing newline; the second
+print formats the int via "%lld"). The ELF binary is executed for real on a
+Linux x86_64 host; the Mach-O binary is checked structurally since it cannot run
+on Linux.
+"""
+
+def add2(a: int, b: int) -> int {
+    return a + b;
+}
+
+with entry {
+    print("JAC_EXEC_OK ");
+    print(add2(20, 22));
+}

--- a/jac/tests/compiler/passes/native/test_exec_link.jac
+++ b/jac/tests/compiler/passes/native/test_exec_link.jac
@@ -145,6 +145,7 @@ test "Mach-O executable has MH_EXECUTE filetype and an LC_MAIN entry" {
         (cmd, cmdsize) = struct.unpack_from("<II", raw, off);
         if cmd == 0x80000028 {  # LC_MAIN
             has_main = True;
+            break;
         }
         off += cmdsize;
     }

--- a/jac/tests/compiler/passes/native/test_exec_link.jac
+++ b/jac/tests/compiler/passes/native/test_exec_link.jac
@@ -1,0 +1,152 @@
+"""Direct tests for the pure-Jac linkers' executable path (build_executable).
+
+Before this, `jac nacompile` was the only thing that exercised
+ElfLinker/MachOLinker.build_executable(): the JIT-based native suite never
+touches the linkers, and test_shared_lib only covers build_shared_object(). So
+the executable layout + relocation path had no direct regression coverage.
+
+These tests link a real relocatable object straight through
+ElfLinker.link / MachOLinker.link with shared=False, injecting `main` + the
+platform entry exactly as the nacompile CLI does. The ELF executable is run for
+real on a Linux x86_64 host (exit code + stdout); the Mach-O executable is
+validated structurally (MH_EXECUTE + LC_MAIN), since it cannot run on Linux.
+"""
+
+import os;
+import struct;
+import subprocess;
+import sys;
+import tempfile;
+import from pathlib { Path }
+import jaclang;
+import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.compile_options { CompileOptions }
+import from jaclang.compiler.passes.native.elf_linker { ElfLinker }
+import from jaclang.compiler.passes.native.macho_linker { MachOLinker }
+import llvmlite.binding as llvm;
+
+glob FIXTURES = str(
+         Path(jaclang.__file__).parent.parent / "tests" / "compiler" / "passes" / "native" / "fixtures"
+     ),
+     FIXTURE = "exec_smoke.na.jac";
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+"""Compile the fixture for `triple` and return its LLVM IR text."""
+def _compile_ir(fixture: str, triple: str) -> str {
+    prev = os.environ.get("JAC_NATIVE_TARGET", None);
+    os.environ["JAC_NATIVE_TARGET"] = triple;
+    try {
+        prog = JacProgram();
+        ir = prog.compile(
+            file_path=os.path.join(FIXTURES, fixture),
+            options=CompileOptions(aot_mode=True, type_check=False)
+        );
+        assert not prog.errors_had , f"compile errors: {[
+            str(e) for e in prog.errors_had
+        ]}";
+        ir_txt = str(ir.gen.llvm_ir);
+    } finally {
+        if prev is None {
+            os.environ.pop("JAC_NATIVE_TARGET", None);
+        } else {
+            os.environ["JAC_NATIVE_TARGET"] = prev;
+        }
+    }
+    return ir_txt;
+}
+
+
+"""Assemble `ir_txt` for `triple` into a relocatable object using the default
+(fixed-base) model — exactly what nacompile emits for an executable. Forcing
+`pic` here would emit GOT-relative data refs that the fixed-base ET_EXEC layout
+mislinks into a segfaulting binary, so this mirrors the real CLI path."""
+def _emit_object(ir_txt: str, triple: str) -> bytes {
+    llvm.initialize_all_targets();
+    llvm.initialize_all_asmprinters();
+    mod = llvm.parse_assembly(ir_txt);
+    mod.verify();
+    tm = llvm.Target.from_triple(triple).create_target_machine(opt=2);
+    return tm.emit_object(mod);
+}
+
+
+"""Inject `main` + `_start` for ELF — mirrors nacompile's _inject_entry_elf."""
+def _inject_elf(ir_txt: str) -> str {
+    globals_ir = ""
+        if "__jac_argc" in ir_txt
+        else "@__jac_argc = global i32 0\n@__jac_argv = global ptr null\n\n";
+    exit_decl = ""
+        if ("@exit" in ir_txt or '@"exit"' in ir_txt)
+        else "declare void @exit(i32) noreturn\n\n";
+    return ir_txt + (
+        "\n; --- injected entry point ---\n" + globals_ir + exit_decl + "declare ptr @llvm.stacksave()\n\n" + "define i32 @main(i32 %argc, ptr %argv) {\nentry:\n" + "    store i32 %argc, ptr @__jac_argc\n" + "    store ptr %argv, ptr @__jac_argv\n" + "    call void @jac_entry()\n    ret i32 0\n}\n\n" + "define void @_start() naked noreturn {\nentry:\n" + "    %sp = call ptr @llvm.stacksave()\n" + "    %argc = load i32, ptr %sp\n" + "    %argv = getelementptr i8, ptr %sp, i64 8\n" + "    %ret = call i32 @main(i32 %argc, ptr %argv)\n" + "    call void @exit(i32 %ret)\n    unreachable\n}\n"
+    );
+}
+
+
+"""Inject `main` for Mach-O — mirrors nacompile's _inject_entry_macho."""
+def _inject_macho(ir_txt: str) -> str {
+    globals_ir = ""
+        if "__jac_argc" in ir_txt
+        else "@__jac_argc = global i32 0\n@__jac_argv = global ptr null\n\n";
+    return ir_txt + (
+        "\n; --- injected entry point ---\n" + globals_ir + "define i32 @main(i32 %argc, ptr %argv) {\nentry:\n" + "    store i32 %argc, ptr @__jac_argc\n" + "    store ptr %argv, ptr @__jac_argv\n" + "    call void @jac_entry()\n    ret i32 0\n}\n"
+    );
+}
+
+
+# ─── tests ───────────────────────────────────────────────────────────────────
+test "ELF executable links, runs, and prints through the C ABI" {
+    triple = llvm.get_default_triple();
+    relobj = _emit_object(_inject_elf(_compile_ir(FIXTURE, triple)), triple);
+    d = tempfile.mkdtemp();
+    out = os.path.join(d, "exec_smoke");
+    ok = ElfLinker.link(
+        obj_bytes=relobj, output_path=out, needed_libs=["libc.so.6"], shared=False
+    );
+    assert ok , "ElfLinker.link(shared=False) returned False";
+    raw = Path(out).read_bytes();
+    assert raw[:4] == b"\x7fELF" , "not an ELF image";
+    e_type = struct.unpack_from("<H", raw, 16)[0];
+    assert e_type == 2 , f"expected ET_EXEC (2), got {e_type}";
+
+    # Only a Linux x86_64 host can execute the produced ELF.
+    if sys.platform.startswith("linux") and ("x86_64" in triple) {
+        res = subprocess.run([out], capture_output=True, timeout=30);
+        assert res.returncode == 0 , f"exec exited {res.returncode}, stderr={res.stderr}";
+        assert b"JAC_EXEC_OK" in res.stdout , f"missing marker in stdout: {res.stdout}";
+        assert b"42" in res.stdout , f"missing result in stdout: {res.stdout}";
+    }
+}
+
+
+test "Mach-O executable has MH_EXECUTE filetype and an LC_MAIN entry" {
+    triple = "x86_64-apple-darwin";
+    relobj = _emit_object(_inject_macho(_compile_ir(FIXTURE, triple)), triple);
+    d = tempfile.mkdtemp();
+    out = os.path.join(d, "exec_smoke");
+    ok = MachOLinker.link(
+        obj_bytes=relobj,
+        output_path=out,
+        needed_libs=["/usr/lib/libSystem.B.dylib"],
+        shared=False
+    );
+    assert ok , "MachOLinker.link(shared=False) returned False";
+    raw = Path(out).read_bytes();
+    assert struct.unpack_from("<I", raw, 0)[0] == 0xFEEDFACF , "not a Mach-O 64 image";
+    filetype = struct.unpack_from("<I", raw, 12)[0];
+    assert filetype == 2 , f"expected MH_EXECUTE (2), got {filetype}";
+    # Scan load commands for LC_MAIN — the executable entry-point command.
+    ncmds = struct.unpack_from("<I", raw, 16)[0];
+    off = 32;
+    has_main = False;
+    for _ in range(ncmds) {
+        (cmd, cmdsize) = struct.unpack_from("<II", raw, off);
+        if cmd == 0x80000028 {  # LC_MAIN
+            has_main = True;
+        }
+        off += cmdsize;
+    }
+    assert has_main , "missing LC_MAIN entry command";
+}


### PR DESCRIPTION
## What

The ELF and Mach-O linkers each hand-rolled the same relocation-loop epilogue in **four** places (`build_executable` + `build_shared_object`, per format): find the output blob for the target section, skip if it isn't in the loadable image, then compute the in-buffer offset and the fixup's final virtual address.

This folds that into a single `linker_common` helper, `_resolve_patch_site()`, returning `(patch_buf, patch_off, patch_vaddr)` ready for `apply_reloc`. The old `_find_patch_target()` is inlined into it (one helper, not two; no callback indirection). All four sites collapse to a call plus an unpack. Format-specific symbol resolution is deliberately left in place — abstracting it would cost more readability than the duplication removes.

## Latent bug fixed along the way

ELF computed the patch vaddr as `base + (sec_off + reloc_off)`, double-counting the section's blob offset; Mach-O used the correct `base + reloc_off`. The two agree only when a segment holds a single section (blob offset 0), so it never surfaced in practice. The shared helper settles on the correct form, which cannot regress the offset-0 case.

## Tests

Adds `test_exec_link` — the first **direct** coverage of `build_executable()`. (The JIT suite never touches the linkers; `test_shared_lib` only covered `build_shared_object()`.) It links a real relocatable object straight through `ElfLinker`/`MachOLinker` with `shared=False`:

- **ELF**: built and **executed for real** on Linux x86_64 — asserts exit 0 and expected stdout.
- **Mach-O**: validated structurally (MH_EXECUTE + LC_MAIN), since it can't run on a Linux host.

All linker suites green: `test_exec_link` (2), `test_shared_lib` (3), `test_pe_linker` (4), `test_wasm_linker` (5). A richer end-to-end program (recursion, heap-allocated lists, string concat, many libc PLT calls) also compiles and runs correctly through `nacompile`.

## Scope

Limited to the linker refactor plus tests — six files, no behavior change beyond the vaddr unification noted above.

## Follow-up

The vaddr fix only *matters* with multiple sections in one segment (blob offset > 0), which is hard to construct deterministically without function-sections-style output — so it is proven safe but not yet proven exercised. A multi-section regression test would lock it in.

