### PR TITLE
docs(typeshed): update stub-install hint to jac install

### DIFF
--- a/jac/jaclang/vendor/typeshed/PROVENANCE.md
+++ b/jac/jaclang/vendor/typeshed/PROVENANCE.md
@@ -12,8 +12,8 @@ verifies the **decompressed tar's** sha256 against `TARBALL_SHA256` (git's
 slip in -- the same guarantee git's content-addressing gave the old `git fetch`.
 
 Third-party stubs are NOT shipped: install the matching `types-*` package
-yourself (`jac add types-foo`); it is resolved via PEP 561 `<pkg>-stubs` from
-the project venv.
+yourself (`jac install types-foo`); it is resolved via PEP 561 `<pkg>-stubs`
+from the project venv.
 
 - Source:  https://github.com/python/typeshed
 - Commit:  bbbf7530a987e59c8458127351cacad2e57f04bf


### PR DESCRIPTION
Follow-up to #7336 (jac add → jac install merge).

The vendored typeshed `PROVENANCE.md` still instructed users to run `jac add types-foo` to install third-party stubs. Since `jac add` was merged into `jac install`, this is the last remaining live doc referencing the old verb — the CLI reference, `jac install --help`, and the type/interop skill guides already use `jac install types-*`.

One-line change to point at the current spelling. No code impact.