### PR TITLE
docs: migrate install/usage docs to the single `jac` binary (#6855)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,22 +23,25 @@ git remote -v
 
 **Setting Up Your Dev Envrionment**
 
+`jaclang` ships as the single `jac` binary (a Zig launcher + bundled CPython) -- there is no pip-installed jaclang. The bootstrap script builds the binary, puts it on PATH, installs the plugins editable, and sets up pre-commit:
+
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -e jac
-jac install -e jac-byllm
-jac install -e jac-scale
-jac install -e jac-mcp
-pip install pre-commit
-pre-commit install
-pip install pytest pytest-xdist pytest-asyncio
+./scripts/fresh_env.sh
+```
+
+This needs [Zig](https://ziglang.org/) 0.16.0 + `zstd`, and the typeshed submodule checked out (`git submodule update --init --recursive`). The script prints the line to add the binary to your PATH permanently, e.g.:
+
+```bash
+export PATH="$PWD/jac/zig-out/bin:$PATH"
 ```
 
 **Run Some Tests**
 
+Tests run through the binary's bundled test runner (pytest + xdist ship inside it -- no separate install). `JAC_TEST_JOBS=auto` runs them in parallel:
+
 ```bash
-pytest jac -n auto
+cd jac
+JAC_TEST_JOBS=auto jac test tests
 # See ci jobs in github actions for more stuff to run
 ```
 
@@ -146,7 +149,7 @@ The docs site has three tiers with different expectations for contributors:
 
 ## Release Flow (for maintainers)
 
-Releasing new versions to PyPI is a two-step process using GitHub Actions.
+Releasing new versions is a two-step process using GitHub Actions. `jaclang` ships as the native `jac` binary (built and attached to the GitHub Release; it is **no longer published to PyPI**), while the plugins (`byllm`, `jac-scale`, `jac-mcp`) still publish to PyPI.
 
 ```
 ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────┐
@@ -180,13 +183,11 @@ After the release PR is merged, the **Publish Release** workflow triggers automa
    - Select the `pypi` environment and click **Approve and deploy**
 3. The workflow then handles everything automatically:
    - Builds all packages once ([precompiling bytecode](https://docs.jaseci.org/reference/publishing/) for packages that need it)
-   - Publishes in dependency order (tiered):
-     - **Tier 1**: `jaclang` (base package; everything depends on it; includes the client and desktop runtimes)
-     - **Tier 2**: `jac-byllm`, `jac-scale`, `jac-mcp` (depend only on `jaclang`)
-     - **Tier 4**: `jaseci` (meta-package; depends on everything above)
-   - Pushes git tags (`{package}-v{version}`, plus `v{version}` for jaseci)
-   - Creates a GitHub Release with artifacts
-   - Builds standalone binaries (if jaseci was released)
+   - Builds the native `jac` binary (this is the `jaclang` release artifact -- it is attached to the GitHub Release, not published to PyPI; includes the client and desktop runtimes)
+   - Publishes the plugins to PyPI in dependency order (tiered):
+     - **Tier 2**: `jac-byllm`, `jac-scale`, `jac-mcp` (build against `jaclang` from the source tree)
+   - Pushes git tags (`{package}-v{version}`, plus the release `v{version}`)
+   - Creates a GitHub Release with the binary artifacts
 
 > **Note**: The workflow waits for each tier on PyPI before publishing the next, so a package never lands before a dependency it pins. Tiers are configured per package in `scripts/release_utils.jac`.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <h3>Designed for Humans and AI to Build Together</h3>
 
   <p>
-    <a href="https://pypi.org/project/jaclang/">
-      <img src="https://img.shields.io/pypi/v/jaclang.svg?style=flat-square" alt="PyPI version">
+    <a href="https://github.com/jaseci-labs/jaseci/releases/latest">
+      <img src="https://img.shields.io/github/v/release/jaseci-labs/jaseci?style=flat-square" alt="Latest release">
     </a>
     <a href="https://codecov.io/gh/Jaseci-Labs/jaseci">
       <img src="https://img.shields.io/codecov/c/github/Jaseci-Labs/jaseci?style=flat-square" alt="Code Coverage">
@@ -36,13 +36,11 @@ Jac is a programming language designed for humans and AI to build together. With
 
 This repository houses the Jaseci stack -- the core libraries and tooling that make Jac work:
 
-- **[`jaclang`](jac/):** The Jac programming language -- compiles to Python bytecode, JavaScript, and native machine code. Ships with the built-in full-stack web/desktop app framework (React-like `cl` components, server, and bundler with full access to the entire npm/node ecosystem). (`pip install jaclang`)
-- **[`byllm`](jac-byllm/):** Plugin for Jac enabling easy integration of large language models into your applications through the innovative [Meaning Typed Programming](https://arxiv.org/pdf/2405.08965) concept. (`pip install byllm`)
-- **[`jac-scale`](jac-scale/):** Plugin for Jac enabling fully abstracted and automated deployment and scaling with FastAPI, Redis, MongoDB, and Kubernetes integration. (`pip install jac-scale`)
-- **[`jac-mcp`](jac-mcp/):** Plugin for Jac providing an MCP server for AI-assisted Jac development with validation, formatting, and documentation tools. (`pip install jac-mcp`)
+- **[`jaclang`](jac/):** The Jac programming language -- compiles to Python bytecode, JavaScript, and native machine code. Ships with the built-in full-stack web/desktop app framework (React-like `cl` components, server, and bundler with full access to the entire npm/node ecosystem). Distributed as the self-contained `jac` binary (see [install below](#installation--setup)).
+- **[`byllm`](jac-byllm/):** Plugin for Jac enabling easy integration of large language models into your applications through the innovative [Meaning Typed Programming](https://arxiv.org/pdf/2405.08965) concept. (`jac install byllm`)
+- **[`jac-scale`](jac-scale/):** Plugin for Jac enabling fully abstracted and automated deployment and scaling with FastAPI, Redis, MongoDB, and Kubernetes integration. (`jac install jac-scale`)
+- **[`jac-mcp`](jac-mcp/):** Plugin for Jac providing an MCP server for AI-assisted Jac development with validation, formatting, and documentation tools. (`jac install jac-mcp`)
 - **[`jac VSCE`](https://github.com/jaseci-labs/jac-vscode/blob/main/README.md):** The official VS Code extension for Jac.
-
-All of these components are bundled together as the [**Jaseci**](jaseci-package/) stack, which can be installed with a simple `pip install jaseci`.
 
 ---
 
@@ -146,10 +144,11 @@ base_route_app = "app"
 default_model = "claude-sonnet-4-20250514"
 ```
 
-Install Jac, set your API key, and run:
+Install Jac, add the plugins this example uses, set your API key, and run:
 
 ```bash
-pip install jaseci
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+jac install byllm jac-scale
 export ANTHROPIC_API_KEY="your-key-here"
 jac start main.jac
 ```
@@ -169,17 +168,25 @@ The best way to learn Jac is by building something real. The [**Build an AI Day 
 ## Installation & Setup
 
 <details>
-<summary><strong>Install from PyPI (Recommended)</strong></summary>
+<summary><strong>Install (Recommended)</strong></summary>
 
 <br>
 
-Get the complete, stable toolkit from PyPI:
+Install the self-contained `jac` binary with one command -- no Python, pip, or uv required:
 
 ```bash
-pip install jaseci
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
-The `jaseci` package is a meta-package that bundles `jaclang`, `byllm`, `jac-scale`, and `jac-mcp` together for convenience. This is the fastest way to get started with building applications.
+Then add plugins as you need them:
+
+```bash
+jac install byllm        # AI/LLM integration
+jac install jac-scale    # production deployment & scaling
+jac install jac-mcp      # MCP server for AI-assisted development
+```
+
+See the [installation guide](https://docs.jaseci.org/quick-guide/install/) for versions, upgrading, and IDE setup.
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ nav:
 
 To open a preview of the mkdocs server locally, following steps should be followed.
 
-1. Install necessaries such as pygments and jaclang syntax highlighting from source.
+1. Install the docs tooling (MkDocs plus the `jac-highlighter` Pygments lexer for Jac syntax highlighting). This is the standalone docs-preview package -- it does not install jaclang.
 
     ```bash
     cd docs

--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -170,29 +170,29 @@ SSO linkages previously lived in a dedicated `sso_accounts` collection keyed by 
 
 #### 1. Heavy Dependencies Moved to Optional Install Groups
 
-`pip install jac-scale` no longer installs pymongo, redis, prometheus-client, apscheduler, kubernetes, or docker. These are now optional extras.
+`jac install jac-scale` no longer installs pymongo, redis, prometheus-client, apscheduler, kubernetes, or docker. These are now optional extras.
 
 **Impact:** Existing installations that rely on any of these packages must update their install command.
 
 **Before:**
 
 ```bash
-pip install jac-scale
+jac install jac-scale
 ```
 
 **After:**
 
 ```bash
-pip install jac-scale[all]
+jac install 'jac-scale[all]'
 ```
 
 Or install only what you need:
 
 ```bash
-pip install jac-scale[data]            # pymongo + redis
-pip install jac-scale[monitoring]      # prometheus-client
-pip install jac-scale[scheduler]       # apscheduler
-pip install jac-scale[deploy]          # kubernetes + docker
+jac install 'jac-scale[data]'          # pymongo + redis
+jac install 'jac-scale[monitoring]'    # prometheus-client
+jac install 'jac-scale[scheduler]'     # apscheduler
+jac install 'jac-scale[deploy]'        # kubernetes + docker
 ```
 
 No code changes are required - the same APIs, configuration, and behavior apply. When a feature is used without its dependency installed, a clear error message shows the exact install command needed.

--- a/docs/docs/community/codebase-guide.md
+++ b/docs/docs/community/codebase-guide.md
@@ -56,7 +56,7 @@ jaseci/
 ├── jac-scale/            # Plugin: cloud deployment (FastAPI, Kubernetes, Docker)
 ├── jac-mcp/              # Plugin: MCP server for AI-assisted development
 ├── jac-plugins/          # Additional community plugins
-├── jaseci-package/       # Meta-package that bundles everything for pip install
+├── jaseci-package/       # Plugin-bundle metadata (jaclang ships as the `jac` binary, not pip)
 ├── docs/                 # MkDocs documentation site
 └── scripts/              # Release, CI, and utility scripts
 ```
@@ -277,13 +277,14 @@ GitHub Actions workflows in `.github/workflows/`:
 
 | Workflow | What it checks |
 |----------|---------------|
-| `test-jaseci.yml` | Full test suite across Python versions |
+| `test-binary.yml` | Builds the `jac` binary and runs the full suite through it (the test gate) |
+| `test-jaseci.yml` | Plugin and runtime test jobs (run through the binary) |
 | `jac-check.yml` | Lint and format enforcement |
 | `docs-validation.yml` | Documentation builds without errors |
 | `test-installer.yml` | Clean install from scratch works |
-| `build-standalone.yml` | Standalone binary packaging |
+| `build-standalone.yml` | Native `jac` binary packaging (the jaclang release artifact) |
 | `create-release-pr.yml` | Automated version bump PRs |
-| `release-*.yml` | Per-package PyPI publishing (one per package) |
+| `release-*.yml` | Releases the `jac` binary (jaclang) and publishes the plugins to PyPI |
 | `deploy-docs.yml` | Deploy docs site to production |
 
 Pre-commit hooks run formatting and linting on every commit locally. See `.pre-commit-config.yaml` for the full hook list.

--- a/docs/docs/quick-guide/agent-skills-and-mcp.md
+++ b/docs/docs/quick-guide/agent-skills-and-mcp.md
@@ -65,7 +65,7 @@ claude mcp add jac -- jac mcp
 Other clients (Claude Desktop, Cursor, Windsurf, VS Code) use a JSON configuration block. The **[MCP Server reference](../reference/mcp.md)** has copy-paste configuration for every supported client, the full tool and resource catalog, transport options, and troubleshooting.
 
 !!! tip
-    Already installed Jaseci via PyPI or the install script? `jac-mcp` is likely bundled -- run `jac --version` to check. If it is missing, install it with `pip install jac-mcp`.
+    Already installed Jac via the install script? `jac-mcp` is likely bundled -- run `jac --version` to check. If it is missing, install it with `jac install jac-mcp`.
 
 ## Which to use
 

--- a/docs/docs/quick-guide/faq.md
+++ b/docs/docs/quick-guide/faq.md
@@ -6,7 +6,7 @@ Answers to common questions about Jac, organized by topic. Click a category to e
 
 ??? "Getting Started & Setup"
 
-    ??? question "I updated to the latest Jaseci PyPI packages and my project won't `jac start` properly."
+    ??? question "I updated to the latest Jac toolchain and my project won't `jac start` properly."
         Run `jac purge` to clear the global bytecode cache. This is the recommended approach after upgrading packages:
         ```bash
         jac purge
@@ -29,8 +29,8 @@ Answers to common questions about Jac, organized by topic. Click a category to e
 
     ??? question "What's the difference between Jac, Jaclang, and Jaseci?"
         - Jac: The language
-        - Jaclang: The compiler/runtime
-        - Jaseci: The full framework and ecosystem including plugins (byllm, jac-scale, etc.)
+        - Jaclang: The compiler/runtime, shipped as the self-contained `jac` binary
+        - Jaseci: The broader framework and ecosystem, including plugins (byllm, jac-scale, etc.) installed via `jac install`
 
     ??? question "Do I need to know graph theory to use Jaseci?"
         No. Learn OSP: [OSP Guide](https://docs.jaseci.org/tutorials/language/osp/)

--- a/docs/docs/quick-guide/index.md
+++ b/docs/docs/quick-guide/index.md
@@ -85,7 +85,7 @@ This single file defines a persistent data model, an AI-powered categorizer, a R
     Install Jac, set your API key, and run:
 
     ```bash
-    pip install jaseci
+    curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
     export ANTHROPIC_API_KEY="your-key-here"
     jac start
     ```
@@ -224,10 +224,10 @@ The runtime handles database schemas, user authentication (per-user graph isolat
 ### Step 1: Install
 
 ```bash
-pip install jaseci
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
-This installs the complete Jac ecosystem: `jaclang` (compiler, plus the built-in full-stack frontend/desktop framework), `byllm` (AI integration), and `jac-scale` (deployment).
+This installs the self-contained `jac` binary -- no Python, pip, or uv required. It includes the compiler and the built-in full-stack frontend/desktop framework. Add AI integration and deployment with `jac install byllm` and `jac install jac-scale`.
 
 Verify your installation:
 

--- a/docs/docs/quick-guide/install.md
+++ b/docs/docs/quick-guide/install.md
@@ -6,34 +6,22 @@ Get Jac installed and ready to use in under 2 minutes.
 
 ## One-Line Install (Recommended)
 
-Install Jac with a single command -- no Python setup required:
+Install Jac with a single command:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
-This automatically installs [uv](https://docs.astral.sh/uv/) (if needed), a Python 3.12+ runtime, and the full Jac ecosystem including all plugins.
+This downloads the self-contained native `jac` binary and puts it on your PATH. The binary bundles its own runtime, so **no system Python, pip, or uv is required** -- at install time or afterward.
 
 ### Installer Options
 
 Pass flags after `--` to customize the install:
 
-**Core language only (no plugins):**
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --core
-```
-
 **Specific version:**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --version 2.3.1
-```
-
-**Standalone binary (self-contained, no Python/uv needed at runtime):**
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash -s -- --standalone
 ```
 
 **Uninstall:**
@@ -44,77 +32,32 @@ curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/ins
 
 | Flag | Description |
 |------|-------------|
-| `--core` | Install only the Jac language compiler, no plugins |
-| `--standalone` | Download a pre-built binary from GitHub Releases |
-| `--version V` | Install a specific version |
+| `--version V` | Install a specific release version |
 | `--uninstall` | Remove Jac |
 
 ### Upgrading
 
-Re-run the install command to upgrade to the latest version. The installer detects existing installations and upgrades in place.
+Re-run the install command to upgrade to the latest version. The installer replaces the binary in place.
 
 ---
 
-## Install via pip
+## Installing Plugins
 
-If you already have Python 3.12+ and prefer pip:
-
-```bash
-pip install jaseci
-```
-
-The `jaseci` package is a meta-package that bundles all Jac ecosystem packages together. This installs:
-
-- `jaclang` - The Jac language and compiler (includes the built-in full-stack web and native-desktop app framework)
-- `byllm` - AI/LLM integration
-- `jac-scale` - Production deployment
-
-Verify the installation:
-
-```bash
-jac --version
-```
-
-This also warms the cache, making subsequent commands faster.
-
----
-
-## Installation Options
-
-### Minimal Install (Language Only)
-
-If you only need the core language:
-
-```bash
-pip install jaclang
-```
-
-### Individual Plugins
-
-Install plugins as needed:
+The `jac` binary is the language core. Add plugins -- AI integration, deployment, the MCP server -- with the binary's own installer once `jac` is on your PATH:
 
 ```bash
 # AI/LLM integration
-pip install byllm
+jac install byllm
 
 # Production deployment & scaling
-pip install jac-scale              # Core only (lightweight)
-pip install jac-scale[all]         # Full install with all features
+jac install jac-scale              # core only (lightweight)
+jac install 'jac-scale[all]'       # all features
+
+# MCP server for AI-assisted Jac development
+jac install jac-mcp
 ```
 
-### Virtual Environment (Recommended)
-
-```bash
-# Create environment
-python -m venv jac-env
-
-# Activate it
-source jac-env/bin/activate   # Linux/Mac
-jac-env\Scripts\activate      # Windows
-
-# Install Jac
-pip install jaseci
-```
+`jac install` resolves plugins from PyPI into your project environment; jaclang itself is provided by the binary, so it is never reinstalled. See the [CLI reference](../reference/cli/index.md#jac-install) for all options.
 
 ---
 
@@ -252,22 +195,17 @@ jac create my-app --use https://raw.githubusercontent.com/jaseci-labs/jacpacks/m
 
 ## Upgrading Jac
 
-If you installed via the one-line installer, re-run it to upgrade:
+Re-run the one-line installer to upgrade the `jac` binary to the latest version:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
-If you installed via pip:
+To upgrade a plugin, reinstall it:
 
 ```bash
-# Upgrade everything at once
-pip install --upgrade jaseci
-
-# Or upgrade individual packages
-pip install --upgrade jaclang
-pip install --upgrade byllm
-pip install --upgrade jac-scale
+jac install --force-reinstall byllm
+jac install --force-reinstall jac-scale
 ```
 
 ---
@@ -309,7 +247,7 @@ jac create my-app --use <github-url>
 
 ## For Contributors
 
-See the [Contributing Guide](../community/contributing.md) for development setup.
+Building Jac from source uses `./scripts/fresh_env.sh`, which builds the `jac` binary and puts it on your PATH. See the [Contributing Guide](../community/contributing.md) for the full development setup.
 
 ---
 

--- a/docs/docs/quick-guide/project-kinds.md
+++ b/docs/docs/quick-guide/project-kinds.md
@@ -5,8 +5,10 @@ Jac compiles one language to three runtimes -- Python bytecode (server, `sv`), J
 Every example below was run against the current toolchain. Install once and follow along:
 
 ```bash
-pip install jaseci
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
+
+This installs the self-contained `jac` binary -- no Python, pip, or uv required.
 
 !!! tip "`jac run` is kind-aware"
     Set `kind` under `[project]` in `jac.toml` (or let it be inferred from the entry-point's codespace), and a bare `jac run` does the right thing for that kind: **execute** runnable kinds (`cli`, `native-app`), **serve** server kinds (`api-service`, `fullstack`, ...), or **build** artifact kinds (`native-binary`, `shared-library`, `pypi-package`, `npm-package`). `jac run --show` prints the resolved plan and the equivalent primitive command without running it. The explicit verbs shown in each recipe below are those primitives.
@@ -229,7 +231,7 @@ jac bundle
 # → dist/greetlib-0.1.0-py3-none-any.whl
 ```
 
-Upload it with `twine`, then `pip install greetlib` anywhere. The wheel ships your compiled modules and lists `jaclang` as a runtime dependency.
+Upload it with `twine`, then `pip install greetlib` anywhere. The wheel ships your compiled modules and runs under the `jac` binary -- it does not list `jaclang` as a runtime dependency.
 
 :octicons-arrow-right-24: Reference: [Publishing](../reference/publishing.md)
 

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -178,7 +178,7 @@ jac run greet.jac --name Alice
 
 ### jac start
 
-Start a Jac application as an HTTP API server. With the jac-scale plugin installed, use `--scale` to deploy to Kubernetes. Use `--dev` for Hot Module Replacement (HMR) during development.
+Start a Jac application as an HTTP API server. With the jac-scale plugin installed, use `--scale` to deploy to Kubernetes. Use `--dev` for Hot Module Replacement (HMR) during development; live-reload is powered by the `watchdog` library bundled in the `jac` binary, so no extra install is needed.
 
 ```bash
 jac start [-h] [-p PORT] [-m] [--no-main] [-f] [--no-faux] [-d] [--no-dev] [-a API_PORT] [-n] [--no-no_client] [--profile PROFILE] [--client {web,desktop,pwa,mobile}] [--host HOST] [--platform {auto,android,ios}] [--scale] [--no-scale] [-b] [--no-build] [filename]
@@ -341,6 +341,8 @@ See the full [Errors & Warnings](../diagnostics.md) reference for all diagnostic
 ### jac test
 
 Run tests in Jac files.
+
+> **Note:** `jac test` runs through pytest bundled in the `jac` binary -- there is no separate `pytest` install needed.
 
 ```bash
 jac test [-h] [-t TEST_NAME] [-f FILTER] [-x] [-m MAXFAIL] [-d DIRECTORY] [-v] [filepath]
@@ -757,11 +759,11 @@ jac plugins enable byllm
 jac plugins disabled
 ```
 
-> **Note:** To install or uninstall plugins, use `pip install` / `pip uninstall` directly. The `jac plugins` command manages enabled/disabled state for already-installed plugins.
+> **Note:** To install or remove plugins, use `jac install <plugin>` / `jac remove <plugin>`. The `jac plugins` command manages enabled/disabled state for already-installed plugins.
 >
 > **💡 Popular Plugins**:
 >
-> - **jac-scale**: Kubernetes deployment and scaling (`pip install jac-scale`)
+> - **jac-scale**: Kubernetes deployment and scaling (`jac install jac-scale`)
 >
 > (Full-stack web and native-desktop app building ships with `jaclang` core -- no plugin install needed.)
 
@@ -1257,13 +1259,13 @@ For private packages from custom registries (e.g., GitHub Packages), configure s
 
 **No-argument mode** - sync the project environment to `jac.toml`. Installs all Python (pip), git, and plugin-provided (npm, etc.) dependencies in one command. Creates or validates the project virtual environment at `.jac/venv/`. Requires a `jac.toml` in the current (or a parent) directory.
 
-**Package mode** - `jac install <pkg> [pkg ...]` installs one or more packages directly into the **currently activated Python environment** via pip, without reading or modifying `jac.toml`. This is the equivalent of `pip install <pkg>` but invoked through the `jac` CLI. Useful for quick one-off installs or scripts where you do not need a full jac project.
+**Package mode** - `jac install <pkg> [pkg ...]` installs one or more packages directly into the **active project environment** (managed by the `jac` binary, which provides the jaclang runtime), without reading or modifying `jac.toml`. It is the Jac-native equivalent of `pip install <pkg>`: under the hood it wraps pip (or `uv pip`), but the target is the project's `jac`-managed environment rather than a user-managed system Python. Useful for quick one-off installs or scripts where you do not need a full jac project.
 
 > **`jac install <pkg>` vs `jac add <pkg>`**
 >
 > | | `jac install <pkg>` | `jac add <pkg>` |
 > |---|---|---|
-> | Target | Activated Python environment | Project `.jac/venv/` |
+> | Target | Active `jac`-managed environment | Project `.jac/venv/` |
 > | Updates `jac.toml` | No | Yes |
 > | Works outside a project | Yes | No |
 >
@@ -1481,7 +1483,7 @@ jac purge
 
 ### jac bundle
 
-Build a standards-compliant Python wheel (`.whl`) from your project's `jac.toml`. The wheel is `pip install`-ready and requires no `pyproject.toml` or `setuptools`. After building, upload to PyPI (or a private registry) with `twine upload dist/*`. For the full end-to-end workflow, see the [Publishing Packages](../publishing.md) guide.
+Build a standards-compliant Python wheel (`.whl`) from your project's `jac.toml`. The wheel is `pip install`-ready and requires no `pyproject.toml` or `setuptools`. It is consumed under the `jac` binary (which provides the jaclang runtime), so the wheel neither bundles nor declares `jaclang` as a dependency. After building, upload to PyPI (or a private registry) with `twine upload dist/*`. For the full end-to-end workflow, see the [Publishing Packages](../publishing.md) guide.
 
 ```bash
 jac bundle [-h] [-o OUTPUT] [-p]
@@ -1579,7 +1581,7 @@ entry-point = "main.jac"
 [jacpack]
 name = "mytemplate"
 description = "My custom project template"
-jaclang = "0.9.0"
+jaclang = "0.9.0"        # minimum compatible jac binary (host) runtime, not a PyPI dependency
 
 [[jacpack.plugins]]
 name = "jac-client"
@@ -1619,7 +1621,7 @@ jac create myproject --use mytemplate
 
 ### jac eject
 
-Compile a Jac project into a runnable FastAPI + JavaScript app. The output contains **zero `.jac` files**: each walker is compiled to Python and served by a FastAPI backend, and the `.cl.jac` UI is compiled to JavaScript on Vite. The backend runs the walkers on the installed `jaclang` runtime (so persistence, graph traversal, access control, and `by llm()` behave exactly as under `jac start`), and exposes jaclang-native auth. Use it when you want an editable FastAPI/JS codebase you can extend and deploy without writing Jac.
+Compile a Jac project into a runnable FastAPI + JavaScript app. The output contains **zero `.jac` files**: each walker is compiled to Python and served by a FastAPI backend, and the `.cl.jac` UI is compiled to JavaScript on Vite. The backend runs the walkers on the `jac` binary's bundled jaclang runtime (so persistence, graph traversal, access control, and `by llm()` behave exactly as under `jac start`), and exposes jaclang-native auth. Use it when you want an editable FastAPI/JS codebase you can extend and deploy without writing Jac.
 
 ```bash
 jac eject [-h] [-o OUTPUT] [-f] [source]
@@ -1646,7 +1648,7 @@ jac eject [-h] [-o OUTPUT] [-f] [source]
 ├── .jac-ejected         marker (lets re-runs regenerate without --force)
 ├── backend/
 │   ├── main.py          FastAPI app (walkers/functions + auth routes)
-│   ├── requirements.txt  jaclang + fastapi + uvicorn
+│   ├── requirements.txt  jaclang + fastapi + uvicorn (see runtime note below)
 │   └── <module>.py      compiled server modules (real jaclang imports)
 └── frontend/
     ├── package.json     npm dependencies (includes Vite)
@@ -1693,7 +1695,10 @@ The backend listens on `PORT` (default 8000). For frontend dev with hot reload, 
 
 **Caveats**
 
-- The ejected backend requires `jaclang` to be installed at runtime (it imports the runtime from `jaclang.runtimelib.server` and the compiled modules import `jaclang.jac0core.jaclib`). The goal is *zero `.jac` files and an editable FastAPI surface*, not *zero `jaclang` dependency*.
+- The ejected backend imports the jaclang runtime (`jaclang.runtimelib.server`, and the compiled modules import `jaclang.jac0core.jaclib`), so that runtime must be available in the environment that runs `uvicorn`. The goal of `jac eject` is *zero `.jac` files and an editable FastAPI surface*, not zero jaclang runtime.
+
+    !!! warning "Runtime provisioning is being migrated"
+        `jaclang` is no longer published to PyPI -- it ships as the `jac` binary. The generated `requirements.txt` still lists a `jaclang` entry and the run step above uses a plain `pip install`, which no longer resolves. Until eject is updated to package the binary's runtime, run the ejected backend in an environment that already provides the jaclang runtime (for example, a checkout where the `jac` binary is on PATH) rather than relying on a standalone `pip`-based deploy.
 - The generated FastAPI app enables permissive CORS (`allow_origins=["*"]`) for local dev; restrict it before deploying to production.
 - `.impl.jac` and `.test.jac` files are skipped; so are well-known build directories (`.jac`, `.git`, `.venv`, `node_modules`, `__pycache__`, `dist`, `build`, etc.).
 - Persistent state (users, root nodes, graph data) lives under `backend/.jac/data/` after first run, just as it would for `jac start`.

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -48,8 +48,8 @@ The language spec covers all core Jac constructs:
 ## Quick Start
 
 ```bash
-# 1. Install
-pip install jaseci
+# 1. Install the jac binary
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 
 # 2. Scaffold a new project
 jac create myapp --use client
@@ -122,8 +122,8 @@ The `jac` command is your primary interface to the Jac toolchain. For the full r
 
 | Plugin | Package | Description |
 |--------|---------|-------------|
-| byllm | `pip install byllm` | LLM integration |
-| jac-scale | `pip install jac-scale` | Production deployment |
+| byllm | `jac install byllm` | LLM integration |
+| jac-scale | `jac install jac-scale` | Production deployment |
 
 (Full-stack web and native-desktop app building -- formerly the `jac-client` / `jac-desktop` plugins -- now ship with `jaclang` core; no separate install.)
 

--- a/docs/docs/reference/language/foundation.md
+++ b/docs/docs/reference/language/foundation.md
@@ -84,17 +84,16 @@ obj Person {
 ### 1 Installation
 
 ```bash
-# Full installation with all plugins
-pip install jaseci
-
-# Minimal installation
-pip install jaclang
+# Install the Jac toolchain
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 
 # Individual plugins
-pip install byllm        # LLM integration
-pip install jac-scale    # Production deployment
-# (full-stack web + native-desktop app building ships with jaclang core)
+jac install byllm        # LLM integration
+jac install jac-scale    # Production deployment
+# (full-stack web + native-desktop app building ships with the jac binary)
 ```
+
+This installs the self-contained `jac` binary -- no Python, pip, or uv required.
 
 ### 2 Your First Program
 

--- a/docs/docs/reference/mcp.md
+++ b/docs/docs/reference/mcp.md
@@ -4,12 +4,12 @@ The `jac-mcp` plugin provides a [Model Context Protocol](https://modelcontextpro
 
 ## Installation
 
-If you installed Jaseci via PyPI or the install script, `jac-mcp` is likely already included. Run `jac --version` to check -- it prints all installed plugins. If `jac-mcp` appears in the list, you're good to go.
+`jac-mcp` is a plugin -- it is **not** bundled in the core `jac` binary, so you install it with `jac install jac-mcp`. To check whether it is already present, run `jac --version` or `jac plugins`, which list the installed plugins. If `jac-mcp` appears, you're good to go.
 
-Otherwise, install it separately:
+Otherwise, install it:
 
 ```bash
-pip install jac-mcp
+jac install jac-mcp
 ```
 
 ## Quick Start
@@ -216,7 +216,7 @@ Then configure your client to connect to:
 </details>
 
 !!! tip
-If your `jac` binary is installed in a virtualenv, use the full path in the `command` field (e.g., `/path/to/venv/bin/jac`). You can find it with `which jac`.
+`jac` is a standalone binary. If it is not on your client's PATH, use its full path in the `command` field (e.g., `/path/to/jac`). You can find it with `which jac`.
 
 ## CLI Reference
 
@@ -1107,16 +1107,16 @@ Convert Python code to idiomatic Jac.
 
 ### "command not found: jac"
 
-The `jac` binary is not on your PATH. If installed in a virtualenv, use the full path:
+The `jac` binary is not on your PATH. `jac` is a standalone binary -- make sure its install location is on your PATH, or point your client at its full path:
 
 ```json
 {
-  "command": "/path/to/venv/bin/jac",
+  "command": "/path/to/jac",
   "args": ["mcp"]
 }
 ```
 
-Find the path with `which jac` or `python -m site --user-base`.
+Find the path with `which jac`.
 
 ### Server connects but shows no tools
 
@@ -1128,8 +1128,8 @@ The compiler bridge enforces a 10-second timeout per operation. If your code is 
 
 ### Resources show "Error: File not found"
 
-Resource paths are resolved relative to the jaclang package installation. In a **development install** (`pip install -e`), resources are read directly from the repository's `docs/` directory. In a **PyPI install**, bundled copies are used. If you see missing resources after a PyPI install, update to the latest version:
+jaclang's documentation resources are always bundled inside the `jac` binary, so resources resolve from that bundled copy. If you see missing or stale resources, upgrade the plugin:
 
 ```bash
-pip install --upgrade jac-mcp
+jac install jac-mcp
 ```

--- a/docs/docs/reference/plugin-authoring.md
+++ b/docs/docs/reference/plugin-authoring.md
@@ -126,13 +126,14 @@ class JacCmd {
 [project]
 name = "jac-hello"
 version = "0.1.0"
-dependencies = ["jaclang"]
 
 [project.entry-points."jac"]
 hello = "jac_hello.plugin:JacCmd"
 ```
 
-After `pip install -e .`, `jac --help` will list `hello` in the *general* group and `jac hello Alice --shout` will print `HELLO, ALICE!`.
+> Note: plugins do **not** depend on PyPI `jaclang` - `jaclang` is the host runtime provided by the `jac` binary that loads your plugin, so it never belongs in `dependencies`.
+
+After `jac install -e .`, `jac --help` will list `hello` in the *general* group and `jac hello Alice --shout` will print `HELLO, ALICE!`.
 
 A few things worth noticing:
 
@@ -764,14 +765,15 @@ name = "jac-myplugin"
 version = "0.1.0"
 description = "What this plugin does"
 requires-python = ">=3.12"
-dependencies = ["jaclang>=0.13"]
 
 [project.entry-points."jac"]
 myplugin = "jac_myplugin.plugin:JacCmd"
 myplugin_plugin_config = "jac_myplugin.plugin_config:JacMypluginPluginConfig"
 ```
 
-Build a wheel with `python -m build` and publish with `twine upload`. The plugin becomes active in any environment that has both your wheel and `jaclang` installed -- no other registration step is required.
+> Note: do **not** list PyPI `jaclang` in `dependencies` - `jaclang` is the host runtime supplied by the `jac` binary that loads your plugin, not a PyPI package.
+
+Build a wheel with `jac bundle` (the Jac-native build path; `python -m build` also works) and publish with `twine upload` -- plugins **are** distributed on PyPI. The plugin becomes active in any project using the `jac` binary once it is installed there (`jac install <plugin>`) -- no other registration step is required.
 
 ### `jac plugins` command
 

--- a/docs/docs/reference/plugins/byllm.md
+++ b/docs/docs/reference/plugins/byllm.md
@@ -60,7 +60,7 @@ This means your Jac type system functions as the LLM's output schema. Declaring 
 ## Installation
 
 ```bash
-pip install byllm
+jac install byllm
 ```
 
 For local inference without an API key, byLLM supports two paths -- pick the one that fits your environment (see [Built-in Local Models](#built-in-local-models) for the full discussion):
@@ -78,18 +78,18 @@ For local inference without an API key, byLLM supports two paths -- pick the one
 
 === "In-process `local:*` (opt-in extra)"
     ```bash
-    pip install 'byllm[local]'
+    jac install 'byllm[local]'
     ```
     ```toml
     [plugins.byllm.model]
     default_model = "local:gemma-4-e4b"
     ```
-    No daemon, single `pip install`, fully in-process. Adds `llama-cpp-python` and `huggingface_hub` as dependencies. See [Built-in Local Models](#built-in-local-models) for bundled aliases, GPU build flags, and the `jac model` cache CLI.
+    No daemon, single `jac install`, fully in-process. Adds `llama-cpp-python` and `huggingface_hub` as dependencies. See [Built-in Local Models](#built-in-local-models) for bundled aliases, GPU build flags, and the `jac model` cache CLI.
 
 For video support, install with the `video` extra:
 
 ```bash
-pip install byllm[video]
+jac install 'byllm[video]'
 ```
 
 ---
@@ -254,16 +254,16 @@ You can also override per-file with `glob llm = Model(...)` (see [Per-module ove
 ## Built-in Local Models
 
 !!! tip "Most users want Ollama, not this."
-    Ollama is the recommended local-first path: native installer, automatic GPU detection across CUDA/Metal/Vulkan, curated registry of quantized models, and full byLLM compatibility through litellm (`default_model = "ollama/<model>"`). It works without anything from this section. The `local:*` route below is for users who specifically don't want a separate daemon -- everything stays inside the Python process and a single `pip install`.
+    Ollama is the recommended local-first path: native installer, automatic GPU detection across CUDA/Metal/Vulkan, curated registry of quantized models, and full byLLM compatibility through litellm (`default_model = "ollama/<model>"`). It works without anything from this section. The `local:*` route below is for users who specifically don't want a separate daemon -- everything stays inside the Python process and a single `jac install`.
 
 Any model name prefixed with `local:` runs in-process via `llama.cpp`, with weights pulled from HuggingFace on first use and cached under `~/.cache/jac/models/<alias>/`. No API key, no separate daemon, and no proxy server -- the GGUF is loaded directly into the Jac process. Activate by installing the `[local]` extra:
 
 ```bash
-pip install 'byllm[local]' \
+jac install 'byllm[local]' \
   --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
 ```
 
-The `--extra-index-url` flag points pip at `llama-cpp-python`'s prebuilt wheel index. Without it, pip falls back to the PyPI source tarball and runs a 30-60 second C++ build (`llama-cpp-python` does not publish wheels on PyPI). Use `/cu124`, `/metal`, `/vulkan` etc. for the matching GPU build (see [GPU Acceleration](#gpu-acceleration) below).
+The `--extra-index-url` flag points the installer at `llama-cpp-python`'s prebuilt wheel index. Without it, it falls back to the PyPI source tarball and runs a 30-60 second C++ build (`llama-cpp-python` does not publish wheels on PyPI). Use `/cu124`, `/metal`, `/vulkan` etc. for the matching GPU build (see [GPU Acceleration](#gpu-acceleration) below).
 
 The `local:*` route bypasses LiteLLM and replicates what cloud providers do server-side: it flattens multimodal content blocks for `llama.cpp`'s chat templates, rewrites OpenAI-style `json_schema` response formats into the GBNF grammar shape `llama.cpp` understands, and injects schema descriptions (e.g. `1=WORK, 2=PERSONAL, ...`) into the prompt so small open-weight models see the same constraints frontier models receive natively.
 
@@ -279,7 +279,7 @@ def categorize(title: str) -> Category by llm();
 default_model = "local:gemma-4-e4b"
 ```
 
-After `pip install 'byllm[local]'` (see [Installation](#installation)), the first `by llm()` call downloads the GGUF (interactive TTY prompts; non-TTY contexts require `BYLLM_AUTO_DOWNLOAD=1` or a prior `jac model pull`).
+After `jac install 'byllm[local]'` (see [Installation](#installation)), the first `by llm()` call downloads the GGUF (interactive TTY prompts; non-TTY contexts require `BYLLM_AUTO_DOWNLOAD=1` or a prior `jac model pull`).
 
 ### Bundled Aliases
 
@@ -365,7 +365,7 @@ When no model is explicitly set, byLLM picks one in this order:
 1. `BYLLM_DEFAULT_MODEL` environment variable
 2. `[plugins.byllm.model].default_model` in `jac.toml`
 3. **Auto-detect** -- if any provider API key is present (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `MISTRAL_API_KEY`, `GROQ_API_KEY`, `TOGETHER_API_KEY`, `DEEPSEEK_API_KEY`), falls through to `gpt-4o-mini`
-4. Otherwise, falls back to `local:<default_alias>` if the `[local]` extra is installed -- the bundled in-process runtime takes over so `by llm()` works offline out of the box. If `[local]` isn't installed and no key is set, byLLM raises a `ConfigurationError` listing the three concrete fixes (set an API key, configure `default_model` explicitly with an Ollama or other model, or `pip install 'byllm[local]'`).
+4. Otherwise, falls back to `local:<default_alias>` if the `[local]` extra is installed -- the bundled in-process runtime takes over so `by llm()` works offline out of the box. If `[local]` isn't installed and no key is set, byLLM raises a `ConfigurationError` listing the three concrete fixes (set an API key, configure `default_model` explicitly with an Ollama or other model, or `jac install 'byllm[local]'`).
 
 ### Managing the Cache
 
@@ -1522,7 +1522,7 @@ with entry {
 ```
 
 !!! note "Video requires extra dependency"
-    Video support requires `pip install byllm[video]`.
+    Video support requires `jac install 'byllm[video]'`.
 
 #### Video Parameters
 

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -8,10 +8,10 @@ You also get project scaffolding (`jac create --use client`), npm dependency man
 
 ## Installation
 
-jac-client ships with `jaclang` core -- there is nothing extra to install:
+jac-client ships with `jaclang` core -- there is nothing extra to install. Just install the `jac` binary:
 
 ```bash
-pip install jaclang        # or: pip install jaseci  (the full stack)
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
 ---

--- a/docs/docs/reference/plugins/jac-desktop.md
+++ b/docs/docs/reference/plugins/jac-desktop.md
@@ -18,10 +18,10 @@ The `desktop` target registers automatically as part of `jaclang` core, so
 
 ## Installation
 
-The desktop target ships with `jaclang` core -- there is nothing extra to install:
+The desktop target ships with `jaclang` core -- there is nothing extra to install. Just install the `jac` binary:
 
 ```bash
-pip install jaclang        # or: pip install jaseci  (the full stack)
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
 Building a desktop app links a small native webview wrapper (`libwebview.so`),

--- a/docs/docs/reference/plugins/jac-scale.md
+++ b/docs/docs/reference/plugins/jac-scale.md
@@ -12,25 +12,25 @@ jac-scale is lightweight by default. Install only the extras you need:
 
 ```bash
 # Core only - FastAPI server, auth, CLI (no heavy dependencies)
-pip install jac-scale
+jac install jac-scale
 
 # Add MongoDB + Redis for persistent storage and distributed cache
-pip install jac-scale[data]
+jac install 'jac-scale[data]'
 
 # Add Prometheus metrics and observability
-pip install jac-scale[monitoring]
+jac install 'jac-scale[monitoring]'
 
 # Add APScheduler for cron and background task scheduling
-pip install jac-scale[scheduler]
+jac install 'jac-scale[scheduler]'
 
 # Add Kubernetes + Docker for deployment and image building
-pip install jac-scale[deploy]
+jac install 'jac-scale[deploy]'
 
 # Everything - recommended for production or if unsure
-pip install jac-scale[all]
+jac install 'jac-scale[all]'
 ```
 
-Groups are combinable: `pip install jac-scale[data,monitoring]`
+Groups are combinable: `jac install 'jac-scale[data,monitoring]'`
 
 After installing, enable the plugin:
 
@@ -40,7 +40,7 @@ jac plugins enable scale
 
 !!! note
     When a feature is used without its dependency installed, you get a clear error with the exact install command:
-    `ImportError: 'pymongo' is required for this feature. Install it with: pip install jac-scale[data]`
+    `ImportError: 'pymongo' is required for this feature. Install it with: jac install 'jac-scale[data]'`
 
 | Group | What it adds | When you need it |
 |-------|-------------|-----------------|
@@ -2241,7 +2241,7 @@ backoff_seconds = [1, 5, 30]
 dead_letter_suffix = ".dlq"
 ```
 
-To use Redis Streams you need the `[data]` extra: `pip install jac-scale[data]`. Without it, jac-scale silently uses `LocalEventStream` and logs a warning at startup.
+To use Redis Streams you need the `[data]` extra: `jac install 'jac-scale[data]'`. Without it, jac-scale silently uses `LocalEventStream` and logs a warning at startup.
 
 ### Publishing
 
@@ -3009,7 +3009,7 @@ Packages are installed at pod startup before the application starts. For frequen
 
 ### Jaseci Source Pinning (Experimental)
 
-When using `--experimental` mode, Jaseci packages are installed from the GitHub repository instead of PyPI. Pin a specific branch or commit for reproducible builds.
+When using `--experimental` mode, the Jaseci plugin packages (jac-scale and friends) are installed from the GitHub repository instead of PyPI. Pin a specific branch or commit for reproducible builds. (The jaclang runtime itself always comes from the pod's `jac` binary base image -- it is never installed from PyPI in either mode.)
 
 **Defaults:**
 
@@ -3031,7 +3031,11 @@ jaseci_commit = "a1b2c3d4"
 
 ### Package Version Pinning
 
-Pin specific PyPI versions for Jaseci packages installed inside the pod. Use `"none"` to skip a package entirely.
+Pin specific PyPI versions for the Jaseci plugin packages installed inside the pod. Use `"none"` to skip a package entirely.
+
+> The pod's base image provides the `jac` binary, which is the jaclang runtime -- so jaclang is host-provided and is never pinned or `pip install`ed here. Only the plugins below are installed into the pod.
+>
+> **Note:** `jaclang` is no longer on PyPI, so the pod image must install the `jac` binary (e.g. via the install script). The cluster deploy code is being migrated to this model; until then, deploys that expect a PyPI `jaclang` will not resolve.
 
 **Defaults:** all packages default to `"latest"` from PyPI.
 
@@ -3039,7 +3043,6 @@ Pin specific PyPI versions for Jaseci packages installed inside the pod. Use `"n
 
 ```toml
 [plugins.scale.kubernetes.plugin_versions]
-jaclang = "0.1.5"      # Pin to a specific version
 jac_scale = "latest"   # Latest from PyPI (default)
 jac_client = "0.1.0"   # Specific version
 jac_byllm = "none"     # Skip installation entirely
@@ -3048,7 +3051,6 @@ jac_mcp = "latest"     # Optional MCP server plugin
 
 | Package | Description |
 |---------|-------------|
-| `jaclang` | Core Jac language runtime |
 | `jac_scale` | This scaling plugin |
 | `jac_client` | Frontend/client support |
 | `jac_byllm` | LLM integration (set to `"none"` to exclude) |
@@ -4125,11 +4127,16 @@ Browser → Load Balancer → Wildcard Ingress (*.preview.example.com) → Proxy
 - `service.yaml` -- ClusterIP Service on port 8080
 - `ingress.yaml` -- Wildcard Ingress (replace `*.example.com` with your domain)
 
-The proxy itself is a Jac application at `jac-scale/providers/proxy/sandbox_proxy.jac`. Build it with the provided Dockerfile at `jac-scale/targets/kubernetes/templates/sandbox-proxy.Dockerfile`:
+The proxy itself is a Jac application. Build it with a Dockerfile that installs the self-contained `jac` binary (which provides the jaclang runtime), then layers in the plugins:
 
 ```dockerfile
 FROM python:3.12-slim
-RUN pip install --no-cache-dir aiohttp kubernetes_asyncio jaclang "jac-scale[all]"
+# Install the `jac` binary -- no PyPI jaclang; the binary provides the runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+ENV PATH="/root/.local/bin:${PATH}"
+RUN jac install aiohttp kubernetes_asyncio "jac-scale[all]"
 COPY sandbox_proxy.jac /app/sandbox_proxy.jac
 WORKDIR /app
 EXPOSE 8080

--- a/docs/docs/tutorials/ai/multimodal.md
+++ b/docs/docs/tutorials/ai/multimodal.md
@@ -16,13 +16,13 @@ This enables powerful use cases: extracting structured data from photos (receipt
 Images are supported in the default byLLM distribution:
 
 ```bash
-pip install byllm
+jac install byllm
 ```
 
 For video support, install with the `video` extra:
 
 ```bash
-pip install byllm[video]
+jac install 'byllm[video]'
 ```
 
 ---
@@ -326,7 +326,7 @@ with entry {
 | Video input | `Video(path="video.mp4", fps=1)` |
 | Structured output | Return objects/enums from images |
 | Multiple formats | URLs, files, PIL, bytes all supported |
-| Install video | `pip install byllm[video]` |
+| Install video | `jac install 'byllm[video]'` |
 
 ---
 

--- a/docs/docs/tutorials/ai/quickstart.md
+++ b/docs/docs/tutorials/ai/quickstart.md
@@ -9,12 +9,12 @@ In this tutorial, you'll set up byLLM, write your first AI-powered function, exp
 > **Prerequisites**
 >
 > - Completed: [Installation](../../quick-guide/install.md)
-> - Jac installed with `pip install jaseci`
+> - Jac installed via the [one-line installer](../../quick-guide/install.md) (`curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash`)
 > - **Either** an API key from OpenAI/Anthropic/Google, **or** Ollama installed for local inference (recommended), **or** ~5 GB of disk for the bundled in-process `local:*` runtime
 > - Time: ~20 minutes
 
 !!! tip "No API key? Run a model locally."
-    byLLM has two local-inference paths. **Ollama** (recommended) is a separate daemon with automatic GPU detection -- `ollama pull gemma3:4b` then set `default_model = "ollama/gemma3:4b"` in `jac.toml` and you're done. **Built-in `local:*`** runs entirely in-process via `llama.cpp` -- single `pip install 'byllm[local]'`, no daemon. Use Ollama unless you specifically need the no-daemon property. See [Built-in Local Models](../../reference/plugins/byllm.md#built-in-local-models) for the full discussion.
+    byLLM has two local-inference paths. **Ollama** (recommended) is a separate daemon with automatic GPU detection -- `ollama pull gemma3:4b` then set `default_model = "ollama/gemma3:4b"` in `jac.toml` and you're done. **Built-in `local:*`** runs entirely in-process via `llama.cpp` -- single `jac install 'byllm[local]'`, no daemon. Use Ollama unless you specifically need the no-daemon property. See [Built-in Local Models](../../reference/plugins/byllm.md#built-in-local-models) for the full discussion.
 
 ---
 
@@ -25,7 +25,7 @@ In this tutorial, you'll set up byLLM, write your first AI-powered function, exp
 If you haven't already:
 
 ```bash
-pip install byllm
+jac install byllm
 ```
 
 ### 2. Pick a Backend
@@ -61,7 +61,7 @@ pip install byllm
     For users who specifically don't want a separate daemon, byLLM ships an in-process runtime as an opt-in extra:
 
     ```bash
-    pip install 'byllm[local]'
+    jac install 'byllm[local]'
     ```
 
     ```toml
@@ -73,7 +73,7 @@ pip install byllm
     The first `by llm()` call will prompt to download the model (~5 GB) to `~/.cache/jac/models/`. Set `BYLLM_AUTO_DOWNLOAD=1` to skip the prompt, or pre-fetch with `jac model pull gemma-4-e4b`. To skip the source build of `llama-cpp-python`, install with the prebuilt wheel index:
 
     ```bash
-    pip install 'byllm[local]' \
+    jac install 'byllm[local]' \
       --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
     ```
 

--- a/docs/docs/tutorials/first-app/build-ai-day-planner.md
+++ b/docs/docs/tutorials/first-app/build-ai-day-planner.md
@@ -4,11 +4,13 @@ In this tutorial, you'll build a full-stack AI day planner from scratch -- a sin
 
 **Prerequisites:** [Installation](../../quick-guide/install.md) complete.
 
-**Required Packages:** This tutorial uses **jaclang**, **jac-client**, **jac-scale**, and **byllm**. If you installed Jac using the [one-line installer](../../quick-guide/install.md#one-line-install-recommended), all packages are already included -- skip to the version check below. If you prefer pip:
+**Required Packages:** This tutorial uses **jaclang**, **jac-client**, **jac-scale**, and **byllm**. If you installed Jac using the [one-line installer](../../quick-guide/install.md#one-line-install-recommended), all packages are already included -- skip to the version check below. Otherwise install the toolchain:
 
 ```bash
-pip install jaseci
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
+
+This installs the self-contained `jac` binary -- no Python, pip, or uv required.
 
 Verify your installation meets the minimum requirements:
 
@@ -28,7 +30,7 @@ The `jac --version` output lists all installed plugins and their versions. Check
 **Local AI Model:** Parts 5+ use AI features. The tutorial defaults to a local model -- Google Gemma 4 E4B running in-process via `llama.cpp` -- so **no API key is required**. Install the local-model dependency once:
 
 ```bash
-pip install 'byllm[local]'
+jac install 'byllm[local]'
 ```
 
 The first AI call downloads ~5 GB of GGUF weights to your machine and caches them; subsequent runs are instant. If you'd rather use a cloud model (Anthropic Claude, Google Gemini, Ollama, etc.), see the "Use a cloud model instead" callout in [Part 5](#part-5-making-it-smart-with-ai).
@@ -1089,7 +1091,7 @@ Your day planner works, but it doesn't leverage AI yet. This part introduces one
 Jac's AI features need an LLM to run. The tutorial defaults to a **local model** -- Google Gemma 4 E4B, running in-process via `llama.cpp` -- so there's no API key to manage and no per-call cost. Install the local-model dependency once:
 
 ```bash
-pip install 'byllm[local]'
+jac install 'byllm[local]'
 ```
 
 The first time you run an AI feature, byLLM prompts you (in an interactive terminal) to download the ~5 GB GGUF weights, caches them under `~/.cache/jac/models/`, and uses the cached copy from then on. If you'd rather pre-fetch the weights now -- useful in CI, Docker, or just to know the download is done -- run:
@@ -1973,7 +1975,7 @@ jac start main.jac  # or: jac start
 !!! warning "Common issue"
     If adding a task silently fails (nothing happens), check the terminal running `jac start` for error messages. The most common culprits:
 
-    - `byllm[local]` not installed -- re-run `pip install 'byllm[local]'`
+    - `byllm[local]` not installed -- re-run `jac install 'byllm[local]'`
     - Weights not downloaded yet in a non-interactive terminal -- run `jac model pull gemma-4-e4b` once, or set `BYLLM_AUTO_DOWNLOAD=1` and let `jac start` fetch them
     - If you switched to a cloud model, a missing or invalid API key causes a server error -- check the export
 

--- a/docs/docs/tutorials/fullstack/setup.md
+++ b/docs/docs/tutorials/fullstack/setup.md
@@ -10,7 +10,7 @@ In this tutorial, you'll set up a full-stack project, understand the file struct
 >
 > - Completed: [Installation](../../quick-guide/install.md)
 > - Familiar with: HTML/CSS basics, React concepts helpful
-> - Install: `pip install jaseci`
+> - Install: `curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash` (installs the self-contained `jac` binary -- no Python, pip, or uv required)
 > - Time: ~15 minutes
 
 ---

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -12,7 +12,7 @@ This tutorial covers deploying to a local Kubernetes cluster (minikube or Docker
 > - jac-scale installed and enabled:
 >
 >   ```bash
->   pip install jac-scale
+>   jac install jac-scale
 >   ```
 >
 > - Time: ~10 minutes

--- a/jac-byllm/README.md
+++ b/jac-byllm/README.md
@@ -15,10 +15,10 @@
 
 byLLM is an innovative AI integration framework built for the Jaseci ecosystem, implementing the cutting-edge Meaning Typed Programming (MTP) paradigm. MTP revolutionizes AI integration by embedding prompt engineering directly into code semantics, making AI interactions more natural and maintainable. While primarily designed to complement the Jac programming language, byLLM also provides a powerful Python library interface.
 
-Installation is simple via PyPI:
+Installation is simple via the Jac plugin installer:
 
 ```bash
-pip install byllm
+jac install byllm
 ```
 
 ## Basic Example

--- a/jac-byllm/examples/agentic_ai/aider-genius-lite/README.md
+++ b/jac-byllm/examples/agentic_ai/aider-genius-lite/README.md
@@ -28,23 +28,13 @@ A simple Jac-based Streamlit application for AI-powered code generation with tas
 
    ```bash
    # Navigate to the jac-byllm directory
-   cd /home/udith/jaseci/jac-byllm
+   cd <repo>/jac-byllm
 
    # Start the backend API server
    jac start genius_lite.jac
    ```
 
-3. **Run the frontend:**
-
-   ```bash
-   # In a new terminal, navigate to the genius lite directory
-   cd /home/udith/jaseci/jac-byllm/examples/agentic_ai/aider-genius-lite
-
-   # Start the Jac Streamlit frontend
-   jac streamlit frontend.jac
-   ```
-
-4. **Open your browser** to `http://localhost:8501`
+3. **Open your browser** to `http://localhost:8501`
 
 ## Usage
 

--- a/jac-byllm/examples/agentic_ai/friendzone-lite/README.md
+++ b/jac-byllm/examples/agentic_ai/friendzone-lite/README.md
@@ -60,12 +60,6 @@ obj Response {
    jac start friendzone_lite.jac
    ```
 
-2. Run the frontend:
-
-   ```bash
-   jac streamlit frontend.jac
-   ```
-
 ## Frontend Features
 
 ### ️ Web Interface
@@ -152,10 +146,10 @@ friendzone-lite/
 
 ## Getting Started
 
-1. **Install Dependencies**:
+1. **Install the `jac` binary** (see the [Jac install guide](https://docs.jaseci.org/)):
 
    ```bash
-   pip install jaclang jac-streamlit
+   curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
    ```
 
 2. **Set OpenAI API Key**:
@@ -167,9 +161,7 @@ friendzone-lite/
 3. **Run the Application**:
 
    ```bash
-
    jac start friendzone_lite.jac
-   jac streamlit frontend.jac
    ```
 
 ## Technical Details

--- a/jac-byllm/examples/agentic_ai/task-manager-lite/README.md
+++ b/jac-byllm/examples/agentic_ai/task-manager-lite/README.md
@@ -48,12 +48,6 @@ A lightweight AI-powered task management system that intelligently routes user r
    jac start task_manager.jac
    ```
 
-2. Run the frontend:
-
-   ```bash
-   jac streamlit frontend.jac
-   ```
-
 ## Example Requests
 
 ### Task Management
@@ -120,10 +114,10 @@ task-manager-lite/
 
 ## Getting Started
 
-1. **Install Dependencies**:
+1. **Install the `jac` binary** (see the [Jac install guide](https://docs.jaseci.org/)):
 
    ```bash
-   pip install jaclang jac-streamlit
+   curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
    ```
 
 2. **Set OpenAI API Key**:
@@ -136,7 +130,6 @@ task-manager-lite/
 
    ```bash
    jac start task_manager.jac
-   jac streamlit frontend.jac
    ```
 
 ## Technical Details

--- a/jac-mcp/README.md
+++ b/jac-mcp/README.md
@@ -1,0 +1,64 @@
+<div align="center">
+
+[About Jac] | [Quick Start] | [Full Reference] | [Discord]
+
+</div>
+
+[About Jac]: https://www.jac-lang.org
+[Quick Start]: https://docs.jaseci.org/quick-guide/agent-skills-and-mcp/
+[Full Reference]: https://docs.jaseci.org/reference/mcp/
+[Discord]: https://discord.gg/6j3QNdtcN6
+
+# jac-mcp : MCP Server for AI-Assisted Jac Development
+
+`jac-mcp` is a plugin for the Jac language that provides a [Model Context Protocol](https://modelcontextprotocol.io/) server, giving AI assistants deep knowledge of Jac. It exposes grammar specifications, documentation, code examples, compiler tools, and prompt templates through a standardized protocol -- so any MCP-compatible AI client can write, validate, format, and debug Jac code.
+
+## Installation
+
+`jac-mcp` is a plugin that runs on top of the `jac` binary, which provides the jaclang runtime. Install the binary first (see the [installation guide](https://docs.jaseci.org/quick-guide/install/)), then add the plugin:
+
+```bash
+jac install jac-mcp
+```
+
+> `jaclang` is provided by the `jac` binary at runtime (a host dependency); it is not pulled from PyPI.
+
+## Quick Start
+
+Start the MCP server with the default **stdio** transport, ready for IDE integration:
+
+```bash
+jac mcp
+```
+
+Inspect the available resources, tools, and prompts:
+
+```bash
+jac mcp --inspect
+```
+
+Then add the server to your AI client's MCP configuration. A minimal entry looks like:
+
+```json
+{
+  "mcpServers": {
+    "jac": {
+      "command": "jac",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+See the [MCP reference](https://docs.jaseci.org/reference/mcp/) for the full list of tools, resources, prompts, transport options, and per-IDE integration steps.
+
+## Documentation
+
+- **Agent Skills & MCP guide**: [https://docs.jaseci.org/quick-guide/agent-skills-and-mcp/](https://docs.jaseci.org/quick-guide/agent-skills-and-mcp/)
+- **MCP reference**: [https://docs.jaseci.org/reference/mcp/](https://docs.jaseci.org/reference/mcp/)
+- **Jac language**: [https://www.jac-lang.org](https://www.jac-lang.org)
+- **GitHub repository**: [https://github.com/jaseci-labs/jaseci](https://github.com/jaseci-labs/jaseci)
+
+## License
+
+MIT

--- a/jac-mcp/examples/mcp-dashboard-studio/README.md
+++ b/jac-mcp/examples/mcp-dashboard-studio/README.md
@@ -24,10 +24,16 @@ An interactive developer dashboard for working with [Jac](https://www.jac-lang.o
 
 ## Requirements
 
-1. Python 3.12+
-2. [uv](https://docs.astral.sh/uv/) for package management
-3. Node.js 18+ (for the client build)
-4. A modern browser: Chrome, Firefox, Edge, or Safari 16.4+ (the app uses the Clipboard API)
+1. The `jac` binary (provides `jaclang` and the built-in client framework) -- install it separately:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
+   ```
+
+2. Python 3.12+
+3. [uv](https://docs.astral.sh/uv/) for package management
+4. Node.js 18+ (for the client build)
+5. A modern browser: Chrome, Firefox, Edge, or Safari 16.4+ (the app uses the Clipboard API)
 
 ---
 
@@ -40,14 +46,16 @@ git clone https://github.com/Developer-Linus/mcp-dashboard-studio.git
 cd mcp-dashboard-studio
 ```
 
-**2. Create a virtual environment and install all dependencies**
+**2. Create a virtual environment and install the app's dependencies**
 
 ```bash
 uv venv
 uv sync
 ```
 
-This installs everything listed in `pyproject.toml`, including `jaclang`, `jac-client`, and `jac-mcp`.
+This installs the app's PyPI dependencies listed in `pyproject.toml`, including `jac-mcp`.
+`jaclang` itself is provided by the `jac` binary you installed above (the client
+framework ships inside `jaclang` core, so there is no separate `jac-client` package).
 
 **3. Start everything**
 

--- a/jac-scale/README.md
+++ b/jac-scale/README.md
@@ -61,36 +61,23 @@ cd jaseci
 git submodule update --init --recursive
 ```
 
-### 2. Create Python Virtual Environment
+### 2. Build the `jac` Binary
+
+Build the `jac` binary from the cloned repository and put it on your `PATH`:
 
 ```bash
-python -m venv venv
+./scripts/fresh_env.sh
 ```
 
-### 3. Activate the Virtual Environment
+### 3. Install JAC-Scale
 
-**Linux/Mac:**
-
-```bash
-source venv/bin/activate
-```
-
-**Windows:**
+Install JAC-Scale in editable mode from the cloned repository:
 
 ```bash
-venv\Scripts\activate
-```
-
-### 4. Install JAC and JAC-Scale
-
-Install both packages in editable mode from the cloned repository:
-
-```bash
-pip install -e ./jac
 jac install -e ./jac-scale
 ```
 
-### 5. Download the Demo Application
+### 4. Download the Demo Application
 
 Download the Travel Planner demo application from GitHub:
 
@@ -142,7 +129,7 @@ cd traveller
 cd traveller
 ```
 
-### 6. Configure Environment Variables
+### 5. Configure Environment Variables
 
 You should now be in the `traveller` folder. Create a `.env` file:
 
@@ -164,13 +151,14 @@ Add the following to your `.env` file:
 OPENAI_API_KEY=your-openai-api-key-here
 ```
 
-### 7. Install Demo Application Requirements
+### 6. Install Demo Application Requirements
 
 ```bash
-pip install byllm python-dotenv
+jac install byllm
+pip install python-dotenv
 ```
 
-### 8. Run the Application with JAC Start
+### 7. Run the Application with JAC Start
 
 To run your application using FastAPI with ShelfStorage (no Kubernetes required):
 
@@ -190,7 +178,7 @@ jac start main.jac
 - Application: http://localhost:8000
 - Swagger Documentation: http://localhost:8000/docs
 
-### 9. Set Up Kubernetes (For JAC Scale)
+### 8. Set Up Kubernetes (For JAC Scale)
 
 To use `jac start --scale`, you need Kubernetes installed on your machine.
 
@@ -204,7 +192,7 @@ To use `jac start --scale`, you need Kubernetes installed on your machine.
 - Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - Enable Kubernetes in Docker Desktop settings (easier setup)
 
-### 10. Deploy with JAC Scale
+### 9. Deploy with JAC Scale
 
 Once Kubernetes is running, you have two deployment methods:
 
@@ -274,7 +262,7 @@ jac start main.jac --scale --build
 - Sharing your application with others
 - Creating reproducible deployments
 
-### 11. Clean Up Kubernetes Resources
+### 10. Clean Up Kubernetes Resources
 
 When you're done testing, remove all created Kubernetes resources:
 
@@ -314,38 +302,25 @@ cd jaseci
 git submodule update --init --recursive
 ```
 
-### 2. Create Python Virtual Environment
+### 2. Build the `jac` Binary
+
+Build the `jac` binary from the cloned repository and put it on your `PATH`:
 
 ```bash
-python -m venv venv
+./scripts/fresh_env.sh
 ```
 
-### 3. Activate the Virtual Environment
+### 3. Install JAC-Scale
 
-**Linux/Mac:**
-
-```bash
-source venv/bin/activate
-```
-
-**Windows:**
-
-```bash
-venv\Scripts\activate
-```
-
-### 4. Install JAC and JAC-Scale
-
-Install the packages in editable mode from the cloned repository (the full-stack
+Install JAC-Scale in editable mode from the cloned repository (the full-stack
 client framework ships inside `jac`/`jaclang`, so there is no separate `jac-client`
 package to install):
 
 ```bash
-pip install -e ./jac
 jac install -e ./jac-scale
 ```
 
-### 5. Create Todo application using jac-client
+### 4. Create Todo application using jac-client
 
 Lets create the todo application using jac client.For that lets run following command
 
@@ -360,7 +335,7 @@ cp jac-scale/examples/todo/app.jac todo/app.jac
 cd todo
 ```
 
-### 8. Run the Application Locally
+### 5. Run the Application Locally
 
 To run your application run the following command
 
@@ -377,7 +352,7 @@ jac start app.jac
 you can add new todo tasks
  from the frontend at http://localhost:8000/cl/app
 
-### 9. Set Up Kubernetes (For JAC Scale)
+### 6. Set Up Kubernetes (For JAC Scale)
 
 To use `jac start --scale`, you need Kubernetes installed on your machine.
 
@@ -391,7 +366,7 @@ To use `jac start --scale`, you need Kubernetes installed on your machine.
 - Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - Enable Kubernetes in Docker Desktop settings (easier setup)
 
-### 10. Deploy with JAC Scale
+### 7. Deploy with JAC Scale
 
 Once Kubernetes is running, you have two deployment methods:
 
@@ -436,7 +411,7 @@ jac start app.jac --scale --build
 - Sharing your application with others
 - Creating reproducible deployments
 
-### 11. Clean Up Kubernetes Resources
+### 8. Clean Up Kubernetes Resources
 
 When you're done testing, remove all created Kubernetes resources:
 

--- a/jac-scale/jac_scale/microservices/getting_started.md
+++ b/jac-scale/jac_scale/microservices/getting_started.md
@@ -20,7 +20,7 @@ isn't on PyPI yet. Editable install from the repo:
 git clone https://github.com/Jaseci-Labs/jaseci.git
 cd jaseci
 git checkout feat/k8s-microservice-mode
-pip install -e ./jac
+./scripts/fresh_env.sh
 jac install -e ./jac-scale --extras deploy
 jac --version
 ```

--- a/jac/README.md
+++ b/jac/README.md
@@ -9,7 +9,7 @@
 
 [Jac Website] | [Getting started] | [Learn] | [Documentation] | [Contributing]
 
-  [![PyPI version](https://img.shields.io/pypi/v/jaclang.svg)](https://pypi.org/project/jaclang/) [![Tests](https://github.com/Jaseci-Labs/jaclang/actions/workflows/run_pytest.yml/badge.svg)](https://github.com/Jaseci-Labs/jaclang/actions/workflows/run_pytest.yml) [![codecov](https://codecov.io/github/chandralegend/jaclang/graph/badge.svg?token=OAX26B0FE4)](https://codecov.io/github/chandralegend/jaclang)
+  [![Latest release](https://img.shields.io/github/v/release/jaseci-labs/jaseci.svg)](https://github.com/jaseci-labs/jaseci/releases/latest) [![Tests](https://github.com/Jaseci-Labs/jaclang/actions/workflows/run_pytest.yml/badge.svg)](https://github.com/Jaseci-Labs/jaclang/actions/workflows/run_pytest.yml) [![codecov](https://codecov.io/github/chandralegend/jaclang/graph/badge.svg?token=OAX26B0FE4)](https://codecov.io/github/chandralegend/jaclang)
 </div>
 
 This is the main source code repository for the [Jac] programming language. It contains the compiler, language server, and documentation.
@@ -33,10 +33,10 @@ This is the main source code repository for the [Jac] programming language. It c
 
 ## Quick Start
 
-To install Jac, run:
+Jac ships as a single self-contained native binary -- no Python, pip, or uv required. To install it, run:
 
 ```bash
-pip install jaclang
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
 Run `jac` in the terminal to see whether it is installed correctly.
@@ -46,16 +46,16 @@ Read ["Getting Started"] from [Docs] for more information.
 ["Getting Started"]: https://docs.jaseci.org/learn/tour/
 [Docs]: https://docs.jaseci.org/jac_book/
 
-## Installing from Source
+## Building from Source
 
-If you really want to install from source (though this is not recommended):
+The `jac` binary is built with [Zig](https://ziglang.org/) from this source tree (the build reads metadata from `jac.toml`; there is no `pyproject.toml` or pip install). For a full development environment, run the repository's bootstrap script:
 
 ```bash
-# with a local clone at `path/to/repo`:
-pip install path/to/repo/jac
-# or to have `pip` clone for you:
-pip install git+https://github.com/jaseci-labs/jaseci#subdirectory=jac
+# from the repository root
+./scripts/fresh_env.sh
 ```
+
+This builds the `jac` binary and puts it on your PATH. See [`launcher/README.md`](launcher/README.md) for the low-level `zig build` steps and the binary's internals.
 
 ## Getting Help
 

--- a/jac/examples/raylib_shooter/README.md
+++ b/jac/examples/raylib_shooter/README.md
@@ -145,7 +145,7 @@ The current frame rate is shown top-left. The loop runs **uncapped** (no
 
 ## Requirements
 
-- The `jac` CLI (`pip install jaclang`, or the repo's `.venv`) - for the Jac build
+- The `jac` binary (built via `./scripts/fresh_env.sh`, or installed via the install script) - for the Jac build
   (i.e. the default benchmark and `--jac`).
 - A `zig` toolchain - for the Zig build (the default benchmark and `--zig`).
   `demo.sh` downloads one into `.build/` automatically if you don't already have

--- a/jac/jaclang/cli/skills/jac-by-llm.md
+++ b/jac/jaclang/cli/skills/jac-by-llm.md
@@ -72,7 +72,7 @@ Method-level `by llm` automatically includes the object's `has` fields as contex
 | Anthropic | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
 | Google | `gemini/gemini-2.0-flash` | `GOOGLE_API_KEY` |
 | Ollama | `ollama/llama3:70b` | none - local daemon |
-| Built-in local | `local:gemma-4-e4b` | none - `pip install 'byllm[local]'`, then `jac model pull gemma-4-e4b` |
+| Built-in local | `local:gemma-4-e4b` | none - `jac install 'byllm[local]'`, then `jac model pull gemma-4-e4b` |
 
 Env vars take precedence over `api_key` in `jac.toml`; `BYLLM_DEFAULT_MODEL=...` overrides the project default for one shell. The glob name needn't be `llm` - any module-level glob holding a `Model` works: `glob fast = Model(model_name="gpt-4o-mini"); def quick_label(text: str) -> str by fast();`.
 
@@ -122,7 +122,7 @@ def parse_receipt(img: Image) -> Receipt by llm();   # structured output straigh
 def describe_clip(v: Video) -> str by llm();
 
 # Call as parse_receipt(Image("receipt.jpg")) - Image also accepts URLs, raw bytes, PIL images.
-# Video(path="clip.mp4", fps=1): fps = frames sampled/sec; needs `pip install byllm[video]`.
+# Video(path="clip.mp4", fps=1): fps = frames sampled/sec; needs `jac install 'byllm[video]'`.
 # Requires a vision-capable model (e.g. gpt-4o, claude-sonnet-4-6).
 ```
 

--- a/jac/jaclang/cli/skills/jac-config.md
+++ b/jac/jaclang/cli/skills/jac-config.md
@@ -85,7 +85,7 @@ jac plugins enable byllm
 jac plugins disabled          # list disabled
 ```
 
-Install/uninstall plugins with pip (e.g. `pip install jac-scale`); `jac plugins` only toggles already-installed ones. **There is no `jac plugins info` action.** The env var `JAC_DISABLED_PLUGINS` disables plugins without touching jac.toml (useful when a broken plugin blocks the CLI itself).
+Install/remove plugins with `jac install` / `jac remove` (e.g. `jac install jac-scale`); `jac plugins` only toggles already-installed ones. **There is no `jac plugins info` action.** The env var `JAC_DISABLED_PLUGINS` disables plugins without touching jac.toml (useful when a broken plugin blocks the CLI itself).
 
 ## .jacignore
 

--- a/jac/jaclang/cli/skills/jac-packaging.md
+++ b/jac/jaclang/cli/skills/jac-packaging.md
@@ -3,7 +3,7 @@ name: jac-packaging
 description: Packaging a Jac project as a wheel and publishing it to PyPI, and npm packages via `jac bundle --target npm` - jac.toml metadata, the package-directory layout, console-script and plugin entry points, extras, precompiled bytecode, twine/npm upload. Load when turning a project into a pip-installable CLI tool, an importable library, a Jac plugin, or an npm component library. Pair with `jac-scaffold` (creating the project) and `jac-impl-files` (source layout).
 ---
 
-`jac bundle` builds a standard PEP 427 wheel plus an sdist (`dist/<name>-<version>-py3-none-any.whl`, `dist/<name>-<version>.tar.gz`) straight from `jac.toml` - no `setup.py`, no `pyproject.toml`. Upload with `twine`. `jac bundle --target npm` builds an npm tarball from the same `jac.toml`. This covers three shapes: a **CLI tool** (installs a terminal command), an **importable library** (`pip install` then `import`), and an **npm component library**.
+`jac bundle` builds a standard PEP 427 wheel plus an sdist (`dist/<name>-<version>-py3-none-any.whl`, `dist/<name>-<version>.tar.gz`) straight from `jac.toml` - no `setup.py`, no `pyproject.toml`. Upload with `twine`. `jac bundle --target npm` builds an npm tarball from the same `jac.toml`. This covers three shapes: a **CLI tool** (installs a terminal command), an **importable library** (consumed under the `jac` binary, then `import`), and an **npm component library**.
 
 ## The package directory - REQUIRED
 
@@ -43,7 +43,6 @@ Homepage = "https://example.com/greet"
 greet = "greet.cli:main"
 
 [dependencies]
-jaclang = ">=0.16.0"
 rich = ">=13.0.0"
 
 [optional-dependencies.data]
@@ -52,7 +51,7 @@ pymongo = ">=4.0,<5.0"
 
 - **`[project]`** -> wheel `METADATA`. The TOML key is **`requires-python`** (hyphen), not `requires_python` - the underscore form is silently ignored and never reaches `METADATA`.
 - **`classifiers` must be a TOML array** (`[...]`). A plain string is a TOML type error and produces malformed wheel metadata.
-- **`[dependencies]`** -> `Requires-Dist` in the wheel, so `pip install` pulls them in. **`jaclang` is NOT auto-added - list it explicitly** or consumers can't import your `.jac` modules (the importer it ships is what runs your code). `[dev-dependencies]` ship as a `dev` extra, not as runtime requirements.
+- **`[dependencies]`** -> `Requires-Dist` in the wheel. **Do NOT list `jaclang` as a dependency** - it is not a PyPI package and cannot be installed that way. `jaclang` is provided by the host `jac` binary that runs your wheel; the `.jac` importer ships inside that binary. Consumers install your wheel into a project managed by the `jac` binary (`jac install <yourpkg>`), not a bare `pip install` in a plain Python env. `[dev-dependencies]` ship as a `dev` extra, not as runtime requirements.
 - **`[optional-dependencies.<group>]`** -> wheel extras: consumers `pip install greet[data]`; during development `jac install --extras data`.
 - **`[entrypoints.scripts]`** -> `console_scripts` in `entry_points.txt`. Format is `command = "package.module:function"`. The function is called with no arguments; read `sys.argv` for CLI args. Omit this whole section for a pure library.
 - **`[entrypoints.jac]`** -> the `jac` entry-point group: declares a **Jac plugin** auto-discovered at startup (`mylib = "mylib.plugin:JacRuntime"`). Use this when publishing a plugin that extends the `jac` CLI/runtime.
@@ -67,7 +66,7 @@ twine upload --repository testpypi dist/*   # TestPyPI first - verify the listin
 twine upload dist/*              # then the real index
 ```
 
-There is no `jac publish` command - use `twine` (separate pip install). In CI authenticate with a token: `twine upload dist/* -u __token__ -p "$PYPI_TOKEN"`. Consumers then `pip install greet`; the CLI command `greet` is on `PATH`, or `import greet` works for a library.
+There is no `jac publish` command - use `twine` (separate pip install). In CI authenticate with a token: `twine upload dist/* -u __token__ -p "$PYPI_TOKEN"`. Consumers then install it into a project managed by the `jac` binary (`jac install greet`); the CLI command `greet` is on `PATH`, or `import greet` works for a library running under the `jac` binary.
 
 `--precompile` / `-p` creates an isolated venv per `python3.X` on `PATH`, compiles all `.jac` to `.jir` bytecode, and folds it into the wheel - consumers skip first-import compilation. Shipped bytecode is keyed by Python version and source hash; if missing/stale the runtime transparently falls back to compiling the bundled `.jac` source, so a mismatch never breaks the package.
 
@@ -99,7 +98,7 @@ jac install -e /path/to/lib # install a cloned library editable
 ## Pitfalls
 
 - **No package directory = empty/unimportable wheel.** The `default` scaffold's root-level `main.jac` is for `jac run`, not for distribution. Move code into a `<name>/` package dir (single top-level files are not collected).
-- **Forgetting `jaclang` in `[dependencies]`** ships a wheel whose `.jac` modules fail to import in a clean environment. It is not added for you.
+- **Do NOT add `jaclang` to `[dependencies]`.** `jaclang` is not a PyPI package - it is the host runtime supplied by the `jac` binary that runs your wheel, and the `.jac` importer ships in that binary. Wheels are consumed under the `jac` binary (`jac install <yourpkg>`), not a bare `pip install` in a plain Python env.
 - **`requires_python` (underscore) is dropped.** Use `requires-python`. Same hyphen-vs-underscore trap does NOT apply to `classifiers` - there the trap is string-vs-array.
 - **Entry-point path is the install-time module path**, e.g. `greet.cli:main` - it must match the package dir name, not the source folder you happened to develop in.
 - **First run of an installed Jac command prints `Jac setup complete! (N modules compiled and cached)`** while jaclang compiles its own cache. One-time and harmless (avoid by shipping `--precompile` bytecode).

--- a/jac/jaclang/cli/skills/jac-sv-deploy.md
+++ b/jac/jaclang/cli/skills/jac-sv-deploy.md
@@ -3,7 +3,7 @@ name: jac-sv-deploy
 description: Running a Jac server in production - jac start flags, database backends (SQLite/Mongo/Redis), secrets, Kubernetes deploys (--scale, TLS, autoscaling, jac status/destroy), webhooks, WebSockets, S3 storage, metrics, distributed locks. Load when moving a server beyond local dev or wiring external services in. Pair with `jac-sv-endpoints`, `jac-sv-microservices` (multi-service k8s), `jac-config`.
 ---
 
-Production serving is jac-scale's job: `pip install jac-scale` (or `jac-scale[all]`), then `jac plugins enable scale` if it isn't already active (`jac plugins` to check).
+Production serving is jac-scale's job: `jac install jac-scale` (or `jac install 'jac-scale[all]'`), then `jac plugins enable scale` if it isn't already active (`jac plugins` to check).
 
 ## jac start
 

--- a/jaseci-package/README.md
+++ b/jaseci-package/README.md
@@ -2,22 +2,30 @@
 
 ### Complete AI-Native Programming Ecosystem
 
-Jaseci is a **meta-package** that provides a unified installation for the complete Jaseci ecosystem.
+Jaseci is the complete AI-native programming ecosystem built around the Jac language.
 
 ## What's Included
 
-When you install `jaseci`, you automatically get:
-
-- **jaclang** - The Jac programming language, including the built-in full-stack web and native-desktop app framework (React-like `cl` components, server, and bundler)
+- **jaclang** - The Jac programming language, including the built-in full-stack web and native-desktop app framework (React-like `cl` components, server, and bundler). Distributed as the self-contained `jac` binary.
 - **byllm** - LLM integration for AI-native programming
 - **jac-scale** - Scalable cloud/runtime services for Jac
 - **jac-mcp** - MCP server for AI-assisted Jac development
 
 ## Installation
 
+Install the `jac` binary (the language core) -- no Python, pip, or uv required:
+
 ```bash
-pip install jaseci
+curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
+
+Then add the plugins you need:
+
+```bash
+jac install byllm jac-scale jac-mcp
+```
+
+> **Note:** `jaclang` is no longer published to PyPI -- it ships only as the `jac` binary, which provides the runtime that the plugins build on. Install plugins individually with `jac install` rather than a bundled meta-package.
 
 ## Quick Start
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,33 +1,34 @@
 #!/usr/bin/env bash
 # Jac Programming Language Installer
 #
+# Downloads the self-contained native `jac` binary from GitHub Releases and
+# puts it on your PATH. No system Python, pip, or uv is required -- the binary
+# bundles its own runtime.
+#
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 #
 # Options:
-#   --core        Install only jaclang (no plugins)
-#   --standalone  Download a pre-built standalone binary from GitHub Releases
-#   --version V   Install a specific version
+#   --version V   Install a specific release version (e.g., 2.3.1)
 #   --uninstall   Remove Jac
 #   --help        Print usage
 #
+# Plugins (byllm, jac-scale, jac-mcp) are installed separately once `jac` is on
+# PATH:
+#   jac install byllm jac-scale jac-mcp
+#
 # Examples:
-#   curl -fsSL ... | bash                          # Full ecosystem via uv
-#   curl -fsSL ... | bash -s -- --core             # Core language only
-#   curl -fsSL ... | bash -s -- --standalone       # Standalone binary (all plugins)
-#   curl -fsSL ... | bash -s -- --standalone --core  # Standalone binary (core only)
+#   curl -fsSL ... | bash                          # Latest jac binary
 #   curl -fsSL ... | bash -s -- --version 2.3.1    # Specific version
+#   curl -fsSL ... | bash -s -- --uninstall        # Remove Jac
 
 set -euo pipefail
 
 REPO="jaseci-labs/jaseci"
 GITHUB_API="https://api.github.com/repos/${REPO}"
-UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 INSTALL_DIR="${HOME}/.local/bin"
 
 # --- Defaults ---
-CORE_ONLY=false
-STANDALONE=false
 VERSION=""
 UNINSTALL=false
 
@@ -63,32 +64,28 @@ usage() {
     cat <<EOF
 Jac Programming Language Installer
 
+Downloads the self-contained native 'jac' binary (bundled runtime; no Python,
+pip, or uv needed) and puts it on your PATH.
+
 USAGE:
     curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
     curl -fsSL ... | bash -s -- [OPTIONS]
 
 OPTIONS:
-    --core        Install only jaclang (no plugins)
-    --standalone  Download a pre-built standalone binary from GitHub Releases
-    --version V   Install a specific version (e.g., 2.3.1)
+    --version V   Install a specific release version (e.g., 2.3.1)
     --uninstall   Remove Jac installation
     --help        Print this help message
 
 EXAMPLES:
-    # Full ecosystem (all plugins) via uv
+    # Latest jac binary
     curl -fsSL ... | bash
-
-    # Core language only via uv
-    curl -fsSL ... | bash -s -- --core
-
-    # Standalone binary with all plugins
-    curl -fsSL ... | bash -s -- --standalone
-
-    # Standalone binary, core only
-    curl -fsSL ... | bash -s -- --standalone --core
 
     # Specific version
     curl -fsSL ... | bash -s -- --version 2.3.1
+
+PLUGINS:
+    Once 'jac' is on PATH, install plugins with the binary's own installer:
+        jac install byllm jac-scale jac-mcp
 EOF
 }
 
@@ -104,7 +101,7 @@ detect_platform() {
         Darwin*) OS="macos" ;;
         MINGW* | MSYS* | CYGWIN*)
             err "Windows detected. Windows support via PowerShell is coming soon."
-            err "For now, please use WSL2 or install manually: pip install jaseci"
+            err "For now, please use WSL2 and re-run this installer inside it."
             exit 1
             ;;
         *)
@@ -128,14 +125,6 @@ detect_platform() {
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --core)
-                CORE_ONLY=true
-                shift
-                ;;
-            --standalone)
-                STANDALONE=true
-                shift
-                ;;
             --version)
                 if [[ $# -lt 2 ]]; then
                     err "--version requires a version argument (e.g., --version 2.3.1)"
@@ -146,6 +135,12 @@ parse_args() {
                 ;;
             --uninstall)
                 UNINSTALL=true
+                shift
+                ;;
+            # Accepted for backward compatibility -- the binary is now the only
+            # distribution, so these are no-ops.
+            --standalone | --core)
+                warn "Note: '$1' is no longer needed; the native binary is the default install."
                 shift
                 ;;
             --help | -h)
@@ -198,70 +193,7 @@ ensure_on_path() {
     fi
 }
 
-# --- uv installation path ---
-
-install_via_uv() {
-    need_cmd "curl"
-
-    # Ensure uv is installed
-    if ! has_cmd uv; then
-        info "Installing uv (Python package manager)..."
-        curl -LsSf "$UV_INSTALL_URL" | sh
-        export PATH="${INSTALL_DIR}:${PATH}"
-
-        if ! has_cmd uv; then
-            err "Failed to install uv. Please install it manually:"
-            err "  curl -LsSf https://astral.sh/uv/install.sh | sh"
-            exit 1
-        fi
-        info "uv installed successfully."
-    else
-        info "uv is already installed."
-    fi
-
-    # Always install jaclang as the tool (it provides the 'jac' entry point).
-    # For full ecosystem, add all plugins via --with flags.
-    local spec="jaclang"
-    if [[ -n "$VERSION" ]]; then
-        spec="jaclang==${VERSION}"
-    fi
-
-    local -a with_args=()
-    if ! $CORE_ONLY; then
-        with_args+=(--with byllm --with jac-scale --with jac-mcp)
-    fi
-
-    # Check if already installed and upgrade vs fresh install
-    if uv tool list 2>/dev/null | grep -q "^jaclang "; then
-        info "Upgrading jaclang..."
-        if [[ -n "$VERSION" ]]; then
-            uv tool install "$spec" "${with_args[@]}" --python ">=3.12" --force
-        else
-            uv tool upgrade jaclang --python ">=3.12"
-        fi
-    else
-        info "Installing jaclang..."
-        uv tool install "$spec" "${with_args[@]}" --python ">=3.12"
-    fi
-
-    ensure_on_path
-
-    # Verify
-    if has_cmd jac; then
-        info ""
-        info "Jac installed successfully!"
-        jac --version 2>/dev/null || true
-        info ""
-        info "Get started:"
-        info "  jac --help"
-        info ""
-    else
-        warn "Installation completed but 'jac' is not on PATH."
-        warn "Try restarting your shell or adding ~/.local/bin to PATH."
-    fi
-}
-
-# --- Standalone binary installation path ---
+# --- Version resolution ---
 
 get_latest_version() {
     local response
@@ -292,44 +224,40 @@ resolve_jaclang_version_from_release() {
         exit 1
     }
 
-    # Find jac-*-linux-x86_64 or jac-*-macos-* asset to extract the jaclang version
+    # Find a jac-<version>-<os>-<arch> asset to extract the jac binary version
+    # (the jaclang version, which can differ from the jaseci release tag).
     local jac_version
     jac_version=$(echo "$response" | grep -o '"name":[[:space:]]*"jac-[^"]*"' | head -1 | grep -oE 'jac-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^jac-//')
 
     if [[ -z "$jac_version" ]]; then
-        err "Could not determine jaclang version from release v${release_tag} assets."
-        err "The jaclang standalone binary may not have been built yet for this release."
+        err "Could not determine the jac binary version from release v${release_tag} assets."
+        err "The native binary may not have been built yet for this release."
         exit 1
     fi
 
     echo "$jac_version"
 }
 
-install_standalone() {
+# --- Binary installation ---
+
+install_binary() {
     need_cmd "curl"
 
-    # Resolve version (this is the jaseci/release version)
+    # Resolve the release tag (the jaseci/release version).
     if [[ -z "$VERSION" ]]; then
         info "Fetching latest version..."
         VERSION=$(get_latest_version)
         info "Latest release: ${VERSION}"
     fi
 
-    # Determine asset name
-    # The jaclang (slim) binary uses the jaclang version in its filename,
-    # which differs from the jaseci release version.
-    local asset_prefix asset_version
-    if $CORE_ONLY; then
-        asset_prefix="jac"
-        info "Resolving jaclang version for release v${VERSION}..."
-        asset_version=$(resolve_jaclang_version_from_release "$VERSION")
-        info "jaclang version: ${asset_version}"
-    else
-        asset_prefix="jaseci"
-        asset_version="$VERSION"
-    fi
+    # The jac binary asset is named with the jaclang version, which can differ
+    # from the jaseci release tag.
+    info "Resolving jac binary version for release v${VERSION}..."
+    local asset_version
+    asset_version=$(resolve_jaclang_version_from_release "$VERSION")
+    info "jac binary version: ${asset_version}"
 
-    local asset="${asset_prefix}-${asset_version}-${OS}-${ARCH}"
+    local asset="jac-${asset_version}-${OS}-${ARCH}"
     local download_url="https://github.com/${REPO}/releases/download/v${VERSION}/${asset}"
     local checksum_url="${download_url}.sha256"
 
@@ -347,10 +275,8 @@ install_standalone() {
         err ""
         err "This could mean:"
         err "  - The version '${VERSION}' does not exist"
-        err "  - Standalone binaries are not available for ${OS}-${ARCH}"
+        err "  - A native binary is not available for ${OS}-${ARCH}"
         err "  - Network issue"
-        err ""
-        err "Try installing via uv instead (remove --standalone flag)."
         exit 1
     fi
 
@@ -389,11 +315,14 @@ install_standalone() {
     # Verify
     if has_cmd jac; then
         info ""
-        info "Jac installed successfully! (standalone binary)"
+        info "Jac installed successfully!"
         jac --version 2>/dev/null || true
         info ""
         info "Get started:"
         info "  jac --help"
+        info ""
+        info "Add plugins (AI, deployment, MCP) when you need them:"
+        info "  jac install byllm jac-scale jac-mcp"
         info ""
     else
         warn "Binary installed to ${INSTALL_DIR}/jac but 'jac' is not on PATH."
@@ -406,25 +335,25 @@ install_standalone() {
 do_uninstall() {
     local removed=false
 
-    # Remove uv-managed installations
-    if has_cmd uv; then
-        if uv tool list 2>/dev/null | grep -q "^jaseci "; then
-            info "Removing jaseci (uv tool)..."
-            uv tool uninstall jaseci
-            removed=true
-        fi
-        if uv tool list 2>/dev/null | grep -q "^jaclang "; then
-            info "Removing jaclang (uv tool)..."
-            uv tool uninstall jaclang
-            removed=true
-        fi
-    fi
-
     # Remove standalone binary
     if [[ -f "${INSTALL_DIR}/jac" ]]; then
         info "Removing ${INSTALL_DIR}/jac..."
         rm -f "${INSTALL_DIR}/jac"
         removed=true
+    fi
+
+    # Clean up any legacy uv-managed installs from older installer versions.
+    if has_cmd uv; then
+        if uv tool list 2>/dev/null | grep -q "^jaseci "; then
+            info "Removing legacy jaseci (uv tool)..."
+            uv tool uninstall jaseci
+            removed=true
+        fi
+        if uv tool list 2>/dev/null | grep -q "^jaclang "; then
+            info "Removing legacy jaclang (uv tool)..."
+            uv tool uninstall jaclang
+            removed=true
+        fi
     fi
 
     if $removed; then
@@ -448,11 +377,7 @@ main() {
 
     info "Detected platform: ${OS}-${ARCH}"
 
-    if $STANDALONE; then
-        install_standalone
-    else
-        install_via_uv
-    fi
+    install_binary
 }
 
 main "$@"


### PR DESCRIPTION
## What

#6855 made `jaclang` ship only as the self-contained native `jac` binary and removed it from PyPI. The documentation still described the old `pip install jaclang` / `pip install jaseci` model throughout, so this PR migrates the docs and the installer to the binary distribution.

## Changes

**Installer**
- `scripts/install.sh` — the default path now downloads the native `jac` binary from GitHub Releases and puts it on PATH (no Python/pip/uv). The uv + PyPI-jaclang path is removed; `--standalone`/`--core` are kept as backward-compat no-ops; `--version`/`--uninstall` retained.

**Headline entry points**
- `install.md`, root `README.md`, `jac/README.md`, `jaseci-package/README.md` — lead with the one-line binary install; plugins via `jac install`; "Building from Source" points at `zig build` / `scripts/fresh_env.sh`; stale PyPI version badges swapped for release badges.

**Reference / quick-guide / tutorials**
- Replaced `pip install jaclang` / `pip install jaseci` with the binary install, and standardized per-plugin installs (`byllm`, `jac-scale`, `jac-mcp`) on `jac install` (extras quoted, e.g. `jac install 'jac-scale[all]'`).

**Contributor & meta docs**
- `CONTRIBUTING.md` — dev setup via `scripts/fresh_env.sh`, tests via `jac test`, release flow describes jaclang as the binary artifact (plugins still publish to PyPI).
- `codebase-guide.md` CI table + repo layout; `docs/README.md` clarifies the docs-preview package has no jaclang dependency.

**Plugin/example READMEs**
- Added the missing `jac-mcp/README.md`. Removed the non-existent `jac streamlit` steps from the agentic_ai example READMEs and fixed stale absolute author paths. Reworked `pip install -e ./jac` dev steps to `scripts/fresh_env.sh`.

**Honest notes for two unmigrated code paths**
- `jac eject` and the jac-scale Kubernetes deploy still install `jaclang` from PyPI in code, so those docs now carry explicit "runtime provisioning is being migrated" warnings and a working binary-install Dockerfile pattern, rather than describing a flow the code can't perform yet. These code regressions are tracked in #6892.

## Verification
- `mkdocs build` produces the site with no content errors.
- `scripts/install.sh` passes `bash -n`.
- Repo-wide grep confirms no residual `pip install jaclang/jaseci`, `pip install -e ./jac`, or bare per-plugin `pip install` remain in docs (only third-party libs and historical release notes).
- All pre-commit hooks pass.

## Related
- Depends on / documents #6855
- Surfaces code regressions in #6892
