### PR TITLE
fix(cli): prepend runtime globals in jac tool jac2js output

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7584.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7584.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix: `jac tool jac2js` emits runtime-ready JavaScript**: The CLI `jac2js` command now prepends active runtime globals (`__jacJsx`/`__jacSpawn` from `@jac/runtime`) to its printed output, so emitted client JS runs in Node, Vite, and desktop hosts without a `ReferenceError`.

--- a/jac/jaclang/cli/commands/impl/transform.impl.jac
+++ b/jac/jaclang/cli/commands/impl/transform.impl.jac
@@ -53,6 +53,7 @@ impl jac2py(filename: str) -> int {
 
 impl jac2js(filename: str) -> int {
     import from jaclang.jac0core.program { JacProgram }
+    import from jaclang.runtimelib.client_surface { prepend_active_runtime_globals }
     if filename.endswith('.jac') {
         try {
             prog = JacProgram();
@@ -68,7 +69,9 @@ impl jac2js(filename: str) -> int {
                 console.error('ECMAScript code generation produced no output.');
                 return 1;
             }
-            console.print(js_output, markup=False, highlight=False);
+            console.print(
+                prepend_active_runtime_globals(js_output), markup=False, highlight=False
+            );
             return 0;
         } except Exception as e {
             console.error(f"Generating JavaScript failed: {e}");

--- a/jac/tests/runtimelib/client/test_helpers.jac
+++ b/jac/tests/runtimelib/client/test_helpers.jac
@@ -121,7 +121,7 @@ def request_endpoint(
             } else {
                 raise;
             }
-        } except (URLError, RemoteDisconnected, TimeoutError) as exc {
+        } except (URLError, RemoteDisconnected, ConnectionError, TimeoutError) as exc {
             last_err = exc;
             time.sleep(poll_interval);
         }


### PR DESCRIPTION
## Summary
- Wrap `jac tool jac2js` output with `prepend_active_runtime_globals()` so standalone `.cl.jac` transpiles include required `@jac/runtime` imports (e.g. `__jacJsx`).
- Aligns the CLI transform path with `jac_to_js`, HMR, eject, and cl test runners.

## Test plan
- [x] `jac tool jac2js` on a minimal JSX `.cl.jac` module emits an `@jac/runtime` import containing `__jacJsx`
- [ ] Existing jac client compile / test suites pass


Made with [Cursor](https://cursor.com)