### PR TITLE
fix(ci): link Linux jac binaries against glibc 2.34 floor (zig -Dtarget)

### DIFF
--- a/.github/workflows/release-jaclang.yml
+++ b/.github/workflows/release-jaclang.yml
@@ -32,13 +32,9 @@ jobs:
         # self-contained; build.zig fetches the per-target python-build-standalone
         # and (for the native backend) the per-target LLVM release.
         include:
-          # Zig cross-links each Linux binary against an explicit glibc 2.34
-          # floor (zig_target) regardless of the runner's own glibc, so the
-          # asset runs on glibc 2.34+ (forward-compatible: covers Ubuntu 20.04+,
-          # Debian 11+, RHEL 9+). This is more durable than pinning the runner
-          # OS -- it survives runner-image retirements and gives x86_64 and
-          # aarch64 the same floor without needing an old ARM runner. macOS sets
-          # no zig_target and builds host-native.
+          # zig_target pins each Linux binary's glibc floor (2.34) regardless of
+          # the runner's glibc, so the asset runs on glibc 2.34+ (e.g. Ubuntu
+          # 22.04). macOS omits it and builds host-native.
           - os: ubuntu-latest
             platform: linux-x86_64
             zig_target: x86_64-linux-gnu.2.34
@@ -83,8 +79,7 @@ jobs:
       # cached here, matching this workflow's fresh-each-release policy.
       - name: Fetch LLVM for the jacllvm shim
         working-directory: jac
-        # ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }}
-        # expands to -Dtarget=... on the Linux legs and to nothing on macOS.
+        # zig_target -> -Dtarget=... on Linux legs; empty (host-native) on macOS.
         run: zig build fetch-llvm ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }} --summary all
 
       - name: Build the jac binary (one command)

--- a/.github/workflows/release-jaclang.yml
+++ b/.github/workflows/release-jaclang.yml
@@ -32,13 +32,19 @@ jobs:
         # self-contained; build.zig fetches the per-target python-build-standalone
         # and (for the native backend) the per-target LLVM release.
         include:
-          # Pin to 22.04 (glibc 2.35) so the binary's glibc floor stays low and
-          # the asset runs on 22.04+ (forward-compatible). ubuntu-latest builds
-          # against a newer glibc and fails on still-supported 22.04 hosts.
-          - os: ubuntu-22.04
+          # Zig cross-links each Linux binary against an explicit glibc 2.34
+          # floor (zig_target) regardless of the runner's own glibc, so the
+          # asset runs on glibc 2.34+ (forward-compatible: covers Ubuntu 20.04+,
+          # Debian 11+, RHEL 9+). This is more durable than pinning the runner
+          # OS -- it survives runner-image retirements and gives x86_64 and
+          # aarch64 the same floor without needing an old ARM runner. macOS sets
+          # no zig_target and builds host-native.
+          - os: ubuntu-latest
             platform: linux-x86_64
+            zig_target: x86_64-linux-gnu.2.34
           - os: ubuntu-24.04-arm
             platform: linux-aarch64
+            zig_target: aarch64-linux-gnu.2.34
           # No macos-x86_64 (Intel) leg: the native (na) backend statically links
           # a pinned LLVM release, and LLVM ships no macOS-x64 prebuilt for 20.1.8
           # (only Linux-X64/ARM64 + macOS-ARM64). Apple Silicon is covered by
@@ -77,11 +83,13 @@ jobs:
       # cached here, matching this workflow's fresh-each-release policy.
       - name: Fetch LLVM for the jacllvm shim
         working-directory: jac
-        run: zig build fetch-llvm --summary all
+        # ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }}
+        # expands to -Dtarget=... on the Linux legs and to nothing on macOS.
+        run: zig build fetch-llvm ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }} --summary all
 
       - name: Build the jac binary (one command)
         working-directory: jac
-        run: zig build --summary all
+        run: zig build ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }} --summary all
 
       - name: Smoke test (no system Python)
         working-directory: jac

--- a/.github/workflows/release-jaclang.yml
+++ b/.github/workflows/release-jaclang.yml
@@ -32,7 +32,10 @@ jobs:
         # self-contained; build.zig fetches the per-target python-build-standalone
         # and (for the native backend) the per-target LLVM release.
         include:
-          - os: ubuntu-latest
+          # Pin to 22.04 (glibc 2.35) so the binary's glibc floor stays low and
+          # the asset runs on 22.04+ (forward-compatible). ubuntu-latest builds
+          # against a newer glibc and fails on still-supported 22.04 hosts.
+          - os: ubuntu-22.04
             platform: linux-x86_64
           - os: ubuntu-24.04-arm
             platform: linux-aarch64


### PR DESCRIPTION
Fixes #7053.

## Problem

The released `jac-*-linux-*` binaries were built on the runner's native glibc (`ubuntu-latest` → glibc 2.36+), so they fail to start on still-supported LTS hosts. On Ubuntu 22.04 (glibc 2.35):

```
GLIBC_2.36 not found (required by jac)
```

The binary never even starts — glibc is forward- but not backward-compatible, so a binary built against a newer glibc cannot run on an older one.

## Fix

Pass `-Dtarget=<arch>-linux-gnu.2.34` to both `fetch-llvm` and `zig build` for the two Linux legs. Zig cross-links against an explicit glibc **2.34** floor regardless of the runner's own glibc. The asset then runs on **glibc 2.34+** (Ubuntu 20.04+, Debian 11+, RHEL 9+) and remains forward-compatible with all newer distros.

Why target-based rather than pinning the runner OS to `ubuntu-22.04`:

- **Durable** — survives runner-image retirements; doesn't depend on GitHub keeping an old runner around.
- **Uniform** — x86_64 and aarch64 get the same floor; aarch64 needs no old ARM runner.
- macOS is unaffected (`zig_target` unset → host-native build).

`build.zig` already honors `-Dtarget`; `fetch-llvm`/`fetch-bun` key their prebuilts on os+arch only, so the glibc suffix is transparent to them.

## Validation

Verified end-to-end on Ubuntu 22.04 (glibc 2.35) before and after:

| | official v0.30.2 | this build |
|---|---|---|
| glibc floor (`objdump -T`) | GLIBC_2.36 | **GLIBC_2.34** |
| `jac --version` | `GLIBC_2.36 not found` | ✅ runs |
| `jac run hello.jac` | — | ✅ prints output |

(First validated by pinning the runner to ubuntu-22.04, which produced a 2.34-floor binary that ran clean; this PR generalizes that to the durable `-Dtarget` form covering both arches.)