### PR TITLE
ci: gate test workflows behind ci-approval environment

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -19,9 +19,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  approval:
+    # Approval gate: contribution-checks depends on this. One approval of the
+    # deployment to the protected 'ci-approval' environment releases the run.
+    environment: ci-approval
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI approved by required reviewer."
+
   contribution-checks:
     name: Contribution Checks
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   contribution-checks:
     name: Contribution Checks
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -9,8 +9,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  jac-check:
+  approval:
+    # Approval gate: jac-check depends on this. One approval of the deployment
+    # to the protected 'ci-approval' environment releases the run.
     environment: ci-approval
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI approved by required reviewer."
+
+  jac-check:
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   jac-check:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -9,9 +9,17 @@ on:
   pull_request:
 
 jobs:
+  approval:
+    # Approval gate: real-e2e depends on this. One approval of the deployment
+    # to the protected 'ci-approval' environment releases the run.
+    environment: ci-approval
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI approved by required reviewer."
+
   real-e2e:
     name: microk8s real-app smoke
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   real-e2e:
     name: microk8s real-app smoke
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -9,9 +9,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  approval:
+    # Approval gate: test-installer depends on this. One approval of the
+    # deployment to the protected 'ci-approval' environment releases the run.
+    environment: ci-approval
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI approved by required reviewer."
+
   test-installer:
     name: Test install methods
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test-installer:
     name: Test install methods
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test-core-compiler:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -35,6 +36,7 @@ jobs:
       run: pytest -x jac/tests/compiler -n auto
 
   test-core-runtime:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -65,6 +67,7 @@ jobs:
       run: pytest -x jac -n auto --ignore=jac/tests/compiler
 
   test-solid-jsdom:
+    environment: ci-approval
     # Runtime exec of the Solid framework backend: compile a Solid component +
     # the @jac/runtime shim to JS and mount it in jsdom under node, asserting
     # render + reactivity. Needs a real `bun install` (jsdom + solid-js), so the
@@ -104,6 +107,7 @@ jobs:
       run: pytest -x -vv jac/tests/runtimelib/test_solid_jsdom.jac
 
   test-client:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -143,6 +147,7 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client -n auto
 
   test-packages-and-docs:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -189,6 +194,7 @@ jobs:
       run: pytest docs/tests/e2e/test_code_blocks.jac -v
 
   test-desktop-native:
+    environment: ci-approval
     # Jac-native desktop tests (issue #6436). Dependency-free by design: they
     # only need the jac toolchain to compile the example hosts and inspect the
     # linked artifacts (DT_NEEDED / $ORIGIN) and run handler logic through the sv
@@ -217,6 +223,7 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client/test_desktop_binding.jac -n auto
 
   test-mcp:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -241,6 +248,7 @@ jobs:
       run: pytest -x jac-mcp -n auto
 
   test-scale:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -343,6 +351,7 @@ jobs:
         pytest -x -vv -s jac-scale/jac_scale/tests/test_scheduling.jac
 
   test-scale-k8s:
+    environment: ci-approval
     # Runs by default; add the 'skip-k8s' label to a PR to skip it.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -404,6 +413,7 @@ jobs:
           pytest  -s -x "jac-scale/jac_scale/tests/test_deploy_k8s.jac::early exit"
 
   test-pypi-build:
+    environment: ci-approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -10,8 +10,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-core-compiler:
+  approval:
+    # Single approval gate: all test jobs depend on this one. Approving its
+    # deployment to the protected 'ci-approval' environment releases the whole
+    # run, so the PR timeline shows one approval instead of one per job.
     environment: ci-approval
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI approved by required reviewer."
+
+  test-core-compiler:
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -36,7 +45,7 @@ jobs:
       run: pytest -x jac/tests/compiler -n auto
 
   test-core-runtime:
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -67,7 +76,7 @@ jobs:
       run: pytest -x jac -n auto --ignore=jac/tests/compiler
 
   test-solid-jsdom:
-    environment: ci-approval
+    needs: approval
     # Runtime exec of the Solid framework backend: compile a Solid component +
     # the @jac/runtime shim to JS and mount it in jsdom under node, asserting
     # render + reactivity. Needs a real `bun install` (jsdom + solid-js), so the
@@ -107,7 +116,7 @@ jobs:
       run: pytest -x -vv jac/tests/runtimelib/test_solid_jsdom.jac
 
   test-client:
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -147,7 +156,7 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client -n auto
 
   test-packages-and-docs:
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -194,7 +203,7 @@ jobs:
       run: pytest docs/tests/e2e/test_code_blocks.jac -v
 
   test-desktop-native:
-    environment: ci-approval
+    needs: approval
     # Jac-native desktop tests (issue #6436). Dependency-free by design: they
     # only need the jac toolchain to compile the example hosts and inspect the
     # linked artifacts (DT_NEEDED / $ORIGIN) and run handler logic through the sv
@@ -223,7 +232,7 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client/test_desktop_binding.jac -n auto
 
   test-mcp:
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -248,7 +257,7 @@ jobs:
       run: pytest -x jac-mcp -n auto
 
   test-scale:
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -351,7 +360,7 @@ jobs:
         pytest -x -vv -s jac-scale/jac_scale/tests/test_scheduling.jac
 
   test-scale-k8s:
-    environment: ci-approval
+    needs: approval
     # Runs by default; add the 'skip-k8s' label to a PR to skip it.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -413,7 +422,7 @@ jobs:
           pytest  -s -x "jac-scale/jac_scale/tests/test_deploy_k8s.jac::early exit"
 
   test-pypi-build:
-    environment: ci-approval
+    needs: approval
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code


### PR DESCRIPTION
## Why

We found that many PRs were merged even though their tests never actually ran in CI. Until the test/CI system is fixed, we want a temporary safeguard: **CI should not run automatically — it runs only after a trusted developer approves it.**

## What this does

Adds `environment: ci-approval` to every CI **test** job. With the `ci-approval` protected environment (already configured in repo settings with required reviewers **marsninja** and **kugesan1105**), each job auto-queues on a PR but **pauses in a "Waiting" state** until a required reviewer clicks **Approve**. Nothing executes until then. One approval releases all waiting jobs in the run.

Gated workflows / jobs:

| Workflow | Jobs gated |
|---|---|
| `test-jaseci.yml` | 10 (all) |
| `jac-check.yml` | 1 |
| `contribution-checks.yml` | 1 |
| `k8s-microservice-real-e2e.yml` | 1 |
| `test-installer.yml` | 1 |

The `pull_request` / `push` triggers are intentionally left intact so PR status checks and auto-queue still work — the environment gate is what holds execution.

## Reverting later

Once the test system is trusted again, remove the `environment: ci-approval` lines (or delete the environment's required reviewers) to restore automatic CI.

> Temporary safeguard until the CI/test reliability issues are resolved.