### PR TITLE
fix(build): unbreak linux-aarch64 binary builds; unify + gate the release build workflows

### DIFF
--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -6,20 +6,31 @@ description: >
 
   The binary is an OUTPUT cache keyed on the content that goes into it (jaclang
   source, build.zig, and the launcher -- including payload.zig, which pins the
-  pbs tag / python version / bundled pip deps). The first job in any workflow on
-  a branch to build it populates the cache; every other job and workflow restores
-  the prebuilt binary in seconds instead of rebuilding. Exact-key match only
-  (no restore-keys), so a stale binary can never be served -- which is why this
-  is safe even though zig's own incremental cache stays disabled (it doesn't
-  reliably invalidate on a jaclang/payload change).
+  pbs tag / python version / bundled pip deps). Merges to main seed the cache;
+  every other job and workflow restores the prebuilt binary in seconds instead
+  of rebuilding (PR branches cross-restore main's entry, and build their own on
+  a miss). Exact-key match only (no restore-keys), so a stale binary can never
+  be served -- which is why this is safe even though zig's own incremental cache
+  stays disabled (it doesn't reliably invalidate on a jaclang/payload change).
 runs:
   using: composite
   steps:
     # typeshed stdlib stubs are vendored as plain files now (no submodule);
     # third-party stubs are installed per-project by `jac add` (PEP 561 types-*).
+    #
+    # Restore/save split with the SAVE GATED TO MAIN, same as the read-mostly
+    # caches below. The binary key changes on every jaclang/launcher edit, so a
+    # per-PR save has almost no reuse value (only a follow-up push touching
+    # neither jaclang nor the launcher would hit it) yet a high pool cost
+    # (~0.1-0.2 GB each). Left unbounded it dominated the 10 GB pool -- dozens of
+    # per-branch binaries -- and its LRU churn evicted the Linux read-mostly
+    # caches (pbs/bun) this action relies on. PR jobs still build their own
+    # binary on a miss (and ci.yml publishes it as an artifact for the same-run
+    # test jobs); only main seeds the shared copy. Exact-key match only (no
+    # restore-keys), so a stale binary can never be served.
     - name: Restore cached jac binary
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         # Also cache the gitignored typeshed stdlib stubs: they are materialized
         # during `zig build` and ci.yml publishes them as an artifact for
@@ -163,6 +174,20 @@ runs:
           SHIM_ARG=(-Dshim-bin=".shim-build/$(ls .shim-build | head -1)")
         fi
         zig build "${SHIM_ARG[@]}" --summary all
+
+    # Seed the shared binary cache from main only (see the note by the restore
+    # step). Saved after the build so both the binary and the materialized
+    # typeshed stdlib stubs (part of this cache's path) exist.
+    - name: Save jac binary cache (main only)
+      if: >-
+        github.ref == 'refs/heads/main' &&
+        steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          jac/zig-out/bin/jac
+          jac/jaclang/vendor/typeshed/stdlib
+        key: jac-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**', 'jac/build.zig', 'jac/launcher/**') }}
 
     # Seed the shared read-mostly caches -- from main only (see the note above
     # the restore steps). Every merge to main runs this action, so a pin bump

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,16 +1,25 @@
 name: Build jac native binaries
 
 # Builds the self-contained `jac` binary per platform and attaches it to a
-# GitHub Release. Primary path: called by release.yml after it cuts the release
-# (a GITHUB_TOKEN-created release emits no release.published event). The
-# release event is the safety net for releases published by a real user.
+# GitHub Release. One parameterized workflow serves both channels:
+#   - channel=release (default): cold, glibc-2.17-pinned builds attached to a
+#     versioned release. Called by release.yml after it cuts the release (a
+#     GITHUB_TOKEN-created release emits no release.published event); the
+#     release event is the safety net for releases published by a real user.
+#   - channel=dev: cache-accelerated host-native builds re-published under the
+#     rolling `dev` prerelease. Called by release-dev.yml on pushes to main.
 
 on:
   workflow_call:
     inputs:
       tag:
-        description: "Canonical release tag v<version> to upload assets to."
+        description: "Release tag to upload assets to: canonical v<version>, or `dev` for the rolling prerelease."
         required: true
+        type: string
+      channel:
+        description: "release: cold + glibc-pinned; dev: cached + host-native."
+        required: false
+        default: release
         type: string
   release:
     types: [published]
@@ -32,9 +41,12 @@ jobs:
       fail-fast: false
       matrix:
         # One native runner per target so the smoke test runs on real hardware.
-        # zig_target pins each Linux binary's glibc floor (2.17, manylinux2014);
-        # macOS builds host-native. No Intel-Mac leg: LLVM ships no macOS-x64
-        # prebuilt for the pinned release.
+        # zig_target pins each Linux binary's glibc floor (2.17, manylinux2014)
+        # on the release channel; the dev channel builds host-native so it can
+        # reuse the native-ABI LLVMPY shim cache (the shim cache key does not
+        # encode a target triple). macOS builds host-native on both channels.
+        # No Intel-Mac leg: LLVM ships no macOS-x64 prebuilt for the pinned
+        # release.
         include:
           - os: ubuntu-latest
             platform: linux-x86_64
@@ -45,14 +57,54 @@ jobs:
           - os: macos-14
             platform: macos-aarch64
     runs-on: ${{ matrix.os }}
+    env:
+      # -Dtarget flag for zig build: set on release-channel Linux legs, empty
+      # (host-native) on the dev channel and macOS.
+      DTARGET: ${{ inputs.channel != 'dev' && matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) || '' }}
     steps:
-      # Check out the release tag, not the caller's ref, so a recovery run
-      # after main advanced still builds the release's own source.
-      # SHA-pinned: this job holds contents:write and ships user-downloaded
-      # binaries, so a re-pointed tag on the action must not reach it.
+      # Check out the release tag (release channel) or the pushed commit (dev
+      # channel), so a recovery run after main advanced still builds the
+      # release's own source. SHA-pinned: this job holds contents:write and
+      # ships user-downloaded binaries, so a re-pointed tag on the action must
+      # not reach it.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.channel == 'dev' && github.sha || inputs.tag || github.event.release.tag_name }}
+
+      # Dev channel only: reuse the read-mostly caches main seeds. The release
+      # channel builds cold on purpose (a cached payload could ship stale
+      # bits). The LLVMPY_* shim is the most expensive artifact and depends
+      # only on native/**, build.zig, and the pinned LLVM slice; same cache key
+      # as setup-jac, so main usually has it warm (the arm64 leg self-seeds:
+      # no other workflow runs on Linux-ARM64).
+      - name: Restore cached LLVMPY shim (dev channel)
+        if: inputs.channel == 'dev'
+        id: shim-cache
+        uses: actions/cache@v4
+        with:
+          path: jac/jaclang/compiler/passes/native/llvm/libjacllvm.*
+          key: jac-shim-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/native/**', 'jac/build.zig', 'jac/launcher/llvm_release.zig') }}
+
+      # Keyed on llvm_release.zig to match the entries setup-jac seeds (the
+      # old release-dev key hashed payload.zig, so it never matched them and
+      # duplicated the ~0.5 GB tree into the cache pool).
+      - name: Restore cached LLVM (dev channel)
+        if: inputs.channel == 'dev' && steps.shim-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: jac/.llvm-build
+          key: llvm-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/llvm_release.zig') }}
+
+      # mkpayload re-validates every seeded .jir per module, so a stale tree
+      # from the previous push is safe and exactly what restore-keys is for.
+      - name: Restore cached JIR precompile tree (dev channel)
+        if: inputs.channel == 'dev'
+        uses: actions/cache@v4
+        with:
+          path: jac/.precompiled-build
+          key: jac-precompiled-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
+          restore-keys: |
+            jac-precompiled-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install host tools (zstd)
         run: |
@@ -63,7 +115,8 @@ jobs:
           fi
 
       - name: Set up Zig 0.16.0
-        uses: mlugg/setup-zig@v2
+        # SHA-pinned: same shipping-binaries rationale as the checkout.
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
           # Fresh cache each run: a cached payload could ship stale bits.
@@ -75,14 +128,26 @@ jobs:
         run: echo "version=$(grep -m1 '^version' jac.toml | sed -E 's/.*"([^"]+)".*/\1/')" >> "$GITHUB_OUTPUT"
 
       # The native backend statically links a pinned LLVM; fetch it per target
-      # before `zig build`.
+      # before `zig build`. Skipped on a dev-channel shim-cache hit
+      # (-Dshim-bin needs no LLVM at all).
       - name: Fetch LLVM for the jacllvm shim
+        if: steps.shim-cache.outputs.cache-hit != 'true'
         working-directory: jac
-        run: zig build fetch-llvm ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }} --summary all
+        run: zig build fetch-llvm $DTARGET --summary all
 
       - name: Build the jac binary (one command)
         working-directory: jac
-        run: zig build ${{ matrix.zig_target && format('-Dtarget={0}', matrix.zig_target) }} --summary all
+        # On a dev-channel shim-cache hit, stage the shim outside its in-tree
+        # place path: the build copies -Dshim-bin back there, and a self-copy
+        # would read the file it is truncating. Mirrors setup-jac.
+        run: |
+          SHIM_ARG=()
+          if [ "${{ steps.shim-cache.outputs.cache-hit }}" = "true" ]; then
+            mkdir -p .shim-build
+            cp jaclang/compiler/passes/native/llvm/libjacllvm.* .shim-build/
+            SHIM_ARG=(-Dshim-bin=".shim-build/$(ls .shim-build | head -1)")
+          fi
+          zig build $DTARGET "${SHIM_ARG[@]}" --summary all
 
       - name: Smoke test (no system Python)
         working-directory: jac
@@ -124,9 +189,10 @@ jobs:
           env -i HOME="$WORK" PATH=/usr/bin:/bin PYTHONPATH=/user/own "$BIN" run "$WORK/leak.jac" | grep -qx 'child /user/own'
 
       # Guards #7082: neither the launcher nor the LLVMPY_* shim may reference
-      # a glibc symbol newer than the zig_target floor.
+      # a glibc symbol newer than the zig_target floor. Release channel only:
+      # dev binaries are host-native with no pinned floor.
       - name: Verify glibc floor (from zig_target)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && inputs.channel != 'dev'
         working-directory: jac
         env:
           ZIG_TARGET: ${{ matrix.zig_target }}
@@ -154,7 +220,11 @@ jobs:
         working-directory: jac
         run: |
           set -euxo pipefail
-          ASSET="jac-${{ steps.ver.outputs.version }}-${{ matrix.platform }}"
+          if [ "${{ inputs.channel }}" = "dev" ]; then
+            ASSET="jac-dev-${{ matrix.platform }}"
+          else
+            ASSET="jac-${{ steps.ver.outputs.version }}-${{ matrix.platform }}"
+          fi
           mkdir -p dist
           cp zig-out/bin/jac "dist/$ASSET"
           # No codesign on macOS: the payload tarball appended past the Mach-O
@@ -179,9 +249,10 @@ jobs:
 
       # With this platform's asset attached, `scripts/install.sh` must resolve,
       # download, checksum-verify, and run it -- catches release-tag/installer
-      # drift at release time on the target hardware.
+      # drift at release time on the target hardware. Release channel only:
+      # install.sh resolves versioned assets, not the rolling dev tag.
       - name: Verify install.sh can fetch + run this release
-        if: github.event_name == 'release' || inputs.tag != ''
+        if: inputs.channel != 'dev' && (github.event_name == 'release' || inputs.tag != '')
         env:
           JAC_VER: ${{ steps.ver.outputs.version }}
           ASSET: ${{ steps.pkg.outputs.asset }}
@@ -215,7 +286,11 @@ jobs:
           bash scripts/install.sh --uninstall
           ! test -e "$BIN"
 
+      # Release channel only: dev binaries are already published on the `dev`
+      # prerelease, and a per-push 3x ~130 MB artifact would be pure storage
+      # churn.
       - name: Upload as workflow artifact
+        if: inputs.channel != 'dev'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.pkg.outputs.asset }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -90,6 +90,7 @@ jobs:
       # duplicated the ~0.5 GB tree into the cache pool).
       - name: Restore cached LLVM (dev channel)
         if: inputs.channel == 'dev' && steps.shim-cache.outputs.cache-hit != 'true'
+        id: llvm-cache
         uses: actions/cache@v4
         with:
           path: jac/.llvm-build
@@ -128,10 +129,12 @@ jobs:
         run: echo "version=$(grep -m1 '^version' jac.toml | sed -E 's/.*"([^"]+)".*/\1/')" >> "$GITHUB_OUTPUT"
 
       # The native backend statically links a pinned LLVM; fetch it per target
-      # before `zig build`. Skipped on a dev-channel shim-cache hit
-      # (-Dshim-bin needs no LLVM at all).
+      # before `zig build`. Skipped on a dev-channel shim-cache hit (-Dshim-bin
+      # needs no LLVM at all) or LLVM-cache hit (tree already restored). Both
+      # gates are vacuous on the release channel: the restore steps are
+      # skipped there, so their cache-hit outputs are empty and the fetch runs.
       - name: Fetch LLVM for the jacllvm shim
-        if: steps.shim-cache.outputs.cache-hit != 'true'
+        if: steps.shim-cache.outputs.cache-hit != 'true' && steps.llvm-cache.outputs.cache-hit != 'true'
         working-directory: jac
         run: zig build fetch-llvm $DTARGET --summary all
 

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,12 +1,22 @@
 name: Release jac dev binary (rolling main)
 
-# Rolling "dev" prerelease: every push to main rebuilds the per-platform
-# binaries and re-publishes them under the single force-moved `dev` tag, so
-# .../releases/download/dev/jac-dev-<platform> always maps to main HEAD.
+# Rolling "dev" prerelease: pushes to main that touch the binary's inputs
+# rebuild the per-platform binaries and re-publish them under the single
+# force-moved `dev` tag, so .../releases/download/dev/jac-dev-<platform>
+# always maps to the last binary-relevant commit on main. The build itself
+# is build-binaries.yml on the dev channel (cached, host-native).
 
 on:
   push:
     branches: [main]
+    # Non-jac pushes (docs, CI plumbing, scripts) cannot change the binary;
+    # skipping them keeps the dev tag pointing at the exact commit the
+    # published binaries were built from -- and stops three full rebuilds
+    # per docs-only merge.
+    paths:
+      - "jac/**"
+      - ".github/workflows/release-dev.yml"
+      - ".github/workflows/build-binaries.yml"
   workflow_dispatch:
 
 permissions:
@@ -47,116 +57,9 @@ jobs:
 
   build:
     needs: prepare
-    strategy:
-      fail-fast: false
-      matrix:
-        # One native runner per target so the smoke test runs on real hardware.
-        # No Intel-Mac leg: LLVM ships no macOS-x64 prebuilt for the pinned release.
-        include:
-          - os: ubuntu-latest
-            platform: linux-x86_64
-          - os: ubuntu-24.04-arm
-            platform: linux-aarch64
-          - os: macos-14
-            platform: macos-aarch64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      # The LLVMPY_* shim is the most expensive artifact and depends only on
-      # native/**, build.zig, and the pinned LLVM slice; same cache key as
-      # setup-jac, so main usually has it warm.
-      - name: Restore cached LLVMPY shim
-        id: shim-cache
-        uses: actions/cache@v4
-        with:
-          path: jac/jaclang/compiler/passes/native/llvm/libjacllvm.*
-          key: jac-shim-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/native/**', 'jac/build.zig', 'jac/launcher/llvm_release.zig') }}
-
-      - name: Restore cached LLVM (jacllvm shim deps)
-        if: steps.shim-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          path: jac/.llvm-build
-          key: llvm-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/launcher/payload.zig') }}
-
-      # mkpayload re-validates every seeded .jir per module, so a stale tree
-      # from the previous push is safe and exactly what restore-keys is for.
-      - name: Restore cached JIR precompile tree
-        uses: actions/cache@v4
-        with:
-          path: jac/.precompiled-build
-          key: jac-precompiled-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
-          restore-keys: |
-            jac-precompiled-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install host tools (zstd)
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update && sudo apt-get install -y zstd
-          else
-            brew install zstd
-          fi
-
-      - name: Set up Zig 0.16.0
-        # SHA-pinned: this job holds contents:write and ships user-downloaded
-        # binaries, so a re-pointed tag on the action must not reach it.
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: 0.16.0
-          # Fresh cache each run: a cached payload could ship stale bits.
-          use-cache: false
-
-      - name: Fetch LLVM for the jacllvm shim
-        if: steps.shim-cache.outputs.cache-hit != 'true'
-        working-directory: jac
-        run: zig build fetch-llvm --summary all
-
-      - name: Build the jac binary (one command)
-        working-directory: jac
-        # On a shim-cache hit, stage the shim outside its in-tree place path:
-        # the build copies -Dshim-bin back there, and a self-copy would read
-        # the file it is truncating. Mirrors setup-jac.
-        run: |
-          SHIM_ARG=()
-          if [ "${{ steps.shim-cache.outputs.cache-hit }}" = "true" ]; then
-            mkdir -p .shim-build
-            cp jaclang/compiler/passes/native/llvm/libjacllvm.* .shim-build/
-            SHIM_ARG=(-Dshim-bin=".shim-build/$(ls .shim-build | head -1)")
-          fi
-          zig build "${SHIM_ARG[@]}" --summary all
-
-      - name: Smoke test (no system Python)
-        working-directory: jac
-        run: |
-          set -euxo pipefail
-          BIN="$PWD/zig-out/bin/jac"
-          WORK="$(mktemp -d)"
-          env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" --version
-          printf 'with entry { print("ok"); }\n' > "$WORK/h.jac"
-          env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" run "$WORK/h.jac" | grep -q ok
-
-      - name: Package asset (+ checksum)
-        id: pkg
-        working-directory: jac
-        run: |
-          set -euxo pipefail
-          ASSET="jac-dev-${{ matrix.platform }}"
-          mkdir -p dist
-          cp zig-out/bin/jac "dist/$ASSET"
-          # No codesign on macOS: the payload tarball appended past the Mach-O
-          # end fails codesign's strict validation; the zig linker's ad-hoc
-          # signature is content-based and survives cp.
-          ( cd dist && shasum -a 256 "$ASSET" > "$ASSET.sha256" )
-          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
-
-      - name: Upload to the `dev` prerelease (clobber)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: jac
-        run: |
-          set -euo pipefail
-          gh release upload dev \
-            "dist/${{ steps.pkg.outputs.asset }}" \
-            "dist/${{ steps.pkg.outputs.asset }}.sha256" \
-            --clobber
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      tag: dev
+      channel: dev

--- a/jac/build.zig
+++ b/jac/build.zig
@@ -96,6 +96,16 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = std.builtin.OptimizeMode.ReleaseSafe,
             .lib = true,
+            // Always take the fork's cross path so nlua0 (its build-time Lua
+            // codegen tool) is built for the host with PUC Lua 5.1 instead of
+            // LuaJIT. nlua0 creates its state through zlua's Lua.init, i.e.
+            // lua_newstate with a malloc-backed allocator, and LuaJIT GC64
+            // only addresses 47-bit GC pointers: on 48-bit-VA hosts (GitHub's
+            // ubuntu-24.04-arm runners) malloc returns >=2^47 addresses that
+            // silently truncate and segfault in the first lpeg-heavy gen step.
+            // The runtime nvim library is unaffected (its C init uses
+            // luaL_newstate, LuaJIT's own sub-2^47 allocator) and keeps LuaJIT.
+            .host = @as([]const u8, "native"),
         }) orelse break :nvim_tree null;
         // The fork's build() returns early while ITS lazy deps (ziglua,
         // libuv, ...) are still being fetched -- upstream's lazyArtifact


### PR DESCRIPTION
## Summary

Fixes the linux-aarch64 binary builds (broken on both the `dev` and versioned release channels since the editor fusion landed, including the v0.30.7 release assets), and cleans up the CI build/cache pipeline that made the failure expensive to iterate on.

### 1. Fix: linux-aarch64 builds segfault in nlua0 (`jac/build.zig`)

Every linux-aarch64 leg of `release-dev` and `build-binaries` dies with a segfault in `nlua0`, the neovim fork's build-time Lua codegen tool ([failing dev run](https://github.com/jaseci-labs/jaseci/actions/runs/28752040151), [failing 0.30.7 release run](https://github.com/jaseci-labs/jaseci/actions/runs/28752852731)).

Root cause: `nlua0` creates its Lua state through zlua's `Lua.init`, i.e. `lua_newstate` with a malloc-backed custom allocator. LuaJIT GC64 only addresses 47-bit GC pointers and relies on its **internal** allocator to stay below 2^47. GitHub's `ubuntu-24.04-arm` runners hand out 48-bit-VA heap addresses, which silently truncate — in both failing runs the fault address is exactly the libc-region address with bit 47 stripped (`0xff7edde...` → `0x7f7edde...`). x86_64 (47-bit userspace) and macOS arm64 (sub-2^47 heap) never trip it.

Fix: pass `-Dhost=native` to the neovim dependency so its build always takes the fork's cross path, which builds host tools with PUC Lua 5.1 (upstream's standard cross flow). The runtime nvim library keeps LuaJIT — its C init uses `luaL_newstate`, LuaJIT's own sub-2^47 allocator. Verified locally: full `zig build stub` (535/535) with the host-tools path active.

### 2. Unify the two binary-build workflows; gate dev rebuilds on `jac/**`

`release-dev.yml` and `build-binaries.yml` carried near-identical 3-platform build jobs that had already drifted (zig action pinning, smoke-test coverage, cache keys) — the aarch64 breakage above had to be chased in both. Folded into one reusable `build-binaries.yml` behind a `channel` input:

- **`channel=release`** (default): cold, glibc-2.17-pinned builds attached to a versioned release — unchanged, plus `setup-zig` is now SHA-pinned like the dev flow already was.
- **`channel=dev`**: cache-accelerated host-native builds re-published under the rolling `dev` prerelease. Gains the env-leak smoke test; skips the workflow-artifact upload (the prerelease is the publication).

`release-dev.yml` keeps only the dev-tag prepare step and calls the reusable workflow. Its push trigger now path-filters on `jac/**` + the build workflows: docs/CI-only merges can't change the binary, so skipping them stops three full rebuilds per merge and keeps the `dev` tag pointing at the commit the published binaries were built from. Also fixes the dev flow's LLVM cache key to hash `llvm_release.zig` (it hashed `payload.zig`, never matched the entries `setup-jac` seeds, and duplicated the ~0.5 GB tree into the pool).

`jac-dev-<platform>` asset naming is unchanged (`k8s-real-e2e` keeps resolving).

### 3. Main-gate the `jac-bin` output cache (`setup-jac`)

The repo's cache pool is over the 10 GB limit (10.8 GB / 134 entries) and in perpetual LRU eviction, driven by unbounded per-branch `jac-bin` saves (46 entries, ~4.7 GB). The churn evicts the Linux read-mostly caches (`pbs`/`bun`), which is why release-workflow binary builds cold-start at ~13 min. `jac-bin` now uses the same restore/save split as the other read-mostly caches: PRs cross-restore main's entry and build on a miss (same-run jobs already share the binary via an artifact); only merges to main seed the shared copy.

## Test plan

- [x] `zig build stub` passes locally with the host-tools nlua0 path active (the path all three CI legs will now take)
- [x] `actionlint` + YAML validation on the changed workflows (info-level notes only, matching existing script patterns)
- [ ] After merge: `release-dev` goes green on linux-aarch64 and re-publishes `jac-dev-linux-aarch64`
- [ ] Re-run `build-binaries` for v0.30.7 (`workflow_dispatch`, tag `v0.30.7`) to attach the missing `jac-0.30.7-linux-aarch64` asset
