### PR TITLE
feat(launcher): announce one-time runtime setup on first run

### DIFF
--- a/jac/launcher/runtime.zig
+++ b/jac/launcher/runtime.zig
@@ -29,6 +29,7 @@
 //! dir iteration).
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Io = std.Io;
 const Allocator = std.mem.Allocator;
 const flate = std.compress.flate;
@@ -350,6 +351,11 @@ pub fn materialize(
 
     // Warm path: a complete extract is marked by `<rt>/.ok`.
     if (pathExists(io, rt, ".ok")) return rt;
+    if (!builtin.is_test)
+        std.debug.print(
+            "jac: first run, performing one-time setup...\n",
+            .{},
+        );
 
     // Cold path: read the compressed payload region into memory.
     const poff = std.math.sub(u64, total, TRAILER_LEN + trailer.payload_len) catch
@@ -371,6 +377,8 @@ pub fn materialize(
 
     try extractPayload(io, gpa, zbuf, rt, pid);
     gcStale(io, root, &trailer.hash16);
+    if (!builtin.is_test)
+        std.debug.print("jac: one-time setup complete.\n", .{});
     return rt;
 }
 


### PR DESCRIPTION
## Summary

The single `jac` binary carries its runtime (a private CPython + jaclang) as a compressed payload appended after the executable. On the **first** launch of a given binary+version, `materialize()` in `launcher/runtime.zig` gzip-decompresses and untars that payload into `<cache>/rt/<hash16>-<pathhash>/`. That cold extract can take a few seconds, during which the process produces no output and reads as a hang.

This adds a short, one-time notice so that first launch is legible as setup rather than a stall.

## What changed

`launcher/runtime.zig` — in `materialize()`, print a start/complete pair around the cold-path extract:

```
jac: first run, performing one-time setup...
jac: one-time setup complete.
```

## Details

- **Cold path only.** The notice sits immediately after the `.ok` warm-path short-circuit, so it fires exactly once — every subsequent run hits `.ok` and returns before this line, staying silent.
- **stderr, not stdout** (via `std.debug.print`, the same channel `die()` already uses) — so it never corrupts `jac`-as-a-`python`-drop-in output or anything in a pipe.
- **Silent under tests.** Guarded by `if (!builtin.is_test)` so the fixture `materialize` cold/warm-path tests stay quiet.
- Covers every entry path, since CLI boot, `jac ninja`, and the desktop host all funnel through `materialize()`.