### PR TITLE
fix(ci): format-sweep only git-tracked .jac files; ignore zig-pkg fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,10 @@ jobs:
             printf '%s\n' "$FILES" | tr '\n' '\0' \
               | xargs -0 --no-run-if-empty jac format --check --lintfix
           else
-            find . -type f -name "*.jac" ! -path "*/fixtures/*" ! -path "./scripts/*" ! -path "*/passes/native/llvm/*" ! -name "*_err.jac" ! -name "*_syntax_err.jac" -print0 | xargs -0 --no-run-if-empty jac format --check --lintfix
+            # Sweep only git-tracked files: the build materializes generated
+            # trees in-place (e.g. jac/zig-pkg/ zig package fetches with their
+            # own sample .jac files), and a bare `find .` walks those too.
+            git ls-files -z '*.jac' | grep -zv -E '(/fixtures/|^scripts/|/passes/native/llvm/|_err\.jac$|_syntax_err\.jac$)' | xargs -0 --no-run-if-empty jac format --check --lintfix
           fi
 
       - name: Verify jir_registry.jac is up to date

--- a/.jacignore
+++ b/.jacignore
@@ -563,3 +563,8 @@ scripts/jac-gdb-helper.jac
 scripts/release.jac
 scripts/release_utils.jac
 scripts/validate_release.jac
+
+# Generated zig package fetches (jac ninja pins fetch into jac/zig-pkg/ at
+# build time; the tree-sitter-jac package ships its own examples/sample.jac).
+# Bare name so any zig-pkg path component is skipped by the check step.
+zig-pkg


### PR DESCRIPTION
Main run on 3a71bdd0 (the #7169 jac ninja merge) failed jac-check with 16 format errors in `./jac/zig-pkg/N-V-.../examples/sample.jac` — not a repo file. The ninja build fetches its pinned zig packages into `jac/zig-pkg/` in-tree during setup-jac's `zig build`, and the tree-sitter-jac package ships its own `examples/sample.jac`; the full-repo format sweep used `find .`, which walks generated/untracked trees.

Two changes:

- The full-mode format sweep now iterates `git ls-files '*.jac'` (same exclusion set as before), so only tracked files are ever formatted — immune to any future build step that materializes `.jac` files in-tree.
- `.jacignore` gains a bare `zig-pkg` entry so the `jac check .` step skips the fetched packages the same way the bare `tests` ignore works (the vendored sample also carries check errors, which would have failed the next step once formatting passed).

Verified locally: the ls-files pipeline resolves 1397 tracked files with the same exclusions.