### PR TITLE
fix(cli): report jac version from jac.toml in dev mode; drop Python line

### DIFF
--- a/jac/jaclang/cli/banners.jac
+++ b/jac/jaclang/cli/banners.jac
@@ -1,5 +1,4 @@
 import platform;
-import sys;
 import from jaclang.cli.console { console }
 glob JAC_LOGO = '   _\n  (_) __ _  ___\n  | |/ _` |/ __|\n  | | (_| | (__\n _/ |\\__,_|\\___|\n|__/',
      JAC_DOCS_URL = 'https://docs.jaseci.org',
@@ -8,7 +7,6 @@ glob JAC_LOGO = '   _\n  (_) __ _  ___\n  | |/ _` |/ __|\n  | | (_| | (__\n _/ |
      JAC_ISSUES_URL = 'https://github.com/Jaseci-Labs/jaseci/issues';
 
 def print_version_banner(version: str) {
-    python_version = f"Python {sys.version.split()[0]}";
     platform_info = platform.platform();
     if (platform.system() == 'Linux') {
         platform_short = f"Linux {platform.machine()}";
@@ -24,7 +22,7 @@ def print_version_banner(version: str) {
     console.print((logo_lines[1] + '     Jac Language'), style='bold cyan');
     console.print(logo_lines[2], style='bold cyan');
     console.print((logo_lines[3] + f"     Version:  {version}"), style='cyan');
-    console.print((logo_lines[4] + f"    {python_version}"), style='cyan');
+    console.print(logo_lines[4], style='cyan');
     console.print(
         (logo_lines[5] + f"                Platform: {platform_short}"), style='cyan'
     );

--- a/jac/jaclang/cli/cli.jac
+++ b/jac/jaclang/cli/cli.jac
@@ -13,6 +13,7 @@ import from jaclang.cli.commands {
 }
 
 def start_cli -> None;
+def jac_version -> str;
 
 with entry:__main__ {
     start_cli();

--- a/jac/jaclang/cli/impl/cli.impl.jac
+++ b/jac/jaclang/cli/impl/cli.impl.jac
@@ -56,14 +56,14 @@ impl start_cli -> None {
 
     if args.version {
         import from jaclang.cli.banners { print_version_banner }
-        print_version_banner(pkg_version('jaclang'));
+        print_version_banner(jac_version());
         return;
     }
 
     if (args.command is None) {
         formatter = get_help_formatter();
         help_text = formatter.format_main_help(
-            registry.get_all(), prog="jac", version=pkg_version('jaclang')
+            registry.get_all(), prog="jac", version=jac_version()
         );
         console.print(help_text);
         return;
@@ -94,6 +94,21 @@ impl start_cli -> None {
     if result.return_code != 0 {
         sys.exit(result.return_code);
     }
+}
+
+impl jac_version -> str {
+    import from jaclang.project.config { JacConfig }
+
+    dev_source = os.environ.get('JAC_DEV_SOURCE');
+    if dev_source {
+        toml_path = Path(dev_source) / 'jac.toml';
+        if toml_path.exists() {
+            try {
+                return JacConfig.load(toml_path).project.version;
+            } except Exception { }
+        }
+    }
+    return pkg_version('jaclang');
 }
 
 def _extract_script_args(registry: object) -> list {


### PR DESCRIPTION
## What

Two small `jac --version` (and `jac` help header) fixes:

1. **Report the version from `jac.toml` when running from source (dev mode).**
2. **Drop the `Python X.Y.Z` line** from the version banner.

## Why

`jac --version` resolved the version via `importlib.metadata.version('jaclang')`, which reads the `jaclang-*.dist-info/METADATA` baked into the binary at `zig build` time.

That's correct for a **packaged build**: `mkpayload` writes the dist-info from `jac.toml`'s `[project] version` (see [payload.zig](https://github.com/jaseci-labs/jaseci/blob/main/jac/launcher/payload.zig)), so `jac.toml` is already the single source of truth there.

But when running **from source in dev mode** (`JAC_DEV_SOURCE` set), `importlib.metadata` reads the *stale baked* dist-info rather than the live `jac/jac.toml`, so `jac --version` could report an old number (e.g. `0.16.7`) while `jac.toml` says `0.30.2`.

## How

- Add a single `jac_version()` resolver (declared in `cli.jac`, implemented in `cli.impl.jac`), used at both display sites — the version banner and the main help header (DRY).
- In dev mode it reads `$JAC_DEV_SOURCE/jac.toml` through the canonical `JacConfig` parser (no hand-rolled TOML); otherwise it falls back to `importlib.metadata.version('jaclang')`.
- `jac.toml`'s `[project] version` remains the single source of truth on both paths.
- Remove the `Python X.Y.Z` line (and the now-unused `import sys`) from `print_version_banner`.

## Before / after (dev mode)

```
# before
... Version:  0.16.7
... Python 3.14.6
... Platform: macOS arm64

# after
... Version:  0.30.2
... Platform: macOS arm64
```

## Verification

- `jac --version` in dev mode now prints `0.30.2` (from `jac/jac.toml`) and omits the Python line.
- `jac format --check --lintfix` passes on all three files.
- `jac check` adds zero new errors vs the base.