### PR TITLE
feat(jaclang): native ptr[T] typed pointers with subscript read/write (closes #6707, #6708)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6707.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6707.feature.md
@@ -1,0 +1,1 @@
+- **Native: typed raw pointers**: Native code can now declare `ptr[T]` values and read or write through them with subscript syntax (`v = p[i]` and `p[i] = val`), with no C shim required.

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -1321,6 +1321,24 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
     }
     # Handle index access: items[i] or expr[i]
     if not nd.is_attr and nd.right?.slices {
+        # ptr[T] subscript read: target lowers to T*, so GEP + load.
+        if self._ptr_elem_llvm_of(nd.target) is not None {
+            ptr_val = self._codegen_expr(nd.target);
+            slices = nd.right.slices or [];
+            if ptr_val is not None and slices {
+                idx_node = slices[0];
+                idx_val = self._codegen_expr(idx_node);
+                if idx_val is None and idx_node?.start {
+                    idx_val = self._codegen_expr(idx_node.start);
+                }
+                if idx_val is not None {
+                    result = self._codegen_ptr_index(ptr_val, idx_val);
+                    if result is not None {
+                        return result;
+                    }
+                }
+            }
+        }
         target_name = self._get_name(nd.target);
         # Simple name with a checked list type
         _idx_list_spec = self._list_spec_of(nd.target)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
@@ -349,4 +349,28 @@ impl NaIRGenPass._codegen_index_set(
         self._emit_rc_release_simple(value, op="list_set", loc=_lset_ctx_loc);
     }
 }
+
+"""Load element i of a typed raw pointer (ptr[T] lowered to T*)."""
+impl NaIRGenPass._codegen_ptr_index(
+    target_val: ir.Value, index_val: ir.Value
+) -> (ir.Value | None) {
+    if not isinstance(target_val.type, ir.PointerType) {
+        return None;
+    }
+    idx = self._coerce_type(index_val, ir.IntType(64));
+    addr = self.builder.gep(target_val, [idx], name="ptr.idx");
+    return self.builder.load(addr, name="ptr.get");
+}
+
+"""Store value at element i of a typed raw pointer (ptr[T] lowered to T*)."""
+impl NaIRGenPass._codegen_ptr_index_set(
+    target_val: ir.Value, index_val: ir.Value, value: ir.Value
+) -> None {
+    if not isinstance(target_val.type, ir.PointerType) {
+        return;
+    }
+    idx = self._coerce_type(index_val, ir.IntType(64));
+    addr = self.builder.gep(target_val, [idx], name="ptr.idx");
+    self.builder.store(self._coerce_type(value, target_val.type.pointee), addr);
+}
 # ─── Phase 5: Inheritance and Vtables ────────────────────────

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -805,7 +805,11 @@ impl NaIRGenPass._codegen_assignment(nd: uni.Assignment) -> None {
                     if idx_val is None and idx_node?.start {
                         idx_val = self._codegen_expr(idx_node.start);
                     }
-                    if idx_val is not None {
+                    if idx_val is not None and self._ptr_elem_llvm_of(target_expr.target) is not None {
+                        # ptr[T] subscript write: target lowers to T*, so GEP + store.
+                        self._codegen_ptr_index_set(target_val, idx_val, value);
+                        _idx_stored = True;
+                    } elif idx_val is not None {
                         # Check if this is a dict assignment (checked type first)
                         dict_type_key = self._dict_key_of(target_expr.target);
                         if dict_type_key is None {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -256,6 +256,25 @@ impl NaIRGenPass._iter_elem_llvm_of(expr: (uni.UniNode | None)) -> (ir.Type | No
     return self._lower_type(args[0]);
 }
 
+"""Return the lowered LLVM element type of a checked `ptr[T]` expression, or
+None when the expression is not a typed raw pointer. Bare `ptr` yields i8.
+Mirrors `_list_elem_llvm_of` (#6707)."""
+impl NaIRGenPass._ptr_elem_llvm_of(expr: (uni.UniNode | None)) -> (ir.Type | None) {
+    if not isinstance(expr, uni.Expr) or expr.type is None {
+        return None;
+    }
+    mangled = expr.type.mangle();
+    if mangled != "ptr" and not mangled.startswith("ptr[") {
+        return None;
+    }
+    args = expr.type.private.type_args or [];
+    if not args {
+        return ir.IntType(8);
+    }
+    elem = self._lower_type(args[0]);
+    return elem if elem is not None else ir.IntType(8);
+}
+
 """Return the native element spec of a checked list type's element
 ("i64"/"f64"/"ptr"/"jacval"), or None when the expression isn't a typed list."""
 impl NaIRGenPass._elem_spec_of(expr: (uni.UniNode | None)) -> (str | None) {
@@ -323,6 +342,21 @@ impl NaIRGenPass._lower_class_type(t: any) -> (ir.Type | None) {
     if cname in ("Iterator", "Iterable") {
         self._ensure_iter_types();
         return self._jac_iter_type.as_pointer();
+    }
+    # ptr[T] -> T* (bare `ptr` defaults to i8*); the element type drives the
+    # pointer's pointee and the subscript load/store stride.
+    if cname == "ptr" {
+        if not type_args {
+            return ir.IntType(8).as_pointer();
+        }
+        _pe = self._lower_type(type_args[0]);
+        if _pe is None {
+            return None;
+        }
+        if isinstance(_pe, ir.VoidType) {
+            return ir.IntType(8).as_pointer();
+        }
+        return _pe.as_pointer();
     }
     # list[T] — bare `list` defaults to a list of i64.
     if cname == "list" {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -420,6 +420,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _list_elem_llvm_of(expr: (uni.UniNode | None)) -> (ir.Type | None);
     # Lowered LLVM element type of a checked Iterator[T] expression (#6403).
     def _iter_elem_llvm_of(expr: (uni.UniNode | None)) -> (ir.Type | None);
+    # Lowered LLVM element type of a checked ptr[T] expression (#6707).
+    def _ptr_elem_llvm_of(expr: (uni.UniNode | None)) -> (ir.Type | None);
     # Element spec ("i64"/"f64"/"ptr"/"jacval") of a checked list type.
     def _elem_spec_of(expr: (uni.UniNode | None)) -> (str | None);
     def _resolve_type_str(type_name: str) -> ir.Type;
@@ -655,6 +657,12 @@ obj NaIRGenPass(ModuleCodegenPass) {
 
     def _codegen_index_set(
         target_val: ir.Value, index_val: ir.Value, value: ir.Value, elem_type_name: str
+    ) -> None;
+    # Load element i of a typed raw pointer (ptr[T] lowered to T*).
+    def _codegen_ptr_index(target_val: ir.Value, index_val: ir.Value) -> (ir.Value | None);
+    # Store value at element i of a typed raw pointer (ptr[T] lowered to T*).
+    def _codegen_ptr_index_set(
+        target_val: ir.Value, index_val: ir.Value, value: ir.Value
     ) -> None;
     # Phase 5: Inheritance, Vtables, and C3 MRO
     def _build_vtable(arch_name: str) -> None;

--- a/jac/jaclang/compiler/type_system/na_builtins.pyi
+++ b/jac/jaclang/compiler/type_system/na_builtins.pyi
@@ -13,11 +13,26 @@ type-checks accurately instead of degrading to UnknownType.
 
 from __future__ import annotations
 
-from typing import Literal, Protocol, TypeVar, overload
+from typing import Generic, Literal, Protocol, TypeVar, overload
 
-__all__ = ["File", "BinaryFile", "open", "Iterable", "Iterator", "iter", "next"]
+__all__ = [
+    "File",
+    "BinaryFile",
+    "open",
+    "Iterable",
+    "Iterator",
+    "iter",
+    "next",
+    "ptr",
+]
 
 _T = TypeVar("_T")
+
+class ptr(Generic[_T]):  # noqa: N801
+    # Typed raw pointer (`ptr[T]` lowers to an LLVM `T*`). Subscripting reads
+    # or writes the element at offset i, matching C typed-pointer semantics.
+    def __getitem__(self, index: int) -> _T: ...
+    def __setitem__(self, index: int, value: _T) -> None: ...
 
 class Iterable(Protocol[_T]):
     def __iter__(self) -> Iterator[_T]: ...

--- a/jac/tests/compiler/passes/native/fixtures/ptr_subscript.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/ptr_subscript.na.jac
@@ -1,0 +1,19 @@
+def sum_roundtrip(p: ptr[i64], n: i64) -> i64 {
+    i: i64 = 0;
+    while i < n {
+        p[i] = i * 10;
+        i = i + 1;
+    }
+    total: i64 = 0;
+    j: i64 = 0;
+    while j < n {
+        total = total + p[j];
+        j = j + 1;
+    }
+    return total;
+}
+
+def write_then_read(p: ptr[i64], idx: i64, val: i64) -> i64 {
+    p[idx] = val;
+    return p[idx];
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -58,6 +58,24 @@ test "arithmetic multiply" {
     assert mul(0, 999) == 0;
 }
 
+# --- Typed raw pointer subscript read/write (#6707, #6708) ---
+test "native ptr[T] subscript read and write round-trip" {
+    (eng, _) = compile_native("ptr_subscript.na.jac");
+    buf = (ctypes.c_int64 * 8)();
+    addr = ctypes.cast(buf, ctypes.c_void_p);
+    sum_roundtrip = get_func(
+        eng, "sum_roundtrip", ctypes.c_int64, ctypes.c_void_p, ctypes.c_int64
+    );
+    assert sum_roundtrip(addr, 8) == 280;
+    assert buf[3] == 30;
+    write_then_read = get_func(
+        eng, "write_then_read", ctypes.c_int64,
+        ctypes.c_void_p, ctypes.c_int64, ctypes.c_int64
+    );
+    assert write_then_read(addr, 5, 999) == 999;
+    assert buf[5] == 999;
+}
+
 # --- Function pointers in struct fields (the OSP dispatch-slot shape) ---
 test "native callable struct field: indirect call through a field" {
     (eng, _) = compile_native("callable_field.na.jac");


### PR DESCRIPTION
## Summary

Adds `ptr[T]` as a first-class native pointer type so `.na.jac` code can read and write through raw pointers with subscript syntax, removing the need for a C shim.

- `ptr[T]` lowers to an LLVM `T*`. The element type comes from the type argument, so GEP handles striding and load/store need no bitcasts or element-type guessing.
- `v = p[i]` lowers to GEP + load; `p[i] = val` lowers to GEP + store.
- The type checker resolves `ptr[T]` via `__getitem__`/`__setitem__`, so `p[i]` is correctly typed instead of `<Unknown>`.

Closes #6707 (subscript write), closes #6708 (subscript read).

## Context

On `main`, `ptr` was not a defined type at all (every use errored with `E2018: Undefined name 'ptr'`), so this introduces the type itself in addition to subscript support. The recommended form is `ptr[T]` (e.g. `ptr[i32]`); the element type drives the access width and stride.

## Changes

- Define `ptr(Generic[_T])` in the native type stub so annotations resolve and subscripts type-check.
- Lower `ptr[T]` to `T*` in native type lowering; add a `ptr[T]` element-type detector.
- Implement subscript read and write in the native codegen dispatch chains, with two small helpers mirroring the existing list-index helpers.

## Testing

- New native test compiles a `ptr[i64]` fixture and exercises read/write round-trips through a ctypes buffer (loop striding sum, single-index write/read).
- Verified the issue reproductions compile and run with no C shim.

> Draft: full native regression suite is still running locally; will mark ready once green.