### PR TITLE
fix(check): unbreak main - baseline the impl files the full-repo jac check now walks individually

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -34,6 +34,7 @@ jac_formatter_pass.jac
 jfast_api.jac
 kubernetes_utils.impl.jac
 kubernetes_utils.jac
+lang_tools.impl.jac
 lang_tools.jac
 llm.jac
 macho_linker.impl.jac
@@ -75,6 +76,7 @@ server.jac
 sym_tab_build_pass.jac
 template_loader.impl.jac
 template_loader.jac
+template_registry.impl.jac
 template_registry.jac
 testing.impl.jac
 testing.jac
@@ -87,6 +89,7 @@ treeprinter.jac
 type_checker_pass.jac
 type_evaluator.jac
 types.jac
+type_utils.impl.jac
 type_utils.jac
 uni_pass.jac
 unitree.jac


### PR DESCRIPTION
Main's CI has failed on every push since ~22:17 UTC yesterday (runs 29539022951, 29539067424, 29541700035): the jac-check job reports 81 error sites across `type_utils.impl.jac`, `template_registry.impl.jac`, and `lang_tools.impl.jac`.

What happened: #7532 cleared the full-repo check baseline, and its own CI was green - but against a merge ref that predated #7512/#7531 landing the same hour. On main, the checker walks `.impl.jac` files as their own units; `.jacignore` still lists the three BASE modules (`type_utils.jac` etc.) by exact name, which does not cover the impl files, so their pre-existing errors now fail every run.

This adds the three `.impl.jac` names to `.jacignore`, next to their base entries, until the 81 sites are actually fixed (they are real errors worth a follow-up, mostly enum/int returns and Optional narrowing in the language tooling).

Not touched here:
- `test-runtime` on main also failed, but that was setup-bun failing to reach GitHub's API (transient; unrelated).
- `Release jac dev binary` fails in `prepare` with HTTP 422 updating the `dev` prerelease - repo release state, needs a maintainer look if the next main push does not clear it. Until one of these passes, no new `:dev` binaries/images publish.