### PR TITLE
fix(ci): skip whole-program gate for the client-only admin-dist build

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -336,7 +336,10 @@ jobs:
           fi
           BIN="$PWD/$(ls jacbin/jac-*linux-x86_64)"
           chmod +x "$BIN"
-          ( cd jac/jaclang/scale/admin/ui && "$BIN" build main.jac )
+          # The admin console is a pure client app; its client bundle is
+          # type-checked by the client toolchain during `build`. Skip the
+          # whole-program gate, which applies native rules to `.cl.jac` code.
+          ( cd jac/jaclang/scale/admin/ui && "$BIN" build main.jac --no_typecheck )
           DIST=jac/jaclang/scale/admin/ui/.jac/client/dist
           test -f "$DIST/index.html"
           mkdir -p dist


### PR DESCRIPTION
The admin-dist job runs `jac build main.jac`, whose whole-program type-check gate runs the native checker over the console's `.cl.jac` client code -- before the client bundle step installs the npm deps, and with native (not JS) type semantics. So `react`, `document`, and JS array/string methods surface as errors and fail the dev-binary release.

The admin console is a pure client app; its client bundle is type-checked by the client toolchain during the same build. Skip the gate for this step with `--no_typecheck`.

## **Description**
