### PR TITLE
refactor(check,native): centralize region-handle facts out of the native backend (follow-up to #7494)

### DIFF
--- a/jac/jaclang/compiler/passes/main/impl/ownership_check_pass.region.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/ownership_check_pass.region.impl.jac
@@ -140,18 +140,6 @@ impl OwnershipCheckPass._region_handle_sid(region: uni.OpenStmt) -> (SymId | Non
     return self._name_sym_id(nm);
 }
 
-impl OwnershipCheckPass._name_is_builtin_region(nm: object) -> bool {
-    if not isinstance(nm, uni.Name) or nm.sym_name != "Region" {
-        return False;
-    }
-    if nm.sym is None or nm.sym.decl is None {
-        return True;
-    }
-    _loc = nm.sym.decl.loc;
-    _mp = _loc.mod_path if _loc is not None else "";
-    return isinstance(_mp, str) and _mp.endswith(".pyi");
-}
-
 impl OwnershipCheckPass._param_is_region_borrow(param: uni.ParamVar) -> bool {
     tag = param.type_tag;
     if tag is None or not is_borrow_kind(tag.ownership) {
@@ -161,7 +149,8 @@ impl OwnershipCheckPass._param_is_region_borrow(param: uni.ParamVar) -> bool {
     while isinstance(_expr, uni.AtomTrailer) {
         _expr = _expr.target;
     }
-    return self._name_is_builtin_region(_expr);
+    import from jaclang.compiler.symbol_utils { is_builtin_region_name }
+    return is_builtin_region_name(_expr);
 }
 
 impl OwnershipCheckPass._region_handle_kind(region: uni.OpenStmt) -> str {

--- a/jac/jaclang/compiler/passes/main/impl/rc_facts_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/rc_facts_pass.impl.jac
@@ -6,6 +6,7 @@ impl RcFactsPass.transform(ir_in: uni.Module) -> uni.Module {
     self._stamp_param_rebound(ir_in);
     self._stamp_move_lowerable(ir_in);
     self._stamp_escapes(ir_in);
+    self._stamp_region_handles(ir_in);
     self._stamp_last_use(ir_in);
     return ir_in;
 }
@@ -96,6 +97,67 @@ impl RcFactsPass._stamp_escapes(ir_in: uni.Module) -> None {
         }
         sym.na_escapes = escapes;
         sym.na_stack_ok = stack_ok and not escapes;
+    }
+}
+
+impl RcFactsPass._asn_makes_region_handle(nd: uni.Assignment) -> bool {
+    import from jaclang.compiler.symbol_utils { is_builtin_region_name }
+    if isinstance(nd.value, uni.FuncCall) and is_builtin_region_name(nd.value.target) {
+        return True;
+    }
+    if nd.type_tag is not None {
+        _tt_expr = nd.type_tag.tag;
+        while isinstance(_tt_expr, uni.AtomTrailer) {
+            _tt_expr = _tt_expr.target;
+        }
+        if is_builtin_region_name(_tt_expr) {
+            return True;
+        }
+    }
+    if (
+        isinstance(nd.value, uni.FuncCall)
+        and isinstance(nd.value.target, uni.Name)
+        and nd.value.target.sym is not None
+        and nd.value.target.sym.decl is not None
+    ) {
+        _cal_ab = nd.value.target.sym.decl.find_parent_of_type(uni.Ability);
+        if _cal_ab is not None
+        and isinstance(_cal_ab.signature, uni.FuncSignature)
+        and _cal_ab.signature.return_type is not None {
+            _rt_expr = _cal_ab.signature.return_type;
+            while isinstance(_rt_expr, uni.AtomTrailer) {
+                _rt_expr = _rt_expr.target;
+            }
+            if is_builtin_region_name(_rt_expr) {
+                return True;
+            }
+        }
+    }
+    if isinstance(nd.value, uni.Name)
+    and nd.value.sym is not None
+    and nd.value.sym.na_region_handle {
+        return True;
+    }
+    return False;
+}
+
+impl RcFactsPass._stamp_region_handles(ir_in: uni.Module) -> None {
+    _changed = True;
+    while _changed {
+        _changed = False;
+        for asn in ir_in.get_all_sub_nodes(uni.Assignment) {
+            if len(asn.target) != 1 or not isinstance(asn.target[0], uni.Name) {
+                continue;
+            }
+            _tgt = asn.target[0];
+            if _tgt.sym is None or _tgt.sym.na_region_handle {
+                continue;
+            }
+            if self._asn_makes_region_handle(asn) {
+                _tgt.sym.na_region_handle = True;
+                _changed = True;
+            }
+        }
     }
 }
 

--- a/jac/jaclang/compiler/passes/main/ownership_check_pass.jac
+++ b/jac/jaclang/compiler/passes/main/ownership_check_pass.jac
@@ -103,7 +103,6 @@ obj OwnershipCheckPass(Transform[uni.Module, uni.Module]) {
     def _open_handle_name(region: uni.OpenStmt) -> (uni.Name | None);
     def _region_handle_sid(region: uni.OpenStmt) -> (SymId | None);
     def _region_handle_kind(region: uni.OpenStmt) -> str;
-    def _name_is_builtin_region(nm: object) -> bool;
     def _param_is_region_borrow(param: uni.ParamVar) -> bool;
     def _region_param_count(region: uni.OpenStmt) -> int;
     def _call_borrows_handle(expr: uni.Expr | None, hsid: SymId) -> bool;

--- a/jac/jaclang/compiler/passes/main/rc_facts_pass.jac
+++ b/jac/jaclang/compiler/passes/main/rc_facts_pass.jac
@@ -79,6 +79,8 @@ obj RcFactsPass(Transform[uni.Module, uni.Module]) {
     def transform(ir_in: uni.Module) -> uni.Module;
     def _stamp_param_rebound(ir_in: uni.Module) -> None;
     def _stamp_escapes(ir_in: uni.Module) -> None;
+    def _stamp_region_handles(ir_in: uni.Module) -> None;
+    def _asn_makes_region_handle(nd: uni.Assignment) -> bool;
     def _use_ok_for_stack(nm: uni.NameAtom) -> bool;
     def _enclosing_fn_scope(nd: uni.UniNode) -> (uni.UniNode | None);
     def _is_param_sym(sym: uni.Symbol) -> bool;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/arena.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/arena.impl.jac
@@ -366,67 +366,20 @@ impl NaIRGenPass._emit_arena_helpers -> None {
     self.osp_anchor_alloc_fn = _aa_fn;
 }
 
-impl NaIRGenPass._name_is_builtin_region(nm: object) -> bool {
-    if not isinstance(nm, uni.Name) or nm.sym_name != "Region" {
-        return False;
-    }
-    if nm.sym is None or nm.sym.decl is None {
-        return True;
-    }
-    _loc = nm.sym.decl.loc;
-    _mp = _loc.mod_path if _loc is not None else "";
-    return isinstance(_mp, str) and _mp.endswith(".pyi");
-}
-
-impl NaIRGenPass._assign_rhs_is_region_handle(nd: uni.Assignment) -> bool {
-    if isinstance(nd.value, uni.FuncCall)
-    and self._name_is_builtin_region(nd.value.target) {
-        return True;
-    }
-    if nd.type_tag is not None {
-        _tt_expr = nd.type_tag.tag;
-        while isinstance(_tt_expr, uni.AtomTrailer) {
-            _tt_expr = _tt_expr.target;
-        }
-        if self._name_is_builtin_region(_tt_expr) {
-            return True;
-        }
-    }
-    if (
-        isinstance(nd.value, uni.FuncCall)
-        and isinstance(nd.value.target, uni.Name)
-        and nd.value.target.sym is not None
-        and nd.value.target.sym.decl is not None
-    ) {
-        _cal_ab = nd.value.target.sym.decl.find_parent_of_type(uni.Ability);
-        if _cal_ab is not None
-        and isinstance(_cal_ab.signature, uni.FuncSignature)
-        and _cal_ab.signature.return_type is not None {
-            _rt_expr = _cal_ab.signature.return_type;
-            while isinstance(_rt_expr, uni.AtomTrailer) {
-                _rt_expr = _rt_expr.target;
-            }
-            if self._name_is_builtin_region(_rt_expr) {
-                return True;
-            }
-        }
-    }
-    if isinstance(nd.value, uni.Name)
-    and nd.value.sym_name in self.region_handle_vars {
-        return True;
-    }
-    return False;
-}
 
 impl NaIRGenPass._register_region_handle_var(
     nd: uni.Assignment, var_name: str
 ) -> None {
-    if not self._assign_rhs_is_region_handle(nd) {
+    _tgt = nd.target[0]
+        if (len(nd.target) == 1 and isinstance(nd.target[0], uni.Name))
+        else None;
+    if _tgt is None or _tgt.sym is None or not _tgt.sym.na_region_handle {
         return;
     }
     self.region_handle_vars.add(var_name);
     if isinstance(nd.value, uni.Name)
-    and nd.value.sym_name in self.region_handle_vars
+    and nd.value.sym is not None
+    and nd.value.sym.na_region_handle
     and nd.value.sym_name != var_name {
         self.region_handle_vars.discard(nd.value.sym_name);
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
@@ -214,7 +214,8 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
         }
 
         if func_name == "Region" {
-            if self._name_is_builtin_region(nd.target) {
+            import from jaclang.compiler.symbol_utils { is_builtin_region_name }
+            if is_builtin_region_name(nd.target) {
                 self._emit_arena_helpers();
                 return self.builder.call(self.region_new_fn, [], name="region.new");
             }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -467,9 +467,9 @@ impl NaIRGenPass._codegen_open_stmt(nd: uni.OpenStmt) -> None {
 
     self._emit_arena_helpers();
     _i8p = ir.IntType(8).as_pointer();
+    import from jaclang.compiler.symbol_utils { is_builtin_region_name }
     _anon_region = (
-        isinstance(nd.target, uni.FuncCall)
-        and self._name_is_builtin_region(nd.target.target)
+        isinstance(nd.target, uni.FuncCall) and is_builtin_region_name(nd.target.target)
     );
     _synth: (str | None) = None;
     if _anon_region {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -919,8 +919,6 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _emit_struct_drop_fields_fn(type_name: str) -> (ir.Function | None);
     def _emit_container_drop_fn(cont_name: str) -> (ir.Function | None);
     def _emit_arena_helpers -> None;
-    def _name_is_builtin_region(nm: object) -> bool;
-    def _assign_rhs_is_region_handle(nd: uni.Assignment) -> bool;
     def _register_region_handle_var(nd: uni.Assignment, var_name: str) -> None;
     def _region_alloc(size: ir.Value, name: str = "region.alloc") -> ir.Value;
     def _region_log_dtor_if_needed(obj_i8: ir.Value, type_name: str) -> None;

--- a/jac/jaclang/compiler/symbol_utils.jac
+++ b/jac/jaclang/compiler/symbol_utils.jac
@@ -10,6 +10,18 @@ enum CallKind {
     FUNCTION = "function"
 }
 
+def is_builtin_region_name(nm: object) -> bool {
+    if not isinstance(nm, uni.Name) or nm.sym_name != "Region" {
+        return False;
+    }
+    if nm.sym is None or nm.sym.decl is None {
+        return True;
+    }
+    _loc = nm.sym.decl.loc;
+    _mp = _loc.mod_path if _loc is not None else "";
+    return isinstance(_mp, str) and _mp.endswith(".pyi");
+}
+
 def resolve_expr_symbol(
     expr: uni.Expr, module: (uni.Module | None) = None
 ) -> (uni.Symbol | None) {

--- a/jac/jaclang/jac0core/unitree.jac
+++ b/jac/jaclang/jac0core/unitree.jac
@@ -92,6 +92,7 @@ obj Symbol {
         ownership: OwnershipKind = OwnershipKind.NONE,
         param_rebound: bool = False,
         na_escapes: bool = False,
+        na_region_handle: bool = False,
         na_stack_ok: bool = False;
 
     def init(

--- a/jac/tests/compiler/test_backend_purity.jac
+++ b/jac/tests/compiler/test_backend_purity.jac
@@ -67,8 +67,18 @@ glob FORBIDDEN: dict[str, str] = {
              "for interop payloads and Ref[...] head detection - the "
              "declared NAME is the consumed fact, not a resolved type"
          ),
-         ("native/na_ir_gen_pass.impl/calls.impl.jac", "symbol_utils"): (
+         ("native/na_ir_gen_pass.impl/stmt.impl.jac", "symbol_utils"): (
              1,
+             "is_builtin_region_name as the shadowing-aware test for the "
+             "anonymous `in Region() {}` open (#7491) - consuming the "
+             "central classification instead of re-implementing name "
+             "resolution"
+         ),
+         ("native/na_ir_gen_pass.impl/calls.impl.jac", "symbol_utils"): (
+             2,
+             "is_builtin_region_name as the shadowing-aware test for the "
+             "builtin Region constructor (#7491) - consuming the central "
+             "classification instead of re-implementing name resolution; and "
              "classify_call as the shadowing-aware builtin test for the "
              "`type(None)` isinstance argument form (#6957) - consuming the "
              "central classification instead of re-implementing name "
@@ -89,12 +99,6 @@ glob FORBIDDEN: dict[str, str] = {
              "scalar LLVM materialization from declared clib annotations "
              "at the declaration site - the backend's lowering role "
              "(sysv sig planning + fixed-param lowering, #6707, #6708)"
-         ),
-         ("native/na_ir_gen_pass.impl/arena.impl.jac", "type_tag.tag"): (
-             1,
-             "declaration-surface read: a `: Region` annotation marks the "
-             "binding as a region handle so drop tracking never depends on "
-             "inference having typed the RHS (#7491 R2)"
          ),
          ("native/na_ir_gen_pass.impl/objects.impl.jac", "type_tag.tag"): (
              1,


### PR DESCRIPTION
**Stacked on #7494** -- only the tip commit (`6336c4c1e`) is new here; review after (or alongside) #7494, whose commits this branch contains.

Follow-up refactor per the facts-once doctrine (`test_backend_purity.jac`): analyses compute facts, backends consume them. #7494 shipped three analysis-shaped decisions inside the native backend; this moves them to the central passes.

## What moves

- **Handle identification becomes a stamped fact.** `Symbol.na_region_handle` is computed once by `RcFactsPass` (direct builtin `Region()` construction, a `: Region` annotation, a callee declared `-> Region`, or an alias of a known handle -- iterated to a fixpoint so alias chains resolve). The backend's syntactic re-derivation (`_assign_rhs_is_region_handle`, including its AST-climbing signature walk) is deleted; `_register_region_handle_var` now only maintains emission-time bookkeeping over the stamped fact. This follows the existing `na_move_lowerable` / `na_stack_ok` precedent.
- **One builtin-`Region` classification.** The shadowing-aware test (`is_builtin_region_name`, from the Greptile P1 fix on #7494) now lives once in `compiler/symbol_utils` beside `classify_call`, consumed by the checker's `&Region` parameter recognition, the constructor lowering, and the anonymous-open detection. Both duplicated `_name_is_builtin_region` copies are deleted.
- **Purity ledger improves in kind.** The `type_tag.tag` re-derivation sanction on `arena.impl.jac` is deleted (the annotation read moved into `RcFactsPass`, where declaration-surface reads are legal); in its place are two sanctions of the blessed kind -- central-API consumption of `is_builtin_region_name` in `calls.impl` / `stmt.impl`, recorded with rationales.

## Deliberately not moved

- Arena IR emission, sentinel-header stamping, dtor-log mechanics, and `region_stack` (an emission-time cursor for "which open am I under") -- lowering state, correctly backend-resident.
- Scope-exit drop placement for handles. Upgrading to borrow-extended NLL last-use drops requires persisting borrow-owner linkage from the ownership pass into stamped facts; that is a real liveness-analysis extension and is deferred rather than smuggled into this refactor.

## Validation

All 534 targeted tests pass unchanged: the 12 native arena tests (including region graphs, growth rule, dynamic extent, own-rebox, Region shadowing), 27 checker region tests, 3 Python drop-timing tests, backend purity, ownership/sendability/markers/move-elision/RC suites, and the 452-test native gen suite.
