### PR TITLE
perf(scale): stage the pod binary at a stable path - seal drops ~23s per deploy

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7413.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7413.feature.md
@@ -1,0 +1,1 @@
+- **Scale deploy: the app seal got ~23s faster on every deploy**: the pod binary that hosts the precompiler is now staged at a stable, content-checked path on the driver, so its one-time runtime setup runs once per binary version instead of on every deploy (the launcher keys its extracted runtime by executable path, and the old per-deploy temp path defeated that cache).

--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -8,7 +8,7 @@ import tarfile;
 import from pathlib { Path }
 import from urllib.request { urlopen }
 import from urllib.error { HTTPError }
-import from jaclang.scale.injector.bundle { TOOLCHAIN_SUBDIR }
+import from jaclang.scale.injector.bundle { TOOLCHAIN_SUBDIR, scale_cache_root }
 import from jaclang.runtimelib.utils { release_arch, host_arch }
 
 glob logger = logging.getLogger(__name__);
@@ -247,26 +247,13 @@ def resolve_pod_base_image(project_dir: str, configured: str) -> str {
 }
 
 
-def _scale_cache_root -> Path {
-    # Cache on the DEPLOY-DRIVER machine (laptop / CI runner / operator pod),
-    # not the cluster: the driver needs the binary before the PVC exists, and
-    # this one copy serves every app/cluster it deploys. The PVC hop is
-    # deduplicated separately by the content-addressed seeder (#7198).
-    base = os.environ.get("JAC_SCALE_CACHE_DIR", "");
-    if base {
-        return Path(base);
-    }
-    return Path(os.environ.get("XDG_CACHE_HOME", "") or (Path.home() / ".cache")) / "jac" / "scale-binaries";
-}
-
-
 def _binary_cache_path(channel: str, arch: str) -> Path {
-    return _scale_cache_root() / f"jac-{channel}-linux-{arch}";
+    return scale_cache_root() / f"jac-{channel}-linux-{arch}";
 }
 
 
 def _admin_dist_cache_path(channel: str) -> Path {
-    return _scale_cache_root() / f"jac-{channel}-admin-dist.tar.gz";
+    return scale_cache_root() / f"jac-{channel}-admin-dist.tar.gz";
 }
 
 

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -196,6 +196,42 @@ def open_det_tar(buf: io.BytesIO) -> tuple[tarfile.TarFile, any] {
 }
 
 
+def scale_cache_root -> Path {
+    # Driver-machine cache; shared with the binary/console download caches.
+    base = os.environ.get("JAC_SCALE_CACHE_DIR", "");
+    if base {
+        return Path(base);
+    }
+    return Path(os.environ.get("XDG_CACHE_HOME", "") or (Path.home() / ".cache")) / "jac" / "scale-binaries";
+}
+
+
+def _staged_pod_jac(pod_binary: bytes) -> Path {
+    # The launcher keys its extracted runtime by (payload, executable path), so
+    # a fresh temp path every deploy re-runs the ~20s one-time setup just to
+    # host the precompiler. A stable path makes that a once-per-binary cost;
+    # the launcher's own per-path GC handles version bumps.
+    jac_path = scale_cache_root() / "pod-jac";
+    if jac_path.is_file() {
+        try {
+            if hashlib.sha256(jac_path.read_bytes()).hexdigest() == hashlib.sha256(
+                pod_binary
+            ).hexdigest() {
+                return jac_path;
+            }
+        } except OSError {
+            ;
+        }
+    }
+    jac_path.parent.mkdir(parents=True, exist_ok=True);
+    tmp = jac_path.with_suffix(f".{os.getpid()}.tmp");
+    tmp.write_bytes(pod_binary);
+    tmp.chmod(0o755);
+    tmp.rename(jac_path);
+    return jac_path;
+}
+
+
 def _precompile_app(base: Path, pod_binary: bytes) -> Path {
     # Seal the app's modules with the pod binary into _precompiled/MANIFEST.json
     # so the deploy artifact is a valid .jab. The seal is mandatory: an
@@ -217,9 +253,7 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
         if not marker.exists() {
             marker.write_text("");
         }
-        jac_path = stage_root / ".pod-jac";
-        jac_path.write_bytes(pod_binary);
-        jac_path.chmod(0o755);
+        jac_path = _staged_pod_jac(pod_binary);
         script = Path(str(__file__)).parent.parent.parent / "utils" / "precompile_bytecode.jac";
         # --seal emits the MANIFEST.json that makes the tree a sealed image.
         result = subprocess.run(
@@ -228,7 +262,6 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
             text=True,
             timeout=600
         );
-        jac_path.unlink();
         if (
             result.returncode != 0
             or not (stage / "_precompiled" / "MANIFEST.json").is_file()

--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -224,10 +224,23 @@ def _staged_pod_jac(pod_binary: bytes) -> Path {
         }
     }
     jac_path.parent.mkdir(parents=True, exist_ok=True);
-    tmp = jac_path.with_suffix(f".{os.getpid()}.tmp");
-    tmp.write_bytes(pod_binary);
-    tmp.chmod(0o755);
-    tmp.rename(jac_path);
+    # mkstemp guarantees a unique temp even for concurrent stagings in one
+    # process; os.replace publishes atomically (last writer wins).
+    (fd, tmp_name) = tempfile.mkstemp(prefix="pod-jac.", dir=str(jac_path.parent));
+    try {
+        with os.fdopen(fd, "wb") as handle {
+            handle.write(pod_binary);
+        }
+        os.chmod(tmp_name, 0o755);
+        os.replace(tmp_name, str(jac_path));
+    } except BaseException {
+        try {
+            os.unlink(tmp_name);
+        } except OSError {
+            ;
+        }
+        raise;
+    }
     return jac_path;
 }
 

--- a/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
+++ b/jac/jaclang/scale/tests/microservices/test_seed_determinism.jac
@@ -30,3 +30,28 @@ test "identical content packs to identical bytes (content-address stable)" {
         shutil.rmtree(d, ignore_errors=True);
     }
 }
+
+
+test "staged pod binary reuses its stable path across packs" {
+    import from jaclang.scale.injector.bundle { _staged_pod_jac }
+    cache = tempfile.mkdtemp();
+    saved = os.environ.get("JAC_SCALE_CACHE_DIR");
+    os.environ["JAC_SCALE_CACHE_DIR"] = cache;
+    try {
+        first = _staged_pod_jac(b"ELF-one");
+        mtime = first.stat().st_mtime_ns;
+        # identical bytes: no rewrite, same file
+        assert _staged_pod_jac(b"ELF-one").stat().st_mtime_ns == mtime;
+        # new binary content replaces the file at the same stable path
+        second = _staged_pod_jac(b"ELF-two");
+        assert second == first;
+        assert second.read_bytes() == b"ELF-two";
+    } finally {
+        os.environ.pop("JAC_SCALE_CACHE_DIR", None);
+        if saved is not None {
+            os.environ["JAC_SCALE_CACHE_DIR"] = saved;
+        }
+        import shutil;
+        shutil.rmtree(cache, ignore_errors=True);
+    }
+}


### PR DESCRIPTION
## What this solves

Micro-profiling the app seal showed 54s split as: **22.8s pod-binary one-time setup + ~14s actual compilation + <1s staging/tar**. The setup waste happens every deploy: `pack_jab` writes the pod binary to a fresh temp path, and the launcher keys its extracted runtime by `(payload, executable path)` - so the same binary re-extracts its ~430MB runtime on the driver on every single seal, just to host the precompiler.

## How

Stage the binary at one stable path under the driver cache (`.../scale-binaries/pod-jac`), written atomically and only when the content actually changed (sha256 compare). First deploy per binary version pays the setup once; every later seal starts the precompiler in ~1.5s. Version bumps reuse the same path, so the launcher's own per-path GC cleans superseded runtime trees - no accumulation. The `scale_cache_root` helper moves from `binary.jac` to `bundle.jac` (the reverse import would be circular); the binary/console download caches use it unchanged.

## Measured (driver-side harness, this_is_jac, 12 modules)

| | fresh temp path (today) | stable path (this PR) |
|---|---|---|
| one-time setup | 22.8s **every deploy** | 0s (warm) |
| precompile 12 modules | ~14s | ~14s |
| staging + tar | 0.3s | 0.3s |
| **seal total** | **~38-54s** | **~15s** |

## Tests

Stable-path behavior: identical bytes do not rewrite the file (mtime unchanged), changed bytes replace it in place at the same path. Existing pack/determinism suites pass (32 tests).