### PR TITLE
fix(ci): bound the launcher test step so a wedged build fails fast, not for 6h

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -57,6 +57,9 @@ jobs:
           - os: macos-14
             platform: macos-aarch64
     runs-on: ${{ matrix.os }}
+    # A wedged step (e.g. a hung test-artifact build/run) must fail loudly, not
+    # sit until GitHub's 6h hard cap holding the release. A cold build is ~20min.
+    timeout-minutes: 45
     env:
       # -Dtarget flag for zig build: set on release-channel Linux legs, empty
       # (host-native) on the dev channel and macOS.
@@ -123,12 +126,13 @@ jobs:
           restore-keys: |
             zig-pkgs-${{ runner.os }}-${{ runner.arch }}-
 
+      # coreutils on macOS provides `gtimeout`, used to bound the test step.
       - name: Install host tools (zstd)
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt-get update && sudo apt-get install -y zstd
           else
-            brew install zstd
+            brew install zstd coreutils
           fi
 
       - name: Set up Zig 0.16.0
@@ -172,9 +176,16 @@ jobs:
       # (append / detect / materialize-steps-over-overlay / graft). runtime.zig
       # is the sole owner of the trailer format, so these guard the whole
       # `--as binary` boot shape. Host-native, no libpython needed.
+      # Wrapped in `timeout` so a wedge (a hung test-artifact compile/link or a
+      # test that blocks on I/O) fails this step in minutes with a SIGTERM
+      # backtrace, instead of hanging the whole build until the job timeout.
+      # macOS `timeout` comes from coreutils (installed with zstd above).
       - name: Launcher unit tests (zig build test)
         working-directory: jac
-        run: zig build test --summary all
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then TIMEOUT=gtimeout; else TIMEOUT=timeout; fi
+          "$TIMEOUT" --signal=TERM --kill-after=30s 15m \
+            zig build test --summary all --verbose
 
       - name: Smoke test (no system Python)
         working-directory: jac


### PR DESCRIPTION
## Problem

The \`Launcher unit tests (zig build test)\` step added in #7274 **hangs on both Linux legs** (linux-x86_64 and linux-aarch64) of \`build-binaries.yml\`. macOS passes the same step in seconds. The build job has **no \`timeout-minutes\`**, so every binary build since #7274 sits on that step until GitHub's 6-hour hard cap.

Consequence for the **v0.31.0 release**: \`tag-and-release\` succeeded and the macOS asset uploaded, but both Linux legs hung at \`zig build test\` — which is upstream of the \`Upload to GitHub Release\` step — so the release shipped with **no \`linux-x86_64\` / \`linux-aarch64\` binaries**. The rolling \`dev\` binary build hangs identically.

### Evidence
- Last green Linux binary build (\`ab9bfd4\`) had **no test step at all** — the step was introduced by #7274 and has hung on **every** Linux run since.
- Release run linux-x86_64 leg: \`Build the jac binary\` finished 14:21:31; \`Launcher unit tests\` then ran 70+ min with no completion before being cancelled.
- The test *logic* (\`appendOverlay\`/\`graftRuntime\`/\`materialize\`/\`cacheRoot\`) is bounded, non-blocking filesystem code — so the wedge is almost certainly in the **build/link of the test artifact on the Linux runner**, not in running the tests. The root cause is still open; these are the guardrails.

## Changes
- **\`timeout-minutes: 45\`** on the build job — a wedged step fails in minutes, not hours, and stops holding a runner + blocking the release. Cold build is ~20 min.
- **Wrap \`zig build test\` in \`timeout ... --verbose\`** (15 min bound; \`gtimeout\` via \`coreutils\` on macOS) — a wedge now dies with a SIGTERM backtrace pointing at the hung compile/link/test, turning a silent 6h hang into a diagnostic signal.

## Follow-up
This unblocks releases and makes the hang debuggable; it does **not** fix the underlying Linux \`zig build test\` wedge from #7274. Once merged, v0.31.0's missing Linux binaries can be recovered with \`gh workflow run build-binaries.yml -f tag=v0.31.0\`.