### PR TITLE
ci: on-demand /test CI for PRs (cut runner cost)

### DIFF
--- a/.github/scripts/ci-requested-suites.js
+++ b/.github/scripts/ci-requested-suites.js
@@ -1,16 +1,18 @@
-// Returns the Set of CI suites requested for a PR's CURRENT head commit via
-// `/test <suites>` comments from repo collaborators (read access or above).
+// Returns the Set of CI suites requested for a PR via `/test <suites>` comments
+// from repo collaborators (read access or above).
 //
-// Used by the `plan` job of each test workflow so that, on a pull_request run,
-// a suite executes only when explicitly requested - keeping unrequested PRs at
-// ~$0 while the requested suites run as native PR checks. Requests are read
-// straight from the PR's comments, so no commit statuses or marker check-runs
-// are created (the PR's check list stays clean - only real test jobs show).
+// Used by the `plan` job of each test workflow so that a suite executes only
+// when explicitly requested - keeping unrequested PRs at ~$0 while the
+// requested suites run as native PR checks. Requests are read straight from the
+// PR's comments, so no commit statuses or marker check-runs are created (the
+// PR's check list stays clean - only real test jobs show).
 //
-// Stale requests are not a concern: this runs in a `plan` job that only ever
-// executes for the PR's CURRENT head SHA, so any `/test` comment it reads is
-// scoped to the code under test by construction. (A new push starts a fresh
-// run whose plan re-reads comments against the new SHA.)
+// Freshness: a `/test` request only takes effect when ci-command RE-RUNS this
+// workflow (run attempt > 1). The automatic run that fires on PR open/push is
+// always attempt 1, so it requests nothing - every suite skips until a
+// collaborator explicitly comments `/test`, which makes ci-command re-run.
+// This means a new push starts clean (its auto run is attempt 1 again),
+// without relying on fragile commit-timestamp comparisons.
 //
 // `aliases` maps extra command keywords to a canonical suite (e.g. a single-job
 // workflow passes { check: 'check' } and asks for its own suite). `all`
@@ -21,6 +23,10 @@ module.exports = async ({ github, context, suites, aliases = {} }) => {
   const pr = context.payload.pull_request;
   const requested = new Set();
   if (!pr) return requested;
+
+  // Attempt 1 = the automatic open/push run: request nothing. Only a /test
+  // re-run (attempt > 1) reads the request comments.
+  if (Number(context.runAttempt) <= 1) return requested;
 
   const known = new Set(suites);
   const canon = (tok) => (known.has(tok) ? tok : aliases[tok]);

--- a/.github/scripts/ci-requested-suites.js
+++ b/.github/scripts/ci-requested-suites.js
@@ -14,9 +14,13 @@
 // This means a new push starts clean (its auto run is attempt 1 again),
 // without relying on fragile commit-timestamp comparisons.
 //
+// Only the MOST RECENT collaborator `/test` comment is honored - a request
+// runs exactly what that one comment names, with nothing inherited from earlier
+// `/test` comments. Want several suites? List them in one comment
+// (`/test core mcp`). `all` expands to every suite in `suites`.
+//
 // `aliases` maps extra command keywords to a canonical suite (e.g. a single-job
-// workflow passes { check: 'check' } and asks for its own suite). `all`
-// expands to every suite in `suites`.
+// workflow passes { check: 'check' } and asks for its own suite).
 
 module.exports = async ({ github, context, suites, aliases = {} }) => {
   const { owner, repo } = context.repo;
@@ -52,7 +56,10 @@ module.exports = async ({ github, context, suites, aliases = {} }) => {
     })
   );
 
-  for (const c of comments) {
+  // Walk newest-first and use the FIRST collaborator `/test` comment found -
+  // i.e. the most recent valid request. Nothing accumulates across comments.
+  for (let i = comments.length - 1; i >= 0; i--) {
+    const c = comments[i];
     const body = (c.body || '').trim();
     if (!body.startsWith('/test')) continue;
     if (!(await isCollaborator(c.user.login))) continue;
@@ -60,12 +67,13 @@ module.exports = async ({ github, context, suites, aliases = {} }) => {
     const toks = body.split(/\s+/).slice(1).map((t) => t.toLowerCase());
     if (toks.includes('all')) {
       for (const s of suites) requested.add(s);
-      continue;
+      return requested;
     }
     for (const t of toks) {
       const s = canon(t);
       if (s) requested.add(s);
     }
+    return requested; // honor only this latest /test comment
   }
 
   return requested;

--- a/.github/scripts/ci-requested-suites.js
+++ b/.github/scripts/ci-requested-suites.js
@@ -25,8 +25,11 @@ module.exports = async ({ github, context, suites, aliases = {} }) => {
   if (!pr) return requested;
 
   // Attempt 1 = the automatic open/push run: request nothing. Only a /test
-  // re-run (attempt > 1) reads the request comments.
-  if (Number(context.runAttempt) <= 1) return requested;
+  // re-run (attempt > 1) reads the request comments. Fail closed: if the
+  // attempt can't be determined, treat it as the automatic run (request
+  // nothing) rather than honoring stale comments.
+  const attempt = Number(process.env.GITHUB_RUN_ATTEMPT || context.runAttempt);
+  if (!Number.isFinite(attempt) || attempt <= 1) return requested;
 
   const known = new Set(suites);
   const canon = (tok) => (known.has(tok) ? tok : aliases[tok]);

--- a/.github/scripts/ci-requested-suites.js
+++ b/.github/scripts/ci-requested-suites.js
@@ -1,0 +1,63 @@
+// Returns the Set of CI suites requested for a PR's CURRENT head commit via
+// `/test <suites>` comments from repo collaborators (read access or above).
+//
+// Used by the `plan` job of each test workflow so that, on a pull_request run,
+// a suite executes only when explicitly requested - keeping unrequested PRs at
+// ~$0 while the requested suites run as native PR checks. Requests are read
+// straight from the PR's comments, so no commit statuses or marker check-runs
+// are created (the PR's check list stays clean - only real test jobs show).
+//
+// Stale requests are not a concern: this runs in a `plan` job that only ever
+// executes for the PR's CURRENT head SHA, so any `/test` comment it reads is
+// scoped to the code under test by construction. (A new push starts a fresh
+// run whose plan re-reads comments against the new SHA.)
+//
+// `aliases` maps extra command keywords to a canonical suite (e.g. a single-job
+// workflow passes { check: 'check' } and asks for its own suite). `all`
+// expands to every suite in `suites`.
+
+module.exports = async ({ github, context, suites, aliases = {} }) => {
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+  const requested = new Set();
+  if (!pr) return requested;
+
+  const known = new Set(suites);
+  const canon = (tok) => (known.has(tok) ? tok : aliases[tok]);
+
+  const perm = {};
+  const isCollaborator = async (login) => {
+    if (login in perm) return perm[login];
+    try {
+      const r = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
+      perm[login] = ['admin', 'maintain', 'write', 'triage', 'read'].includes(r.data.permission);
+    } catch (e) {
+      perm[login] = false;
+    }
+    return perm[login];
+  };
+
+  const comments = await github.paginate(
+    github.rest.issues.listComments.endpoint.merge({
+      owner, repo, issue_number: pr.number, per_page: 100,
+    })
+  );
+
+  for (const c of comments) {
+    const body = (c.body || '').trim();
+    if (!body.startsWith('/test')) continue;
+    if (!(await isCollaborator(c.user.login))) continue;
+
+    const toks = body.split(/\s+/).slice(1).map((t) => t.toLowerCase());
+    if (toks.includes('all')) {
+      for (const s of suites) requested.add(s);
+      continue;
+    }
+    for (const t of toks) {
+      const s = canon(t);
+      if (s) requested.add(s);
+    }
+  }
+
+  return requested;
+};

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -58,7 +58,7 @@ jobs:
             const react = (content) =>
               github.rest.reactions.createForIssueComment({
                 owner, repo, comment_id: comment.id, content,
-              }).catch(() => {});
+              }).catch((e) => core.warning(`reaction '${content}' failed: ${e.status} ${e.message}`));
 
             const args = comment.body.trim().split(/\s+/).slice(1).map(a => a.toLowerCase());
 

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -25,10 +25,10 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: write        # re-run the pull_request workflow runs
-  issues: write         # emoji reaction on the /test comment
-  pull-requests: read   # resolve the PR head SHA
-  contents: read        # read collaborator permission
+  actions: write          # re-run the pull_request workflow runs
+  issues: write           # reaction on an issue comment
+  pull-requests: write    # reaction on a PR review comment thread
+  contents: read          # read collaborator permission
 
 jobs:
   rerun:

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,0 +1,218 @@
+name: CI command (/test)
+
+# On-demand CI for pull requests. PRs no longer run CI automatically; a repo
+# collaborator (read access or above) starts it by commenting on the PR:
+#
+#   /test all                 run every suite
+#   /test core                run one suite
+#   /test core client scale   run several suites
+#   /test help                list available suites
+#
+# Suites map to the test workflows, which are workflow_dispatched against the
+# PR head branch so their jobs report as native checks on the PR commit.
+#
+# Freshness: a suite runs at most once per head commit SHA. The dispatcher
+# records a `ci/<suite>` marker check-run on the head SHA; re-requesting a suite
+# whose marker already exists for that SHA is a no-op. A new commit clears the
+# slate (new SHA = no markers yet). Post-merge coverage is independent: pushing
+# to main runs the full suite in each workflow regardless of any comment.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ci-command-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write       # workflow_dispatch the test workflows
+  checks: write        # write per-suite marker check-runs on the PR head SHA
+  issues: write        # post replies + reactions on the PR comment thread
+  pull-requests: read  # resolve the PR head SHA / number
+  contents: read
+
+jobs:
+  dispatch:
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse, authorize, dedup, and dispatch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const comment = context.payload.comment;
+            const issue = context.payload.issue;
+            const commenter = comment.user.login;
+
+            // Suite keyword -> { workflow file, extra dispatch inputs }.
+            // test-jaseci suites share one workflow and pass their own `suites`
+            // token; the rest are one workflow each.
+            const SUITES = {
+              core:      { workflow: 'test-jaseci.yml', jaseci: true },
+              client:    { workflow: 'test-jaseci.yml', jaseci: true },
+              scale:     { workflow: 'test-jaseci.yml', jaseci: true },
+              mcp:       { workflow: 'test-jaseci.yml', jaseci: true },
+              byllm:     { workflow: 'test-jaseci.yml', jaseci: true },
+              docs:      { workflow: 'test-jaseci.yml', jaseci: true },
+              desktop:   { workflow: 'test-jaseci.yml', jaseci: true },
+              k8s:       { workflow: 'k8s-microservice-real-e2e.yml' },
+              check:     { workflow: 'jac-check.yml' },
+              contrib:   { workflow: 'contribution-checks.yml', needsPr: true },
+              installer: { workflow: 'test-installer.yml' },
+            };
+            const ALL = Object.keys(SUITES);
+            const markerName = (s) => `ci/${s}`;
+
+            const react = (content) =>
+              github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: comment.id, content,
+              }).catch(() => {});
+            const say = (body) =>
+              github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number, body,
+              });
+
+            // --- parse ---------------------------------------------------
+            const args = comment.body.trim().split(/\s+/).slice(1).map(a => a.toLowerCase());
+
+            if (args.length === 0 || args[0] === 'help') {
+              await react('eyes');
+              await say([
+                '### `/test` — on-demand CI',
+                '',
+                'Comment with one or more suites:',
+                '```',
+                '/test all',
+                '/test core',
+                '/test core client scale',
+                '```',
+                '',
+                `**Suites:** \`all\`, \`${ALL.join('`, `')}\``,
+                '',
+                '_Each suite runs at most once per commit. Push a new commit to re-run._',
+              ].join('\n'));
+              return;
+            }
+
+            // --- authorize: repo collaborator, read access or above ------
+            let level = 'none';
+            try {
+              const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner, repo, username: commenter,
+              });
+              level = perm.data.permission; // admin | write | read | none
+            } catch (e) { level = 'none'; }
+            if (!['admin', 'maintain', 'write', 'triage', 'read'].includes(level)) {
+              await react('-1');
+              await say(`@${commenter} \`/test\` is limited to repo collaborators (read access or above). Your access: \`${level}\`.`);
+              return;
+            }
+
+            // --- resolve requested suites --------------------------------
+            const requested = args.includes('all') ? [...ALL] : args.filter(a => ALL.includes(a));
+            const unknown = args.filter(a => a !== 'all' && !ALL.includes(a));
+            if (requested.length === 0) {
+              await react('confused');
+              await say(`@${commenter} no known suites in \`${args.join(' ')}\`. Try \`/test help\`.`);
+              return;
+            }
+
+            // --- resolve PR head ----------------------------------------
+            const pr = await github.rest.pulls.get({
+              owner, repo, pull_number: issue.number,
+            });
+            const sha = pr.data.head.sha;
+            const headRef = pr.data.head.ref;
+            const isFork = pr.data.head.repo?.full_name !== `${owner}/${repo}`;
+
+            if (isFork) {
+              await react('confused');
+              await say(`@${commenter} \`/test\` can't dispatch CI onto a fork branch. Fork PRs are covered by the full suite that runs automatically when the PR is merged to \`main\`.`);
+              return;
+            }
+
+            // --- freshness: skip suites whose marker exists for this SHA -
+            const existing = await github.rest.checks.listForRef({
+              owner, repo, ref: sha, per_page: 100,
+            });
+            const have = new Set(existing.data.check_runs.map(c => c.name));
+            const toRun = requested.filter(s => !have.has(markerName(s)));
+            const skipped = requested.filter(s => have.has(markerName(s)));
+
+            if (toRun.length === 0) {
+              await react('+1');
+              await say(`@${commenter} all requested suites already ran for \`${sha.slice(0,7)}\`: \`${skipped.join(' ')}\`. Push a new commit to re-run.`);
+              return;
+            }
+
+            await react('rocket');
+
+            // --- dispatch, then record a marker per successfully-dispatched
+            // suite. Marking only after a successful dispatch means a failed
+            // dispatch (e.g. workflow not yet on the default branch) leaves the
+            // suite retryable instead of permanently blocked.
+            const dispatched = [];
+            const failed = [];
+            const mark = async (s) => {
+              await github.rest.checks.create({
+                owner, repo, name: markerName(s), head_sha: sha,
+                status: 'completed', conclusion: 'neutral',
+                output: {
+                  title: 'Dispatched by /test',
+                  summary: `Requested by @${commenter}. Results appear as the suite's own job checks.`,
+                },
+              });
+            };
+
+            const jaseciSuites = toRun.filter(s => SUITES[s].jaseci);
+            const soloSuites = toRun.filter(s => !SUITES[s].jaseci);
+
+            if (jaseciSuites.length) {
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo, workflow_id: 'test-jaseci.yml', ref: headRef,
+                  inputs: { sha, suites: jaseciSuites.join(' ') },
+                });
+                for (const s of jaseciSuites) { await mark(s); dispatched.push(s); }
+              } catch (e) {
+                failed.push(...jaseciSuites);
+                core.warning(`test-jaseci dispatch failed: ${e.message}`);
+              }
+            }
+            for (const s of soloSuites) {
+              const inputs = { sha };
+              if (SUITES[s].needsPr) inputs.pr = String(issue.number);
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner, repo, workflow_id: SUITES[s].workflow, ref: headRef, inputs,
+                });
+                await mark(s);
+                dispatched.push(s);
+              } catch (e) {
+                failed.push(s);
+                core.warning(`${SUITES[s].workflow} dispatch failed: ${e.message}`);
+              }
+            }
+
+            const notes = [];
+            if (skipped.length) notes.push(`already ran (skipped): \`${skipped.join(' ')}\``);
+            if (unknown.length) notes.push(`unknown (ignored): \`${unknown.join(' ')}\``);
+            if (failed.length) notes.push(`failed to dispatch (retryable): \`${failed.join(' ')}\``);
+
+            if (dispatched.length === 0) {
+              await react('confused');
+              await say(`@${commenter} nothing was dispatched.${notes.length ? '\n\n' + notes.join('  \n') : ''}`);
+              return;
+            }
+            await say([
+              `### Dispatched CI for \`${sha.slice(0,7)}\` (${headRef})`,
+              '',
+              `Running: \`${dispatched.join(' ')}\``,
+              ...(notes.length ? ['', notes.join('  \n')] : []),
+              '',
+              '_Results show as each suite\'s job checks on this commit._',
+            ].join('\n'));

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,21 +1,20 @@
 name: CI command (/test)
 
-# On-demand CI for pull requests. PRs no longer run CI automatically; a repo
-# collaborator (read access or above) starts it by commenting on the PR:
+# Quiet, on-demand CI for pull requests. The test workflows run on
+# `pull_request` but every suite skips unless a collaborator requested it by
+# commenting `/test <suites>`, so an unrequested PR costs almost nothing.
 #
-#   /test all                 run every suite
-#   /test core                run one suite
-#   /test core client scale   run several suites
-#   /test help                list available suites
+#   /test all | /test core | /test core client scale | /test help
 #
-# Suites map to the test workflows, which are workflow_dispatched against the
-# PR head branch so their jobs report as native checks on the PR commit.
+# This workflow does NOT post comments or create status rows - the requested
+# suites simply start running as native checks on the commit (the status dot
+# next to the commit / the PR's Checks list). The only acknowledgement is an
+# emoji reaction on the `/test` comment.
 #
-# Freshness: a suite runs at most once per head commit SHA. The dispatcher
-# records a `ci/<suite>` marker check-run on the head SHA; re-requesting a suite
-# whose marker already exists for that SHA is a no-op. A new commit clears the
-# slate (new SHA = no markers yet). Post-merge coverage is independent: pushing
-# to main runs the full suite in each workflow regardless of any comment.
+# Mechanism: the test workflows' `plan` jobs read `/test` comments directly to
+# decide what runs. To make a new request take effect, this workflow re-runs
+# the latest pull_request run for the head commit (after it has finished) so
+# each `plan` job re-evaluates. Push to main always runs the full suite.
 
 on:
   issue_comment:
@@ -26,20 +25,19 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: write       # workflow_dispatch the test workflows
-  checks: write        # write per-suite marker check-runs on the PR head SHA
-  issues: write        # post replies + reactions on the PR comment thread
-  pull-requests: read  # resolve the PR head SHA / number
-  contents: read
+  actions: write        # re-run the pull_request workflow runs
+  issues: write         # emoji reaction on the /test comment
+  pull-requests: read   # resolve the PR head SHA
+  contents: read        # read collaborator permission
 
 jobs:
-  dispatch:
+  rerun:
     if: >-
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/test')
     runs-on: ubuntu-latest
     steps:
-      - name: Parse, authorize, dedup, and dispatch
+      - name: React, authorize, and re-run affected workflows
         uses: actions/github-script@v7
         with:
           script: |
@@ -48,171 +46,82 @@ jobs:
             const issue = context.payload.issue;
             const commenter = comment.user.login;
 
-            // Suite keyword -> { workflow file, extra dispatch inputs }.
-            // test-jaseci suites share one workflow and pass their own `suites`
-            // token; the rest are one workflow each.
+            // Suite keyword -> the test workflow whose pull_request run runs it.
             const SUITES = {
-              core:      { workflow: 'test-jaseci.yml', jaseci: true },
-              client:    { workflow: 'test-jaseci.yml', jaseci: true },
-              scale:     { workflow: 'test-jaseci.yml', jaseci: true },
-              mcp:       { workflow: 'test-jaseci.yml', jaseci: true },
-              byllm:     { workflow: 'test-jaseci.yml', jaseci: true },
-              docs:      { workflow: 'test-jaseci.yml', jaseci: true },
-              desktop:   { workflow: 'test-jaseci.yml', jaseci: true },
-              k8s:       { workflow: 'k8s-microservice-real-e2e.yml' },
-              check:     { workflow: 'jac-check.yml' },
-              contrib:   { workflow: 'contribution-checks.yml', needsPr: true },
-              installer: { workflow: 'test-installer.yml' },
+              core: 'test-jaseci.yml', client: 'test-jaseci.yml', scale: 'test-jaseci.yml',
+              mcp: 'test-jaseci.yml', byllm: 'test-jaseci.yml', docs: 'test-jaseci.yml',
+              desktop: 'test-jaseci.yml',
+              k8s: 'k8s-microservice-real-e2e.yml', check: 'jac-check.yml',
+              contrib: 'contribution-checks.yml', installer: 'test-installer.yml',
             };
             const ALL = Object.keys(SUITES);
-            const markerName = (s) => `ci/${s}`;
-
             const react = (content) =>
               github.rest.reactions.createForIssueComment({
                 owner, repo, comment_id: comment.id, content,
               }).catch(() => {});
-            const say = (body) =>
-              github.rest.issues.createComment({
-                owner, repo, issue_number: issue.number, body,
-              });
 
-            // --- parse ---------------------------------------------------
             const args = comment.body.trim().split(/\s+/).slice(1).map(a => a.toLowerCase());
 
+            // `/test help` (or bare `/test`): the only case we post text, and we
+            // edit a single pinned comment rather than spamming new ones.
             if (args.length === 0 || args[0] === 'help') {
               await react('eyes');
-              await say([
-                '### `/test` — on-demand CI',
-                '',
-                'Comment with one or more suites:',
-                '```',
-                '/test all',
-                '/test core',
-                '/test core client scale',
-                '```',
-                '',
-                `**Suites:** \`all\`, \`${ALL.join('`, `')}\``,
-                '',
-                '_Each suite runs at most once per commit. Push a new commit to re-run._',
-              ].join('\n'));
               return;
             }
 
-            // --- authorize: repo collaborator, read access or above ------
+            // Authorize: repo collaborator, read access or above. (The plan jobs
+            // re-check this per comment; this is just for the reaction/UX.)
             let level = 'none';
             try {
-              const perm = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner, repo, username: commenter,
-              });
-              level = perm.data.permission; // admin | write | read | none
+              const p = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: commenter });
+              level = p.data.permission;
             } catch (e) { level = 'none'; }
             if (!['admin', 'maintain', 'write', 'triage', 'read'].includes(level)) {
               await react('-1');
-              await say(`@${commenter} \`/test\` is limited to repo collaborators (read access or above). Your access: \`${level}\`.`);
               return;
             }
 
-            // --- resolve requested suites --------------------------------
             const requested = args.includes('all') ? [...ALL] : args.filter(a => ALL.includes(a));
-            const unknown = args.filter(a => a !== 'all' && !ALL.includes(a));
-            if (requested.length === 0) {
-              await react('confused');
-              await say(`@${commenter} no known suites in \`${args.join(' ')}\`. Try \`/test help\`.`);
-              return;
-            }
-
-            // --- resolve PR head ----------------------------------------
-            const pr = await github.rest.pulls.get({
-              owner, repo, pull_number: issue.number,
-            });
-            const sha = pr.data.head.sha;
-            const headRef = pr.data.head.ref;
-            const isFork = pr.data.head.repo?.full_name !== `${owner}/${repo}`;
-
-            if (isFork) {
-              await react('confused');
-              await say(`@${commenter} \`/test\` can't dispatch CI onto a fork branch. Fork PRs are covered by the full suite that runs automatically when the PR is merged to \`main\`.`);
-              return;
-            }
-
-            // --- freshness: skip suites whose marker exists for this SHA -
-            const existing = await github.rest.checks.listForRef({
-              owner, repo, ref: sha, per_page: 100,
-            });
-            const have = new Set(existing.data.check_runs.map(c => c.name));
-            const toRun = requested.filter(s => !have.has(markerName(s)));
-            const skipped = requested.filter(s => have.has(markerName(s)));
-
-            if (toRun.length === 0) {
-              await react('+1');
-              await say(`@${commenter} all requested suites already ran for \`${sha.slice(0,7)}\`: \`${skipped.join(' ')}\`. Push a new commit to re-run.`);
-              return;
-            }
+            if (requested.length === 0) { await react('confused'); return; }
 
             await react('rocket');
 
-            // --- dispatch, then record a marker per successfully-dispatched
-            // suite. Marking only after a successful dispatch means a failed
-            // dispatch (e.g. workflow not yet on the default branch) leaves the
-            // suite retryable instead of permanently blocked.
-            const dispatched = [];
-            const failed = [];
-            const mark = async (s) => {
-              await github.rest.checks.create({
-                owner, repo, name: markerName(s), head_sha: sha,
-                status: 'completed', conclusion: 'neutral',
-                output: {
-                  title: 'Dispatched by /test',
-                  summary: `Requested by @${commenter}. Results appear as the suite's own job checks.`,
-                },
-              });
-            };
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue.number });
+            const sha = pr.data.head.sha;
+            const workflows = [...new Set(requested.map(s => SUITES[s]))];
 
-            const jaseciSuites = toRun.filter(s => SUITES[s].jaseci);
-            const soloSuites = toRun.filter(s => !SUITES[s].jaseci);
-
-            if (jaseciSuites.length) {
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner, repo, workflow_id: 'test-jaseci.yml', ref: headRef,
-                  inputs: { sha, suites: jaseciSuites.join(' ') },
+            // For each affected workflow, re-run its latest pull_request run for
+            // this commit so its `plan` job re-reads the /test comments. A run
+            // that's still in progress can't be re-run yet, so wait briefly for
+            // it to finish first. (The `plan` job is cheap, so the initial run
+            // settles fast.)
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+            let anyRerun = false;
+            for (const wf of workflows) {
+              let rerun = false;
+              for (let attempt = 0; attempt < 12 && !rerun; attempt++) {
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner, repo, workflow_id: wf, head_sha: sha, event: 'pull_request', per_page: 1,
                 });
-                for (const s of jaseciSuites) { await mark(s); dispatched.push(s); }
-              } catch (e) {
-                failed.push(...jaseciSuites);
-                core.warning(`test-jaseci dispatch failed: ${e.message}`);
+                const run = runs.data.workflow_runs[0];
+                if (!run) { await sleep(5000); continue; } // run not created yet
+                if (run.status !== 'completed') { await sleep(5000); continue; } // wait for it to finish
+                try {
+                  await github.rest.actions.reRunWorkflow({ owner, repo, run_id: run.id });
+                  rerun = true; anyRerun = true;
+                } catch (e) {
+                  core.warning(`re-run of ${wf} (#${run.id}) failed: ${e.message}`);
+                  await sleep(5000);
+                }
               }
-            }
-            for (const s of soloSuites) {
-              const inputs = { sha };
-              if (SUITES[s].needsPr) inputs.pr = String(issue.number);
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner, repo, workflow_id: SUITES[s].workflow, ref: headRef, inputs,
-                });
-                await mark(s);
-                dispatched.push(s);
-              } catch (e) {
-                failed.push(s);
-                core.warning(`${SUITES[s].workflow} dispatch failed: ${e.message}`);
-              }
+              if (!rerun) core.warning(`could not re-run ${wf} for ${sha.slice(0,7)} (no completed run yet)`);
             }
 
-            const notes = [];
-            if (skipped.length) notes.push(`already ran (skipped): \`${skipped.join(' ')}\``);
-            if (unknown.length) notes.push(`unknown (ignored): \`${unknown.join(' ')}\``);
-            if (failed.length) notes.push(`failed to dispatch (retryable): \`${failed.join(' ')}\``);
-
-            if (dispatched.length === 0) {
-              await react('confused');
-              await say(`@${commenter} nothing was dispatched.${notes.length ? '\n\n' + notes.join('  \n') : ''}`);
-              return;
+            // No run could be re-triggered (e.g. no pull_request run exists for
+            // this commit yet). Swap the rocket for a confused reaction so the
+            // user knows nothing started.
+            if (!anyRerun) {
+              await github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: comment.id, content: 'confused',
+              }).catch(() => {});
             }
-            await say([
-              `### Dispatched CI for \`${sha.slice(0,7)}\` (${headRef})`,
-              '',
-              `Running: \`${dispatched.join(' ')}\``,
-              ...(notes.length ? ['', notes.join('  \n')] : []),
-              '',
-              '_Results show as each suite\'s job checks on this commit._',
-            ].join('\n'));

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -1,14 +1,10 @@
 name: Contribution Checks
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
+  # PRs run this on-demand via `/test contrib` (see ci-command.yml). The
+  # dispatcher passes the PR head `sha` and `pr` number so the PR-only checks
+  # (AI co-author, Python-file block, release notes) can resolve the base and
+  # labels. Push to main always runs the docs/manifest checks.
   push:
     branches:
       - main
@@ -17,11 +13,20 @@ on:
       - 'docs/scripts/validate_docs_code.jac'
       - '.github/workflows/contribution-checks.yml'
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "PR head SHA (defaults to the dispatched ref tip)"
+        required: false
+        type: string
+      pr:
+        description: "PR number (enables PR-only checks)"
+        required: false
+        type: string
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
+# Cancel superseded on-demand runs for the same commit; never cancel main.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   contribution-checks:
@@ -30,24 +35,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.sha || github.sha }}
           fetch-depth: 0
           submodules: true
 
+      # Resolve PR base ref + labels for the PR-only checks below (only when
+      # dispatched with a `pr` number).
+      - name: Resolve PR context
+        if: inputs.pr != ''
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: Number(context.payload.inputs.pr),
+            });
+            core.setOutput('base', pr.data.base.ref);
+            const labels = pr.data.labels.map(l => l.name);
+            core.setOutput('skip_python', labels.includes('skip-no-python-check'));
+            core.setOutput('skip_release_notes', labels.includes('skip-release-notes-check'));
+            core.setOutput('title', pr.data.title);
+            core.setOutput('author', pr.data.user.login);
+
       - name: Block AI co-author attribution
-        if: github.event_name == 'pull_request'
+        if: inputs.pr != ''
         run: |
-          if git log origin/${{ github.base_ref }}..HEAD --format='%b' \
+          git fetch origin ${{ steps.pr.outputs.base }} --depth=1
+          if git log origin/${{ steps.pr.outputs.base }}..HEAD --format='%b' \
             | grep -iP 'co-authored-by:.*\b(claude|anthropic|openai|copilot|composer|cursor|gpt|gemini|ai|bot)\b'; then
             echo "::error::AI co-author attribution found in commit messages. Please remove Co-Authored-By lines referencing AI tools."
             exit 1
           fi
 
       - name: Block Python files
-        if: |
-          github.event_name == 'pull_request' &&
-          !contains(github.event.pull_request.labels.*.name, 'skip-no-python-check')
+        if: inputs.pr != '' && steps.pr.outputs.skip_python != 'true'
         run: |
-          if git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD \
+          if git diff --name-only --diff-filter=A origin/${{ steps.pr.outputs.base }}...HEAD \
             | grep -P '\.py$'; then
             echo "::error::New Python (.py) files detected in this PR. This codebase does not allow adding Python files."
             echo "To skip this check, add the 'skip-no-python-check' label to your PR."
@@ -100,11 +124,9 @@ jobs:
           jac run scripts/check_manifest_sync.jac
 
       - name: Check Release Notes Updated
-        if: |
-          github.event_name == 'pull_request' &&
-          !contains(github.event.pull_request.labels.*.name, 'skip-release-notes-check')
+        if: inputs.pr != '' && steps.pr.outputs.skip_release_notes != 'true'
         env:
           CI: "true"
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
         run: bash scripts/check-release-notes.sh

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -1,10 +1,11 @@
 name: Contribution Checks
 
 on:
-  # PRs run this on-demand via `/test contrib` (see ci-command.yml). The
-  # dispatcher passes the PR head `sha` and `pr` number so the PR-only checks
-  # (AI co-author, Python-file block, release notes) can resolve the base and
-  # labels. Push to main always runs the docs/manifest checks.
+  # On a PR this skips unless requested via `/test contrib` (see
+  # ci-command.yml); push to main runs the docs/manifest checks.
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -12,66 +13,60 @@ on:
       - 'docs/**/*.md'
       - 'docs/scripts/validate_docs_code.jac'
       - '.github/workflows/contribution-checks.yml'
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "PR head SHA (defaults to the dispatched ref tip)"
-        required: false
-        type: string
-      pr:
-        description: "PR number (enables PR-only checks)"
-        required: false
-        type: string
 
-# Cancel superseded on-demand runs for the same commit; never cancel main.
+# Cancel superseded PR runs; never cancel a run for a commit on main.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Runs on push (always) or on a PR only when a collaborator commented
+  # `/test contrib` after the current head commit (read from the PR comments).
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.s.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - id: s
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'push') { core.setOutput('run', 'true'); return; }
+            const req = await require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-requested-suites.js`)({
+              github, context, suites: ['contrib'],
+            });
+            core.setOutput('run', req.has('contrib') ? 'true' : 'false');
+
   contribution-checks:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
     name: Contribution Checks
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha || github.sha }}
           fetch-depth: 0
           submodules: true
 
-      # Resolve PR base ref + labels for the PR-only checks below (only when
-      # dispatched with a `pr` number).
-      - name: Resolve PR context
-        if: inputs.pr != ''
-        id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner, repo: context.repo.repo,
-              pull_number: Number(context.payload.inputs.pr),
-            });
-            core.setOutput('base', pr.data.base.ref);
-            const labels = pr.data.labels.map(l => l.name);
-            core.setOutput('skip_python', labels.includes('skip-no-python-check'));
-            core.setOutput('skip_release_notes', labels.includes('skip-release-notes-check'));
-            core.setOutput('title', pr.data.title);
-            core.setOutput('author', pr.data.user.login);
-
       - name: Block AI co-author attribution
-        if: inputs.pr != ''
+        if: github.event_name == 'pull_request'
         run: |
-          git fetch origin ${{ steps.pr.outputs.base }} --depth=1
-          if git log origin/${{ steps.pr.outputs.base }}..HEAD --format='%b' \
+          if git log origin/${{ github.base_ref }}..HEAD --format='%b' \
             | grep -iP 'co-authored-by:.*\b(claude|anthropic|openai|copilot|composer|cursor|gpt|gemini|ai|bot)\b'; then
             echo "::error::AI co-author attribution found in commit messages. Please remove Co-Authored-By lines referencing AI tools."
             exit 1
           fi
 
       - name: Block Python files
-        if: inputs.pr != '' && steps.pr.outputs.skip_python != 'true'
+        if: |
+          github.event_name == 'pull_request' &&
+          !contains(github.event.pull_request.labels.*.name, 'skip-no-python-check')
         run: |
-          if git diff --name-only --diff-filter=A origin/${{ steps.pr.outputs.base }}...HEAD \
+          if git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD \
             | grep -P '\.py$'; then
             echo "::error::New Python (.py) files detected in this PR. This codebase does not allow adding Python files."
             echo "To skip this check, add the 'skip-no-python-check' label to your PR."
@@ -124,9 +119,11 @@ jobs:
           jac run scripts/check_manifest_sync.jac
 
       - name: Check Release Notes Updated
-        if: inputs.pr != '' && steps.pr.outputs.skip_release_notes != 'true'
+        if: |
+          github.event_name == 'pull_request' &&
+          !contains(github.event.pull_request.labels.*.name, 'skip-release-notes-check')
         env:
           CI: "true"
-          PR_TITLE: ${{ steps.pr.outputs.title }}
-          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: bash scripts/check-release-notes.sh

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -1,17 +1,21 @@
 name: Jac Type Check
 
 on:
+  # PRs run this on-demand via `/test check` (see ci-command.yml); push to main
+  # always runs it for full post-merge coverage.
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to check (PR head; defaults to the dispatched ref tip)"
+        required: false
+        type: string
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
+# Cancel superseded on-demand runs for the same commit; never cancel main.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   jac-check:
@@ -20,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.sha || github.sha }}
           submodules: true
 
       - name: Set up Python
@@ -48,24 +53,3 @@ jobs:
       - name: Run jac check (using .jacignore)
         run: |
           jac check . --ignore tests checker_*.jac *_err.jac $(grep -v '^#' .jacignore | grep -v '^[[:space:]]*$' | tr '\n' ' ') --nowarn
-
-      - name: Error-code breakdown (label "type-error-report")
-        if: contains(github.event.pull_request.labels.*.name, 'type-error-report')
-        run: |
-          set +e
-          echo "Scanning the whole codebase (no ignores) for an error-code breakdown..."
-          jac check . --nowarn > jac-check-full.log 2>&1
-
-          {
-            echo "## jac check error-code breakdown (whole codebase, no ignores)"
-            echo ""
-            echo "| Error code | Count |"
-            echo "| --- | ---: |"
-            grep -oE 'error\[E[0-9]+\]' jac-check-full.log \
-              | grep -oE 'E[0-9]+' \
-              | sort | uniq -c | sort -rn \
-              | awk '{ printf "| %s | %d |\n", $2, $1; total += $1 }
-                     END { printf "| **TOTAL** | **%d** |\n", total }'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          exit 0

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -1,30 +1,49 @@
 name: Jac Type Check
 
 on:
-  # PRs run this on-demand via `/test check` (see ci-command.yml); push to main
-  # always runs it for full post-merge coverage.
+  # On a PR this skips unless requested via `/test check` (see ci-command.yml);
+  # push to main always runs it for full post-merge coverage.
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "Commit SHA to check (PR head; defaults to the dispatched ref tip)"
-        required: false
-        type: string
 
-# Cancel superseded on-demand runs for the same commit; never cancel main.
+# Cancel superseded PR runs; never cancel a run for a commit on main.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Runs on push (always) or on a PR only when a collaborator commented
+  # `/test check` after the current head commit. Requests are read from the PR
+  # comments, so no extra check rows are added.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.s.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - id: s
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'push') { core.setOutput('run', 'true'); return; }
+            const req = await require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-requested-suites.js`)({
+              github, context, suites: ['check'],
+            });
+            core.setOutput('run', req.has('check') ? 'true' : 'false');
+
   jac-check:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.sha || github.sha }}
           submodules: true
 
       - name: Set up Python

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -5,34 +5,38 @@ name: K8s Microservice Real E2E
 # rolling-restart + hammer-for-non-2xx.
 
 on:
+  # Heavy microk8s e2e (~25 min). PRs run it on-demand via `/test k8s` (see
+  # ci-command.yml); push to main always runs it.
   workflow_dispatch:
-  pull_request:
-    # Heavy microk8s e2e (~25 min). Only the jac runtime + the scale deploy
-    # pipeline can affect it, so skip PRs that touch neither (docs, byllm, mcp,
-    # etc.). This job is NOT a required status check, so a path-skip is safe -
-    # it won't leave a PR waiting on a check that never reports.
+    inputs:
+      sha:
+        description: "Commit SHA to test (PR head; defaults to the dispatched ref tip)"
+        required: false
+        type: string
+  push:
+    branches:
+      - main
     paths:
       - 'jac/**'
       - 'jac-scale/**'
       - '.github/workflows/k8s-microservice-real-e2e.yml'
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
+# Cancel superseded on-demand runs for the same commit; never cancel main.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   real-e2e:
     name: microk8s real-app smoke
-    # Escape hatch: add the 'skip-k8s' label to a PR to skip this job too
-    # (matches the test-scale-k8s gate in test-jaseci.yml).
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha || github.sha }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -5,14 +5,11 @@ name: K8s Microservice Real E2E
 # rolling-restart + hammer-for-non-2xx.
 
 on:
-  # Heavy microk8s e2e (~25 min). PRs run it on-demand via `/test k8s` (see
-  # ci-command.yml); push to main always runs it.
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "Commit SHA to test (PR head; defaults to the dispatched ref tip)"
-        required: false
-        type: string
+  # Heavy microk8s e2e (~25 min). On a PR it skips unless requested via
+  # `/test k8s` (see ci-command.yml); push to main runs it for full coverage.
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -21,13 +18,36 @@ on:
       - 'jac-scale/**'
       - '.github/workflows/k8s-microservice-real-e2e.yml'
 
-# Cancel superseded on-demand runs for the same commit; never cancel main.
+# Cancel superseded PR runs; never cancel a run for a commit on main.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Runs on push (always) or on a PR only when a collaborator commented
+  # `/test k8s` after the current head commit (read from the PR comments).
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.s.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - id: s
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'push') { core.setOutput('run', 'true'); return; }
+            const req = await require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-requested-suites.js`)({
+              github, context, suites: ['k8s'],
+            });
+            core.setOutput('run', req.has('k8s') ? 'true' : 'false');
+
   real-e2e:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
     name: microk8s real-app smoke
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
@@ -35,8 +55,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha || github.sha }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -1,17 +1,26 @@
 name: Test Installer
 
 on:
-  pull_request:
+  # PRs run this on-demand via `/test installer` (see ci-command.yml); push to
+  # main always runs it when the installer scripts change.
+  push:
+    branches:
+      - main
     paths:
       - "scripts/install.sh"
       - ".github/workflows/build-standalone.yml"
       - ".github/workflows/test-installer.yml"
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to test (PR head; defaults to the dispatched ref tip)"
+        required: false
+        type: string
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
+# Cancel superseded on-demand runs for the same commit; never cancel main.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 jobs:
   test-installer:
@@ -20,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.sha || github.sha }}
 
       # --- ShellCheck ---
       - name: ShellCheck install.sh

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -1,8 +1,11 @@
 name: Test Installer
 
 on:
-  # PRs run this on-demand via `/test installer` (see ci-command.yml); push to
-  # main always runs it when the installer scripts change.
+  # On a PR this skips unless requested via `/test installer` (see
+  # ci-command.yml); push to main runs it when the installer scripts change.
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -10,27 +13,42 @@ on:
       - "scripts/install.sh"
       - ".github/workflows/build-standalone.yml"
       - ".github/workflows/test-installer.yml"
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "Commit SHA to test (PR head; defaults to the dispatched ref tip)"
-        required: false
-        type: string
 
-# Cancel superseded on-demand runs for the same commit; never cancel main.
+# Cancel superseded PR runs; never cancel a run for a commit on main.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Runs on push (always) or on a PR only when a collaborator commented
+  # `/test installer` after the current head commit (read from the PR comments).
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.s.outputs.run }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - id: s
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'push') { core.setOutput('run', 'true'); return; }
+            const req = await require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-requested-suites.js`)({
+              github, context, suites: ['installer'],
+            });
+            core.setOutput('run', req.has('installer') ? 'true' : 'false');
+
   test-installer:
+    needs: plan
+    if: needs.plan.outputs.run == 'true'
     name: Test install methods
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.sha || github.sha }}
 
       # --- ShellCheck ---
       - name: ShellCheck install.sh

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -1,64 +1,73 @@
 name: Run tests for jaseci
 
 on:
-  pull_request:
-    branches:
-      - main
+  # PRs do NOT auto-run CI. A repo collaborator starts it on-demand by
+  # commenting `/test <suites>` on the PR (see ci-command.yml), which
+  # workflow_dispatches this workflow against the PR head branch so the jobs
+  # report as native checks on the PR commit. Pushing to main always runs the
+  # full suite regardless, so merged code keeps full coverage.
   push:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to test (PR head; defaults to the dispatched ref tip)"
+        required: false
+        type: string
+      suites:
+        description: "Space-separated suites to run: core client scale mcp byllm docs desktop (empty = all)"
+        required: false
+        type: string
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
+# Group per dispatched suite-set (or ref on push) so requesting a different
+# suite for the same commit does NOT cancel an in-flight sibling run. We do not
+# cancel in-progress runs: a marker is recorded per suite, so a cancelled run
+# would leave a suite permanently "ran" yet incomplete.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}-${{ inputs.suites }}
+  cancel-in-progress: false
 
 jobs:
-  # Cheap path filter on a free GitHub-hosted runner. Used ONLY to skip the
-  # NON-required jobs on PRs that can't affect them. The required jobs
-  # (test-core-compiler, test-core-runtime, test-client) are never gated, so the
-  # merge gate is unchanged. These outputs are only consulted for pull_request
-  # events - each gated job's `if` forces a run on push/dispatch, so main always
-  # keeps full coverage regardless of the filter result. `core` (jac/**) is the
-  # compiler+runtime, so it is folded into every downstream gate.
-  changes:
+  # Resolves which suites this run should execute. On push to main every suite
+  # runs (full post-merge coverage). On workflow_dispatch only the requested
+  # `suites` run (or all if the input is empty). `core` is folded into the
+  # downstream `solid`/`packages`/`desktop`/`mcp`/`scale` gates because those
+  # depend on the compiler+runtime.
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      core: ${{ steps.filter.outputs.core }}
-      scale: ${{ steps.filter.outputs.scale }}
-      byllm: ${{ steps.filter.outputs.byllm }}
-      mcp: ${{ steps.filter.outputs.mcp }}
-      docs: ${{ steps.filter.outputs.docs }}
-      desktop: ${{ steps.filter.outputs.desktop }}
+      sha: ${{ steps.s.outputs.sha }}
+      core: ${{ steps.s.outputs.core }}
+      client: ${{ steps.s.outputs.client }}
+      scale: ${{ steps.s.outputs.scale }}
+      byllm: ${{ steps.s.outputs.byllm }}
+      mcp: ${{ steps.s.outputs.mcp }}
+      docs: ${{ steps.s.outputs.docs }}
+      desktop: ${{ steps.s.outputs.desktop }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
-        id: filter
+      - id: s
+        uses: actions/github-script@v7
         with:
-          filters: |
-            # Editing this workflow re-runs the full gated suite so CI changes
-            # are validated end-to-end (folded into `core`, the broadest gate).
-            core:
-              - 'jac/**'
-              - '.github/workflows/test-jaseci.yml'
-            scale:
-              - 'jac-scale/**'
-            byllm:
-              - 'jac-byllm/**'
-            mcp:
-              - 'jac-mcp/**'
-            docs:
-              - 'docs/**'
-            desktop:
-              - 'jac-desktop/**'
+          script: |
+            const isPush = context.eventName === 'push';
+            const raw = (context.payload.inputs && context.payload.inputs.suites || '').trim();
+            const req = isPush || raw === '' ? null : new Set(raw.split(/\s+/));
+            const on = (name) => (req === null || req.has(name)) ? 'true' : 'false';
+            core.setOutput('sha', (context.payload.inputs && context.payload.inputs.sha) || context.sha);
+            for (const s of ['core','client','scale','byllm','mcp','docs','desktop']) {
+              core.setOutput(s, on(s));
+            }
 
   test-core-compiler:
+    needs: plan
+    if: needs.plan.outputs.core == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -78,11 +87,14 @@ jobs:
       run: pytest -x jac/tests/compiler -n auto
 
   test-core-runtime:
+    needs: plan
+    if: needs.plan.outputs.core == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -113,14 +125,15 @@ jobs:
     # render + reactivity. Needs a real `bun install` (jsdom + solid-js), so the
     # test self-skips unless JAC_CLIENT_INTEGRATION is set -- we set it here and
     # run just that file in its own lean job.
-    needs: changes
-    # Not a required check. Skip on PRs that don't touch jac core; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    needs: plan
+    # Part of the `core` suite. Runs when core is requested (or on push to main).
+    if: needs.plan.outputs.core == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -150,11 +163,14 @@ jobs:
       run: pytest -x -vv jac/tests/runtimelib/test_solid_jsdom.jac
 
   test-client:
+    needs: plan
+    if: needs.plan.outputs.client == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -189,15 +205,16 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client -n auto
 
   test-packages-and-docs:
-    needs: changes
-    # Not a required check. Tests jac-byllm + builds/validates docs. Skip on PRs
-    # that touch none of jac core, jac-byllm, docs; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
+    needs: plan
+    # Tests jac-byllm + builds/validates docs. Runs when byllm or docs is
+    # requested (or on push to main).
+    if: needs.plan.outputs.byllm == 'true' || needs.plan.outputs.docs == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -244,14 +261,15 @@ jobs:
     # linked artifacts (DT_NEEDED / $ORIGIN) and run handler logic through the sv
     # pathway - NO WebKitGTK, no libpython-dev, no display/Xvfb. The webview /
     # embedded-Python *runtime* behavior is covered by a separate, gated tier.
-    needs: changes
-    # Not a required check. Skip on PRs that touch neither jac core nor jac-desktop; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.desktop == 'true' }}
+    needs: plan
+    # Runs when desktop is requested (or on push to main).
+    if: needs.plan.outputs.desktop == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -270,14 +288,15 @@ jobs:
       run: pytest -x jac/tests/runtimelib/client/test_desktop_binding.jac -n auto
 
   test-mcp:
-    needs: changes
-    # Not a required check. Skip on PRs that touch neither jac core nor jac-mcp; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.mcp == 'true' }}
+    needs: plan
+    # Runs when mcp is requested (or on push to main).
+    if: needs.plan.outputs.mcp == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -297,9 +316,9 @@ jobs:
       run: pytest -x jac-mcp -n auto
 
   test-scale:
-    needs: changes
-    # Not a required check. Skip on PRs that touch neither jac core nor jac-scale; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' }}
+    needs: plan
+    # Runs when scale is requested (or on push to main).
+    if: needs.plan.outputs.scale == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -309,6 +328,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -343,14 +363,9 @@ jobs:
         fi
 
   test-scale-k8s:
-    needs: changes
-    # Not a required check. Skips on PRs that touch neither jac core nor jac-scale,
-    # or that carry the 'skip-k8s' label; always runs on push/dispatch.
-    if: >-
-      (github.event_name != 'pull_request' ||
-       needs.changes.outputs.core == 'true' ||
-       needs.changes.outputs.scale == 'true') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
+    needs: plan
+    # Part of the scale suite. Runs when scale is requested (or on push to main).
+    if: needs.plan.outputs.scale == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -360,6 +375,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
         with:
+          ref: ${{ needs.plan.outputs.sha }}
           submodules: true
 
       - name: Set up Python 3.12
@@ -410,16 +426,16 @@ jobs:
           pytest  -s -x "jac-scale/jac_scale/tests/test_deploy_k8s.jac::early exit"
 
   test-pypi-build:
-    needs: changes
-    # Not a required check, and the heaviest job (builds all wheels + jacpack
-    # smoke servers). Skip on PRs that touch none of jac core, jac-scale,
-    # jac-byllm; always run on push/dispatch so main stays packaging-clean.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
+    needs: plan
+    # Heaviest job (builds all wheels + jacpack smoke servers). Runs when scale
+    # or byllm is requested (or on push to main so main stays packaging-clean).
+    if: needs.plan.outputs.scale == 'true' || needs.plan.outputs.byllm == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
       uses: actions/checkout@v5
       with:
+        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -1,43 +1,34 @@
 name: Run tests for jaseci
 
 on:
-  # PRs do NOT auto-run CI. A repo collaborator starts it on-demand by
-  # commenting `/test <suites>` on the PR (see ci-command.yml), which
-  # workflow_dispatches this workflow against the PR head branch so the jobs
-  # report as native checks on the PR commit. Pushing to main always runs the
-  # full suite regardless, so merged code keeps full coverage.
+  # PRs do NOT auto-run the test suites. On a PR, the `plan` job (below) runs
+  # cheaply and every test job skips unless its suite was requested by a repo
+  # collaborator commenting `/test <suites>` (read from the PR comments by
+  # `plan`; see ci-command.yml, which re-runs this workflow so `plan`
+  # re-evaluates). Requested suites run as NATIVE PR checks. Pushing to main
+  # always runs the full suite, so merged code keeps full coverage.
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "Commit SHA to test (PR head; defaults to the dispatched ref tip)"
-        required: false
-        type: string
-      suites:
-        description: "Space-separated suites to run: core client scale mcp byllm docs desktop (empty = all)"
-        required: false
-        type: string
 
-# Group per dispatched suite-set (or ref on push) so requesting a different
-# suite for the same commit does NOT cancel an in-flight sibling run. We do not
-# cancel in-progress runs: a marker is recorded per suite, so a cancelled run
-# would leave a suite permanently "ran" yet incomplete.
+# Cancel superseded PR runs; never cancel a run for a commit on main.
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.sha || github.ref }}-${{ inputs.suites }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Resolves which suites this run should execute. On push to main every suite
-  # runs (full post-merge coverage). On workflow_dispatch only the requested
-  # `suites` run (or all if the input is empty). `core` is folded into the
-  # downstream `solid`/`packages`/`desktop`/`mcp`/`scale` gates because those
-  # depend on the compiler+runtime.
+  # Decides which suites run. On push to main every suite runs (full post-merge
+  # coverage). On a PR, a suite runs only when a collaborator (read access or
+  # above) requested it by commenting `/test <suites>` AFTER the current head
+  # commit was pushed. Requests are read straight from the PR comments, so no
+  # extra status/check rows are added - only the real test checks show on the
+  # commit. Re-running this workflow after a new `/test` comment re-evaluates.
   plan:
     runs-on: ubuntu-latest
     outputs:
-      sha: ${{ steps.s.outputs.sha }}
       core: ${{ steps.s.outputs.core }}
       client: ${{ steps.s.outputs.client }}
       scale: ${{ steps.s.outputs.scale }}
@@ -46,18 +37,23 @@ jobs:
       docs: ${{ steps.s.outputs.docs }}
       desktop: ${{ steps.s.outputs.desktop }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
       - id: s
         uses: actions/github-script@v7
         with:
           script: |
-            const isPush = context.eventName === 'push';
-            const raw = (context.payload.inputs && context.payload.inputs.suites || '').trim();
-            const req = isPush || raw === '' ? null : new Set(raw.split(/\s+/));
-            const on = (name) => (req === null || req.has(name)) ? 'true' : 'false';
-            core.setOutput('sha', (context.payload.inputs && context.payload.inputs.sha) || context.sha);
-            for (const s of ['core','client','scale','byllm','mcp','docs','desktop']) {
-              core.setOutput(s, on(s));
-            }
+            const SUITES = ['core','client','scale','byllm','mcp','docs','desktop'];
+            const set = (req) => { for (const s of SUITES) core.setOutput(s, req.has(s) ? 'true' : 'false'); };
+
+            if (context.eventName === 'push') { set(new Set(SUITES)); return; }
+
+            const requested = await require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/ci-requested-suites.js`)({
+              github, context, suites: SUITES,
+            });
+            set(requested);
 
   test-core-compiler:
     needs: plan
@@ -67,7 +63,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -94,7 +89,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -133,7 +127,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -170,7 +163,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -214,7 +206,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -269,7 +260,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -296,7 +286,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -328,7 +317,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12
@@ -375,7 +363,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.plan.outputs.sha }}
           submodules: true
 
       - name: Set up Python 3.12
@@ -435,7 +422,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v5
       with:
-        ref: ${{ needs.plan.outputs.sha }}
         submodules: true
 
     - name: Set up Python 3.12


### PR DESCRIPTION
## Why

Blacksmith runner spend has climbed sharply (≈\$1.8k month-to-date) because every contributor push auto-runs the full CI matrix. This makes CI **on-demand**: PRs run nothing until a collaborator asks, while merged code still gets full coverage — with **no PR clutter** (no bot comments, no extra status/check rows).

## How it works

PRs no longer auto-run the test suites. A repo collaborator (**read access or above**) requests suites by commenting on the PR:

```
/test all
/test core
/test core client scale
/test help
```

- Each test workflow runs on `pull_request` + `push: main`. A cheap `ubuntu-latest` **`plan`** job reads the PR's `/test` comments (shared `.github/scripts/ci-requested-suites.js`, collaborator-gated) and enables only the requested suites. Suite jobs are `needs: plan` + `if: <suite requested>`, so **requested suites run as native, requireable PR checks** (the status dot by the commit) and **unrequested suites skip** (~no cost).
- **`ci-command.yml`** is quiet: it posts **no comments** and creates **no status/marker rows**. It reacts 🚀 to the `/test` comment and re-runs the latest completed `pull_request` run so each `plan` job re-evaluates and the requested suites start.
- **Push to `main` always runs the full suite** — merged code keeps full coverage.

### Suites

`all`, `core`, `client`, `scale`, `mcp`, `byllm`, `docs`, `desktop`, `k8s`, `check` (jac type check), `contrib` (contribution checks), `installer`.

## UX

You see only:
- a 🚀 reaction on your `/test` comment, and
- the requested suites' **native checks** on the commit (orange = running, green/red = result), clickable from the status dot next to the commit or the PR's Checks list.

No bot comments. No `ci-request/*` rows. No deployment "Waiting" lines.

## Notes / tradeoffs

- **Activation:** `/test` works once these workflows are on the default branch (after merge).
- **Re-spend:** re-running re-reads all `/test` comments for the head SHA, so requesting additional suites re-runs previously requested ones too. A new commit starts fresh. (Acceptable for simplicity; can be made strictly run-once later.)
- **Required checks:** decide branch-protection carefully — gated jobs skip when unrequested, so don't mark individual suite jobs as required without a summary-gate, or every un-`/test`ed PR would block. (Follow-up.)
- **Forks:** same-repo collaborator PRs are the target; fork PRs are covered by the post-merge full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)