### PR TITLE
feat(cli): make `jac x` polyglot — run npm tools via bun

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/6995.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/6995.feature.md
@@ -1,0 +1,1 @@
+- **Feature: `jac x` runs npm tools too**: `jac x <tool>` now also resolves the project's npm tools (`node_modules/.bin`) and runs them through the jac-managed bun runtime, searching the project Python venv, then project npm, then the global site.

--- a/jac/jaclang/cli/commands/execution.jac
+++ b/jac/jaclang/cli/commands/execution.jac
@@ -229,6 +229,14 @@ def debug(filename: str, main: bool = True, cache: bool = False) -> int;
             dest="use_global"
         ),
         Arg.create(
+            "node",
+            typ=bool,
+            default=False,
+            help="Resolve from the project's npm tools (node_modules/.bin) only",
+            short="n",
+            dest="use_node"
+        ),
+        Arg.create(
             "list_tools",
             typ=bool,
             default=False,
@@ -244,12 +252,18 @@ def debug(filename: str, main: bool = True, cache: bool = False) -> int;
             "Run the 'hf' tool (project venv first, else global)"
         ),
         ("jac x black .", "Run an installed formatter on the current directory"),
+        ("jac x eslint .", "Run a project npm tool (node_modules/.bin) via bun"),
         ("jac x --global hf whoami", "Force the global-site copy of a tool"),
+        ("jac x --node vite build", "Force the project's npm tool"),
         ("jac x --list", "List the CLI tools available here"),
 
     ],
     group="execution"
 )
 def x(
-    name: str = "", use_global: bool = False, list_tools: bool = False, args: list = []
+    name: str = "",
+    use_global: bool = False,
+    use_node: bool = False,
+    list_tools: bool = False,
+    args: list = []
 ) -> int;

--- a/jac/jaclang/cli/commands/impl/execution.impl.jac
+++ b/jac/jaclang/cli/commands/impl/execution.impl.jac
@@ -925,6 +925,70 @@ def _console_scripts_in(site_dir: object) -> list {
     return found;
 }
 
+"""Path to the project's npm tool directory (.jac/client/node_modules/.bin), or None.
+
+npm/bun/pnpm all populate node_modules/.bin with one shim per package executable,
+so it is the canonical surface for "what npm tools can run here". Returns the path
+regardless of whether it exists yet; existence is checked at scan time.
+"""
+def _node_bin_dir -> object {
+    import from jaclang.project.config { get_config }
+
+    config = get_config();
+    if config is None {
+        return None;
+    }
+    return config.get_client_dir() / "node_modules" / ".bin";
+}
+
+"""Names of the npm tools available in a node_modules/.bin directory.
+
+On Windows a tool ships as several shims (`tsc`, `tsc.cmd`, `tsc.ps1`); those
+collapse to one base name so the listing matches what the user would type.
+"""
+def _node_tools_in(bin_dir: object) -> list {
+    names: set = set();
+    if bin_dir is None or not bin_dir.exists() {
+        return [];
+    }
+    for entry in bin_dir.iterdir() {
+        if entry.is_dir() {
+            continue;
+        }
+        base = entry.name;
+        for suffix in [".cmd", ".ps1", ".exe", ".bat"] {
+            if base.endswith(suffix) {
+                base = base[:-len(suffix)];
+                break;
+            }
+        }
+        if base and not base.startswith(".") {
+            names.add(base);
+        }
+    }
+    return sorted(names);
+}
+
+"""Resolve the runnable shim path for `name` in a node_modules/.bin dir, or None."""
+def _find_node_tool(bin_dir: object, name: str) -> object {
+    if bin_dir is None or not bin_dir.exists() {
+        return None;
+    }
+    for candidate in [
+        name,
+        name + ".cmd",
+        name + ".exe",
+        name + ".bat",
+        name + ".ps1"
+    ] {
+        shim = bin_dir / candidate;
+        if shim.exists() {
+            return shim;
+        }
+    }
+    return None;
+}
+
 """Load a console-script entry point under the Jac runtime and invoke it.
 
 The chosen site-packages dir is moved to the front of sys.path so the tool and its
@@ -969,64 +1033,145 @@ def _run_entry_point(name: str, ep: object, site_dir: object, args: list) -> int
     }
 }
 
-"""Print the console-script tools available across the resolved sites.
+"""Run an npm tool's bin shim through the jac-managed bun runtime.
+
+The shim is executed by bun (resolved via get_bun: system bun -> .jac/bin/bun ->
+auto-download), so npm tools run without a system Node install. Runs as a
+subprocess from the project root and returns the tool's exit code.
+"""
+def _run_node_tool(name: str, bin_path: object, args: list) -> int {
+    import subprocess;
+    import from jaclang.runtimelib.client.bun_installer { get_bun }
+    import from jaclang.project.config { get_config }
+
+    bun = get_bun();
+    if bun is None {
+        console.error(
+            f"Cannot run npm tool '{name}': the bun runtime is unavailable.",
+            hint="Install bun, or run the project once (e.g. 'jac start') to let jac provision it."
+        );
+        return 1;
+    }
+    config = get_config();
+    cwd = str(config.project_root) if config and config.project_root else None;
+    result = subprocess.run([bun, str(bin_path)] + list(args), cwd=cwd);
+    return result.returncode;
+}
+
+"""Resolve the ordered (label, kind, location) tiers `jac x` searches.
+
+Default precedence is locality-first: the project Python venv, then the project's
+npm tools (node_modules/.bin), then the global Python site — first match wins.
+`use_global` restricts to the global Python site; `use_node` restricts to the npm
+tier. `kind` is "py" (a site-packages dir) or "node" (a node_modules/.bin dir).
+"""
+def _tool_tiers(use_global: bool, use_node: bool) -> list {
+    if use_node {
+        node_bin = _node_bin_dir();
+        return [("node", "node", node_bin)] if node_bin is not None else [];
+    }
+    py_sites = _tool_site_dirs(use_global);
+    if use_global {
+        return [(label, "py", loc) for (label, loc) in py_sites];
+    }
+    tiers: list = [];
+    node_bin = _node_bin_dir();
+    node_inserted = False;
+    for (label, loc) in py_sites {
+        tiers.append((label, "py", loc));
+        # Project-local npm tools rank just below the project venv and above the
+        # global Python site.
+        if label == "project" and node_bin is not None {
+            tiers.append(("node", "node", node_bin));
+            node_inserted = True;
+        }
+    }
+    if node_bin is not None and not node_inserted {
+        tiers.append(("node", "node", node_bin));
+    }
+    return tiers;
+}
+
+"""Print the CLI tools available across the resolved tiers (Python and npm).
 
 Names are deduplicated in precedence order, so a tool shadowed by a higher-precedence
 tier is listed only once, against the tier that would actually run.
 """
-def _list_tools(sites: list) -> int {
+def _list_tools(tiers: list) -> int {
     seen: set = set();
     rows: list = [];
-    for (label, site_dir) in sites {
-        for (script_name, dist_name, _ep) in _console_scripts_in(site_dir) {
-            if script_name in seen {
-                continue;
+    for (label, kind, loc) in tiers {
+        if kind == "py" {
+            for (script_name, dist_name, _ep) in _console_scripts_in(loc) {
+                if script_name in seen {
+                    continue;
+                }
+                seen.add(script_name);
+                rows.append((script_name, dist_name, label));
             }
-            seen.add(script_name);
-            rows.append((script_name, dist_name, label));
+        } else {
+            for tool_name in _node_tools_in(loc) {
+                if tool_name in seen {
+                    continue;
+                }
+                seen.add(tool_name);
+                rows.append((tool_name, "npm", label));
+            }
         }
     }
     if not rows {
         console.info(
-            "No CLI tools available. Install one with 'jac install <package>' "
-            "or 'jac install --global <package>'."
+            "No CLI tools available. Install one with 'jac install <package>', "
+            "'jac install --global <package>', or add an npm package for node tools."
         );
         return 0;
     }
     console.print("\nAvailable CLI tools (run with 'jac x <name>'):\n", style="info");
     width = max([len(r[0]) for r in rows]);
-    for (script_name, dist_name, label) in sorted(rows) {
-        console.print(f"  {script_name.ljust(width)}  {dist_name} [{label}]");
+    for (tool_name, origin, label) in sorted(rows) {
+        console.print(f"  {tool_name.ljust(width)}  {origin} [{label}]");
     }
     return 0;
 }
 
-"""Run an installed package's console-script entry point under the Jac runtime."""
+"""Run an installed CLI tool (Python console-script or npm bin) under the runtime."""
 impl x(
-    name: str = "", use_global: bool = False, list_tools: bool = False, args: list = []
+    name: str = "",
+    use_global: bool = False,
+    use_node: bool = False,
+    list_tools: bool = False,
+    args: list = []
 ) -> int {
-    sites = _tool_site_dirs(use_global);
+    tiers = _tool_tiers(use_global, use_node);
 
     # No tool name given → behave like --list and show what's runnable here.
     if list_tools or not name {
-        return _list_tools(sites);
+        return _list_tools(tiers);
     }
 
-    # First matching tier wins (project venv before global site).
-    for (label, site_dir) in sites {
-        for (script_name, _dist_name, ep) in _console_scripts_in(site_dir) {
-            if script_name == name {
-                return _run_entry_point(name, ep, site_dir, args);
+    # First matching tier wins (project venv → project npm → global site).
+    for (label, kind, loc) in tiers {
+        if kind == "py" {
+            for (script_name, _dist_name, ep) in _console_scripts_in(loc) {
+                if script_name == name {
+                    return _run_entry_point(name, ep, loc, args);
+                }
+            }
+        } else {
+            bin_path = _find_node_tool(loc, name);
+            if bin_path is not None {
+                return _run_node_tool(name, bin_path, args);
             }
         }
     }
 
-    searched = ", ".join([f"{label} ({d})" for (label, d) in sites]) or "no sites";
+    searched = ", ".join([f"{label} ({loc})" for (label, kind, loc) in tiers])
+    or "no tiers";
     console.error(
         f"No CLI tool named '{name}' found.",
-        hint=f"Install the package that provides it — 'jac install <package>' "
-        f"(project) or 'jac install --global <package>' — then 'jac x {name}'. "
-        f"Searched: {searched}."
+        hint=f"Install it — 'jac install <package>' (project Python), "
+        f"'jac install --global <package>', or add an npm package (node) — "
+        f"then 'jac x {name}'. Searched: {searched}."
     );
     return 1;
 }

--- a/jac/tests/cli/test_x_command.jac
+++ b/jac/tests/cli/test_x_command.jac
@@ -11,7 +11,7 @@ import sys;
 import tempfile;
 import shutil;
 import from pathlib { Path }
-import from unittest.mock { patch }
+import from unittest.mock { patch, MagicMock }
 
 import from jaclang.cli.commands { execution as exec_cmds }
 
@@ -160,10 +160,8 @@ test "x runs the project-tier tool when it shadows a global one" {
         make_fake_tool(proj_site, "demo", "demo_proj_pkg", exit_body(11));
         make_fake_tool(glob_site, "demo", "demo_glob_pkg", exit_body(22));
 
-        sites = [("project", proj_site), ("global", glob_site)];
-        with patch(
-            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
-        ) {
+        tiers = [("project", "py", proj_site), ("global", "py", glob_site)];
+        with patch("jaclang.cli.commands.execution._tool_tiers", return_value=tiers) {
             rc = exec_cmds.x(name="demo");
         }
         # Project tier wins -> its exit code (11), not the global one (22).
@@ -190,10 +188,8 @@ test "x falls back to the global tier when the project lacks the tool" {
         make_fake_tool(proj_site, "other", "demo_other_pkg", exit_body(5));
         make_fake_tool(glob_site, "demo", "demo_fallback_pkg", exit_body(22));
 
-        sites = [("project", proj_site), ("global", glob_site)];
-        with patch(
-            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
-        ) {
+        tiers = [("project", "py", proj_site), ("global", "py", glob_site)];
+        with patch("jaclang.cli.commands.execution._tool_tiers", return_value=tiers) {
             rc = exec_cmds.x(name="demo");
         }
         assert rc == 22;
@@ -213,10 +209,8 @@ test "x returns 1 when no tier provides the tool" {
     try {
         glob_site = Path(tmp) / "glob";
         make_fake_tool(glob_site, "demo", "demo_missing_pkg", exit_body(0));
-        sites = [("global", glob_site)];
-        with patch(
-            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
-        ) {
+        tiers = [("global", "py", glob_site)];
+        with patch("jaclang.cli.commands.execution._tool_tiers", return_value=tiers) {
             rc = exec_cmds.x(name="not-installed");
         }
         assert rc == 1;
@@ -231,10 +225,8 @@ test "x with no name (or --list) lists tools and returns 0" {
     try {
         glob_site = Path(tmp) / "glob";
         make_fake_tool(glob_site, "demo", "demo_list_pkg", exit_body(0));
-        sites = [("global", glob_site)];
-        with patch(
-            "jaclang.cli.commands.execution._tool_site_dirs", return_value=sites
-        ) {
+        tiers = [("global", "py", glob_site)];
+        with patch("jaclang.cli.commands.execution._tool_tiers", return_value=tiers) {
             assert exec_cmds.x(list_tools=True) == 0;
             assert exec_cmds.x(name="") == 0;
         }
@@ -294,5 +286,188 @@ test "_tool_site_dirs with use_global skips the project tier" {
         os.chdir(old_cwd);
         shutil.rmtree(tmp, ignore_errors=True);
         reset_config();
+    }
+}
+
+
+# ===== npm tier: discovery, tier ordering, routing, and bun exec =====
+"""Create a node_modules/.bin shim named `tool` in `bin_dir`."""
+def make_fake_node_bin(bin_dir: Path, tool: str) -> Path {
+    bin_dir.mkdir(parents=True, exist_ok=True);
+    shim = bin_dir / tool;
+    shim.write_text("#!/usr/bin/env node\nconsole.log('hi');\n");
+    return shim;
+}
+
+test "_node_tools_in lists bins and returns empty for a missing dir" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        bin_dir = Path(tmp) / "bin";
+        make_fake_node_bin(bin_dir, "eslint");
+        make_fake_node_bin(bin_dir, "vite");
+        names = exec_cmds._node_tools_in(bin_dir);
+        assert "eslint" in names;
+        assert "vite" in names;
+        assert exec_cmds._node_tools_in(Path(tmp) / "nope") == [];
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "_find_node_tool resolves a present shim and None otherwise" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        bin_dir = Path(tmp) / "bin";
+        make_fake_node_bin(bin_dir, "vite");
+        found = exec_cmds._find_node_tool(bin_dir, "vite");
+        assert found is not None;
+        assert found.name == "vite";
+        assert exec_cmds._find_node_tool(bin_dir, "absent") is None;
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "_tool_tiers orders project python, project npm, then global" {
+    reset_config();
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    old_cwd = os.getcwd();
+    try {
+        project_dir = Path(tmp) / "proj";
+        project_dir.mkdir();
+        (project_dir / "jac.toml").write_text(
+            '[project]\nname = "xproj"\nversion = "0.1.0"\n'
+        );
+        os.chdir(project_dir);
+        reset_config();
+
+        kinds = [
+            (label, kind) for (label, kind, loc) in exec_cmds._tool_tiers(False, False)
+        ];
+        assert ("project", "py") in kinds;
+        assert ("node", "node") in kinds;
+        assert ("global", "py") in kinds;
+        # Locality-first: project venv, then project npm, then global site.
+        assert kinds.index(("project", "py")) < kinds.index(("node", "node"));
+        assert kinds.index(("node", "node")) < kinds.index(("global", "py"));
+    } finally {
+        os.chdir(old_cwd);
+        shutil.rmtree(tmp, ignore_errors=True);
+        reset_config();
+    }
+}
+
+test "_tool_tiers with use_node yields only the npm tier" {
+    reset_config();
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    old_cwd = os.getcwd();
+    try {
+        project_dir = Path(tmp) / "proj";
+        project_dir.mkdir();
+        (project_dir / "jac.toml").write_text(
+            '[project]\nname = "xproj"\nversion = "0.1.0"\n'
+        );
+        os.chdir(project_dir);
+        reset_config();
+
+        tiers = exec_cmds._tool_tiers(False, True);
+        kinds = {kind for (label, kind, loc) in tiers};
+        assert kinds == {"node"};
+    } finally {
+        os.chdir(old_cwd);
+        shutil.rmtree(tmp, ignore_errors=True);
+        reset_config();
+    }
+}
+
+test "_tool_tiers with use_global has no npm or project tier" {
+    reset_config();
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    old_cwd = os.getcwd();
+    try {
+        project_dir = Path(tmp) / "proj";
+        project_dir.mkdir();
+        (project_dir / "jac.toml").write_text(
+            '[project]\nname = "xproj"\nversion = "0.1.0"\n'
+        );
+        os.chdir(project_dir);
+        reset_config();
+
+        labels = [label for (label, kind, loc) in exec_cmds._tool_tiers(True, False)];
+        kinds = [kind for (label, kind, loc) in exec_cmds._tool_tiers(True, False)];
+        assert "node" not in kinds;
+        assert "project" not in labels;
+    } finally {
+        os.chdir(old_cwd);
+        shutil.rmtree(tmp, ignore_errors=True);
+        reset_config();
+    }
+}
+
+test "x routes an npm-tier match to the node runner" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        bin_dir = Path(tmp) / "bin";
+        make_fake_node_bin(bin_dir, "demo");
+        tiers = [("node", "node", bin_dir)];
+        with patch("jaclang.cli.commands.execution._tool_tiers", return_value=tiers), patch(
+            "jaclang.cli.commands.execution._run_node_tool", return_value=42
+        ) as mock_node {
+            rc = exec_cmds.x(name="demo", args=["build"]);
+        }
+        assert rc == 42;
+        assert mock_node.called;
+        # Called as _run_node_tool(name, shim_path, args).
+        assert mock_node.call_args[0][0] == "demo";
+        assert mock_node.call_args[0][1].name == "demo";
+        assert mock_node.call_args[0][2] == ["build"];
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "_run_node_tool invokes bun with the shim and forwards args" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        bin_dir = Path(tmp) / "bin";
+        shim = make_fake_node_bin(bin_dir, "demo");
+        with patch(
+            "jaclang.runtimelib.client.bun_installer.get_bun", return_value="/fake/bun"
+        ), patch("subprocess.run") as mock_run {
+            mock_run.return_value = MagicMock(returncode=3);
+            rc = exec_cmds._run_node_tool("demo", shim, ["a", "b"]);
+        }
+        assert rc == 3;
+        assert mock_run.call_args[0][0] == ["/fake/bun", str(shim), "a", "b"];
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "_run_node_tool errors cleanly when bun is unavailable" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        shim = make_fake_node_bin(Path(tmp) / "bin", "demo");
+        with patch(
+            "jaclang.runtimelib.client.bun_installer.get_bun", return_value=None
+        ) {
+            assert exec_cmds._run_node_tool("demo", shim, []) == 1;
+        }
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
+    }
+}
+
+test "x --list includes npm tools" {
+    tmp = tempfile.mkdtemp(prefix="jac_x_test_");
+    try {
+        bin_dir = Path(tmp) / "bin";
+        make_fake_node_bin(bin_dir, "vite");
+        tiers = [("node", "node", bin_dir)];
+        with patch("jaclang.cli.commands.execution._tool_tiers", return_value=tiers) {
+            assert exec_cmds.x(list_tools=True) == 0;
+        }
+    } finally {
+        shutil.rmtree(tmp, ignore_errors=True);
     }
 }


### PR DESCRIPTION
## What

Extends `jac x` (added in #6994) from a Python-only tool runner into a **polyglot** one: it now also runs the project's **npm** tools, executed through the jac-managed **bun** runtime — so npm CLIs work without a system Node install.

## Behavior

- **Tiers, locality-first:** project Python venv → **project npm (`.jac/client/node_modules/.bin`)** → global Python site. First match wins.
- **Execution:** Python tools run in-process (unchanged); npm tools run as a subprocess via `get_bun()` (`[bun, <bin-shim>, ...args]`) from the project root. bun executes the node-shebang shims, so **no system Node is required**.
- **Flags:** new `--node`/`-n` restricts to the npm tier (mirrors `--global`/`-g`). `--list` tags each tool by tier (`[project]`/`[node]`/`[global]`).

## Examples

```
jac x eslint .              # runs node_modules/.bin/eslint via bun
jac x --node vite build     # force the project's npm tool
jac x --list                # tools across both ecosystems, tier-tagged
```

## Notes

- npm tier is project-scoped (jac manages npm deps per project); no global npm tier.
- Locally-installed tools only (no `bun x` network fallback) — matching the Python side's "must be installed" behavior.

## Tests

`jac/tests/cli/test_x_command.jac` extended: `_node_tools_in` / `_find_node_tool` discovery, `_tool_tiers` ordering + `--node`/`--global` modes, `x` routing an npm match to the node runner, and `_run_node_tool` invoking bun with the shim + args (and the bun-unavailable error path).