### PR TITLE
ci(release): drop stale jaclang-* tag scheme, steer binary dispatch to canonical v<version> tag

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -89,12 +89,11 @@ jobs:
             TAG="manual-$(date +%Y%m%d-%H%M%S)"
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
+            # The canonical release tag is `v<version>` (e.g. v0.30.1). The
+            # `jac-lang-docs-*` form is still accepted for docs-only releases;
+            # anything else (incl. the canonical `v*`) is used verbatim.
             if [[ $TAG_NAME =~ ^jac-lang-docs-(.+)$ ]]; then
               TAG="${BASH_REMATCH[1]}"
-            elif [[ $TAG_NAME =~ ^jaclang-(.+)$ ]]; then
-              TAG="${BASH_REMATCH[1]}"
-            elif [[ $TAG_NAME =~ ^v(.+)$ ]]; then
-              TAG="$TAG_NAME"
             else
               TAG="$TAG_NAME"
             fi

--- a/.github/workflows/release-jaclang.yml
+++ b/.github/workflows/release-jaclang.yml
@@ -11,7 +11,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to upload assets to (e.g. jaclang-0.16.7). Empty = artifact only."
+        # Use the canonical release tag `v<version>` (e.g. v0.30.1) so binaries
+        # land on the release the publish pipeline already cut. Do NOT invent a
+        # new tag (e.g. `jaclang-0.30.1`) -- that creates a duplicate release.
+        # Empty = build the artifact only, attach nothing.
+        description: "Canonical release tag to upload assets to (e.g. v0.30.1). Empty = artifact only."
         required: false
         type: string
 


### PR DESCRIPTION
## Why

Version 0.30.1 ended up with **two** GitHub Releases — the canonical `v0.30.1` (cut automatically by the publish pipeline) and a hand-made duplicate `jaclang-0.30.1` that stole the "Latest" badge and the binaries. The release pipeline is designed to produce a single release tagged `v<version>`, with `release-jaclang.yml` attaching the native binaries to it on the publish event.

The retired `jaclang-vX.Y.Z` scheme survived in two spots that nudge maintainers back toward hand-typed tags and duplicate releases:

- **deploy-docs.yml** matched `^jaclang-(.+)$` when deriving the docs version string. The canonical `v*` tag already falls through to verbatim use, so the branch is dead — dropped it (kept the `jac-lang-docs-*` form for docs-only releases).
- **release-jaclang.yml**'s `workflow_dispatch` `tag` input suggested `jaclang-0.16.7` as the example, which invites creating a second release (e.g. `jaclang-0.30.1`) instead of attaching to `v0.30.1`. Pointed it at the canonical `v<version>` tag and added a warning against inventing a tag.

## Notes

This is a docs/guardrail cleanup only — no change to what the pipeline actually does on the happy path (releases were already tagged `v<version>`). It does not retroactively fix the existing `jaclang-0.30.1` duplicate; that needs a manual release/tag deletion + re-mark `v0.30.1` as Latest.