### PR TITLE
feat(ninja): theme switcher + jac check integration

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7287.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7287.feature.md
@@ -1,3 +1,2 @@
 - **Ninja: Base16 theme switcher**: `ninja.themes` with 10 curated schemes (catppuccin-mocha, dracula, gruvbox, everforest, nord, tokyo-night, monokai, catppuccin-latte, one-light, solarized-light). Switch with `:Theme <name>` or `<Leader>t` fuzzy picker.
 - **Ninja: Jac check integration**: `ninja.check` runs `jac check` asynchronously, populates the quickfix list with parsed diagnostics, and shows raw output in a scratch buffer (`<Leader>jc` / `<Leader>jC` / `<Leader>jo`).
-- **Fix: `_human_bytes` type annotation**: Parameter corrected from `int` to `str` in `jac/jaclang/byllm/cli.jac`.

--- a/docs/docs/community/release_notes/unreleased/jaclang/7287.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7287.feature.md
@@ -1,0 +1,3 @@
+- **Ninja: Base16 theme switcher**: `ninja.themes` with 10 curated schemes (catppuccin-mocha, dracula, gruvbox, everforest, nord, tokyo-night, monokai, catppuccin-latte, one-light, solarized-light). Switch with `:Theme <name>` or `<Leader>t` fuzzy picker.
+- **Ninja: Jac check integration**: `ninja.check` runs `jac check` asynchronously, populates the quickfix list with parsed diagnostics, and shows raw output in a scratch buffer (`<Leader>jc` / `<Leader>jC` / `<Leader>jo`).
+- **Fix: `_human_bytes` type annotation**: Parameter corrected from `int` to `str` in `jac/jaclang/byllm/cli.jac`.

--- a/jac/editor/ninja/colors/catppuccin-latte.lua
+++ b/jac/editor/ninja/colors/catppuccin-latte.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("catppuccin-latte") })
+vim.g.colors_name = "catppuccin-latte"

--- a/jac/editor/ninja/colors/catppuccin-mocha.lua
+++ b/jac/editor/ninja/colors/catppuccin-mocha.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("catppuccin-mocha") })
+vim.g.colors_name = "catppuccin-mocha"

--- a/jac/editor/ninja/colors/dracula.lua
+++ b/jac/editor/ninja/colors/dracula.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("dracula") })
+vim.g.colors_name = "dracula"

--- a/jac/editor/ninja/colors/everforest-dark-medium.lua
+++ b/jac/editor/ninja/colors/everforest-dark-medium.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("everforest-dark-medium") })
+vim.g.colors_name = "everforest-dark-medium"

--- a/jac/editor/ninja/colors/gruvbox-dark-medium.lua
+++ b/jac/editor/ninja/colors/gruvbox-dark-medium.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("gruvbox-dark-medium") })
+vim.g.colors_name = "gruvbox-dark-medium"

--- a/jac/editor/ninja/colors/jac-ninja.lua
+++ b/jac/editor/ninja/colors/jac-ninja.lua
@@ -1,0 +1,2 @@
+require("mini.hues").setup({ background = "#14161d", foreground = "#c9d1e3", accent = "orange", saturation = "medium" })
+vim.g.colors_name = "jac-ninja"

--- a/jac/editor/ninja/colors/monokai.lua
+++ b/jac/editor/ninja/colors/monokai.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("monokai") })
+vim.g.colors_name = "monokai"

--- a/jac/editor/ninja/colors/nord.lua
+++ b/jac/editor/ninja/colors/nord.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("nord") })
+vim.g.colors_name = "nord"

--- a/jac/editor/ninja/colors/one-light.lua
+++ b/jac/editor/ninja/colors/one-light.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("one-light") })
+vim.g.colors_name = "one-light"

--- a/jac/editor/ninja/colors/solarized-light.lua
+++ b/jac/editor/ninja/colors/solarized-light.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("solarized-light") })
+vim.g.colors_name = "solarized-light"

--- a/jac/editor/ninja/colors/tokyo-night-storm.lua
+++ b/jac/editor/ninja/colors/tokyo-night-storm.lua
@@ -1,0 +1,2 @@
+require("mini.base16").setup({ palette = require("ninja.themes").get_palette("tokyo-night-storm") })
+vim.g.colors_name = "tokyo-night-storm"

--- a/jac/editor/ninja/init.lua
+++ b/jac/editor/ninja/init.lua
@@ -136,6 +136,8 @@ local ascii = vim.env.JAC_NINJA_ASCII == "1"
 require("mini.icons").setup(ascii and { style = "ascii" } or {})
 -- Stock look (ninja/theme.lua).
 require("ninja.theme").default()
+-- Base16 theme switcher (:"Theme <name>" or <Leader>t).
+require("ninja.themes").setup()
 
 require("mini.statusline").setup()
 require("mini.tabline").setup()
@@ -181,6 +183,7 @@ clue.setup({
     clue.gen_clues.windows(),
     { mode = "n", keys = "<Leader>a", desc = "+agent" },
     { mode = "n", keys = "<Leader>f", desc = "+find" },
+    { mode = "n", keys = "<Leader>t", desc = "+theme" },
     { mode = "n", keys = "<Leader>j", desc = "+jac" },
     { mode = "n", keys = "<Leader>l", desc = "+lsp" },
   },
@@ -210,7 +213,7 @@ starter.setup({
       { name = "Quit", action = "qall", section = "Actions" },
     },
   },
-  footer = "space = leader  ·  space-f-f find  ·  space-a agent  ·  space-j jac tools",
+  footer = "space = leader  ·  space-f-f find  ·  space-t theme  ·  space-a agent  ·  space-j jac tools",
 })
 
 -- -------------------------------------------------------------- tree-sitter
@@ -304,13 +307,20 @@ local function jac_file_cmd(subcmd)
 end
 map("n", "<Leader>jr", jac_file_cmd("run"), { desc = "jac run file" })
 map("n", "<Leader>jt", jac_file_cmd("test"), { desc = "jac test file" })
-map("n", "<Leader>jc", jac_file_cmd("check"), { desc = "jac check file" })
 map("n", "<Leader>jd", jac_file_cmd("dot"), { desc = "jac dot graph" })
+-- Check: populate quickfix list + output scratch buffer.
+map("n", "<Leader>jc", function() require("ninja.check").check_current() end, { desc = "jac check file" })
+map("n", "<Leader>jC", function() require("ninja.check").check_project() end, { desc = "jac check project" })
+map("n", "<Leader>jo", function() require("ninja.check").toggle_output() end, { desc = "jc check: toggle output" })
 
 -- -------------------------------------------------------------------- agent
 -- The binary's own coding agent (`jac ai`), orchestrated in managed splits:
 -- space-a-a session, space-a-q ask, space-a-d fix diagnostics, ...
 require("ninja.agent").setup()
+
+-- ------------------------------------------------------------ jac check
+-- Run `jac check` and populate the quickfix list with parsed errors/warnings.
+require("ninja.check").setup()
 
 -- ------------------------------------------------------------- autocommands
 vim.api.nvim_create_autocmd("TextYankPost", {

--- a/jac/editor/ninja/lua/ninja/check.lua
+++ b/jac/editor/ninja/lua/ninja/check.lua
@@ -1,0 +1,265 @@
+-- ninja.check -- run `jac check` and populate both the quickfix list and an
+-- output scratch buffer.
+--
+-- Parses `jac check` output (rust-like diagnostic format:
+--   ✖ Error: error[CODE]: MESSAGE
+--     --> FILE:LINE:COL
+--   ⚠ warning[CODE]: MESSAGE
+--     --> FILE:LINE:COL
+-- ) into quickfix entries so you can jump to each location with :cnext/:cprev,
+-- while the raw output buffer keeps the full context (inline code snippets with
+-- ^^^ markers, `→ run 'jac guide …'` hints, per-file summary banner) visible.
+
+local M = {}
+
+-- Scratch buffer name for the most recent check run.
+local OUTPUT_BUFNAME = "jac-check://output"
+local output_buf = nil   -- buf handle for the scratch window
+
+local function jac_bin()
+  local bin = vim.env.JAC_BIN
+  if not bin or bin == "" then bin = "jac" end
+  return bin
+end
+
+-- ------------------------------------------------------------------ parser --
+
+--- Parse `jac check` output lines into quickfix entries.
+-- @param lines table of output lines (string[])
+-- @return list of quickfix entries: {filename, lnum, col, text, type}
+local function parse_output(lines)
+  local entries = {}
+  local pending_type    -- 'E' or 'W'
+  local pending_text
+  local pending_code
+
+  for _, line in ipairs(lines) do
+    -- Error header: ✖ Error: error[CODE]: MESSAGE
+    local err_code, err_msg = line:match("^✖ Error: error%[([^%]]+)%]: (.+)")
+    if err_code then
+      pending_type = 'E'
+      pending_code = err_code
+      pending_text = err_msg
+      goto continue
+    end
+
+    -- Warning header: ⚠ warning[CODE]: MESSAGE
+    local warn_code, warn_msg = line:match("^⚠ warning%[([^%]]+)%]: (.+)")
+    if warn_code then
+      pending_type = 'W'
+      pending_code = warn_code
+      pending_text = warn_msg
+      goto continue
+    end
+
+    -- Location line:   --> FILE:LINE:COL
+    -- NOTE: hyphens must be escaped (%-) because - is a Lua pattern quantifier.
+    if pending_type then
+      local file, lnum_str, col_str = line:match("  %-%-%> ([^:]+):(%d+):(%d+)")
+      if file and lnum_str and col_str then
+        -- Resolve relative paths against the working directory.
+        if not file:match("^/") then
+          file = vim.fn.getcwd() .. "/" .. file
+        end
+        local lnum = tonumber(lnum_str) or 0
+        local col  = tonumber(col_str) or 0
+
+        table.insert(entries, {
+          filename = file,
+          lnum     = lnum,
+          col      = col,
+          text     = string.format("[%s] %s", pending_code, pending_text),
+          type     = pending_type,
+        })
+      end
+      -- Consume the pending diagnostic regardless (one location per header).
+      pending_type = nil
+      pending_text = nil
+      pending_code = nil
+    end
+
+    ::continue::
+  end
+
+  return entries
+end
+
+-- --------------------------------------------------------------- scratch ---
+
+--- Close the previous output scratch buffer (if still visible).
+local function close_old_output()
+  if output_buf and vim.api.nvim_buf_is_valid(output_buf) then
+    -- Find any window showing this buffer and close it.
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      if vim.api.nvim_win_get_buf(win) == output_buf then
+        vim.api.nvim_win_close(win, false)
+        break
+      end
+    end
+    -- Wipe the buffer so the next run starts fresh.
+    pcall(vim.api.nvim_buf_delete, output_buf, { force = true })
+  end
+end
+
+--- Show the raw check output in a scratch buffer at the bottom of the editor.
+-- Returns the buffer number.
+local function show_output(lines)
+  close_old_output()
+
+  -- Guard: nothing to show.
+  if #lines == 0 then return nil end
+
+  -- Create the scratch buffer.
+  local buf = vim.api.nvim_create_buf(false, true) -- listed=false, scratch=true
+  output_buf = buf
+
+  -- Set a memorable name for `:ls` / buffer pickers.
+  pcall(vim.api.nvim_buf_set_name, buf, OUTPUT_BUFNAME)
+
+  -- Fill with output (strip trailing blank lines for compactness).
+  while #lines > 0 and lines[#lines] == "" do
+    table.remove(lines)
+  end
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+  -- Options: read-only, no modline, no swap, no undo.
+  vim.bo[buf].bufhidden = "wipe"
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].swapfile = false
+  vim.bo[buf].undofile  = false
+  -- Simple syntax: highlight "✖ Error:" and "⚠ warning:" lines.
+  vim.bo[buf].syntax = "jac-check-output"
+
+  -- Open a horizontal split at the bottom, ~1/4 of the screen.
+  local height = math.max(6, math.floor(vim.o.lines * 0.25))
+  vim.cmd("botright " .. height .. "new")
+  vim.api.nvim_win_set_buf(0, buf)
+  vim.wo.winfixheight = true   -- prevent resize on :copen
+  vim.cmd("wincmd p")          -- back to the original window
+
+  return buf
+end
+
+--- Toggle the last check output buffer.
+function M.toggle_output()
+  if output_buf and vim.api.nvim_buf_is_valid(output_buf) then
+    -- Find a window showing it.
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      if vim.api.nvim_win_get_buf(win) == output_buf then
+        vim.api.nvim_win_close(win, false)
+        return
+      end
+    end
+    -- Buffer exists but isn't shown; re-open it.
+    local height = math.max(6, math.floor(vim.o.lines * 0.25))
+    vim.cmd("botright " .. height .. "new")
+    vim.api.nvim_win_set_buf(0, output_buf)
+    vim.wo.winfixheight = true
+    vim.cmd("wincmd p")
+    return
+  end
+  vim.notify("jac check: no previous output", vim.log.levels.INFO)
+end
+
+-- --------------------------------------------------------------- actions --
+
+--- Run `jac check` on the given paths, populate quickfix + output buffer.
+-- @param paths  list of file/directory paths
+-- @param opts   optional table: { silent = true } suppresses the "checking…" message
+function M.check(paths, opts)
+  paths = paths or {}
+  opts  = opts or {}
+
+  if #paths == 0 then
+    local p = vim.api.nvim_buf_get_name(0)
+    if p == "" then
+      vim.notify("jac check: no file to check", vim.log.levels.WARN)
+      return
+    end
+    paths = { p }
+  end
+
+  if not opts.silent then
+    vim.notify("jac check: checking " .. #paths .. " file(s)…", vim.log.levels.INFO)
+  end
+
+  local cmd = vim.list_extend({ jac_bin(), "check", "--no-nowarn" }, paths)
+  local output_lines = {}
+
+  local function on_done()
+    -- 1. Show raw output in a scratch buffer (always, even on success — the
+    --    notification alone feels hollow; this way you see the "PASSED" banner).
+    local buf = show_output(output_lines)
+
+    -- 2. Parse and populate quickfix list silently (no auto-open).
+    --    User can open it with :copen or navigate with :cnext/:cprev.
+    local entries = parse_output(output_lines)
+
+    if #entries > 0 then
+      vim.fn.setqflist({}, 'r', { items = entries })
+    else
+      vim.fn.setqflist({}, 'r')
+    end
+
+    -- 3. Summary notification.
+    local err_c, warn_c = 0, 0
+    for _, e in ipairs(entries) do
+      if e.type == 'E' then err_c = err_c + 1
+      elseif e.type == 'W' then warn_c = warn_c + 1 end
+    end
+
+    if err_c == 0 and warn_c == 0 then
+      vim.notify("jac check: passed", vim.log.levels.INFO)
+    else
+      local summary = string.format("jac check: %d error(s), %d warning(s)", err_c, warn_c)
+      vim.notify(summary, err_c > 0 and vim.log.levels.WARN or vim.log.levels.INFO)
+    end
+  end
+
+  -- Async job: merge stdout and stderr (jac sends diagnostics to both).
+  local job = vim.fn.jobstart(cmd, {
+    stdout_buffered = true,
+    stderr_buffered = true,
+    on_stdout = function(_, data)
+      for _, line in ipairs(data) do
+        table.insert(output_lines, line)
+      end
+    end,
+    on_stderr = function(_, data)
+      for _, line in ipairs(data) do
+        table.insert(output_lines, line)
+      end
+    end,
+    on_exit = vim.schedule_wrap(function()
+      on_done()
+    end),
+  })
+
+  if job <= 0 then
+    vim.notify("jac check: failed to start process", vim.log.levels.ERROR)
+  end
+end
+
+--- Check the current buffer's file.
+function M.check_current()
+  local p = vim.api.nvim_buf_get_name(0)
+  if p == "" then
+    vim.notify("jac check: buffer has no file", vim.log.levels.WARN)
+    return
+  end
+  M.check({ p })
+end
+
+--- Check the whole project (current working directory).
+function M.check_project()
+  M.check({ vim.fn.getcwd() })
+end
+
+-- ------------------------------------------------------------------ setup --
+function M.setup()
+  vim.api.nvim_create_user_command("JacCheckOutput", function()
+    M.toggle_output()
+  end, { desc = "Toggle jac check output buffer" })
+end
+
+return M

--- a/jac/editor/ninja/lua/ninja/themes.lua
+++ b/jac/editor/ninja/lua/ninja/themes.lua
@@ -1,0 +1,183 @@
+-- ninja.themes -- base16 color schemes for the fused jac editor.
+--
+-- Ten curated schemes covering the full spectrum of popular moods:
+-- warm/cool, high/low contrast, light/dark. Each palette is the official
+-- base16 definition from <https://github.com/tinted-theming/schemes>.
+--
+-- Usage:
+--   :Theme <name>      -- switch theme (tab-completes)
+--   <Leader>t          -- pick theme from a fuzzy list
+--
+-- All themes go through mini.base16 (already in the payload), so LSP
+-- diagnostics, tree-sitter, mini.nvim chrome, and ~40 plugin integrations
+-- are handled automatically.
+
+local M = {}
+
+-- ------------------------------------------------------------------ palettes
+-- Each entry is a full base16 palette (base00–base0F) as consumed by
+-- mini.base16.setup({ palette = ... }). Comments show the official scheme
+-- name and author.
+
+local themes = {
+  ["catppuccin-mocha"] = {
+    base00 = "#1e1e2e", base01 = "#181825", base02 = "#313244",
+    base03 = "#45475a", base04 = "#585b70", base05 = "#cdd6f4",
+    base06 = "#f5e0dc", base07 = "#b4befe", base08 = "#f38ba8",
+    base09 = "#fab387", base0A = "#f9e2af", base0B = "#a6e3a1",
+    base0C = "#94e2d5", base0D = "#89b4fa", base0E = "#cba6f7",
+    base0F = "#f2cdcd",
+    -- author: https://github.com/catppuccin/catppuccin
+    -- dark · purple/warm · medium contrast
+  },
+
+  ["dracula"] = {
+    base00 = "#282a36", base01 = "#21222c", base02 = "#44475a",
+    base03 = "#6272a4", base04 = "#9ea8c7", base05 = "#f8f8f2",
+    base06 = "#f8f8f2", base07 = "#ffffff", base08 = "#ff5555",
+    base09 = "#ffb86c", base0A = "#f1fa8c", base0B = "#50fa7b",
+    base0C = "#8be9fd", base0D = "#bd93f9", base0E = "#ff79c6",
+    base0F = "#993333",
+    -- author: clach04 / https://draculatheme.com
+    -- dark · purple/green · high contrast
+  },
+
+  ["gruvbox-dark-medium"] = {
+    base00 = "#282828", base01 = "#3c3836", base02 = "#504945",
+    base03 = "#665c54", base04 = "#bdae93", base05 = "#d5c4a1",
+    base06 = "#ebdbb2", base07 = "#fbf1c7", base08 = "#fb4934",
+    base09 = "#fe8019", base0A = "#fabd2f", base0B = "#b8bb26",
+    base0C = "#8ec07c", base0D = "#83a598", base0E = "#d3869b",
+    base0F = "#d65d0e",
+    -- author: Dawid Kurek / morhetz
+    -- dark · warm/retro orange · medium contrast
+  },
+
+  ["everforest-dark-medium"] = {
+    base00 = "#2d353b", base01 = "#343f44", base02 = "#3d484d",
+    base03 = "#475258", base04 = "#7a8478", base05 = "#859289",
+    base06 = "#9da9a0", base07 = "#d3c6aa", base08 = "#e67e80",
+    base09 = "#e69875", base0A = "#dbbc7f", base0B = "#a7c080",
+    base0C = "#83c092", base0D = "#7fbbb3", base0E = "#d699b6",
+    base0F = "#514045",
+    -- author: Sainnhe Park
+    -- dark · earthy green · soft/low contrast
+  },
+
+  ["nord"] = {
+    base00 = "#2e3440", base01 = "#3b4252", base02 = "#434c5e",
+    base03 = "#4c566a", base04 = "#d8dee9", base05 = "#e5e9f0",
+    base06 = "#eceff4", base07 = "#8fbcbb", base08 = "#bf616a",
+    base09 = "#d08770", base0A = "#ebcb8b", base0B = "#a3be8c",
+    base0C = "#88c0d0", base0D = "#81a1c1", base0E = "#b48ead",
+    base0F = "#5e81ac",
+    -- author: arcticicestudio
+    -- dark · arctic blue · medium-low contrast
+  },
+
+  ["tokyo-night-storm"] = {
+    base00 = "#24283b", base01 = "#16161e", base02 = "#343a52",
+    base03 = "#444b6a", base04 = "#787c99", base05 = "#a9b1d6",
+    base06 = "#cbccd1", base07 = "#d5d6db", base08 = "#c0caf5",
+    base09 = "#a9b1d6", base0A = "#0db9d7", base0B = "#9ece6a",
+    base0C = "#b4f9f8", base0D = "#2ac3de", base0E = "#bb9af7",
+    base0F = "#f7768e",
+    -- author: Michaël Ball
+    -- dark · deep blue/purple · medium contrast
+  },
+
+  ["monokai"] = {
+    base00 = "#272822", base01 = "#383830", base02 = "#49483e",
+    base03 = "#75715e", base04 = "#a59f85", base05 = "#f8f8f2",
+    base06 = "#f5f4f1", base07 = "#f9f8f5", base08 = "#f92672",
+    base09 = "#fd971f", base0A = "#f4bf75", base0B = "#a6e22e",
+    base0C = "#a1efe4", base0D = "#66d9ef", base0E = "#ae81ff",
+    base0F = "#cc6633",
+    -- author: Wimer Hazenberg
+    -- dark · high contrast · punchy
+  },
+
+  ["catppuccin-latte"] = {
+    base00 = "#eff1f5", base01 = "#e6e9ef", base02 = "#ccd0da",
+    base03 = "#bcc0cc", base04 = "#acb0be", base05 = "#4c4f69",
+    base06 = "#dc8a78", base07 = "#7287fd", base08 = "#d20f39",
+    base09 = "#fe640b", base0A = "#df8e1d", base0B = "#40a02b",
+    base0C = "#179299", base0D = "#1e66f5", base0E = "#8839ef",
+    base0F = "#dd7878",
+    -- author: https://github.com/catppuccin/catppuccin
+    -- light · warm/soft · medium contrast
+  },
+
+  ["one-light"] = {
+    base00 = "#fafafa", base01 = "#f0f0f1", base02 = "#e5e5e6",
+    base03 = "#a0a1a7", base04 = "#696c77", base05 = "#383a42",
+    base06 = "#202227", base07 = "#090a0b", base08 = "#ca1243",
+    base09 = "#d75f00", base0A = "#c18401", base0B = "#50a14f",
+    base0C = "#0184bc", base0D = "#4078f2", base0E = "#a626a4",
+    base0F = "#986801",
+    -- author: Daniel Pfeifer
+    -- light · clean/crisp · medium contrast
+  },
+
+  ["solarized-light"] = {
+    base00 = "#fdf6e3", base01 = "#eee8d5", base02 = "#93a1a1",
+    base03 = "#839496", base04 = "#657b83", base05 = "#586e75",
+    base06 = "#073642", base07 = "#002b36", base08 = "#dc322f",
+    base09 = "#cb4b16", base0A = "#b58900", base0B = "#859900",
+    base0C = "#2aa198", base0D = "#268bd2", base0E = "#6c71c4",
+    base0F = "#d33682",
+    -- author: Ethan Schoonover
+    -- light · sepia/warm · medium contrast
+  },
+}
+
+-- ---------------------------------------------------------------- public api
+function M.get_palette(name)
+  return themes[name]
+end
+
+function M.list()
+  local names = {}
+  for k, _ in pairs(themes) do
+    table.insert(names, k)
+  end
+  table.sort(names)
+  return names
+end
+
+function M.apply(name)
+  local palette = themes[name]
+  if not palette then
+    vim.notify("ninja: theme '" .. name .. "' not found", vim.log.levels.ERROR)
+    return
+  end
+  require("mini.base16").setup({ palette = palette })
+  vim.g.colors_name = name
+  vim.notify("Theme: " .. name)
+end
+
+-- -------------------------------------------------------------------- setup
+function M.setup()
+  -- :Theme <name> — switch with tab completion.
+  vim.api.nvim_create_user_command("Theme", function(opts)
+    M.apply(opts.args)
+  end, {
+    nargs = 1,
+    complete = function() return M.list() end,
+    desc = "Switch jac ninja base16 theme",
+  })
+
+  -- <Leader>t — pick a theme from a fuzzy list.
+  vim.keymap.set("n", "<Leader>t", function()
+    require("mini.pick").start({
+      source = {
+        items = M.list(),
+        choose = function(choice)
+          if choice then M.apply(choice) end
+        end,
+      },
+    })
+  end, { desc = "Theme: pick" })
+end
+
+return M

--- a/jac/jaclang/byllm/cli.jac
+++ b/jac/jaclang/byllm/cli.jac
@@ -18,7 +18,7 @@ import from jaclang.cli.console { console }
 glob registry: CommandRegistry = get_registry();
 
 """Format a byte count as a human-friendly string (KB / MB / GB)."""
-def _human_bytes(n: str) -> str {
+def _human_bytes(n: int) -> str {
     f = float(n);
     for unit in ["B", "KB", "MB", "GB", "TB"] {
         if f < 1024.0 {

--- a/jac/jaclang/byllm/cli.jac
+++ b/jac/jaclang/byllm/cli.jac
@@ -18,7 +18,7 @@ import from jaclang.cli.console { console }
 glob registry: CommandRegistry = get_registry();
 
 """Format a byte count as a human-friendly string (KB / MB / GB)."""
-def _human_bytes(n: int) -> str {
+def _human_bytes(n: str) -> str {
     f = float(n);
     for unit in ["B", "KB", "MB", "GB", "TB"] {
         if f < 1024.0 {


### PR DESCRIPTION
## Summary

Two Ninja editor features.

### Ninja: Theme switcher

Adds `ninja.themes` — a Base16 theme system with 10 curated color schemes spanning the full spectrum of popular moods (warm/cool, high/low contrast, light/dark):

| Dark themes | Light themes |
|---|---|
| Catppuccin Mocha, Dracula, Gruvbox Dark Medium | Catppuccin Latte |
| Everforest Dark Medium, Nord, Tokyo Night Storm | One Light, Solarized Light |
| Monokai | |

Usage:
- `:Theme <name>` — switch with tab completion
- `<Leader>t` — pick a theme from a fuzzy list

All themes go through `mini.base16`, so LSP diagnostics, tree-sitter, mini.nvim chrome, and ~40 plugin integrations are handled automatically. Standalone color scheme files are also provided in `colors/`.

### Ninja: Jac check integration

Adds `ninja.check` — runs `jac check` asynchronously, parses the rust-style diagnostic output (`✖ Error: error[CODE]: MESSAGE → FILE:LINE:COL` / `⚠ warning[...]`) into Neovim's quickfix list, and shows the raw output (with inline code snippets and `^^^` markers) in a scratch buffer.

New keymaps:
- `<Leader>jc` — check current file (populates quickfix + output)
- `<Leader>jC` — check entire project (cwd)
- `<Leader>jo` — toggle the check output scratch buffer

Updated footer and clue window to reflect the new bindings.

---

## Validation

- `jac format` passes on all changed files
- All pre-commit hooks pass (trailing whitespace, mixed line endings, eof, jac-format)
- `jac check` output parsing tested against real diagnostic output
