### PR TITLE
fix(native): length-aware bytes concat and bytes()/bytearray() ctors (#6743)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6745.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6745.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Native `bytes` concatenation and the `bytes()`/`bytearray()` constructors**: `bytes + bytes` no longer crashes native code generation, and `bytes([...])`/`bytearray([...])` now return a length-aware value that preserves embedded NUL bytes, matching the interpreter.

--- a/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
@@ -6232,23 +6232,24 @@ impl NativeBuiltinEmitter.emit_frozenset(
 impl NativeBuiltinEmitter.emit_bytes(
     self, ctx: NativeEmitCtx, args: list[ir.Value]
 ) -> (ir.Value | None) {
-    # bytes(list_of_ints) -> i8* string from list elements
+    # bytes(list[int]) -> length-aware jacbytes struct (#6404 Track 0): allocate
+    # exactly list_len data bytes and store each trunc'd element. No NUL
+    # terminator — the length is carried explicitly so embedded 0x00 survives,
+    # mirroring the other byte-producing paths (struct.pack, file reads).
     if not args {
         return None;
     }
     p = ctx.pass_ref;
     b = get_builder(p);
     i8 = ir.IntType(8);
-    i8p = i8.as_pointer();
     i64 = ir.IntType(64);
     val = args[0];
-    # bytes(list[int]) -> convert each int element to a byte
     for (lk, lhelpers) in p.list_helpers.items() {
         ltype = p.list_types.get(lk);
         if ltype is not None and val.type == ltype.as_pointer() {
             list_len = b.call(lhelpers["len"], [val], name="bytes.len");
-            alloc_sz = b.add(list_len, ir.Constant(i64, 1), name="bytes.alloc");
-            buf = b.call(p.rc_alloc_fn, [alloc_sz], name="bytes.buf");
+            bv = p._bytes_alloc(list_len);
+            data = p._bytes_data_ptr(bv);
             func = b.basic_block.function;
             entry_bb = b.basic_block;
             loop_bb = func.append_basic_block(name="bytes.loop");
@@ -6263,16 +6264,13 @@ impl NativeBuiltinEmitter.emit_bytes(
             b.position_at_start(body_bb);
             elem = b.call(lhelpers["get"], [val, idx], name="bytes.elem");
             byte_val = b.trunc(elem, i8, name="bytes.trunc");
-            bp = b.gep(buf, [idx], name="bytes.bp");
+            bp = b.gep(data, [idx], name="bytes.bp");
             b.store(byte_val, bp);
             nidx = b.add(idx, ir.Constant(i64, 1), name="bytes.nidx");
             idx.add_incoming(nidx, body_bb);
             b.branch(loop_bb);
             b.position_at_start(done_bb);
-            # Null-terminate
-            end_ptr = b.gep(buf, [list_len], name="bytes.endptr");
-            b.store(ir.Constant(i8, 0), end_ptr);
-            return buf;
+            return bv;
         }
     }
     return None;
@@ -6281,7 +6279,7 @@ impl NativeBuiltinEmitter.emit_bytes(
 impl NativeBuiltinEmitter.emit_bytearray(
     self, ctx: NativeEmitCtx, args: list[ir.Value]
 ) -> (ir.Value | None) {
-    # bytearray(list_of_ints) -> same as bytes: i8* string
+    # bytearray(list_of_ints) -> same length-aware jacbytes value as bytes()
     return self.emit_bytes(ctx, args);
 }
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -884,6 +884,24 @@ impl NaIRGenPass._emit_binary_op(
         self._mark_owned(buf);
         return buf;
     }
+    # bytes concatenation (jacbytes* + jacbytes*) — check before numeric dispatch.
+    # bytes are the length-aware struct, not i8*, so the str branch above misses
+    # them; allocate len(a)+len(b) and memcpy both data regions (embedded NULs
+    # survive). _bytes_alloc marks the result owned, so the caller owns it (rc=1).
+    if op == Tok.PLUS and self._is_bytes_value(left) and self._is_bytes_value(right) {
+        i8p = ir.IntType(8).as_pointer();
+        i64 = ir.IntType(64);
+        llen = self._bytes_len_val(left);
+        rlen = self._bytes_len_val(right);
+        total = self.builder.add(llen, rlen, name="by.cat.total");
+        result = self._bytes_alloc(total);
+        dst = self._bytes_data_ptr(result);
+        memcpy_fn = self._get_or_declare_extern("memcpy", i8p, [i8p, i8p, i64]);
+        self.builder.call(memcpy_fn, [dst, self._bytes_data_ptr(left), llen]);
+        rdst = self.builder.gep(dst, [llen], name="by.cat.rdst");
+        self.builder.call(memcpy_fn, [rdst, self._bytes_data_ptr(right), rlen]);
+        return result;
+    }
     # String repeat (i8* * i64 or i64 * i8*): allocate n*len buffer, loop-copy
     if op == Tok.STAR_MUL {
         str_val: (ir.Value | None) = None;

--- a/jac/tests/compiler/passes/native/fixtures/bytes_ops.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/bytes_ops.na.jac
@@ -72,3 +72,33 @@ def empty_len() -> int {
     b = b"";
     return len(b);
 }
+
+def concat_len() -> int {
+    c = b"x" + b"y";
+    return len(c);
+}
+
+def concat_embedded_nul_len() -> int {
+    c = b"a\x00" + b"\x00b";
+    return len(c);
+}
+
+def concat_idx() -> int {
+    c = b"AB" + b"CD";
+    return c[2];
+}
+
+def ctor_len() -> int {
+    d = bytes([65, 0, 66]);
+    return len(d);
+}
+
+def ctor_idx_after_nul() -> int {
+    d = bytes([65, 0, 66]);
+    return d[2];
+}
+
+def bytearray_ctor_len() -> int {
+    d = bytearray([65, 0, 66]);
+    return len(d);
+}

--- a/jac/tests/compiler/passes/native/test_native_bytes_struct.jac
+++ b/jac/tests/compiler/passes/native/test_native_bytes_struct.jac
@@ -124,6 +124,43 @@ test "empty bytes length" {
     assert f() == 0;
 }
 
+# ─── bytes building: concatenation and the bytes()/bytearray() constructors ───
+test "bytes concat length" {
+    (eng, _) = compile_native("bytes_ops.na.jac");
+    f = get_func(eng, "concat_len", ctypes.c_int64);
+    assert f() == 2;
+}
+
+test "bytes concat keeps embedded NUL (length-aware)" {
+    (eng, _) = compile_native("bytes_ops.na.jac");
+    f = get_func(eng, "concat_embedded_nul_len", ctypes.c_int64);
+    assert f() == 4;
+}
+
+test "bytes concat copies right operand at correct offset" {
+    (eng, _) = compile_native("bytes_ops.na.jac");
+    f = get_func(eng, "concat_idx", ctypes.c_int64);
+    assert f() == 67;
+}
+
+test "bytes() constructor length counts bytes past NUL" {
+    (eng, _) = compile_native("bytes_ops.na.jac");
+    f = get_func(eng, "ctor_len", ctypes.c_int64);
+    assert f() == 3;
+}
+
+test "bytes() constructor byte after NUL is reachable" {
+    (eng, _) = compile_native("bytes_ops.na.jac");
+    f = get_func(eng, "ctor_idx_after_nul", ctypes.c_int64);
+    assert f() == 66;
+}
+
+test "bytearray() constructor length counts bytes past NUL" {
+    (eng, _) = compile_native("bytes_ops.na.jac");
+    f = get_func(eng, "bytearray_ctor_len", ctypes.c_int64);
+    assert f() == 3;
+}
+
 # ─── struct module: unpack / pack / calcsize ───
 test "struct unpack u32 little-endian" {
     (eng, _) = compile_native("struct_pack.na.jac");


### PR DESCRIPTION
## Summary

Fixes the two native-backend `bytes` defects reported in #6743. Both worked on **@sv** and broke only on **na**, violating the sv↔na congruence principle of #6404. Each is fixed in place by reusing the existing length-aware `bytes` infrastructure from #6727.

### Bug 1 — `bytes + bytes` crashed native codegen

A `bytes` value is the length-aware `%"jacbytes"*` struct pointer, not `i8*`, so `b1 + b2` missed the string-concat branch in `_emit_binary_op` and fell through to numeric dispatch, raising an uncaught `TypeError: Type of #1 arg mismatch: i64 != %"jacbytes"*` at compile time.

Added a bytes-concat branch (before numeric dispatch) that allocates `len(a)+len(b)` and `memcpy`s both data regions, reusing `_bytes_alloc` / `_bytes_data_ptr` / `_bytes_len_val`. Because field `+=` lowers through `_emit_binary_op`, augmented `+=` on a `bytes` field inherits the fix.

### Bug 2 — `bytes([ints])` silently returned the wrong length

`emit_bytes` still built the pre-#6727 NUL-terminated `i8*`, so `len(bytes([65, 0, 66]))` `strlen`'d the buffer and stopped at the first `0x00`, returning `1` instead of `3`.

Rebuilt `emit_bytes` on the length-aware struct (`_bytes_alloc` + store each `trunc`'d element, no NUL terminator) so embedded NULs survive and `len()` is exact. `emit_bytearray` delegates and is fixed too.

## Tests

Added six targeted tests to `test_native_bytes_struct.jac` (driven by new functions in the `bytes_ops.na.jac` fixture): concat length, concat with embedded NUL, concat right-operand offset, `bytes()` length past NUL, `bytes()` byte-after-NUL, and `bytearray()` length. All fail on `main` (Bug 1 crashes the fixture module; Bug 2 asserts the wrong length) and pass with this change. Full `test_native_bytes_struct.jac` suite is green (44 tests).

Repros from the issue now match @sv:

| repro | @sv | na before | na after |
|---|---|---|---|
| `b"x" + b"y"` → `len` | 2 | compile crash | 2 |
| `bytes([65, 0, 66])` → `len` | 3 | 1 | 3 |

Closes #6743.