### PR TITLE
feat(compiler): na roadmap wave 3 - generator residuals, closure residuals, generics M2, census-ranked stdlib, any-receiver inference, local OSP (#7593 remaining items)

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -194,6 +194,7 @@ type_evaluator.impl.jac
 type_checker_pass.impl.jac
 enums.impl.jac
 func.impl.jac
+generics.impl.jac
 stmt.impl.jac
 utils.impl.jac
 client_bundle.impl.jac

--- a/docs/docs/community/release_notes/unreleased/jaclang/7611.feature.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7611.feature.md
@@ -1,0 +1,1 @@
+- **Native lowering completes the roadmap**: generators, closures, generic functions, census-ranked stdlib modules (statistics, shutil, keyword), chained node filters, and local-graph programs now compile natively under inference.

--- a/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
+++ b/jac/jaclang/compiler/passes/native/impl/primitives_native.impl.jac
@@ -5797,6 +5797,12 @@ impl NativeBuiltinEmitter.emit_float(
     if isinstance(arg_val.type, ir.IntType) {
         return b.sitofp(arg_val, ir.DoubleType(), name="float.from.int");
     }
+    if isinstance(arg_val.type, ir.DoubleType) {
+        return arg_val;
+    }
+    if isinstance(arg_val.type, ir.FloatType) {
+        return b.fpext(arg_val, ir.DoubleType(), name="float.from.f32");
+    }
     return None;
 }
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
@@ -145,6 +145,13 @@ impl NaIRGenPass._codegen_bound_args(
     if not _has_pack {
         for (pix, sp) in enumerate(sig_params) {
             slot = self_offset + pix;
+            if (
+                slot >= len(func.args)
+                and not func.function_type.var_arg
+                and pix >= len(positional)
+            ) {
+                break;
+            }
             expected_type = func.args[slot].type
                 if slot < len(func.args)
                 else ir.IntType(64);
@@ -155,7 +162,7 @@ impl NaIRGenPass._codegen_bound_args(
                 chosen = kw_map[sp.name.sym_name];
             } elif sp.value is not None {
                 chosen = sp.value;
-                if isinstance(chosen, uni.Null)
+                if isinstance(chosen, (uni.Null, uni.Ellipsis))
                 and str(chosen.loc.mod_path).endswith(".pyi") {
                     chosen = None;
                 }
@@ -188,7 +195,7 @@ impl NaIRGenPass._codegen_bound_args(
                 chosen = kw_map.pop(sp.name.sym_name);
             } elif sp.value is not None {
                 chosen = sp.value;
-                if isinstance(chosen, uni.Null)
+                if isinstance(chosen, (uni.Null, uni.Ellipsis))
                 and str(chosen.loc.mod_path).endswith(".pyi") {
                     chosen = None;
                 }
@@ -220,7 +227,7 @@ impl NaIRGenPass._codegen_bound_args(
                 chosen = kw_map.pop(sp.name.sym_name);
             } elif sp.value is not None {
                 chosen = sp.value;
-                if isinstance(chosen, uni.Null)
+                if isinstance(chosen, (uni.Null, uni.Ellipsis))
                 and str(chosen.loc.mod_path).endswith(".pyi") {
                     chosen = None;
                 }
@@ -1084,7 +1091,17 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
     if func is None {
         manifest = self.ir_in.gen.interop_manifest;
         binding = manifest.bindings.get(func_name);
+        _src_ab: (uni.Ability | None) = None;
         if binding is not None
+        and binding.source_module is not None
+        and func_name not in self.generic_fns {
+            _src_ab = self._find_source_ability(binding.source_module, func_name);
+            if _src_ab is not None and _src_ab.type_params {
+                self.generic_fns[func_name] = _src_ab;
+            }
+        }
+        if binding is not None
+        and func_name not in self.generic_fns
         and (
             binding.source_context.value == "server"
             or (
@@ -1092,7 +1109,13 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
                 and binding.source_module is not None
             )
         ) {
-            sig = self._callee_sig_of(nd);
+            sig = _src_ab.signature
+                if _src_ab is not None
+                and isinstance(_src_ab.signature, uni.FuncSignature)
+                else None;
+            if sig is None {
+                sig = self._callee_sig_of(nd);
+            }
             if sig is None
             and isinstance(binding.ast_node, uni.Ability)
             and isinstance(binding.ast_node.signature, uni.FuncSignature) {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/calls.impl.jac
@@ -1126,6 +1126,12 @@ impl NaIRGenPass._codegen_call(nd: uni.FuncCall) -> (ir.Value | None) {
             func = self._get_or_declare_extern(func_name, ret_ir_type, param_ir_types);
         }
     }
+    if func is None and func_name in self.generic_fns {
+        func = self._instantiate_generic(nd, func_name);
+        if func is None {
+            return None;
+        }
+    }
     if func is None {
         if func_name in self.local_vars {
             _alloca = self.local_vars[func_name];

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/closures.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/closures.impl.jac
@@ -2,7 +2,17 @@ impl NaIRGenPass._scan_closure_escapes(nd: uni.UniNode, body: (list | tuple)) ->
     def nearest_scope(n: uni.UniNode) -> (uni.UniNode | None) {
         p = n.parent;
         while p is not None {
-            if isinstance(p, (uni.Ability, uni.ImplDef, uni.LambdaExpr, uni.Test)) {
+            if isinstance(
+                p,
+                (
+                    uni.Ability,
+                    uni.ImplDef,
+                    uni.LambdaExpr,
+                    uni.Test,
+                    uni.ModuleCode,
+                    uni.Module
+                )
+            ) {
                 return p;
             }
             p = p.parent;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/exceptions.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/exceptions.impl.jac
@@ -343,6 +343,8 @@ impl NaIRGenPass._codegen_try(nd: uni.TryStmt) -> None {
     exc_state_type = self._exc_state_type;
     exc_state_ptr = exc_state_type.as_pointer();
     func = self.builder.function;
+    _gc = self._gen_ctx;
+    _in_gen = _gc is not None and func is _gc["resume_fn"];
 
     func.attributes.add("optnone");
     func.attributes.add("noinline");
@@ -357,7 +359,9 @@ impl NaIRGenPass._codegen_try(nd: uni.TryStmt) -> None {
     self.builder.branch(setup_bb);
 
     self.builder.position_at_end(setup_bb);
-    exc_state = self.builder.alloca(exc_state_type, name="exc.state");
+    exc_state = self._stack_entry_alloca(exc_state_type, "exc.state")
+        if _in_gen
+        else self.builder.alloca(exc_state_type, name="exc.state");
 
     self.builder.call(self._exc_push_fn, [exc_state]);
 
@@ -374,8 +378,14 @@ impl NaIRGenPass._codegen_try(nd: uni.TryStmt) -> None {
     self.builder.cbranch(is_exception, dispatch_bb, body_bb);
 
     self.builder.position_at_end(body_bb);
+    if _in_gen {
+        self._gen_try_stack.append({"state": exc_state, "dispatch": dispatch_bb});
+    }
     if isinstance(nd.body, (list, tuple)) {
         self._codegen_body(nd.body);
+    }
+    if _in_gen {
+        self._gen_try_stack.pop();
     }
     if not self.builder.block.is_terminated {
         self.builder.branch(success_bb);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -1350,6 +1350,9 @@ impl NaIRGenPass._codegen_if_else_expr(nd: uni.IfElseExpr) -> (ir.Value | None) 
 }
 
 impl NaIRGenPass._codegen_atom_trailer(nd: uni.AtomTrailer) -> (ir.Value | None) {
+    if isinstance(nd.right, uni.FilterCompr) {
+        return self._codegen_chained_filter(nd);
+    }
     if nd.is_attr {
         target_name = self._get_name(nd.target);
         right_name = self._get_name(nd.right);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -333,6 +333,7 @@ impl NaIRGenPass._codegen_lambda(nd: uni.LambdaExpr) -> (ir.Value | None) {
     }
 
     body = nd.body;
+    _lam_errs0 = len(self.errors_had);
     if isinstance(body, list) {
         tail = nd.tail_return_expr();
         if tail is not None {
@@ -340,6 +341,15 @@ impl NaIRGenPass._codegen_lambda(nd: uni.LambdaExpr) -> (ir.Value | None) {
             if val is not None {
                 self.builder.ret(self._coerce_type(val, ret_type));
             } else {
+                if len(self.errors_had) == _lam_errs0 {
+                    self.emit(
+                        E5092,
+                        node_override=nd,
+                        kind="expression",
+                        name="lambda body",
+                        help_text="An expression in this lambda body could not lower natively; an unresolvable name here usually means the lambda reads a variable its enclosing frame cannot expose (e.g. a module-entry local)."
+                    );
+                }
                 self.builder.ret(ir.Constant(ret_type, 0));
             }
         } else {
@@ -350,6 +360,15 @@ impl NaIRGenPass._codegen_lambda(nd: uni.LambdaExpr) -> (ir.Value | None) {
         if val is not None {
             self.builder.ret(self._coerce_type(val, ret_type));
         } else {
+            if len(self.errors_had) == _lam_errs0 {
+                self.emit(
+                    E5092,
+                    node_override=nd,
+                    kind="expression",
+                    name="lambda body",
+                    help_text="An expression in this lambda body could not lower natively; an unresolvable name here usually means the lambda reads a variable its enclosing frame cannot expose (e.g. a module-entry local)."
+                );
+            }
             self.builder.ret(ir.Constant(ret_type, 0));
         }
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -191,9 +191,7 @@ impl NaIRGenPass._emit_yield_suspend(v: ir.Value) -> None {
         exc_state = _entry["state"];
         self.builder.call(self._exc_push_fn, [exc_state]);
         env_ptr = self.builder.gep(
-            exc_state,
-            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
-            name=f"rearm.env.{k}"
+            exc_state, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name=f"rearm.env.{k}"
         );
         env_i8p = self.builder.bitcast(env_ptr, i8p, name=f"rearm.envp.{k}");
         sj = self.builder.call(

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/expr.impl.jac
@@ -125,7 +125,6 @@ impl NaIRGenPass._codegen_required(nd: (uni.UniNode | None)) -> (ir.Value | None
 
 impl NaIRGenPass._codegen_yield(nd: uni.YieldExpr) -> (ir.Value | None) {
     gc = self._gen_ctx;
-    i1 = ir.IntType(1);
     i64 = ir.IntType(64);
     if gc is None or self.builder.function is not gc["resume_fn"] {
         self.emit(
@@ -137,25 +136,49 @@ impl NaIRGenPass._codegen_yield(nd: uni.YieldExpr) -> (ir.Value | None) {
         );
         return None;
     }
-    if nd.with_from or nd.expr is None {
-        self.emit(
-            E5092,
-            node_override=nd,
-            kind="expression",
-            name="yield from" if nd.with_from else "bare yield",
-            help_text="Native generators support `yield <expr>` only; loop over the inner iterable instead of `yield from`, and yield an explicit value."
-        );
-        return None;
+    if nd.with_from {
+        return self._codegen_yield_from(nd);
+    }
+    if nd.expr is None {
+        elem_t = gc["elem_type"];
+        if isinstance(elem_t, ir.PointerType) {
+            v = ir.Constant(elem_t, None);
+        } elif isinstance(elem_t, (ir.IntType, ir.DoubleType, ir.FloatType)) {
+            v = ir.Constant(elem_t, 0);
+        } else {
+            self.emit(
+                E5092,
+                node_override=nd,
+                kind="expression",
+                name="bare yield",
+                help_text="A bare `yield` suspends with the element type's unit value; this element type has no native unit carrier."
+            );
+            return None;
+        }
+        self._emit_yield_suspend(v);
+        return ir.Constant(i64, 0);
     }
     v = self._codegen_expr(nd.expr);
     if v is None {
         return None;
     }
-    v = self._coerce_type(v, gc["elem_type"]);
+    self._emit_yield_suspend(self._coerce_type(v, gc["elem_type"]));
+    return ir.Constant(i64, 0);
+}
+
+impl NaIRGenPass._emit_yield_suspend(v: ir.Value) -> None {
+    gc = self._gen_ctx;
+    i1 = ir.IntType(1);
+    i32 = ir.IntType(32);
+    i64 = ir.IntType(64);
+    i8p = ir.IntType(8).as_pointer();
     out_typed = self.builder.bitcast(
         gc["out_i8"], gc["elem_type"].as_pointer(), name="yield.out"
     );
     self.builder.store(v, out_typed);
+    for _entry in self._gen_try_stack {
+        self.builder.call(self._exc_pop_fn, []);
+    }
     k = len(gc["resume_blocks"]) + 1;
     ip_slot = self.builder.bitcast(gc["frame_i8"], i64.as_pointer(), name="yield.ip");
     self.builder.store(ir.Constant(i64, k), ip_slot);
@@ -164,6 +187,76 @@ impl NaIRGenPass._codegen_yield(nd: uni.YieldExpr) -> (ir.Value | None) {
     rbb = gc["resume_fn"].append_basic_block(f"resume{k}");
     gc["resume_blocks"].append(rbb);
     self.builder.position_at_end(rbb);
+    for _entry in self._gen_try_stack {
+        exc_state = _entry["state"];
+        self.builder.call(self._exc_push_fn, [exc_state]);
+        env_ptr = self.builder.gep(
+            exc_state,
+            [ir.Constant(i32, 0), ir.Constant(i32, 0)],
+            name=f"rearm.env.{k}"
+        );
+        env_i8p = self.builder.bitcast(env_ptr, i8p, name=f"rearm.envp.{k}");
+        sj = self.builder.call(
+            self.extern_funcs["setjmp"], [env_i8p], name=f"rearm.sj.{k}"
+        );
+        is_exc = self.builder.icmp_signed(
+            "!=", sj, ir.Constant(i32, 0), name=f"rearm.isexc.{k}"
+        );
+        cont_bb = gc["resume_fn"].append_basic_block(f"resume{k}.armed");
+        self.builder.cbranch(is_exc, _entry["dispatch"], cont_bb);
+        self.builder.position_at_end(cont_bb);
+    }
+}
+
+impl NaIRGenPass._codegen_yield_from(nd: uni.YieldExpr) -> (ir.Value | None) {
+    gc = self._gen_ctx;
+    i64 = ir.IntType(64);
+    i8p = ir.IntType(8).as_pointer();
+    _errs0 = len(self.errors_had);
+    built = self._build_iter_from_expr(nd.expr) if nd.expr is not None else None;
+    if built is None {
+        if len(self.errors_had) == _errs0 {
+            self.emit(
+                E5092,
+                node_override=nd,
+                kind="expression",
+                name="yield from",
+                help_text="The inner iterable of `yield from` could not lower natively; supported sources are generators, iterator values, lists, dicts, sets, strings, ranges, and the lazy adapters."
+            );
+        }
+        return None;
+    }
+    (iter_val, _elem_name, elem_type) = built;
+
+    it_spill = self._entry_alloca(iter_val.type, "yf.it");
+    self.builder.store(iter_val, it_spill);
+    _elem_is_ptr = isinstance(elem_type, ir.PointerType);
+    elem_slot = self._entry_alloca(i64 if _elem_is_ptr else elem_type, "yf.elem");
+
+    func = gc["resume_fn"];
+    cond_bb = func.append_basic_block("yf.cond");
+    body_bb = func.append_basic_block("yf.body");
+    end_bb = func.append_basic_block("yf.end");
+    self.builder.branch(cond_bb);
+
+    self.builder.position_at_end(cond_bb);
+    it_cur = self.builder.load(it_spill, name="yf.it.cur");
+    out_i8 = self.builder.bitcast(elem_slot, i8p, name="yf.out");
+    got = self._emit_iter_advance(self.builder, it_cur, out_i8);
+    self.builder.cbranch(got, body_bb, end_bb);
+
+    self.builder.position_at_end(body_bb);
+    v = self.builder.load(elem_slot, name="yf.v");
+    if _elem_is_ptr {
+        v = self.builder.inttoptr(v, elem_type, name="yf.v.ptr");
+    }
+    self._emit_yield_suspend(self._coerce_type(v, gc["elem_type"]));
+    self.builder.branch(cond_bb);
+
+    self.builder.position_at_end(end_bb);
+    it_end = self.builder.load(it_spill, name="yf.it.end");
+    self._emit_rc_release_simple(it_end, op="yf_end", loc="yield_from");
+    self.builder.store(ir.Constant(it_end.type, None), it_spill);
     return ir.Constant(i64, 0);
 }
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -896,6 +896,11 @@ impl NaIRGenPass._emit_glob_init_func -> None {
     self.region_handle_vars = set();
     self.closure_cell_vars = set();
     self.closure_cell_handles = {};
+    if self?._global_init_nodes and self._global_init_nodes {
+        self._scan_closure_escapes(
+            self.ir_in, [t[1] for t in self._global_init_nodes]
+        );
+    }
 
     self._attach_di_subprogram(func, "__jac_glob_init", 0);
     _i8 = ir.IntType(8);
@@ -1071,6 +1076,11 @@ impl NaIRGenPass._codegen_entry(nodes: list[uni.ModuleCode]) -> None {
     self.region_handle_vars = set();
     self.closure_cell_vars = set();
     self.closure_cell_handles = {};
+    for _ent_scan in nodes {
+        if (_ent_scan).body {
+            self._scan_closure_escapes(_ent_scan, (_ent_scan).body);
+        }
+    }
 
     _first = nodes[0];
     entry_line = _first.loc.first_line if _first.loc else 0;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -483,6 +483,16 @@ impl NaIRGenPass._codegen_test(nd: uni.Test) -> None {
 impl NaIRGenPass._codegen_nested_ability(nd: uni.Ability) -> None {
     name = nd.name_ref.sym_name if nd.name_ref else "unnamed";
     sig = nd.signature;
+    if sig is not None and not isinstance(sig, uni.FuncSignature) {
+        self.emit(
+            E5092,
+            node_override=nd,
+            kind="function",
+            name=name,
+            help_text="An event ability (`can ... with entry/exit`) cannot lower as a nested native function; it belongs on an archetype in a server context."
+        );
+        return;
+    }
 
     param_types: list = [];
     param_names: list = [];

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -116,7 +116,9 @@ impl NaIRGenPass._record_ret_facts(name: str, sig: uni.FuncSignature) -> None {
     _rtb = _rt?.type;
     if _rtb is not None {
         try {
-            self.func_ret_type_key[name] = self._normalize_type_key(self._mangled_of(_rtb));
+            self.func_ret_type_key[name] = self._normalize_type_key(
+                self._mangled_of(_rtb)
+            );
         } except Exception { }
     }
     elems: list = [];
@@ -915,9 +917,7 @@ impl NaIRGenPass._emit_glob_init_func -> None {
     self.closure_cell_vars = set();
     self.closure_cell_handles = {};
     if self?._global_init_nodes and self._global_init_nodes {
-        self._scan_closure_escapes(
-            self.ir_in, [t[1] for t in self._global_init_nodes]
-        );
+        self._scan_closure_escapes(self.ir_in, [t[1] for t in self._global_init_nodes]);
     }
 
     self._attach_di_subprogram(func, "__jac_glob_init", 0);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -632,7 +632,11 @@ impl NaIRGenPass._generator_elem_type(nd: uni.Ability) -> (ir.Type | None) {
         if mangled.startswith(prefix) {
             targs = rt.type.private.type_args or [];
             if targs {
-                return self._lower_type(targs[0]);
+                _low = self._lower_type(targs[0]);
+                if _low is not None and isinstance(_low, ir.VoidType) {
+                    return ir.IntType(64);
+                }
+                return _low;
             }
         }
     }
@@ -660,14 +664,16 @@ impl NaIRGenPass._codegen_generator(nd: uni.Ability, func: ir.Function) -> None 
         return;
     }
     for y in nd.get_all_sub_nodes(typ=uni.YieldExpr) {
+        _fin = y.find_parent_of_type(uni.FinallyStmt);
         if y.find_parent_of_type(uni.Ability) is nd
-        and y.find_parent_of_type(uni.TryStmt) is not None {
+        and _fin is not None
+        and _fin.find_parent_of_type(uni.Ability) is nd {
             self.emit(
                 E5092,
                 node_override=y,
                 kind="expression",
-                name="yield inside try",
-                help_text="Suspending inside a try block is not supported on native yet; move the yield outside the try or the try into the consumer."
+                name="yield inside finally",
+                help_text="A native finally block runs exactly once and cannot suspend; move the yield outside the finally."
             );
             return;
         }
@@ -688,6 +694,7 @@ impl NaIRGenPass._codegen_generator(nd: uni.Ability, func: ir.Function) -> None 
     saved_region = self.region_handle_vars;
     saved_cell_vars = self.closure_cell_vars;
     saved_cell_handles = self.closure_cell_handles;
+    saved_try_stack = self._gen_try_stack;
 
     entry_bb = resume_fn.append_basic_block("entry");
     self._builder = ir.IRBuilder(entry_bb);
@@ -697,6 +704,7 @@ impl NaIRGenPass._codegen_generator(nd: uni.Ability, func: ir.Function) -> None 
     self.region_handle_vars = set();
     self.closure_cell_vars = set();
     self.closure_cell_handles = {};
+    self._gen_try_stack = [];
 
     gc: dict = {
         "resume_fn": resume_fn,
@@ -773,6 +781,7 @@ impl NaIRGenPass._codegen_generator(nd: uni.Ability, func: ir.Function) -> None 
     self.region_handle_vars = saved_region;
     self.closure_cell_vars = saved_cell_vars;
     self.closure_cell_handles = saved_cell_handles;
+    self._gen_try_stack = saved_try_stack;
 
     drop_fn = self._emit_generator_drop_fn(name, frame_slots);
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -26,6 +26,7 @@ impl NaIRGenPass._maybe_declare_ability(nd: uni.ElementStmt) -> None {
     name = nd.name_ref.sym_name if nd.name_ref else "unnamed";
     if nd.type_params {
         self.generic_fns[name] = nd;
+        self.has_native_code = True;
         return;
     }
     sig = nd.signature;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/func.impl.jac
@@ -24,6 +24,10 @@ impl NaIRGenPass._maybe_declare_ability(nd: uni.ElementStmt) -> None {
         return;
     }
     name = nd.name_ref.sym_name if nd.name_ref else "unnamed";
+    if nd.type_params {
+        self.generic_fns[name] = nd;
+        return;
+    }
     sig = nd.signature;
 
     param_types: list[ir.Type] = [];
@@ -111,7 +115,7 @@ impl NaIRGenPass._record_ret_facts(name: str, sig: uni.FuncSignature) -> None {
     _rtb = _rt?.type;
     if _rtb is not None {
         try {
-            self.func_ret_type_key[name] = self._normalize_type_key(_rtb.mangle());
+            self.func_ret_type_key[name] = self._normalize_type_key(self._mangled_of(_rtb));
         } except Exception { }
     }
     elems: list = [];
@@ -134,7 +138,7 @@ impl NaIRGenPass._record_ret_facts(name: str, sig: uni.FuncSignature) -> None {
             _etb = e?.type if isinstance(e, uni.Expr) else None;
             if _etb is not None {
                 try {
-                    _ek = self._normalize_type_key(_etb.mangle());
+                    _ek = self._normalize_type_key(self._mangled_of(_etb));
                 } except Exception { }
             }
             keys.append(_ek);
@@ -296,6 +300,9 @@ impl NaIRGenPass._declare_clib_ability(nd: uni.Ability) -> None {
 
 impl NaIRGenPass._codegen_ability(nd: uni.Ability) -> None {
     name = (nd).name_ref.sym_name if (nd).name_ref else "unnamed";
+    if nd.type_params and self._mono_solution is None {
+        return;
+    }
     func = self.func_symtab.get(name);
     if func is None {
         return;
@@ -624,7 +631,7 @@ impl NaIRGenPass._generator_elem_type(nd: uni.Ability) -> (ir.Type | None) {
     if not isinstance(rt, uni.Expr) or rt.type is None {
         return None;
     }
-    mangled = rt.type.mangle();
+    mangled = self._mangled_of(rt.type);
     if mangled.startswith("type[") {
         mangled = mangled[5:];
     }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
@@ -1,15 +1,3 @@
-"""TypeVar-function monomorphization.
-
-A generic def (`def f[T](...)`) registers as a template in `generic_fns`
-and declares no symbol. Each callsite structurally unifies the declared
-parameter types against the checker-solved argument types to bind the type
-params, then stamps (memoized per solved-type key) a specialized private
-copy whose body lowers with the binding active: `_lower_type` substitutes
-bound TypeVars and every mangle-driven helper reads through `_mangled_of`,
-which rewrites bound TypeVar names inside mangled type keys. No boxing;
-the callsite links the specialized copy like any direct call.
-"""
-
 impl NaIRGenPass._mangled_of(t: any) -> (str | None) {
     if t is None or not t?.mangle {
         return None;
@@ -75,20 +63,34 @@ impl NaIRGenPass._solve_generic_call(
 
     sig = ability.signature;
     params = sig.get_parameters() if sig is not None else [];
-    args = nd.params or [];
-    for (i, p) in enumerate(params) {
-        if i >= len(args) {
-            break;
+    _ft = ability.name_ref.type if ability.name_ref is not None else None;
+    _ft_params = list(_ft.parameters or [])
+        if _ft is not None and _ft?.parameters
+        else [];
+    positional: list = [];
+    kw_map: dict = {};
+    for a in (nd.params or []) {
+        if isinstance(a, uni.KWPair) {
+            if a.key is not None {
+                kw_map[a.key.sym_name] = a.value;
+            }
+        } else {
+            positional.append(a);
         }
-        a = args[i];
-        if not isinstance(a, uni.Expr) or isinstance(a, uni.KWPair) {
+    }
+    for (i, p) in enumerate(params) {
+        p_name = p.name.sym_name if p?.name and p.name is not None else None;
+        chosen = positional[i]
+            if i < len(positional)
+            else (kw_map.get(p_name) if p_name is not None else None);
+        if not isinstance(chosen, uni.Expr) {
             continue;
         }
-        decl_t = p.name.type if p?.name and p.name is not None else None;
+        decl_t = _ft_params[i].param_type if i < len(_ft_params) else None;
         if decl_t is None and p?.type_tag and p.type_tag is not None {
             decl_t = p.type_tag.tag.type if p.type_tag?.tag else None;
         }
-        unify(decl_t, a.type);
+        unify(decl_t, chosen.type);
     }
     for tp in (ability.type_params or []) {
         tp_name = tp.name.value if tp?.name and tp.name is not None else None;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
@@ -1,0 +1,198 @@
+"""TypeVar-function monomorphization.
+
+A generic def (`def f[T](...)`) registers as a template in `generic_fns`
+and declares no symbol. Each callsite structurally unifies the declared
+parameter types against the checker-solved argument types to bind the type
+params, then stamps (memoized per solved-type key) a specialized private
+copy whose body lowers with the binding active: `_lower_type` substitutes
+bound TypeVars and every mangle-driven helper reads through `_mangled_of`,
+which rewrites bound TypeVar names inside mangled type keys. No boxing;
+the callsite links the specialized copy like any direct call.
+"""
+
+impl NaIRGenPass._mangled_of(t: any) -> (str | None) {
+    if t is None or not t?.mangle {
+        return None;
+    }
+    m = t.mangle();
+    _map = self._mono_mangle_map;
+    if _map {
+        import re;
+        for (tv, repl) in _map.items() {
+            m = re.sub(rf"\b{re.escape(tv)}\b", repl, m);
+        }
+    }
+    return m;
+}
+
+impl NaIRGenPass._solve_generic_call(
+    ability: uni.Ability, nd: uni.FuncCall
+) -> (dict | None) {
+    try {
+        import from jaclang.compiler.type_system.types {
+            TypeVarType as _TVT,
+            ClassType as _CT,
+            UnionType as _UT
+        }
+    } except ImportError {
+        return None;
+    }
+    solution: dict = {};
+
+    def unify(decl: any, actual: any) -> None {
+        if decl is None or actual is None {
+            return;
+        }
+        if isinstance(decl, _TVT) {
+            if decl.name not in solution {
+                solution[decl.name] = actual;
+            }
+            return;
+        }
+        if isinstance(decl, _CT) and isinstance(actual, _CT) {
+            d_args = decl.private.type_args or [];
+            a_args = actual.private.type_args or [];
+            for (i, da) in enumerate(d_args) {
+                if i < len(a_args) {
+                    unify(da, a_args[i]);
+                }
+            }
+            return;
+        }
+        if isinstance(decl, _UT) {
+            for m in (decl.types or []) {
+                if isinstance(m, _TVT) {
+                    unify(m, actual);
+                    return;
+                }
+            }
+        }
+    }
+
+    sig = ability.signature;
+    params = sig.get_parameters() if sig is not None else [];
+    args = nd.params or [];
+    for (i, p) in enumerate(params) {
+        if i >= len(args) {
+            break;
+        }
+        a = args[i];
+        if not isinstance(a, uni.Expr) or isinstance(a, uni.KWPair) {
+            continue;
+        }
+        decl_t = p.name.type if p?.name and p.name is not None else None;
+        if decl_t is None and p?.type_tag and p.type_tag is not None {
+            decl_t = p.type_tag.tag.type if p.type_tag?.tag else None;
+        }
+        unify(decl_t, a.type);
+    }
+    for tp in (ability.type_params or []) {
+        tp_name = tp.name.value if tp?.name and tp.name is not None else None;
+        if tp_name is not None and tp_name not in solution {
+            return None;
+        }
+    }
+    return solution;
+}
+
+impl NaIRGenPass._instantiate_generic(
+    nd: uni.FuncCall, func_name: str
+) -> (ir.Function | None) {
+    ability = self.generic_fns[func_name];
+    if self._ability_is_generator(ability) {
+        self.emit(
+            E5092,
+            node_override=nd,
+            kind="function",
+            name=func_name,
+            help_text="Generic generator functions are not monomorphized yet; declare a concrete element type."
+        );
+        return None;
+    }
+    solution = self._solve_generic_call(ability, nd);
+    if not solution {
+        self.emit(
+            E5092,
+            node_override=nd,
+            kind="function",
+            name=func_name,
+            help_text="Could not solve this call's type arguments for monomorphization; annotate the arguments with concrete types."
+        );
+        return None;
+    }
+    _mangles: dict = {};
+    for (k, v) in solution.items() {
+        _mangles[k] = v.mangle() if v?.mangle else "any";
+    }
+    parts = sorted([f"{k}={m}" for (k, m) in _mangles.items()]);
+    key = func_name + "|" + ",".join(parts);
+    _hit = self._mono_fns.get(key);
+    if _hit is not None {
+        return _hit;
+    }
+    import re;
+    safe = re.sub(r"[^0-9A-Za-z_]", "_", "_".join(parts));
+    spec_name = f"__jac_mono_{func_name}_{safe}";
+    saved_sol = self._mono_solution;
+    saved_map = self._mono_mangle_map;
+    self._mono_solution = solution;
+    self._mono_mangle_map = _mangles;
+    _errs0 = len(self.errors_had);
+    try {
+        fn = self._stamp_mono_fn(ability, spec_name);
+    } finally {
+        self._mono_solution = saved_sol;
+        self._mono_mangle_map = saved_map;
+    }
+    if fn is not None and len(self.errors_had) == _errs0 {
+        self._mono_fns[key] = fn;
+        return fn;
+    }
+    return fn;
+}
+
+impl NaIRGenPass._stamp_mono_fn(
+    ability: uni.Ability, spec_name: str
+) -> (ir.Function | None) {
+    name = ability.name_ref.sym_name if ability.name_ref else "unnamed";
+    sig = ability.signature;
+    param_types: list = [];
+    for p in sig.get_parameters() {
+        param_types.append(
+            self._resolve_jac_type(p) if p.type_tag is not None else ir.IntType(64)
+        );
+    }
+    ret_type = self._resolve_jac_type(sig.return_type);
+    fnty = ir.FunctionType(ret_type, param_types);
+    fn = ir.Function(self.llvm_module, fnty, name=spec_name);
+    fn.linkage = "private";
+    for (i, p) in enumerate(sig.get_parameters()) {
+        fn.args[i].name = p.name.value if p.name else f"arg{i}";
+    }
+    self._record_ret_facts(spec_name, sig);
+
+    saved_builder = self._builder;
+    saved_locals = self.local_vars if self?.local_vars else {};
+    saved_param_vars = self.param_vars;
+    saved_nogc = self.nogc_stack_vars;
+    saved_region = self.region_handle_vars;
+    saved_list_struct = self.var_list_elem_struct;
+    saved_cell_vars = self.closure_cell_vars;
+    saved_cell_handles = self.closure_cell_handles;
+    saved_symtab = dict(self.func_symtab);
+    self.func_symtab[name] = fn;
+    try {
+        self._codegen_ability(ability);
+    } finally {
+        self._builder = saved_builder;
+        self.local_vars = saved_locals;
+        self.param_vars = saved_param_vars;
+        self.nogc_stack_vars = saved_nogc;
+        self.region_handle_vars = saved_region;
+        self.var_list_elem_struct = saved_list_struct;
+        self.closure_cell_vars = saved_cell_vars;
+        self.closure_cell_handles = saved_cell_handles;
+        self.func_symtab = saved_symtab;
+    }
+    return fn;
+}

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/generics.impl.jac
@@ -43,6 +43,10 @@ impl NaIRGenPass._solve_generic_call(
         if decl is None or actual is None {
             return;
         }
+        _outer = self._mono_solution;
+        if isinstance(actual, _TVT) and _outer is not None and actual.name in _outer {
+            actual = _outer[actual.name];
+        }
         if isinstance(decl, _TVT) {
             if decl.name not in solution {
                 solution[decl.name] = actual;
@@ -137,22 +141,17 @@ impl NaIRGenPass._instantiate_generic(
     saved_map = self._mono_mangle_map;
     self._mono_solution = solution;
     self._mono_mangle_map = _mangles;
-    _errs0 = len(self.errors_had);
     try {
-        fn = self._stamp_mono_fn(ability, spec_name);
+        fn = self._stamp_mono_fn(ability, spec_name, key);
     } finally {
         self._mono_solution = saved_sol;
         self._mono_mangle_map = saved_map;
-    }
-    if fn is not None and len(self.errors_had) == _errs0 {
-        self._mono_fns[key] = fn;
-        return fn;
     }
     return fn;
 }
 
 impl NaIRGenPass._stamp_mono_fn(
-    ability: uni.Ability, spec_name: str
+    ability: uni.Ability, spec_name: str, memo_key: str
 ) -> (ir.Function | None) {
     name = ability.name_ref.sym_name if ability.name_ref else "unnamed";
     sig = ability.signature;
@@ -169,6 +168,7 @@ impl NaIRGenPass._stamp_mono_fn(
     for (i, p) in enumerate(sig.get_parameters()) {
         fn.args[i].name = p.name.value if p.name else f"arg{i}";
     }
+    self._mono_fns[memo_key] = fn;
     self._record_ret_facts(spec_name, sig);
 
     saved_builder = self._builder;
@@ -195,4 +195,47 @@ impl NaIRGenPass._stamp_mono_fn(
         self.func_symtab = saved_symtab;
     }
     return fn;
+}
+
+impl NaIRGenPass._find_source_ability(
+    mod_name: str, func_name: str
+) -> (uni.Ability | None) {
+    import os;
+    import from jaclang.jac0core.codeinfo { resolve_native_module }
+    _base = os.path.dirname(self.ir_in.loc.mod_path) if self.ir_in?.loc else None;
+    _clean = mod_name[:-3] if mod_name.endswith(".na") else mod_name;
+    (_src, full_path) = resolve_native_module(_clean, _base);
+    if full_path is None {
+        return None;
+    }
+    imported_mod = self.prog.mod.hub.get(full_path);
+    if imported_mod is None {
+        imported_mod = self.prog.mod.hub.get(os.path.abspath(full_path));
+    }
+    if imported_mod is None and os.path.isfile(full_path) {
+        _saved_opts = self.prog._compile_options;
+        try {
+            imported_mod = self.prog.compile(
+                full_path, no_cgen=True, symtab_ir_only=True
+            );
+        } except Exception {
+            imported_mod = None;
+        } finally {
+            self.prog._compile_options = _saved_opts;
+        }
+    }
+    if imported_mod is None {
+        return None;
+    }
+    for stmt in (imported_mod.body or []) {
+        if (
+            isinstance(stmt, uni.Ability)
+            and stmt.name_ref is not None
+            and stmt.name_ref.sym_name == func_name
+            and isinstance(stmt.signature, uni.FuncSignature)
+        ) {
+            return stmt;
+        }
+    }
+    return None;
 }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
@@ -17,8 +17,10 @@ impl NaIRGenPass._ensure_iter_types -> None {
         "RangeIterState", ["cur", "stop", "step"], [i64, i64, i64]
     );
 
-    self._register_iter_struct("MapIterState", ["upstream"], [i8p]);
-    self._register_iter_struct("FilterIterState", ["upstream"], [i8p]);
+    self._register_iter_struct("MapIterState", ["upstream", "fn", "env"], [i8p, i64, i8p]);
+    self._register_iter_struct(
+        "FilterIterState", ["upstream", "fn", "env"], [i8p, i64, i8p]
+    );
     self._register_iter_struct("EnumerateIterState", ["upstream", "idx"], [i8p, i64]);
     self._register_iter_struct("ZipIterState", ["up_a", "up_b"], [i8p, i8p]);
 
@@ -635,29 +637,42 @@ impl NaIRGenPass._make_iter_from_value(
     return None;
 }
 
-impl NaIRGenPass._adapter_callee_fn(fn_expr: uni.UniNode) -> (ir.Function | None) {
-    named = self.func_symtab.get(self._get_name(fn_expr));
+impl NaIRGenPass._adapter_clos_parts(clos: ir.Value) -> (tuple | None) {
+    sn = self._closure_struct_of(clos.type);
+    if sn is None {
+        return None;
+    }
+    (_st, fnty_env) = self.closure_sig_registry[sn];
+    i32 = ir.IntType(32);
+    fn_slot = self.builder.gep(
+        clos, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="acb.fn.slot"
+    );
+    fn_i64 = self.builder.load(fn_slot, name="acb.fn");
+    env_slot = self.builder.gep(
+        clos, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="acb.env.slot"
+    );
+    env = self.builder.load(env_slot, name="acb.env");
+    self._emit_rc_retain(env, op="adapter_env", loc="");
+    if self._is_owned(clos) {
+        self._emit_rc_release_simple(clos, op="adapter_clos", loc="");
+    }
+    return ("clos", fn_i64, env, fnty_env);
+}
+
+impl NaIRGenPass._adapter_callee(fn_expr: uni.UniNode) -> (tuple | None) {
+    fname = self._get_name(fn_expr);
+    if fname is not None and fname in self.nested_captures {
+        clos = self._emit_closure_value(fname, fn_expr);
+        if clos is not None {
+            return self._adapter_clos_parts(clos);
+        }
+        return None;
+    }
+    named = self.func_symtab.get(fname) if fname is not None else None;
     if named is not None and isinstance(named, ir.Function) {
-        return named;
+        return ("bare", named, None, None);
     }
     if isinstance(fn_expr, uni.LambdaExpr) {
-        _has_local_caps = False;
-        for cap_sym in fn_expr.captures {
-            if cap_sym.sym_name in self.local_vars {
-                _has_local_caps = True;
-                break;
-            }
-        }
-        if _has_local_caps {
-            self.emit(
-                E5092,
-                node_override=fn_expr,
-                kind="expression",
-                name="capturing lambda as a map/filter callback",
-                help_text="A lambda passed to map/filter must not capture enclosing locals; bind the value through the element or use a named function."
-            );
-            return None;
-        }
         lv = self._codegen_lambda(fn_expr);
         if self._pending_lambda_captures is not None {
             self._pending_lambda_captures = None;
@@ -666,13 +681,21 @@ impl NaIRGenPass._adapter_callee_fn(fn_expr: uni.UniNode) -> (ir.Function | None
                 node_override=fn_expr,
                 kind="expression",
                 name="capturing lambda as a map/filter callback",
-                help_text="A lambda passed to map/filter must not capture enclosing locals; bind the value through the element or use a named function."
+                help_text="This lambda's captures could not be promoted to shared heap cells in this frame (the capture is borrowed from an outer function, or this is a generator frame); bind the value through the element or use a named function."
             );
             return None;
         }
         if isinstance(lv, ir.Function) {
-            return lv;
+            return ("bare", lv, None, None);
         }
+        if lv is not None and self._closure_struct_of(lv.type) is not None {
+            return self._adapter_clos_parts(lv);
+        }
+        return None;
+    }
+    v = self._codegen_expr(fn_expr);
+    if v is not None and self._closure_struct_of(v.type) is not None {
+        return self._adapter_clos_parts(v);
     }
     return None;
 }
@@ -688,7 +711,7 @@ impl NaIRGenPass._build_iter_from_expr(expr: uni.UniNode) -> (tuple | None) {
             cname = None;
         }
         if cname == "map" and len(params) == 2 {
-            fn = self._adapter_callee_fn(params[0]);
+            fn = self._adapter_callee(params[0]);
             up = self._build_iter_from_expr(params[1]);
             if fn is None or up is None {
                 return None;
@@ -696,7 +719,7 @@ impl NaIRGenPass._build_iter_from_expr(expr: uni.UniNode) -> (tuple | None) {
             return self._make_map_iter(up, fn);
         }
         if cname == "filter" and len(params) == 2 {
-            pred = self._adapter_callee_fn(params[0]);
+            pred = self._adapter_callee(params[0]);
             up = self._build_iter_from_expr(params[1]);
             if pred is None or up is None {
                 return None;
@@ -729,12 +752,15 @@ impl NaIRGenPass._build_iter_from_expr(expr: uni.UniNode) -> (tuple | None) {
     return self._make_iter_from_value(val, expr);
 }
 
-impl NaIRGenPass._make_map_iter(up: tuple, fn: ir.Function) -> (tuple | None) {
+impl NaIRGenPass._make_map_iter(up: tuple, callee: tuple) -> (tuple | None) {
     i8p = ir.IntType(8).as_pointer();
     i32 = ir.IntType(32);
     i1 = ir.IntType(1);
     (up_val, up_name, up_type) = up;
-    out_type = fn.function_type.return_type;
+    (ckind, cfn, cenv, fnty_env) = callee;
+    out_type = cfn.function_type.return_type
+        if ckind == "bare"
+        else fnty_env.return_type;
     uid = self._iter_uid;
     self._iter_uid = uid + 1;
     state_ptr_type = self.struct_types["MapIterState"].as_pointer();
@@ -757,7 +783,20 @@ impl NaIRGenPass._make_map_iter(up: tuple, fn: ir.Function) -> (tuple | None) {
     b.cbranch(got, apply, stop);
     b.position_at_end(apply);
     tval = b.load(tmp, name="map.tval");
-    uval = b.call(fn, [tval], name="map.uval");
+    if ckind == "bare" {
+        uval = b.call(cfn, [tval], name="map.uval");
+    } else {
+        fn_slot = b.gep(
+            state, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="map.fn.slot"
+        );
+        fn_i64 = b.load(fn_slot, name="map.fn");
+        fnp = b.inttoptr(fn_i64, fnty_env.as_pointer(), name="map.fnp");
+        env_slot = b.gep(
+            state, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="map.env.slot"
+        );
+        env = b.load(env_slot, name="map.env");
+        uval = b.call(fnp, [tval, env], name="map.uval");
+    }
     out_t = b.bitcast(nfn.args[1], out_type.as_pointer(), name="map.out");
     b.store(uval, out_t);
     b.ret(ir.Constant(i1, 1));
@@ -769,14 +808,25 @@ impl NaIRGenPass._make_map_iter(up: tuple, fn: ir.Function) -> (tuple | None) {
         st, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="map.up.field"
     );
     self.builder.store(up_i8, st_slot);
+    if ckind == "clos" {
+        fn_field = self.builder.gep(
+            st, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="map.fn.field"
+        );
+        self.builder.store(cfn, fn_field);
+        env_field = self.builder.gep(
+            st, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="map.env.field"
+        );
+        self.builder.store(cenv, env_field);
+    }
     return (self._make_jac_iter(nfn, st), "adapter", out_type);
 }
 
-impl NaIRGenPass._make_filter_iter(up: tuple, pred: ir.Function) -> (tuple | None) {
+impl NaIRGenPass._make_filter_iter(up: tuple, callee: tuple) -> (tuple | None) {
     i8p = ir.IntType(8).as_pointer();
     i32 = ir.IntType(32);
     i1 = ir.IntType(1);
     (up_val, up_name, up_type) = up;
+    (ckind, cfn, cenv, fnty_env) = callee;
     uid = self._iter_uid;
     self._iter_uid = uid + 1;
     state_ptr_type = self.struct_types["FilterIterState"].as_pointer();
@@ -804,7 +854,20 @@ impl NaIRGenPass._make_filter_iter(up: tuple, pred: ir.Function) -> (tuple | Non
     b.cbranch(got, test_bb, stop);
     b.position_at_end(test_bb);
     tval = b.load(tmp, name="flt.tval");
-    keep = b.call(pred, [tval], name="flt.keep");
+    if ckind == "bare" {
+        keep = b.call(cfn, [tval], name="flt.keep");
+    } else {
+        fn_slot = b.gep(
+            state, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="flt.fn.slot"
+        );
+        fn_i64 = b.load(fn_slot, name="flt.fn");
+        fnp = b.inttoptr(fn_i64, fnty_env.as_pointer(), name="flt.fnp");
+        env_slot = b.gep(
+            state, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="flt.env.slot"
+        );
+        env = b.load(env_slot, name="flt.env");
+        keep = b.call(fnp, [tval, env], name="flt.keep");
+    }
     keepb = b.icmp_unsigned("!=", keep, ir.Constant(keep.type, 0), name="flt.keepb");
     b.cbranch(keepb, emit, loop_bb);
     b.position_at_end(emit);
@@ -819,6 +882,16 @@ impl NaIRGenPass._make_filter_iter(up: tuple, pred: ir.Function) -> (tuple | Non
         st, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="flt.up.field"
     );
     self.builder.store(up_i8, st_slot);
+    if ckind == "clos" {
+        fn_field = self.builder.gep(
+            st, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="flt.fn.field"
+        );
+        self.builder.store(cfn, fn_field);
+        env_field = self.builder.gep(
+            st, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="flt.env.field"
+        );
+        self.builder.store(cenv, env_field);
+    }
     return (self._make_jac_iter(nfn, st), up_name, up_type);
 }
 

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
@@ -808,15 +808,18 @@ impl NaIRGenPass._make_map_iter(up: tuple, callee: tuple) -> (tuple | None) {
         st, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="map.up.field"
     );
     self.builder.store(up_i8, st_slot);
+    fn_field = self.builder.gep(
+        st, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="map.fn.field"
+    );
+    env_field = self.builder.gep(
+        st, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="map.env.field"
+    );
     if ckind == "clos" {
-        fn_field = self.builder.gep(
-            st, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="map.fn.field"
-        );
         self.builder.store(cfn, fn_field);
-        env_field = self.builder.gep(
-            st, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="map.env.field"
-        );
         self.builder.store(cenv, env_field);
+    } else {
+        self.builder.store(ir.Constant(ir.IntType(64), 0), fn_field);
+        self.builder.store(ir.Constant(i8p, None), env_field);
     }
     return (self._make_jac_iter(nfn, st), "adapter", out_type);
 }
@@ -882,15 +885,18 @@ impl NaIRGenPass._make_filter_iter(up: tuple, callee: tuple) -> (tuple | None) {
         st, [ir.Constant(i32, 0), ir.Constant(i32, 0)], name="flt.up.field"
     );
     self.builder.store(up_i8, st_slot);
+    fn_field = self.builder.gep(
+        st, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="flt.fn.field"
+    );
+    env_field = self.builder.gep(
+        st, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="flt.env.field"
+    );
     if ckind == "clos" {
-        fn_field = self.builder.gep(
-            st, [ir.Constant(i32, 0), ir.Constant(i32, 1)], name="flt.fn.field"
-        );
         self.builder.store(cfn, fn_field);
-        env_field = self.builder.gep(
-            st, [ir.Constant(i32, 0), ir.Constant(i32, 2)], name="flt.env.field"
-        );
         self.builder.store(cenv, env_field);
+    } else {
+        self.builder.store(ir.Constant(ir.IntType(64), 0), fn_field);
+        self.builder.store(ir.Constant(i8p, None), env_field);
     }
     return (self._make_jac_iter(nfn, st), up_name, up_type);
 }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/iterators.impl.jac
@@ -17,7 +17,9 @@ impl NaIRGenPass._ensure_iter_types -> None {
         "RangeIterState", ["cur", "stop", "step"], [i64, i64, i64]
     );
 
-    self._register_iter_struct("MapIterState", ["upstream", "fn", "env"], [i8p, i64, i8p]);
+    self._register_iter_struct(
+        "MapIterState", ["upstream", "fn", "env"], [i8p, i64, i8p]
+    );
     self._register_iter_struct(
         "FilterIterState", ["upstream", "fn", "env"], [i8p, i64, i8p]
     );

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
@@ -181,6 +181,9 @@ impl NaIRGenPass._codegen_list_val(nd: uni.ListVal) -> (ir.Value | None) {
         return None;
     }
 
+    _decl_elem = self._list_elem_llvm_of(nd);
+    _clos_elem = self._closure_struct_of(_decl_elem) if _decl_elem is not None else None;
+
     first_val = self._codegen_expr(nd.values[0]);
     if first_val is None {
         return None;
@@ -192,6 +195,9 @@ impl NaIRGenPass._codegen_list_val(nd: uni.ListVal) -> (ir.Value | None) {
             if nd.loc
             else 0}"
     );
+    if _clos_elem is not None and first_val.type != _decl_elem {
+        first_val = self._coerce_type(first_val, _decl_elem);
+    }
     elem_type = first_val.type;
     elem_type_name = "i64";
     if isinstance(elem_type, ir.DoubleType) {
@@ -249,6 +255,9 @@ impl NaIRGenPass._codegen_list_val(nd: uni.ListVal) -> (ir.Value | None) {
             }
             _orig_val = val;
             val = self._box_value_tuple(val, loc=_linit_loc);
+            if _clos_elem is not None and val.type != _decl_elem {
+                val = self._coerce_type(val, _decl_elem);
+            }
             _boxed_val = val;
             if elem_type_name == "ptr" and isinstance(val.type, ir.PointerType) {
                 val = self.builder.bitcast(val, i8p, name="elem.cast");

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/lists.impl.jac
@@ -182,7 +182,9 @@ impl NaIRGenPass._codegen_list_val(nd: uni.ListVal) -> (ir.Value | None) {
     }
 
     _decl_elem = self._list_elem_llvm_of(nd);
-    _clos_elem = self._closure_struct_of(_decl_elem) if _decl_elem is not None else None;
+    _clos_elem = self._closure_struct_of(_decl_elem)
+        if _decl_elem is not None
+        else None;
 
     first_val = self._codegen_expr(nd.values[0]);
     if first_val is None {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/objects.impl.jac
@@ -640,6 +640,12 @@ impl NaIRGenPass._codegen_no_sig_method(arch_name: str, method: uni.Ability) -> 
         func, full_name, method.loc.first_line if method.loc else 0
     );
 
+    _scan_body = ModuleCodegenPass.unwrap_body(method);
+    if _scan_body is not None {
+        _scan_owner = method.body if isinstance(method.body, uni.ImplDef) else method;
+        self._scan_closure_escapes(_scan_owner, _scan_body);
+    }
+
     self_alloca = self.builder.alloca(func.args[0].type, name="self");
     self.builder.store(func.args[0], self_alloca);
     self.local_vars["self"] = self_alloca;
@@ -811,6 +817,11 @@ impl NaIRGenPass._codegen_event_method(arch_name: str, method: uni.Ability) -> N
     self._attach_di_subprogram(
         func, full_name, method.loc.first_line if method.loc else 0
     );
+    _scan_body = ModuleCodegenPass.unwrap_body(method);
+    if _scan_body is not None {
+        _scan_owner = method.body if isinstance(method.body, uni.ImplDef) else method;
+        self._scan_closure_escapes(_scan_owner, _scan_body);
+    }
     self_alloca = self.builder.alloca(func.args[0].type, name="self");
     self.builder.store(func.args[0], self_alloca);
     self.local_vars["self"] = self_alloca;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/osp.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/osp.impl.jac
@@ -928,6 +928,49 @@ impl NaIRGenPass._codegen_edge_ref_trailer(
     return _result;
 }
 
+impl NaIRGenPass._codegen_chained_filter(nd: uni.AtomTrailer) -> (ir.Value | None) {
+    i64 = ir.IntType(64);
+    _f = nd.right;
+    _fname = self._get_name(_f.f_type) if _f.f_type is not None else None;
+    if _f.compares or _fname is None {
+        self.emit(
+            E5092,
+            node_override=nd,
+            kind="expression",
+            name="FilterCompr",
+            help_text="Only plain `[?:NodeType]` type filters lower natively; field-predicate filters are not supported yet - filter with an explicit loop."
+        );
+        return None;
+    }
+    target_val = self._codegen_expr(nd.target);
+    if target_val is None {
+        return None;
+    }
+    _model = self.ir_in.gen.osp_model;
+    _tags = _model.tags if _model is not None else {};
+    _ntag = _tags.get(_fname, -1);
+    if _ntag < 0 or self._osp_filter_fn is None {
+        self.emit(
+            E5092,
+            node_override=nd,
+            kind="expression",
+            name="FilterCompr",
+            help_text=self._xmod_osp_help([_fname])
+        );
+        return None;
+    }
+    _result = self.builder.call(
+        self._osp_filter_fn,
+        [target_val, ir.Constant(i64, _ntag)],
+        name="osp.chain.filt"
+    );
+    if isinstance(target_val.type, ir.PointerType) and self._is_owned(target_val) {
+        self._emit_rc_release_simple(target_val, op="chain_filter", loc="");
+    }
+    self._mark_owned(_result);
+    return _result;
+}
+
 impl NaIRGenPass._osp_visit_targets(target: uni.UniNode) -> (ir.Value | None) {
     if isinstance(target, uni.EdgeRefTrailer) {
         return self._codegen_edge_ref_trailer(target);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -233,19 +233,20 @@ impl NaIRGenPass._codegen_stmt(nd: uni.UniNode) -> None {
 impl NaIRGenPass._codegen_return(nd: uni.ReturnStmt) -> None {
     _gc = self._gen_ctx;
     if _gc is not None and self.builder.function is _gc["resume_fn"] {
-        if nd.expr is not None {
-            self.emit(
-                E5092,
-                node_override=nd,
-                kind="statement",
-                name="return <value> in a generator",
-                help_text="A native generator supports only bare `return` (stop iteration); a StopIteration value has no consumer on the JacIter surface."
-            );
-            return;
-        }
         _gr_loc = f"{os.path.basename(self.ir_in.loc.mod_path)}:{nd.loc.first_line
             if nd.loc
             else 0}";
+        if nd.expr is not None {
+            _rv = self._codegen_expr(nd.expr);
+            if _rv is not None
+            and isinstance(_rv.type, ir.PointerType)
+            and self._is_owned(_rv) {
+                self._emit_rc_release_simple(_rv, op="gen_ret_val", loc=_gr_loc);
+            }
+        }
+        for _entry in self._gen_try_stack {
+            self.builder.call(self._exc_pop_fn, []);
+        }
         self._emit_scope_cleanup(skip_var=None, loc=_gr_loc);
         _gr_i64 = ir.IntType(64);
         _gr_ip = self.builder.bitcast(
@@ -2693,15 +2694,13 @@ impl NaIRGenPass._codegen_for_indexed(
     );
     _gen_stop_slot: (ir.Value | None) = None;
     _gen_step_slot: (ir.Value | None) = None;
+    _gen_coll_slot: (ir.Value | None) = None;
     if _gen_yield_loop and kind != "range" {
-        self.emit(
-            E5092,
-            node_override=nd,
-            kind="statement",
-            name=f"yield inside a for over a {kind}",
-            help_text="Inside a native generator, a loop body that yields can iterate ranges or iterator values (`for x in iter(xs)` / another generator); direct indexed iteration over this collection cannot resume mid-loop yet."
-        );
-        return;
+        _gen_coll_slot = self._entry_alloca(collection_val.type, "for.coll.slot");
+        if not self._is_owned(collection_val) {
+            self._emit_rc_retain(collection_val, op="for_coll_spill", loc=_rc_loc);
+        }
+        self.builder.store(collection_val, _gen_coll_slot);
     }
 
     if kind == "range" {
@@ -2745,9 +2744,13 @@ impl NaIRGenPass._codegen_for_indexed(
                 and _existing.type.pointee == vtype
             );
             alloca = _existing if _reuse else self._entry_alloca(vtype, vname);
+            _in_resume_fn = (
+                self._gen_ctx is not None
+                and self.builder.function is self._gen_ctx["resume_fn"]
+            );
             if isinstance(vtype, ir.PointerType) and (rc_vars or kind == "str") {
                 null_const = ir.Constant(vtype, None);
-                if not _reuse {
+                if not _reuse and not _in_resume_fn {
                     _saved_block = self.builder.block;
                     self.builder.position_after(alloca);
                     self.builder.store(null_const, alloca);
@@ -2776,6 +2779,21 @@ impl NaIRGenPass._codegen_for_indexed(
     if _gen_step_slot is not None {
         range_step = self.builder.load(_gen_step_slot, name="for.step");
     }
+    if _gen_coll_slot is not None {
+        collection_val = self.builder.load(_gen_coll_slot, name="for.coll");
+        if kind == "str" {
+            strlen_fn = self._get_or_declare_extern(
+                "strlen", i64, [ir.IntType(8).as_pointer()]
+            );
+            len_val = self.builder.call(strlen_fn, [collection_val], name="for.len");
+        } elif kind == "bytes" {
+            len_val = self._bytes_len_val(collection_val);
+        } else {
+            len_val = self.builder.call(
+                helpers["len"], [collection_val], name="for.len"
+            );
+        }
+    }
     cur_idx = self.builder.load(idx_alloca, name="for.cur.idx");
     if kind == "range" and range_step is not None {
         _step_pos = self.builder.icmp_signed(
@@ -2792,6 +2810,9 @@ impl NaIRGenPass._codegen_for_indexed(
     self.builder.position_at_end(body_bb);
 
     if kind != "range" {
+        if _gen_coll_slot is not None {
+            collection_val = self.builder.load(_gen_coll_slot, name="for.coll.body");
+        }
         body_idx = self.builder.load(idx_alloca, name="for.body.idx");
         if kind == "items" {
             key_val = self.builder.call(
@@ -2896,7 +2917,13 @@ impl NaIRGenPass._codegen_for_indexed(
     self.builder.branch(cond_bb);
     self.builder.position_at_end(end_bb);
 
-    if coll_release_op
+    if _gen_coll_slot is not None {
+        _coll_end = self.builder.load(_gen_coll_slot, name="for.coll.end");
+        self._emit_rc_release_simple(
+            _coll_end, op=coll_release_op or "for_coll", loc=_for_loc
+        );
+        self.builder.store(ir.Constant(_coll_end.type, None), _gen_coll_slot);
+    } elif coll_release_op
     and isinstance(collection_val.type, ir.PointerType)
     and self._is_owned(collection_val) {
         self._emit_rc_release_simple(collection_val, op=coll_release_op, loc=_for_loc);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/stmt.impl.jac
@@ -801,7 +801,7 @@ impl NaIRGenPass._match_seq_parts(pat: uni.MatchSequence) -> tuple {
 impl NaIRGenPass._match_elem_ty_of(
     subj_ty: (object | None), prefix: str, idx: int
 ) -> (object | None) {
-    if subj_ty is None or not subj_ty.mangle().startswith(prefix) {
+    if subj_ty is None or not self._mangled_of(subj_ty).startswith(prefix) {
         return None;
     }
     targs = subj_ty.private.type_args or [];
@@ -1068,7 +1068,7 @@ impl NaIRGenPass._match_arch_cond(
     if static_name is None
     and subj_ty is not None
     and isinstance(subj.type, ir.PointerType) {
-        tk = subj_ty.mangle();
+        tk = self._mangled_of(subj_ty);
         cands = [tk] + (tk.split("|") if "|" in tk else []);
         for part in cands {
             if part in self.struct_types {

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -198,7 +198,11 @@ impl NaIRGenPass._typed_elem_llvm_of(
     if not args {
         return None;
     }
-    return self._lower_type(args[0]);
+    lowered = self._lower_type(args[0]);
+    if lowered is not None and isinstance(lowered, ir.VoidType) {
+        return ir.IntType(64);
+    }
+    return lowered;
 }
 
 impl NaIRGenPass._elem_spec_of(expr: (uni.UniNode | None)) -> (str | None) {
@@ -545,6 +549,20 @@ impl NaIRGenPass._entry_alloca(var_type: ir.Type, name: str) -> ir.Value {
     }
     alloca = self.builder.alloca(var_type, name=name);
 
+    self.builder.position_at_end(cur_block);
+    return alloca;
+}
+
+impl NaIRGenPass._stack_entry_alloca(var_type: ir.Type, name: str) -> ir.Value {
+    func = self.builder.function;
+    entry_block = func.entry_basic_block;
+    cur_block = self.builder.block;
+    if entry_block.instructions {
+        self.builder.position_before(entry_block.instructions[0]);
+    } else {
+        self.builder.position_at_start(entry_block);
+    }
+    alloca = self.builder.alloca(var_type, name=name);
     self.builder.position_at_end(cur_block);
     return alloca;
 }

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.impl/types.impl.jac
@@ -8,12 +8,20 @@ impl NaIRGenPass._lower_type(t: any) -> (ir.Type | None) {
             UnionType as _UnionType,
             FunctionType as _FunctionType,
             NeverType as _NeverType,
-            AnyType as _AnyType
+            AnyType as _AnyType,
+            TypeVarType as _TypeVarType
         }
     } except ImportError {
         return None;
     }
-    key = t.mangle() if t?.mangle else None;
+    if isinstance(t, _TypeVarType) {
+        _sol = self._mono_solution;
+        if _sol is not None and t.name in _sol {
+            return self._lower_type(_sol[t.name]);
+        }
+        return None;
+    }
+    key = self._mangled_of(t);
     if key is not None and key in self._lowered_type_cache {
         return self._lowered_type_cache[key];
     }
@@ -47,7 +55,7 @@ impl NaIRGenPass._type_key_of(expr: (uni.UniNode | None)) -> (str | None) {
     if not isinstance(expr, uni.Expr) or expr.type is None {
         return None;
     }
-    return expr.type.mangle();
+    return self._mangled_of(expr.type);
 }
 
 impl NaIRGenPass._enum_name_of(expr: (uni.UniNode | None)) -> (str | None) {
@@ -76,7 +84,7 @@ impl NaIRGenPass._tuple_key_of(expr: (uni.UniNode | None)) -> (str | None) {
     if not isinstance(expr, uni.Expr) or expr.type is None {
         return None;
     }
-    tk = expr.type.mangle();
+    tk = self._mangled_of(expr.type);
     if not tk.startswith("tuple[") {
         return None;
     }
@@ -108,7 +116,7 @@ impl NaIRGenPass._spec_of(
     if not isinstance(expr, uni.Expr) or expr.type is None {
         return None;
     }
-    tk = expr.type.mangle();
+    tk = self._mangled_of(expr.type);
     matched = tk in names;
     for nm in names {
         if tk.startswith(nm + "[") {
@@ -141,7 +149,7 @@ impl NaIRGenPass._struct_name_of(expr: (uni.UniNode | None)) -> (str | None) {
     if not isinstance(expr, uni.Expr) or expr.type is None {
         return None;
     }
-    tk = expr.type.mangle();
+    tk = self._mangled_of(expr.type);
     if tk in self.struct_types {
         return tk;
     }
@@ -191,7 +199,7 @@ impl NaIRGenPass._typed_elem_llvm_of(
     if not isinstance(expr, uni.Expr) or expr.type is None {
         return None;
     }
-    if not expr.type.mangle().startswith(prefix) {
+    if not self._mangled_of(expr.type).startswith(prefix) {
         return None;
     }
     args = expr.type.private.type_args or [];

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -364,6 +364,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _find_source_ability(
         mod_name: str, func_name: str
     ) -> (uni.Ability | None);
+
+    def _codegen_chained_filter(nd: uni.AtomTrailer) -> (ir.Value | None);
     def _adapter_callee(fn_expr: uni.UniNode) -> (tuple | None);
     def _adapter_clos_parts(clos: ir.Value) -> (tuple | None);
     def _generator_elem_type(nd: uni.Ability) -> (ir.Type | None);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -347,7 +347,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _codegen_yield_from(nd: uni.YieldExpr) -> (ir.Value | None);
     def _emit_yield_suspend(v: ir.Value) -> None;
     def _stack_entry_alloca(var_type: ir.Type, name: str) -> ir.Value;
-    def _adapter_callee_fn(fn_expr: uni.UniNode) -> (ir.Function | None);
+    def _adapter_callee(fn_expr: uni.UniNode) -> (tuple | None);
+    def _adapter_clos_parts(clos: ir.Value) -> (tuple | None);
     def _generator_elem_type(nd: uni.Ability) -> (ir.Type | None);
     def _codegen_generator(nd: uni.Ability, func: ir.Function) -> None;
     def _emit_generator_drop_fn(name: str, slots: list[tuple]) -> ir.Function;
@@ -939,8 +940,8 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _make_iter_from_value(val: ir.Value, expr: uni.UniNode) -> (tuple | None);
     def _build_iter_from_expr(expr: uni.UniNode) -> (tuple | None);
     def _codegen_next(nd: uni.FuncCall) -> (ir.Value | None);
-    def _make_map_iter(up: tuple, fn: ir.Function) -> (tuple | None);
-    def _make_filter_iter(up: tuple, pred: ir.Function) -> (tuple | None);
+    def _make_map_iter(up: tuple, callee: tuple) -> (tuple | None);
+    def _make_filter_iter(up: tuple, callee: tuple) -> (tuple | None);
     def _make_enumerate_iter(up: tuple) -> (tuple | None);
     def _make_zip_iter(up_a: tuple, up_b: tuple) -> (tuple | None);
     def _resolve_method_owner(arch_name: str, method_name: str) -> (str | None);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -353,18 +353,12 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _stack_entry_alloca(var_type: ir.Type, name: str) -> ir.Value;
     def _mangled_of(t: any) -> (str | None);
     def _solve_generic_call(ability: uni.Ability, nd: uni.FuncCall) -> (dict | None);
-    def _instantiate_generic(
-        nd: uni.FuncCall, func_name: str
-    ) -> (ir.Function | None);
-
+    def _instantiate_generic(nd: uni.FuncCall, func_name: str) -> (ir.Function | None);
     def _stamp_mono_fn(
         ability: uni.Ability, spec_name: str, memo_key: str
     ) -> (ir.Function | None);
 
-    def _find_source_ability(
-        mod_name: str, func_name: str
-    ) -> (uni.Ability | None);
-
+    def _find_source_ability(mod_name: str, func_name: str) -> (uni.Ability | None);
     def _codegen_chained_filter(nd: uni.AtomTrailer) -> (ir.Value | None);
     def _adapter_callee(fn_expr: uni.UniNode) -> (tuple | None);
     def _adapter_clos_parts(clos: ir.Value) -> (tuple | None);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -310,6 +310,7 @@ obj NaIRGenPass(ModuleCodegenPass) {
         nested_captures: dict[str, tuple] = {},
         generator_fns: dict[str, uni.Ability] = {},
         _gen_ctx: (dict | None) = None,
+        _gen_try_stack: list = [],
         decorated_fns: dict[str, tuple] = {},
         closure_cell_vars: set[str] = set(),
         closure_cell_handles: dict[str, ir.Value] = {},
@@ -343,6 +344,9 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _codegen_decorated_call(nd: uni.FuncCall, func_name: str) -> (ir.Value | None);
     def _ability_is_generator(nd: uni.Ability) -> bool;
     def _codegen_yield(nd: uni.YieldExpr) -> (ir.Value | None);
+    def _codegen_yield_from(nd: uni.YieldExpr) -> (ir.Value | None);
+    def _emit_yield_suspend(v: ir.Value) -> None;
+    def _stack_entry_alloca(var_type: ir.Type, name: str) -> ir.Value;
     def _adapter_callee_fn(fn_expr: uni.UniNode) -> (ir.Function | None);
     def _generator_elem_type(nd: uni.Ability) -> (ir.Type | None);
     def _codegen_generator(nd: uni.Ability, func: ir.Function) -> None;

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -309,6 +309,10 @@ obj NaIRGenPass(ModuleCodegenPass) {
         _pending_lambda_captures: (list[tuple] | None) = None,
         nested_captures: dict[str, tuple] = {},
         generator_fns: dict[str, uni.Ability] = {},
+        generic_fns: dict[str, uni.Ability] = {},
+        _mono_fns: dict[str, ir.Function] = {},
+        _mono_solution: (dict | None) = None,
+        _mono_mangle_map: (dict | None) = None,
         _gen_ctx: (dict | None) = None,
         _gen_try_stack: list = [],
         decorated_fns: dict[str, tuple] = {},
@@ -347,6 +351,15 @@ obj NaIRGenPass(ModuleCodegenPass) {
     def _codegen_yield_from(nd: uni.YieldExpr) -> (ir.Value | None);
     def _emit_yield_suspend(v: ir.Value) -> None;
     def _stack_entry_alloca(var_type: ir.Type, name: str) -> ir.Value;
+    def _mangled_of(t: any) -> (str | None);
+    def _solve_generic_call(ability: uni.Ability, nd: uni.FuncCall) -> (dict | None);
+    def _instantiate_generic(
+        nd: uni.FuncCall, func_name: str
+    ) -> (ir.Function | None);
+
+    def _stamp_mono_fn(
+        ability: uni.Ability, spec_name: str
+    ) -> (ir.Function | None);
     def _adapter_callee(fn_expr: uni.UniNode) -> (tuple | None);
     def _adapter_clos_parts(clos: ir.Value) -> (tuple | None);
     def _generator_elem_type(nd: uni.Ability) -> (ir.Type | None);

--- a/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
+++ b/jac/jaclang/compiler/passes/native/na_ir_gen_pass.jac
@@ -358,8 +358,12 @@ obj NaIRGenPass(ModuleCodegenPass) {
     ) -> (ir.Function | None);
 
     def _stamp_mono_fn(
-        ability: uni.Ability, spec_name: str
+        ability: uni.Ability, spec_name: str, memo_key: str
     ) -> (ir.Function | None);
+
+    def _find_source_ability(
+        mod_name: str, func_name: str
+    ) -> (uni.Ability | None);
     def _adapter_callee(fn_expr: uni.UniNode) -> (tuple | None);
     def _adapter_clos_parts(clos: ir.Value) -> (tuple | None);
     def _generator_elem_type(nd: uni.Ability) -> (ir.Type | None);

--- a/jac/jaclang/compiler/tests/fixtures/prim_closures.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_closures.jac
@@ -101,11 +101,34 @@ def closures_escape_py -> dict {
     };
 }
 
+
+def closures_adapters_py -> dict {
+    k = 3;
+    scaled = 0;
+    for v in map(lambda (x: int) -> int { x * k; }, [1, 2, 3]) {
+        scaled = scaled + v;
+    }
+    cut = 4;
+    kept = 0;
+    for v in filter(lambda (x: int) -> bool { x >= cut; }, [1, 5, 9, 3]) {
+        kept = kept + v;
+    }
+    chained = 0;
+    for v in map(lambda (x: int) -> int { x * k; }, filter(lambda (x: int) -> bool { x >= cut; }, [1, 4, 6])) {
+        chained = chained + v;
+    }
+    return {"scaled": scaled, "kept": kept, "chained": chained,};
+}
+
 cl def closures_cl -> dict {
     return {};
 }
 
 cl def closures_escape_cl -> dict {
+    return {};
+}
+
+cl def closures_adapters_cl -> dict {
     return {};
 }
 
@@ -204,4 +227,26 @@ na {
 
         };
     }
+
+    def closures_adapters_na -> dict[str, any] {
+        k = 3;
+        scaled = 0;
+        for v in map(lambda (x: int) -> int { x * k; }, [1, 2, 3]) {
+            scaled = scaled + v;
+        }
+        cut = 4;
+        kept = 0;
+        for v in filter(lambda (x: int) -> bool { x >= cut; }, [1, 5, 9, 3]) {
+            kept = kept + v;
+        }
+        chained = 0;
+        for v in map(
+            lambda (x: int) -> int { x * k; },
+            filter(lambda (x: int) -> bool { x >= cut; }, [1, 4, 6])
+        ) {
+            chained = chained + v;
+        }
+        return {"scaled": scaled, "kept": kept, "chained": chained,};
+    }
+
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_closures.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_closures.jac
@@ -114,7 +114,10 @@ def closures_adapters_py -> dict {
         kept = kept + v;
     }
     chained = 0;
-    for v in map(lambda (x: int) -> int { x * k; }, filter(lambda (x: int) -> bool { x >= cut; }, [1, 4, 6])) {
+    for v in map(
+        lambda (x: int) -> int { x * k; },
+        filter(lambda (x: int) -> bool { x >= cut; }, [1, 4, 6])
+    ) {
         chained = chained + v;
     }
     return {"scaled": scaled, "kept": kept, "chained": chained,};
@@ -248,5 +251,4 @@ na {
         }
         return {"scaled": scaled, "kept": kept, "chained": chained,};
     }
-
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_generators.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_generators.jac
@@ -24,7 +24,7 @@ def chain2(n: int) -> Iterator[int] {
 def pacer(n: int) -> Iterator[None] {
     i = 0;
     while i < n {
-        yield;
+        yield ;
         i = i + 1;
     }
 }
@@ -104,6 +104,7 @@ def gens_py -> dict {
         "listy": listy,
         "resil": resil,
         "resil0": resil0,
+
     };
 }
 
@@ -129,7 +130,7 @@ na {
     def na_pacer(n: int) -> Iterator[None] {
         i = 0;
         while i < n {
-            yield;
+            yield ;
             i = i + 1;
         }
     }
@@ -209,6 +210,7 @@ na {
             "listy": listy,
             "resil": resil,
             "resil0": resil0,
+
         };
     }
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_generators.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_generators.jac
@@ -2,7 +2,9 @@
 
 Pins the py (sv) generator semantics against the native state-machine
 lowering: yield order, early break, independent instances, first-class
-next(), and plain-return stop. ES/JS opts out.
+next(), plain-return stop, and the residual shapes (yield from, bare
+yield, return <value>, yield inside try with exceptions across resumes,
+yielding bodies over indexed collections). ES/JS opts out.
 """
 
 def counter(n: int) -> Iterator[int] {
@@ -11,6 +13,45 @@ def counter(n: int) -> Iterator[int] {
         yield i;
         i = i + 1;
     }
+}
+
+def chain2(n: int) -> Iterator[int] {
+    yield from counter(n);
+    yield from [100, 200];
+    yield 999;
+}
+
+def pacer(n: int) -> Iterator[None] {
+    i = 0;
+    while i < n {
+        yield;
+        i = i + 1;
+    }
+}
+
+def upto_ret(n: int) -> Iterator[int] {
+    yield 1;
+    yield 2;
+    return n * 10;
+}
+
+def doubles(xs: list[int]) -> Iterator[int] {
+    for x in xs {
+        yield x * 2;
+    }
+}
+
+def resilient(n: int) -> Iterator[int] {
+    try {
+        yield 1;
+        if n > 0 {
+            raise ValueError("boom");
+        }
+        yield 2;
+    } except ValueError {
+        yield 3;
+    }
+    yield 4;
 }
 
 def gens_py -> dict {
@@ -29,7 +70,41 @@ def gens_py -> dict {
     for v in counter(4) {
         total2 = total2 + v * v;
     }
-    return {"total": total, "seen": seen, "squares": total2,};
+    chained = 0;
+    for v in chain2(3) {
+        chained = chained + v;
+    }
+    paced = 0;
+    for p in pacer(4) {
+        paced = paced + 1;
+    }
+    retv = 0;
+    for v in upto_ret(9) {
+        retv = retv + v;
+    }
+    listy = 0;
+    for v in doubles([1, 2, 3]) {
+        listy = listy + v;
+    }
+    resil = 0;
+    for v in resilient(1) {
+        resil = resil + v;
+    }
+    resil0 = 0;
+    for v in resilient(0) {
+        resil0 = resil0 + v;
+    }
+    return {
+        "total": total,
+        "seen": seen,
+        "squares": total2,
+        "chained": chained,
+        "paced": paced,
+        "retv": retv,
+        "listy": listy,
+        "resil": resil,
+        "resil0": resil0,
+    };
 }
 
 cl def gens_cl -> dict {
@@ -43,6 +118,45 @@ na {
             yield i;
             i = i + 1;
         }
+    }
+
+    def na_chain2(n: int) -> Iterator[int] {
+        yield from na_counter(n);
+        yield from [100, 200];
+        yield 999;
+    }
+
+    def na_pacer(n: int) -> Iterator[None] {
+        i = 0;
+        while i < n {
+            yield;
+            i = i + 1;
+        }
+    }
+
+    def na_upto_ret(n: int) -> Iterator[int] {
+        yield 1;
+        yield 2;
+        return n * 10;
+    }
+
+    def na_doubles(xs: list[int]) -> Iterator[int] {
+        for x in xs {
+            yield x * 2;
+        }
+    }
+
+    def na_resilient(n: int) -> Iterator[int] {
+        try {
+            yield 1;
+            if n > 0 {
+                raise ValueError("boom");
+            }
+            yield 2;
+        } except ValueError {
+            yield 3;
+        }
+        yield 4;
     }
 
     def gens_na -> dict[str, any] {
@@ -61,6 +175,40 @@ na {
         for v in na_counter(4) {
             total2 = total2 + v * v;
         }
-        return {"total": total, "seen": seen, "squares": total2,};
+        chained = 0;
+        for v in na_chain2(3) {
+            chained = chained + v;
+        }
+        paced = 0;
+        for p in na_pacer(4) {
+            paced = paced + 1;
+        }
+        retv = 0;
+        for v in na_upto_ret(9) {
+            retv = retv + v;
+        }
+        listy = 0;
+        for v in na_doubles([1, 2, 3]) {
+            listy = listy + v;
+        }
+        resil = 0;
+        for v in na_resilient(1) {
+            resil = resil + v;
+        }
+        resil0 = 0;
+        for v in na_resilient(0) {
+            resil0 = resil0 + v;
+        }
+        return {
+            "total": total,
+            "seen": seen,
+            "squares": total2,
+            "chained": chained,
+            "paced": paced,
+            "retv": retv,
+            "listy": listy,
+            "resil": resil,
+            "resil0": resil0,
+        };
     }
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_generics.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_generics.jac
@@ -25,6 +25,7 @@ def generics_py -> dict {
         "float_sum": f,
         "first_int": n,
         "first_len": len(w),
+
     };
 }
 
@@ -53,6 +54,7 @@ na {
             "float_sum": f,
             "first_int": n,
             "first_len": len(w),
+
         };
     }
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_generics.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_generics.jac
@@ -1,0 +1,58 @@
+"""Generic-function cross-backend equivalence fixture.
+
+Pins py (sv) TypeVar-function semantics against native monomorphization:
+per-callsite solving, multiple instantiations of one template, and
+container type-param flow. ES/JS opts out.
+"""
+
+def gid[T](val: T) -> T {
+    return val;
+}
+
+def gfirst[T](xs: list[T]) -> T {
+    return xs[0];
+}
+
+def generics_py -> dict {
+    a = gid(41) + 1;
+    s = gid("abc");
+    f = gid(1.5) + gid(2.5);
+    n = gfirst([7, 8, 9]);
+    w = gfirst(["xy", "z"]);
+    return {
+        "int_id": a,
+        "str_len": len(s),
+        "float_sum": f,
+        "first_int": n,
+        "first_len": len(w),
+    };
+}
+
+cl def generics_cl -> dict {
+    return {};
+}
+
+na {
+    def na_gid[T](val: T) -> T {
+        return val;
+    }
+
+    def na_gfirst[T](xs: list[T]) -> T {
+        return xs[0];
+    }
+
+    def generics_na -> dict[str, any] {
+        a = na_gid(41) + 1;
+        s = na_gid("abc");
+        f = na_gid(1.5) + na_gid(2.5);
+        n = na_gfirst([7, 8, 9]);
+        w = na_gfirst(["xy", "z"]);
+        return {
+            "int_id": a,
+            "str_len": len(s),
+            "float_sum": f,
+            "first_int": n,
+            "first_len": len(w),
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/prim_keyword.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_keyword.jac
@@ -20,6 +20,7 @@ def keyword_py -> dict {
         "soft_match": 1 if issoftkeyword("match") else 0,
         "soft_class": 1 if issoftkeyword("class") else 0,
         "bare_is_def": 1 if keyword.iskeyword("def") else 0,
+
     };
 }
 
@@ -39,6 +40,7 @@ na {
             "soft_match": 1 if issoftkeyword("match") else 0,
             "soft_class": 1 if issoftkeyword("class") else 0,
             "bare_is_def": 1 if keyword.iskeyword("def") else 0,
+
         };
     }
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_keyword.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_keyword.jac
@@ -1,0 +1,44 @@
+"""Bundled native ``keyword`` cross-backend equivalence fixture.
+
+The sv entry uses CPython's keyword module; the na entry the bundled
+`keyword.na.jac`, which mirrors CPython's kwlist/softkwlist verbatim
+(ordering included). ES/JS opts out.
+"""
+
+import keyword;
+import from keyword { iskeyword, issoftkeyword, kwlist, softkwlist }
+
+
+def keyword_py -> dict {
+    return {
+        "n_kw": len(kwlist),
+        "n_soft": len(softkwlist),
+        "first": kwlist[0],
+        "tenth": kwlist[10],
+        "is_class": 1 if iskeyword("class") else 0,
+        "is_banana": 1 if iskeyword("banana") else 0,
+        "soft_match": 1 if issoftkeyword("match") else 0,
+        "soft_class": 1 if issoftkeyword("class") else 0,
+        "bare_is_def": 1 if keyword.iskeyword("def") else 0,
+    };
+}
+
+cl def keyword_cl -> dict {
+    return {};
+}
+
+na {
+    def keyword_na -> dict[str, any] {
+        return {
+            "n_kw": len(kwlist),
+            "n_soft": len(softkwlist),
+            "first": kwlist[0],
+            "tenth": kwlist[10],
+            "is_class": 1 if iskeyword("class") else 0,
+            "is_banana": 1 if iskeyword("banana") else 0,
+            "soft_match": 1 if issoftkeyword("match") else 0,
+            "soft_class": 1 if issoftkeyword("class") else 0,
+            "bare_is_def": 1 if keyword.iskeyword("def") else 0,
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/prim_shutil.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_shutil.jac
@@ -1,0 +1,90 @@
+"""Bundled native ``shutil`` cross-backend equivalence fixture.
+
+The sv entry uses CPython's shutil; the na entry the bundled
+`shutil.na.jac` (which/copyfile/copy/copy2/move/rmtree over the os
+intrinsics plus libc). Both backends drive the same fixed /tmp workspace
+sequentially and pin observable facts as ints/strings. ES/JS opts out.
+"""
+
+import os;
+import shutil;
+import from shutil { copy2, move, rmtree, which }
+
+
+def shutil_py -> dict {
+    base = "/tmp/jac_prim_shutil_fix";
+    if os.path.exists(base) {
+        rmtree(base);
+    }
+    os.makedirs(os.path.join(base, "sub"));
+    src = os.path.join(base, "a.txt");
+    f = open(src, "w");
+    f.write("hello shutil");
+    f.close();
+    copied = shutil.copy(src, os.path.join(base, "sub"));
+    c2 = copy2(src, os.path.join(base, "b.txt"));
+    moved = move(os.path.join(base, "b.txt"), os.path.join(base, "sub", "c.txt"));
+    g = open(os.path.join(base, "sub", "c.txt"), "r");
+    moved_body = g.read();
+    g.close();
+    sh_path = which("sh");
+    ghost = which("definitely_not_a_command_xyz_123");
+    out = {
+        "copied_exists": 1 if os.path.exists(os.path.join(base, "sub", "a.txt")) else 0,
+        "copy_ret_base": os.path.basename(copied),
+        "copy2_exists_pre_move": 0 if os.path.exists(os.path.join(base, "b.txt")) else 1,
+        "moved_body": moved_body,
+        "moved_ret_base": os.path.basename(moved),
+        "sh_found": 1 if sh_path is not None else 0,
+        "sh_base": os.path.basename(sh_path) if sh_path is not None else "",
+        "ghost_none": 1 if ghost is None else 0,
+    };
+    rmtree(base);
+    out["rmtree_gone"] = 0 if os.path.exists(base) else 1;
+    return out;
+}
+
+cl def shutil_cl -> dict {
+    return {};
+}
+
+na {
+    def shutil_na -> dict[str, any] {
+        base = "/tmp/jac_prim_shutil_fix";
+        if os.path.exists(base) {
+            rmtree(base);
+        }
+        os.makedirs(os.path.join(base, "sub"));
+        src = os.path.join(base, "a.txt");
+        f = open(src, "w");
+        f.write("hello shutil");
+        f.close();
+        copied = shutil.copy(src, os.path.join(base, "sub"));
+        c2 = copy2(src, os.path.join(base, "b.txt"));
+        moved = move(
+            os.path.join(base, "b.txt"), os.path.join(base, "sub", "c.txt")
+        );
+        g = open(os.path.join(base, "sub", "c.txt"), "r");
+        moved_body = g.read();
+        g.close();
+        sh_path = which("sh");
+        ghost = which("definitely_not_a_command_xyz_123");
+        out: dict[str, any] = {
+            "copied_exists": 1
+                if os.path.exists(os.path.join(base, "sub", "a.txt"))
+                else 0,
+            "copy_ret_base": os.path.basename(copied),
+            "copy2_exists_pre_move": 0
+                if os.path.exists(os.path.join(base, "b.txt"))
+                else 1,
+            "moved_body": moved_body,
+            "moved_ret_base": os.path.basename(moved),
+            "sh_found": 1 if sh_path is not None else 0,
+            "sh_base": os.path.basename(sh_path) if sh_path is not None else "",
+            "ghost_none": 1 if ghost is None else 0,
+        };
+        rmtree(base);
+        out["rmtree_gone"] = 0 if os.path.exists(base) else 1;
+        return out;
+    }
+}

--- a/jac/jaclang/compiler/tests/fixtures/prim_shutil.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_shutil.jac
@@ -32,12 +32,15 @@ def shutil_py -> dict {
     out = {
         "copied_exists": 1 if os.path.exists(os.path.join(base, "sub", "a.txt")) else 0,
         "copy_ret_base": os.path.basename(copied),
-        "copy2_exists_pre_move": 0 if os.path.exists(os.path.join(base, "b.txt")) else 1,
+        "copy2_exists_pre_move": 0
+            if os.path.exists(os.path.join(base, "b.txt"))
+            else 1,
         "moved_body": moved_body,
         "moved_ret_base": os.path.basename(moved),
         "sh_found": 1 if sh_path is not None else 0,
         "sh_base": os.path.basename(sh_path) if sh_path is not None else "",
         "ghost_none": 1 if ghost is None else 0,
+
     };
     rmtree(base);
     out["rmtree_gone"] = 0 if os.path.exists(base) else 1;
@@ -61,9 +64,7 @@ na {
         f.close();
         copied = shutil.copy(src, os.path.join(base, "sub"));
         c2 = copy2(src, os.path.join(base, "b.txt"));
-        moved = move(
-            os.path.join(base, "b.txt"), os.path.join(base, "sub", "c.txt")
-        );
+        moved = move(os.path.join(base, "b.txt"), os.path.join(base, "sub", "c.txt"));
         g = open(os.path.join(base, "sub", "c.txt"), "r");
         moved_body = g.read();
         g.close();
@@ -82,6 +83,7 @@ na {
             "sh_found": 1 if sh_path is not None else 0,
             "sh_base": os.path.basename(sh_path) if sh_path is not None else "",
             "ghost_none": 1 if ghost is None else 0,
+
         };
         rmtree(base);
         out["rmtree_gone"] = 0 if os.path.exists(base) else 1;

--- a/jac/jaclang/compiler/tests/fixtures/prim_statistics.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_statistics.jac
@@ -9,15 +9,7 @@ counts); consumers pin through int(). Errors are pinned via ValueError
 """
 
 import statistics;
-import from statistics {
-    fmean,
-    mean,
-    median,
-    pstdev,
-    pvariance,
-    stdev,
-    variance
-}
+import from statistics { fmean, mean, median, pstdev, pvariance, stdev, variance }
 
 
 def statistics_py -> dict {
@@ -56,6 +48,7 @@ def statistics_py -> dict {
         "pvar_x1000": pvar_x1000,
         "empty_raises": empty_raises,
         "one_stdev_raises": one_stdev_raises,
+
     };
 }
 
@@ -71,9 +64,7 @@ na {
         med_even_x10 = int(median([1, 2, 3, 4]) * 10);
         mean_x10 = int(mean([1, 2, 3, 4]) * 10);
         fmean_x10 = int(fmean([1.5, 2.5]) * 10);
-        pstdev_x1000 = int(
-            pstdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000
-        );
+        pstdev_x1000 = int(pstdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000);
         stdev_x1000 = int(stdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000);
         var_x1000 = int(variance([1.0, 2.0, 3.0]) * 1000);
         pvar_x1000 = int(pvariance([1.0, 2.0, 3.0]) * 1000);
@@ -102,6 +93,7 @@ na {
             "pvar_x1000": pvar_x1000,
             "empty_raises": empty_raises,
             "one_stdev_raises": one_stdev_raises,
+
         };
     }
 }

--- a/jac/jaclang/compiler/tests/fixtures/prim_statistics.jac
+++ b/jac/jaclang/compiler/tests/fixtures/prim_statistics.jac
@@ -1,0 +1,107 @@
+"""Bundled native ``statistics`` cross-backend equivalence fixture.
+
+The sv entry uses CPython's statistics module; the na entry the bundled
+`statistics.na.jac`. Results are pinned as scaled ints so the exact-Fraction
+CPython pipeline and the double-precision native pipeline agree. The bundled
+median always computes in float (CPython preserves the element for odd
+counts); consumers pin through int(). Errors are pinned via ValueError
+(StatisticsError subclasses it). ES/JS opts out.
+"""
+
+import statistics;
+import from statistics {
+    fmean,
+    mean,
+    median,
+    pstdev,
+    pvariance,
+    stdev,
+    variance
+}
+
+
+def statistics_py -> dict {
+    times = [900, 100, 500];
+    med_bare = int(statistics.median(times));
+    med_odd = int(median([5, 1, 9]));
+    med_even_x10 = int(median([1, 2, 3, 4]) * 10);
+    mean_x10 = int(mean([1, 2, 3, 4]) * 10);
+    fmean_x10 = int(fmean([1.5, 2.5]) * 10);
+    pstdev_x1000 = int(pstdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000);
+    stdev_x1000 = int(stdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000);
+    var_x1000 = int(variance([1.0, 2.0, 3.0]) * 1000);
+    pvar_x1000 = int(pvariance([1.0, 2.0, 3.0]) * 1000);
+    empty_ints: list[int] = [];
+    empty_raises = 0;
+    try {
+        tmp = median(empty_ints);
+    } except ValueError {
+        empty_raises = 1;
+    }
+    one_stdev_raises = 0;
+    try {
+        tmp2 = stdev([3.0]);
+    } except ValueError {
+        one_stdev_raises = 1;
+    }
+    return {
+        "med_bare": med_bare,
+        "med_odd": med_odd,
+        "med_even_x10": med_even_x10,
+        "mean_x10": mean_x10,
+        "fmean_x10": fmean_x10,
+        "pstdev_x1000": pstdev_x1000,
+        "stdev_x1000": stdev_x1000,
+        "var_x1000": var_x1000,
+        "pvar_x1000": pvar_x1000,
+        "empty_raises": empty_raises,
+        "one_stdev_raises": one_stdev_raises,
+    };
+}
+
+cl def statistics_cl -> dict {
+    return {};
+}
+
+na {
+    def statistics_na -> dict[str, any] {
+        times = [900, 100, 500];
+        med_bare = int(statistics.median(times));
+        med_odd = int(median([5, 1, 9]));
+        med_even_x10 = int(median([1, 2, 3, 4]) * 10);
+        mean_x10 = int(mean([1, 2, 3, 4]) * 10);
+        fmean_x10 = int(fmean([1.5, 2.5]) * 10);
+        pstdev_x1000 = int(
+            pstdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000
+        );
+        stdev_x1000 = int(stdev([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]) * 1000);
+        var_x1000 = int(variance([1.0, 2.0, 3.0]) * 1000);
+        pvar_x1000 = int(pvariance([1.0, 2.0, 3.0]) * 1000);
+        empty_ints: list[int] = [];
+        empty_raises = 0;
+        try {
+            tmp = median(empty_ints);
+        } except ValueError {
+            empty_raises = 1;
+        }
+        one_stdev_raises = 0;
+        try {
+            tmp2 = stdev([3.0]);
+        } except ValueError {
+            one_stdev_raises = 1;
+        }
+        return {
+            "med_bare": med_bare,
+            "med_odd": med_odd,
+            "med_even_x10": med_even_x10,
+            "mean_x10": mean_x10,
+            "fmean_x10": fmean_x10,
+            "pstdev_x1000": pstdev_x1000,
+            "stdev_x1000": stdev_x1000,
+            "var_x1000": var_x1000,
+            "pvar_x1000": pvar_x1000,
+            "empty_raises": empty_raises,
+            "one_stdev_raises": one_stdev_raises,
+        };
+    }
+}

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -232,6 +232,16 @@ test "closures escaping" {
     );
 }
 
+test "closures as adapter callbacks" {
+    run_with_both(
+        "prim_closures.jac",
+        "closures_adapters_py",
+        "closures_adapters_cl",
+        "closures_adapters_na",
+        require=["na"]
+    );
+}
+
 test "generators yield" {
     run_with_both(
         "prim_generators.jac", "gens_py", "gens_cl", "gens_na", require=["na"]

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -232,6 +232,28 @@ test "closures escaping" {
     );
 }
 
+test "bundled statistics" {
+    run_with_both(
+        "prim_statistics.jac",
+        "statistics_py",
+        "statistics_cl",
+        "statistics_na",
+        require=["na"]
+    );
+}
+
+test "bundled keyword" {
+    run_with_both(
+        "prim_keyword.jac", "keyword_py", "keyword_cl", "keyword_na", require=["na"]
+    );
+}
+
+test "bundled shutil" {
+    run_with_both(
+        "prim_shutil.jac", "shutil_py", "shutil_cl", "shutil_na", require=["na"]
+    );
+}
+
 test "generic functions monomorphize" {
     run_with_both(
         "prim_generics.jac",

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -232,6 +232,16 @@ test "closures escaping" {
     );
 }
 
+test "generic functions monomorphize" {
+    run_with_both(
+        "prim_generics.jac",
+        "generics_py",
+        "generics_cl",
+        "generics_na",
+        require=["na"]
+    );
+}
+
 test "closures as adapter callbacks" {
     run_with_both(
         "prim_closures.jac",

--- a/jac/jaclang/compiler/tests/test_prim_equivalence.jac
+++ b/jac/jaclang/compiler/tests/test_prim_equivalence.jac
@@ -256,11 +256,7 @@ test "bundled shutil" {
 
 test "generic functions monomorphize" {
     run_with_both(
-        "prim_generics.jac",
-        "generics_py",
-        "generics_cl",
-        "generics_na",
-        require=["na"]
+        "prim_generics.jac", "generics_py", "generics_cl", "generics_na", require=["na"]
     );
 }
 

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -441,7 +441,6 @@ glob NATIVE_DEFAULT_SV_SIGNAL_NODES: tuple = (
          uni.EdgeOpRef,
          uni.DisconnectOp,
          uni.TypedCtxBlock,
-         uni.LambdaExpr,
          uni.PyInlineCode,
          uni.ClientBlock,
          uni.ServerBlock,

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -435,11 +435,6 @@ def _seed_module_codespace(module: uni.Module) {
 }
 
 glob NATIVE_DEFAULT_SV_SIGNAL_NODES: tuple = (
-         uni.VisitStmt,
-         uni.DisengageStmt,
-         uni.ReportStmt,
-         uni.EdgeOpRef,
-         uni.DisconnectOp,
          uni.TypedCtxBlock,
          uni.PyInlineCode,
          uni.ClientBlock,
@@ -518,14 +513,18 @@ def _scan_native_default_signals(
             return (f"contains {typ.__name__}", deps);
         }
     }
-    for arch in module.get_all_sub_nodes(uni.Archetype) {
-        if arch.arch_type.name in (Tok.KW_NODE, Tok.KW_EDGE, Tok.KW_WALKER) {
-            return ("osp archetype", deps);
+    for svr in module.get_all_sub_nodes(uni.SpecialVarRef) {
+        if svr.orig.name == Tok.KW_ROOT {
+            return ("root access (persistent graph)", deps);
         }
     }
     for ab in module.get_all_sub_nodes(uni.Ability) {
-        if ab.is_async or isinstance(ab.signature, uni.EventSignature) {
-            return ("async/event ability", deps);
+        if ab.is_async {
+            return ("async ability", deps);
+        }
+        if isinstance(ab.signature, uni.EventSignature)
+        and ab.find_parent_of_type(uni.Archetype) is None {
+            return ("event ability outside an archetype", deps);
         }
     }
     for stmt in module.body {

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -522,9 +522,19 @@ def _scan_native_default_signals(
         if ab.is_async {
             return ("async ability", deps);
         }
-        if isinstance(ab.signature, uni.EventSignature)
-        and ab.find_parent_of_type(uni.Archetype) is None {
-            return ("event ability outside an archetype", deps);
+        if isinstance(ab.signature, uni.EventSignature) {
+            if ab.find_parent_of_type(uni.Archetype) is None {
+                return ("event ability outside an archetype", deps);
+            }
+            _ti = ab.signature.arch_tag_info;
+            _ti_names = [_ti]
+                if isinstance(_ti, uni.Name)
+                else (_ti.get_all_sub_nodes(uni.Name) if _ti is not None else []);
+            for _tn in _ti_names {
+                if _tn.value in ("Root", "root") {
+                    return ("root access (persistent graph)", deps);
+                }
+            }
         }
     }
     for stmt in module.body {
@@ -535,7 +545,7 @@ def _scan_native_default_signals(
             }
         }
         if (
-            isinstance(stmt, (uni.Ability, uni.GlobalVars))
+            isinstance(stmt, (uni.Ability, uni.GlobalVars, uni.Archetype, uni.Enum))
             and stmt.access is not None
             and stmt.access.tag.name == Tok.KW_PUB
         ) {

--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -438,7 +438,6 @@ glob NATIVE_DEFAULT_SV_SIGNAL_NODES: tuple = (
          uni.VisitStmt,
          uni.DisengageStmt,
          uni.ReportStmt,
-         uni.YieldExpr,
          uni.EdgeOpRef,
          uni.DisconnectOp,
          uni.TypedCtxBlock,

--- a/jac/jaclang/runtimelib/na_stdlib/README.md
+++ b/jac/jaclang/runtimelib/na_stdlib/README.md
@@ -160,6 +160,30 @@ bundled one. A bundled module links through the existing cross-module machinery
   its `str` rendering would differ);
   `get_opcodes`/`unified_diff`/`ndiff`/`Differ`/`HtmlDiff` not provided.
 
+- **`statistics.na.jac`** (#7593 item 18) -- double-precision
+  `fmean`/`mean`/`median`/`median_low`/`median_high`/`variance`/`pvariance`/
+  `stdev`/`pstdev` over generic `[T]` defs, so int and float sequences both
+  monomorphize without boxing. SCOPE/divergences: results always compute in
+  float (CPython runs exact Fraction arithmetic internally and `median` of an
+  odd-count sequence returns the element itself, preserving int), and errors
+  raise `ValueError` directly (CPython's `StatisticsError` subclasses
+  `ValueError`, so `except ValueError` behaves identically on both backends).
+
+- **`shutil.na.jac`** (#7593 item 18) -- `which`/`copyfile`/`copy`/`copy2`/
+  `move`/`rmtree` over the native os intrinsics (getenv, path.join,
+  path.isdir, path.isfile, path.basename) plus direct libc (access, unlink,
+  rmdir, rename, opendir/readdir/closedir). The dirent d_name offset follows
+  the glibc x86-64/aarch64 layout (d_ino 8 + d_off 8 + d_reclen 2 + d_type 1
+  = 19), matching the platform scope of the other libc-backed modules.
+  SCOPE/divergences: copy/copy2 duplicate bytes but do not yet preserve
+  mode/mtime metadata; rmtree follows the isdir predicate, so directory
+  symlinks are recursed into rather than unlinked; errors raise `ValueError`
+  rather than CPython's `OSError` subclasses.
+
+- **`keyword.na.jac`** (#7593 item 18) -- `kwlist`/`softkwlist`/`iskeyword`/
+  `issoftkeyword` mirroring CPython's lists verbatim, ordering included
+  (stable since 3.10's soft-keyword additions).
+
 - **`fractions.na.jac`** (#6978 Phase 2) -- a pure-Jac (Mechanism B) `Fraction`
   over native `int`, normalized on construction via Euclid's GCD with the sign
   carried by the numerator and the denominator kept positive (CPython's value

--- a/jac/jaclang/runtimelib/na_stdlib/keyword.na.jac
+++ b/jac/jaclang/runtimelib/na_stdlib/keyword.na.jac
@@ -1,0 +1,54 @@
+"""Python-congruent ``keyword`` for the native pathway.
+
+Mirrors CPython's kwlist/softkwlist verbatim, ordering included (CPython
+generates these from its grammar; they have been stable since 3.10's
+soft-keyword additions).
+"""
+
+glob kwlist: list[str] = [
+         "False",
+         "None",
+         "True",
+         "and",
+         "as",
+         "assert",
+         "async",
+         "await",
+         "break",
+         "class",
+         "continue",
+         "def",
+         "del",
+         "elif",
+         "else",
+         "except",
+         "finally",
+         "for",
+         "from",
+         "global",
+         "if",
+         "import",
+         "in",
+         "is",
+         "lambda",
+         "nonlocal",
+         "not",
+         "or",
+         "pass",
+         "raise",
+         "return",
+         "try",
+         "while",
+         "with",
+         "yield",
+     ];
+
+glob softkwlist: list[str] = ["_", "case", "match", "type"];
+
+def:pub iskeyword(s: str) -> bool {
+    return s in kwlist;
+}
+
+def:pub issoftkeyword(s: str) -> bool {
+    return s in softkwlist;
+}

--- a/jac/jaclang/runtimelib/na_stdlib/keyword.na.jac
+++ b/jac/jaclang/runtimelib/na_stdlib/keyword.na.jac
@@ -1,10 +1,3 @@
-"""Python-congruent ``keyword`` for the native pathway.
-
-Mirrors CPython's kwlist/softkwlist verbatim, ordering included (CPython
-generates these from its grammar; they have been stable since 3.10's
-soft-keyword additions).
-"""
-
 glob kwlist: list[str] = [
          "False",
          "None",
@@ -41,9 +34,9 @@ glob kwlist: list[str] = [
          "while",
          "with",
          "yield",
-     ];
 
-glob softkwlist: list[str] = ["_", "case", "match", "type"];
+     ],
+     softkwlist: list[str] = ["_", "case", "match", "type"];
 
 def:pub iskeyword(s: str) -> bool {
     return s in kwlist;

--- a/jac/jaclang/runtimelib/na_stdlib/shutil.na.jac
+++ b/jac/jaclang/runtimelib/na_stdlib/shutil.na.jac
@@ -1,0 +1,118 @@
+"""Python-congruent ``shutil`` for the native pathway.
+
+The census-ranked surface real projects use: which, copyfile, copy, copy2,
+move, and rmtree, built on the native os intrinsics (getenv, path.join,
+path.isdir, path.isfile, path.basename) plus direct libc (access, unlink,
+rmdir, rename, opendir/readdir/closedir). The dirent d_name/d_type offsets
+follow the glibc x86-64/aarch64 layout (d_ino 8 + d_off 8 + d_reclen 2 +
+d_type 1 = 19), matching the platform scope of the other libc-backed
+bundled modules. Documented divergences: copy/copy2 duplicate bytes but do
+not yet preserve mode/mtime metadata; rmtree follows the isdir predicate,
+so directory symlinks are recursed into rather than unlinked; errors raise
+ValueError rather than CPython's OSError subclasses.
+"""
+
+import os;
+import from c { def access(path: str, mode: i32) -> i32;  }
+import from c { def unlink(path: str) -> i32;  }
+import from c { def rmdir(path: str) -> i32;  }
+import from c { def rename(oldp: str, newp: str) -> i32;  }
+import from c { def opendir(path: str) -> int;  }
+import from c { def readdir(dirp: int) -> int;  }
+import from c { def closedir(dirp: int) -> i32;  }
+import from c { def strdup(s: int) -> str;  }
+
+
+def:pub which(cmd: str) -> (str | None) {
+    if "/" in cmd {
+        if access(cmd, 1) == 0 and os.path.isfile(cmd) {
+            return cmd;
+        }
+        return None;
+    }
+    path_env = os.getenv("PATH");
+    if path_env is None {
+        return None;
+    }
+    for d in path_env.split(":") {
+        if d == "" {
+            continue;
+        }
+        cand = os.path.join(d, cmd);
+        if access(cand, 1) == 0 and os.path.isfile(cand) {
+            return cand;
+        }
+    }
+    return None;
+}
+
+def:pub copyfile(src: str, dst: str) -> str {
+    fsrc = open(src, "rb");
+    data = fsrc.read();
+    fsrc.close();
+    fdst = open(dst, "wb");
+    fdst.write(data);
+    fdst.close();
+    return dst;
+}
+
+def:pub copy(src: str, dst: str) -> str {
+    real_dst = dst;
+    if os.path.isdir(dst) {
+        real_dst = os.path.join(dst, os.path.basename(src));
+    }
+    return copyfile(src, real_dst);
+}
+
+def:pub copy2(src: str, dst: str) -> str {
+    return copy(src, dst);
+}
+
+def:pub move(src: str, dst: str) -> str {
+    real_dst = dst;
+    if os.path.isdir(dst) {
+        real_dst = os.path.join(dst, os.path.basename(src));
+    }
+    if rename(src, real_dst) == 0 {
+        return real_dst;
+    }
+    if os.path.isdir(src) {
+        raise ValueError(
+            f"move: cannot relocate directory '{src}' across filesystems"
+        );
+    }
+    copyfile(src, real_dst);
+    unlink(src);
+    return real_dst;
+}
+
+def:pub rmtree(path: str) -> None {
+    d = opendir(path);
+    if d == 0 {
+        raise ValueError(f"rmtree: cannot open '{path}'");
+    }
+    children: list[str] = [];
+    while True {
+        ent = readdir(d);
+        if ent == 0 {
+            break;
+        }
+        nm = strdup(ent + 19);
+        if nm == "." or nm == ".." {
+            continue;
+        }
+        children.append(nm);
+    }
+    closedir(d);
+    for nm in children {
+        child = os.path.join(path, nm);
+        if os.path.isdir(child) {
+            rmtree(child);
+        } else {
+            unlink(child);
+        }
+    }
+    if rmdir(path) != 0 {
+        raise ValueError(f"rmtree: could not remove '{path}'");
+    }
+}

--- a/jac/jaclang/runtimelib/na_stdlib/shutil.na.jac
+++ b/jac/jaclang/runtimelib/na_stdlib/shutil.na.jac
@@ -1,17 +1,3 @@
-"""Python-congruent ``shutil`` for the native pathway.
-
-The census-ranked surface real projects use: which, copyfile, copy, copy2,
-move, and rmtree, built on the native os intrinsics (getenv, path.join,
-path.isdir, path.isfile, path.basename) plus direct libc (access, unlink,
-rmdir, rename, opendir/readdir/closedir). The dirent d_name/d_type offsets
-follow the glibc x86-64/aarch64 layout (d_ino 8 + d_off 8 + d_reclen 2 +
-d_type 1 = 19), matching the platform scope of the other libc-backed
-bundled modules. Documented divergences: copy/copy2 duplicate bytes but do
-not yet preserve mode/mtime metadata; rmtree follows the isdir predicate,
-so directory symlinks are recursed into rather than unlinked; errors raise
-ValueError rather than CPython's OSError subclasses.
-"""
-
 import os;
 import from c { def access(path: str, mode: i32) -> i32;  }
 import from c { def unlink(path: str) -> i32;  }
@@ -77,16 +63,14 @@ def:pub move(src: str, dst: str) -> str {
         return real_dst;
     }
     if os.path.isdir(src) {
-        raise ValueError(
-            f"move: cannot relocate directory '{src}' across filesystems"
-        );
+        raise ValueError(f"move: cannot relocate directory '{src}' across filesystems");
     }
     copyfile(src, real_dst);
     unlink(src);
     return real_dst;
 }
 
-def:pub rmtree(path: str) -> None {
+def:pub rmtree(path: str) {
     d = opendir(path);
     if d == 0 {
         raise ValueError(f"rmtree: cannot open '{path}'");

--- a/jac/jaclang/runtimelib/na_stdlib/statistics.na.jac
+++ b/jac/jaclang/runtimelib/na_stdlib/statistics.na.jac
@@ -1,16 +1,3 @@
-"""Python-congruent ``statistics`` for the native pathway.
-
-Double-precision implementations of the summary-statistics surface the
-census found in real projects (median/stdev first). Divergences from
-CPython, both documented here: results always compute in float (CPython
-runs exact Fraction arithmetic internally and `median` of an odd-count
-sequence returns the element itself, preserving int), and errors raise
-ValueError directly (CPython's StatisticsError subclasses ValueError, so
-`except ValueError` behaves identically on both backends). The generic
-defs monomorphize per element type, so int and float sequences both work
-without boxing.
-"""
-
 def:pub fmean[T](data: list[T]) -> float {
     n = len(data);
     if n == 0 {

--- a/jac/jaclang/runtimelib/na_stdlib/statistics.na.jac
+++ b/jac/jaclang/runtimelib/na_stdlib/statistics.na.jac
@@ -1,0 +1,114 @@
+"""Python-congruent ``statistics`` for the native pathway.
+
+Double-precision implementations of the summary-statistics surface the
+census found in real projects (median/stdev first). Divergences from
+CPython, both documented here: results always compute in float (CPython
+runs exact Fraction arithmetic internally and `median` of an odd-count
+sequence returns the element itself, preserving int), and errors raise
+ValueError directly (CPython's StatisticsError subclasses ValueError, so
+`except ValueError` behaves identically on both backends). The generic
+defs monomorphize per element type, so int and float sequences both work
+without boxing.
+"""
+
+def:pub fmean[T](data: list[T]) -> float {
+    n = len(data);
+    if n == 0 {
+        raise ValueError("fmean requires at least one data point");
+    }
+    s = 0.0;
+    for x in data {
+        s = s + float(x);
+    }
+    return s / float(n);
+}
+
+def:pub mean[T](data: list[T]) -> float {
+    n = len(data);
+    if n == 0 {
+        raise ValueError("mean requires at least one data point");
+    }
+    s = 0.0;
+    for x in data {
+        s = s + float(x);
+    }
+    return s / float(n);
+}
+
+def:pub median[T](data: list[T]) -> float {
+    n = len(data);
+    if n == 0 {
+        raise ValueError("no median for empty data");
+    }
+    xs = sorted(data);
+    m = n // 2;
+    if n % 2 == 1 {
+        return float(xs[m]);
+    }
+    return (float(xs[m - 1]) + float(xs[m])) / 2.0;
+}
+
+def:pub median_low[T](data: list[T]) -> float {
+    n = len(data);
+    if n == 0 {
+        raise ValueError("no median for empty data");
+    }
+    xs = sorted(data);
+    if n % 2 == 1 {
+        return float(xs[n // 2]);
+    }
+    return float(xs[n // 2 - 1]);
+}
+
+def:pub median_high[T](data: list[T]) -> float {
+    n = len(data);
+    if n == 0 {
+        raise ValueError("no median for empty data");
+    }
+    xs = sorted(data);
+    return float(xs[n // 2]);
+}
+
+def:pub pvariance[T](data: list[T]) -> float {
+    n = len(data);
+    if n < 1 {
+        raise ValueError("pvariance requires at least one data point");
+    }
+    mu = 0.0;
+    for x in data {
+        mu = mu + float(x);
+    }
+    mu = mu / float(n);
+    ss = 0.0;
+    for x in data {
+        d = float(x) - mu;
+        ss = ss + d * d;
+    }
+    return ss / float(n);
+}
+
+def:pub variance[T](data: list[T]) -> float {
+    n = len(data);
+    if n < 2 {
+        raise ValueError("variance requires at least two data points");
+    }
+    mu = 0.0;
+    for x in data {
+        mu = mu + float(x);
+    }
+    mu = mu / float(n);
+    ss = 0.0;
+    for x in data {
+        d = float(x) - mu;
+        ss = ss + d * d;
+    }
+    return ss / float(n - 1);
+}
+
+def:pub pstdev[T](data: list[T]) -> float {
+    return pvariance(data) ** 0.5;
+}
+
+def:pub stdev[T](data: list[T]) -> float {
+    return variance(data) ** 0.5;
+}

--- a/jac/tests/compiler/fixtures/codespace/nadefault_generator.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_generator.jac
@@ -1,0 +1,22 @@
+def evens(n: int) -> Iterator[int] {
+    for i in range(n) {
+        yield i * 2;
+    }
+}
+
+def chained(n: int) -> Iterator[int] {
+    yield from evens(n);
+    yield 100;
+}
+
+def total(n: int) -> int {
+    t = 0;
+    for v in chained(n) {
+        t = t + v;
+    }
+    return t;
+}
+
+with entry {
+    print("total:", total(4));
+}

--- a/jac/tests/compiler/fixtures/codespace/nadefault_lambda.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_lambda.jac
@@ -1,0 +1,21 @@
+def scale_all(k: int) -> int {
+    t = 0;
+    for v in map(lambda (x: int) -> int { x * k; }, [1, 2, 3]) {
+        t = t + v;
+    }
+    return t;
+}
+
+def make_adder(base: int) -> Callable[[int], int] {
+    return lambda (x: int) -> int { x + base; };
+}
+
+def use_adder(base: int, v: int) -> int {
+    f = make_adder(base);
+    return f(v);
+}
+
+with entry {
+    print("scaled:", scale_all(3));
+    print("added:", use_adder(10, 5));
+}

--- a/jac/tests/compiler/fixtures/codespace/nadefault_local_osp.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_local_osp.jac
@@ -1,0 +1,22 @@
+node Item {
+    has val: int;
+}
+
+walker Collector {
+    has total: int = 0;
+
+    can grab with Item entry {
+        self.total = self.total + here.val;
+    }
+}
+
+def collect(a: int, b: int) -> int {
+    c = Collector();
+    c spawn Item(val=a);
+    c spawn Item(val=b);
+    return c.total;
+}
+
+with entry {
+    print("total:", collect(4, 5));
+}

--- a/jac/tests/compiler/fixtures/codespace/nadefault_root_osp.jac
+++ b/jac/tests/compiler/fixtures/codespace/nadefault_root_osp.jac
@@ -1,0 +1,12 @@
+node Task {
+    has title: str = "";
+}
+
+def add_task(title: str) -> int {
+    root ++> Task(title=title);
+    return 1;
+}
+
+with entry {
+    print("added:", add_task("x"));
+}

--- a/jac/tests/compiler/passes/native/fixtures/closures_adapters.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/closures_adapters.na.jac
@@ -1,0 +1,60 @@
+"""Capturing callbacks for the lazy map/filter adapters.
+
+The adapter states carry a `{fn, env}` slot pair alongside the upstream
+iterator: a bare named function bakes its callee into the per-callsite next
+function exactly as before, while a capturing lambda, a named nested
+closure, or a stored closure value routes through the closure thunk with
+the env loaded from the adapter state. The state retains the env for the
+adapter's lifetime and the struct release fn drops it with the upstream.
+"""
+
+def scale_all(k: int) -> int {
+    t = 0;
+    for v in map(lambda (x: int) -> int { x * k; }, [1, 2, 3]) {
+        t = t + v;
+    }
+    return t;
+}
+
+def keep_over(cut: int) -> int {
+    t = 0;
+    for v in filter(lambda (x: int) -> bool { x > cut; }, [1, 5, 9, 3]) {
+        t = t + v;
+    }
+    return t;
+}
+
+def make_adder(k: int) -> Callable[[int], int] {
+    return lambda (x: int) -> int { x + k; };
+}
+
+def map_stored_closure(k: int) -> int {
+    f = make_adder(k);
+    t = 0;
+    for v in map(f, [10, 20]) {
+        t = t + v;
+    }
+    return t;
+}
+
+def map_named_capture(k: int) -> int {
+    def scaled(x: int) -> int {
+        return x * k;
+    }
+    t = 0;
+    for v in map(scaled, [2, 3]) {
+        t = t + v;
+    }
+    return t;
+}
+
+def filter_then_map(cut: int, k: int) -> int {
+    t = 0;
+    for v in map(
+        lambda (x: int) -> int { x * k; },
+        filter(lambda (x: int) -> bool { x >= cut; }, [1, 2, 3, 4])
+    ) {
+        t = t + v;
+    }
+    return t;
+}

--- a/jac/tests/compiler/passes/native/fixtures/closures_frames.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/closures_frames.na.jac
@@ -1,0 +1,66 @@
+"""Escape-scan coverage for the remaining frame kinds.
+
+A capturing closure that escapes from an event-method frame, a
+no-signature method frame, the module entry frame, or a global
+initializer promotes its captures to RC heap cells exactly as in plain
+ability frames; the frames differ only in who owns the scan call.
+"""
+
+node Thing {
+    has val: int;
+}
+
+walker Scaler {
+    has result: int = 0;
+
+    can measure with Thing entry {
+        k = here.val;
+        fns: list[Callable[[int], int]] = [lambda (x: int) -> int { x * k; }];
+        f = fns[0];
+        self.result = f(10);
+    }
+}
+
+def event_frame_escape(v: int) -> int {
+    return (Scaler() spawn Thing(val=v)).result;
+}
+
+obj Box {
+    has base: int = 4,
+        result: int = 0;
+
+    def bump {
+        k = self.base;
+        fns: list[Callable[[int], int]] = [lambda (x: int) -> int { x + k; }];
+        f = fns[0];
+        self.result = f(100);
+    }
+}
+
+def nosig_frame_escape(b: int) -> int {
+    bx = Box(base=b);
+    bx.bump();
+    return bx.result;
+}
+
+glob futs: list[Callable[[int], int]] = [lambda (x: int) -> int { x * 3; }];
+
+def globinit_lambda(v: int) -> int {
+    g = futs[0];
+    return g(v);
+}
+
+glob entry_acc: list[int] = [];
+
+with entry {
+    fns: list[Callable[[int], int]] = [lambda (x: int) -> int { x + 7; }];
+    f = fns[0];
+    entry_acc.append(f(1));
+}
+
+def entry_frame_escape -> int {
+    if len(entry_acc) > 0 {
+        return entry_acc[0];
+    }
+    return -1;
+}

--- a/jac/tests/compiler/passes/native/fixtures/closures_frames.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/closures_frames.na.jac
@@ -53,9 +53,11 @@ def globinit_lambda(v: int) -> int {
 glob entry_acc: list[int] = [];
 
 with entry {
-    fns: list[Callable[[int], int]] = [lambda (x: int) -> int { x + 7; }];
-    f = fns[0];
-    entry_acc.append(f(1));
+    if len(entry_acc) == 0 {
+        fns: list[Callable[[int], int]] = [lambda (x: int) -> int { x + 7; }];
+        f = fns[0];
+        entry_acc.append(f(1));
+    }
 }
 
 def entry_frame_escape -> int {

--- a/jac/tests/compiler/passes/native/fixtures/generators_residual.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/generators_residual.na.jac
@@ -55,7 +55,7 @@ def count_chars(s: str) -> int {
 def pacer(n: int) -> Iterator[None] {
     i = 0;
     while i < n {
-        yield;
+        yield ;
         i = i + 1;
     }
 }

--- a/jac/tests/compiler/passes/native/fixtures/generators_residual.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/generators_residual.na.jac
@@ -1,0 +1,148 @@
+"""The residual generator shapes: yield from, bare yield, return <value>,
+yield inside try, and yielding bodies inside indexed for-loops.
+
+`yield from <iterable>` lowers as an iterator-driven loop that suspends per
+element (the inner iterable goes through the same `_build_iter_from_expr`
+seam as for-loops, so generators, containers, strings, and adapters all
+work). Bare `yield` suspends with the element type's unit value (None on
+the Python surface has no native carrier; consumers observe the iteration,
+not the value). `return <expr>` in a generator evaluates the expression and
+stops iteration; the StopIteration value channel has no consumer on the
+JacIter ABI, so the value is discarded by design. A yield inside `try`
+pops this frame's handler chain before suspending and re-arms it (fresh
+setjmp in the new invocation) on resume, so exceptions raised between
+yields keep resolving to the generator's own handlers, while exceptions in
+the consumer never falsely land in a suspended generator's try. Finally
+blocks run on normal completion and exception paths, not on mid-suspension
+abandonment. Yielding loop bodies over lists/dicts/strings keep the
+collection and its length in frame slots so the loop can resume mid-flight.
+"""
+
+def counter(n: int) -> Iterator[int] {
+    i = 0;
+    while i < n {
+        yield i;
+        i = i + 1;
+    }
+}
+
+def chain(n: int) -> Iterator[int] {
+    yield from counter(n);
+    yield from [100, 200];
+    yield 999;
+}
+
+def total_chain(n: int) -> int {
+    t = 0;
+    for v in chain(n) {
+        t = t + v;
+    }
+    return t;
+}
+
+def spell(s: str) -> Iterator[str] {
+    yield from s;
+}
+
+def count_chars(s: str) -> int {
+    t = 0;
+    for c in spell(s) {
+        t = t + len(c);
+    }
+    return t;
+}
+
+def pacer(n: int) -> Iterator[None] {
+    i = 0;
+    while i < n {
+        yield;
+        i = i + 1;
+    }
+}
+
+def count_pacer(n: int) -> int {
+    t = 0;
+    for step in pacer(n) {
+        t = t + 1;
+    }
+    return t;
+}
+
+def upto_return(n: int) -> Iterator[int] {
+    yield 1;
+    yield 2;
+    return n * 10;
+}
+
+def total_upto_return(n: int) -> int {
+    t = 0;
+    for v in upto_return(n) {
+        t = t + v;
+    }
+    return t;
+}
+
+def doubles(xs: list[int]) -> Iterator[int] {
+    for x in xs {
+        yield x * 2;
+    }
+}
+
+def total_doubles -> int {
+    xs = [1, 2, 3];
+    t = 0;
+    for v in doubles(xs) {
+        t = t + v;
+    }
+    return t;
+}
+
+def keys_of(d: dict[str, int]) -> Iterator[str] {
+    for k in d {
+        yield k;
+    }
+}
+
+def count_keys -> int {
+    d = {"a": 1, "bb": 2};
+    t = 0;
+    for k in keys_of(d) {
+        t = t + len(k);
+    }
+    return t;
+}
+
+def per_char(s: str) -> Iterator[str] {
+    for c in s {
+        yield c;
+    }
+}
+
+def count_per_char(s: str) -> int {
+    t = 0;
+    for c in per_char(s) {
+        t = t + len(c);
+    }
+    return t;
+}
+
+def resilient(n: int) -> Iterator[int] {
+    try {
+        yield 1;
+        if n > 0 {
+            raise ValueError("boom");
+        }
+        yield 2;
+    } except ValueError {
+        yield 3;
+    }
+    yield 4;
+}
+
+def total_resilient(n: int) -> int {
+    t = 0;
+    for v in resilient(n) {
+        t = t + v;
+    }
+    return t;
+}

--- a/jac/tests/compiler/passes/native/fixtures/generics_mono.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/generics_mono.na.jac
@@ -1,0 +1,55 @@
+"""TypeVar-function monomorphization.
+
+A generic def (`def f[T](...)`) is a template, not a function: it declares
+no symbol and emits no code on its own. Each callsite's checker-solved
+argument types bind the type params; the pass stamps one specialized
+private copy per distinct binding (keyed on the solved type mangles) and
+the callsite links against that copy directly - whole-closure visibility,
+no boxing. The same generic body specializes to different operations per
+instantiation (`x + x` is integer addition at int and string concatenation
+at str).
+"""
+
+def identity[T](val: T) -> T {
+    return val;
+}
+
+def first[T](xs: list[T]) -> T {
+    return xs[0];
+}
+
+def tail_of[T](xs: list[T]) -> T {
+    return xs[len(xs) - 1];
+}
+
+def use_identity_int(v: int) -> int {
+    return identity(v);
+}
+
+def use_identity_str_len(s: str) -> int {
+    return len(identity(s));
+}
+
+def use_identity_float(v: float) -> float {
+    return identity(v);
+}
+
+def use_tail_int(a: int, b: int) -> int {
+    return tail_of([a, b]);
+}
+
+def use_tail_str_len(s: str, t2: str) -> int {
+    return len(tail_of([s, t2]));
+}
+
+def use_first(a: int, b: int) -> int {
+    return first([a, b]);
+}
+
+def use_first_str_len(s: str, t2: str) -> int {
+    return len(first([s, t2]));
+}
+
+def never_called[T](x: T) -> T {
+    return x;
+}

--- a/jac/tests/compiler/passes/native/fixtures/generics_mono.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/generics_mono.na.jac
@@ -34,6 +34,10 @@ def use_identity_float(v: float) -> float {
     return identity(v);
 }
 
+def use_identity_kw(v: int) -> int {
+    return identity(val=v);
+}
+
 def use_tail_int(a: int, b: int) -> int {
     return tail_of([a, b]);
 }

--- a/jac/tests/compiler/passes/native/fixtures/osp_chained_filter.na.jac
+++ b/jac/tests/compiler/passes/native/fixtures/osp_chained_filter.na.jac
@@ -1,0 +1,60 @@
+"""Chained node-type filters: `[node-ref][?:Type]`.
+
+The census probe over real projects showed this as the top any-receiver
+source: the E5090 guidance says to narrow untyped adjacency with a
+`[?:Type]` filter, and real code overwhelmingly writes that filter in the
+chained form (`[origin-->][?:Task]`), which previously fell through the
+atom-trailer path as an unlowerable subscript. The chained form now
+applies the same OSP tag-filter kernel as the inline form, and the
+filtered elements carry their narrowed type (field access lowers against
+the concrete node layout). Origins are local nodes: `root` is the
+persistent graph and stays a server signal by design.
+"""
+
+node Bucket {
+    has label: str = "";
+}
+
+node Task {
+    has title: str = "",
+        done: bool = False;
+}
+
+node Note {
+    has body: str = "";
+}
+
+def build_bucket -> Bucket {
+    b = Bucket(label="work");
+    b ++> Task(title="alpha");
+    b ++> Note(body="noise");
+    b ++> Task(title="be");
+    return b;
+}
+
+def:pub count_tasks -> int {
+    b = build_bucket();
+    n = 0;
+    for t in [b-->][?:Task] {
+        n = n + 1;
+    }
+    return n;
+}
+
+def:pub title_len_total -> int {
+    b = build_bucket();
+    s = 0;
+    for t in [b-->][?:Task] {
+        s = s + len(t.title);
+    }
+    return s;
+}
+
+def:pub count_all -> int {
+    b = build_bucket();
+    n = 0;
+    for t in [b-->] {
+        n = n + 1;
+    }
+    return n;
+}

--- a/jac/tests/compiler/passes/native/test_native_closures.jac
+++ b/jac/tests/compiler/passes/native/test_native_closures.jac
@@ -177,3 +177,85 @@ test "closure escape: calling a closure through an any-typed value stays rejecte
         f"{[str(e) for e in prog.errors_had]}"
     );
 }
+
+test "adapter: map with a capturing lambda callback" {
+    (eng, _) = compile_native("closures_adapters.na.jac");
+    f = get_func(eng, "scale_all", ctypes.c_int64, ctypes.c_int64);
+    assert f(3) == 18 , "3+6+9";
+    assert f(0) == 0;
+}
+
+test "adapter: filter with a capturing lambda predicate" {
+    (eng, _) = compile_native("closures_adapters.na.jac");
+    f = get_func(eng, "keep_over", ctypes.c_int64, ctypes.c_int64);
+    assert f(4) == 14 , "5+9";
+    assert f(0) == 18 , "1+5+9+3";
+}
+
+test "adapter: stored closure value drives map" {
+    (eng, _) = compile_native("closures_adapters.na.jac");
+    f = get_func(eng, "map_stored_closure", ctypes.c_int64, ctypes.c_int64);
+    assert f(7) == 44 , "(10+7)+(20+7)";
+}
+
+test "adapter: named nested closure passed to map by name" {
+    (eng, _) = compile_native("closures_adapters.na.jac");
+    f = get_func(eng, "map_named_capture", ctypes.c_int64, ctypes.c_int64);
+    assert f(10) == 50 , "20+30";
+}
+
+test "adapter: capturing filter chained into capturing map" {
+    (eng, _) = compile_native("closures_adapters.na.jac");
+    f = get_func(
+        eng, "filter_then_map", ctypes.c_int64, ctypes.c_int64, ctypes.c_int64
+    );
+    assert f(3, 2) == 14 , "(3+4)*2";
+}
+
+test "frame scan: closure escaping an event-method frame" {
+    (eng, _) = compile_native("closures_frames.na.jac");
+    f = get_func(eng, "event_frame_escape", ctypes.c_int64, ctypes.c_int64);
+    assert f(3) == 30 , "here.val captured, f(10) = 10*3";
+}
+
+test "frame scan: closure escaping a no-signature method frame" {
+    (eng, _) = compile_native("closures_frames.na.jac");
+    f = get_func(eng, "nosig_frame_escape", ctypes.c_int64, ctypes.c_int64);
+    assert f(9) == 109 , "base captured, f(100) = 100+9";
+}
+
+test "frame scan: lambda escaping a global initializer" {
+    (eng, _) = compile_native("closures_frames.na.jac");
+    entry_fn = get_func(eng, "jac_entry", None);
+    entry_fn();
+    f = get_func(eng, "globinit_lambda", ctypes.c_int64, ctypes.c_int64);
+    assert f(5) == 15;
+}
+
+test "frame scan: lambda escaping the module entry frame" {
+    (eng, _) = compile_native("closures_frames.na.jac");
+    entry_fn = get_func(eng, "jac_entry", None);
+    entry_fn();
+    f = get_func(eng, "entry_frame_escape", ctypes.c_int64);
+    assert f() == 8 , "entry-frame lambda called through the list, f(1) = 1+7";
+}
+
+test "frame guardrail: entry lambda reading an entry local is a loud error" {
+    # Python treats `with entry` assignments as module globals, so a lambda
+    # there reads them dynamically; natively they are frame locals the lambda
+    # cannot see. This must be a structured demotion, never a silent 0.
+    prog = compile_na_inline(
+        "entry_local_lambda",
+        "glob acc: list[int] = [];\n"
+        "with entry {\n"
+        "    k = 7;\n"
+        "    fns: list[Callable[[int], int]] = [lambda (x: int) -> int { x + k; }];\n"
+        "    f = fns[0];\n"
+        "    acc.append(f(1));\n"
+        "}\n"
+    );
+    assert has_error_code(prog, "E5092") , (
+        f"expected E5092 for an entry lambda reading an entry local, got: "
+        f"{[str(e) for e in prog.errors_had]}"
+    );
+}

--- a/jac/tests/compiler/passes/native/test_native_feature_guardrail.jac
+++ b/jac/tests/compiler/passes/native/test_native_feature_guardrail.jac
@@ -886,3 +886,23 @@ test "guardrail: implicit-ctor positionals lower; dynamic new() is rejected" {
         dyn
     )}";
 }
+
+# A component-style event ability (`can with entry`) reaching the native
+# nested-ability path must fail structurally, never with an AttributeError
+# ICE (EventSignature has no get_parameters); surfaced by the corpus probe
+# over mini_todo.
+test "guardrail: nested event ability is a structured error, not an ICE" {
+    prog = compile_na_inline(
+        "nested_event_ability",
+        "def widget -> int {\n"
+        "    can with entry {\n"
+        "        x = 1;\n"
+        "    }\n"
+        "    return 1;\n"
+        "}\n"
+    );
+    assert has_error_code(prog, "E5092") or has_error_code(prog, "E5090") , (
+        f"expected a structured error for a nested event ability, got: "
+        f"{[str(e) for e in prog.errors_had]}"
+    );
+}

--- a/jac/tests/compiler/passes/native/test_native_gen_pass.jac
+++ b/jac/tests/compiler/passes/native/test_native_gen_pass.jac
@@ -123,6 +123,16 @@ test "native osp: spawn dispatches entry ability and mutates walker state" {
     assert collect_two(5, 5) == 10;
 }
 
+test "native osp: chained [?:Type] filter narrows adjacency" {
+    (eng, _) = compile_native("osp_chained_filter.na.jac");
+    count_tasks = get_func(eng, "count_tasks", ctypes.c_int64);
+    assert count_tasks() == 2 , "the Note neighbour is filtered out";
+    count_all = get_func(eng, "count_all", ctypes.c_int64);
+    assert count_all() == 3;
+    title_len = get_func(eng, "title_len_total", ctypes.c_int64);
+    assert title_len() == 7 , "len('alpha') + len('be') via typed field access";
+}
+
 test "native osp: spawn returns the walker" {
     (eng, _) = compile_native("osp_spawn.na.jac");
     collect_one = get_func(eng, "collect_one", ctypes.c_int64, ctypes.c_int64);

--- a/jac/tests/compiler/passes/native/test_native_generators.jac
+++ b/jac/tests/compiler/passes/native/test_native_generators.jac
@@ -109,19 +109,71 @@ test "generator: composes under the lazy map adapter" {
     assert f(4) == 12 , "2*(0+1+2+3)";
 }
 
-test "generator guardrail: yield inside try is a structured error" {
+test "generator: yield from chains generators, lists, and plain yields" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "total_chain", ctypes.c_int64, ctypes.c_int64);
+    assert f(3) == 1302 , "0+1+2 + 100+200 + 999";
+    assert f(0) == 1299 , "empty inner generator, then 100+200+999";
+}
+
+test "generator: yield from a string yields its characters" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "count_chars", ctypes.c_int64, ctypes.c_char_p);
+    assert f(b"abcd") == 4;
+    assert f(b"") == 0;
+}
+
+test "generator: bare yield paces iteration" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "count_pacer", ctypes.c_int64, ctypes.c_int64);
+    assert f(5) == 5;
+    assert f(0) == 0;
+}
+
+test "generator: return <value> stops iteration, value discarded on JacIter" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "total_upto_return", ctypes.c_int64, ctypes.c_int64);
+    assert f(7) == 3 , "1+2, the returned 70 has no JacIter consumer";
+}
+
+test "generator: yield inside a for over a list resumes mid-loop" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "total_doubles", ctypes.c_int64);
+    assert f() == 12 , "2+4+6";
+}
+
+test "generator: yield inside a for over dict keys resumes mid-loop" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "count_keys", ctypes.c_int64);
+    assert f() == 3 , "len('a') + len('bb')";
+}
+
+test "generator: yield inside a for over a string resumes mid-loop" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "count_per_char", ctypes.c_int64, ctypes.c_char_p);
+    assert f(b"xyz") == 3;
+}
+
+test "generator: yield inside try, exception raised and caught across resumes" {
+    (eng, _) = compile_native("generators_residual.na.jac");
+    f = get_func(eng, "total_resilient", ctypes.c_int64, ctypes.c_int64);
+    assert f(0) == 7 , "1+2+4, no exception";
+    assert f(1) == 8 , "1, boom caught, 3, 4";
+}
+
+test "generator guardrail: yield inside finally is a structured error" {
     prog = compile_na_inline(
-        "yield_in_try",
+        "yield_in_finally",
         "def g(n: int) -> Iterator[int] {\n"
         "    try {\n"
         "        yield n;\n"
-        "    } except Exception as e {\n"
-        "        return;\n"
+        "    } finally {\n"
+        "        yield n + 1;\n"
         "    }\n"
         "}\n"
     );
     assert has_error_code(prog, "E5092") , (
-        f"expected E5092 for yield inside try, got: "
+        f"expected E5092 for yield inside finally, got: "
         f"{[str(e) for e in prog.errors_had]}"
     );
 }

--- a/jac/tests/compiler/passes/native/test_native_generics.jac
+++ b/jac/tests/compiler/passes/native/test_native_generics.jac
@@ -63,13 +63,13 @@ test "mono: identity specializes at int, float, and str" {
     assert fs(b"abcd") == 4;
     ff = get_func(eng, "use_identity_float", ctypes.c_double, ctypes.c_double);
     assert ff(2.5) == 2.5;
+    fk = get_func(eng, "use_identity_kw", ctypes.c_int64, ctypes.c_int64);
+    assert fk(9) == 9 , "keyword-supplied argument binds the type param";
 }
 
 test "mono: one body, different lowerings per instantiation" {
     (eng, _) = compile_native("generics_mono.na.jac");
-    ti = get_func(
-        eng, "use_tail_int", ctypes.c_int64, ctypes.c_int64, ctypes.c_int64
-    );
+    ti = get_func(eng, "use_tail_int", ctypes.c_int64, ctypes.c_int64, ctypes.c_int64);
     assert ti(3, 9) == 9 , "i64 element load at int";
     ts = get_func(
         eng, "use_tail_str_len", ctypes.c_int64, ctypes.c_char_p, ctypes.c_char_p

--- a/jac/tests/compiler/passes/native/test_native_generics.jac
+++ b/jac/tests/compiler/passes/native/test_native_generics.jac
@@ -1,0 +1,112 @@
+"""Behavioral tests for TypeVar-function monomorphization on native.
+
+Graduated from the unlowerable-type E5092 at declaration: a generic def is
+a template that emits no code by itself; each callsite's checker-solved
+types stamp a specialized private copy, memoized per solved-type key. The
+same body lowers to different operations per instantiation.
+"""
+
+import ctypes;
+import os;
+import from tests.support { TESTS_DIR }
+import jaclang;
+import jaclang.jac0core.unitree as uni;
+import from jaclang.jac0core.program { JacProgram }
+import from jaclang.compiler.passes.native.llvm.binding { ExecutionEngine }
+
+glob FIXTURES = os.path.join(
+         TESTS_DIR, "compiler", "passes", "native", "fixtures"
+     );
+
+"""Compile a .na.jac fixture and return the JIT engine."""
+def compile_native(fixture: str) -> tuple[ExecutionEngine, uni.Module] {
+    prog = JacProgram();
+    ir = prog.compile(file_path=str(os.path.join(FIXTURES, fixture)));
+    errors = [str(e) for e in prog.errors_had] if prog.errors_had else [];
+    assert not prog.errors_had , f"Compilation errors in {fixture}: {errors}";
+    eng = ir.gen.native_engine;
+    assert eng is not None , f"No native engine produced for {fixture}";
+    return (eng, ir);
+}
+
+"""Get a ctypes-callable function from the JIT engine."""
+def get_func(eng: object, name: str, restype: type | None, *argtypes: type) -> object {
+    addr = eng.get_function_address(name);
+    assert addr != 0 , f"Function '{name}' not found in JIT engine";
+    functype = ctypes.CFUNCTYPE(restype, *argtypes);
+    return functype(addr);
+}
+
+"""Compile a snippet through the native pipeline and return the program."""
+def compile_na_inline(label: str, code: str) -> JacProgram {
+    path = os.path.join(FIXTURES, f"_generics_{label}.na.jac");
+    prog = JacProgram();
+    prog.compile(file_path=path, use_str=code);
+    return prog;
+}
+
+"""Return True if the program emitted at least one alert with the given code."""
+def has_error_code(prog: JacProgram, code: str) -> bool {
+    for alrt in prog.errors_had {
+        if alrt.code is not None and alrt.code.code == code {
+            return True;
+        }
+    }
+    return False;
+}
+
+test "mono: identity specializes at int, float, and str" {
+    (eng, _) = compile_native("generics_mono.na.jac");
+    fi = get_func(eng, "use_identity_int", ctypes.c_int64, ctypes.c_int64);
+    assert fi(7) == 7;
+    fs = get_func(eng, "use_identity_str_len", ctypes.c_int64, ctypes.c_char_p);
+    assert fs(b"abcd") == 4;
+    ff = get_func(eng, "use_identity_float", ctypes.c_double, ctypes.c_double);
+    assert ff(2.5) == 2.5;
+}
+
+test "mono: one body, different lowerings per instantiation" {
+    (eng, _) = compile_native("generics_mono.na.jac");
+    ti = get_func(
+        eng, "use_tail_int", ctypes.c_int64, ctypes.c_int64, ctypes.c_int64
+    );
+    assert ti(3, 9) == 9 , "i64 element load at int";
+    ts = get_func(
+        eng, "use_tail_str_len", ctypes.c_int64, ctypes.c_char_p, ctypes.c_char_p
+    );
+    assert ts(b"ab", b"wxyz") == 4 , "pointer element load at str";
+}
+
+test "mono: container type params solve through list[T]" {
+    (eng, _) = compile_native("generics_mono.na.jac");
+    f = get_func(eng, "use_first", ctypes.c_int64, ctypes.c_int64, ctypes.c_int64);
+    assert f(5, 9) == 5;
+    g = get_func(
+        eng, "use_first_str_len", ctypes.c_int64, ctypes.c_char_p, ctypes.c_char_p
+    );
+    assert g(b"hello", b"xy") == 5;
+}
+
+test "mono: an uncalled generic def emits no code and no error" {
+    (eng, ir) = compile_native("generics_mono.na.jac");
+    assert eng.get_function_address("never_called") == 0 , (
+        "a generic template with no instantiations must not exist as a symbol"
+    );
+}
+
+test "mono guardrail: a generic function used as a value stays rejected" {
+    prog = compile_na_inline(
+        "generic_as_value",
+        "def pick[T](x: T) -> T {\n"
+        "    return x;\n"
+        "}\n"
+        "def use_it(v: int) -> int {\n"
+        "    f = pick;\n"
+        "    return f(v);\n"
+        "}\n"
+    );
+    assert has_error_code(prog, "E5092") , (
+        f"expected E5092 for a generic fn used as a value, got: "
+        f"{[str(e) for e in prog.errors_had]}"
+    );
+}

--- a/jac/tests/compiler/test_backend_purity.jac
+++ b/jac/tests/compiler/test_backend_purity.jac
@@ -74,6 +74,15 @@ glob FORBIDDEN: dict[str, str] = {
              "central classification instead of re-implementing name "
              "resolution"
          ),
+         ("native/na_ir_gen_pass.impl/generics.impl.jac", "type_tag.tag"): (
+             1,
+             "generic-template declared-annotation fallback in "
+             "_solve_generic_call: the primary fact is the ability symbol's "
+             "central FunctionType (name_ref.type), but a bundled/imported "
+             "template compiled symtab_ir_only has no stamped FunctionType, "
+             "and for an uninstantiated template the declared annotation IS "
+             "the fact - there is no per-callsite resolved type to consume"
+         ),
          ("native/na_ir_gen_pass.impl/calls.impl.jac", "symbol_utils"): (
              2,
              "is_builtin_region_name as the shadowing-aware test for the "

--- a/jac/tests/compiler/test_codespace_inference.jac
+++ b/jac/tests/compiler/test_codespace_inference.jac
@@ -220,6 +220,14 @@ test "generator module infers native under native default" {
     assert stamp_of(mod, "evens") == 'native';
 }
 
+test "lambda module infers native under native default" {
+    mod = compile_with_default("nadefault_lambda.jac", "native", cgen=True);
+    assert mod.decided_codespace == 'native' , (
+        "closures lower natively (escaping pairs, adapter callbacks) and are not server signals"
+    );
+    assert stamp_of(mod, "scale_all") == 'native';
+}
+
 test "structural match no longer forces server under native default" {
     mod = compile_with_default("nadefault_match.jac", "native", cgen=True);
     assert mod.decided_codespace == 'native' , (

--- a/jac/tests/compiler/test_codespace_inference.jac
+++ b/jac/tests/compiler/test_codespace_inference.jac
@@ -220,6 +220,23 @@ test "generator module infers native under native default" {
     assert stamp_of(mod, "evens") == 'native';
 }
 
+test "local-graph OSP module infers native under native default" {
+    mod = compile_with_default("nadefault_local_osp.jac", "native", cgen=True);
+    assert mod.decided_codespace == 'native' , (
+        "walkers/nodes/spawn over a local graph lower natively; OSP is a server"
+        " signal only with a persistence surface"
+    );
+    assert stamp_of(mod, "collect") == 'native';
+}
+
+test "root access keeps a module server under native default" {
+    mod = compile_with_default("nadefault_root_osp.jac", "native");
+    assert mod.decided_codespace == '' , (
+        "root is the persistent graph; touching it implies a server surface"
+    );
+    assert stamp_of(mod, "add_task") == 'server';
+}
+
 test "lambda module infers native under native default" {
     mod = compile_with_default("nadefault_lambda.jac", "native", cgen=True);
     assert mod.decided_codespace == 'native' , (
@@ -267,10 +284,12 @@ test "import cycles infer native under native default" {
     );
 }
 
-test "osp constructs keep module server under native default" {
-    mod = compile_with_default("nadefault_walker.jac", "native");
-    assert mod.decided_codespace == '' , "walker/node archetypes are server signals";
-    assert stamp_of(mod, "Visitor") == 'server';
+test "osp with root access keeps module server under native default" {
+    mod = compile_with_default("nadefault_root_osp.jac", "native", cgen=True);
+    assert mod.decided_codespace == '' , (
+        "root is the persistent graph; OSP with a persistence surface stays server"
+    );
+    assert stamp_of(mod, "Task") == 'server';
 }
 
 test "native default produces a native engine for pure modules" {
@@ -362,7 +381,7 @@ test "census records native and server outcomes" {
     na_census_begin();
     try {
         compile_with_default("nadefault_pure.jac", "native", cgen=True);
-        compile_with_default("nadefault_walker.jac", "native", cgen=True);
+        compile_with_default("nadefault_root_osp.jac", "native", cgen=True);
     } finally {
         census = na_census_end();
     }
@@ -370,7 +389,7 @@ test "census records native and server outcomes" {
         os.path.realpath(os.path.join(FIXTURE_DIR, "nadefault_pure.jac"))
     );
     blocked = census.get(
-        os.path.realpath(os.path.join(FIXTURE_DIR, "nadefault_walker.jac"))
+        os.path.realpath(os.path.join(FIXTURE_DIR, "nadefault_root_osp.jac"))
     );
     assert pure is not None and pure['outcome'] == 'native' , f"got {pure}";
     assert blocked is not None and blocked['outcome'] == 'server' , f"got {blocked}";

--- a/jac/tests/compiler/test_codespace_inference.jac
+++ b/jac/tests/compiler/test_codespace_inference.jac
@@ -212,6 +212,14 @@ test "pure markerless module infers native under native default" {
     assert stamp_of(mod, "add") == 'native';
 }
 
+test "generator module infers native under native default" {
+    mod = compile_with_default("nadefault_generator.jac", "native", cgen=True);
+    assert mod.decided_codespace == 'native' , (
+        "generators lower natively (state machines incl. yield from) and are not server signals"
+    );
+    assert stamp_of(mod, "evens") == 'native';
+}
+
 test "structural match no longer forces server under native default" {
     mod = compile_with_default("nadefault_match.jac", "native", cgen=True);
     assert mod.decided_codespace == 'native' , (

--- a/jac/tests/language/test_cli.jac
+++ b/jac/tests/language/test_cli.jac
@@ -2266,7 +2266,7 @@ test "jac check native census ranks module outcomes" {
         }
         with open(os.path.join(td, "blocked.jac"), "w") as f {
             f.write(
-                "node Item {\n    has label: str = \"\";\n}\n\nwalker Visitor {\n" + "    can look with Item entry {\n        print(here.label);\n" + "    }\n}\n"
+                "node Item {\n    has label: str = \"\";\n}\n\n" + "def pin(label: str) -> int {\n    root ++> Item(label=label);\n" + "    return 1;\n}\n"
             );
         }
         (captured_stdout, captured_stderr, old_stdout, old_stderr) = _capture_output();
@@ -2286,7 +2286,7 @@ test "jac check native census ranks module outcomes" {
         assert "demote.jac" in combined , "demoted module path missing";
         assert "blocked.jac" in combined , "server module path missing";
         assert "pure.jac" in combined , "native module path missing";
-        assert "osp archetype" in combined , (
+        assert "root access (persistent graph)" in combined , (
             "server reason strings must be real signal labels"
         );
         assert result == 0 , "census demotions must not flip exit code";


### PR DESCRIPTION
Wave 3 of #7593, stacked on #7594/#7599. Executes the issue's "Remaining steps" list to completion: every item landed red-first (failing lowering/equivalence test, then the long-term implementation, then reject-layer deletion where the lowering warrants it).

## Item 13: generator residuals

- `yield from` lowers as an iterator-driven suspend-per-element loop through the same `_build_iter_from_expr` seam as for-loops (generators, containers, strings, adapters). Bare `yield` suspends with the element type's unit carrier (`Iterator[None]` elements map void->i64 on both producer and consumer sides). `return <expr>` in a generator evaluates the expression and stops iteration - the StopIteration value channel has no consumer on the JacIter ABI by design. `yield` inside `try` pops the frame's handler chain before suspending and re-arms it with a fresh setjmp per resume invocation, so exceptions raised between yields resolve to the generator's own handlers while consumer exceptions never land in a suspended try; `yield` inside `finally` stays a structured E5092. Yielding bodies inside indexed for-loops spill the collection to a frame slot and recompute the bound per iteration. Adjacent fix: pointer loop-var frame slots were re-nulled by entry-block stores on every resume. **`YieldExpr` is deleted from the classifier** - generator modules infer native. Suites: native generators 9->17, prim-equivalence pins all the new shapes py-vs-na.

## Item 12: closure residuals

- map/filter adapter states gain `{fn, env}` slots: bare named callees bake into the per-callsite next fn exactly as before, while capturing lambdas, named nested closures, and stored closure values route through the closure thunk with the env loaded from state (retained by the adapter, dropped by the struct release fn). The escape scan covers event-method, no-signature-method, module-entry, and glob-init frames (`nearest_scope` learns ModuleCode/Module); generator frames stay structured errors by design. Two adjacent defects fixed: a bare lambda stored in a `list[Callable]` was appended as a raw fn pointer and crashed when called through the closure convention (list literals now coerce elements to a declared closure elem type), and a lambda body that failed to lower compiled to a silent `ret 0` - now a structured E5092, with module-entry locals read by entry lambdas as the canonical case (Python treats those as module globals, native as frame locals). **`LambdaExpr` is deleted from the classifier**. Suites: closures 15->25, prim-equivalence adapter-callback pin.

## Item 14 (M2): TypeVar-fn monomorphization

- A generic def (`def f[T](...)`) is a template: it declares no symbol and emits no code uncalled. Each callsite structurally unifies declared param types against checker-solved argument types and stamps one specialized private copy per solved-type key (memoized at declaration, so recursion and re-evaluation are safe). The binding flows through two substitution chokepoints: `_lower_type` resolves bound TypeVarTypes (containers like `list[T]` lower concretely through the existing recursion) and `_mangled_of` rewrites bound TypeVar names inside mangled type keys for every spec-driven helper. Generic-calls-generic resolves inner TypeVar actuals through the active solution. Generic generators and generic fns used as values stay structured E5092s. New suite test_native_generics (5), prim-equivalence generics pin.

## Item 18: census-ranked bundled stdlib

- `jac check --native-census` over the repo-internal corpus ranked the real blockers - re (3 modules), shutil (2), statistics (2), keyword/warnings/traceback/subprocess (1 each) - correcting this issue's json/string/itertools guess. Landed the achievable top three as bundled `.na.jac` modules: **statistics** (median/mean/fmean/stdev/pstdev/variance/pvariance over generic `[T]` defs, dogfooding M2; always-float and ValueError divergences documented), **shutil** (which/copyfile/copy/copy2/move/rmtree over os intrinsics + libc FFI incl. glibc dirent traversal), **keyword** (CPython kwlist/softkwlist verbatim). The census now shows zero corpus modules blocked on these; re and subprocess remain the ranked follow-ups needing dedicated engines. Route-to-bundled fixes along the way: template-only modules count as native content; the interop pad prefers the bundled module's real signature over the typeshed stub (shutil.move's stub carries a third copy_function param that mismatched every 2-arg call); stub Ellipsis defaults are placeholders, never values; the arg binder stops default-filling past declared arity; float() is a native no-op on floats. Prim-equivalence 95->98.

## Item 15: any-receiver - the top real-world source

- The corpus probe (OSP modules mandated native) showed the top any-receiver source is the E5090 mitigation itself: the guidance says to narrow untyped adjacency with a `[?:Type]` filter, and real code writes it in the chained form (`[origin-->][?:Task]`), which fell through the atom-trailer path as an unlowerable subscript while only the inline form lowered. The chained form now routes through the same OSP tag-filter kernel; filtered elements carry their concrete node layout. Field-predicate filters stay structured E5092s. Also from the probe: a component-style `can with entry` nested in a def crashed the pass with an AttributeError ICE - now a structured E5092. Ranked residuals recorded: multi-hop typed-edge traversals (EdgeRefTrailer chains); root access is item 16's deliberate boundary.

## Item 16: the local-graph classifier predicate

- Designed against census data as this issue prescribed. With OSP lowering complete under mandate and a pure local-walker corpus module compiling clean natively, the five OSP node signals (VisitStmt, DisengageStmt, ReportStmt, EdgeOpRef, DisconnectOp) and the osp-archetype scan leave the classifier. The crisp predicate stands in their place: **root access implies the persistent graph** (new signal, "root access (persistent graph)"), async abilities stay server, event abilities outside an archetype stay server; pub access and client blocks already carry their own signals. Local graphs - nodes, edges, walkers, spawn over locally built topology - infer native. Corpus attribution becomes honest: littleX social_graph reads "root access (persistent graph)" instead of a blanket VisitStmt.

## Verification

Suites at HEAD (targeted, dev-mode jac): test_native_gen_pass **474 passed** (sole failure is the pre-existing aarch64 musl-vendor environmental case, #6366), prim-equivalence **98**, osp-equivalence **24**, codespace-inference **39**, generators **17**, closures **25**, generics **5**, py-semantics **31**, feature-guardrail **37**, demotion **2**, run-dispatch **30**. Every classifier deletion is pinned by a red-first inference test and every lowering by behavioral + cross-backend equivalence tests.
