### PR TITLE
fix(compiler): bust in-memory hub when .impl.jac annex changes

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7337.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7337.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: Stale in-memory module cache on .impl.jac annex edits**: `get_bytecode` now checks whether a module in the in-memory hub is still fresh before reusing it. Previously, editing a `.impl.jac` file within the same persistent process would return stale bytecode from the hub.

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -117,6 +117,13 @@ impl JacCompiler.get_bytecode(
     if (
         (not rebuild)
         and (full_target in actual_program.mod.hub)
+        and not actual_program.is_hub_entry_fresh(full_target)
+    ) {
+        actual_program.invalidate_module(full_target);
+    }
+    if (
+        (not rebuild)
+        and (full_target in actual_program.mod.hub)
         and actual_program.mod.hub[full_target].gen.py_bytecode
     ) {
         codeobj = actual_program.mod.hub[full_target].gen.py_bytecode;
@@ -231,6 +238,7 @@ impl JacCompiler.get_bytecode(
         file_path=full_target, target_program=actual_program, options=options
     );
     if result.gen.py_bytecode {
+        actual_program.hub_cache_stamp(full_target);
         try {
             import from jaclang.jac0core.jir_passes { JirWriter }
             import pickle;

--- a/jac/tests/compiler/test_importer.jac
+++ b/jac/tests/compiler/test_importer.jac
@@ -281,3 +281,48 @@ test "get bytecode uses JIR cache on second call" {
         }
     }
 }
+
+test "get_bytecode busts in-memory hub when .impl.jac changes" {
+    # Regression: in a persistent process, editing a .impl.jac annex left a
+    # stale in-memory module in mod.hub; get_bytecode returned it with no
+    # freshness check. Cold runs were fine (disk cache busts via modkey).
+    with tempfile.TemporaryDirectory(dir=_test_tmp_dir) as d {
+        mod = os.path.join(d, "mod.jac");
+        impl_file = os.path.join(d, "mod.impl.jac");
+        with open(mod, "w") as f {
+            f.write(
+                "obj Thing {\n    has tag: int = 0;\n    def get_tag() -> int;\n}\n"
+            );
+        }
+        def write_body(v: int) {
+            with open(impl_file, "w") as f {
+                f.write(
+                    "impl Thing.get_tag() -> int {\n    return " + str(v) + ";\n}\n"
+                );
+            }
+        }
+        write_body(10);
+        past = time.time() - 5;
+        os.utime(mod, (past, past));
+        os.utime(impl_file, (past, past));
+        compiler = JacCompiler();
+        prog = JacProgram();
+        def tag_of -> int {
+            code = compiler.get_bytecode(mod, prog);
+            ns: dict = {};
+            exec(code, ns);
+            return ns["Thing"]().get_tag();
+        }
+        assert tag_of() == 10 , "first compile should use the annex body";
+        # edit the annex in the SAME persistent process
+        write_body(20);
+        future = time.time() + 5;
+        os.utime(impl_file, (future, future));
+        got = tag_of();
+        assert got == 20 , (
+            "stale in-memory hub bytecode reused; expected 20 after " + "annex edit, got " + str(
+                got
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Description

In a persistent process, `get_bytecode` returned a stale in-memory module from `mod.hub` even when the corresponding `.impl.jac` file had been edited. Cold runs were fine because the disk cache busts via modkey.

## Fix

Adds a freshness check before the existing hub lookup in `get_bytecode`: if a module is in the hub but not fresh, invalidate it so the next compile picks up the new annex content.

## Test

Added a regression test `get_bytecode busts in-memory hub when .impl.jac changes` that:
1. Creates a module with an impl annex
2. Compiles and verifies the first body
3. Edits the impl file in the same persistent process
4. Verifies the recompile picks up the new body