### PR TITLE
ci(test-binary): fetch typeshed stubs on a binary-cache hit

### DIFF
--- a/.github/workflows/test-binary.yml
+++ b/.github/workflows/test-binary.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Set up jac (build the binary once, cached)
         uses: ./.github/actions/setup-jac
 
+      # setup-jac only runs `zig build` (which fetches the gitignored typeshed
+      # stdlib stubs into the checkout) on a binary-cache MISS. On a cache HIT
+      # the prebuilt binary is restored and the build -- and the stub fetch with
+      # it -- is skipped, so the stubs the upload step below publishes for
+      # test-compiler are absent (the upload then hard-fails on if-no-files-found).
+      # `zig build fetch-typeshed` is a lightweight, idempotent fetch (builds the
+      # small payload tool, no binary build, no LLVM/pbs) that materializes them
+      # regardless of the cache outcome; on a miss it is a no-op (stamp check).
+      - name: Set up Zig 0.16.0 (for the typeshed fetch on a binary-cache hit)
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Materialize typeshed stdlib stubs into the checkout
+        working-directory: jac
+        run: zig build fetch-typeshed --summary all
+
       - name: Hermeticity + smoke (no system Python)
         working-directory: jac
         run: |
@@ -100,9 +118,10 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-      # setup-jac's `zig build` already materialized the gitignored typeshed
-      # stdlib stubs into the checkout; publish them so the test jobs get them
-      # without a zig toolchain (they only download the prebuilt binary).
+      # The fetch-typeshed step above materialized the gitignored typeshed stdlib
+      # stubs into the checkout (on both a binary-cache hit and miss); publish
+      # them so the test jobs get them without a zig toolchain (they only
+      # download the prebuilt binary).
       - name: Upload typeshed stdlib stubs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Why

The \`jac single-binary self-test\` workflow is failing on \`main\` ([run](https://github.com/jaseci-labs/jaseci/actions/runs/28203921503)). The \`build\` job dies at the **Upload typeshed stdlib stubs** step:

```
##[error]No files were found with the provided path: jac/jaclang/vendor/typeshed/stdlib. No artifacts will be uploaded.
```

The upload step (and the \`test-compiler\` job that downloads the artifact) relied on \`setup-jac\`'s \`zig build\` having materialized the gitignored typeshed stdlib stubs into the checkout. But \`setup-jac\` only runs \`zig build\` on a binary-cache **miss** — on a **hit** it restores the prebuilt binary and skips the build, and the typeshed fetch with it.

The triggering commit (\`115a0e5b9\`) touched only workflow YAML, so the binary-cache key (\`hashFiles('jac/jaclang/**', 'jac/build.zig', 'jac/launcher/**')\`) matched a prior build and served the cached binary. The stubs were never fetched, and the upload hard-failed on \`if-no-files-found: error\`. Earlier commits passed only because they happened to miss the binary cache.

## Fix

Add an explicit \`zig build fetch-typeshed\` step to the \`build\` job that runs regardless of the cache outcome. It is a lightweight, idempotent fetch — it builds only the small \`payload\` tool (no binary build, no LLVM/pbs) and is a no-op on a miss thanks to the \`.typeshed-sha\` stamp check — so the stubs are guaranteed present before the upload publishes them for \`test-compiler\`.

Scoped to \`test-binary.yml\`'s \`build\` job (the only consumer that uploads the stubs); the shared \`setup-jac\` action and the other 11 workflows that use it are untouched.