### PR TITLE
feat(native): user-defined __iter__/__next__ in the iterator protocol (#6403)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6726.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6726.feature.md
@@ -1,0 +1,1 @@
+- **Feature: User-defined iterators in native code (#6403)**: Any `obj` that implements `__iter__`/`__next__` can now be iterated in the native (`na {}` → LLVM) backend. It works in `for` loops, via first-class `iter()`/`next()`, through the `map()` adapter, and across function boundaries as `Iterator[T]`, with `StopIteration` ending iteration as in Python.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
@@ -897,7 +897,9 @@ impl NaIRGenPass._make_zip_iter(up_a: tuple, up_b: tuple) -> (tuple | None) {
 
 # ─── User-defined iterators (#6403 M2) ───────────────────────
 """Resolve a method function for an archetype, walking its MRO; None if absent."""
-impl NaIRGenPass._resolve_method(arch_name: str, method_name: str) -> (ir.Function | None) {
+impl NaIRGenPass._resolve_method(
+    arch_name: str, method_name: str
+) -> (ir.Function | None) {
     for check_name in self._mro_of(arch_name) {
         full_name = f"{check_name}.{method_name}";
         if full_name in self.method_funcs {
@@ -910,7 +912,7 @@ impl NaIRGenPass._resolve_method(arch_name: str, method_name: str) -> (ir.Functi
 """Whether an archetype implements the iterator protocol (__iter__/__next__)."""
 impl NaIRGenPass._arch_implements_iter(arch_name: str) -> bool {
     return self._resolve_method(arch_name, "__next__") is not None
-        or self._resolve_method(arch_name, "__iter__") is not None;
+    or self._resolve_method(arch_name, "__iter__") is not None;
 }
 
 """Monomorphic next-fn bridging a user iterator's `__next__` into the protocol.
@@ -937,9 +939,7 @@ impl NaIRGenPass._user_iter_next_fn(
     struct_ptr_type = self.struct_types[iter_struct].as_pointer();
     state_ptr_type = self.struct_types["UserIterState"].as_pointer();
     nfty = ir.FunctionType(i1, [i8p, i8p]);
-    fn = ir.Function(
-        self.llvm_module, nfty, name="__iter_next_user_" + iter_struct
-    );
+    fn = ir.Function(self.llvm_module, nfty, name="__iter_next_user_" + iter_struct);
     fn.linkage = "private";
     fn.attributes.add("optnone");
     fn.attributes.add("noinline");

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
@@ -909,7 +909,13 @@ impl NaIRGenPass._resolve_method(
     return None;
 }
 
-"""Whether an archetype implements the iterator protocol (__iter__/__next__)."""
+"""Whether an archetype participates in the iterator protocol.
+
+The OR routes both shapes the bridge handles: a self-iterator (has `__next__`,
+used directly) and a re-iterable (has `__iter__`, which yields a separate
+cursor). It is not the Python "is iterable" test — that requires `__iter__`,
+which the type checker already enforces before this pass, so a `__next__`-only
+object never reaches codegen as a for-loop / `iter()` target."""
 impl NaIRGenPass._arch_implements_iter(arch_name: str) -> bool {
     return self._resolve_method(arch_name, "__next__") is not None
     or self._resolve_method(arch_name, "__iter__") is not None;
@@ -936,7 +942,11 @@ impl NaIRGenPass._user_iter_next_fn(
     i32 = ir.IntType(32);
     i1 = ir.IntType(1);
     exc_state_type = self._get_exception_state_type();
-    struct_ptr_type = self.struct_types[iter_struct].as_pointer();
+    # The receiver is bitcast to `__next__`'s own declared self-parameter type,
+    # not the concrete iter_struct pointer: when `__next__` is resolved up the
+    # MRO its LLVM signature expects the declaring class's pointer, so coercing
+    # to that (as the standard method-call path does) keeps the call well-typed.
+    struct_ptr_type = next_method_fn.function_type.args[0];
     state_ptr_type = self.struct_types["UserIterState"].as_pointer();
     nfty = ir.FunctionType(i1, [i8p, i8p]);
     fn = ir.Function(self.llvm_module, nfty, name="__iter_next_user_" + iter_struct);
@@ -1046,11 +1056,25 @@ impl NaIRGenPass._make_user_iter_from_obj(
     }
     it_obj = self.builder.call(iter_fn, [obj_val], name="usr.iter");
     self._mark_owned(it_obj);
-    if self._is_owned(obj_val) and obj_val != it_obj {
+    # Build the iterator BEFORE releasing the source, so a non-drivable
+    # `__iter__` result (e.g. one returning a builtin Iterator[T] box rather
+    # than a user iterator object, which `_infer_type_name`/`_make_user_iter`
+    # can't resolve a `__next__` for) bails with no partial side effects:
+    # release the owned `__iter__` result and leave `obj_val` for the caller's
+    # fall-through path.
+    iter_struct = self._infer_type_name(it_obj);
+    built = self._make_user_iter(it_obj, iter_struct)
+        if iter_struct is not None
+        else None;
+    if built is None {
+        self._emit_rc_release_simple(it_obj, op="user_iter_unresolved");
+        return None;
+    }
+    # The separate iterator is in hand, so drop the iterable temporary if owned.
+    if self._is_owned(obj_val) {
         self._emit_rc_release_simple(obj_val, op="user_iter_src");
     }
-    iter_struct = self._infer_type_name(it_obj) or struct_name;
-    return self._make_user_iter(it_obj, iter_struct);
+    return built;
 }
 
 # ─── First-class next() ──────────────────────────────────────

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
@@ -41,6 +41,9 @@ impl NaIRGenPass._ensure_iter_types -> None {
     self._register_iter_struct("FilterIterState", ["upstream"], [i8p]);
     self._register_iter_struct("EnumerateIterState", ["upstream", "idx"], [i8p, i64]);
     self._register_iter_struct("ZipIterState", ["up_a", "up_b"], [i8p, i8p]);
+    # user iterator object stored as i8* so the generic dtor OWNS (releases) it,
+    # cascading into the object's own struct destructor (#6403 M2).
+    self._register_iter_struct("UserIterState", ["obj"], [i8p]);
 }
 
 """Register an identified struct + its field index/type maps."""
@@ -609,6 +612,14 @@ impl NaIRGenPass._make_iter_from_value(
         et = self._iter_elem_llvm_of(expr);
         return (val, "iter", et if et is not None else i8p);
     }
+    # User-defined iterator/iterable (#6403 M2): a struct implementing
+    # __iter__/__next__ is bridged into a JacIter whose next-fn drives the
+    # user's __next__ (StopIteration -> i1 0). It composes with the lazy
+    # adapters and crosses function boundaries like any other JacIter.
+    ustruct = self._struct_name_of(expr);
+    if ustruct is not None and self._arch_implements_iter(ustruct) {
+        return self._make_user_iter_from_obj(val, ustruct, expr);
+    }
     return None;
 }
 
@@ -884,6 +895,164 @@ impl NaIRGenPass._make_zip_iter(up_a: tuple, up_b: tuple) -> (tuple | None) {
     return (self._make_jac_iter(nfn, st), "tuple", tuple_type);
 }
 
+# ─── User-defined iterators (#6403 M2) ───────────────────────
+"""Resolve a method function for an archetype, walking its MRO; None if absent."""
+impl NaIRGenPass._resolve_method(arch_name: str, method_name: str) -> (ir.Function | None) {
+    for check_name in self._mro_of(arch_name) {
+        full_name = f"{check_name}.{method_name}";
+        if full_name in self.method_funcs {
+            return self.method_funcs[full_name];
+        }
+    }
+    return None;
+}
+
+"""Whether an archetype implements the iterator protocol (__iter__/__next__)."""
+impl NaIRGenPass._arch_implements_iter(arch_name: str) -> bool {
+    return self._resolve_method(arch_name, "__next__") is not None
+        or self._resolve_method(arch_name, "__iter__") is not None;
+}
+
+"""Monomorphic next-fn bridging a user iterator's `__next__` into the protocol.
+Each call advances by invoking the user's `__next__`; a StopIteration raised
+there is the protocol's `i1 0` end-of-iteration (no exception leaks to the
+loop), while any other exception is re-raised to the enclosing handler. The
+StopIteration is caught with a local setjmp handler, so the fn carries the same
+optnone/noinline discipline try/except does (keep allocas off SSA across the
+non-local jump)."""
+impl NaIRGenPass._user_iter_next_fn(
+    iter_struct: str, next_method_fn: ir.Function, elem_type: ir.Type
+) -> ir.Function {
+    key = "user:" + iter_struct;
+    if key in self._iter_next_fns {
+        return self._iter_next_fns[key];
+    }
+    if self._exc_raise_fn is None {
+        self._declare_exception_runtime();
+    }
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    i1 = ir.IntType(1);
+    exc_state_type = self._get_exception_state_type();
+    struct_ptr_type = self.struct_types[iter_struct].as_pointer();
+    state_ptr_type = self.struct_types["UserIterState"].as_pointer();
+    nfty = ir.FunctionType(i1, [i8p, i8p]);
+    fn = ir.Function(
+        self.llvm_module, nfty, name="__iter_next_user_" + iter_struct
+    );
+    fn.linkage = "private";
+    fn.attributes.add("optnone");
+    fn.attributes.add("noinline");
+    fn.args[0].name = "state";
+    fn.args[1].name = "out";
+    entry_bb = fn.append_basic_block("entry");
+    call_bb = fn.append_basic_block("call");
+    caught_bb = fn.append_basic_block("caught");
+    stop_bb = fn.append_basic_block("stop");
+    reraise_bb = fn.append_basic_block("reraise");
+    b = ir.IRBuilder(entry_bb);
+    state = b.bitcast(fn.args[0], state_ptr_type, name="usr.state");
+    obj_i8 = b.load(
+        b.gep(state, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="usr.obj.slot"),
+        name="usr.obj.i8"
+    );
+    recv = b.bitcast(obj_i8, struct_ptr_type, name="usr.obj");
+    # Push a local handler and setjmp around the __next__ call.
+    exc_state = b.alloca(exc_state_type, name="usr.exc.state");
+    b.call(self._exc_push_fn, [exc_state]);
+    env_ptr = b.gep(
+        exc_state, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="usr.env.ptr"
+    );
+    env_i8p = b.bitcast(env_ptr, i8p, name="usr.env.i8p");
+    sj = b.call(self.extern_funcs["setjmp"], [env_i8p], name="usr.sj");
+    is_exc = b.icmp_signed("!=", sj, ir.Constant(i32, 0), name="usr.is.exc");
+    b.cbranch(is_exc, caught_bb, call_bb);
+    # Normal path: __next__ returned a value.
+    b.position_at_end(call_bb);
+    v = b.call(next_method_fn, [recv], name="usr.v");
+    b.call(self._exc_pop_fn, []);
+    out_t = b.bitcast(fn.args[1], elem_type.as_pointer(), name="usr.out");
+    b.store(v, out_t);
+    b.ret(ir.Constant(i1, 1));
+    # Exception path: distinguish StopIteration (end) from a real error.
+    b.position_at_end(caught_bb);
+    b.call(self._exc_pop_fn, []);
+    exc_type_ptr = b.gep(
+        exc_state, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="usr.exc.type.ptr"
+    );
+    exc_type_val = b.load(exc_type_ptr, name="usr.exc.type");
+    stop_id = self._get_or_register_exc_type("StopIteration");
+    is_stop = b.icmp_signed(
+        "==", exc_type_val, ir.Constant(i32, stop_id), name="usr.is.stop"
+    );
+    b.cbranch(is_stop, stop_bb, reraise_bb);
+    b.position_at_end(stop_bb);
+    b.ret(ir.Constant(i1, 0));
+    b.position_at_end(reraise_bb);
+    exc_obj_ptr = b.gep(
+        exc_state, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="usr.exc.obj.ptr"
+    );
+    reraise_obj = b.load(exc_obj_ptr, name="usr.reraise.obj");
+    b.call(self._exc_raise_fn, [reraise_obj, exc_type_val]);
+    b.unreachable();
+    self._iter_next_fns[key] = fn;
+    return fn;
+}
+
+"""Box a user iterator object (owns a +1 ref) into a JacIter over its
+`__next__`. The object is stored as i8* so the generic dtor releases it,
+cascading into the object's own struct destructor."""
+impl NaIRGenPass._make_user_iter(it_obj: ir.Value, iter_struct: str) -> (tuple | None) {
+    next_method_fn = self._resolve_method(iter_struct, "__next__");
+    if next_method_fn is None {
+        return None;
+    }
+    elem_type = next_method_fn.function_type.return_type;
+    next_fn = self._user_iter_next_fn(iter_struct, next_method_fn, elem_type);
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    st = self._alloc_iter_struct("UserIterState");
+    obj_i8 = self.builder.bitcast(it_obj, i8p, name="usr.obj.store");
+    self.builder.store(
+        obj_i8,
+        self.builder.gep(
+            st, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="usr.obj.field"
+        )
+    );
+    return (self._make_jac_iter(next_fn, st), "user", elem_type);
+}
+
+"""Build a JacIter from a user iterable/iterator object (#6403 M2).
+If the object is already an iterator (has __next__) it is its own iterator
+(Python's `iter(it) is it`); otherwise `__iter__()` produces a fresh one. Every
+function returns an owned (+1) pointer, so `__iter__`'s result needs no retain;
+a borrowed self-iterator does (the JacIter releases it at end of life). The
+iterable temporary is released once its separate iterator is in hand."""
+impl NaIRGenPass._make_user_iter_from_obj(
+    obj_val: ir.Value, struct_name: str, expr: uni.UniNode
+) -> (tuple | None) {
+    if self._resolve_method(struct_name, "__next__") is not None {
+        it_obj = obj_val;
+        iter_struct = struct_name;
+        if not self._is_owned(it_obj) {
+            self._emit_rc_retain(it_obj, op="user_iter");
+            self._mark_owned(it_obj);
+        }
+        return self._make_user_iter(it_obj, iter_struct);
+    }
+    iter_fn = self._resolve_method(struct_name, "__iter__");
+    if iter_fn is None {
+        return None;
+    }
+    it_obj = self.builder.call(iter_fn, [obj_val], name="usr.iter");
+    self._mark_owned(it_obj);
+    if self._is_owned(obj_val) and obj_val != it_obj {
+        self._emit_rc_release_simple(obj_val, op="user_iter_src");
+    }
+    iter_struct = self._infer_type_name(it_obj) or struct_name;
+    return self._make_user_iter(it_obj, iter_struct);
+}
+
 # ─── First-class next() ──────────────────────────────────────
 """Lower `next(it)`: pull one element from a first-class iterator value.
 
@@ -937,21 +1106,28 @@ impl NaIRGenPass._try_iter_protocol_for(nd: uni.InForStmt) -> bool {
         and self._get_name(coll.target) in ["map", "filter", "enumerate", "zip", "iter"]
         and coll.call_kind == "builtin"
     );
+    # A user-defined object implementing __iter__/__next__ is bridged into a
+    # fresh (owned) JacIter, driven exactly like a builtin iterator (#6403 M2).
+    _ustruct = self._struct_name_of(coll) if not is_adapter_call else None;
+    is_user_iterable = _ustruct is not None and self._arch_implements_iter(_ustruct);
     built: (tuple | None) = None;
     owns_iter = False;
-    if is_adapter_call {
+    if is_adapter_call or is_user_iterable {
         built = self._build_iter_from_expr(coll);
         owns_iter = True;
     } else {
-        # A stored first-class iterator value (`it: Iterator[T]`); #6403 phase 2.
-        # The loop borrows it (the variable still owns the +1), so it must NOT
-        # be released here.
+        # A first-class iterator value (`it: Iterator[T]`); #6403 phase 2.
+        # A borrowed binding (`for x in it`) stays owned by its variable and is
+        # released at that variable's end of life, so the loop must NOT release
+        # it. An owned temporary (`for x in gen()`, an iterator returned from a
+        # call) has no other owner — the loop is responsible for releasing it.
         elem_t = self._iter_elem_llvm_of(coll);
         if elem_t is not None {
             iv = self._codegen_expr(coll);
             if iv is not None {
                 ename = "tuple" if isinstance(elem_t, ir.LiteralStructType) else "iter";
                 built = (iv, ename, elem_t);
+                owns_iter = self._is_owned(iv);
             }
         }
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -833,10 +833,12 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _user_iter_next_fn(
         iter_struct: str, next_method_fn: ir.Function, elem_type: ir.Type
     ) -> ir.Function;
+
     def _make_user_iter(it_obj: ir.Value, iter_struct: str) -> (tuple | None);
     def _make_user_iter_from_obj(
         obj_val: ir.Value, struct_name: str, expr: uni.UniNode
     ) -> (tuple | None);
+
     def _try_iter_protocol_for(nd: uni.InForStmt) -> bool;
     # Phase 16: Context Managers
     def _codegen_with(nd: uni.WithStmt) -> None;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -827,6 +827,16 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _make_filter_iter(up: tuple, pred: ir.Function) -> (tuple | None);
     def _make_enumerate_iter(up: tuple) -> (tuple | None);
     def _make_zip_iter(up_a: tuple, up_b: tuple) -> (tuple | None);
+    # User-defined __iter__/__next__ bridged into the protocol (#6403 M2).
+    def _resolve_method(arch_name: str, method_name: str) -> (ir.Function | None);
+    def _arch_implements_iter(arch_name: str) -> bool;
+    def _user_iter_next_fn(
+        iter_struct: str, next_method_fn: ir.Function, elem_type: ir.Type
+    ) -> ir.Function;
+    def _make_user_iter(it_obj: ir.Value, iter_struct: str) -> (tuple | None);
+    def _make_user_iter_from_obj(
+        obj_val: ir.Value, struct_name: str, expr: uni.UniNode
+    ) -> (tuple | None);
     def _try_iter_protocol_for(nd: uni.InForStmt) -> bool;
     # Phase 16: Context Managers
     def _codegen_with(nd: uni.WithStmt) -> None;

--- a/jac/tests/compiler/passes/native/fixtures/iter_user.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/iter_user.na.jac
@@ -7,8 +7,9 @@
 # for-loops, work with first-class iter()/next(), compose under the lazy
 # adapters, and cross function boundaries — exactly like a builtin iterator.
 # Returns ints so tests can assert via ctypes.
-
-def double(x: int) -> int { return x * 2; }
+def double(x: int) -> int {
+    return x * 2;
+}
 
 # A self-iterator: the object is its own iterator (Python's most common idiom,
 # `__iter__` returns self).
@@ -16,10 +17,13 @@ obj Counter {
     has cur: int;
     has stop: int;
 
-    def __iter__() -> Counter { return self; }
-
+    def __iter__() -> Counter {
+        return self;
+    }
     def __next__() -> int {
-        if self.cur >= self.stop { raise StopIteration("done"); }
+        if self.cur >= self.stop {
+            raise StopIteration("done");
+        }
         v = self.cur;
         self.cur = self.cur + 1;
         return v;
@@ -32,10 +36,13 @@ obj Cursor {
     has cur: int;
     has stop: int;
 
-    def __iter__() -> Cursor { return self; }
-
+    def __iter__() -> Cursor {
+        return self;
+    }
     def __next__() -> int {
-        if self.cur >= self.stop { raise StopIteration("stop"); }
+        if self.cur >= self.stop {
+            raise StopIteration("stop");
+        }
         v = self.cur;
         self.cur = self.cur + 1;
         return v;
@@ -45,7 +52,9 @@ obj Cursor {
 obj NumberRange {
     has n: int;
 
-    def __iter__() -> Cursor { return Cursor(cur=0, stop=self.n); }
+    def __iter__() -> Cursor {
+        return Cursor(cur=0, stop=self.n);
+    }
 }
 
 # --- for-loop over a self-iterator: 0+1+2+3+4 = 10 ---
@@ -98,7 +107,9 @@ def user_map_compose() -> int {
 def user_break() -> int {
     total: int = 0;
     for x in Counter(cur=0, stop=100) {
-        if x == 3 { break; }
+        if x == 3 {
+            break;
+        }
         total = total + x;
     }
     return total;
@@ -122,10 +133,13 @@ def user_cross_fn() -> int {
 obj Boom {
     has n: int;
 
-    def __iter__() -> Boom { return self; }
-
+    def __iter__() -> Boom {
+        return self;
+    }
     def __next__() -> int {
-        if self.n <= 0 { raise ValueError("boom"); }
+        if self.n <= 0 {
+            raise ValueError("boom");
+        }
         self.n = self.n - 1;
         return self.n;
     }
@@ -145,4 +159,4 @@ def user_next_propagates() -> int {
     }
 }
 
-with entry {}
+with entry { }

--- a/jac/tests/compiler/passes/native/fixtures/iter_user.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/iter_user.na.jac
@@ -20,6 +20,7 @@ obj Counter {
     def __iter__() -> Counter {
         return self;
     }
+
     def __next__() -> int {
         if self.cur >= self.stop {
             raise StopIteration("done");
@@ -39,6 +40,7 @@ obj Cursor {
     def __iter__() -> Cursor {
         return self;
     }
+
     def __next__() -> int {
         if self.cur >= self.stop {
             raise StopIteration("stop");
@@ -136,6 +138,7 @@ obj Boom {
     def __iter__() -> Boom {
         return self;
     }
+
     def __next__() -> int {
         if self.n <= 0 {
             raise ValueError("boom");
@@ -157,6 +160,22 @@ def user_next_propagates() -> int {
     } except ValueError {
         return 42;
     }
+}
+
+# A subclass that inherits __iter__/__next__ from its base.
+obj SubCounter(Counter) {
+    has extra: int;
+}
+
+# --- a subclass driving inherited __iter__/__next__: 0+1+2+3 = 6. The receiver
+#     is coerced to __next__'s declared self type, so an inherited method stays
+#     well-typed. ---
+def user_inherited_iter() -> int {
+    total: int = 0;
+    for x in SubCounter(cur=0, stop=4, extra=99) {
+        total = total + x;
+    }
+    return total;
 }
 
 with entry { }

--- a/jac/tests/compiler/passes/native/fixtures/iter_user.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/iter_user.na.jac
@@ -1,0 +1,148 @@
+# Native fixture: user-defined iterator protocol (#6403 M2).
+#
+# A user `obj` that implements `__iter__`/`__next__` is bridged into the same
+# boxed JacIter the builtin iterators use: a per-element call to the user's
+# `__next__`, with a StopIteration caught and translated to the iterator
+# protocol's `i1 0` exhaustion flag. Bridged user iterators therefore drive
+# for-loops, work with first-class iter()/next(), compose under the lazy
+# adapters, and cross function boundaries — exactly like a builtin iterator.
+# Returns ints so tests can assert via ctypes.
+
+def double(x: int) -> int { return x * 2; }
+
+# A self-iterator: the object is its own iterator (Python's most common idiom,
+# `__iter__` returns self).
+obj Counter {
+    has cur: int;
+    has stop: int;
+
+    def __iter__() -> Counter { return self; }
+
+    def __next__() -> int {
+        if self.cur >= self.stop { raise StopIteration("done"); }
+        v = self.cur;
+        self.cur = self.cur + 1;
+        return v;
+    }
+}
+
+# An iterable whose `__iter__` returns a *separate* fresh iterator object — the
+# other standard idiom (a re-iterable collection).
+obj Cursor {
+    has cur: int;
+    has stop: int;
+
+    def __iter__() -> Cursor { return self; }
+
+    def __next__() -> int {
+        if self.cur >= self.stop { raise StopIteration("stop"); }
+        v = self.cur;
+        self.cur = self.cur + 1;
+        return v;
+    }
+}
+
+obj NumberRange {
+    has n: int;
+
+    def __iter__() -> Cursor { return Cursor(cur=0, stop=self.n); }
+}
+
+# --- for-loop over a self-iterator: 0+1+2+3+4 = 10 ---
+def user_self_for() -> int {
+    total: int = 0;
+    for x in Counter(cur=0, stop=5) {
+        total = total + x;
+    }
+    return total;
+}
+
+# --- for-loop over a borrowed self-iterator variable: 0+1+2 = 3 ---
+def user_self_for_var() -> int {
+    c = Counter(cur=0, stop=3);
+    total: int = 0;
+    for x in c {
+        total = total + x;
+    }
+    return total;
+}
+
+# --- for-loop over an iterable whose __iter__ yields a separate cursor:
+#     0+1+2+3 = 6 ---
+def user_separate_for() -> int {
+    total: int = 0;
+    for x in NumberRange(n=4) {
+        total = total + x;
+    }
+    return total;
+}
+
+# --- first-class iter()/next() over a user iterator: a=10,b=11 -> 1011 ---
+def user_iter_next() -> int {
+    it = iter(Counter(cur=10, stop=20));
+    a = next(it);
+    b = next(it);
+    return a * 100 + b;
+}
+
+# --- map() over a user iterator (adapter composition): (0+1+2)*2 = 6 ---
+def user_map_compose() -> int {
+    total: int = 0;
+    for x in map(double, Counter(cur=0, stop=3)) {
+        total = total + x;
+    }
+    return total;
+}
+
+# --- break mid-iteration over a user iterator: stop at x==3, sum 0+1+2 = 3 ---
+def user_break() -> int {
+    total: int = 0;
+    for x in Counter(cur=0, stop=100) {
+        if x == 3 { break; }
+        total = total + x;
+    }
+    return total;
+}
+
+# --- a user iterator boxed as Iterator[T] and returned across a function
+#     boundary, then for-looped by the caller: 0+1+2+3+4 = 10 ---
+def user_gen() -> Iterator[int] {
+    return iter(Counter(cur=0, stop=5));
+}
+
+def user_cross_fn() -> int {
+    total: int = 0;
+    for x in user_gen() {
+        total = total + x;
+    }
+    return total;
+}
+
+# A user iterator whose __next__ raises a NON-StopIteration error partway.
+obj Boom {
+    has n: int;
+
+    def __iter__() -> Boom { return self; }
+
+    def __next__() -> int {
+        if self.n <= 0 { raise ValueError("boom"); }
+        self.n = self.n - 1;
+        return self.n;
+    }
+}
+
+# --- a non-StopIteration exception raised inside __next__ must propagate out of
+#     the for-loop (not be swallowed as end-of-iteration): caught -> 42 ---
+def user_next_propagates() -> int {
+    total: int = 0;
+    try {
+        for x in Boom(n=2) {
+            total = total + x;
+        }
+        return -1;
+    } except ValueError {
+        return 42;
+    }
+}
+
+with entry {}

--- a/jac/tests/compiler/passes/native/test_native_iterators.jac
+++ b/jac/tests/compiler/passes/native/test_native_iterators.jac
@@ -232,3 +232,10 @@ test "user iter next non-stopiteration propagates" {
     f = get_func(eng, "user_next_propagates", ctypes.c_int64);
     assert f() == 42;
 }
+
+# A subclass driving __iter__/__next__ inherited from its base.
+test "user iter inherited from base" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_inherited_iter", ctypes.c_int64);
+    assert f() == 6;
+}

--- a/jac/tests/compiler/passes/native/test_native_iterators.jac
+++ b/jac/tests/compiler/passes/native/test_native_iterators.jac
@@ -178,3 +178,57 @@ test "iter next keyword arg rejected" {
     assert errs , "expected a type error for next(it=...)";
     assert any("does not match any parameter" in e for e in errs) , errs;
 }
+
+# --- #6403 M2: user-defined __iter__/__next__ bridged into the protocol ---
+# A user `obj` implementing the iterator protocol drives for-loops, works with
+# first-class iter()/next(), composes under map/filter/enumerate, and crosses
+# function boundaries — its `__next__`'s StopIteration becomes the protocol's
+# i1-0 exhaustion flag.
+test "user iter self for-loop" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_self_for", ctypes.c_int64);
+    assert f() == 10;
+}
+
+test "user iter borrowed var for-loop" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_self_for_var", ctypes.c_int64);
+    assert f() == 3;
+}
+
+test "user iter separate iterator for-loop" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_separate_for", ctypes.c_int64);
+    assert f() == 6;
+}
+
+test "user iter first-class iter next" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_iter_next", ctypes.c_int64);
+    assert f() == 1011;
+}
+
+test "user iter under map adapter" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_map_compose", ctypes.c_int64);
+    assert f() == 6;
+}
+
+test "user iter break mid-iteration" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_break", ctypes.c_int64);
+    assert f() == 3;
+}
+
+test "user iter crosses function boundary" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_cross_fn", ctypes.c_int64);
+    assert f() == 10;
+}
+
+# A non-StopIteration error from __next__ must propagate, not end the loop.
+test "user iter next non-stopiteration propagates" {
+    (eng, _) = compile_native("iter_user.na.jac");
+    f = get_func(eng, "user_next_propagates", ctypes.c_int64);
+    assert f() == 42;
+}


### PR DESCRIPTION
## Summary

Completes the **M2 "user iterators"** milestone of #6403: the native (`na {}` → LLVM) backend can now iterate over any `obj` that implements the iterator protocol (`__iter__`/`__next__`). Previously such a type type-checked but the backend rejected it with `Native pathway does not yet support for-loop iterable element type ...`.

A user iterator is **bridged into the same boxed `JacIter`** the builtin iterators already use, so it is a first-class citizen of the protocol rather than a special case:

- drives `for` loops,
- works with first-class `iter()` / `next()`,
- composes under the lazy `map()` adapter,
- and **crosses function boundaries** (returned or passed as `Iterator[T]`).

## How it works

- A new `UserIterState { i8* obj }` owns a +1 reference to the iterator object. Storing it as `i8*` means the existing generic struct destructor releases it and cascades into the object's own destructor — no bespoke teardown.
- A per-iterator-type next-fn invokes the user's `__next__` under a **local setjmp handler**. A `StopIteration` raised there becomes the protocol's `i1 0` end-of-iteration flag (no exception leaks into the loop); **any other exception is re-raised** to the enclosing handler. The next-fn carries the same `optnone`/`noinline` discipline `try`/`except` does.
- Both standard idioms are handled: a **self-iterator** (`__iter__` returns `self`) and a **re-iterable** whose `__iter__` returns a fresh cursor object. Ownership rides the existing invariant that every pointer a function returns is owned, so `__iter__`'s result needs no extra retain, while a borrowed self-iterator does.

## Incidental fix

The for-loop drive also leaked a first-class iterator that was an **owned temporary** (`for x in gen()`): nobody released it. The loop now releases it when `_is_owned`, while a borrowed iterator *variable* stays owned by its binding. Verified with an RSS leak probe (0 growth over 500k build-and-drop cycles).

## Tests

7 new cases in `test_native_iterators.jac` (fixture `iter_user.na.jac`): both idioms, a borrowed iterator variable, first-class `iter()`/`next()`, `map()` composition, `break` mid-iteration, cross-function `Iterator[int]`, and non-`StopIteration` propagation. The existing native iterator + GC suites stay green.

## Scope

`filter` / `enumerate` / `zip` over a *user* iterable still need the central type checker to bind the element typevar `_T` from a user type satisfying `Iterable[_T]` (a generic-inference capability in a separate subsystem) — left as a follow-up. `map` works today because its result element type comes from the mapping function, not the input. The pre-existing borrowed-container lifetime behavior of the builtin container iterators is also unchanged here.