### PR TITLE
fix(cli): stop jac ai from routing trivial greetings into Build

### DIFF
--- a/jac/jaclang/byllm/tests/test_ai_agent.jac
+++ b/jac/jaclang/byllm/tests/test_ai_agent.jac
@@ -324,6 +324,59 @@ test "a scripted MockLLM drives the AgentSession walker through its phases" {
 }
 
 
+test "the conversational fast-path recognises greetings but not code requests" {
+    # Bare greetings / pleasantries are conversational (route Plan -> Done).
+    for g in [
+        "hi",
+        "Hi!",
+        "  hello  ",
+        "hey there",
+        "thanks",
+        "ok",
+        "Good morning",
+        ""
+    ] {
+        assert ai.is_conversational_prompt(g) , g;
+    }
+    # Real work is not conversational (must still reach the classifier / Build).
+    for r in [
+        "add a greeting endpoint",
+        "fix the bug in model.jac",
+        "hello, add a User node",
+        "build me a calculator"
+    ] {
+        assert not ai.is_conversational_prompt(r) , r;
+    }
+}
+
+
+test "a greeting routes Plan -> Done and never enters Build/QA" {
+    proj = make_project();
+    events: list = [];
+    arm(proj, events);
+
+    # Only the Plan phase runs the model (one conversational reply). The
+    # deterministic fast-path then routes Plan -> Done, so no classifier output
+    # is consumed and Build/QA never run.
+    ai.agent_model = Model(
+        model_name="mockllm",
+        config={
+            "outputs": ["Hi! I'm the Jac coding agent -- what can I build for you?"]
+        }
+    );
+
+    out = capturing(lambda { AgentSessionSpawn("hi"); });
+
+    assert "conversational prompt" in out , out;
+    assert "Done" in out , out;
+    # A greeting must not enter Build/QA, and must not write any project files.
+    assert "Build wrote no files" not in out , out;
+    assert not list(Path(proj).glob("*.py")) , out;
+
+    shutil.rmtree(proj, ignore_errors=True);
+}
+
+
 """Spawn an AgentSession bounded to two steps so the walk halts after QA."""
 def AgentSessionSpawn(objective: str) {
     ai.AgentSession(

--- a/jac/jaclang/cli/ai_agent.jac
+++ b/jac/jaclang/cli/ai_agent.jac
@@ -297,6 +297,9 @@ sem request_needs_code_changes.objective = "The user's original request for this
 sem request_needs_code_changes.plan = "The plan and findings produced by the Plan phase so far.";
 
 
+def is_conversational_prompt(objective: str) -> bool;
+
+
 edge Flow {}
 
 node PhaseState {

--- a/jac/jaclang/cli/impl/ai_agent.impl.jac
+++ b/jac/jaclang/cli/impl/ai_agent.impl.jac
@@ -1891,12 +1891,102 @@ impl QA.directive -> str {
 
 sem run_phase.directive = "A short instruction kicking off the current phase.";
 
+impl is_conversational_prompt(objective: str) -> bool {
+    text = objective.strip().lower();
+    while text and text[-1] in "!.?,;:" {
+        text = text[:-1].strip();
+    }
+    if not text {
+        return True;
+    }
+    GREETINGS = {
+        "hi",
+        "hii",
+        "hiya",
+        "hey",
+        "hello",
+        "helo",
+        "yo",
+        "sup",
+        "howdy",
+        "gm",
+        "thanks",
+        "thank you",
+        "thankyou",
+        "thx",
+        "ty",
+        "ok",
+        "okay",
+        "k",
+        "cool",
+        "nice",
+        "great",
+        "awesome",
+        "bye",
+        "goodbye",
+        "cya"
+    };
+    if text in GREETINGS {
+        return True;
+    }
+    words = text.split();
+    if len(words) <= 3 {
+        SIMPLE = {
+            "hi",
+            "hii",
+            "hiya",
+            "hey",
+            "hello",
+            "helo",
+            "yo",
+            "sup",
+            "howdy",
+            "there",
+            "gm",
+            "good",
+            "morning",
+            "afternoon",
+            "evening",
+            "night",
+            "thanks",
+            "thank",
+            "you",
+            "thankyou",
+            "thx",
+            "ty",
+            "ok",
+            "okay",
+            "cool",
+            "nice",
+            "great",
+            "awesome",
+            "bye",
+            "goodbye",
+            "cya",
+            "please"
+        };
+        if all(w in SIMPLE for w in words) {
+            return True;
+        }
+    }
+    return False;
+}
+
 impl Plan.run with AgentSession entry {
     if agent.bus.cancel_requested {
         return;
     }
     self.step(visitor);
     if self.halt(visitor) {
+        return;
+    }
+
+    if is_conversational_prompt(visitor.objective) {
+        console.print(
+            "  ↳ conversational prompt -- answered in Plan, skipping Build/QA",
+            style="green"
+        );
+        visit [->:Flow:->][?:Done];
         return;
     }
 
@@ -1929,7 +2019,9 @@ impl Build.run with AgentSession entry {
     if self.halt(visitor) {
         return;
     }
-    if int(result.get("n_write", 0) or 0) == 0 and visitor.build_nudges < 2 {
+    if int(result.get("n_write", 0) or 0) == 0
+    and visitor.build_nudges < 2
+    and not is_conversational_prompt(visitor.objective) {
         visitor.build_nudges += 1;
         self.ctx.append(
             {


### PR DESCRIPTION
## Problem

`jac ai` treats a trivial conversational prompt as a code-changing request. Entering `hi` goes through `Plan`, gets routed into `Build`, and can then re-enter `Build` because no files were written -- turning a benign greeting into the coding workflow (and a potential self-loop).

Root causes:
- `Plan.run` decides `Plan -> Build` vs `Plan -> Done` via the model-backed `request_needs_code_changes` classifier, which is biased toward Build and also defaults to Build on error/malformed output.
- `Build.run` re-enters itself when the phase ended with zero writes, which is pathological after a misroute.

## Fix

Add a deterministic `is_conversational_prompt` fast-path:
- `Plan.run` short-circuits `Plan -> Done` for bare greetings/pleasantries (`hi`, `thanks`, `ok`, `good morning`, ...) *before* the model classifier runs, so they never reach Build/QA.
- The same check gates `Build.run`'s no-write re-entry nudge, so even a misroute can never self-loop on a conversational prompt.

Real code requests (`add a greeting endpoint`, `hello, add a User node`, ...) are not matched and still flow through the classifier to Build.

## Tests

- `the conversational fast-path recognises greetings but not code requests` -- unit-tests the classifier both ways.
- `a greeting routes Plan -> Done and never enters Build/QA` -- drives the `AgentSession` walker with a scripted MockLLM and asserts a `hi` prompt terminates in `Done`, never entering Build/QA and writing no files.

Both pass; the existing scripted-walker test (real code task) still routes through Build.

Closes #6763