### PR TITLE
ci: cut PR runner usage via concurrency cancel + path filters

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/contribution-checks.yml'
   workflow_dispatch:
 
+# Cancel superseded PR runs; never cancel a run for a commit on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   contribution-checks:
     name: Contribution Checks

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -8,6 +8,11 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+# Cancel superseded PR runs; never cancel a run for a commit on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   jac-check:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -7,10 +7,26 @@ name: K8s Microservice Real E2E
 on:
   workflow_dispatch:
   pull_request:
+    # Heavy microk8s e2e (~25 min). Only the jac runtime + the scale deploy
+    # pipeline can affect it, so skip PRs that touch neither (docs, byllm, mcp,
+    # etc.). This job is NOT a required status check, so a path-skip is safe -
+    # it won't leave a PR waiting on a check that never reports.
+    paths:
+      - 'jac/**'
+      - 'jac-scale/**'
+      - '.github/workflows/k8s-microservice-real-e2e.yml'
+
+# Cancel superseded PR runs; never cancel a run for a commit on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   real-e2e:
     name: microk8s real-app smoke
+    # Escape hatch: add the 'skip-k8s' label to a PR to skip this job too
+    # (matches the test-scale-k8s gate in test-jaseci.yml).
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -8,6 +8,11 @@ on:
       - ".github/workflows/test-installer.yml"
   workflow_dispatch:
 
+# Cancel superseded PR runs; never cancel a run for a commit on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-installer:
     name: Test install methods

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -9,7 +9,50 @@ on:
       - main
   workflow_dispatch:
 
+# Cancel superseded PR runs; never cancel a run for a commit on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  # Cheap path filter on a free GitHub-hosted runner. Used ONLY to skip the
+  # NON-required jobs on PRs that can't affect them. The required jobs
+  # (test-core-compiler, test-core-runtime, test-client) are never gated, so the
+  # merge gate is unchanged. These outputs are only consulted for pull_request
+  # events - each gated job's `if` forces a run on push/dispatch, so main always
+  # keeps full coverage regardless of the filter result. `core` (jac/**) is the
+  # compiler+runtime, so it is folded into every downstream gate.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+      scale: ${{ steps.filter.outputs.scale }}
+      byllm: ${{ steps.filter.outputs.byllm }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+      docs: ${{ steps.filter.outputs.docs }}
+      desktop: ${{ steps.filter.outputs.desktop }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            # Editing this workflow re-runs the full gated suite so CI changes
+            # are validated end-to-end (folded into `core`, the broadest gate).
+            core:
+              - 'jac/**'
+              - '.github/workflows/test-jaseci.yml'
+            scale:
+              - 'jac-scale/**'
+            byllm:
+              - 'jac-byllm/**'
+            mcp:
+              - 'jac-mcp/**'
+            docs:
+              - 'docs/**'
+            desktop:
+              - 'jac-desktop/**'
+
   test-core-compiler:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -70,6 +113,9 @@ jobs:
     # render + reactivity. Needs a real `bun install` (jsdom + solid-js), so the
     # test self-skips unless JAC_CLIENT_INTEGRATION is set -- we set it here and
     # run just that file in its own lean job.
+    needs: changes
+    # Not a required check. Skip on PRs that don't touch jac core; always run on push/dispatch.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -143,6 +189,10 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client -n auto
 
   test-packages-and-docs:
+    needs: changes
+    # Not a required check. Tests jac-byllm + builds/validates docs. Skip on PRs
+    # that touch none of jac core, jac-byllm, docs; always run on push/dispatch.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -194,6 +244,9 @@ jobs:
     # linked artifacts (DT_NEEDED / $ORIGIN) and run handler logic through the sv
     # pathway - NO WebKitGTK, no libpython-dev, no display/Xvfb. The webview /
     # embedded-Python *runtime* behavior is covered by a separate, gated tier.
+    needs: changes
+    # Not a required check. Skip on PRs that touch neither jac core nor jac-desktop; always run on push/dispatch.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.desktop == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -217,6 +270,9 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client/test_desktop_binding.jac -n auto
 
   test-mcp:
+    needs: changes
+    # Not a required check. Skip on PRs that touch neither jac core nor jac-mcp; always run on push/dispatch.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.mcp == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -241,6 +297,9 @@ jobs:
       run: pytest -x jac-mcp -n auto
 
   test-scale:
+    needs: changes
+    # Not a required check. Skip on PRs that touch neither jac core nor jac-scale; always run on push/dispatch.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -284,8 +343,14 @@ jobs:
         fi
 
   test-scale-k8s:
-    # Runs by default; add the 'skip-k8s' label to a PR to skip it.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
+    needs: changes
+    # Not a required check. Skips on PRs that touch neither jac core nor jac-scale,
+    # or that carry the 'skip-k8s' label; always runs on push/dispatch.
+    if: >-
+      (github.event_name != 'pull_request' ||
+       needs.changes.outputs.core == 'true' ||
+       needs.changes.outputs.scale == 'true') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -345,6 +410,11 @@ jobs:
           pytest  -s -x "jac-scale/jac_scale/tests/test_deploy_k8s.jac::early exit"
 
   test-pypi-build:
+    needs: changes
+    # Not a required check, and the heaviest job (builds all wheels + jacpack
+    # smoke servers). Skip on PRs that touch none of jac core, jac-scale,
+    # jac-byllm; always run on push/dispatch so main stays packaging-clean.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code


### PR DESCRIPTION
Every PR ran the full test matrix on every push, with no auto-cancellation and almost no path scoping, which burns a lot of self-hosted runner time. This PR trims that spend without weakening the merge gate.

## Changes

**1. Concurrency (auto-cancel superseded PR runs)**
All PR-triggered workflows (`test-jaseci`, `contribution-checks`, `jac-check`, `k8s-microservice-real-e2e`, `test-installer`) get a `concurrency` group with `cancel-in-progress` scoped to `pull_request` events only. Pushing a new commit to a PR now cancels the prior in-flight run instead of paying for it to finish. Commits on `main` are never cancelled.

**2. k8s microservice e2e (heaviest standalone job, ~25 min) path-filtered**
It previously ran on every PR with no filter. Now it only runs when `jac/**` or `jac-scale/**` change, still honors the `skip-k8s` label, and keeps `workflow_dispatch`. It is not a required status check, so a path-skip cannot hang a PR.

**3. test-jaseci non-required jobs gated behind a cheap path filter**
A new `changes` job (free GitHub-hosted runner, `dorny/paths-filter`) computes which areas a PR touches. The non-required jobs now skip when irrelevant:

| Job | Runs on a PR only when it touches |
| --- | --- |
| `test-pypi-build` | jac / jac-scale / jac-byllm |
| `test-scale` (x5) | jac / jac-scale |
| `test-scale-k8s` (x2) | jac / jac-scale (+ skip-k8s label) |
| `test-packages-and-docs` | jac / jac-byllm / docs |
| `test-mcp` | jac / jac-mcp |
| `test-solid-jsdom` | jac |
| `test-desktop-native` | jac / jac-desktop |

## Safety

- The required checks (`test-core-compiler`, `test-core-runtime`, `test-client`, `jac-check`, `Contribution Checks`) are never gated, so the merge gate is unchanged. A required check is never path-skipped (which would leave a PR waiting forever).
- Each gated job force-runs on `push` and `workflow_dispatch` (`github.event_name != 'pull_request'`), so `main` always keeps full coverage regardless of the filter.
- Editing `test-jaseci.yml` itself triggers the full gated suite (folded into the `core` filter), so CI changes are validated end to end - including this PR.