### PR TITLE
fix(scale): make the bootstrap guard execute the shipped jac binary

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7280.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7280.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: pod bootstrap guard detects unrunnable binaries**: the init-container guard now executes the shipped `jac` binary instead of only checking it exists on PATH, so a wrong-arch or corrupt binary fails at the guard with the `JAC_NODE_ARCH` guidance instead of a bare `Exec format error` later in the boot.

--- a/jac/jaclang/scale/deploy/target/kubernetes/runtime_bootstrap.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/runtime_bootstrap.jac
@@ -69,8 +69,11 @@ def build_runtime_install_commands(
     tc = f"{APP_MOUNT_PATH}/{TOOLCHAIN_SUBDIR}";
     commands.append(f'install -m 0755 "{tc}/bin/jac" "$HOME/.local/bin/jac"');
     commands.append('export PATH="$HOME/.local/bin:$PATH"');
+    # The guard must EXECUTE the binary: `command -v` only checks the file is
+    # on PATH, so a wrong-arch binary passed it and died later with a bare
+    # 'Exec format error' instead of this message.
     commands.append(
-        'if ! command -v jac >/dev/null 2>&1; then echo "[jac-scale] FATAL: '
+        'if ! jac --version >/dev/null 2>&1; then echo "[jac-scale] FATAL: '
         'shipped jac binary did not run (toolchain unpack failed, or the '
         'binary arch does not match the node - set JAC_NODE_ARCH and '
         'redeploy)." >&2; exit 1; fi'

--- a/jac/jaclang/scale/deploy/target/kubernetes/runtime_bootstrap.jac
+++ b/jac/jaclang/scale/deploy/target/kubernetes/runtime_bootstrap.jac
@@ -69,9 +69,6 @@ def build_runtime_install_commands(
     tc = f"{APP_MOUNT_PATH}/{TOOLCHAIN_SUBDIR}";
     commands.append(f'install -m 0755 "{tc}/bin/jac" "$HOME/.local/bin/jac"');
     commands.append('export PATH="$HOME/.local/bin:$PATH"');
-    # The guard must EXECUTE the binary: `command -v` only checks the file is
-    # on PATH, so a wrong-arch binary passed it and died later with a bare
-    # 'Exec format error' instead of this message.
     commands.append(
         'if ! jac --version >/dev/null 2>&1; then echo "[jac-scale] FATAL: '
         'shipped jac binary did not run (toolchain unpack failed, or the '

--- a/jac/jaclang/scale/tests/microservices/test_binary_injector.jac
+++ b/jac/jaclang/scale/tests/microservices/test_binary_injector.jac
@@ -115,6 +115,20 @@ test "overlay bootstrap injects [dev] jaclang_source; pod compiles on boot" {
 }
 
 
+test "bootstrap guard executes the shipped binary, not just a PATH lookup" {
+    cmds = build_runtime_install_commands(KubernetesConfig(), False);
+    guards = [
+        c
+        for c in cmds
+        if "FATAL" in c
+    ];
+    assert len(guards) == 1;
+    assert "jac --version" in guards[0];
+    assert "command -v" not in guards[0];
+    assert "JAC_NODE_ARCH" in guards[0];
+}
+
+
 test "runtime_container_env exposes HOME + PATH, no JAC_NO_PRECOMPILE" {
     names = [e["name"] for e in runtime_container_env()];
     assert "HOME" in names;


### PR DESCRIPTION
## Summary

Follow-up to #7250. The `jac-bootstrap` init container guards the shipped binary with `command -v jac`, which only checks the file exists on PATH with the execute bit set. A binary built for the wrong architecture passes that check, so the pod died later on the first real `jac` invocation with a bare `bash: cannot execute binary file: Exec format error` (exit 126) and the FATAL message with the `JAC_NODE_ARCH` hint never fired; it was effectively dead code for the exact failure it names.

The guard now runs `jac --version`, so an unrunnable binary (wrong arch, corrupt unpack) fails at the guard and the init-container log shows the actionable message instead of the raw exec error.

## Tests

`jac test jac/jaclang/scale/tests/microservices/test_binary_injector.jac` (20 passed), including a new case asserting the guard executes the binary (`jac --version`), no longer uses `command -v`, and carries the `JAC_NODE_ARCH` guidance.