### PR TITLE
docs: remove em-dashes repo-wide in README and give .jab/--as binary first-class docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <h1>The Jac Programming Language</h1>
   <h3>The Only Language You Need to Build Anything</h3>
 
-  <p>One self-contained binary. One Python-like language. AI, graphs, persistence, APIs, UIs, and cloud deployment as language features — compiled to Python bytecode, JavaScript, and native machine code.</p>
+  <p>One self-contained binary. One Python-like language. AI, graphs, persistence, APIs, UIs, and cloud deployment as language features, compiled to Python bytecode, JavaScript, and native machine code.</p>
 
   <p>
     <a href="https://github.com/jaseci-labs/jaseci/releases/latest">
@@ -38,15 +38,15 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/demo-dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/demo-light.svg">
-    <img alt="Install jac, create a web app, and serve it — three commands" src="docs/docs/assets/readme/demo-dark.svg" width="880">
+    <img alt="Install jac, create a web app, and serve it in three commands" src="docs/docs/assets/readme/demo-dark.svg" width="880">
   </picture>
 </div>
 
-Jac is a programming language designed for humans and AI to build together. It compiles one clean, Python-like syntax to Python bytecode, JavaScript, and native machine code — with the entire PyPI, npm, and C ecosystems available without wrappers or interop layers. The things every real application needs — an LLM call, a data model that persists, a REST API, a frontend, a deployment story — are language features, not frameworks you assemble around it.
+Jac is a programming language designed for humans and AI to build together. It compiles one clean, Python-like syntax to Python bytecode, JavaScript, and native machine code, with the entire PyPI, npm, and C ecosystems available without wrappers or interop layers. The things every real application needs (an LLM call, a data model that persists, a REST API, a frontend, a deployment story) are language features, not frameworks you assemble around it.
 
 ## Try Jac in 30 seconds
 
-Install the self-contained `jac` binary — no Python, pip, Node, or C toolchain required:
+Install the self-contained `jac` binary. No Python, pip, Node, or C toolchain required:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
@@ -85,7 +85,7 @@ Hello, Ada!
 Hello, Alan!
 ```
 
-Now run it again — the people accumulate. The graph hanging off `root` **persists between runs automatically**, and that same machinery backs Jac servers in production. No database to set up, ever.
+Now run it again: the people accumulate. The graph hanging off `root` **persists between runs automatically**, and that same machinery backs Jac servers in production. No database to set up, ever.
 
 > Don't want to install anything? Open the [**Jac Playground**](https://playground.jaseci.org) in your browser.
 >
@@ -93,13 +93,13 @@ Now run it again — the people accumulate. The graph hanging off `root` **persi
 
 ## One binary, your whole toolchain
 
-One download replaces the entire modern development stack — interpreter and JS runtime, compilers and linker, package managers, server, and deployer:
+One download replaces the interpreter, the JS runtime, the compilers and linker, the package managers, the server, and the deployer:
 
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/one-binary-dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/one-binary-light.svg">
-    <img alt="The jac binary bundles CPython, Bun, LLVM and a Zig linker, a package manager, a REST server, and a Kubernetes deployer — and builds every kind of artifact" src="docs/docs/assets/readme/one-binary-dark.svg" width="880">
+    <img alt="The jac binary bundles CPython, Bun, LLVM and a Zig linker, a package manager, a REST server, and a Kubernetes deployer, and builds every kind of artifact" src="docs/docs/assets/readme/one-binary-dark.svg" width="880">
   </picture>
 </div>
 
@@ -110,18 +110,18 @@ One download replaces the entire modern development stack — interpreter and JS
 
 | Capability | What it replaces | How you use it |
 |---|---|---|
-| **CPython 3.14** | System Python, pyenv, venvs | Bundled — runs your `.jac` files and PyPI imports |
-| **Bun** | Node.js, npm, npx | Bundled — compiles `cl` code to JS, manages npm deps |
-| **LLVM + Zig linker** | gcc, clang, make, cmake | Bundled — `jac build --as native` produces real binaries |
+| **CPython 3.14** | System Python, pyenv, venvs | Bundled -- runs your `.jac` files and PyPI imports |
+| **Bun** | Node.js, npm, npx | Bundled -- compiles `cl` code to JS, manages npm deps |
+| **LLVM + Zig linker** | gcc, clang, make, cmake | Bundled -- `jac build --as native` produces real binaries |
 | **Package manager** | pip, npm, pipx | `jac install` for PyPI *and* npm, in one `jac.toml` |
 | **Universal tool runner** | npx, pipx run | `jac x` runs any installed PyPI or npm CLI tool |
-| **REST server** | Flask, FastAPI, Express | `jac start` — walkers become API endpoints |
-| **Kubernetes deployer** | Docker + kubectl + Helm | `jac start --scale` — one-command K8s deployment |
-| **AI integration** | LangChain, prompt libraries | `by llm()` — built into the language |
-| **MCP server** | Separate MCP packages | `jac mcp` — AI-assisted development, built in |
+| **REST server** | Flask, FastAPI, Express | `jac start` -- walkers become API endpoints |
+| **Kubernetes deployer** | Docker + kubectl + Helm | `jac start --scale` -- one-command K8s deployment |
+| **AI integration** | LangChain, prompt libraries | `by llm()` -- built into the language |
+| **MCP server** | Separate MCP packages | `jac mcp` -- AI-assisted development, built in |
 | **Type checker** | mypy, pyright, tsc | `jac check` |
 | **Formatter & test runner** | black, ruff, pytest, jest | `jac fmt`, `jac test` |
-| **Language server** | Separate LSP packages | `jac lsp` — IDE support built in |
+| **Language server** | Separate LSP packages | `jac lsp` -- IDE support built in |
 
 Full story: [One Binary, Build Anything](https://docs.jaseci.org/quick-guide/one-binary/).
 
@@ -142,12 +142,14 @@ The commands you'll use every day:
 
 ## Build anything
 
-The same language — and the same skills — produce every kind of software. Each row is one command away:
+One language and one skill set produce every kind of software. Each row is one command away:
 
 | What you're building | The command | Guide |
 |---|---|---|
 | Script / CLI tool | `jac run app.jac` | [CLI & native](https://docs.jaseci.org/build/cli-and-native/) |
 | Zero-dependency native executable | `jac build --as native` | [CLI & native](https://docs.jaseci.org/build/cli-and-native/) |
+| Single-file app bundle (`.jab`) | `jac build` | [CLI reference](https://docs.jaseci.org/reference/cli/#jac-build) |
+| Self-contained app executable | `jac build --as binary` | [CLI reference](https://docs.jaseci.org/reference/cli/#jac-build) |
 | REST API (+ Swagger, auth, persistence) | `jac start api.jac` | [Backend APIs](https://docs.jaseci.org/build/backend-apis/) |
 | Microservices | `sv import` + `jac start` | [Backend APIs](https://docs.jaseci.org/build/backend-apis/) |
 | Full-stack web app | `jac start` | [Full-stack web](https://docs.jaseci.org/build/fullstack-web/) |
@@ -160,7 +162,7 @@ The same language — and the same skills — produce every kind of software. Ea
 | WebAssembly in the browser | `jac build` in a `web-static` project | [Native pathway](https://docs.jaseci.org/reference/language/native-pathway/) |
 | Kubernetes deployment | `jac start --scale` | [Deploy & scale](https://docs.jaseci.org/reference/plugins/jac-scale/) |
 
-Proof it's real: a [playable chess engine](https://docs.jaseci.org/tutorials/native/chess/) compiled to a standalone binary, a [raylib game running as WebAssembly](jac/examples/raylib_shooter/web) in the browser, and [littleX](jac/examples/littleX) — a full Twitter-style social app, backend to frontend, in about 1,100 lines of Jac.
+Proof it's real: a [playable chess engine](https://docs.jaseci.org/tutorials/native/chess/) compiled to a standalone binary, a [raylib game running as WebAssembly](jac/examples/raylib_shooter/web) in the browser, and [littleX](jac/examples/littleX), a full Twitter-style social app, backend to frontend, in about 1,100 lines of Jac.
 
 ## AI, graphs, and UIs are language features
 
@@ -177,9 +179,9 @@ with entry {
 }
 ```
 
-No prompt, no parsing, no API glue. The compiler constructs the prompt from your function's name, argument names, and types (plus optional `sem` annotations), and the return type is an enforced output schema — this is [Meaning-Typed Programming](https://arxiv.org/abs/2405.08965). Declare your model once in `jac.toml`, run `jac install byllm`, and use any [LiteLLM-compatible provider](https://docs.litellm.ai/docs/providers) — or fully local models with `jac install 'byllm[local]'`. [Learn more →](https://docs.jaseci.org/reference/plugins/byllm/)
+No prompt, no parsing, no API glue. The compiler constructs the prompt from your function's name, argument names, and types (plus optional `sem` annotations), and the return type is an enforced output schema. This is [Meaning-Typed Programming](https://arxiv.org/abs/2405.08965). Declare your model once in `jac.toml`, run `jac install byllm`, and use any [LiteLLM-compatible provider](https://docs.litellm.ai/docs/providers), or go fully local with `jac install 'byllm[local]'`. [Learn more →](https://docs.jaseci.org/reference/plugins/byllm/)
 
-### Your data is a graph — and your API writes itself
+### Your data is a graph, and your API writes itself
 
 ```jac
 node Task {
@@ -208,7 +210,7 @@ walker:pub list_tasks {
 jac start api.jac --no-client   # POST /walker/add_task · /walker/list_tasks
 ```
 
-Model your domain as nodes and edges; send **walkers** to traverse it. Mark a walker `:pub` and `jac start` turns it into a REST endpoint — request bodies map onto its fields, `report` becomes the JSON response, Swagger docs appear at `/docs`, and every user gets their own isolated, persistent graph. No ORM, no schema migrations, no session plumbing. [Graphs & walkers →](https://docs.jaseci.org/tutorials/language/osp/)
+Model your domain as nodes and edges; send **walkers** to traverse it. Mark a walker `:pub` and `jac start` turns it into a REST endpoint: request bodies map onto its fields, `report` becomes the JSON response, Swagger docs appear at `/docs`, and every user gets their own isolated, persistent graph. No ORM, no schema migrations, no session plumbing. [Graphs & walkers →](https://docs.jaseci.org/tutorials/language/osp/)
 
 ### Frontend and backend in one file
 
@@ -246,9 +248,9 @@ cl def:pub app -> JsxElement {
 }
 ```
 
-Code in `cl` compiles to a React/JSX bundle for the browser; everything else compiles to Python for the server. That `await add_todo(...)` in the click handler is a real RPC — the compiler generates the HTTP call, serialization, and shared types across the boundary. `jac start` serves it; `jac start --dev` gives you hot reload. [Full-stack tutorial →](https://docs.jaseci.org/build/fullstack-web/)
+Code in `cl` compiles to a React/JSX bundle for the browser; everything else compiles to Python for the server. That `await add_todo(...)` in the click handler is a real RPC: the compiler generates the HTTP call, serialization, and shared types across the boundary. `jac start` serves it; `jac start --dev` gives you hot reload. [Full-stack tutorial →](https://docs.jaseci.org/build/fullstack-web/)
 
-For all three ideas in one file — an AI categorizer, a native-compiled scoring function, a persistent graph, and a React UI — see [`jac/examples/mini_todo`](jac/examples/mini_todo).
+For all three ideas in one file (an AI categorizer, a native-compiled scoring function, a persistent graph, and a React UI), see [`jac/examples/mini_todo`](jac/examples/mini_todo).
 
 ## Laptop to Kubernetes without changing your code
 
@@ -257,25 +259,25 @@ jac start main.jac           # local: REST API + auth + Swagger + persistence
 jac start main.jac --scale   # cloud: Kubernetes with Redis, MongoDB, load balancing
 ```
 
-Your code doesn't change when you outgrow one machine. The `scale` subsystem ships inside the binary: `--scale` builds the images, provisions Redis and MongoDB, and deploys to Kubernetes with health checks — zero Dockerfiles, zero YAML, zero DevOps. [Deploy & scale →](https://docs.jaseci.org/reference/plugins/jac-scale/)
+Your code doesn't change when you outgrow one machine. The `scale` subsystem ships inside the binary: `--scale` builds the images, provisions Redis and MongoDB, and deploys to Kubernetes with health checks. Zero Dockerfiles, zero YAML, zero DevOps. [Deploy & scale →](https://docs.jaseci.org/reference/plugins/jac-scale/)
 
 ## Learn Jac
 
-- [**Build an AI Day Planner**](https://docs.jaseci.org/tutorials/first-app/build-ai-day-planner/) — the flagship tutorial: every core concept in one guided full-stack project
-- [**Jac Fundamentals**](https://docs.jaseci.org/tutorials/language/basics/) — the language itself, for Python developers
-- [**Build a Chess Engine**](https://docs.jaseci.org/tutorials/native/chess/) — the native pathway, from source to standalone binary
-- [**WebAssembly in the Browser**](https://docs.jaseci.org/tutorials/native/wasm/) — native-speed compute, client-side
-- [**Jac Playground**](https://playground.jaseci.org) — run Jac in your browser, and [**Ask Jac GPT**](https://jac-gpt.jaseci.org) — a docs-trained assistant
+- [**Build an AI Day Planner**](https://docs.jaseci.org/tutorials/first-app/build-ai-day-planner/) -- the flagship tutorial: every core concept in one guided full-stack project
+- [**Jac Fundamentals**](https://docs.jaseci.org/tutorials/language/basics/) -- the language itself, for Python developers
+- [**Build a Chess Engine**](https://docs.jaseci.org/tutorials/native/chess/) -- the native pathway, from source to standalone binary
+- [**WebAssembly in the Browser**](https://docs.jaseci.org/tutorials/native/wasm/) -- native-speed compute, client-side
+- [**Jac Playground**](https://playground.jaseci.org) -- run Jac in your browser, and [**Ask Jac GPT**](https://jac-gpt.jaseci.org) -- a docs-trained assistant
 - In your terminal: `jac guide` (curated references), `jac ai` (interactive coding agent), `jac mcp` (wire Jac expertise into Claude Code, Cursor, and friends)
 
 ## What's in this repo
 
-This is the Jaseci monorepo — everything that makes Jac work:
+This is the Jaseci monorepo, home to everything that makes Jac work:
 
 | Directory | What it is |
 |---|---|
-| [`jac/`](jac/) | **jaclang** — the compiler, runtime, and everything inside the `jac` binary: the language, the full-stack client framework, the `scale` deployment subsystem, the MCP server, and the LLVM native pathway |
-| [`jac-byllm/`](jac-byllm/) | **byllm** — AI/LLM integration via Meaning-Typed Programming (`jac install byllm`) |
+| [`jac/`](jac/) | **jaclang** -- the compiler, runtime, and everything inside the `jac` binary: the language, the full-stack client framework, the `scale` deployment subsystem, the MCP server, and the LLVM native pathway |
+| [`jac-byllm/`](jac-byllm/) | **byllm** -- AI/LLM integration via Meaning-Typed Programming (`jac install byllm`) |
 | [`docs/`](docs/) | The documentation site at [docs.jaseci.org](https://docs.jaseci.org) |
 | [`scripts/`](scripts/) | The installer and release tooling |
 
@@ -283,7 +285,7 @@ The official VS Code extension lives at [jaseci-labs/jac-vscode](https://github.
 
 ## Research
 
-Jac's core ideas are peer-reviewed research, not just design taste. Meaning-Typed Programming — the foundation of `by llm()` — is described in [*"Meaning-Typed Programming: Language Abstractions and Compilation for AI-Integrated Applications"*](https://arxiv.org/abs/2405.08965). The project grew out of research at the University of Michigan and is now developed in the open by a global community.
+Jac's core ideas are peer-reviewed research, not just design taste. Meaning-Typed Programming, the foundation of `by llm()`, is described in [*"Meaning-Typed Programming: Language Abstractions and Compilation for AI-Integrated Applications"*](https://arxiv.org/abs/2405.08965). The project grew out of research at the University of Michigan and is now developed in the open by a global community.
 
 ## Built with Jac
 
@@ -298,11 +300,11 @@ Building something with Jac? Tell us on [Discord](https://discord.gg/6j3QNdtcN6)
 
 ## Contributing
 
-We welcome contributions of every size — from typo fixes to compiler passes.
+We welcome contributions of every size, from typo fixes to compiler passes.
 
 - **Ask questions & share ideas** on our [Discord server](https://discord.gg/6j3QNdtcN6)
 - **Report bugs** via [GitHub issues](https://github.com/jaseci-labs/jaseci/issues)
-- **Send PRs** — start with the [contributing guide](https://docs.jaseci.org/community/contributing/) and [CONTRIBUTING.md](CONTRIBUTING.md); `bash scripts/fresh_env.sh` sets up a dev environment
+- **Send PRs**: start with the [contributing guide](https://docs.jaseci.org/community/contributing/) and [CONTRIBUTING.md](CONTRIBUTING.md); `bash scripts/fresh_env.sh` sets up a dev environment
 
 ## License
 

--- a/docs/docs/assets/readme/demo-dark.svg
+++ b/docs/docs/assets/readme/demo-dark.svg
@@ -10,15 +10,15 @@
   <circle cx="24" cy="26" r="7" fill="#ff5f56"/>
   <circle cx="46" cy="26" r="7" fill="#ffbd2e"/>
   <circle cx="68" cy="26" r="7" fill="#27c93f"/>
-  <text class="t dim" x="440" y="31" text-anchor="middle">jac — zero to full-stack</text>
+  <text class="t dim" x="440" y="31" text-anchor="middle">jac · zero to full-stack</text>
   <line x1="1" y1="48" x2="879" y2="48" stroke="#21262d"/>
 
   <text class="t" x="28" y="84"><tspan class="acc">$ </tspan><tspan class="fg">curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash</tspan></text>
-  <text class="t" x="28" y="110"><tspan class="ok">✓ </tspan><tspan class="dim">jac installed — one self-contained binary (no Python, no Node, no C toolchain)</tspan></text>
+  <text class="t" x="28" y="110"><tspan class="ok">✓ </tspan><tspan class="dim">jac installed · one self-contained binary (no Python, no Node, no C toolchain)</tspan></text>
 
   <text class="t" x="28" y="148"><tspan class="acc">$ </tspan><tspan class="fg">jac create myapp --kind web-app &amp;&amp; cd myapp &amp;&amp; jac install</tspan></text>
 
   <text class="t" x="28" y="186"><tspan class="acc">$ </tspan><tspan class="fg">jac start</tspan></text>
-  <text class="t" x="28" y="212"><tspan class="acc">▸ </tspan><tspan class="dim">REST API + auth + Swagger docs + React frontend — no database, no glue code</tspan></text>
+  <text class="t" x="28" y="212"><tspan class="acc">▸ </tspan><tspan class="dim">REST API + auth + Swagger docs + React frontend · no database, no glue code</tspan></text>
   <text class="t" x="28" y="238"><tspan class="ok">✓ </tspan><tspan class="fg">serving at </tspan><tspan class="acc">http://localhost:8000</tspan></text>
 </svg>

--- a/docs/docs/assets/readme/demo-light.svg
+++ b/docs/docs/assets/readme/demo-light.svg
@@ -10,15 +10,15 @@
   <circle cx="24" cy="26" r="7" fill="#ff5f56"/>
   <circle cx="46" cy="26" r="7" fill="#ffbd2e"/>
   <circle cx="68" cy="26" r="7" fill="#27c93f"/>
-  <text class="t dim" x="440" y="31" text-anchor="middle">jac — zero to full-stack</text>
+  <text class="t dim" x="440" y="31" text-anchor="middle">jac · zero to full-stack</text>
   <line x1="1" y1="48" x2="879" y2="48" stroke="#eaeef2"/>
 
   <text class="t" x="28" y="84"><tspan class="acc">$ </tspan><tspan class="fg">curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash</tspan></text>
-  <text class="t" x="28" y="110"><tspan class="ok">✓ </tspan><tspan class="dim">jac installed — one self-contained binary (no Python, no Node, no C toolchain)</tspan></text>
+  <text class="t" x="28" y="110"><tspan class="ok">✓ </tspan><tspan class="dim">jac installed · one self-contained binary (no Python, no Node, no C toolchain)</tspan></text>
 
   <text class="t" x="28" y="148"><tspan class="acc">$ </tspan><tspan class="fg">jac create myapp --kind web-app &amp;&amp; cd myapp &amp;&amp; jac install</tspan></text>
 
   <text class="t" x="28" y="186"><tspan class="acc">$ </tspan><tspan class="fg">jac start</tspan></text>
-  <text class="t" x="28" y="212"><tspan class="acc">▸ </tspan><tspan class="dim">REST API + auth + Swagger docs + React frontend — no database, no glue code</tspan></text>
+  <text class="t" x="28" y="212"><tspan class="acc">▸ </tspan><tspan class="dim">REST API + auth + Swagger docs + React frontend · no database, no glue code</tspan></text>
   <text class="t" x="28" y="238"><tspan class="ok">✓ </tspan><tspan class="fg">serving at </tspan><tspan class="acc">http://localhost:8000</tspan></text>
 </svg>

--- a/docs/docs/assets/readme/one-binary-dark.svg
+++ b/docs/docs/assets/readme/one-binary-dark.svg
@@ -9,7 +9,7 @@
 
   <!-- Left panel: the binary -->
   <rect x="16" y="40" width="300" height="340" rx="12" fill="#161b22" stroke="#30363d"/>
-  <text class="mono acc" x="32" y="74" font-size="20" font-weight="bold">jac<tspan class="dim" font-size="12" font-weight="normal"> — one self-contained binary</tspan></text>
+  <text class="mono acc" x="32" y="74" font-size="20" font-weight="bold">jac<tspan class="dim" font-size="12" font-weight="normal"> · one self-contained binary</tspan></text>
   <text class="sans dim" x="32" y="96" font-size="11.5">No Python. No Node. No C toolchain.</text>
 
   <g font-size="11" text-anchor="middle" class="sans fg">

--- a/docs/docs/assets/readme/one-binary-light.svg
+++ b/docs/docs/assets/readme/one-binary-light.svg
@@ -9,7 +9,7 @@
 
   <!-- Left panel: the binary -->
   <rect x="16" y="40" width="300" height="340" rx="12" fill="#ffffff" stroke="#d0d7de"/>
-  <text class="mono acc" x="32" y="74" font-size="20" font-weight="bold">jac<tspan class="dim" font-size="12" font-weight="normal"> — one self-contained binary</tspan></text>
+  <text class="mono acc" x="32" y="74" font-size="20" font-weight="bold">jac<tspan class="dim" font-size="12" font-weight="normal"> · one self-contained binary</tspan></text>
   <text class="sans dim" x="32" y="96" font-size="11.5">No Python. No Node. No C toolchain.</text>
 
   <g font-size="11" text-anchor="middle" class="sans fg">

--- a/docs/docs/build/cli-and-native.md
+++ b/docs/docs/build/cli-and-native.md
@@ -53,6 +53,9 @@ jac nacompile sum.na.jac -o sum
 
 Jac ships its own native linker, so there's no `gcc`/`ld` in the loop. The native subset requires a `with entry` block and allows no walkers/nodes/async or Python imports.
 
+!!! tip "Shipping a full app instead?"
+    The native subset is the price of the smallest possible artifact. To ship *any* Jac program (walkers, Python imports, even a web client) as one executable, use `jac build --as binary` -- it fuses your app's sealed `.jab` onto the `jac` launcher so the file carries the full runtime. A plain `jac build` emits the sealed `.jab` bundle itself, which any Jac install runs with zero live compilation. See [Ship it](../quick-guide/project-kinds.md#ship-it-one-file-or-one-executable) and [`jac build`](../reference/cli/index.md#jac-build).
+
 ## Run natively in place {#cli-native}
 
 Set `kind = "cli-native"` in `jac.toml` when you want the *program* to execute through the native pathway rather than producing a distributable artifact -- the same `.na.jac` subset, run as a command. A bare `jac run` then compiles-and-executes it. (`cli` runs on the Python VM; `cli-native` runs the native build; `native-binary` ships the executable.)

--- a/docs/docs/quick-guide/one-binary.md
+++ b/docs/docs/quick-guide/one-binary.md
@@ -14,7 +14,7 @@ That's it. You now have a compiler, a runtime, a package manager, a server, a bu
 |---|---|---|
 | **CPython 3.14** | System Python, pyenv, venvs | Bundled -- runs your `.jac` files and PyPI imports |
 | **Bun** | Node.js, npm, npx | Bundled -- compiles `.cl.jac` to JS, manages npm deps |
-| **LLVM + Zig linker** | gcc, clang, make, cmake | Bundled -- `jac nacompile` produces native binaries |
+| **LLVM + Zig linker** | gcc, clang, make, cmake | Bundled -- `jac build --as native` produces native binaries |
 | **Package manager** | pip, npm, pipx | `jac install` for PyPI and npm |
 | **REST server** | Flask, FastAPI, Express | `jac start` -- walkers become API endpoints |
 | **Kubernetes deployer** | Docker + kubectl + Helm | `jac start --scale` -- one-command K8s deployment |
@@ -97,6 +97,24 @@ With Jac installed, you no longer need these on your development machine:
 
 !!! note
     You only need these replacements if you're building with Jac. If you have other Python or Node projects, keep those toolchains installed for them.
+
+## Your App Ships as One Binary Too
+
+The one-binary idea applies to what you build, not just the toolchain. `jac build` type-checks the whole project (fail-closed) and emits a single sealed **`.jab`** app bundle: client dist, serve manifest, and native binaries baked in and hash-verified. Any machine with Jac installed runs or serves it with zero live compilation:
+
+```bash
+jac build                  # -> dist/<app>.jab
+jac run dist/<app>.jab     # cli kinds execute
+jac start dist/<app>.jab   # servable kinds production-serve
+```
+
+For machines with nothing installed at all -- no Jac, no Python, no Node -- project the same app to a **self-contained executable**. `jac build --as binary` appends the sealed `.jab` onto a copy of the `jac` launcher, producing one file that carries the full runtime:
+
+```bash
+jac build --as binary      # -> one executable, full runtime included
+```
+
+And when your program fits the restricted `na` subset, `jac build --as native` compiles it through LLVM into a small, dependency-free binary instead. See [`jac build`](../reference/cli/index.md#jac-build) for all artifact projections and the binary-vs-native trade-off.
 
 ## How It Works
 

--- a/docs/docs/quick-guide/project-kinds.md
+++ b/docs/docs/quick-guide/project-kinds.md
@@ -44,6 +44,26 @@ Each recipe name links to its guided **"I like to build…" track** -- a 5-minut
 
 Read across a row and the composition is the point: a full-stack app is just a *service* plus a *client*; in-browser native swaps the server for an `na` module compiled to wasm; a desktop app is a full-stack app plus a *shell*; microservices are a *service* replicated. The 🚧 rows aren't missing "kinds" -- they're capability combinations that aren't wired yet.
 
+## Ship it: one file or one executable
+
+Whatever you build, two universal projections turn it into something you can hand to someone else.
+
+**A sealed app bundle (`.jab`)** -- a bare `jac build` type-checks the whole project (fail-closed) and emits one self-describing `.jab`: client dist, serve manifest, and native binaries baked in and hash-verified. Any machine with Jac installed runs or serves it with zero live compilation, kind-aware:
+
+```bash
+jac build                  # -> dist/<app>.jab
+jac run dist/<app>.jab     # cli kinds execute
+jac start dist/<app>.jab   # servable kinds production-serve
+```
+
+**A self-contained executable** -- `jac build --as binary` appends that same sealed `.jab` onto a copy of the `jac` launcher, producing one file that carries the full runtime. Hand it to a machine with no Jac, no Python, no Node:
+
+```bash
+jac build --as binary      # -> one executable, full runtime included
+```
+
+How is `--as binary` different from the [Native binary](#native-binary) recipe below? `--as native` compiles the restricted `na` subset through LLVM into a small, dependency-free binary. `--as binary` packages *any* app -- walkers, Python imports, a full web client -- with the runtime included; the trade is a larger file. Details and the other projections (wheel, npm, source): [`jac build`](../reference/cli/index.md#jac-build).
+
 ---
 
 ## Backend & CLI
@@ -120,7 +140,7 @@ jac nacompile sum.na.jac -o sum
 Sum of 1 to 10: 55
 ```
 
-The result is a real native binary (a few KB here) you can ship without Python or Jac installed.
+The result is a real native binary (a few KB here) you can ship without Python or Jac installed. To ship a *full* app (walkers, Python imports, a web client) as one executable instead, see [Ship it](#ship-it-one-file-or-one-executable).
 
 :octicons-arrow-right-24: Full tutorial: [Build a Chess Engine](../tutorials/native/chess.md) · Reference: [Native pathway](../reference/language/native-pathway.md)
 
@@ -520,4 +540,4 @@ These aren't missing "kinds" -- they're **capability combinations that aren't wi
 - **Full-stack package** (`sv` + `cl` + *attach*) -- An installable feature that brings its own routes, UI components, and data models into your app (think "drop in payments and get a checkout button + endpoints + models"). `sv import` composes *services* over HTTP, but there's no attachable in-process package yet. This needs a no-entry "package" artifact and conflict-resolution semantics across the three runtimes.
 
 !!! info "Want to follow the design?"
-    The unified build/artifact work that would close these gaps is tracked in the Jac repo's `jac build` / `.jab` proposals.
+    The unified `jac build` verb and the sealed `.jab` artifact have shipped ([see Ship it](#ship-it-one-file-or-one-executable)). What remains for this row is the attachable *package* form: a no-entry `.jab` a host app can mount, plus its conflict-resolution semantics, tracked in the Jac repo's proposals and issues.

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -1631,7 +1631,8 @@ jac build [-h] [--as {jab,sealed,binary,wheel,npm,source,native}] [-o OUTPUT] [-
 | `--as` | Emits | Replaces |
 |--------|-------|----------|
 | `jab` (default) | A sealed `.jab` app bundle (deterministic `tar.gz` of the sealed image) | -- |
-| `sealed` / `binary` | Sealed image / native binary form | -- |
+| `sealed` | The sealed image as an unpacked directory (exactly what a `.jab` archives) | -- |
+| `binary` | A self-contained app executable: a copy of the `jac` launcher with your sealed `.jab` appended as an overlay | -- |
 | `wheel` | A `pip install`-ready Python wheel in `dist/` | `jac bundle` |
 | `npm` | An npm tarball | `jac bundle --target npm` |
 | `source` | An editable FastAPI + JavaScript source tree (zero `.jac` files) | `jac eject` |
@@ -1640,6 +1641,11 @@ jac build [-h] [--as {jab,sealed,binary,wheel,npm,source,native}] [-o OUTPUT] [-
 **The type-check gate.** `jac build` refuses to emit an artifact if the program fails the whole-program type check. Pass `--no_typecheck` to skip the gate, or `--check_only` to run the gate and emit nothing (useful in CI).
 
 **The `.jab` artifact.** A `.jab` is a single self-describing sealed app bundle: client dist, serve manifest, and native binaries are baked in and hash-verified at load, so [`jac run app.jab`](#jac-run) / [`jac start app.jab`](#jac-start) execute or serve it with **zero live compilation**. It is kind-aware: `cli` kinds execute, servable kinds production-serve, and attachable packages refuse to run standalone.
+
+**Shipping an executable: `binary` vs `native`.** These two projections solve different problems and are easy to confuse:
+
+- `--as binary` packages **any** app (walkers, Python imports, a full web client) into one executable by appending the sealed `.jab` onto a copy of the running `jac` launcher. The file carries the full runtime and boots through the same path as `jac run app.jab`, with zero live compilation. Because it embeds the runtime, the artifact is large but complete: hand it to a machine with no Jac, Python, or Node installed. The entry point resolves the same way `jac run` does (a `main.jac` or the `[project]` entry-point in `jac.toml`); an entry-less package is rejected at build time.
+- `--as native` AOT-compiles the restricted `na` subset through LLVM into a **small, dependency-free** binary (no walkers, no async, no Python imports). Reach for it when your program fits the [native pathway](../language/native-pathway.md) and you want the smallest possible artifact.
 
 **Building a wheel (publish to PyPI):**
 


### PR DESCRIPTION
Follow-up to #7339: fixes the em-dash hook violations that shipped with the README merge, and closes the .jab documentation gaps so the distribution story is discoverable outside the changelog.

## Em-dash cleanup (ban-em-dashes hook)

- README.md: all em-dashes removed; prose restructured (commas, colons, parens) and table cells/bullets converted to the repo's ` -- ` convention
- The four README SVGs: separators swapped to middle dots (hook only scans markdown, but the rule is the rule)
- Every markdown file touched by this PR verified clean

## .jab / --as binary documentation

The CLI reference was the only place the sealed-artifact work (#7258, #7274, #7306) was documented; the narrative docs never caught up:

- **reference/cli/index.md**: split the lumped `sealed / binary` projection row into two real entries and added a "Shipping an executable: `binary` vs `native`" section covering the launcher + `.jab` overlay mechanics, entry-point resolution, and when to reach for each
- **quick-guide/one-binary.md**: new "Your App Ships as One Binary Too" section (`jac build` -> `.jab`, `jac run app.jab`, `--as binary`); toolchain table now says `jac build --as native` instead of `jac nacompile`
- **quick-guide/project-kinds.md**: new "Ship it: one file or one executable" recipes, a cross-link from the native-binary recipe, and the stale roadmap note ("tracked in the jac build / .jab proposals") updated now that the unified build has shipped
- **build/cli-and-native.md**: tip in the native-binary track pointing full apps at `--as binary`
- **README.md**: build-anything matrix gains "Single-file app bundle (.jab)" and "Self-contained app executable" rows

Also verified while reviewing greptile's comments on #7339: `jac build --client desktop` is accepted at the CLI (the client target registry extends the static choices list at runtime), so no README change was needed there.
