### PR TITLE
ci(jac-gpt): probe OpenAI reachability before server start

### DIFF
--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -552,6 +552,20 @@ jobs:
         path: jac-gpt/services/faiss_index
         key: jac-gpt-faiss-v1
 
+    - name: Probe OpenAI reachability
+      # jac-gpt rebuilds its FAISS index at startup on a cache miss, which needs
+      # a live OpenAI call. This probe disambiguates the two failure modes the
+      # server-start step otherwise hides: a bad/empty key (HTTP 401) vs. the
+      # runner being unable to reach api.openai.com at all (UNREACHABLE).
+      continue-on-error: true
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+        curl -sS --max-time 15 -o /dev/null -w "openai HTTP %{http_code}\n" \
+          https://api.openai.com/v1/models \
+          -H "Authorization: Bearer $OPENAI_API_KEY" \
+          || echo "OPENAI UNREACHABLE FROM RUNNER"
+
     - name: Start jac-gpt server in background
       working-directory: jac-gpt
       env:

--- a/.github/workflows/test-jaseci.yml
+++ b/.github/workflows/test-jaseci.yml
@@ -553,18 +553,42 @@ jobs:
         key: jac-gpt-faiss-v1
 
     - name: Probe OpenAI reachability
-      # jac-gpt rebuilds its FAISS index at startup on a cache miss, which needs
-      # a live OpenAI call. This probe disambiguates the two failure modes the
-      # server-start step otherwise hides: a bad/empty key (HTTP 401) vs. the
-      # runner being unable to reach api.openai.com at all (UNREACHABLE).
+      # jac-gpt rebuilds its FAISS index at startup on a cache miss, which embeds
+      # docs via the OpenAI client running in jac-gpt's installed venv. That
+      # client fails with APIConnectionError even when the key is valid and the
+      # runner's curl reaches OpenAI -- a TLS/CA problem inside the jac runtime,
+      # not egress. Probe BOTH layers so the log says which it is:
+      #   1. system curl  -> runner-level egress + key
+      #   2. jac runtime  -> the Python/httpx path that actually fails, with the
+      #      raw exception + the CA bundle it resolves (certifi/SSL_CERT_FILE).
       continue-on-error: true
+      working-directory: jac-gpt
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
-        curl -sS --max-time 15 -o /dev/null -w "openai HTTP %{http_code}\n" \
+        echo "--- layer 1: system curl ---"
+        curl -sS --max-time 15 -o /dev/null -w "curl openai HTTP %{http_code}\n" \
           https://api.openai.com/v1/models \
           -H "Authorization: Bearer $OPENAI_API_KEY" \
-          || echo "OPENAI UNREACHABLE FROM RUNNER"
+          || echo "curl: OPENAI UNREACHABLE FROM RUNNER"
+        echo "--- layer 2: jac runtime python (httpx/openai) ---"
+        jac - <<'PYEOF' || echo "jac-python probe raised (see above)"
+        import ssl, os
+        try:
+            import certifi
+            print("certifi:", certifi.where())
+        except Exception as e:
+            print("certifi: MISSING", e)
+        print("ssl default verify paths:", ssl.get_default_verify_paths())
+        print("SSL_CERT_FILE:", os.environ.get("SSL_CERT_FILE"))
+        print("REQUESTS_CA_BUNDLE:", os.environ.get("REQUESTS_CA_BUNDLE"))
+        import httpx
+        try:
+            r = httpx.get("https://api.openai.com/v1/models", timeout=15)
+            print("httpx openai HTTP", r.status_code)
+        except Exception as e:
+            print("httpx FAILED:", type(e).__name__, repr(e))
+        PYEOF
 
     - name: Start jac-gpt server in background
       working-directory: jac-gpt


### PR DESCRIPTION
## Why

`test-pypi-build` started failing on main: the jac-gpt server-start step rebuilds its FAISS index at startup whenever the `jac-gpt-faiss-v1` cache misses, and that rebuild fires a live OpenAI call. The GitHub Actions cache for that index aged out (7-day eviction), so startup now needs OpenAI — and the call is failing with a buried `OpenAIException - Connection error`.

The current step hides *why*: a bad/empty key and an egress-blocked runner look the same in the log.

## What

Adds a non-fatal `curl` probe to `api.openai.com/v1/models` right before the server starts. The next run will print one of:
- `openai HTTP 200` — reachable, key valid (problem is elsewhere)
- `openai HTTP 401` — reachable, key bad/empty
- `OPENAI UNREACHABLE FROM RUNNER` — egress blocked

This is purely diagnostic (`continue-on-error: true`); it does not change the gate. Follow-up will re-seed the FAISS cache and/or decouple startup from the live call so a cache eviction can't hard-fail this gate again.