### PR TITLE
fix(release): pass Docker Hub secrets through to the called binary workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -21,6 +21,13 @@ on:
         required: false
         default: release
         type: string
+    # Called workflows do not see the caller's repo secrets unless passed
+    # explicitly; without these the docker-image job skips its push steps.
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
   release:
     types: [published]
   workflow_dispatch:
@@ -410,6 +417,15 @@ jobs:
           mv ctx/arm64/jac-* ctx/arm64/jac
           chmod +x ctx/amd64/jac ctx/arm64/jac
           cp docker/jaclang.Dockerfile ctx/Dockerfile
+
+      # Forks skip publishing quietly, but on the org repo missing secrets
+      # mean a misconfiguration (e.g. a caller not passing them through) --
+      # fail loudly instead of green-skipping the publish.
+      - name: Fail if publishing secrets are missing (org repo)
+        if: github.repository == 'Jaseci-Labs/jaseci' && env.DOCKERHUB_USERNAME == ''
+        run: |
+          echo "::error::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN did not reach this job; workflow_call callers must pass them via 'secrets:'."
+          exit 1
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         if: env.DOCKERHUB_USERNAME != ''

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -372,6 +372,9 @@ jobs:
       contents: read
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # Presence flag ("true"/"false"): `secrets` is not available in step
+      # `if:` expressions, and the token value itself must not sit in env.
+      DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -422,7 +425,7 @@ jobs:
       # mean a misconfiguration (e.g. a caller not passing them through) --
       # fail loudly instead of green-skipping the publish.
       - name: Fail if publishing secrets are missing (org repo)
-        if: github.repository == 'Jaseci-Labs/jaseci' && (env.DOCKERHUB_USERNAME == '' || secrets.DOCKERHUB_TOKEN == '')
+        if: github.repository == 'Jaseci-Labs/jaseci' && (env.DOCKERHUB_USERNAME == '' || env.DOCKERHUB_TOKEN_SET != 'true')
         run: |
           echo "::error::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN did not reach this job; workflow_call callers must pass them via 'secrets:'."
           exit 1

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -422,7 +422,7 @@ jobs:
       # mean a misconfiguration (e.g. a caller not passing them through) --
       # fail loudly instead of green-skipping the publish.
       - name: Fail if publishing secrets are missing (org repo)
-        if: github.repository == 'Jaseci-Labs/jaseci' && env.DOCKERHUB_USERNAME == ''
+        if: github.repository == 'Jaseci-Labs/jaseci' && (env.DOCKERHUB_USERNAME == '' || secrets.DOCKERHUB_TOKEN == '')
         run: |
           echo "::error::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN did not reach this job; workflow_call callers must pass them via 'secrets:'."
           exit 1

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -63,3 +63,6 @@ jobs:
     with:
       tag: dev
       channel: dev
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,9 @@ jobs:
     uses: ./.github/workflows/build-binaries.yml
     with:
       tag: v${{ needs.resolve.outputs.version }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # Reveal draft as published + latest once every asset is attached. Gated on
   # build-binaries: a failed leg skips this, so a half-built draft never becomes


### PR DESCRIPTION
## What this solves

The `docker-image` job from #7356 never published: on the first dev run after the merge ([run 29160213562](https://github.com/jaseci-labs/jaseci/actions/runs/29160213562)) the job "succeeded" in 19 seconds with every Docker step skipped, and `jaseci/jaclang:dev` does not exist on Docker Hub.

Root cause: `build-binaries.yml` runs as a **called workflow** (`workflow_call`) from `release-dev.yml` and `release.yml`, and called workflows do not see the caller's repo secrets unless they are passed through. `DOCKERHUB_USERNAME` was therefore empty, and every step gated on `if: env.DOCKERHUB_USERNAME != ''` — the fork-friendly skip — silently skipped on the org repo too. Both channels are affected; the next release would have green-skipped the `<version>`/`latest` publish the same way.

## How

- `build-binaries.yml`: declare `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` as optional `workflow_call` secrets.
- `release-dev.yml` + `release.yml`: pass the two secrets explicitly at the call sites (explicit rather than `secrets: inherit`, so this workflow does not receive unrelated PyPI/Expo tokens).
- Guard step in the `docker-image` job: on the org repo, missing secrets now **fail the job loudly** instead of green-skipping the publish; forks still skip quietly.

## Notes

`release-dev.yml` triggers on changes to itself and to `build-binaries.yml`, so merging this PR kicks off a dev run that should publish the first `jaseci/jaclang:dev` image with no further action. Direct `release: published` / `workflow_dispatch` invocations were never affected (secrets are available there natively).