### PR TITLE
docs: align CLI docs with the #7258 unified .jab artifact + verb reorg

### DIFF
--- a/docs/docs/build/libraries.md
+++ b/docs/docs/build/libraries.md
@@ -19,7 +19,7 @@ version = "0.1.0"
 ```
 
 ```bash
-jac bundle
+jac build --as wheel
 # → dist/greetlib-0.1.0-py3-none-any.whl
 ```
 
@@ -27,7 +27,7 @@ Upload it with `twine`, then `pip install greetlib` anywhere. The wheel ships yo
 
 ## npm package {#js-package}
 
-The client-side counterpart: a `cl` component (or function) library published to npm so any JavaScript/TypeScript project can `npm install` it. `jac bundle --target npm` compiles your client modules to ES-module JavaScript, generates `package.json`, and emits `.d.ts` declarations. (Modules that cross a server boundary can't ship as standalone npm packages -- keep server-coupled code in your app.)
+The client-side counterpart: a `cl` component (or function) library published to npm so any JavaScript/TypeScript project can `npm install` it. `jac build --as npm` compiles your client modules to ES-module JavaScript, generates `package.json`, and emits `.d.ts` declarations. (Modules that cross a server boundary can't ship as standalone npm packages -- keep server-coupled code in your app.)
 
 ## Shared library (C ABI) {#native-lib}
 

--- a/docs/docs/community/breaking-changes.md
+++ b/docs/docs/community/breaking-changes.md
@@ -393,7 +393,7 @@ connect(left=root(), right=Item())
 
 #### 1. Filter Comprehension Syntax Changed from `(?:...)` to `[?:...]`
 
-The parenthesized filter comprehension syntax `(?:Type)` and `(?:Type, condition)` is now deprecated in favor of bracket syntax `[?:Type]` and `[?:Type, condition]`. The old syntax still parses but emits deprecation warning **W0061**. The formatter (`jac format`) automatically converts old syntax to new.
+The parenthesized filter comprehension syntax `(?:Type)` and `(?:Type, condition)` is now deprecated in favor of bracket syntax `[?:Type]` and `[?:Type, condition]`. The old syntax still parses but emits deprecation warning **W0061**. The formatter (`jac fmt`) automatically converts old syntax to new.
 
 **Before:**
 
@@ -423,7 +423,7 @@ visit [-->[?:MyNode]];
 
 **Why:** The `[?` token sequence is unambiguous in all contexts, including nested inside edge ref chain brackets. Bracket syntax is consistent with how edge references already use `[...]`.
 
-**Migration:** Run `jac format` on your `.jac` files to auto-convert, or manually replace `(?:` with `[?:` and `(?` with `[?` (adjusting closing `)` to `]`).
+**Migration:** Run `jac fmt` on your `.jac` files to auto-convert, or manually replace `(?:` with `[?:` and `(?` with `[?` (adjusting closing `)` to `]`).
 
 ---
 
@@ -908,7 +908,7 @@ jac start main.jac --scale --build  # with build
 - `jac serve` → `jac start`
 - `jac scale` → `jac start --scale`
 - `jac scale -b` → `jac start --scale --build` (or `jac start --scale -b`)
-- The `jac destroy` command remains unchanged for removing Kubernetes deployments
+- The `jac scale destroy` command is used for removing Kubernetes deployments
 
 #### 2. Build Artifacts Consolidated to `.jac/` Directory
 

--- a/docs/docs/quick-guide/project-kinds.md
+++ b/docs/docs/quick-guide/project-kinds.md
@@ -40,7 +40,7 @@ Each recipe name links to its guided **"I like to build…" track** -- a 5-minut
 
 **Legend** -- ● uses this block · ◐ talks to a *remote* server (doesn't bundle one) · ×N replicated per service. **status**: ✅ shipping · 🧪 beta (works, with caveats footnoted below) · 🚧 not yet wired end-to-end ([see roadmap](#on-the-roadmap)). Columns 2–7 are *composition* (what it's made of): **sv / cl / na** = which runtimes compile (`na` to a host binary, or to WebAssembly for [in-browser native](#in-browser-native-wasm)) · **served** = hosted by `jac start` (exposing any `sv` walkers/functions as a REST API) · **packaged** = produces a distributable artifact · **shell** = wrapped in a native desktop/mobile shell. The **requires** column is a different axis -- *setup cost*: toolchains you install yourself, excluding the built-in `scale` subsystem (which ships with `jaclang` core; its optional deploy deps are pulled per-project via `[scale.*]` config + `jac install`) and the full-stack client/desktop framework (which also ships with `jaclang` core).
 
-<small>¹ Only to *upload* to PyPI; `jac bundle` itself needs nothing. &nbsp; ² The desktop target ships with `jaclang` core (no Rust); it embeds the OS webview. On Linux you need the WebKitGTK system libraries (a bundled helper script installs them). &nbsp; ³ Only to *publish* (`npm publish`); `jac bundle` builds the `.tgz` with no Node/npm. &nbsp; ⁴ The binary renders your `cl` UI today; wiring `sv` walkers onto the embedded interpreter, HMR dev mode, and per-OS installers are in progress ([#6436](https://github.com/jaseci-labs/jaseci/issues/6436)). &nbsp; ⁵ Frontend-only Capacitor wrapper -- the app talks to a Jac server you deploy separately. &nbsp; ⁶ Beta React Native (Expo/Metro) frontend built from a mobUI source tree (`@jac/mobui` primitives, no HTML) that also compiles for the web; it talks to a Jac server you deploy separately.</small>
+<small>¹ Only to *upload* to PyPI; `jac build --as wheel` itself needs nothing. &nbsp; ² The desktop target ships with `jaclang` core (no Rust); it embeds the OS webview. On Linux you need the WebKitGTK system libraries (a bundled helper script installs them). &nbsp; ³ Only to *publish* (`npm publish`); `jac build --as npm` builds the `.tgz` with no Node/npm. &nbsp; ⁴ The binary renders your `cl` UI today; wiring `sv` walkers onto the embedded interpreter, HMR dev mode, and per-OS installers are in progress ([#6436](https://github.com/jaseci-labs/jaseci/issues/6436)). &nbsp; ⁵ Frontend-only Capacitor wrapper -- the app talks to a Jac server you deploy separately. &nbsp; ⁶ Beta React Native (Expo/Metro) frontend built from a mobUI source tree (`@jac/mobui` primitives, no HTML) that also compiles for the web; it talks to a Jac server you deploy separately.</small>
 
 Read across a row and the composition is the point: a full-stack app is just a *service* plus a *client*; in-browser native swaps the server for an `na` module compiled to wasm; a desktop app is a full-stack app plus a *shell*; microservices are a *service* replicated. The 🚧 rows aren't missing "kinds" -- they're capability combinations that aren't wired yet.
 
@@ -230,7 +230,7 @@ description = "A tiny Jac library"
 ```
 
 ```bash
-jac bundle
+jac build --as wheel
 # → dist/greetlib-0.1.0-py3-none-any.whl
 ```
 
@@ -240,7 +240,7 @@ Upload it with `twine`, then `pip install greetlib` anywhere. The wheel ships yo
 
 ### npm package
 
-The client-side counterpart to the Python package: a `cl` component (or function) library published to [npm](https://www.npmjs.com) so any JavaScript or TypeScript project can `npm install` it -- whether or not they use Jac. The same `jac.toml` drives it; `--target npm` compiles your client modules to ES-module JavaScript, generates `package.json`, and emits `.d.ts` TypeScript declarations.
+The client-side counterpart to the Python package: a `cl` component (or function) library published to [npm](https://www.npmjs.com) so any JavaScript or TypeScript project can `npm install` it -- whether or not they use Jac. The same `jac.toml` drives it; `jac build --as npm` compiles your client modules to ES-module JavaScript, generates `package.json`, and emits `.d.ts` TypeScript declarations.
 
 ```jac
 # greetui/index.cl.jac
@@ -264,14 +264,14 @@ name = "@myscope/greetui"   # optional scoped npm name
 ```
 
 ```bash
-jac bundle --target npm
-# → dist/myscope-greetui-0.1.0.tgz   (jac bundle --target all builds the wheel too)
+jac build --as npm
+# → dist/myscope-greetui-0.1.0.tgz   (run jac build --as wheel to build the wheel too)
 ```
 
 The generated `package.json` wires in `@jaseci/runtime` automatically for JSX/reactive code. Upload it with `npm publish` (Jac builds the tarball but doesn't upload, exactly like `twine` for wheels).
 
 !!! note "npm packages must be standalone client code"
-    A module that crosses a server boundary (an `sv` import or call) can't run from a plain `npm install`, so `jac bundle --target npm` rejects it with a clear error. Keep server-coupled code in your app, not in the published library.
+    A module that crosses a server boundary (an `sv` import or call) can't run from a plain `npm install`, so `jac build --as npm` rejects it with a clear error. Keep server-coupled code in your app, not in the published library.
 
 :octicons-arrow-right-24: Reference: [Publishing to npm](../reference/publishing.md#publishing-to-npm-npmjsorg)
 

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The `jac` command is your primary interface for working with Jac projects. It handles the full development lifecycle: running programs (`jac run`), type-checking code (`jac check`), running tests (`jac test`), formatting and linting (`jac format`, `jac lint`), managing dependencies (`jac add`, `jac install`), serving APIs (`jac start`), and even compiling to native binaries (`jac nacompile`). Think of it as combining the roles of `python`, `pip`, `pytest`, `black`, and `flask` into a single unified tool.
+The `jac` command is your primary interface for working with Jac projects. It handles the full development lifecycle: running programs (`jac run`), type-checking code (`jac check`), running tests (`jac test`), formatting and linting (`jac fmt`, `jac check --lint`), managing dependencies (`jac add`, `jac install`), serving APIs (`jac start`), and even compiling to native binaries (`jac nacompile`, or `jac build --as native`). Think of it as combining the roles of `python`, `pip`, `pytest`, `black`, and `flask` into a single unified tool.
 
 The CLI is extensible through plugins, and several capabilities are built into core. The built-in `scale` subsystem (formerly the `jac-scale` plugin, now part of `jaclang` core) adds deployment commands and flags automatically -- for example, `jac start --scale` for Kubernetes deployment. The built-in full-stack client framework (formerly the `jac-client` / `jac-desktop` plugins, now part of `jaclang` core) contributes others, such as `jac build --client desktop` for desktop app packaging. Installable plugins like `byllm` add their own commands the same way.
 
@@ -12,26 +12,27 @@ A task-first index into the commands below. The full alphabetical list follows i
 
 | I want to… | Command(s) |
 |---|---|
-| Run a program | `jac run` (no filename → runs the project by its `kind`) · `jac enter` |
+| Run a program | `jac run` (no filename → runs the project by its `kind`; `--entry <walker>` runs a specific entrypoint) |
 | Start a web/API server | `jac start` |
-| Deploy to Kubernetes | `jac start --scale` · `jac status` · `jac destroy` |
+| Run the live hot-reload dev loop | `jac dev` · `jac start --dev` |
+| Deploy to Kubernetes | `jac start --scale` · `jac scale status` · `jac scale destroy` |
 | Create a new project | `jac create` |
-| Set up / build a client target (web, desktop, mobile) | `jac setup` · `jac build` |
-| Compile a native binary or C-ABI shared library | `jac nacompile` |
-| Build a distributable package | `jac bundle` (wheel/npm) |
+| Set up / build a client shell (web, desktop, mobile) | `jac setup` · `jac build --client <target>` |
+| Compile a native binary or C-ABI shared library | `jac nacompile` · `jac build --as native` |
+| Build one distributable artifact (.jab, wheel, npm, source) | `jac build --as {jab,wheel,npm,source,…}` |
 | Add, remove, or update dependencies | `jac add` · `jac remove` · `jac update` |
-| Install project dependencies | `jac install` |
+| Install project dependencies (preview with `--plan`) | `jac install` · `jac install --plan` |
 | Run an installed CLI tool under Jac | `jac x` |
-| Type-check, format, or lint | `jac check` · `jac format` · `jac lint` · `jac precommit` |
+| Type-check, format, or lint | `jac check` · `jac fmt` · `jac check --lint` · `jac precommit` |
 | Run tests | `jac test` |
-| Debug or visualize a graph | `jac debug` · `jac dot` · `jac browse` |
+| Debug or visualize a graph | `jac run --debug` · `jac dot` · `jac browse` |
 | Have an AI agent write or edit code in my project | `jac ai` |
 | Query code structure (definitions, uses, walkers) | `jac code` |
 | Inspect or recover the persistence DB | `jac db` |
 | Manage config, plugins, or profiles | `jac config` · `jac plugins` |
 | Manage byLLM local models | `jac model` |
 | Use Jac from an AI assistant | `jac guide` · `jac mcp` |
-| Convert between Python, Jac, and JS | `jac py2jac` · `jac jac2py` · `jac jac2js` |
+| Convert between Python, Jac, and JS | `jac tool py2jac` · `jac tool jac2py` · `jac tool jac2js` |
 | Clean caches / artifacts | `jac clean` · `jac purge` |
 
 ---
@@ -40,19 +41,18 @@ A task-first index into the commands below. The full alphabetical list follows i
 
 | Command | Description |
 |---------|-------------|
-| `jac run` | Execute a Jac file, or (no filename) run the current project by its kind |
+| `jac run` | Execute a Jac file or `.jab`, or (no filename) run the current project by its kind (`--entry <walker>`, `--debug`) |
 | `jac start` | Start REST API server (use `--scale` for K8s deployment) |
-| `jac create` | Create new project |
-| `jac check` | Type check code |
+| `jac dev` | Live hot-reload dev loop (project-entry resolution + HMR serve) |
+| `jac build` | Type-check gate, then emit one artifact (`--as jab\|sealed\|binary\|wheel\|npm\|source\|native`; default `.jab`; `--client` builds a client shell) |
+| `jac create` | Create new project (`--pack` to bundle a directory into a `.jacpack` template) |
+| `jac check` | Type check code (`--lint` to lint, `--lint --fix` to auto-fix) |
 | `jac test` | Run tests |
-| `jac format` | Format code |
-| `jac lint` | Lint code (use `--fix` to auto-fix) |
+| `jac fmt` | Format code |
 | `jac precommit` | Run format + check using `jac.toml` lint settings (installable as a git hook) |
 | `jac clean` | Clean project build artifacts |
 | `jac purge` | Purge global bytecode cache (works even if corrupted) |
-| `jac enter` | Run specific entrypoint |
 | `jac dot` | Generate graph visualization |
-| `jac debug` | Interactive debugger |
 | `jac browse` | Automate a headless browser over CDP (navigate, click, snapshot, screenshot) |
 | `jac ai` | Launch an interactive Jac coding agent (works with local models, no API key) |
 | `jac code` | Query code structure via the compiler (symbols, uses, walkers, slices) |
@@ -62,26 +62,16 @@ A task-first index into the commands below. The full alphabetical list follows i
 | `jac plugins` | Manage plugins |
 | `jac model` | Manage byLLM local-model weights (Gemma 4, Qwen 3.5, …) |
 | `jac config` | Manage project configuration |
-| `jac destroy` | Remove Kubernetes deployment (scale) |
-| `jac status` | Show deployment status of Kubernetes resources (scale) |
+| `jac scale` | Manage local microservices (status/stop/restart/logs) and platform deployments (status/destroy) |
 | `jac add` | Add packages to project |
-| `jac install` | Install project dependencies from `jac.toml`, or `jac install <pkg>` to install packages into the project's `.jac/venv` |
+| `jac install` | Install project dependencies from `jac.toml` (`--plan` to preview the resolved plan), or `jac install <pkg>` to install packages into the project's `.jac/venv` |
 | `jac x` | Run an installed CLI tool (Python console-script or npm tool) under the `jac` runtime |
 | `jac remove` | Remove packages from project |
 | `jac update` | Update dependencies to latest compatible versions |
-| `jac bundle` | Build a distributable `.whl` from `jac.toml` |
-| `jac jacpack` | Manage project templates (.jacpack files) |
-| `jac eject` | Compile a project into a runnable FastAPI + JavaScript app (zero `.jac` files) |
-| `jac grammar` | Extract and print the Jac grammar |
+| `jac tool` | Language tools & source transforms (`jac2py`, `py2jac`, `jac2js`, `grammar`, IR, AST) |
 | `jac guide` | Show curated Jac reference guides |
-| `jac script` | Run project scripts |
-| `jac py2jac` | Convert Python to Jac |
-| `jac jac2py` | Convert Jac to Python |
-| `jac tool` | Language tools (IR, AST) |
 | `jac lsp` | Language server |
-| `jac jac2js` | Convert Jac to JavaScript |
-| `jac build` | Build for target platform (jac-client) |
-| `jac setup` | Setup build target (jac-client) |
+| `jac setup` | Setup client build target (jac-client) |
 | `jac db` | Inspect persistence DB, manage rescue aliases, recover quarantined data |
 
 ---
@@ -114,27 +104,31 @@ _/ |\__,_|\___|    Python 3.12.3
 
 ### jac run
 
-Execute a Jac file, or (with no filename) run the current project.
+Execute a Jac file, a prebuilt `.jab` artifact, or (with no filename) run the current project.
 
 **Note:** `jac <file>` is shorthand for `jac run <file>` - both work identically.
 
 ```bash
-jac run [-h] [-s] [--show] [-m] [--no-main] [-c] [--no-cache] [-e DIAGNOSTICS] [--profile PROFILE] [filename] [args ...]
+jac run [-h] [-s] [--show] [-m] [--no-main] [-c] [--no-cache] [-e DIAGNOSTICS] [--profile PROFILE] [--entry ENTRY] [-n NODE] [-r ROOT] [--debug] [filename] [args ...]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `filename` | Jac file to run. Omit to dispatch on the project's `jac.toml` | (project) |
+| `filename` | Jac file (or `.jab` artifact) to run. Omit to dispatch on the project's `jac.toml` | (project) |
 | `-s, --show` | Print the resolved project run-plan (kind, action, equivalent command) without executing | `False` |
 | `-m, --main` | Treat module as `__main__` | `True` |
 | `-c, --cache` | Enable compilation cache | `True` |
 | `-e, --diagnostics` | Diagnostic verbosity: `error`, `all`, or `none` | `error` |
 | `--profile` | Configuration profile to load (e.g. prod, staging) | `""` |
+| `--entry` | Run a specific entrypoint (function/walker) instead of the module's `with entry` block | None |
+| `-n, --node` | Starting node ID (with `--entry`) | None |
+| `-r, --root` | Root executor ID (with `--entry`) | None |
+| `--debug` | Launch the interactive debugger on the file | `False` |
 | `args` | Arguments passed to the script (available via `sys.argv[1:]`) | |
 
 Like Python, everything after the filename is passed to the script. Jac flags must come **before** the filename.
 
-**Project-aware run (no filename).** Inside a project, a bare `jac run` resolves the project *kind* from `[project] kind` in `jac.toml` (or infers it from the entry-point's codespace) and does the natural action for that kind: **execute** runnable kinds (`cli`, `cli-native`), **serve** server kinds (`service`, `web-app`, ...), or **build** artifact kinds (`native-binary`, `native-lib`, `py-package`, `js-package`). Use `jac run --show` to preview the plan and the equivalent primitive command (`run` / `start` / `nacompile` / `bundle`) without running it. See [project kinds](../../quick-guide/project-kinds.md) and [config `[project]`](../config/index.md).
+**Project-aware run (no filename).** Inside a project, a bare `jac run` resolves the project *kind* from `[project] kind` in `jac.toml` (or infers it from the entry-point's codespace) and does the natural action for that kind: **execute** runnable kinds (`cli`, `cli-native`), **serve** server kinds (`service`, `web-app`, ...), or **build** artifact kinds (`native-binary`, `native-lib`, `py-package`, `js-package`). Use `jac run --show` to preview the plan and the equivalent primitive command (`run` / `start` / `nacompile` / `build`) without running it. See [project kinds](../../quick-guide/project-kinds.md) and [config `[project]`](../config/index.md).
 
 **Diagnostics modes:**
 
@@ -172,6 +166,33 @@ jac run -e none main.jac
 
 # Pass flag-like arguments to the script
 jac run script.jac --verbose --output result.txt
+```
+
+**Running a specific entrypoint (`--entry`).** By default `jac run` executes a module's `with entry` block. Pass `--entry <name>` to invoke a specific function or walker instead, optionally seeding a starting node (`-n/--node`) and root (`-r/--root`). Flags come **before** the filename; script arguments follow it.
+
+```bash
+# Invoke a specific walker
+jac run --entry my_walker main.jac
+
+# With arguments passed to the entrypoint
+jac run --entry process_data main.jac arg1 arg2
+
+# With root and starting node
+jac run --entry my_walker -r root_id -n node_id main.jac
+```
+
+**Running a prebuilt `.jab` artifact.** `jac run app.jab` executes a sealed artifact with **zero live compilation** -- the sealed image (client dist, serve manifest, native binaries) is baked in and hash-verified at load. `cli`-kind artifacts execute; use [`jac start`](#jac-start) to production-serve servable kinds.
+
+```bash
+# Execute a sealed artifact
+jac run app.jab
+```
+
+**Interactive debugger (`--debug`).** Pass `--debug` to launch the interactive debugger on a file. See [VS Code Debugger Setup](#vs-code-debugger-setup) below for editor integration.
+
+```bash
+# Start the debugger
+jac run --debug main.jac
 ```
 
 **Passing arguments to scripts:**
@@ -274,6 +295,31 @@ jac start --scale --build
 >
 ---
 
+### jac dev
+
+The dedicated live hot-reload development loop. `jac dev` resolves the project entry point and serves it with Hot Module Replacement (HMR), rebuilding on every save. Unlike [`jac run`](#jac-run) / [`jac start`](#jac-start), it always works from **live source** and never reads a sealed `.jab` artifact. (`jac start --dev` still exists for HMR serving; `jac dev` is the purpose-built loop.)
+
+```bash
+jac dev [-h] [-p PORT] [--api_port API_PORT]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-p, --port` | Port to serve on | `8000` |
+| `--api_port` | Separate API port for HMR (0 = same as `port`) | `0` |
+
+**Examples:**
+
+```bash
+# Start the hot-reload dev loop
+jac dev
+
+# On a custom port
+jac dev -p 3000
+```
+
+---
+
 ### jac create
 
 Initialize a new Jac project with configuration. Creates a project folder with the given name containing the project files, including an `AGENTS.md` that points AI coding agents at `jac guide`.
@@ -291,6 +337,8 @@ jac create [-h] [-f] [-k KIND] [-u USE] [-l] [name]
 | `-k, --kind` | Project kind: cli, cli-native, native-binary, native-lib, service, service-mesh, py-package, js-package, web-app, web-static, desktop, mobile | `cli` |
 | `-u, --use` | Custom template: file path or URL to a `.jacpack`, or a named variant (e.g. `jac-shadcn`) | `default` |
 | `-l, --list_jacpacks` | List available project kinds and named variants | `False` |
+| `--pack DIR` | Bundle a template directory into a distributable `.jacpack` file (absorbs `jac jacpack pack`) | None |
+| `--pack_output F` | Output path for the bundled `.jacpack` (with `--pack`) | `<name>.jacpack` |
 
 `--kind` and `--use` are mutually exclusive.
 
@@ -326,18 +374,22 @@ jac create myapp --force
 
 # Create in current directory
 jac create
+
+# Bundle a template directory into a .jacpack (absorbs `jac jacpack pack`)
+jac create --pack ./my-template
+jac create --pack ./my-template --pack_output custom-name.jacpack
 ```
 
-**See Also:** Use `jac jacpack` to create and bundle custom templates.
+**See Also:** Use `jac create --pack` to bundle a directory into a distributable `.jacpack` template, then `jac create --use <file>.jacpack` to scaffold from it.
 
 ---
 
 ### jac check
 
-Type check Jac code for errors.
+Type check Jac code for errors. Pass `--lint` to also run the linter (this absorbs the former `jac lint`), and `--lint --fix` to auto-fix lint violations.
 
 ```bash
-jac check [-h] [-e] [-i [IGNORE ...]] [-p] [--nowarn] paths [paths ...]
+jac check [-h] [-e] [-i [IGNORE ...]] [-p] [--nowarn] [--lint] [--fix] paths [paths ...]
 ```
 
 | Option | Description | Default |
@@ -347,6 +399,8 @@ jac check [-h] [-e] [-i [IGNORE ...]] [-p] [--nowarn] paths [paths ...]
 | `-i, --ignore` | Space-separated list of files/folders to ignore | None |
 | `-p, --parse_only` | Only check syntax (skip type checking) | `False` |
 | `--nowarn` | Suppress warning output | `False` |
+| `--lint` | Also run the linter and report style/lint violations | `False` |
+| `--fix` | With `--lint`, auto-fix lint violations (code corrections) | `False` |
 
 **Examples:**
 
@@ -362,9 +416,20 @@ jac check myproject/ --ignore fixtures tests
 
 # Check excluding multiple patterns
 jac check . --ignore node_modules dist __pycache__
+
+# Type-check and lint the current directory
+jac check . --lint
+
+# Lint and auto-fix violations
+jac check . --lint --fix
+
+# Lint excluding folders
+jac check . --lint --ignore fixtures
 ```
 
 Errors and warnings are displayed with structured diagnostic codes (e.g., `E1030`, `W2001`). You can suppress individual diagnostics inline with `# jac:ignore[CODE]`:
+
+> **Lint Rules**: `jac check --lint` (formerly `jac lint`) reports style violations; add `--fix` to apply auto-fixes. Configure rules via [`[check.lint]`](../config/index.md#checklint) in `jac.toml`. See [Lint Rules](../diagnostics.md#lint-rules-w3xxx-e3xxx) for the full list with diagnostic codes.
 
 <!-- jac-skip -->
 ```jac
@@ -430,12 +495,12 @@ jac test main.jac -v
 
 ---
 
-### jac format
+### jac fmt
 
-Format Jac code according to style guidelines. For auto-linting (code corrections like combining consecutive `has` statements, converting `@staticmethod` to `static`), use `jac lint --fix` instead.
+Format Jac code according to style guidelines. For auto-linting (code corrections like combining consecutive `has` statements, converting `@staticmethod` to `static`), use `jac check --lint --fix` instead.
 
 ```bash
-jac format [-h] [-s] [-l] [-c] paths [paths ...]
+jac fmt [-h] [-s] [-l] [-c] paths [paths ...]
 ```
 
 | Option | Description | Default |
@@ -449,61 +514,35 @@ jac format [-h] [-s] [-l] [-c] paths [paths ...]
 
 ```bash
 # Preview formatting
-jac format main.jac -s
+jac fmt main.jac -s
 
 # Apply formatting
-jac format main.jac
+jac fmt main.jac
 
 # Format entire directory
-jac format .
+jac fmt .
 
 # Check formatting without modifying (useful in CI)
-jac format . --check
+jac fmt . --check
 ```
 
-> **Note**: For auto-linting (code corrections), use `jac lint --fix` instead. See [`jac lint`](#jac-lint) below.
+> **Note**: For auto-linting (code corrections), use `jac check --lint --fix` instead. See [`jac check`](#jac-check) above.
 >
-> **Safety**: If the formatter detects that comments were displaced (e.g., moved to the end of the file), it emits error `E5051` and refuses to save the file. Run `jac format <file> -s` to inspect the output without writing.
+> **Safety**: If the formatter detects that comments were displaced (e.g., moved to the end of the file), it emits error `E5051` and refuses to save the file. Run `jac fmt <file> -s` to inspect the output without writing.
 
 ---
 
 ### jac lint
 
-Lint Jac files and report violations. Use `--fix` to auto-fix violations.
-
-```bash
-jac lint [-h] [-f] [--ignore IGNORE] paths [paths ...]
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `paths` | Files/directories to lint | Required |
-| `-f, --fix` | Auto-fix lint violations | `False` |
-| `--ignore` | Comma-separated files/folders to ignore | `""` |
-
-**Examples:**
-
-```bash
-# Report lint violations
-jac lint main.jac
-
-# Auto-fix violations
-jac lint main.jac --fix
-
-# Lint entire directory
-jac lint .
-
-# Lint excluding folders
-jac lint . --ignore fixtures
-```
-
-> **Lint Rules**: Configure rules via [`[check.lint]`](../config/index.md#checklint) in `jac.toml`. See [Lint Rules](../diagnostics.md#lint-rules-w3xxx-e3xxx) for the full list with diagnostic codes.
+Linting has folded into `jac check`. Run **`jac check --lint`** to report violations and **`jac check --lint --fix`** to auto-fix them. See [`jac check`](#jac-check) above for options and examples.
 
 ---
 
 ### jac precommit
 
-Run a pre-commit pipeline (`jac format --lintfix` followed by `jac check`) using the lint settings from `jac.toml`. Exits non-zero if any file was reformatted or `jac check` reported errors, so it can gate a commit. Because formatting honors [`[check.lint]`](../config/index.md#checklint), enabling the opt-in `strip-comments` / `strip-docstrings` rules there makes `jac precommit` apply them too.
+*Hidden from `jac --help` (still functional).*
+
+Run a pre-commit pipeline (`jac fmt --lintfix` followed by `jac check`) using the lint settings from `jac.toml`. Exits non-zero if any file was reformatted or `jac check` reported errors, so it can gate a commit. Because formatting honors [`[check.lint]`](../config/index.md#checklint), enabling the opt-in `strip-comments` / `strip-docstrings` rules there makes `jac precommit` apply them too.
 
 ```bash
 jac precommit [-h] [-s] [-v] [-i] [paths ...]
@@ -538,39 +577,15 @@ jac precommit --install
 
 ### jac enter
 
-Run a specific entrypoint in a Jac file.
-
-```bash
-jac enter [-h] [-m] [-r ROOT] [-n NODE] filename entrypoint [args ...]
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `filename` | Jac file | Required |
-| `entrypoint` | Function/walker to invoke (positional) | Required |
-| `args` | Arguments to pass | None |
-| `-m, --main` | Treat as `__main__` | `True` |
-| `-r, --root` | Root executor ID | None |
-| `-n, --node` | Starting node ID | None |
-
-**Examples:**
-
-```bash
-# Run specific entrypoint
-jac enter main.jac my_walker
-
-# With arguments
-jac enter main.jac process_data arg1 arg2
-
-# With root and node
-jac enter main.jac my_walker -r root_id -n node_id
-```
+Running a specific entrypoint has folded into `jac run`. Use **`jac run --entry <walker> <file>`** (with optional `-n/--node` and `-r/--root`). See [`jac run`](#jac-run) above.
 
 ---
 
 ## Visualization & Debug
 
 ### jac dot
+
+*Hidden from `jac --help` (still functional).*
 
 Generate DOT graph visualization.
 
@@ -610,23 +625,11 @@ jac dot main.jac -s my_session -d 3
 
 ### jac debug
 
-Start interactive debugger.
+Interactive debugging has folded into `jac run`. Use **`jac run --debug <file>`** to launch the debugger on a file. See [`jac run`](#jac-run) above.
 
 ```bash
-jac debug [-h] [-m] [-c] filename
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `filename` | Jac file to debug | Required |
-| `-m, --main` | Run main entry | `True` |
-| `-c, --cache` | Use cache | `False` |
-
-**Examples:**
-
-```bash
-# Start debugger
-jac debug main.jac
+# Start the debugger
+jac run --debug main.jac
 ```
 
 #### VS Code Debugger Setup
@@ -672,6 +675,8 @@ For a complete walkthrough, see the [Debugging in VS Code Tutorial](../../tutori
 ## Browser Automation
 
 ### jac browse
+
+*Hidden from `jac --help` (still functional).*
 
 Drive a headless Chrome/Chromium over the Chrome DevTools Protocol (CDP): navigate, interact with elements, inspect the page, and capture screenshots. The driver is zero-dependency -- it speaks CDP over a hand-rolled WebSocket, so no Playwright or Selenium install is required. Interactions use real CDP input events (trusted clicks and keystrokes), not JavaScript injection.
 
@@ -1061,7 +1066,7 @@ jac db alias add "old.module.LegacyName" "new.module.NewName"
 jac db alias remove "old.module.LegacyName"
 ```
 
-Both arguments to `alias add` are fully-qualified `module.ClassName` strings -- the `module` part is what would have appeared in the stored row's `arch_module` field. For files imported via `jac enter app.jac`, the module is `__main__`.
+Both arguments to `alias add` are fully-qualified `module.ClassName` strings -- the `module` part is what would have appeared in the stored row's `arch_module` field. For files run via `jac run app.jac`, the module is `__main__`.
 
 > **When to use this vs. the decorator.** The [`@archetype_alias`](../persistence.md#class-renames-the-alias-decorator) decorator is the normal path: it's code-resident, travels through git, applies wherever the code runs. `jac db alias add` is the rescue path: emergency recovery in production without a code deploy. Decorator first, CLI as the safety net.
 
@@ -1281,20 +1286,27 @@ jac start --scale --build   # Build and deploy
 
 ---
 
-### jac status
+### jac scale
 
-Show the deployment status of your Jac application on Kubernetes. Displays a color-coded table with the health of each component (application, Redis, MongoDB, Prometheus, Grafana), pod readiness counts, and service URLs.
+`jac scale <action>` is the unified noun for scale operations. It has two modes depending on the argument:
+
+- **Local microservices** -- `jac scale <action> [name]` manages locally-running services: `status`, `stop`, `restart`, `logs`.
+- **Platform deployment** -- given a `.jac` app file, `jac scale <action> <file.jac> [--target T] [--component C]` operates on a platform deployment: `status` (health of each component) and `destroy` (tear the deployment down). This absorbs the former top-level `jac status` / `jac destroy` verbs.
+
+To *deploy* in the first place, run `jac start --scale` (see [`jac start`](#jac-start) above).
 
 ```bash
-jac status [-h] file_path [--target TARGET]
+jac scale <action> [name|file] [--target TARGET] [--component COMPONENT]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `file_path` | Path to the `.jac` file | Required |
-| `--target` | Deployment target platform | `kubernetes` |
+| `action` | `status`, `stop`, `restart`, `logs` (local) or `status`, `destroy` (platform, with a `.jac` file) | Required |
+| `name` / `file` | Local service name, or the path to the `.jac` app file for platform actions | None |
+| `--target` | Deployment target platform (platform actions) | `kubernetes` |
+| `--component` | Restrict the action to a single component (platform actions) | None |
 
-**Example output:**
+**Platform status output (`jac scale status app.jac`):**
 
 ```
   Jac Scale - Deployment Status
@@ -1330,31 +1342,18 @@ jac status [-h] file_path [--target TARGET]
 **Examples:**
 
 ```bash
-# Check deployment status
-jac status app.jac
+# Local microservices
+jac scale status
+jac scale logs my-service
+jac scale restart my-service
+jac scale stop my-service
 
-# Check status with explicit target
-jac status app.jac --target kubernetes
-```
+# Platform deployment status of a .jac app
+jac scale status app.jac
+jac scale status app.jac --target kubernetes
 
----
-
-### jac destroy
-
-Remove a deployment.
-
-```bash
-jac destroy [-h] file_path
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `file_path` | Jac file to undeploy | Required |
-
-**Examples:**
-
-```bash
-jac destroy main.jac
+# Tear down a platform deployment
+jac scale destroy app.jac
 ```
 
 ---
@@ -1410,7 +1409,7 @@ For private packages from custom registries (e.g., GitHub Packages), configure s
 
 ### jac install
 
-`jac install` has two modes depending on whether package names are passed:
+`jac install` has two modes depending on whether package names are passed. Pass `--plan` (optionally with `--json`) to preview the resolved dependency plan without installing anything -- this absorbs the former `jac deps`.
 
 **No-argument mode** - sync the project environment to `jac.toml`. Installs all Python (pip), git, and plugin-provided (npm, etc.) dependencies in one command. Creates or validates the project virtual environment at `.jac/venv/`. Requires a `jac.toml` in the current (or a parent) directory.
 
@@ -1430,7 +1429,7 @@ For private packages from custom registries (e.g., GitHub Packages), configure s
 ```bash
 jac install [-h] [packages ...] [-e PATH] [-d] [-x group [group ...]] [-v]
             [--force-reinstall] [--no-cache-dir] [--pre] [--dry-run]
-            [--no-deps] [--quiet] [--prefer-binary] [--global]
+            [--no-deps] [--quiet] [--prefer-binary] [--global] [--plan] [--json]
 ```
 
 | Option | Description | Default |
@@ -1448,6 +1447,8 @@ jac install [-h] [packages ...] [-e PATH] [-d] [-x group [group ...]] [-v]
 | `--quiet` | Suppress pip output | `False` |
 | `--prefer-binary` | Prefer pre-built wheels over source distributions | `False` |
 | `--global` | Install into the binary's own jac-owned site (importable from any project), not the project's `.jac/venv`. Works outside a project. | `False` |
+| `--plan` | Resolve and print the dependency plan without installing anything (absorbs the former `jac deps`) | `False` |
+| `--json` | With `--plan`, emit the plan as machine-readable JSON | `False` |
 
 **Examples:**
 
@@ -1493,6 +1494,10 @@ jac install --dry-run
 
 # Install without using pip's download cache
 jac install --no-cache-dir
+
+# Preview the resolved dependency plan without installing (formerly `jac deps`)
+jac install --plan
+jac install --plan --json
 ```
 
 Optional groups are declared under `[optional-dependencies]` in `jac.toml`. See the [Configuration Reference](../config/index.md#optional-dependencies).
@@ -1509,7 +1514,7 @@ Optional groups are declared under `[optional-dependencies]` in `jac.toml`. See 
 
 `jac x <tool>` runs an installed command-line tool under the `jac` runtime -- the Jac-native, cross-ecosystem equivalent of `pipx run` / `npx`. It resolves a **Python console-script** (from an installed package's entry points) or an **npm tool** (from `node_modules/.bin`) and runs it. Python tools execute in-process under the bundled interpreter; npm tools run through the jac-managed **bun** runtime -- so **neither a system Python nor a system Node is required**.
 
-The CLI tools you install with `jac install` / `jac add` are therefore runnable without putting anything on your shell `PATH`, and resolution is project-aware: inside a project, a tool installed in that project shadows a global one of the same name.
+The CLI tools you install with `jac install` / `jac add` are therefore runnable without putting anything on your shell `PATH`, and resolution is project-aware: inside a project, a tool installed in that project shadows a global one of the same name. `jac x <name>` also runs custom scripts defined in the `[scripts]` section of `jac.toml` -- this absorbs the former `jac script`. A bare `jac x` (or `jac x --list`) lists everything runnable.
 
 > **Resolution order (first match wins).** By default `jac x` searches tiers **locality-first**:
 >
@@ -1684,58 +1689,90 @@ jac purge
 
 ---
 
-### jac bundle
+### jac build
 
-Build a standards-compliant Python wheel (`.whl`) from your project's `jac.toml`. The wheel is `pip install`-ready and requires no `pyproject.toml` or `setuptools`. It is consumed under the `jac` binary (which provides the jaclang runtime), so the wheel neither bundles nor declares `jaclang` as a dependency. After building, upload to PyPI (or a private registry) with `twine upload dist/*`. For the full end-to-end workflow, see the [Publishing Packages](../publishing.md) guide.
+Run the whole-program **type-check gate** (fail-closed; reuses [`jac check`](#jac-check)), then emit **one** artifact. By default `jac build` produces a `.jab` -- a single self-describing sealed app bundle. Use `--as` to select a different projection. `jac build` is now the single front door that the former `jac bundle` (wheel/npm), `jac eject` (source), and project-level `jac nacompile` (native/binary) folded into.
 
 ```bash
-jac bundle [-h] [-o OUTPUT] [-p]
+jac build [-h] [--as {jab,sealed,binary,wheel,npm,source,native}] [-o OUTPUT] [-n] [-c]
+          [--client {web,pwa,static,mobile,desktop,cef,react-native}] [-p PLATFORM] [filename]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-o, --output` | Directory to write the `.whl` file | `dist` |
-| `-p, --precompile` | Compile `.jac` → `.jir` bytecode for every `python3.X` found on `PATH` before packaging | off |
+| `filename` | Entry `.jac` file (omit to use the project entry) | (project) |
+| `--as` | Artifact projection: `jab`, `sealed`, `binary`, `wheel`, `npm`, `source`, `native` | `jab` |
+| `-o, --output` | Output directory | `dist` |
+| `-n, --no_typecheck` | Skip the type-check gate | `False` |
+| `-c, --check_only` | Run the gate only; emit nothing | `False` |
+| `--client` | Build a client shell (`web`, `pwa`, `static`, `mobile`, `desktop`, `cef`, `react-native`) | None |
+| `-p, --platform` | Platform selector for `--client` builds | Current platform |
 
-**What it does:**
+**Projections (`--as`):**
 
-1. Reads `[project]` from `jac.toml` and validates required fields (`name`, `version`).
-2. Discovers source files under the package directory (defaults to the directory named after the project, or the explicit `[project.include]` `packages` list). Includes `*.jac`, `*.py`, `*.pyi`, `*.lark`, `py.typed`, and `*.jir` by default.
-3. Generates a PEP 427-compliant `.whl` archive with `METADATA`, `WHEEL`, `RECORD`, `top_level.txt`, and optional `entry_points.txt`. The build is reproducible (fixed ZIP timestamps).
-4. Writes `<name>-<version>-py3-none-any.whl` to the output directory.
+| `--as` | Emits | Replaces |
+|--------|-------|----------|
+| `jab` (default) | A sealed `.jab` app bundle (deterministic `tar.gz` of the sealed image) | -- |
+| `sealed` / `binary` | Sealed image / native binary form | -- |
+| `wheel` | A `pip install`-ready Python wheel in `dist/` | `jac bundle` |
+| `npm` | An npm tarball | `jac bundle --target npm` |
+| `source` | An editable FastAPI + JavaScript source tree (zero `.jac` files) | `jac eject` |
+| `native` | A standalone native binary | project-level `jac nacompile` |
 
-> **Note on bytecode:** `jac bundle` ships `.jir` files only if they already exist in your source tree. Use `--precompile` to auto-generate `.jir` files for every `python3.X` interpreter on `PATH` before packaging, each version gets its own isolated venv so compilation is clean.
+**The type-check gate.** `jac build` refuses to emit an artifact if the program fails the whole-program type check. Pass `--no_typecheck` to skip the gate, or `--check_only` to run the gate and emit nothing (useful in CI).
 
-**Examples:**
+**The `.jab` artifact.** A `.jab` is a single self-describing sealed app bundle: client dist, serve manifest, and native binaries are baked in and hash-verified at load, so [`jac run app.jab`](#jac-run) / [`jac start app.jab`](#jac-start) execute or serve it with **zero live compilation**. It is kind-aware: `cli` kinds execute, servable kinds production-serve, and attachable packages refuse to run standalone.
+
+**Building a wheel (publish to PyPI):**
 
 ```bash
-# Build wheel into dist/ (default)
-jac bundle
+# Type-check, then build a wheel into dist/
+jac build --as wheel
 
 # Build to a custom directory
-jac bundle -o /tmp/wheels
-
-# Pre-compile for all Python versions on PATH, then build
-jac bundle --precompile
-
-# Upload to PyPI after building
-jac bundle --precompile && twine upload dist/*
-
-# Install locally to test before publishing
-pip install dist/mylib-1.0.0-py3-none-any.whl
+jac build --as wheel -o /tmp/wheels
 ```
 
-**Requirements:**
+After a wheel build the tool prints `Upload with: twine upload dist/*`. There is no `--publish` flag; upload with twine:
 
-A `[project]` section must exist in `jac.toml`. At minimum:
-
-```toml
-[project]
-name = "mylib"
-version = "1.0.0"
+```bash
+jac build --as wheel && twine upload dist/*
 ```
 
-See the [Configuration Reference](../config/index.md#project) for the full set of publishing fields (`license`, `readme`, `authors`, `[project.include]`, and more).
+**Building an npm tarball:**
+
+```bash
+jac build --as npm      # prints "Publish with: npm publish"
+```
+
+To produce **both** a wheel and an npm tarball, run both commands (there is no single "all" projection):
+
+```bash
+jac build --as wheel
+jac build --as npm
+```
+
+**Building a native binary or editable source tree:**
+
+```bash
+# Standalone native binary (project-level; see `jac nacompile` for file-level .na.jac)
+jac build --as native
+
+# Editable FastAPI + JavaScript source tree (formerly `jac eject`)
+jac build --as source -o /tmp/myapp-out
+```
+
+**Building a client shell:**
+
+```bash
+# Build a desktop client shell
+jac build --client desktop
+
+# Build a mobile client shell for a platform
+jac build --client mobile -p android
+```
+
+> **Note:** The `[project.include]` / `**/*.jir` collection settings in `jac.toml` govern what `jac build --as wheel` collects (this was formerly `jac bundle`). See the [Configuration Reference](../config/index.md#project) for the full set of publishing fields (`name`, `version`, `license`, `readme`, `authors`, `[project.include]`, and more). For the full end-to-end publishing workflow, see the [Publishing Packages](../publishing.md) guide.
 
 ---
 
@@ -1743,22 +1780,15 @@ See the [Configuration Reference](../config/index.md#project) for the full set o
 
 ### jac jacpack
 
-Manage project templates. Bundle template directories into distributable `.jacpack` files or list available templates.
+Template packing has folded into [`jac create`](#jac-create). Bundle a template directory into a distributable `.jacpack` with **`jac create --pack <dir>`** (`--pack_output F` for a custom path), and list available templates/kinds with **`jac create --list_jacpacks`**. The `.jacpack` concept below is unchanged.
 
 ```bash
-jac jacpack [action] [path] [-o OUTPUT]
+# Bundle a template directory into a .jacpack (formerly `jac jacpack pack`)
+jac create --pack <dir> [--pack_output out.jacpack]
+
+# List available project kinds and named variants (formerly `jac jacpack list`)
+jac create --list_jacpacks
 ```
-
-| Action | Description |
-|--------|-------------|
-| `pack` | Bundle a template directory into a `.jacpack` file |
-| `list` | List available templates (default) |
-| `info` | Show information about a template |
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `path` | Template directory (for pack) or `.jacpack` file (for info) | None |
-| `-o, --output` | Output file path for bundled template | `<name>.jacpack` |
 
 **Template Directory Structure:**
 
@@ -1798,18 +1828,14 @@ root_gitignore_entries = [".jac/"]
 **Examples:**
 
 ```bash
-# List available templates
-jac jacpack list
+# List available templates / project kinds
+jac create --list_jacpacks
 
 # Bundle a template directory
-jac jacpack pack ./my-template
+jac create --pack ./my-template
 
 # Bundle with custom output path
-jac jacpack pack ./my-template -o custom-name.jacpack
-
-# Show template info
-jac jacpack info ./my-template
-jac jacpack info mytemplate.jacpack
+jac create --pack ./my-template --pack_output custom-name.jacpack
 ```
 
 **Using Templates with `jac create`:**
@@ -1824,116 +1850,31 @@ jac create myproject --use mytemplate
 
 ### jac eject
 
-Compile a Jac project into a runnable FastAPI + JavaScript app. The output contains **zero `.jac` files**: each walker is compiled to Python and served by a FastAPI backend, and the `.cl.jac` UI is compiled to JavaScript on Vite. The backend runs the walkers on the `jac` binary's bundled jaclang runtime (so persistence, graph traversal, access control, and `by llm()` behave exactly as under `jac start`), and exposes jaclang-native auth. Use it when you want an editable FastAPI/JS codebase you can extend and deploy without writing Jac.
+Ejecting has folded into [`jac build`](#jac-build). Use **`jac build --as source`** to compile a Jac project into a runnable FastAPI + JavaScript source tree with **zero `.jac` files** -- each walker becomes a Python FastAPI route and the `.cl.jac` UI compiles to JavaScript on Vite. Use it when you want an editable FastAPI/JS codebase you can extend and deploy without writing Jac.
 
 ```bash
-jac eject [-h] [-o OUTPUT] [-f] [source]
-```
+# Eject the current project (formerly `jac eject`)
+jac build --as source
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `source` | Project directory to eject (must contain `jac.toml`) | `.` |
-| `-o, --output` | Output directory | `<project>/ejected` (overridable via `[eject].output`) |
-| `-f, --force` | Overwrite a non-eject directory at the output path | `False` |
+# Eject to a chosen output directory
+jac build --as source -o /tmp/myapp-out
+```
 
 **What gets emitted**
 
-- Server-side `.sv.jac` (and the server scope of plain `.jac`) modules become Python via the compiler's `gen.py`, keeping their real `jaclang.jac0core.jaclib` imports.
-- Client-side `.cl.jac` modules become JavaScript via `gen.js` (JSX lowers to `__jacJsx(...)`, `has` to `useState`, `sv import` to HTTP RPC stubs). Client modules never go to the backend.
-- A generated `backend/main.py` is the FastAPI app: one `POST /walker/<Name>` per walker, `POST /function/<name>` per function, plus `/user/register` and `/user/login`. `:pub` walkers/functions are open endpoints; the rest require a bearer token.
-- `.impl.jac` / `.test.jac` files are skipped (they merge into their declaration sibling at compile time).
-- A project with no client `app` component (no `cl {}` block / `.cl.jac`) ejects **backend-only**: the `frontend/` scaffold is skipped so there is no broken Vite build.
+- Server-side `.sv.jac` (and the server scope of plain `.jac`) modules become Python, keeping their real `jaclang.jac0core.jaclib` imports; client-side `.cl.jac` modules become JavaScript. A generated `backend/main.py` FastAPI app exposes one `POST /walker/<Name>` per walker, `POST /function/<name>` per function, plus `/user/register` and `/user/login` (`:pub` walkers/functions are open; the rest require a bearer token).
+- A project with no client `app` component ejects **backend-only** (the `frontend/` scaffold is skipped). `.impl.jac` / `.test.jac` files are skipped.
 
-**Output layout**
+**Persistence.** By default the object graph persists to a local SQLite file via the jaclang runtime. To persist through SQLAlchemy instead (so the same backend can target Postgres/MySQL), set `driver = "sqlalchemy"` under `[eject.db]` in `jac.toml`; the connection URL is overridable at runtime with `JAC_DB_URL`.
 
-```
-<project>/ejected/
-├── .jac-ejected         marker (lets re-runs regenerate without --force)
-├── backend/
-│   ├── main.py          FastAPI app (walkers/functions + auth routes)
-│   ├── requirements.txt  jaclang + fastapi + uvicorn (see runtime note below)
-│   └── <module>.py      compiled server modules (real jaclang imports)
-└── frontend/
-    ├── package.json     npm dependencies (includes Vite)
-    ├── vite.config.js   dev server proxying /walker, /function, /user to the backend
-    ├── index.html       SPA shell
-    └── src/             compiled .cl.jac modules + vendored @jac/runtime
-```
-
-The generated `backend/main.py` wires up jaclang's `UserManager` and `ExecutionManager`: `/user/register` and `/user/login` create and authenticate users (each gets their own persistent SQLite-backed root graph), and each walker route resolves the bearer token to a user (falling back to a `__guest__` user for `:pub` walkers) before running the walker in that user's context. When a built frontend is present at `frontend/dist`, `main.py` mounts it so a single `uvicorn main:app` serves both the API and the UI.
-
-**Persistence**
-
-By default the object graph persists to a local SQLite file via the jaclang runtime. To persist through SQLAlchemy instead (so the same backend can target Postgres/MySQL), opt in via `jac.toml`:
-
-```toml
-[eject.db]
-driver = "sqlalchemy"   # or "sqlite"
-```
-
-This vendors a `backend/_jac_sqldb.py` SQLAlchemy `PersistentMemory` backend and registers it through the runtime's `get_persistent_memory` hook, and adds `SQLAlchemy` to `requirements.txt`. The connection URL defaults to a SQLite file under `backend/` and is overridable at runtime with `JAC_DB_URL` (e.g. `postgresql://...`). This is a single-writer backend (correct for one uvicorn worker); for multi-process writers use the built-in scale `MongoBackend`.
-
-**Examples**
-
-```bash
-# Eject the current project to ./ejected/
-jac eject
-
-# Eject a specific project to a chosen output directory
-jac eject ./myapp -o /tmp/myapp-out
-
-# Overwrite an existing (non-eject) directory at the output path
-jac eject ./myapp --force
-```
-
-**Running the ejected project**
-
-```bash
-cd ejected
-(cd frontend && npm install && npm run build)
-cd backend && pip install -r requirements.txt && uvicorn main:app
-```
-
-The backend listens on `PORT` (default 8000). For frontend dev with hot reload, run `npm run dev` in `frontend/` instead; its Vite config proxies `/walker`, `/function`, and `/user` to the backend.
-
-**Caveats**
-
-- The ejected backend imports the jaclang runtime (`jaclang.runtimelib.server`, and the compiled modules import `jaclang.jac0core.jaclib`), so that runtime must be available in the environment that runs `uvicorn`. The goal of `jac eject` is *zero `.jac` files and an editable FastAPI surface*, not zero jaclang runtime.
-
-    !!! warning "Runtime provisioning is being migrated"
-        `jaclang` is no longer published to PyPI -- it ships as the `jac` binary. The generated `requirements.txt` still lists a `jaclang` entry and the run step above uses a plain `pip install`, which no longer resolves. Until eject is updated to package the binary's runtime, run the ejected backend in an environment that already provides the jaclang runtime (for example, a checkout where the `jac` binary is on PATH) rather than relying on a standalone `pip`-based deploy.
-- The generated FastAPI app enables permissive CORS (`allow_origins=["*"]`) for local dev; restrict it before deploying to production.
-- `.impl.jac` and `.test.jac` files are skipped; so are well-known build directories (`.jac`, `.git`, `.venv`, `node_modules`, `__pycache__`, `dist`, `build`, etc.).
-- Persistent state (users, root nodes, graph data) lives under `backend/.jac/data/` after first run, just as it would for `jac start`.
-
-**Extending eject from a plugin**
-
-`jaclang.cli.commands.impl.eject` exports `load_eject_project_metadata(src: Path) -> dict`, which parses `jac.toml` and returns `project_name`, `entry_point`, `entry_module`, and the raw `toml_data`, so callers can read sections like `[scale]` or `[dependencies.npm]` without re-parsing.
+!!! warning "Runtime provisioning is being migrated"
+    `jaclang` is no longer published to PyPI -- it ships as the `jac` binary. The generated `requirements.txt` still lists a `jaclang` entry, which no longer resolves via a plain `pip install`. Until source ejection is updated to package the binary's runtime, run the ejected backend in an environment that already provides the jaclang runtime (for example, a checkout where the `jac` binary is on PATH).
 
 ---
 
 ### jac jac2js
 
-Generate JavaScript output from Jac code (used for jac-client frontend compilation).
-
-```bash
-jac jac2js [-h] filename
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `filename` | Jac file to compile to JS | Required |
-
-**Examples:**
-
-```bash
-# Generate JS from Jac file
-jac jac2js app.jac
-```
-
-> **Deprecated:** `jac js` is a deprecated alias for `jac jac2js` and will be
-> removed in a future release. It still works but emits a deprecation warning
-> on stderr; update scripts to use `jac jac2js`.
+Generating JavaScript from Jac has moved under [`jac tool`](#jac-tool). Use **`jac tool jac2js <file>`** (used for client frontend compilation). See [`jac tool`](#jac-tool) below.
 
 ---
 
@@ -1979,102 +1920,57 @@ See [Agent Skills and MCP](../../quick-guide/agent-skills-and-mcp.md) for using 
 
 ### jac grammar
 
-Extract and print the Jac grammar.
-
-```bash
-jac grammar [-h] [--lark] [-o OUTPUT]
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--lark` | Output in Lark format instead of EBNF | `False` |
-| `-o, --output` | Write output to file instead of stdout | None |
-
-**Examples:**
-
-```bash
-# Print grammar in EBNF format
-jac grammar
-
-# Print in Lark format
-jac grammar --lark
-
-# Save to file
-jac grammar -o grammar.ebnf
-```
+Extracting the grammar has moved under [`jac tool`](#jac-tool). Use **`jac tool grammar`** (add `--lark` for Lark format, `-o OUT` to write to a file). See [`jac tool`](#jac-tool) below.
 
 ---
 
 ### jac script
 
-Run custom scripts defined in the `[scripts]` section of `jac.toml`.
-
-```bash
-jac script [-h] [-l] [name]
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `name` | Script name to run | None |
-| `-l, --list_scripts` | List available scripts | `False` |
-
-**Examples:**
-
-```bash
-# Run a script
-jac script dev
-
-# List available scripts
-jac script --list
-```
-
-See [Configuration: Scripts](../config/index.md#scripts) for defining scripts in `jac.toml`.
+Running custom scripts has folded into [`jac x`](#jac-x). Use **`jac x <name>`** to run a script defined in the `[scripts]` section of `jac.toml` (a bare `jac x`, or `jac x --list`, lists the available tools and scripts). See [Configuration: Scripts](../config/index.md#scripts) for defining scripts.
 
 ---
 
 ### jac py2jac
 
-Convert Python code to Jac.
-
-```bash
-jac py2jac filename
-```
-
-**Examples:**
-
-```bash
-jac py2jac script.py
-```
+Converting Python to Jac has moved under [`jac tool`](#jac-tool). Use **`jac tool py2jac <file>`**. See [`jac tool`](#jac-tool) below.
 
 ---
 
 ### jac jac2py
 
-Convert Jac code to Python.
-
-```bash
-jac jac2py filename
-```
-
-**Examples:**
-
-```bash
-jac jac2py main.jac
-```
+Converting Jac to Python has moved under [`jac tool`](#jac-tool). Use **`jac tool jac2py <file>`**. See [`jac tool`](#jac-tool) below.
 
 ---
 
 ### jac tool
 
-Access language tools (IR, AST, etc.).
+`jac tool <name>` fronts the language tools (IR, AST) and the source transforms. The transforms `jac2py`, `py2jac`, `jac2js`, and `grammar` are now invoked through `jac tool` (they were formerly top-level `jac jac2py` / `jac py2jac` / `jac jac2js` / `jac grammar`).
 
 ```bash
-jac tool tool [args ...]
+jac tool <name> [args ...]
 ```
 
-**Available tools:**
+| Tool | Description |
+|------|-------------|
+| `jac2py <file>` | Convert Jac code to Python |
+| `py2jac <file>` | Convert Python code to Jac |
+| `jac2js <file>` | Convert Jac code to JavaScript (used for client frontend compilation) |
+| `grammar [--lark] [-o OUT]` | Extract and print the Jac grammar (EBNF, or `--lark` for Lark format) |
+| `ir [ast\|sym\|py] <file>` | Inspect compiler IR: AST, symbol table, or generated Python |
+
+**Examples:**
 
 ```bash
+# Source transforms
+jac tool jac2py main.jac
+jac tool py2jac script.py
+jac tool jac2js app.jac
+
+# Grammar
+jac tool grammar                 # EBNF to stdout
+jac tool grammar --lark          # Lark format
+jac tool grammar -o grammar.ebnf # write to file
+
 # View IR options
 jac tool ir
 
@@ -2087,6 +1983,8 @@ jac tool ir sym main.jac
 # View generated Python
 jac tool ir py main.jac
 ```
+
+> **Deprecated:** `jac js` is a deprecated alias for `jac tool jac2js` and will be removed in a future release. It still works but emits a deprecation warning on stderr; update scripts to use `jac tool jac2js`.
 
 ---
 
@@ -2102,28 +2000,13 @@ Editors normally launch this for you; configure your editor's LSP client to run 
 
 ---
 
-### jac completions
-
-Generate a shell completion script for `jac`.
-
-```bash
-jac completions [-s bash|zsh|fish] [-i]
-```
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-s, --shell` | Shell to generate completions for | `bash` |
-| `-i, --install` | Append the completions to your shell config (`~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`) | off |
-
-```bash
-jac completions --shell zsh --install
-```
-
----
-
 ### jac nacompile
 
+*Hidden from `jac --help` (still functional).*
+
 Compile a `.na.jac` file to a standalone native ELF executable. No external compiler, assembler, or linker is required. The entire pipeline runs in pure Python using llvmlite and a built-in ELF linker.
+
+> **Project-level vs. file-level.** For a whole-project native build, use [`jac build --as native`](#jac-build) (or `--as binary`), which runs the type-check gate first. `jac nacompile` remains the file-level tool for compiling an individual `.na.jac` file, building `--shared` C-ABI libraries, and cross-compiling with `--target wasm32`.
 
 ```bash
 jac nacompile filename [-o OUTPUT]
@@ -2161,6 +2044,8 @@ jac nacompile chess.na.jac -o mychess
 ---
 
 ### jac completions
+
+*Hidden from `jac --help` (still functional).*
 
 Generate and install shell completion scripts for the `jac` CLI.
 
@@ -2203,16 +2088,6 @@ jac completions --shell fish --install
 
 ---
 
-### jac lsp
-
-Start the Language Server Protocol server (for IDE integration).
-
-```bash
-jac lsp
-```
-
----
-
 ## Plugin Commands
 
 Plugins can add new commands and extend existing ones. These commands are available when the corresponding plugin is installed.
@@ -2221,25 +2096,25 @@ Plugins can add new commands and extend existing ones. These commands are availa
 
 These commands ship with `jaclang` core -- no separate install needed.
 
-#### jac build
+#### jac build --client
 
-Build a Jac application for a specific target.
+Build a **client shell** for a specific target. This is the `--client` mode of [`jac build`](#jac-build); see that section for the artifact projections (`.jab`, wheel, npm, source, native). A bare `jac build` (no `--client`) runs the type-check gate and emits a `.jab`, not a client shell.
 
 ```bash
-jac build [filename] [--client TARGET] [-p PLATFORM]
+jac build [filename] --client TARGET [-p PLATFORM]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `filename` | Path to .jac file | `main.jac` |
-| `--client` | Build target (`web`, `desktop`, `pwa`, `mobile`) | `web` |
+| `--client` | Client shell target (`web`, `desktop`, `pwa`, `mobile`, `static`, `cef`, `react-native`) | None |
 | `-p, --platform` | **Mobile:** `android`, `ios`, `all`. **Desktop:** `windows` names the sidecar `jac-sidecar.exe` | Current platform |
 
 **Examples:**
 
 ```bash
-# Build web target (default)
-jac build
+# Build the web client shell
+jac build --client web
 
 # Build desktop app
 jac build --client desktop
@@ -2316,7 +2191,7 @@ jac run main.jac
 jac test -v
 
 # Lint and fix
-jac lint . --fix
+jac check . --lint --fix
 ```
 
 ### Publishing a Package
@@ -2333,8 +2208,8 @@ mylib/
 ```
 
 ```bash
-# Build wheel from jac.toml
-jac bundle
+# Type-check gate, then build a wheel from jac.toml
+jac build --as wheel
 
 # Test locally in a clean environment before uploading
 python -m venv test_env && source test_env/bin/activate
@@ -2360,10 +2235,10 @@ jac start -p 8000
 jac start --scale
 
 # Check deployment status
-jac status main.jac
+jac scale status main.jac
 
 # Remove deployment
-jac destroy main.jac
+jac scale destroy main.jac
 ```
 
 ## See Also

--- a/docs/docs/reference/config/index.md
+++ b/docs/docs/reference/config/index.md
@@ -58,7 +58,7 @@ You typically don't need to modify this file until you add dependencies or custo
 
 ### [project]
 
-Project metadata. Runtime fields (`entry-point`, `jac-version`) are used by `jac run` and `jac start`. Publishing fields (`license`, `readme`, `keywords`, `requires-python`, `authors`, `maintainers`, and `[project.include]`) are used by `jac bundle` when building a distributable wheel. All publishing fields are optional -- a project that is never published only needs `name`.
+Project metadata. Runtime fields (`entry-point`, `jac-version`) are used by `jac run` and `jac start`. Publishing fields (`license`, `readme`, `keywords`, `requires-python`, `authors`, `maintainers`, and `[project.include]`) are used by `jac build --as wheel` when building a distributable wheel. All publishing fields are optional -- a project that is never published only needs `name`.
 
 ```toml
 [project]
@@ -69,7 +69,7 @@ entry-point = "main.jac"
 kind = "service"   # drives `jac run` (omit to infer from the entry-point)
 jac-version = ">=0.15.0"
 
-# Publishing metadata -- only needed to run `jac bundle`
+# Publishing metadata -- only needed to run `jac build --as wheel`
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -260,7 +260,7 @@ whose top-level `with entry` runs on import are not pulled into test collection.
 
 ### [format]
 
-Defaults for `jac format`:
+Defaults for `jac fmt`:
 
 ```toml
 [format]
@@ -280,7 +280,7 @@ print_errs = true   # Print errors to console
 
 #### [check.lint]
 
-Configure which auto-lint rules are active during `jac lint` and `jac lint --fix`. Rules use a select/ignore model with two group keywords:
+Configure which auto-lint rules are active during `jac check --lint` and `jac check --lint --fix`. Rules use a select/ignore model with two group keywords:
 
 - `"default"` - code-transforming rules only (safe, auto-fixable)
 - `"all"` - every rule, including unfixable rules like `no-print`
@@ -343,7 +343,7 @@ Diagnostic codes can be suppressed inline with `# jac:ignore[CODE]` comments. Se
 select = ["default", "strip-comments", "strip-docstrings"]
 ```
 
-The two are independent, so you can strip comments while keeping docstrings (or vice versa). With a rule selected, `jac format --lintfix` removes the content and `jac check` reports it. They are also the rules driving [`jac precommit`](../cli/index.md#jac-precommit) when configured.
+The two are independent, so you can strip comments while keeping docstrings (or vice versa). With a rule selected, `jac fmt --lintfix` removes the content and `jac check` reports it. They are also the rules driving [`jac precommit`](../cli/index.md#jac-precommit) when configured.
 
 **Excluding files from lint:**
 
@@ -579,15 +579,15 @@ Custom command shortcuts:
 dev = "jac run main.jac"
 test = "jac test -v"
 build = "jac build main.jac -t"
-lint = "jac lint . --fix"
-format = "jac format ."
+lint = "jac check . --lint --fix"
+format = "jac fmt ."
 ```
 
 Run with:
 
 ```bash
-jac script dev
-jac script test
+jac x dev
+jac x test
 ```
 
 ---
@@ -643,7 +643,7 @@ base_url = "${BASE_URL:?Base URL is required}"      # Required with error
 
 ### [project.include]
 
-Controls which files and directories `jac bundle` collects into the wheel.
+Controls which files and directories `jac build --as wheel` collects into the wheel.
 
 > **Note:** Earlier releases used a separate `[package]` / `[package.include]` section for publishing metadata. As of jaclang 0.15, `[package]` has been merged into `[project]` -- all publishing fields now live under `[project]` (see above), and file-inclusion rules live under `[project.include]`. Plain `[package]` tables are no longer read.
 
@@ -677,7 +677,7 @@ Simple patterns without a path separator (e.g. `"*.jac"`) are matched recursivel
 | `**/*.pyi` | Type stub files |
 | `**/*.lark` | Lark grammar files |
 | `**/py.typed` | PEP 561 type marker |
-| `**/*.jir` | Pre-compiled JIR bytecode (collected if already present -- see [`jac bundle`](../cli/index.md#jac-bundle)) |
+| `**/*.jir` | Pre-compiled JIR bytecode (collected if already present -- see [`jac build`](../cli/index.md#jac-build)) |
 | `_precompiled/manifest.json` | JIR precompile manifest |
 
 **Always excluded** (regardless of patterns):
@@ -772,7 +772,7 @@ api_key = "${OPENAI_API_KEY}"
 [scripts]
 dev = "jac run main.jac"
 test = "jac test"
-lint = "jac lint . --fix"
+lint = "jac check . --lint --fix"
 ```
 
 ---

--- a/docs/docs/reference/diagnostics.md
+++ b/docs/docs/reference/diagnostics.md
@@ -342,7 +342,7 @@ Emitted by `ViewLowerPass` when a `{...}` JSX slot's statement-template body vio
 
 ## Lint Rules (W3xxx / E3xxx)
 
-Emitted by `jac lint`. Rules can be configured in [`jac.toml`](config/index.md#checklint). The kebab-case name in brackets is used for `jac.toml` configuration.
+Emitted by `jac check --lint`. Rules can be configured in [`jac.toml`](config/index.md#checklint). The kebab-case name in brackets is used for `jac.toml` configuration.
 
 | Code | Rule Name | Message | Group |
 |------|-----------|---------|-------|

--- a/docs/docs/reference/language/library-mode.md
+++ b/docs/docs/reference/language/library-mode.md
@@ -10,7 +10,7 @@
 
 Jac provides a library mode that enables developers to express all Jac language features as standard Python code. This mode provides complete access to Jac's object-spatial programming capabilities through the `jaclang.lib` package, allowing developers to work entirely within Python syntax.
 
-This page focuses on what is unique to library mode: the `jaclang.lib` API surface and the `jac jac2py` workflow. For how Jac compiles to and interoperates with Python in general (bytecode transpilation, bidirectional imports, type-only imports), see [Python Integration](python-integration.md#jac-compiles-to-python-bytecode). Library mode itself corresponds to adoption [Pattern 5: Pure Python + Jac Library](python-integration.md#pattern-5-pure-python-jac-library).
+This page focuses on what is unique to library mode: the `jaclang.lib` API surface and the `jac tool jac2py` workflow. For how Jac compiles to and interoperates with Python in general (bytecode transpilation, bidirectional imports, type-only imports), see [Python Integration](python-integration.md#jac-compiles-to-python-bytecode). Library mode itself corresponds to adoption [Pattern 5: Pure Python + Jac Library](python-integration.md#pattern-5-pure-python-jac-library).
 
 Library mode is designed for:
 
@@ -24,7 +24,7 @@ Library mode is designed for:
 
 ### **Converting Jac Code to Pure Python**
 
-The `jac jac2py` command transpiles Jac source files into equivalent Python code, emitting clean `jaclang.lib` imports with type hints and docstrings so the output works with standard Python IDEs, linters, and formatters. (The same transpilation pipeline underpins all Jac→Python compilation -- see [How it Works: Transpilation to Native Python](python-integration.md#how-it-works-transpilation-to-native-python).)
+The `jac tool jac2py` command transpiles Jac source files into equivalent Python code, emitting clean `jaclang.lib` imports with type hints and docstrings so the output works with standard Python IDEs, linters, and formatters. (The same transpilation pipeline underpins all Jac→Python compilation -- see [How it Works: Transpilation to Native Python](python-integration.md#how-it-works-transpilation-to-native-python).)
 
 ---
 
@@ -90,7 +90,7 @@ with entry {
 
 ### **The Library Mode Python Equivalent**
 
-Run `jac jac2py friends.jac` to generate:
+Run `jac tool jac2py friends.jac` to generate:
 
 ??? example "Generated Python code"
     ```python

--- a/docs/docs/reference/persistence.md
+++ b/docs/docs/reference/persistence.md
@@ -22,7 +22,7 @@ walker create {
 }
 ```
 
-After `jac enter app.jac create`, alice and bob live in `.jac/data/<app>.db`. A subsequent `jac enter app.jac dump` (with a walker that traverses `[-->]`) sees them.
+After `jac run --entry create app.jac`, alice and bob live in `.jac/data/<app>.db`. A subsequent `jac run --entry dump app.jac` (with a walker that traverses `[-->]`) sees them.
 
 **Backends.** Out of the box, `SqliteMemory` writes to `.jac/data/<app>.db`. Configure a Mongo database under `[scale.*]` and set `MONGODB_URI`, then `jac install` pulls in `pymongo` and persistence flips to the [scale](plugins/jac-scale.md) `MongoBackend`. The storage swaps; the developer-facing model (this page) doesn't change.
 
@@ -237,7 +237,7 @@ node User {
 }
 ```
 
-**The argument is the fully-qualified old name as it appeared in stored data** -- i.e. `__module__ + "." + __name__` of the class at the time it was persisted. For files imported via `jac enter app.jac`, the module is `__main__`.
+**The argument is the fully-qualified old name as it appeared in stored data** -- i.e. `__module__ + "." + __name__` of the class at the time it was persisted. For files run via `jac run --entry ... app.jac`, the module is `__main__`.
 
 ### Code-resident vs. DB-resident aliases
 
@@ -446,7 +446,7 @@ walker dump {
 ```
 
 ```bash
-jac enter app.jac create
+jac run --entry create app.jac
 # (alice and bob persist)
 ```
 
@@ -471,7 +471,7 @@ walker dump {
 ```
 
 ```bash
-jac enter app.jac dump
+jac run --entry dump app.jac
 # alice:30:x@y   ← age coerced int→str, email defaulted, class resolved via alias
 # bob:25:x@y
 ```

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -1253,7 +1253,7 @@ Because a JS error boundary catches every error regardless of declared type, per
 
 ### Comments inside JSX
 
-Use Jac's block-comment syntax wrapped in a JSX expression slot -- `{#* ... *#}` -- to leave a note inside a JSX tree. The comment renders nothing and is preserved verbatim by `jac format`:
+Use Jac's block-comment syntax wrapped in a JSX expression slot -- `{#* ... *#}` -- to leave a note inside a JSX tree. The comment renders nothing and is preserved verbatim by `jac fmt`:
 
 ```jac
 cl {
@@ -2644,7 +2644,7 @@ Changes to `.jac` files automatically reload without restart.
 ### Debug Mode
 
 ```bash
-jac debug main.jac
+jac run --debug main.jac
 ```
 
 Provides:

--- a/docs/docs/reference/plugins/jac-scale-http.md
+++ b/docs/docs/reference/plugins/jac-scale-http.md
@@ -1753,10 +1753,10 @@ Overrides for `sv_walker_call` must end by returning the rehydrated walker insta
 | `jac start app.jac --scale --build` | Build image and deploy |
 | `jac start app.jac --scale --target kubernetes` | Explicit deployment target (default) |
 | `jac start app.jac --scale --enable-tls` | Enable HTTPS on a live deployment (no redeploy) |
-| `jac status app.jac` | Show live deployment status |
-| `jac status app.jac --target kubernetes` | Status for a specific target |
-| `jac destroy app.jac` | Remove Kubernetes deployment (prompts for confirmation) |
-| `jac destroy app.jac --target kubernetes` | Destroy a specific target |
+| `jac scale status app.jac` | Show live deployment status |
+| `jac scale status app.jac --target kubernetes` | Status for a specific target |
+| `jac scale destroy app.jac` | Remove Kubernetes deployment (prompts for confirmation) |
+| `jac scale destroy app.jac --target kubernetes` | Destroy a specific target |
 
 ---
 

--- a/docs/docs/reference/plugins/jac-scale-kubernetes.md
+++ b/docs/docs/reference/plugins/jac-scale-kubernetes.md
@@ -622,7 +622,7 @@ A **Pod Logs** dashboard is automatically added to Grafana with two panels: log 
 Check the live health of all deployed components:
 
 ```bash
-jac status app.jac
+jac scale status app.jac
 ```
 
 Displays a table with:
@@ -660,7 +660,7 @@ Tagged resource types: Deployments, StatefulSets, Services, ConfigMaps, Secrets,
 ### Remove Deployment
 
 ```bash
-jac destroy app.jac
+jac scale destroy app.jac
 ```
 
 !!! warning
@@ -836,7 +836,7 @@ Values using `${ENV_VAR}` syntax are resolved from the local environment at depl
 2. A Kubernetes `Opaque` Secret named `{app_name}-secrets` is created (or updated if it already exists)
 3. The Secret is attached to the deployment pod spec via `envFrom.secretRef`
 4. All keys become environment variables inside the container
-5. On `jac destroy`, the Secret is automatically cleaned up
+5. On `jac scale destroy`, the Secret is automatically cleaned up
 
 ### Example
 

--- a/docs/docs/reference/publishing.md
+++ b/docs/docs/reference/publishing.md
@@ -1,6 +1,6 @@
 # Publishing Packages
 
-Jac projects publish to [PyPI](https://pypi.org) as standard Python wheels -- no `pyproject.toml`, no `setuptools`, no `build` backend. The `jac bundle` command reads your `jac.toml` and produces a PEP 427-compliant `.whl` that `pip install` consumes directly. Anyone can then `pip install` your package, whether or not they use Jac.
+Jac projects publish to [PyPI](https://pypi.org) as standard Python wheels -- no `pyproject.toml`, no `setuptools`, no `build` backend. The `jac build --as wheel` command reads your `jac.toml` and produces a PEP 427-compliant `.whl` that `pip install` consumes directly. Anyone can then `pip install` your package, whether or not they use Jac.
 
 This page covers the end-to-end flow: declaring metadata, building a wheel, testing it, and uploading it.
 
@@ -9,7 +9,7 @@ This page covers the end-to-end flow: declaring metadata, building a wheel, test
 The publishing pipeline has three steps:
 
 1. **Declare** package metadata in the `[project]` section of `jac.toml`.
-2. **Build** a wheel with `jac bundle` -- it lands in `dist/`.
+2. **Build** a wheel with `jac build --as wheel` -- it lands in `dist/`.
 3. **Upload** the wheel to PyPI with `twine` (upload is intentionally out of scope for `jac`).
 
 Jac builds the wheel itself: it generates the `METADATA`, `WHEEL`, `RECORD`, `top_level.txt`, and `entry_points.txt` files and packs them into a reproducible ZIP archive. The result is indistinguishable from a wheel produced by `hatch` or `setuptools`.
@@ -61,7 +61,7 @@ See the [Configuration Reference](config/index.md#project) for the full field li
 
 ### Controlling what ships
 
-By default `jac bundle` collects a single directory named after the project (`mylib/`, with hyphens converted to underscores). Override this with `[project.include]`:
+By default `jac build --as wheel` collects a single directory named after the project (`mylib/`, with hyphens converted to underscores). Override this with `[project.include]`:
 
 ```toml
 [project.include]
@@ -98,16 +98,16 @@ Consumers who install your package into a Jac project (`jac install mylib`) can 
 ## 2. Build the wheel
 
 ```bash
-jac bundle
+jac build --as wheel
 ```
 
 This writes `dist/<name>-<version>-py3-none-any.whl`. Build to a different directory with `-o`:
 
 ```bash
-jac bundle -o /tmp/wheels
+jac build --as wheel -o /tmp/wheels
 ```
 
-`jac bundle` ships `.jir` bytecode files only if they already exist in your source tree -- it does not regenerate them. Shipped bytecode is keyed by Python version and validated against a source hash; on a consumer running a different Python version (or if the bytecode is missing or stale), the runtime transparently recompiles the bundled `.jac` source on first import -- a mismatch never breaks the package.
+`jac build --as wheel` ships `.jir` bytecode files only if they already exist in your source tree -- it does not regenerate them. Shipped bytecode is keyed by Python version and validated against a source hash; on a consumer running a different Python version (or if the bytecode is missing or stale), the runtime transparently recompiles the bundled `.jac` source on first import -- a mismatch never breaks the package.
 
 Wheels are reproducible: every ZIP entry uses a fixed timestamp, so the same source produces a byte-identical wheel.
 
@@ -141,11 +141,11 @@ In CI, authenticate with an API token: `twine upload dist/* -u __token__ -p "$PY
 
 ## Publishing to npm (npmjs.org)
 
-Client-side Jac libraries can also be published to [npm](https://www.npmjs.com) so JavaScript and TypeScript projects can `npm install` them -- whether or not they use Jac. `jac bundle --target npm` reads the same `jac.toml` and produces an npm-compatible `.tgz`: it compiles your client modules to JavaScript (ES modules), generates `package.json`, and emits `.d.ts` TypeScript declarations.
+Client-side Jac libraries can also be published to [npm](https://www.npmjs.com) so JavaScript and TypeScript projects can `npm install` them -- whether or not they use Jac. `jac build --as npm` reads the same `jac.toml` and produces an npm-compatible `.tgz`: it compiles your client modules to JavaScript (ES modules), generates `package.json`, and emits `.d.ts` TypeScript declarations.
 
 ```bash
-jac bundle --target npm        # -> dist/<name>-<version>.tgz
-jac bundle --target all        # build both the wheel and the npm tarball
+jac build --as npm             # -> dist/<name>-<version>.tgz
+jac build --as wheel           # build the wheel; run both commands for wheel + npm tarball
 ```
 
 What goes in the package:
@@ -162,17 +162,13 @@ What goes in the package:
 - **TypeScript declarations.** A `.d.ts` is generated for each module and `package.json` `types`/`exports` point at the entry's declarations, so TypeScript consumers get full type-checking. Function signatures, `obj`/`node` classes, and globals are all typed; JSDoc is also embedded in the `.js`.
 
 !!! note "Pure client code only"
-    npm packages must be standalone client code. A module that crosses a server boundary (a `sv` import/call) can't run as a plain npm install, so `jac bundle --target npm` rejects it with a clear error. Keep server-coupled code in your app, not in the published library.
+    npm packages must be standalone client code. A module that crosses a server boundary (a `sv` import/call) can't run as a plain npm install, so `jac build --as npm` rejects it with a clear error. Keep server-coupled code in your app, not in the published library.
 
 ### The runtime dependency
 
 Libraries that use JSX or the reactive API (`createSignal`, `createEffect`, …) reference the Jac client runtime. The build wires an `import { … } from "@jaseci/runtime"` into those modules and adds `@jaseci/runtime` to `dependencies` automatically. The runtime is a normal, React-independent npm package; modules that explicitly `import from react` instead get `react`/`react-dom` added to `peerDependencies`.
 
-Maintainers publish the runtime itself with:
-
-```bash
-jac bundle --target npm-runtime   # builds @jaseci/runtime at the jaclang version
-```
+The `@jaseci/runtime` package itself is produced by an internal maintenance build (run when cutting a jaclang release), not by a user-facing `jac build` projection -- it emits `@jaseci/runtime` at the current jaclang version.
 
 ### Upload to npm
 
@@ -201,7 +197,7 @@ jac install -e /path/to/cloned/lib
 
 ## See Also
 
-- [`jac bundle`](cli/index.md#jac-bundle) -- command reference (`--target wheel|npm|all|npm-runtime`)
+- [`jac build`](cli/index.md#jac-build) -- command reference (`--as wheel|npm`)
 - [`jac install`](cli/index.md#jac-install) -- installing dependencies and editable installs
 - [Configuration Reference](config/index.md#project) -- every `jac.toml` field
 - [Plugins (Removed)](plugin-authoring.md) -- why Jac no longer has a plugin system

--- a/docs/docs/tutorials/extend/publish-a-library.md
+++ b/docs/docs/tutorials/extend/publish-a-library.md
@@ -5,7 +5,7 @@ Build a reusable library in Jac and ship it to PyPI as a wheel and to npm as a p
 **What you'll do:**
 
 1. Scaffold a `py-package` project and write a small library
-2. Build a PyPI-ready wheel with `jac bundle` and test it locally
+2. Build a PyPI-ready wheel with `jac build --as wheel` and test it locally
 3. Upload it with twine
 4. Do the same for npm with a `js-package`
 
@@ -72,7 +72,7 @@ jac test
 ## 3. Build the wheel
 
 ```bash
-jac bundle
+jac build --as wheel
 ```
 
 ```
@@ -112,7 +112,7 @@ The npm flow is symmetric -- the `js-package` kind compiles `cl` (client) code t
 cd ..
 jac create jsgreet --kind js-package
 cd jsgreet
-jac bundle --target npm
+jac build --as npm
 ```
 
 ```
@@ -128,7 +128,7 @@ npm publish dist/jsgreet-0.1.0.tgz --access public
 ```
 
 !!! tip "One project, both targets"
-    `jac bundle --target all` builds the wheel *and* the npm tarball from a single project, when your library has both server-usable and client-usable modules. Modules that cross the server boundary are rejected with a clear error at bundle time.
+    There's no single "all" command -- run `jac build --as wheel` and `jac build --as npm` separately to produce both the wheel *and* the npm tarball from a single project, when your library has both server-usable and client-usable modules. Modules that cross the server boundary are rejected with a clear error at build time.
 
 ## Gotchas
 

--- a/docs/docs/tutorials/production/kubernetes.md
+++ b/docs/docs/tutorials/production/kubernetes.md
@@ -270,10 +270,10 @@ Auto-creating the SA + RoleBindings from `jac.toml` is on the roadmap but not ye
 
 ### Check Status
 
-Use `jac status main.jac` to see the health of all deployment components at a glance:
+Use `jac scale status main.jac` to see the health of all deployment components at a glance:
 
 ```bash
-jac status main.jac
+jac scale status main.jac
 ```
 
 This displays a table showing each component's status (Running, Degraded, Pending, Restarting, or Not Deployed), pod readiness counts, and service URLs.
@@ -302,7 +302,7 @@ kubectl logs -l app=jaseci -f
 Remove all Kubernetes resources created by scale:
 
 ```bash
-jac destroy main.jac
+jac scale destroy main.jac
 ```
 
 This removes:
@@ -366,7 +366,7 @@ alias kubectl='microk8s kubectl'
 
 ```bash
 # Check all component statuses at once
-jac status main.jac
+jac scale status main.jac
 
 # Or use kubectl for more detail
 kubectl get pods
@@ -400,7 +400,7 @@ kubectl logs -l app=redis
 
 ```bash
 # Quick overview of all components
-jac status main.jac
+jac scale status main.jac
 
 # Describe a pod for events
 kubectl describe pod <pod-name>


### PR DESCRIPTION
## What

PR #7258 collapsed the `jac` CLI to 24 intent-named verbs and introduced `jac build` (the fail-closed whole-program type-check gate), the single-file **`.jab`** sealed artifact, and `jac dev`. The docs still described the old surface. This updates them to match what shipped.

## Changes

**CLI reference (`reference/cli/index.md`) — reorganized around the new surface**
- New `jac build` section: the type-check gate, the default `.jab`, and the `--as jab|sealed|binary|wheel|npm|source|native` projections (with the wheel → `twine upload` and npm → `npm publish` flows).
- New `jac dev` section (hot-reload dev loop) and a unified `jac scale` section (local microservice `status/stop/restart/logs` + platform `status/destroy` on a `.jac` app).
- `jac run` now documents `.jab` execution, `--entry`/`--node`/`--root` (absorbs `enter`), and `--debug` (absorbs `debug`); `jac check` documents `--lint [--fix]`; `jac install` documents `--plan [--json]`; `jac create` documents `--pack`.
- `lint`, `enter`, `debug`, `jacpack`, `eject`, `script`, and the AST transforms become redirect stubs pointing at their new homes; `nacompile`/`dot`/`browse`/`precommit` are marked hidden-but-functional. The `#jac-bundle` anchor becomes `#jac-build`.

**Tombstoned commands fixed across guides / tutorials / reference**
`format→fmt`, `lint→check --lint`, `deps→install --plan`, `script→x`, `jacpack→create --pack`, `enter→run --entry`, `debug→run --debug`, `bundle→build --as wheel|npm`, `eject→build --as source`, `jac2py|py2jac|jac2js|grammar→jac tool <name>`, and top-level `status|destroy→jac scale status|destroy`.

**Publishing flow** rewritten to `jac build --as wheel` + `twine upload dist/*` (there is no `--publish` flag or `--target all`; `@jaseci/runtime` is now an internal maintenance build).

## Deliberately left alone
- Working `jac nacompile` usages (incl. `--shared` and `--target wasm32`) in tutorials — the verb is hidden but still functional, and those two modes have no `jac build` equivalent.
- `jac start --dev` / `jac start --scale` / `jac build --client …` (all still valid).
- Plugin-system content (out of scope; belongs to a separate PR).

## Validation
Every changed file was independently re-checked for surviving tombstoned commands and correct replacements. `mkdocs build --strict` passes — all anchors and cross-links resolve (one stale intra-page link, `#jac-start---scale` → `#jac-start-scale`, fixed).

Files: 14 changed (+344 / −473).