### PR TITLE
refactor(scale): unify jac-binary resolution on jac_executable()

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7279.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7279.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Unify jac-binary resolution on a single helper**: Removed the legacy `resolve_jac_binary()` pathway and the pip-era `Path(sys.executable).parent / "jac"` sibling guesses, standardizing every call site on the `JAC_EXECUTABLE`-first `jac_executable()` helper (now in `jaclang.scale.runtime.context.util`). No behavior change under the single-binary launcher.

--- a/docs/docs/community/release_notes/unreleased/jaclang/7279.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7279.refactor.md
@@ -1,1 +1,0 @@
-- **Refactor: Unify jac-binary resolution on a single helper**: Removed the legacy `resolve_jac_binary()` pathway and the pip-era `Path(sys.executable).parent / "jac"` sibling guesses, standardizing every call site on the `JAC_EXECUTABLE`-first `jac_executable()` helper (now in `jaclang.scale.runtime.context.util`). No behavior change under the single-binary launcher.

--- a/jac/jaclang/runtimelib/client/targets/desktop/desktop_build.jac
+++ b/jac/jaclang/runtimelib/client/targets/desktop/desktop_build.jac
@@ -174,9 +174,9 @@ def _bundle_runtime(host_binary: Path) {
 }
 
 def _jac_bin -> str {
-    cand = Path(os.path.dirname(os.sys.executable)) / "jac";
-    if cand.exists() {
-        return str(cand);
+    exe = os.environ.get("JAC_EXECUTABLE");
+    if exe and os.path.exists(exe) {
+        return exe;
     }
     found = shutil.which("jac");
     if found {

--- a/jac/jaclang/scale/deploy/target/kubernetes/microservice/manifest_builder.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/microservice/manifest_builder.jac
@@ -69,7 +69,7 @@ obj MicroserviceManifestBuilder {
         import os;
         import subprocess;
         import from jaclang.cli.console { console }
-        import from jaclang.scale.injector.binary { jac_executable }
+        import from jaclang.scale.runtime.context.util { jac_executable }
         client_entry = self._client_entry();
         if not client_entry {
             return;

--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -250,14 +250,6 @@ def pack_binary_bytes(binary_bytes: bytes) -> bytes {
 }
 
 
-def jac_executable -> str {
-    # The driver invoking ITSELF must not depend on `jac` being on PATH (the
-    # launcher exports its real path as JAC_EXECUTABLE); bench/operator hosts
-    # without PATH setup otherwise silently fall back to on-pod builds.
-    return os.environ.get("JAC_EXECUTABLE", "") or shutil.which("jac") or "jac";
-}
-
-
 def ensure_admin_dist_built(source_root: Path) -> None {
     # Build the admin console `_dist` on the host (like the client bundle) so the gateway ships it pre-built instead of doing a heavy on-pod `bun` build that can OOM-kill the container.
     admin = source_root / "jaclang" / "scale" / "admin";
@@ -276,6 +268,7 @@ def ensure_admin_dist_built(source_root: Path) -> None {
     logger.info(
         "Building the admin console on the host (ships pre-built to the gateway)."
     );
+    import from jaclang.scale.runtime.context.util { jac_executable }
     try {
         result = subprocess.run(
             [jac_executable(), "build", "main.jac", "--client", "web"],

--- a/jac/jaclang/scale/plugin.jac
+++ b/jac/jaclang/scale/plugin.jac
@@ -602,7 +602,7 @@ class JacScalePlugin {
         import from pathlib { Path }
         import from jaclang.scale.runtime.context.util {
             pick_free_port,
-            resolve_jac_binary,
+            jac_executable,
             wait_for_health
         }
 
@@ -650,7 +650,7 @@ class JacScalePlugin {
         child_env["JAC_SV_SIBLING"] = "1";
 
         cmd = [
-            resolve_jac_binary(),
+            jac_executable(),
             "start",
             str(module_file),
             "--port",

--- a/jac/jaclang/scale/runtime/context/util.jac
+++ b/jac/jaclang/scale/runtime/context/util.jac
@@ -1,7 +1,6 @@
+import os;
 import socket;
 import shutil;
-import sys;
-import from pathlib { Path }
 
 def pick_free_port(name: str, base: int = 18000, retries: int = 100) -> int {
     start: int = base + (hash(name) % 1000);
@@ -21,16 +20,11 @@ def pick_free_port(name: str, base: int = 18000, retries: int = 100) -> int {
     raise RuntimeError(f"Could not find free port near {start}");
 }
 
-def resolve_jac_binary -> str {
-    found: str = shutil.which("jac") or "";
-    if found {
-        return found;
-    }
-    candidate = Path(sys.executable).parent / "jac";
-    if candidate.exists() {
-        return str(candidate);
-    }
-    return "jac";
+def jac_executable -> str {
+    # Re-invoking jac must not depend on `jac` being on PATH: the single-binary
+    # launcher pins its real path in JAC_EXECUTABLE. Fall back to PATH, then a
+    # bare name for dev / link-source runs.
+    return os.environ.get("JAC_EXECUTABLE", "") or shutil.which("jac") or "jac";
 }
 
 glob _DEFAULT_HTTP_FORWARD_TIMEOUT: float = 30.0;

--- a/jac/jaclang/scale/runtime/orchestrator/process_manager.impl.jac
+++ b/jac/jaclang/scale/runtime/orchestrator/process_manager.impl.jac
@@ -97,8 +97,8 @@ impl ServiceProcessManager.start_service(name: str) -> bool {
     entry = self.registry.entries[name];
     port = self._assign_port(entry);
 
-    import from jaclang.scale.runtime.context.util { resolve_jac_binary }
-    jac_bin: str = resolve_jac_binary();
+    import from jaclang.scale.runtime.context.util { jac_executable }
+    jac_bin: str = jac_executable();
 
     cmd = [jac_bin, "start", entry.file, "--port", str(port), "--no_client"];
     logger.info(f"Starting {name}: {' '.join(cmd)}");

--- a/jac/jaclang/scale/tests/data/test_memory_hierarchy.jac
+++ b/jac/jaclang/scale/tests/data/test_memory_hierarchy.jac
@@ -154,8 +154,8 @@ def post_request(
 }
 
 def start_server(fixtures_dir: Path, jac_file: Path, port: int) -> subprocess.Popen {
-    jac_executable = Path(sys.executable).parent / "jac";
-    cmd = [str(jac_executable), "start", str(jac_file.name), "--port", str(port)];
+    import from jaclang.scale.runtime.context.util { jac_executable }
+    cmd = [jac_executable(), "start", str(jac_file.name), "--port", str(port)];
 
     env = os.environ.copy();
 

--- a/jac/jaclang/scale/tests/data/test_scalar_clobber_cross_process.jac
+++ b/jac/jaclang/scale/tests/data/test_scalar_clobber_cross_process.jac
@@ -21,7 +21,6 @@ import contextlib;
 import gc;
 import os;
 import subprocess;
-import sys;
 import time;
 import from pathlib { Path }
 import from typing { cast }
@@ -72,9 +71,8 @@ def login(base_url: str, username: str) -> str {
 def start_pod(
     fixtures_dir: Path, jac_file: Path, port: int, env_extra: dict
 ) -> subprocess.Popen {
-    import shutil;
-    jac_executable = shutil.which("jac") or str(Path(sys.executable).parent / "jac");
-    cmd = [str(jac_executable), "start", str(jac_file.name), "--port", str(port)];
+    import from jaclang.scale.runtime.context.util { jac_executable }
+    cmd = [jac_executable(), "start", str(jac_file.name), "--port", str(port)];
     env = os.environ.copy();
     env.update(env_extra);
     server = subprocess.Popen(

--- a/jac/jaclang/scale/tests/misc/test_scheduling.jac
+++ b/jac/jaclang/scale/tests/misc/test_scheduling.jac
@@ -7,7 +7,6 @@ import glob;
 import shutil;
 import socket;
 import subprocess;
-import sys;
 import time;
 import unittest.mock;
 import requests;
@@ -52,9 +51,9 @@ def _cleanup {
 
 def _start_server(port: int) -> subprocess.Popen {
     base_url = f"http://localhost:{port}";
-    jac_exe = Path(sys.executable).parent / "jac";
+    import from jaclang.scale.runtime.context.util { jac_executable }
     proc = subprocess.Popen(
-        [str(jac_exe), "start", "test_api.jac", "--port", str(port)],
+        [jac_executable(), "start", "test_api.jac", "--port", str(port)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/jac/jaclang/scale/tests/server/test_admin.jac
+++ b/jac/jaclang/scale/tests/server/test_admin.jac
@@ -591,7 +591,6 @@ test "admin ui includes jac.toml and styles for build" {
 
 test "admin UI build emits admin based assets and keeps useEffect lambda" {
     import os;
-    import sys;
     import shutil;
     import subprocess;
     import tempfile;
@@ -601,12 +600,8 @@ test "admin UI build emits admin based assets and keeps useEffect lambda" {
     ui_dir = Path(jaclang.scale.admin.__file__).parent / "ui";
     assert (ui_dir / "main.jac").exists() , "admin UI source missing";
 
-    # Use the `jac` that matches the running interpreter, not whatever a
-    # bare `jac` resolves to on PATH (which may be an unrelated old env).
-    jac_bin = os.path.join(os.path.dirname(sys.executable), "jac");
-    if not os.path.exists(jac_bin) {
-        jac_bin = "jac";
-    }
+    import from jaclang.scale.runtime.context.util { jac_executable }
+    jac_bin = jac_executable();
 
     tmp = tempfile.mkdtemp(prefix="admin_ui_build_");
     try {

--- a/jac/jaclang/scale/tests/server/test_examples.jac
+++ b/jac/jaclang/scale/tests/server/test_examples.jac
@@ -5,7 +5,6 @@ import gc;
 import io;
 import socket;
 import subprocess;
-import sys;
 import time;
 import requests;
 import from pathlib { Path }
@@ -61,10 +60,9 @@ obj JacScaleTestRunner {
             print("Example directory setup complete");
         }
 
-        jac_executable = Path(sys.executable).parent / "jac";
-
+        import from jaclang.scale.runtime.context.util { jac_executable }
         cmd = [
-            str(jac_executable),
+            jac_executable(),
             "start",
             str(self.example_file),
             "--port",

--- a/jac/jaclang/scale/tests/server/test_serve.jac
+++ b/jac/jaclang/scale/tests/server/test_serve.jac
@@ -7,7 +7,7 @@ import re;
 import select;
 import socket;
 import subprocess;
-import sys;
+import from jaclang.scale.runtime.context.util { jac_executable }
 import time;
 import uuid;
 import shutil;
@@ -65,10 +65,8 @@ def _start_server(
     base_url: str,
     extra_args: list[str] | None = None
 ) -> subprocess.Popen {
-    jac_executable = Path(sys.executable).parent / "jac";
-
     cmd = [
-        str(jac_executable),
+        jac_executable(),
         "start",
         test_file.name if not extra_args else str(test_file),
         "--port",
@@ -1495,9 +1493,8 @@ def setup_dev_mode_server -> subprocess.Popen {
     }
     _cleanup_db_files(dm_fixtures_dir);
 
-    jac_executable = Path(sys.executable).parent / "jac";
     cmd = [
-        str(jac_executable),
+        jac_executable(),
         "start",
         str(dm_test_file),
         "--port",
@@ -1923,8 +1920,7 @@ test "server startup - port fallback integration" {
         response = requests.get(f"http://localhost:{port1}/healthz", timeout=5);
         assert response.status_code == 200 , "First server should be running";
 
-        jac_executable = Path(sys.executable).parent / "jac";
-        cmd = [str(jac_executable), "start", sv_test_file.name, "--port", str(port1)];
+        cmd = [jac_executable(), "start", sv_test_file.name, "--port", str(port1)];
 
         sp2 = subprocess.Popen(
             cmd,
@@ -2107,7 +2103,6 @@ test "pwa target uses jac-scale server" {
     import tempfile;
 
     port = get_free_port();
-    jac_executable = Path(sys.executable).parent / "jac";
 
     with tempfile.TemporaryDirectory() as temp_dir {
         temp_path = Path(temp_dir);
@@ -2126,15 +2121,7 @@ theme_color = "#000000"
 '''
         );
         server = subprocess.Popen(
-            [
-                str(jac_executable),
-                "start",
-                "--client",
-                "pwa",
-                "main.jac",
-                "-p",
-                str(port)
-            ],
+            [jac_executable(), "start", "--client", "pwa", "main.jac", "-p", str(port)],
             cwd=temp_dir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/jac/jaclang/scale/tests/server/test_user_identity.jac
+++ b/jac/jaclang/scale/tests/server/test_user_identity.jac
@@ -10,7 +10,6 @@ import glob;
 import shutil;
 import socket;
 import subprocess;
-import sys;
 import time;
 import requests;
 import from pathlib { Path }
@@ -52,13 +51,13 @@ def _unique_user(prefix: str) -> str {
 def _start_server(port: int) -> subprocess.Popen {
     import os;
     base_url = f"http://localhost:{port}";
-    jac_exe = Path(sys.executable).parent / "jac";
+    import from jaclang.scale.runtime.context.util { jac_executable }
     # Make the fake-emailer Python module discoverable by the dotted-path
     # provider in jac.toml ('test_emailer_fake:FakeEmailer').
     env = dict(os.environ);
     env['PYTHONPATH'] = str(FIXTURES_DIR) + os.pathsep + env.get('PYTHONPATH', '');
     proc = subprocess.Popen(
-        [str(jac_exe), "start", "test_api.jac", "--port", str(port)],
+        [jac_executable(), "start", "test_api.jac", "--port", str(port)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/jac/jaclang/scale/tests/server/test_webhook.jac
+++ b/jac/jaclang/scale/tests/server/test_webhook.jac
@@ -10,7 +10,6 @@ import json;
 import os;
 import socket;
 import subprocess;
-import sys;
 import time;
 import uuid;
 import shutil;
@@ -45,9 +44,8 @@ def _start_server(
     base_url: str,
     env: dict | None = None
 ) -> subprocess.Popen {
-    jac_executable = Path(sys.executable).parent / "jac";
-
-    cmd = [str(jac_executable), "start", test_file.name, "--port", str(port)];
+    import from jaclang.scale.runtime.context.util { jac_executable }
+    cmd = [jac_executable(), "start", test_file.name, "--port", str(port)];
 
     proc_env = os.environ.copy();
     if env {

--- a/jac/jaclang/scale/tests/server_support.jac
+++ b/jac/jaclang/scale/tests/server_support.jac
@@ -16,7 +16,6 @@ import glob;
 import os;
 import shutil;
 import subprocess;
-import sys;
 import time;
 import contextlib;
 import requests;
@@ -148,8 +147,8 @@ def call_walker(
 
 """Start `jac start` in fixtures_dir and block until /healthz responds."""
 def start_server(fixtures_dir: Path, jac_file: Path, port: int) -> subprocess.Popen {
-    jac_executable = shutil.which("jac") or str(Path(sys.executable).parent / "jac");
-    cmd = [str(jac_executable), "start", str(jac_file.name), "--port", str(port)];
+    import from jaclang.scale.runtime.context.util { jac_executable }
+    cmd = [jac_executable(), "start", str(jac_file.name), "--port", str(port)];
     env = os.environ.copy();
     server = subprocess.Popen(
         cmd,


### PR DESCRIPTION
## What

Consolidates jac-binary resolution onto a single `jac_executable()` helper and deletes the legacy `resolve_jac_binary()` pathway plus the pip-era `Path(sys.executable).parent / "jac"` sibling guesses.

## Why

Under the single-binary launcher, `sys.executable` **is** the jac binary and its real path is exported as `JAC_EXECUTABLE`. The old assumption that a `jac` console-script sits next to `python` in a `bin/` directory no longer holds. The codebase also had two competing resolvers with different priority orders:

- `jac_executable()` honored `JAC_EXECUTABLE` first (correct).
- `resolve_jac_binary()` ignored it and fell back to the fragile `sys.executable` sibling guess.

## Changes

- Canonical `jac_executable()` (`JAC_EXECUTABLE` -> PATH -> `"jac"`) now lives in the lightweight `scale/runtime/context/util.jac`; the duplicate in `scale/injector/binary.jac` is removed.
- Repointed `plugin.jac`, `process_manager`, `manifest_builder`, and 12 scale test sites onto the shared helper.
- `desktop_build._jac_bin()` now prefers `JAC_EXECUTABLE` without importing `scale`, keeping core decoupled from the scale layer.

`[sys.executable, "-m", "jaclang", ...]` subprocess spawns and `[sys.executable, "-m", "pip", ...]` installs are intentionally left as-is: under the launcher `sys.executable` is the correct, pinned primitive for re-invoking the interpreter.

## Testing

- `jac check` on all 15 changed files: identical error counts to baseline (no new errors); the new imports resolve.
- Runtime smoke test: `jac_executable()` returns the live jac path, and a forced `JAC_EXECUTABLE` is correctly overridden by the launcher's boot-time pin.

No behavior change under the launcher. Net: 15 files, +36 / -76.
