### PR TITLE
fix(installer): authenticate install.sh GitHub API calls when a token is set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,6 +1196,11 @@ jobs:
           fi
 
       - name: "install: download + run the binary"
+        env:
+          # install.sh authenticates its GitHub API calls when a token is set;
+          # shared runners (macOS especially) exhaust the unauthenticated
+          # per-IP rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/install.sh
 
       - name: "install: verify jac"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,11 @@ jobs:
           fi
 
       - name: "install: download + run the binary"
+        env:
+          # install.sh authenticates its GitHub API calls when a token is set;
+          # shared runners (macOS especially) exhaust the unauthenticated
+          # per-IP rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/install.sh
 
       - name: "install: verify jac"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,6 +59,17 @@ need_cmd() {
     fi
 }
 
+# GitHub API requests: authenticate when GITHUB_TOKEN/GH_TOKEN is set, since
+# unauthenticated calls share a per-IP rate limit that CI runners exhaust.
+api_curl() {
+    local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+    if [[ -n "$token" ]]; then
+        curl -fsSL -H "Authorization: Bearer ${token}" "$@"
+    else
+        curl -fsSL "$@"
+    fi
+}
+
 # --- Usage ---
 
 usage() {
@@ -200,7 +211,7 @@ ensure_on_path() {
 
 get_latest_version() {
     local response
-    response=$(curl -fsSL "${GITHUB_API}/releases/latest" 2>/dev/null) || {
+    response=$(api_curl "${GITHUB_API}/releases/latest" 2>/dev/null) || {
         err "Failed to query GitHub API for latest release."
         err "Check your internet connection or specify a version with --version."
         exit 1
@@ -222,7 +233,7 @@ get_latest_version() {
 resolve_jaclang_version_from_release() {
     local release_tag="$1"
     local response
-    response=$(curl -fsSL "${GITHUB_API}/releases/tags/v${release_tag}" 2>/dev/null) || {
+    response=$(api_curl "${GITHUB_API}/releases/tags/v${release_tag}" 2>/dev/null) || {
         err "Failed to query GitHub API for release v${release_tag}."
         exit 1
     }


### PR DESCRIPTION
## What

Fixes the Nightly **installer-live (macos-14, macos-aarch64)** job, which dies with
"Failed to query GitHub API for latest release" (e.g. runs 29146815372, 29138971158).

> Originally this PR also fixed the jac-check `E1001` on main from #7364's `lit_value`
> widening, but #7373 landed the identical fix first — rebased onto it, so this PR is
> now installer-only. The remaining diff touches no `jac/jaclang/` files.

## Root cause

`install.sh` queries `api.github.com` unauthenticated. GitHub's unauthenticated API rate
limit is per-IP (60 req/hr), and the shared macOS runner IP pool routinely has it
exhausted → HTTP 403 → `curl -f` fails. That's why only the macOS leg fails and only
intermittently (linux runners have more IP headroom).

## Change

- `scripts/install.sh`: new `api_curl` helper that adds `Authorization: Bearer $token`
  when `GITHUB_TOKEN`/`GH_TOKEN` is set, used for both GitHub API queries. End-user
  `curl ... | bash` behavior is unchanged (no token → anonymous, exactly as before).
- `nightly.yml` + `ci.yml`: pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the
  `bash scripts/install.sh` steps so CI's calls are authenticated (5000 req/hr per token).

## Tests

- `install.sh` version-resolution exercised anonymous and with a Bearer token: both
  resolve `v0.31.3`.
- `api_curl` fallback verified under `set -euo pipefail` with both/either/neither token
  var set; `bash -n` clean.
- The installer-test jobs (both platforms) passed on this PR's CI, exercising the full
  install → run → uninstall path with the modified script.
