### PR TITLE
fix(check): ignore plugin_bridge.na.jac in full-repo jac check

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -410,6 +410,7 @@ jac/jaclang/runtimelib/client/targets/desktop/native/cef/cef_subprocess.na.jac
 jac/jaclang/runtimelib/client/targets/desktop/native/host_boot.jac
 jac/jaclang/runtimelib/client/targets/desktop/native/inprocess_dispatch.jac
 jac/jaclang/runtimelib/client/targets/desktop/native/oauth_broker.jac
+jac/jaclang/runtimelib/client/targets/desktop/native/plugin_bridge.na.jac
 jac/jaclang/runtimelib/client/targets/desktop/plugin/plugin_host.jac
 jac/jaclang/runtimelib/client/targets/impl/mobile_target.impl.jac
 jac/jaclang/runtimelib/client/targets/impl/pwa_target.impl.jac


### PR DESCRIPTION
## Summary

The `CI` workflow has been red on `main` across many commits. Every job passes except the `jac-check` job's **Run jac check** step, which fails on a single file:

```
jac/jaclang/runtimelib/client/targets/desktop/native/plugin_bridge.na.jac FAILED
  error[E5090]: Native pathway does not yet support function 'respond'          (x2)
  error[E5090]: Native pathway does not yet support function 'PyRun_SimpleString'
  492 passed, 1 failed
```

## Root cause

`plugin_bridge.na.jac` is — per its own docstring — a **reference source that is not compiled by nacompile**; it is inlined into generated host source between the `BRIDGE START` / `BRIDGE END` markers. It legitimately cannot pass native-pathway checking because it calls host-only intrinsics (`respond` from `webview`, and `PyRun_SimpleString`).

Its six siblings in the same `native/` directory (`cef/*.na.jac`, `host_boot.jac`, `inprocess_dispatch.jac`, `oauth_broker.jac`) are all already in `.jacignore`. This file was **omitted** when `.jacignore` was re-baselined in #7167, even though its failing code had already landed in #7045 three days earlier. On push to `main`, CI runs `jac check .` over the whole tree, so the omission keeps the job red.

## Fix

Add the missing entry to `.jacignore`, next to its siblings.

## Verification

Reproduced locally with the exact `IGNORE_ARGS` the CI step builds from `.jacignore`:

- `jac check` on the file alone → reproduces the 3 `E5090` errors.
- With the ignore entry present → `jac check` exits 0.