### PR TITLE
ci(release-dev): shim/LLVM caches, pin setup-zig to a SHA, surface codesign failures

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -80,6 +80,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The LLVMPY_* shim is the single most expensive build artifact (statically
+      # links ~0.5 GB of LLVM archives; several minutes) and depends only on
+      # native/**, build.zig, and the pinned slice (llvm_release.zig) -- NOT on
+      # jaclang/**. Same cache key as setup-jac, so CI on main usually has it
+      # warm: a hit skips both the LLVM fetch and the static link (-Dshim-bin
+      # below), leaving only the payload assembly this push actually changed.
+      - name: Restore cached LLVMPY shim
+        id: shim-cache
+        uses: actions/cache@v4
+        with:
+          path: jac/jaclang/compiler/passes/native/llvm/libjacllvm.*
+          key: jac-shim-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/native/**', 'jac/build.zig', 'jac/launcher/llvm_release.zig') }}
+
+      # On a shim miss the extracted LLVM tree is still needed; cache it too
+      # (same key as setup-jac; payload.zig pins the LLVM release), so even a
+      # cold shim link skips the ~1.5-2 GB download.
+      - name: Restore cached LLVM (jacllvm shim deps)
+        if: steps.shim-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: jac/.llvm-build
+          key: llvm-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/payload.zig') }}
+
       - name: Install host tools (zstd)
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
@@ -89,7 +112,10 @@ jobs:
           fi
 
       - name: Set up Zig 0.16.0
-        uses: mlugg/setup-zig@v2
+        # Pinned to a full SHA (not the mutable v2 tag): this job holds
+        # `contents: write` and publishes binaries users download, so a
+        # re-pointed tag on this third-party action must not reach it.
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
           # Fresh cache each run: build.zig's payload step doesn't reliably
@@ -99,14 +125,28 @@ jobs:
 
       # The native (na) backend statically links a pinned LLVM into the LLVMPY_*
       # shim, so the per-target LLVM release must be extracted before `zig build`
-      # (there is no llvmlite wheel anymore). One-time ~1.5-2 GB download.
+      # (there is no llvmlite wheel anymore). Skipped entirely when a cached shim
+      # was restored (-Dshim-bin needs no LLVM).
       - name: Fetch LLVM for the jacllvm shim
+        if: steps.shim-cache.outputs.cache-hit != 'true'
         working-directory: jac
         run: zig build fetch-llvm --summary all
 
       - name: Build the jac binary (one command)
         working-directory: jac
-        run: zig build --summary all
+        # On a shim-cache hit, stage the restored shim OUTSIDE its in-tree place
+        # path before passing it via -Dshim-bin: the build's place step copies
+        # -Dshim-bin back to that path, and a self-copy would read the file it
+        # is truncating. On a miss the plain build links the shim from source,
+        # places it in-tree, and the cache saves it at job end. Mirrors setup-jac.
+        run: |
+          SHIM_ARG=()
+          if [ "${{ steps.shim-cache.outputs.cache-hit }}" = "true" ]; then
+            mkdir -p .shim-build
+            cp jaclang/compiler/passes/native/llvm/libjacllvm.* .shim-build/
+            SHIM_ARG=(-Dshim-bin=".shim-build/$(ls .shim-build | head -1)")
+          fi
+          zig build "${SHIM_ARG[@]}" --summary all
 
       - name: Smoke test (no system Python)
         working-directory: jac
@@ -126,7 +166,9 @@ jobs:
           ASSET="jac-dev-${{ matrix.platform }}"
           mkdir -p dist
           cp zig-out/bin/jac "dist/$ASSET"
-          if [ "$RUNNER_OS" = "macOS" ]; then codesign --force --sign - "dist/$ASSET" || true; fi
+          # No `|| true`: a signing failure should fail the job, not silently
+          # ship a binary that was never re-signed after the copy.
+          if [ "$RUNNER_OS" = "macOS" ]; then codesign --force --sign - "dist/$ASSET"; fi
           ( cd dist && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Follow-up to #7108, addressing the Greptile review comments on that PR — the ones I agree with, with reasoning for the one I declined.

## Applied

**1. Reuse the LLVMPY shim across pushes (Greptile P2: "Full LLVM re-download on every push")**
Greptile suggested caching the LLVM download; this goes one better using the `-Dshim-bin` mechanism from #7107. The build job now restores the built shim with the **same cache keys as setup-jac**, so CI on main keeps them warm:
- Shim hit → skip the LLVM fetch *and* the multi-minute static link; only the payload (the part a push to main actually changes) rebuilds.
- Shim miss → still restore the extracted `.llvm-build` tree instead of re-downloading ~1.5–2 GB per matrix leg.

The shim key covers all of its inputs (`jac/native/**`, `jac/build.zig`, `jac/launcher/llvm_release.zig`), so a stale shim can never be served. `use-cache: false` on setup-zig stays — the payload-staleness concern it guards is untouched. release-jaclang.yml deliberately keeps linking from source per #7107's stance for shipped versioned releases; the dev channel is a prerelease where build speed is the point.

**2. Pin `mlugg/setup-zig` to a full commit SHA (Greptile P1)**
Third-party action in a `contents: write` job that publishes binaries users download. Pinned to `d1434d0` (v2.2.1).

**3. Fail on codesign errors (Greptile P2)**
Dropped the `|| true` so a macOS signing failure fails the job instead of silently uploading a binary that was never re-signed after the copy.

## Declined

**Pin `actions/checkout` to a SHA (Greptile P2)** — first-party GitHub action, and the repo convention everywhere else is unpinned `@v4`/`@v5` (26 uses across workflows). Pinning this single use adds no meaningful protection while breaking convention; if the project wants SHA-pinning for first-party actions it should be a repo-wide change.

## Possible follow-ups (out of scope here)
- `release-jaclang.yml` has the same unpinned `mlugg/setup-zig@v2` and `codesign || true` patterns.
- The dev workflow predates #7082 and has no `zig_target` glibc floor pins, so dev Linux binaries require the runner's glibc (newer than the 2.17 floor the versioned releases guarantee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)