### PR TITLE
feat(cli): colorize top-level help to match argparse's 3.14 theme

### DIFF
--- a/jac/jaclang/cli/impl/help.impl.jac
+++ b/jac/jaclang/cli/impl/help.impl.jac
@@ -1,3 +1,28 @@
+# Palette mirroring Python 3.14's argparse color theme, so the hand-rolled
+# top-level help matches the auto-colored `jac COMMAND --help` output.
+glob _HELP_RESET: str = "\033[0m",
+     _HELP_HEADER: str = "\033[1;34m",   # bold blue  -> section/group headers
+     _HELP_CMD: str = "\033[32m",         # green      -> command & option names
+     _HELP_PROG: str = "\033[1;35m",      # bold magenta -> program name
+     _HELP_TITLE: str = "\033[1m";        # bold       -> title line
+
+"""Wrap `text` in an ANSI `code` only when the console has color enabled.
+
+Reuses `JacConsole.use_color`, the master switch resolved from NO_COLOR /
+TERM=dumb / stdout.isatty(), so piped or captured help stays plain text.
+"""
+def _help_color(text: str, code: str) -> str {
+    import from jaclang.cli.console { console }
+    try {
+        if not console.use_color {
+            return text;
+        }
+    } except Exception {
+        return text;
+    }
+    return f"{code}{text}{_HELP_RESET}";
+}
+
 impl CommandGroups.get_display_name(group: str) -> str {
     return self.groups.get(group, group.title());
 }
@@ -20,16 +45,19 @@ impl HelpFormatter.format_main_help(
 
     lines: list[str] = [];
 
-    lines.append("Jac Programming Language CLI");
+    lines.append(_help_color("Jac Programming Language CLI", _HELP_TITLE));
     if version {
         lines.append(f"Version: {version}");
     }
     lines.append("");
-    lines.append(f"Usage: {prog} [OPTIONS] COMMAND [ARGS]...");
+    lines.append(
+        f"{_help_color('Usage:', _HELP_HEADER)} "
+        f"{_help_color(prog, _HELP_PROG)} [OPTIONS] COMMAND [ARGS]..."
+    );
     lines.append("");
-    lines.append("Options:");
-    lines.append("  -V, --version  Show version and exit");
-    lines.append("  -h, --help     Show this message and exit");
+    lines.append(_help_color("Options:", _HELP_HEADER));
+    lines.append(f"  {_help_color('-V, --version', _HELP_CMD)}  Show version and exit");
+    lines.append(f"  {_help_color('-h, --help', _HELP_CMD)}     Show this message and exit");
     lines.append("");
 
     grouped: dict[str, list[CommandSpec]] = {};
@@ -59,12 +87,12 @@ impl HelpFormatter.format_main_help(
             display_name += f"  [{list(sources)[0]}]";
         }
 
-        lines.append(f"{display_name}:");
+        lines.append(_help_color(f"{display_name}:", _HELP_HEADER));
 
         cmds.sort(key=lambda c: str : c.name);
         for cmd in cmds {
             padding = " " * (12 - len(cmd.name));
-            lines.append(f"  {cmd.name}{padding}{cmd.help}");
+            lines.append(f"  {_help_color(cmd.name, _HELP_CMD)}{padding}{cmd.help}");
         }
 
         lines.append("");
@@ -74,10 +102,10 @@ impl HelpFormatter.format_main_help(
         if group not in ordered_groups {
             cmds = grouped[group];
             display_name = self.groups.get_display_name(group);
-            lines.append(f"{display_name}:");
+            lines.append(_help_color(f"{display_name}:", _HELP_HEADER));
             for cmd in cmds {
                 padding = " " * (12 - len(cmd.name));
-                lines.append(f"  {cmd.name}{padding}{cmd.help}");
+                lines.append(f"  {_help_color(cmd.name, _HELP_CMD)}{padding}{cmd.help}");
             }
             lines.append("");
         }
@@ -93,7 +121,10 @@ impl HelpFormatter.format_curated_help(
     import from jaclang.cli.command { CommandSpec }
     lines: list[str] = [];
 
-    lines.append(f"Usage: {prog} COMMAND [ARGS]...");
+    lines.append(
+        f"{_help_color('Usage:', _HELP_HEADER)} "
+        f"{_help_color(prog, _HELP_PROG)} COMMAND [ARGS]..."
+    );
     lines.append("");
 
     by_tier: dict[str, list[CommandSpec]] = {};
@@ -111,11 +142,13 @@ impl HelpFormatter.format_curated_help(
         if not cmds {
             continue;
         }
-        lines.append(f"{self.groups.tier_sections.get(tier, tier)}:");
+        lines.append(
+            _help_color(f"{self.groups.tier_sections.get(tier, tier)}:", _HELP_HEADER)
+        );
         cmds.sort(key=lambda c: str : c.name);
         for cmd in cmds {
             padding = " " * (12 - len(cmd.name));
-            lines.append(f"  {cmd.name}{padding}{cmd.help}");
+            lines.append(f"  {_help_color(cmd.name, _HELP_CMD)}{padding}{cmd.help}");
         }
         lines.append("");
     }

--- a/jac/jaclang/cli/impl/help.impl.jac
+++ b/jac/jaclang/cli/impl/help.impl.jac
@@ -1,16 +1,9 @@
-# Palette mirroring Python 3.14's argparse color theme, so the hand-rolled
-# top-level help matches the auto-colored `jac COMMAND --help` output.
 glob _HELP_RESET: str = "\033[0m",
-     _HELP_HEADER: str = "\033[1;34m",   # bold blue  -> section/group headers
-     _HELP_CMD: str = "\033[32m",         # green      -> command & option names
-     _HELP_PROG: str = "\033[1;35m",      # bold magenta -> program name
-     _HELP_TITLE: str = "\033[1m";        # bold       -> title line
+     _HELP_HEADER: str = "\033[1;34m",
+     _HELP_CMD: str = "\033[32m",
+     _HELP_PROG: str = "\033[1;35m",
+     _HELP_TITLE: str = "\033[1m";
 
-"""Wrap `text` in an ANSI `code` only when the console has color enabled.
-
-Reuses `JacConsole.use_color`, the master switch resolved from NO_COLOR /
-TERM=dumb / stdout.isatty(), so piped or captured help stays plain text.
-"""
 def _help_color(text: str, code: str) -> str {
     import from jaclang.cli.console { console }
     try {
@@ -57,7 +50,9 @@ impl HelpFormatter.format_main_help(
     lines.append("");
     lines.append(_help_color("Options:", _HELP_HEADER));
     lines.append(f"  {_help_color('-V, --version', _HELP_CMD)}  Show version and exit");
-    lines.append(f"  {_help_color('-h, --help', _HELP_CMD)}     Show this message and exit");
+    lines.append(
+        f"  {_help_color('-h, --help', _HELP_CMD)}     Show this message and exit"
+    );
     lines.append("");
 
     grouped: dict[str, list[CommandSpec]] = {};
@@ -105,7 +100,9 @@ impl HelpFormatter.format_main_help(
             lines.append(_help_color(f"{display_name}:", _HELP_HEADER));
             for cmd in cmds {
                 padding = " " * (12 - len(cmd.name));
-                lines.append(f"  {_help_color(cmd.name, _HELP_CMD)}{padding}{cmd.help}");
+                lines.append(
+                    f"  {_help_color(cmd.name, _HELP_CMD)}{padding}{cmd.help}"
+                );
             }
             lines.append("");
         }

--- a/jac/tests/cli/test_help_color.jac
+++ b/jac/tests/cli/test_help_color.jac
@@ -1,0 +1,115 @@
+"""Color-scheme tests for the top-level `HelpFormatter`.
+
+The hand-rolled `jac` / `jac --help` screens are colorized to match the theme
+Python 3.14's argparse applies to `jac COMMAND --help`, so the two help
+surfaces read as one system. Coloring is gated through `JacConsole.use_color`
+(NO_COLOR / TERM=dumb / stdout.isatty()); these tests pin that contract:
+
+  1. When color is enabled, section headers, command names, and the program
+     name are wrapped in the expected ANSI roles.
+  2. When color is disabled, the output is byte-for-byte plain text — no ANSI.
+  3. Coloring never changes layout: stripping the ANSI from the colored output
+     reproduces the plain output exactly (padding is computed on raw lengths,
+     so columns stay aligned).
+"""
+
+import re;
+import from jaclang.cli.help { HelpFormatter }
+import from jaclang.cli.command { CommandSpec }
+import from jaclang.cli.console { _get_console }
+
+
+# ANSI roles the formatter uses (mirrors argparse's 3.14 theme).
+glob _HEADER: str = "\033[1;34m",   # bold blue  -> section/group headers
+     _CMD: str = "\033[32m",         # green      -> command names
+     _PROG: str = "\033[1;35m";      # bold magenta -> program name
+
+
+def _specs -> list[CommandSpec] {
+    return [
+        CommandSpec(
+            name="run", help="Run a Jac program", group="execution", tier="core"
+        ),
+        CommandSpec(
+            name="check", help="Type check Jac files", group="analysis", tier="core"
+        )
+    ];
+}
+
+
+def _strip_ansi(s: str) -> str {
+    return re.sub("\033\\[[0-9;]*m", "", s);
+}
+
+
+"""Render `fn()` with the live console's `use_color` forced on/off, restored after."""
+def _with_color(enabled: bool, fn: any) -> str {
+    c = _get_console();
+    saved = c.use_color;
+    c.use_color = enabled;
+    try {
+        return fn();
+    } finally {
+        c.use_color = saved;
+    }
+}
+
+
+test "main help applies the argparse-matching palette when color is enabled" {
+    fmt = HelpFormatter();
+    out = _with_color(
+        True,
+        lambda : fmt.format_main_help(
+            _specs(), prog="jac", version="9.9.9", verbose=True
+        )
+    );
+    assert _HEADER in out , f"section headers not colored bold-blue; captured={out!r}";
+    assert _CMD in out , f"command names not colored green; captured={out!r}";
+    assert _PROG in out , f"program name not colored magenta; captured={out!r}";
+}
+
+
+test "main help is plain text when color is disabled" {
+    fmt = HelpFormatter();
+    out = _with_color(
+        False,
+        lambda : fmt.format_main_help(
+            _specs(), prog="jac", version="9.9.9", verbose=True
+        )
+    );
+    assert "\033[" not in out , f"disabled color still emitted ANSI escapes; captured={out!r}";
+    # Data still present, just uncolored.
+    assert "Program Execution:" in out , f"header text missing; captured={out!r}";
+    assert "run" in out and "check" in out , f"command names missing; captured={out!r}";
+}
+
+
+test "main help coloring preserves layout (strip-ANSI == plain)" {
+    fmt = HelpFormatter();
+    on = _with_color(
+        True,
+        lambda : fmt.format_main_help(
+            _specs(), prog="jac", version="9.9.9", verbose=True
+        )
+    );
+    off = _with_color(
+        False,
+        lambda : fmt.format_main_help(
+            _specs(), prog="jac", version="9.9.9", verbose=True
+        )
+    );
+    assert _strip_ansi(on) == off , f"coloring changed layout; stripped={_strip_ansi(on)!r} plain={off!r}";
+}
+
+
+test "curated (bare jac) help colors headers/commands/prog and stays plain when off" {
+    fmt = HelpFormatter();
+    on = _with_color(True, lambda : fmt.format_curated_help(_specs(), prog="jac"));
+    off = _with_color(False, lambda : fmt.format_curated_help(_specs(), prog="jac"));
+
+    assert _HEADER in on , f"curated headers not colored; captured={on!r}";
+    assert _CMD in on , f"curated command names not colored; captured={on!r}";
+    assert _PROG in on , f"curated program name not colored; captured={on!r}";
+    assert "\033[" not in off , f"curated help emitted ANSI when color disabled; captured={off!r}";
+    assert _strip_ansi(on) == off , f"curated coloring changed layout; stripped={_strip_ansi(on)!r} plain={off!r}";
+}

--- a/jac/tests/cli/test_help_color.jac
+++ b/jac/tests/cli/test_help_color.jac
@@ -20,9 +20,9 @@ import from jaclang.cli.console { _get_console }
 
 
 # ANSI roles the formatter uses (mirrors argparse's 3.14 theme).
-glob _HEADER: str = "\033[1;34m",   # bold blue  -> section/group headers
-     _CMD: str = "\033[32m",         # green      -> command names
-     _PROG: str = "\033[1;35m";      # bold magenta -> program name
+glob _HEADER: str = "\033[1;34m",  # bold blue  -> section/group headers
+     _CMD: str = "\033[32m",  # green      -> command names
+     _PROG: str = "\033[1;35m";  # bold magenta -> program name
 
 
 def _specs -> list[CommandSpec] {
@@ -59,9 +59,8 @@ test "main help applies the argparse-matching palette when color is enabled" {
     fmt = HelpFormatter();
     out = _with_color(
         True,
-        lambda : fmt.format_main_help(
-            _specs(), prog="jac", version="9.9.9", verbose=True
-        )
+        lambda :
+            fmt.format_main_help(_specs(), prog="jac", version="9.9.9", verbose=True)
     );
     assert _HEADER in out , f"section headers not colored bold-blue; captured={out!r}";
     assert _CMD in out , f"command names not colored green; captured={out!r}";
@@ -73,9 +72,8 @@ test "main help is plain text when color is disabled" {
     fmt = HelpFormatter();
     out = _with_color(
         False,
-        lambda : fmt.format_main_help(
-            _specs(), prog="jac", version="9.9.9", verbose=True
-        )
+        lambda :
+            fmt.format_main_help(_specs(), prog="jac", version="9.9.9", verbose=True)
     );
     assert "\033[" not in out , f"disabled color still emitted ANSI escapes; captured={out!r}";
     # Data still present, just uncolored.
@@ -88,17 +86,17 @@ test "main help coloring preserves layout (strip-ANSI == plain)" {
     fmt = HelpFormatter();
     on = _with_color(
         True,
-        lambda : fmt.format_main_help(
-            _specs(), prog="jac", version="9.9.9", verbose=True
-        )
+        lambda :
+            fmt.format_main_help(_specs(), prog="jac", version="9.9.9", verbose=True)
     );
     off = _with_color(
         False,
-        lambda : fmt.format_main_help(
-            _specs(), prog="jac", version="9.9.9", verbose=True
-        )
+        lambda :
+            fmt.format_main_help(_specs(), prog="jac", version="9.9.9", verbose=True)
     );
-    assert _strip_ansi(on) == off , f"coloring changed layout; stripped={_strip_ansi(on)!r} plain={off!r}";
+    assert _strip_ansi(on) == off , f"coloring changed layout; stripped={_strip_ansi(
+        on
+    )!r} plain={off!r}";
 }
 
 
@@ -111,5 +109,7 @@ test "curated (bare jac) help colors headers/commands/prog and stays plain when 
     assert _CMD in on , f"curated command names not colored; captured={on!r}";
     assert _PROG in on , f"curated program name not colored; captured={on!r}";
     assert "\033[" not in off , f"curated help emitted ANSI when color disabled; captured={off!r}";
-    assert _strip_ansi(on) == off , f"curated coloring changed layout; stripped={_strip_ansi(on)!r} plain={off!r}";
+    assert _strip_ansi(on) == off , f"curated coloring changed layout; stripped={_strip_ansi(
+        on
+    )!r} plain={off!r}";
 }


### PR DESCRIPTION
## Summary

The hand-rolled top-level help screens (bare `jac` and `jac --help`, rendered by `HelpFormatter`) emitted **plain text**, while each subcommand's `jac COMMAND --help` gets **Python 3.14's default argparse coloring**. The result was two visually inconsistent help surfaces — the top-level screens looked washed out next to the vibrant per-command help.

This colorizes the top-level formatter to mirror the same theme:

- **bold-blue** section/group headers (`Usage:`, `Options:`, `Program Execution:`, ...)
- **green** command and option names
- **bold-magenta** program name

## Gating & safety

- Coloring routes through the existing `JacConsole.use_color` master switch (`NO_COLOR` / `TERM=dumb` / `stdout.isatty()`), so piped or captured help stays plain — no ANSI corruption of redirected output.
- Padding is computed on **raw** (un-colored) name lengths, so column alignment is unchanged.
- No new dependency — consistent with the deliberate "no `rich` dependency" decision.

## Tests

Adds `tests/cli/test_help_color.jac` pinning the contract:
1. palette applied when color is enabled,
2. output is byte-for-byte plain when color is disabled,
3. `strip-ANSI(colored) == plain` (coloring never changes layout).

All 4 new tests pass; existing `test_console_*` suite (27 tests) stays green.