### PR TITLE
ci(installer): verify install.sh against real releases + harden it

### DIFF
--- a/.github/workflows/release-jaclang.yml
+++ b/.github/workflows/release-jaclang.yml
@@ -116,6 +116,30 @@ jobs:
             "dist/${{ steps.pkg.outputs.asset }}.sha256" \
             --clobber
 
+      # End-to-end check of the user-facing install path. Now that THIS
+      # platform's asset is attached to the release, `scripts/install.sh` must be
+      # able to resolve, download, checksum-verify, and run it. This is the gate
+      # that catches release-tag/installer scheme drift (the kind that silently
+      # breaks `curl ... | bash`) at release time, on the same native hardware
+      # the asset targets, instead of in users' terminals. Gated like the upload
+      # above -- only meaningful once the asset is actually on a release. Runs in
+      # an isolated $HOME so the runner's PATH/profile is left untouched.
+      - name: Verify install.sh can fetch + run this release
+        if: github.event_name == 'release' || inputs.tag != ''
+        env:
+          JAC_VER: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euxo pipefail
+          HOME="$(mktemp -d)"; export HOME
+          bash scripts/install.sh --version "$JAC_VER"
+          BIN="$HOME/.local/bin/jac"
+          test -x "$BIN"
+          "$BIN" --version
+          printf 'with entry { print("installed ok"); }\n' > "$HOME/h.jac"
+          "$BIN" run "$HOME/h.jac" | grep -q "installed ok"
+          bash scripts/install.sh --uninstall
+          ! test -e "$BIN"
+
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-installer.yml
+++ b/.github/workflows/test-installer.yml
@@ -9,6 +9,12 @@ on:
     paths:
       - "scripts/install.sh"
       - ".github/workflows/test-installer.yml"
+  # Daily run against the LIVE latest release. install.sh breakage is usually
+  # caused by release/tag changes elsewhere (not edits to install.sh), so a
+  # path-filtered PR trigger alone never catches it -- the schedule exercises the
+  # real `curl ... | bash` path on a cadence and fails if it regresses.
+  schedule:
+    - cron: "17 8 * * *"
   workflow_dispatch:
 
 # Cancel superseded PR runs; never cancel a run for a commit on main.
@@ -38,49 +44,44 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # The installer downloads from the latest published release. Until a
-      # release carries the native `jac-<ver>-<platform>` binary asset (the
-      # first release after the binary clean break), skip gracefully instead of
-      # failing -- there is nothing for the installer to fetch yet.
-      - name: Check for a native binary asset on the latest release
-        id: gate
+      # The latest GitHub Release MUST carry this platform's native binary: the
+      # release pipeline guarantees it (plugin-only releases don't cut a Release,
+      # so the latest Release always has the binaries install.sh fetches). A
+      # missing asset is a release regression that breaks `curl ... | bash`, not
+      # a flaky test -- fail loudly here instead of silently skipping (the old
+      # behavior, which let real breakage pass green throughout the binary
+      # clean-break window).
+      - name: Require a native binary asset on the latest release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if gh release view --repo "$GITHUB_REPOSITORY" \
+          if ! gh release view --repo "$GITHUB_REPOSITORY" \
                --json assets --jq '.assets[].name' 2>/dev/null \
                | grep -q "jac-.*-${{ matrix.platform }}$"; then
-            echo "has_asset=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_asset=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No jac-*-${{ matrix.platform }} asset on the latest release yet; skipping the download test."
+            echo "::error::Latest GitHub Release has no jac-*-${{ matrix.platform }} asset; 'curl ... | bash' is broken for this platform."
+            exit 1
           fi
 
       - name: "install: download + run the binary"
-        if: steps.gate.outputs.has_asset == 'true'
         run: bash scripts/install.sh
 
       - name: "install: verify jac"
-        if: steps.gate.outputs.has_asset == 'true'
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           which jac
           jac --version
 
       - name: "install: run a test program"
-        if: steps.gate.outputs.has_asset == 'true'
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           echo 'with entry { print("hello from the jac binary"); }' > /tmp/test_install.jac
           jac /tmp/test_install.jac
 
       - name: "install: uninstall"
-        if: steps.gate.outputs.has_asset == 'true'
         run: bash scripts/install.sh --uninstall
 
       - name: "install: verify removal"
-        if: steps.gate.outputs.has_asset == 'true'
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           if command -v jac &>/dev/null; then

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,14 @@ demo/
 
 node_modules
 
+# Zig build artifacts. jac/.gitignore covers the in-tree binary build under jac/,
+# but `jac run` invoking the native backend emits a .zig-cache/ at the *repo
+# root* (its cwd) too -- and a release `git add -A` (create-release-pr.yml) will
+# otherwise sweep in the >100 MB outputs and get rejected by GitHub's file-size
+# limit. These patterns are path-anchored to any depth, so they catch both.
+.zig-cache/
+zig-out/
+
 # Agent / IDE working notes (not repo artifacts)
 AGENTS.md
 PLAN.md

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -264,10 +264,12 @@ install_binary() {
     # Create install directory
     mkdir -p "$INSTALL_DIR"
 
-    # Download to temp location
-    local tmpdir
+    # Download to temp location. `tmpdir` is intentionally NOT `local`: the EXIT
+    # trap below fires after install_binary returns, so a function-local would be
+    # out of scope and trip `set -u` ("unbound variable") during cleanup. The
+    # `${tmpdir:-}` guard keeps the trap safe if we exit before it is assigned.
     tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' EXIT
+    trap 'rm -rf "${tmpdir:-}"' EXIT
 
     info "Downloading ${asset}..."
     if ! curl -fsSL -o "${tmpdir}/${asset}" "$download_url"; then


### PR DESCRIPTION
## Why

The user-facing install path — `curl -fsSL .../scripts/install.sh | bash` — broke in production while CI stayed green:

```
[jac] Could not determine latest version from GitHub Releases.
[jac] Please specify a version with --version.
```

Root cause was release-side (a binary release landed on a non-canonical `jaclang-<ver>` tag, fixed separately by #6972 + a fresh `v<version>` release), but the **test gaps that let it ship silently** are what this PR closes.

## Why CI didn't catch it

- **`test-installer.yml` only ran on PRs touching `install.sh`**, and its asset "gate" turned a missing/mis-tagged latest release into a **silent green skip** (`::notice::`). The breakage was caused by a release change, not an `install.sh` edit, so the workflow never ran — and even if it had, it would have skipped.
- **`release-jaclang.yml` built and uploaded the binary but never ran the installer**, so tag/installer drift only surfaced in users' terminals.

## Changes

- **`release-jaclang.yml`**: after each platform uploads its asset, run `scripts/install.sh --version <ver>` against the just-published release (isolated `$HOME`), run a program, and uninstall — failing the release if `install.sh` can't fetch/run the binary it just shipped. Runs on the same native hardware the asset targets.
- **`test-installer.yml`**: add a **daily schedule** (installer breakage is usually caused by release changes, not `install.sh` edits, so a path-filtered PR trigger alone never catches it) and convert the skip-gate into a **hard failure** when the latest release lacks this platform's binary.
- **`install.sh`**: fix a `set -u` *"unbound variable"* crash in the EXIT trap — the trap referenced a function-local `tmpdir` that is out of scope when it fires at exit. (Latent because the gate had never let the real install run in CI.)

## Note on ordering

`install.sh` is intentionally kept strict to canonical `v<version>` tags (matching the corrected pipeline in #6972), so these checks only go green once a properly `v`-tagged release is the latest. The companion `v0.30.2` release re-establishes that.