### PR TITLE
feat(cli): add `jac x` to run installed CLI tools under the jac runtime

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6994.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6994.feature.md
@@ -1,0 +1,1 @@
+- **Feature: `jac x` runs installed CLI tools**: `jac x <tool>` runs an installed package's console-script command under the bundled runtime, resolving from the project venv first and the global site second.

--- a/jac/jaclang/cli/commands/execution.jac
+++ b/jac/jaclang/cli/commands/execution.jac
@@ -208,3 +208,50 @@ def start(
     group="execution"
 )
 def debug(filename: str, main: bool = True, cache: bool = False) -> int;
+
+"""Run a CLI tool from an installed package's console-script entry point."""
+@registry.command(
+    name="x",
+    help="Run an installed CLI tool (console-script) under the Jac runtime",
+    args=[
+        Arg.create(
+            "name",
+            kind=ArgKind.POSITIONAL,
+            default="",
+            help="Tool/command name to run (omit to list available tools)"
+        ),
+        Arg.create(
+            "global",
+            typ=bool,
+            default=False,
+            help="Resolve from the jac-owned global site only, ignoring the project venv",
+            short="g",
+            dest="use_global"
+        ),
+        Arg.create(
+            "list_tools",
+            typ=bool,
+            default=False,
+            help="List the CLI tools available to run here",
+            short="l"
+        ),
+        Arg.create(
+            "args", kind=ArgKind.REMAINDER, help="Arguments passed to the tool"
+        ),
+
+    ],
+    examples=[
+        ("jac x hf download gpt2", "Run the 'hf' tool (project venv first, else global)"),
+        ("jac x black .", "Run an installed formatter on the current directory"),
+        ("jac x --global hf whoami", "Force the global-site copy of a tool"),
+        ("jac x --list", "List the CLI tools available here"),
+
+    ],
+    group="execution"
+)
+def x(
+    name: str = "",
+    use_global: bool = False,
+    list_tools: bool = False,
+    args: list = []
+) -> int;

--- a/jac/jaclang/cli/commands/execution.jac
+++ b/jac/jaclang/cli/commands/execution.jac
@@ -235,13 +235,14 @@ def debug(filename: str, main: bool = True, cache: bool = False) -> int;
             help="List the CLI tools available to run here",
             short="l"
         ),
-        Arg.create(
-            "args", kind=ArgKind.REMAINDER, help="Arguments passed to the tool"
-        ),
+        Arg.create("args", kind=ArgKind.REMAINDER, help="Arguments passed to the tool"),
 
     ],
     examples=[
-        ("jac x hf download gpt2", "Run the 'hf' tool (project venv first, else global)"),
+        (
+            "jac x hf download gpt2",
+            "Run the 'hf' tool (project venv first, else global)"
+        ),
         ("jac x black .", "Run an installed formatter on the current directory"),
         ("jac x --global hf whoami", "Force the global-site copy of a tool"),
         ("jac x --list", "List the CLI tools available here"),
@@ -250,8 +251,5 @@ def debug(filename: str, main: bool = True, cache: bool = False) -> int;
     group="execution"
 )
 def x(
-    name: str = "",
-    use_global: bool = False,
-    list_tools: bool = False,
-    args: list = []
+    name: str = "", use_global: bool = False, list_tools: bool = False, args: list = []
 ) -> int;

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -933,20 +933,24 @@ sees itself as argv[0]. A SystemExit raised by the tool is captured into a retur
 code rather than terminating jac, so post-hooks still run.
 """
 def _run_entry_point(name: str, ep: object, site_dir: object, args: list) -> int {
+    # Snapshot sys.path/sys.argv so the chosen tier and the tool's argv are a
+    # localized, fully-reverted side effect — a later import (or a second
+    # `jac x` in the same process) must not resolve against this tier.
+    saved_path = list(sys.path);
+    saved_argv = sys.argv;
     site_str = str(site_dir);
     if site_str in sys.path {
         sys.path.remove(site_str);
     }
     sys.path.insert(0, site_str);
     try {
-        func = ep.load();
-    } except Exception as e {
-        console.error(f"Failed to load tool '{name}': {e}");
-        return 1;
-    }
-    saved_argv = sys.argv;
-    sys.argv = [name] + list(args);
-    try {
+        try {
+            func = ep.load();
+        } except Exception as e {
+            console.error(f"Failed to load tool '{name}': {e}");
+            return 1;
+        }
+        sys.argv = [name] + list(args);
         result = func();
         return result if isinstance(result, int) else 0;
     } except SystemExit as se {
@@ -960,6 +964,8 @@ def _run_entry_point(name: str, ep: object, site_dir: object, args: list) -> int
         return 1;
     } finally {
         sys.argv = saved_argv;
+        sys.path.clear();
+        sys.path.extend(saved_path);
     }
 }
 

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -874,3 +874,156 @@ impl debug(filename: str, main: bool = True, cache: bool = False) -> int {
     }
     return 0;
 }
+
+"""Resolve the ordered (tier_label, site_packages_dir) list to search for CLI tools.
+
+The project venv (.jac/venv) is searched before the jac-owned global site, mirroring
+how `jac install` targets the project venv by default and `--global` the shared site.
+When use_global is set, only the global site is searched.
+"""
+def _tool_site_dirs(use_global: bool) -> list {
+    import site;
+    import from pathlib { Path }
+    import from jaclang.project.config { get_config }
+    import from jaclang.project.dependencies { get_venv_site_packages }
+
+    sites: list = [];
+    if not use_global {
+        config = get_config();
+        if config is not None {
+            sites.append(("project", get_venv_site_packages(config.get_venv_dir())));
+        }
+    }
+    try {
+        global_sites = site.getsitepackages();
+    } except (AttributeError, IndexError, OSError) {
+        global_sites = [];
+    }
+    if global_sites {
+        sites.append(("global", Path(global_sites[0])));
+    }
+    return sites;
+}
+
+"""List (script_name, dist_name, entry_point) for every console-script in site_dir."""
+def _console_scripts_in(site_dir: object) -> list {
+    import from importlib.metadata { distributions }
+
+    found: list = [];
+    if not site_dir.exists() {
+        return found;
+    }
+    for dist in distributions(path=[str(site_dir)]) {
+        dist_name = dist.metadata["Name"] if dist.metadata else None;
+        dist_name = dist_name or "?";
+        for ep in dist.entry_points {
+            if ep.group == "console_scripts" {
+                found.append((ep.name, dist_name, ep));
+            }
+        }
+    }
+    return found;
+}
+
+"""Load a console-script entry point under the Jac runtime and invoke it.
+
+The chosen site-packages dir is moved to the front of sys.path so the tool and its
+dependencies resolve from the selected tier, and sys.argv is rewritten so the tool
+sees itself as argv[0]. A SystemExit raised by the tool is captured into a return
+code rather than terminating jac, so post-hooks still run.
+"""
+def _run_entry_point(name: str, ep: object, site_dir: object, args: list) -> int {
+    site_str = str(site_dir);
+    if site_str in sys.path {
+        sys.path.remove(site_str);
+    }
+    sys.path.insert(0, site_str);
+    try {
+        func = ep.load();
+    } except Exception as e {
+        console.error(f"Failed to load tool '{name}': {e}");
+        return 1;
+    }
+    saved_argv = sys.argv;
+    sys.argv = [name] + list(args);
+    try {
+        result = func();
+        return result if isinstance(result, int) else 0;
+    } except SystemExit as se {
+        if se.code is None {
+            return 0;
+        }
+        if isinstance(se.code, int) {
+            return se.code;
+        }
+        console.error(str(se.code));
+        return 1;
+    } finally {
+        sys.argv = saved_argv;
+    }
+}
+
+"""Print the console-script tools available across the resolved sites.
+
+Names are deduplicated in precedence order, so a tool shadowed by a higher-precedence
+tier is listed only once, against the tier that would actually run.
+"""
+def _list_tools(sites: list) -> int {
+    seen: set = set();
+    rows: list = [];
+    for (label, site_dir) in sites {
+        for (script_name, dist_name, _ep) in _console_scripts_in(site_dir) {
+            if script_name in seen {
+                continue;
+            }
+            seen.add(script_name);
+            rows.append((script_name, dist_name, label));
+        }
+    }
+    if not rows {
+        console.info(
+            "No CLI tools available. Install one with 'jac install <package>' "
+            "or 'jac install --global <package>'."
+        );
+        return 0;
+    }
+    console.print("\nAvailable CLI tools (run with 'jac x <name>'):\n", style="info");
+    width = max([len(r[0]) for r in rows]);
+    for (script_name, dist_name, label) in sorted(rows) {
+        console.print(f"  {script_name.ljust(width)}  {dist_name} [{label}]");
+    }
+    return 0;
+}
+
+"""Run an installed package's console-script entry point under the Jac runtime."""
+impl x(
+    name: str = "",
+    use_global: bool = False,
+    list_tools: bool = False,
+    args: list = []
+) -> int {
+    sites = _tool_site_dirs(use_global);
+
+    # No tool name given → behave like --list and show what's runnable here.
+    if list_tools or not name {
+        return _list_tools(sites);
+    }
+
+    # First matching tier wins (project venv before global site).
+    for (label, site_dir) in sites {
+        for (script_name, _dist_name, ep) in _console_scripts_in(site_dir) {
+            if script_name == name {
+                return _run_entry_point(name, ep, site_dir, args);
+            }
+        }
+    }
+
+    searched = ", ".join([f"{label} ({d})" for (label, d) in sites]) or "no sites";
+    console.error(
+        f"No CLI tool named '{name}' found.",
+        hint=f"Install the package that provides it — 'jac install <package>' "
+        f"(project) or 'jac install --global <package>' — then 'jac x {name}'. "
+        f"Searched: {searched}."
+    );
+    return 1;
+}

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -997,10 +997,7 @@ def _list_tools(sites: list) -> int {
 
 """Run an installed package's console-script entry point under the Jac runtime."""
 impl x(
-    name: str = "",
-    use_global: bool = False,
-    list_tools: bool = False,
-    args: list = []
+    name: str = "", use_global: bool = False, list_tools: bool = False, args: list = []
 ) -> int {
     sites = _tool_site_dirs(use_global);
 

--- a/jac/tests/cli/test_x_command.jac
+++ b/jac/tests/cli/test_x_command.jac
@@ -114,8 +114,9 @@ test "_run_entry_point runs the tool, forwards argv, returns its exit code" {
         # The tool saw itself as argv[0] with the forwarded args after it.
         recorded = Path(argv_file).read_text();
         assert recorded == repr(["demo", "alpha", "beta"]);
-        # The caller's argv was restored.
+        # The caller's argv and sys.path were both restored (no tier leak).
         assert sys.argv == saved_argv;
+        assert sys.path == saved_path;
     } finally {
         cleanup_site(Path(tmp) / "site", ["demo_run_pkg"]);
         sys.path.clear();

--- a/jac/tests/cli/test_x_command.jac
+++ b/jac/tests/cli/test_x_command.jac
@@ -28,7 +28,7 @@ Writes `<pkg>/__init__.py` (whose `main` is `body`) plus a `.dist-info` with
 METADATA and entry_points.txt, so importlib.metadata finds the entry point and
 `ep.load()` can import it once `site_dir` is on sys.path.
 """
-def make_fake_tool(site_dir: Path, script: str, pkg: str, body: str) -> None {
+def make_fake_tool(site_dir: Path, script: str, pkg: str, body: str) {
     pkg_dir = site_dir / pkg;
     pkg_dir.mkdir(parents=True, exist_ok=True);
     (pkg_dir / "__init__.py").write_text(body);
@@ -58,7 +58,7 @@ def find_ep(site_dir: Path, script: str) -> object {
 }
 
 """Drop a fabricated package from sys.path / sys.modules so tests don't leak."""
-def cleanup_site(site_dir: Path, pkgs: list) -> None {
+def cleanup_site(site_dir: Path, pkgs: list) {
     site_str = str(site_dir);
     if site_str in sys.path {
         sys.path.remove(site_str);
@@ -103,9 +103,7 @@ test "_run_entry_point runs the tool, forwards argv, returns its exit code" {
     try {
         site = Path(tmp) / "site";
         argv_file = str(Path(tmp) / "argv.txt");
-        body = "import sys\ndef main():\n    open(" + repr(
-            argv_file
-        ) + ", 'w').write(repr(sys.argv))\n    sys.exit(7)\n";
+        body = "import sys\ndef main():\n    open(" + repr(argv_file) + ", 'w').write(repr(sys.argv))\n    sys.exit(7)\n";
         make_fake_tool(site, "demo", "demo_run_pkg", body);
 
         ep = find_ep(site, "demo");
@@ -135,9 +133,7 @@ test "_run_entry_point treats a clean (None) exit as success" {
     try {
         site = Path(tmp) / "site";
         # main returns normally -> no SystemExit -> rc 0.
-        make_fake_tool(
-            site, "demo", "demo_none_pkg", "def main():\n    return None\n"
-        );
+        make_fake_tool(site, "demo", "demo_none_pkg", "def main():\n    return None\n");
         ep = find_ep(site, "demo");
         rc = exec_cmds._run_entry_point("demo", ep, site, []);
         assert rc == 0;

--- a/jac/tests/cli/test_x_command.jac
+++ b/jac/tests/cli/test_x_command.jac
@@ -1,0 +1,301 @@
+"""Tests for the `jac x` command (run an installed console-script under the runtime).
+
+These exercise the resolver helpers and the `x` handler directly, without going
+through CLI startup, so they do not depend on a real venv or network installs.
+Fake packages with `console_scripts` entry points are fabricated on disk and
+discovered via importlib.metadata exactly as a real install would be.
+"""
+
+import os;
+import sys;
+import tempfile;
+import shutil;
+import from pathlib { Path }
+import from unittest.mock { patch }
+
+import from jaclang.cli.commands { execution as exec_cmds }
+
+
+"""Reset global config singleton (mirrors test_dependencies)."""
+def reset_config {
+    import from jaclang.project { config as config_mod }
+    config_mod._config = None;
+}
+
+"""Fabricate an installed package exposing one console-script in `site_dir`.
+
+Writes `<pkg>/__init__.py` (whose `main` is `body`) plus a `.dist-info` with
+METADATA and entry_points.txt, so importlib.metadata finds the entry point and
+`ep.load()` can import it once `site_dir` is on sys.path.
+"""
+def make_fake_tool(site_dir: Path, script: str, pkg: str, body: str) -> None {
+    pkg_dir = site_dir / pkg;
+    pkg_dir.mkdir(parents=True, exist_ok=True);
+    (pkg_dir / "__init__.py").write_text(body);
+    dist = site_dir / (pkg + "-1.0.dist-info");
+    dist.mkdir(parents=True, exist_ok=True);
+    (dist / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: " + pkg + "\nVersion: 1.0\n"
+    );
+    (dist / "entry_points.txt").write_text(
+        "[console_scripts]\n" + script + " = " + pkg + ":main\n"
+    );
+}
+
+"""A `main` body that exits with `code`."""
+def exit_body(code: int) -> str {
+    return "import sys\ndef main():\n    sys.exit(" + str(code) + ")\n";
+}
+
+"""Find the entry point named `script` in `site_dir` (or None)."""
+def find_ep(site_dir: Path, script: str) -> object {
+    for (n, d, ep) in exec_cmds._console_scripts_in(site_dir) {
+        if n == script {
+            return ep;
+        }
+    }
+    return None;
+}
+
+"""Drop a fabricated package from sys.path / sys.modules so tests don't leak."""
+def cleanup_site(site_dir: Path, pkgs: list) -> None {
+    site_str = str(site_dir);
+    if site_str in sys.path {
+        sys.path.remove(site_str);
+    }
+    for pkg in pkgs {
+        sys.modules.pop(pkg, None);
+    }
+}
+
+
+# ===== _console_scripts_in =====
+test "_console_scripts_in discovers console-script entry points" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        site = Path(tmp) / "site";
+        make_fake_tool(site, "demo", "demo_disco_pkg", exit_body(0));
+        found = exec_cmds._console_scripts_in(site);
+        names = [n for (n, d, ep) in found];
+        assert "demo" in names;
+        for (n, d, ep) in found {
+            if n == "demo" {
+                assert d == "demo_disco_pkg";
+                assert ep.group == "console_scripts";
+            }
+        }
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "_console_scripts_in returns empty for a missing dir" {
+    missing = Path(tempfile.gettempdir()) / "jac_x_definitely_missing_dir_xyz";
+    assert exec_cmds._console_scripts_in(missing) == [];
+}
+
+
+# ===== _run_entry_point =====
+test "_run_entry_point runs the tool, forwards argv, returns its exit code" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    saved_path = list(sys.path);
+    saved_argv = list(sys.argv);
+    try {
+        site = Path(tmp) / "site";
+        argv_file = str(Path(tmp) / "argv.txt");
+        body = "import sys\ndef main():\n    open(" + repr(
+            argv_file
+        ) + ", 'w').write(repr(sys.argv))\n    sys.exit(7)\n";
+        make_fake_tool(site, "demo", "demo_run_pkg", body);
+
+        ep = find_ep(site, "demo");
+        assert ep is not None;
+        rc = exec_cmds._run_entry_point("demo", ep, site, ["alpha", "beta"]);
+
+        assert rc == 7;
+        # The tool saw itself as argv[0] with the forwarded args after it.
+        recorded = Path(argv_file).read_text();
+        assert recorded == repr(["demo", "alpha", "beta"]);
+        # The caller's argv was restored.
+        assert sys.argv == saved_argv;
+    } finally {
+        cleanup_site(Path(tmp) / "site", ["demo_run_pkg"]);
+        sys.path.clear();
+        sys.path.extend(saved_path);
+        sys.argv.clear();
+        sys.argv.extend(saved_argv);
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "_run_entry_point treats a clean (None) exit as success" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    saved_path = list(sys.path);
+    saved_argv = list(sys.argv);
+    try {
+        site = Path(tmp) / "site";
+        # main returns normally -> no SystemExit -> rc 0.
+        make_fake_tool(
+            site, "demo", "demo_none_pkg", "def main():\n    return None\n"
+        );
+        ep = find_ep(site, "demo");
+        rc = exec_cmds._run_entry_point("demo", ep, site, []);
+        assert rc == 0;
+    } finally {
+        cleanup_site(Path(tmp) / "site", ["demo_none_pkg"]);
+        sys.path.clear();
+        sys.path.extend(saved_path);
+        sys.argv.clear();
+        sys.argv.extend(saved_argv);
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+
+# ===== x() precedence (project venv before global site) =====
+test "x runs the project-tier tool when it shadows a global one" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    saved_path = list(sys.path);
+    saved_argv = list(sys.argv);
+    try {
+        proj_site = Path(tmp) / "proj";
+        glob_site = Path(tmp) / "glob";
+        make_fake_tool(proj_site, "demo", "demo_proj_pkg", exit_body(11));
+        make_fake_tool(glob_site, "demo", "demo_glob_pkg", exit_body(22));
+
+        sites = [("project", proj_site), ("global", glob_site)];
+        with patch(
+            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
+        ) {
+            rc = exec_cmds.x(name="demo");
+        }
+        # Project tier wins -> its exit code (11), not the global one (22).
+        assert rc == 11;
+    } finally {
+        cleanup_site(Path(tmp) / "proj", ["demo_proj_pkg"]);
+        cleanup_site(Path(tmp) / "glob", ["demo_glob_pkg"]);
+        sys.path.clear();
+        sys.path.extend(saved_path);
+        sys.argv.clear();
+        sys.argv.extend(saved_argv);
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "x falls back to the global tier when the project lacks the tool" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    saved_path = list(sys.path);
+    saved_argv = list(sys.argv);
+    try {
+        proj_site = Path(tmp) / "proj";
+        glob_site = Path(tmp) / "glob";
+        # Project has some other tool; global has 'demo'.
+        make_fake_tool(proj_site, "other", "demo_other_pkg", exit_body(5));
+        make_fake_tool(glob_site, "demo", "demo_fallback_pkg", exit_body(22));
+
+        sites = [("project", proj_site), ("global", glob_site)];
+        with patch(
+            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
+        ) {
+            rc = exec_cmds.x(name="demo");
+        }
+        assert rc == 22;
+    } finally {
+        cleanup_site(Path(tmp) / "proj", ["demo_other_pkg"]);
+        cleanup_site(Path(tmp) / "glob", ["demo_fallback_pkg"]);
+        sys.path.clear();
+        sys.path.extend(saved_path);
+        sys.argv.clear();
+        sys.argv.extend(saved_argv);
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "x returns 1 when no tier provides the tool" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        glob_site = Path(tmp) / "glob";
+        make_fake_tool(glob_site, "demo", "demo_missing_pkg", exit_body(0));
+        sites = [("global", glob_site)];
+        with patch(
+            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
+        ) {
+            rc = exec_cmds.x(name="not-installed");
+        }
+        assert rc == 1;
+    } finally {
+        cleanup_site(Path(tmp) / "glob", ["demo_missing_pkg"]);
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "x with no name (or --list) lists tools and returns 0" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        glob_site = Path(tmp) / "glob";
+        make_fake_tool(glob_site, "demo", "demo_list_pkg", exit_body(0));
+        sites = [("global", glob_site)];
+        with patch(
+            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
+        ) {
+            assert exec_cmds.x(list_tools=True) == 0;
+            assert exec_cmds.x(name="") == 0;
+        }
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+
+# ===== _tool_site_dirs ordering (the precedence the live demo couldn't show) =====
+test "_tool_site_dirs lists the project venv before the global site" {
+    reset_config();
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    old_cwd = os.getcwd();
+    try {
+        project_dir = Path(tmp) / "proj";
+        project_dir.mkdir();
+        (project_dir / "jac.toml").write_text(
+            '[project]\nname = "xproj"\nversion = "0.1.0"\n'
+        );
+        os.chdir(project_dir);
+        reset_config();
+
+        sites = exec_cmds._tool_site_dirs(False);
+        labels = [label for (label, d) in sites];
+        assert labels[0] == "project";
+        assert "global" in labels;
+        # The project tier points inside this project's .jac/venv.
+        proj_path = str(sites[0][1]);
+        assert ".jac" in proj_path;
+        assert "venv" in proj_path;
+        assert str(project_dir) in proj_path;
+    } finally {
+        os.chdir(old_cwd);
+        shutil.rmtree(tmp, ignore_errors=True);
+        reset_config();
+    }
+}
+
+test "_tool_site_dirs with use_global skips the project tier" {
+    reset_config();
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    old_cwd = os.getcwd();
+    try {
+        project_dir = Path(tmp) / "proj";
+        project_dir.mkdir();
+        (project_dir / "jac.toml").write_text(
+            '[project]\nname = "xproj"\nversion = "0.1.0"\n'
+        );
+        os.chdir(project_dir);
+        reset_config();
+
+        sites = exec_cmds._tool_site_dirs(True);
+        labels = [label for (label, d) in sites];
+        assert "project" not in labels;
+    } finally {
+        os.chdir(old_cwd);
+        shutil.rmtree(tmp, ignore_errors=True);
+        reset_config();
+    }
+}


### PR DESCRIPTION
## What

Adds `jac x <name> [args...]` — run an installed package's console-script entry point under the bundled jac runtime, so Python CLI tools (e.g. `hf` from `huggingface_hub`) are runnable without a system Python.

## Behavior

- **Resolution / precedence:** the project venv (`.jac/venv`) is searched first, then the jac-owned global site (`jac install --global`). First match wins, so a project-installed tool shadows a global one — folder-sensitive by virtue of the discovered `jac.toml`.
- **In-process:** the entry point is imported and called under jac's interpreter (`SystemExit` captured into the return code) — no shebang/standalone-python dependency.
- **Flags:** `--global`/`-g` forces the global site only; `--list`/`-l` (or no name) lists runnable tools, deduped in precedence order. jac's own flags go before the tool name; everything after is forwarded to the tool.

## Examples

```
jac x hf download gpt2      # run the project's hf, else the global one
jac x black .               # run an installed formatter
jac x --global hf whoami    # force the global-site copy
jac x --list                # list tools available here
```

## Files

- `jac/jaclang/cli/commands/execution.jac` — `x` command declaration
- `jac/jaclang/cli/commands/impl/execution.impl.jac` — handler + resolver helpers
- `jac/tests/cli/test_x_command.jac` — 10 tests (entry-point discovery, in-process run + argv forwarding + exit-code passthrough, project-shadows-global precedence, global fallback, not-found, listing, site ordering)