### PR TITLE
refactor(littleX): report graph nodes and typed bundles instead of view-model DTOs

### DIFF
--- a/jac/examples/littleX/components/ChannelsTab.cl.jac
+++ b/jac/examples/littleX/components/ChannelsTab.cl.jac
@@ -18,13 +18,13 @@ import from .ui.dialog {
 }
 import from .TweetCard { TweetCard }
 import from .Composer { Composer }
-sv import from ..social_graph { ChannelView, TweetView }
+sv import from ..social_graph { ChannelBundle, Tweet }
 
 def:pub ChannelsTab(
-    channels: list[ChannelView],
+    channels: list[ChannelBundle],
     channelsLoading: bool,
-    selectedChannel: ChannelView | None,
-    channelPosts: list[TweetView],
+    selectedChannel: ChannelBundle | None,
+    channelPosts: list[Tweet],
     profileAvatar: str,
     profileUsername: str,
     onCreateChannel: Callable[[str, str], None],
@@ -140,8 +140,8 @@ def:pub ChannelsTab(
                 for ch in channels {
                     <div
                         className="lx-fade-up mx-4 mb-3 flex cursor-pointer items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-muted/40"
-                        key={ch.id}
-                        onClick={lambda { onSelectChannel(ch.id); }}
+                        key={jid(ch.channel)}
+                        onClick={lambda { onSelectChannel(jid(ch.channel)); }}
                     >
                         <div
                             className="flex size-11 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary"
@@ -152,11 +152,11 @@ def:pub ChannelsTab(
                             <div
                                 className="font-display font-bold text-foreground truncate"
                             >
-                                {ch.name}
+                                {ch.channel.name}
                             </div>
-                            {if ch.description {
+                            {if ch.channel.description {
                                 <div className="text-sm text-muted-foreground truncate">
-                                    {ch.description}
+                                    {ch.channel.description}
                                 </div>
                             }}
                             <div
@@ -200,7 +200,7 @@ def:pub ChannelsTab(
                             <div
                                 className="font-display text-lg font-extrabold text-foreground truncate"
                             >
-                                {selectedChannel.name}
+                                {selectedChannel.channel.name}
                             </div>
                             <div
                                 className="flex items-center gap-1 text-xs text-muted-foreground"
@@ -221,7 +221,7 @@ def:pub ChannelsTab(
                                 size="sm"
                                 className="shrink-0"
                                 onClick={lambda { if selectedChannel {
-                                    onLeaveChannel(selectedChannel.id);
+                                    onLeaveChannel(jid(selectedChannel.channel));
                                 }}}
                             >
                                 Leave
@@ -231,16 +231,16 @@ def:pub ChannelsTab(
                                 size="sm"
                                 className="shrink-0 font-semibold"
                                 onClick={lambda { if selectedChannel {
-                                    onJoinChannel(selectedChannel.id);
+                                    onJoinChannel(jid(selectedChannel.channel));
                                 }}}
                             >
                                 Join
                             </Button>
                         } }
                     </div>
-                    {if selectedChannel.description {
+                    {if selectedChannel.channel.description {
                         <p className="mt-2 text-sm text-foreground/80">
-                            {selectedChannel.description}
+                            {selectedChannel.channel.description}
                         </p>
                     }}
                 </div>
@@ -248,7 +248,7 @@ def:pub ChannelsTab(
                     <Composer
                         avatar={profileAvatar}
                         avatarAlt={profileUsername}
-                        placeholder={"Post in #" + selectedChannel.name}
+                        placeholder={"Post in #" + selectedChannel.channel.name}
                         value={channelComposerText}
                         onChange={lambda (v: str) { channelComposerText = v; }}
                         onPost={lambda {
@@ -280,7 +280,7 @@ def:pub ChannelsTab(
                 }
                 for tweet in channelPosts {
                     <TweetCard
-                        key={tweet.id}
+                        key={jid(tweet)}
                         {tweet}
                         myUsername={profileUsername}
                         {onLike}

--- a/jac/examples/littleX/components/ExploreTab.cl.jac
+++ b/jac/examples/littleX/components/ExploreTab.cl.jac
@@ -5,10 +5,10 @@ import from .ui.avatar { Avatar, AvatarImage, AvatarFallback }
 import from .ui.button { Button }
 import from .ui.skeleton { Skeleton }
 import from .ui.empty { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription }
-sv import from ..social_graph { UserView }
+sv import from ..social_graph { Profile }
 
 def:pub ExploreTab(
-    allProfiles: list[UserView],
+    allProfiles: list[Profile],
     followingIds: list[str],
     myProfileId: str,
     onFollow: Callable[[str], None],
@@ -32,7 +32,7 @@ def:pub ExploreTab(
             }for u in allProfiles {
                 <div
                     className="lx-fade-up flex items-center gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-muted/30"
-                    key={u.id}
+                    key={jid(u)}
                 >
                     <Avatar className="size-11 shrink-0">
                         <AvatarImage
@@ -66,21 +66,21 @@ def:pub ExploreTab(
                             {u.bio or "No bio yet"}
                         </div>
                     </div>
-                    {if u.id in followingIds {
+                    {if jid(u) in followingIds {
                         <Button
                             variant="outline"
                             size="sm"
                             className="group shrink-0 rounded-full hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
-                            onClick={lambda { onUnfollow(u.id); }}
+                            onClick={lambda { onUnfollow(jid(u)); }}
                         >
                             <span className="group-hover:hidden">Following</span>
                             <span className="hidden group-hover:inline">Unfollow</span>
                         </Button>
-                    } elif u.id != myProfileId {
+                    } elif jid(u) != myProfileId {
                         <Button
                             size="sm"
                             className="shrink-0 rounded-full font-semibold"
-                            onClick={lambda { onFollow(u.id); }}
+                            onClick={lambda { onFollow(jid(u)); }}
                         >
                             Follow
                         </Button>

--- a/jac/examples/littleX/components/FeedTab.cl.jac
+++ b/jac/examples/littleX/components/FeedTab.cl.jac
@@ -6,7 +6,7 @@ import from .ui.empty { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescrip
 import from .TweetCard { TweetCard }
 import from .Composer { Composer }
 import from .WelcomeBanner { WelcomeBanner }
-sv import from ..social_graph { TweetView }
+sv import from ..social_graph { Tweet }
 
 def:pub FeedTab(
     showWelcome: bool,
@@ -17,7 +17,7 @@ def:pub FeedTab(
     onComposerChange: Callable[[str], None],
     onPost: Callable[[], None],
     feedLoading: bool,
-    tweets: list[TweetView],
+    tweets: list[Tweet],
     onLike: Callable[[str], None],
     onComment: Callable[[str, str], None],
     onDelete: Callable[[str], None],
@@ -68,7 +68,7 @@ def:pub FeedTab(
                 skip;
             }for tweet in tweets {
                 <TweetCard
-                    key={tweet.id}
+                    key={jid(tweet)}
                     {tweet}
                     myUsername={profileUsername}
                     {onLike}

--- a/jac/examples/littleX/components/ProfileTab.cl.jac
+++ b/jac/examples/littleX/components/ProfileTab.cl.jac
@@ -4,10 +4,10 @@ import from .ui.avatar { Avatar, AvatarImage, AvatarFallback }
 import from .ui.button { Button }
 import from .ui.textarea { Textarea }
 import from .TweetCard { TweetCard }
-sv import from ..social_graph { ProfileView }
+sv import from ..social_graph { ProfileBundle }
 
 def:pub ProfileTab(
-    myProfile: ProfileView | None,
+    myProfile: ProfileBundle | None,
     displayUsername: str,
     profileAvatar: str,
     profileUsername: str,
@@ -80,7 +80,9 @@ def:pub ProfileTab(
                     </div>
                 } else {
                     <p className="mt-3 text-sm text-foreground/90">
-                        {myProfile.bio if myProfile and myProfile.bio else "No bio yet"}
+                        {myProfile.profile.bio
+                            if myProfile and myProfile.profile.bio
+                            else "No bio yet"}
                     </p>
                 } }
                 <div className="mt-4 flex gap-5 text-sm">
@@ -111,7 +113,7 @@ def:pub ProfileTab(
             <div className="border-t border-border">
                 {for tweet in myTweets {
                     <TweetCard
-                        key={tweet.id}
+                        key={jid(tweet)}
                         {tweet}
                         myUsername={profileUsername}
                         {onLike}

--- a/jac/examples/littleX/components/RightSidebar.cl.jac
+++ b/jac/examples/littleX/components/RightSidebar.cl.jac
@@ -7,7 +7,7 @@ import from .ui.card { Card, CardHeader, CardTitle, CardContent }
 import from .ui.avatar { Avatar, AvatarImage, AvatarFallback }
 import from .ui.badge { Badge }
 import from .ui.hover_card { HoverCard, HoverCardTrigger, HoverCardContent }
-sv import from ..social_graph { UserView, TrendingTag }
+sv import from ..social_graph { Profile, TrendingTag }
 
 def:pub RightSidebar(
     searchQuery: str,
@@ -16,7 +16,7 @@ def:pub RightSidebar(
     onClearSearch: Callable[[], None],
     trendingTags: list[TrendingTag],
     onTrendClick: Callable[[str], None],
-    toFollow: list[UserView],
+    toFollow: list[Profile],
     onFollow: Callable[[str], None],
     onShowMore: Callable[[], None],
 ) -> JsxElement {
@@ -91,7 +91,7 @@ def:pub RightSidebar(
                         {for u in toFollow[:5] {
                             <div
                                 className="flex items-center gap-2 px-4 py-2 transition-colors hover:bg-muted/50"
-                                key={u.id}
+                                key={jid(u)}
                             >
                                 <Avatar className="size-9 shrink-0">
                                     <AvatarImage
@@ -171,7 +171,7 @@ def:pub RightSidebar(
                                 <Button
                                     size="sm"
                                     className="shrink-0 rounded-full font-semibold"
-                                    onClick={lambda { onFollow(u.id); }}
+                                    onClick={lambda { onFollow(jid(u)); }}
                                 >
                                     Follow
                                 </Button>

--- a/jac/examples/littleX/components/TweetCard.cl.jac
+++ b/jac/examples/littleX/components/TweetCard.cl.jac
@@ -17,10 +17,10 @@ import from .ui.alert_dialog {
     AlertDialogCancel
 }
 import from ..lib.utils { cn }
-sv import from ..social_graph { TweetView }
+sv import from ..social_graph { Tweet }
 
 def:pub TweetCard(
-    tweet: TweetView,
+    tweet: Tweet,
     myUsername: str,
     onLike: Callable[[str], None],
     onComment: Callable[[str, str], None],
@@ -30,6 +30,9 @@ def:pub TweetCard(
     has showComments: bool = False,
         commentText: str = "";
 
+    # Whose tweet this is falls out of data the client already holds -
+    # no server round trip needed to answer a viewer-relative question.
+    is_mine = tweet.author_username == myUsername;
     is_liked = myUsername in tweet.likes;
     like_count = len(tweet.likes);
     comment_count = len(tweet.comments);
@@ -83,7 +86,7 @@ def:pub TweetCard(
                     </span>
                     <span className="text-muted-foreground">·</span>
                     <span className="text-muted-foreground">{date_str}</span>
-                    {if tweet.is_mine {
+                    {if is_mine {
                         <div className="ml-auto">
                             <AlertDialog>
                                 <AlertDialogTrigger asChild={True}>
@@ -108,7 +111,7 @@ def:pub TweetCard(
                                         <AlertDialogCancel>Cancel</AlertDialogCancel>
                                         <AlertDialogAction
                                             className="bg-destructive text-white hover:bg-destructive/90"
-                                            onClick={lambda { onDelete(tweet.id); }}
+                                            onClick={lambda { onDelete(jid(tweet)); }}
                                         >
                                             Delete
                                         </AlertDialogAction>
@@ -150,7 +153,7 @@ def:pub TweetCard(
                                     size="sm"
                                     className="h-8 gap-1.5 rounded-full px-2 text-muted-foreground hover:bg-repost/10 hover:text-repost"
                                     onClick={lambda { onRepost(
-                                        tweet.id, tweet.content, tweet.author_username
+                                        jid(tweet), tweet.content, tweet.author_username
                                     ); }}
                                 >
                                     <Repeat2 size={16}/>
@@ -169,7 +172,7 @@ def:pub TweetCard(
                                             if is_liked
                                             else "text-muted-foreground"
                                     )}
-                                    onClick={lambda { onLike(tweet.id); }}
+                                    onClick={lambda { onLike(jid(tweet)); }}
                                 >
                                     <Heart
                                         size={16}
@@ -226,7 +229,7 @@ def:pub TweetCard(
                                 onChange={lambda (e: ChangeEvent) { commentText = e.target.value; }}
                                 onKeyDown={lambda (e: KeyboardEvent) { if e.key == "Enter"
                                 and commentText.strip() {
-                                    onComment(tweet.id, commentText);
+                                    onComment(jid(tweet), commentText);
                                     commentText = "";
                                 }}}
                             />
@@ -234,7 +237,7 @@ def:pub TweetCard(
                                 size="icon"
                                 disabled={not commentText.strip()}
                                 onClick={lambda { if commentText.strip() {
-                                    onComment(tweet.id, commentText);
+                                    onComment(jid(tweet), commentText);
                                     commentText = "";
                                 }}}
                             >

--- a/jac/examples/littleX/components/TweetCard.cl.jac
+++ b/jac/examples/littleX/components/TweetCard.cl.jac
@@ -32,7 +32,9 @@ def:pub TweetCard(
 
     # Whose tweet this is falls out of data the client already holds -
     # no server round trip needed to answer a viewer-relative question.
-    is_mine = tweet.author_username == myUsername;
+    # The empty-string check keeps unowned tweets unowned while the
+    # viewer's profile is still loading (myUsername == "").
+    is_mine = tweet.author_username != "" and tweet.author_username == myUsername;
     is_liked = myUsername in tweet.likes;
     like_count = len(tweet.likes);
     comment_count = len(tweet.comments);

--- a/jac/examples/littleX/frontend.cl.jac
+++ b/jac/examples/littleX/frontend.cl.jac
@@ -26,11 +26,11 @@ sv import from .social_graph {
     create_channel_tweet
 }
 sv import from .social_graph {
-    UserView,
-    TweetView,
-    ChannelView,
+    Profile,
+    Tweet,
     TrendingTag,
-    ProfileView
+    ProfileBundle,
+    ChannelBundle
 }
 import from "lucide-react" { Feather, Sun, Moon, Pencil }
 import from .components.ui.button { Button }
@@ -54,21 +54,21 @@ def:pub app -> JsxElement {
         authLoading: bool = False,
         activeTab: str = "feed",
         darkMode: bool = True,
-        myProfile: ProfileView | None = None,
-        tweets: list[TweetView] = [],
+        myProfile: ProfileBundle | None = None,
+        tweets: list[Tweet] = [],
         feedLoading: bool = True,
         composerText: str = "",
         searchQuery: str = "",
-        allProfiles: list[UserView] = [],
+        allProfiles: list[Profile] = [],
         editingBio: bool = False,
         bioText: str = "",
         trendingTags: list[TrendingTag] = [],
         notifCount: int = 0,
         showWelcome: bool = False,
-        channels: list[ChannelView] = [],
+        channels: list[ChannelBundle] = [],
         channelsLoading: bool = False,
-        selectedChannel: ChannelView | None = None,
-        channelPosts: list[TweetView] = [];
+        selectedChannel: ChannelBundle | None = None,
+        channelPosts: list[Tweet] = [];
 
     can with entry {
         isLoggedIn = jacIsLoggedIn();
@@ -160,19 +160,20 @@ def:pub app -> JsxElement {
             />;
     }
 
-    profileUsername = myProfile.username if myProfile else "";
+    profileUsername = myProfile.profile.username if myProfile else "";
     displayUsername = profileUsername.split("@")[0]
         if "@" in profileUsername
         else profileUsername;
     profileAvatar = "https://i.pravatar.cc/150?u=fake@" + profileUsername;
-    myProfileId = myProfile.id if myProfile else "";
+    myProfileId = jid(myProfile.profile) if myProfile else "";
     followingIds = [
-        f.id for f in (myProfile.following if myProfile and myProfile.following else [])
+        jid(f)
+        for f in (myProfile.following if myProfile and myProfile.following else [])
     ];
     toFollow = [
         u
         for u in allProfiles
-        if u.id not in followingIds and u.id != myProfileId
+        if jid(u) not in followingIds and jid(u) != myProfileId
     ];
 
     return
@@ -206,8 +207,8 @@ def:pub app -> JsxElement {
                                 onClick={lambda {
                                     editingBio = not editingBio;
                                     bioText = (
-                                        myProfile.bio
-                                            if myProfile and myProfile.bio
+                                        myProfile.profile.bio
+                                            if myProfile and myProfile.profile.bio
                                             else ""
                                     );
                                 }}

--- a/jac/examples/littleX/frontend.impl.jac
+++ b/jac/examples/littleX/frontend.impl.jac
@@ -117,7 +117,9 @@ impl app.handleLike(tweetId: str) -> None {
         myProfile = profileResult.reports[0] if profileResult.reports else myProfile;
     }
     if selectedChannel {
-        detailResult = root spawn get_channel_detail(channel_id=selectedChannel.id);
+        detailResult = root spawn get_channel_detail(
+            channel_id=jid(selectedChannel.channel)
+        );
         detail = detailResult.reports[0] if detailResult.reports else None;
         if detail {
             selectedChannel = detail;
@@ -131,7 +133,9 @@ impl app.handleComment(tweetId: str, content: str) -> None {
     feedResult = root spawn load_feed(search_query=searchQuery);
     tweets = feedResult.reports[0] if feedResult.reports else [];
     if selectedChannel {
-        detailResult = root spawn get_channel_detail(channel_id=selectedChannel.id);
+        detailResult = root spawn get_channel_detail(
+            channel_id=jid(selectedChannel.channel)
+        );
         detail = detailResult.reports[0] if detailResult.reports else None;
         if detail {
             selectedChannel = detail;
@@ -170,7 +174,7 @@ impl app.handleUnfollow(profileId: str) -> None {
 }
 
 impl app.handleSaveBio -> None {
-    uname = myProfile.username if myProfile else "";
+    uname = myProfile.profile.username if myProfile else "";
     root spawn setup_profile(username=uname, bio=bioText);
     profileResult = root spawn get_profile();
     myProfile = profileResult.reports[0] if profileResult.reports else myProfile;
@@ -243,7 +247,7 @@ impl app.handleJoinChannel(channelId: str) -> None {
     root spawn join_channel(channel_id=channelId);
     result = root spawn get_channels();
     channels = result.reports[0] if result.reports else [];
-    if selectedChannel and selectedChannel.id == channelId {
+    if selectedChannel and jid(selectedChannel.channel) == channelId {
         detailResult = root spawn get_channel_detail(channel_id=channelId);
         detail = detailResult.reports[0] if detailResult.reports else None;
         if detail {
@@ -257,7 +261,7 @@ impl app.handleLeaveChannel(channelId: str) -> None {
     root spawn leave_channel(channel_id=channelId);
     result = root spawn get_channels();
     channels = result.reports[0] if result.reports else [];
-    if selectedChannel and selectedChannel.id == channelId {
+    if selectedChannel and jid(selectedChannel.channel) == channelId {
         detailResult = root spawn get_channel_detail(channel_id=channelId);
         detail = detailResult.reports[0] if detailResult.reports else None;
         if detail {
@@ -280,8 +284,12 @@ impl app.handleChannelPost(text: str) -> None {
     if not text.strip() or not selectedChannel {
         return;
     }
-    root spawn create_channel_tweet(channel_id=selectedChannel.id, content=text);
-    detailResult = root spawn get_channel_detail(channel_id=selectedChannel.id);
+    root spawn create_channel_tweet(
+        channel_id=jid(selectedChannel.channel), content=text
+    );
+    detailResult = root spawn get_channel_detail(
+        channel_id=jid(selectedChannel.channel)
+    );
     detail = detailResult.reports[0] if detailResult.reports else None;
     if detail {
         selectedChannel = detail;

--- a/jac/examples/littleX/social_graph.jac
+++ b/jac/examples/littleX/social_graph.jac
@@ -5,6 +5,13 @@ typed edges. Walkers are the mobile agents the client spawns - each one
 declares where it starts (`with Root entry`) and what to do at every node
 type it lands on (`with Tweet entry`, ...). Traversal is `visit`, never a
 hand-rolled loop, and shared fan-out lives in small base walkers.
+
+Walkers report graph nodes directly: a node's identity is its jid, which
+travels with the node (`jid(x)` resolves it on both sides of the wire), so
+no archetype carries a hand-rolled id field. Where the client needs
+edge-derived context alongside a node (follower lists, member counts,
+viewer membership), the walker reports a typed bundle that carries the
+node itself rather than a copy of its fields.
 """
 
 import datetime;
@@ -13,41 +20,20 @@ def _now -> str {
     return datetime.datetime.now(datetime.UTC).replace(tzinfo=None).isoformat() + "Z";
 }
 
-# --- View models: the typed contract returned to the client ---
-obj UserView {
-    has id: str,
-        username: str,
-        bio: str = "";
+# --- Report bundles: a node plus the edge-derived context the client
+#     needs alongside it. The node travels whole - identity included. ---
+obj ProfileBundle {
+    has profile: Profile,
+        followers: list[Profile],
+        following: list[Profile],
+        tweets: list[Tweet];
 }
 
-obj TweetView {
-    has id: str,
-        content: str,
-        author_username: str,
-        created_at: str,
-        likes: list[str],
-        comments: list[dict[str, str]],
-        is_mine: bool = False;
-}
-
-obj ProfileView {
-    has id: str,
-        username: str,
-        bio: str,
-        followers: list[UserView],
-        following: list[UserView],
-        tweets: list[TweetView];
-}
-
-obj ChannelView {
-    has id: str,
-        name: str,
-        description: str,
-        creator_username: str,
-        created_at: str,
+obj ChannelBundle {
+    has channel: Channel,
         member_count: int,
         is_member: bool,
-        posts: list[TweetView] = [];
+        posts: list[Tweet] = [];
 }
 
 obj TrendingTag {
@@ -61,29 +47,22 @@ edge Post {}
 edge Member {}
 edge ChannelPost {}
 
-# --- Graph nodes: data, plus the methods that present it as a view.
-#     A node knows how to describe itself; walkers decide when to ask. ---
+# --- Graph nodes: data, plus the methods that bundle it with nearby
+#     context. A node knows its own neighborhood; walkers decide when
+#     to ask. ---
 node Profile {
     has username: str = "",
         bio: str = "",
         created_at: str = "";
 
-    def to_user_view -> UserView {
-        return UserView(id=jid(self), username=self.username, bio=self.bio);
-    }
-
     # Followers / following fall straight out of the edges - no graph scan.
-    def to_profile_view -> ProfileView {
-        followers = [p.to_user_view() for p in [self<-:Follow:<-[?:Profile]]];
-        following = [p.to_user_view() for p in [self->:Follow:->[?:Profile]]];
-        tweets = [t.to_view() for t in [self-->[?:Tweet]]];
-        tweets.sort(key=lambda (t: TweetView) { t.created_at; }, reverse=True);
-        return ProfileView(
-            id=jid(self),
-            username=self.username,
-            bio=self.bio,
-            followers=followers,
-            following=following,
+    def to_bundle -> ProfileBundle {
+        tweets = [self-->[?:Tweet]];
+        tweets.sort(key=lambda (t: Tweet) { t.created_at; }, reverse=True);
+        return ProfileBundle(
+            profile=self,
+            followers=[self<-:Follow:<-[?:Profile]],
+            following=[self->:Follow:->[?:Profile]],
             tweets=tweets
         );
     }
@@ -95,20 +74,6 @@ node Tweet {
         created_at: str = "",
         likes: list[str] = [],
         comments: list[dict[str, str]] = [];
-
-    def to_view -> TweetView {
-        mine = [root-->[?:Profile]];
-        is_mine: bool = len(mine) > 0 and self.author_username == mine[0].username;
-        return TweetView(
-            id=jid(self),
-            content=self.content,
-            author_username=self.author_username,
-            created_at=self.created_at,
-            likes=self.likes,
-            comments=self.comments,
-            is_mine=is_mine
-        );
-    }
 }
 
 node Channel {
@@ -117,20 +82,16 @@ node Channel {
         creator_username: str = "",
         created_at: str = "";
 
-    def to_view(with_posts: bool) -> ChannelView {
+    def to_bundle(with_posts: bool) -> ChannelBundle {
         mine = [root-->[?:Profile]];
         is_member: bool = len(mine) > 0 and len([edge mine[0]->:Member:->self]) > 0;
-        posts: list[TweetView] = [];
+        posts: list[Tweet] = [];
         if with_posts {
-            posts = [t.to_view() for t in [self-->[?:Tweet]]];
-            posts.sort(key=lambda (t: TweetView) { t.created_at; }, reverse=True);
+            posts = [self-->[?:Tweet]];
+            posts.sort(key=lambda (t: Tweet) { t.created_at; }, reverse=True);
         }
-        return ChannelView(
-            id=jid(self),
-            name=self.name,
-            description=self.description,
-            creator_username=self.creator_username,
-            created_at=self.created_at,
+        return ChannelBundle(
+            channel=self,
             member_count=len([self<-:Member:<-[?:Profile]]),
             is_member=is_member,
             posts=posts
@@ -142,7 +103,7 @@ node Channel {
 walker setup_profile {
     has username: str = "",
         bio: str = "",
-        reports: list[ProfileView] = [];
+        reports: list[ProfileBundle] = [];
 
     can run with Root entry {
         # The `else` fires when `visit` enqueues nothing - i.e. no profile
@@ -161,26 +122,26 @@ walker setup_profile {
         if self.bio {
             here.bio = self.bio;
         }
-        report here.to_profile_view();
+        report here.to_bundle();
     }
 }
 
 walker get_profile {
-    has reports: list[ProfileView] = [];
+    has reports: list[ProfileBundle] = [];
 
     can run with Root entry {
         visit [-->[?:Profile]];
     }
 
     can give with Profile entry {
-        report here.to_profile_view();
+        report here.to_bundle();
     }
 }
 
 # --- Accumulator walkers: fan out, gather at each node, report once at exit ---
 walker:pub get_all_profiles {
-    has results: list[UserView] = [],
-        reports: list[list[UserView]] = [];
+    has results: list[Profile] = [],
+        reports: list[list[Profile]] = [];
 
     can run with Root entry {
         for r in allroots() {
@@ -189,7 +150,7 @@ walker:pub get_all_profiles {
     }
 
     can gather with Profile entry {
-        self.results.append(here.to_user_view());
+        self.results.append(here);
     }
 
     can deliver with Root exit {
@@ -234,8 +195,8 @@ walker get_trending {
 
 walker load_feed {
     has search_query: str = "",
-        feed: list[TweetView] = [],
-        reports: list[list[TweetView]] = [];
+        feed: list[Tweet] = [],
+        reports: list[list[Tweet]] = [];
 
     can run with Root entry {
         mine = [-->[?:Profile]];
@@ -247,7 +208,7 @@ walker load_feed {
     }
 
     can gather with Tweet entry {
-        self.feed.append(here.to_view());
+        self.feed.append(here);
     }
 
     can deliver with Root exit {
@@ -260,15 +221,15 @@ walker load_feed {
                 if q in t.content.lower()
             ];
         }
-        result.sort(key=lambda (t: TweetView) { t.created_at; }, reverse=True);
+        result.sort(key=lambda (t: Tweet) { t.created_at; }, reverse=True);
         report result;
     }
 }
 
 walker get_channels {
     has seen: dict[str, bool] = {},
-        results: list[ChannelView] = [],
-        reports: list[list[ChannelView]] = [];
+        results: list[ChannelBundle] = [],
+        reports: list[list[ChannelBundle]] = [];
 
     can run with Root entry {
         for r in allroots() {
@@ -281,12 +242,14 @@ walker get_channels {
         cid = jid(here);
         if cid not in self.seen {
             self.seen[cid] = True;
-            self.results.append(here.to_view(False));
+            self.results.append(here.to_bundle(False));
         }
     }
 
     can deliver with Root exit {
-        self.results.sort(key=lambda (c: ChannelView) { c.created_at; }, reverse=True);
+        self.results.sort(
+            key=lambda (c: ChannelBundle) { c.channel.created_at; }, reverse=True
+        );
         report self.results;
     }
 }
@@ -304,7 +267,7 @@ walker create_tweet {
             content=self.content, author_username=here.username, created_at=_now()
         );
         grant(new, level=WritePerm);
-        report new.to_view();
+        report new;
     }
 }
 
@@ -324,7 +287,7 @@ walker create_channel {
             created_at=_now()
         );
         grant(new, level=ConnectPerm);
-        report new.to_view(False);
+        report new.to_bundle(False);
     }
 }
 
@@ -474,11 +437,11 @@ walker leave_channel(find_channel) {
 }
 
 walker get_channel_detail(find_channel) {
-    has reports: list[ChannelView] = [];
+    has reports: list[ChannelBundle] = [];
 
     can act with Channel entry {
         if jid(here) == self.channel_id {
-            report here.to_view(True);
+            report here.to_bundle(True);
             disengage;
         }
     }
@@ -495,7 +458,7 @@ walker create_channel_tweet(find_channel) {
                     content=self.content, author_username=me.username, created_at=_now()
                 );
                 grant(new, level=WritePerm);
-                report new.to_view();
+                report new;
             }
             disengage;
         }

--- a/jac/examples/littleX/tests/test_fullstack.cl.jac
+++ b/jac/examples/littleX/tests/test_fullstack.cl.jac
@@ -49,20 +49,21 @@ test "two users: signup, post, follow, and feed propagation" {
     assert bob.token;
     assert alice.token != bob.token;
 
-    # Each sets up a profile; users only ever see their own.
+    # Each sets up a profile; users only ever see their own. A reported
+    # node keeps its identity: `jid()` works on it straight off the wire.
     alice.activate();
     alice_profile = (root spawn setup_profile(username="alice")).reports[0];
     bob.activate();
     bob_profile = (root spawn setup_profile(username="bob")).reports[0];
-    assert alice_profile["username"] == "alice";
-    assert bob_profile["username"] == "bob";
-    assert alice_profile["id"] != bob_profile["id"];
+    assert alice_profile["profile"]["username"] == "alice";
+    assert bob_profile["profile"]["username"] == "bob";
+    assert jid(alice_profile["profile"]) != jid(bob_profile["profile"]);
 
     # Alice posts a tweet.
     alice.activate();
     tweet = (root spawn create_tweet(content="hello world")).reports[0];
     assert tweet["content"] == "hello world";
-    assert tweet["is_mine"] == True;
+    assert tweet["author_username"] == "alice";
 
     # Before following, Alice's tweet is NOT in Bob's feed.
     bob.activate();
@@ -71,7 +72,9 @@ test "two users: signup, post, follow, and feed propagation" {
 
     # Bob follows Alice.
     bob.activate();
-    follow = (root spawn follow_user(target_id=alice_profile["id"])).reports[0];
+    follow = (
+        root spawn follow_user(target_id=jid(alice_profile["profile"]))
+    ).reports[0];
     assert follow["success"] == True;
 
     # Bob now sees Alice's tweet in his feed.

--- a/jac/examples/littleX/tests/test_fullstack.cl.jac
+++ b/jac/examples/littleX/tests/test_fullstack.cl.jac
@@ -72,9 +72,9 @@ test "two users: signup, post, follow, and feed propagation" {
 
     # Bob follows Alice.
     bob.activate();
-    follow = (
-        root spawn follow_user(target_id=jid(alice_profile["profile"]))
-    ).reports[0];
+    follow = (root spawn follow_user(target_id=jid(alice_profile["profile"]))).reports[
+        0
+    ];
     assert follow["success"] == True;
 
     # Bob now sees Alice's tweet in his feed.

--- a/jac/examples/littleX/tests/test_littlex.jac
+++ b/jac/examples/littleX/tests/test_littlex.jac
@@ -40,6 +40,11 @@ def first_report(response: TestResponse) -> any {
     return reports[0] if reports else None;
 }
 
+"""Return a reported node's jid: `_jac_id` is how identity crosses the wire."""
+def jid_of(reported: any) -> str {
+    return str(reported["_jac_id"]);
+}
+
 # -- Auth --
 test "register and login issues a token" {
     client = make_client();
@@ -66,18 +71,18 @@ test "profile setup and retrieval" {
     created = first_report(
         client.post("/walker/setup_profile", json={"username": "alice", "bio": "hi"})
     );
-    assert created["username"] == "alice";
-    assert created["bio"] == "hi";
+    assert created["profile"]["username"] == "alice";
+    assert created["profile"]["bio"] == "hi";
 
     fetched = first_report(client.post("/walker/get_profile", json={}));
-    assert fetched["id"] == created["id"];
+    assert jid_of(fetched["profile"]) == jid_of(created["profile"]);
     assert fetched["tweets"] == [];
 
     updated = first_report(
         client.post("/walker/setup_profile", json={"username": "", "bio": "updated"})
     );
-    assert updated["username"] == "alice";
-    assert updated["bio"] == "updated";
+    assert updated["profile"]["username"] == "alice";
+    assert updated["profile"]["bio"] == "updated";
 
     client.close();
 }
@@ -92,7 +97,8 @@ test "create tweet shows up in the feed" {
         client.post("/walker/create_tweet", json={"content": "hello world"})
     );
     assert tweet["content"] == "hello world";
-    assert tweet["is_mine"] == True;
+    assert tweet["author_username"] == "alice";
+    assert jid_of(tweet);
 
     feed = first_report(client.post("/walker/load_feed", json={}));
     assert len(list(feed)) == 1;
@@ -108,7 +114,7 @@ test "like and comment on a tweet" {
     tweet = first_report(
         client.post("/walker/create_tweet", json={"content": "rate this"})
     );
-    tweet_id = tweet["id"];
+    tweet_id = jid_of(tweet);
 
     liked = first_report(
         client.post("/walker/like_tweet", json={"tweet_id": tweet_id})
@@ -143,7 +149,7 @@ test "delete a tweet removes it from the feed" {
     );
 
     deleted = first_report(
-        client.post("/walker/delete_tweet", json={"tweet_id": tweet["id"]})
+        client.post("/walker/delete_tweet", json={"tweet_id": jid_of(tweet)})
     );
     assert deleted["success"] == True;
 
@@ -193,7 +199,7 @@ test "follow and unfollow another user" {
     bob_profile = first_report(
         client.post("/walker/setup_profile", json={"username": "bob"})
     );
-    bob_id = bob_profile["id"];
+    bob_id = jid_of(bob_profile["profile"]);
 
     client.login("alice", "secret123");
     client.post("/walker/setup_profile", json={"username": "alice"});
@@ -226,7 +232,9 @@ test "feed includes tweets from followed users" {
     client.login("alice", "secret123");
     client.post("/walker/setup_profile", json={"username": "alice"});
     client.post("/walker/create_tweet", json={"content": "alice's update"});
-    client.post("/walker/follow_user", json={"target_id": bob_profile["id"]});
+    client.post(
+        "/walker/follow_user", json={"target_id": jid_of(bob_profile["profile"])}
+    );
 
     feed = first_report(client.post("/walker/load_feed", json={}));
     contents = {t["content"] for t in feed};
@@ -267,7 +275,7 @@ test "channel create, join, post and detail" {
             "/walker/create_channel", json={"name": "jac-lang", "description": "chat"}
         )
     );
-    channel_id = channel["id"];
+    channel_id = jid_of(channel["channel"]);
     assert channel["is_member"] == True;
     assert channel["member_count"] == 1;
 
@@ -311,8 +319,8 @@ test "users only see their own profile via get_profile" {
     client.login("bob", "secret123");
     bob = first_report(client.post("/walker/setup_profile", json={"username": "bob"}));
 
-    assert alice["id"] != bob["id"];
-    assert bob["username"] == "bob";
+    assert jid_of(alice["profile"]) != jid_of(bob["profile"]);
+    assert bob["profile"]["username"] == "bob";
 
     client.close();
 }

--- a/jac/examples/littleX/tests/test_littlex.jac
+++ b/jac/examples/littleX/tests/test_littlex.jac
@@ -42,6 +42,7 @@ def first_report(response: TestResponse) -> any {
 
 """Return a reported node's jid: `_jac_id` is how identity crosses the wire."""
 def jid_of(reported: any) -> str {
+    assert "_jac_id" in reported , f"expected a reported node, got {reported}";
     return str(reported["_jac_id"]);
 }
 


### PR DESCRIPTION
## What

Refactors the littleX example from view-model DTOs to the node-report idiom already established by the smaller examples (day_planner, mini_todo):

- **View models deleted**: `UserView`, `TweetView`, `ChannelView`, and `ProfileView` are gone. Walkers report graph nodes (`Profile`, `Tweet`) directly — a node's identity is its jid, which travels with the node (`jid(x)` resolves it on both sides of the wire), so no archetype carries a hand-rolled `id` field.
- **Typed bundles where edge context is needed**: when the client needs edge-derived context alongside a node, the walker reports a bundle that carries the node itself rather than a copy of its fields — `ProfileBundle{profile, followers, following, tweets}` and `ChannelBundle{channel, member_count, is_member, posts}`.
- **Viewer-relative logic moves client-side**: `is_mine` is now computed in `TweetCard` from `tweet.author_username == myUsername` instead of being stamped by the server, dropping the per-tweet root scan in the old `Tweet.to_view()`.
- **Frontend identity is jid-only**: list keys and handler callbacks use `jid(node)` in place of the deleted `.id` fields.
- **Tests follow the new shapes**: the HTTP-level tests read identity via the `_jac_id` wire field (`jid_of` helper); the fullstack test asserts `jid()` works on nodes straight off the wire.

## Why

Explicit `has id: str` fields on DTOs were the only way a plain obj could carry identity, forcing every walker to copy node fields into parallel view classes. Reporting nodes keeps one source of truth, exercises the runtime's node serialization path, and makes littleX teach the same idiom as the rest of the examples.

## Testing

- `jac check` clean on the app
- 12/12 `tests/test_littlex.jac` pass
- 1/1 `tests/test_fullstack.cl.jac` (real cl→sv bridge under bun) passes