### PR TITLE
docs: cover the three :pub/:protect/:priv access-modifier contexts

### DIFF
--- a/docs/docs/quick-guide/syntax-cheatsheet.md
+++ b/docs/docs/quick-guide/syntax-cheatsheet.md
@@ -409,13 +409,16 @@ obj Account {
 # Access Modifiers
 # ============================================================
 
-# Access modifiers work on obj, class, node, edge, walker,
-# def, has -- controlling visibility and API exposure
+# Access modifiers work on obj, class, node, edge, walker, def, has.
+# Same tags, three contexts (see reference/language/access-modifiers):
+#   members  -> :pub anywhere / :protect class+subclasses / :priv class
+#   top-level-> :pub exported / :protect same project / :priv this module
+#   endpoints-> only :pub skips auth; everything else requires a token
 
 obj:pub Profile {
-    has:pub name: str;          # Public (default)
-    has:priv ssn: str;          # Private
-    has:protect age: int;       # Protected
+    has:pub name: str;          # member: public
+    has:protect age: int;       # member: this class + subclasses
+    has:priv ssn: str;          # member: this class only
 }
 
 # Public walker becomes REST endpoint with `jac start`

--- a/docs/docs/reference/language/access-modifiers.md
+++ b/docs/docs/reference/language/access-modifiers.md
@@ -1,0 +1,104 @@
+# Access Modifiers
+
+Jac has three access modifiers -- `:pub`, `:protect`, and `:priv` -- written as a tag on a declaration (`def:pub`, `has:priv`, `walker:protect`, `glob:protect`, ...). They share one intuition: `:pub` is the most exposed, `:priv` the most contained, and `:protect` sits in the middle.
+
+The crucial thing to understand is that **the same three keywords mean different things depending on where the symbol is declared**, and one *additional*, orthogonal meaning when the symbol is served as an HTTP endpoint. There are three contexts:
+
+| Context | Applies to | What the modifier controls |
+|---|---|---|
+| [Member encapsulation](#member-encapsulation) | `has` / `def` declared **inside an archetype** | who may reference the member in source |
+| [Module / project visibility](#module--project-visibility) | top-level `glob` / `obj` / `def` / `enum` / `walker` | which modules may reference the symbol in source |
+| [Service auth](#service-auth) | served `def` / `walker` endpoints (`jac serve`) | whether an HTTP caller must authenticate |
+
+The first two are **compile-time reference rules** enforced by `AccessCheckPass`. The third is a **runtime auth rule** applied by the server. They are independent: a single tag on a top-level `walker` is read by *both* the visibility rule and the auth rule, but they ask different questions.
+
+---
+
+## Member encapsulation
+
+For a `has` field or `def` ability declared **inside an archetype** (`obj`, `node`, `edge`, `walker`, `class`), the modifier is classic OOP encapsulation:
+
+| tag | accessible from |
+|---|---|
+| `:pub` | anywhere |
+| `:protect` | the declaring archetype **and its subclasses** |
+| `:priv` | the declaring archetype **only** |
+
+```jac
+obj PetRecord {
+    has:pub  name: str;
+    has:protect medical_history: list[str] = [];   # this class + subclasses
+    has:priv owner_contact: str = "";               # this class only
+
+    def:protect add_record(r: str) { self.medical_history.append(r); }
+}
+
+obj VetRecord(PetRecord) {
+    def:pub note(n: str) {
+        self.add_record(n);          # OK: protected, accessible from a subclass
+        # self.owner_contact;        # ERROR: private to PetRecord
+    }
+}
+```
+
+---
+
+## Module / project visibility
+
+For a **top-level** symbol (`glob`, `obj`, `def`, `enum`, `walker` at module scope, not inside a class), the modifier controls cross-module reference legality. A *project* is the directory tree rooted at its `jac.toml`.
+
+| tag | visible from | meaning |
+|---|---|---|
+| `:pub` | any module, **including a consuming project** | exported library endpoint -- need not even be referenced inside its own project |
+| `:protect` | any module **within the same project** (same `jac.toml` root) | project-internal |
+| `:priv` | the **declaring module only** | module-internal |
+
+```jac
+glob:pub     API_VERSION = "1.0";   # other projects may import this
+glob:protect retry_budget = 3;      # any module in this project; not exported
+glob:priv    _cache = {};           # this module only
+```
+
+A reference from the same module is always allowed regardless of tag.
+
+> **Note:** these are *visibility* rules -- they govern whether one symbol may legally reference another in source. They do **not** control which walkers/functions become HTTP endpoints; that is [service auth](#service-auth) below.
+
+---
+
+## Service auth
+
+When a top-level `def` or `walker` is served via `jac serve` / `jac start`, the modifier additionally decides whether an HTTP caller must authenticate. This axis is **secure-by-default** and only distinguishes `:pub` from everything else:
+
+| tag on a served `def` / `walker` | auth required? | notes |
+|---|---|---|
+| `:pub` | **no** | open endpoint. Anonymous callers run on the shared guest graph (`root.shared`); a caller presenting a valid token runs on their own root. |
+| `:protect` | **yes** | JWT required; runs on the caller's own isolated root. |
+| `:priv` | **yes** | JWT required; runs on the caller's own isolated root. |
+| (unmarked) | **yes** | identical to `:priv` -- secure by default. |
+
+> **`:protect` is not a middle auth tier.** For endpoint auth, only `:pub` is exempt; `:protect`, `:priv`, and the unmarked default all require authentication and behave identically. The three-way gradient exists for the *visibility* axis above, not for auth. Don't reach for `:protect` expecting "lighter" auth -- there is no such thing.
+
+See [jac-scale](../plugins/jac-scale.md) for the full serve/auth model, including per-user data isolation and permission grants (which are a *third*, separate concern from endpoint auth).
+
+---
+
+## Enforcement and rollout
+
+The compile-time visibility rules (member and module/project) are reported by `AccessCheckPass` in the type-check schedule. They are **warnings by default**, promoted to **hard errors** with:
+
+```toml
+# jac.toml
+[check]
+enforce_access = true
+```
+
+Diagnostics, each individually suppressible via `[check] suppress` or `# jac:ignore[...]`:
+
+| code | violation |
+|---|---|
+| `E/W2034` | use of a `:priv` member outside its declaring archetype |
+| `E/W2035` | use of a `:protect` member outside the class hierarchy |
+| `E/W2037` | cross-module use of a `:priv` (module-private) top-level symbol |
+| `E/W2038` | cross-project use of a `:protect` (project-protected) top-level symbol |
+
+Symbols with no Jac source (Python/builtin/synthetic) are always treated as public. The service-auth behavior is unaffected by `enforce_access` -- auth is applied at serve time regardless.

--- a/docs/docs/reference/language/functions-objects.md
+++ b/docs/docs/reference/language/functions-objects.md
@@ -444,16 +444,20 @@ def another_function {
 
 ### 10 Access Modifiers
 
+For a **top-level** `def`, the access tag controls cross-module visibility (a *project* is the directory tree rooted at its `jac.toml`):
+
 ```jac
-# Public (default, accessible everywhere)
+# Public -- visible to any module, including a consuming project (exported)
 def:pub public_func { }
 
-# Private (accessible only within the module)
-def:priv _private_func { }
+# Protected -- visible within the same project (shared jac.toml root)
+def:protect _project_func { }
 
-# Protected (accessible within module and subclasses)
-def:protect _protected_func { }
+# Private -- visible only within the declaring module
+def:priv _private_func { }
 ```
+
+The same tags mean *member encapsulation* on a `has`/`def` declared inside an archetype (`:protect` then means the declaring class **and its subclasses**), and a separate auth-only meaning on served endpoints. See the [Access Modifiers reference](access-modifiers.md) for the full three-context model.
 
 ??? example "Try it: Functions complete example"
     ```jac

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -1314,7 +1314,7 @@ Walkers have two access levels when served as API endpoints (`:priv` is the expl
 | Access | Description |
 |--------|-------------|
 | Public (`:pub`) | Accessible without authentication. Anonymous callers run on the shared guest graph (`root.shared`); a caller presenting a valid token runs on their own root. |
-| Protected (default) and Private (`:priv`) | Require JWT authentication; per-user isolated (each user operates on their own graph). The unmarked default and `:priv` behave identically. |
+| Default, Protected (`:protect`), and Private (`:priv`) | Require JWT authentication; per-user isolated (each user operates on their own graph). For endpoint auth these behave identically -- **only `:pub` is exempt**. `:protect` is _not_ a middle auth tier; its three-way gradient applies to source-level [visibility](../language/access-modifiers.md), not to authentication. |
 
 ### Permission Functions Reference
 
@@ -3504,7 +3504,7 @@ Outside Kubernetes, sv-to-sv calls find peer providers via auto-spawn (single-pr
 JAC_SV_<PEER_MODULE>_URL=http://<peer>-service.<namespace>.svc.cluster.local:<container_port>
 ```
 
-The env-var key uses the raw module name (the value to the right of `sv import from`) upper-cased and joined with `JAC_SV_…_URL`. The URL host uses the Kubernetes Service name with DNS-1123 normalization (so `jac_coder_sv` becomes `jac-coder-sv-service`). Self is skipped (no service points env at itself).
+The env-var key uses the raw module name (the value to the right of `sv import from`) upper-cased and joined with `JAC_SV_..._URL`. The URL host uses the Kubernetes Service name with DNS-1123 normalization (so `jac_coder_sv` becomes `jac-coder-sv-service`). Self is skipped (no service points env at itself).
 
 You do not write these env vars by hand in `--scale` K8s mode; K-track derives them from `[plugins.scale.microservices.routes]` and the configured namespace.
 

--- a/docs/docs/tutorials/language/basics.md
+++ b/docs/docs/tutorials/language/basics.md
@@ -463,27 +463,29 @@ You'll learn more about `can` in the [OSP tutorial](osp.md).
 
 ## Access Modifiers
 
-When you deploy a Jac application as a server (with `jac start`), access modifiers control which functions and walkers become HTTP endpoints and how authentication is handled. This is one of Jac's most distinctive features: instead of manually defining API routes with decorators (like Flask's `@app.route`), you simply annotate your functions with `:pub` or `:priv` and the framework automatically generates REST endpoints with the right authentication behavior.
+Jac's three access modifiers -- `:pub`, `:protect`, `:priv` -- control *source-level visibility*, and they mean different things depending on where a symbol is declared. For **top-level** functions and walkers, they govern which modules may reference the symbol:
 
 ```jac
-# Public endpoint -- auto-generates an HTTP API
+# Exported -- visible to any module, including consuming projects
 def:pub add_task(title: str) -> dict { ...; }
 
-# Private -- requires authentication, per-user data isolation
-def:priv get_tasks -> list { ...; }
+# Project-internal -- visible within this project (same jac.toml root)
+def:protect retry(title: str) -> dict { ...; }
 
-# Protected -- accessible within the module
-def:protect helper -> None { ...; }
+# Module-internal -- visible only in this module
+def:priv get_tasks -> list { ...; }
 ```
 
-| Modifier | Visibility | Use Case |
-|----------|-----------|----------|
-| `def:pub` | Public HTTP endpoint | APIs anyone can call |
-| `def:priv` | Authenticated endpoint | Per-user data isolation |
-| `def:protect` | Module-internal | Helper functions |
-| `def` | Default (module-level) | Regular functions |
+| Modifier | Top-level visibility | Use Case |
+|----------|---------------------|----------|
+| `def:pub` | Any module, including a consuming project | Exported library API |
+| `def:protect` | Same project (shared `jac.toml`) | Project-internal helper |
+| `def:priv` | Declaring module only | Module-internal helper |
+| `def` | Declaring module only (default) | Regular functions |
 
-These modifiers also apply to walkers (`walker:pub`, `walker:priv`).
+The *same* tags mean something different on a `has`/`def` declared **inside a class** (member encapsulation: `:protect` = subclasses too), and a *separate*, auth-only meaning when a function or walker is served as an HTTP endpoint -- there, **only `:pub` skips authentication** and everything else requires a token. See the [Access Modifiers reference](../../reference/language/access-modifiers.md) for the full three-context model.
+
+These modifiers also apply to walkers (`walker:pub`, `walker:protect`, `walker:priv`).
 
 ---
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
           - Foundation: "reference/language/foundation.md"
           - Primitives & Codespace Semantics: "reference/language/primitives.md"
           - Functions & Objects: "reference/language/functions-objects.md"
+          - Access Modifiers: "reference/language/access-modifiers.md"
           - Object-Spatial Programming: "reference/language/osp.md"
           - Concurrency: "reference/language/concurrency.md"
           - Comprehensions & Filters: "reference/language/advanced.md"

--- a/jac/jaclang/cli/skills/jac-has-fields.md
+++ b/jac/jaclang/cli/skills/jac-has-fields.md
@@ -74,7 +74,7 @@ obj Account {
 - **Parent defaults force child defaults.** If any inherited field has a default, every field in the subclass needs one too (dataclass constraint). `obj Animal { has name: str = "x"; }` + `obj Dog(Animal) { has breed: str; }` **passes `jac check` but crashes at runtime**: `TypeError: non-default argument 'breed' follows default argument`. Give `breed` a default.
 - **All attributes must be `has`-declared.** `p.height = 175` on an object with no `has height` is the dynamic-attribute anti-pattern - it may run today but breaks portability (server/client/native) and will be rejected by future compilers. Declare every field upfront.
 - **Backtick-escaped keywords don't work in `has`** (`has \`class: str;` = runtime SyntaxError) - pick a non-keyword name. See `jac-core-cheatsheet`.
-- Access tags: `has:priv secret: str = "";` / `has:pub name: str = "";` control cross-module visibility, same as `def:priv`/`def:pub`.
+- Access tags on members are *encapsulation*: `has:pub` anywhere, `has:protect` the declaring class **and its subclasses**, `has:priv` the declaring class only (`has:priv secret: str = "";`). This differs from top-level `def`/`glob`, where the same tags mean module/project visibility.
 - `has name;` without a type is a parse error. Field access is attribute-style: `user.name`, NOT `user["name"]`.
 - For optional references use `T | None` and guard `is None` - full type rules in `jac-types`.
 - On **walkers**, `has` fields are also the spawn parameters (`root spawn W(field=...)`) - a required field with no default makes every spawn pass it (E1050 trap) - see `jac-walker-patterns`.

--- a/jac/jaclang/cli/skills/jac-sv-auth.md
+++ b/jac/jaclang/cli/skills/jac-sv-auth.md
@@ -9,6 +9,7 @@ Jac's server auth is built on **per-user data isolation**: every registered user
 
 - **`def:pub` / `walker:pub`** - no auth required. An **anonymous** caller runs on the shared guest graph (`root` is `root.shared`); a caller who *does* send a valid token runs on **their own root**. So `root` inside a `:pub` endpoint is not one fixed graph - it depends on the caller's token.
 - **Plain `def` / `def:priv`** (and plain `walker` / `walker:priv`) - JWT required (`401 UNAUTHORIZED` without one); runs on the caller's own isolated root. **Plain and `:priv` behave identically** - secure by default; `:priv` is just the explicit spelling.
+- **`def:protect` / `walker:protect`** - for auth, identical to `:priv`: JWT required, own root. `:protect` is *not* a middle auth tier - **only `:pub` skips auth**. Its three-way gradient (`:pub`/`:protect`/`:priv`) is the *source-visibility* axis (module vs project vs world), not the auth axis. Don't pick `:protect` expecting lighter auth.
 - **`def _helper`** - underscore prefix keeps a function off the API entirely (underscore *walkers* become middleware - see `jac-sv-endpoints`).
 
 ```jac


### PR DESCRIPTION
## What

PR #6837 landed compile-time enforcement of `:pub` / `:protect` / `:priv`, but the docs still described the modifiers one axis at a time -- and contradicted themselves on `:protect`. This adds a single canonical reference page and fixes the scattered errors so each of the three contexts a tag participates in is covered correctly.

### New canonical page

`reference/language/access-modifiers.md` lays out the three contexts and, critically, that **the same keyword means different things by declaration site**:

| Context | Applies to | Controls |
|---|---|---|
| Member encapsulation | `has`/`def` inside an archetype | `:protect` = declaring class **+ subclasses** |
| Module/project visibility | top-level `glob`/`obj`/`def`/`enum`/`walker` | `:protect` = same project (shared `jac.toml`) |
| Service auth (`jac serve`) | served `def`/`walker` | **only `:pub` skips auth**; `:protect`/`:priv`/unmarked all require a token |

Includes the `enforce_access` rollout and the `E/W2034`-`E/W2038` diagnostics.

### Fixes to existing docs

- **`tutorials/language/basics.md`** -- defined `def:protect` as "module-internal helper" (wrong on every axis) and labeled `def:priv` an "authenticated endpoint". Rewritten to the correct top-level visibility model with a link to the new page.
- **`reference/language/functions-objects.md`** -- described *top-level* defs using *member* (subclass) semantics for `:protect`. Corrected to module/project visibility.
- **`reference/plugins/jac-scale.md`** & **`jac-sv-auth.md` skill** -- auth tables omitted `:protect`, inviting readers to assume a middle auth tier that does not exist. Now state explicitly that only `:pub` is exempt and the gradient belongs to the visibility axis, not auth.
- **`jac-has-fields.md` skill** -- called member tags "cross-module visibility"; corrected to encapsulation.
- **`quick-guide/syntax-cheatsheet.md`** -- added a three-context summary comment.

Nav updated to list the new page under the language reference.

## Test

Docs-only. `markdownlint` and the em-dash ban hook pass.