### PR TITLE
feat(scale): zero-config microservice mode + --no-image deploy

### DIFF
--- a/jac-scale/jac_scale/admin/impl/logs.impl.jac
+++ b/jac-scale/jac_scale/admin/impl/logs.impl.jac
@@ -102,7 +102,12 @@ def _app_name -> str {
 (no routes table or it's empty). Drives the per-mode forks below."""
 def _is_microservice_mode -> bool {
     try {
-        routes: dict = get_scale_config().get_microservices_config().get("routes", {});
+        import from jac_scale.microservices.discovery { resolve_microservices_config }
+        routes: dict = resolve_microservices_config(
+            get_scale_config().get_microservices_config(), "."
+        ).get(
+            "routes", {}
+        );
         return bool(routes);
     } except Exception {
         return False;
@@ -129,7 +134,10 @@ def _services_for_mode(microservice: bool, routes: dict, app_name: str) -> list[
 """Configured services list for the admin UI dropdown."""
 def _microservice_services -> list[str] {
     try {
-        ms = get_scale_config().get_microservices_config();
+        import from jac_scale.microservices.discovery { resolve_microservices_config }
+        ms = resolve_microservices_config(
+            get_scale_config().get_microservices_config(), "."
+        );
         routes: dict = ms.get("routes", {});
         return _services_for_mode(bool(routes), routes, _app_name());
     } except Exception {

--- a/jac-scale/jac_scale/admin/impl/traces.impl.jac
+++ b/jac-scale/jac_scale/admin/impl/traces.impl.jac
@@ -50,7 +50,10 @@ def _tempo_base_url -> str {
 """Configured microservice route keys + 'gateway'. Empty list off-K8s."""
 def _trace_services -> list[str] {
     try {
-        ms = get_scale_config().get_microservices_config();
+        import from jac_scale.microservices.discovery { resolve_microservices_config }
+        ms = resolve_microservices_config(
+            get_scale_config().get_microservices_config(), "."
+        );
         routes: dict = ms.get("routes", {});
         names: list[str] = list(routes.keys());
         return ["gateway"] + sorted(names);

--- a/jac-scale/jac_scale/microservices/cli/plan.jac
+++ b/jac-scale/jac_scale/microservices/cli/plan.jac
@@ -302,6 +302,13 @@ def _render_cluster_wide(bundle: Any, ms_cfg: Any) -> None {
         lines.append(f"  user_secret: {name} ({len(data)} keys)");
     }
 
+    scm = bundle.get("source_configmap") if isinstance(bundle, dict) else None;
+    if isinstance(scm, dict) {
+        name = sget(dget(scm, "metadata"), "name") or "?";
+        data = dget(scm, "data");
+        lines.append(f"  source_configmap: {name} ({len(data)} files, --no-image)");
+    }
+
     if not lines {
         return;
     }
@@ -360,6 +367,15 @@ obj Plan {
         bundle_raw = target.generate_manifests(app_config);
         bundle: dict = bundle_raw if isinstance(bundle_raw, dict) else {};
         (ms_cfg, svc_configs) = Plan._load_ms_cfg();
+
+        # Resolve zero-config routes from source so the plan's route column
+        # matches the pod specs the builder actually emitted (which also use
+        # discovery). Without this the plan would render discovered services
+        # as "internal-only" even though the gateway routes to them.
+        import from jac_scale.microservices.discovery { resolve_microservices_config }
+        ms_cfg = resolve_microservices_config(
+            ms_cfg, app_config.code_folder or ".", app_config.file_name
+        );
 
         routes_any: Any = ms_cfg.get("routes", {});
         routes: dict = {};
@@ -547,6 +563,10 @@ obj Plan {
         out: list = [];
         if self.bundle.get("user_secret") {
             out.append(self.bundle["user_secret"]);
+        }
+        # --no-image source ConfigMap, applied before Deployments mount it.
+        if self.bundle.get("source_configmap") {
+            out.append(self.bundle["source_configmap"]);
         }
         for key in ["pvcs", "deployments", "services", "pdbs"] {
             for m in dget(self.bundle, key).values() {

--- a/jac-scale/jac_scale/microservices/discovery.jac
+++ b/jac-scale/jac_scale/microservices/discovery.jac
@@ -1,0 +1,201 @@
+"""Zero-config service discovery for microservice mode.
+
+A project is a microservice app when it ships sibling `.jac` modules that
+expose server endpoints - i.e. a module with a `to sv:` section (or an
+explicit `sv def:pub` / `sv walker:pub` at module scope). Each such module
+is a service; the project entry-point is the gateway and is never itself a
+service. The gateway-facing route prefix is derived by convention
+(`derive_prefix`), identical to what `jac setup microservice` would write.
+
+This lets `[plugins.scale.microservices]` and its `routes` table be optional:
+`jac start main.jac` (local) and `jac start main.jac --scale` (K8s) both
+discover the same service set from source, with or without an explicit
+config block. An explicit routes block always wins - discovery only fills
+the gap when none is declared.
+
+Discovery is pure and memoized per (project_root, entry) so the hot config
+path - `get_microservices_config()` is read on every sv RPC for the timeout -
+parses the source tree at most once per process.
+"""
+
+import os;
+import logging;
+import from pathlib { Path }
+import jaclang.jac0core.unitree as uni;
+import from jaclang.jac0core.constant { SymbolAccess, Tokens as Tok }
+import from jac_scale.microservices.setup {
+    scan_jac_files,
+    derive_module_name,
+    derive_prefix
+}
+
+glob _logger = logging.getLogger(__name__),
+     # {cache_key: {module_name: prefix}}. cache_key folds project root + entry so
+     # a process that deploys several projects (tests) does not cross-pollinate.
+     _discovery_cache: dict[str, dict[str, str]] = {};
+
+
+"""Parse a single .jac file to its AST (no semantic analysis). None on any
+parse/read error - a malformed sibling must not break discovery for the
+rest of the project."""
+def _parse_module(file_path: str) -> any {
+    import from jaclang.jac0core.compiler { JacCompiler }
+    import from jaclang.jac0core.program { JacProgram }
+    import from jaclang.jac0core.helpers { read_file_with_encoding }
+    try {
+        src_text = read_file_with_encoding(file_path);
+        return JacCompiler().parse_str(
+            source_str=src_text, file_path=file_path, target_program=JacProgram()
+        );
+    } except Exception as e {
+        _logger.debug(f"discovery: could not parse {file_path}: {e}");
+        return None;
+    }
+}
+
+
+"""True if a `to sv:` block (or sv-prefixed element) body exposes at least
+one public ability or public walker - the HTTP-callable endpoints that make
+a module a service."""
+def _block_exposes_endpoint(body: any) -> bool {
+    for el in body {
+        if isinstance(el, uni.Ability) and el?.access_type == SymbolAccess.PUBLIC {
+            return True;
+        }
+        if (
+            isinstance(el, uni.Archetype)
+            and el?.arch_kind == "walker"
+            and el?.access_type == SymbolAccess.PUBLIC
+        ) {
+            return True;
+        }
+    }
+    return False;
+}
+
+
+"""True if `mod` declares server endpoints intended for the gateway.
+
+The intentional marker is an explicit server context: a `to sv:` ServerBlock
+(implicit block) or a top-level element carrying the `sv` prefix token. We do
+NOT treat a plain `def:pub` in a default-context `.jac` as a service marker -
+that would misclassify every ordinary server module (and the gateway itself)
+as a microservice. Only an explicit `sv` intent counts."""
+def _module_is_service(mod: any) -> bool {
+    if mod is None or not mod?.body {
+        return False;
+    }
+    for item in mod.body {
+        if isinstance(item, uni.ServerBlock) and _block_exposes_endpoint(item.body) {
+            return True;
+        }
+        # Explicit `sv def:pub` / `sv walker:pub` written as a single
+        # prefixed statement at module scope (no `to sv:` header). The
+        # parser left-attaches a KW_SERVER token onto the statement's kids.
+        if _block_exposes_endpoint([item]) {
+            for k in (item.kid or []) {
+                if isinstance(k, uni.Token) and k?.name == Tok.KW_SERVER {
+                    return True;
+                }
+            }
+        }
+    }
+    return False;
+}
+
+
+"""Resolve the project entry-point (the gateway) so it is excluded from the
+service set. Reads `[project].entry-point`; falls back to `main.jac`."""
+def _resolve_entry_stem(project_root: str, entry_file: str | None) -> str {
+    if entry_file {
+        return Path(entry_file).stem;
+    }
+    try {
+        import from jac_scale.config_loader { get_scale_config }
+        cfg = get_scale_config(Path(project_root)).get_jac_config();
+        ep = str(getattr(cfg, "entry_point", "") or "main.jac");
+        return Path(ep).stem;
+    } except Exception as e {
+        _logger.debug(f"discovery: entry-point resolution fell back to 'main': {e}");
+        return "main";
+    }
+}
+
+
+"""Discover the service modules of a project as a {module_name: prefix} map.
+
+Scans `project_root` for `.jac` modules that expose server endpoints,
+excludes the entry-point (gateway) and client/impl/native sources, and maps
+each surviving module name to its conventional gateway prefix. Memoized per
+(project_root, entry)."""
+def discover_services(
+    project_root: str = ".", entry_file: str | None = None
+) -> dict[str, str] {
+    abs_root = os.path.abspath(project_root);
+    entry_stem = _resolve_entry_stem(project_root, entry_file);
+    cache_key = f"{abs_root}::{entry_stem}";
+    if cache_key in _discovery_cache {
+        return dict(_discovery_cache[cache_key]);
+    }
+
+    routes: dict[str, str] = {};
+    for rel in scan_jac_files(project_root) {
+        # scan_jac_files already drops build/cache dirs; here we drop the
+        # codespaces that are never standalone services.
+        if rel.endswith((".cl.jac", ".impl.jac", ".na.jac", ".test.jac")) {
+            continue;
+        }
+        module_name = derive_module_name(rel);
+        if module_name == entry_stem {
+            continue;  # entry-point is the gateway, not a service
+        }
+        if module_name in routes {
+            continue;
+        }
+        mod = _parse_module(os.path.join(abs_root, rel));
+        if _module_is_service(mod) {
+            routes[module_name] = derive_prefix(module_name);
+        }
+    }
+
+    _discovery_cache[cache_key] = dict(routes);
+    if routes {
+        _logger.info(
+            f"Auto-discovered {len(routes)} microservice(s) from source: "
+            f"{', '.join(sorted(routes.keys()))}"
+        );
+    }
+    return dict(routes);
+}
+
+
+"""Fill an ms_config's `routes` (and flip `enabled`) from source discovery
+when no explicit routes table is declared.
+
+This is the single chokepoint for zero-config activation, called from the
+real start/deploy/runtime entry points (the `jac start` pre-hook, the K8s
+manifest builder, the in-pod gateway + sv-registry) rather than from the
+generic config reader - so a plain `get_microservices_config()` stays a pure
+config read with no filesystem scan. An explicit routes block always wins;
+discovery only fills the gap. Returns a new dict; the input is not mutated."""
+def resolve_microservices_config(
+    ms_config: dict[str, any], project_root: str = ".", entry_file: str | None = None
+) -> dict[str, any] {
+    out: dict[str, any] = dict(ms_config);
+    if out.get("routes") {
+        return out;  # explicit routes win; no discovery
+    }
+    discovered = discover_services(project_root, entry_file);
+    if discovered {
+        out["routes"] = discovered;
+        out["enabled"] = True;
+    }
+    return out;
+}
+
+
+"""Clear the discovery memo (tests, or after a source change in a long-lived
+process)."""
+def reset_discovery_cache {
+    _discovery_cache.clear();
+}

--- a/jac-scale/jac_scale/microservices/docs.md
+++ b/jac-scale/jac_scale/microservices/docs.md
@@ -82,7 +82,23 @@ sv {
 }
 ```
 
-### 2. Configure jac.toml
+### 2. Configure jac.toml (optional)
+
+Microservice mode is **zero-config**: with no `[plugins.scale.microservices]`
+block at all, `jac start` discovers every sibling module that has a `to sv:`
+(or `sv {}`) section, treats the entry-point as the gateway, and derives a
+route prefix per service by convention (`products_app` -> `/api/products`,
+`cart_app` -> `/api/cart`). The same discovery drives local runs and `--scale`
+deploys. So this is enough:
+
+```toml
+[project]
+name = "my_app"
+entry-point = "main.jac"
+```
+
+Declare a block only to override the conventions or add knobs. An explicit
+routes table always wins over discovery:
 
 ```toml
 [plugins.scale.microservices]
@@ -99,8 +115,9 @@ orders_app = "/api/orders"
 entry = "main.jac"
 ```
 
-Services are NOT declared individually - `sv import` handles discovery.
-The TOML only maps module names to gateway prefixes.
+Services are NOT declared individually - the `to sv:` marker (and
+`sv import`) handle discovery. The TOML only maps module names to gateway
+prefixes when you want non-default routing.
 
 ### 3. Start
 
@@ -139,10 +156,30 @@ jac scale restart cart_app               # restart one service
 jac scale logs products_app              # view logs
 jac scale destroy                        # stop everything
 
+# Deploy to Kubernetes
+jac start main.jac --scale                         # build per-app image + deploy
+jac start main.jac --scale --no-image              # imageless: source via ConfigMap
+
 # Preview before applying (no cluster contact, no docker build)
 jac start main.jac --scale --dry-run               # per-service plan + lint
 jac start main.jac --scale --dry-run --show-yaml   # + raw multi-doc YAML
+jac start main.jac --scale --no-image --dry-run    # preview the imageless plan
 ```
+
+### `--no-image`: deploy without building an image
+
+`--no-image` skips the per-app Docker build. It packs your project's
+`.jac`/`.toml` source into a Kubernetes ConfigMap mounted at `/app`, and
+runs a cached `jac-scale-base:<version>` image (built once per cluster from
+the installed jac-scale, reused on every later deploy). A code change just
+re-applies the ConfigMap and rolls the pods - a `JAC_SOURCE_HASH` env stamp
+forces the rollout. MongoDB/Redis are still provisioned as usual.
+
+Use it for fast iteration on local clusters. The source must fit a
+ConfigMap (~1 MB total); for larger projects, or ones that need extra
+OS/pip dependencies baked in, use the default build path (omit `--no-image`).
+Remote clusters need `[plugins.scale.kubernetes].image_registry` set so the
+base image can be pushed somewhere the nodes can pull it.
 
 `--dry-run` runs the same manifest generation as the real deploy but
 exits before any side effect. Sub-second. Default output is a

--- a/jac-scale/jac_scale/microservices/getting_started.md
+++ b/jac-scale/jac_scale/microservices/getting_started.md
@@ -40,26 +40,60 @@ before cleanup.
 
 ## Deploy your own app
 
-Minimum `jac.toml`:
+### Zero-config (recommended)
+
+You don't need a `[plugins.scale.microservices]` block at all. Minimum
+`jac.toml`:
 
 ```toml
 [project]
 name = "my_app"
 entry-point = "main.jac"
+```
 
-[plugins.scale.microservices]
-enabled = true
+A **service** is any sibling `.jac` module with a `to sv:` section that
+exposes a public endpoint:
 
+```jac
+# my_service.jac
+to sv:
+
+def:pub ping -> dict { return {"ok": true}; }
+```
+
+The entry-point (`main.jac`) is the **gateway** and is never itself a
+service. `jac start` discovers every `to sv:` module in the project, maps
+each to a conventional route prefix (`my_service` -> `/api/my_service`,
+`orders_app` -> `/api/orders`), and activates microservice mode - the same
+behavior locally and on Kubernetes:
+
+```bash
+jac start main.jac           # local: gateway + one subprocess per service
+jac start main.jac --scale   # K8s: gateway pod + one Deployment per service
+```
+
+To override the auto-derived prefixes (or add a service the scan can't
+reach), declare a routes block - it always wins over discovery:
+
+```toml
 [plugins.scale.microservices.routes]
 my_service = "/api/my"
 ```
 
-`my_service.jac` is a sibling file with `def:pub` functions discoverable
-via `sv import`. Then:
+### Deploy without building an image (`--no-image`)
 
 ```bash
-jac start main.jac --scale
+jac start main.jac --scale --no-image
 ```
+
+Instead of building a per-app Docker image, this ships your project source
+into a **ConfigMap** mounted at `/app` in every pod, running a cached
+`jac-scale-base:<version>` image (built once per cluster, reused after).
+No Dockerfile, no per-deploy build - a code change just re-applies the
+ConfigMap and rolls the pods (a `JAC_SOURCE_HASH` env stamp triggers the
+rollout). Best for fast iteration; the source must fit a ConfigMap (~1 MB).
+For large projects or ones needing extra OS/pip deps, use the default
+image-build path (drop `--no-image`).
 
 No Dockerfile, no registry config required for local clusters.
 `jac start --scale` detects your cluster type from kubeconfig, builds

--- a/jac-scale/jac_scale/microservices/images/base_image.jac
+++ b/jac-scale/jac_scale/microservices/images/base_image.jac
@@ -1,0 +1,177 @@
+"""Build-once jac-scale base image for `--no-image` deploys.
+
+`--scale --no-image` ships the project's source into the cluster via a
+ConfigMap (see manifest_builder._build_source_configmap) rather than baking
+it into a per-app image. The pods still need an image with `jac` + `jac-scale`
+installed to run that source - this module provides it.
+
+The base image carries ONLY the runtime (no user code), so it is identical
+across every app and every deploy of the same jac-scale version. We build it
+at most once per (version, cluster) and reuse it thereafter: the first
+`--no-image` deploy pays a one-time base build, every subsequent deploy - and
+every source change - is build-free (the change rides the ConfigMap).
+
+Distribution mirrors auto_build's per-cluster strategy: minikube builds into
+its own daemon via docker-env; k3d/kind build locally then import to nodes;
+remote clusters build + push to a registry.
+"""
+
+import logging;
+import tempfile;
+import from pathlib { Path }
+import from jac_scale.microservices.images.cluster_detect {
+    detect_cluster_type,
+    k3d_cluster_name,
+    kind_cluster_name,
+    _active_context_name,
+    get_minikube_docker_env,
+    CLUSTER_MINIKUBE,
+    CLUSTER_K3D,
+    CLUSTER_KIND,
+    CLUSTER_REMOTE,
+    CLUSTER_UNKNOWN
+}
+import from jac_scale.microservices.images.build_helpers {
+    run_docker_build,
+    run_docker_push,
+    run_k3d_image_import,
+    run_kind_image_load,
+    _docker_image_id
+}
+
+glob _logger = logging.getLogger(__name__),
+     # Runtime-only image: jac + jac-scale + jac-client, no user code. Mirrors the
+     # install layer of scripts/Dockerfile.microservice but omits `COPY . /app`.
+     _BASE_DOCKERFILE: str = "FROM python:3.12-slim\n\n"
+     "RUN apt-get update \\\n"
+     "    && apt-get install -y --no-install-recommends git curl \\\n"
+     "    && rm -rf /var/lib/apt/lists/*\n\n"
+     "RUN git config --system --add safe.directory '*'\n\n"
+     "RUN pip install --no-cache-dir --upgrade pip \\\n"
+     "    && pip install --no-cache-dir \\\n"
+     "        jaclang \\\n"
+     "        \"jac-scale[deploy,data,tracing]\" \\\n"
+     "        jac-client\n\n"
+     "WORKDIR /app\n"
+     "RUN jac --version\n"
+     "EXPOSE 8000\n";
+
+
+"""Installed jac-scale version, used to tag the base image so an upgrade
+rebuilds it. Falls back to 'latest' when metadata is unavailable."""
+def _base_image_version -> str {
+    try {
+        import from importlib.metadata { version }
+        return str(version("jac-scale"));
+    } except Exception {
+        return "latest";
+    }
+}
+
+
+"""Base image tag. Prefixed with the registry for remote clusters so the
+push target is well-formed; bare `jac-scale-base:<ver>` for local clusters."""
+def base_image_tag(registry_url: str | None = None) -> str {
+    tag = f"jac-scale-base:{_base_image_version()}";
+    if registry_url {
+        return f"{registry_url.rstrip('/')}/{tag}";
+    }
+    return tag;
+}
+
+
+"""Write the base Dockerfile into a fresh temp build context (no user code)
+and return (context_dir, dockerfile_path)."""
+def _write_base_context -> tuple[Path, Path] {
+    ctx = Path(tempfile.mkdtemp(prefix="jac-scale-base-"));
+    df = ctx / "Dockerfile";
+    df.write_text(_BASE_DOCKERFILE);
+    return (ctx, df);
+}
+
+
+"""Ensure a jac-scale base image is available to the active cluster and
+return its tag. Builds it once per (version, cluster) and reuses it after.
+
+`registry_url` is required for remote clusters (where the image must be
+pushed somewhere the nodes can pull from) and ignored for local clusters."""
+def ensure_base_image(registry_url: str | None = None, dry_run: bool = False) -> str {
+    if dry_run {
+        # Planning only: report the tag we *would* use without touching the
+        # docker daemon or cluster.
+        return base_image_tag(registry_url);
+    }
+    cluster_type = detect_cluster_type();
+    if cluster_type == CLUSTER_UNKNOWN {
+        raise RuntimeError(
+            "Could not detect a Kubernetes cluster for --no-image. Set up a "
+            "kubectl context first:\n"
+            "  - Local:  minikube start  (or k3d / kind)\n"
+            "  - Remote: aws eks update-kubeconfig / gcloud container clusters get-credentials"
+        );
+    }
+
+    if cluster_type == CLUSTER_MINIKUBE {
+        tag = base_image_tag();
+        env = get_minikube_docker_env();
+        if _docker_image_id(tag, env) {
+            _logger.info(f"Reusing cached base image {tag} (minikube daemon)");
+            return tag;
+        }
+        _logger.info(f"Building jac-scale base image {tag} (one-time, minikube)...");
+        (ctx, df) = _write_base_context();
+        run_docker_build(ctx, tag, df, {}, env);
+        return tag;
+    }
+
+    if cluster_type == CLUSTER_K3D {
+        cluster = k3d_cluster_name(_active_context_name());
+        tag = base_image_tag();
+        if not _docker_image_id(tag) {
+            _logger.info(f"Building jac-scale base image {tag} (one-time, k3d)...");
+            (ctx, df) = _write_base_context();
+            run_docker_build(ctx, tag, df, {});
+        } else {
+            _logger.info(f"Reusing cached base image {tag} (local daemon)");
+        }
+        # Import is idempotent and cheap; always run so a fresh cluster gets it.
+        run_k3d_image_import(tag, cluster);
+        return tag;
+    }
+
+    if cluster_type == CLUSTER_KIND {
+        cluster = kind_cluster_name(_active_context_name());
+        tag = base_image_tag();
+        if not _docker_image_id(tag) {
+            _logger.info(f"Building jac-scale base image {tag} (one-time, kind)...");
+            (ctx, df) = _write_base_context();
+            run_docker_build(ctx, tag, df, {});
+        } else {
+            _logger.info(f"Reusing cached base image {tag} (local daemon)");
+        }
+        run_kind_image_load(tag, cluster);
+        return tag;
+    }
+
+    # CLUSTER_REMOTE
+    if not registry_url {
+        raise RuntimeError(
+            "Remote K8s with --no-image needs a registry to host the base "
+            "image. Add to jac.toml:\n"
+            "  [plugins.scale.kubernetes]\n"
+            "  image_registry = \"my-registry.example.com/myorg\"\n"
+            "Or deploy to a local cluster (minikube/k3d/kind)."
+        );
+    }
+    tag = base_image_tag(registry_url);
+    if not _docker_image_id(tag) {
+        _logger.info(f"Building jac-scale base image {tag} (one-time, remote)...");
+        (ctx, df) = _write_base_context();
+        run_docker_build(ctx, tag, df, {});
+    } else {
+        _logger.info(f"Reusing cached base image {tag} (local daemon)");
+    }
+    # Push every deploy: a no-op when the registry already has the layers.
+    run_docker_push(tag);
+    return tag;
+}

--- a/jac-scale/jac_scale/plugin.jac
+++ b/jac-scale/jac_scale/plugin.jac
@@ -30,6 +30,20 @@ def _scale_pre_hook(context: HookContext) -> None {
     ms_config = scale_config.get_microservices_config();
     is_sv_sibling = os.environ.get("JAC_SV_SIBLING") == "1";
 
+    # Zero-config: if no explicit routes block is declared, auto-discover the
+    # service set from source (modules with `to sv:` endpoints) relative to
+    # the entry file's directory. This makes `[plugins.scale.microservices]`
+    # optional - a `sv import` app activates microservice mode by its source
+    # shape alone. An explicit routes block always wins.
+    if not is_sv_sibling {
+        ms_filename = context.get_arg("filename");
+        ms_project_root = (os.path.dirname(ms_filename) or '.') if ms_filename else '.';
+        import from jac_scale.microservices.discovery { resolve_microservices_config }
+        ms_config = resolve_microservices_config(
+            ms_config, ms_project_root, ms_filename
+        );
+    }
+
     if ms_config.get("enabled", False) and not is_sv_sibling {
         scale_flag = context.get_arg("scale", False);
         if not scale_flag {
@@ -142,6 +156,7 @@ def _scale_pre_hook(context: HookContext) -> None {
         # --dry-run cancels execution before the deploy. auto_build and
         # guard_fallback_image stay at their defaults (False) so
         # generate_manifests never tries to build an image.
+        no_image = context.get_arg("no_image", False);
         dry_run = context.get_arg("dry_run", False);
         if dry_run {
             if target != "kubernetes-microservice" {
@@ -151,6 +166,13 @@ def _scale_pre_hook(context: HookContext) -> None {
                 context.set_data("cancel_execution", True);
                 context.set_data("cancel_return_code", 1);
                 return;
+            }
+            # Reflect --no-image in the plan (source ConfigMap + base image
+            # tag) without building anything: dry_run short-circuits the base
+            # build in _base_image.
+            if no_image {
+                deployment_target.no_image = True;
+                deployment_target.dry_run = True;
             }
             show_yaml: bool = bool(context.get_arg("show_yaml", False));
             try {
@@ -176,8 +198,17 @@ def _scale_pre_hook(context: HookContext) -> None {
         # build=False for manifest-shape assertions construct the
         # target without these flags and fall through to parent behavior.
         if target == "kubernetes-microservice" {
-            deployment_target.auto_build = True;
-            deployment_target.guard_fallback_image = True;
+            if no_image {
+                # Imageless deploy: project source rides into a cached
+                # jac-scale base image via a ConfigMap. No per-app docker
+                # build. auto_build stays off; the base image is resolved
+                # (built-once + cached) by the target.
+                deployment_target.no_image = True;
+                deployment_target.guard_fallback_image = True;
+            } else {
+                deployment_target.auto_build = True;
+                deployment_target.guard_fallback_image = True;
+            }
         }
 
         # Deploy. Cancel execution on failure so we don't fall through to
@@ -312,6 +343,13 @@ class JacCmd {
                     default=False,
                     help="Build and push Docker image (with --scale)",
                     short="b"
+                ),
+                Arg.create(
+                    "no-image",
+                    typ=bool,
+                    default=False,
+                    help="Deploy without building a Docker image: ship project source via a ConfigMap into a cached jac-scale base image (with --scale)",
+                    short=""
                 ),
                 Arg.create(
                     "experimental",
@@ -658,18 +696,29 @@ class JacCmd {
             import from jac_scale.microservices.local_deployer { LocalDeployer }
 
             scale_config = get_scale_config();
-            ms_config = scale_config.get_microservices_config();
+            import from jac_scale.microservices.discovery {
+                resolve_microservices_config
+            }
+            # Resolve routes from source discovery (cwd) when no explicit
+            # routes block is declared, so `jac scale ...` and the in-pod
+            # `jac scale gateway` work zero-config.
+            ms_config = resolve_microservices_config(
+                scale_config.get_microservices_config(), "."
+            );
 
             if not ms_config.get("enabled", False) {
                 console.print(
-                    "Microservice mode is not enabled in jac.toml", style="error"
+                    "Microservice mode is not active: no [plugins.scale.microservices] "
+                    "routes block and no services discovered in the project "
+                    "(a service is a `.jac` module with a `to sv:` endpoint).",
+                    style="error"
                 );
                 return 1;
             }
 
             if not ms_config.get("routes", {}) {
                 console.print(
-                    "No routes configured in [plugins.scale.microservices.routes]",
+                    "No microservices found (no routes block, no `to sv:` modules).",
                     style="error"
                 );
                 return 1;
@@ -945,13 +994,20 @@ class JacScalePlugin {
             return dict(sv_client._registry);
         }
 
-        # K8s mode: build DNS map from configured routes.
+        # K8s mode: build DNS map from configured routes. Routes are resolved
+        # from source discovery (cwd == /app in-pod) when no explicit routes
+        # block is declared, so zero-config apps still resolve peers via DNS.
         try {
             import from jac_scale.config_loader { get_scale_config }
+            import from jac_scale.microservices.discovery {
+                resolve_microservices_config
+            }
             import from jac_scale.targets.kubernetes.microservice.runtime_resolver {
                 build_k8s_registry
             }
-            ms_cfg = get_scale_config().get_microservices_config();
+            ms_cfg = resolve_microservices_config(
+                get_scale_config().get_microservices_config(), "."
+            );
             routes: dict[str, str] = ms_cfg.get("routes", {});
             port: int = int(ms_cfg.get("gateway_port", 8000));
             return build_k8s_registry(routes, port);

--- a/jac-scale/jac_scale/targets/kubernetes/microservice/manifest_builder.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/microservice/manifest_builder.jac
@@ -13,7 +13,33 @@ import from jac_scale.abstractions.autoscaler { DEFAULT_CPU_UTILIZATION_TARGET }
 glob GATEWAY_NAME: str = "__gateway__",
      # +5s cushion lets uvicorn finish exiting AFTER our drain middleware
      # completes; without it, SIGKILL can arrive mid-drain.
-     _UVICORN_EXIT_CUSHION_S: int = 5;
+     _UVICORN_EXIT_CUSHION_S: int = 5,
+     # Name of the volume that mounts --no-image project source at /app.
+     _SOURCE_VOLUME_NAME: str = "jac-source",
+     # K8s ConfigMap objects cap at ~1Mi total. Stay under it with headroom
+     # for the apiserver's own encoding overhead; over this we fail loud and
+     # tell the user to use an image build instead.
+     _SOURCE_CONFIGMAP_MAX_BYTES: int = 950000,
+     # Source file extensions shipped in the --no-image ConfigMap: everything
+     # jac needs to compile + run the project. Build artifacts / binaries are
+     # excluded by extension and by the dir filter in scan.
+     _SOURCE_FILE_EXTS: list[str] = [".jac", ".toml", ".env", ".txt"];
+
+
+"""Sanitize a project-relative path into a valid ConfigMap data key
+([-._a-zA-Z0-9]). The real directory layout is restored at mount time via
+the volume's items[].path, so the key only needs to be unique + valid."""
+def _sanitize_cm_key(rel_path: str) -> str {
+    out: str = "";
+    for ch in rel_path {
+        if ch.isalnum() or ch in "-._" {
+            out += ch;
+        } else {
+            out += "_";
+        }
+    }
+    return out or "f";
+}
 
 
 """DNS-1123-valid K8s resource name. Module level so
@@ -30,12 +56,55 @@ obj MicroserviceManifestBuilder {
     has k8s_config: KubernetesConfig,
         secrets: dict[str, str] = {},
         deploy_context: DeployContext = DeployContext(),
-        logger: any = None;
+        logger: any = None,
+        # Project root + entry file used for zero-config route discovery when
+        # no explicit [plugins.scale.microservices.routes] block is declared.
+        # Set by generate_manifests() from the AppConfig; default to cwd so
+        # direct callers (tests) still resolve sensibly.
+        project_root: str = ".",
+        entry_file: str | None = None,
+        # `--no-image`: mount project source from a ConfigMap into a base
+        # image instead of baking a per-app image. Adds a source ConfigMap to
+        # the bundle and a /app volume mount to every pod.
+        no_image: bool = False,
+        # {relative_path: sanitized_configmap_key}, populated by
+        # _build_source_configmap and read by the per-pod source volume so
+        # items[].path can restore the real directory layout.
+        _source_key_map: dict[str, str] = {},
+        # Short content hash of the --no-image source set, stamped into pods
+        # as JAC_SOURCE_HASH so a code change rolls the Deployments (a
+        # ConfigMap edit alone does not change the pod template otherwise).
+        _source_hash: str = "";
+
+    """Microservices config with routes resolved from source discovery when
+    no explicit routes table is declared (zero-config). Memoized in
+    discovery, so repeated calls in a single build are cheap."""
+    def _resolved_ms_config -> dict[str, any] {
+        import from jac_scale.config_loader { get_scale_config }
+        import from jac_scale.microservices.discovery { resolve_microservices_config }
+        return resolve_microservices_config(
+            get_scale_config().get_microservices_config(),
+            self.project_root,
+            self.entry_file
+        );
+    }
 
     """Lift pod-specs into full Deployment + Service + HPA + PDB
     bundle. Returns `{deployments, services, autoscalers, pdbs, pod_specs}`,
     plus optional `pvcs`, `user_secret`, `ingress`."""
     def generate_manifests(app_config: AppConfig, image: str) -> dict[str, any] {
+        # Anchor zero-config route discovery to the deploy's project dir so
+        # an app with no explicit routes block still fans out one pod per
+        # discovered service.
+        if app_config.code_folder {
+            self.project_root = app_config.code_folder;
+        }
+        if app_config.file_name {
+            self.entry_file = app_config.file_name;
+        }
+        # Build the source ConfigMap first (when --no-image) so its key map is
+        # populated before pod specs request the /app source volume.
+        source_configmap = self._build_source_configmap();
         pod_specs = self.generate_service_pod_specs(app_config, image);
         deployments: dict[str, dict[str, any]] = {};
         services: dict[str, dict[str, any]] = {};
@@ -70,6 +139,9 @@ obj MicroserviceManifestBuilder {
         user_secret = self._build_user_secret_manifest();
         if user_secret is not None {
             bundle["user_secret"] = user_secret;
+        }
+        if source_configmap is not None {
+            bundle["source_configmap"] = source_configmap;
         }
         try {
             import from jac_scale.config_loader { get_scale_config }
@@ -113,15 +185,15 @@ obj MicroserviceManifestBuilder {
     ) -> dict[str, dict[str, any]] {
         app_name = app_config.app_name or self.k8s_config.app_name;
 
-        import from jac_scale.config_loader { get_scale_config }
-        ms_cfg = get_scale_config().get_microservices_config();
+        ms_cfg = self._resolved_ms_config();
         routes: dict[str, str] = ms_cfg.get("routes", {});
 
         if not routes {
             raise ValueError(
-                "[plugins.scale.microservices.routes] is empty in jac.toml. "
-                "Microservice mode needs at least one declared service.\n"
-                "Add to your jac.toml:\n"
+                "No microservices found. Microservice mode needs at least "
+                "one service - a `.jac` module with a `to sv:` section that "
+                "exposes a public endpoint, sitting next to your entry file.\n"
+                "Either add such a module, or declare routes explicitly:\n"
                 "  [plugins.scale.microservices.routes]\n"
                 "  my_service = \"/api/my\"\n"
                 "where 'my_service' is the name of a .jac file in the "
@@ -325,6 +397,167 @@ obj MicroserviceManifestBuilder {
         return f"{self.k8s_config.app_name}-secrets";
     }
 
+    """Name of the ConfigMap holding project source for --no-image deploys."""
+    def _source_configmap_name -> str {
+        return f"{self.k8s_config.app_name}-source";
+    }
+
+    """Collect (relative_path, text) for every source file under the project
+    root that jac needs to compile + run. Excludes build/cache dirs and
+    non-source extensions. Mirrors the .dockerignore intent of an image build."""
+    def _collect_source_files -> list[tuple[str, str]] {
+        import os;
+        import from pathlib { Path }
+        base = Path(self.project_root).resolve();
+        exclude_dirs: set[str] = {
+            ".jac",
+            "__pycache__",
+            "node_modules",
+            ".git",
+            ".github",
+            ".vscode",
+            ".idea",
+            "dist",
+            "build",
+            ".venv",
+            "venv",
+            ".pytest_cache",
+            ".mypy_cache",
+            ".ruff_cache"
+        };
+        out: list[tuple[str, str]] = [];
+        for path in sorted(base.rglob("*")) {
+            if not path.is_file() {
+                continue;
+            }
+            rel = path.relative_to(base);
+            rel_parts = rel.parts;
+            should_skip = False;
+            for part in rel_parts {
+                if part in exclude_dirs {
+                    should_skip = True;
+                }
+            }
+            if should_skip {
+                continue;
+            }
+            # Match by suffix, including double extensions (.cl.jac, .impl.jac).
+            name = path.name;
+            ok = False;
+            for ext in _SOURCE_FILE_EXTS {
+                if name.endswith(ext) {
+                    ok = True;
+                }
+            }
+            if not ok {
+                continue;
+            }
+            try {
+                text = path.read_text();
+            } except Exception {
+                # Binary or unreadable file with a matching suffix: skip it
+                # rather than corrupt the ConfigMap.
+                continue;
+            }
+            out.append((rel.as_posix(), text));
+        }
+        return out;
+    }
+
+    """Source ConfigMap for --no-image deploys: each project source file as a
+    data entry, keyed by a sanitized path. Returns None when --no-image is
+    off. Raises if the source exceeds the ConfigMap size ceiling (the user
+    should switch to an image build for a project that large)."""
+    def _build_source_configmap -> dict[str, any] | None {
+        if not self.no_image {
+            return None;
+        }
+        files = self._collect_source_files();
+        if not files {
+            raise ValueError(
+                f"--no-image found no source files under '{self.project_root}'. "
+                "Run the deploy from your project directory."
+            );
+        }
+        import hashlib;
+        hasher = hashlib.sha256();
+        data: dict[str, str] = {};
+        key_for_path: dict[str, str] = {};
+        used_keys: set[str] = set();
+        total: int = 0;
+        for (rel, text) in files {
+            hasher.update(rel.encode("utf-8"));
+            hasher.update(b"\x00");
+            hasher.update(text.encode("utf-8"));
+            total += len(text.encode("utf-8"));
+            key = _sanitize_cm_key(rel);
+            # Disambiguate sanitize-collisions (a/b.jac vs a-b.jac).
+            base_key = key;
+            i: int = 1;
+            while key in used_keys {
+                key = f"{base_key}.{i}";
+                i += 1;
+            }
+            used_keys.add(key);
+            data[key] = text;
+            key_for_path[rel] = key;
+        }
+        if total > _SOURCE_CONFIGMAP_MAX_BYTES {
+            raise ValueError(
+                f"--no-image project source is {total} bytes, over the "
+                f"{_SOURCE_CONFIGMAP_MAX_BYTES}-byte ConfigMap ceiling. "
+                "Deploy with an image build instead (drop --no-image; "
+                "`jac start --scale` auto-builds), which has no size limit."
+            );
+        }
+        if self.logger {
+            self.logger.info(
+                f"Packed {len(files)} source file(s) ({total} bytes) into "
+                f"ConfigMap '{self._source_configmap_name()}' for --no-image deploy"
+            );
+        }
+        # Stash the key map so the per-pod volume can restore the directory
+        # layout via items[].path, and the content hash so pods roll on a
+        # source change.
+        self._source_key_map = key_for_path;
+        self._source_hash = hasher.hexdigest()[:12];
+        return {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": self._source_configmap_name(),
+                "namespace": self.k8s_config.namespace,
+                "labels": {
+                    "app": "jac-scale-source",
+                    "managed": "jac-scale",
+                    "jac-scale.role": "source"
+                }
+            },
+            "data": data
+        };
+    }
+
+    """(volume, volumeMount) that project the source ConfigMap onto /app.
+    Empty tuple when --no-image is off. items[].path restores the real
+    directory layout from the sanitized keys."""
+    def _source_volume_and_mount(
+        key_map: dict[str, str]
+    ) -> tuple[list[dict[str, any]], list[dict[str, any]]] {
+        if not self.no_image or not key_map {
+            return ([], []);
+        }
+        items: list[dict[str, any]] = [];
+        for (rel, key) in key_map.items() {
+            items.append({"key": key, "path": rel});
+        }
+        volume = {
+            "name": _SOURCE_VOLUME_NAME,
+            "configMap": {"name": self._source_configmap_name(), "items": items}
+        };
+        mount = {"name": _SOURCE_VOLUME_NAME, "mountPath": "/app"};
+        return ([volume], [mount]);
+    }
+
     """ServiceAccount; empty -> namespace default SA. Microservice mode
     does NOT auto-provision SA - apps point this at a pre-bound one."""
     def _service_account_name -> str {
@@ -335,9 +568,7 @@ obj MicroserviceManifestBuilder {
     _build_env for `JAC_SV_<PEER>_URL` injection. Returns {} on read failure."""
     def _microservice_routes -> dict[str, str] {
         try {
-            import from jac_scale.config_loader { get_scale_config }
-            ms_cfg = get_scale_config().get_microservices_config();
-            return dict(ms_cfg.get("routes", {}));
+            return dict(self._resolved_ms_config().get("routes", {}));
         } except Exception {
             return {};
         }
@@ -369,6 +600,13 @@ obj MicroserviceManifestBuilder {
             {"name": "K8S_APP_NAME", "value": self.k8s_config.app_name},
             {"name": "K8S_NAMESPACE", "value": self.k8s_config.namespace}
         ];
+
+        # --no-image: stamp the source content hash so a code change (new
+        # ConfigMap) rolls the Deployment - a ConfigMap volume update alone
+        # does not mutate the pod template.
+        if self.no_image and self._source_hash {
+            env.append({"name": "JAC_SOURCE_HASH", "value": self._source_hash});
+        }
 
         # When tracing is enabled, point pods at the in-cluster Alloy OTLP
         # receiver. Added before user env so a per-service override wins.
@@ -758,8 +996,12 @@ obj MicroserviceManifestBuilder {
             container["resources"] = resources;
         }
         (shared_vols, shared_mounts) = self._shared_volumes_for_service(svc_name);
-        if shared_mounts {
-            container["volumeMounts"] = shared_mounts;
+        (source_vols, source_mounts) = self._source_volume_and_mount(
+            self._source_key_map
+        );
+        all_mounts = source_mounts + shared_mounts;
+        if all_mounts {
+            container["volumeMounts"] = all_mounts;
         }
         # envFrom for the user secret: created BEFORE Deployments in
         # apply_manifests so the secretRef resolves at pod startup.
@@ -774,8 +1016,9 @@ obj MicroserviceManifestBuilder {
         if sa_name {
             spec["serviceAccountName"] = sa_name;
         }
-        if shared_vols {
-            spec["volumes"] = shared_vols;
+        all_vols = source_vols + shared_vols;
+        if all_vols {
+            spec["volumes"] = all_vols;
         }
         if self.deploy_context.init_containers {
             spec["initContainers"] = list(self.deploy_context.init_containers);

--- a/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
+++ b/jac-scale/jac_scale/targets/kubernetes/microservice/target.jac
@@ -54,11 +54,23 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         # path. Test path keeps them False -> parent KubernetesTarget
         # behavior (build_via_registry / python_image fallback).
         auto_build: bool = False,
-        guard_fallback_image: bool = False;
+        guard_fallback_image: bool = False,
+        # `--no-image`: deploy project source via a ConfigMap into a cached
+        # jac-scale base image instead of building a per-app image. Mutually
+        # exclusive with auto_build (the pre-hook sets one or the other).
+        no_image: bool = False,
+        # --dry-run: resolve the base image tag for the plan without building
+        # or touching the cluster.
+        dry_run: bool = False;
 
     """Auto-build path when `auto_build=True`: prefer user's pre-built
     docker_image_name, else auto_build_and_distribute. Else parent behavior."""
     def _handle_image_registry(app_name: str, app_config: AppConfig) -> str {
+        if self.no_image {
+            # Imageless: pods run the cached jac-scale base image; user code
+            # is mounted from a ConfigMap (built in generate_manifests).
+            return self._base_image();
+        }
         if self.auto_build {
             user_image = self.k8s_config.docker_image_name;
             if user_image and user_image != f"{app_name}:latest" {
@@ -78,30 +90,37 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         return KubernetesTarget._handle_image_registry(self, app_name, app_config);
     }
 
-    """Reads image_registry from raw config (KubernetesConfig.from_dict
-    drops unknown keys so we can't go via the typed view) and hands off
-    to the cluster-aware auto-build pipeline."""
+    """image_registry from raw [plugins.scale.kubernetes] config.
+    KubernetesConfig.from_dict drops unknown keys, so the typed view would
+    lose this. Empty/missing -> None (fine for local; remote needs it)."""
+    def _registry_url -> str | None {
+        try {
+            import from jac_scale.config_loader { get_scale_config }
+            raw = get_scale_config().load();
+            k8s_raw = raw.get("kubernetes", {});
+            return str(k8s_raw.get("image_registry", "")).strip();
+        } except Exception {
+            return None;
+        }
+    }
+
+    """Resolve (build-once + cache) the jac-scale base image for --no-image."""
+    def _base_image -> str {
+        import from jac_scale.microservices.images.base_image { ensure_base_image }
+        image_tag = ensure_base_image(self._registry_url(), dry_run=self.dry_run);
+        if self.logger {
+            self.logger.info(f"Using jac-scale base image: {image_tag}");
+        }
+        return image_tag;
+    }
+
     def _auto_build_image(app_name: str, app_config: AppConfig) -> str {
         import from pathlib { Path }
         import from jac_scale.microservices.images.auto_build {
             auto_build_and_distribute
         }
 
-        # Read image_registry directly from raw [plugins.scale.kubernetes]
-        # config; KubernetesConfig.from_dict drops unknown keys, so going
-        # via the typed view would lose this. Empty/missing -> None,
-        # which is fine for local clusters and signals "needs registry"
-        # for remote.
-        registry_url: str | None = None;
-        try {
-            import from jac_scale.config_loader { get_scale_config }
-            raw = get_scale_config().load();
-            k8s_raw = raw.get("kubernetes", {});
-            reg = str(k8s_raw.get("image_registry", "")).strip();
-            registry_url = reg;
-        } except Exception {
-            registry_url = None;
-        }
+        registry_url: str | None = self._registry_url();
 
         project_dir = Path(app_config.code_folder).resolve();
         if self.logger {
@@ -137,8 +156,13 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         # pod-spec. Skipped silently in tests (no kube config / not on a
         # real cluster); the provisioning helper is idempotent for re-deploys.
         try {
+            # Provision on any production deploy path: image auto-build OR
+            # imageless (--no-image). Both run real pods that need the DBs;
+            # only the flagless test path (both False) skips provisioning.
             self._deploy_context = MicroserviceDatabaseProvisioner(
-                k8s_target=self, logger=self.logger, enabled=self.auto_build
+                k8s_target=self,
+                logger=self.logger,
+                enabled=self.auto_build or self.no_image
             ).provision(
                 app_name
             );
@@ -391,7 +415,8 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
             k8s_config=self.k8s_config,
             secrets=self.secrets,
             deploy_context=self._deploy_context,
-            logger=self.logger
+            logger=self.logger,
+            no_image=self.no_image
         );
         return builder.generate_manifests(app_config, image);
     }
@@ -490,6 +515,22 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
                     f"Applied Secret for user-defined [plugins.scale.secrets] "
                     f"({len(user_secret['stringData'])} keys)",
                     {"name": user_secret["metadata"]["name"]}
+                );
+            }
+        }
+
+        # Source ConfigMap (--no-image): applied before Deployments so the
+        # /app volume resolves at pod startup. A rolled ConfigMap triggers a
+        # rollout via the content hash stamped into the pod template.
+        source_configmap = bundle.get("source_configmap");
+        if source_configmap {
+            self._apply_or_replace_configmap(core_v1, namespace, source_configmap);
+            if self.logger {
+                self.logger.info(
+                    f"Applied source ConfigMap '{source_configmap['metadata'][
+                        'name'
+                    ]}' "
+                    f"({len(source_configmap.get('data', {}))} files)"
                 );
             }
         }
@@ -692,6 +733,26 @@ obj KubernetesMicroserviceTarget(KubernetesTarget) {
         } except ApiException as e {
             if e.status == 404 {
                 core_v1.create_namespaced_service(namespace=namespace, body=manifest);
+            } else {
+                raise;
+            }
+        }
+    }
+
+    def _apply_or_replace_configmap(
+        core_v1: any, namespace: str, manifest: dict[str, any]
+    ) {
+        name: str = manifest["metadata"]["name"];
+        try {
+            core_v1.read_namespaced_config_map(name=name, namespace=namespace);
+            core_v1.replace_namespaced_config_map(
+                name=name, namespace=namespace, body=manifest
+            );
+        } except ApiException as e {
+            if e.status == 404 {
+                core_v1.create_namespaced_config_map(
+                    namespace=namespace, body=manifest
+                );
             } else {
                 raise;
             }

--- a/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/counter_app.jac
+++ b/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/counter_app.jac
@@ -1,0 +1,10 @@
+"""Counter service. `_app` suffix exercises derive_prefix stripping."""
+glob _n: int = 0;
+
+to sv:
+
+def:pub bump -> dict {
+    global _n;
+    _n += 1;
+    return {"count": _n};
+}

--- a/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/greeter.jac
+++ b/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/greeter.jac
@@ -1,0 +1,6 @@
+"""Greeter service (no config block - discovered by `to sv:`)."""
+to sv:
+
+def:pub greet(name: str) -> dict {
+    return {"msg": f"Hello, {name}!"};
+}

--- a/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/jac.toml
+++ b/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/jac.toml
@@ -1,0 +1,3 @@
+[project]
+name = "zeroconf-shop"
+entry-point = "main.jac"

--- a/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/main.jac
+++ b/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/main.jac
@@ -1,0 +1,8 @@
+"""Gateway entry. sv-imports a service; itself never a service."""
+sv import from greeter { greet }
+
+to sv:
+
+def:pub hello -> dict {
+    return greet("world");
+}

--- a/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/models.jac
+++ b/jac-scale/jac_scale/tests/fixtures/zeroconf_ms/models.jac
@@ -1,0 +1,4 @@
+"""Pure data module - NOT a service (no `to sv:` endpoints)."""
+node Tally {
+    has total: int = 0;
+}

--- a/jac-scale/jac_scale/tests/test_zeroconf_microservice.jac
+++ b/jac-scale/jac_scale/tests/test_zeroconf_microservice.jac
@@ -1,0 +1,156 @@
+"""Tests for zero-config microservice mode: source-driven service discovery
+(no [plugins.scale.microservices] block), route auto-fill, and the
+--no-image ConfigMap source-injection deploy path."""
+
+import os;
+import from pathlib { Path }
+import from jac_scale.microservices.discovery {
+    discover_services,
+    resolve_microservices_config,
+    reset_discovery_cache
+}
+import from jac_scale.targets.kubernetes.microservice.manifest_builder {
+    MicroserviceManifestBuilder
+}
+import from jac_scale.targets.kubernetes.kubernetes_config { KubernetesConfig }
+import from jac_scale.microservices.images.base_image { base_image_tag }
+
+
+glob _FIXTURE: str = os.path.join(
+         os.path.dirname(__file__), "fixtures", "zeroconf_ms"
+     );
+
+
+# --------------------------------------------------------------------------
+# Discovery
+# --------------------------------------------------------------------------
+test "discover_services finds `to sv:` modules and excludes the entry/gateway" {
+    reset_discovery_cache();
+    routes = discover_services(_FIXTURE);
+    # greeter + counter_app are services; main (entry) and models (pure data)
+    # are not.
+    assert set(routes.keys()) == {"greeter", "counter_app"} , f"got {routes}";
+}
+
+test "discover_services derives conventional prefixes (strips _app)" {
+    reset_discovery_cache();
+    routes = discover_services(_FIXTURE);
+    assert routes["greeter"] == "/api/greeter";
+    assert routes["counter_app"] == "/api/counter";
+}
+
+test "discover_services excludes a module passed as the explicit entry file" {
+    reset_discovery_cache();
+    # Pretend greeter is the entry: it should drop out of the service set.
+    routes = discover_services(_FIXTURE, entry_file="greeter.jac");
+    assert "greeter" not in routes;
+    assert "counter_app" in routes;
+}
+
+test "discover_services returns {} for a project with no `to sv:` modules" {
+    import tempfile;
+    reset_discovery_cache();
+    tmp = tempfile.mkdtemp(prefix="zc-noservices-");
+    # A lone data module (no `to sv:` endpoints) is not a service.
+    (Path(tmp) / "models.jac").write_text("node Tally { has total: int = 0; }\n");
+    routes = discover_services(tmp, entry_file="main.jac");
+    assert routes == {} , f"expected no services, got {routes}";
+}
+
+
+# --------------------------------------------------------------------------
+# resolve_microservices_config
+# --------------------------------------------------------------------------
+test "resolve fills routes + enables when none declared (zero-config)" {
+    reset_discovery_cache();
+    resolved = resolve_microservices_config({"enabled": False, "routes": {}}, _FIXTURE);
+    assert resolved["enabled"] is True;
+    assert set(resolved["routes"].keys()) == {"greeter", "counter_app"};
+}
+
+test "resolve leaves an explicit routes block untouched (no discovery)" {
+    reset_discovery_cache();
+    explicit = {"enabled": True, "routes": {"only_app": "/api/only"}};
+    resolved = resolve_microservices_config(explicit, _FIXTURE);
+    assert resolved["routes"] == {"only_app": "/api/only"};
+}
+
+test "resolve does not mutate the input config" {
+    reset_discovery_cache();
+    original = {"enabled": False, "routes": {}};
+    _ = resolve_microservices_config(original, _FIXTURE);
+    assert original["routes"] == {};
+    assert original["enabled"] is False;
+}
+
+
+# --------------------------------------------------------------------------
+# --no-image: source ConfigMap + pod volume injection
+# --------------------------------------------------------------------------
+test "no_image builder packs project source into a ConfigMap" {
+    cfg = KubernetesConfig(app_name="zc", namespace="zc-dev");
+    builder = MicroserviceManifestBuilder(
+        k8s_config=cfg, no_image=True, project_root=_FIXTURE
+    );
+    cm = builder._build_source_configmap();
+    assert cm is not None;
+    assert cm["kind"] == "ConfigMap";
+    assert cm["metadata"]["name"] == "zc-source";
+    # The .jac + .toml sources are packed.
+    files = set(builder._source_key_map.keys());
+    assert "main.jac" in files;
+    assert "greeter.jac" in files;
+    assert "jac.toml" in files;
+    # A content hash was computed for rollout triggering.
+    assert builder._source_hash != "";
+}
+
+test "no_image off yields no source ConfigMap" {
+    cfg = KubernetesConfig(app_name="zc", namespace="zc-dev");
+    builder = MicroserviceManifestBuilder(k8s_config=cfg, project_root=_FIXTURE);
+    assert builder._build_source_configmap() is None;
+}
+
+test "no_image pod spec mounts source at /app and stamps JAC_SOURCE_HASH" {
+    cfg = KubernetesConfig(app_name="zc", namespace="zc-dev");
+    builder = MicroserviceManifestBuilder(
+        k8s_config=cfg, no_image=True, project_root=_FIXTURE
+    );
+    # Populate the key map + hash (done by _build_source_configmap).
+    _ = builder._build_source_configmap();
+    spec = builder._build_service_pod_spec("greeter", "jac-scale-base:1.0");
+    container = spec["containers"][0];
+
+    mounts = container.get("volumeMounts", []);
+    mount_paths = [m["mountPath"] for m in mounts];
+    assert "/app" in mount_paths;
+
+    vols = spec.get("volumes", []);
+    src_vol = next(
+        (
+            v
+            for v in vols
+            if v["name"] == "jac-source"
+        ),
+        None
+    );
+    assert src_vol is not None;
+    assert src_vol["configMap"]["name"] == "zc-source";
+    # items[].path restores the real layout from sanitized keys.
+    paths = {it["path"] for it in src_vol["configMap"]["items"]};
+    assert "greeter.jac" in paths;
+
+    pairs = {e["name"]: e["value"] for e in container["env"]};
+    assert pairs.get("JAC_SOURCE_HASH") == builder._source_hash;
+}
+
+
+# --------------------------------------------------------------------------
+# Base image
+# --------------------------------------------------------------------------
+test "base_image_tag is registry-prefixed only when a registry is given" {
+    bare = base_image_tag();
+    assert bare.startswith("jac-scale-base:");
+    prefixed = base_image_tag("reg.example.com/org");
+    assert prefixed == f"reg.example.com/org/{bare}";
+}


### PR DESCRIPTION
## Summary

Makes jac-scale microservice mode **zero-config end to end**. The same `sv import` app runs three ways with no `[plugins.scale.microservices]` block:

| Command | Behavior |
|---|---|
| `jac start main.jac` | Local: gateway + one subprocess per discovered service |
| `jac start main.jac --scale` | K8s: gateway pod + one Deployment per service (image auto-built) |
| `jac start main.jac --scale --no-image` | K8s: source shipped via ConfigMap into a cached base image — **no docker build** |

## How it works

**Auto-detection & routing.** A *service* is any sibling `.jac` module with a `to sv:` section exposing a public endpoint; the `[project].entry-point` is the gateway and is never a service. The new `discovery.jac` statically parses the project (reusing `JacCompiler.parse_str`, memoized) and derives route prefixes by the same convention `jac setup microservice` uses (`orders_app → /api/orders`). It keys on the **explicit `to sv:` marker** — not the default SERVER context — so ordinary monolith servers and the gateway are never misclassified. An explicit `routes` block always wins.

`resolve_microservices_config()` is the single chokepoint that fills routes + auto-enables when none are declared. It is wired into every genuine entry point (the `jac start` pre-hook, K8s manifest builder, in-pod `get_sv_registry`/gateway, dry-run plan, admin logs/traces). `get_microservices_config()` itself stays a pure config read (no filesystem scan).

**`--no-image`.** `base_image.jac` builds a `jac-scale-base:<version>` image **once per cluster** (jac-scale runtime, no user code) and reuses it. The manifest builder packs project `.jac`/`.toml` source into a ConfigMap mounted read-only at `/app`, with a `JAC_SOURCE_HASH` env stamp that rolls pods on any source change. MongoDB/Redis still provision normally. The ConfigMap is read-only at `/app` — safe because jac's bytecode cache writes to `$HOME` and the anchor store uses MongoDB.

## Changes

- **New** `microservices/discovery.jac` — `discover_services()` + `resolve_microservices_config()`
- **New** `microservices/images/base_image.jac` — build-once-and-cache base image
- `plugin.jac` — pre-hook discovery, `--no-image` flag, in-pod sv-registry/`jac scale gateway` resolution
- `targets/kubernetes/microservice/{manifest_builder,target}.jac` — source ConfigMap, `/app` volume, `no_image`/`dry_run` plumbing, DB provisioning on the imageless path
- `microservices/cli/plan.jac` — dry-run reflects discovered routes + the source ConfigMap
- `admin/impl/{logs,traces}.impl.jac` — service dropdowns resolve discovery in-pod
- Docs updated (`docs.md`, `getting_started.md`)

## Testing

- New `tests/test_zeroconf_microservice.jac` + `tests/fixtures/zeroconf_ms/` (no microservices config block): discovery, route resolution, ConfigMap injection, base-image tagging.
- All 9 microservice-related suites pass (73 tests); existing explicit-routes e2e fixture unaffected (explicit wins, no discovery).
- All three paths validated via `--scale [--no-image] --dry-run` (+ `--show-yaml`); local boot confirmed routing to discovered services.

## Caveat

`--no-image` is validated through dry-run/manifest generation and unit tests, but **not yet exercised against a live cluster** (no published jac-scale image exists; the base is built locally on first deploy).