### PR TITLE
perf(launcher): swap runtime payload gzip->zstd via vendored libzstd

### DIFF
--- a/jac/build.zig
+++ b/jac/build.zig
@@ -18,7 +18,11 @@
 //!
 //! Build-time host tools: just `zig` and a network connection. The old bash /
 //! curl / git / zstd / tar dependencies are gone -- payload.zig does HTTP,
-//! integrity, (de)compression and tar in std. It shells out only to the
+//! integrity, decompression and tar in std, and the runtime payload rides
+//! vendored libzstd on both ends (a pinned build.zig.zon dep, statically
+//! compiled into the payload tool's encoder and the launcher's decoder; see
+//! linkLibzstd for why std.compress.zstd is not enough). It shells out only
+//! to the
 //! freshly-fetched pbs python (pip + JIR precompile), which provides its own
 //! pip, and -- best-effort, optional -- to `strip` to shrink the unstripped
 //! pbs libpython (~245 MiB -> ~20 MiB); without `strip` the build still works,
@@ -84,6 +88,9 @@ pub fn build(b: *std.Build) void {
         .link_libc = true,
     });
     launcher_mod.addOptions("build_options", launcher_opts);
+    // The launcher decodes its payload with vendored libzstd (statically
+    // linked; still no runtime deps beyond libc) -- see linkLibzstd.
+    linkLibzstd(b, launcher_mod, .decompress);
     const stub = b.addExecutable(.{ .name = "jac", .root_module = launcher_mod });
 
     // The assembled ninja tree staged into the payload as nvim/ (runtime/ +
@@ -154,6 +161,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    // The shim shares embed.zig's materialize path, so it needs the same
+    // vendored libzstd decoder as the launcher stub.
+    linkLibzstd(b, pyembed_mod, .decompress);
     const pyembed = b.addLibrary(.{ .name = "jacpyembed", .root_module = pyembed_mod, .linkage = .dynamic });
     // Place the shim into the source tree (gitignored) so the editable dev loop --
     // which serves the desktop assets from source, not the payload -- finds it via
@@ -173,17 +183,20 @@ pub fn build(b: *std.Build) void {
     // --- unit tests (pure Zig, no libpython) -------------------------------
     addTests(b, target, optimize);
 
-    // The one pure-Zig build tool (launcher/payload.zig) that replaces the old
-    // bash scripts; it links only std (http/zstd/flate/tar/crypto) and shells
-    // out only to the fetched pbs python (pip + JIR precompile). Built for the
-    // host since it runs at build time. Created here (not inside the payload
-    // block) so the arch-independent `fetch-typeshed` step can reuse it.
+    // The one Zig build tool (launcher/payload.zig) that replaces the old
+    // bash scripts; it uses std for http/tar/crypto and all DEcompression, plus
+    // vendored libzstd (below) for the one thing std cannot do: ENcode the zstd
+    // runtime payload. It shells out only to the fetched pbs python (pip + JIR
+    // precompile). Built for the host since it runs at build time. Created here
+    // (not inside the payload block) so the arch-independent `fetch-typeshed`
+    // step can reuse it.
     const tool_mod = b.createModule(.{
         .root_source_file = b.path("launcher/payload.zig"),
         .target = b.graph.host,
         .optimize = .ReleaseSafe,
         .link_libc = true,
     });
+    linkLibzstd(b, tool_mod, .compress);
     const tool = b.addExecutable(.{ .name = "payload", .root_module = tool_mod });
     const root = b.pathFromRoot(".");
 
@@ -270,7 +283,7 @@ pub fn build(b: *std.Build) void {
     };
 
     // --- runtime payload: -Dpayload override, else fetch pbs + mkpayload ----
-    const payload: std.Build.LazyPath = if (b.option([]const u8, "payload", "Path to a prebuilt runtime payload .tar.gz")) |p|
+    const payload: std.Build.LazyPath = if (b.option([]const u8, "payload", "Path to a prebuilt runtime payload .tar.zst")) |p|
         .{ .cwd_relative = p }
     else payload: {
         const pbs_dir = b.pathFromRoot(b.fmt(".pbs-build/{s}", .{osarch}));
@@ -300,7 +313,7 @@ pub fn build(b: *std.Build) void {
         }
         mk.step.dependOn(&fetch.step);
         mk.step.dependOn(&fetch_ts.step);
-        const out = mk.addOutputFileArg("payload.tar.gz");
+        const out = mk.addOutputFileArg("payload.tar.zst");
         // Optional trailing flags (parsed after the positional pbs/root/out):
         // --shim ships the Zig-built LLVMPY_* shim instead of pip-installing the
         // llvmlite wheel; --skip-precompile drops the JIR precompile (fast
@@ -791,21 +804,90 @@ fn addTests(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.built
         .root_source_file = b.path("launcher/runtime.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
+    // The materialize test decodes the fixture through the launcher's real
+    // libzstd-backed path.
+    linkLibzstd(b, runtime_mod, .decompress);
     const runtime_tests = b.addTest(.{ .name = "runtime-tests", .root_module = runtime_mod });
     test_step.dependOn(&b.addRunArtifact(runtime_tests).step);
 
     // payload.zig's staging/floor tests (filesystem-only; no network or pbs
     // tree). Rooted at a tiny aggregator -- payload.zig has its own `pub fn main`
     // (the build CLI), which collides with the `--listen=-` test runner if used
-    // as the test root directly.
+    // as the test root directly. Links both libzstd sides so the round-trip
+    // test runs the production pipe: tool encode -> launcher decode.
     const payload_mod = b.createModule(.{
         .root_source_file = b.path("launcher/payload_test.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
+    linkLibzstd(b, payload_mod, .both);
     const payload_tests = b.addTest(.{ .name = "payload-tests", .root_module = payload_mod });
     test_step.dependOn(&b.addRunArtifact(payload_tests).step);
+}
+
+/// Compile the needed side(s) of upstream libzstd (pinned in build.zig.zon)
+/// into `mod`. Zig std ships a zstd DEcoder but no encoder -- and that pure-Zig
+/// decoder measures ~15x slower than even std flate on the runtime payload
+/// (12 MB/s vs 193 MB/s at ReleaseSmall; libzstd decodes at ~1 GB/s) -- so BOTH
+/// ends of the payload pipe bind libzstd: `.compress` into the build-time
+/// payload tool, `.decompress` into everything that runs `materialize` (the
+/// launcher stub, the pyembed shim, and their tests). The objects are linked
+/// statically; shipped binaries gain no runtime dependency beyond the libc
+/// they already carry. ZSTD_MULTITHREAD parallelizes mkpayload's level-19
+/// pass (pthreads via link_libc); ZSTD_DISABLE_ASM skips the amd64 .S huffman
+/// kernels so the decoder stays portable plain C across all pinned targets.
+const ZstdSide = enum { compress, decompress, both };
+fn linkLibzstd(b: *std.Build, mod: *std.Build.Module, side: ZstdSide) void {
+    const dep = b.lazyDependency("zstd", .{}) orelse return;
+    mod.addIncludePath(dep.path("lib"));
+    const flags: []const []const u8 = &.{ "-DZSTD_MULTITHREAD", "-DZSTD_DISABLE_ASM" };
+    mod.addCSourceFiles(.{
+        .root = dep.path("lib"),
+        .files = &.{
+            "common/debug.c",
+            "common/entropy_common.c",
+            "common/error_private.c",
+            "common/fse_decompress.c",
+            "common/pool.c",
+            "common/threading.c",
+            "common/xxhash.c",
+            "common/zstd_common.c",
+        },
+        .flags = flags,
+    });
+    if (side != .decompress) mod.addCSourceFiles(.{
+        .root = dep.path("lib"),
+        .files = &.{
+            "compress/fse_compress.c",
+            "compress/hist.c",
+            "compress/huf_compress.c",
+            "compress/zstd_compress.c",
+            "compress/zstd_compress_literals.c",
+            "compress/zstd_compress_sequences.c",
+            "compress/zstd_compress_superblock.c",
+            "compress/zstd_double_fast.c",
+            "compress/zstd_fast.c",
+            "compress/zstd_lazy.c",
+            "compress/zstd_ldm.c",
+            "compress/zstd_opt.c",
+            "compress/zstd_preSplit.c",
+            "compress/zstdmt_compress.c",
+        },
+        .flags = flags,
+    });
+    if (side != .compress) mod.addCSourceFiles(.{
+        .root = dep.path("lib"),
+        .files = &.{
+            "decompress/huf_decompress.c",
+            "decompress/zstd_ddict.c",
+            "decompress/zstd_decompress.c",
+            "decompress/zstd_decompress_block.c",
+        },
+        .flags = flags,
+    });
 }
 
 /// Non-panicking Dependency.artifact(): null while the dependency's own lazy

--- a/jac/build.zig.zon
+++ b/jac/build.zig.zon
@@ -28,6 +28,17 @@
             .hash = "N-V-__8AALDbAQFZ-jWm-8J2Jhx1u6pxw8_0FGK9shl_v4d9",
             .lazy = true,
         },
+        // Upstream libzstd, statically compiled into both ends of the runtime
+        // payload pipe (see linkLibzstd in build.zig): the encoder into the
+        // build-time payload tool (Zig std has no zstd encoder) and the decoder
+        // into the launcher stub + pyembed shim (std's pure-Zig decoder is ~15x
+        // slower than libzstd on this payload). Shipped binaries stay
+        // self-contained -- the objects are static, nothing dynamic is added.
+        .zstd = .{
+            .url = "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz",
+            .hash = "N-V-__8AAPZ7fwBg4JoCzM_0o2A8wxH2hsUUeiU1iuZv53L5",
+            .lazy = true,
+        },
     },
     .paths = .{
         "build.zig",

--- a/jac/launcher/README.md
+++ b/jac/launcher/README.md
@@ -16,15 +16,15 @@ build trivial: the launcher links only libc, with **zero Python at build time**.
 | File | Role |
 |---|---|
 | `launcher.zig` | Process entry. Materializes the payload, `dlopen`s the bundled libpython, `dlsym`s ~6 `Py_*` functions, runs the jaclang boot dance. No `@cImport`, no Python headers. |
-| `runtime.zig` | Pure-Zig payload materialization + the SOLE owner of the on-disk trailer format: `parseTrailer`, cache resolution, gzip+tar extract into `~/.cache/jac/rt/<hash16>-<pathhash>` (path-folded so co-located checkouts don't collide), stale GC, plus the `.jab`-overlay helpers (`overlayForPath`, `appendOverlay`, `graftRuntime`). Unit-tested (`zig build test`). |
-| `pack.zig` | Build-time tool: `[stub][payload.tar.gz][trailer]` -> final `jac`. |
-| `payload.zig` | Build-time payload tool (pure std): `fetch-pbs` (HTTP + verify + zstd-extract a python-build-standalone tree), `fetch-typeshed` (HTTP tarball + sha256-verify the stdlib stubs), `mkpayload` (stage CPython + jaclang site, tar+gzip). Shells out only to the fetched pbs python for pip + JIR precompile. Replaces the old bash/curl/git/zstd/tar scripts. |
-| `tests/fixture.zig` | base64 tar.gz fixture for the materialize unit test. |
+| `runtime.zig` | Pure-Zig payload materialization + the SOLE owner of the on-disk trailer format: `parseTrailer`, cache resolution, zstd+tar extract into `~/.cache/jac/rt/<hash16>-<pathhash>` (path-folded so co-located checkouts don't collide), stale GC, plus the `.jab`-overlay helpers (`overlayForPath`, `appendOverlay`, `graftRuntime`). Unit-tested (`zig build test`). |
+| `pack.zig` | Build-time tool: `[stub][payload.tar.zst][trailer]` -> final `jac`. |
+| `payload.zig` | Build-time payload tool: `fetch-pbs` (HTTP + verify + zstd-extract a python-build-standalone tree), `fetch-typeshed` (HTTP tarball + sha256-verify the stdlib stubs), `mkpayload` (stage CPython + jaclang site, tar + zstd -19 via vendored libzstd -- Zig std decodes zstd but has no encoder; the dep is pinned in build.zig.zon and compiled into this build-time tool only). Shells out only to the fetched pbs python for pip + JIR precompile. Replaces the old bash/curl/git/zstd/tar scripts. |
+| `tests/fixture.zig` | base64 tar.zst fixture for the materialize unit test. |
 
 ## Binary shape
 
 ```
-jac = [ launcher stub (links libc only) ][ runtime.tar.gz ][ trailer ]
+jac = [ launcher stub (links libc only) ][ runtime.tar.zst ][ trailer ]
 trailer = "JACBIN01" | payload_len(u64 LE) | sha256_hex(64)   (80 bytes, at EOF)
 ```
 
@@ -74,7 +74,7 @@ zig build                            # -> zig-out/bin/jac
 ./zig-out/bin/jac --version
 
 zig build -Dpayload-progress         # same, but stream the payload build live
-zig build -Dpayload=/tmp/p.tar.gz    # pack a prebuilt payload (skip fetch+assemble)
+zig build -Dpayload=/tmp/p.tar.zst   # pack a prebuilt payload (skip fetch+assemble)
 ```
 
 Build-time host deps: just `zig` + network (plus an optional, best-effort

--- a/jac/launcher/launcher.zig
+++ b/jac/launcher/launcher.zig
@@ -1,7 +1,7 @@
 //! jaclang single-binary launcher (Zig) -- dlopen embed.
 //!
 //! This executable carries the jaclang runtime + a private CPython as a
-//! gzip-compressed payload appended after the image (see `runtime.zig`). On
+//! zstd-compressed payload appended after the image (see `runtime.zig`). On
 //! first run it materializes that payload into a versioned cache dir, then
 //! **dlopens** the bundled shared libpython and drives it in-process. Nothing
 //! Python is linked at build time -- the launcher links only libc/libdl, exactly
@@ -12,7 +12,7 @@
 //! verbatim with the `na` desktop host (via the libjacpyembed shim). This file
 //! is now just the *headless CLI frontend* over that shared core: worker mode
 //! (drop-in `python`) and the jaclang CLI boot. The pure-Zig materialization
-//! half (trailer parse, cache resolution, gzip+tar extract, GC) lives in
+//! half (trailer parse, cache resolution, zstd+tar extract, GC) lives in
 //! `runtime.zig` and is unit-tested separately.
 
 const std = @import("std");

--- a/jac/launcher/pack.zig
+++ b/jac/launcher/pack.zig
@@ -1,8 +1,8 @@
-//! Build-time tool: concatenate `[ stub ][ payload.tar.gz ][ trailer ]` into
+//! Build-time tool: concatenate `[ stub ][ payload.tar.zst ][ trailer ]` into
 //! the final `jac` binary. The trailer (magic | payload_len u64 LE | sha256 hex)
 //! matches what `runtime.zig` parses at startup.
 //!
-//!   pack <stub> <payload.tar.gz> <out>
+//!   pack <stub> <payload.tar.zst> <out>
 
 const std = @import("std");
 const Io = std.Io;
@@ -19,7 +19,7 @@ pub fn main(init: std.process.Init) !void {
         if (n < args.len) args[n] = a;
     }
     if (n < 4) {
-        std.debug.print("usage: pack <stub> <payload.tar.gz> <out>\n", .{});
+        std.debug.print("usage: pack <stub> <payload.tar.zst> <out>\n", .{});
         return error.Usage;
     }
 

--- a/jac/launcher/payload.zig
+++ b/jac/launcher/payload.zig
@@ -1,11 +1,14 @@
-//! Build-time payload tool (pure Zig, std-only) -- replaces the three bash
-//! scripts (fetch-pbs.sh, fetch-typeshed.sh, mkpayload.sh) with one executable.
+//! Build-time payload tool (Zig) -- replaces the three bash scripts
+//! (fetch-pbs.sh, fetch-typeshed.sh, mkpayload.sh) with one executable.
 //!
 //! The host-tool dependencies the scripts needed (bash, curl, git, zstd, tar,
 //! find, cp) are gone: HTTP is `std.http.Client`, integrity is
 //! `std.crypto.sha2`, the pbs archive is decoded with `std.compress.zstd`, the
-//! typeshed tarball with `std.compress.flate`, the final payload is written with
-//! `std.tar.Writer` + `std.compress.flate` (gzip), and all file shuffling is
+//! typeshed tarball with `std.compress.flate`, the final payload is written
+//! with `std.tar.Writer` + vendored libzstd (`ZSTD_compress2`; Zig std has no
+//! zstd encoder -- the dep is pinned in build.zig.zon, and the launcher binds
+//! its decode side for the same reason: see runtime.zig's PayloadDecoder),
+//! and all file shuffling is
 //! `std.Io.Dir`. The remaining shellouts are to the freshly-fetched pbs
 //! `python` -- pip installs and the JIR precompile -- because those genuinely
 //! require executing CPython (see launcher/README.md "Bucket B"), plus a
@@ -24,9 +27,9 @@
 //!       (jaclang/vendor/typeshed/PIN) into jaclang/vendor/typeshed/stdlib,
 //!       verified against jaclang/vendor/typeshed/TARBALL_SHA256. Idempotent.
 //!
-//!   payload mkpayload <pbs-python-dir> <repo-root> <out.tar.gz>
+//!   payload mkpayload <pbs-python-dir> <repo-root> <out.tar.zst>
 //!       Assemble the runtime payload: jaclang site + private CPython, tarred
-//!       and gzip-compressed (the format runtime.zig decompresses).
+//!       and zstd-compressed (the format runtime.zig decompresses).
 //!
 //!   payload typeshed-sha <commit>
 //!       Print the decompressed-tar sha256 for a typeshed commit -- the value to
@@ -142,7 +145,7 @@ pub fn main(init: std.process.Init) !void {
             try fetchTypeshed(io, gpa, a, argv[2]);
         },
         .mkpayload => {
-            if (n < 5) die("usage: payload mkpayload <pbs-python-dir> <repo-root> <out.tar.gz> [--shim=PATH] [--skip-precompile] [--link-source=PATH] [--precompiled-cache=DIR] [--nvim=DIR] [--seal] [--debug-src]\n(--seal: freeze bootstrap + emit MANIFEST.json; the payload boots from JIR, sources ship for tracebacks)", .{});
+            if (n < 5) die("usage: payload mkpayload <pbs-python-dir> <repo-root> <out.tar.zst> [--shim=PATH] [--skip-precompile] [--link-source=PATH] [--precompiled-cache=DIR] [--nvim=DIR] [--seal] [--debug-src]\n(--seal: freeze bootstrap + emit MANIFEST.json; the payload boots from JIR, sources ship for tracebacks)", .{});
             // Trailing flags (after the positional pbs/root/out, see build.zig):
             var shim_so: ?[]const u8 = null;
             var pyembed_so: ?[]const u8 = null;
@@ -1131,8 +1134,8 @@ fn mkPayload(
         }
     }
 
-    log("==> packing tar | gzip", .{});
-    try tarGzDir(io, gpa, a, stage, out);
+    log("==> packing tar | zstd -{d}", .{PAYLOAD_ZSTD_LEVEL});
+    try tarZstDir(io, gpa, a, stage, out);
     log("==> payload: {s}", .{out});
 }
 
@@ -1698,19 +1701,67 @@ fn runChild(io: Io, argv: []const []const u8, env: ?*const std.process.Environ.M
     return ok;
 }
 
-/// tar `stage` (its top-level `python` + `site`) and gzip it to `out`. The
-/// runtime side (runtime.zig) decompresses this exact format.
-fn tarGzDir(io: Io, gpa: Allocator, a: Allocator, stage: []const u8, out: []const u8) !void {
-    var file = try Dir.cwd().createFile(io, out, .{ .truncate = true });
-    defer file.close(io);
-    var fbuf: [64 * 1024]u8 = undefined;
-    var fw = file.writer(io, &fbuf);
+// ----------------------------------------------------- libzstd (encode only)
+// Upstream libzstd, pinned in build.zig.zon and compiled into this build-time
+// tool by build.zig's linkLibzstdCompress. ONLY the encoder is bound here:
+// everything this tool DECODES (pbs, typeshed, zips) stays std, and the
+// shipped launcher decodes the payload with pure `std.compress.zstd`. Zig std
+// has no zstd encoder -- that gap is this dependency's entire reason to exist.
+extern fn ZSTD_createCCtx() ?*anyopaque;
+extern fn ZSTD_freeCCtx(cctx: ?*anyopaque) usize;
+extern fn ZSTD_CCtx_setParameter(cctx: ?*anyopaque, param: c_int, value: c_int) usize;
+extern fn ZSTD_compress2(cctx: ?*anyopaque, dst: [*]u8, dst_cap: usize, src: [*]const u8, src_len: usize) usize;
+extern fn ZSTD_compressBound(src_len: usize) usize;
+extern fn ZSTD_isError(code: usize) c_uint;
+extern fn ZSTD_getErrorName(code: usize) [*:0]const u8;
 
-    const cbuf = try gpa.alloc(u8, flate.max_window_len);
-    defer gpa.free(cbuf);
-    var comp = try flate.Compress.init(&fw.interface, cbuf, .gzip, .best);
+// ZSTD_cParameter values -- part of zstd's stable public API (zstd.h).
+const ZSTD_c_compressionLevel: c_int = 100;
+const ZSTD_c_windowLog: c_int = 101;
+const ZSTD_c_nbWorkers: c_int = 400;
 
-    var tw: std.tar.Writer = .{ .underlying_writer = &comp.writer };
+/// Ratio knob for the runtime payload. 19 is the top non-ultra level: on the
+/// staged tree it beats the old gzip `.best` by ~10% while decode speed --
+/// the number every pod cold start pays -- is level-independent.
+const PAYLOAD_ZSTD_LEVEL = 19;
+
+fn setCParam(cctx: ?*anyopaque, param: c_int, value: c_int) void {
+    const rc = ZSTD_CCtx_setParameter(cctx, param, value);
+    if (ZSTD_isError(rc) != 0)
+        die("zstd: set parameter {d}={d}: {s}", .{ param, value, ZSTD_getErrorName(rc) });
+}
+
+/// zstd-compress `bytes` at PAYLOAD_ZSTD_LEVEL with the window log pinned to
+/// `runtime.PAYLOAD_WINDOW_LOG` -- the launcher sizes its decode window from
+/// that same constant, so an oversized-window payload cannot be produced.
+/// No frame checksum: the launcher sha256-verifies the compressed bytes via
+/// the trailer before ever decoding. Caller frees the returned frame.
+fn zstdCompressAlloc(gpa: Allocator, bytes: []const u8) ![]u8 {
+    const cctx = ZSTD_createCCtx() orelse die("zstd: ZSTD_createCCtx failed", .{});
+    defer _ = ZSTD_freeCCtx(cctx);
+    setCParam(cctx, ZSTD_c_compressionLevel, PAYLOAD_ZSTD_LEVEL);
+    setCParam(cctx, ZSTD_c_windowLog, runtime.PAYLOAD_WINDOW_LOG);
+    // Parallel compression (build.zig compiles with ZSTD_MULTITHREAD); the
+    // emitted frame is worker-count-independent, so builds stay reproducible.
+    // Best-effort: a failure here only costs build-time speed.
+    _ = ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, @intCast(@min(std.Thread.getCpuCount() catch 1, 32)));
+
+    const dst = try gpa.alloc(u8, ZSTD_compressBound(bytes.len));
+    errdefer gpa.free(dst);
+    const n = ZSTD_compress2(cctx, dst.ptr, dst.len, bytes.ptr, bytes.len);
+    if (ZSTD_isError(n) != 0) die("zstd: compress failed: {s}", .{ZSTD_getErrorName(n)});
+    return gpa.realloc(dst, n) catch dst[0..n];
+}
+
+/// tar `stage` (its top-level `python` + `site`) and zstd it to `out`. The
+/// runtime side (runtime.zig extractPayload) decompresses this exact format
+/// with pure std. The full tar is built in memory (~430 MB plus the compress
+/// bound) -- a build-machine-only cost that buys one-shot multithreaded
+/// ZSTD_compress2 instead of a hand-rolled streaming Io.Writer adapter.
+fn tarZstDir(io: Io, gpa: Allocator, a: Allocator, stage: []const u8, out: []const u8) !void {
+    var aw: Io.Writer.Allocating = .init(gpa);
+    defer aw.deinit();
+    var tw: std.tar.Writer = .{ .underlying_writer = &aw.writer };
 
     var stage_dir = try Dir.cwd().openDir(io, stage, .{ .iterate = true });
     defer stage_dir.close(io);
@@ -1727,8 +1778,9 @@ fn tarGzDir(io: Io, gpa: Allocator, a: Allocator, stage: []const u8, out: []cons
         }
     }
 
-    try comp.finish();
-    try fw.interface.flush();
+    const frame = try zstdCompressAlloc(gpa, aw.written());
+    defer gpa.free(frame);
+    try Dir.cwd().writeFile(io, .{ .sub_path = out, .data = frame });
 }
 
 // ----------------------------------------------------------------- tests
@@ -1779,4 +1831,58 @@ test "stageFloor stages the floor allow-list + CA bundle, skips non-floor archiv
     try testing.expect(fileExists(io, exp(a, stage, "cacert.pem")));
     // The non-floor archive present in build/lib must NOT be staged.
     try testing.expect(!fileExists(io, exp(a, stage, try std.fmt.allocPrint(a, "{s}/libX11.a", .{osarch}))));
+}
+
+// The production payload pipe end-to-end: libzstd ENCODE (this tool, exactly
+// as mkpayload runs it) -> the launcher's own `runtime.PayloadDecoder` +
+// std.tar DECODE. Guards the two-sided encode/decode contract (level +
+// `PAYLOAD_WINDOW_LOG` on this side, the windowLogMax cap on the launcher
+// side). The big incompressible member forces multiple zstd blocks (raw-block
+// path); the text member exercises the compressed-block path.
+test "tarZstDir round-trips through the launcher's payload decoder" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(gpa);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var base_buf: [MAX_PATH]u8 = undefined;
+    const base = base_buf[0..try tmp.dir.realPath(io, &base_buf)];
+
+    const stage = try std.fmt.allocPrint(a, "{s}/stage", .{base});
+    try Dir.cwd().createDirPath(io, try std.fmt.allocPrint(a, "{s}/python/bin", .{stage}));
+    const text = "#!/bin/sh\nexec fake python\n" ** 64;
+    try Dir.cwd().writeFile(io, .{
+        .sub_path = try std.fmt.allocPrint(a, "{s}/python/bin/python", .{stage}),
+        .data = text,
+    });
+    const big = try a.alloc(u8, 3 * zstd.block_size_max + 12345);
+    var prng = std.Random.DefaultPrng.init(42);
+    prng.random().bytes(big);
+    try Dir.cwd().writeFile(io, .{
+        .sub_path = try std.fmt.allocPrint(a, "{s}/python/big.bin", .{stage}),
+        .data = big,
+    });
+
+    const out = try std.fmt.allocPrint(a, "{s}/payload.tar.zst", .{base});
+    try tarZstDir(io, gpa, a, stage, out);
+
+    const frame = try Dir.cwd().readFileAlloc(io, out, gpa, .unlimited);
+    defer gpa.free(frame);
+    const dctx = runtime.ZSTD_createDCtx() orelse return error.OutOfMemory;
+    defer _ = runtime.ZSTD_freeDCtx(dctx);
+    const dbuf = try gpa.alloc(u8, 1 << 20);
+    defer gpa.free(dbuf);
+    var dec = runtime.PayloadDecoder.init(dctx, frame, dbuf);
+
+    const dest = try std.fmt.allocPrint(a, "{s}/dest", .{base});
+    try Dir.cwd().createDirPath(io, dest);
+    var dest_dir = try Dir.cwd().openDir(io, dest, .{});
+    defer dest_dir.close(io);
+    try std.tar.extract(io, dest_dir, &dec.reader, .{ .mode_mode = .ignore, .strip_components = 0 });
+
+    try testing.expectEqualStrings(text, try dest_dir.readFileAlloc(io, "python/bin/python", a, .unlimited));
+    try testing.expectEqualSlices(u8, big, try dest_dir.readFileAlloc(io, "python/big.bin", a, .unlimited));
 }

--- a/jac/launcher/runtime.zig
+++ b/jac/launcher/runtime.zig
@@ -1,30 +1,35 @@
 //! Runtime materialization for the jaclang single binary (Zig launcher).
 //!
-//! Pure-Zig half of the launcher: everything between "the process started" and
-//! "CPython is about to be initialized". It is deliberately free of any
-//! `@cImport`/libpython dependency so it can be unit-tested with plain
-//! `zig test` (see the tests at the bottom of this file). The CPython embed
-//! lives in `launcher.zig`, which calls `materialize` and then boots.
+//! The non-Python half of the launcher: everything between "the process
+//! started" and "CPython is about to be initialized". It is deliberately free
+//! of any `@cImport`/libpython dependency so it can be unit-tested via `zig
+//! build test` (see the tests at the bottom of this file); its one non-std
+//! ingredient is the vendored libzstd DEcoder (plain `extern fn`s, statically
+//! linked in by build.zig's linkLibzstd). The CPython embed lives in
+//! `launcher.zig`, which calls `materialize` and then boots.
 //!
 //! Binary shape (written by launcher/pack.zig):
 //!
-//!     [ exe stub ][ runtime.tar.gz payload ][ trailer ]
+//!     [ exe stub ][ runtime.tar.zst payload ][ trailer ]
 //!
 //!     trailer = magic("JACBIN01", 8) | payload_len(u64 LE, 8) | sha256_hex(64)
 //!               = 80 bytes, fixed, at EOF.
 //!
-//! On first run the payload is gzip-decompressed and untarred into
+//! On first run the payload is zstd-decompressed and untarred into
 //! `<cache>/rt/<hash16>-<pathhash>/` (atomic temp-dir + rename). `<hash16>` is
 //! the first 16 hex chars of the trailer digest (the payload version);
 //! `<pathhash>` folds in the binary's own path so co-located checkouts with
 //! identical payloads get distinct trees (see `rtKey`, issue #7012). A `.ok`
 //! marker guards against partial extracts; subsequent runs short-circuit on it.
 //!
-//! The payload is gzip (deflate), not zstd, so BOTH ends of the pipe are pure
-//! std: launcher/payload.zig compresses with `std.compress.flate.Compress` at
-//! build time and this module decompresses with `std.compress.flate.Decompress`
-//! -- no libzstd and no `zstd` host tool anywhere. Versus the C launcher this
-//! also drops the hand-rolled ustar reader (-> std.tar) and the
+//! The payload is zstd, and BOTH ends of the pipe bind vendored libzstd
+//! (pinned in build.zig.zon, compiled in statically -- no runtime dependency
+//! beyond the libc the launcher already links): launcher/payload.zig encodes
+//! at build time because Zig std has no zstd encoder, and this module decodes
+//! through `PayloadDecoder` below because std's pure-Zig zstd decoder measured
+//! ~15x SLOWER than even std flate on this payload (12 MB/s vs 193 MB/s at
+//! ReleaseSmall, w=2^24; libzstd decodes it at ~1 GB/s). Versus the C launcher
+//! this module also drops the hand-rolled ustar reader (-> std.tar) and the
 //! `system("rm -rf")` / `system("find")` shellouts (-> std.Io.Dir.deleteTree +
 //! dir iteration).
 
@@ -32,7 +37,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const Io = std.Io;
 const Allocator = std.mem.Allocator;
-const flate = std.compress.flate;
 
 /// Trailer layout: magic(8) + payload_len u64-LE(8) + sha256 hex(64) = 80 bytes.
 /// This is the ONE authoritative definition of the on-disk trailer wire format
@@ -51,10 +55,104 @@ pub const MAGIC_LEN = 8;
 pub const HASH_LEN = 64; // sha256 hex
 pub const TRAILER_LEN = MAGIC_LEN + 8 + HASH_LEN; // 80
 
-/// deflate sliding-window buffer. Unlike zstd's tunable window, deflate's window
-/// is fixed at 32 KiB (`flate.max_window_len`), so this is constant regardless of
-/// the compression level payload.zig packs with.
-const GZIP_BUF_LEN = flate.max_window_len;
+/// zstd window log the payload is ENCODED with -- the one number both ends of
+/// the pipe must agree on. payload.zig pins its `ZSTD_c_windowLog` to this,
+/// and `extractPayload` caps the decoder at it (`ZSTD_d_windowLogMax`), so a
+/// payload this launcher carries can never be rejected as window-oversized.
+/// 2^24 = 16 MiB: within ~0.5% of level 19's default ratio on the runtime
+/// tree, while keeping the decoder's cold-path window allocation (and nothing
+/// else -- the warm path allocates zero) small.
+pub const PAYLOAD_WINDOW_LOG = 24;
+
+/// Staging buffer between the libzstd decoder and std.tar. Plain output space
+/// -- libzstd keeps the sliding window internally -- so the size only tunes
+/// copy granularity; it just needs to comfortably exceed tar's 512-byte
+/// header reads.
+const DECODE_BUF_LEN = 1 << 20;
+
+// ------------------------------------------------------ libzstd (decode only)
+// Vendored libzstd, statically compiled in by build.zig's linkLibzstd (same
+// pinned dep the build-time encoder uses). Plain extern fns -- no @cImport, no
+// headers -- so this module still tests via `zig build test` and adds nothing
+// dynamic to the shipped launcher. See the module doc for why libzstd and not
+// `std.compress.zstd` (~15x decode gap on this payload).
+const ZSTD_inBuffer = extern struct { src: ?*const anyopaque, size: usize, pos: usize };
+const ZSTD_outBuffer = extern struct { dst: ?*anyopaque, size: usize, pos: usize };
+pub extern fn ZSTD_createDCtx() ?*anyopaque;
+pub extern fn ZSTD_freeDCtx(dctx: ?*anyopaque) usize;
+extern fn ZSTD_DCtx_setParameter(dctx: ?*anyopaque, param: c_int, value: c_int) usize;
+extern fn ZSTD_decompressStream(dctx: ?*anyopaque, out: *ZSTD_outBuffer, in: *ZSTD_inBuffer) usize;
+extern fn ZSTD_isError(code: usize) c_uint;
+
+/// ZSTD_dParameter value -- part of zstd's stable public API (zstd.h).
+const ZSTD_d_windowLogMax: c_int = 100;
+
+/// Streaming zstd decoder over the in-memory compressed payload, exposed as a
+/// std `Io.Reader` so `std.tar.extract` can consume it -- the uncompressed
+/// tar (~430 MB) is never held in memory. libzstd owns the sliding window
+/// internally, so unlike `std.compress.zstd` the reader buffer here is plain
+/// staging space with no window-retention contract: `stream` fills the
+/// buffer and returns 0, the vtable-documented indirect pattern.
+pub const PayloadDecoder = struct {
+    dctx: *anyopaque,
+    src: []const u8,
+    src_pos: usize = 0,
+    /// True between frames (and before the first byte): after a frame fully
+    /// flushes, libzstd resets to await another frame, and a further call with
+    /// no input left must read as clean end-of-stream -- only running dry
+    /// MID-frame is truncation.
+    frame_done: bool = true,
+    reader: Io.Reader,
+
+    pub fn init(dctx: *anyopaque, src: []const u8, buffer: []u8) PayloadDecoder {
+        // Refuse frames windowed beyond the encode-side pin (defense in depth
+        // against a tampered payload demanding a huge window). Best-effort.
+        _ = ZSTD_DCtx_setParameter(dctx, ZSTD_d_windowLogMax, PAYLOAD_WINDOW_LOG);
+        return .{
+            .dctx = dctx,
+            .src = src,
+            .reader = .{
+                .vtable = &.{ .stream = stream },
+                .buffer = buffer,
+                .seek = 0,
+                .end = 0,
+            },
+        };
+    }
+
+    fn stream(r: *Io.Reader, w: *Io.Writer, limit: Io.Limit) Io.Reader.StreamError!usize {
+        _ = w;
+        _ = limit;
+        const d: *PayloadDecoder = @alignCast(@fieldParentPtr("reader", r));
+        // Reclaim consumed prefix; no history needs to survive in the buffer.
+        if (r.seek == r.end) {
+            r.seek = 0;
+            r.end = 0;
+        } else if (r.end == r.buffer.len) {
+            const keep = r.buffer[r.seek..r.end];
+            @memmove(r.buffer[0..keep.len], keep);
+            r.end = keep.len;
+            r.seek = 0;
+        }
+        // Buffer full of unconsumed data: cannot happen with tar-sized reads.
+        if (r.end == r.buffer.len) return error.ReadFailed;
+        // Clean EOF: everything consumed and the last frame fully flushed.
+        if (d.src_pos == d.src.len and d.frame_done) return error.EndOfStream;
+        var out = ZSTD_outBuffer{ .dst = r.buffer[r.end..].ptr, .size = r.buffer.len - r.end, .pos = 0 };
+        var in = ZSTD_inBuffer{ .src = d.src.ptr, .size = d.src.len, .pos = d.src_pos };
+        const rc = ZSTD_decompressStream(d.dctx, &out, &in);
+        d.src_pos = in.pos;
+        // Corrupt frame -- post-sha256, so an encoder/decoder mismatch, not
+        // bit rot.
+        if (ZSTD_isError(rc) != 0) return error.ReadFailed;
+        d.frame_done = rc == 0;
+        // No output and input exhausted mid-frame: truncated stream.
+        if (out.pos == 0 and !d.frame_done and d.src_pos == d.src.len)
+            return error.ReadFailed;
+        r.end += out.pos;
+        return 0;
+    }
+};
 
 const MAX_PATH = Io.Dir.max_path_bytes;
 
@@ -403,12 +501,13 @@ fn extractPayload(
         var dest = try Io.Dir.cwd().openDir(io, tmp, .{});
         defer dest.close(io);
 
-        const window = try gpa.alloc(u8, GZIP_BUF_LEN);
-        defer gpa.free(window);
+        const dctx = ZSTD_createDCtx() orelse return Error.MaterializeFailed;
+        defer _ = ZSTD_freeDCtx(dctx);
+        const buf = try gpa.alloc(u8, DECODE_BUF_LEN);
+        defer gpa.free(buf);
 
-        var src = Io.Reader.fixed(zbuf);
-        var dz = flate.Decompress.init(&src, .gzip, window);
-        try std.tar.extract(io, dest, &dz.reader, .{
+        var dec = PayloadDecoder.init(dctx, zbuf, buf);
+        try std.tar.extract(io, dest, &dec.reader, .{
             .mode_mode = .ignore,
             .strip_components = 0,
         });
@@ -511,8 +610,8 @@ test "cacheRoot prefers XDG_CACHE_HOME and falls back when unwritable" {
     try testing.expect(std.mem.indexOf(u8, fb, "jac-cache-4242") != null);
 }
 
-// End-to-end exercise of the gzip+tar plumbing: assemble a real
-// [stub][payload.tar.gz][trailer] binary from the committed fixture, run
+// End-to-end exercise of the zstd+tar plumbing: assemble a real
+// [stub][payload.tar.zst][trailer] binary from the committed fixture, run
 // materialize, and assert the tree extracted with correct contents -- then
 // re-run to prove the `.ok` warm-path short-circuits.
 // Test helper: assemble a fake jac binary (4-byte stub + payload + trailer).

--- a/jac/launcher/tests/fixture.zig
+++ b/jac/launcher/tests/fixture.zig
@@ -1,17 +1,23 @@
 //! Test fixture: a tiny `python/`+`site/` runtime tree, tarred and
-//! gzip-compressed, base64-encoded as source (the repo disallows committed
+//! zstd-compressed, base64-encoded as source (the repo disallows committed
 //! binary files). Decoded by runtime.zig's end-to-end materialize test.
+//!
+//! Regenerate: untar/re-tar the tree, then `zstd -19 --no-check` +
+//! `base64 -w0` (any conformant frame whose window fits
+//! runtime.PAYLOAD_WINDOW_LOG works; --no-check matches the packer, which
+//! skips the frame checksum because the trailer sha256 already covers the
+//! compressed bytes).
 
 const std = @import("std");
 
-pub const payload_tar_gz_b64 =
-    "H4sIAAAAAAACA+3VSw6CMBSF4Y5dhRvAPuhjPSA3kaBA4JrI7iUyIxrjoA2R803aWQd/0tNPfOlaKWJSs+Dc65ytzzf3YLwXRycSuI9cDPOTYp/6pf+1LuV2+mulcov+ifvfiqGh4cQPjtDfW/u5vzGr/kY5JY4K/RP0Lyemc1dRtvQ/CNiRsWaSkd/4ff990Br/f7L+LY1MldxMf610yNE/df+KqI8w/9/3X6/3X3trsP8pLOmzrsHuAwAAAAAAAAAAAAAA/IUnlAy0nAAoAAA=";
+pub const payload_tar_zst_b64 =
+    "KLUv/WAAJzUFAKIGFhiQOweoKIPvf1WsOfp/7tLIl6JJ/f57TgHKE1YxVYfZEU2T447cqDb2J+4kHhDYvYM7MjJ4rtxdpVhDPUBWYMEoIlOTkSzPPCw6Pl/BGduWX6vlU/OQjpwdIEAzKCM5BTjYesC+/1bjHwNjKhk5NlMQQIU4MAZ1IExGC8ZCJYwBRBl1FY4dMdXsMHuACbmp+nApDcjAvNQBR8pXCQ8waIDlJOI=";
 
 /// Decode the fixture payload into freshly allocated bytes (caller frees).
 pub fn payloadAlloc(a: std.mem.Allocator) ![]u8 {
     const dec = std.base64.standard.Decoder;
-    const n = try dec.calcSizeForSlice(payload_tar_gz_b64);
+    const n = try dec.calcSizeForSlice(payload_tar_zst_b64);
     const out = try a.alloc(u8, n);
-    try dec.decode(out, payload_tar_gz_b64);
+    try dec.decode(out, payload_tar_zst_b64);
     return out;
 }


### PR DESCRIPTION
## What

Swaps the single-binary runtime payload from gzip to zstd, with upstream **zstd 1.5.7 pinned in `build.zig.zon`** and statically compiled into both ends of the pipe by a new `linkLibzstd()` build helper:

- **Encode** (build-time payload tool): `tarZstDir` tars the staged tree in memory and one-shot `ZSTD_compress2` at level 19, multithreaded, with `windowLog` pinned to the shared `runtime.PAYLOAD_WINDOW_LOG = 24`. Zig std has no zstd encoder — the sole reason the dep exists on this side.
- **Decode** (launcher stub + pyembed shim): a new `runtime.PayloadDecoder`, a minimal `Io.Reader` over `ZSTD_decompressStream` feeding `std.tar.extract`. Still fully streaming — the uncompressed tar is never held in memory. Shipped binaries gain no dynamic dependency; the objects are static and the launcher still links only libc.

## Why libzstd on the decode side too

Measured on the real dev payload (127 MB tar, ReleaseSmall = the launcher's shipped optimize mode):

| decoder | throughput | 127 MB payload |
|---|---|---|
| std flate (old gzip path) | 193 MB/s | 0.66 s |
| std zstd, wlog 24 | 12.3 MB/s | 10.4 s |
| std zstd, best tuning (wlog 17) | 74 MB/s | 1.7 s |
| libzstd | ~1 GB/s | 0.12 s |

`std.compress.zstd` turns out to be pathologically slow at large windows (its buffer rebase memmoves the 16 MiB window repeatedly) and never beats the flate decoder it would replace — a "pure std" format swap would have made cold starts *slower*. libzstd removes decompression from the cold-start equation entirely.

## Results

- **Cold-start extraction 8.5 s → 1.78 s** end-to-end on the dev payload (130 MB / 4,954 files; sha256 + decode + all file writes — decode itself is now ~0.1 s). Warm path unchanged (zero allocations, `.ok` short-circuit).
- **Payload ~25% smaller**: identical content compresses to 28.8 MB (zstd -19) vs 38.2 MB (gzip -9).
- Extraction is now file-write bound, so k8s-side fixes (per-node payload cache) get their full effect.

## Notes

- The new round-trip test runs the exact production pipe (tool encode → launcher decode) and caught the one subtle libzstd contract: after a frame fully flushes, the DCtx resets to await *another* frame, so exhausted input must read as clean EOF (`frame_done`), not truncation. The materialize fixture is regenerated as a zstd frame (`zstd -19 --no-check | base64 -w0`).
- The decoder caps `ZSTD_d_windowLogMax` at the encode-side pin, keeping the two-sided window contract enforced.
- No cache/compat migration: the rt cache is content-keyed and launcher + payload ship in the same binary; old trees are GC'd by the existing `gcStale` path.
- Trailer format, `.jab` overlays, and pack.zig are untouched (the trailer is format-agnostic).
