### PR TITLE
test(e2e): fix flaky rendering test by dropping networkidle goto

### DIFF
--- a/docs/tests/e2e/test_code_blocks.jac
+++ b/docs/tests/e2e/test_code_blocks.jac
@@ -142,8 +142,17 @@ def _stop_server(server: any) {
     }
 }
 
-"""Start server, launch browser, navigate to test page, run callback(page, resp)."""
-def _with_page(callback: any, wait_until: str = "networkidle") {
+"""Start server, launch browser, navigate to test page, run callback(page, resp).
+
+Navigation waits for `domcontentloaded`, not `networkidle`. The fixture's
+`run-code.js` spawns the Pyodide web worker on `DOMContentLoaded`, so the page
+keeps pulling bytes from the CDN long after the DOM is ready and `networkidle`
+(500ms of zero network activity) is never reached within the `goto` timeout —
+flaking the fast rendering tests that don't even need Pyodide. Each test already
+waits on the specific element/condition it depends on (Monaco, Pyodide output,
+Viz SVG, response headers), so none relies on the network going idle.
+"""
+def _with_page(callback: any, wait_until: str = "domcontentloaded") {
     (server, base_url) = _start_server();
     try {
         with sync_playwright() as p {


### PR DESCRIPTION
## Summary

Fixes the intermittent `test-packages-and-docs` CI failure where `rendering: plain block buttons` timed out on `Page.goto` (30s).

Closes #6673.

## Root cause

`_with_page()` navigated with the default `wait_until="networkidle"`. `networkidle` only resolves after **500ms of zero network activity**, but the test fixture's `run-code.js` unconditionally spawns the **Pyodide web worker** on `DOMContentLoaded` — so the page keeps pulling bytes from the CDN (Pyodide is a large download) long after the DOM is ready. The network never goes idle within the 30s `goto` timeout, flaking the fast rendering tests that **don't even need Pyodide**.

Each test gets a fresh browser + server, so Pyodide is re-fetched cold every time, making this especially timing-sensitive on CI runners.

## Fix

Navigate with `domcontentloaded` instead of `networkidle`.

This is safe because **every test already waits on the specific element/condition it depends on** via explicit Playwright waits — none of them relies on the network going idle:

| Test | Explicit wait it relies on |
|------|----------------------------|
| rendering (buttons) | `wait_for_selector(".jcb-btn--run", timeout=MONACO_TIMEOUT)` |
| rendering (monaco) | `wait_for_selector(".monaco-editor")` + `wait_for_function(monaco.editor.getModels()...)` |
| headers | `resp.headers` (available immediately on goto) + `evaluate(SharedArrayBuffer)` |
| execution (run/error/disabled) | `wait_for_selector`/`wait_for_function` with `PYODIDE_TIMEOUT` (120s) |
| execution (graph) | `wait_for_selector(".graph-container .viz-viewport svg")` |

Changing the **default** hardens all nine tests rather than just the one that happened to flake — the execution tests were equally vulnerable (they got lucky on timing).

## Why not vendor the CDN scripts?

The issue offered a second option (vendor/stub the four CDN scripts). I didn't take it because:
- These CDNs are a genuine part of the production docs site (`docs/docs/index.html`), so vendoring would diverge the test fixture from prod.
- The libs are large (viz.js, monaco); stubbing them would break the monaco and graph tests that need the real libraries.
- `domcontentloaded` fully addresses the root cause (the networkidle + Pyodide-worker interaction) without touching fixture fidelity.

## Test plan

- [ ] `test-packages-and-docs` CI job passes (and stops flaking on the rendering test across multiple runs)
- [ ] All 9 E2E tests in `docs/tests/e2e/test_code_blocks.jac` pass

## Notes

- No release-note fragment added: the `check-release-notes` CI gate is scoped to the shipped code packages (`jac/jaclang/`, etc.); a `docs/tests/` change falls outside all mapped package folders, so no fragment is required or appropriate.