### PR TITLE
fix(launcher): use lto-full pbs for aarch64-linux (no pgo build exists)

### DIFF
--- a/jac/launcher/fetch-pbs.sh
+++ b/jac/launcher/fetch-pbs.sh
@@ -10,19 +10,25 @@ set -euo pipefail
 OSARCH="${1:?os-arch (e.g. macos-aarch64)}"
 DEST="${2:?dest dir}"
 
-# Pinned pbs release. Must stay a non-LTO ('pgo', not 'pgo+lto') *full* archive:
-# the launcher dlopens the shared libpython, so a full archive (with the .dylib/
-# .so + lib-dynload) is required; non-LTO avoids LLVM-bitcode link issues.
+# Pinned pbs release. We want a *full* archive (the shared .dylib/.so +
+# lib-dynload, since the launcher dlopens the shared libpython) and prefer the
+# 'pgo' flavor (most optimized, non-LTO -- LTO ships LLVM bitcode in the static
+# libs, which we avoid). python-build-standalone does NOT publish a PGO build
+# for aarch64 Linux (PGO needs to run the target during the build), so that one
+# platform falls back to 'lto-full'. The launcher only links libc and loads the
+# finished shared libpython at runtime, so the LTO-bitcode concern (a static-
+# link issue) does not apply to it.
 PBS_TAG="20241206"
 PBS_PY="3.12.8"
+FLAVOR="pgo-full"
 case "$OSARCH" in
   macos-aarch64) PLAT="aarch64-apple-darwin" ;;
   macos-x86_64)  PLAT="x86_64-apple-darwin" ;;
   linux-x86_64)  PLAT="x86_64-unknown-linux-gnu" ;;
-  linux-aarch64) PLAT="aarch64-unknown-linux-gnu" ;;
+  linux-aarch64) PLAT="aarch64-unknown-linux-gnu"; FLAVOR="lto-full" ;;
   *) echo "fetch-pbs: unsupported platform '$OSARCH'" >&2; exit 1 ;;
 esac
-ASSET="cpython-${PBS_PY}+${PBS_TAG}-${PLAT}-pgo-full.tar.zst"
+ASSET="cpython-${PBS_PY}+${PBS_TAG}-${PLAT}-${FLAVOR}.tar.zst"
 
 if [ -f "$DEST/python/PYTHON.json" ]; then
   exit 0


### PR DESCRIPTION
## What

The `release-jaclang.yml` matrix now builds for all four platforms `install.sh` supports (added in #6895), but the `linux-aarch64` build fails at `zig build`.

**Root cause:** the binary bundles a [python-build-standalone](https://github.com/astral-sh/python-build-standalone) CPython, and `fetch-pbs.sh` hardcodes the `pgo-full` flavor. pbs `20241206` does **not** publish a PGO build for `aarch64-unknown-linux-gnu` (PGO requires running the target during the build) — only `debug`/`lto`/`noopt`. So the download 404s and the build fails. The other three targets (`x86_64-linux`, `x86_64-macos`, `aarch64-macos`) all have `pgo-full`.

## Fix

Select the pbs flavor per platform: keep `pgo-full` everywhere it exists, fall back to `lto-full` for `aarch64-linux`. The launcher only links libc and `dlopen`s the finished shared libpython at runtime, so the LTO/static-link bitcode concern that originally ruled out LTO does not apply here.

## Validation

Built all four platforms via a `workflow_dispatch` artifact run on a fork — `linux-aarch64` now builds and packages successfully (along with the three unchanged targets). The release `v0.30.0` already has the other platforms' assets; after this merges, re-running `release-jaclang.yml` for `v0.30.0` attaches `jac-0.30.0-linux-aarch64`.

## Related
- Follows #6895 (the 4-platform matrix that surfaced this)
