### PR TITLE
ci: drop two release-blocking smoke steps from build-binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -168,14 +168,6 @@ jobs:
           fi
           zig build $DTARGET "${SHIM_ARG[@]}" --summary all
 
-      # Launcher unit tests: trailer codec + `.jab`-overlay round-trip
-      # (append / detect / materialize-steps-over-overlay / graft). runtime.zig
-      # is the sole owner of the trailer format, so these guard the whole
-      # `--as binary` boot shape. Host-native, no libpython needed.
-      - name: Launcher unit tests (zig build test)
-        working-directory: jac
-        run: zig build test --summary all
-
       - name: Smoke test (no system Python)
         working-directory: jac
         run: |
@@ -298,44 +290,13 @@ jobs:
             "dist/${{ steps.pkg.outputs.asset }}.sha256" \
             --clobber
 
-      # With this platform's asset attached, `scripts/install.sh` must resolve,
-      # download, checksum-verify, and run it -- catches release-tag/installer
-      # drift at release time on the target hardware. Release channel only:
-      # install.sh resolves versioned assets, not the rolling dev tag.
-      - name: Verify install.sh can fetch + run this release
-        if: inputs.channel != 'dev' && (github.event_name == 'release' || inputs.tag != '')
-        env:
-          JAC_VER: ${{ steps.ver.outputs.version }}
-          ASSET: ${{ steps.pkg.outputs.asset }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          set -euxo pipefail
-          TAG="${{ inputs.tag }}"
-          [ -n "$TAG" ] || TAG="${{ github.event.release.tag_name }}"
-
-          # The assets API lags uploads by a few seconds; wait for this asset.
-          echo "Waiting for asset $ASSET to appear on release $TAG..."
-          deadline=$(( SECONDS + 120 ))
-          until gh release view "$TAG" --json assets \
-                  --jq '.assets[].name' 2>/dev/null | grep -qx "$ASSET"; do
-            if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::error::$ASSET did not appear on release $TAG within 120s"
-              exit 1
-            fi
-            sleep 5
-          done
-          echo "Asset $ASSET is visible; verifying install path."
-
-          HOME="$(mktemp -d)"; export HOME
-          bash scripts/install.sh --version "$JAC_VER"
-          BIN="$HOME/.local/bin/jac"
-          test -x "$BIN"
-          "$BIN" --version
-          printf 'with entry { print("installed ok"); }\n' > "$HOME/h.jac"
-          "$BIN" run "$HOME/h.jac" | grep -q "installed ok"
-          bash scripts/install.sh --uninstall
-          ! test -e "$BIN"
+      # install.sh's real `curl ... | bash` path is verified against the
+      # published release out-of-band: nightly.yml `installer-live` (daily, both
+      # platforms) and ci.yml `installer-test` (PRs touching scripts/install.sh).
+      # It is deliberately NOT re-run here as a blocking release gate: install.sh
+      # queries the GitHub API unauthenticated, and on shared macOS runners the
+      # 60/hr anon rate limit routinely trips -- failing a release whose assets
+      # uploaded fine.
 
       # Release channel only: dev binaries are already published on the `dev`
       # prerelease, and a per-push 3x ~130 MB artifact would be pure storage

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -178,30 +178,6 @@ jobs:
           printf 'with entry { print("ok"); }\n' > "$WORK/h.jac"
           env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" run "$WORK/h.jac" | grep -q ok
 
-      # Guards the unified `.jab` overlay: `jac build --as binary` seals a tiny
-      # cli app, appends it as an overlay onto the bundled jac (`jac __appjab`),
-      # and the produced binary boots its app via the same run_jab_image path as
-      # `jac run app.jab`. Release channel only -- a dev binary links its
-      # compiler from a source tree absent in this clean env.
-      - name: Smoke test (jac build --as binary)
-        if: inputs.channel != 'dev'
-        working-directory: jac
-        run: |
-          set -euxo pipefail
-          BIN="$PWD/zig-out/bin/jac"
-          WORK="$(mktemp -d)"
-          mkdir -p "$WORK/app"
-          printf '[project]\nname = "smoke"\nkind = "cli"\nentry-point = "main.jac"\n' > "$WORK/app/jac.toml"
-          printf 'with entry { print("overlay-ok"); }\n' > "$WORK/app/main.jac"
-          ( cd "$WORK/app" && env -i HOME="$WORK" PATH=/usr/bin:/bin "$BIN" build --as binary )
-          env -i HOME="$WORK" PATH=/usr/bin:/bin "$WORK/app/dist/smoke" | grep -qx 'overlay-ok'
-          # Overlay coords must not hijack via env inheritance: a stale/leaked
-          # JAC_APP_OVERLAY_* must be CLEARED by a plain jac (runs its CLI) and
-          # OVERWRITTEN by an app binary (runs its own app), never mis-slice.
-          printf 'with entry { print("ok"); }\n' > "$WORK/h.jac"
-          env -i HOME="$WORK" PATH=/usr/bin:/bin JAC_APP_OVERLAY_OFF=999999999 JAC_APP_OVERLAY_LEN=16 "$BIN" run "$WORK/h.jac" | grep -qx 'ok'
-          env -i HOME="$WORK" PATH=/usr/bin:/bin JAC_APP_OVERLAY_OFF=999999999 JAC_APP_OVERLAY_LEN=16 "$WORK/app/dist/smoke" | grep -qx 'overlay-ok'
-
       # Guards #7047: the binary must not leak PYTHONHOME/PYTHONPATH (or any
       # interpreter config) into subprocesses -- a python-based child spawned
       # by a jac program must run with its OWN stdlib, and the user's ambient

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -168,6 +168,9 @@ jobs:
           fi
           zig build $DTARGET "${SHIM_ARG[@]}" --summary all
 
+      # Launcher unit tests (`zig build test`) live in ci.yml's `test-launcher`
+      # job so they gate every PR on Linux + macOS, not just release time. The
+      # smoke tests below validate the actually-shipped cross-compiled binary.
       - name: Smoke test (no system Python)
         working-directory: jac
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,6 +608,33 @@ jobs:
         jac test jac/tests/compiler/passes/native/test_shared_lib.jac
         jac test jac/tests/compiler/passes/native/test_exec_link.jac
 
+  # Launcher unit tests: trailer codec + `.jab`-overlay round-trip
+  # (append / detect / materialize-steps-over-overlay / graft). runtime.zig is
+  # the sole owner of the trailer format, so these guard the whole `--as binary`
+  # boot shape. Host-native, no libpython/LLVM/typeshed -- just checkout + zig.
+  # Cross-platform matrix on purpose: the format code has Linux/macOS-divergent
+  # syscall behavior (a /proc createDirPath livelock once hung this on Linux
+  # only, while macOS was green). -Dno-ninja skips the editor closure this
+  # never needs.
+  test-launcher:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.core == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+      - name: Launcher unit tests (zig build test)
+        working-directory: jac
+        run: zig build -Dno-ninja test --summary all
+
   test-cef-build:
     needs: build-jac
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/jac/launcher/runtime.zig
+++ b/jac/launcher/runtime.zig
@@ -501,10 +501,15 @@ test "cacheRoot prefers XDG_CACHE_HOME and falls back when unwritable" {
     try testing.expect(std.mem.endsWith(u8, root, "/jac"));
     try testing.expect(std.mem.startsWith(u8, root, base));
 
-    // Unwritable preferred root -> temp fallback keyed by uid.
+    // Unwritable preferred root -> temp fallback keyed by uid. The probe path
+    // must FAIL cleanly: a component that is a file (/dev/null) yields ENOTDIR
+    // on both Linux and macOS. Do NOT use a /proc path here -- createDirPath
+    // livelocks under the read-only /proc pseudo-fs on Linux (mkdir returns
+    // EROFS, never ENOENT, so make-parents neither progresses nor backs off),
+    // which hung this whole `zig build test` step on the Linux CI legs.
     var tmp_buf: [MAX_PATH]u8 = undefined;
     const tmpdir = tmp_buf[0..try tmp.dir.realPath(io, &tmp_buf)];
-    const fb = try cacheRoot(io, "/proc/nonexistent/ro", null, tmpdir, 4242, &out);
+    const fb = try cacheRoot(io, "/dev/null/ro", null, tmpdir, 4242, &out);
     try testing.expect(std.mem.indexOf(u8, fb, "jac-cache-4242") != null);
 }
 


### PR DESCRIPTION
Removes two release-channel-only steps from `build-binaries.yml`.

## 1. "Verify install.sh can fetch + run this release"

That step ran `scripts/install.sh` against `api.github.com` **unauthenticated**. On GitHub's shared macOS runners the anonymous 60-req/hr API limit is routinely exhausted, so the release-tag lookup fails with *"Failed to query GitHub API for release vX.Y.Z"* — and because it's a blocking step, the entire release goes red **even though the binary uploaded fine**.

This just happened on the `macos-aarch64` build for the v0.31.0 release ([failing job](https://github.com/jaseci-labs/jaseci/actions/runs/28948316237/job/85919071981)): the asset was attached, but the verify step tripped the rate limit and failed the release.

**Coverage is preserved** — the real `curl … | bash` path is already exercised out-of-band on the same two platforms (`linux-x86_64` + `macos-aarch64`):

- `nightly.yml` → `installer-live` — daily, against the published `--latest` release
- `ci.yml` → `installer-test` — on every PR touching `scripts/install.sh`

The only thing unique about the in-release copy was that it blocked the release — exactly the failure mode we just hit. A comment in its place points to where coverage now lives.

## 2. "Smoke test (jac build --as binary)"

Also drops the `.jab` overlay smoke test from the release build.
