### PR TITLE
fix(ci): point release workflow guards at renamed jaseci-labs/jac repo

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -425,7 +425,7 @@ jobs:
       # mean a misconfiguration (e.g. a caller not passing them through) --
       # fail loudly instead of green-skipping the publish.
       - name: Fail if publishing secrets are missing (org repo)
-        if: github.repository == 'Jaseci-Labs/jaseci' && (env.DOCKERHUB_USERNAME == '' || env.DOCKERHUB_TOKEN_SET != 'true')
+        if: github.repository == 'jaseci-labs/jac' && (env.DOCKERHUB_USERNAME == '' || env.DOCKERHUB_TOKEN_SET != 'true')
         run: |
           echo "::error::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN did not reach this job; workflow_call callers must pass them via 'secrets:'."
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ permissions: {}
 jobs:
   create-release-pr:
     if: >-
-      github.repository == 'Jaseci-Labs/jaseci' &&
+      github.repository == 'jaseci-labs/jac' &&
       github.event_name == 'workflow_dispatch' &&
       inputs.action == 'create-pr'
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -103,7 +103,7 @@ jobs:
 
   resolve:
     if: |
-      github.repository == 'Jaseci-Labs/jaseci' && (
+      github.repository == 'jaseci-labs/jac' && (
         (github.event_name == 'workflow_dispatch' && inputs.action == 'publish') || (
           github.event_name == 'pull_request' &&
           github.event.pull_request.merged == true &&


### PR DESCRIPTION
## Problem

The repository was renamed from `jaseci-labs/jaseci` to `jaseci-labs/jac` (same repo id `422711680`; the old name now 301-redirects). The Release workflow and the reusable build-binaries workflow still gate jobs on the **old** name:

```yaml
if: github.repository == 'Jaseci-Labs/jaseci' && ...
```

Since `github.repository` now resolves to `jaseci-labs/jac`, that equality is false, so a dispatched `Release` run skips **every** job:

- `create-release-pr` and `resolve` are directly guarded, so both skip.
- `approve`, `tag-and-release`, `build-binaries`, `publish`, and `summary` all `needs: resolve`, so they cascade to skipped.

Example: [run 29247588436](https://github.com/jaseci-labs/jac/actions/runs/29247588436) — all 8 jobs skipped.

The `build-binaries` "fail loudly if publishing secrets are missing (org repo)" safety step is guarded the same way, so it was silently dead on the org repo (a real misconfiguration would now green-skip instead of failing).

## Fix

Repoint all three `github.repository ==` guards at the current canonical name `jaseci-labs/jac`:

- `.github/workflows/release.yml` — `create-release-pr` and `resolve` guards
- `.github/workflows/build-binaries.yml` — missing-secrets safety guard

GitHub Actions string comparison is case-insensitive, so this matches regardless of stored casing.

## Scope note

Only the three functional `github.repository ==` guards are changed. The remaining `jaseci-labs/jaseci` occurrences in the tree are historical issue-reference comments (`jaseci-labs/jaseci#NNNN`) and redirect-backed doc/URL references, which are intentionally left untouched.