### PR TITLE
feat(compiler): na roadmap wave 1 - census telemetry plus the S-tier lowering gaps (#7593 items 21, 1, 2, 3, 20, 4, 5)

### DIFF
--- a/jac/jaclang/cli/check_report.jac
+++ b/jac/jaclang/cli/check_report.jac
@@ -7,3 +7,5 @@ def print_failures(failed_results: list, nowarn: bool = False) -> None;
 def print_failed_summary(failed_results: list) -> None;
 
 def print_final_summary(passed_count: int, failed_count: int, elapsed: float) -> None;
+
+def print_native_census(census: dict) -> None;

--- a/jac/jaclang/cli/commands/analysis.jac
+++ b/jac/jaclang/cli/commands/analysis.jac
@@ -58,10 +58,18 @@ glob registry = get_registry();
             short="",
             help="With --lint: auto-fix violations"
         ),
+        Arg.create(
+            "native-census",
+            typ=bool,
+            default=False,
+            short="",
+            help="Compile with codegen and report per-module native outcome (native / demoted / server) ranked by reason (needs the native toolchain)"
+        ),
 
     ],
     examples=[
         ("jac check myprogram.jac", "Check a single file"),
+        ("jac check . --native-census", "Rank modules by native compile outcome"),
         ("jac check . --lint", "Report lint violations only"),
         ("jac check . --lint --fix", "Auto-fix lint violations"),
         ("jac check file1.jac file2.jac", "Check multiple files"),
@@ -88,7 +96,8 @@ def check(
     parse_only: bool = False,
     nowarn: bool = False,
     lint_only: bool = False,
-    fix: bool = False
+    fix: bool = False,
+    native_census: bool = False
 ) -> int;
 
 def lint(paths: list, fix: bool = False, ignore: (list | None) = None) -> int;

--- a/jac/jaclang/cli/commands/impl/analysis.impl.jac
+++ b/jac/jaclang/cli/commands/impl/analysis.impl.jac
@@ -5,7 +5,8 @@ import from jaclang.cli.check_report {
     print_file_progress,
     print_failures,
     print_failed_summary,
-    print_final_summary
+    print_final_summary,
+    print_native_census
 }
 
 def _maybe_malloc_trim {
@@ -23,7 +24,8 @@ impl check(
     parse_only: bool = False,
     nowarn: bool = False,
     lint_only: bool = False,
-    fix: bool = False
+    fix: bool = False,
+    native_census: bool = False
 ) -> int {
     import from jaclang.jac0core.program { JacProgram }
     import from jaclang.jac0core.diagnostic_utils { resolve_diagnostic_tokens }
@@ -45,6 +47,10 @@ impl check(
                 unknown_codes
             )
         );
+    }
+    if native_census {
+        import from jaclang.jac0core.compiler { na_census_begin }
+        na_census_begin();
     }
 
     total_files = failed_files=total_errors=total_warnings=0;
@@ -95,7 +101,7 @@ impl check(
                 file_path=file_path,
                 options=CompileOptions(
                     type_check=not parse_only,
-                    no_cgen=True,
+                    no_cgen=not native_census,
                     force_target_program=True,
                     suppress_codes=suppressed_codes
                 )
@@ -159,6 +165,10 @@ impl check(
         _maybe_malloc_trim();
     }
 
+    if native_census {
+        import from jaclang.jac0core.compiler { na_census_end }
+        print_native_census(na_census_end());
+    }
     if print_errs and len(failed_results) > 0 {
         print_failures(failed_results, nowarn);
     }

--- a/jac/jaclang/cli/impl/check_report.impl.jac
+++ b/jac/jaclang/cli/impl/check_report.impl.jac
@@ -67,3 +67,96 @@ impl print_final_summary(passed_count: int, failed_count: int, elapsed: float) -
     }
     console.print(separator(", ".join(parts) + f" in {elapsed:.2f}s"));
 }
+
+def _census_relpath(path: str) -> str {
+    import os;
+    try {
+        return os.path.relpath(path);
+    } except ValueError {
+        return path;
+    }
+}
+
+impl print_native_census(census: dict) -> None {
+    import from jaclang.cli.console { console }
+    import from jaclang.jac0core.codeinfo { effective_default_codespace }
+    console.print("");
+    console.print(separator("native census"));
+    console.print(f"default codespace: {effective_default_codespace()}");
+    counts: dict[str, int] = {};
+    for rec in census.values() {
+        counts[rec['outcome']] = counts.get(rec['outcome'], 0) + 1;
+    }
+    console.print(
+        ", ".join(f"{counts.get(k, 0)} {k}" for k in ('native', 'demoted', 'server'))
+    );
+    native_paths = sorted(
+        _census_relpath(p)
+        for (p, rec) in census.items()
+        if rec['outcome'] == 'native'
+    );
+    if native_paths {
+        console.print("");
+        console.print("native modules:");
+        for p in native_paths {
+            console.print(f"  {p}");
+        }
+    }
+    demoted = [
+        (p, rec)
+        for (p, rec) in census.items()
+        if rec['outcome'] == 'demoted'
+    ];
+    if demoted {
+        console.print("");
+        console.print("demotions (ranked by first error code):");
+        by_code: dict[str, list] = {};
+        for (p, rec) in demoted {
+            by_code.setdefault(rec['code'] or '<uncoded>', []).append((p, rec));
+        }
+        ranked = sorted(by_code.items(), key=lambda (x: tuple) { (-len(x[1]), x[0]); });
+        for (code, entries) in ranked {
+            console.print(f"  {code}  ({len(entries)})");
+            for (p, rec) in sorted(entries) {
+                console.print(f"    {_census_relpath(p)}  {rec['detail']}");
+            }
+        }
+    }
+    server = [
+        (p, rec)
+        for (p, rec) in census.items()
+        if rec['outcome'] == 'server'
+    ];
+    if server {
+        console.print("");
+        console.print("server modules (ranked by classifier signal):");
+        by_reason: dict[str, list] = {};
+        for (p, rec) in server {
+            by_reason.setdefault(rec['detail'] or '<unknown>', []).append(p);
+        }
+        ranked_r = sorted(
+            by_reason.items(), key=lambda (x: tuple) { (-len(x[1]), x[0]); }
+        );
+        for (reason, paths) in ranked_r {
+            console.print(f"  {reason}  ({len(paths)})");
+            for p in sorted(paths) {
+                console.print(f"    {_census_relpath(p)}");
+            }
+        }
+    }
+    seamed = [
+        (p, rec)
+        for (p, rec) in census.items()
+        if rec['seams']
+    ];
+    if seamed {
+        console.print("");
+        console.print("native modules with demoted methods (seams):");
+        for (p, rec) in sorted(seamed) {
+            console.print(f"  {_census_relpath(p)}");
+            for s in rec['seams'] {
+                console.print(f"    {s}");
+            }
+        }
+    }
+}

--- a/jac/jaclang/compiler/passes/main/impl/capability_check_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/capability_check_pass.impl.jac
@@ -335,17 +335,6 @@ impl native_capability_violations(mod: uni.Module) -> list {
                 continue;
             }
 
-            if isinstance(nd, uni.CompareExpr) and len(nd.ops) > 1 {
-                _plain_ops = (Tok.EE, Tok.NE, Tok.LT, Tok.GT, Tok.LTE, Tok.GTE);
-                for _o in nd.ops {
-                    _oname = _o.name if isinstance(_o, uni.Token) else str(_o);
-                    if _oname not in _plain_ops {
-                        out.append((nd, "chained comparison operator", _oname, None));
-                        break;
-                    }
-                }
-            }
-
             if isinstance(nd, uni.FormattedValue) {
                 _conv = nd.conversion if nd.conversion is not None else -1;
                 if _conv not in (-1, 115) {

--- a/jac/jaclang/compiler/passes/main/impl/capability_check_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/main/impl/capability_check_pass.impl.jac
@@ -327,14 +327,6 @@ impl native_capability_violations(mod: uni.Module) -> list {
                 continue;
             }
 
-            if isinstance(nd, uni.BinaryExpr)
-            and isinstance(nd.op, uni.Token)
-            and nd.op.name == Tok.WALRUS_EQ
-            and not isinstance(nd.left, uni.Name) {
-                out.append((nd, "binary operator", "WALRUS_EQ", None));
-                continue;
-            }
-
             if isinstance(nd, uni.FormattedValue) {
                 _conv = nd.conversion if nd.conversion is not None else -1;
                 if _conv not in (-1, 115) {

--- a/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
@@ -5674,6 +5674,10 @@ impl NativeBuiltinEmitter.emit_str(
             if obj_s is not None {
                 return obj_s;
             }
+            cont_s = p._emit_container_repr(arg_val, ctx.type_key or None);
+            if cont_s is not None {
+                return cont_s;
+            }
             return b.bitcast(arg_val, i8p, name="str.identity");
         }
 
@@ -5686,6 +5690,13 @@ impl NativeBuiltinEmitter.emit_str(
 
     if isinstance(arg_val.type, ir.DoubleType) {
         return p._emit_float_repr(arg_val);
+    }
+
+    if isinstance(arg_val.type, ir.LiteralStructType) {
+        cont_s = p._emit_container_repr(arg_val, ctx.type_key or None);
+        if cont_s is not None {
+            return cont_s;
+        }
     }
     rc_alloc_fn = p.rc_alloc_fn;
     buf_ptr = b.call(rc_alloc_fn, [ir.Constant(ir.IntType(64), 32)], name="str.buf");

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/builtins.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/builtins.impl.jac
@@ -62,6 +62,9 @@ impl NaIRGenPass._emit_print(nd: uni.FuncCall) -> (ir.Value | None) {
             args.append(self._emit_float_repr(val));
         } elif isinstance(val.type, ir.PointerType) {
             obj_s = self._emit_obj_str(val);
+            if obj_s is None {
+                obj_s = self._emit_container_repr(val, self._type_key_of(param));
+            }
             if obj_s is not None {
                 if self._is_owned(val) {
                     self._emit_rc_release_typed(val, op="print_obj_src", loc="");
@@ -82,6 +85,19 @@ impl NaIRGenPass._emit_print(nd: uni.FuncCall) -> (ir.Value | None) {
             }
             fmt_parts.append("%s");
             args.append(val);
+        } elif isinstance(val.type, ir.LiteralStructType) {
+            _tup_s = self._emit_container_repr(val, self._type_key_of(param));
+            if _tup_s is None {
+                self.emit(
+                    E5092,
+                    node_override=param,
+                    kind="print argument",
+                    name=type(param).__name__
+                );
+                return None;
+            }
+            fmt_parts.append("%s");
+            args.append(_tup_s);
         }
     }
 
@@ -400,6 +416,11 @@ impl NaIRGenPass._codegen_fstring(nd: uni.FString) -> (ir.Value | None) {
                 } elif want == "str" {
                     if val.type != ir.IntType(8).as_pointer() {
                         obj_s = self._emit_obj_str(val);
+                        if obj_s is None {
+                            obj_s = self._emit_container_repr(
+                                val, self._type_key_of(part.format_part)
+                            );
+                        }
                         if obj_s is not None {
                             if self._is_owned(val) {
                                 self._emit_rc_release_typed(
@@ -408,6 +429,14 @@ impl NaIRGenPass._codegen_fstring(nd: uni.FString) -> (ir.Value | None) {
                             }
                             val = obj_s;
                             obj_strs.append(obj_s);
+                        } else {
+                            self.emit(
+                                E5092,
+                                node_override=part,
+                                kind="f-string value",
+                                name=type(part.format_part).__name__
+                            );
+                            return None;
                         }
                     }
                     fmt_parts.append(directive);
@@ -430,15 +459,44 @@ impl NaIRGenPass._codegen_fstring(nd: uni.FString) -> (ir.Value | None) {
                 args.append(self._emit_float_repr(val));
             } elif isinstance(val.type, ir.PointerType) {
                 obj_s = self._emit_obj_str(val);
+                if obj_s is None {
+                    obj_s = self._emit_container_repr(
+                        val, self._type_key_of(part.format_part)
+                    );
+                }
                 if obj_s is not None {
                     if self._is_owned(val) {
                         self._emit_rc_release_typed(val, op="fstr_obj_src", loc="");
                     }
                     val = obj_s;
                     obj_strs.append(obj_s);
+                } elif val.type != ir.IntType(8).as_pointer() {
+                    self.emit(
+                        E5092,
+                        node_override=part,
+                        kind="f-string value",
+                        name=type(part.format_part).__name__
+                    );
+                    return None;
                 }
                 fmt_parts.append("%s");
                 args.append(val);
+            } elif isinstance(val.type, ir.LiteralStructType) {
+                _tup_s = self._emit_container_repr(
+                    val, self._type_key_of(part.format_part)
+                );
+                if _tup_s is None {
+                    self.emit(
+                        E5092,
+                        node_override=part,
+                        kind="f-string value",
+                        name=type(part.format_part).__name__
+                    );
+                    return None;
+                }
+                obj_strs.append(_tup_s);
+                fmt_parts.append("%s");
+                args.append(_tup_s);
             }
         }
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/builtins.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/builtins.impl.jac
@@ -971,6 +971,74 @@ impl NaIRGenPass._emit_sys_argv -> (ir.Value | None) {
     return new_list;
 }
 
+impl NaIRGenPass._emit_sys_stream(stream: str) -> (ir.Value | None) {
+    i1 = ir.IntType(1);
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    i8p = ir.IntType(8).as_pointer();
+    file_st = self._get_file_struct_type();
+    self._emit_file_helpers();
+
+    import platform as _plat;
+    libc_name = stream;
+    if _plat.system() == "Darwin" {
+        libc_name = "__stdoutp" if stream == "stdout" else "__stderrp";
+    }
+    if libc_name not in self.extern_funcs {
+        libc_gv = ir.GlobalVariable(self.llvm_module, i8p, name=libc_name);
+        libc_gv.linkage = "external";
+        self.extern_funcs[libc_name] = libc_gv;
+    }
+    libc_gv = self.extern_funcs[libc_name];
+
+    sing_key = f"__jac_sys_{stream}";
+    if sing_key not in self.extern_funcs {
+        hdr_ty = ir.LiteralStructType([i64, i64, file_st]);
+        sing = ir.GlobalVariable(self.llvm_module, hdr_ty, name=f".sys.{stream}");
+        sing.linkage = "private";
+        sing.initializer = ir.Constant(
+            hdr_ty,
+            [
+                ir.Constant(i64, RC_SENTINEL),
+                ir.Constant(i64, 0),
+                ir.Constant(
+                    file_st,
+                    [
+                        ir.Constant(i8p, None),
+                        ir.Constant(i8p, None),
+                        ir.Constant(i8p, None),
+                        ir.Constant(i1, 0)
+                    ]
+                )
+            ]
+        );
+        self.extern_funcs[sing_key] = sing;
+    }
+    sing = self.extern_funcs[sing_key];
+
+    z32 = ir.Constant(i32, 0);
+    file_ptr = self.builder.gep(
+        sing, [z32, ir.Constant(i32, 2)], name=f"sys.{stream}.obj"
+    );
+    handle = self.builder.load(libc_gv, name=f"sys.{stream}.handle");
+    self.builder.store(
+        handle, self.builder.gep(file_ptr, [z32, z32], name=f"sys.{stream}.hp")
+    );
+    self.builder.store(
+        self._make_global_string(f"<{stream}>"),
+        self.builder.gep(file_ptr, [z32, ir.Constant(i32, 1)], name=f"sys.{stream}.pp")
+    );
+    self.builder.store(
+        self._make_global_string("w"),
+        self.builder.gep(file_ptr, [z32, ir.Constant(i32, 2)], name=f"sys.{stream}.mp")
+    );
+    self.builder.store(
+        ir.Constant(i1, 0),
+        self.builder.gep(file_ptr, [z32, ir.Constant(i32, 3)], name=f"sys.{stream}.cp")
+    );
+    return file_ptr;
+}
+
 impl NaIRGenPass._emit_sys_exit(args: list[ir.Value]) -> (ir.Value | None) {
     i32 = ir.IntType(32);
     exit_fn = self._get_or_declare_extern("exit", ir.VoidType(), [i32]);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
@@ -625,7 +625,8 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
                         func_name,
                         [arg_val],
                         kwargs=self._split_call_kwargs(nd),
-                        kw_node=nd
+                        kw_node=nd,
+                        type_key=(self._type_key_of(params_l[0]) or "")
                     );
 
                     if isinstance(arg_val.type, ir.PointerType)

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/core.impl.jac
@@ -991,7 +991,8 @@ impl NaIRGenPass._dispatch_builtin(
     func_name: str,
     args: list[ir.Value],
     kwargs: (dict | None) = None,
-    kw_node: (uni.UniNode | None) = None
+    kw_node: (uni.UniNode | None) = None,
+    type_key: str = ""
 ) -> (ir.Value | None) {
     self._ensure_emitters();
     _emit_fn = getattr(self._native_builtin_emitter, "emit_" + func_name, None);
@@ -1008,7 +1009,7 @@ impl NaIRGenPass._dispatch_builtin(
         return None;
     }
     _ctx = self._native_emit_ctx_class(
-        pass_ref=self, type_key="", call_kwargs=(kwargs or {})
+        pass_ref=self, type_key=type_key, call_kwargs=(kwargs or {})
     );
     return _emit_fn(_ctx, args);
 }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -538,18 +538,28 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
     if right is None {
         return None;
     }
+    op = nd.ops[0].name if isinstance(nd.ops[0], uni.Token) else str(nd.ops[0]);
+    return self._codegen_compare_link(op, left, right, nd.left, nd.rights[0]);
+}
 
+impl NaIRGenPass._codegen_compare_link(
+    op: str,
+    left: ir.Value,
+    right: ir.Value,
+    left_node: uni.UniNode,
+    right_node: uni.UniNode,
+    release_operands: bool = True
+) -> (ir.Value | None) {
     _cmp_left_orig = left;
     _cmp_right_orig = right;
-    op = nd.ops[0].name if isinstance(nd.ops[0], uni.Token) else str(nd.ops[0]);
 
     if self?.jacval_type and op in (Tok.KW_IS, Tok.KW_ISN, Tok.EE, Tok.NE) {
         _none_negate = op in (Tok.KW_ISN, Tok.NE);
-        _right_node = nd.rights[0];
+        _right_node = right_node;
         if isinstance(_right_node, uni.CfgExpr) {
             _right_node = _right_node.expr;
         }
-        _left_node = nd.left;
+        _left_node = left_node;
         if isinstance(_left_node, uni.CfgExpr) {
             _left_node = _left_node.expr;
         }
@@ -583,9 +593,11 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                     );
                 }
 
-                self._release_owned_operands(
-                    left_coerced, _cmp_right_orig, op="cmp_in_dict"
-                );
+                if release_operands {
+                    self._release_owned_operands(
+                        left_coerced, _cmp_right_orig, op="cmp_in_dict"
+                    );
+                }
                 return result;
             }
         }
@@ -608,9 +620,11 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                     );
                 }
 
-                self._release_owned_operands(
-                    left_coerced, _cmp_right_orig, op="cmp_in_set"
-                );
+                if release_operands {
+                    self._release_owned_operands(
+                        left_coerced, _cmp_right_orig, op="cmp_in_set"
+                    );
+                }
                 return result;
             }
         }
@@ -642,8 +656,8 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                 elem = self.builder.call(
                     helpers["get"], [right, idx], name="list.in.elem"
                 );
-                _lin_left_tk = self._type_key_of(nd.left);
-                _lin_coll_tk = self._type_key_of(nd.rights[0]) or "";
+                _lin_left_tk = self._type_key_of(left_node);
+                _lin_coll_tk = self._type_key_of(right_node) or "";
 
                 _lin_str_elems = (
                     _lin_left_tk == "str"
@@ -698,9 +712,11 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                     result = self.builder.zext(result, i64, name="notin.i64");
                 }
 
-                self._release_owned_operands(
-                    left_coerced, _cmp_right_orig, op="cmp_in_list"
-                );
+                if release_operands {
+                    self._release_owned_operands(
+                        left_coerced, _cmp_right_orig, op="cmp_in_list"
+                    );
+                }
                 return result;
             }
         }
@@ -847,7 +863,8 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                 right = self.builder.bitcast(right, left.type);
             }
             _is_result = self.builder.icmp_unsigned("==", left, right, name="is.eq");
-            if isinstance(_cmp_left_orig.type, ir.PointerType)
+            if release_operands
+            and isinstance(_cmp_left_orig.type, ir.PointerType)
             and self._is_owned(_cmp_left_orig) {
                 self._emit_rc_release_simple(
                     _cmp_left_orig,
@@ -855,7 +872,8 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                     loc=getattr(_cmp_left_orig, 'jac_loc', '')
                 );
             }
-            if isinstance(_cmp_right_orig.type, ir.PointerType)
+            if release_operands
+            and isinstance(_cmp_right_orig.type, ir.PointerType)
             and self._is_owned(_cmp_right_orig) {
                 self._emit_rc_release_simple(
                     _cmp_right_orig,
@@ -880,7 +898,8 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                 right = self.builder.bitcast(right, left.type);
             }
             _isn_result = self.builder.icmp_unsigned("!=", left, right, name="is.ne");
-            if isinstance(_cmp_left_orig.type, ir.PointerType)
+            if release_operands
+            and isinstance(_cmp_left_orig.type, ir.PointerType)
             and self._is_owned(_cmp_left_orig) {
                 self._emit_rc_release_simple(
                     _cmp_left_orig,
@@ -888,7 +907,8 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
                     loc=getattr(_cmp_left_orig, 'jac_loc', '')
                 );
             }
-            if isinstance(_cmp_right_orig.type, ir.PointerType)
+            if release_operands
+            and isinstance(_cmp_right_orig.type, ir.PointerType)
             and self._is_owned(_cmp_right_orig) {
                 self._emit_rc_release_simple(
                     _cmp_right_orig,
@@ -912,13 +932,15 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
         (left, right) = self._promote_to_float(left, right);
     }
     _cmp_result = self._emit_comparison(op, left, right, is_float);
-    if isinstance(_cmp_left_orig.type, ir.PointerType)
+    if release_operands
+    and isinstance(_cmp_left_orig.type, ir.PointerType)
     and self._is_owned(_cmp_left_orig) {
         self._emit_rc_release_simple(
             _cmp_left_orig, op="cmp_op", loc=getattr(_cmp_left_orig, 'jac_loc', '')
         );
     }
-    if isinstance(_cmp_right_orig.type, ir.PointerType)
+    if release_operands
+    and isinstance(_cmp_right_orig.type, ir.PointerType)
     and self._is_owned(_cmp_right_orig) {
         self._emit_rc_release_simple(
             _cmp_right_orig, op="cmp_op", loc=getattr(_cmp_right_orig, 'jac_loc', '')
@@ -930,16 +952,9 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
 impl NaIRGenPass._codegen_compare_chain(
     nd: uni.CompareExpr, left: ir.Value
 ) -> (ir.Value | None) {
-    _plain = (Tok.EE, Tok.NE, Tok.LT, Tok.GT, Tok.LTE, Tok.GTE);
     op_names: list[str] = [];
     for _o in nd.ops {
         _name = _o.name if isinstance(_o, uni.Token) else str(_o);
-        if _name not in _plain {
-            self.emit(
-                E5092, node_override=nd, kind="chained comparison operator", name=_name
-            );
-            return None;
-        }
         op_names.append(_name);
     }
     operands: list = [left];
@@ -951,14 +966,20 @@ impl NaIRGenPass._codegen_compare_chain(
             return None;
         }
         operands.append(right);
-        (l2, r2) = (cur, right);
-        is_float = isinstance(l2.type, (ir.DoubleType, ir.FloatType))
-        or isinstance(r2.type, (ir.DoubleType, ir.FloatType));
-        if is_float {
-            (l2, r2) = self._promote_to_float(l2, r2);
-        }
-        link = self._emit_comparison(op_name, l2, r2, is_float);
+        left_node = nd.left if i == 0 else nd.rights[i - 1];
+        _errs_before = len(self.errors_had);
+        link = self._codegen_compare_link(
+            op_name, cur, right, left_node, nd.rights[i], release_operands=False
+        );
         if link is None {
+            if len(self.errors_had) == _errs_before {
+                self.emit(
+                    E5092,
+                    node_override=nd,
+                    kind="chained comparison operator",
+                    name=op_name
+                );
+            }
             return None;
         }
         link = self._to_bool(link);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -1271,6 +1271,9 @@ impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None)
                     import sys as _sys;
                     return self._make_global_string(_sys.byteorder);
                 }
+                if right_name == "stdout" or right_name == "stderr" {
+                    return self._emit_sys_stream(right_name);
+                }
             }
 
             if (

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -333,6 +333,9 @@ impl NaIRGenPass._codegen_pipe_fwd(nd: uni.BinaryExpr) -> (ir.Value | None) {
 }
 
 impl NaIRGenPass._codegen_walrus(nd: uni.BinaryExpr) -> (ir.Value | None) {
+    if not isinstance(nd.left, uni.Name) {
+        return self._codegen_expr(nd.right);
+    }
     var_name = self._get_name(nd.left);
     if var_name is None {
         self.emit(E5092, node_override=nd, kind="binary operator", name="WALRUS_EQ");

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -906,8 +906,8 @@ impl NaIRGenPass._codegen_compare(nd: uni.CompareExpr) -> (ir.Value | None) {
         }
         return self._to_bool(left);
     }
-    is_float = isinstance(left.type, ir.DoubleType)
-    or isinstance(right.type, ir.DoubleType);
+    is_float = isinstance(left.type, (ir.DoubleType, ir.FloatType))
+    or isinstance(right.type, (ir.DoubleType, ir.FloatType));
     if is_float {
         (left, right) = self._promote_to_float(left, right);
     }
@@ -952,8 +952,8 @@ impl NaIRGenPass._codegen_compare_chain(
         }
         operands.append(right);
         (l2, r2) = (cur, right);
-        is_float = isinstance(l2.type, ir.DoubleType)
-        or isinstance(r2.type, ir.DoubleType);
+        is_float = isinstance(l2.type, (ir.DoubleType, ir.FloatType))
+        or isinstance(r2.type, (ir.DoubleType, ir.FloatType));
         if is_float {
             (l2, r2) = self._promote_to_float(l2, r2);
         }
@@ -996,7 +996,7 @@ impl NaIRGenPass._codegen_unary(nd: uni.UnaryExpr) -> (ir.Value | None) {
     }
     op = nd.op.name if isinstance(nd.op, uni.Token) else str(nd.op);
     if op == Tok.MINUS {
-        if isinstance(operand.type, ir.DoubleType) {
+        if isinstance(operand.type, (ir.DoubleType, ir.FloatType)) {
             return self.builder.fneg(operand, name="fneg");
         } elif isinstance(operand.type, ir.IntType) {
             return self.builder.neg(operand, name="neg");

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
@@ -6,6 +6,9 @@ impl NaIRGenPass._emit_list_helpers(elem_type_name: str, elem_type: ir.Type) -> 
     if elem_type_name == "ptr" {
         elem_type = ir.IntType(8).as_pointer();
     }
+    if elem_type_name == "i64" and isinstance(elem_type, ir.IntType) {
+        elem_type = ir.IntType(64);
+    }
 
     list_struct = self.llvm_module.context.get_identified_type(
         f"List.{elem_type_name}"
@@ -218,6 +221,8 @@ impl NaIRGenPass._codegen_list_val(nd: uni.ListVal) -> (ir.Value | None) {
     append_val = first_val;
     if elem_type_name == "ptr" and isinstance(first_val.type, ir.PointerType) {
         append_val = self.builder.bitcast(first_val, i8p, name="elem.cast");
+    } else {
+        append_val = self._coerce_type(append_val, helpers["elem_type"]);
     }
     _linit_loc = f"{os.path.basename(self.ir_in.loc.mod_path)}:{nd.loc.first_line
         if nd.loc
@@ -248,7 +253,7 @@ impl NaIRGenPass._codegen_list_val(nd: uni.ListVal) -> (ir.Value | None) {
             if elem_type_name == "ptr" and isinstance(val.type, ir.PointerType) {
                 val = self.builder.bitcast(val, i8p, name="elem.cast");
             } else {
-                val = self._coerce_type(val, elem_type);
+                val = self._coerce_type(val, helpers["elem_type"]);
             }
             self._rc_call_with_ctx(
                 helpers["append"], [list_val, val], op="list_init", loc=_linit_loc

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -558,6 +558,13 @@ impl NaIRGenPass._demote_method_if_unlowerable(
             f"(un-lowerable): {_why}\n"
         );
     }
+    try {
+        import from jaclang.jac0core.compiler { na_census_seam }
+        na_census_seam(
+            self.ir_in.loc.mod_path,
+            f"{full_name}: " + str(self.prog.errors_had[err_mark]).split('\n')[0]
+        );
+    } except Exception { }
     del self.prog.errors_had[err_mark:];
     del self.errors_had[local_mark:];
     func.blocks.clear();

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/repr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/repr.impl.jac
@@ -1,0 +1,758 @@
+impl NaIRGenPass._split_type_args(s: str, sep: str = ",") -> list[str] {
+    parts: list[str] = [];
+    depth = 0;
+    cur = "";
+    for ch in s {
+        if ch == "[" {
+            depth += 1;
+        } elif ch == "]" {
+            depth -= 1;
+        }
+        if ch == sep and depth == 0 {
+            parts.append(cur);
+            cur = "";
+        } else {
+            cur += ch;
+        }
+    }
+    parts.append(cur);
+    return parts;
+}
+
+impl NaIRGenPass._repr_const_str(text: str) -> ir.Value {
+    g = self._make_global_string(text, name_prefix=".repr.c");
+    if self._nogc_headerless() {
+        i8p = ir.IntType(8).as_pointer();
+        _strdup = self._get_or_declare_extern("strdup", i8p, [i8p]);
+        return self.builder.call(_strdup, [g], name="rp.c.dup");
+    }
+    return g;
+}
+
+impl NaIRGenPass._repr_acc_concat(
+    acc_slot: ir.Value, piece: ir.Value, own_piece: bool
+) -> None {
+    b = self.builder;
+    cur = b.load(acc_slot, name="rp.cur");
+    res = self._emit_binary_op(Tok.PLUS, cur, piece);
+    self._emit_rc_release_simple(cur, op="mstr_old", loc="");
+    if own_piece {
+        self._emit_rc_release_simple(piece, op="mstr_val", loc="");
+    }
+    b.store(res, acc_slot);
+}
+
+impl NaIRGenPass._repr_maybe_sep(
+    fn: ir.Function, i_val: ir.Value, acc_slot: ir.Value, sep_g: ir.Value
+) -> None {
+    b = self.builder;
+    i64 = ir.IntType(64);
+    need = b.icmp_signed(">", i_val, ir.Constant(i64, 0), name="rp.sep.need");
+    sep_bb = fn.append_basic_block("rp.sep");
+    cont_bb = fn.append_basic_block("rp.sep.cont");
+    b.cbranch(need, sep_bb, cont_bb);
+    b.position_at_end(sep_bb);
+    self._repr_acc_concat(acc_slot, sep_g, False);
+    b.branch(cont_bb);
+    b.position_at_end(cont_bb);
+}
+
+impl NaIRGenPass._repr_call_elem_fn(elem_fn: ir.Function, elem: ir.Value) -> ir.Value {
+    _pty = elem_fn.args[0].type;
+    v = elem if elem.type == _pty else self._coerce_type(elem, _pty);
+    res = self.builder.call(elem_fn, [v], name="rp.piece");
+    return self._mark_owned(res);
+}
+
+impl NaIRGenPass._repr_elem_spec_of_key(elem_key: str) -> (tuple | None) {
+    i64 = ir.IntType(64);
+    i8p = ir.IntType(8).as_pointer();
+    _parts = self._split_type_args(elem_key, "|");
+    if len(_parts) == 2 and ("NoneType" in _parts or "None" in _parts) {
+        _other = _parts[0] if _parts[1] in ("NoneType", "None") else _parts[1];
+        _inner = self._repr_elem_spec_of_key(_other);
+        if _inner is None or _inner[0] != "ptr" {
+            return None;
+        }
+        return ("ptr", i8p);
+    }
+    if len(_parts) > 1 {
+        return None;
+    }
+    if elem_key in ("int", "bool") {
+        return ("i64", i64);
+    }
+    if elem_key == "float" {
+        return ("f64", ir.DoubleType());
+    }
+    if elem_key == "str" {
+        return ("ptr", i8p);
+    }
+    if elem_key in self.struct_types {
+        return ("ptr", i8p);
+    }
+    if elem_key.endswith("]") {
+        for _pfx in ("list[", "dict[", "set[", "frozenset[", "tuple[") {
+            if elem_key.startswith(_pfx) {
+                return ("ptr", i8p);
+            }
+        }
+    }
+    return None;
+}
+
+impl NaIRGenPass._repr_field_llvm_of_key(field_key: str) -> (ir.Type | None) {
+    if field_key == "bool" {
+        return ir.IntType(1);
+    }
+    _spec = self._repr_elem_spec_of_key(field_key);
+    if _spec is None {
+        return None;
+    }
+    return _spec[1];
+}
+
+impl NaIRGenPass._repr_fn_for_type_key(type_key: str) -> (ir.Function | None) {
+    _cached = self._repr_fns.get(type_key);
+    if _cached is not None {
+        return _cached;
+    }
+    fn: (ir.Function | None) = None;
+    _parts = self._split_type_args(type_key, "|");
+    if len(_parts) > 1 {
+        if len(_parts) == 2 and ("NoneType" in _parts or "None" in _parts) {
+            _other = _parts[0] if _parts[1] in ("NoneType", "None") else _parts[1];
+            _ofn = self._repr_fn_for_type_key(_other);
+            if _ofn is not None and isinstance(_ofn.args[0].type, ir.PointerType) {
+                fn = _ofn;
+            }
+        }
+    } elif type_key == "int" {
+        fn = self._repr_leaf_fn("int");
+    } elif type_key == "bool" {
+        fn = self._repr_leaf_fn("bool");
+    } elif type_key == "float" {
+        fn = self._float_repr_fn();
+    } elif type_key == "str" {
+        fn = self._repr_str_fn();
+    } elif type_key in self.struct_types {
+        fn = self._repr_obj_fn(type_key);
+    } elif type_key.endswith("]") {
+        if type_key.startswith("list[") {
+            fn = self._repr_list_fn(type_key);
+        } elif type_key.startswith("dict[") {
+            fn = self._repr_dict_fn(type_key);
+        } elif type_key.startswith("set[") or type_key.startswith("frozenset[") {
+            fn = self._repr_set_fn(type_key);
+        } elif type_key.startswith("tuple[") {
+            fn = self._repr_tuple_fn(type_key);
+        }
+    }
+    if fn is not None {
+        self._repr_fns[type_key] = fn;
+    }
+    return fn;
+}
+
+impl NaIRGenPass._repr_leaf_fn(kind: str) -> (ir.Function | None) {
+    if kind not in ("int", "bool") {
+        return None;
+    }
+    _cached = self._repr_fns.get(kind);
+    if _cached is not None {
+        return _cached;
+    }
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    fnty = ir.FunctionType(i8p, [i64]);
+    fn = ir.Function(
+        self.llvm_module, fnty, name=f"__jac_repr_{native_safe_sym(kind)}"
+    );
+    fn.linkage = "private";
+    fn.args[0].name = "v";
+    v = fn.args[0];
+    saved_builder = self._builder;
+    entry_bb = fn.append_basic_block("entry");
+    b = ir.IRBuilder(entry_bb);
+    self._builder = b;
+    if kind == "bool" {
+        t_g = self._make_global_string("True", name_prefix=".repr.true");
+        f_g = self._make_global_string("False", name_prefix=".repr.false");
+        nz = b.icmp_signed("!=", v, ir.Constant(i64, 0), name="rp.b.nz");
+        sel = b.select(nz, t_g, f_g, name="rp.b.sel");
+        if self._nogc_headerless() {
+            _strdup = self._get_or_declare_extern("strdup", i8p, [i8p]);
+            sel = b.call(_strdup, [sel], name="rp.b.dup");
+        }
+        b.ret(sel);
+    } else {
+        snprintf = self._get_or_declare_extern(
+            "snprintf", i32, [i8p, i64, i8p], var_arg=True
+        );
+        fmt_g = self._make_global_string("%lld", name_prefix=".repr.fmt.int");
+        cap = ir.Constant(i64, 24);
+        buf = b.call(self.rc_alloc_fn, [cap], name="rp.i.buf");
+        b.call(snprintf, [buf, cap, fmt_g, v]);
+        self._emit_set_type_tag(b, buf, "str");
+        b.ret(buf);
+    }
+    self._builder = saved_builder;
+    self._repr_fns[kind] = fn;
+    return fn;
+}
+
+impl NaIRGenPass._repr_str_fn -> ir.Function {
+    _cached = self._repr_fns.get("str");
+    if _cached is not None {
+        return _cached;
+    }
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    i1 = ir.IntType(1);
+    i8 = ir.IntType(8);
+    i8p = i8.as_pointer();
+    i64 = ir.IntType(64);
+    fnty = ir.FunctionType(i8p, [i8p]);
+    fn = ir.Function(
+        self.llvm_module, fnty, name=f"__jac_repr_{native_safe_sym('str')}"
+    );
+    fn.linkage = "private";
+    fn.args[0].name = "s";
+    s = fn.args[0];
+    saved_builder = self._builder;
+    entry_bb = fn.append_basic_block("entry");
+    b = ir.IRBuilder(entry_bb);
+    self._builder = b;
+    SQ = ir.Constant(i8, 0x27);
+    DQ = ir.Constant(i8, 0x22);
+    BSL = ir.Constant(i8, 0x5C);
+
+    null_bb = fn.append_basic_block("rp.s.null");
+    scan_bb = fn.append_basic_block("rp.s.scan");
+    is_null = b.icmp_unsigned("==", s, ir.Constant(i8p, None), name="rp.s.isnull");
+    b.cbranch(is_null, null_bb, scan_bb);
+    b.position_at_end(null_bb);
+    b.ret(self._repr_const_str("None"));
+
+    b.position_at_end(scan_bb);
+    strlen_fn = self._get_or_declare_extern("strlen", i64, [i8p]);
+    slen = b.call(strlen_fn, [s], name="rp.s.len");
+    has_sq = b.alloca(i1, name="rp.has.sq");
+    has_dq = b.alloca(i1, name="rp.has.dq");
+    si = b.alloca(i64, name="rp.si");
+    b.store(ir.Constant(i1, 0), has_sq);
+    b.store(ir.Constant(i1, 0), has_dq);
+    b.store(ir.Constant(i64, 0), si);
+    sc_cond = fn.append_basic_block("rp.sc.cond");
+    sc_body = fn.append_basic_block("rp.sc.body");
+    sc_done = fn.append_basic_block("rp.sc.done");
+    b.branch(sc_cond);
+    b.position_at_end(sc_cond);
+    sidx = b.load(si, name="rp.sidx");
+    b.cbranch(b.icmp_signed("<", sidx, slen, name="rp.sc.go"), sc_body, sc_done);
+    b.position_at_end(sc_body);
+    sc = b.load(b.gep(s, [sidx], name="rp.sc.ptr"), name="rp.sc.ch");
+    b.store(
+        b.or_(b.load(has_sq), b.icmp_unsigned("==", sc, SQ, name="rp.sc.isq")), has_sq
+    );
+    b.store(
+        b.or_(b.load(has_dq), b.icmp_unsigned("==", sc, DQ, name="rp.sc.idq")), has_dq
+    );
+    b.store(b.add(sidx, ir.Constant(i64, 1)), si);
+    b.branch(sc_cond);
+    b.position_at_end(sc_done);
+    use_dq = b.and_(
+        b.load(has_sq), b.not_(b.load(has_dq), name="rp.no.dq"), name="rp.use.dq"
+    );
+    quote = b.select(use_dq, DQ, SQ, name="rp.quote");
+
+    cap = b.add(b.mul(slen, ir.Constant(i64, 4)), ir.Constant(i64, 3), name="rp.cap");
+    buf = b.call(self.rc_alloc_fn, [cap], name="rp.s.buf");
+    b.store(quote, buf);
+    oi = b.alloca(i64, name="rp.oi");
+    wi = b.alloca(i64, name="rp.wi");
+    b.store(ir.Constant(i64, 1), oi);
+    b.store(ir.Constant(i64, 0), wi);
+
+    w_cond = fn.append_basic_block("rp.w.cond");
+    w_body = fn.append_basic_block("rp.w.body");
+    w_done = fn.append_basic_block("rp.w.done");
+    b.branch(w_cond);
+    b.position_at_end(w_cond);
+    widx = b.load(wi, name="rp.widx");
+    b.cbranch(b.icmp_signed("<", widx, slen, name="rp.w.go"), w_body, w_done);
+    b.position_at_end(w_body);
+    c = b.load(b.gep(s, [widx], name="rp.c.ptr"), name="rp.c");
+    is_bsl = b.icmp_unsigned("==", c, BSL, name="rp.is.bsl");
+    is_q = b.icmp_unsigned("==", c, quote, name="rp.is.q");
+    is_tab = b.icmp_unsigned("==", c, ir.Constant(i8, 0x09), name="rp.is.tab");
+    is_nl = b.icmp_unsigned("==", c, ir.Constant(i8, 0x0A), name="rp.is.nl");
+    is_cr = b.icmp_unsigned("==", c, ir.Constant(i8, 0x0D), name="rp.is.cr");
+    ge_sp = b.icmp_unsigned(">=", c, ir.Constant(i8, 0x20), name="rp.ge.sp");
+    not_del = b.icmp_unsigned("!=", c, ir.Constant(i8, 0x7F), name="rp.not.del");
+    in_rng = b.and_(ge_sp, not_del, name="rp.in.rng");
+    is_special = b.or_(is_bsl, is_q, name="rp.is.special");
+    is_ctrl = b.or_(b.or_(is_tab, is_nl, name="rp.tn"), is_cr, name="rp.is.ctrl");
+    is_plain = b.and_(in_rng, b.not_(is_special, name="rp.not.sp"), name="rp.is.plain");
+    is_hex = b.not_(
+        b.or_(b.or_(is_special, is_ctrl, name="rp.sc1"), is_plain, name="rp.sc2"),
+        name="rp.is.hex"
+    );
+
+    hi = b.lshr(c, ir.Constant(i8, 4), name="rp.hi");
+    lo = b.and_(c, ir.Constant(i8, 0x0F), name="rp.lo");
+    hi_lt = b.icmp_unsigned("<", hi, ir.Constant(i8, 10), name="rp.hi.lt");
+    lo_lt = b.icmp_unsigned("<", lo, ir.Constant(i8, 10), name="rp.lo.lt");
+    hi_hex = b.select(
+        hi_lt,
+        b.add(hi, ir.Constant(i8, 48)),
+        b.add(hi, ir.Constant(i8, 87)),
+        name="rp.hi.x"
+    );
+    lo_hex = b.select(
+        lo_lt,
+        b.add(lo, ir.Constant(i8, 48)),
+        b.add(lo, ir.Constant(i8, 87)),
+        name="rp.lo.x"
+    );
+
+    o0 = b.select(is_plain, c, BSL, name="rp.o0");
+    ctrl_ch = b.select(
+        is_tab,
+        ir.Constant(i8, 0x74),
+        b.select(is_nl, ir.Constant(i8, 0x6E), ir.Constant(i8, 0x72), name="rp.nr"),
+        name="rp.ctrl.ch"
+    );
+    special_ch = b.select(is_bsl, BSL, quote, name="rp.special.ch");
+    o1 = b.select(
+        is_special,
+        special_ch,
+        b.select(is_ctrl, ctrl_ch, ir.Constant(i8, 0x78), name="rp.o1.x"),
+        name="rp.o1"
+    );
+    klen = b.select(
+        is_plain,
+        ir.Constant(i64, 1),
+        b.select(is_hex, ir.Constant(i64, 4), ir.Constant(i64, 2), name="rp.k0"),
+        name="rp.klen"
+    );
+
+    oi_cur = b.load(oi, name="rp.oi.cur");
+    b.store(o0, b.gep(buf, [oi_cur], name="rp.s0"));
+    b.store(o1, b.gep(buf, [b.add(oi_cur, ir.Constant(i64, 1))], name="rp.s1"));
+    b.store(hi_hex, b.gep(buf, [b.add(oi_cur, ir.Constant(i64, 2))], name="rp.s2"));
+    b.store(lo_hex, b.gep(buf, [b.add(oi_cur, ir.Constant(i64, 3))], name="rp.s3"));
+    b.store(b.add(oi_cur, klen), oi);
+    b.store(b.add(widx, ir.Constant(i64, 1)), wi);
+    b.branch(w_cond);
+    b.position_at_end(w_done);
+    oi_end = b.load(oi, name="rp.oi.end");
+    b.store(quote, b.gep(buf, [oi_end], name="rp.qc"));
+    b.store(
+        ir.Constant(i8, 0),
+        b.gep(buf, [b.add(oi_end, ir.Constant(i64, 1))], name="rp.nul")
+    );
+    self._emit_set_type_tag(b, buf, "str");
+    b.ret(buf);
+    self._builder = saved_builder;
+    self._repr_fns["str"] = fn;
+    return fn;
+}
+
+impl NaIRGenPass._repr_obj_fn(arch_name: str) -> ir.Function {
+    _cached = self._repr_fns.get(arch_name);
+    if _cached is not None {
+        return _cached;
+    }
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    i8p = ir.IntType(8).as_pointer();
+    pty = self.struct_types[arch_name].as_pointer();
+    fnty = ir.FunctionType(i8p, [pty]);
+    fn = ir.Function(
+        self.llvm_module, fnty, name=f"__jac_repr_{native_safe_sym(arch_name)}"
+    );
+    fn.linkage = "private";
+    fn.args[0].name = "obj";
+    o = fn.args[0];
+    saved_builder = self._builder;
+    entry_bb = fn.append_basic_block("entry");
+    b = ir.IRBuilder(entry_bb);
+    self._builder = b;
+    null_bb = fn.append_basic_block("rp.o.null");
+    live_bb = fn.append_basic_block("rp.o.live");
+    is_null = b.icmp_unsigned("==", o, ir.Constant(pty, None), name="rp.o.isnull");
+    b.cbranch(is_null, null_bb, live_bb);
+    b.position_at_end(null_bb);
+    b.ret(self._repr_const_str("None"));
+    b.position_at_end(live_bb);
+    _m = self._resolve_method(arch_name, "__repr__");
+    if _m is None {
+        _res = self._emit_default_obj_repr(o, arch_name);
+    } else {
+        _res = None;
+        if self._arch_has_vtable(arch_name) {
+            _res = self._codegen_virtual_call(o, "__repr__", [o], arch_name);
+        }
+        if _res is None {
+            _co = [self._coerce_type(o, _m.args[0].type)];
+            _res = self.builder.call(_m, _co, name="call.__repr__");
+        }
+    }
+    b.ret(self._coerce_type(_res, i8p));
+    self._builder = saved_builder;
+    self._repr_fns[arch_name] = fn;
+    return fn;
+}
+
+impl NaIRGenPass._repr_seq_fn(
+    fn_name: str,
+    cont_ptr_ty: ir.Type,
+    elem_fn: ir.Function,
+    open_text: str,
+    close_text: str,
+    empty_text: (str | None)
+) -> ir.Function {
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    fnty = ir.FunctionType(i8p, [cont_ptr_ty]);
+    fn = ir.Function(self.llvm_module, fnty, name=fn_name);
+    fn.linkage = "private";
+    fn.args[0].name = "cont";
+    c_arg = fn.args[0];
+    saved_builder = self._builder;
+    entry_bb = fn.append_basic_block("entry");
+    b = ir.IRBuilder(entry_bb);
+    self._builder = b;
+    null_bb = fn.append_basic_block("rp.null");
+    init_bb = fn.append_basic_block("rp.init");
+    is_null = b.icmp_unsigned(
+        "==", c_arg, ir.Constant(cont_ptr_ty, None), name="rp.isnull"
+    );
+    b.cbranch(is_null, null_bb, init_bb);
+    b.position_at_end(null_bb);
+    b.ret(self._repr_const_str("None"));
+    b.position_at_end(init_bb);
+    open_g = self._make_global_string(open_text, name_prefix=".repr.open");
+    close_g = self._make_global_string(close_text, name_prefix=".repr.close");
+    sep_g = self._make_global_string(", ", name_prefix=".repr.sep");
+    z32 = ir.Constant(i32, 0);
+    len_v = b.load(b.gep(c_arg, [z32, z32], name="rp.len.p"), name="rp.len");
+    if empty_text is not None {
+        empty_bb = fn.append_basic_block("rp.empty");
+        main_bb = fn.append_basic_block("rp.main");
+        is_empty = b.icmp_signed("==", len_v, ir.Constant(i64, 0), name="rp.isempty");
+        b.cbranch(is_empty, empty_bb, main_bb);
+        b.position_at_end(empty_bb);
+        b.ret(self._repr_const_str(empty_text));
+        b.position_at_end(main_bb);
+    }
+    data = b.load(
+        b.gep(c_arg, [z32, ir.Constant(i32, 2)], name="rp.data.p"), name="rp.data"
+    );
+    acc = b.alloca(i8p, name="rp.acc");
+    iv = b.alloca(i64, name="rp.i");
+    b.store(self._rc_strdup(open_g, name="rp.acc0"), acc);
+    b.store(ir.Constant(i64, 0), iv);
+    cond_bb = fn.append_basic_block("rp.cond");
+    body_bb = fn.append_basic_block("rp.body");
+    done_bb = fn.append_basic_block("rp.done");
+    b.branch(cond_bb);
+    b.position_at_end(cond_bb);
+    i_cur = b.load(iv, name="rp.iv");
+    b.cbranch(b.icmp_signed("<", i_cur, len_v, name="rp.more"), body_bb, done_bb);
+    b.position_at_end(body_bb);
+    self._repr_maybe_sep(fn, i_cur, acc, sep_g);
+    elem = b.load(b.gep(data, [i_cur], name="rp.elem.p"), name="rp.elem");
+    piece = self._repr_call_elem_fn(elem_fn, elem);
+    self._repr_acc_concat(acc, piece, True);
+    b.store(b.add(i_cur, ir.Constant(i64, 1), name="rp.inc"), iv);
+    b.branch(cond_bb);
+    b.position_at_end(done_bb);
+    _fin = b.load(acc, name="rp.fin");
+    res = self._emit_binary_op(Tok.PLUS, _fin, close_g);
+    self._emit_rc_release_simple(_fin, op="mstr_old", loc="");
+    self._emit_set_type_tag(b, res, "str");
+    b.ret(res);
+    self._builder = saved_builder;
+    return fn;
+}
+
+impl NaIRGenPass._repr_list_fn(type_key: str) -> (ir.Function | None) {
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    _inner = type_key[5:-1];
+    _spec = self._repr_elem_spec_of_key(_inner);
+    if _spec is None {
+        return None;
+    }
+    elem_fn = self._repr_fn_for_type_key(_inner);
+    if elem_fn is None {
+        return None;
+    }
+    self._emit_list_helpers(_spec[0], _spec[1]);
+    _st = self.list_types.get(_spec[0]);
+    if _st is None {
+        return None;
+    }
+    return self._repr_seq_fn(
+        f"__jac_repr_{native_safe_sym(type_key)}",
+        _st.as_pointer(),
+        elem_fn,
+        "[",
+        "]",
+        None
+    );
+}
+
+impl NaIRGenPass._repr_set_fn(type_key: str) -> (ir.Function | None) {
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    _inner = type_key[4:-1] if type_key.startswith("set[") else type_key[10:-1];
+    _spec = self._repr_elem_spec_of_key(_inner);
+    if _spec is None {
+        return None;
+    }
+    elem_fn = self._repr_fn_for_type_key(_inner);
+    if elem_fn is None {
+        return None;
+    }
+    self._emit_set_helpers(_spec[0], _spec[1]);
+    _st = self.set_types.get(_spec[0]);
+    if _st is None {
+        return None;
+    }
+    return self._repr_seq_fn(
+        f"__jac_repr_{native_safe_sym(type_key)}",
+        _st.as_pointer(),
+        elem_fn,
+        "{",
+        "}",
+        "set()"
+    );
+}
+
+impl NaIRGenPass._repr_dict_fn(type_key: str) -> (ir.Function | None) {
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    _args = self._split_type_args(type_key[5:-1]);
+    if len(_args) != 2 {
+        return None;
+    }
+    _kspec = self._repr_elem_spec_of_key(_args[0]);
+    _vspec = self._repr_elem_spec_of_key(_args[1]);
+    if _kspec is None or _vspec is None {
+        return None;
+    }
+    kfn = self._repr_fn_for_type_key(_args[0]);
+    vfn = self._repr_fn_for_type_key(_args[1]);
+    if kfn is None or vfn is None {
+        return None;
+    }
+    self._emit_dict_helpers(_kspec[0], _vspec[0], _kspec[1], _vspec[1]);
+    _st = self.dict_types.get(f"{_kspec[0]}:{_vspec[0]}");
+    if _st is None {
+        return None;
+    }
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    pty = _st.as_pointer();
+    fnty = ir.FunctionType(i8p, [pty]);
+    fn = ir.Function(
+        self.llvm_module, fnty, name=f"__jac_repr_{native_safe_sym(type_key)}"
+    );
+    fn.linkage = "private";
+    fn.args[0].name = "d";
+    d_arg = fn.args[0];
+    saved_builder = self._builder;
+    entry_bb = fn.append_basic_block("entry");
+    b = ir.IRBuilder(entry_bb);
+    self._builder = b;
+    null_bb = fn.append_basic_block("rp.d.null");
+    init_bb = fn.append_basic_block("rp.d.init");
+    is_null = b.icmp_unsigned("==", d_arg, ir.Constant(pty, None), name="rp.d.isnull");
+    b.cbranch(is_null, null_bb, init_bb);
+    b.position_at_end(null_bb);
+    b.ret(self._repr_const_str("None"));
+    b.position_at_end(init_bb);
+    open_g = self._make_global_string("{", name_prefix=".repr.open");
+    close_g = self._make_global_string("}", name_prefix=".repr.close");
+    sep_g = self._make_global_string(", ", name_prefix=".repr.sep");
+    colon_g = self._make_global_string(": ", name_prefix=".repr.colon");
+    z32 = ir.Constant(i32, 0);
+    len_v = b.load(b.gep(d_arg, [z32, z32], name="rp.d.len.p"), name="rp.d.len");
+    keys = b.load(
+        b.gep(d_arg, [z32, ir.Constant(i32, 2)], name="rp.d.keys.p"), name="rp.d.keys"
+    );
+    vals = b.load(
+        b.gep(d_arg, [z32, ir.Constant(i32, 3)], name="rp.d.vals.p"), name="rp.d.vals"
+    );
+    acc = b.alloca(i8p, name="rp.acc");
+    iv = b.alloca(i64, name="rp.i");
+    b.store(self._rc_strdup(open_g, name="rp.acc0"), acc);
+    b.store(ir.Constant(i64, 0), iv);
+    cond_bb = fn.append_basic_block("rp.cond");
+    body_bb = fn.append_basic_block("rp.body");
+    done_bb = fn.append_basic_block("rp.done");
+    b.branch(cond_bb);
+    b.position_at_end(cond_bb);
+    i_cur = b.load(iv, name="rp.iv");
+    b.cbranch(b.icmp_signed("<", i_cur, len_v, name="rp.more"), body_bb, done_bb);
+    b.position_at_end(body_bb);
+    self._repr_maybe_sep(fn, i_cur, acc, sep_g);
+    k_el = b.load(b.gep(keys, [i_cur], name="rp.k.p"), name="rp.k");
+    self._repr_acc_concat(acc, self._repr_call_elem_fn(kfn, k_el), True);
+    self._repr_acc_concat(acc, colon_g, False);
+    v_el = b.load(b.gep(vals, [i_cur], name="rp.v.p"), name="rp.v");
+    self._repr_acc_concat(acc, self._repr_call_elem_fn(vfn, v_el), True);
+    b.store(b.add(i_cur, ir.Constant(i64, 1), name="rp.inc"), iv);
+    b.branch(cond_bb);
+    b.position_at_end(done_bb);
+    _fin = b.load(acc, name="rp.fin");
+    res = self._emit_binary_op(Tok.PLUS, _fin, close_g);
+    self._emit_rc_release_simple(_fin, op="mstr_old", loc="");
+    self._emit_set_type_tag(b, res, "str");
+    b.ret(res);
+    self._builder = saved_builder;
+    return fn;
+}
+
+impl NaIRGenPass._repr_tuple_fn(type_key: str) -> (ir.Function | None) {
+    import from jaclang.jac0core.codeinfo { native_safe_sym }
+    _fkeys = self._split_type_args(type_key[6:-1]);
+    if not _fkeys or _fkeys == [""] {
+        return None;
+    }
+    _ffns: list = [];
+    _ftys: list = [];
+    for fk in _fkeys {
+        _f = self._repr_fn_for_type_key(fk);
+        if _f is None {
+            return None;
+        }
+        _ft = self._repr_field_llvm_of_key(fk);
+        if _ft is None {
+            return None;
+        }
+        _ffns.append(_f);
+        _ftys.append(_ft);
+    }
+    i8p = ir.IntType(8).as_pointer();
+    i32 = ir.IntType(32);
+    pty = ir.LiteralStructType(_ftys).as_pointer();
+    fnty = ir.FunctionType(i8p, [pty]);
+    fn = ir.Function(
+        self.llvm_module, fnty, name=f"__jac_repr_{native_safe_sym(type_key)}"
+    );
+    fn.linkage = "private";
+    fn.args[0].name = "t";
+    t_arg = fn.args[0];
+    saved_builder = self._builder;
+    entry_bb = fn.append_basic_block("entry");
+    b = ir.IRBuilder(entry_bb);
+    self._builder = b;
+    null_bb = fn.append_basic_block("rp.t.null");
+    live_bb = fn.append_basic_block("rp.t.live");
+    is_null = b.icmp_unsigned("==", t_arg, ir.Constant(pty, None), name="rp.t.isnull");
+    b.cbranch(is_null, null_bb, live_bb);
+    b.position_at_end(null_bb);
+    b.ret(self._repr_const_str("None"));
+    b.position_at_end(live_bb);
+    open_g = self._make_global_string("(", name_prefix=".repr.open");
+    sep_g = self._make_global_string(", ", name_prefix=".repr.sep");
+    close_g = self._make_global_string(
+        ",)" if len(_ffns) == 1 else ")", name_prefix=".repr.close"
+    );
+    z32 = ir.Constant(i32, 0);
+    cur = self._rc_strdup(open_g, name="rp.t.acc0");
+    for (idx, ffn) in enumerate(_ffns) {
+        if idx > 0 {
+            nxt = self._emit_binary_op(Tok.PLUS, cur, sep_g);
+            self._emit_rc_release_simple(cur, op="mstr_old", loc="");
+            cur = nxt;
+        }
+        fld = b.load(
+            b.gep(t_arg, [z32, ir.Constant(i32, idx)], name=f"rp.t.{idx}.p"),
+            name=f"rp.t.{idx}"
+        );
+        piece = self._repr_call_elem_fn(ffn, fld);
+        nxt = self._emit_binary_op(Tok.PLUS, cur, piece);
+        self._emit_rc_release_simple(cur, op="mstr_old", loc="");
+        self._emit_rc_release_simple(piece, op="mstr_val", loc="");
+        cur = nxt;
+    }
+    res = self._emit_binary_op(Tok.PLUS, cur, close_g);
+    self._emit_rc_release_simple(cur, op="mstr_old", loc="");
+    self._emit_set_type_tag(b, res, "str");
+    b.ret(res);
+    self._builder = saved_builder;
+    return fn;
+}
+
+impl NaIRGenPass._emit_container_repr(
+    val: ir.Value, type_key: (str | None)
+) -> (ir.Value | None) {
+    if not type_key {
+        return None;
+    }
+    base = type_key;
+    _parts = self._split_type_args(type_key, "|");
+    if len(_parts) == 2 and ("NoneType" in _parts or "None" in _parts) {
+        base = _parts[0] if _parts[1] in ("NoneType", "None") else _parts[1];
+    } elif len(_parts) > 1 {
+        return None;
+    }
+    if not base.endswith("]") {
+        return None;
+    }
+    if self.rc_alloc_fn is None {
+        self._emit_rc_helpers();
+    }
+    if isinstance(val.type, ir.LiteralStructType) {
+        if not base.startswith("tuple[") {
+            return None;
+        }
+        fn = self._repr_fn_for_type_key(base);
+        if fn is None {
+            return None;
+        }
+        boxed = self._box_value_tuple(val);
+        arg = (
+            boxed
+                if boxed.type == fn.args[0].type
+                else self.builder.bitcast(boxed, fn.args[0].type, name="tup.repr.arg")
+        );
+        res = self.builder.call(fn, [arg], name="tup.repr");
+        self._mark_owned(res);
+        self._emit_rc_release_simple(boxed, op="mstr_val", loc="");
+        return res;
+    }
+    if not isinstance(val.type, ir.PointerType) {
+        return None;
+    }
+    _pointee = val.type.pointee;
+    _pname = getattr(_pointee, "name", "") or "";
+    ok = False;
+    if base.startswith("list[") {
+        ok = _pname.startswith("List.");
+    } elif base.startswith("dict[") {
+        ok = _pname.startswith("Dict.");
+    } elif base.startswith("set[") or base.startswith("frozenset[") {
+        ok = _pname.startswith("Set.");
+    } elif base.startswith("tuple[") {
+        ok = isinstance(_pointee, ir.LiteralStructType);
+    }
+    if not ok {
+        return None;
+    }
+    fn = self._repr_fn_for_type_key(base);
+    if fn is None {
+        return None;
+    }
+    arg = (
+        val
+            if val.type == fn.args[0].type
+            else self.builder.bitcast(val, fn.args[0].type, name="cont.repr.arg")
+    );
+    res = self.builder.call(fn, [arg], name="cont.repr");
+    return self._mark_owned(res);
+}

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -738,8 +738,8 @@ impl NaIRGenPass._match_value_eq(
     and subj.type != pat.type {
         pat = self._coerce_type(pat, subj.type);
     }
-    is_float = isinstance(subj.type, ir.DoubleType)
-    or isinstance(pat.type, ir.DoubleType);
+    is_float = isinstance(subj.type, (ir.DoubleType, ir.FloatType))
+    or isinstance(pat.type, (ir.DoubleType, ir.FloatType));
     (lhs, rhs) = (subj, pat);
     if is_float {
         (lhs, rhs) = self._promote_to_float(subj, pat);
@@ -768,7 +768,7 @@ impl NaIRGenPass._bind_match_pattern(pat: uni.MatchPattern, subj: ir.Value) -> N
 impl NaIRGenPass._apply_scalar_aug_op(
     current: ir.Value, rhs: ir.Value, aug_op: str
 ) -> (ir.Value | None) {
-    if not isinstance(current.type, (ir.IntType, ir.DoubleType)) {
+    if not isinstance(current.type, (ir.IntType, ir.DoubleType, ir.FloatType)) {
         return None;
     }
     op_toks = {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -558,7 +558,7 @@ impl NaIRGenPass._to_bool(val: ir.Value) -> ir.Value {
             "!=", val, ir.Constant(val.type, 0), name="tobool"
         );
     }
-    if isinstance(val.type, ir.DoubleType) {
+    if isinstance(val.type, (ir.DoubleType, ir.FloatType)) {
         return self.builder.fcmp_unordered(
             "!=", val, ir.Constant(val.type, 0.0), name="tobool"
         );
@@ -901,11 +901,12 @@ impl NaIRGenPass._coerce_type_inner(val: ir.Value, target_type: ir.Type) -> ir.V
 impl NaIRGenPass._promote_to_float(
     left: ir.Value, right: ir.Value
 ) -> tuple[(ir.Value, ir.Value)] {
-    if isinstance(left.type, ir.IntType) {
-        left = self.builder.sitofp(left, ir.DoubleType(), name="cast");
+    f64 = ir.DoubleType();
+    if isinstance(left.type, (ir.IntType, ir.FloatType)) {
+        left = self._coerce_type(left, f64);
     }
-    if isinstance(right.type, ir.IntType) {
-        right = self.builder.sitofp(right, ir.DoubleType(), name="cast");
+    if isinstance(right.type, (ir.IntType, ir.FloatType)) {
+        right = self._coerce_type(right, f64);
     }
     return (left, right);
 }
@@ -1264,8 +1265,8 @@ impl NaIRGenPass._emit_binary_op(
         }
     }
 
-    is_float = isinstance(left.type, ir.DoubleType)
-    or isinstance(right.type, ir.DoubleType)
+    is_float = isinstance(left.type, (ir.DoubleType, ir.FloatType))
+    or isinstance(right.type, (ir.DoubleType, ir.FloatType))
     or op == Tok.DIV;
     if is_float {
         (left, right) = self._promote_to_float(left, right);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -286,6 +286,15 @@ obj NaIRGenPass(ModuleCodegenPass) {
         nd: uni.CompareExpr, left: ir.Value
     ) -> (ir.Value | None);
 
+    def _codegen_compare_link(
+        op: str,
+        left: ir.Value,
+        right: ir.Value,
+        left_node: uni.UniNode,
+        right_node: uni.UniNode,
+        release_operands: bool = True
+    ) -> (ir.Value | None);
+
     def _codegen_unary(nd: uni.UnaryExpr) -> (ir.Value | None);
     def _codegen_call(nd: uni.FuncCall) -> (ir.Value | None);
     def _codegen_rc_intrinsic(func_name: str) -> bool;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -636,6 +636,7 @@ obj NaIRGenPass(ModuleCodegenPass) {
     ) -> (ir.Value | None);
 
     def _emit_sys_argv -> (ir.Value | None);
+    def _emit_sys_stream(stream: str) -> (ir.Value | None);
     def _emit_sys_exit(args: list[ir.Value]) -> (ir.Value | None);
     def _emit_math_call(name: str, nd: uni.FuncCall) -> (ir.Value | None);
     def _emit_math_const(name: str) -> (ir.Value | None);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -176,6 +176,7 @@ obj NaIRGenPass(ModuleCodegenPass) {
         _bytes_struct_type: (object | None) = None,
         _bytes_repr_function: (object | None) = None,
         _float_repr_function: (object | None) = None,
+        _repr_fns: dict[str, object] = {},
         _jac_iter_type: (object | None) = None,
         _iter_structs_registered: bool = False,
         _iter_next_fns: dict[str, ir.Function] = {},
@@ -502,6 +503,37 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _codegen_method_call(nd: uni.FuncCall) -> (ir.Value | None);
     def _emit_obj_str(val: ir.Value) -> (ir.Value | None);
     def _emit_default_obj_repr(val: ir.Value, type_name: str) -> ir.Value;
+    def _emit_container_repr(
+        val: ir.Value, type_key: (str | None)
+    ) -> (ir.Value | None);
+
+    def _repr_fn_for_type_key(type_key: str) -> (ir.Function | None);
+    def _repr_str_fn -> ir.Function;
+    def _repr_leaf_fn(kind: str) -> (ir.Function | None);
+    def _repr_obj_fn(arch_name: str) -> ir.Function;
+    def _repr_list_fn(type_key: str) -> (ir.Function | None);
+    def _repr_dict_fn(type_key: str) -> (ir.Function | None);
+    def _repr_set_fn(type_key: str) -> (ir.Function | None);
+    def _repr_tuple_fn(type_key: str) -> (ir.Function | None);
+    def _repr_seq_fn(
+        fn_name: str,
+        cont_ptr_ty: ir.Type,
+        elem_fn: ir.Function,
+        open_text: str,
+        close_text: str,
+        empty_text: (str | None)
+    ) -> ir.Function;
+
+    def _repr_elem_spec_of_key(elem_key: str) -> (tuple | None);
+    def _repr_field_llvm_of_key(field_key: str) -> (ir.Type | None);
+    def _split_type_args(s: str, sep: str = ",") -> list[str];
+    def _repr_const_str(text: str) -> ir.Value;
+    def _repr_acc_concat(acc_slot: ir.Value, piece: ir.Value, own_piece: bool) -> None;
+    def _repr_maybe_sep(
+        fn: ir.Function, i_val: ir.Value, acc_slot: ir.Value, sep_g: ir.Value
+    ) -> None;
+
+    def _repr_call_elem_fn(elem_fn: ir.Function, elem: ir.Value) -> ir.Value;
     def _codegen_field_access(
         obj_val: ir.Value, field_name: str, type_name: str
     ) -> (ir.Value | None);
@@ -876,7 +908,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
         func_name: str,
         args: list[ir.Value],
         kwargs: (dict | None) = None,
-        kw_node: (uni.UniNode | None) = None
+        kw_node: (uni.UniNode | None) = None,
+        type_key: str = ""
     ) -> (ir.Value | None);
 
     def _split_call_kwargs(nd: uni.FuncCall) -> dict;

--- a/jac/jaclang/compiler/passes/native/primitives_native.jac
+++ b/jac/jaclang/compiler/passes/native/primitives_native.jac
@@ -1590,10 +1590,14 @@ class NativeBuiltinEmitter(BuiltinEmitter[(ir.Value, NativeEmitCtx)]) {
             return p._emit_float_repr(arg_val);
         }
         if isinstance(arg_val.type, ir.PointerType) and arg_val.type == i8p {
-            fmt = p._get_snprintf_fmt("'%s'");
-            fmt_ptr = b.bitcast(fmt, i8p, name="repr.fmt.ptr");
-            b.call(snprintf, [buf_ptr, ir.Constant(i64, 64), fmt_ptr, arg_val]);
-            return buf_ptr;
+            str_repr = b.call(p._repr_str_fn(), [arg_val], name="repr.str");
+            return p._mark_owned(str_repr);
+        }
+        if isinstance(arg_val.type, (ir.PointerType, ir.LiteralStructType)) {
+            cont_s = p._emit_container_repr(arg_val, ctx.type_key or None);
+            if cont_s is not None {
+                return cont_s;
+            }
         }
         return None;
     }

--- a/jac/jaclang/compiler/tests/fixtures/prim_chain_cmp.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_chain_cmp.jac
@@ -1,0 +1,75 @@
+"""Chained-comparison cross-backend equivalence fixture (#7593 item 2).
+
+Pins CPython chain semantics for membership (in / not in) and identity
+(is / is not) links against the native lowering. ES/JS opts out.
+"""
+
+obj Box {
+    has v: int = 0;
+}
+
+def chain_cmp_py -> dict {
+    t = Box();
+    u = t;
+    w = Box();
+    a = 1 if 1 < 2 in [2, 5] else 0;
+    b = 1 if 1 < 2 in [3, 5] else 0;
+    c = 1 if 3 > 2 not in [9, 8] else 0;
+    d = 1 if "a" < "b" in ["b", "c"] else 0;
+    e = 1 if "a" < ("be" + "ta") in ["beta", "x"] else 0;
+    f = 1 if "a" < "kb" in {"ka": 1, "kb": 2} else 0;
+    g = 1 if t is u is u else 0;
+    h = 1 if t is u is w else 0;
+    i = 1 if w is not t is not u else 0;
+    j = 1 if 0 < 1 < 2 else 0;
+    return {
+        "mixed_in_true": a,
+        "mixed_in_false": b,
+        "notin_chain": c,
+        "str_in_chain": d,
+        "heap_middle_chain": e,
+        "dict_in_chain": f,
+        "is_alias_chain": g,
+        "is_alias_break": h,
+        "isnot_chain": i,
+        "plain_chain": j,
+    };
+}
+
+cl def chain_cmp_cl -> dict {
+    return {};
+}
+
+na {
+    obj NaBox {
+        has v: int = 0;
+    }
+
+    def chain_cmp_na -> dict[str, any] {
+        t = NaBox();
+        u = t;
+        w = NaBox();
+        a = 1 if 1 < 2 in [2, 5] else 0;
+        b = 1 if 1 < 2 in [3, 5] else 0;
+        c = 1 if 3 > 2 not in [9, 8] else 0;
+        d = 1 if "a" < "b" in ["b", "c"] else 0;
+        e = 1 if "a" < ("be" + "ta") in ["beta", "x"] else 0;
+        f = 1 if "a" < "kb" in {"ka": 1, "kb": 2} else 0;
+        g = 1 if t is u is u else 0;
+        h = 1 if t is u is w else 0;
+        i = 1 if w is not t is not u else 0;
+        j = 1 if 0 < 1 < 2 else 0;
+        return {
+            "mixed_in_true": a,
+            "mixed_in_false": b,
+            "notin_chain": c,
+            "str_in_chain": d,
+            "heap_middle_chain": e,
+            "dict_in_chain": f,
+            "is_alias_chain": g,
+            "is_alias_break": h,
+            "isnot_chain": i,
+            "plain_chain": j,
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/prim_repr.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_repr.jac
@@ -1,0 +1,62 @@
+"""Container repr cross-backend equivalence fixture (#7593 item 5).
+
+Pins CPython repr text for containers against the native repr family.
+Set fixtures use ascending small ints so CPython's hash order coincides
+with native insertion order. ES/JS opts out.
+"""
+
+def repr_py -> dict {
+    lst: list[int] = [1, 2, 3];
+    empty: list[int] = [];
+    nested: list[list[int]] = [[1, 2], [3]];
+    quoting: list[str] = ["a", "b'c"];
+    dct: dict[str, int] = {"a": 1, "b": 2};
+    st: set[int] = {1, 2, 3};
+    tup: tuple[int, str] = (1, "x");
+    bools: list[bool] = [True, False];
+    floats: list[float] = [1.0, 2.5];
+    fs: list[int] = [1, 2];
+    return {
+        "lst": str(lst),
+        "empty": str(empty),
+        "nested": str(nested),
+        "quoting": str(quoting),
+        "dct": str(dct),
+        "st": str(st),
+        "tup": str(tup),
+        "bools": str(bools),
+        "floats": str(floats),
+        "fstr": f"v={fs}",
+    };
+}
+
+cl def repr_cl -> dict {
+    return {};
+}
+
+na {
+    def repr_na -> dict[str, any] {
+        lst: list[int] = [1, 2, 3];
+        empty: list[int] = [];
+        nested: list[list[int]] = [[1, 2], [3]];
+        quoting: list[str] = ["a", "b'c"];
+        dct: dict[str, int] = {"a": 1, "b": 2};
+        st: set[int] = {1, 2, 3};
+        tup: tuple[int, str] = (1, "x");
+        bools: list[bool] = [True, False];
+        floats: list[float] = [1.0, 2.5];
+        fs: list[int] = [1, 2];
+        return {
+            "lst": str(lst),
+            "empty": str(empty),
+            "nested": str(nested),
+            "quoting": str(quoting),
+            "dct": str(dct),
+            "st": str(st),
+            "tup": str(tup),
+            "bools": str(bools),
+            "floats": str(floats),
+            "fstr": f"v={fs}",
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/prim_sys.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_sys.jac
@@ -8,11 +8,17 @@ by the "sys argv via nacompile" test. ES/JS opts out.
 import sys;
 
 def sys_py() -> dict {
+    stdout_n = sys.stdout.write("eq-out\n");
+    stderr_n = sys.stderr.write("eq-err\n");
+    sys.stdout.flush();
+    sys.stderr.flush();
     return {
         "maxsize": sys.maxsize,
         "byteorder": sys.byteorder,
         "platform": sys.platform,
         "maxsize_is_i64max": sys.maxsize == 9223372036854775807,
+        "stdout_n": stdout_n,
+        "stderr_n": stderr_n,
     };
 }
 
@@ -23,11 +29,17 @@ cl def sys_cl() -> dict {
 na {
     def sys_na() -> dict[str, any] {
         maxsize_is_i64max: int = sys.maxsize == 9223372036854775807;
+        stdout_n = sys.stdout.write("eq-out\n");
+        stderr_n = sys.stderr.write("eq-err\n");
+        sys.stdout.flush();
+        sys.stderr.flush();
         return {
             "maxsize": sys.maxsize,
             "byteorder": sys.byteorder,
             "platform": sys.platform,
             "maxsize_is_i64max": maxsize_is_i64max,
+            "stdout_n": stdout_n,
+            "stderr_n": stderr_n,
         };
     }
 }

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -200,6 +200,12 @@ test "generators yield" {
     );
 }
 
+test "container repr" {
+    run_with_both(
+        "prim_repr.jac", "repr_py", "repr_cl", "repr_na", require=["na"]
+    );
+}
+
 test "chained comparisons with membership and identity" {
     run_with_both(
         "prim_chain_cmp.jac",

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -200,6 +200,16 @@ test "generators yield" {
     );
 }
 
+test "chained comparisons with membership and identity" {
+    run_with_both(
+        "prim_chain_cmp.jac",
+        "chain_cmp_py",
+        "chain_cmp_cl",
+        "chain_cmp_na",
+        require=["na"]
+    );
+}
+
 test "zlib bundled" {
     run_with_both("prim_zlib.jac", "zlib_py", "zlib_cl", "zlib_na", require=["na"]);
 }

--- a/jac/jaclang/jac0core/codeinfo.jac
+++ b/jac/jaclang/jac0core/codeinfo.jac
@@ -112,6 +112,9 @@ glob NATIVE_SUPPORTED_STDLIB: set[str] = {
      },
      _effective_codespace_ctx: ContextVar[str] = ContextVar(
          "jac_effective_default_codespace", default=""
+     ),
+     _closure_cap_ctx: ContextVar[int] = ContextVar(
+         "jac_native_closure_cap", default=0
      );
 
 def set_effective_default_codespace(value: str) {
@@ -136,6 +139,31 @@ def effective_default_codespace -> str {
         return BuildConfig().default_codespace;
     } except Exception {
         return "server";
+    }
+}
+
+def set_native_closure_cap(value: int) {
+    _closure_cap_ctx.set(value);
+}
+
+def get_native_closure_cap_override -> int {
+    return _closure_cap_ctx.get();
+}
+
+def effective_native_closure_cap -> int {
+    cur = _closure_cap_ctx.get();
+    if cur > 0 {
+        return cur;
+    }
+    try {
+        import from jaclang.project.config { get_config, BuildConfig }
+        cfg = get_config();
+        if cfg is not None {
+            return cfg.build.native_closure_cap;
+        }
+        return BuildConfig().native_closure_cap;
+    } except Exception {
+        return 256;
     }
 }
 

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -455,7 +455,52 @@ glob NATIVE_DEFAULT_SV_SIGNAL_NODES: tuple = (
      ),
      _na_default_scan_cache: dict[str, tuple] = {},
      _na_demotion_memo: dict[str, tuple] = {},
+     _na_census: dict[str, dict] = {},
+     _na_census_state: dict[str, bool] = {"enabled": False},
      _NA_DEFAULT_CLOSURE_CAP: int = 256;
+
+def na_census_begin() {
+    _na_census.clear();
+    _na_demotion_memo.clear();
+    _na_default_scan_cache.clear();
+    _na_census_state["enabled"] = True;
+}
+
+def na_census_record(path: str, outcome: str, code: str = '', detail: str = '') {
+    if not _na_census_state["enabled"] or not path {
+        return;
+    }
+    key = os.path.realpath(path);
+    prev = _na_census.get(key);
+    if prev is not None and prev['outcome'] == 'demoted' and outcome != 'demoted' {
+        return;
+    }
+    _na_census[key] = {
+        'outcome': outcome,
+        'code': code,
+        'detail': detail,
+        'seams': (prev['seams'] if prev is not None else [])
+    };
+}
+
+def na_census_seam(path: str, reason: str) {
+    if not _na_census_state["enabled"] or not path {
+        return;
+    }
+    key = os.path.realpath(path);
+    rec = _na_census.get(key);
+    if rec is None {
+        rec = {'outcome': 'native', 'code': '', 'detail': '', 'seams': []};
+        _na_census[key] = rec;
+    }
+    rec['seams'].append(reason);
+}
+
+def na_census_end() -> dict {
+    snap = dict(_na_census);
+    _na_census_state["enabled"] = False;
+    return snap;
+}
 
 def _default_codespace_for(target_program: JacProgram) -> str {
     import from jaclang.jac0core.codeinfo { effective_default_codespace }
@@ -468,7 +513,7 @@ def _default_codespace_for(target_program: JacProgram) -> str {
 
 def _scan_native_default_signals(
     module: uni.Module, base_dir: str
-) -> tuple[bool, list[str]] {
+) -> tuple[str, list[str]] {
     import from jaclang.jac0core.codeinfo {
         NATIVE_SUPPORTED_STDLIB,
         is_bundled_native_module,
@@ -477,24 +522,24 @@ def _scan_native_default_signals(
     deps: list[str] = [];
     for typ in NATIVE_DEFAULT_SV_SIGNAL_NODES {
         if module.get_all_sub_nodes(typ) {
-            return (True, deps);
+            return (f"contains {typ.__name__}", deps);
         }
     }
     for arch in module.get_all_sub_nodes(uni.Archetype) {
         if arch.arch_type.name in (Tok.KW_NODE, Tok.KW_EDGE, Tok.KW_WALKER) {
-            return (True, deps);
+            return ("osp archetype", deps);
         }
     }
     for ab in module.get_all_sub_nodes(uni.Ability) {
         if ab.is_async or isinstance(ab.signature, uni.EventSignature) {
-            return (True, deps);
+            return ("async/event ability", deps);
         }
     }
     for stmt in module.body {
         if isinstance(stmt, uni.ContextAwareNode) {
             tok = stmt._source_context_token();
             if tok is not None and tok.name in (Tok.KW_SERVER, Tok.KW_CLIENT) {
-                return (True, deps);
+                return ("explicit sv/cl marker", deps);
             }
         }
         if (
@@ -502,7 +547,7 @@ def _scan_native_default_signals(
             and stmt.access is not None
             and stmt.access.tag.name == Tok.KW_PUB
         ) {
-            return (True, deps);
+            return ("pub access", deps);
         }
     }
     for imp in module.get_all_sub_nodes(uni.Import) {
@@ -510,7 +555,7 @@ def _scan_native_default_signals(
             continue;
         }
         if imp.is_virtual_jac or imp.has_string_path {
-            return (True, deps);
+            return ("virtual/string-path import", deps);
         }
         targets: list[tuple[str, (str | None), bool]] = [];
         if imp.from_loc is not None {
@@ -543,14 +588,14 @@ def _scan_native_default_signals(
                 if clean and is_bundled_native_module(clean) {
                     continue;
                 }
-                return (True, deps);
+                return (f"non-native import '{clean}'", deps);
             }
             if path is not None and path.endswith('.na.jac') {
                 continue;
             }
             if path is not None
             and (path.endswith('.cl.jac') or path.endswith('.sv.jac')) {
-                return (True, deps);
+                return ("cl/sv module import", deps);
             }
             if path is not None and path.endswith('.jac') {
                 deps.append(os.path.abspath(path));
@@ -568,10 +613,10 @@ def _scan_native_default_signals(
             ] is not None {
                 continue;
             }
-            return (True, deps);
+            return (f"unresolved import '{clean}'", deps);
         }
     }
-    return (False, deps);
+    return ('', deps);
 }
 
 def _try_resolve_import(nd: (uni.ModulePath | uni.ModuleItem)) -> (str | None) {
@@ -612,9 +657,9 @@ def _mark_demoted_native(path: str) {
     }
 }
 
-def _native_default_dep_scan(path: str) -> (tuple[bool, list[str]] | None) {
+def _native_default_dep_scan(path: str) -> (tuple[str, list[str]] | None) {
     if _is_demoted_native(os.path.realpath(path)) {
-        return (True, []);
+        return ("previously-demoted", []);
     }
     import from jaclang.jac0core.bccache {
         discover_annex_files,
@@ -638,35 +683,35 @@ def _native_default_dep_scan(path: str) -> (tuple[bool, list[str]] | None) {
     if cached is not None and cached[0] == fresh_key {
         return (cached[1], cached[2]);
     }
-    has_sv = bool(discover_variant_files(path));
+    sv_reason = "sv-variant-file" if discover_variant_files(path) else '';
     deps: list[str] = [];
-    if not has_sv {
+    if not sv_reason {
         base_dir = os.path.dirname(os.path.abspath(path)) or '.';
         for f in files {
             try {
                 src = read_file_with_encoding(f);
             } except Exception {
-                has_sv = True;
+                sv_reason = "unreadable annex";
                 break;
             }
             (dep_mod, had_err) = rd_parse(src, f, prog=JacProgram());
             if had_err {
-                has_sv = True;
+                sv_reason = "parse error";
                 break;
             }
             (f_sv, f_deps) = _scan_native_default_signals(dep_mod, base_dir);
             if f_sv {
-                has_sv = True;
+                sv_reason = f_sv;
                 break;
             }
             deps.extend(f_deps);
         }
     }
-    if has_sv {
+    if sv_reason {
         deps = [];
     }
-    _na_default_scan_cache[path] = (fresh_key, has_sv, deps);
-    return (has_sv, deps);
+    _na_default_scan_cache[path] = (fresh_key, sv_reason, deps);
+    return (sv_reason, deps);
 }
 
 def _native_default_deps_ok(root_path: str, root_deps: list[str]) -> bool {
@@ -741,24 +786,31 @@ def _native_default_path_ok(path: str) -> bool {
     return _native_default_deps_ok(ap, deps);
 }
 
-def _native_default_closure_ok(module: uni.Module) -> bool {
+def _native_default_closure_verdict(module: uni.Module) -> tuple[bool, str] {
     import from jaclang.jac0core.bccache { discover_variant_files }
     mod_path = module.loc.mod_path if module.loc is not None else '';
     if not mod_path {
-        return False;
+        return (False, "no module path");
     }
     if _is_demoted_native(os.path.realpath(mod_path)) {
-        return False;
+        return (False, "previously-demoted");
     }
     if discover_variant_files(mod_path) {
-        return False;
+        return (False, "sv-variant-file");
     }
     base_dir = os.path.dirname(os.path.abspath(mod_path)) or '.';
-    (has_sv, deps) = _scan_native_default_signals(module, base_dir);
-    if has_sv {
-        return False;
+    (sv_reason, deps) = _scan_native_default_signals(module, base_dir);
+    if sv_reason {
+        return (False, sv_reason);
     }
-    return _native_default_deps_ok(os.path.abspath(mod_path), deps);
+    if not _native_default_deps_ok(os.path.abspath(mod_path), deps) {
+        return (False, "import-closure (sv dep, cycle, or cap)");
+    }
+    return (True, '');
+}
+
+def _native_default_closure_ok(module: uni.Module) -> bool {
+    return _native_default_closure_verdict(module)[0];
 }
 
 obj JacCompiler {

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -457,7 +457,7 @@ glob NATIVE_DEFAULT_SV_SIGNAL_NODES: tuple = (
      _na_demotion_memo: dict[str, tuple] = {},
      _na_census: dict[str, dict] = {},
      _na_census_state: dict[str, bool] = {"enabled": False},
-     _NA_DEFAULT_CLOSURE_CAP: int = 256;
+     _na_cap_noted: dict[str, bool] = {};
 
 def na_census_begin() {
     _na_census.clear();
@@ -657,6 +657,27 @@ def _mark_demoted_native(path: str) {
     }
 }
 
+def _note_native_closure_cap(root_path: str, cap: int) {
+    rp = os.path.realpath(root_path);
+    if rp in _na_cap_noted {
+        return;
+    }
+    _na_cap_noted[rp] = True;
+    try {
+        import from jaclang.cli.console { console }
+        console.print(
+            f"note: {root_path} preferred native but its import closure "
+            f"exceeded the inference cap ({cap} modules); compiled in the "
+            f"server codespace. Raise [build] native_closure_cap in jac.toml "
+            f"to scan larger closures.",
+            style="dim",
+            file=sys.stderr
+        );
+    } except Exception {
+        ;
+    }
+}
+
 def _native_default_dep_scan(path: str) -> (tuple[str, list[str]] | None) {
     if _is_demoted_native(os.path.realpath(path)) {
         return ("previously-demoted", []);
@@ -715,10 +736,13 @@ def _native_default_dep_scan(path: str) -> (tuple[str, list[str]] | None) {
 }
 
 def _native_default_deps_ok(root_path: str, root_deps: list[str]) -> bool {
+    import from jaclang.jac0core.codeinfo { effective_native_closure_cap }
+    cap = effective_native_closure_cap();
     edges: dict[str, list[str]] = {root_path: list(root_deps)};
     queue: list[str] = list(root_deps);
     while queue {
-        if len(edges) > _NA_DEFAULT_CLOSURE_CAP {
+        if len(edges) > cap {
+            _note_native_closure_cap(root_path, cap);
             return False;
         }
         dep = queue.pop();

--- a/jac/jaclang/jac0core/impl/compiler.impl.jac
+++ b/jac/jaclang/jac0core/impl/compiler.impl.jac
@@ -689,13 +689,20 @@ impl JacCompiler.parse_str(
     if run_codespace_infer {
         _opts = target_program._compile_options;
         _analysis_only = _opts is not None and _opts.no_cgen;
-        if (
+        _native_eligible = (
             not _analysis_only
             and target_program is not self._internal_program
             and _default_codespace_for(target_program) == 'native'
-            and _native_default_closure_ok(mod)
-        ) {
-            _coerce_native_module(mod);
+        );
+        if _native_eligible {
+            (_na_ok, _na_why) = _native_default_closure_verdict(mod);
+            if _na_ok {
+                _coerce_native_module(mod);
+                na_census_record(mod.loc.mod_path, 'native');
+            } else {
+                _seed_module_codespace(mod);
+                na_census_record(mod.loc.mod_path, 'server', '', _na_why);
+            }
         } else {
             _seed_module_codespace(mod);
         }
@@ -749,6 +756,13 @@ impl JacCompiler.compile(
             if len(_wrap_prog.errors_had) > _pre_errs
             else f"{type(_crash).__name__}: {_crash}"
     );
+    _demote_alerts = _wrap_prog.errors_had[_pre_errs:];
+    _demote_code = (
+        _demote_alerts[0].code.code
+            if (_demote_alerts and _demote_alerts[0].code is not None)
+            else type(_crash).__name__
+    );
+    na_census_record(_resolved, 'demoted', _demote_code, _first_err);
     _mark_demoted_native(_resolved);
     _wrap_prog.errors_had = _wrap_prog.errors_had[:_pre_errs];
     try {

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -2654,6 +2654,8 @@ impl PyastGenPass.exit_binary_expr(nd: uni.BinaryExpr) -> None {
                 )
             )
         ];
+    } elif (nd.op.name in [Tok.WALRUS_EQ]) and not isinstance(nd.left, uni.Name) {
+        nd.gen.py_ast = [self.sync(cast(ast3.expr, self.py_ast_val(nd.right)))];
     } elif (nd.op.gen.py_ast and isinstance(self.py_ast_val(nd.op), ast3.AST)) {
         nd.gen.py_ast = [
             self.sync(

--- a/jac/jaclang/project/config.jac
+++ b/jac/jaclang/project/config.jac
@@ -63,6 +63,7 @@ obj BuildConfig {
     has typecheck: bool = False,
         dir: str = ".jac",
         default_codespace: str = "native",
+        native_closure_cap: int = 256,
         native: NativeBuildConfig = NativeBuildConfig();
 }
 

--- a/jac/jaclang/project/impl/config.impl.jac
+++ b/jac/jaclang/project/impl/config.impl.jac
@@ -1114,10 +1114,26 @@ impl _parse_toml_data(
             );
             _default_cs = _builtin_cs;
         }
+        _builtin_cap = BuildConfig().native_closure_cap;
+        try {
+            _cap = int(build_data.get("native_closure_cap", _builtin_cap));
+        } except (TypeError, ValueError) {
+            _cap = 0;
+        }
+        if _cap < 1 {
+            import from jaclang.cli.console { console }
+            console.warning(
+                f"[build] native_closure_cap="
+                f"'{build_data.get('native_closure_cap')}' must be a positive "
+                f"integer; defaulting to {_builtin_cap}."
+            );
+            _cap = _builtin_cap;
+        }
         config.build = BuildConfig(
             typecheck=build_data.get("typecheck", False),
             dir=build_data.get("dir", ".jac"),
-            default_codespace=_default_cs
+            default_codespace=_default_cs,
+            native_closure_cap=_cap
         );
     }
     if "gc" in data {

--- a/jac/tests/compiler/fixtures/codespace/nadefault_capchain_a.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_capchain_a.jac
@@ -1,0 +1,10 @@
+import from nadefault_capchain_b { fb }
+import from nadefault_capchain_c { fc }
+
+def fa -> int {
+    return fb() + fc() + 1;
+}
+
+with entry {
+    print("fa:", fa());
+}

--- a/jac/tests/compiler/fixtures/codespace/nadefault_capchain_b.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_capchain_b.jac
@@ -1,0 +1,3 @@
+def fb -> int {
+    return 2;
+}

--- a/jac/tests/compiler/fixtures/codespace/nadefault_capchain_c.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_capchain_c.jac
@@ -1,0 +1,3 @@
+def fc -> int {
+    return 3;
+}

--- a/jac/tests/compiler/passes/native/fixtures/container_repr.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/container_repr.na.jac
@@ -1,0 +1,88 @@
+"""Container repr fixtures (#7593 item 5): str/print/f-string of containers
+must produce CPython-exact repr text."""
+
+def list_int_str -> str {
+    x: list[int] = [1, 2, 3];
+    return str(x);
+}
+
+def list_empty_str -> str {
+    x: list[int] = [];
+    return str(x);
+}
+
+def nested_list_str -> str {
+    x: list[list[int]] = [[1, 2], [3]];
+    return str(x);
+}
+
+def list_str_quoting -> str {
+    x: list[str] = ["a", "b'c", 'd"e'];
+    return str(x);
+}
+
+def dict_str -> str {
+    d: dict[str, int] = {"a": 1, "b": 2};
+    return str(d);
+}
+
+def set_str -> str {
+    s: set[int] = {1, 2, 3};
+    return str(s);
+}
+
+def tuple_str -> str {
+    t: tuple[int, str] = (1, "x");
+    return str(t);
+}
+
+def one_tuple_str -> str {
+    t: tuple[int] = (1, );
+    return str(t);
+}
+
+def bool_list_str -> str {
+    x: list[bool] = [True, False];
+    return str(x);
+}
+
+def opt_str_list -> str {
+    x: list[str | None] = ["a", None];
+    return str(x);
+}
+
+def float_list_str -> str {
+    x: list[float] = [1.0, 2.5, 1e300];
+    return str(x);
+}
+
+def fstr_container -> str {
+    x: list[int] = [1, 2];
+    return f"v={x}";
+}
+
+obj P {
+    has n: int;
+
+    def __repr__ -> str {
+        return f"P({self.n})";
+    }
+}
+
+obj Plain {
+    has n: int;
+}
+
+def obj_elem_repr -> str {
+    return str([P(n=1)]);
+}
+
+def obj_elem_default -> str {
+    return str([Plain(n=1)]);
+}
+
+with entry {
+    x: list[int] = [1, 2, 3];
+    print(x);
+    print((1, 2));
+}

--- a/jac/tests/compiler/passes/native/fixtures/f32_promotion.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/f32_promotion.na.jac
@@ -1,0 +1,64 @@
+"""Regression fixtures (#7593 item 1): f32 operands promote to double in
+arithmetic/comparisons; results narrow back at typed sinks."""
+
+def mixed_add(a: f32, b: f64) -> f64 {
+    return a + b;
+}
+
+def mixed_add_rev(a: f64, b: f32) -> f64 {
+    return a + b;
+}
+
+def same_add(a: f32, b: f32) -> f64 {
+    return a + b;
+}
+
+def same_add_narrow(a: f32, b: f32) -> f32 {
+    return a + b;
+}
+
+def mixed_mul(a: f32, b: f64) -> f64 {
+    return a * b;
+}
+
+def mixed_div(a: f32, b: f64) -> f64 {
+    return a / b;
+}
+
+def mixed_mod(a: f32, b: f64) -> f64 {
+    return a % b;
+}
+
+def mixed_floordiv(a: f32, b: f64) -> f64 {
+    return a // b;
+}
+
+def f32_int_add(a: f32, n: int) -> f64 {
+    return a + n;
+}
+
+def cmp_mixed_lt(a: f32, b: f64) -> bool {
+    return a < b;
+}
+
+def cmp_same_lt(a: f32, b: f32) -> bool {
+    return a < b;
+}
+
+def cmp_chain(a: f32, b: f64, c: f64) -> bool {
+    return a < b < c;
+}
+
+def neg32(a: f32) -> f64 {
+    return -a;
+}
+
+obj P {
+    has x: f32 = 1.5;
+}
+
+def field_aug(delta: f64) -> f64 {
+    p = P();
+    p.x += delta;
+    return p.x;
+}

--- a/jac/tests/compiler/passes/native/fixtures/py_chain_cmp_mixed.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/py_chain_cmp_mixed.na.jac
@@ -1,0 +1,47 @@
+"""Chained comparisons with membership and identity links (#7593 item 2).
+
+CPython evaluates `a < b in xs` as `(a < b) and (b in xs)` with b
+evaluated once; `t is u is w` as `(t is u) and (u is w)`. Before the fix
+na statically rejected any chain containing in/not in/is/is not.
+"""
+
+glob _BUMPS: int = 0;
+
+def bump(v: int) -> int {
+    _BUMPS += 1;
+    return v;
+}
+
+obj Box {
+    has v: int = 0;
+}
+
+def:pub chain_in_cases -> int {
+    a = 1 if 1 < 2 in [2, 5] else 0;
+    b = 1 if 1 < 2 in [3, 5] else 0;
+    c = 1 if 3 > 2 not in [9, 8] else 0;
+    d = 1 if "a" < "b" in ["b", "c"] else 0;
+    e = 1 if "a" < ("be" + "ta") in ["beta", "x"] else 0;
+    return a * 10000 + b * 1000 + c * 100 + d * 10 + e;
+}
+
+def:pub chain_is_cases -> int {
+    t = Box();
+    u = t;
+    w = Box();
+    a = 1 if t is u is u else 0;
+    b = 1 if t is u is w else 0;
+    c = 1 if w is not t is not u else 0;
+    d = 1 if 0 < 1 < 2 else 0;
+    return a * 1000 + b * 100 + c * 10 + d;
+}
+
+def:pub chain_middle_once -> int {
+    _BUMPS = 0;
+    ok = 1 if 1 < bump(2) in [2, 9] else 0;
+    return ok * 10 + _BUMPS;
+}
+
+with entry {
+    bump(0);
+}

--- a/jac/tests/compiler/passes/native/fixtures/sys_streams.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/sys_streams.na.jac
@@ -1,0 +1,21 @@
+"""Native sys.stdout / sys.stderr stream objects (#7593 item 4).
+
+The write() count is laundered through a comparison because the sv
+checker types sys.stdout as Unknown (typeshed `TextIO | MaybeNone` does
+not resolve), so returning it from an int-typed def fails E1001. The
+comparison still pins the native byte-count value.
+"""
+
+import sys;
+
+def write_out() -> int {
+    n = sys.stdout.write("out-bytes\n");
+    sys.stdout.flush();
+    return 10 if n == 10 else 0;
+}
+
+def write_err() -> int {
+    n = sys.stderr.write("err-7\n");
+    sys.stderr.flush();
+    return 6 if n == 6 else 0;
+}

--- a/jac/tests/compiler/passes/native/fixtures/sys_streams_bin.jac
+++ b/jac/tests/compiler/passes/native/fixtures/sys_streams_bin.jac
@@ -1,0 +1,11 @@
+"""AOT fixture: sys.stdout/sys.stderr share the libc stdio buffers with
+print(), and stderr bytes stay on fd 2 (#7593 item 4)."""
+
+import sys;
+
+with entry {
+    n = sys.stdout.write("A:");
+    sys.stdout.write("bc\n");
+    sys.stderr.write("E:err\n");
+    print("n", n);
+}

--- a/jac/tests/compiler/passes/native/test_native_feature_guardrail.jac
+++ b/jac/tests/compiler/passes/native/test_native_feature_guardrail.jac
@@ -728,6 +728,99 @@ test "declared libc open(path, flags) extern resolves without the file-open buil
     )}";
 }
 
+"""Compile a snippet through the sv pipeline (plain .jac path)."""
+def compile_sv_inline(label: str, code: str) -> JacProgram {
+    path = os.path.join(FIXTURES_DIR, f"_guardrail_{label}.jac");
+    prog = JacProgram();
+    prog.compile(file_path=path, use_str=code);
+    return prog;
+}
+
+# Walrus on non-Name targets is a SyntaxError in CPython; Jac rejects it
+# with the general E0020 in ASTValidationPass on every backend. These pin
+# that E0020 stays the single diagnostic: no native-specific E5090
+# duplicate, no E5007 bootstrap cascade, no E9001/E9002 ICE (#7593 item 3).
+test "walrus on a subscript target: one general E0020, no native cascade" {
+    prog = compile_na_inline(
+        "walrus_subscript_lhs",
+        "with entry { xs = [1, 2, 3]; print((xs[0] := 9)); }\n"
+    );
+    assert has_error_code(prog, "E0020") , f"Expected general E0020, got: {fmt_errors(
+        prog
+    )}";
+    assert not has_error_code(prog, "E5090") , f"native E5090 duplicate leaked: {fmt_errors(
+        prog
+    )}";
+    assert not has_error_code(prog, "E5007") , f"bootstrap E5007 cascade leaked: {fmt_errors(
+        prog
+    )}";
+    for alrt in prog.errors_had {
+        if alrt.code is not None {
+            assert alrt.code.code not in ("E9001", "E9002") , f"ICE leaked: {fmt_errors(
+                prog
+            )}";
+        }
+    }
+}
+
+test "walrus on an attribute target: one general E0020, no native cascade" {
+    prog = compile_na_inline(
+        "walrus_attr_lhs",
+        "obj Box { has f: int = 0; }\n"
+        "with entry { b = Box(); print((b.f := 5)); }\n"
+    );
+    assert has_error_code(prog, "E0020") , f"Expected general E0020, got: {fmt_errors(
+        prog
+    )}";
+    assert not has_error_code(prog, "E5090") , f"native E5090 duplicate leaked: {fmt_errors(
+        prog
+    )}";
+    assert not has_error_code(prog, "E5007") , f"bootstrap E5007 cascade leaked: {fmt_errors(
+        prog
+    )}";
+    for alrt in prog.errors_had {
+        if alrt.code is not None {
+            assert alrt.code.code not in ("E9001", "E9002") , f"ICE leaked: {fmt_errors(
+                prog
+            )}";
+        }
+    }
+}
+
+test "walrus on a subscript target is the same single E0020 on sv" {
+    prog = compile_sv_inline(
+        "walrus_subscript_sv",
+        "with entry { xs = [1, 2, 3]; print((xs[0] := 9)); }\n"
+    );
+    assert has_error_code(prog, "E0020") , f"Expected general E0020, got: {fmt_errors(
+        prog
+    )}";
+    assert not has_error_code(prog, "E5007") , f"bootstrap E5007 cascade leaked: {fmt_errors(
+        prog
+    )}";
+    for alrt in prog.errors_had {
+        if alrt.code is not None {
+            assert alrt.code.code not in ("E9001", "E9002") , f"ICE leaked: {fmt_errors(
+                prog
+            )}";
+        }
+    }
+}
+
+# Green pin (already true on main): check-time shape yields exactly E0020.
+test "walrus on a subscript target at check time is E0020 only" {
+    prog = check_na_inline(
+        "walrus_subscript_lhs_chk",
+        "with entry { xs = [1, 2, 3]; print((xs[0] := 9)); }\n"
+    );
+    assert has_error_code(prog, "E0020") , f"Expected general E0020, got: {fmt_errors(
+        prog
+    )}";
+    assert not has_error_code(prog, "E5090") , f"native E5090 duplicate leaked: {fmt_errors(
+        prog
+    )}";
+}
+
 # Negative control: known clib types must compile without E2018/E5090.
 test "clib decl with known types is not rejected" {
     prog = compile_na_inline(

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -3241,6 +3241,72 @@ test "sys argv via nacompile" {
     }
 }
 
+test "native sys stream write returns count and hits the real fds" {
+    (eng, _) = compile_native("sys_streams.na.jac");
+    wout = get_func(eng, "write_out", ctypes.c_int64);
+    (r, w) = os.pipe();
+    saved = os.dup(1);
+    os.dup2(w, 1);
+    os.close(w);
+    try {
+        n = wout();
+    } finally {
+        os.dup2(saved, 1);
+        os.close(saved);
+    }
+    got = os.read(r, 64);
+    os.close(r);
+    assert n == 10 , f"write must return the byte count, got {n}";
+    assert got == b"out-bytes\n" , f"fd1 bytes wrong: {got!r}";
+    werr = get_func(eng, "write_err", ctypes.c_int64);
+    (r2, w2) = os.pipe();
+    saved2 = os.dup(2);
+    os.dup2(w2, 2);
+    os.close(w2);
+    try {
+        n2 = werr();
+    } finally {
+        os.dup2(saved2, 2);
+        os.close(saved2);
+    }
+    got2 = os.read(r2, 64);
+    os.close(r2);
+    assert n2 == 6 , f"stderr write count wrong, got {n2}";
+    assert got2 == b"err-7\n" , f"fd2 bytes wrong: {got2!r}";
+}
+
+test "sys stdout/stderr streams via nacompile" {
+    import tempfile;
+    fixture = str(os.path.join(FIXTURES, "sys_streams_bin.jac"));
+    with tempfile.TemporaryDirectory() as tmpdir {
+        out_bin = os.path.join(tmpdir, "sys_streams_bin");
+        comp = subprocess.run(
+            [sys.executable, "-m", "jaclang", "nacompile", fixture, "-o", out_bin],
+            capture_output=True,
+            text=True,
+            timeout=120
+        );
+        assert comp.returncode == 0 , (
+            f"nacompile failed: exit={comp.returncode}\n"
+            f"stderr: {comp.stderr[-500:] if comp.stderr else '(empty)'}"
+        );
+        result = subprocess.run(
+            [out_bin], capture_output=True, text=True, timeout=10
+        );
+        assert result.returncode == 0 , (
+            f"Native binary crashed: exit={result.returncode}\n"
+            f"stderr: {result.stderr[-500:] if result.stderr else '(empty)'}"
+        );
+        assert result.stdout == "A:bc\nn 2\n" , (
+            f"stream writes must share the stdio buffer with print, "
+            f"got stdout: {result.stdout!r}"
+        );
+        assert result.stderr == "E:err\n" , (
+            f"stderr bytes must stay on fd 2, got: {result.stderr!r}"
+        );
+    }
+}
+
 test "native osp kernel links transitively through an imported module (issue #6669)" {
     # A thin entry that uses no OSP itself but imports a module whose `run_it`
     # does the `spawn`. The kernel's glob-init is referenced only transitively,

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -244,6 +244,84 @@ test "arithmetic float add" {
     assert abs(fadd(-1.0, 1.0)) < 1e-10;
 }
 
+# Regression (#7593 item 1): f32 operands must promote to double instead of
+# crashing the binop/compare emitters.
+test "arithmetic f32 promotion binops" {
+    (eng, _) = compile_native("f32_promotion.na.jac");
+    ma = get_func(
+        eng, "mixed_add", ctypes.c_double, ctypes.c_float, ctypes.c_double
+    );
+    assert ma(1.5, 2.25) == 3.75;
+    mr = get_func(
+        eng, "mixed_add_rev", ctypes.c_double, ctypes.c_double, ctypes.c_float
+    );
+    assert mr(2.25, 1.5) == 3.75;
+    sa = get_func(
+        eng, "same_add", ctypes.c_double, ctypes.c_float, ctypes.c_float
+    );
+    assert sa(1.5, 2.25) == 3.75;
+    mm = get_func(
+        eng, "mixed_mul", ctypes.c_double, ctypes.c_float, ctypes.c_double
+    );
+    assert mm(1.5, 2.0) == 3.0;
+    md = get_func(
+        eng, "mixed_div", ctypes.c_double, ctypes.c_float, ctypes.c_double
+    );
+    assert md(1.5, 0.5) == 3.0;
+    mo = get_func(
+        eng, "mixed_mod", ctypes.c_double, ctypes.c_float, ctypes.c_double
+    );
+    assert mo(5.5, 2.0) == 1.5;
+    mf = get_func(
+        eng, "mixed_floordiv", ctypes.c_double, ctypes.c_float, ctypes.c_double
+    );
+    assert mf(5.5, 2.0) == 2.0;
+    fi = get_func(
+        eng, "f32_int_add", ctypes.c_double, ctypes.c_float, ctypes.c_int64
+    );
+    assert fi(1.5, 2) == 3.5;
+}
+
+test "arithmetic f32 promotion comparisons" {
+    (eng, _) = compile_native("f32_promotion.na.jac");
+    cl = get_func(
+        eng, "cmp_mixed_lt", ctypes.c_bool, ctypes.c_float, ctypes.c_double
+    );
+    assert cl(1.5, 2.25);
+    assert not cl(2.5, 2.25);
+    cs = get_func(
+        eng, "cmp_same_lt", ctypes.c_bool, ctypes.c_float, ctypes.c_float
+    );
+    assert cs(1.5, 2.25);
+    assert not cs(2.25, 1.5);
+    cc = get_func(
+        eng,
+        "cmp_chain",
+        ctypes.c_bool,
+        ctypes.c_float,
+        ctypes.c_double,
+        ctypes.c_double
+    );
+    assert cc(1.0, 2.0, 3.0);
+    assert not cc(1.0, 3.0, 2.0);
+}
+
+test "arithmetic f32 result narrows at typed sinks" {
+    (eng, _) = compile_native("f32_promotion.na.jac");
+    sn = get_func(
+        eng, "same_add_narrow", ctypes.c_float, ctypes.c_float, ctypes.c_float
+    );
+    assert sn(1.5, 2.25) == 3.75;
+    ng = get_func(eng, "neg32", ctypes.c_double, ctypes.c_float);
+    assert ng(1.5) == -1.5;
+}
+
+test "aug assign f32 field promotes" {
+    (eng, _) = compile_native("f32_promotion.na.jac");
+    fa = get_func(eng, "field_aug", ctypes.c_double, ctypes.c_double);
+    assert fa(0.25) == 1.75;
+}
+
 # --- TestNativeControlFlowExecution ---
 test "control flow abs val" {
     (eng, _) = compile_native("control_flow.na.jac");

--- a/jac/tests/compiler/passes/native/test_native_py_semantics.jac
+++ b/jac/tests/compiler/passes/native/test_native_py_semantics.jac
@@ -63,6 +63,31 @@ test "chained comparison: three-link chain with mixed directions" {
     assert result == 1 , f"Expected 1 (1<2<3>2), got {result}";
 }
 
+# --- #7593 item 2: membership/identity links in chains ---
+test "chained comparison: membership links lower like single 'in'" {
+    (eng, _) = compile_native("py_chain_cmp_mixed.na.jac");
+    get_func(eng, "jac_entry", None)();
+    cases = get_func(eng, "chain_in_cases", ctypes.c_int64);
+    result = cases();
+    assert result == 10111 , f"Expected 10111, got {result}";
+}
+
+test "chained comparison: identity links lower like single 'is'" {
+    (eng, _) = compile_native("py_chain_cmp_mixed.na.jac");
+    get_func(eng, "jac_entry", None)();
+    cases = get_func(eng, "chain_is_cases", ctypes.c_int64);
+    result = cases();
+    assert result == 1001 , f"Expected 1001, got {result}";
+}
+
+test "chained comparison: membership middle operand evaluated once" {
+    (eng, _) = compile_native("py_chain_cmp_mixed.na.jac");
+    get_func(eng, "jac_entry", None)();
+    once = get_func(eng, "chain_middle_once", ctypes.c_int64);
+    result = once();
+    assert result == 11 , f"Expected 11 (true, one bump), got {result}";
+}
+
 # --- 2b: or/and yield the deciding operand value, not a truth bit ---
 test "bool ops: int or/and return the operand value" {
     (eng, _) = compile_native("py_bool_ops.na.jac");

--- a/jac/tests/compiler/passes/native/test_native_repr.jac
+++ b/jac/tests/compiler/passes/native/test_native_repr.jac
@@ -1,0 +1,148 @@
+"""End-to-end tests for native container repr (#7593 item 5).
+
+`str(container)`, `f"{container}"`, and `print(container)` must produce
+CPython-exact repr text, recursing through nested containers and
+dispatching obj elements to `__repr__` (not `__str__`).
+"""
+
+import ctypes;
+import os;
+import from tests.support { TESTS_DIR }
+import from jaclang.jac0core.program { JacProgram }
+import jaclang.jac0core.unitree as uni;
+import from jaclang.compiler.passes.native.llvm.binding { ExecutionEngine }
+
+glob FIXTURES = os.path.join(
+         TESTS_DIR, "compiler", "passes", "native", "fixtures"
+     );
+
+"""Compile a .na.jac fixture and return the JIT engine."""
+def compile_native(fixture: str) -> tuple[ExecutionEngine, uni.Module] {
+    prog = JacProgram();
+    ir = prog.compile(file_path=str(os.path.join(FIXTURES, fixture)));
+    errors = [str(e) for e in prog.errors_had] if prog.errors_had else [];
+    assert not prog.errors_had , f"Compilation errors in {fixture}: {errors}";
+    eng = ir.gen.native_engine;
+    assert eng is not None , f"No native engine produced for {fixture}";
+    return (eng, ir);
+}
+
+"""Get a ctypes-callable function from the JIT engine."""
+def get_func(eng: object, name: str, restype: type | None, *argtypes: type) -> object {
+    addr = eng.get_function_address(name);
+    assert addr != 0 , f"Function '{name}' not found in JIT engine";
+    functype = ctypes.CFUNCTYPE(restype, *argtypes);
+    return functype(addr);
+}
+
+"""Run a void JIT function and capture what it writes to fd 1 (C stdout)."""
+def capture_stdout(fn: object) -> bytes {
+    libc = ctypes.CDLL(None);
+    (r, w) = os.pipe();
+    saved = os.dup(1);
+    os.dup2(w, 1);
+    try {
+        fn();
+        libc.fflush(None);
+    } finally {
+        os.dup2(saved, 1);
+        os.close(saved);
+        os.close(w);
+        data = os.read(r, 65536);
+        os.close(r);
+    }
+    return data;
+}
+
+test "str(list[int]) is CPython repr" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "list_int_str", ctypes.c_char_p);
+    assert f() == b"[1, 2, 3]";
+}
+
+test "str of empty list" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "list_empty_str", ctypes.c_char_p);
+    assert f() == b"[]";
+}
+
+test "nested list repr" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "nested_list_str", ctypes.c_char_p);
+    assert f() == b"[[1, 2], [3]]";
+}
+
+test "str elements get CPython quote choice" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "list_str_quoting", ctypes.c_char_p);
+    assert f() == b"['a', \"b'c\", 'd\"e']";
+}
+
+test "dict repr" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "dict_str", ctypes.c_char_p);
+    assert f() == b"{'a': 1, 'b': 2}";
+}
+
+test "set repr" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "set_str", ctypes.c_char_p);
+    assert f() == b"{1, 2, 3}";
+}
+
+test "tuple repr" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "tuple_str", ctypes.c_char_p);
+    assert f() == b"(1, 'x')";
+}
+
+test "one-tuple trailing comma" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "one_tuple_str", ctypes.c_char_p);
+    assert f() == b"(1,)";
+}
+
+test "bool elements repr as True/False" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "bool_list_str", ctypes.c_char_p);
+    assert f() == b"[True, False]";
+}
+
+test "None element in optional-str list" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "opt_str_list", ctypes.c_char_p);
+    assert f() == b"['a', None]";
+}
+
+test "float elements use repr formatting" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "float_list_str", ctypes.c_char_p);
+    assert f() == b"[1.0, 2.5, 1e+300]";
+}
+
+test "f-string container interpolation" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "fstr_container", ctypes.c_char_p);
+    assert f() == b"v=[1, 2]";
+}
+
+test "obj element uses __repr__" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "obj_elem_repr", ctypes.c_char_p);
+    assert f() == b"[P(1)]";
+}
+
+test "obj element default repr" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    f = get_func(eng, "obj_elem_default", ctypes.c_char_p);
+    out = f();
+    assert out.startswith(b"[<Plain object at 0x") , f"got {out!r}";
+    assert out.endswith(b">]") , f"got {out!r}";
+}
+
+test "print(list) and print(tuple) to stdout" {
+    (eng, _) = compile_native("container_repr.na.jac");
+    entry = get_func(eng, "jac_entry", None);
+    out = capture_stdout(entry);
+    assert out == b"[1, 2, 3]\n(1, 2)\n" , f"got {out!r}";
+}

--- a/jac/tests/compiler/test_codespace_inference.jac
+++ b/jac/tests/compiler/test_codespace_inference.jac
@@ -259,6 +259,42 @@ test "cascade: importer of a demoted module demotes with it" {
     assert mod.decided_codespace == '' , "importer of a demoted dep must demote too";
 }
 
+test "census records demotion with first error code" {
+    import from jaclang.jac0core.compiler { na_census_begin, na_census_end }
+    na_census_begin();
+    try {
+        compile_with_default("nadefault_nolower.jac", "native", cgen=True);
+    } finally {
+        census = na_census_end();
+    }
+    rec = census.get(
+        os.path.realpath(os.path.join(FIXTURE_DIR, "nadefault_nolower.jac"))
+    );
+    assert rec is not None , "demoted module missing from census";
+    assert rec['outcome'] == 'demoted' , f"expected demoted, got {rec}";
+    assert rec['code'] == 'E5092' , f"expected first-error code, got {rec}";
+}
+
+test "census records native and server outcomes" {
+    import from jaclang.jac0core.compiler { na_census_begin, na_census_end }
+    na_census_begin();
+    try {
+        compile_with_default("nadefault_pure.jac", "native", cgen=True);
+        compile_with_default("nadefault_walker.jac", "native", cgen=True);
+    } finally {
+        census = na_census_end();
+    }
+    pure = census.get(
+        os.path.realpath(os.path.join(FIXTURE_DIR, "nadefault_pure.jac"))
+    );
+    blocked = census.get(
+        os.path.realpath(os.path.join(FIXTURE_DIR, "nadefault_walker.jac"))
+    );
+    assert pure is not None and pure['outcome'] == 'native' , f"got {pure}";
+    assert blocked is not None and blocked['outcome'] == 'server' , f"got {blocked}";
+    assert blocked['detail'] != '' , "server record must carry the classifier reason";
+}
+
 test "explicit .na.jac mandate still fails loudly" {
     import from jaclang.jac0core.compile_options { CompileOptions }
     prog = JacProgram();

--- a/jac/tests/compiler/test_codespace_inference.jac
+++ b/jac/tests/compiler/test_codespace_inference.jac
@@ -259,6 +259,33 @@ test "cascade: importer of a demoted module demotes with it" {
     assert mod.decided_codespace == '' , "importer of a demoted dep must demote too";
 }
 
+test "closure cap exceeded skips native inference with a note" {
+    import io;
+    import sys;
+    import from jaclang.jac0core.codeinfo { set_native_closure_cap }
+    set_native_closure_cap(1);
+    buf = io.StringIO();
+    old_stderr = sys.stderr;
+    sys.stderr = buf;
+    try {
+        mod = compile_with_default("nadefault_capchain_a.jac", "native", cgen=True);
+    } finally {
+        sys.stderr = old_stderr;
+        set_native_closure_cap(0);
+    }
+    assert mod.decided_codespace == '' , "cap-exceeded root must stay server";
+    assert stamp_of(mod, "fa") == 'server';
+    assert "native_closure_cap" in buf.getvalue() , (
+        f"note must name the knob, got: {buf.getvalue()!r}"
+    );
+}
+
+test "capped chain still infers native under the default cap" {
+    mod = compile_with_default("nadefault_capchain_a.jac", "native", cgen=True);
+    assert mod.decided_codespace == 'native' , "3-module pure chain fits default cap";
+    assert mod.gen.native_engine is not None;
+}
+
 test "census records demotion with first error code" {
     import from jaclang.jac0core.compiler { na_census_begin, na_census_end }
     na_census_begin();

--- a/jac/tests/compiler/test_rd_parser_validation.jac
+++ b/jac/tests/compiler/test_rd_parser_validation.jac
@@ -195,6 +195,7 @@ glob GAP_FILES = [
          "walrus_complex_lhs": "with entry { (a + b) := 5; }",
          "walrus_call_lhs": "with entry { foo() := 5; }",
          "walrus_subscript_lhs": "with entry { a[0] := 5; }",
+         "walrus_attr_lhs": "with entry { a.b := 5; }",
          "assign_to_root": 'with entry { root = "s"; }',
          "assign_to_super": "with entry { super = 1; }",
          "for_in_target_root": "with entry { for root in [1, 2] { } }",

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -2244,6 +2244,60 @@ test "jac check disable_error_code warns on unknown diagnostics" {
     assert "E9999" in combined , "unknown warning should use canonical code casing";
 }
 
+test "jac check native-census flag maps to check arg" {
+    parser = get_registry().finalize();
+    (args, _) = parser.parse_known_args(
+        ["check", fixture_path("warnings_only.jac"), "--native-census"]
+    );
+    assert getattr(args, "native_census", False) == True , (
+        "kebab flag should map to native_census dest"
+    );
+}
+
+test "jac check native census ranks module outcomes" {
+    with tempfile.TemporaryDirectory() as td {
+        with open(os.path.join(td, "pure.jac"), "w") as f {
+            f.write("def add(a: int, b: int) -> int {\n    return a + b;\n}\n");
+        }
+        with open(os.path.join(td, "demote.jac"), "w") as f {
+            f.write(
+                "obj Widget {\n    has size: int = 0;\n\n    def render -> str {\n"
+                + "        return \"ok\";\n    }\n}\n\ndef build -> str {\n"
+                + "    w = new(Widget, 5);\n    return w.render();\n}\n"
+            );
+        }
+        with open(os.path.join(td, "blocked.jac"), "w") as f {
+            f.write(
+                "node Item {\n    has label: str = \"\";\n}\n\nwalker Visitor {\n"
+                + "    can look with Item entry {\n        print(here.label);\n"
+                + "    }\n}\n"
+            );
+        }
+        (captured_stdout, captured_stderr, old_stdout, old_stderr) =
+            _capture_output();
+        _reset_config();
+        try {
+            result = analysis.check([td], native_census=True);
+            combined = captured_stdout.getvalue() + captured_stderr.getvalue();
+        } finally {
+            _restore_output(old_stdout, old_stderr);
+            set_config(None);
+            _reset_config();
+        }
+        assert "native census" in combined.lower() , "census header missing";
+        assert "E5092" in combined , (
+            "demoted module must be ranked by its first error code"
+        );
+        assert "demote.jac" in combined , "demoted module path missing";
+        assert "blocked.jac" in combined , "server module path missing";
+        assert "pure.jac" in combined , "native module path missing";
+        assert "osp archetype" in combined , (
+            "server reason strings must be real signal labels"
+        );
+        assert result == 0 , "census demotions must not flip exit code";
+    }
+}
+
 test "lexer does not hang on unterminated jsx" {
     # BUG: Unterminated JSX (e.g. `<div>hello` with no closing tag)
     # hits EOF while the lexer is still in JSX_CONTENT mode.

--- a/jac/tests/project/test_config.jac
+++ b/jac/tests/project/test_config.jac
@@ -463,6 +463,34 @@ test "dev section parsing" {
     assert as_int.dev.test_jobs == "0";
 }
 
+test "parse build native_closure_cap" {
+    config_mod._config = None;
+    cfg = JacConfig.from_toml_str("\n[build]\nnative_closure_cap = 8\n");
+    assert cfg.build.native_closure_cap == 8;
+
+    config_mod._config = None;
+    base = JacConfig.from_toml_str("\n[build]\ntypecheck = true\n");
+    assert base.build.native_closure_cap == 256;
+
+    config_mod._config = None;
+    bad = JacConfig.from_toml_str("\n[build]\nnative_closure_cap = 0\n");
+    assert bad.build.native_closure_cap == 256 , "invalid cap falls back to default";
+}
+
+test "closure cap override resolves through effective_native_closure_cap" {
+    import from jaclang.jac0core.codeinfo {
+        set_native_closure_cap,
+        effective_native_closure_cap
+    }
+    set_native_closure_cap(3);
+    try {
+        assert effective_native_closure_cap() == 3;
+    } finally {
+        set_native_closure_cap(0);
+    }
+    assert effective_native_closure_cap() == 256;
+}
+
 test "parse full config" {
     config_mod._config = None;
     toml_str = "\n[project]\nname = \"full-project\"\nversion = \"1.2.3\"\ndescription = \"A full project\"\nauthors = [\"Jane Doe <jane@example.com>\"]\nlicense = \"MIT\"\nentry-point = \"app.jac\"\n\n[dependencies]\nnumpy = \">=1.24.0\"\npandas = \">=2.0.0\"\n\n[run]\nsession = \"my_session\"\nmain = false\ncache = false\n\n[build]\ntypecheck = true\n\n[test]\ndirectory = \"tests\"\nverbose = true\nfail_fast = true\nmax_failures = 5\n\n[serve]\nport = 9000\n\n[cache]\nenabled = false\ndir = \".cache\"\n\n[scripts]\nstart = \"jac run app.jac\"\nlint = \"jac lint . --fix\"\n\n[byllm]\ndefault_model = \"gpt-4\"\ntemperature = 0.7\n\n[environments.development]\n[environments.development.serve]\nport = 3000\n\n[environments.production]\n[environments.production.serve]\nport = 8000\n";


### PR DESCRIPTION
Part of #7593. First execution wave of the na lowering-coverage roadmap, following the issue's own sequencing: the census tool first (so the rest of the table can be ranked by measurement), then the S-tier gaps, then the two S-M/M items that unblock the f-string work. Every item landed test-first (each suite written and observed red before the fix), one commit per item.

## Item 21: `jac check --native-census` demotion telemetry

- Compiles the project with codegen and prints a ranked per-module table: **native** / **demoted** (grouped by first error code) / **server** (grouped by the classifier signal that blocked inference), plus per-method seam demotions.
- The classifier now carries labeled reasons ("osp archetype", "contains LambdaExpr", "non-native import 'x'", ...) through `_scan_native_default_signals` and the closure verdict; the bool-facing wrappers stay shape-stable so no call site changes behavior.
- The demote-and-retry wrapper records the first alert's diagnostic code before stripping errors; per-method demotion records a seam line before its alerts are deleted.
- Tests: parser-mapping + tempdir-project behavior in `test_cli.jac`, census-record assertions in `test_codespace_inference.jac`.

## Item 1: f32 <-> double promotion in native arithmetic

- f32 values (annotations, clib struct fields, FFI returns) crashed or miscompiled every arithmetic path: f32+f64 raised the builder's same-type ValueError, f32+f32 fell into the int branch and died on `.width`, f32<f64 emitted mixed-width fcmp that failed LLVM parse, and f32 field aug-assign silently degraded to plain assignment.
- One coercion policy: all float arithmetic unifies at double through the existing `_coerce_type` cast table; results narrow back for free at the typed sinks (return/store/call-arg/aug coerce-back). Compare paths, match-eq, `_to_bool`, and unary minus widened alongside.
- Tests: `fixtures/f32_promotion.na.jac` + four suites in `test_native_gen_pass.jac` (binops, comparisons incl. chains, narrowing sinks, field aug-assign).

## Item 2: membership/identity links in chained comparisons

- `a < b in xs` and `t is u is w` were statically rejected (E5090) while plain relational chains already lowered. The single-op compare body is extracted into `_codegen_compare_link` with caller-controlled operand release, and the chain path routes every link through it - CPython semantics with the middle operand evaluated once.
- Release gating is the load-bearing piece: in chain mode the shared middle operand feeds two links and is released exactly once by the chain-end loop (the owned-heap-middle fixture case is the double-release canary). Unlowerable chain links now emit a loud E5092 instead of silent None. The static E5090 branch is deleted; auto-native inference widens with no classifier change.
- Tests: `fixtures/py_chain_cmp_mixed.na.jac` + `test_native_py_semantics.jac`; cross-backend `prim_chain_cmp.jac` (`require=["na"]`).

## Item 3: walrus on non-Name targets - resolved by alignment, not lowering

- `(xs[i] := v)` / `(obj.f := v)` are SyntaxError in CPython (NamedExpr targets must be names), so the native pathway must not invent semantics for them. `ASTValidationPass` already rejects the shape with the general E0020 on every backend; this deletes the noise stacked on top: the native-specific E5090 duplicate (identical predicate), and the E5007 + E9001 empty-py_ast ICE cascade that followed E0020 in both PyastGenPass and NaIRGenPass (both now recover by lowering to the RHS value on the already-failed module).
- Tests: guardrail pins that E0020 is the single diagnostic across na-compile / sv-compile / check-time shapes; `walrus_attr_lhs` added to the validation matrix.

## Item 20: configurable native-inference closure cap with a skip note

- The 256-module closure cap silently punted oversized roots to the server codespace. Classification is already per-root, so semantics stay unchanged; the cap is now configurable via a flat `[build] native_closure_cap` key in jac.toml (positive-int validated with a warning fallback, mirroring the `default_codespace` knob), overridable per-context for tests, and loud: cap-exceed emits a one-per-file stderr note naming the knob and writes no demotion memo, so a raised cap re-infers natively.
- Tests: cap-trip + note assertion and default-cap control in `test_codespace_inference.jac` (new 3-module fixture chain); knob parsing + effective-resolution in `test_config.jac`.

## Item 4: native `sys.stdout` / `sys.stderr` stream objects

- Both lower to immortal File-struct singletons whose handle is the live libc stdout/stderr FILE* (extern data global; `__stdoutp`/`__stderrp` on Darwin). The existing native File machinery dispatches `.write`/`.flush` with zero new method code, and because the handle is the real libc stream, stream writes and `print()` interleave correctly in one stdio buffer (pinned byte-exact by the AOT test). A static RC_SENTINEL header makes the singletons retain/release-safe with no special-casing.
- Known follow-ups recorded in #7593: the sv checker types `sys.stdout` as Unknown (typeshed `TextIO | MaybeNone` does not resolve), `print(file=...)` kwargs are still silently dropped, `sys.stdin`, PE-linker extern-data support.
- Tests: JIT fd-capture suite + nacompile AOT byte-exact suite in `test_native_gen_pass.jac`; `prim_sys.jac` extended with write-count parity keys.

## Item 5: CPython-exact container repr for print / str / f-strings

- `print(list)` E5092'd, `str(dict)` returned struct-garbage bytes, `f"{x}"` for containers silently printed garbage, and `print((1,2))` dropped the argument. Containers now repr exactly like CPython through a synthesized runtime function family: one private `__jac_repr_<key>` fn per static type key, cached on the pass, recursing through nested containers and dispatching obj elements to `__repr__` (default `<T object at 0x..>` fallback, never `__str__`), with the bytes-repr quote-choice/escape algorithm ported for str elements and shortest-roundtrip float repr reused for floats.
- Repr is driven by the static Jac type key: list specs collapse to i64/f64/ptr in LLVM, so the ir.Value alone cannot distinguish `list[str]` from `list[list[int]]`. Dynamic/`any`/multi-union keys keep today's E5092 - strictly more programs lower, none silently wrong. f-string pointers that still cannot repr now E5092 instead of emitting raw `%s` garbage.
- Also fixes a latent crash: list literals now coerce every element to the registered i64 storage type (`[True, False]` died on i1-vs-i64), and top-level `repr(str)` upgrades from a truncating 64-byte `'%s'` snprintf to the exact algorithm.
- Tests: `test_native_repr.jac` (15 byte-exact cases incl. nested containers, quote choice, one-tuples, `__repr__` dispatch, fd-captured print) and cross-backend `prim_repr.jac` (`require=["na"]`).

## Verification

Suites at HEAD: `test_native_gen_pass.jac` 461 passed, `test_prim_equivalence.jac` 82 passed, `test_native_py_semantics.jac` 28, `test_native_feature_guardrail.jac` 35, `test_native_repr.jac` 15, `test_native_obj_str.jac` 8, `test_codespace_inference.jac` 26, `test_config.jac` 134, `test_rd_parser_validation.jac` 195, `test_native_demotion.jac` 2. The only local failure is the pre-existing `aarch64 standalone binary runs (#6366)` case, which needs an aarch64 musl vendor this host cannot stage; it fails identically on a clean tree.