### PR TITLE
ci(release): drop the macOS ad-hoc codesign of packaged jac binaries

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -175,7 +175,7 @@ jobs:
           printf 'with entry { print("ok"); }\n' > "$WORK/h.jac"
           env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" run "$WORK/h.jac" | grep -q ok
 
-      - name: Package asset (+ checksum, ad-hoc codesign on macOS)
+      - name: Package asset (+ checksum)
         id: pkg
         working-directory: jac
         run: |
@@ -183,9 +183,13 @@ jobs:
           ASSET="jac-dev-${{ matrix.platform }}"
           mkdir -p dist
           cp zig-out/bin/jac "dist/$ASSET"
-          # No `|| true`: a signing failure should fail the job, not silently
-          # ship a binary that was never re-signed after the copy.
-          if [ "$RUNNER_OS" = "macOS" ]; then codesign --force --sign - "dist/$ASSET"; fi
+          # No codesign on macOS, deliberately: the binary is a Mach-O stub
+          # with the payload tarball appended (launcher/pack.zig), and codesign
+          # rejects any file with data past the Mach-O end ("main executable
+          # failed strict validation"). Re-signing is also unnecessary -- the
+          # zig linker ad-hoc signs the stub, that signature is content-based
+          # so it survives cp, and the smoke test above already executed these
+          # exact bytes on this runner.
           ( cd dist && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-jaclang.yml
+++ b/.github/workflows/release-jaclang.yml
@@ -152,7 +152,7 @@ jobs:
           [ -f "$SHIM" ] || SHIM="zig-out/lib/libjacllvm.so"
           check "$SHIM"
 
-      - name: Package asset (+ checksum, ad-hoc codesign on macOS)
+      - name: Package asset (+ checksum)
         id: pkg
         working-directory: jac
         run: |
@@ -160,7 +160,13 @@ jobs:
           ASSET="jac-${{ steps.ver.outputs.version }}-${{ matrix.platform }}"
           mkdir -p dist
           cp zig-out/bin/jac "dist/$ASSET"
-          if [ "$RUNNER_OS" = "macOS" ]; then codesign --force --sign - "dist/$ASSET" || true; fi
+          # No codesign on macOS, deliberately: the binary is a Mach-O stub
+          # with the payload tarball appended (launcher/pack.zig), and codesign
+          # rejects any file with data past the Mach-O end ("main executable
+          # failed strict validation") -- the old `codesign ... || true` here
+          # failed on every run. The zig linker's ad-hoc signature on the stub
+          # is content-based and survives cp, and the smoke test above already
+          # executed these exact bytes on this runner.
           ( cd dist && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

The macOS leg of the rolling dev release is failing on main at the "Package asset" step ([failing run](https://github.com/jaseci-labs/jaseci/actions/runs/28603031638/job/84816087919)):

```
+ codesign --force --sign - dist/jac-dev-macos-aarch64
dist/jac-dev-macos-aarch64: replacing existing signature
dist/jac-dev-macos-aarch64: main executable failed strict validation
```

## Root cause

The packaged `jac` binary is a Mach-O stub with the payload tarball appended after it (`launcher/pack.zig` writes `[stub][payload.tar.gz][trailer]`). `codesign` refuses to sign any file with data past the end of the Mach-O — that is exactly what "main executable failed strict validation" means. The re-sign step has therefore **never succeeded**: `release-jaclang.yml` silenced it with `|| true` on every release, and when #7109 removed the silencer in `release-dev.yml` (correctly, on the assumption the step was doing something), every macOS dev-release run started failing.

## Fix

Remove the codesign call from both workflows, with a comment explaining why. Re-signing is not just impossible for this artifact — it's unnecessary:

- The zig linker ad-hoc signs the arm64 stub at link time; that signature is content-based and survives the `cp` into `dist/` byte-for-byte.
- macOS validates only the mapped executable pages, so the appended payload doesn't affect execution — which is why the shipped binaries have always worked despite the sign step silently failing.
- The smoke test step already executes those exact bytes on the same runner before packaging, in both workflows.