### PR TITLE
chore(install): drop inaccurate byllm plugin message; simplify post-install output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,11 +13,6 @@
 #   --uninstall   Remove Jac
 #   --help        Print usage
 #
-# Scale and the MCP server ship built into jac (the jaclang.scale /
-# jaclang.cli.mcp plugins); only scale's third-party deps install on demand.
-# Other plugins (byllm) install separately once `jac` is on PATH:
-#   jac install byllm
-#
 # Examples:
 #   curl -fsSL ... | bash                          # Latest jac binary
 #   curl -fsSL ... | bash -s -- --version 2.3.1    # Specific version
@@ -94,12 +89,6 @@ EXAMPLES:
 
     # Specific version
     curl -fsSL ... | bash -s -- --version 2.3.1
-
-PLUGINS:
-    Scale and the MCP server ship built into jac (jaclang.scale /
-    jaclang.cli.mcp). Once 'jac' is on PATH, install the other plugins with the
-    binary's own installer:
-        jac install byllm
 EOF
 }
 
@@ -336,13 +325,7 @@ install_binary() {
         info "Performing initial setup, this may take a moment..."
         # No stderr redirect: the launcher narrates its one-time extract
         # (payload read, sha256, live percent) on stderr -- show it.
-        jac --version || true
-        info ""
-        info "Get started:"
-        info "  jac --help"
-        info ""
-        info "Scale (deployment) and the MCP server ship built in; add other plugins when needed:"
-        info "  jac install byllm"
+        jac || true
         info ""
     else
         warn "Binary installed to ${INSTALL_DIR}/jac but 'jac' is not on PATH."


### PR DESCRIPTION
## Summary

The installer told users that byLLM is an add-on plugin to install after the fact:

```
[jac] Scale (deployment) and the MCP server ship built in; add other plugins when needed:
[jac]   jac install byllm
```

That is inaccurate. byLLM was folded into core (#7064) and ships inside the `jac` binary as `jaclang.byllm`, exactly like scale (`jaclang.scale`) and the MCP server (`jaclang.cli.mcp`). All three are built in; none is a separate package.

`jac install <name>` is a generic package installer (e.g. `jac install requests`). "byllm" is not a package, not a capability, and not an install alias, so `jac install byllm` does not enable the feature. byLLM's optional third-party deps form the `llm` capability, pulled per-project by declaring a `[byllm]` intent in `jac.toml` and running `jac install`.

## Changes

- Remove the `jac install byllm` / "other plugins" message from all three places it appeared: the header comment, the `--help` PLUGINS section, and the post-install success output.
- Drop the "Get started: jac --help" block from the post-install output.
- Call bare `jac` instead of `jac --version` to trigger the one-time payload extraction (both invoke the launcher's first-run setup; the bare call keeps the output minimal).