### PR TITLE
style: fix full-repo jac format --lintfix failure on main

### DIFF
--- a/jac/jaclang/jac0core/compile_options.jac
+++ b/jac/jaclang/jac0core/compile_options.jac
@@ -9,9 +9,6 @@ obj CompileOptions {
         force_target_program: bool = False,
         aot_mode: bool = False,
         suppress_codes: list[str] = field(default_factory=`list),
-        # Explicit client-kind override for mobUI enforcement; when left at
-        # the defaults, the kind and root are discovered per module from the
-        # owning project's jac.toml (see jaclang.project.client_kind).
         project_kind: str = "web",
         project_root: (str | None) = None,
         cancel_token: any = None;

--- a/jac/jaclang/jac0core/jir.jac
+++ b/jac/jaclang/jac0core/jir.jac
@@ -137,12 +137,6 @@ def _related_files(source_path: str) -> list[tuple[str, str]] {
 glob _client_kind_probe_active: bool = False;
 
 def _module_client_kind(source_path: str) -> str {
-    # The owning project's client_kind participates in the module key so
-    # flipping `[project] client_kind` in jac.toml invalidates bytecode
-    # compiled under the other kind (mobUI diagnostics such as E1105 only
-    # run when the module actually recompiles). Reentrancy-guarded: during
-    # bootstrap, before jaclang.project itself is compiled, every module
-    # keys as the default "web".
     global _client_kind_probe_active;
     if _client_kind_probe_active {
         return "web";

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -388,10 +388,6 @@ impl JacConfig.merge_from_toml_file(toml_path: Path) -> None {
 impl JacConfig.get_plugin_deps(dep_type: str) -> dict[str, any] {
     deps = self.plugin_dependencies.get(dep_type, {});
 
-    # Nested tables are scopes ("dev", per-target sections like
-    # "react_native"), not dependencies; only name -> version-string pairs
-    # are direct deps. Leaking a table here would put a dict into a
-    # generated package.json.
     return {
         k: v
         for (k, v) in deps.items()

--- a/jac/jaclang/runtimelib/client/compiler.jac
+++ b/jac/jaclang/runtimelib/client/compiler.jac
@@ -1,10 +1,3 @@
-"""Web (Vite) client compiler.
-
-The target-agnostic compilation engine lives in JacClientCompiler
-(module/page compilation, dependency walking, asset copying, source maps);
-ViteCompiler owns only the web-specific steps: the browser runtime bundle,
-the desktop SDK module, the Vite entry file, and the Vite bundling itself.
-"""
 import contextlib;
 import from collections.abc { Callable }
 import from pathlib { Path }

--- a/jac/jaclang/runtimelib/client/impl/client_runtime_core.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/client_runtime_core.impl.jac
@@ -12,11 +12,7 @@ impl JacAwaiting(props: dict) -> JsxElement {
     );
 }
 
-async def _awaitPlatformReady -> None {
-    # Platforms with asynchronous credential storage (React Native /
-    # SecureStore) publish a readiness promise; awaiting it here keeps
-    # early walker/function calls from going out before the auth token is
-    # primed. Web wires nothing, so this is a no-op there.
+async def _awaitPlatformReady {
     ready = globalThis.__jacPlatformReady__;
     if ready {
         await ready;

--- a/jac/jaclang/runtimelib/client/impl/client_runtime_native.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/client_runtime_native.impl.jac
@@ -1,9 +1,7 @@
 impl __jacWirePlatformAdapters -> None {
     globalThis.__jacGetRenderer__ = __jacGetRenderer;
     globalThis.__jacGetApiBaseUrl__ = __getApiBaseUrl;
-    # Token reads are synchronous but SecureStore is async: start priming
-    # now and let the core fetch paths await readiness so early walker
-    # calls never go out unauthenticated.
+
     globalThis.__jacPlatformReady__ = __ensureNativeTokenPrimed();
     globalThis.__jacGetLocalStorage__ = __getLocalStorage;
     globalThis.__jacSetLocalStorage__ = __setLocalStorage;
@@ -568,8 +566,7 @@ impl __nativeRouter(props: dict = {}) -> JsxElement {
         pending = globalThis.__jacPendingNavigation__;
         if pending {
             globalThis.__jacPendingNavigation__ = None;
-            # Queued redirects (e.g. a 401 during mount) predate any user
-            # navigation, so replace rather than push.
+
             _performNavigation(nav_ref.current, pending, {"replace": True});
         }
     }
@@ -731,8 +728,6 @@ impl navigate(path: str) -> None {
     nav_ref = globalThis.__jacNativeNavigationRef__;
     nav = nav_ref.current if nav_ref and nav_ref.current else None;
     if nav == None {
-        # The container is not ready yet (e.g. a walker 401 fired during
-        # mount). Queue the target; __nativeRouter flushes it onReady.
         globalThis.__jacPendingNavigation__ = path;
         return;
     }

--- a/jac/jaclang/runtimelib/client/impl/compiler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/compiler.impl.jac
@@ -3,9 +3,6 @@ import from jaclang.cli.console { console }
 impl ViteCompiler.compile(
     self: ViteCompiler, module: ModuleType, module_path: Path
 ) -> tuple[list[str], list[str]] {
-    # The target-agnostic work (module + dependency + page compilation, PWA
-    # runtime, root assets) is delegated to the shared engine; only the
-    # web-specific steps live here.
     (client_exports, client_globals) = self.jac_client_compiler.compile(
         module, module_path, target_name="web"
     );

--- a/jac/jaclang/runtimelib/client/impl/jac_client_compiler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/jac_client_compiler.impl.jac
@@ -401,10 +401,7 @@ impl JacClientCompiler.compile_runtime_utils(
     import re;
     import json;
     import importlib;
-    # The compiled runtime imports the RN tag map as a relative JS module;
-    # regenerate it inside the compiled dir from the canonical Jac module.
-    # All list constants are exported so adding a tag set to html_tag_map
-    # never silently breaks the native bundle.
+
     for _m in re.finditer(
         r'from\s+[\'"]((?:\./)?[^\'"]*html_tag_map\.js)[\'"]', runtimeutils_js
     ) {
@@ -480,9 +477,6 @@ impl JacClientCompiler._write_source_map(
         raw_js = mod.gen.js or '';
         raw_start = full_output.find(raw_js) if raw_js else -1;
         if raw_start < 0 {
-            # The emitted JS was transformed beyond prepending (imports
-            # rewritten, bodies merged); a line map offset would be wrong,
-            # and a wrong map is worse than none.
             return;
         }
         header_lines = full_output[:raw_start].count('\n');

--- a/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
@@ -417,10 +417,7 @@ impl ViteBundler._generate_vite_config_content(
     ui_alias_str = (
         f'\n      "@jac/mobui": path.resolve(buildDir, "{compiled_ui_relative}"),'
     );
-    # @jac/mobui renders through react-native primitives; on the web that only
-    # works when the project ships react-native-web. Aliasing react-native
-    # unconditionally would break every web build that imports it without
-    # the shim installed.
+
     pkg_deps = self.config_loader.get_package_config().get('dependencies', {});
     if 'react-native-web' in pkg_deps {
         ui_alias_str += '\n      "react-native": "react-native-web",';

--- a/jac/jaclang/runtimelib/client/jac_client_compiler.jac
+++ b/jac/jaclang/runtimelib/client/jac_client_compiler.jac
@@ -29,12 +29,9 @@ class JacClientCompiler {
             'AuthGuard',
             'JacClientErrorBoundary'
         ];
-        # .native.cl.jac must come before .cl.jac so Header.native.cl.jac
-        # maps to Header.js, not Header.native.js.
+
         COMPOUND_EXTENSIONS = ['.native.cl.jac', CLIENT_SUFFIX] + list(ANNEX_SUFFIXES);
-        # Targets whose platform runtime (bundled with client_runtime_core)
-        # lives in this plugin dir. Web has no entry here: its runtime is
-        # emitted by the ViteCompiler pipeline.
+
         PLATFORM_RUNTIME_FILES = {"react-native": "client_runtime_native.cl.jac"};
     }
 

--- a/jac/jaclang/runtimelib/client/targets/node_tooling_common.jac
+++ b/jac/jaclang/runtimelib/client/targets/node_tooling_common.jac
@@ -18,10 +18,6 @@ def check_command_available(
 }
 
 def resolve_node_runner -> list[str] {
-    # Argv prefix for running a package binary (`<bundled bun> x expo ...`).
-    # All JS tooling runs on the bun bundled with the jac binary -- Node.js
-    # is never consulted, so behavior is identical on every machine. Set
-    # JAC_BUN to substitute a specific bun binary.
     return [_require_bundled_bun(), "x"];
 }
 

--- a/jac/jaclang/runtimelib/client/targets/react_native/build.jac
+++ b/jac/jaclang/runtimelib/client/targets/react_native/build.jac
@@ -42,9 +42,6 @@ def _iter_user_js_files(compiled_dir: Path) -> list[Path] {
 }
 
 def read_user_js_sources(compiled_dir: Path) -> list[tuple[Path, str]] {
-    # One tree walk + read shared by the read-only lints; callers that run
-    # several lints back-to-back pass the same list instead of re-reading
-    # the whole compiled tree per lint.
     sources = [];
     for js_file in _iter_user_js_files(compiled_dir) {
         try {
@@ -127,8 +124,6 @@ def stage_compiled_entry(compiled_dir: Path, rn_dir: Path, entry_module: str) ->
     try {
         os.rename(staged_tmp, staged_tree);
     } except BaseException {
-        # Never leave the project without a jac-src tree: put the previous
-        # staging back if the swap failed after the first rename.
         if staged_old.exists() and not staged_tree.exists() {
             os.rename(staged_old, staged_tree);
         }
@@ -402,9 +397,7 @@ def strip_css_imports(compiled_dir: Path) -> int {
         r"^[^\S\n]*import\s+(?:[^'\"\n]*?\sfrom\s+)?['\"][^'\"\n]+\.(?:css|scss|sass|less)['\"]\s*;?\s*(?://[^\n]*)?$",
         re.MULTILINE
     );
-    # Bindings (braced, default, or namespace) may span lines in compiled
-    # output; they can never contain quotes or semicolons, which keeps the
-    # lazy match from jumping across statements or into string literals.
+
     css_multi_pattern = re.compile(
         r"import\s+(?:[^;'\"]*?\sfrom\s+)?['\"][^'\"\n]+\.(?:css|scss|sass|less)['\"]\s*;?",
         re.DOTALL

--- a/jac/jaclang/runtimelib/client/targets/react_native/common.jac
+++ b/jac/jaclang/runtimelib/client/targets/react_native/common.jac
@@ -28,8 +28,6 @@ def run_manifest_install(project_dir: Path) {
 def resolve_rn_project_dir(
     project_dir: Path, client_cfg: (JacClientConfig | None) = None
 ) -> Path {
-    # Callers that already hold a JacClientConfig pass it in so one build/dev
-    # invocation parses jac.toml once instead of per helper call.
     if client_cfg is None {
         client_cfg = JacClientConfig(project_dir);
     }

--- a/jac/jaclang/runtimelib/client/targets/react_native/html_tag_map.jac
+++ b/jac/jaclang/runtimelib/client/targets/react_native/html_tag_map.jac
@@ -43,10 +43,6 @@ def supported_rn_html_tags -> frozenset {
 }
 
 def rn_tag_suggestions -> dict[str, str] {
-    # Per-tag fix-it advice derived from the canonical sets above; consumed
-    # by JsxIntrinsicGuardPass (E1105). List containers suggest ScrollView
-    # even though the runtime renders them as View: scrollable content is
-    # almost always what a ported <ul>/<ol> wants on native.
     suggestions: dict[str, str] = {};
     for tag in RN_HTML_VIEW_TAGS {
         suggestions[tag] = "View";

--- a/jac/jaclang/runtimelib/react_entry.jac
+++ b/jac/jaclang/runtimelib/react_entry.jac
@@ -66,9 +66,6 @@ def build_pages_react_entry_script(
 
     lines.extend(
         [
-            # AuthGuard is a compiled Jac function taking the redirect path as
-            # a positional string, not a props-consuming React component, so
-            # it needs a wrapper component rather than createElement props.
             f'function _AuthGuardRoute() {{ return AuthGuard("{auth_redirect}"); }}',
             'const authGuardElement = React.createElement(_AuthGuardRoute, null);',
             '',
@@ -114,9 +111,6 @@ def build_pages_react_entry_script(
 }
 
 def build_web_error_overlay_entry_script(file_path: str, errors: str) -> str {
-    # Both values are compiler/filesystem strings interpolated into generated
-    # JS: the path lands in a double-quoted literal, the errors in a template
-    # literal, so each needs its own escape set.
     safe_path = file_path.replace("\\", "\\\\").replace('"', '\\"').replace(
         "\n", "\\n"
     ).replace(

--- a/jac/jaclang/utils/precompile_bytecode.jac
+++ b/jac/jaclang/utils/precompile_bytecode.jac
@@ -131,9 +131,6 @@ def main {
     out_dir = precompiled_dir / pyver;
     out_dir.mkdir(parents=True, exist_ok=True);
 
-    # A seeded _precompiled (previous build) may carry trees for other python
-    # versions and .jir files for since-deleted sources; drop both so the
-    # bundle ships exactly the current module set.
     for stale_dir in sorted(precompiled_dir.iterdir()) {
         if stale_dir.is_dir() and stale_dir.name != pyver {
             shutil.rmtree(stale_dir, ignore_errors=True);
@@ -164,11 +161,6 @@ def main {
         sys.stderr.flush();
 
         try {
-            # Up-to-date check: a seeded .jir whose embedded module key matches
-            # the recomputed key was compiled from identical source with the
-            # same jaclang/python/format versions -- the exact criterion the
-            # runtime uses to accept a bundled JIR -- so recompiling it can
-            # only reproduce the same bytecode.
             if jir_path.is_file()
             and jir_matches_source(jir_path.read_bytes(), jac_path) {
                 reused += 1;


### PR DESCRIPTION
Main's `Jac Type Check` workflow is red ([failing run](https://github.com/jaseci-labs/jaseci/actions/runs/28603031599/job/84816261912)): the full-repo `jac format --check --lintfix` step flags 20 files.

**Why it slipped through:** PR runs scope the format check to the files changed vs. the merge-base, and #6227 / #7118 passed that on their branches — but the push-to-main run checks the whole repo, and the combination of the two merges left these files unformatted under the current lint config.

**Fix:** ran exactly what CI printed — `jac format --lintfix` on the flagged files. The diff is almost entirely comment/docstring removal, which is intended: `jac/jac.toml` opts `jac/jaclang/**` into the `strip-comments` / `strip-docstrings` deslop rules.

**Verification (local, mirroring the workflow):**
- full-repo `jac format --check --lintfix` (same `find` exclusions as CI) now passes
- `jac gen-jir-registry --verify` passes
- `jac check` on the touched files reports identical error counts before/after the reformat (zero new issues)