### PR TITLE
ci: add rolling dev binary release from main

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,142 @@
+name: Release jac dev binary (rolling main)
+
+# Rolling "dev" build of the self-contained `jac` binary. On every push to main
+# this rebuilds the per-platform binaries and re-publishes them to a single
+# prerelease tag `dev`, force-moved to the current main HEAD. The download URLs
+# are therefore stable and always map to the tip of upstream main:
+#
+#   https://github.com/<owner>/<repo>/releases/download/dev/jac-dev-linux-x86_64
+#   https://github.com/<owner>/<repo>/releases/download/dev/jac-dev-linux-aarch64
+#   https://github.com/<owner>/<repo>/releases/download/dev/jac-dev-macos-aarch64
+#
+# This mirrors release-jaclang.yml (the versioned, tagged release path) but with
+# a push-on-main trigger and a fixed, clobbered `dev` tag instead of a per-version
+# one. The `dev` release is kept as a *prerelease* so it never shows as "Latest".
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# A newer push to main supersedes an in-flight dev build: cancel the old run so
+# the `dev` tag/assets always reflect the most recent main commit.
+concurrency:
+  group: release-dev
+  cancel-in-progress: true
+
+jobs:
+  # Force-move the `dev` tag to the current commit and ensure the prerelease
+  # exists, before the matrix jobs upload their assets to it.
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Point the `dev` prerelease at this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+          SHA="${GITHUB_SHA}"
+          SHORT="${SHA:0:7}"
+          NOTES="Rolling build of \`main\` @ ${SHORT}. Auto-updated on every push to main; not a stable release."
+          # Move the dev tag to HEAD (created on first run, force-moved after).
+          git tag -f dev "$SHA"
+          git push -f origin refs/tags/dev
+          if gh release view dev >/dev/null 2>&1; then
+            gh release edit dev --prerelease --target "$SHA" \
+              --title "Dev build (main)" --notes "$NOTES"
+          else
+            gh release create dev --prerelease --target "$SHA" \
+              --title "Dev build (main)" --notes "$NOTES"
+          fi
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        # One native runner per target so the smoke test runs on real hardware.
+        # The launcher links only libc and dlopens libpython, so each build is
+        # self-contained; build.zig fetches the per-target python-build-standalone
+        # and (for the native backend) the per-target LLVM release.
+        include:
+          - os: ubuntu-latest
+            platform: linux-x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux-aarch64
+          # No macos-x86_64 (Intel) leg: the native (na) backend statically links
+          # a pinned LLVM release, and LLVM ships no macOS-x64 prebuilt for 20.1.8
+          # (only Linux-X64/ARM64 + macOS-ARM64). Apple Silicon is covered by
+          # macos-aarch64; restoring Intel-Mac needs an x86_64 LLVM static source.
+          - os: macos-14
+            platform: macos-aarch64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install host tools (zstd)
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update && sudo apt-get install -y zstd
+          else
+            brew install zstd
+          fi
+
+      - name: Set up Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          # Fresh cache each run: build.zig's payload step doesn't reliably
+          # invalidate on jaclang/ changes, so a cached payload could ship stale
+          # bits. Force a rebuild.
+          use-cache: false
+
+      # The native (na) backend statically links a pinned LLVM into the LLVMPY_*
+      # shim, so the per-target LLVM release must be extracted before `zig build`
+      # (there is no llvmlite wheel anymore). One-time ~1.5-2 GB download.
+      - name: Fetch LLVM for the jacllvm shim
+        working-directory: jac
+        run: zig build fetch-llvm --summary all
+
+      - name: Build the jac binary (one command)
+        working-directory: jac
+        run: zig build --summary all
+
+      - name: Smoke test (no system Python)
+        working-directory: jac
+        run: |
+          set -euxo pipefail
+          BIN="$PWD/zig-out/bin/jac"
+          WORK="$(mktemp -d)"
+          env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" --version
+          printf 'with entry { print("ok"); }\n' > "$WORK/h.jac"
+          env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" run "$WORK/h.jac" | grep -q ok
+
+      - name: Package asset (+ checksum, ad-hoc codesign on macOS)
+        id: pkg
+        working-directory: jac
+        run: |
+          set -euxo pipefail
+          ASSET="jac-dev-${{ matrix.platform }}"
+          mkdir -p dist
+          cp zig-out/bin/jac "dist/$ASSET"
+          if [ "$RUNNER_OS" = "macOS" ]; then codesign --force --sign - "dist/$ASSET" || true; fi
+          ( cd dist && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to the `dev` prerelease (clobber)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: jac
+        run: |
+          set -euo pipefail
+          gh release upload dev \
+            "dist/${{ steps.pkg.outputs.asset }}" \
+            "dist/${{ steps.pkg.outputs.asset }}.sha256" \
+            --clobber


### PR DESCRIPTION
## What

Adds `.github/workflows/release-dev.yml`: a rolling "dev" build of the self-contained `jac` binary that always maps to upstream `main`.

On every push to `main` it rebuilds the per-platform binaries and re-publishes them to a single **prerelease** tag `dev`, force-moved to the current main HEAD. Download URLs are therefore stable and always reflect the tip of main:

- `.../releases/download/dev/jac-dev-linux-x86_64`
- `.../releases/download/dev/jac-dev-linux-aarch64`
- `.../releases/download/dev/jac-dev-macos-aarch64`

(plus matching `.sha256` files)

## How

- **Trigger:** `push` to `main` + manual `workflow_dispatch`.
- **`prepare` job:** force-moves the `dev` git tag to the current commit, then creates-or-updates a prerelease `dev` targeting it. Marked prerelease so it never displays as "Latest".
- **`build` matrix:** the same three legs as `release-jaclang.yml` (linux-x86_64, linux-aarch64, macos-aarch64) with identical LLVM-fetch + `zig build` + smoke-test steps.
- **Assets:** version-less names uploaded with `--clobber` so URLs are stable and overwritten in place.
- **Concurrency:** `cancel-in-progress` on a `release-dev` group, so a newer push supersedes an in-flight build.

## Notes / trade-offs

- This runs the full 3-platform matrix (incl. the one-time ~1.5–2 GB LLVM download per leg, uncached) on **every** merge to main. On a busy day that's meaningful runner cost. If that's too heavy we can switch the trigger to "after main tests pass" (`workflow_run`) or a nightly cron.
- First run creates the `dev` tag/release; subsequent runs force-move it. No manual setup or new secrets needed (uses default `GITHUB_TOKEN` with `contents: write`, same as `release-jaclang.yml`).