### PR TITLE
chore(check): ignore littleX frontend.cl.jac — nondeterministic E1100 type-identity flake

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -563,3 +563,10 @@ scripts/jac-gdb-helper.jac
 scripts/release.jac
 scripts/release_utils.jac
 scripts/validate_release.jac
+
+# Type-identity flake: E1100 "Cannot assign list[TweetView] to JSX prop of
+# type list[TweetView]" — the same view class materializes as two distinct
+# type objects depending on module-load order, so this file passes or fails
+# the full-repo check nondeterministically (passed run 28711953731, failed
+# run 28718624475 on identical trees).
+jac/examples/littleX/frontend.cl.jac


### PR DESCRIPTION
Main run [28718624475](https://github.com/jaseci-labs/jaseci/actions/runs/28718624475) failed jac-check on `jac/examples/littleX/frontend.cl.jac` with 8 errors of the form:

> E1100: Cannot assign `list[TweetView]` to JSX prop 'tweets' of type `list[TweetView]`

i.e. a type rejected against itself — the same view class materializing as two distinct type objects depending on module-load order. The previous main run [28711953731](https://github.com/jaseci-labs/jaseci/actions/runs/28711953731) **passed** this file on an equivalent tree (it was among the 504 passing files, which is why the #7167 re-baseline did not include it), so the outcome is nondeterministic run to run.

Park it in the .jacignore ledger so the jac-check gate is deterministic; the actual checker type-identity bug (same class compared by object identity across two load paths in JSX prop checking) is the real follow-up.