### PR TITLE
fix(client): enhance route sanitization and collision detection in RouteScanner

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7636.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7636.bugfix.md
@@ -1,0 +1,1 @@
+- **jac-client: hyphenated page filenames no longer break the production client build**: route/layout filenames are now sanitized into valid JS identifiers, and colliding identifiers raise a clear error instead of a bundler failure.

--- a/jac/jaclang/runtimelib/client/impl/route_scanner.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/route_scanner.impl.jac
@@ -114,6 +114,16 @@ impl RouteScanner._file_to_route_path(filename: str) -> str {
     return filename;
 }
 
+def _sanitize_segment(segment: str) -> list[str] {
+    fragments: list[str] = [];
+    for fragment in re.split(r'[^0-9A-Za-z]+', segment) {
+        if len(fragment) > 0 {
+            fragments.append(fragment[0].upper() + fragment[1:]);
+        }
+    }
+    return fragments;
+}
+
 impl RouteScanner._file_to_component_name(file_path: Path) -> str {
     try {
         relative = file_path.relative_to(self.pages_dir);
@@ -127,26 +137,37 @@ impl RouteScanner._file_to_component_name(file_path: Path) -> str {
         }
 
         clean = re.sub(r'^\[\.\.\.(\w+)\]$', r'\1', part);
-
         clean = re.sub(r'^\[(\w+)\]$', r'\1', clean);
-        parts.append(clean[0].upper() + clean[1:] if len(clean) > 0 else clean);
+        parts.extend(_sanitize_segment(clean));
     }
     return self.COMPONENT_PREFIX + "".join(parts);
 }
 
 impl RouteScanner._detect_collisions(routes: list[RouteEntry]) -> None {
-    seen: dict[(str, Path)] = {};
+    seen_paths: dict[(str, Path)] = {};
+    seen_imports: dict[(str, Path)] = {};
     for route in routes {
         if route.is_layout {
             continue;
         }
-        if route.path in seen {
+        if route.path in seen_paths {
             raise ClientBundleError(
                 f"Route collision: '{route.path}' is defined by both "
-                f"'{seen[route.path]}' and '{route.file_path}'. "
+                f"'{seen_paths[route.path]}' and '{route.file_path}'. "
                 f"Remove one of them."
             );
         }
-        seen[route.path] = route.file_path;
+        seen_paths[route.path] = route.file_path;
+
+        if route.component_import in seen_imports {
+            raise ClientBundleError(
+                f"Route import-name collision: '{seen_imports[
+                    route.component_import
+                ]}' "
+                f"and '{route.file_path}' both sanitize to the JS identifier "
+                f"'{route.component_import}'. Rename one of the files."
+            );
+        }
+        seen_imports[route.component_import] = route.file_path;
     }
 }

--- a/jac/jaclang/runtimelib/client/impl/route_scanner.impl.jac
+++ b/jac/jaclang/runtimelib/client/impl/route_scanner.impl.jac
@@ -146,28 +146,26 @@ impl RouteScanner._file_to_component_name(file_path: Path) -> str {
 impl RouteScanner._detect_collisions(routes: list[RouteEntry]) -> None {
     seen_paths: dict[(str, Path)] = {};
     seen_imports: dict[(str, Path)] = {};
-    for route in routes {
-        if route.is_layout {
-            continue;
-        }
-        if route.path in seen_paths {
+    all_entries = routes + list(self._layouts.values());
+    for entry in all_entries {
+        if (not entry.is_layout) and (entry.path in seen_paths) {
             raise ClientBundleError(
-                f"Route collision: '{route.path}' is defined by both "
-                f"'{seen_paths[route.path]}' and '{route.file_path}'. "
+                f"Route collision: '{entry.path}' is defined by both "
+                f"'{seen_paths[entry.path]}' and '{entry.file_path}'. "
                 f"Remove one of them."
             );
         }
-        seen_paths[route.path] = route.file_path;
-
-        if route.component_import in seen_imports {
+        if not entry.is_layout {
+            seen_paths[entry.path] = entry.file_path;
+        }
+        other = seen_imports.get(entry.component_import);
+        if other {
             raise ClientBundleError(
-                f"Route import-name collision: '{seen_imports[
-                    route.component_import
-                ]}' "
-                f"and '{route.file_path}' both sanitize to the JS identifier "
-                f"'{route.component_import}'. Rename one of the files."
+                f"Route import-name collision: '{other}' and '{entry.file_path}' "
+                f"both sanitize to the JS identifier '{entry.component_import}'. "
+                f"Rename one of the files."
             );
         }
-        seen_imports[route.component_import] = route.file_path;
+        seen_imports[entry.component_import] = entry.file_path;
     }
 }

--- a/jac/tests/runtimelib/test_hmr_client.jac
+++ b/jac/tests/runtimelib/test_hmr_client.jac
@@ -1101,3 +1101,19 @@ test "renaming a page moves its route" {
         assert not (compiled_dir / "pages" / "index.js").exists() , "stale compiled JS of the old name must be gone";
     }
 }
+
+test "hyphenated page filenames sanitize to valid JS identifiers in _routes.js" {
+    with TemporaryDirectory() as tmpdir {
+        (reloader, compiled_dir, pages_dir) = _routed_project(
+            tmpdir, extra_pages={"features/about-connections.jac": "About"}
+        );
+        routes = (compiled_dir / "_routes.js").read_text();
+        assert "PagesFeaturesAboutConnections" in routes;
+        for line in routes.splitlines() {
+            if line.startswith("import ") {
+                imported_name = line.split(" as ")[1].split(" ")[0];
+                assert "-" not in imported_name , f"invalid JS identifier: {imported_name}";
+            }
+        }
+    }
+}

--- a/jac/tests/runtimelib/test_hmr_client.jac
+++ b/jac/tests/runtimelib/test_hmr_client.jac
@@ -1117,3 +1117,31 @@ test "hyphenated page filenames sanitize to valid JS identifiers in _routes.js" 
         }
     }
 }
+
+test "a page and a layout that sanitize to the same identifier raise ClientBundleError" {
+    import from jaclang.runtimelib.client { RouteScanner }
+    import from jaclang.runtimelib.client_bundle { ClientBundleError }
+
+    with TemporaryDirectory() as tmpdir {
+        unique_dir = Path(tmpdir) / f"project_{uuid.uuid4().hex[:8]}";
+        pages_dir = unique_dir / "pages";
+        pages_dir.mkdir(parents=True);
+        (pages_dir / "admin-layout.jac").write_text(
+            "cl {\n    def page() {\n        return <div>Admin</div>;\n    }\n}\n"
+        );
+        admin_dir = pages_dir / "admin";
+        admin_dir.mkdir();
+        (admin_dir / "layout.jac").write_text(
+            "cl {\n    def layout() {\n        return <div>Layout</div>;\n    }\n}\n"
+        );
+        scanner = RouteScanner(unique_dir);
+        raised = False;
+        try {
+            scanner.scan();
+        } except ClientBundleError as err {
+            raised = True;
+            assert "PagesAdminLayout" in str(err);
+        }
+        assert raised , "expected a ClientBundleError on page/layout identifier collision";
+    }
+}


### PR DESCRIPTION
Fixes #7634

## Problem

`RouteScanner._file_to_component_name` built JS import identifiers straight from file-based route path segments, only uppercasing the first character of each segment. Hyphens (and any other non-identifier characters) passed straight through into the generated `_routes.js`, producing invalid JS:

```js
import { page as PagesFeaturesFoo-bar } from "./pages/features/foo-bar.js";
```

`vite build` (Rollup) fails to parse this, so `jac build` / `jac start --scale` fail. The dev server tolerates the same invalid syntax (esbuild treats it as a non-fatal dep-scan warning) and serves the route anyway — which is why this only surfaces at build/deploy time, not in local dev.

## Fix

- `_file_to_component_name` now splits each path segment on runs of non-alphanumeric characters and PascalCases each fragment, so `about-connections` → `AboutConnections` instead of `About-connections`.
- `_detect_collisions` now also checks for two different route/layout files sanitizing to the same JS identifier (e.g. `pages/admin-layout.jac` and `pages/admin/layout.jac` both become `PagesAdminLayout`), raising a clear `ClientBundleError` instead of letting it surface as an opaque "Identifier has already been declared" from the bundler. This covers layouts too, not just page routes — layouts live in a separate collection from routes but land in the same `_routes.js` import scope.

URL paths are untouched — only the generated JS identifier changes.

## Testing

- `tests/runtimelib/test_hmr_client.jac`:
  - `hyphenated page filenames sanitize to valid JS identifiers in _routes.js` — reuses the existing `_routed_project` HMR helper.
  - `a page and a layout that sanitize to the same identifier raise ClientBundleError` — covers the page/layout collision case directly via `RouteScanner`.
- Both confirmed to fail without the fix and pass with it. Full suite (26 tests) passes.
- Reproduced the issue's own repro steps end to end (`jac create --kind web-app`, add `pages/features/foo-bar.jac`, `jac build`): build now exits 0, and the generated `_routes.js` contains `PagesFeaturesFooBar` importing from `./pages/features/foo-bar.js`.
