### PR TITLE
docs(readme): reframe "What's inside the binary" around components and add an anatomy visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ One download replaces the interpreter, the JS runtime, the compilers and linker,
   </picture>
 </div>
 
-<details>
+<details open>
 <summary><strong>What's inside the binary (and what you can uninstall)</strong></summary>
 
 <br>

--- a/README.md
+++ b/README.md
@@ -108,20 +108,28 @@ One download replaces the interpreter, the JS runtime, the compilers and linker,
 
 <br>
 
-| Capability | What it replaces | How you use it |
+"Bundled" undersells it, so here is the actual anatomy. The `jac` you download is a small native **launcher stub** with the entire **runtime payload** appended to the same file. The first run unpacks the payload into a per-version cache; every run after that is instant.
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/binary-anatomy-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/binary-anatomy-light.svg">
+    <img alt="Anatomy of the jac binary: a native launcher stub plus a runtime payload carrying a private CPython, the precompiled Jac compiler and runtime, a statically linked LLVM, the Bun executable, vendored typeshed stubs, and static libc archives" src="docs/docs/assets/readme/binary-anatomy-light.svg" width="880">
+  </picture>
+</div>
+
+| Component | How it's in the binary | What you can uninstall |
 |---|---|---|
-| **CPython 3.14** | System Python, pyenv, venvs | Bundled -- runs your `.jac` files and PyPI imports |
-| **Bun** | Node.js, npm, npx | Bundled -- compiles `cl` code to JS, manages npm deps |
-| **LLVM + Zig linker** | gcc, clang, make, cmake | Bundled -- `jac build --as native` produces real binaries |
-| **Package manager** | pip, npm, pipx | `jac install` for PyPI *and* npm, in one `jac.toml` |
-| **Universal tool runner** | npx, pipx run | `jac x` runs any installed PyPI or npm CLI tool |
-| **REST server** | Flask, FastAPI, Express | `jac start` -- walkers become API endpoints |
-| **Kubernetes deployer** | Docker + kubectl + Helm | `jac start --scale` -- one-command K8s deployment |
-| **AI integration** | LangChain, prompt libraries | `by llm()` -- built into the language |
-| **MCP server** | Separate MCP packages | `jac mcp` -- AI-assisted development, built in |
-| **Type checker** | mypy, pyright, tsc | `jac check` |
-| **Formatter & test runner** | black, ruff, pytest, jest | `jac fmt`, `jac test` |
-| **Language server** | Separate LSP packages | `jac lsp` -- IDE support built in |
+| **Launcher stub** | The `jac` file itself: native machine code linked against libc only; everything below rides in the appended payload | -- |
+| **CPython 3.14** | A private [python-build-standalone](https://github.com/astral-sh/python-build-standalone) build (PGO+LTO, stripped), `dlopen`ed by the launcher at startup -- your system Python is never consulted | Python, pyenv, conda |
+| **Jac compiler + runtime** | Precompiled to JIR in the payload's private site -- includes the REST server (`jac start`), client framework, K8s deployer (`--scale`), and byLLM (`by llm()`); their optional third-party deps (litellm, pymongo, ...) resolve per-project via `jac install` | Flask, FastAPI, Express · Docker, kubectl, Helm · LangChain |
+| **Bun** | The real Bun executable, carried inside the payload and invoked by absolute path -- never on your `PATH` | Node.js, npm, npx, yarn |
+| **LLVM 22** | Statically linked into a single `jacllvm` shared library behind the llvmlite ABI | gcc, clang |
+| **Linker + C floor** | Jac's own linker emits ELF / Mach-O / PE / wasm directly; static libc + crt archives, a musl runtime (Linux), and wasm32 libc bitcode are vendored in the payload | ld, lld, make, cmake, emscripten |
+| **Package manager** | pip runs inside the private interpreter, npm resolution goes through the carried Bun -- one `jac.toml`, an automatic `.jac/venv`, and `jac x` to run any installed CLI tool | pip, pipx, uv, poetry, venv/virtualenv |
+| **Type checker** | Built into the compiler (`jac check`), with the typeshed stdlib stubs vendored at a pinned commit | mypy, pyright, tsc |
+| **Dev tooling** | Formatter, test runner, language server, and MCP server are modules of the same site (`jac fmt` / `jac test` / `jac lsp` / `jac mcp`) | black, ruff, pytest, jest |
+| **`jac ninja` editor** | A pinned Neovim fork statically linked into the launcher itself -- boots in milliseconds, with `jac lsp` pre-wired | a separate editor + LSP setup |
 
 Full story: [One Binary, Build Anything](https://docs.jaseci.org/quick-guide/one-binary/).
 

--- a/docs/docs/assets/readme/binary-anatomy-dark.svg
+++ b/docs/docs/assets/readme/binary-anatomy-dark.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Anatomy of the jac binary: a native launcher stub with a runtime payload appended to it, carrying a private CPython, the precompiled Jac compiler and runtime, a statically linked LLVM, the Bun executable, vendored typeshed stubs, and static libc archives; it replaces the whole development toolchain">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #e6edf3; }
+    .dim { fill: #8b949e; }
+    .acc { fill: #ff9100; }
+  </style>
+
+  <!-- Left panel: anatomy of the one file -->
+  <rect x="16" y="32" width="380" height="384" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="mono acc" x="32" y="66" font-size="20" font-weight="bold">jac<tspan class="dim" font-size="12" font-weight="normal"> · one file on disk</tspan></text>
+
+  <!-- Launcher stub -->
+  <rect x="32" y="84" width="348" height="40" rx="6" fill="#21262d" stroke="#30363d"/>
+  <text class="sans fg" x="44" y="101" font-size="11" font-weight="bold">launcher stub</text>
+  <text class="sans dim" x="368" y="101" font-size="11" text-anchor="end">native code · links libc only</text>
+  <text class="sans dim" x="44" y="116" font-size="10">jac ninja editor (Neovim fork) statically linked in</text>
+
+  <!-- Payload container -->
+  <rect x="32" y="136" width="348" height="260" rx="8" fill="none" stroke="#30363d" stroke-dasharray="4 3"/>
+  <text class="sans dim" x="44" y="156" font-size="10.5">runtime payload · appended, unpacked once to a cache</text>
+
+  <g font-size="11" class="sans">
+    <rect x="44" y="168" width="324" height="30" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="fg" x="56" y="187">CPython 3.14</text><text class="dim" x="356" y="187" text-anchor="end">dlopened at boot</text>
+    <rect x="44" y="204" width="324" height="30" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="fg" x="56" y="223">Jac compiler + runtime</text><text class="dim" x="356" y="223" text-anchor="end">precompiled JIR</text>
+    <rect x="44" y="240" width="324" height="30" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="fg" x="56" y="259">LLVM 22 · jacllvm shim</text><text class="dim" x="356" y="259" text-anchor="end">statically linked</text>
+    <rect x="44" y="276" width="324" height="30" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="fg" x="56" y="295">Bun</text><text class="dim" x="356" y="295" text-anchor="end">own executable · off PATH</text>
+    <rect x="44" y="312" width="324" height="30" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="fg" x="56" y="331">typeshed stdlib stubs</text><text class="dim" x="356" y="331" text-anchor="end">vendored · pinned</text>
+    <rect x="44" y="348" width="324" height="30" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="fg" x="56" y="367">libc · musl · wasm32 floors</text><text class="dim" x="356" y="367" text-anchor="end">static archives</text>
+  </g>
+
+  <!-- Center: arrow -->
+  <text class="mono acc" x="480" y="192" font-size="12" text-anchor="middle">replaces</text>
+  <line x1="412" y1="210" x2="530" y2="210" stroke="#ff9100" stroke-width="2"/>
+  <path d="M530,203 L548,210 L530,217 Z" fill="#ff9100"/>
+  <text class="mono dim" x="480" y="238" font-size="10.5" text-anchor="middle">install nothing else</text>
+
+  <!-- Right panel: what you can uninstall -->
+  <rect x="564" y="32" width="300" height="384" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans acc" x="580" y="66" font-size="13" font-weight="bold" letter-spacing="1">YOU CAN UNINSTALL</text>
+  <g font-size="13" class="sans">
+    <text class="acc" x="584" y="100">✕</text><text class="fg" x="602" y="100" text-decoration="line-through">Python · pyenv · conda</text>
+    <text class="acc" x="584" y="129">✕</text><text class="fg" x="602" y="129" text-decoration="line-through">venv · virtualenv</text>
+    <text class="acc" x="584" y="158">✕</text><text class="fg" x="602" y="158" text-decoration="line-through">pip · pipx · uv · poetry</text>
+    <text class="acc" x="584" y="187">✕</text><text class="fg" x="602" y="187" text-decoration="line-through">Node.js · npm · yarn</text>
+    <text class="acc" x="584" y="216">✕</text><text class="fg" x="602" y="216" text-decoration="line-through">gcc · clang · make · cmake</text>
+    <text class="acc" x="584" y="245">✕</text><text class="fg" x="602" y="245" text-decoration="line-through">ld · lld · emscripten</text>
+    <text class="acc" x="584" y="274">✕</text><text class="fg" x="602" y="274" text-decoration="line-through">mypy · black · pytest</text>
+    <text class="acc" x="584" y="303">✕</text><text class="fg" x="602" y="303" text-decoration="line-through">Flask · FastAPI · Express</text>
+    <text class="acc" x="584" y="332">✕</text><text class="fg" x="602" y="332" text-decoration="line-through">Docker · kubectl · Helm</text>
+  </g>
+  <text class="sans dim" x="580" y="372" font-size="10.5">(keep them for your non-Jac projects)</text>
+
+  <text class="mono dim" x="440" y="438" font-size="11" text-anchor="middle">first run unpacks the payload once into a per-version cache · every run after is instant</text>
+</svg>

--- a/docs/docs/assets/readme/binary-anatomy-light.svg
+++ b/docs/docs/assets/readme/binary-anatomy-light.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Anatomy of the jac binary: a native launcher stub with a runtime payload appended to it, carrying a private CPython, the precompiled Jac compiler and runtime, a statically linked LLVM, the Bun executable, vendored typeshed stubs, and static libc archives; it replaces the whole development toolchain">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #1f2328; }
+    .dim { fill: #57606a; }
+    .acc { fill: #bc4c00; }
+  </style>
+
+  <!-- Left panel: anatomy of the one file -->
+  <rect x="16" y="32" width="380" height="384" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="mono acc" x="32" y="66" font-size="20" font-weight="bold">jac<tspan class="dim" font-size="12" font-weight="normal"> · one file on disk</tspan></text>
+
+  <!-- Launcher stub -->
+  <rect x="32" y="84" width="348" height="40" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text class="sans fg" x="44" y="101" font-size="11" font-weight="bold">launcher stub</text>
+  <text class="sans dim" x="368" y="101" font-size="11" text-anchor="end">native code · links libc only</text>
+  <text class="sans dim" x="44" y="116" font-size="10">jac ninja editor (Neovim fork) statically linked in</text>
+
+  <!-- Payload container -->
+  <rect x="32" y="136" width="348" height="260" rx="8" fill="none" stroke="#d0d7de" stroke-dasharray="4 3"/>
+  <text class="sans dim" x="44" y="156" font-size="10.5">runtime payload · appended, unpacked once to a cache</text>
+
+  <g font-size="11" class="sans">
+    <rect x="44" y="168" width="324" height="30" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="fg" x="56" y="187">CPython 3.14</text><text class="dim" x="356" y="187" text-anchor="end">dlopened at boot</text>
+    <rect x="44" y="204" width="324" height="30" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="fg" x="56" y="223">Jac compiler + runtime</text><text class="dim" x="356" y="223" text-anchor="end">precompiled JIR</text>
+    <rect x="44" y="240" width="324" height="30" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="fg" x="56" y="259">LLVM 22 · jacllvm shim</text><text class="dim" x="356" y="259" text-anchor="end">statically linked</text>
+    <rect x="44" y="276" width="324" height="30" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="fg" x="56" y="295">Bun</text><text class="dim" x="356" y="295" text-anchor="end">own executable · off PATH</text>
+    <rect x="44" y="312" width="324" height="30" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="fg" x="56" y="331">typeshed stdlib stubs</text><text class="dim" x="356" y="331" text-anchor="end">vendored · pinned</text>
+    <rect x="44" y="348" width="324" height="30" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="fg" x="56" y="367">libc · musl · wasm32 floors</text><text class="dim" x="356" y="367" text-anchor="end">static archives</text>
+  </g>
+
+  <!-- Center: arrow -->
+  <text class="mono acc" x="480" y="192" font-size="12" text-anchor="middle">replaces</text>
+  <line x1="412" y1="210" x2="530" y2="210" stroke="#bc4c00" stroke-width="2"/>
+  <path d="M530,203 L548,210 L530,217 Z" fill="#bc4c00"/>
+  <text class="mono dim" x="480" y="238" font-size="10.5" text-anchor="middle">install nothing else</text>
+
+  <!-- Right panel: what you can uninstall -->
+  <rect x="564" y="32" width="300" height="384" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans acc" x="580" y="66" font-size="13" font-weight="bold" letter-spacing="1">YOU CAN UNINSTALL</text>
+  <g font-size="13" class="sans">
+    <text class="acc" x="584" y="100">✕</text><text class="fg" x="602" y="100" text-decoration="line-through">Python · pyenv · conda</text>
+    <text class="acc" x="584" y="129">✕</text><text class="fg" x="602" y="129" text-decoration="line-through">venv · virtualenv</text>
+    <text class="acc" x="584" y="158">✕</text><text class="fg" x="602" y="158" text-decoration="line-through">pip · pipx · uv · poetry</text>
+    <text class="acc" x="584" y="187">✕</text><text class="fg" x="602" y="187" text-decoration="line-through">Node.js · npm · yarn</text>
+    <text class="acc" x="584" y="216">✕</text><text class="fg" x="602" y="216" text-decoration="line-through">gcc · clang · make · cmake</text>
+    <text class="acc" x="584" y="245">✕</text><text class="fg" x="602" y="245" text-decoration="line-through">ld · lld · emscripten</text>
+    <text class="acc" x="584" y="274">✕</text><text class="fg" x="602" y="274" text-decoration="line-through">mypy · black · pytest</text>
+    <text class="acc" x="584" y="303">✕</text><text class="fg" x="602" y="303" text-decoration="line-through">Flask · FastAPI · Express</text>
+    <text class="acc" x="584" y="332">✕</text><text class="fg" x="602" y="332" text-decoration="line-through">Docker · kubectl · Helm</text>
+  </g>
+  <text class="sans dim" x="580" y="372" font-size="10.5">(keep them for your non-Jac projects)</text>
+
+  <text class="mono dim" x="440" y="438" font-size="11" text-anchor="middle">first run unpacks the payload once into a per-version cache · every run after is instant</text>
+</svg>


### PR DESCRIPTION
## Summary

Rework the collapsible **"What's inside the binary (and what you can uninstall)"** README section:

- **Reframed the table around the components that comprise the binary** and what each lets you uninstall, replacing the vague "Bundled" wording with the actual integration mechanism of each piece, sourced from `jac/build.zig` and `jac/launcher/payload.zig`:
  - launcher stub: native code linked against libc only, payload appended to the same file
  - CPython 3.14: private python-build-standalone build (PGO+LTO, stripped), `dlopen`ed at startup
  - Jac compiler + runtime: precompiled to JIR in the payload's private site
  - LLVM 22: statically linked into the `jacllvm` shared library (llvmlite ABI)
  - Bun: real executable carried in the payload, invoked by absolute path, never on `PATH`
  - linker + C floor: Jac's own linker, plus vendored static libc/crt, musl, and wasm32 libc archives
  - typeshed stubs vendored at a pinned commit; `jac ninja` (pinned Neovim fork) statically linked into the stub
- **Added a new anatomy visual** (`binary-anatomy-light.svg` / `binary-anatomy-dark.svg`) in the same style as the existing README SVGs: left panel shows the launcher stub + payload contents with each component's integration mechanism, right panel lists what you can uninstall.

## Preview

The visual renders in both color schemes via the same `<picture>` pattern used elsewhere in the README.