### PR TITLE
fix(scale): import the default HPA autoscaler eagerly so deploys don't race the runtime-cache extraction (#7243)

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jac-scale/7243.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/7243.bugfix.md
@@ -1,0 +1,1 @@
+Fixed Jac Scale deploys failing with `[Errno 2] No such file ... hpa_autoscaler.jac`: the default HPA autoscaler is now imported eagerly so the prebuilt binary extracts it at module load instead of racing the lazy extraction during manifest apply. Fixes #7243 (autoscaler case).

--- a/docs/docs/community/release_notes/unreleased/jac-scale/7243.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/7243.bugfix.md
@@ -1,1 +1,0 @@
-Fixed Jac Scale deploys failing with `[Errno 2] No such file ... hpa_autoscaler.jac`: the default HPA autoscaler is now imported eagerly so the prebuilt binary extracts it at module load instead of racing the lazy extraction during manifest apply. Fixes #7243 (autoscaler case).

--- a/docs/docs/community/release_notes/unreleased/jac-scale/7285.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jac-scale/7285.bugfix.md
@@ -1,0 +1,1 @@
+Fixed Jac Scale deploys failing with `[Errno 2] No such file ... hpa_autoscaler.jac`: the default HPA autoscaler is now imported eagerly so the prebuilt binary extracts it at module load instead of racing the lazy extraction during manifest apply. Fixes #7243 (autoscaler case).

--- a/jac/jaclang/scale/deploy/autoscale/factory.jac
+++ b/jac/jaclang/scale/deploy/autoscale/factory.jac
@@ -1,5 +1,12 @@
 import from typing { Callable }
 import from jaclang.scale.deploy.autoscale.autoscaler { Autoscaler }
+# HPA (the default engine) is imported eagerly, not lazily inside create().
+# The prebuilt-binary runtime cache extracts lazily-imported modules on first
+# access, so importing this at deploy time can race that extraction
+# (jaseci#7243) and fail with "[Errno 2] No such file ... hpa_autoscaler.jac",
+# aborting the manifest apply. Importing at module load extracts it before any
+# deploy runs. KEDA stays lazy below (optional engine, rarely used).
+import from jaclang.scale.deploy.autoscale.hpa_autoscaler { HPAAutoscaler }
 import from jaclang.scale.observability.logger { Logger }
 
 type AutoscalerFactoryFn = Callable[[dict[str, any], Logger | None], Autoscaler];
@@ -20,7 +27,6 @@ class AutoscalerFactory {
         }
 
         if engine is None or engine == "hpa" {
-            import from jaclang.scale.deploy.autoscale.hpa_autoscaler { HPAAutoscaler }
             return HPAAutoscaler(logger=logger);
         }
         if engine == "keda" {


### PR DESCRIPTION
## Summary

Fixes the autoscaler case of #7243. Production deploys through jac-scale fail non-deterministically with `[Errno 2] No such file or directory` on `jaclang/scale/deploy/autoscale/hpa_autoscaler.jac`, aborting the manifest apply (and, per #7244, leaving a half-created workload with no Ingress).

## Root cause

`AutoscalerFactory.create()` imports the HPA autoscaler **lazily, inside the method** (runs at deploy time):

```jac
if engine is None or engine == "hpa" {
    import from jaclang.scale.deploy.autoscale.hpa_autoscaler { HPAAutoscaler }  # lazy
    return HPAAutoscaler(logger=logger);
}
```

On the prebuilt `jac` binary, the runtime cache (`~/.cache/jac/rt/<hash>/site/...`) extracts lazily-imported modules on first access. A deploy-time import races that extraction: the manifest apply reads the path before the unpack lands, so it fails on a file that exists in source and is present moments later. Which file varies run to run; `hpa_autoscaler.jac` is the one on the HPA path because it is the only deploy module still imported lazily (the rest are imported at module load and unpack early).

## Fix

Import the default HPA engine at **module load** instead of lazily in `create()`, so the binary extracts it before any deploy runs:

```jac
import from jaclang.scale.deploy.autoscale.hpa_autoscaler { HPAAutoscaler }
...
if engine is None or engine == "hpa" {
    return HPAAutoscaler(logger=logger);
}
```

- **No circular import**: `hpa_autoscaler` imports only `autoscaler` / `_optdeps.kubernetes` / logger / k8s utils, never `factory`, and the built-in engines are not self-registered.
- **KEDA stays lazy** (optional engine, rarely used, may pull optional deps) — only the always-used default is made eager.
- `factory` is already imported at module load by `kubernetes_target` / the microservice target, so HPA now unpacks when the deploy target loads, not mid-apply.

## Scope / follow-ups

This closes the observed autoscaler failure. The sibling data-file case in #7243 (`database/redis.conf.template`, read via `Path(__file__).parent`) is the same class and warrants the same eager treatment. The complete fix is upstream in the binary's runtime-cache extraction (make lazy unpack race-free / eager for deploy resources); #7244 is the complementary hardening (an optional autoscaler failure should not abort the deploy or gate the Ingress).

## Testing

Verified by source inspection against `main` (no circular import; import path unchanged). I could not build the prebuilt binary locally to reproduce the race end to end; relying on CI plus a jac-scale deploy to confirm the autoscaler path.

Related: #7243, #7244.