### PR TITLE
fix(docs): run docs build/serve through the jac binary's embedded Python

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -136,15 +136,20 @@ jobs:
           COPY .pre-commit-config.yaml ./.pre-commit-config.yaml
 
           # jaclang is the prebuilt single binary (copied in via jac/zig-out from
-          # the setup-jac build step), not a pip install.
+          # the setup-jac build step), not a pip install. Install the docs deps
+          # (mkdocs etc.) into the binary's own global site with --global so they
+          # sit beside the bundled jaclang; the container is then served via
+          # `jac run` (see CMD). The binary's embedded Python is the only
+          # interpreter where `import jaclang` resolves, which the mkdocs build
+          # hook (handle_jac_compile_data.py) requires.
           ENV PATH="/app/jac/zig-out/bin:${PATH}"
-          RUN jac install -e ./docs
+          RUN jac install -e ./docs --global
 
           EXPOSE 8000
 
           HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:8000/health || exit 1
 
-          CMD ["python", "docs/scripts/mkdocs_serve.py"]
+          CMD ["jac", "run", "docs/scripts/mkdocs_serve.py"]
           EOF
 
           docker buildx build --load \

--- a/docs/scripts/mkdocs_serve.py
+++ b/docs/scripts/mkdocs_serve.py
@@ -7,7 +7,6 @@ and watchdog to watch file changes and rebuild MkDocs site.
 
 import asyncio
 import os
-import subprocess
 import threading
 from collections.abc import Awaitable, Callable
 
@@ -38,6 +37,27 @@ evtSource.onmessage = function(event) {
 };
 </script>
 """
+
+
+def build_site(root_dir: str) -> None:
+    """Build the MkDocs site in-process, from ``root_dir`` as the working dir.
+
+    The build is run in-process (rather than via a ``mkdocs`` subprocess) so it
+    uses the current interpreter -- the jac binary's embedded Python. That is the
+    only interpreter where ``import jaclang`` resolves, which the build hook
+    (``scripts/handle_jac_compile_data.py``) requires; jaclang ships inside the
+    single binary and is not pip-installable. The hook also uses paths relative
+    to the docs root, so we chdir there for the duration of the build.
+    """
+    from mkdocs.commands.build import build as mkdocs_build
+    from mkdocs.config import load_config
+
+    prev_cwd = os.getcwd()
+    os.chdir(root_dir)
+    try:
+        mkdocs_build(load_config())
+    finally:
+        os.chdir(prev_cwd)
 
 
 class RebuildCheckMiddleware(BaseHTTPMiddleware):
@@ -213,15 +233,12 @@ class DebouncedRebuildHandler(FileSystemEventHandler):
         try:
             rebuild_in_progress = True
             print("\nRebuilding MkDocs site...")
-            subprocess.run(["mkdocs", "build"], check=True, cwd=self.root_dir)
+            build_site(self.root_dir)
             print("Rebuild complete.")
             reload_queue.put_nowait("reload")
-        except subprocess.CalledProcessError as e:
+        except Exception as e:
+            # Keep the watcher alive across a failed rebuild; surface the cause.
             print(f"Rebuild failed: {e}")
-        except FileNotFoundError:
-            print(
-                "Error: mkdocs not found. Please install it via `pip install mkdocs`."
-            )
         finally:
             rebuild_in_progress = False
             self._rebuild_lock.release()
@@ -249,7 +266,7 @@ def serve_with_watch(port: int = 8000) -> None:
     ]
 
     print("Initial build of MkDocs site...")
-    subprocess.run(["mkdocs", "build"], check=True, cwd=root_dir)
+    build_site(root_dir)
     reload_queue.put_nowait("reload")
 
     # Set up file watcher


### PR DESCRIPTION
## Problem

The **Build and Deploy jac-lang.org Documentation** job has been failing on `main` since the single-binary migration (#6855). The Docker build dies at:

```
#13 [9/9] RUN jac install -e ./docs
✖ Error: No jac.toml found
```

The docs container was still built on the pre-single-binary model (system `python3.12` + pip), which no longer works:

1. `jac install -e ./docs` ran from the Dockerfile's `WORKDIR /app` (no `jac.toml`); the editable-install semantics now require a consuming project with a `jac.toml` in cwd, or `--global`.
2. Even past that, the container served via system Python 3.12, but the mkdocs build hook (`docs/scripts/handle_jac_compile_data.py`) does `import jaclang`. jaclang is no longer pip-installable, ships only inside the binary, and now targets Python **3.14** — so only the binary's embedded Python can import it.

## Fix

Run the docs build and serve entirely through the `jac` binary's embedded Python:

- **`deploy-docs.yml`**: `jac install -e ./docs --global` puts the docs deps (mkdocs, uvicorn, …) into the binary's own global site, beside the bundled jaclang; the container is served with `jac run docs/scripts/mkdocs_serve.py`.
- **`mkdocs_serve.py`**: build mkdocs **in-process** (`mkdocs.commands.build.build` + `load_config`) instead of spawning a `mkdocs` subprocess, so the build runs in the same interpreter where `import jaclang` resolves. The helper chdirs to the docs root (the hook uses relative paths). Removed the now-unused `subprocess` import and broadened the rebuild error handler.

## Notes

The change follows directly from how `jac install --global` and `jac run` are implemented, but the full Docker build could not be exercised locally (no prebuilt binary, and it now requires Python 3.14). CI's build + smoke-test step will validate the runtime path.