### PR TITLE
refactor(lint): collapse redundant Name/SpecialVarRef canonicalizer in _exprs_are_identical

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7563.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7563.refactor.md
@@ -1,0 +1,1 @@
+- **Refactor: Collapse duplicate expression canonicalization in the lint pass**: `_exprs_are_identical` no longer special-cases `Name`/`SpecialVarRef` (the latter branch was dead code, since `SpecialVarRef` subclasses `Name`); both now defer to the shared `_expr_to_key` path with identical results. No behavior change.

--- a/docs/docs/community/release_notes/unreleased/jaclang/7563.refactor.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7563.refactor.md
@@ -1,1 +1,0 @@
-- **Refactor: Collapse duplicate expression canonicalization in the lint pass**: `_exprs_are_identical` no longer special-cases `Name`/`SpecialVarRef` (the latter branch was dead code, since `SpecialVarRef` subclasses `Name`); both now defer to the shared `_expr_to_key` path with identical results. No behavior change.

--- a/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
@@ -1054,9 +1054,6 @@ impl JacAutoLintPass._exprs_are_identical(expr1: uni.Expr, expr2: uni.Expr) -> b
     if type(expr1) != type(expr2) {
         return False;
     }
-    if isinstance(expr1, uni.Name) and isinstance(expr2, uni.Name) {
-        return expr1.value == expr2.value;
-    }
     if isinstance(expr1, uni.AtomTrailer) and isinstance(expr2, uni.AtomTrailer) {
         if expr1.is_attr != expr2.is_attr {
             return False;
@@ -1071,12 +1068,6 @@ impl JacAutoLintPass._exprs_are_identical(expr1: uni.Expr, expr2: uni.Expr) -> b
             return expr1.right.value == expr2.right.value;
         }
         return self._exprs_are_identical(expr1.right, expr2.right);
-    }
-    if isinstance(expr1, uni.SpecialVarRef) and isinstance(expr2, uni.SpecialVarRef) {
-        if expr1.name and expr2.name {
-            return expr1.name.value == expr2.name.value;
-        }
-        return expr1.name is None and expr2.name is None;
     }
     key1 = self._expr_to_key(expr1);
     key2 = self._expr_to_key(expr2);


### PR DESCRIPTION
## What

The pass has two overlapping expression canonicalizers: `_expr_to_key` (expr -> canonical string) and `_exprs_are_identical` (structural equality, which already falls back to `_expr_to_key` comparison for the cases it doesn't special-case). `_exprs_are_identical` carried explicit `Name` and `SpecialVarRef` branches that duplicate what the `_expr_to_key` fallback already computes.

This removes both branches so `Name`/`SpecialVarRef` comparison flows through the single `_expr_to_key` path.

## Why this is behavior-preserving (and why the naive removal is not)

`SpecialVarRef` is a subclass of `Name` (`obj SpecialVarRef(Name)`). That has two consequences the change relies on:

- The `Name` branch was **load-bearing for `SpecialVarRef`**: because `isinstance(specialvarref, Name)` is true, that branch intercepted `SpecialVarRef` pairs and compared them by `.value`. The dedicated `SpecialVarRef` branch below it (comparing `.name.value`) was therefore **dead code** -- it could never run for two same-typed nodes. Removing only the `Name` branch reroutes `SpecialVarRef` pairs into that previously-dead branch and changes results (verified: it breaks 10 comment-preservation tests).

- `_expr_to_key` also checks `isinstance(expr, Name)` first, so `_expr_to_key(specialvarref)` returns `.value` too. Removing **both** branches routes `Name` and `SpecialVarRef` to the key fallback, which compares `.value == .value` -- exactly what the original live `Name` branch did.

So the correct dedup removes both branches together. The `AtomTrailer` branch stays (it handles non-attr trailers that `_expr_to_key` maps to `None`).

## Behavior

No functional change. Full `test_jac_auto_lint_pass` suite passes (68/68), including the comment-preservation tests that the naive one-branch removal regressed.
