### PR TITLE
fix(skills): update jac-cl-js-interop and jac-cl-routing for URLSearchParams usage

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7346.docs.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7346.docs.md
@@ -1,0 +1,1 @@
+- **Skills: correct the Jac's new(...) builtin**: in `jac-cl-routing` guide taught constructing `URLSearchParams` via Jac's new(...) builtin

--- a/jac/jaclang/cli/skills/jac-cl-js-interop.md
+++ b/jac/jaclang/cli/skills/jac-cl-js-interop.md
@@ -16,6 +16,7 @@ ws = new(WebSocket, url);
 parsed = new(URL, String(window.location.origin));
 now = new(Date);
 evt = new(CustomEvent, "my-event", {"detail": {"key": "value"}});
+params = new(URLSearchParams, window.location.search);
 m = new(Map);
 promise = new(Promise, lambda(resolve: any, reject: any) {
     resolve.call(None, result);
@@ -83,7 +84,7 @@ useEffect(lambda {
 
 ## Browser globals
 
-`localStorage.getItem/setItem/removeItem`, `window.addEventListener`, `document.querySelector`, `setTimeout`/`setInterval`/`clearInterval`, `requestAnimationFrame`, `JSON.parse/stringify`, `URLSearchParams`, `encodeURIComponent`, `globalThis.*` (including `[client.vite.define]` build-time constants) - all available directly, no import. See the `jac check` note above.
+`localStorage.getItem/setItem/removeItem`, `window.addEventListener`, `document.querySelector`, `setTimeout`/`setInterval`/`clearInterval`, `requestAnimationFrame`, `JSON.parse/stringify`, `encodeURIComponent`, `globalThis.*` (including `[client.vite.define]` build-time constants) - all available directly, no import. `URLSearchParams` is available too, but it's a constructor - build it with `new(URLSearchParams, ...)`, not a bare call (see above). See the `jac check` note above.
 
 ## Timing patterns (all use `Ref` value fields - see `jac-npm-packages`)
 

--- a/jac/jaclang/cli/skills/jac-cl-routing.md
+++ b/jac/jaclang/cli/skills/jac-cl-routing.md
@@ -141,11 +141,11 @@ Also note `return children;` alone fails `jac check` with `E1002: Cannot return 
 - **Links:** `<Link to="/about">About</Link>`. NOT `<a href>` for in-app paths (full reload, loses state); plain `<a>` only for external URLs.
 - **Programmatic:** `nav = useNavigate();` then from a handler: `nav("/dashboard")`, `nav("/login", {"replace": True})` (no history entry), `nav(-1)` (back), `nav(1)` (forward). Call the hook at component top, the function in handlers - never inside JSX attribute values.
 - **Redirect as render:** `return <Navigate to="/login" replace={True} />;`.
-- **Query params:** no `useSearchParams` hook - parse `useLocation().search` with the browser's `URLSearchParams`:
+- **Query params:** no `useSearchParams` hook - parse `useLocation().search` with the browser's `URLSearchParams`. `URLSearchParams` is a constructor, not a plain function - build it with the `new()` builtin (see `jac-cl-js-interop`); a bare `URLSearchParams(...)` call throws `TypeError: ... cannot be invoked without 'new'` at runtime:
 
 ```
 location = useLocation();
-searchParams = URLSearchParams(location.search);
+searchParams = new(URLSearchParams, location.search);
 query = searchParams.get("q") or "";
 page = int(searchParams.get("page") or "1");
 # update: nav(f"/search?q={query}&page={page + 1}");


### PR DESCRIPTION
## Summary

Fixes a skills  bug where the client-routing guide taught constructing `URLSearchParams` as a bare function call instead of via Jac's `new(...)` builtin, causing generated client code to throw `TypeError: ... cannot be invoked without 'new'` at runtime in the browser.

## Problem

`jac-cl-routing.md`'s "Query params" section showed:

```jac
searchParams = URLSearchParams(location.search);
```

`URLSearchParams` is a JS constructor, not a plain function. Jac has no `new` keyword — constructors must go through the `new(Cls, ...args)` ambient builtin, which lowers to `Reflect.construct(Cls, [args])`. Every other browser constructor in these skills (`WebSocket`, `URL`, `Date`, `CustomEvent`) was already documented correctly; this one line called `URLSearchParams` bare.

`jac-cl-js-interop.md`'s "Browser globals" line compounded the issue by grouping `URLSearchParams` with genuinely-callable-directly globals (`localStorage`, `window`, `document`, `JSON`), reinforcing the wrong pattern even where the bad code sample wasn't visible.

This was reported by a team member (Savini) as a JacHammer dogfood finding: JacCoder generated client code with this exact pattern, which then surfaced as a preview error (`Failed to construct 'URLSearchParams': Please use the 'new' operator, this DOM object constructor cannot be called as a function.`) that burned iterations to self-correct.

## Verification

- Compiled the buggy line via the Jac compiler: emits literal `URLSearchParams(loc)`, a bare JS call.
- Ran the generated JS in both Node and Bun (Bun is what `jac build` actually shells out to for the client bundle): both throw a `TypeError` — same defect class as the reported browser error.
- Compiled/ran the fixed line (`new(URLSearchParams, loc)` → `Reflect.construct(URLSearchParams, [loc])`): works correctly, parses the query string as expected.
- Confirmed `new(...)` is the right spelling to teach over raw `Reflect.construct(...)`: the latter only works in client code and produces a `NameError` if compiled to Python (server-side), since `Reflect` doesn't exist there.

## Changes

- **`jac-cl-routing.md`**: query-params example now uses `new(URLSearchParams, location.search)`, with a note explaining `URLSearchParams` is a constructor and what the bare-call failure looks like.
- **`jac-cl-js-interop.md`**: added `URLSearchParams` to the `new(...)` constructor examples list; removed it from the "available directly, no `new` needed" browser-globals bucket, with a cross-reference back to the constructor section.

## Test plan

- [x] `jac check` / `jac build` on a project using the updated query-params pattern succeeds
- [x] Generated client bundle constructs `URLSearchParams` via `Reflect.construct` (no bare call)
- [x] Manually verify query param parsing works in a running app (`?q=...&page=...`)
