### PR TITLE
fix(routing): repair auth_redirect config, broken since file-based routing shipped

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6878.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6878.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `auth_redirect` in `jac.toml` now works in file-based routing**: Setting `[plugins.client.routing] auth_redirect = "/dashboard"` now correctly redirects unauthenticated users to the configured path instead of always falling back to `/login`.

--- a/jac/jaclang/runtimelib/client/impl/compiler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/compiler.impl.jac
@@ -140,10 +140,11 @@ impl ViteCompiler._create_pages_entry_content(
     }
     auth_redirect = "/login";
     try {
-        import from jaclang.runtimelib.client.config_loader { PluginConfig }
-        config = PluginConfig.load(self.project_dir);
-        if config and config?.routing and config.routing {
-            auth_redirect = config.routing.get('auth_redirect', '/login');
+        import from jaclang.runtimelib.client.config_loader { JacClientConfig }
+        config = JacClientConfig(project_dir=self.project_dir);
+        routing = config.get_section('routing');
+        if routing {
+            auth_redirect = routing.get('auth_redirect', '/login');
         }
     } except Exception as e {
         console.warning(

--- a/jac/jaclang/runtimelib/client/impl/config_loader.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/config_loader.impl.jac
@@ -153,6 +153,7 @@ impl JacClientConfig.get_default_config(self: JacClientConfig) -> dict[str, any]
         'ts': {'compilerOptions': {}, 'include': [], 'exclude': []},
         'configs': {},  # Generic config file generation: { "postcss": {...}, "tailwind": {...} }
         'paths': {},  # Import path aliases: { "@components/*": "./components/*" }
+        'routing': {'auth_redirect': '/login'},  # File-based routing config
         'npm': {},  # NPM registry config: { "scoped_registries": {...}, "auth": {...} }
         'package': {
             'name': '',
@@ -232,6 +233,7 @@ impl JacClientConfig.load(self: JacClientConfig) -> dict[str, any] {
         'ts': client_config.get('ts', {}),
         'configs': client_config.get('configs', {}),
         'paths': client_config.get('paths', {}),
+        'routing': client_config.get('routing', {}),
         'npm': client_config.get('npm', {}),
         'pwa': client_config.get('pwa', {}),
         'package': {

--- a/jac/jaclang/runtimelib/react_entry.jac
+++ b/jac/jaclang/runtimelib/react_entry.jac
@@ -96,13 +96,11 @@ def build_pages_react_entry_script(
             ''
         ]
     );
-    # AuthGuard is a runtime function compiled with plain parameters (not React
-    # props destructuring), so wrap it in a component that passes the redirect
-    # string directly.
+    # AuthGuard uses the props-destructure
+    # Must use React.createElement with a props object to pass the redirect prop
     lines.extend(
         [
-            f'function _AuthGuardRoute() {{ return AuthGuard("{auth_redirect}"); }}',
-            'const authGuardElement = React.createElement(_AuthGuardRoute, null);',
+            f'const authGuardElement = React.createElement(AuthGuard, {{ redirect: "{auth_redirect}" }});',
             '',
             'function App() {',
             '\tconst routeChildren = [',


### PR DESCRIPTION
## Summary

`auth_redirect` in `jac.toml` has never worked since file-based routing was introduced in PR #4422. Four stacked bugs prevented the configured value from ever reaching the generated `_entry.js`. Users always got redirected to `/login` regardless of their config.

## Bugs fixed

**Bug 1 - Wrong import in `compiler.impl.jac`**
`PluginConfig` does not exist; the class has always been `JacClientConfig`. Caused an `ImportError` on every build, caught silently by the `except` block.

**Bug 2 - Wrong call pattern in `compiler.impl.jac`**
`PluginConfig.load(self.project_dir)` called `load()` as a classmethod, passing a `Path` as `self`. `load()` is an instance method. Fixed to `JacClientConfig(project_dir=...).get_section('routing')`.

**Bug 3 - `routing` key dropped in `config_loader.impl.jac`**
`JacClientConfig.load()` builds a `user_config` dict that was missing the `routing` key entirely, so `[plugins.client.routing]` values from `jac.toml` were silently discarded. Fixed by adding `routing` to both `get_default_config()` and `user_config`.

**Bug 4 - Wrong `AuthGuard` call convention in `react_entry.jac`**
`build_pages_react_entry_script()` generated `AuthGuard("/dashboard")`, passing a plain string as `props`. Since PR #3736, `AuthGuard` compiles with the props-destructure ABI: `function AuthGuard(props) { const {redirect} = props; }`. `props.redirect` on a string is `undefined`, falling back to `"/login"`. Fixed to `React.createElement(AuthGuard, { redirect: "/hora" })`. This is the same fix PR #6494 applied to `.cl.jac` call sites, now applied to the string-generation path in `react_entry.jac`.

## Files changed

- `jac/jaclang/runtimelib/client/impl/compiler.impl.jac` - Bugs 1, 2
- `jac/jaclang/runtimelib/client/impl/config_loader.impl.jac` - Bug 3
- `jac/jaclang/runtimelib/react_entry.jac` - Bug 4

## How to verify

Add to `jac.toml`:
```toml
[plugins.client.routing]
auth_redirect = "/dashboard"
```

Before this fix: unauthenticated users always land on `/login`.
After this fix: unauthenticated users land on `/dashboard`.