### PR TITLE
fix(ownership): clear jac-check type errors in ownership pass impls

### DIFF
--- a/jac/jaclang/compiler/passes/main/impl/ownership_check_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/ownership_check_pass.impl.jac
@@ -158,13 +158,13 @@ impl OwnershipCheckPass._stamp_ownership -> None {
 
     for nd in self.idx_assignments {
         own_target = self._is_own_decl(nd);
-        if own_target is not None {
+        if own_target is not None and own_target.sym is not None {
             sid = self._name_sym_id(own_target);
             own_target.sym.ownership = OwnershipKind.OWN;
             self.owned_decl[sid] = own_target;
         }
         borrow_target = self._is_borrow_decl(nd);
-        if borrow_target is not None {
+        if borrow_target is not None and borrow_target.sym is not None {
             sid = self._name_sym_id(borrow_target);
             is_mut = nd.type_tag.ownership == OwnershipKind.MUT_BORROW
                 if nd.type_tag
@@ -217,15 +217,17 @@ impl OwnershipCheckPass._stamp_ownership -> None {
     }
 
     for nd in self.idx_assignments {
-        target = self._borrow_target(nd);
+        borrow_target = self._borrow_target(nd);
         owner = self._borrow_source_owner(nd);
-        if target is not None and owner is not None {
-            borrow_id = self._name_sym_id(target);
+        if borrow_target is not None
+        and borrow_target.sym is not None
+        and owner is not None {
+            borrow_id = self._name_sym_id(borrow_target);
             owner_id = self._name_sym_id(owner);
             self.borrow_meta[borrow_id] = BorrowMeta(
-                name=target.sym_name,
+                name=borrow_target.sym_name,
                 owner=owner_id,
-                is_mut=is_mut_kind(target.sym.ownership)
+                is_mut=is_mut_kind(borrow_target.sym.ownership)
                 or (
                     is_mut_kind(nd.value.ownership)
                         if isinstance(nd.value, uni.UnaryExpr)

--- a/jac/jaclang/compiler/passes/main/impl/ownership_check_pass.sendability.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/ownership_check_pass.sendability.impl.jac
@@ -30,7 +30,7 @@ impl OwnershipCheckPass._emit_sendability_diagnostics -> None {
                 continue;
             }
             sid = self._sym_id(nm);
-            if sid is None or sid not in tracked {
+            if sid is None or sid not in tracked or nm.sym is None {
                 continue;
             }
             ownership = nm.sym.ownership;


### PR DESCRIPTION
## Summary

`jac-check` has been failing on `main` since #7149 landed (first red run: [29199755490](https://github.com/jaseci-labs/jac/actions/runs/29199755490), still red on [29209183897](https://github.com/jaseci-labs/jac/actions/runs/29209183897)) — 9 type errors in the ownership pass jac sources:

- **`ownership_check_pass.impl.jac:163,172`** — `_stamp_ownership` reads/writes `.sym.ownership` where `.sym` is `Symbol | None`; the non-None guarantee lives inside `_is_own_decl`/`_is_borrow_decl`, which the checker can't see across the call boundary (E1099).
- **`ownership_check_pass.impl.jac:220-234`** — the final loop rebound `target`, already typed `Expr` from an earlier binding in the same function, to `Name | None`, cascading into six errors on `_name_sym_id(target)`, `.sym_name`, and `.sym` (E1001/E1030/E1053).
- **`ownership_check_pass.sendability.impl.jac:36`** — same `Symbol | None` access in `_emit_sendability_diagnostics` (E1099).

## Fix

Add explicit `.sym is not None` narrowing guards (unreachable at runtime — the helpers already guarantee non-None) and rename the rebound variable to `borrow_target`. No behavior change.

## Verification

- `jac check jac/jaclang/compiler/passes/main/ownership_check_pass.jac --ignore <CI args> --nowarn` — was 9 errors across the 3 reported files, now passes clean
- `jac fmt --check --lintfix` on both files — passes
- `jac test` on all four ownership suites (`test_ownership_check_pass`, `test_ownership_sendability`, `test_ownership_region`, `test_ownership_markers`) — 52 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)