### PR TITLE
fix(ci): baseline the type_utils impl annex in .jacignore to unbreak main jac-check

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -606,8 +606,9 @@ scripts/integration_tests.jac
 zig-pkg
 
 # Impl annexes of modules already baselined above by bare name (lang_tools.jac,
-# template_registry.jac). Scoped CI passes changed files explicitly, and an
-# .impl.jac arg resolves to its (baselined known-bad) module after ignore
-# filtering runs -- so the annex paths must be listed too.
+# template_registry.jac, type_utils.jac). Scoped CI passes changed files
+# explicitly, and an .impl.jac arg resolves to its (baselined known-bad) module
+# after ignore filtering runs -- so the annex paths must be listed too.
 jac/jaclang/utils/impl/lang_tools.impl.jac
 jac/jaclang/project/impl/template_registry.impl.jac
+jac/jaclang/compiler/type_system/impl/type_utils.impl.jac


### PR DESCRIPTION
## Problem

The jac-check job is the only red job on main's CI, failing in the full sweep with 15 errors in `jac/jaclang/compiler/type_system/impl/type_utils.impl.jac` (example: [run 29551025670](https://github.com/jaseci-labs/jac/actions/runs/29551025670/job/87794082685)).

Root cause: `.jacignore` baselines the module by bare name (`type_utils.jac`), which covers the declaration module but does not match the impl annex filename. The sweep therefore checks the annex as its own entry, which resolves to the baselined known-bad module, and its errors surface.

## Fix

One line: add the annex path to the existing impl-annex block, mirroring the entries already present for `lang_tools.impl.jac` and `template_registry.impl.jac`. The comment above the block is extended to mention `type_utils.jac`.

## Verification

Locally on the failing main commit (13cfcb5ee):

- Scoped-style invocation (annex passed explicitly with CI's ignore args): file is filtered out, zero files checked.
- Full CI-style sweep (`jac check . --ignore <same args> --nowarn`): every git-tracked file passes; `type_utils.jac` and its annex no longer appear in the sweep.

## Relation to #7537

This restores the pre-failure baseline so main goes green immediately. The real typing fixes for type_utils live in #7537, which shrinks the baseline and removes these ignore entries again when it lands.
