### PR TITLE
docs: fix breaking-changes link depth in collected 0.30.4 release notes

### DIFF
--- a/docs/docs/community/release_notes/jaclang.md
+++ b/docs/docs/community/release_notes/jaclang.md
@@ -6,7 +6,7 @@ This document provides a summary of new features, improvements, and bug fixes in
 
 ### Breaking Changes
 
-- **Breaking: byLLM folded into `jaclang` core**: The `jac-byllm` package is no longer separate. The `by llm()` feature ships inside the `jac` binary and is importable as `jaclang.byllm` (was `byllm`); update imports accordingly (e.g. `import from byllm.lib { Model }` becomes `import from jaclang.byllm.lib { Model }`). byLLM's dependencies are now the `llm` capability (litellm, pillow) -- declare `[plugins.byllm]` in `jac.toml` and run `jac install`; optional runtimes are the `llm.local`, `llm.mcp`, and `llm.video` capabilities. `import jaclang` no longer pulls litellm: heavy deps load lazily behind `_optdeps` shims, and a real model call without the `llm` capability raises an actionable "run `jac install`" error. See [Breaking Changes](../../breaking-changes.md).
+- **Breaking: byLLM folded into `jaclang` core**: The `jac-byllm` package is no longer separate. The `by llm()` feature ships inside the `jac` binary and is importable as `jaclang.byllm` (was `byllm`); update imports accordingly (e.g. `import from byllm.lib { Model }` becomes `import from jaclang.byllm.lib { Model }`). byLLM's dependencies are now the `llm` capability (litellm, pillow) -- declare `[plugins.byllm]` in `jac.toml` and run `jac install`; optional runtimes are the `llm.local`, `llm.mcp`, and `llm.video` capabilities. `import jaclang` no longer pulls litellm: heavy deps load lazily behind `_optdeps` shims, and a real model call without the `llm` capability raises an actionable "run `jac install`" error. See [Breaking Changes](../breaking-changes.md).
 
 ### New Features
 


### PR DESCRIPTION
The 0.30.4 release PR (#7110) hoisted the unreleased fragments into `community/release_notes/jaclang.md`, and the byllm fold-in note (#7064) carried a mis-authored relative link: `../../breaking-changes.md` resolves to `community/release_notes/breaking-changes.md`, which doesn't exist. mkdocs strict mode aborts, so `test-packages-and-docs` is red on main (it flagged this on #7110 post-merge; the binary release pipeline is unaffected since it doesn't build docs).

Correct target from `jaclang.md` is `../breaking-changes.md` -- exactly what the mkdocs warning suggested. Unreleased fragments aren't part of the mkdocs build, which is why the bad link never failed CI until the release collected it.