### PR TITLE
chore(release): title GitHub Releases "jac" instead of "jaclang"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "summary=jaclang $VERSION" >> "$GITHUB_OUTPUT"
+          echo "summary=jac $VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved release version: $VERSION"
 
   # Human approval gate (release-approval environment required reviewers).
@@ -195,7 +195,7 @@ jobs:
             echo "Tag ${VTAG} already exists; leaving it in place."
           else
             echo "Tagging ${VTAG} at ${GITHUB_SHA}"
-            git tag --annotate --message="jaclang ${VERSION}" "$VTAG" "$GITHUB_SHA"
+            git tag --annotate --message="jac ${VERSION}" "$VTAG" "$GITHUB_SHA"
             git push origin "refs/tags/${VTAG}"
           fi
 
@@ -214,7 +214,7 @@ jobs:
           VTAG="v${VERSION}"
 
           {
-            echo "## jaclang ${VERSION} (native \`jac\` binary)"
+            echo "## jac ${VERSION} (native \`jac\` binary)"
             echo ""
             echo "Install: \`curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash\`"
           } > release_notes.md


### PR DESCRIPTION
## What

Changes the GitHub Release **display name** from `jaclang X.Y.Z` to `jac X.Y.Z`, so a release reads **`Release: jac 0.31.3`**.

The word `jaclang` in the release title is a hardcoded literal in the `resolve` job's `summary` output -- it is decoupled from `jac.toml` (which only supplies the `version`). Three display-only spots change:

| Spot | Before | After |
|------|--------|-------|
| Release title (`summary`) | `Release: jaclang 0.31.3` | `Release: jac 0.31.3` |
| Release-notes heading | `## jaclang 0.31.3 (native jac binary)` | `## jac 0.31.3 (native jac binary)` |
| Git tag annotation | `jaclang 0.31.3` | `jac 0.31.3` |

Binary assets are already named `jac-<version>-<platform>`, so nothing there changes.

## Scope

Display text only. The package name in `jac.toml` (`name = "jaclang"`), the `jac/jaclang/` source tree, imports, PyPI history, and the `jaseci/jaclang` Docker image are intentionally **not** touched -- that would be a separate, breaking rename.

## Note

Independent of #7414 (the repo-guard fix); the two PRs edit different, non-overlapping lines of `release.yml`.