### PR TITLE
fix(install): show initial-setup message before first jac invocation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -321,6 +321,8 @@ install_binary() {
     if has_cmd jac; then
         info ""
         info "Jac installed successfully!"
+        info ""
+        info "Performing initial setup, this may take a moment..."
         jac --version 2>/dev/null || true
         info ""
         info "Get started:"


### PR DESCRIPTION
The install script pauses noticeably at `jac --version` because the first invocation triggers per-project launcher provisioning. This adds a "Performing initial setup, this may take a moment..." message so users understand work is happening rather than the installer appearing to hang.