### PR TITLE
fix(compiler): backticked `root entry trigger resolves to the Root class

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7608.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7608.bugfix.md
@@ -1,0 +1,1 @@
+- **Fix**: a backticked `` `root `` entry trigger compiled to the jaclib `root()` function instead of the `Root` class, so spawning the walker failed with `TypeError: issubclass() arg 2 must be a class`. Both `exit_ability` and `exit_event_signature` now normalize the backticked `root` to `Root` and register the jaclib import.

--- a/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
+++ b/jac/jaclang/jac0core/passes/impl/pyast_gen_pass.impl.jac
@@ -1564,6 +1564,12 @@ impl PyastGenPass.exit_ability(nd: uni.Ability) -> None {
                 trigger_arg = tinfo;
             }
         }
+        for n in ast3.walk(trigger_arg) {
+            if (isinstance(n, ast3.Name) and (n.id in ('Root', 'root'))) {
+                n.id = 'Root';
+                self.jaclib_imports.add('Root');
+            }
+        }
 
         trigger_thunk = self.sync(
             ast3.Lambda(
@@ -1834,7 +1840,8 @@ impl PyastGenPass.exit_event_signature(nd: uni.EventSignature) -> None {
     }
     if annotation {
         for n in ast3.walk(annotation) {
-            if (isinstance(n, ast3.Name) and (n.id == 'Root')) {
+            if (isinstance(n, ast3.Name) and (n.id in ('Root', 'root'))) {
+                n.id = 'Root';
                 self.jaclib_imports.add('Root');
             }
         }

--- a/jac/tests/language/fixtures/backtick_root_trigger.jac
+++ b/jac/tests/language/fixtures/backtick_root_trigger.jac
@@ -1,0 +1,11 @@
+walker BtickRootProbe {
+    has reports: list[str] = [];
+    can g with `root entry {
+        report "hit";
+    }
+}
+
+with entry {
+    result = root spawn BtickRootProbe();
+    print(result.reports);
+}

--- a/jac/tests/language/test_bugs.jac
+++ b/jac/tests/language/test_bugs.jac
@@ -1,9 +1,12 @@
 """Bug regression tests – migrated from tests/language/test_bugs.py."""
 
+import io;
 import os;
+import sys;
 import from tests.support { JAC_ROOT }
 import jaclang;
 import from jaclang.jac0core.program { JacProgram }
+import from jaclang.jac0core.runtime { JacRuntime }
 
 glob FIXTURES = os.path.join(JAC_ROOT, "tests", "language", "fixtures");
 
@@ -11,4 +14,18 @@ test "impl match confusion issue" {
     mypass = JacProgram();
     mypass.compile(os.path.join(FIXTURES, "impl_match_confused.jac"));
     assert len(mypass.errors_had) == 1;
+}
+
+test "backticked root entry trigger executes at runtime" {
+    old_stdout = sys.stdout;
+    buf = io.StringIO();
+    sys.stdout = buf;
+    try {
+        JacRuntime.jac_import(
+            target="backtick_root_trigger", base_path=FIXTURES, override_name="__main__"
+        );
+    } finally {
+        sys.stdout = old_stdout;
+    }
+    assert "['hit']" in buf.getvalue();
 }


### PR DESCRIPTION
Fixes #7607.

## Summary

A backticked `` `root `` entry trigger compiled to the jaclib `root()` **function** instead of the `Root` **class**, so spawning the walker died with `TypeError: issubclass() arg 2 must be a class`.

`PyastGenPass.exit_ability` never normalized the backticked name, and `exit_event_signature` matched only the already-capitalized `Root`:

```jac
if (isinstance(n, ast3.Name) and (n.id == 'Root')) {
    self.jaclib_imports.add('Root');
}
```

Neither path rewrote the lowercase `root` the backtick escape produces, so codegen emitted a reference to the accessor function and dispatch then ran `issubclass()` against it.

Both paths now normalize `root` to `Root` and register the jaclib import.

## Scope

This is in the shared Python codegen path, so `jac run`, `jac start`, and `jac build` were all affected equally.

## Verification

`jac test jac/tests/language/test_bugs.jac`: 2/2.

The regression test spawns the walker and asserts on its report rather than grepping generated source, so it fails on the original `TypeError` rather than on a codegen text change.

## Note

Split out of #7517, where this was found while validating `jac build --as source`. It is unrelated to source conversion and stands on its own.
