### PR TITLE
ci: give create-release-pr room for a cold binary build (10 -> 40 min)

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
   create-release-pr:
     if: github.repository == 'Jaseci-Labs/jaseci'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
+    timeout-minutes: 40
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
The create-release-pr job's setup-jac step is a ~2.5 min cache restore on a warm cache, but a 15-25 min full build (pbs fetch + LLVM slice range-fetch + payload precompile) whenever a `jac/` change invalidates the binary cache key. The 10-minute job timeout therefore kills the FIRST release attempt after any compiler/launcher merge, and GitHub reports the self-timeout as a bare 'cancelled'.

This ate two release dispatches tonight (runs 28552323191 and 28553655200): each raced the post-#7100-merge main build that was still seeding the new cache, missed, started a cold build, and was guillotined at 10:17. 40 minutes covers the cold path with margin; the warm path is unaffected.