### PR TITLE
ci: cache the Zig package store to stop flaky lua.org fetches

### DIFF
--- a/.github/actions/setup-jac/action.yml
+++ b/.github/actions/setup-jac/action.yml
@@ -132,6 +132,28 @@ runs:
         restore-keys: |
           jac-precompiled-${{ runner.os }}-${{ runner.arch }}-
 
+    # The Zig package store (.zig-cache/p): every git/tarball dependency
+    # `zig build` fetches -- the pinned neovim fork and, transitively, its PUC
+    # Lua source off lua.org's FTP (historically the flakiest fetch in the whole
+    # build), plus mini.nvim, tree-sitter-jac, libuv, zlua, lpeg, luv, etc.
+    # Content-addressed and immutable (the hash IS the identity), so unlike zig's
+    # build-artifact cache it can never ship stale bits -- which is why we cache
+    # only the `p/` package subdir and leave o/,h/ (the payload-artifact cache,
+    # deliberately disabled via use-cache:false) untouched. mlugg/setup-zig pins
+    # ZIG_GLOBAL_CACHE_DIR to $GITHUB_WORKSPACE/.zig-cache. Keyed on build.zig.zon
+    # (which pins the neovim fork hash, and thus its entire transitive closure);
+    # restore-keys so a zon bump still reuses every unchanged package (Lua
+    # included) instead of re-hitting lua.org. Only engaged on a binary miss.
+    - name: Restore cached Zig package store
+      id: zig-pkgs-cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: .zig-cache/p
+        key: zig-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig.zon') }}
+        restore-keys: |
+          zig-pkgs-${{ runner.os }}-${{ runner.arch }}-
+
     - name: Set up Zig 0.16.0
       if: steps.cache.outputs.cache-hit != 'true' || steps.typeshed-cache.outputs.cache-hit != 'true'
       uses: mlugg/setup-zig@v2
@@ -155,7 +177,10 @@ runs:
       if: steps.typeshed-cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: jac
-      run: zig build fetch-typeshed --summary all
+      # -Dno-ninja: typeshed materialization is editor-independent, so skip
+      # configuring (and fetching) the neovim + Lua closure. Load-bearing on a
+      # binary-cache hit, where no full build ran to fetch it otherwise.
+      run: zig build -Dno-ninja fetch-typeshed --summary all
 
     - name: Build the jac binary
       if: steps.cache.outputs.cache-hit != 'true'
@@ -246,6 +271,21 @@ runs:
         path: jac/.precompiled-build
         key: jac-precompiled-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/jaclang/**') }}
 
+    # Seed the Zig package store from main only (see the restore note). Like the
+    # precompile cache, a restore-keys prefix hit still leaves cache-hit != true,
+    # so each merge re-saves the refreshed closure under the current
+    # build.zig.zon hash. Same key as build-binaries.yml's dev-channel entry, so
+    # the two share one ~20 MB entry per os/arch.
+    - name: Save Zig package store cache (main only)
+      if: >-
+        github.ref == 'refs/heads/main' &&
+        steps.cache.outputs.cache-hit != 'true' &&
+        steps.zig-pkgs-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: .zig-cache/p
+        key: zig-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig.zon') }}
+
     # Binary cache hits skip `zig build`, which is what normally runs fetch-typeshed.
     # Older cache entries only stored the binary, so materialize stubs when missing.
     - id: typeshed_check
@@ -269,7 +309,10 @@ runs:
       if: steps.cache.outputs.cache-hit == 'true' && steps.typeshed_check.outputs.needed == 'true'
       shell: bash
       working-directory: jac
-      run: zig build fetch-typeshed
+      # -Dno-ninja: this path only runs on a binary-cache hit (no build), so
+      # without it a bare `fetch-typeshed` would fetch the neovim + Lua closure
+      # purely to materialize stubs.
+      run: zig build -Dno-ninja fetch-typeshed
 
     - name: Put jac on PATH
       shell: bash

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -107,6 +107,22 @@ jobs:
           restore-keys: |
             jac-precompiled-${{ runner.os }}-${{ runner.arch }}-
 
+      # The Zig package store (.zig-cache/p): the neovim fork + its transitive
+      # PUC Lua source off lua.org's FTP (the build's flakiest fetch), mini.nvim,
+      # tree-sitter-jac, etc. Content-addressed source packages -- immutable, so
+      # (unlike the payload-artifact caches above, kept dev-only to avoid
+      # shipping stale bits) this is safe on BOTH channels, and a release is
+      # exactly when a lua.org blip must not fail the build. Same key as
+      # setup-jac so the Linux-x86_64 leg reuses the entry main seeds; a cross
+      # -Dtarget build fetches the same source, so os/arch is the right axis.
+      - name: Cache the Zig package store (avoids re-fetching Lua/neovim deps)
+        uses: actions/cache@v4
+        with:
+          path: .zig-cache/p
+          key: zig-pkgs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('jac/build.zig.zon') }}
+          restore-keys: |
+            zig-pkgs-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Install host tools (zstd)
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
 
       - name: Materialize typeshed stdlib stubs into the checkout
         working-directory: jac
-        run: zig build fetch-typeshed --summary all
+        # -Dno-ninja: typeshed is editor-independent. setup-jac above may have
+        # hit the binary cache (no build), so a bare fetch-typeshed would pull
+        # the neovim + Lua closure just to materialize stubs.
+        run: zig build -Dno-ninja fetch-typeshed --summary all
 
       - name: Hermeticity + smoke (no system Python)
         working-directory: jac
@@ -169,7 +172,10 @@ jobs:
           use-cache: false
       - name: Vendor static-musl runtime
         working-directory: jac
-        run: zig build vendor-musl --summary all
+        # -Dno-ninja: harvesting musl from the Zig toolchain is editor-independent;
+        # without it, configuring the build fetches the neovim + Lua closure (incl.
+        # the flaky lua.org tarball) for nothing. This job never bundles the editor.
+        run: zig build -Dno-ninja vendor-musl --summary all
       - name: Compiler suite via the binary
         working-directory: jac
         run: |
@@ -235,7 +241,10 @@ jobs:
           use-cache: false
       - name: Vendor static-musl runtime
         working-directory: jac
-        run: zig build vendor-musl --summary all
+        # -Dno-ninja: harvesting musl from the Zig toolchain is editor-independent;
+        # without it, configuring the build fetches the neovim + Lua closure (incl.
+        # the flaky lua.org tarball) for nothing. This job never bundles the editor.
+        run: zig build -Dno-ninja vendor-musl --summary all
       - name: Runtime suite via the binary (everything except compiler)
         working-directory: jac
         run: |


### PR DESCRIPTION
## Problem

The `jac` build's flakiest network fetch is the **PUC Lua 5.1.5 tarball off lua.org's FTP**, pulled transitively through the pinned neovim fork → `ziglua` (`.lua51 = https://www.lua.org/ftp/lua-5.1.5.tar.gz`). lua.org's FTP intermittently times out, failing otherwise-green CI/binary builds.

It was the **one build download cached nowhere**: `setup-jac` and `build-binaries.yml` already cache pbs / LLVM / bun / typeshed / precompile, but never the Zig **package store** (`.zig-cache/p`) — where Lua, the neovim fork, mini.nvim, tree-sitter-jac, libuv, lpeg, luv, and the tree-sitters all land.

## Changes

**1. Cache `.zig-cache/p` (the Zig package store)**
- Added to `setup-jac` (restore on binary-cache miss, main-only save — matching the existing pool-management pattern) and to `build-binaries.yml` (both channels).
- Content-addressed and immutable — the hash *is* the identity — so unlike Zig's build-artifact cache it can never ship stale bits. We cache **only** the `p/` package subdir, leaving `o/`,`h/` (the payload-artifact cache, deliberately disabled via `use-cache: false`) untouched.
- `mlugg/setup-zig` pins `ZIG_GLOBAL_CACHE_DIR` to `$GITHUB_WORKSPACE/.zig-cache` even with `use-cache: false`, so `p/` is the right path.
- Keyed on `build.zig.zon` (which pins the neovim fork hash, hence its whole transitive closure) with a `restore-keys` prefix, so even a zon bump reuses every unchanged package (Lua included) instead of re-hitting lua.org. Same key across both workflows → they share one ~20 MB entry per os/arch.

**2. `-Dno-ninja` on editor-irrelevant `zig build` aux steps** (`fetch-typeshed`, `vendor-musl`)
- These never bundle the editor, but configuring the build still fetches the entire neovim + Lua closure — notably on the common binary-cache-**hit** path, where no full build runs. `-Dno-ninja` skips it. Verified with a clean cache that these steps now fetch **zero** external packages.

## Net effect

lua.org (and the whole editor closure) is contacted only on a genuinely cold package cache — first build after a `build.zig.zon` change on a runner whose prefix cache was also evicted. Everywhere else it's a cache restore or skipped outright.

Pool impact is negligible (~20 MB/entry vs. the existing 0.5 GB LLVM entry).

## Notes

This makes the flake rare but doesn't remove the source dependency. Making it fully hermetic (mirror/vendor `lua-5.1.5.tar.gz` via a `jaseci-labs/ziglua` fork, keeping the same content hash) is a follow-up in the fork repos.