### PR TITLE
feat(scripts): extend go_hard_jac.sh to remove Node/Deno toolchains; harden apt guard

### DIFF
--- a/scripts/go_hard_jac.sh
+++ b/scripts/go_hard_jac.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# go_hard_jac.sh -- aggressively remove Python toolchains from this machine.
+# go_hard_jac.sh -- aggressively remove Python and Node toolchains from this machine.
 #
-# Supports macOS and Ubuntu. "Go hard" = rip out every Python you control:
-# Homebrew pythons, pyenv, conda/miniforge, uv, pipx, poetry/pipenv virtualenvs,
-# pip caches, and user site-packages. On Ubuntu it also purges apt-installed
-# alternate interpreters (e.g. deadsnakes python3.x) and python3-pip/venv.
+# Supports macOS and Ubuntu. "Go hard" = rip out every Python and Node you control:
+#   * Python: Homebrew pythons, pyenv, conda/miniforge, uv, pipx, poetry/pipenv
+#     virtualenvs, pip caches, and user site-packages. On Ubuntu it also purges
+#     apt-installed alternate interpreters (e.g. deadsnakes python3.x) and
+#     python3-pip/venv.
+#   * Node: nvm, fnm, nodenv, volta, the asdf nodejs plugin, npm/yarn/pnpm/
+#     corepack/bun caches + config, and user-scoped global package dirs. On macOS
+#     it uninstalls Homebrew node/yarn/pnpm; on Ubuntu it purges the apt
+#     nodejs/npm/yarn packages.
 #
 # It deliberately CANNOT remove the operating system's own Python, because doing
 # so breaks the machine:
@@ -12,10 +17,15 @@
 #     (git, clang, make live there too) -- not removable, and we never try.
 #   * Ubuntu: /usr/bin/python3 is load-bearing for apt, the desktop, and much of
 #     the base system. Purging it cascades into apt/ubuntu-minimal/etc.
-# Two guard rails enforce this:
+# Node has no such protected floor on either OS (no part of the base system ships
+# a load-bearing node), so every Node install found is removed.
+# Two guard rails enforce all of this:
 #   1. Every direct delete must resolve to a path under $HOME, or it is refused.
-#   2. Every apt purge is simulated first; if it would touch a protected core
-#      package (apt, dpkg, python3, ubuntu-*, systemd, gdm3, ...), it is skipped.
+#   2. Every apt purge is simulated first. It is skipped unless apt can cleanly
+#      resolve the removal AND it touches no protected core package (apt, dpkg,
+#      python3, the package backing /usr/bin/python3, ubuntu-*, systemd, ...).
+#      A simulation that errors out (non-zero exit / "unmet dependencies") means
+#      the removal would break the dependency graph -- so we fail safe and skip.
 #
 # This does NOT touch the `jac` binary itself (jac ships its own private bundled
 # CPython and is independent of the host Python this removes). Remove jac
@@ -106,7 +116,7 @@ fi
 
 # --- confirmation ---------------------------------------------------------------
 if [[ $DRY_RUN -eq 0 && $ASSUME_YES -eq 0 ]]; then
-  printf '\nThis will permanently delete the Python toolchains listed above.\n'
+  printf '\nThis will permanently delete the Python and Node toolchains listed above.\n'
   read -r -p 'Type "go hard" to proceed: ' answer
   [[ "$answer" == "go hard" ]] || { err "aborted (got: '${answer}')"; exit 1; }
 fi
@@ -153,53 +163,136 @@ for d in "$HOME"/.local/lib/python*; do
 done
 
 # ================================================================================
-# 3. OS package manager: remove non-system Python distributions
+# 3. Node version managers, package-manager caches, and config (both OSes; $HOME)
+# ================================================================================
+log "Removing Node version managers (nvm / fnm / nodenv / volta)"
+for p in .nvm .fnm .nodenv .volta \
+         .local/share/fnm "Library/Application Support/fnm" "Library/Caches/fnm"; do
+  rmrf "$HOME/$p"
+done
+
+# asdf is multi-language; remove only its Node plugin + installed node versions,
+# never the whole ~/.asdf (that would take out other languages it manages).
+log "Removing asdf Node plugin + versions (leaving the rest of asdf intact)"
+rmrf "$HOME/.asdf/plugins/nodejs"
+rmrf "$HOME/.asdf/installs/nodejs"
+
+log "Removing npm cache, config, and user-global package dirs"
+for p in .npm .npmrc .npm-global .npm-packages .node-gyp .node_modules \
+         .node_repl_history .cache/node .cache/node-gyp "Library/Caches/node-gyp"; do
+  rmrf "$HOME/$p"
+done
+
+log "Removing yarn caches + config"
+for p in .yarn .yarnrc .yarnrc.yml .cache/yarn .config/yarn "Library/Caches/Yarn"; do
+  rmrf "$HOME/$p"
+done
+
+log "Removing pnpm store + config"
+for p in .pnpm-store .pnpm-state .local/share/pnpm .config/pnpm \
+         "Library/pnpm" "Library/Caches/pnpm"; do
+  rmrf "$HOME/$p"
+done
+
+log "Removing corepack + bun + deno"
+for p in .local/share/corepack "Library/Caches/corepack" .bun \
+         .deno .cache/deno "Library/Caches/deno"; do
+  rmrf "$HOME/$p"
+done
+
+# ================================================================================
+# 4. OS package manager: remove non-system Python and Node distributions
 # ================================================================================
 if [[ "$OS" == "macos" ]]; then
   if command -v brew >/dev/null 2>&1; then
-    # Every python formula brew installed (python@3.x and the unversioned python).
-    # Plain string + while-read (not mapfile) so this also runs under the macOS
-    # system bash 3.2 -- a toolchain-removal script must not lean on Homebrew bash.
-    BREW_PY="$(brew list --formula 2>/dev/null | grep -E '^python(@[0-9.]+)?$' || true)"
-    if [[ -z "$BREW_PY" ]]; then
-      log "No Homebrew python formulae installed"
-    else
-      log "Removing Homebrew pythons: $(printf '%s' "$BREW_PY" | tr '\n' ' ')"
-      # No --force / --ignore-dependencies: if something still depends on a
-      # python, surface it instead of breaking that tool silently.
+    # Uninstall every installed formula whose name matches $1 (anchored regex);
+    # $2 is a label for logging. Plain string + while-read (not mapfile) so this
+    # also runs under the macOS system bash 3.2 -- a toolchain-removal script must
+    # not lean on Homebrew bash. No --force / --ignore-dependencies: if something
+    # still depends on a formula, surface it instead of breaking that tool.
+    brew_remove_matching() {
+      local regex="$1" label="$2" matches
+      matches="$(brew list --formula 2>/dev/null | grep -E "$regex" || true)"
+      if [[ -z "$matches" ]]; then
+        log "No Homebrew $label installed"
+        return 0
+      fi
+      log "Removing Homebrew $label: $(printf '%s' "$matches" | tr '\n' ' ')"
       while IFS= read -r f; do
         [[ -z "$f" ]] && continue
         if ! run brew uninstall "$f"; then
           warn "could not uninstall $f -- something still depends on it:"
           brew uses --installed "$f" 2>/dev/null | sed 's/^/      /' || true
         fi
-      done <<< "$BREW_PY"
-      run brew autoremove
-      run brew cleanup -s
-    fi
+      done <<< "$matches"
+    }
+
+    brew_remove_matching '^python(@[0-9.]+)?$' "pythons"
+    brew_remove_matching '^(node(@[0-9.]+)?|nodejs|yarn|pnpm|fnm|nvm|nodenv|volta|bun|deno)$' "node toolchains"
+    run brew autoremove
+    run brew cleanup -s
   else
-    warn "Homebrew not found -- skipping brew python removal"
+    warn "Homebrew not found -- skipping brew removal"
   fi
 
 elif [[ "$OS" == "ubuntu" ]]; then
-  # guard rail #2: simulate each purge; refuse if it would remove a core package.
+  # guard rail #2: simulate each purge and skip it unless apt can cleanly resolve
+  # the removal AND it touches no protected core package.
   PROTECTED='apt|apt-utils|dpkg|libapt-pkg[0-9.]*|python3|python3-minimal|libpython3-stdlib|libpython3\.[0-9]+-minimal|libpython3\.[0-9]+-stdlib|ubuntu-minimal|ubuntu-standard|ubuntu-desktop|ubuntu-server|systemd|gdm3|netplan\.io|software-properties-common|update-manager-core|command-not-found'
+
+  # Resolved package that owns the OS interpreter (e.g. /usr/bin/python3 ->
+  # python3.12 -> the `python3.12` package). Computed below once apt/dpkg are
+  # confirmed present; we must never purge it, and on stock Ubuntu it is exactly
+  # what the versioned-interpreter scan finds.
+  SYS_PKG=""
 
   apt_safe_purge() {
     local pkg="$1"
     dpkg -l "$pkg" 2>/dev/null | grep -q '^ii' || return 0   # not installed
-    local sim
-    sim="$(apt-get -s remove "$pkg" 2>/dev/null || true)"
+
+    # Never touch the package backing the OS interpreter.
+    if [[ -n "$SYS_PKG" && "$pkg" == "$SYS_PKG" ]]; then
+      warn "skipping '$pkg' -- it backs the protected system interpreter ($SYSTEM_PY)"
+      return 0
+    fi
+
+    # Simulate the exact purge we would run. Keep the assignment inside the `if`
+    # so `set -e` does not abort on apt's non-zero exit -- we want to inspect it.
+    local sim rc
+    if sim="$(apt-get -s purge "$pkg" 2>&1)"; then rc=0; else rc=$?; fi
+
+    # Fail safe: a resolver error / "unmet dependencies" means the removal would
+    # break the dependency graph (e.g. python3 depends on python3.12). The old
+    # code read the absence of `Remv` lines here as "harmless" and proceeded --
+    # that is how the system interpreter slipped past the guard. Refuse instead.
+    if [[ $rc -ne 0 ]] || grep -qiE '^(E:|the following packages have unmet dependencies)' <<<"$sim"; then
+      warn "skipping '$pkg' -- apt cannot cleanly remove it (would break dependencies)"
+      return 0
+    fi
     if grep -qE "^Remv ($PROTECTED) " <<<"$sim"; then
       warn "skipping purge of '$pkg' -- would cascade into protected core packages"
       return 0
     fi
-    run sudo apt-get -y purge "$pkg"
+
+    # A failed real purge must not abort the whole teardown (set -e); warn on.
+    run sudo apt-get -y purge "$pkg" || warn "purge of '$pkg' failed -- continuing"
   }
 
   if command -v apt-get >/dev/null 2>&1; then
-    SYS_BASENAME="$(basename "${SYSTEM_PY:-python3}")"   # e.g. python3 (the default)
-    log "Purging apt-installed alternate interpreters (system $SYS_BASENAME is protected)"
+    # Resolve the package that owns the real interpreter behind /usr/bin/python3
+    # and add it to the protected set, so neither a direct purge nor a cascade
+    # can take it out. basename-of-symlink (the old approach) gave "python3",
+    # which never matched the real "python3.12" package being deleted.
+    if [[ -x "$SYSTEM_PY" ]]; then
+      sys_real="$(readlink -f "$SYSTEM_PY" 2>/dev/null || printf '%s' "$SYSTEM_PY")"
+      SYS_PKG="$(dpkg -S "$sys_real" 2>/dev/null | head -n1 | cut -d: -f1 || true)"
+    fi
+    if [[ -n "$SYS_PKG" ]]; then
+      PROTECTED="$PROTECTED|$(printf '%s' "$SYS_PKG" | sed 's/[.]/\\./g')"
+      log "Purging apt-installed alternate interpreters (system package '$SYS_PKG' is protected)"
+    else
+      log "Purging apt-installed alternate interpreters (system package unresolved; relying on dependency guard)"
+    fi
 
     # Versioned interpreters like python3.11 / python3.13 (deadsnakes etc.).
     APT_PY="$(dpkg-query -W -f='${Package}\n' 'python3.[0-9]*' 2>/dev/null \
@@ -215,17 +308,36 @@ elif [[ "$OS" == "ubuntu" ]]; then
       apt_safe_purge "$pkg"
     done
 
-    run sudo apt-get -y autoremove --purge
+    # Node toolchains installed via apt (nodejs/npm, plus the yarn apt repo).
+    # No protected floor here -- nothing in the base system ships a load-bearing
+    # node -- but apt_safe_purge still refuses anything that would cascade into a
+    # protected core package.
+    log "Purging apt-installed Node toolchains (nodejs / npm / yarn)"
+    for pkg in nodejs npm yarn; do
+      apt_safe_purge "$pkg"
+    done
+
+    # NodeSource / Yarn apt repos live outside $HOME; we never edit system files
+    # automatically -- just report them so a later apt-get does not silently
+    # resurrect node.
+    for f in /etc/apt/sources.list.d/nodesource.list \
+             /etc/apt/sources.list.d/yarn.list \
+             /etc/apt/keyrings/nodesource.gpg \
+             /usr/share/keyrings/yarnkey.gpg; do
+      [[ -e "$f" ]] && warn "leftover apt repo file (remove by hand): $f"
+    done
+
+    run sudo apt-get -y autoremove --purge || warn "autoremove failed -- continuing"
   else
     warn "apt-get not found -- skipping apt python removal"
   fi
 fi
 
 # ================================================================================
-# 4. Report shell-rc lines that still reference removed tools (NOT auto-edited)
+# 5. Report shell-rc lines that still reference removed tools (NOT auto-edited)
 # ================================================================================
-log "Scanning shell rc files for stale Python references (edit these by hand)"
-RC_PATTERN='pyenv|conda|miniconda|anaconda|miniforge|mambaforge|/uv\b|pipx|/Library/Python|\.local/lib/python|python@|deadsnakes'
+log "Scanning shell rc files for stale Python/Node references (edit these by hand)"
+RC_PATTERN='pyenv|conda|miniconda|anaconda|miniforge|mambaforge|/uv\b|pipx|/Library/Python|\.local/lib/python|python@|deadsnakes|nvm|NVM_DIR|fnm|nodenv|volta|\.npm|npm-global|npm-packages|pnpm|PNPM_HOME|corepack|\.bun|BUN_INSTALL|N_PREFIX|yarn|deno|DENO_INSTALL'
 for rc in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.zshenv" \
           "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
   [[ -f "$rc" ]] || continue
@@ -236,10 +348,11 @@ for rc in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.zshenv" \
 done
 
 # ================================================================================
-# 5. Final state
+# 6. Final state
 # ================================================================================
-log "Done. Remaining Python-ish commands on PATH:"
-for c in python python3 pip pip3 pyenv conda uv uvx pipx poetry; do
+log "Done. Remaining Python/Node commands on PATH:"
+for c in python python3 pip pip3 pyenv conda uv uvx pipx poetry \
+         node nodejs npm npx yarn pnpm corepack nvm fnm volta nodenv bun deno; do
   if p="$(command -v "$c" 2>/dev/null)"; then
     printf '      %-8s -> %s\n' "$c" "$p"
   fi
@@ -249,6 +362,8 @@ cat <<EOF
 
 The only Python that should remain is the OS system interpreter
 (${SYSTEM_PY:-/usr/bin/python3}) -- that is the floor on $OS and removing it
-would break core OS tooling. Open a new shell (or 'exec \$SHELL') so PATH and
-any rc edits take effect.
+would break core OS tooling. Node has no protected floor, so any 'node' still
+shown above is one this script could not reach (e.g. a system-prefix global
+install, or an nvm/fnm shim left on PATH for the *current* shell). Open a new
+shell (or 'exec \$SHELL') so PATH and any rc edits take effect.
 EOF


### PR DESCRIPTION
## Summary
Extends `scripts/go_hard_jac.sh` (previously Python-only) to also rip out Node and Deno toolchains on macOS and Ubuntu, and hardens the existing apt safety guard.

### Node / Deno removal
- Node version managers: nvm, fnm, nodenv, volta, and the asdf **nodejs plugin only** (leaves the rest of asdf intact since it's multi-language)
- npm / yarn / pnpm / corepack / bun caches + config and user-scoped global package dirs
- Deno install dir + caches
- **macOS:** refactored the brew logic into a reusable `brew_remove_matching <regex> <label>` helper, now used for both pythons and `node@*/nodejs/yarn/pnpm/fnm/nvm/nodenv/volta/bun/deno`
- **Ubuntu:** purges `nodejs`/`npm`/`yarn` via the same `apt_safe_purge` guard; reports leftover NodeSource/Yarn apt repo files (system files outside `$HOME`, reported not deleted)
- rc-file scan and final PATH report extended for Node/Deno

Node/Deno have no protected system floor on either OS, so every install found is removed. The `$HOME`-only delete guard and the simulated-purge guard still apply.

### apt guard hardening (fixes a fail-open bug)
- Skip a purge when apt cannot cleanly resolve it (resolver error / unmet deps), instead of treating the absence of `Remv` lines as harmless — this is what previously let the system interpreter slip past the guard
- Protect the package actually backing `/usr/bin/python3` (resolved via `dpkg -S`), not a basename that never matched the real package
- A failing `apt-get` no longer aborts the whole teardown under `set -e`

## Testing
- `bash -n scripts/go_hard_jac.sh` parses clean
- Full `--dry-run` exits 0 on Ubuntu 24.04; system `python3.12` is correctly skipped, Node installs (nvm/bun) detected and targeted, stale rc lines reported