### PR TITLE
ci: on-demand /test for PRs to cut runner cost

### DIFF
--- a/.github/scripts/ci-requested-suites.sh
+++ b/.github/scripts/ci-requested-suites.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Decides which CI suites a run should execute, based on `/test` comments, and
+# writes a single `requested=<space-separated suites>` line to $GITHUB_OUTPUT
+# for the shared `plan` job (ci-plan.yml) to expose to its callers.
+#
+# Rules (see CONTRIBUTING.md "Running CI on your PR"):
+#   - On push events: every known suite is enabled (full post-merge coverage).
+#   - On a pull_request: a suite is enabled only if the MOST RECENT `/test`
+#     comment from a repo collaborator (read access or above) named it. `all`
+#     expands to every suite. Nothing accumulates across comments.
+#   - Only honored on a re-run (GITHUB_RUN_ATTEMPT > 1): the automatic run that
+#     fires on PR open/push is attempt 1 and requests nothing, so a new commit
+#     starts clean. Fail closed if the attempt can't be determined.
+#
+# Requires: gh (authenticated via GH_TOKEN/GITHUB_TOKEN), jq. Both are
+# preinstalled on GitHub-hosted runners.
+set -euo pipefail
+
+# The canonical suite list. Keep in sync with ci-rerun-on-test.sh and
+# CONTRIBUTING.md.
+ALL_SUITES="core client scale mcp byllm docs desktop macos pypi k8s check contrib installer"
+
+out="${GITHUB_OUTPUT:-/dev/stdout}"
+
+emit() { # emit <space-separated requested suites>
+  local req
+  req="$(echo "$1" | xargs || true)"   # normalize whitespace
+  echo "requested=$req" >> "$out"
+}
+
+# push -> run everything (full post-merge coverage).
+if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]]; then
+  emit "$ALL_SUITES"
+  exit 0
+fi
+
+# Only a /test re-run (attempt > 1) reads comments; fail closed otherwise so a
+# fresh PR push (attempt 1) requests nothing.
+attempt="${GITHUB_RUN_ATTEMPT:-0}"
+if ! [[ "$attempt" =~ ^[0-9]+$ ]] || (( attempt <= 1 )); then
+  emit ""
+  exit 0
+fi
+
+# PR number from the event payload.
+pr="$(jq -r '.pull_request.number // .issue.number // empty' "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/null || true)"
+if [[ -z "$pr" ]]; then emit ""; exit 0; fi
+
+repo="${GITHUB_REPOSITORY:?}"
+
+# All PR comments, oldest-first. Output per line: "<login>\t<body-first-line>".
+mapfile -t lines < <(
+  gh api --paginate "repos/$repo/issues/$pr/comments" \
+    --jq '.[] | [.user.login, (.body // "" | gsub("\r";"") | split("\n")[0])] | @tsv' \
+  2>/dev/null || true
+)
+
+is_collaborator() { # is_collaborator <login>  -> exit 0 if read+ access
+  local login="$1" perm
+  perm="$(gh api "repos/$repo/collaborators/$login/permission" --jq '.permission' 2>/dev/null || echo none)"
+  case "$perm" in admin|maintain|write|triage|read) return 0;; *) return 1;; esac
+}
+
+# Walk newest-first; the first valid collaborator `/test` comment wins.
+requested=""
+for (( i=${#lines[@]}-1; i>=0; i-- )); do
+  IFS=$'\t' read -r login body <<< "${lines[$i]}"
+  body="${body#"${body%%[![:space:]]*}"}"   # ltrim leading whitespace
+  [[ "$body" == /test* ]] || continue
+  is_collaborator "$login" || continue
+
+  read -ra toks <<< "${body#/test}"          # tokens after `/test`
+  for t in "${toks[@]}"; do
+    t="${t,,}"
+    if [[ "$t" == all ]]; then
+      requested="$ALL_SUITES"
+      break
+    fi
+    for s in $ALL_SUITES; do
+      [[ "$t" == "$s" && " $requested " != *" $s "* ]] && requested="$requested $s"
+    done
+  done
+  break   # honor only this latest /test comment
+done
+
+emit "$requested"

--- a/.github/scripts/ci-requested-suites.sh
+++ b/.github/scripts/ci-requested-suites.sh
@@ -1,86 +1,66 @@
 #!/usr/bin/env bash
-# Decides which CI suites a run should execute, based on `/test` comments, and
-# writes a single `requested=<space-separated suites>` line to $GITHUB_OUTPUT
-# for the shared `plan` job (ci-plan.yml) to expose to its callers.
+# Prints `requested=<space-separated suites>` to $GITHUB_OUTPUT for ci.yml's plan
+# job, which gates each suite on it.
 #
-# Rules (see CONTRIBUTING.md "Running CI on your PR"):
-#   - On push events: every known suite is enabled (full post-merge coverage).
-#   - On a pull_request: a suite is enabled only if the MOST RECENT `/test`
-#     comment from a repo collaborator (read access or above) named it. `all`
-#     expands to every suite. Nothing accumulates across comments.
-#   - Only honored on a re-run (GITHUB_RUN_ATTEMPT > 1): the automatic run that
-#     fires on PR open/push is attempt 1 and requests nothing, so a new commit
-#     starts clean. Fail closed if the attempt can't be determined.
+#   push        -> every orchestrated suite (full post-merge coverage)
+#   PR attempt 1 -> nothing (the auto run on open/push requests nothing, so a
+#                  fresh commit starts clean)
+#   PR re-run   -> the suites named by the most recent `/test` comment from a
+#                  read+ collaborator; `all` expands to every suite
 #
-# Requires: gh (authenticated via GH_TOKEN/GITHUB_TOKEN), jq. Both are
-# preinstalled on GitHub-hosted runners.
+# Only ci.yml's suites are emitted. `contrib` is a valid /test token but runs via
+# its own always-on workflow, so it is not orchestrated here (see
+# ci-rerun-on-test.sh). Requires gh + jq (preinstalled on GitHub runners).
 set -euo pipefail
 
-# The canonical suite list. Keep in sync with ci-rerun-on-test.sh and
-# CONTRIBUTING.md.
-ALL_SUITES="core client scale mcp byllm docs desktop macos pypi k8s check contrib installer"
-
+# Suites ci.yml orchestrates. Keep in sync with ci.yml and ci-rerun-on-test.sh.
+SUITES="core client scale mcp byllm docs desktop macos pypi k8s check installer"
 out="${GITHUB_OUTPUT:-/dev/stdout}"
 
-emit() { # emit <space-separated requested suites>
-  local req
-  req="$(echo "$1" | xargs || true)"   # normalize whitespace
-  echo "requested=$req" >> "$out"
-}
+emit() { echo "requested=$(echo "$1" | xargs || true)" >> "$out"; }
 
-# push -> run everything (full post-merge coverage).
-if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]]; then
-  emit "$ALL_SUITES"
-  exit 0
-fi
+# Push: full coverage.
+[[ "${GITHUB_EVENT_NAME:-}" == "push" ]] && { emit "$SUITES"; exit 0; }
 
-# Only a /test re-run (attempt > 1) reads comments; fail closed otherwise so a
-# fresh PR push (attempt 1) requests nothing.
+# Only a /test re-run (attempt > 1) reads comments; otherwise request nothing.
 attempt="${GITHUB_RUN_ATTEMPT:-0}"
-if ! [[ "$attempt" =~ ^[0-9]+$ ]] || (( attempt <= 1 )); then
-  emit ""
-  exit 0
-fi
+[[ "$attempt" =~ ^[0-9]+$ ]] && (( attempt > 1 )) || { emit ""; exit 0; }
 
-# PR number from the event payload.
 pr="$(jq -r '.pull_request.number // .issue.number // empty' "${GITHUB_EVENT_PATH:-/dev/null}" 2>/dev/null || true)"
-if [[ -z "$pr" ]]; then emit ""; exit 0; fi
-
+[[ -n "$pr" ]] || { emit ""; exit 0; }
 repo="${GITHUB_REPOSITORY:?}"
 
-# All PR comments, oldest-first. Output per line: "<login>\t<body-first-line>".
+# All PR comments, oldest-first: "<login>\t<body-first-line>".
 mapfile -t lines < <(
   gh api --paginate "repos/$repo/issues/$pr/comments" \
     --jq '.[] | [.user.login, (.body // "" | gsub("\r";"") | split("\n")[0])] | @tsv' \
   2>/dev/null || true
 )
 
-is_collaborator() { # is_collaborator <login>  -> exit 0 if read+ access
-  local login="$1" perm
-  perm="$(gh api "repos/$repo/collaborators/$login/permission" --jq '.permission' 2>/dev/null || echo none)"
+# Read+ access (read/triage/write/maintain/admin) on this repo.
+is_collaborator() {
+  local perm
+  perm="$(gh api "repos/$repo/collaborators/$1/permission" --jq '.permission' 2>/dev/null || echo none)"
   case "$perm" in admin|maintain|write|triage|read) return 0;; *) return 1;; esac
 }
 
-# Walk newest-first; the first valid collaborator `/test` comment wins.
+# Newest-first: the first valid collaborator `/test` comment wins.
 requested=""
 for (( i=${#lines[@]}-1; i>=0; i-- )); do
   IFS=$'\t' read -r login body <<< "${lines[$i]}"
-  body="${body#"${body%%[![:space:]]*}"}"   # ltrim leading whitespace
+  body="${body#"${body%%[![:space:]]*}"}"   # ltrim
   [[ "$body" == /test* ]] || continue
   is_collaborator "$login" || continue
 
-  read -ra toks <<< "${body#/test}"          # tokens after `/test`
+  read -ra toks <<< "${body#/test}"
   for t in "${toks[@]}"; do
     t="${t,,}"
-    if [[ "$t" == all ]]; then
-      requested="$ALL_SUITES"
-      break
-    fi
-    for s in $ALL_SUITES; do
+    [[ "$t" == all ]] && { requested="$SUITES"; break; }
+    for s in $SUITES; do
       [[ "$t" == "$s" && " $requested " != *" $s "* ]] && requested="$requested $s"
     done
   done
-  break   # honor only this latest /test comment
+  break   # only the latest /test comment counts
 done
 
 emit "$requested"

--- a/.github/scripts/ci-rerun-on-test.sh
+++ b/.github/scripts/ci-rerun-on-test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Handles a `/test ...` PR comment: reacts to it and re-runs the latest
+# pull_request run of the affected workflow(s) so their `plan` re-evaluates the
+# request (see ci-requested-suites.sh). Posts NO comments and creates NO
+# status/check rows - the only acknowledgement is an emoji reaction.
+#
+# All on-demand suites are owned by the single orchestrator ci.yml, so a /test
+# almost always just re-runs that one workflow. The exception is `contrib`
+# (contribution-checks.yml), which stays auto-on-PR and is re-run directly.
+#
+# Invoked by ci-command.yml on `issue_comment`. Requires: gh (authenticated via
+# GH_TOKEN), jq. Reads the event from $GITHUB_EVENT_PATH.
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?}"
+event="${GITHUB_EVENT_PATH:?}"
+
+comment_id="$(jq -r '.comment.id' "$event")"
+pr="$(jq -r '.issue.number' "$event")"
+commenter="$(jq -r '.comment.user.login' "$event")"
+body="$(jq -r '.comment.body' "$event")"
+
+react() { # react <content>  (best-effort; never fails the job)
+  gh api -X POST "repos/$repo/issues/comments/$comment_id/reactions" \
+    -f "content=$1" >/dev/null 2>&1 || echo "::warning::reaction '$1' failed"
+}
+
+# Suites owned by the ci.yml orchestrator (everything except `contrib`).
+ORCHESTRATED="core client scale mcp byllm docs desktop macos pypi k8s check installer"
+ALL="$ORCHESTRATED contrib"
+
+# tokens after `/test`, lowercased
+read -ra toks <<< "${body#*/test}"
+args=()
+for t in "${toks[@]}"; do args+=("${t,,}"); done
+
+# `/test` or `/test help`: just acknowledge.
+if [[ ${#args[@]} -eq 0 || "${args[0]}" == help ]]; then
+  react eyes
+  exit 0
+fi
+
+# Authorize: repo collaborator, read access or above.
+perm="$(gh api "repos/$repo/collaborators/$commenter/permission" --jq '.permission' 2>/dev/null || echo none)"
+case "$perm" in
+  admin|maintain|write|triage|read) ;;
+  *) react "-1"; exit 0 ;;
+esac
+
+# Resolve requested suites.
+requested=""
+for a in "${args[@]}"; do
+  if [[ "$a" == all ]]; then requested="$ALL"; break; fi
+  [[ " $ALL " == *" $a "* && " $requested " != *" $a "* ]] && requested="$requested $a"
+done
+requested="${requested## }"
+if [[ -z "$requested" ]]; then react confused; exit 0; fi
+
+react rocket
+
+sha="$(gh api "repos/$repo/pulls/$pr" --jq '.head.sha')"
+
+# Which workflow files need a re-run. ci.yml covers all orchestrated suites;
+# contribution-checks.yml only if `contrib` was named.
+workflows=""
+for s in $requested; do
+  if [[ " $ORCHESTRATED " == *" $s "* ]]; then
+    [[ " $workflows " == *" ci.yml "* ]] || workflows="$workflows ci.yml"
+  elif [[ "$s" == contrib ]]; then
+    [[ " $workflows " == *" contribution-checks.yml "* ]] || workflows="$workflows contribution-checks.yml"
+  fi
+done
+
+# Re-run each affected workflow's latest pull_request run for this commit so its
+# plan re-reads the comments. A run that's still in progress can't be re-run yet,
+# so wait briefly for it to finish first.
+any_rerun=false
+for wf in $workflows; do
+  rerun=false
+  for _ in $(seq 1 12); do
+    read -r run_id status < <(
+      gh api "repos/$repo/actions/workflows/$wf/runs?head_sha=$sha&event=pull_request&per_page=1" \
+        --jq '.workflow_runs[0] | "\(.id // "") \(.status // "")"' 2>/dev/null || echo " "
+    )
+    if [[ -z "$run_id" ]]; then sleep 5; continue; fi              # run not created yet
+    if [[ "$status" != "completed" ]]; then sleep 5; continue; fi  # wait for it to finish
+    if gh api -X POST "repos/$repo/actions/runs/$run_id/rerun" >/dev/null 2>&1; then
+      rerun=true; any_rerun=true; break
+    fi
+    echo "::warning::re-run of $wf (#$run_id) failed"
+    sleep 5
+  done
+  $rerun || echo "::warning::could not re-run $wf for ${sha:0:7} (no completed run yet)"
+done
+
+# Nothing could be re-triggered: swap the rocket for a confused reaction so the
+# user knows nothing started.
+$any_rerun || react confused

--- a/.github/scripts/ci-rerun-on-test.sh
+++ b/.github/scripts/ci-rerun-on-test.sh
@@ -1,98 +1,81 @@
 #!/usr/bin/env bash
-# Handles a `/test ...` PR comment: reacts to it and re-runs the latest
-# pull_request run of the affected workflow(s) so their `plan` re-evaluates the
-# request (see ci-requested-suites.sh). Posts NO comments and creates NO
-# status/check rows - the only acknowledgement is an emoji reaction.
+# Handles a `/test ...` PR comment: authorize, react, and re-run the affected
+# workflow's latest pull_request run so its plan job re-reads the request (see
+# ci-requested-suites.sh). The re-run is the trigger -- this posts no comments
+# and creates no status rows; the only feedback is an emoji reaction.
 #
-# All on-demand suites are owned by the single orchestrator ci.yml, so a /test
-# almost always just re-runs that one workflow. The exception is `contrib`
-# (contribution-checks.yml), which stays auto-on-PR and is re-run directly.
+# Reactions:  eyes = help/ack   -1 = not a collaborator   confused = nothing to
+# run / couldn't re-run   rocket = re-run started.
 #
-# Invoked by ci-command.yml on `issue_comment`. Requires: gh (authenticated via
-# GH_TOKEN), jq. Reads the event from $GITHUB_EVENT_PATH.
+# Almost everything is orchestrated by ci.yml, so a /test re-runs that single
+# workflow. `contrib` is the exception: it has its own always-on workflow
+# (contribution-checks.yml), re-run directly here.
+#
+# Invoked by ci-command.yml on issue_comment. Requires gh + jq.
 set -euo pipefail
 
 repo="${GITHUB_REPOSITORY:?}"
 event="${GITHUB_EVENT_PATH:?}"
-
 comment_id="$(jq -r '.comment.id' "$event")"
 pr="$(jq -r '.issue.number' "$event")"
 commenter="$(jq -r '.comment.user.login' "$event")"
 body="$(jq -r '.comment.body' "$event")"
 
-react() { # react <content>  (best-effort; never fails the job)
-  gh api -X POST "repos/$repo/issues/comments/$comment_id/reactions" \
-    -f "content=$1" >/dev/null 2>&1 || echo "::warning::reaction '$1' failed"
-}
+react() { gh api -X POST "repos/$repo/issues/comments/$comment_id/reactions" -f "content=$1" >/dev/null 2>&1 || true; }
 
-# Suites owned by the ci.yml orchestrator (everything except `contrib`).
 ORCHESTRATED="core client scale mcp byllm docs desktop macos pypi k8s check installer"
 ALL="$ORCHESTRATED contrib"
 
-# tokens after `/test`, lowercased
+# Tokens after `/test`, lowercased.
 read -ra toks <<< "${body#*/test}"
 args=()
 for t in "${toks[@]}"; do args+=("${t,,}"); done
 
-# `/test` or `/test help`: just acknowledge.
-if [[ ${#args[@]} -eq 0 || "${args[0]}" == help ]]; then
-  react eyes
-  exit 0
-fi
+# Bare `/test` or `/test help`: just acknowledge.
+if [[ ${#args[@]} -eq 0 || "${args[0]}" == help ]]; then react eyes; exit 0; fi
 
-# Authorize: repo collaborator, read access or above.
+# Authoritative auth: read+ collaborator. (ci-command.yml already blocks obvious
+# outsiders via author_association before the runner starts; this is the precise
+# check that also covers read/triage roles.)
 perm="$(gh api "repos/$repo/collaborators/$commenter/permission" --jq '.permission' 2>/dev/null || echo none)"
-case "$perm" in
-  admin|maintain|write|triage|read) ;;
-  *) react "-1"; exit 0 ;;
-esac
+case "$perm" in admin|maintain|write|triage|read) ;; *) react "-1"; exit 0 ;; esac
 
-# Resolve requested suites.
+# Resolve the requested suites.
 requested=""
 for a in "${args[@]}"; do
-  if [[ "$a" == all ]]; then requested="$ALL"; break; fi
+  [[ "$a" == all ]] && { requested="$ALL"; break; }
   [[ " $ALL " == *" $a "* && " $requested " != *" $a "* ]] && requested="$requested $a"
 done
 requested="${requested## }"
-if [[ -z "$requested" ]]; then react confused; exit 0; fi
+[[ -n "$requested" ]] || { react confused; exit 0; }
 
-react rocket
+# Map suites -> workflow files to re-run (ci.yml covers all orchestrated suites).
+workflows=""
+for s in $requested; do
+  if [[ " $ORCHESTRATED " == *" $s "* ]]; then wf="ci.yml"
+  elif [[ "$s" == contrib ]]; then wf="contribution-checks.yml"
+  else continue; fi
+  [[ " $workflows " == *" $wf "* ]] || workflows="$workflows $wf"
+done
 
 sha="$(gh api "repos/$repo/pulls/$pr" --jq '.head.sha')"
 
-# Which workflow files need a re-run. ci.yml covers all orchestrated suites;
-# contribution-checks.yml only if `contrib` was named.
-workflows=""
-for s in $requested; do
-  if [[ " $ORCHESTRATED " == *" $s "* ]]; then
-    [[ " $workflows " == *" ci.yml "* ]] || workflows="$workflows ci.yml"
-  elif [[ "$s" == contrib ]]; then
-    [[ " $workflows " == *" contribution-checks.yml "* ]] || workflows="$workflows contribution-checks.yml"
-  fi
-done
-
-# Re-run each affected workflow's latest pull_request run for this commit so its
-# plan re-reads the comments. A run that's still in progress can't be re-run yet,
-# so wait briefly for it to finish first.
+# Re-run each affected workflow's latest pull_request run for this commit. A run
+# still in progress can't be re-run, so wait briefly for it to finish.
 any_rerun=false
 for wf in $workflows; do
-  rerun=false
   for _ in $(seq 1 12); do
     read -r run_id status < <(
       gh api "repos/$repo/actions/workflows/$wf/runs?head_sha=$sha&event=pull_request&per_page=1" \
         --jq '.workflow_runs[0] | "\(.id // "") \(.status // "")"' 2>/dev/null || echo " "
     )
-    if [[ -z "$run_id" ]]; then sleep 5; continue; fi              # run not created yet
-    if [[ "$status" != "completed" ]]; then sleep 5; continue; fi  # wait for it to finish
-    if gh api -X POST "repos/$repo/actions/runs/$run_id/rerun" >/dev/null 2>&1; then
-      rerun=true; any_rerun=true; break
-    fi
-    echo "::warning::re-run of $wf (#$run_id) failed"
+    [[ -z "$run_id" || "$status" != "completed" ]] && { sleep 5; continue; }
+    gh api -X POST "repos/$repo/actions/runs/$run_id/rerun" >/dev/null 2>&1 && { any_rerun=true; break; }
     sleep 5
   done
-  $rerun || echo "::warning::could not re-run $wf for ${sha:0:7} (no completed run yet)"
+  $any_rerun || echo "::warning::could not re-run $wf for ${sha:0:7} (no completed run yet)"
 done
 
-# Nothing could be re-triggered: swap the rocket for a confused reaction so the
-# user knows nothing started.
-$any_rerun || react confused
+# React only after we know the outcome: rocket if something started, else
+# confused (the API only adds reactions, so we must not react early).
+$any_rerun && react rocket || react confused

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,0 +1,47 @@
+name: CI command (/test)
+
+# Quiet, on-demand CI for pull requests. The test workflows run on
+# `pull_request` but every suite skips unless a collaborator requested it by
+# commenting `/test <suites>`, so an unrequested PR costs almost nothing.
+#
+#   /test all | /test core | /test core client scale | /test help
+#
+# This workflow does NOT post comments or create status rows - the requested
+# suites simply start running as native checks on the commit (the status dot
+# next to the commit / the PR's Checks list). The only acknowledgement is an
+# emoji reaction on the `/test` comment.
+#
+# Mechanism: the test workflows share one `plan` job (ci-plan.yml) that reads
+# `/test` comments at run time. To make a new request take effect, this workflow
+# re-runs the latest pull_request run for the head commit (after it finishes) so
+# each `plan` re-evaluates. Push to main always runs the full suite.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ci-command-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write          # re-run the pull_request workflow runs
+  issues: write           # reaction on an issue comment
+  pull-requests: write    # reaction on a PR review comment thread
+  contents: read          # read collaborator permission
+
+jobs:
+  rerun:
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/test')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: React, authorize, and re-run affected workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/ci-rerun-on-test.sh

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,20 +1,8 @@
 name: CI command (/test)
 
-# Quiet, on-demand CI for pull requests. The test workflows run on
-# `pull_request` but every suite skips unless a collaborator requested it by
-# commenting `/test <suites>`, so an unrequested PR costs almost nothing.
-#
+# Handles `/test <suites>` PR comments. Reacts with an emoji and re-runs ci.yml
+# so its plan job re-reads the request -- no bot comments, no status rows.
 #   /test all | /test core | /test core client scale | /test help
-#
-# This workflow does NOT post comments or create status rows - the requested
-# suites simply start running as native checks on the commit (the status dot
-# next to the commit / the PR's Checks list). The only acknowledgement is an
-# emoji reaction on the `/test` comment.
-#
-# Mechanism: the test workflows share one `plan` job (ci-plan.yml) that reads
-# `/test` comments at run time. To make a new request take effect, this workflow
-# re-runs the latest pull_request run for the head commit (after it finishes) so
-# each `plan` re-evaluates. Push to main always runs the full suite.
 
 on:
   issue_comment:
@@ -25,23 +13,28 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  actions: write          # re-run the pull_request workflow runs
-  issues: write           # reaction on an issue comment
-  pull-requests: write    # reaction on a PR review comment thread
-  contents: read          # read collaborator permission
+  actions: write        # re-run the workflow runs
+  issues: write         # add the emoji reaction
+  pull-requests: read   # read the PR head sha
+  contents: read        # read collaborator permission
 
 jobs:
   rerun:
+    # First-line auth gate: only run for PR `/test` comments from someone with a
+    # write-side association. This blocks outsiders before a runner even starts.
+    # The script still does the authoritative read+ collaborator check (this
+    # coarse filter can't see read/triage roles).
     if: >-
       github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/test')
+      startsWith(github.event.comment.body, '/test') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
-      - name: React, authorize, and re-run affected workflows
+      - name: React, authorize, and re-run ci.yml
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/ci-rerun-on-test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: Tests
+
+# The on-demand CI orchestrator. PRs no longer auto-run the heavy suites; a
+# collaborator requests them by commenting `/test <suites>` (see ci-command.yml).
+# This is the ONE workflow that triggers on pull_request: a single `plan` job
+# reads the request, then each suite is invoked as a reusable workflow gated on
+# the result. So the PR shows exactly one gate row (`plan`) plus the real suite
+# checks -- not one gate per workflow.
+#
+# Push to main runs every suite (full post-merge coverage).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main, "feat/**"]
+
+# The `plan` job reads PR comments + collaborator permission to decide which
+# suites run; that needs these read scopes. Called workflows inherit this cap.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+# Cancel superseded PR runs; never cancel a run for a commit on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # The single on-demand gate. Returns `requested`: a space-separated list of
+  # suites to run. On push it returns everything; on a PR it returns only what
+  # the latest `/test` comment asked for (empty on the first attempt, so a fresh
+  # commit starts clean -- see ci-requested-suites.sh).
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      requested: ${{ steps.s.outputs.requested }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - id: s
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/ci-requested-suites.sh
+
+  # core suite: binary build + compiler + runtime.
+  core:
+    needs: plan
+    if: contains(format(' {0} ', needs.plan.outputs.requested), ' core ')
+    uses: ./.github/workflows/test-binary.yml
+    secrets: inherit
+
+  # Plugin / client / docs / pypi / k8s suites all live in one file; it gates
+  # each job internally on the suites it owns. Invoked whenever any of them was
+  # requested (and on push, when `requested` is the full list).
+  jaseci:
+    needs: plan
+    if: >-
+      contains(format(' {0} ', needs.plan.outputs.requested), ' client ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' scale ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' mcp ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' byllm ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' docs ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' desktop ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' macos ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' pypi ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' core ') ||
+      contains(format(' {0} ', needs.plan.outputs.requested), ' k8s ')
+    uses: ./.github/workflows/test-jaseci.yml
+    with:
+      requested: ${{ needs.plan.outputs.requested }}
+    secrets: inherit
+
+  # check suite: jac format + type check.
+  check:
+    needs: plan
+    if: contains(format(' {0} ', needs.plan.outputs.requested), ' check ')
+    uses: ./.github/workflows/jac-check.yml
+    secrets: inherit
+
+  # installer suite: install.sh shellcheck + download/run smoke.
+  installer:
+    needs: plan
+    if: contains(format(' {0} ', needs.plan.outputs.requested), ' installer ')
+    uses: ./.github/workflows/test-installer.yml
+    secrets: inherit
+
+  # k8s suite: heavy microk8s real-app e2e.
+  k8s:
+    needs: plan
+    if: contains(format(' {0} ', needs.plan.outputs.requested), ' k8s ')
+    uses: ./.github/workflows/k8s-microservice-real-e2e.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,19 @@
 name: Tests
 
-# The on-demand CI orchestrator. PRs no longer auto-run the heavy suites; a
-# collaborator requests them by commenting `/test <suites>` (see ci-command.yml).
-# This is the ONE workflow that triggers on pull_request: a single `plan` job
-# reads the request, then each suite is invoked as a reusable workflow gated on
-# the result. So the PR shows exactly one gate row (`plan`) plus the real suite
-# checks -- not one gate per workflow.
-#
-# Push to main runs every suite (full post-merge coverage).
+# On-demand CI orchestrator. The ONLY test workflow that triggers on a PR: one
+# cheap `plan` job reads the `/test` request (see ci-requested-suites.sh), then
+# each suite runs as a reusable workflow gated on it. So a PR shows one `plan`
+# row plus the real suite checks, not a gate per workflow. Push to main runs
+# everything (full post-merge coverage).
 
 on:
   pull_request:
     branches: [main]
   push:
-    branches: [main, "feat/**"]
+    branches: [main]
 
-# The `plan` job reads PR comments + collaborator permission to decide which
-# suites run; that needs these read scopes. Called workflows inherit this cap.
+# Read scopes for the plan job (reads PR comments + collaborator permission).
+# Called workflows inherit this cap.
 permissions:
   contents: read
   pull-requests: read
@@ -28,10 +25,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # The single on-demand gate. Returns `requested`: a space-separated list of
-  # suites to run. On push it returns everything; on a PR it returns only what
-  # the latest `/test` comment asked for (empty on the first attempt, so a fresh
-  # commit starts clean -- see ci-requested-suites.sh).
+  # The single on-demand gate. `requested` = space-separated suites to run.
   plan:
     runs-on: ubuntu-latest
     outputs:
@@ -53,9 +47,9 @@ jobs:
     uses: ./.github/workflows/test-binary.yml
     secrets: inherit
 
-  # Plugin / client / docs / pypi / k8s suites all live in one file; it gates
-  # each job internally on the suites it owns. Invoked whenever any of them was
-  # requested (and on push, when `requested` is the full list).
+  # Several suites share one file (it gates each job internally); call it when
+  # any of them was requested. `core` is here too: its solid-jsdom job lives in
+  # this file; `k8s` likewise has a job here alongside the standalone k8s suite.
   jaseci:
     needs: plan
     if: >-

--- a/.github/workflows/jac-check.yml
+++ b/.github/workflows/jac-check.yml
@@ -1,17 +1,12 @@
 name: Jac Type Check
 
+# Called by the ci.yml orchestrator, which owns the on-demand gate and only
+# invokes this workflow when the `check` suite was requested (or on push to main).
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, labeled]
-  workflow_dispatch:
+  workflow_call:
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  contents: read
 
 jobs:
   jac-check:

--- a/.github/workflows/k8s-microservice-real-e2e.yml
+++ b/.github/workflows/k8s-microservice-real-e2e.yml
@@ -4,17 +4,14 @@ name: K8s Microservice Real E2E
 # K8s pipeline against microk8s, verifies pods + gateway routing,
 # rolling-restart + hammer-for-non-2xx.
 
+# Heavy microk8s e2e (~25 min). Called by the ci.yml orchestrator, which owns the
+# on-demand gate and only invokes this workflow when the `k8s` suite was
+# requested (or on push to main).
 on:
-  workflow_dispatch:
-  pull_request:
-    # Heavy microk8s e2e (~25 min). Only the jac runtime + the scale deploy
-    # pipeline can affect it, so skip PRs that touch neither (docs, byllm, mcp,
-    # etc.). This job is NOT a required status check, so a path-skip is safe -
-    # it won't leave a PR waiting on a check that never reports.
-    paths:
-      - 'jac/**'
-      - 'jac-scale/**'
-      - '.github/workflows/k8s-microservice-real-e2e.yml'
+  workflow_call:
+
+permissions:
+  contents: read
 
 # Cancel superseded PR runs; never cancel a run for a commit on main.
 concurrency:
@@ -24,8 +21,7 @@ concurrency:
 jobs:
   real-e2e:
     name: microk8s real-app smoke
-    # Escape hatch: add the 'skip-k8s' label to a PR to skip this job too
-    # (matches the test-scale-k8s gate in test-jaseci.yml).
+    # The 'skip-k8s' label still force-skips this even when k8s was requested.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-k8s') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25

--- a/.github/workflows/test-binary.yml
+++ b/.github/workflows/test-binary.yml
@@ -11,12 +11,11 @@ name: jac single-binary self-test
 # build work eliminated). Runs on 4-vCPU runners so `-n auto` spins up ~4 xdist
 # workers per job instead of ~2 on a free runner.
 
+# Called by the ci.yml orchestrator, which owns the on-demand gate and only
+# invokes this workflow when the `core` suite was requested (or on push to main).
+# Provides the `core` suite: the binary build + compiler + runtime.
 on:
-  workflow_dispatch:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main, "feat/**"]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -4,17 +4,15 @@ name: Test Installer
 # self-contained native `jac` binary from the latest GitHub Release and runs it.
 # jaclang is no longer on PyPI -- there is no uv/pip install path to test.
 
+# Called by the ci.yml orchestrator, which owns the on-demand gate and only
+# invokes this workflow when the `installer` suite was requested (or on push to
+# main). Exercises the user-facing install path: scripts/install.sh downloads the
+# self-contained native `jac` binary from the latest GitHub Release and runs it.
 on:
-  pull_request:
-    paths:
-      - "scripts/install.sh"
-      - ".github/workflows/test-installer.yml"
-  workflow_dispatch:
+  workflow_call:
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  contents: read
 
 jobs:
   shellcheck:

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -28,7 +28,7 @@ jobs:
     # render + reactivity. Needs a real `bun install` (jsdom + solid-js), so the
     # test self-skips unless JAC_CLIENT_INTEGRATION is set -- we set it here and
     # run just that file in its own lean job.
-    # Part of the `core` suite (`/test core` / `/test all`); runs on push too.
+    # core suite.
     if: contains(format(' {0} ', inputs.requested), ' core ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -54,7 +54,7 @@ jobs:
       run: jac test jac/tests/runtimelib/test_solid_jsdom.jac -x
 
   test-client:
-    # `client` suite (`/test client` / `/test all`); runs on push too.
+    # client suite.
     if: contains(format(' {0} ', inputs.requested), ' client ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -81,8 +81,7 @@ jobs:
       run: jac test jac/tests/runtimelib/client
 
   test-packages-and-docs:
-    # Tests jac-byllm + builds/validates docs. Runs for `byllm` or `docs`
-    # (`/test byllm`, `/test docs`, `/test all`); runs on push too.
+    # byllm + docs suites (jac-byllm tests and the docs build).
     if: >-
       contains(format(' {0} ', inputs.requested), ' byllm ') ||
       contains(format(' {0} ', inputs.requested), ' docs ')
@@ -140,7 +139,7 @@ jobs:
     # linked artifacts (DT_NEEDED / $ORIGIN) and run handler logic through the sv
     # pathway - NO WebKitGTK, no libpython-dev, no display/Xvfb. The webview /
     # embedded-Python *runtime* behavior is covered by a separate, gated tier.
-    # `desktop` suite (`/test desktop` / `/test all`); runs on push too.
+    # desktop suite.
     if: contains(format(' {0} ', inputs.requested), ' desktop ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -159,8 +158,7 @@ jobs:
     # Lean macOS-only coverage for the pure-Jac Mach-O linker changes: the
     # dylib dlopen/dlsym round-trip that guards #6821 plus the executable /
     # dylib arm64 code-signing invariants added in PR #6828.
-    # `macos` suite (`/test macos` / `/test all`). macos-latest is a premium
-    # runner, so it stays opt-in on PRs; runs on push too.
+    # macos suite (premium runner, so opt-in on PRs).
     if: contains(format(' {0} ', inputs.requested), ' macos ')
     runs-on: macos-latest
     steps:
@@ -188,7 +186,7 @@ jobs:
   # check needs a Windows binary build, tracked as a follow-up.
 
   test-mcp:
-    # `mcp` suite (`/test mcp` / `/test all`); runs on push too.
+    # mcp suite.
     if: contains(format(' {0} ', inputs.requested), ' mcp ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -210,7 +208,7 @@ jobs:
       run: jac test .
 
   test-scale:
-    # `scale` suite (`/test scale` / `/test all`); runs on push too.
+    # scale suite.
     if: contains(format(' {0} ', inputs.requested), ' scale ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
@@ -250,8 +248,7 @@ jobs:
         fi
 
   test-scale-k8s:
-    # `k8s` suite (`/test k8s` / `/test all`); runs on push too. The 'skip-k8s'
-    # label still force-skips it.
+    # k8s suite; the 'skip-k8s' label force-skips it.
     if: >-
       contains(format(' {0} ', inputs.requested), ' k8s ') &&
       !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
@@ -312,8 +309,7 @@ jobs:
           jac test jac_scale/tests/test_deploy_k8s.jac -x --test_name "early exit"
 
   test-pypi-build:
-    # `pypi` suite (`/test pypi` / `/test all`). The heaviest job (all wheels +
-    # jacpack smoke servers), so it stays opt-in on PRs; runs on push too.
+    # pypi suite: builds all wheels + runs the jacpack smoke servers (heaviest).
     if: contains(format(' {0} ', inputs.requested), ' pypi ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -1,18 +1,19 @@
 name: Run tests for jaseci
 
+# Called by the ci.yml orchestrator, which owns the on-demand gate. It passes the
+# space-separated list of requested suites as `inputs.requested`; each job below
+# gates on it. This one file holds several suites (core's solid-jsdom, client,
+# scale, mcp, byllm, docs, desktop, macos, pypi, k8s), so the gate is per-job.
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      requested:
+        description: "Space-separated suites to run (from ci.yml's plan)."
+        required: true
+        type: string
 
-# Cancel superseded PR runs; never cancel a run for a commit on main.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  contents: read
 
 jobs:
   # NOTE: jaclang's own test suite (formerly test-core-compiler / test-core-runtime,
@@ -21,53 +22,14 @@ jobs:
   # the same changes on PRs to main. Removed here as part of the clean break off the
   # editable install (#6852). The jobs below cover plugins / client / docs / pypi.
 
-  # Cheap path filter on a free GitHub-hosted runner. Used ONLY to skip the
-  # NON-required jobs on PRs that can't affect them. The required client/plugin
-  # jobs (e.g. test-client) are never gated, so the merge gate is unchanged. These
-  # outputs are only consulted for pull_request events - each gated job's `if`
-  # forces a run on push/dispatch, so main always keeps full coverage regardless of
-  # the filter result. `core` (jac/**) is jaclang itself, so it is folded into every
-  # downstream gate.
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      core: ${{ steps.filter.outputs.core }}
-      scale: ${{ steps.filter.outputs.scale }}
-      byllm: ${{ steps.filter.outputs.byllm }}
-      mcp: ${{ steps.filter.outputs.mcp }}
-      docs: ${{ steps.filter.outputs.docs }}
-      desktop: ${{ steps.filter.outputs.desktop }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            # Editing this workflow re-runs the full gated suite so CI changes
-            # are validated end-to-end (folded into `core`, the broadest gate).
-            core:
-              - 'jac/**'
-              - '.github/workflows/test-jaseci.yml'
-            scale:
-              - 'jac-scale/**'
-            byllm:
-              - 'jac-byllm/**'
-            mcp:
-              - 'jac-mcp/**'
-            docs:
-              - 'docs/**'
-            desktop:
-              - 'jac-desktop/**'
-
   test-solid-jsdom:
     # Runtime exec of the Solid framework backend: compile a Solid component +
     # the @jac/runtime shim to JS and mount it in jsdom under node, asserting
     # render + reactivity. Needs a real `bun install` (jsdom + solid-js), so the
     # test self-skips unless JAC_CLIENT_INTEGRATION is set -- we set it here and
     # run just that file in its own lean job.
-    needs: changes
-    # Not a required check. Skip on PRs that don't touch jac core; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    # Part of the `core` suite (`/test core` / `/test all`); runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' core ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -92,6 +54,8 @@ jobs:
       run: jac test jac/tests/runtimelib/test_solid_jsdom.jac -x
 
   test-client:
+    # `client` suite (`/test client` / `/test all`); runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' client ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -117,10 +81,11 @@ jobs:
       run: jac test jac/tests/runtimelib/client
 
   test-packages-and-docs:
-    needs: changes
-    # Not a required check. Tests jac-byllm + builds/validates docs. Skip on PRs
-    # that touch none of jac core, jac-byllm, docs; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.byllm == 'true' || needs.changes.outputs.docs == 'true' }}
+    # Tests jac-byllm + builds/validates docs. Runs for `byllm` or `docs`
+    # (`/test byllm`, `/test docs`, `/test all`); runs on push too.
+    if: >-
+      contains(format(' {0} ', inputs.requested), ' byllm ') ||
+      contains(format(' {0} ', inputs.requested), ' docs ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -175,9 +140,8 @@ jobs:
     # linked artifacts (DT_NEEDED / $ORIGIN) and run handler logic through the sv
     # pathway - NO WebKitGTK, no libpython-dev, no display/Xvfb. The webview /
     # embedded-Python *runtime* behavior is covered by a separate, gated tier.
-    needs: changes
-    # Not a required check. Skip on PRs that touch neither jac core nor jac-desktop; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.desktop == 'true' }}
+    # `desktop` suite (`/test desktop` / `/test all`); runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' desktop ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -195,10 +159,9 @@ jobs:
     # Lean macOS-only coverage for the pure-Jac Mach-O linker changes: the
     # dylib dlopen/dlsym round-trip that guards #6821 plus the executable /
     # dylib arm64 code-signing invariants added in PR #6828.
-    needs: changes
-    # Not a required check. macos-latest is a premium runner; skip on PRs that
-    # don't touch jac core; always run on push/dispatch to keep main covered.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    # `macos` suite (`/test macos` / `/test all`). macos-latest is a premium
+    # runner, so it stays opt-in on PRs; runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' macos ')
     runs-on: macos-latest
     steps:
     - name: Check out code
@@ -225,9 +188,8 @@ jobs:
   # check needs a Windows binary build, tracked as a follow-up.
 
   test-mcp:
-    needs: changes
-    # Not a required check. Skip on PRs that touch neither jac core nor jac-mcp; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.mcp == 'true' }}
+    # `mcp` suite (`/test mcp` / `/test all`); runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' mcp ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code
@@ -248,9 +210,8 @@ jobs:
       run: jac test .
 
   test-scale:
-    needs: changes
-    # Not a required check. Skip on PRs that touch neither jac core nor jac-scale; always run on push/dispatch.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' }}
+    # `scale` suite (`/test scale` / `/test all`); runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' scale ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -289,13 +250,10 @@ jobs:
         fi
 
   test-scale-k8s:
-    needs: changes
-    # Not a required check. Skips on PRs that touch neither jac core nor jac-scale,
-    # or that carry the 'skip-k8s' label; always runs on push/dispatch.
+    # `k8s` suite (`/test k8s` / `/test all`); runs on push too. The 'skip-k8s'
+    # label still force-skips it.
     if: >-
-      (github.event_name != 'pull_request' ||
-       needs.changes.outputs.core == 'true' ||
-       needs.changes.outputs.scale == 'true') &&
+      contains(format(' {0} ', inputs.requested), ' k8s ') &&
       !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
@@ -354,11 +312,9 @@ jobs:
           jac test jac_scale/tests/test_deploy_k8s.jac -x --test_name "early exit"
 
   test-pypi-build:
-    needs: changes
-    # Not a required check, and the heaviest job (builds all wheels + jacpack
-    # smoke servers). Skip on PRs that touch none of jac core, jac-scale,
-    # jac-byllm; always run on push/dispatch so main stays packaging-clean.
-    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' || needs.changes.outputs.scale == 'true' || needs.changes.outputs.byllm == 'true' }}
+    # `pypi` suite (`/test pypi` / `/test all`). The heaviest job (all wheels +
+    # jacpack smoke servers), so it stays opt-in on PRs; runs on push too.
+    if: contains(format(' {0} ', inputs.requested), ' pypi ')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Check out code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,37 @@ python docs/scripts/mkdocs_serve.py
    - Fill in the PR description with details about your changes
    - Submit the pull request to the `main` branch of `jaseci-labs/jaseci`
 
+**Running CI on your PR (`/test`)**
+
+To keep CI cost under control, the test suites **do not run automatically** on a
+pull request. Instead, a repo collaborator (read access or above) starts them on
+demand by commenting on the PR:
+
+```
+/test all                  # run every suite
+/test core                 # run a single suite
+/test core client scale    # run several suites in one comment
+/test help                 # react with eyes (acknowledges the command)
+```
+
+- Only the **most recent** `/test` comment is honored: list everything you want
+  in one comment (`/test core mcp`), since a later `/test mcp` replaces an
+  earlier `/test core` rather than adding to it.
+- A **new commit starts clean**: pushing resets the request, so re-comment
+  `/test ...` to run again on the new commit.
+- Requested suites appear as **native checks on the commit** (the status dot next
+  to the commit and in the PR's *Checks* list); there are no extra bot comments
+  or status rows. The bot only adds a rocket reaction to your comment.
+- If you comment while a run is still in progress for that commit, the bot reacts
+  rocket then confused and does nothing; wait for the current run to finish, then
+  re-comment.
+- Merging to `main` always runs the **full** suite, so merged code keeps full
+  coverage regardless of what was run on the PR.
+
+Available suites: `core`, `client`, `scale`, `mcp`, `byllm`, `docs`, `desktop`,
+`macos`, `pypi`, `k8s`, `check` (jac type check), `contrib` (contribution
+checks), `installer`.
+
 > **Tip: PR Best Practices**
 >
 > - Make sure all pre-commit checks pass before pushing


### PR DESCRIPTION
## Why

Auto-running the full test matrix on every PR push drives Blacksmith spend up sharply. This makes CI **on-demand**: a PR runs nothing heavy until a collaborator asks for it, with **no PR clutter** (no bot comments, no extra status rows) - while merged code still gets full coverage.

## How it works

A repo collaborator (**read access or above**) requests suites by commenting on the PR:

```
/test all
/test core
/test core client scale
/test help
```

- A single orchestrator (**`ci.yml`**) triggers on `pull_request` + `push: main`. One cheap `plan` job (free runner) reads the latest `/test` comment and decides which suites run; each suite is invoked as a reusable workflow gated on that result. The PR shows **one `plan` row plus the real suite checks**, not a gate per workflow.
- **`ci-command.yml`** (on `issue_comment`) is quiet: it reacts 🚀 and re-runs the latest `ci.yml` run so `plan` re-evaluates. No comments, no extra status/marker rows.
- **Collaborators only** can trigger; others get 👎 and nothing runs.
- Requested suites appear as **native checks on the commit**.
- **Freshness:** a new commit starts clean (the auto run requests nothing; only a `/test` re-run reads comments). Only the **most recent** `/test` comment is honored - list several in one comment (`/test core mcp`).
- **Push to `main` runs every suite**, so merged code keeps full coverage.

### Suites

`core` (binary build/compiler/runtime + solid-jsdom), `client`, `scale`, `mcp`, `byllm`, `docs`, `desktop`, `macos`, `pypi`, `k8s`, `check` (jac type check), `contrib` (contribution checks), `installer`.

## Notes

- `/test` activates once these workflows are on the default branch (after merge).
- Required checks: gated suites skip when unrequested, so before marking individual suite jobs as required in branch protection, add a summary-gate job (follow-up).