### PR TITLE
ci: run the jaclang compiler test suite (prim equivalence) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,10 @@ jobs:
         run: |
           chmod +x "$PWD/bin/jac"
           echo "$PWD/bin" >> "$GITHUB_PATH"
+      - name: Set up Node.js (ES backend for the equivalence suite)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Set up Zig 0.16.0 (vendor static-musl runtime)
         uses: mlugg/setup-zig@v2
         with:
@@ -177,6 +181,20 @@ jobs:
             echo "## binary compiler-suite result"
             echo '```'
             grep -E '^(FAILED|ERROR)|passed|failed' /tmp/compiler.log | tail -60 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"
+      - name: Cross-backend equivalence suite (py/es/native congruence)
+        working-directory: jac
+        run: |
+          set -uxo pipefail
+          WORK="$(mktemp -d)"
+          rc=0
+          HOME="$WORK" JAC_TEST_JOBS=auto jac test jaclang/compiler/tests | tee /tmp/equivalence.log || rc=$?
+          {
+            echo "## binary equivalence-suite result"
+            echo '```'
+            grep -E '^(FAILED|ERROR)|passed|failed' /tmp/equivalence.log | tail -60 || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$rc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,13 @@ jobs:
           exit "$rc"
       - name: Cross-backend equivalence suite (py/es/native congruence)
         working-directory: jac
+        # The suite's cross-module tests build fixture paths under jac/tests/
+        # from jaclang.__file__, which only resolve in the checkout, not in the
+        # binary's bundled site copy. Run this one step through the checkout's
+        # `[dev] jaclang_source` loop (as k8s-real-e2e does) so the suite
+        # exercises THIS checkout's compiler and harness.
+        env:
+          JAC_NO_DEV_SOURCE: ""
         run: |
           set -uxo pipefail
           WORK="$(mktemp -d)"

--- a/jac/jaclang/compiler/tests/xbackend_equiv.jac
+++ b/jac/jaclang/compiler/tests/xbackend_equiv.jac
@@ -27,6 +27,7 @@ import jaclang;
 import from jaclang.compiler.passes.ecmascript { EsastGenPass }
 import from jaclang.compiler.passes.ecmascript.es_unparse { es_to_js }
 import from jaclang.compiler.passes.ecmascript.estree { Node as EsNode }
+import from jaclang.jac0core.codeinfo { native_safe_sym }
 import from jaclang.jac0core.program { JacProgram }
 
 glob FIXTURES = str(
@@ -173,7 +174,7 @@ def unbox_jacval(jv: JacVal) -> object {
     return None;
 }
 
-def run_native_function(eng: object, func_name: str) -> dict {
+def run_native_function(eng: object, func_name: str, ir: object = None) -> dict {
     class DictStruct(ctypes.Structure) {
         has _fields_: list = [
             ("len", ctypes.c_int64),
@@ -189,11 +190,34 @@ def run_native_function(eng: object, func_name: str) -> dict {
     # back to this module's __jac_glob_init when no `with entry` block emitted a
     # jac_entry. Fixtures carry no entry block, so this only runs initializers.
     init_addr = eng.get_function_address("jac_entry");
-    if init_addr == 0 {
-        init_addr = eng.get_function_address("__jac_glob_init");
-    }
     if init_addr != 0 {
         ctypes.CFUNCTYPE(None)(init_addr)();
+    } else {
+        own_init = eng.get_function_address("__jac_glob_init");
+        if own_init != 0 {
+            ctypes.CFUNCTYPE(None)(own_init)();
+        }
+        # Without a jac_entry nothing has chained the glob inits of linked
+        # native imports (they are renamed to __jac_glob_init_<safe_sym> at
+        # link time), so run them here too -- otherwise an imported module's
+        # runtime-initialized globals (e.g. the bytes alphabets in
+        # na_stdlib/base64.na.jac) are read as null pointers and the JIT'd
+        # fixture segfaults.
+        manifest = ir.gen.interop_manifest if (ir is not None) else None;
+        sources = manifest.native_transitive_sources if manifest else [];
+        seen_srcs: set = set();
+        for src_mod in sources {
+            if src_mod is None or src_mod in seen_srcs {
+                continue;
+            }
+            seen_srcs.add(src_mod);
+            imp_init = eng.get_function_address(
+                "__jac_glob_init_" + native_safe_sym(src_mod)
+            );
+            if imp_init != 0 {
+                ctypes.CFUNCTYPE(None)(imp_init)();
+            }
+        }
     }
     f = get_func(eng, func_name, ctypes.POINTER(DictStruct));
     dict_ptr = f();
@@ -276,8 +300,8 @@ def run_with_both(
     }
     na_keys: int = 0;
     try {
-        (eng, _) = compile_native(fixture);
-        na_result = run_native_function(eng, na_fn);
+        (eng, na_ir) = compile_native(fixture);
+        na_result = run_native_function(eng, na_fn, na_ir);
         na_keys = len(set(py_result.keys()) & set(na_result.keys()));
         compare_results(py_result, na_result, f"{label} [NA]", tolerance);
     } except Exception {


### PR DESCRIPTION
## Problem

The tri-backend equivalence suite at `jac/jaclang/compiler/tests/` (`test_prim_equivalence.jac`, `test_osp_equivalence.jac`, `test_shared_types_equivalence.jac`, `test_socket_equivalence.jac`, `test_ssl_equivalence.jac`, `test_urllib_equivalence.jac`, plus `test_code_intel.jac` — 111 tests) is not executed by any CI workflow:

- `test-compiler` runs `jac test tests/compiler` (i.e. `jac/tests/compiler`) only.
- `test-runtime` runs `jac test tests/ --ignore tests/compiler` (i.e. `jac/tests`) only.
- `test-native-macos` runs exactly two Mach-O linker test files.
- Grepping `.github/workflows/` for `jaclang/compiler/tests` finds nothing, and `nightly.yml` / `build-binaries.yml` contain no `jac test` invocations at all.

So every `require=["na"]` / `require=["cl"]` pin in the equivalence suite — the enforced regression guards for the na_stdlib congruence work landed under #6978 Phase 1 (hashlib/hmac, secrets, uuid, json, os, datetime, ssl, socket, urllib, zlib) — has never actually gated a merge: 36 tests pin `na`, 10 pin `na`+`cl`, 3 pin `cl`.

## Change

1. **`ci.yml`**: extend the `test-compiler` job with one more step that runs `jac test jaclang/compiler/tests`, mirroring the existing compiler-suite step (own log + step-summary block), and add a Node.js setup step (the `cl`/ECMAScript legs shell out to `node`; 13 tests pin it). The step runs through the checkout's `[dev] jaclang_source` loop (`JAC_NO_DEV_SOURCE: ""`, the same mechanism `k8s-real-e2e` uses): the suite's cross-module tests build fixture paths under `jac/tests/compiler/passes/native/fixtures/` from `jaclang.__file__`, which only resolve in the checkout — the binary's bundled site copy ships no `tests/` tree (the 7-failure fingerprint in this PR's first CI run). The native (`na`) legs still run on the shipped binary's bundled LLVM JIT (`libjacllvm.so` resolves via the payload fallback).
2. **`xbackend_equiv.jac`**: carries dc9f72c53 ("chain linked-module glob inits in the native equivalence harness") from #7086. Without it, fixtures linking bundled na_stdlib modules with runtime-initialized globals run them with null globals under the JIT — on the ubuntu runners this aborted the `zlib bundled` xdist worker (zlib's error-code constants read as 0, taking the error path into an uncaught abort). The same commit rides several open na_stdlib PRs; git dedupes it on merge.

No new workflow file, no change to the required-check set.

## Verification

First CI run of this PR (before the two fixes above): **102 passed, 9 failed in 90s** — 7 × osp cross-module `OSError: Could not read file .../site/tests/compiler/passes/native/fixtures/xmod_*.na.jac` (site-copy path issue, fixed by the dev-source loop), 1 × `zlib bundled` worker crash (fixed by dc9f72c53), 1 × `json bundled` TypeError that is fallout of the crashed worker's queue being redistributed mid-run (`json bundled` passes in isolation, serially, and in local parallel runs with the harness fix applied).

Local runs on this branch (macOS arm64, dev binary): parallel full suite **92 passed, 19 failed in 16s**; serial minus the libcrypto legs **62 passed, 2 failed in 63s**. Every local failure is a macOS-environment artifact that passed on the ubuntu runners in this PR's first CI run:

- `node` was not installed locally, which hard-fails every `require=["cl"]` pin.
- Apple's `/usr/lib/libcrypto.dylib` is a load-abort stub — `dlopen` via the JIT's `LoadLibraryPermanently` aborts the worker, killing the libcrypto/libssl/socket-floor legs (hashlib, secrets, uuid, ssl, socket, urllib). The runners load real OpenSSL 3.
- `prim_os.jac [NA]` `isdir_tmp` mismatch is the macOS `/tmp` symlink; `/tmp` is a real directory on the runners.

The `test-compiler` run on this PR is the authoritative check that the suite passes in the environment it will gate.

Refs #6978.
