### PR TITLE
fix(scale): self-heal Redis consumer groups on NOGROUP (stop XREADGROUP hot-loop)

### DIFF
--- a/jac/jaclang/scale/events/streams/redis.jac
+++ b/jac/jaclang/scale/events/streams/redis.jac
@@ -106,21 +106,31 @@ obj RedisEventStream(EventStreamBroker) {
         return start_from;
     }
 
-    def _ensure_group(topic: str, group: str, start_from: str = "latest") -> None {
+    def _ensure_group(
+        topic: str, group: str, start_from: str = "latest", force: bool = False
+    ) -> None {
         key = f"{topic}::{group}";
-        if key in self._ensured_groups {
+        if not force and key in self._ensured_groups {
             return;
         }
         try {
             self._get_client().xgroup_create(
                 topic, group, id=self._resolve_start_id(start_from), mkstream=True
             );
+            # Created cleanly — safe to memoize.
+            self._ensured_groups.add(key);
         } except Exception as e {
-            if "BUSYGROUP" not in str(e) {
+            if "BUSYGROUP" in str(e) {
+                # Group already exists; memoize so we skip the round-trip.
+                self._ensured_groups.add(key);
+            } else {
+                # Do NOT memoize on a genuine failure. Caching an un-created
+                # group poisons the reader: every later XREADGROUP returns
+                # NOGROUP forever and _ensure_group short-circuits on the stale
+                # entry. Leave it uncached so the next call retries the create.
                 _logger.warning(f"XGROUP CREATE failed for {topic}/{group}: {e}");
             }
         }
-        self._ensured_groups.add(key);
     }
 
     def _decode_message(topic: str, group: str, msg_id: any, fields: dict) -> Event {
@@ -170,17 +180,40 @@ obj RedisEventStream(EventStreamBroker) {
         grp = group or self._default_group;
         self._ensure_group(topic, grp, start_from);
         block_ms = max(1, int(timeout_seconds * 1000));
-        try {
-            result = self._get_client().xreadgroup(
-                groupname=grp,
-                consumername=self._consumer_name,
-                streams={topic: ">"},
-                count=max_messages,
-                block=block_ms
-            );
-        } except Exception as e {
-            _logger.error(f"XREADGROUP failed for {topic}/{grp}: {e}");
-            return [];
+        result: any = None;
+        attempt = 0;
+        while attempt < 2 {
+            try {
+                result = self._get_client().xreadgroup(
+                    groupname=grp,
+                    consumername=self._consumer_name,
+                    streams={topic: ">"},
+                    count=max_messages,
+                    block=block_ms
+                );
+                break;
+            } except Exception as e {
+                # NOGROUP means the stream/group vanished after we cached it as
+                # ensured — typically the stream was evicted under Redis memory
+                # pressure, which drops its consumer groups. Drop the stale cache
+                # entry, recreate the group (MKSTREAM), and retry once. Without
+                # this the reader hot-loops on NOGROUP with no backoff: the
+                # block= timeout does not apply because NOGROUP fails immediately,
+                # so one vanished stream pins a CPU core and floods the logs.
+                if "NOGROUP" in str(e) and attempt == 0 {
+                    self._ensured_groups.discard(f"{topic}::{grp}");
+                    self._ensure_group(topic, grp, start_from, force=True);
+                    attempt += 1;
+                    continue;
+                }
+                _logger.error(f"XREADGROUP failed for {topic}/{grp}: {e}");
+                # Pace the unrecoverable-error path: callers (consumer_loop,
+                # stream_events) re-invoke consume immediately on an empty
+                # return, so a persistent failure here must not become a hot
+                # loop the way a fast-failing XREADGROUP would.
+                time.sleep(0.5);
+                return [];
+            }
         }
         events: list[Event] = [];
         if not result {

--- a/jac/jaclang/scale/tests/data/test_redis_stream.jac
+++ b/jac/jaclang/scale/tests/data/test_redis_stream.jac
@@ -111,6 +111,50 @@ test "ack prevents redelivery in same group" {
 }
 
 
+test "consume self-heals after the stream and group are evicted (NOGROUP)" {
+    # Regression for the XREADGROUP NOGROUP hot-loop: when the run stream is
+    # evicted under Redis memory pressure its consumer group is destroyed, but
+    # the broker still has the group cached in _ensured_groups. A later XADD
+    # recreates the stream without the group, so every read used to NOGROUP
+    # forever with no backoff. consume() must now drop the stale cache entry,
+    # recreate the group, and deliver the event.
+    _flush_redis();
+    b = _make_broker(group="t_evict");
+
+    b.publish("evict.topic", Event(event_type="e.one", data={"n": 1}));
+    got1 = b.consume(
+        "evict.topic",
+        group="t_evict",
+        max_messages=1,
+        timeout_seconds=2.0,
+        start_from="earliest"
+    );
+    assert len(got1) == 1;
+    assert got1[0].data["n"] == 1;
+
+    # Simulate the eviction: deleting the stream key destroys the stream AND
+    # its consumer group, while the broker keeps the group cached.
+    client = get_redis_client(REDIS_URI);
+    client.delete("evict.topic");
+
+    # A publisher re-creates the stream via XADD but not the group.
+    b.publish("evict.topic", Event(event_type="e.two", data={"n": 2}));
+
+    got2 = b.consume(
+        "evict.topic",
+        group="t_evict",
+        max_messages=1,
+        timeout_seconds=2.0,
+        start_from="earliest"
+    );
+    assert len(got2) == 1;
+    assert got2[0].data["n"] == 2;
+
+    b.stop(drain=False);
+    cleanup_connections();
+}
+
+
 test "consume returns empty on timeout when stream is empty" {
     _flush_redis();
     b = _make_broker(group="t_empty");


### PR DESCRIPTION
## Summary

`RedisEventStream` hot-loops on `NOGROUP` and floods logs + Redis whenever a run stream's consumer group disappears. On prod during the hackathon this was ~600 ERROR lines/sec per active run (77k+ in a 15 min window), it pinned CPU on jac-coder-sv, and the peer/local consumers silently stopped receiving events. Root cause is a poisoned, never-invalidated group cache in `jac/jaclang/scale/events/streams/redis.jac`.

## Root cause

`_ensure_group` memoized every `(topic, group)` in `self._ensured_groups` **unconditionally** (even when `XGROUP CREATE` failed) and the cache was never invalidated. So:

1. A run stream `jc.run.<id>` is created; first `consume()` creates the group and caches it.
2. Under Redis memory pressure (`allkeys-lru`, jaseci-labs/jacBuilder#551) the stream key is **evicted**, which destroys its consumer group.
3. The publisher's next `XADD` recreates the stream **without** the group.
4. `consume()` sees the group cached as "ensured", skips creation, and `XREADGROUP` returns `NOGROUP`. It logs ERROR and retries **immediately** — the `block=` timeout does not apply because `NOGROUP` fails instantly — so it spins a CPU core forever.

## Fix

- `_ensure_group`: memoize only on a clean create or `BUSYGROUP`; never cache a group that failed to create. Adds a `force` flag to bypass the cache for recreation.
- `consume`: on `NOGROUP`, drop the stale cache entry, recreate the group (`MKSTREAM`), and retry once; on an unrecoverable error, pace the return so callers (`consumer_loop`, jac-coder `stream_events`) cannot hot-loop.
- Regression test: publish + consume (creates group), delete the stream key to simulate eviction, re-publish, and assert `consume` self-heals and delivers the next event.

## Test

`jac/jaclang/scale/tests/data/test_redis_stream.jac` — new test `consume self-heals after the stream and group are evicted (NOGROUP)` (testcontainers Redis). Without the fix, step 4's `consume` returns `[]` and logs NOGROUP; with it, the event is delivered.

## Release notes

Fixed a Redis event-stream consumer hot-loop: a consumer group destroyed by Redis key eviction is now recreated on `NOGROUP` instead of retrying forever, eliminating the ERROR-log/CPU flood.

Refs jaseci-labs/jacBuilder#687. Amplified by jaseci-labs/jacBuilder#551 (Redis `allkeys-lru` eviction).
