### PR TITLE
docs(guides): sync skills + reference with this week's shipped features

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6945.docs.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6945.docs.md
@@ -1,0 +1,1 @@
+- **Docs: guides cover desktop IPC, client framework, access enforcement, and third-party stubs**: The `jac guide` skills and the mkdocs reference now document the `@jac/desktop` OS-capability plugins, the `[plugins.client] framework` and `[check] enforce_access` config keys, and installing third-party type stubs via `jac add types-*`.

--- a/docs/docs/reference/language/python-integration.md
+++ b/docs/docs/reference/language/python-integration.md
@@ -439,6 +439,9 @@ Jac imports Python modules using standard import mechanisms without requiring co
 !!! note "Typing across the boundary"
     Untyped Python return values arrive in Jac as `any`. Jac's gradual-typing rules apply strictly inside `.jac` source: an `any` value cannot be silently assigned into a declared non-`any` destination. Two ways to handle this at a boundary -- ship a `.pyi` stub alongside the Python utility (the import stays strongly typed and downstream Jac code is unchanged), or annotate the receiving local as `any` and either narrow with `isinstance` or re-type with the [`as` cast operator](foundation.md#10-the-as-cast-operator) (`value as Type`) before use. See [The `any` Type and Gradual Typing](foundation.md#the-any-type-and-gradual-typing) for the full rule and migration patterns.
 
+!!! note "Third-party type stubs"
+    The `jac` binary bundles only the typeshed **standard-library** stubs. For a third-party PyPI package that ships no inline types, install its stub package into the project (`jac add types-requests`); the checker resolves it via PEP 561 (`<pkg>-stubs`) from the project's `.jac/venv`, so stub versions track the installed package instead of a vendored snapshot.
+
 ---
 
 #### **Pattern 4: Mostly Python**

--- a/docs/docs/reference/plugins/jac-desktop.md
+++ b/docs/docs/reference/plugins/jac-desktop.md
@@ -85,12 +85,12 @@ hand-writing those magic strings, import the typed `@jac/desktop` client SDK fro
 `cl` code:
 
 ```jac
-import from "@jac/desktop" { fs, dialog, clipboard, notification, app_window, shell, path }
+import from "@jac/desktop" { fs, dialog, notification }
 
 async def export_notes(text: str) -> None {
     picked = await dialog.save_file("Export", "notes.txt");
     if not picked["canceled"] {
-        await fs.write_file(picked["path"], text);
+        await fs.write_file(picked["path"] as str, text);   # dict values are `any` - cast at the boundary
         await notification.send("Saved", "Notes exported.");
     }
 }

--- a/docs/docs/reference/plugins/jac-desktop.md
+++ b/docs/docs/reference/plugins/jac-desktop.md
@@ -75,6 +75,72 @@ resizable = true
 
 ---
 
+## OS capabilities (plugin IPC)
+
+A desktop app can reach OS capabilities the browser sandbox forbids. The native
+host runs a plugin host and injects a bridge onto the webview's global:
+`window.__jac.invoke(plugin, command, args)` (async; resolves to data or throws a
+structured `PluginError`) and `window.__jac.on(event, callback)`. Rather than
+hand-writing those magic strings, import the typed `@jac/desktop` client SDK from
+`cl` code:
+
+```jac
+import from "@jac/desktop" { fs, dialog, clipboard, notification, app_window, shell, path }
+
+async def export_notes(text: str) -> None {
+    picked = await dialog.save_file("Export", "notes.txt");
+    if not picked["canceled"] {
+        await fs.write_file(picked["path"], text);
+        await notification.send("Saved", "Notes exported.");
+    }
+}
+```
+
+Seven built-in capability plugins ship with the desktop target (every method is
+`async`):
+
+| SDK object | Capability | Methods |
+|---|---|---|
+| `fs` | Filesystem | `read_file`, `write_file`, `list_dir`, `exists`, `mkdir`, `remove`, `stat` |
+| `dialog` | Native dialogs | `open_file`, `save_file`, `message` |
+| `clipboard` | System clipboard | `read`, `write` |
+| `notification` | OS notifications | `send` |
+| `app_window` | Window control | `set_title`, `set_size`, `fullscreen`, `terminate` |
+| `shell` | Run a command | `exec` |
+| `path` | OS directories | `home`, `data`, `config`, `cache`, `temp`, `resolve` |
+
+The window-control object is named `app_window` (not `window`) so it never
+shadows the ambient browser `window` global.
+
+`@jac/*` modules resolve through the `jac.modules` entry-point group, so SDKs like
+`@jac/desktop` are available without vendoring them into your project.
+
+### Security gating
+
+Each capability is gated under `[plugins.desktop.plugins]` in `jac.toml`. A key is
+a plugin name; its value is either `true` (enabled with defaults) or a table of
+per-plugin config. `window`, `path`, `notification`, and `dialog` are enabled by
+default; `shell` is **deny-all** by default. An unknown plugin key is reported as
+an error rather than silently ignored.
+
+```toml
+[plugins.desktop.plugins]
+fs = { allow_read = ["$HOME"], allow_write = ["$APP_DATA"] }   # glob allow-lists (defaults shown)
+clipboard = { allow_read = true, allow_write = true }
+shell = { allow = ["git *"] }                                  # patterns must be explicitly allowed
+notification = true
+```
+
+!!! warning "Pass SDK arguments positionally"
+    Call SDK methods with positional arguments, not keywords. The `cl` compiler
+    cannot resolve parameter names across the `@jac/desktop` module boundary, so a
+    keyword call such as `dialog.save_file(title="Export")` compiles to a single
+    options object in the first positional slot and the host rejects it. Use
+    `dialog.save_file("Export", "notes.txt")`. Tracked in
+    [issue #6675](https://github.com/jaseci-labs/jaseci/issues/6675).
+
+---
+
 ## How it works
 
 1. `WebTarget` builds the `cl` codespace with the standard Vite pipeline into

--- a/jac/jaclang/cli/skills/jac-config.md
+++ b/jac/jaclang/cli/skills/jac-config.md
@@ -17,13 +17,16 @@ description: The jac.toml control plane - every section ([project], [dependencie
 | `[optional-dependencies.<group>]` | extras: `jac install --extras <group>`, wheel extras on publish |
 | `[serve]` | `jac start` defaults: `port`, `base_route_app` (client app served at `/`), `cl_route_prefix` |
 | `[run]` | `jac run` defaults: `cache`, `session`, `diagnostics` (`"error"`/`"all"`/`"none"`) |
+| `[check]` | type-check behavior: `enforce_access` (promote `:pub`/`:protect`/`:priv` visibility violations from warnings to hard errors), `warn_native_seams` (warn when a native-eligible method falls back to Python) |
 | `[check.lint]` | lint rule selection: `select = ["default"]` / `["all"]`, `ignore = ["combine-has"]`, `exclude = ["legacy/*"]` |
 | `[test]` | `jac test` defaults: `directory`, `filter`, `verbose`, `fail_fast`, `max_failures` |
 | `[build]` | `typecheck`, `dir` (artifact root, default `.jac/` - holds `cache/`, `venv/`, `client/`, `data/`) |
 | `[scripts]` | named command shortcuts run via `jac script <name>` |
 | `[environments]` / `[environment]` | per-profile overrides (below) |
 | `[plugins]` | `enabled` / `disabled` lists; `[plugins.<name>.*]` plugin settings (byllm models, scale server, client paths/vite) |
+| `[plugins.client]` | `framework` = `"react"` (default) / `"preact"` / `"solid"` (experimental) - which JS framework the `cl` target emits; `[plugins.client.routing] auth_redirect = "/path"` for unauthenticated redirects |
 | `[plugins.client.app_meta_data]` | served page's head/SEO config: `title`, `description`, `keywords`, `author`, `theme_color`, `icon` |
+| `[plugins.desktop]` / `[plugins.desktop.plugins]` | desktop app identity + window geometry; per-capability OS-plugin gates (`fs`/`clipboard`/`shell` allow-lists) - see `jac-desktop-app` |
 | `[jac-shadcn]` | theme config (`style`, `baseColor`, `theme`, `font`, `radius`) managed by `jac add --shadcn` / `jac retheme` - don't hand-edit (see `jac-shadcn-components`) |
 | `[npm]` | npm-publish overrides: `name = "@scope/pkg"`, `entry` (see `jac-packaging`) |
 | `[jacpack]` | marks the project as a `jac create` template (see `jac-scaffold`) |

--- a/jac/jaclang/cli/skills/jac-desktop-app.md
+++ b/jac/jaclang/cli/skills/jac-desktop-app.md
@@ -48,12 +48,12 @@ resizable = true
 The native host exposes OS capabilities to your `cl` UI through a plugin bridge: `window.__jac.invoke(plugin, command, args)` (async, resolves to data or throws) and `window.__jac.on(event, cb)`. Don't hand-write those magic strings - import the typed SDK instead:
 
 ```jac
-import from "@jac/desktop" { fs, dialog, clipboard, notification, app_window, shell, path }
+import from "@jac/desktop" { fs, dialog, notification }
 
 async def export_notes(text: str) -> None {
     picked = await dialog.save_file("Export", "notes.txt");   # POSITIONAL args - see gotcha
     if not picked["canceled"] {
-        await fs.write_file(picked["path"], text);
+        await fs.write_file(picked["path"] as str, text);     # dict values are `any` - cast at the boundary
         await notification.send("Saved", "Notes exported.");
     }
 }

--- a/jac/jaclang/cli/skills/jac-desktop-app.md
+++ b/jac/jaclang/cli/skills/jac-desktop-app.md
@@ -1,6 +1,6 @@
 ---
 name: jac-desktop-app
-description: Packaging a full-stack Jac app as a native desktop app - `jac build/start --client desktop`, `[plugins.desktop]` window config, OS-webview architecture (no Rust, no Electron), Linux build deps, output layout, current limitations. Load when shipping a `cl` UI as a desktop binary.
+description: Packaging a full-stack Jac app as a native desktop app - `jac build/start --client desktop`, `[plugins.desktop]` window config, the `@jac/desktop` OS-capability plugins (fs/dialog/clipboard/notification/window/shell/path IPC), OS-webview architecture (no Rust, no Electron), Linux build deps, output layout, current limitations. Load when shipping a `cl` UI as a desktop binary or calling OS capabilities from it.
 ---
 
 The desktop target turns a full-stack Jac app into **one `jac nacompile`d binary plus the OS's own web engine** - no Rust toolchain, no Electron, no PyInstaller, no separate backend process. It builds the same Vite `cl` bundle the web target produces, then compiles a native host that embeds CPython to serve that bundle on a loopback port and renders it in the OS-native webview: WebKitGTK (Linux), WKWebView (macOS), WebView2 (Windows). Same `cl`/`sv` source as the web target - only the target flag changes.
@@ -42,6 +42,50 @@ min_width = 800
 min_height = 600
 resizable = true
 ```
+
+## OS capabilities - the `@jac/desktop` plugins (IPC)
+
+The native host exposes OS capabilities to your `cl` UI through a plugin bridge: `window.__jac.invoke(plugin, command, args)` (async, resolves to data or throws) and `window.__jac.on(event, cb)`. Don't hand-write those magic strings - import the typed SDK instead:
+
+```jac
+import from "@jac/desktop" { fs, dialog, clipboard, notification, app_window, shell, path }
+
+async def export_notes(text: str) -> None {
+    picked = await dialog.save_file("Export", "notes.txt");   # POSITIONAL args - see gotcha
+    if not picked["canceled"] {
+        await fs.write_file(picked["path"], text);
+        await notification.send("Saved", "Notes exported.");
+    }
+}
+```
+
+Seven built-in capability objects (every method is `async`, call with `await`):
+
+| Import | Capability | Methods |
+|---|---|---|
+| `fs` | Filesystem | `read_file`, `write_file`, `list_dir`, `exists`, `mkdir`, `remove`, `stat` |
+| `dialog` | Native dialogs | `open_file`, `save_file`, `message` |
+| `clipboard` | System clipboard | `read`, `write` |
+| `notification` | OS notifications | `send` |
+| `app_window` | Window control | `set_title`, `set_size`, `fullscreen`, `terminate` |
+| `shell` | Run a command | `exec` |
+| `path` | OS dirs | `home`, `data`, `config`, `cache`, `temp`, `resolve` |
+
+The window object is imported as **`app_window`, not `window`** - it must not shadow the browser's ambient `window` global.
+
+### Security gating - `[plugins.desktop.plugins]` in `jac.toml`
+
+Each key is a plugin name; the value is `true` (enabled with defaults) or a table of per-plugin config. **`window`, `path`, `notification`, `dialog` are enabled by default; `shell` is deny-all by default.** Set a plugin to `false` to disable it entirely. A typo'd plugin key is rejected (not silently ignored).
+
+```toml
+[plugins.desktop.plugins]
+fs = { allow_read = ["$HOME"], allow_write = ["$APP_DATA"] }   # glob allow-lists (these are the defaults)
+clipboard = { allow_read = true, allow_write = true }
+shell = { allow = ["git *"] }                                  # deny-all until you allow patterns
+notification = true
+```
+
+**Gotcha - pass arguments POSITIONALLY, not by keyword.** The `cl` compiler can't resolve param names across the `@jac/desktop` module boundary, so `dialog.save_file(title="Export")` silently compiles to one options object in the first positional slot and the host rejects it. Use `dialog.save_file("Export", "notes.txt")`. (Tracked in [#6675](https://github.com/jaseci-labs/jaseci/issues/6675).)
 
 ## Output layout
 

--- a/jac/jaclang/cli/skills/jac-python-interop.md
+++ b/jac/jaclang/cli/skills/jac-python-interop.md
@@ -25,7 +25,7 @@ import numpy as np;                                      # any installed PyPI pa
 import from sklearn.linear_model { LinearRegression }
 ```
 
-Local `.py` files import the same way: `import validators;` then `validators.validate_title(t)` - drop the file next to your `.jac` sources, zero config. Note `jac check` can only type what it can resolve: stdlib modules are fully stubbed, while a PyPI package that isn't installed (or ships no types) reports its members as Unknown.
+Local `.py` files import the same way: `import validators;` then `validators.validate_title(t)` - drop the file next to your `.jac` sources, zero config. Note `jac check` can only type what it can resolve: stdlib modules are fully stubbed, while a PyPI package that isn't installed (or ships no types) reports its members as Unknown. **Only the typeshed *stdlib* stubs ship in the `jac` binary** - third-party stubs are no longer bundled. For a typed PyPI package without inline types, install its stub package (`jac add types-requests`) and the checker resolves it via PEP 561 from the project's `.jac/venv`, so types track the installed version.
 
 **The untyped boundary:** untyped Python returns arrive as `any`, and Jac's strict rule blocks `any` from flowing silently into typed destinations (E1001). Three fixes - type the source (`.pyi` stub), accept-and-narrow with `isinstance`, or `value as Type` cast. Full playbook in `jac-types`.
 

--- a/jac/jaclang/cli/skills/jac-types.md
+++ b/jac/jaclang/cli/skills/jac-types.md
@@ -57,7 +57,7 @@ An `any` value cannot silently flow into a declared non-`any` destination (annot
 
 The 3-step playbook for an untyped boundary (PyPI call, `json.loads`, walker report):
 
-1. **Type the source** - add a return annotation, a `.pyi` stub next to the Python file, or a typed `has reports: list[T] = [];` on the walker. Best: downstream code stays clean.
+1. **Type the source** - add a return annotation, a `.pyi` stub next to the Python file, install a third-party lib's stub package (`jac add types-requests` - only stdlib stubs ship in the binary, so third-party `types-*` are PEP 561-resolved from `.jac/venv`), or a typed `has reports: list[T] = [];` on the walker. Best: downstream code stays clean.
 2. **Accept-and-narrow** - take it into an inferred/`any` local, then `isinstance`-narrow before flowing into typed destinations.
 3. **Cast at the use site** - `value as Type` when you know the runtime shape (see above).
 


### PR DESCRIPTION
Several user-facing changes landed this past week but were documented only in release-note fragments. This brings the `jac guide` skills and the mkdocs reference up to date.

## Desktop IPC (#6567)
The `@jac/desktop` OS-capability plugin system shipped with only a release note. Documented in both the `jac-desktop-app` skill and the `jac-desktop` reference:
- The seven built-in capability objects (`fs`, `dialog`, `clipboard`, `notification`, `app_window`, `shell`, `path`) and their methods.
- The low-level `window.__jac.invoke(plugin, command, args)` / `window.__jac.on(...)` bridge the SDK wraps.
- `[plugins.desktop.plugins]` security gating (default-on plugins, deny-all `shell`, fs/clipboard allow-lists).
- The positional-args boundary gotcha (#6675).

## jac-config skill
Added newly-shipped `jac.toml` keys to the section map:
- `[check] enforce_access` / `warn_native_seams` (#6837, #6934).
- `[plugins.client] framework = "react" | "preact" | "solid"` (#6539).
- `[plugins.desktop]` / `[plugins.desktop.plugins]` capability gates.

## Third-party type stubs (#6904)
Only stdlib typeshed stubs ship in the `jac` binary now; third-party stubs install via `jac add types-*` and resolve through PEP 561. Noted in `jac-python-interop`, `jac-types`, and the python-integration reference.

## Validation
- All 37 `jac guide` skills parse cleanly through the real `parse_guide` frontmatter parser (name/description/body intact, balanced code fences).
- Both edited reference docs have balanced fences and valid admonition indentation.
- Diff is docs/skills only.

A `docs` release-note fragment is added in a follow-up commit on this branch.