### PR TITLE
docs(release): Docker Hub overview for jaseci/jaclang, synced by a standalone workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -463,16 +463,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
-
-      # The Docker Hub repo overview, kept in git next to the Dockerfile and
-      # re-synced on every publish. Ordered after the push so a sync failure
-      # can never block the image itself.
-      - name: Sync the Docker Hub repo overview
-        if: env.DOCKERHUB_USERNAME != ''
-        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: jaseci/jaclang
-          short-description: "Official Jac image: the jac binary with its runtime pre-extracted and the serve stack baked in"
-          readme-filepath: docker/jaclang.README.md

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -463,3 +463,16 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+
+      # The Docker Hub repo overview, kept in git next to the Dockerfile and
+      # re-synced on every publish. Ordered after the push so a sync failure
+      # can never block the image itself.
+      - name: Sync the Docker Hub repo overview
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: jaseci/jaclang
+          short-description: "Official Jac image: the jac binary with its runtime pre-extracted and the serve stack baked in"
+          readme-filepath: docker/jaclang.README.md

--- a/.github/workflows/dockerhub-overview.yml
+++ b/.github/workflows/dockerhub-overview.yml
@@ -1,0 +1,30 @@
+# Publishes docker/jaclang.README.md as the Docker Hub repo overview for
+# jaseci/jaclang. No build, no image push - just the Hub description API.
+# Runs on manual dispatch, and automatically when the README (or this
+# workflow) changes on main - so merging an overview edit is the trigger.
+name: Sync Docker Hub overview
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - docker/jaclang.README.md
+      - .github/workflows/dockerhub-overview.yml
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      # SHA-pinned: this job sees the Docker Hub org token.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4.0.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: jaseci/jaclang
+          short-description: "Official Jac image: the jac binary with its runtime pre-extracted and the serve stack baked in"
+          readme-filepath: docker/jaclang.README.md

--- a/docker/jaclang.README.md
+++ b/docker/jaclang.README.md
@@ -1,0 +1,58 @@
+# jaseci/jaclang
+
+The official image for [Jac](https://www.jac-lang.org): the self-contained
+`jac` binary on a slim Debian base, with the runtime pre-extracted and the
+scale serving stack (FastAPI, Uvicorn, MongoDB driver, ...) pre-installed.
+Containers start instantly - none of jac's one-time setup runs at boot.
+
+Built multi-arch (`linux/amd64`, `linux/arm64`) by
+[jaseci-labs/jaseci](https://github.com/jaseci-labs/jaseci) CI from the same
+binaries attached to each GitHub release.
+
+## Tags
+
+| Tag | Meaning |
+| --- | ------- |
+| `<version>` (e.g. `0.31.3`) | that jaclang release |
+| `latest` | the newest release |
+| `dev` | rolling build of `main` (unstable, moves on every push) |
+
+## Usage
+
+Check the toolchain:
+
+```console
+docker run --rm jaseci/jaclang:latest --version
+```
+
+Run a program from the current directory:
+
+```console
+docker run --rm -v "$PWD":/app jaseci/jaclang:latest run main.jac
+```
+
+Start the server for an app:
+
+```console
+docker run --rm -p 3000:3000 -v "$PWD":/app jaseci/jaclang:latest start main.jac --port 3000
+```
+
+Use as a base image:
+
+```dockerfile
+FROM jaseci/jaclang:latest
+WORKDIR /app
+COPY . .
+RUN jac install
+CMD ["jac", "start", "main.jac"]
+```
+
+This image is also the default pod base for `jac scale` Kubernetes
+deployments: deploys pick the tag matching their release channel automatically
+when `[scale.kubernetes].python_image` is unset.
+
+## Source
+
+- Website and docs: https://www.jac-lang.org
+- Repository / issues: https://github.com/jaseci-labs/jaseci
+- Dockerfile: https://github.com/jaseci-labs/jaseci/blob/main/docker/jaclang.Dockerfile

--- a/docker/jaclang.README.md
+++ b/docker/jaclang.README.md
@@ -44,8 +44,11 @@ FROM jaseci/jaclang:latest
 WORKDIR /app
 COPY . .
 RUN jac install
-CMD ["jac", "start", "main.jac"]
+CMD ["start", "main.jac"]
 ```
+
+(`CMD` supplies arguments to the image's inherited `jac` entrypoint, so
+`start main.jac` runs as `jac start main.jac`.)
 
 This image is also the default pod base for `jac scale` Kubernetes
 deployments: deploys pick the tag matching their release channel automatically


### PR DESCRIPTION
## What this solves

The [jaseci/jaclang](https://hub.docker.com/r/jaseci/jaclang) repo on Docker Hub shows "No overview available" — no tag scheme, no usage guidance.

## How

Two files, no coupling to the build pipeline:

- `docker/jaclang.README.md` — the overview, kept in git next to the Dockerfile: tag scheme (`<version>`/`latest`/`dev`), verified usage examples, base-image example, and the `jac scale` auto-selection note.
- `.github/workflows/dockerhub-overview.yml` — a standalone workflow that pushes the README to the Hub description API (`peter-evans/dockerhub-description`, SHA-pinned). No build, no image push. Triggers: `workflow_dispatch`, plus `push` to main filtered to the README/workflow paths — so **merging this PR is itself the trigger**, and future README edits re-sync on merge.

Neither path is in `release-dev.yml`'s filter, so merging this runs no binary builds.

## Notes

Docker Hub's description API is stricter about auth than the push API; if the existing org token lacks the scope, the run fails visibly and the fix is re-minting `DOCKERHUB_TOKEN`.