### PR TITLE
fix(jac-scale): first read-gated write to a new node no longer phantom-conflicts

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/6919.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/6919.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: first write to a freshly-created node no longer fails with a spurious write conflict**: on MongoDB-backed deployments, the first persist of a brand-new node that a request had read from raised `WriteConflict` even with no concurrent writer, so the node was never saved. Such first writes now insert correctly, while genuine concurrent overwrites still surface a conflict.

--- a/jac-scale/jac_scale/impl/memory_hierarchy.mongo.impl.jac
+++ b/jac-scale/jac_scale/impl/memory_hierarchy.mongo.impl.jac
@@ -945,32 +945,56 @@ impl MongoBackend._put_node_atomic(
                 cas_filter = {'_id': _id, 'data.version': cas_version};
             }
         }
+        # CAS update with upsert OFF: a stale read of an EXISTING doc must return
+        # None (-> WriteConflict), never silently insert a duplicate. The blind
+        # no-dependency path (cas_version is None) may upsert freely.
         merged_doc = self.collection.find_one_and_update(
             cas_filter,
             [{'$set': set_doc}],
             projection={'data.edges': 1, 'data.version': 1},
             upsert=(cas_version is None),
             return_document=ReturnDocument.AFTER
-            # upsert only on the no-CAS (blind append) path: a version miss must
-            # NOT mint a spurious duplicate doc.
         );
         if merged_doc is None {
-            # Version-gated path (upsert=False) with no match: the node moved or
-            # vanished since this request read it. Either way the optimistic
-            # assumption failed -> conflict, and the request boundary replays
-            # (re-reading the now-current graph). We do NOT fall back to an
-            # upsert here: that read-then-upsert was a TOCTOU window, and an
-            # EDGE_LIST_DELTA only targets a node the request already loaded, so
-            # a genuinely absent doc is itself a stale-read to converge on.
-            # The find_one is diagnostic only (best-effort actual version).
-            actual = -1;
+            # No match on the version-gated path. Two cases:
+            #   (a) the doc EXISTS but at a different version -> a real concurrent
+            #       change; surface a WriteConflict and let the request replay.
+            #   (b) the doc does NOT exist and we expected v0-or-absent -> this is
+            #       the FIRST persist of a never-written anchor (a read-gated first
+            #       write). "Expected v0" includes "does not exist yet", so insert
+            #       rather than raise a phantom conflict. A racing inserter that
+            #       beats us trips the unique _id index -> DuplicateKeyError, which
+            #       we convert to a WriteConflict so the boundary converges.
+            import from pymongo.errors { DuplicateKeyError }
             existing = self.collection.find_one({'_id': _id}, {'data.version': 1});
-            if existing is not None {
-                actual = existing.get('data', {}).get('version', -1);
+            if existing is None and cas_version is not None and cas_version <= 0 {
+                try {
+                    merged_doc = self.collection.find_one_and_update(
+                        {'_id': _id, 'data.version': {'$exists': False}},
+                        [{'$set': set_doc}],
+                        projection={'data.edges': 1, 'data.version': 1},
+                        upsert=True,
+                        return_document=ReturnDocument.AFTER
+                    );
+                } except DuplicateKeyError {
+                    raise WriteConflict(
+                        anchor_id=anchor.id,
+                        expected_version=cas_version,
+                        actual_version=0
+                    );
+                }
             }
-            raise WriteConflict(
-                anchor_id=anchor.id, expected_version=cas_version, actual_version=actual
-            );
+            if merged_doc is None {
+                actual = -1;
+                if existing is not None {
+                    actual = existing.get('data', {}).get('version', -1);
+                }
+                raise WriteConflict(
+                    anchor_id=anchor.id,
+                    expected_version=cas_version,
+                    actual_version=actual
+                );
+            }
         }
 
         if self._l2_ref {

--- a/jac-scale/jac_scale/tests/data/test_occ_replay.jac
+++ b/jac-scale/jac_scale/tests/data/test_occ_replay.jac
@@ -91,6 +91,37 @@ test "OCC: a read-gated stale write conflicts" {
 }
 
 
+test "OCC: a read-gated first write to a never-persisted anchor inserts, not conflicts" {
+    (client, uri) = _get_mongo();
+    client.drop_database(_DB);
+    backend: any = MongoBackend(mongo_url=uri, db_name=_DB);
+    coll: any = client[_DB]["_anchors"];
+
+    # A brand-new anchor that has NEVER been persisted: no document exists yet.
+    root_arch: any = Root();
+    ranch: any = root_arch.__jac__;
+    ranch.persistent = True;
+    ranch.root = ranch.id;
+    rid: str = str(ranch.id);
+    assert coll.find_one({"_id": rid}) is None;
+
+    # The request READ a traversal from this node -> cas_version=0. "Expected v0"
+    # must include "does not exist yet": the write inserts the doc rather than
+    # raising a phantom WriteConflict(expected v0, found v-1).
+    conflicted = False;
+    try {
+        backend._put_node_atomic(ranch, [str(uuid4())], [], set(), 0);
+    } except WriteConflict {
+        conflicted = True;
+    }
+    assert not conflicted , "first read-gated write to an absent doc must insert, not conflict";
+    stored: any = coll.find_one({"_id": rid});
+    assert stored is not None;
+    assert stored["data"]["version"] == 1;
+    assert len(stored["data"]["edges"]) == 1;
+}
+
+
 test "OCC: a read-gated write on a legacy doc (no data.version) does not conflict" {
     (client, uri) = _get_mongo();
     client.drop_database(_DB);


### PR DESCRIPTION
## Problem

On MongoDB-backed `jac-scale` deployments, the OCC (optimistic concurrency) write path in `_put_node_atomic` raised a spurious conflict on the **first** persist of a brand-new node:

```
WriteConflict: anchor 00000000-... changed concurrently (expected v0, found v-1)
```

When a request reads a traversal from a node it takes a read-set dependency and writes with `cas_version=0`. If that node had **never been persisted**, the version-gated `find_one_and_update` ran with `upsert=False`, matched no document, and raised `WriteConflict` — even though no concurrent writer existed. The `found v-1` is just the "document absent" sentinel, not a real race. Net effect: the node was silently never saved.

This reproduces deterministically against a fresh database (e.g. CI), which is why it surfaced as a failing `graph nodes and helpers` job while passing on warm local databases.

## Fix

Treat *"expected v0"* as including *"does not exist yet"*:

- The main CAS update keeps `upsert=False`, so a stale read of an **existing** doc still returns no match → clean `WriteConflict` (no duplicate insert).
- On a CAS miss where the document is **genuinely absent** and the expected version is `<= 0`, perform a guarded insert. A racing inserter that wins the unique `_id` index trips `DuplicateKeyError`, which is converted back into a `WriteConflict` so the request boundary converges.

An earlier, simpler attempt (blanket `upsert` whenever `cas_version == 0`) was rejected because it caused a `DuplicateKeyError` crash in the concurrent find-or-create race — the loser fell through to insert an already-existing `_id` instead of getting a clean conflict. The committed fix avoids that.

## Tests

Added a regression test in `test_occ_replay.jac` — *"a read-gated first write to a never-persisted anchor inserts, not conflicts"* — covering the exact gap (existing tests seeded the root via `_write_to_db`, never through `_put_node_atomic` with `cas_version=0`).

Verified against a real MongoDB:
- RED: new test fails on unfixed code with the exact `WriteConflict` error.
- GREEN: all 7 OCC tests pass, including the two find-or-create tests the naive fix broke.
- No regressions across `test_mongo_layer123` (19), `test_scalar_clobber_cross_process` (2), `test_commit_failure_surfacing` (2), `test_schema_repair_mongo` (4), and the MongoDB path of `test_persistence_race`.