### PR TITLE
fix(client): timestamp client-error lines so stale ones are distinguishable

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7449.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7449.bugfix.md
@@ -1,1 +1,1 @@
-- **Fix: client-error log lines are timestamped**: the dev server wrote `Client error: ...` with no timestamp into an append-only `.jac-server.log`, so a fixed error stayed in the tail and read as if it were still live. Anything verifying a fix by re-reading the log could never confirm success. The line now carries an ISO timestamp; existing `grep`/regex consumers still match.
+- **Fix: client-error log lines are timestamped**: `Client error: ...` had no timestamp in the append-only `.jac-server.log`, so an already-fixed error still read as live.

--- a/docs/docs/community/release_notes/unreleased/jaclang/7449.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7449.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: client-error log lines are timestamped**: the dev server wrote `Client error: ...` with no timestamp into an append-only `.jac-server.log`, so a fixed error stayed in the tail and read as if it were still live. Anything verifying a fix by re-reading the log could never confirm success. The line now carries an ISO timestamp; existing `grep`/regex consumers still match.

--- a/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
@@ -619,7 +619,10 @@ function jacErrorReporter() {{
             loc += ")";
           }} catch(e) {{}}
         }}
-        console.error("Client error: " + data.type + ": " + data.message + loc);
+        // Timestamped: the server log is append-only, so an un-timestamped error
+        // is indistinguishable from a live one once it has been fixed. Readers
+        // (and agents) need this to tell a stale line from a current failure.
+        console.error("[" + new Date(now).toISOString() + "] Client error: " + data.type + ": " + data.message + loc);
         if (data.phase === "load") {{
           try {{ reportClientLoad(data); }} catch (e) {{}}
           server.ws.send({{

--- a/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/vite_bundler.impl.jac
@@ -619,9 +619,7 @@ function jacErrorReporter() {{
             loc += ")";
           }} catch(e) {{}}
         }}
-        // Timestamped: the server log is append-only, so an un-timestamped error
-        // is indistinguishable from a live one once it has been fixed. Readers
-        // (and agents) need this to tell a stale line from a current failure.
+        // Timestamped: the log is append-only, so a fixed error otherwise reads as live.
         console.error("[" + new Date(now).toISOString() + "] Client error: " + data.type + ": " + data.message + loc);
         if (data.phase === "load") {{
           try {{ reportClientLoad(data); }} catch (e) {{}}


### PR DESCRIPTION
## Problem

The dev server reports client errors with no timestamp (`vite_bundler.impl.jac`):

```js
console.error("Client error: " + data.type + ": " + data.message + loc);
```

Callers redirect that stdout into an **append-only** `.jac-server.log` that is never truncated. So once an error is logged, it stays in the tail forever - and with no timestamp, **a fixed error is indistinguishable from a live one**. Anything that verifies a fix by re-reading the log keeps seeing the failure it just repaired, and can never confirm success.

This is not hypothetical. In a real agent run:

1. A component imported `DocumentIcon`, which does not exist in the icon package.
2. The browser reported `SyntaxError: ... does not provide an export named 'DocumentIcon'` -> appended to the log.
3. The agent **correctly diagnosed and fixed it** ("DocumentIcon doesn't exist. Fix DocumentsView and AppShell").
4. It re-read the log to confirm... and saw **the same error**, because nothing had removed it.
5. It then grepped the source and `compiled/` for `DocumentIcon` and found nothing - correctly, it had just deleted it.
6. Unable to explain an error whose cause it could not find, it invented a stale-Vite-deps-cache theory and looped on greps until the run hit the loop detector and died.

The agent could not verify its own fix, so it could not stop.

## Fix

Prefix the line with an ISO timestamp, reusing the `now` the deduper already computes:

```
[2026-07-14T09:40:51.306Z] Client error: SyntaxError: ... does not provide an export named 'DocumentIcon' (main.jac:2:1)
```

A reader can now compare the timestamp against when it last edited, and ignore anything older.

## Compatibility

The prefix does not break existing consumers - verified both:

- a plain `grep "Client error"` still matches
- regex scans like `SyntaxError:.*` (used by tools that parse this log) still match

`jac check` on the file reports the same 7 pre-existing errors as `main` - no new ones. The emitted JS was executed to confirm it is valid and produces the line above.
