### PR TITLE
feat(langserve): docstrings in completion items + hover

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7296.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7296.feature.md
@@ -1,0 +1,1 @@
+- **Langserve: docstrings in completions**: Completion items now carry the declaration's docstring as `documentation`, shown in the editor's completion popup for objects, enums, abilities, modules, and `has` fields. Hover reuses the same extraction and now renders docstrings via their parsed literal value (quotes stripped).

--- a/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
@@ -251,7 +251,7 @@ impl collect_member_syms(
 }
 
 impl doc_of_sym(sym: Symbol) -> (str | None) {
-    if not sym or not sym.decl {
+    if not sym.decl {
         return None;
     }
     decl = sym.decl.name_of;
@@ -266,6 +266,11 @@ impl doc_of_sym(sym: Symbol) -> (str | None) {
     return None;
 }
 
+impl completion_item_from_sym(name: str, sym: Symbol) -> CompletionItem {
+    kind = completion_kind_from_sym(sym);
+    return CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym));
+}
+
 impl get_completion_items(
     ty: (types.TypeBase | uni.UniScopeNode)
 ) -> list[CompletionItem] {
@@ -274,10 +279,7 @@ impl get_completion_items(
         scope: (uni.UniScopeNode | None) = ty;
         while scope {
             for (name, sym) in scope.names_in_scope.items() {
-                kind = completion_kind_from_sym(sym);
-                ret.append(
-                    CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym))
-                );
+                ret.append(completion_item_from_sym(name, sym));
             }
             scope = scope.parent_scope;
         }
@@ -287,18 +289,12 @@ impl get_completion_items(
         }
         for cls in ty.shared.mro {
             for (name, sym) in cls.shared.symbol_table.names_in_scope.items() {
-                kind = completion_kind_from_sym(sym);
-                ret.append(
-                    CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym))
-                );
+                ret.append(completion_item_from_sym(name, sym));
             }
         }
     } elif isinstance(ty, types.ModuleType) {
         for (name, sym) in ty.symbol_table.names_in_scope.items() {
-            kind = completion_kind_from_sym(sym);
-            ret.append(
-                CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym))
-            );
+            ret.append(completion_item_from_sym(name, sym));
         }
     }
     return ret;

--- a/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
+++ b/jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
@@ -250,6 +250,22 @@ impl collect_member_syms(
     return [];
 }
 
+impl doc_of_sym(sym: Symbol) -> (str | None) {
+    if not sym or not sym.decl {
+        return None;
+    }
+    decl = sym.decl.name_of;
+    if isinstance(decl, uni.AstDocNode) and decl.doc {
+        return decl.doc.lit_value;
+    }
+    if isinstance(decl, uni.HasVar) {
+        if (arch_has := decl.find_parent_of_type(uni.ArchHas)) and arch_has.doc {
+            return arch_has.doc.lit_value;
+        }
+    }
+    return None;
+}
+
 impl get_completion_items(
     ty: (types.TypeBase | uni.UniScopeNode)
 ) -> list[CompletionItem] {
@@ -259,7 +275,9 @@ impl get_completion_items(
         while scope {
             for (name, sym) in scope.names_in_scope.items() {
                 kind = completion_kind_from_sym(sym);
-                ret.append(CompletionItem(label=name, kind=kind));
+                ret.append(
+                    CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym))
+                );
             }
             scope = scope.parent_scope;
         }
@@ -270,13 +288,17 @@ impl get_completion_items(
         for cls in ty.shared.mro {
             for (name, sym) in cls.shared.symbol_table.names_in_scope.items() {
                 kind = completion_kind_from_sym(sym);
-                ret.append(CompletionItem(label=name, kind=kind));
+                ret.append(
+                    CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym))
+                );
             }
         }
     } elif isinstance(ty, types.ModuleType) {
         for (name, sym) in ty.symbol_table.names_in_scope.items() {
             kind = completion_kind_from_sym(sym);
-            ret.append(CompletionItem(label=name, kind=kind));
+            ret.append(
+                CompletionItem(label=name, kind=kind, documentation=doc_of_sym(sym))
+            );
         }
     }
     return ret;

--- a/jac/jaclang/compiler/type_system/type_utils.jac
+++ b/jac/jaclang/compiler/type_system/type_utils.jac
@@ -49,7 +49,8 @@ obj ParamAssignmentTracker {
 obj CompletionItem {
     has label: str,
         kind: int,
-        detail: (str | None) = None;
+        detail: (str | None) = None,
+        documentation: (str | None) = None;
 }
 
 enum CompletionItemKind {
@@ -79,6 +80,8 @@ enum CompletionItemKind {
     Operator = 24,
     TypeParameter = 25,
 }
+
+def doc_of_sym(sym: Symbol) -> (str | None);
 
 def completion_kind_from_sym(sym: Symbol) -> int;
 

--- a/jac/jaclang/compiler/type_system/type_utils.jac
+++ b/jac/jaclang/compiler/type_system/type_utils.jac
@@ -83,6 +83,8 @@ enum CompletionItemKind {
 
 def doc_of_sym(sym: Symbol) -> (str | None);
 
+def completion_item_from_sym(name: str, sym: Symbol) -> CompletionItem;
+
 def completion_kind_from_sym(sym: Symbol) -> int;
 
 def get_completion_items(

--- a/jac/jaclang/langserve/engine.jac
+++ b/jac/jaclang/langserve/engine.jac
@@ -14,7 +14,7 @@ import from jaclang.jac0core.constant { SymbolType }
 import from jaclang.jac0core.program { JacProgram }
 import from jaclang.cli.console { console }
 import from jaclang.jac0core.bccache { discover_base_file, discover_annex_files }
-import from jaclang.compiler.type_system.type_utils { get_completion_items }
+import from jaclang.compiler.type_system.type_utils { doc_of_sym, get_completion_items }
 import from jaclang.compiler.type_system.types {
     ClassType,
     FunctionType,

--- a/jac/jaclang/langserve/impl/engine.impl.jac
+++ b/jac/jaclang/langserve/impl/engine.impl.jac
@@ -452,8 +452,8 @@ impl JacLangServer.get_node_info(sym_node: uni.AstSymbolNode) -> Optional[str] {
                 node_info += f"': '{sym_node.name_spec.type.shared.class_name}";
             }
         }
-        if isinstance(sym_node, uni.AstDocNode) and sym_node.doc {
-            node_info += f"'\n'{sym_node.doc.value}";
+        if sym_node.sym and (doc := doc_of_sym(sym_node.sym)) {
+            node_info += f"'\n'{doc}";
         }
         if isinstance(sym_node, uni.Ability) and sym_node.signature {
             node_info += f"'\n'{sym_node.signature.unparse()}";
@@ -549,8 +549,19 @@ impl JacLangServer.get_completion_items_of(
         if item.detail {
             detail = lspt.CompletionItemLabelDetails(detail=item.detail);
         }
+        documentation: lspt.MarkupContent | None = None;
+        if item.documentation {
+            documentation = lspt.MarkupContent(
+                kind=lspt.MarkupKind.PlainText, value=item.documentation
+            );
+        }
         items.append(
-            lspt.CompletionItem(label=item.label, kind=item.kind, label_details=detail,)
+            lspt.CompletionItem(
+                label=item.label,
+                kind=item.kind,
+                label_details=detail,
+                documentation=documentation,
+            )
         );
     }
     return lspt.CompletionList(is_incomplete=False, items=items,);

--- a/jac/jaclang/lsp/types.jac
+++ b/jac/jaclang/lsp/types.jac
@@ -273,7 +273,8 @@ obj CompletionItemLabelDetails {
 obj CompletionItem {
     has label: str = "",
         kind: Optional[CompletionItemKind] = None,
-        label_details: Optional[CompletionItemLabelDetails] = None;
+        label_details: Optional[CompletionItemLabelDetails] = None,
+        documentation: Optional[MarkupContent] = None;
 }
 
 obj CompletionList {

--- a/jac/tests/langserve/fixtures/completion_docs.jac
+++ b/jac/tests/langserve/fixtures/completion_docs.jac
@@ -1,0 +1,25 @@
+"""Completion documentation test fixture."""
+
+"""Cardinal directions."""
+enum Direction {
+    North,
+    South,
+}
+
+"""A circle shape."""
+obj Circle {
+    """Radius of the circle."""
+    has radius: float;
+    has undocumented_field: int;
+
+    """Adds two numbers."""
+    def add_values(a: int, b: int) -> int {
+        return a + b;
+    }
+}
+
+with entry {
+    z
+    c = Circle(radius=1.0);
+    c.
+}

--- a/jac/tests/langserve/test_server.jac
+++ b/jac/tests/langserve/test_server.jac
@@ -82,6 +82,16 @@ def create_server(workspace_path: str | None = None) -> JacLangServer {
     return lsp;
 }
 
+"""Return documentation text for a completion label, if present."""
+def completion_doc(items: list[lspt.CompletionItem], label: str) -> (str | None) {
+    for item in items {
+        if item.label == label and item.documentation {
+            return item.documentation.value;
+        }
+    }
+    return None;
+}
+
 obj Case {
     has pos: lspt.Position,
         expected: list[str],
@@ -410,6 +420,33 @@ test "test_completion" {
                 assert completion in str(completions);
             }
         }
+    } finally {
+        teardown_test();
+    }
+}
+
+test "test_completion_docs" {
+    import asyncio;
+
+    setup_test();
+    try {
+        lsp = create_server();
+        docs_file = uris.from_fs_path(fixture_path("completion_docs.jac"));
+        lsp.type_check_file(docs_file);
+
+        scope_results = asyncio.run(
+            lsp.get_completion(docs_file, lspt.Position(21, 5), completion_trigger="")
+        );
+        assert completion_doc(scope_results.items, "Circle") == "A circle shape.";
+        assert completion_doc(scope_results.items, "Direction") == "Cardinal directions.";
+
+        member_results = asyncio.run(
+            lsp.get_completion(docs_file, lspt.Position(23, 6), completion_trigger=".")
+        );
+        assert completion_doc(member_results.items, "radius") == "Radius of the circle.";
+        assert completion_doc(member_results.items, "add_values") == "Adds two numbers.";
+        assert completion_doc(member_results.items, "undocumented_field") is None;
+        assert completion_doc(member_results.items, "Circle") is None;
     } finally {
         teardown_test();
     }


### PR DESCRIPTION
## What

Surfaces declaration docstrings in the language server:

- Completion items now carry the declaration's docstring as `CompletionItem.documentation`, shown in the editor's completion popup for objects, enums, abilities, modules, and `has` fields.
- Hover reuses the same extraction via a shared `doc_of_sym` helper, and now renders the **parsed literal value** (quotes stripped) instead of the raw source text.

## How

- New `doc_of_sym(sym)` in `type_system/type_utils` — the single source of truth for "docstring of a symbol". Handles `AstDocNode` decls directly and walks `HasVar → ArchHas` for `has`-field docs.
- Threads a `documentation` field through the internal `CompletionItem` and the LSP wire type, wrapped in `MarkupContent(PlainText)` at the boundary — mirroring the existing `detail`/`label_details` flow.
- `get_node_info` (hover) rewired to call `doc_of_sym`, replacing its inline extraction. Hover now also works on symbol *usages* and `has`-fields, matching completion.

## Tests

- Adds `test_completion_docs` and its fixture (`completion_docs.jac`).
- Full langserve suite green (30 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)