### PR TITLE
refactor(lint): deslop test-pinned source files and retarget the tests at real code

### DIFF
--- a/jac.toml
+++ b/jac.toml
@@ -28,19 +28,9 @@ exclude = [
     #  - jir_registry.jac is generated (jac gen-jir-registry) and must match its
     #    commented output;
     #  - plugin_bridge.na.jac carries functional `# --- BRIDGE ... ---` markers the
-    #    native bridge extractor reads;
-    #  - the rest carry exact source locations / source strings that langserve and
-    #    runtime tests assert against.
+    #    native bridge extractor reads.
     "jir_registry.jac",
     "plugin_bridge.na.jac",
-    "constant.jac",
-    "unitree.jac",
-    "type_utils.jac",
-    "types.jac",
-    "mobile_target.impl.jac",
-    "cli.jac",
-    "dev.jac",
-    "lsp/server.jac",
 ]
 
 [plugins.byllm.model]

--- a/jac/jac.toml
+++ b/jac/jac.toml
@@ -46,17 +46,7 @@ exclude = [
     #  - jir_registry.jac is generated (jac gen-jir-registry) and must match its
     #    commented output;
     #  - plugin_bridge.na.jac carries functional `# --- BRIDGE ... ---` markers the
-    #    native bridge extractor reads;
-    #  - the rest carry exact source locations / source strings that langserve and
-    #    runtime tests assert against.
+    #    native bridge extractor reads.
     "jir_registry.jac",
     "plugin_bridge.na.jac",
-    "constant.jac",
-    "unitree.jac",
-    "type_utils.jac",
-    "types.jac",
-    "mobile_target.impl.jac",
-    "cli.jac",
-    "dev.jac",
-    "lsp/server.jac",
 ]

--- a/jac/jaclang/compiler/passes/native/llvm/ir/types.jac
+++ b/jac/jaclang/compiler/passes/native/llvm/ir/types.jac
@@ -1,15 +1,10 @@
-"""
-Classes that are LLVM types
-"""
 import struct;
 import from jaclang.compiler.passes.native.llvm { ir_layer_typed_pointers_enabled }
 import from jaclang.compiler.passes.native.llvm.ir._utils { _StrCaching }
 def _wrapname(x: Any) -> object {
     return '"{0}"'.format(x.replace('\\', '\\5c').replace('"', '\\22'));
 }
-"""
-    The base class for all LLVM types.
-    """
+
 class Type(_StrCaching) {
     with entry {
         is_pointer = False;
@@ -19,18 +14,19 @@ class Type(_StrCaching) {
     def __repr__(self: Type) -> object {
         return ("<%s %s>" % (`type(self), str(self)));
     }
+
     def _to_string(self: Type) -> object {
         raise NotImplementedError;
     }
+
     def as_pointer(self: Type, addrspace: Any = 0) -> object {
         return PointerType(self, addrspace);
     }
+
     def __ne__(self: Type, other: Any) -> object {
         return not (self == other);
     }
-    """
-        Convert this type object to an LLVM type.
-        """
+
     def _get_ll_global_value_type(
         self: Type, target_data: Any, context: Any = None
     ) -> object {
@@ -47,9 +43,6 @@ class Type(_StrCaching) {
         }
     }
 
-    """
-        Get the ABI size of this type according to data layout *target_data*.
-        """
     def get_abi_size(self: Type, target_data: Any, context: Any = None) -> object {
         llty = self._get_ll_global_value_type(target_data, context);
         return target_data.get_abi_size(llty);
@@ -61,34 +54,20 @@ class Type(_StrCaching) {
         llty = self._get_ll_global_value_type(target_data, context);
         return target_data.get_element_offset(llty, ndx);
     }
-    """
-        Get the minimum ABI alignment of this type according to data layout
-        *target_data*.
-        """
+
     def get_abi_alignment(self: Type, target_data: Any, context: Any = None) -> object {
         llty = self._get_ll_global_value_type(target_data, context);
         return target_data.get_abi_alignment(llty);
     }
 
-    """
-        Format constant *value* of this type.  This method may be overriden
-        by subclasses.
-        """
     def format_constant(self: Type, value: Any) -> object {
         return str(value);
     }
 
-    """
-        Wrap constant *value* if necessary.  This method may be overriden
-        by subclasses (especially aggregate types).
-        """
     def wrap_constant_value(self: Type, value: Any) -> object {
         return value;
     }
 
-    """
-        Create a LLVM constant of this type with the given Python value.
-        """
     def __call__(self: Type, value: Any) -> object {
         import from jaclang.compiler.passes.native.llvm.ir { Constant }
         return Constant(self, value);
@@ -99,29 +78,26 @@ class MetaDataType(Type) {
     def _to_string(self: MetaDataType) -> object {
         return "metadata";
     }
+
     def as_pointer(self: MetaDataType) -> object {
         raise TypeError;
     }
+
     def __eq__(self: MetaDataType, other: Any) -> object {
         return isinstance(other, MetaDataType);
     }
+
     def __hash__(self: MetaDataType) -> object {
         return hash(MetaDataType);
     }
 }
-"""
-    The label type is the type of e.g. basic blocks.
-    """
+
 class LabelType(Type) {
     def _to_string(self: LabelType) -> object {
         return "label";
     }
 }
 
-"""
-    The type of all pointer values.
-    By default (without specialisation) represents an opaque pointer.
-    """
 class PointerType(Type) {
     with entry {
         is_opaque = True;
@@ -139,10 +115,12 @@ class PointerType(Type) {
         }
         return super.__new__(cls);
     }
+
     def init(self: PointerType, pointee: Any = None, addrspace: Any = 0) -> object {
         assert ((pointee is None) or (`type(pointee) is PointerType));
         self.addrspace = addrspace;
     }
+
     def _to_string(self: PointerType) -> object {
         if (self.addrspace != 0) {
             return "ptr addrspace({0})".format(self.addrspace);
@@ -150,24 +128,21 @@ class PointerType(Type) {
             return "ptr";
         }
     }
+
     def __eq__(self: PointerType, other: Any) -> object {
         return (isinstance(other, PointerType) and (self.addrspace == other.addrspace));
     }
+
     def __hash__(self: PointerType) -> object {
         return hash(PointerType);
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         return cls();
     }
 }
 
-"""
-    The type of typed pointer values. To be removed eventually.
-    """
 class _TypedPointerType(PointerType) {
     def init(self: _TypedPointerType, pointee: Any, addrspace: Any = 0) -> object {
         super.init(None, addrspace);
@@ -176,6 +151,7 @@ class _TypedPointerType(PointerType) {
         self.pointee = pointee;
         self.is_opaque = False;
     }
+
     def _to_string(self: _TypedPointerType) -> object {
         if ir_layer_typed_pointers_enabled {
             return "{0}*".format(self.pointee)
@@ -184,18 +160,18 @@ class _TypedPointerType(PointerType) {
         }
         return super._to_string();
     }
+
     def __eq__(self: _TypedPointerType, other: Any) -> object {
         if isinstance(other, _TypedPointerType) {
             return ((self.pointee, self.addrspace) == (other.pointee, other.addrspace));
         }
         return (isinstance(other, PointerType) and (self.addrspace == other.addrspace));
     }
+
     def __hash__(self: _TypedPointerType) -> object {
         return hash(_TypedPointerType);
     }
-    """
-        Resolve the type of the i-th element (for getelementptr lookups).
-        """
+
     def gep(self: _TypedPointerType, i: Any) -> object {
         if not isinstance(i.type, IntType) {
             raise TypeError(i.type);
@@ -204,31 +180,25 @@ class _TypedPointerType(PointerType) {
     }
 }
 
-"""
-    The type for empty values (e.g. a function returning no value).
-    """
 class VoidType(Type) {
     def _to_string(self: VoidType) -> object {
         return 'void';
     }
+
     def __eq__(self: VoidType, other: Any) -> object {
         return isinstance(other, VoidType);
     }
+
     def __hash__(self: VoidType) -> object {
         return hash(VoidType);
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         return cls();
     }
 }
 
-"""
-    The type for functions.
-    """
 class FunctionType(Type) {
     def init(
         self: FunctionType, return_type: Any, args: Any, var_arg: Any = False
@@ -237,6 +207,7 @@ class FunctionType(Type) {
         self.args = `tuple(args);
         self.var_arg = var_arg;
     }
+
     def _to_string(self: FunctionType) -> object {
         if self.args {
             strargs = ', '.join([str(a) for a in self.args]);
@@ -251,6 +222,7 @@ class FunctionType(Type) {
             return '{0} ()'.format(self.return_type);
         }
     }
+
     def __eq__(self: FunctionType, other: Any) -> object {
         if isinstance(other, FunctionType) {
             return (
@@ -262,12 +234,11 @@ class FunctionType(Type) {
             return False;
         }
     }
+
     def __hash__(self: FunctionType) -> object {
         return hash(FunctionType);
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         params = `tuple(
@@ -279,9 +250,6 @@ class FunctionType(Type) {
     }
 }
 
-"""
-    The type for integers.
-    """
 class IntType(Type) {
     with entry {
         null = '0';
@@ -300,6 +268,7 @@ class IntType(Type) {
         }
         return cls.__new(bits);
     }
+
     @classmethod
     def __new(cls: Any, bits: Any) -> object {
         assert (isinstance(bits, int) and (bits >= 0));
@@ -307,15 +276,19 @@ class IntType(Type) {
         self.width = bits;
         return self;
     }
+
     def __getnewargs__(self: IntType) -> object {
         return (self.width, );
     }
+
     def __copy__(self: IntType) -> object {
         return self;
     }
+
     def _to_string(self: IntType) -> object {
         return ('i%u' % (self.width, ));
     }
+
     def __eq__(self: IntType, other: Any) -> object {
         if isinstance(other, IntType) {
             return (self.width == other.width);
@@ -323,9 +296,11 @@ class IntType(Type) {
             return False;
         }
     }
+
     def __hash__(self: IntType) -> object {
         return hash(IntType);
     }
+
     def format_constant(self: IntType, val: Any) -> object {
         if isinstance(val, bool) {
             return str(val).lower();
@@ -333,31 +308,24 @@ class IntType(Type) {
             return str(val);
         }
     }
+
     def wrap_constant_value(self: IntType, val: Any) -> object {
         if (val is None) {
             return 0;
         }
         return val;
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         return IntType(typeref.type_width);
     }
 }
 
-"""
-    Truncate to single-precision float.
-    """
 def _as_float(value: Any) -> object {
     return struct.unpack('f', struct.pack('f', value))[0];
 }
 
-"""
-    Truncate to half-precision float.
-    """
 def _as_half(value: Any) -> object {
     try {
         return struct.unpack('e', struct.pack('e', value))[0];
@@ -374,10 +342,7 @@ def _format_float_as_hex(
     out = '{{0:#{0}x}}'.format(numdigits).format(intrep);
     return out;
 }
-"""
-    Format *value* as a hexadecimal string of its IEEE double precision
-    representation.
-    """
+
 def _format_double(value: Any) -> object {
     return _format_float_as_hex(value, 'd', 'Q', 16);
 }
@@ -386,28 +351,26 @@ class _BaseFloatType(Type) {
     def __new__(cls: Any) -> object {
         return cls._instance_cache;
     }
+
     def __eq__(self: _BaseFloatType, other: Any) -> object {
         return isinstance(other, `type(self));
     }
+
     def __hash__(self: _BaseFloatType) -> object {
         return hash(`type(self));
     }
+
     @classmethod
     def _create_instance(cls: Any) -> object {
         cls._instance_cache = super.__new__(cls);
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         return cls();
     }
 }
 
-"""
-    The type for single-precision floats.
-    """
 class HalfType(_BaseFloatType) {
     with entry {
         null = '0.0';
@@ -416,14 +379,12 @@ class HalfType(_BaseFloatType) {
     def __str__(self: HalfType) -> object {
         return 'half';
     }
+
     def format_constant(self: HalfType, value: Any) -> object {
         return _format_double(_as_half(value));
     }
 }
 
-"""
-    The type for single-precision floats.
-    """
 class FloatType(_BaseFloatType) {
     with entry {
         null = '0.0';
@@ -432,14 +393,12 @@ class FloatType(_BaseFloatType) {
     def __str__(self: FloatType) -> object {
         return 'float';
     }
+
     def format_constant(self: FloatType, value: Any) -> object {
         return _format_double(_as_float(value));
     }
 }
 
-"""
-    The type for double-precision floats.
-    """
 class DoubleType(_BaseFloatType) {
     with entry {
         null = '0.0';
@@ -448,6 +407,7 @@ class DoubleType(_BaseFloatType) {
     def __str__(self: DoubleType) -> object {
         return 'double';
     }
+
     def format_constant(self: DoubleType, value: Any) -> object {
         return _format_double(value);
     }
@@ -458,14 +418,17 @@ with entry {
         _cls._create_instance();
     }
 }
+
 class _Repeat(object) {
     def init(self: _Repeat, value: Any, size: Any) -> object {
         self.value = value;
         self.size = size;
     }
+
     def __len__(self: _Repeat) -> object {
         return self.size;
     }
+
     def __getitem__(self: _Repeat, item: Any) -> object {
         if (0 <= item < self.size) {
             return self.value;
@@ -474,41 +437,48 @@ class _Repeat(object) {
         }
     }
 }
-"""
-    The type for vectors of primitive data items (e.g. "<f32 x 4>").
-    """
+
 class VectorType(Type) {
     def init(self: VectorType, element: Any, count: Any) -> object {
         self.element = element;
         self.count = count;
     }
-    @property
-    def elements(self: VectorType) -> object {
-        return _Repeat(self.element, self.count);
+
+    has elements: object {
+        getter {
+            return _Repeat(self.element, self.count);
+        }
     }
+
     def __len__(self: VectorType) -> object {
         return self.count;
     }
+
     def _to_string(self: VectorType) -> object {
         return ("<%d x %s>" % (self.count, self.element));
     }
+
     def __eq__(self: VectorType, other: Any) -> object {
         if isinstance(other, VectorType) {
             return ((self.element == other.element) and (self.count == other.count));
         }
     }
+
     def __hash__(self: VectorType) -> object {
         return hash(VectorType);
     }
+
     def __copy__(self: VectorType) -> object {
         return self;
     }
+
     def format_constant(self: VectorType, value: Any) -> object {
         itemstring = ", ".join(
             ["{0} {1}".format(x.type, x.get_reference()) for x in value]
         );
         return "<{0}>".format(itemstring);
     }
+
     def wrap_constant_value(self: VectorType, values: Any) -> object {
         import from jaclang.compiler.passes.native.llvm.ir { Value, Constant }
         if not isinstance(values, (`list, `tuple)) {
@@ -532,9 +502,7 @@ class VectorType(Type) {
             for (ty, val) in zip(self.elements, values)
         ];
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         [elemtyperef] = typeref.elements;
@@ -544,10 +512,6 @@ class VectorType(Type) {
     }
 }
 
-"""
-    Base class for aggregate types.
-    See http://llvm.org/docs/LangRef.html#t-aggregate
-    """
 class Aggregate(Type) {
     def wrap_constant_value(self: Aggregate, values: Any) -> object {
         import from jaclang.compiler.passes.native.llvm.ir { Value, Constant }
@@ -566,35 +530,36 @@ class Aggregate(Type) {
     }
 }
 
-"""
-    The type for fixed-size homogenous arrays (e.g. "[f32 x 3]").
-    """
 class ArrayType(Aggregate) {
     def init(self: ArrayType, element: Any, count: Any) -> object {
         self.element = element;
         self.count = count;
     }
-    @property
-    def elements(self: ArrayType) -> object {
-        return _Repeat(self.element, self.count);
+
+    has elements: object {
+        getter {
+            return _Repeat(self.element, self.count);
+        }
     }
+
     def __len__(self: ArrayType) -> object {
         return self.count;
     }
+
     def _to_string(self: ArrayType) -> object {
         return ("[%d x %s]" % (self.count, self.element));
     }
+
     def __eq__(self: ArrayType, other: Any) -> object {
         if isinstance(other, ArrayType) {
             return ((self.element == other.element) and (self.count == other.count));
         }
     }
+
     def __hash__(self: ArrayType) -> object {
         return hash(ArrayType);
     }
-    """
-        Resolve the type of the i-th element (for getelementptr lookups).
-        """
+
     def gep(self: ArrayType, i: Any) -> object {
         if not isinstance(i.type, IntType) {
             raise TypeError(i.type);
@@ -608,9 +573,7 @@ class ArrayType(Aggregate) {
         );
         return "[{0}]".format(itemstring);
     }
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
+
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         [elemtyperef] = typeref.elements;
@@ -620,42 +583,36 @@ class ArrayType(Aggregate) {
     }
 }
 
-"""
-    The base type for heterogenous struct types.
-    """
 class BaseStructType(Aggregate) {
     with entry {
         _packed = False;
     }
 
-    """
-        A boolean attribute that indicates whether the structure uses
-        packed layout.
-        """
-    @property
-    def packed(self: BaseStructType) -> object {
-        return self._packed;
+    has packed: object {
+        getter {
+            return self._packed;
+        }
+        setter(self: BaseStructType, val: Any) -> object {
+            self._packed = bool(val);
+        }
     }
 
-    @packed.setter
-    def packed(self: BaseStructType, val: Any) -> object {
-        self._packed = bool(val);
-    }
     def __len__(self: BaseStructType) -> object {
         assert (self.elements is not None);
         return len(self.elements);
     }
+
     def __iter__(self: BaseStructType) -> object {
         assert (self.elements is not None);
         return iter(self.elements);
     }
-    @property
-    def is_opaque(self: BaseStructType) -> object {
-        return (self.elements is None);
+
+    has is_opaque: object {
+        getter {
+            return (self.elements is None);
+        }
     }
-    """
-        Return the LLVM IR for the structure representation
-        """
+
     def structure_repr(self: BaseStructType) -> object {
         ret = '{%s}' % ', '.join([str(x) for x in self.elements]);
         return self._wrap_packed(ret);
@@ -668,12 +625,7 @@ class BaseStructType(Aggregate) {
         ret = "{{{0}}}".format(itemstring);
         return self._wrap_packed(ret);
     }
-    """
-        Resolve the type of the i-th element (for getelementptr lookups).
 
-        *i* needs to be a LLVM constant, so that the type can be determined
-        at compile-time.
-        """
     def gep(self: BaseStructType, i: Any) -> object {
         if not isinstance(i.type, IntType) {
             raise TypeError(i.type);
@@ -681,9 +633,6 @@ class BaseStructType(Aggregate) {
         return self.elements[i.constant];
     }
 
-    """
-        Internal helper to wrap textual repr of struct type into packed struct
-        """
     def _wrap_packed(self: BaseStructType, textrepr: Any) -> object {
         if self.packed {
             return '<{}>'.format(textrepr);
@@ -692,9 +641,6 @@ class BaseStructType(Aggregate) {
         }
     }
 
-    """
-        Create from a jaclang.compiler.passes.native.llvm.binding.TypeRef
-        """
     @classmethod
     def from_llvm(cls: Any, typeref: Any, ir_ctx: Any) -> object {
         if typeref.is_literal_struct {
@@ -706,19 +652,11 @@ class BaseStructType(Aggregate) {
     }
 }
 
-"""
-    The type of "literal" structs, i.e. structs with a literally-defined
-    type (by contrast with IdentifiedStructType).
-    """
 class LiteralStructType(BaseStructType) {
     with entry {
         null = 'zeroinitializer';
     }
 
-    """
-        *elems* is a sequence of types to be used as members.
-        *packed* controls the use of packed layout.
-        """
     def init(self: LiteralStructType, elems: Any, packed: Any = False) -> object {
         self.elements = `tuple(elems);
         self.packed = packed;
@@ -727,6 +665,7 @@ class LiteralStructType(BaseStructType) {
     def _to_string(self: LiteralStructType) -> object {
         return self.structure_repr();
     }
+
     def __eq__(self: LiteralStructType, other: Any) -> object {
         if isinstance(other, LiteralStructType) {
             return (
@@ -734,28 +673,17 @@ class LiteralStructType(BaseStructType) {
             );
         }
     }
+
     def __hash__(self: LiteralStructType) -> object {
         return hash(LiteralStructType);
     }
 }
 
-"""
-    A type which is a named alias for another struct type, akin to a typedef.
-    While literal struct types can be structurally equal (see
-    LiteralStructType), identified struct types are compared by name.
-
-    Do not use this directly.
-    """
 class IdentifiedStructType(BaseStructType) {
     with entry {
         null = 'zeroinitializer';
     }
 
-    """
-        *context* is a jaclang.compiler.passes.native.llvm.ir.Context.
-        *name* is the identifier for the new struct type.
-        *packed* controls the use of packed layout.
-        """
     def init(
         self: IdentifiedStructType, context: Any, name: Any, packed: Any = False
     ) -> object {
@@ -769,9 +697,7 @@ class IdentifiedStructType(BaseStructType) {
     def _to_string(self: IdentifiedStructType) -> object {
         return "%{name}".format(name=_wrapname(self.name));
     }
-    """
-        Returns the string for the declaration of the type
-        """
+
     def get_declaration(self: IdentifiedStructType) -> object {
         if self.is_opaque {
             out = "{strrep} = type opaque".format(strrep=str(self));
@@ -788,9 +714,11 @@ class IdentifiedStructType(BaseStructType) {
             return ((self.name == other.name) and (self.packed == other.packed));
         }
     }
+
     def __hash__(self: IdentifiedStructType) -> object {
         return hash(IdentifiedStructType);
     }
+
     def set_body(self: IdentifiedStructType, *elems: Any) -> object {
         if not self.is_opaque {
             raise RuntimeError("{name} is already defined".format(name=self.name));
@@ -798,4 +726,3 @@ class IdentifiedStructType(BaseStructType) {
         self.elements = `tuple(elems);
     }
 }
-

--- a/jac/jaclang/compiler/type_system/type_utils.jac
+++ b/jac/jaclang/compiler/type_system/type_utils.jac
@@ -1,21 +1,9 @@
-"""
-Functions that operate on Type objects.
-
-PyrightReference: packages/pyright-internal/src/analyzer/typeUtils.ts
-"""
 import from enum { Enum }
 import jaclang.jac0core.unitree as uni;
 import from jaclang.jac0core.constant { Tokens as Tok }
 import from jaclang.jac0core.unitree { Symbol }
 import from . { types }
-"""Result of get_property_write_type: classifies the assignment target.
 
-NOT_PROPERTY  — symbol is not @property / @cached_property; fall through
-               to the normal declared-type path.
-READ_ONLY     — @property with no setter; assignment is illegal.
-WRITABLE      — @cached_property or @property with setter; `write_type`
-               holds the type that values must match.
-"""
 class PropertyWriteKind(Enum) {
     with entry {
         NOT_PROPERTY = 0;
@@ -29,7 +17,6 @@ obj PropertyWriteResult {
         write_type: (types.TypeBase | None) = None;
 }
 
-"""Represents a member of a class."""
 obj ClassMember {
     has symbol: Symbol,
         class_type: types.ClassType,
@@ -45,48 +32,14 @@ obj ClassMember {
 
 def compute_mro_linearization(cls: types.ClassType) -> None;
 
-"""Resolve a type to its primitive type name (str/int/list/...), or None.
-
-Returns the primitive name if `ty` is a primitive `ClassType` (per
-JAC_TYPE_REGISTRY), walking the MRO so subtypes like `LiteralString` resolve to
-`str`. The single source of truth for "what primitive is this type", shared by
-codegen backends instead of each re-deriving it.
-"""
 def primitive_type_name_of(ty: (types.TypeBase | None)) -> (str | None);
 
-"""
-Primitive type name of an EXPRESSION, resolved through the program's type
-authority, or "" when unknown.
-
-This is the sanctioned codegen-time read of expression types: the
-evaluator is the single type authority and `Expr.type` is its
-memoization, populated lazily - checking stamps what its rules evaluate,
-and the first query for anything else computes and caches it (diagnostics
-from such late queries are deferred/managed by the checker's reporter
-machinery, see TypeCheckPass.emit). Backends call this instead of
-importing the evaluator, so expression-type derivation has exactly one
-owner. (Measured across the ES + OSP corpora: a stamp, when present,
-never disagrees with the evaluator - the lazy query only ever fills
-gaps.)
-"""
 def expr_primitive_name(prog: object, expr_node: uni.UniNode) -> str;
 
-"""
-Tracks parameter assignments for function calls.
-
-    This class helps in tracking which parameters have been matched
-    with arguments in a function call. It supports positional, named,
-    *args, and **kwargs arguments.
-"""
 obj ParamAssignmentTracker {
     has params: list[types.Parameter],
         curr_param_idx: int = 0,
         matched_params: set[types.Parameter] = set(),
-        # Params *possibly* filled by a `*`/`**` spread of statically-unknown
-        # contents. Kept apart from `matched_params` (definite positional/keyword
-        # binds): a spread satisfies required-param checks but must NOT trigger a
-        # duplicate-argument error for a later explicit keyword, since we cannot
-        # prove the spread actually set that key.
         spread_filled: set[types.Parameter] = set(),
         varargs: (types.Parameter | None) = None,
         kwargs: (types.Parameter | None) = None;
@@ -100,14 +53,12 @@ obj ParamAssignmentTracker {
     def get_unmatched_required_params -> list[types.Parameter];
 }
 
-"""A completion item."""
 obj CompletionItem {
     has label: str,
         kind: int,
         detail: (str | None) = None;
 }
 
-"""The kind of a completion entry."""
 enum CompletionItemKind {
     Text = 1,
     Method = 2,
@@ -146,8 +97,6 @@ def lookup_symtab(
     symtable: uni.UniScopeNode, name: str, builtins_to_inject: uni.Module
 ) -> (Symbol | None);
 
-"""Collect a name's [primary, *overloads], descending only the statically-live
-branch of `if`/`elif`/`else` guards so dead-branch declarations don't resolve."""
 def collect_member_syms(
     scope: uni.UniScopeNode, name: str, deep: bool = False
 ) -> list[Symbol];
@@ -156,93 +105,45 @@ def class_implements_protocol(
     cls: types.ClassType, proto: types.ClassType, evaluator: any = None
 ) -> bool;
 
-# Generator / Iterator return-type helpers.
-"""Type args of Generator/AsyncGenerator/AwaitableGenerator, or None."""
 def get_generator_type_args(
     return_type: types.TypeBase
 ) -> (list[types.TypeBase] | None);
 
-"""Yield type Y of a generator-like return type, or None.
-
-`is_async` selects the `Async*` family; otherwise the sync family
-(Generator/Iterator/Iterable/AwaitableGenerator).
-"""
 def get_generator_yield_type(
     declared_return_type: types.TypeBase, is_async: bool
 ) -> (types.TypeBase | None);
 
-"""R parameter of Generator[Y, S, R] (send/return), or None."""
 def get_declared_generator_return_type(
     return_type: types.TypeBase
 ) -> (types.TypeBase | None);
 
-"""True if `return_type` is any generator/iterator-family builtin."""
 def is_generator_family_type(return_type: types.TypeBase) -> bool;
 
-"""
-Module source flags computed from file path.
-
-Similar to Pyright's SourceFileInfo flags (_isStubFile, _isTypingStubFile, etc.).
-These flags are computed once when a module is loaded and stored on ModuleType.
-"""
 obj ModuleSourceFlags {
-    has is_stub_file: bool = False,  # True if .pyi file
-        is_stdlib_stub: bool = False,  # True if from vendor/typeshed/stdlib/
-        is_typing_stub: bool = False,  # True if typing.pyi or typing_extensions.pyi
-        is_builtin_stub: bool = False;  # True if builtins.pyi, abc.pyi, etc.
+    has is_stub_file: bool = False,
+        is_stdlib_stub: bool = False,
+        is_typing_stub: bool = False,
+        is_builtin_stub: bool = False;
 }
 
 def compute_module_source_flags(file_path: str) -> ModuleSourceFlags;
 
-# -------------------------------------------------------------------------
-# Type specialization utilities
-# -------------------------------------------------------------------------
-"""
-Convert a type to its instance form.
-
-- ClassType (instantiable) -> ClassType (instance)
-- UnionType -> converted members
-- Other types -> unchanged
-"""
 def convert_to_instance(ty: types.TypeBase) -> types.TypeBase;
 
-"""Synthesize the implicit `Self` TypeVar marker.
-
-The marker is keyed by `is_self=True`. The binding context (which class
-`Self` resolves to) is supplied by the caller of `apply_solved_type_vars`.
-"""
 def synthesize_self_type_var -> types.TypeVarType;
 
-"""
-Apply type variable substitutions to a type.
-
-This is the unified function for TypeVar substitution. It handles:
-- Direct TypeVarType -> lookup in solution or class type_args
-- Self type -> class_type instance
-- Nested TypeVars in ClassType (e.g., tuple[int, T] -> tuple[int, Item])
-- UnionType -> specialize each member
-- FunctionType -> specialize parameters and return type
-"""
 def apply_solved_type_vars(
     ty: types.TypeBase,
     solution: dict[str, types.TypeBase],
     class_type: (types.ClassType | None) = None
 ) -> types.TypeBase;
 
-"""
-Build a cumulative TypeVar name -> concrete type mapping for a specialized class.
-
-Walks the MRO accumulating bindings so that inherited TypeVars are resolved
-transitively. Used by specialize_member_type and FunctionType.specialize.
-"""
 def build_type_var_solution(class_type: types.ClassType) -> dict[str, types.TypeBase];
 
-"""Build type_params → type_args mapping from a specialized class."""
 def build_solution_from_specialized_class(
     class_type: types.ClassType
 ) -> dict[str, types.TypeBase];
 
-"""Specialize a base class using type args from the derived class."""
 def specialize_for_base_class(
     src_type: types.ClassType, base_class: types.ClassType
 ) -> types.ClassType;

--- a/jac/jaclang/compiler/type_system/types.jac
+++ b/jac/jaclang/compiler/type_system/types.jac
@@ -1,4 +1,3 @@
-"""Representation of types used during type analysis."""
 import from abc { ABC }
 import from enum { IntEnum, auto }
 import from pathlib { Path }
@@ -6,7 +5,6 @@ import from typing { ClassVar }
 import type from jaclang.jac0core.unitree { Expr, Symbol }
 import type from jaclang.jac0core.unitree { UniScopeNode as SymbolTable }
 
-"""Enumeration of type categories."""
 enum TypeCategory(IntEnum) {
     Unbound,
     Unknown,
@@ -21,19 +19,6 @@ enum TypeCategory(IntEnum) {
     EnumMember
 }
 
-"""
-Flags to set on a type.
-
-    foo = 42  # <-- Here type of foo is `int` class, Instance type.
-    foo = int # <-- Here type of foo is `type[int]`, Instantiable is set.
-    foo: int = 42
-         ^^^------- Here the type of the expression `int` is `type[int]`
-                    That is same as the prefetched int_class that has the
-                    flag Instantiable set.
-
-                    calling convertToInstance() will return the same type
-                    with Instance flag set.
-"""
 class TypeFlags(IntEnum) {
     with entry {
         Null = 0;
@@ -43,7 +28,6 @@ class TypeFlags(IntEnum) {
     }
 }
 
-"""Enumeration of parameter categories."""
 class ParameterCategory(IntEnum) {
     with entry {
         Positional = auto();
@@ -52,13 +36,6 @@ class ParameterCategory(IntEnum) {
     }
 }
 
-"""
-Maps to pyright's TypeBase<T> in the types.ts file.
-
-    This is the base class for all type instance of the jaclang that holds
-    information about the type's category and any additional metadata and
-    utilities to analyze type information and provide type checking.
-"""
 obj TypeBase(ABC) {
     has flags: TypeFlags = TypeFlags.Null;
 
@@ -68,10 +45,6 @@ obj TypeBase(ABC) {
 
     has category: TypeCategory { getter; }
 
-    # Canonical, stable string key for this type ("int", "list[int]",
-    # "dict[str,MyStruct]"). The ONLY string form of a type intended for
-    # keying (backend emission caches, layout tables, cached semantics);
-    # `__str__` stays the human-facing display form.
     def mangle -> str;
     def is_instantiable -> bool;
     def is_instance -> bool;
@@ -80,7 +53,6 @@ obj TypeBase(ABC) {
     def is_any_type -> bool;
 }
 
-"""Represents a type that is not bound to a specific value or context."""
 obj UnboundType(TypeBase) {
     with entry {
         CATEGORY: ClassVar[TypeCategory] = TypeCategory.Unbound;
@@ -89,7 +61,6 @@ obj UnboundType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a type that is not known or cannot be determined."""
 obj UnknownType(TypeBase) {
     with entry {
         CATEGORY: ClassVar[TypeCategory] = TypeCategory.Unknown;
@@ -98,7 +69,6 @@ obj UnknownType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a type that can never occur."""
 obj NeverType(TypeBase) {
     with entry {
         CATEGORY: ClassVar[TypeCategory] = TypeCategory.Never;
@@ -107,7 +77,6 @@ obj NeverType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a type that can be anything."""
 obj AnyType(TypeBase) {
     with entry {
         CATEGORY: ClassVar[TypeCategory] = TypeCategory.Any;
@@ -116,20 +85,14 @@ obj AnyType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a module type."""
 obj ModuleType(TypeBase) {
     has mod_name: str = "",
         file_uri: Path = Path(""),
         symbol_table: SymbolTable | None = None,
-        # Module source flags (similar to Pyright's SourceFileInfo)
-        # These are computed once when the module is loaded based on file path.
-        is_stub_file: bool = False,  # True if .pyi file
-        is_stdlib_stub: bool = False,  # True if from vendor/typeshed/stdlib/
-        is_typing_stub: bool = False,  # True if typing.pyi or typing_extensions.pyi
-        is_builtin_stub: bool = False,  # True if builtins.pyi, abc.pyi, etc.
-        # True for modules backed by a file in a language the Jac compiler
-        # cannot parse (e.g. .js/.ts/.css/assets). Lookups against these
-        # modules yield AnyType (gradual) instead of erroring on missing names.
+        is_stub_file: bool = False,
+        is_stdlib_stub: bool = False,
+        is_typing_stub: bool = False,
+        is_builtin_stub: bool = False,
         is_external: bool = False;
 
     with entry {
@@ -139,16 +102,6 @@ obj ModuleType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a type variable.
-
-TypeVarType supports two mutually exclusive constraint modes:
-1. bound - TypeVar("T", bound=Foo) means T can be Foo or any subclass
-2. constraints - TypeVar("T", Foo, Bar) means T must be exactly Foo or Bar
-
-The is_class_type_param flag distinguishes:
-- Class type parameters (T from class Foo[T]) - should be substituted during specialization
-- Module-level TypeVars (glob T = TypeVar('T', bound=int)) - should NOT be substituted
-"""
 obj TypeVarType(TypeBase) {
     has name: str = "",
         is_covariant: bool = False,
@@ -166,15 +119,7 @@ obj TypeVarType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a class type."""
 obj ClassType(TypeBase) {
-    # `private` is per-instance and always populated (the default
-    # factory creates a fresh `ClassDetailsPrivate` for every instance
-    # that doesn't override it).  `_shared` may legitimately be None
-    # for detached property ClassTypes produced by `create_property`
-    # without an enclosing class context — read `_shared` directly
-    # when handling that case, or use the `shared` accessor (which
-    # asserts non-null) for the common case.
     has _shared: (ClassType.ClassDetailsShared | None) = None,
         private: ClassType.ClassDetailsPrivate = ClassType.ClassDetailsPrivate();
 
@@ -184,13 +129,6 @@ obj ClassType(TypeBase) {
 
     has shared: ClassType.ClassDetailsShared { getter; }
 
-    """
-Holds the shared details of class type.
-
-        The shared detail of classes will points to the same instance across multiple clones
-        of the same class. This is needed when we do `==` between two classes, if they have the
-        same shared object, that means they both are the same class (with different context).
-    """
     obj ClassDetailsShared {
         has class_name: str,
             symbol_table: SymbolTable,
@@ -198,11 +136,10 @@ Holds the shared details of class type.
             type_params: (list[TypeVarType] | None) = None,
             base_classes: (list[TypeBase] | None) = None,
             is_builtin_class: bool = False,
-            is_from_stdlib_stub: bool = False,  # True if from vendor/typeshed/stdlib/
+            is_from_stdlib_stub: bool = False,
             is_data_class: bool = False,
             is_namedtuple: bool = False,
             is_typeddict: bool = False,
-            # Ordered field name -> declared value type; None for non-TypedDicts.
             typeddict_fields: (dict[str, TypeBase] | None) = None,
             is_root_class: bool = False,
             is_enum_class: bool = False,
@@ -212,20 +149,9 @@ Holds the shared details of class type.
         def postinit -> None;
     }
 
-    """
-Holds the private details of class type.
-
-        The private details of classes will be unique to each class instance.
-    """
     obj ClassDetailsPrivate {
         has type_args: (list[TypeBase] | None) = None,
-            # Alias name for special forms (e.g., "Callable", "Union").
-            # This is set when loading special forms from typing module
-            # to distinguish between different _SpecialForm instances.
             alias_name: (str | None) = None,
-            # Literal value for Literal types (e.g., Literal["hello"], Literal[42]).
-            # Similar to Pyright's classType.priv.literalValue.
-            # When set, this ClassType represents a literal type like Literal["x"].
             literal_value: (str | int | bool | None) = None;
 
         def postinit -> None;
@@ -240,8 +166,6 @@ Holds the private details of class type.
         member: str, r_overloaded: list | None = None
     ) -> (Symbol | None);
 
-    # `class_name` may be a single name, a list of acceptable names, or
-    # omitted to check only the builtin flag.
     def is_builtin(class_name: (str | list[str] | None) = None) -> bool;
     def is_data_class -> bool;
     def is_namedtuple -> bool;
@@ -250,15 +174,12 @@ Holds the private details of class type.
     def is_edge_type -> bool;
     def is_node_type -> bool;
     def is_walker_type -> bool;
-    # Check if this is a special form with the given alias name (like Pyright's isSpecialBuiltIn)
     def is_special_form(name: (str | None) = None) -> bool;
-    # Literal type support (similar to Pyright's literalValue handling)
     def clone_with_literal(value: (str | int | bool | None)) -> ClassType;
     def is_literal_type -> bool;
     def get_literal_value -> (str | int | bool | None);
 }
 
-"""Enumeration of parameter kinds."""
 class ParamKind(IntEnum) {
     with entry {
         POSONLY = 0;
@@ -269,27 +190,14 @@ class ParamKind(IntEnum) {
     }
 }
 
-"""
-Based on Pyright's FunctionTypeFlags. These flags control how the
-function type behaves during type checking.
-"""
 enum FunctionTypeFlags(IntEnum) {
     Null = 0,
-    # The *args and **kwargs parameters do not need to be present for this
-    # function to be compatible. This is used for Callable[..., x] (gradual typing).
-    # When set, the function accepts any arguments.
-    # Note: In Jac, all function parameters are typed (Any if unknown), so
-    # GradualCallableForm can only come from Callable[..., T] annotations.
     GradualCallableForm = 1 << 0,
-    # Function is decorated with @staticmethod
     StaticMethod = 1 << 1,
-    # Function is decorated with @classmethod
     ClassMethod = 1 << 2,
-    # Function is a synthesized method (e.g., dataclass __init__)
     SynthesizedMethod = 1 << 3,
 }
 
-"""Represents a function parameter."""
 obj Parameter {
     has name: str,
         category: ParameterCategory,
@@ -302,24 +210,12 @@ obj Parameter {
     def clone -> Parameter;
 }
 
-"""
-This Type is used for both actual function definitions and for
-Callable type annotations.
-Callable annotations are distinguished by having an empty `func_name`.
-    - `Callable[[int, str], bool]` creates a FunctionType with empty func_name.
-    - `Callable[..., bool]` creates a FunctionType with GradualCallableForm flag.
-"""
 obj FunctionType(TypeBase) {
     has func_name: str = "",
         return_type: (TypeBase | None) = None,
         parameters: (list[Parameter] | None) = None,
-        # Using int for bitwise flag operations (FunctionTypeFlags values combined)
         function_flags: int = 0,
         type_params: (list[TypeVarType] | None) = None,
-        # True for `async def` / async abilities. A call to one evaluates to a
-        # coroutine (`Coroutine[Any, Any, return_type]`) at the call site, so
-        # callers must `await` it. The declared `return_type` itself stays the
-        # unwrapped type (it is what `return` statements are checked against).
         is_async: bool = False;
 
     with entry {
@@ -334,17 +230,11 @@ obj FunctionType(TypeBase) {
     def is_from_callable_annotation -> bool;
 }
 
-"""
-This is a factory function for creating FunctionType instances that
-represent Callable type annotations. The resulting FunctionType has
-an empty func_name to distinguish it from actual function definitions.
-"""
 def create_callable_type(
     param_types: list[TypeBase], return_type: TypeBase, is_gradual: bool = False
 ) -> FunctionType {
     parameters: list[Parameter] = [];
 
-    # Create positional-only parameters with synthesized names
     for (idx, param_type) in enumerate(param_types) {
         parameters.append(
             Parameter(
@@ -359,7 +249,6 @@ def create_callable_type(
         );
     }
 
-    # Set GradualCallableForm flag only for Callable[..., T] form
     flags: int = FunctionTypeFlags.GradualCallableForm
         if is_gradual
         else FunctionTypeFlags.Null;
@@ -372,7 +261,6 @@ def create_callable_type(
     );
 }
 
-"""Represents an overloaded type."""
 obj OverloadedType(TypeBase) {
     has overloads: (list[FunctionType] | None) = None;
 
@@ -384,7 +272,6 @@ obj OverloadedType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Represents a union type."""
 obj UnionType(TypeBase) {
     has types: (list[TypeBase] | None) = None;
 
@@ -396,14 +283,12 @@ obj UnionType(TypeBase) {
     def __str__ -> str;
 }
 
-"""Information about a specific enum member."""
 obj EnumMemberInfo {
     has member_name: str,
         value_type: (TypeBase | None) = None,
         literal_value: (int | str | None) = None;
 }
 
-"""Represents a specific enum member type (e.g., Color.RED)."""
 obj EnumMemberType(TypeBase) {
     has enum_class: (ClassType | None) = None,
         member_info: (EnumMemberInfo | None) = None;

--- a/jac/jaclang/jac0core/constant.jac
+++ b/jac/jaclang/jac0core/constant.jac
@@ -1,7 +1,5 @@
-"""Constants across the project."""
 import from enum { Enum, IntEnum, IntFlag, StrEnum }
 
-"""Symbol types."""
 enum SymbolType {
     MODULE = 'module',
     MOD_VAR = 'mod_var',
@@ -34,7 +32,6 @@ enum SymbolType {
     }
 }
 
-"""LSP Token types for Jac."""
 enum JacSemTokenType: int {
     NAMESPACE = 0,
     TYPE = 1,
@@ -69,7 +66,6 @@ enum JacSemTokenType: int {
     }
 }
 
-"""LSP Token modifiers for Jac."""
 class JacSemTokenModifier(IntFlag) {
     with entry {
         DECLARATION = 1 << 0;
@@ -84,11 +80,9 @@ class JacSemTokenModifier(IntFlag) {
         DEFAULT_LIBRARY = 1 << 9;
     }
 
-    """Return the string list of token modifiers."""
     static def as_str_list -> list[str];
 }
 
-"""Token constants for Jac."""
 class Constants(StrEnum) {
     with entry {
         HERE = 'here';
@@ -98,11 +92,9 @@ class Constants(StrEnum) {
         SUPER_ROOT_UUID = '00000000-0000-0000-0000-000000000000';
     }
 
-    """Return the string representation of the token."""
     def __str__(self: Constants) -> str;
 }
 
-"""Code execution context for client/server/native separation."""
 enum CodeContext {
     SERVER = 'server',
     CLIENT = 'client',
@@ -120,14 +112,8 @@ enum CodeContext {
     }
 }
 
-"""Edge direction indicator."""
-enum EdgeDir {
-    IN = 1,
-    OUT = 2,
-    ANY = 3
-}
+enum EdgeDir { IN = 1, OUT = 2, ANY = 3 }
 
-"""Symbol access levels."""
 enum SymbolAccess {
     PRIVATE = 'private',
     PUBLIC = 'public',
@@ -139,11 +125,6 @@ enum SymbolAccess {
     }
 }
 
-"""Where a symbol's runtime binding lives (storage class).
-
-Computed centrally from the symbol table so backends never re-derive
-scoping facts (see analysis-centralization-plan, Phase 2).
-"""
 enum SymbolStorage {
     LOCAL = 'local',
     PARAM = 'param',
@@ -157,7 +138,6 @@ enum SymbolStorage {
     }
 }
 
-"""Token constants for the lexer."""
 class Tokens(StrEnum) {
     with entry {
         FLOAT = 'FLOAT';
@@ -375,7 +355,6 @@ class Tokens(StrEnum) {
     }
 }
 
-"""Token name to string value mapping."""
 glob TOKEN_MAP: dict[str, str] = {
          'ABILITY_OP': ':can:',
          'ADD_EQ': '+=',

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -1,4 +1,3 @@
-"""Abstract class for IR Passes for Jac."""
 import ast as ast3;
 import builtins;
 import os;
@@ -33,9 +32,7 @@ import from jaclang.jac0core.treeprinter {
     printgraph_symtab_tree
 }
 
-"""Abstract syntax tree node for Jac."""
 obj UniNode {
-    """Initialize ast."""
     has kid: Sequence[UniNode] = [],
         parent: (UniNode | None) by postinit,
         __sub_node_tab: (dict[(type, list[UniNode])] | None) by postinit,
@@ -44,16 +41,7 @@ obj UniNode {
         loc: CodeLocInfo by postinit;
 
     def postinit -> None;
-    """Visitor double-dispatch hooks (generated overrides per node kind).
-
-    `UniPass.enter_node`/`exit_node` call these; the base impls route to the
-    pass's `default_enter`/`default_exit`, and each handled node kind gets a
-    generated override that calls the pass's `enter_<kind>`/`exit_<kind>`
-    ability directly -- static, native-lowerable double dispatch (#6942 A.1).
-    Regenerate overrides with `jac gen-uni-dispatch`.
-    """
     def accept_enter(v: UniPass) -> None;
-
     def accept_exit(v: UniPass) -> None;
 
     has gen: CodeGenTarget { getter; setter(value: CodeGenTarget); }
@@ -92,7 +80,6 @@ obj UniNode {
     def unparse -> str;
 }
 
-"""Symbol."""
 obj Symbol {
     has defn: list[NameAtom] by postinit,
         uses: list[NameAtom] by postinit,
@@ -120,16 +107,13 @@ obj Symbol {
     def __repr__ -> str;
 }
 
-"""Represents an inherited symbol table for selective imports."""
 obj InheritedSymbolTable {
     has base_symbol_table: UniScopeNode,
         load_all_symbols: bool = False,
         symbols: list[str] = [];
 }
 
-"""Symbol Table."""
 obj UniScopeNode(UniNode) {
-    """Initialize."""
     has scope_name: str by postinit,
         parent_scope: (UniScopeNode | None) by postinit,
         kid_scope: list[UniScopeNode] by postinit,
@@ -155,9 +139,6 @@ obj UniScopeNode(UniNode) {
     ) -> (UniNode | None);
 
     def find_scope(name: str) -> (UniScopeNode | None);
-    # Symbols defined in strictly-enclosing function-like scopes
-    # (Ability/ImplDef/LambdaExpr/Test) that are referenced inside this
-    # scope, i.e. its free variables, deduped in source order.
     def get_enclosing_captures -> list[Symbol];
     def link_kid_scope(key_node: UniScopeNode) -> UniScopeNode;
     def def_insert(
@@ -180,7 +161,6 @@ obj UniScopeNode(UniNode) {
     def __repr__ -> str;
 }
 
-"""Nodes that have link to a symbol in symbol table."""
 obj AstSymbolNode(UniNode) {
     has name_spec: NameAtom by postinit,
         semstr: str by postinit;
@@ -196,20 +176,16 @@ obj AstSymbolNode(UniNode) {
     has type_sym_tab: (UniScopeNode | None) { getter; }
 }
 
-"""Nodes that have link to a symbol in symbol table."""
 obj AstSymbolStubNode(AstSymbolNode) {
     def _init_stub(sym_type: SymbolType) -> None;
 }
 
-"""Nodes that have access."""
 obj AstAccessNode(UniNode) {
     has access: (SubTag[Token] | None) = None;
     has access_type: SymbolAccess { getter; }
     has public_access: bool { getter; }
 }
 
-"""Base class for nodes that can be marked with execution context
-(client/server)."""
 obj ContextAwareNode(UniNode) {
     has code_context: CodeContext by postinit;
 
@@ -217,34 +193,28 @@ obj ContextAwareNode(UniNode) {
     def _source_context_token -> (Token | None);
 }
 
-"""Nodes that have access."""
 obj AstDocNode(UniNode) {
     has doc: (String | None) = None;
 }
 
-"""Nodes that have access."""
 obj AstAsyncNode(UniNode) {
     has is_async: bool = False;
 }
 
-"""Nodes that have access."""
 obj AstElseBodyNode(UniNode) {
     has else_body: (ElseStmt | ElseIf | None) = None;
 }
 
-"""Nodes that have access."""
 obj AstTypedVarNode(UniNode) {
     has type_tag: (SubTag[Expr] | None) = None;
 }
 
-"""WalkerStmtOnlyNode node type for Jac Ast."""
 obj WalkerStmtOnlyNode(UniNode) {
     has from_walker: bool by postinit;
 
     def postinit -> None;
 }
 
-"""BasicBlockStmt node type for Jac Uniir."""
 obj UniCFGNode(UniNode) {
     has bb_in: list[UniCFGNode] by postinit,
         bb_out: list[UniCFGNode] by postinit,
@@ -255,8 +225,6 @@ obj UniCFGNode(UniNode) {
     def get_tail -> UniCFGNode;
 }
 
-"""A CFG node that branches on a condition with true/false targets.
-Used by CfgExpr wrappers inside BoolExpr operands and IfElseExpr branches."""
 obj ConditionalNode(UniCFGNode) {
     has sc_true_target: (UniCFGNode | None) = None,
         sc_false_target: (UniCFGNode | None) = None;
@@ -264,35 +232,6 @@ obj ConditionalNode(UniCFGNode) {
     def postinit -> None;
 }
 
-"""Expression is a combination of values, variables operators and fuctions that
-are evaluated to produce a value.
-
-    1. Literal Expressions.
-    2. Binary Operations.
-    3. Unary Operations.
-    4. Ternary Operations.
-    5. Attribute Access.
-    6. Subscript.
-    7. Call Expression.
-    8. List Value.
-    9. Dictionary Value.
-    10. Set Value.
-    11. Generator Expression.
-    12. Lambda Expression.
-    13. Conditional Expression.
-    14. Yield Expression.
-    etc.
-
-    An expression can be assigned to a variable, passed to a function, or
-    retuurend from a function.
-
-    Examples:
-        "hello world"         # literal.
-        <expr>(<expr>, ...);  # call.
-        <expr>.NAME           # attribute.
-        <expr>[<expr>]        # subscript.
-        <expr> if <expr> else <expr>  # ternary.
-    """
 obj Expr(UniNode) {
     has _type_sym_tab: (UniScopeNode | None) by postinit,
         type: (TypeBase | None) by postinit,
@@ -306,9 +245,6 @@ obj Expr(UniNode) {
     }
 }
 
-"""Wrapper that promotes an expression to a CFG-participating conditional node.
-Used for each BoolExpr operand and each IfElseExpr branch so that type
-narrowing can be resolved with a single backward CFG walk."""
 obj CfgExpr(Expr, ConditionalNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -318,32 +254,25 @@ obj CfgExpr(Expr, ConditionalNode) {
     def postinit -> None;
 }
 
-"""AtomExpr node type for Jac Ast."""
 obj AtomExpr(Expr, AstSymbolStubNode) {}
 
-"""ElementStmt node type for Jac Ast."""
 obj ElementStmt(AstDocNode) {}
 
-"""ArchBlockStmt node type for Jac Ast."""
 obj ArchBlockStmt(UniNode) {}
 
-"""EnumBlockStmt node type for Jac Ast."""
 obj EnumBlockStmt(UniNode) {
     has is_enum_stmt: bool = False;
 }
 
-"""CodeBlockStmt node type for Jac Ast."""
 obj CodeBlockStmt(UniCFGNode) {
     def postinit -> None;
 }
 
-"""AstImplNeedingNode node type for Jac Ast."""
 obj AstImplNeedingNode[T](AstSymbolNode) {
     has body: (T | None);
     has needs_impl: bool { getter; }
 }
 
-"""NameAtom node type for Jac Ast."""
 obj NameAtom(AtomExpr, EnumBlockStmt) {
     has name_of: AstSymbolNode by postinit,
         _sym: (Symbol | None) by postinit,
@@ -373,17 +302,14 @@ obj NameAtom(AtomExpr, EnumBlockStmt) {
     has sem_token: (tuple[(SemTokType, SemTokMod)] | None) { getter; }
 }
 
-"""ArchSpec node type for Jac Ast."""
 obj ArchSpec(ElementStmt, CodeBlockStmt, AstSymbolNode, AstAsyncNode, AstDocNode) {
     has decorators: (Sequence[Expr] | None);
 
     def postinit -> None;
 }
 
-"""MatchPattern node type for Jac Ast."""
 obj MatchPattern(UniNode) {}
 
-"""SubTag node type for Jac Ast."""
 obj SubTag[T](UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -393,7 +319,6 @@ obj SubTag[T](UniNode) {
     def postinit -> None;
 }
 
-"""Whole Program node type for Jac Ast."""
 obj Module(AstDocNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -427,7 +352,6 @@ obj Module(AstDocNode, UniScopeNode) {
     }
 }
 
-"""Whole Program node type for Jac Ast."""
 obj ProgramModule(UniNode) {
     has main_mod: (Module | None) = None,
         main: Module by postinit,
@@ -436,7 +360,6 @@ obj ProgramModule(UniNode) {
     def postinit -> None;
 }
 
-"""TypeParam node type for Jac Ast: T, T: Bound, T = Default."""
 obj TypeParam(AstSymbolNode, UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -448,7 +371,6 @@ obj TypeParam(AstSymbolNode, UniNode) {
     def postinit -> None;
 }
 
-"""TypeAlias node type for Jac Ast: type Name[T, E = X] = TypeExpr;"""
 obj TypeAlias(ContextAwareNode, AstAccessNode, ElementStmt, AstSymbolNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -460,7 +382,6 @@ obj TypeAlias(ContextAwareNode, AstAccessNode, ElementStmt, AstSymbolNode, UniSc
     def postinit -> None;
 }
 
-"""GlobalVars node type for Jac Ast."""
 obj GlobalVars(ContextAwareNode, ElementStmt, AstAccessNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -471,7 +392,6 @@ obj GlobalVars(ContextAwareNode, ElementStmt, AstAccessNode) {
     def postinit -> None;
 }
 
-"""Test node type for Jac Ast."""
 obj Test(ContextAwareNode, AstSymbolNode, ElementStmt, CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -488,7 +408,6 @@ obj Test(ContextAwareNode, AstSymbolNode, ElementStmt, CodeBlockStmt, UniScopeNo
     def postinit -> None;
 }
 
-"""ModuleCode node type for Jac Ast."""
 obj ModuleCode(ContextAwareNode, ElementStmt, ArchBlockStmt, EnumBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -499,7 +418,6 @@ obj ModuleCode(ContextAwareNode, ElementStmt, ArchBlockStmt, EnumBlockStmt) {
     def postinit -> None;
 }
 
-"""ClientBlock node type for cl { ... } blocks in Jac Ast."""
 obj ClientBlock(ElementStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -510,7 +428,6 @@ obj ClientBlock(ElementStmt) {
     def postinit -> None;
 }
 
-"""ServerBlock node type for sv { ... } blocks in Jac Ast."""
 obj ServerBlock(ElementStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -521,7 +438,6 @@ obj ServerBlock(ElementStmt) {
     def postinit -> None;
 }
 
-"""NativeBlock node type for na { ... } blocks in Jac Ast."""
 obj NativeBlock(ElementStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -532,7 +448,6 @@ obj NativeBlock(ElementStmt) {
     def postinit -> None;
 }
 
-"""PyInlineCode node type for Jac Ast."""
 obj PyInlineCode(ElementStmt, ArchBlockStmt, EnumBlockStmt, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -542,7 +457,6 @@ obj PyInlineCode(ElementStmt, ArchBlockStmt, EnumBlockStmt, CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""Import node type for Jac Ast."""
 obj Import(ContextAwareNode, ElementStmt, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -560,7 +474,6 @@ obj Import(ContextAwareNode, ElementStmt, CodeBlockStmt) {
     has __jac_detected: bool { getter; }
 }
 
-"""ModulePath node type for Jac Ast."""
 obj ModulePath(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -580,13 +493,6 @@ obj ModulePath(UniNode) {
     def resolve_relative_path_list -> list[str];
 }
 
-"""ModuleItem node type for Jac Ast.
-
-    Name can be either:
-    - Name: for regular named imports (e.g., useState, axios)
-    - Token (KW_DEFAULT): for default imports (Category 2)
-    - Token (STAR_MUL): for namespace imports (Category 4)
-    """
 obj ModuleItem(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -603,7 +509,6 @@ obj ModuleItem(UniNode) {
     def resolve_relative_path -> str;
 }
 
-"""ObjectArch node type for Jac Ast."""
 obj Archetype(ContextAwareNode, ArchSpec, AstAccessNode, ArchBlockStmt, AstImplNeedingNode, UniScopeNode, UniCFGNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -619,15 +524,12 @@ obj Archetype(ContextAwareNode, ArchSpec, AstAccessNode, ArchBlockStmt, AstImplN
     def _get_impl_resolved_body -> list;
 
     has is_abstract: bool { getter; }
-    # OSP kind ("node" | "edge" | "walker") from sym_category; None for
-    # obj/class archetypes. The single API for archetype-kind queries.
     has arch_kind: (str | None) { getter; }
 
     def get_has_vars -> list[HasVar];
     def get_methods -> list[Ability];
 }
 
-"""AstImplOnlyNode node type for Jac Ast."""
 obj ImplDef(ContextAwareNode, CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymbolNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -642,7 +544,6 @@ obj ImplDef(ContextAwareNode, CodeBlockStmt, ElementStmt, ArchBlockStmt, AstSymb
     def create_impl_name_node -> Name;
 }
 
-"""SemDef node type for Jac Ast."""
 obj SemDef(ElementStmt, AstSymbolNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -654,14 +555,6 @@ obj SemDef(ElementStmt, AstSymbolNode, UniScopeNode) {
     def create_sem_name_node -> Name;
 }
 
-"""Enum node type for Jac Ast.
-
-`value_type` holds the typed-base shorthand `: T` from `enum X: T { ... }`
-(desugars to `class X(IntEnum)` for int, `class X(StrEnum)` for str, and the
-mixin pattern `class X(T, Enum)` for everything else). `base_classes` holds
-the parenthesized form `enum X(B1, B2) { ... }`. The two are mutually
-exclusive at the grammar level — the parser never populates both.
-"""
 obj Enum(ContextAwareNode, ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -673,7 +566,6 @@ obj Enum(ContextAwareNode, ArchSpec, AstAccessNode, AstImplNeedingNode, ArchBloc
     def postinit -> None;
 }
 
-"""Ability node type for Jac Ast."""
 obj Ability(ContextAwareNode, AstAccessNode, ElementStmt, AstAsyncNode, ArchBlockStmt, CodeBlockStmt, AstImplNeedingNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -686,9 +578,7 @@ obj Ability(ContextAwareNode, AstAccessNode, ElementStmt, AstAsyncNode, ArchBloc
         signature: FuncSignature | EventSignature | None,
         decorators: (Sequence[Expr] | None) = None,
         type_params: (Sequence[TypeParam] | None) = None,
-        accessor_kind: str = "",  # "" | "property" | "setter" | "deleter"
-        # Resolved trigger types of an event ability (`can ... with T entry`),
-        # written by TypeCheckPass; None when unresolved/untyped.
+        accessor_kind: str = "",
         event_triggers: (list[TypeBase] | None) = None;
 
     def postinit -> None;
@@ -700,12 +590,9 @@ obj Ability(ContextAwareNode, AstAccessNode, ElementStmt, AstAsyncNode, ArchBloc
     has is_genai_ability: bool { getter; }
 
     def py_resolve_name -> str;
-    # Checker-resolved trigger type names as canonical mangled keys; None
-    # when unresolved (callers fall back to flattening the trigger AST).
     def event_trigger_type_names -> (list[str] | None);
 }
 
-"""FuncSignature node type for Jac Ast."""
 obj FuncSignature(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -724,7 +611,6 @@ obj FuncSignature(UniNode) {
     has is_in_py_class: bool { getter; }
 }
 
-"""EventSignature node type for Jac Ast."""
 obj EventSignature(WalkerStmtOnlyNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -735,7 +621,6 @@ obj EventSignature(WalkerStmtOnlyNode) {
     def postinit -> None;
 }
 
-"""Parameter kinds."""
 class ParamKind(IntEnum) {
     with entry {
         POSONLY = 0;
@@ -746,7 +631,6 @@ class ParamKind(IntEnum) {
     }
 }
 
-"""ParamVar node type for Jac Ast."""
 obj ParamVar(AstSymbolNode, AstTypedVarNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -762,7 +646,6 @@ obj ParamVar(AstSymbolNode, AstTypedVarNode) {
     has is_kwargs: bool { getter; }
 }
 
-"""ArchHas node type for Jac Ast."""
 obj ArchHas(AstAccessNode, AstDocNode, ArchBlockStmt, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -774,7 +657,6 @@ obj ArchHas(AstAccessNode, AstDocNode, ArchBlockStmt, CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""HasVar node type for Jac Ast."""
 obj HasVar(AstSymbolNode, AstTypedVarNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -787,7 +669,6 @@ obj HasVar(AstSymbolNode, AstTypedVarNode) {
     def postinit -> None;
 }
 
-"""TypedCtxBlock node type for Jac Ast."""
 obj TypedCtxBlock(CodeBlockStmt, WalkerStmtOnlyNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -798,7 +679,6 @@ obj TypedCtxBlock(CodeBlockStmt, WalkerStmtOnlyNode, UniScopeNode) {
     def postinit -> None;
 }
 
-"""IfStmt node type for Jac Ast."""
 obj IfStmt(CodeBlockStmt, AstElseBodyNode, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -809,13 +689,11 @@ obj IfStmt(CodeBlockStmt, AstElseBodyNode, UniScopeNode) {
     def postinit -> None;
 }
 
-"""ElseIf node type for Jac Ast."""
 obj ElseIf(IfStmt) {
     def accept_enter(v: UniPass) -> None;
     def accept_exit(v: UniPass) -> None;
 }
 
-"""ElseStmt node type for Jac Ast."""
 obj ElseStmt(UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -825,7 +703,6 @@ obj ElseStmt(UniScopeNode) {
     def postinit -> None;
 }
 
-"""ExprStmt node type for Jac Ast."""
 obj ExprStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -836,7 +713,6 @@ obj ExprStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""TryStmt node type for Jac Ast."""
 obj TryStmt(AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -849,14 +725,6 @@ obj TryStmt(AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""AwaitingClause node type for Jac Ast.
-
-Holds the `awaiting { ... }` arm of a `try` statement. Renders/produces
-a value during the dispatched-but-not-joined window of any `flow`/`wait`
-work inside the `try` body. In a JSX slot on the `cl` target, lowered
-into the React `Suspense` fallback of the synthesized `<JacAwaiting>`
-wrapper. On `sv`/`na` the clause is currently ignored with W2020 until
-the streaming-SSR and native-thread lowerings land."""
 obj AwaitingClause(CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -866,7 +734,6 @@ obj AwaitingClause(CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""Except node type for Jac Ast."""
 obj Except(CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -878,7 +745,6 @@ obj Except(CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""FinallyStmt node type for Jac Ast."""
 obj FinallyStmt(CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -888,7 +754,6 @@ obj FinallyStmt(CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""IterForStmt node type for Jac Ast."""
 obj IterForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -901,7 +766,6 @@ obj IterForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""InForStmt node type for Jac Ast."""
 obj InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -913,7 +777,6 @@ obj InForStmt(AstAsyncNode, AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""WhileStmt node type for Jac Ast."""
 obj WhileStmt(AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -924,7 +787,6 @@ obj WhileStmt(AstElseBodyNode, CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""WithStmt node type for Jac Ast."""
 obj WithStmt(AstAsyncNode, CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -935,7 +797,6 @@ obj WithStmt(AstAsyncNode, CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""ExprAsItem node type for Jac Ast."""
 obj ExprAsItem(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -946,7 +807,6 @@ obj ExprAsItem(UniNode) {
     def postinit -> None;
 }
 
-"""RaiseStmt node type for Jac Ast."""
 obj RaiseStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -957,7 +817,6 @@ obj RaiseStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""AssertStmt node type for Jac Ast."""
 obj AssertStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -968,7 +827,6 @@ obj AssertStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""CtrlStmt node type for Jac Ast."""
 obj CtrlStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -978,7 +836,6 @@ obj CtrlStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""DeleteStmt node type for Jac Ast."""
 obj DeleteStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -990,7 +847,6 @@ obj DeleteStmt(CodeBlockStmt) {
     has py_ast_targets: list[ast3.AST] { getter; }
 }
 
-"""ReportStmt node type for Jac Ast."""
 obj ReportStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1000,7 +856,6 @@ obj ReportStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""ReturnStmt node type for Jac Ast."""
 obj ReturnStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1010,7 +865,6 @@ obj ReturnStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""VisitStmt node type for Jac Ast."""
 obj VisitStmt(WalkerStmtOnlyNode, AstElseBodyNode, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1021,14 +875,12 @@ obj VisitStmt(WalkerStmtOnlyNode, AstElseBodyNode, CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""DisengageStmt node type for Jac Ast."""
 obj DisengageStmt(WalkerStmtOnlyNode, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
     def postinit -> None;
 }
 
-"""AwaitExpr node type for Jac Ast."""
 obj AwaitExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1038,9 +890,6 @@ obj AwaitExpr(Expr) {
     def postinit -> None;
 }
 
-"""CastExpr node type for Jac Ast.
-Represents `value as cast_type` -- an unchecked, type-erased cast. At runtime
-it evaluates to `value` unchanged; statically its type is `cast_type`."""
 obj CastExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1051,7 +900,6 @@ obj CastExpr(Expr) {
     def postinit -> None;
 }
 
-"""GlobalStmt node type for Jac Ast."""
 obj GlobalStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1061,13 +909,11 @@ obj GlobalStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""NonLocalStmt node type for Jac Ast."""
 obj NonLocalStmt(GlobalStmt) {
     def accept_enter(v: UniPass) -> None;
     def accept_exit(v: UniPass) -> None;
 }
 
-"""Assignment node type for Jac Ast."""
 obj Assignment(AstTypedVarNode, EnumBlockStmt, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1080,7 +926,6 @@ obj Assignment(AstTypedVarNode, EnumBlockStmt, CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""ConcurrentExpr node type for Jac Ast."""
 obj ConcurrentExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1091,7 +936,6 @@ obj ConcurrentExpr(Expr) {
     def postinit -> None;
 }
 
-"""BinaryExpr node type for Jac Ast."""
 obj BinaryExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1103,7 +947,6 @@ obj BinaryExpr(Expr) {
     def postinit -> None;
 }
 
-"""CompareExpr node type for Jac Ast."""
 obj CompareExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1115,9 +958,6 @@ obj CompareExpr(Expr) {
     def postinit -> None;
 }
 
-"""BoolExpr node type for Jac Ast.
-Each operand is wrapped in a CfgExpr so that short-circuit evaluation
-is modeled at the expression level in the CFG."""
 obj BoolExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1128,7 +968,6 @@ obj BoolExpr(Expr) {
     def postinit -> None;
 }
 
-"""LambdaExpr node type for Jac Ast."""
 obj LambdaExpr(Expr, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1138,12 +977,9 @@ obj LambdaExpr(Expr, UniScopeNode) {
 
     def postinit -> None;
 
-    # Free variables captured from enclosing function scopes, derived
-    # from symbol tables (see UniScopeNode.get_enclosing_captures).
     has captures: list[Symbol] { getter; }
 }
 
-"""UnaryExpr node type for Jac Ast."""
 obj UnaryExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1154,9 +990,6 @@ obj UnaryExpr(Expr) {
     def postinit -> None;
 }
 
-"""IfElseExpr node type for Jac Ast.
-Each branch is wrapped in a CfgExpr so that conditional evaluation
-is modeled at the expression level in the CFG."""
 obj IfElseExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1168,7 +1001,6 @@ obj IfElseExpr(Expr) {
     def postinit -> None;
 }
 
-"""MultiString node type for Jac Ast."""
 obj MultiString(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1176,13 +1008,10 @@ obj MultiString(AtomExpr) {
     has strings: Sequence[(String | FString)];
 
     def postinit -> None;
-    # The concatenated literal value, joining the plain-string parts (f-string
-    # parts are dynamic and contribute nothing static). Used for a `sem` value,
-    # whose parts are always plain strings.
+
     has lit_value: str { getter; }
 }
 
-"""FString node type for Jac Ast."""
 obj FString(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1194,7 +1023,6 @@ obj FString(AtomExpr) {
     def postinit -> None;
 }
 
-"""FormattedValue node type for Jac Ast."""
 obj FormattedValue(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1206,7 +1034,6 @@ obj FormattedValue(Expr) {
     def postinit -> None;
 }
 
-"""ListVal node type for Jac Ast."""
 obj ListVal(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1216,7 +1043,6 @@ obj ListVal(AtomExpr) {
     def postinit -> None;
 }
 
-"""SetVal node type for Jac Ast."""
 obj SetVal(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1226,7 +1052,6 @@ obj SetVal(AtomExpr) {
     def postinit -> None;
 }
 
-"""TupleVal node type for Jac Ast."""
 obj TupleVal(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1236,7 +1061,6 @@ obj TupleVal(AtomExpr) {
     def postinit -> None;
 }
 
-"""DictVal node type for Jac Ast."""
 obj DictVal(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1246,7 +1070,6 @@ obj DictVal(AtomExpr) {
     def postinit -> None;
 }
 
-"""KVPair node type for Jac Ast."""
 obj KVPair(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1257,7 +1080,6 @@ obj KVPair(UniNode) {
     def postinit -> None;
 }
 
-"""KWPair node type for Jac Ast."""
 obj KWPair(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1268,7 +1090,6 @@ obj KWPair(UniNode) {
     def postinit -> None;
 }
 
-"""InnerCompr node type for Jac Ast."""
 obj InnerCompr(AstAsyncNode, UniScopeNode, UniCFGNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1280,14 +1101,6 @@ obj InnerCompr(AstAsyncNode, UniScopeNode, UniCFGNode) {
     def postinit -> None;
 }
 
-"""ListCompr node type for Jac Ast.
-
-Inherits UniCFGNode so the comprehension is a flow-sensitive node:
-cfg_build_pass wires each `if` filter as a CfgExpr predecessor whose
-true edge feeds back into the comprehension itself, so the existing
-CFG narrowing engine threads filter narrowing into the head expression
-without any side-channel state on the type evaluator.
-"""
 obj ListCompr(AtomExpr, UniScopeNode, UniCFGNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1298,23 +1111,16 @@ obj ListCompr(AtomExpr, UniScopeNode, UniCFGNode) {
     def postinit -> None;
 }
 
-"""GenCompr node type for Jac Ast."""
 obj GenCompr(ListCompr) {
     def accept_enter(v: UniPass) -> None;
     def accept_exit(v: UniPass) -> None;
 }
 
-"""SetCompr node type for Jac Ast."""
 obj SetCompr(ListCompr) {
     def accept_enter(v: UniPass) -> None;
     def accept_exit(v: UniPass) -> None;
 }
 
-"""DictCompr node type for Jac Ast.
-
-Same UniCFGNode rationale as ListCompr -- the conditional filters wire
-through the CFG so narrowing flows into the head key/value expressions.
-"""
 obj DictCompr(AtomExpr, UniScopeNode, UniCFGNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1325,7 +1131,6 @@ obj DictCompr(AtomExpr, UniScopeNode, UniCFGNode) {
     def postinit -> None;
 }
 
-"""AtomTrailer node type for Jac Ast."""
 obj AtomTrailer(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1341,7 +1146,6 @@ obj AtomTrailer(Expr) {
     has as_attr_list: list[AstSymbolNode] { getter; }
 }
 
-"""AtomUnit node type for Jac Ast."""
 obj AtomUnit(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1351,7 +1155,6 @@ obj AtomUnit(Expr) {
     def postinit -> None;
 }
 
-"""YieldExpr node type for Jac Ast."""
 obj YieldExpr(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1362,7 +1165,6 @@ obj YieldExpr(Expr) {
     def postinit -> None;
 }
 
-"""FuncCall node type for Jac Ast."""
 obj FuncCall(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1370,25 +1172,12 @@ obj FuncCall(Expr) {
     has target: Expr,
         params: (Sequence[(Expr | KWPair)] | None),
         genai_call: (Expr | None),
-        # Call-site classification ("method" | "instantiation" | "builtin"
-        # | "function"), stamped by TypeCheckPass at resolution time from
-        # symbol_utils.classify_call. None on nodes synthesized after
-        # checking (e.g. desugared pipe-forward); backends classify those
-        # on the spot.
         call_kind: (str | None) = None,
-        # Resolved callee declaration, stamped by TypeCheckPass at
-        # resolution time (symbol_utils.ability_of_symbol). Backends read
-        # the resolved signature (parameters, default-arg exprs) off this
-        # instead of keeping name-keyed AST-signature caches. Like
-        # `Expr.type`, this is never serialized to JIR - TypeInferencePass
-        # restamps it on load. None for builtins, unresolved targets, and
-        # nodes synthesized after checking.
         callee_decl: (Ability | None) by postinit;
 
     def postinit -> None;
 }
 
-"""Slice item node type for IndexSlice."""
 obj Slice(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1400,7 +1189,6 @@ obj Slice(UniNode) {
     def postinit -> None;
 }
 
-"""IndexSlice node type for Jac Ast."""
 obj IndexSlice(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1411,7 +1199,6 @@ obj IndexSlice(AtomExpr) {
     def postinit -> None;
 }
 
-"""EdgeRefTrailer node type for Jac Ast."""
 obj EdgeRefTrailer(Expr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1423,7 +1210,6 @@ obj EdgeRefTrailer(Expr) {
     def postinit -> None;
 }
 
-"""EdgeOpRef node type for Jac Ast."""
 obj EdgeOpRef(WalkerStmtOnlyNode, AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1434,7 +1220,6 @@ obj EdgeOpRef(WalkerStmtOnlyNode, AtomExpr) {
     def postinit -> None;
 }
 
-"""DisconnectOp node type for Jac Ast."""
 obj DisconnectOp(WalkerStmtOnlyNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1444,7 +1229,6 @@ obj DisconnectOp(WalkerStmtOnlyNode) {
     def postinit -> None;
 }
 
-"""ConnectOpRef node type for Jac Ast."""
 obj ConnectOp(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1456,7 +1240,6 @@ obj ConnectOp(UniNode) {
     def postinit -> None;
 }
 
-"""FilterCompr node type for Jac Ast."""
 obj FilterCompr(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1467,7 +1250,6 @@ obj FilterCompr(AtomExpr) {
     def postinit -> None;
 }
 
-"""AssignCompr node type for Jac Ast."""
 obj AssignCompr(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1477,7 +1259,6 @@ obj AssignCompr(AtomExpr) {
     def postinit -> None;
 }
 
-"""JsxElement node type for Jac Ast."""
 obj JsxElement(AtomExpr) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1494,7 +1275,6 @@ obj JsxElement(AtomExpr) {
     def get_body_end_line -> (int | None);
 }
 
-"""JsxElementName node type for Jac Ast."""
 obj JsxElementName(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1504,14 +1284,12 @@ obj JsxElementName(UniNode) {
     def postinit -> None;
 }
 
-"""JsxAttribute node type for Jac Ast (base class)."""
 obj JsxAttribute(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
     def postinit -> None;
 }
 
-"""JsxSpreadAttribute node type for Jac Ast."""
 obj JsxSpreadAttribute(JsxAttribute) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1521,12 +1299,6 @@ obj JsxSpreadAttribute(JsxAttribute) {
     def postinit -> None;
 }
 
-"""JsxNormalAttribute node type for Jac Ast.
-
-The `is_shorthand` flag marks attributes parsed from the `{name}` JSX
-attribute shorthand — semantically identical to `name={name}` but the
-formatter must round-trip the shorter spelling. Both `name` and `value`
-point at the same identifier when this flag is set."""
 obj JsxNormalAttribute(JsxAttribute) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1538,14 +1310,12 @@ obj JsxNormalAttribute(JsxAttribute) {
     def postinit -> None;
 }
 
-"""JsxChild node type for Jac Ast (base class)."""
 obj JsxChild(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
     def postinit -> None;
 }
 
-"""JsxText node type for Jac Ast."""
 obj JsxText(JsxChild) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1556,7 +1326,6 @@ obj JsxText(JsxChild) {
     def get_normalized_text -> str;
 }
 
-"""JsxExpression node type for Jac Ast."""
 obj JsxExpression(JsxChild) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1566,38 +1335,15 @@ obj JsxExpression(JsxChild) {
     def postinit -> None;
 }
 
-"""JsxSlot: a `{...}` JSX child whose body is a sequence of statements.
-
-When a `{...}` slot in JSX child position contains anything other than a
-single expression -- a JSX statement, control flow yielding JSX, an
-assignment followed by an expression, an explicit `return` guard -- the
-parser emits a `JsxSlot` instead of `JsxExpression`. The slot lowers to
-an IIFE that runs the body and returns either the accumulated JSX
-children fragment (if any JSX was emitted statement-by-statement) or the
-value of the last expression.
-
-Single-expression slots (`{name}`, `{1 + 2}`, `{<p>hi</p>}`) still emit
-`JsxExpression` so the cheap path (no IIFE) is preserved.
-"""
 obj JsxSlot(JsxChild) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
 
     has body: list[UniNode];
-    # The body holds the author's faithful `{ stmt; ... }` statement
-    # template. No pre-codegen pass mutates it — the cl-target accumulator
-    # IIFE is synthesized at codegen time (EsastGenPass), so the surface
-    # tokens round-trip through the formatter/unparser unchanged.
+
     def postinit -> None;
 }
 
-"""JsxComment node type for Jac Ast.
-
-Represents a Jac-native JSX block comment of the form ``{#* ... *#}``.
-The whole brace-wrapped span is owned by this node so the formatter can
-round-trip the comment verbatim; codegen passes treat it as a no-op
-child and emit nothing.
-"""
 obj JsxComment(JsxChild) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1607,7 +1353,6 @@ obj JsxComment(JsxChild) {
     def postinit -> None;
 }
 
-"""MatchStmt node type for Jac Ast."""
 obj MatchStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1618,7 +1363,6 @@ obj MatchStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""MatchCase node type for Jac Ast."""
 obj MatchCase(CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1630,7 +1374,6 @@ obj MatchCase(CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""SwitchStmt node type for Jac Ast."""
 obj SwitchStmt(CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1641,7 +1384,6 @@ obj SwitchStmt(CodeBlockStmt) {
     def postinit -> None;
 }
 
-"""SwitchCase node type for Jac Ast."""
 obj SwitchCase(CodeBlockStmt, UniScopeNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1652,7 +1394,6 @@ obj SwitchCase(CodeBlockStmt, UniScopeNode) {
     def postinit -> None;
 }
 
-"""MatchOr node type for Jac Ast."""
 obj MatchOr(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1662,7 +1403,6 @@ obj MatchOr(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchAs node type for Jac Ast."""
 obj MatchAs(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1673,13 +1413,11 @@ obj MatchAs(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchWild node type for Jac Ast."""
 obj MatchWild(MatchPattern) {
     def accept_enter(v: UniPass) -> None;
     def accept_exit(v: UniPass) -> None;
 }
 
-"""MatchValue node type for Jac Ast."""
 obj MatchValue(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1689,7 +1427,6 @@ obj MatchValue(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchSingleton node type for Jac Ast."""
 obj MatchSingleton(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1699,7 +1436,6 @@ obj MatchSingleton(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchSequence node type for Jac Ast."""
 obj MatchSequence(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1709,7 +1445,6 @@ obj MatchSequence(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchMapping node type for Jac Ast."""
 obj MatchMapping(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1719,7 +1454,6 @@ obj MatchMapping(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchKVPair node type for Jac Ast."""
 obj MatchKVPair(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1730,7 +1464,6 @@ obj MatchKVPair(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchStar node type for Jac Ast."""
 obj MatchStar(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1741,7 +1474,6 @@ obj MatchStar(MatchPattern) {
     def postinit -> None;
 }
 
-"""MatchArch node type for Jac Ast."""
 obj MatchArch(MatchPattern) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1753,7 +1485,6 @@ obj MatchArch(MatchPattern) {
     def postinit -> None;
 }
 
-"""Token node type for Jac Ast."""
 obj Token(UniNode) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1765,8 +1496,6 @@ obj Token(UniNode) {
         c_end: int by postinit,
         pos_start: int by postinit,
         pos_end: int by postinit,
-        # True for tokens synthesized during parsing (e.g. by `gen_token`),
-        # whose source positions are approximate; comment injection skips them.
         _is_synthetic: bool = False;
 
     def init(
@@ -1785,7 +1514,6 @@ obj Token(UniNode) {
     def unparse -> str;
 }
 
-"""Name node type for Jac Ast."""
 obj Name(Token, NameAtom) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1823,7 +1551,6 @@ obj Name(Token, NameAtom) {
     }
 }
 
-"""SpecialVarRef node type for Jac Ast."""
 obj SpecialVarRef(Name) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1834,7 +1561,6 @@ obj SpecialVarRef(Name) {
     def py_resolve_name -> str;
 }
 
-"""Literal node type for Jac Ast."""
 obj Literal(Token, AtomExpr) {
     with entry {
         SYMBOL_TYPE = SymbolType.VAR;
@@ -1869,7 +1595,6 @@ obj Literal(Token, AtomExpr) {
     }
 }
 
-"""BuiltinType node type for Jac Ast."""
 obj BuiltinType(Name, Literal) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1881,7 +1606,6 @@ obj BuiltinType(Name, Literal) {
     has lit_value: Callable[([], Any)] { getter; }
 }
 
-"""Float node type for Jac Ast."""
 obj Float(Literal) {
     def accept_exit(v: UniPass) -> None;
 
@@ -1892,7 +1616,6 @@ obj Float(Literal) {
     has lit_value: float { getter; }
 }
 
-"""Int node type for Jac Ast."""
 obj Int(Literal) {
     def accept_exit(v: UniPass) -> None;
 
@@ -1903,7 +1626,6 @@ obj Int(Literal) {
     has lit_value: int { getter; }
 }
 
-"""String node type for Jac Ast."""
 obj String(Literal) {
     def accept_exit(v: UniPass) -> None;
     def accept_enter(v: UniPass) -> None;
@@ -1915,7 +1637,6 @@ obj String(Literal) {
     has lit_value: str { getter; }
 }
 
-"""Bool node type for Jac Ast."""
 obj Bool(Literal) {
     def accept_exit(v: UniPass) -> None;
 
@@ -1926,7 +1647,6 @@ obj Bool(Literal) {
     has lit_value: bool { getter; }
 }
 
-"""Null node type for Jac Ast."""
 obj Null(Literal) {
     def accept_exit(v: UniPass) -> None;
 
@@ -1937,7 +1657,6 @@ obj Null(Literal) {
     has lit_value: None { getter; }
 }
 
-"""Ellipsis node type for Jac Ast."""
 obj Ellipsis(Literal) {
     def accept_exit(v: UniPass) -> None;
 
@@ -1948,12 +1667,10 @@ obj Ellipsis(Literal) {
     has lit_value: EllipsisType { getter; }
 }
 
-"""EmptyToken node type for Jac Ast."""
 obj EmptyToken(Token) {
     def init(orig_src: (Source | None) = None) -> None;
 }
 
-"""Semicolon node type for Jac Ast."""
 obj Semi(Token, CodeBlockStmt) {
     def accept_exit(v: UniPass) -> None;
     def init(
@@ -1969,7 +1686,6 @@ obj Semi(Token, CodeBlockStmt) {
     ) -> None;
 }
 
-"""CommentToken node type for Jac Ast."""
 obj CommentToken(Token) {
     def accept_exit(v: UniPass) -> None;
     def init(
@@ -1987,7 +1703,6 @@ obj CommentToken(Token) {
     ) -> None;
 }
 
-"""SourceString node type for Jac Ast."""
 obj Source(EmptyToken) {
     has comments: list[CommentToken] by postinit,
         inline_suppressions: dict[int, set[str]] by postinit,
@@ -1998,7 +1713,6 @@ obj Source(EmptyToken) {
     has code: str { getter; }
 }
 
-"""SourceString node type for Jac Ast."""
 obj PythonModuleAst(EmptyToken) {
     has orig_src: Source by postinit,
         file_path: str by postinit;

--- a/jac/jaclang/lsp/server.jac
+++ b/jac/jaclang/lsp/server.jac
@@ -1,5 +1,3 @@
-"""LSP server infrastructure: LanguageServer, Workspace, TextDocument, PositionCodec."""
-
 import asyncio;
 import enum;
 import io;
@@ -41,18 +39,11 @@ import from . { uris }
 glob logger = logging.getLogger("jaclang.lsp.server"),
      RE_CONTENT_LENGTH = re.compile(r"Content-Length: (\d+)");
 
-# ---------------------------------------------------------------------------
-# Serialization helpers
-# ---------------------------------------------------------------------------
 def _to_camel_case(name: str) -> str;
 def _to_snake_case(name: str) -> str;
 def to_dict(`obj: any) -> any;
 def from_dict(data: any, cls: any) -> any;
 
-# ---------------------------------------------------------------------------
-# PositionCodec — UTF-16 ↔ UTF-32 position conversion
-# ---------------------------------------------------------------------------
-"""Converts between LSP client positions (UTF-16) and Python positions (UTF-32)."""
 obj PositionCodec {
     has encoding: str = PositionEncodingKind.Utf16;
 
@@ -62,10 +53,6 @@ obj PositionCodec {
     def range_from_client_units(lines: list[str], range: Range) -> Range;
 }
 
-# ---------------------------------------------------------------------------
-# TextDocument — in-memory document with incremental sync
-# ---------------------------------------------------------------------------
-"""A text document managed by the workspace."""
 obj TextDocument {
     has uri: str = "",
         _source: Optional[str] = None,
@@ -86,10 +73,6 @@ obj TextDocument {
     def _apply_full_change(change: any) -> None;
 }
 
-# ---------------------------------------------------------------------------
-# Workspace — manages open text documents
-# ---------------------------------------------------------------------------
-"""Manages open documents and workspace folders."""
 obj Workspace {
     has root_uri: Optional[str] = None,
         _sync_kind: TextDocumentSyncKind = TextDocumentSyncKind.Incremental,
@@ -107,10 +90,6 @@ obj Workspace {
     def remove_text_document(doc_uri: str) -> None;
 }
 
-# ---------------------------------------------------------------------------
-# LanguageServer — the main LSP server
-# ---------------------------------------------------------------------------
-"""Base language server with feature registration, transport, and lifecycle."""
 obj LanguageServer {
     has name: str = "",
         version: str = "",
@@ -134,7 +113,6 @@ obj LanguageServer {
     def show_message_log(message: str, msg_type: any = None) -> None;
     def send_request(method: str, params: any = None) -> None;
     def shutdown -> None;
-    # Internal transport methods
     def _send_notification(method: str, params: any) -> None;
     def _send_response(msg_id: any, result: any) -> None;
     def _write_message(body: dict) -> None;

--- a/jac/jaclang/runtimelib/client/cli.jac
+++ b/jac/jaclang/runtimelib/client/cli.jac
@@ -1,13 +1,3 @@
-"""Command line interface tool for the Jac Client.
-
-This module extends core CLI commands to add the --npm flag for
-client-side (frontend) package management:
-- `jac add --npm`: Add npm dependencies
-- `jac remove --npm`: Remove npm dependencies
-
-For creating client projects, use: `jac create --kind web-app`
-"""
-
 import from jaclang.cli.registry { get_registry }
 import from jaclang.cli.command { Arg, ArgKind, HookContext }
 import from jaclang.project.config { JacConfig }
@@ -20,8 +10,6 @@ import os;
 
 glob registry = get_registry();
 
-# Register targets when module loads
-# Import base target classes - this should trigger annex pass to auto-discover .impl.jac files
 import from jaclang.runtimelib.client.targets.web_target { WebTarget }
 import from jaclang.runtimelib.client.targets.mobile_target { MobileTarget }
 import from jaclang.runtimelib.client.targets.register {
@@ -31,7 +19,6 @@ import from jaclang.runtimelib.client.targets.register {
 import from jaclang.runtimelib.client.targets.registry { ClientTarget }
 import from pathlib { Path }
 
-"""Register 'build' command at module level."""
 @registry.command(
     name="build",
     help="Build a Jac application for a specific target",
@@ -51,7 +38,7 @@ import from pathlib { Path }
                 "Choices reflect installed targets (desktop builds a native webview app)."
             ),
             choices=["web", "pwa", "mobile"],
-            short=""  # Disable auto-generated -t (may conflict with other plugins)
+            short=""
         ),
         Arg.create(
             "platform",
@@ -59,7 +46,7 @@ import from pathlib { Path }
             default=None,
             help="Platform for desktop/mobile builds (windows, macos, linux, all, android, ios)",
             choices=["windows", "macos", "linux", "all", "android", "ios"],
-            short="p"  # Use -p for platform
+            short="p"
         ),
 
     ],
@@ -78,17 +65,9 @@ import from pathlib { Path }
 def build(
     filename: str = "main.jac", target: str = "web", platform: str | None = None
 ) -> int {
-    # This will be handled by the pre_hook
     return 0;
 }
 
-"""Register 'setup' command at module level.
-
-Note: --platform is wired in via extend_command (see create_cmd) so it survives
-when a higher-priority plugin (e.g. jac-scale) replaces this spec - primary
-args on a spec are spec-local, but extension args are preserved across
-priority replacement by the registry.
-"""
 @registry.command(
     name="setup",
     help="Setup a build target (one-time initialization)",
@@ -107,23 +86,15 @@ priority replacement by the registry.
     source="jac-client"
 )
 def setup(target: str, platform: str | None = None) -> int {
-    # This will be handled by the pre_hook
     return 0;
 }
 
-"""Jac CLI extensions for client-side development."""
 class JacClientCmd {
-    """Create Jac CLI cmds.
-
-    Extends core commands (create/add/remove/start/build/setup) with client-side
-    behavior; see ``create_cmd`` implementation.
-    """
     @hookimpl
     static def create_cmd {
         register_targets();
         registry = get_registry();
 
-        # Extend the core 'create' command with --skip flag for client template
         registry.extend_command(
             command_name="create",
             args=[
@@ -139,7 +110,6 @@ class JacClientCmd {
             source="jac-client"
         );
 
-        # Extend the core 'add' command with --npm flag
         registry.extend_command(
             command_name="add",
             args=[
@@ -155,7 +125,6 @@ class JacClientCmd {
             source="jac-client"
         );
 
-        # Extend the core 'remove' command with --npm flag
         registry.extend_command(
             command_name="remove",
             args=[
@@ -171,16 +140,10 @@ class JacClientCmd {
             source="jac-client"
         );
 
-        # Add pre-hook to build command (command is registered at module level)
         registry.extend_command(
             command_name="build", pre_hook=_handle_build_target, source="jac-client"
         );
 
-        # Add pre-hook + --platform to setup command. Registering --platform via
-        # extend_command (instead of inline on the @registry.command above) keeps
-        # the arg attached when a higher-priority plugin re-registers `setup`
-        # (e.g. jac-scale's microservice handler). See registry.impl.jac for the
-        # corresponding extra_args preservation logic.
         registry.extend_command(
             command_name="setup",
             args=[
@@ -198,14 +161,12 @@ class JacClientCmd {
             source="jac-client"
         );
 
-        # Extend 'start' command with --client flag
-        # Note: jac-scale also uses --client, so we use --client to avoid conflict
         if registry.has_command("start") {
             registry.extend_command(
                 command_name="start",
                 args=[
                     Arg.create(
-                        "client",  # Use client to avoid conflict with jac-scale's --client
+                        "client",
                         typ=str,
                         default="web",
                         help=(
@@ -213,7 +174,7 @@ class JacClientCmd {
                             "Choices reflect installed targets (desktop builds a native webview app)."
                         ),
                         choices=["web", "pwa", "mobile"],
-                        short=""  # Disable auto-generated short flag
+                        short=""
                     ),
                     Arg.create(
                         "host",
@@ -247,23 +208,16 @@ class JacClientCmd {
     }
 }
 
-"""Pre-hook to handle --skip flag for create command."""
 def _handle_create_skip(ctx: HookContext) {
-    # Check if --skip flag is set
     skip_flag = ctx.get_arg("skip", False);
     if skip_flag {
-        # Set environment variable to skip npm installation
         os.environ["JAC_CLIENT_SKIP_NPM_INSTALL"] = "1";
     }
-    # Let core create command run normally
 }
 
-"""Pre-hook to handle --npm flag for adding npm dependencies."""
 def _handle_npm_add(ctx: HookContext) -> None {
-    # Check if --npm flag is set
     npm_flag = ctx.get_arg("npm", False);
     if not npm_flag {
-        # Let core add command run normally
         return;
     }
 
@@ -297,7 +251,6 @@ def _handle_npm_add(ctx: HookContext) -> None {
     packages = ctx.get_arg("packages", []);
     dev = ctx.get_arg("dev", False);
 
-    # If no packages specified, install all npm packages from jac.toml
     if not packages {
         if dep_type.install_all_handler is None {
             console.error(f"No install_all handler registered for {dep_type.name}");
@@ -326,7 +279,6 @@ def _handle_npm_add(ctx: HookContext) -> None {
         return;
     }
 
-    # Install specific packages
     try {
         resolver = DependencyResolver(config=config);
         console.print(
@@ -350,16 +302,6 @@ def _handle_npm_add(ctx: HookContext) -> None {
     }
 }
 
-"""Pick the client target, auto-routing a client-only project to `static`.
-
-When the caller did not request a specific target (still the `web` default),
-a project that declares `kind = "web-static"` (a browser-only app with no server)
-is routed to the `static` target so `jac build` / `jac start` produce a
-portable dist and a minimal static serve without the user passing
-`--client static`. An explicit non-web `--client` (e.g. `--client pwa`) always
-wins; `--client web` is indistinguishable from the default, so it does not
-override the client-kind routing.
-"""
 def _auto_client_target(config: JacConfig, requested: str, project_dir: Path) -> str {
     if requested != "web" {
         return requested;
@@ -371,13 +313,11 @@ def _auto_client_target(config: JacConfig, requested: str, project_dir: Path) ->
             return "static";
         }
     } except Exception {
-        # Kind resolution is best-effort; fall back to the requested target.
         return requested;
     }
     return requested;
 }
 
-"""Return True when a setup-required target has not been initialized yet."""
 def _target_setup_missing(
     target_name: str, target: ClientTarget, project_dir: Path
 ) -> bool {
@@ -391,14 +331,9 @@ def _target_setup_missing(
         return not android_dir.exists() and not ios_dir.exists();
     }
 
-    # Fallback for future targets that may implement custom setup semantics.
     return False;
 }
 
-"""Pre-hook to handle --client flag for build command.
-
-Uses TargetFactory for lazy loading and polymorphic dispatch.
-"""
 def _handle_build_target(ctx: HookContext) -> None {
     import from jaclang.cli.console { console }
     import from jaclang.runtimelib.client.targets.registry { get_target_factory }
@@ -408,7 +343,6 @@ def _handle_build_target(ctx: HookContext) -> None {
     target_name = ctx.get_arg("client", "web");
     platform = ctx.get_arg("platform", None);
 
-    # Get config and project_dir first (needed for factory)
     config = get_config();
     if not config {
         console.error("No jac.toml found. Run 'jac create' to create a project.");
@@ -419,10 +353,8 @@ def _handle_build_target(ctx: HookContext) -> None {
 
     project_dir = config.project_root or Path.cwd();
 
-    # Auto-route a client-only (kind = "web-static") project to the static target.
     target_name = _auto_client_target(config, target_name, project_dir);
 
-    # Use factory to create target (lazy loading for non-web targets)
     factory = get_target_factory();
     try {
         target = factory.create(target_name, project_dir);
@@ -437,18 +369,15 @@ def _handle_build_target(ctx: HookContext) -> None {
         return;
     }
 
-    # Store target info in context for use by build handler
     ctx.set_data("build_target", target);
     ctx.set_data("build_platform", platform);
 
-    # Warn only when setup is actually missing (avoid false positive warnings).
     if _target_setup_missing(target_name, target, project_dir) {
         console.warning(
             f"Target '{target_name}' requires setup. Run 'jac setup {target_name}' first."
         );
     }
 
-    # Build using target's build method (polymorphic dispatch)
     try {
         entry_file = ctx.get_arg("filename", None);
         if not entry_file {
@@ -466,7 +395,6 @@ def _handle_build_target(ctx: HookContext) -> None {
             entry_path = project_dir / entry_path;
         }
 
-        # Polymorphic call - each target handles its own build logic
         bundle_path = target.build(entry_path, project_dir, platform);
 
         console.success(f"Build complete: {bundle_path}");
@@ -484,7 +412,6 @@ def _handle_build_target(ctx: HookContext) -> None {
     }
 }
 
-"""Extract config, entry path, and project dir from context. Returns None on error."""
 def _get_start_context(ctx: HookContext) -> tuple | None {
     import from pathlib { Path }
     import from jaclang.project.config { get_config }
@@ -518,11 +445,6 @@ def _get_start_context(ctx: HookContext) -> tuple | None {
     return (config, entry_path, project_dir);
 }
 
-"""Pre-hook to handle --client flag for start command.
-
-Uses TargetFactory for lazy loading and polymorphic dispatch.
-Web target falls through to core jac start, others use target.dev()/start().
-"""
 def _handle_start_target(ctx: HookContext) -> None {
     import from jaclang.cli.console { console }
     import from jaclang.runtimelib.client.targets.registry { get_target_factory }
@@ -531,17 +453,14 @@ def _handle_start_target(ctx: HookContext) -> None {
 
     target_name = ctx.get_arg("client", "web");
 
-    # Get context for all targets (need project_dir for factory)
     start_ctx = _get_start_context(ctx);
     if not start_ctx {
         return;
     }
     (config, entry_path, project_dir) = start_ctx;
 
-    # Auto-route a client-only (kind = "web-static") project to the static target.
     target_name = _auto_client_target(config, target_name, project_dir);
 
-    # Warn about debug mode in production
     dev_mode = ctx.get_arg("dev", False);
     if not dev_mode and is_debug_mode(config) {
         console.warning(
@@ -549,7 +468,6 @@ def _handle_start_target(ctx: HookContext) -> None {
         );
     }
 
-    # Use factory to create target (lazy loading for non-web targets)
     factory = get_target_factory();
     try {
         target = factory.create(target_name, project_dir);
@@ -564,11 +482,8 @@ def _handle_start_target(ctx: HookContext) -> None {
         return;
     }
 
-    # Store target info in context
     ctx.set_data("start_client_target", target);
 
-    # Match core `jac start`: in --dev, `port` is the Vite (frontend) port and `api_port` is
-    # the API port (0 = use port+1). In non-dev, `port` is the single server port (API / preview).
     start_port = ctx.get_arg("port", 8000);
     if start_port is None {
         start_port = 8000;
@@ -578,9 +493,7 @@ def _handle_start_target(ctx: HookContext) -> None {
         start_api = 0;
     }
 
-    # Handle non-web targets (desktop, pwa) - they override dev/start behavior
     if target_name != "web" {
-        # Check if target setup is actually missing
         if _target_setup_missing(target_name, target, project_dir) {
             console.error(
                 f"Target '{target_name}' not set up. Run 'jac setup {target_name}' first."
@@ -599,12 +512,11 @@ def _handle_start_target(ctx: HookContext) -> None {
                 if target_name == "mobile" {
                     os.environ["JAC_MOBILE_DEV_HOST"] = str(ctx.get_arg("host", ""));
                 }
-                # Use target's dev() method (polymorphic dispatch)
+
                 target.dev(
                     entry_path, project_dir, port=start_port, api_port=start_api
                 );
             } else {
-                # Use target's start() method (polymorphic dispatch)
                 target.start(entry_path, project_dir, api_port=start_port);
             }
             ctx.set_data("cancel_execution", True);
@@ -618,14 +530,8 @@ def _handle_start_target(ctx: HookContext) -> None {
         }
         return;
     }
-    # Web target: let existing core jac start command handle it
-    # (no cancellation - falls through to default behavior with HMR support)
 }
 
-"""Pre-hook to handle setup command.
-
-Uses TargetFactory for lazy loading and polymorphic dispatch.
-"""
 def _handle_setup_target(ctx: HookContext) -> None {
     import from jaclang.cli.console { console }
     import from jaclang.runtimelib.client.targets.registry { get_target_factory }
@@ -634,14 +540,9 @@ def _handle_setup_target(ctx: HookContext) -> None {
 
     factory = get_target_factory();
 
-    # `target` is jac-client's positional; `subcommand` is what jac-scale's
-    # higher-priority `setup` spec exposes. Reading both keeps us routable no
-    # matter which plugin wins the surface registration.
     target_name = ctx.get_arg("target", None) or ctx.get_arg("subcommand", None);
     available_targets = factory.get_available_target_names();
     if target_name and target_name not in available_targets {
-        # Unknown to us - let another plugin's handler claim it (e.g. jac-scale's
-        # `jac setup microservice`). Do NOT cancel.
         return;
     }
     if not target_name {
@@ -654,7 +555,6 @@ def _handle_setup_target(ctx: HookContext) -> None {
         return;
     }
 
-    # Get config and project_dir first
     config = get_config();
     if not config {
         console.error("No jac.toml found. Run 'jac create' to create a project.");
@@ -665,7 +565,6 @@ def _handle_setup_target(ctx: HookContext) -> None {
 
     project_dir = config.project_root or Path.cwd();
 
-    # Use factory to create target (lazy loading)
     try {
         target = factory.create(target_name, project_dir);
     } except ValueError as e {
@@ -679,8 +578,6 @@ def _handle_setup_target(ctx: HookContext) -> None {
         return;
     }
 
-    # Setup using target's setup method (polymorphic dispatch).
-    # JAC_MOBILE_SETUP_PLATFORM is set/restored in mobile_setup_env (swap/restore).
     setup_platform = ctx.get_arg("platform", None);
     prev_setup_platform_env = None;
     if target_name == "mobile" and setup_platform {
@@ -692,7 +589,6 @@ def _handle_setup_target(ctx: HookContext) -> None {
         );
         target.setup(project_dir);
 
-        # Verify setup completed successfully
         if target_name == "pwa" {
             pwa_icons_dir = project_dir / "pwa_icons";
             if not pwa_icons_dir.exists() {
@@ -729,12 +625,9 @@ def _handle_setup_target(ctx: HookContext) -> None {
     }
 }
 
-"""Pre-hook to handle --npm flag for removing npm dependencies."""
 def _handle_npm_remove(ctx: HookContext) -> None {
-    # Check if --npm flag is set
     npm_flag = ctx.get_arg("npm", False);
     if not npm_flag {
-        # Let core remove command run normally
         return;
     }
 

--- a/jac/jaclang/runtimelib/client/targets/impl/mobile_target.impl.jac
+++ b/jac/jaclang/runtimelib/client/targets/impl/mobile_target.impl.jac
@@ -1,4 +1,3 @@
-"""Implementation of MobileTarget methods (see `plugin/src/targets/mobile/` for logic)."""
 import os;
 import platform as platform_mod;
 import from pathlib { Path }
@@ -59,16 +58,6 @@ import from jaclang.runtimelib.client.targets.mobile.scaffold {
     _ensure_placeholder_index
 }
 
-# ==============================================================================
-# Target Implementation
-# ==============================================================================
-"""Setup mobile target - install Capacitor and scaffold platform project.
-
-Scaffolds selected platform(s):
-- explicit via JAC_MOBILE_SETUP_PLATFORM=android|ios|all
-- otherwise from [plugins.client.mobile].default_platform
-- otherwise host default (ios on macOS, android elsewhere)
-"""
 impl MobileTarget.setup(project_dir: Path) -> None {
     android_dir = project_dir / "android";
     ios_dir = project_dir / "ios";
@@ -109,7 +98,6 @@ impl MobileTarget.setup(project_dir: Path) -> None {
     needs_android = "android" in platforms;
     needs_ios = "ios" in platforms;
 
-    # Early return when required platform scaffolds already exist.
     if (not needs_android or android_dir.exists())
     and (not needs_ios or ios_dir.exists()) {
         return;
@@ -118,7 +106,6 @@ impl MobileTarget.setup(project_dir: Path) -> None {
     console.print("\n📱 Setting up mobile target (Capacitor)", style="bold");
     console.print(f"  Project directory: {project_dir}", style="muted");
 
-    # Check prerequisites for selected platforms
     try {
         checked: set[str] = set();
         for plat in platforms {
@@ -143,7 +130,6 @@ impl MobileTarget.setup(project_dir: Path) -> None {
     _ensure_capacitor_deps(project_dir);
     _ensure_capacitor_config(project_dir, web_dist_dir);
 
-    # Scaffold selected platforms.
     if needs_android {
         _ensure_android_platform(project_dir, web_dist_dir);
     }
@@ -151,7 +137,6 @@ impl MobileTarget.setup(project_dir: Path) -> None {
         _ensure_ios_platform(project_dir, web_dist_dir);
     }
 
-    # Write [plugins.client.mobile] into jac.toml
     mobile_cfg = _load_mobile_config(project_dir);
     app_name = mobile_cfg.get("app_name", DEFAULT_APP_NAME);
     app_id = mobile_cfg.get("app_id", DEFAULT_APP_ID);
@@ -181,7 +166,6 @@ impl MobileTarget.setup(project_dir: Path) -> None {
     }
 }
 
-"""Build mobile app - build web bundle first, then sync and build native app."""
 impl MobileTarget.build(
     entry_file: Path, project_dir: Path, platform: Optional[str] = None
 ) -> Path {
@@ -197,7 +181,6 @@ impl MobileTarget.build(
     _try_check_mobile_dependencies(selected_platform);
     _require_macos_for_ios(selected_platform);
 
-    # Ensure Capacitor scaffold exists
     prev_setup_platform = mobile_setup_platform_env_swap(selected_platform);
     try {
         self.setup(project_dir);
@@ -209,7 +192,6 @@ impl MobileTarget.build(
     web_bundle_path = super.build(entry_file, project_dir, None);
     console.print(f"  ✔ Web bundle built: {web_bundle_path}", style="success");
 
-    # Ensure webDir is up to date in config
     bundler = ViteBundler(project_dir=project_dir);
     web_dist_dir = Path(bundler.output_dir).resolve();
     _ensure_capacitor_config(project_dir, web_dist_dir);
@@ -222,7 +204,6 @@ impl MobileTarget.build(
     );
     console.print("  ✔ Capacitor sync complete", style="success");
 
-    # Platform-specific build
     if selected_platform == "android" {
         artifact = _build_android(project_dir, mobile_cfg);
     } else {
@@ -233,8 +214,6 @@ impl MobileTarget.build(
     return artifact;
 }
 
-"""Start mobile dev: Vite HMR + Jac API + Capacitor live-reload.
-`port` = Vite dev server, `api_port` = Jac API (0 = port+1), same as core `jac start --dev`."""
 impl MobileTarget.dev(
     entry_file: Path, project_dir: Path, port: int = 8000, api_port: int = 0
 ) -> None {
@@ -291,9 +270,7 @@ impl MobileTarget.dev(
     }
     compiler = builder._get_compiler();
     compiler.compiled_dir.mkdir(parents=True, exist_ok=True);
-    # Full compile graph (entry + all .jac deps) with add_runtime_imports per file,
-    # matching production dev - compiling only the entry leaves imported modules
-    # (e.g. components/*.js) without __jacJsx and causes "__jacJsx is not defined".
+
     (_, mod, _) = compiler.jac_compiler.compile_module(entry_file);
     if not mod {
         raise RuntimeError(f"Failed to compile client entry module: {entry_file}");
@@ -304,9 +281,6 @@ impl MobileTarget.dev(
     toml_base_url = _get_api_base_url_str(project_dir);
     server_port = cast(int, resolve_mobile_server_port(toml_base_url, effective_api));
 
-    # Verify both ports are free BEFORE rewriting capacitor.config.json and
-    # running adb reverse. The API subprocess otherwise silently bumps to a
-    # different port, breaking the handshake with the device.
     _assert_mobile_port_available(vite_port, "Vite");
     if server_port != vite_port {
         _assert_mobile_port_available(server_port, "API");
@@ -334,8 +308,6 @@ impl MobileTarget.dev(
         raise RuntimeError("Failed to start Vite dev server");
     }
 
-    # `jac start --dev` normally starts HotReloader, but the mobile pre-hook cancels that
-    # handler - so we watch .jac here and re-run the same ViteCompiler.compile graph Vite serves.
     if _mobile_ensure_watchdog() {
         import from jaclang.runtimelib.watcher { JacFileWatcher }
 
@@ -414,7 +386,6 @@ impl MobileTarget.dev(
     }
 }
 
-"""Start mobile app: production web bundle, sync, run (no Vite HMR)."""
 impl MobileTarget.start(
     entry_file: Path, project_dir: Path, api_port: int = 8000
 ) -> None {

--- a/jac/jaclang/runtimelib/client/targets/mobile/dev.jac
+++ b/jac/jaclang/runtimelib/client/targets/mobile/dev.jac
@@ -1,4 +1,3 @@
-"""Mobile target: Vite HMR, Capacitor live-reload, and dev workflow helpers."""
 import json;
 import os;
 import shutil;
@@ -14,24 +13,11 @@ import from jaclang.runtimelib.client.targets.mobile.common {
     _resolve_npx
 }
 
-"""Read [plugins.client.api] base_url for warnings and port resolution."""
 def _get_api_base_url_str(project_dir: Path) -> str {
     loader = JacClientConfig(project_dir);
     return loader.get_api_config().get("base_url", "") or "";
 }
 
-"""Fail fast if a port is already bound.
-
-The mobile dev flow reserves ports via adb reverse and rewrites
-capacitor.config.json with a fixed Vite URL. The API subprocess
-(`jaclang start`) silently bumps the port on EADDRINUSE - which leaves
-adb-reverse / cap-config pointing at a port nothing is listening on, so the
-device can never reach the API. Probing the port before we configure
-anything makes the failure mode explicit instead of arriving as a confusing
-"WebView won't connect" issue later.
-
-`role` is a short label (e.g. "Vite" or "API") used in the error message.
-"""
 def _assert_mobile_port_available(port: int, role: str) {
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM);
     try {
@@ -50,7 +36,6 @@ def _assert_mobile_port_available(port: int, role: str) {
     }
 }
 
-"""API connectivity for mobile dev."""
 def _warn_mobile_dev_api_url(project_dir: Path) {
     base = _get_api_base_url_str(project_dir);
     if base {
@@ -64,21 +49,12 @@ def _warn_mobile_dev_api_url(project_dir: Path) {
     }
 }
 
-"""Read mobile dev options set by jac-client CLI (see cli.jac). Vite port: resolve_mobile_vite_port."""
 def _mobile_read_dev_env -> tuple[str, str] {
     host_ov = os.environ.get("JAC_MOBILE_DEV_HOST", "");
     plat_mode = os.environ.get("JAC_MOBILE_PLATFORM", "auto");
     return (host_ov, plat_mode);
 }
 
-"""Best-effort ADB reverse for Android mobile dev connectivity.
-
-No-op when adb is not on PATH - adb only exists when the Android SDK platform
-tools are installed, so a missing binary means there is no device to reverse
-ports to anyway. The previous implementation called subprocess unconditionally
-and emitted noisy "[Errno 2] No such file" warnings on every dev run on hosts
-without adb.
-"""
 def _mobile_setup_android_port_reverse(vite_port: int, server_port: int) {
     if not shutil.which("adb") {
         return;
@@ -113,7 +89,6 @@ def _mobile_setup_android_port_reverse(vite_port: int, server_port: int) {
     }
 }
 
-"""Return True if watchdog is available (required for .jac → client HMR)."""
 def _mobile_ensure_watchdog -> bool {
     try {
         import watchdog;
@@ -128,12 +103,6 @@ def _mobile_ensure_watchdog -> bool {
     }
 }
 
-"""Remove stale Jac modules from JacRuntime hub before mobile dev recompiles.
-
-The client bundle compiler reuses JacRuntime.program.mod.hub entries; without
-evicting changed modules, compile_module() may return stale JS and Vite reloads
-the same bytes.
-"""
 def _mobile_invalidate_runtime_module_cache(paths: list[str]) -> None {
     try {
         import from jaclang { JacRuntime as Jac }
@@ -166,13 +135,10 @@ def _mobile_invalidate_runtime_module_cache(paths: list[str]) -> None {
             del hub[k];
         }
     } except Exception {
-        # Cache eviction is best-effort; compile still proceeds if this fails.
         return;
     }
 }
 
-"""Recompile the Vite client graph after a .jac file change (runs on watchdog thread).
-"""
 def _mobile_hmr_on_jac_changed(
     event: FileChangeEvent, compiler: any, entry_file: Path, project_dir: Path
 ) -> None {
@@ -206,7 +172,6 @@ def _mobile_hmr_on_jac_changed(
     }
 }
 
-"""Start Jac API only for mobile dev."""
 def _mobile_start_backend_server(
     entry_file: Path, project_dir: Path, port: int
 ) -> any {
@@ -228,11 +193,6 @@ def _mobile_start_backend_server(
     );
 }
 
-"""Write server.url into capacitor.config.json for live-reload.
-
-During dev, the Capacitor WebView loads directly from the Vite dev server
-instead of the static webDir. We save the original config and restore it on exit.
-"""
 def _inject_capacitor_dev_url(project_dir: Path, dev_url: str) -> str | None {
     config_path = project_dir / "capacitor.config.json";
     if not config_path.exists() {
@@ -256,7 +216,6 @@ def _inject_capacitor_dev_url(project_dir: Path, dev_url: str) -> str | None {
     return original;
 }
 
-"""Restore capacitor.config.json to its pre-dev state."""
 def _restore_capacitor_config(project_dir: Path, original: str | None) -> None {
     if original is None {
         return;
@@ -266,7 +225,6 @@ def _restore_capacitor_config(project_dir: Path, original: str | None) -> None {
     console.print("  ✔ Restored capacitor.config.json", style="muted");
 }
 
-"""Run cap run (no --live-reload; server.url in config points to Vite)."""
 def _run_cap_run_live_reload(
     project_dir: Path, plat: str, _lr_host: str, _lr_port: int
 ) -> int {
@@ -278,14 +236,6 @@ def _run_cap_run_live_reload(
     return result.returncode;
 }
 
-"""Describe the user-facing outcome of `cap run`. Pure / no side effects.
-
-Returns a dict with:
-  ok       - True when rc == 0 (cap run succeeded).
-  messages - list[str] for the user. Must NOT claim deployment when rc != 0
-             (the original code printed "📱 App deployed" unconditionally,
-             misleading users when there was no device or no Android SDK).
-"""
 def _describe_cap_run_completion(rc: int, dev_url: str) -> dict {
     if rc == 0 {
         return {

--- a/jac/tests/langserve/test_server.jac
+++ b/jac/tests/langserve/test_server.jac
@@ -269,14 +269,14 @@ test "test_go_to_definition_md_path" {
             (9, 25, "jaclang/jac0core/unitree.jac:0:0-0:0"),
             (10, 34, "jaclang/__init__.py:22:"),
             (11, 35, "jaclang/jac0core/constant.jac:0:0-0:0"),
-            (11, 47, "jaclang/jac0core/constant.jac:4:5-4:15"),
+            (11, 47, "jaclang/jac0core/constant.jac:2:5-2:15"),
             (13, 47, "jaclang/compiler/type_system/type_utils.jac:0:0-0:0"),
             (14, 34, "jaclang/compiler/type_system/__init__.py:0:0-0:0"),
-            (18, 5, "compiler/type_system/types.jac:61:4-61:12"),
+            (18, 5, "compiler/type_system/types.jac:38:4-38:12"),
             (20, 34, "jaclang/jac0core/unitree.jac:0:0-0:0"),
             (22, 22, "tests/langserve/fixtures/circle.jac:7:5-7:8"),
             (23, 28, "jaclang/lsp/uris.jac:0:0-0:0"),
-            (24, 40, "jaclang/lsp/server.jac:113:4-113:18"),
+            (24, 40, "jaclang/lsp/server.jac:92:4-92:18"),
             (26, 31, "jaclang/lsp/types.jac:0:0-0:0"),
 
         ];

--- a/jac/tests/runtimelib/client/test_mobile_target.jac
+++ b/jac/tests/runtimelib/client/test_mobile_target.jac
@@ -88,7 +88,7 @@ test "cli exposes mobile dev flags and cap live-reload" {
     ).read_text();
     mobile_dev = (_client_dir / "targets" / "mobile" / "dev.jac").read_text();
     mobile = mobile_impl + mobile_dev;
-    assert "--live-reload" in mobile;
+    assert "_run_cap_run_live_reload" in mobile;
     assert "_mobile_start_backend_server" in mobile;
     assert "def _mobile_setup_android_port_reverse" in mobile;
     assert '["adb", "reverse"' in mobile;
@@ -101,7 +101,7 @@ test "cli exposes mobile dev flags and cap live-reload" {
 test "cli exposes mobile setup platform selector" {
     cli = (_client_dir / "cli.jac").read_text();
     assert "Platform for mobile setup (android, ios, all)" in cli;
-    assert "JAC_MOBILE_SETUP_PLATFORM" in cli;
+    assert "mobile_setup_platform_env_swap" in cli;
     mobile_config = (_client_dir / "targets" / "mobile" / "config.jac").read_text();
     assert "MOBILE_SETUP_PLATFORM_ENV" in mobile_config;
     assert "_resolve_mobile_setup_mode" in mobile_config;


### PR DESCRIPTION
## What

Removes the test-related entries from the `[check.lint]` **deslop denylist** in both `jac.toml` and `jac/jac.toml`, lets `jac format --lintfix` strip their comments/docstrings, and updates the tests that were pinning those comments/source-locations in place.

Only `jir_registry.jac` (generated, must match its commented generator output) and `plugin_bridge.na.jac` (carries functional `# --- BRIDGE ... ---` markers an extractor reads) remain excluded — those are genuinely load-bearing.

## Why

The exclude entries existed only because a handful of tests asserted against the *text* of comments or against exact source line numbers that docstrings happened to shift. That coupling meant these files could never be deslopped like the rest of the tree. Re-pointing the tests at real code identifiers (and correcting the position expectations) removes the coupling, so the files participate in the normal deslop policy.

Note: config resolves to the **nearest** `jac.toml`, and `jac/jac.toml` mirrors the root's `[check.lint]` verbatim, so both had to change.

## Changes

**Deslopped (comments/docstrings stripped):** `constant.jac`, `unitree.jac`, `type_utils.jac`, `types.jac`, `llvm/ir/types.jac`, `mobile_target.impl.jac`, client `cli.jac`, mobile `dev.jac`, `lsp/server.jac`.

**Tests retargeted:**
- `test_mobile_target.jac` — two assertions grepped source for strings that only ever existed inside comments (`--live-reload`, `JAC_MOBILE_SETUP_PLATFORM`). Retargeted at the real implementing identifiers (`_run_cap_run_live_reload`, `mobile_setup_platform_env_swap`).
- `test_server.jac` — three go-to-definition assertions hardcoded definition line numbers that shifted when docstrings were removed (`constant.jac` 4→2, `types.jac` 61→38, `server.jac` 113→92).

## Verification

Ran the affected suites (langserve, runtimelib/client, project, compiler, language, cli, utils, publish) on this branch and on the base, and diffed the failure sets: **identical** — only pre-existing environment-dependent failures (native libcef/webview/libpython builds, bun/npm app creation, venv PATH, cache timing). **Zero new failures.**

- The deslopped compiler-internal files are already in `.jacignore`, so CI's `jac check . --nowarn` skips them.
- In-context `jac check` of the non-ignored files reports **0 errors, 0 warnings**, matching base.
- `jac format --check` is idempotent on the deslopped files.

## Note for reviewers

Removing a file from `[check.lint].exclude` subjects it to *all* lint rules, not just the deslop rules — so a few advisory warnings (e.g. `too-many-params` on `unitree.jac`'s AST constructors) now surface. They are report-only and don't fail CI (`--nowarn`). A cleaner long-term fix would be per-rule suppression of just W3050/W3051 rather than whole-file exclusion; happy to follow up if preferred.