### PR TITLE
fix(desktop): inject CEF platform block structurally, not via comment markers

### DIFF
--- a/jac/jaclang/runtimelib/client/targets/desktop/desktop_build.jac
+++ b/jac/jaclang/runtimelib/client/targets/desktop/desktop_build.jac
@@ -254,36 +254,41 @@ def _jac_sdk_js -> str {
     return boot[start:end];
 }
 
-def _splice_platform(host_src: str, platform_src: str, drop_entry: bool) -> str {
-    plat = platform_src[:-1] if platform_src.endswith("\n") else platform_src;
-    out: list[str] = [];
-    for line in host_src.split("\n") {
-        if line == "# PLATFORM" {
-            out.append(plat);
-            continue;
+def _top_level_import_boundary(lines: list[str]) -> int {
+    depth = 0;
+    idx = 0;
+    for line in lines {
+        stripped = line.strip();
+        if (
+            depth == 0
+            and stripped != ""
+            and (not stripped.startswith("#"))
+            and (not stripped.startswith("import"))
+        ) {
+            return idx;
         }
-        if drop_entry and line == "# ENTRY" {
-            continue;
-        }
-        out.append(line);
+        depth += line.count("{") - line.count("}");
+        idx += 1;
     }
-    return "\n".join(out);
+    return len(lines);
+}
+
+def _inject_platform(host_src: str, platform_src: str) -> str {
+    plat = platform_src[:-1] if platform_src.endswith("\n") else platform_src;
+    lines = host_src.split("\n");
+    at = _top_level_import_boundary(lines);
+    return "\n".join(lines[:at] + [plat] + lines[at:]);
 }
 
 def _nacompile_cef(
-    cef_dir: Path,
-    source_name: str,
-    build_name: str,
-    output: Path,
-    drop_entry: bool,
-    shared: bool,
+    cef_dir: Path, source_name: str, build_name: str, output: Path, shared: bool,
 ) -> Path {
     build_dir = cef_dir / ".build";
     build_dir.mkdir(parents=True, exist_ok=True);
     build_src = build_dir / build_name;
     host_src = (cef_dir / source_name).read_text();
     platform_src = (cef_dir / "cef_platform.na.jac").read_text();
-    build_src.write_text(_splice_platform(host_src, platform_src, drop_entry));
+    build_src.write_text(_inject_platform(host_src, platform_src));
     cmd = [_jac_bin(), "nacompile"];
     if shared {
         cmd.append("--shared");
@@ -305,7 +310,6 @@ def build_cef_dispatch(cef_dir: Path) -> Path {
         "cef_dispatch.na.jac",
         "cef_dispatch_build.na.jac",
         cef_dir / "libcef_dispatch.so",
-        False,
         True,
     );
 }
@@ -316,7 +320,6 @@ def build_cef_subprocess(cef_dir: Path) -> Path {
         "cef_subprocess.na.jac",
         "cef_subprocess_build.na.jac",
         cef_dir / "cef-subprocess",
-        True,
         False,
     );
 }


### PR DESCRIPTION
## What's failing

On **main**, the **Run tests for jaseci → `test-cef-build`** job fails at the `jac run build.jac` step with a cascade of `E1053 (Cannot assign <Unknown>…)` and `E5090 (Native pathway does not yet support function…)` errors for every symbol defined in `cef_platform.na.jac` (`cef_stub_*`, `cef_main_args_create`, `_assert_cef_abi`).

## Root cause

The CEF native build can't share symbols across modules (`jac nacompile` limitation), so `desktop_build._splice_platform` **textually splices** `cef_platform.na.jac` into the host module (`cef_dispatch.na.jac` / `cef_subprocess.na.jac`) before compiling. It located the splice point by **exact-line-matching the comments** `# PLATFORM` and `# ENTRY`.

The repo-wide `strip-comments` deslop rule (enabled in `jac.toml`) deletes those comments. So when `jac format --lintfix` ran across the tree (#7025), it stripped the markers — silently disabling the splice. With `cef_platform.na.jac` never injected, every platform symbol became undefined and the build aborted. It only surfaced on CI because symbol resolution happens in the from-source compiler; a prebuilt local binary masks it.

In other words: load-bearing build directives were encoded as comments, in a tree whose formatter is configured to strip all comments — so the format gate and the CEF build were in direct contradiction.

## Fix

Replace the comment-marker splice with **structural injection** in `desktop_build.jac`:

- `_top_level_import_boundary()` scans for the end of the host's top-level `import` section, tracking brace depth so the `def`s nested inside `import from "..." { ... }` blocks aren't mistaken for the boundary.
- `_inject_platform()` inserts the platform source at that boundary — after the imports it depends on (it calls libc), before the first declaration that uses it.
- Drop the vestigial `# ENTRY` / `drop_entry` path, which only ever removed a lone comment line (a no-op).

The `.na.jac` sources stay **pure, marker-free Jac**, so the deslop pass can never break this build again — and no `jac.toml` exclude special-casing is needed. The only changed file is `desktop_build.jac`.

## Verification

- `jac run build.jac` → `OK.`; both `libcef_dispatch.so` and `cef-subprocess` build. The generated units now contain the full platform block injected immediately after the imports, matching the original working layout.
- `jac format --check --lintfix` on `desktop_build.jac` passes (comment-free, canonical).
- `jac check` adds zero new errors vs the base.