### PR TITLE
docs: rewrite Code of Conduct with Jac/Jaseci ethos

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Jac/Jaseci Code of Conduct
 
-Our brains can be categorized into the limbic system and the realm of the cerebellum, understand that our social and emotional competence lives in the libmic system, and our ability to solve problems and appreciate beauty lives in the realm of the cerebellum. These systems are often at odds, and one is more evolved than the other. Jac and Jaseci are products of the cerebellum and we should engage Jac and Jaseci with the competence the cerebellem affords. Therefore, any friction that comes from the realm of the limbic system will be smited out of our community. Thats all. 
+Our brains can be categorized into the limbic system and the realm of the cerebellum, understand that our social and emotional competence lives in the libmic system, and our ability to solve problems and appreciate beauty lives in the realm of the cerebellum. These systems are often at odds, and one is more evolved than the other. Jac and Jaseci are products of the cerebellum and we should engage Jac and Jaseci with the competence the cerebellem affords. Therefore, any friction that comes from the realm of the limbic system will be smited out of our community. Thats all.
 
-But with that, here are guidelines to follow: 
+But with that, here are guidelines to follow:
 
 * Bring joy to others as a default. But not at the cost of what is logical and reasonably true in the realm of Jac realizing its potential.
 
@@ -10,6 +10,6 @@ But with that, here are guidelines to follow:
 
 * Use your common sense.
 
-* AI is a tool for learning and execution, it would be irrational to use it for only one of thoese things. 
+* AI is a tool for learning and execution, it would be irrational to use it for only one of thoese things.
 
-* Only make the thing (Jac) better, never worse. 
+* Only make the thing (Jac) better, never worse.

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ This is what Claude said I should say when I asked it:
 
 Building well with Jac and Jaseci rewards a certain mindset: careful reasoning, curiosity, and a bias toward solving the problem in front of us. That's the energy we want here. Heat and ego—flame wars, status games, drama for its own sake--don't move the work forward, so we keep them out. Bring your judgment and your standards; leave the friction at the door.
 
-But with that, here are guidelines to follow (more of what I say):
+Both true, but with that, here are guidelines to follow (more of what I say):
 
 * Bring joy to others as a default. But not at the cost of what is logical and reasonably true in the realm of Jac realizing its potential.
 
@@ -16,6 +16,8 @@ But with that, here are guidelines to follow (more of what I say):
 
 * Use your common sense.
 
-* AI is a tool for learning and execution, it would be irrational to use it for only one of thoese things.
+* AI is a tool for learning and execution, it would be irrational not to use it nor to use it for only one of thoese things.
 
 * Only make Jac better, never worse.
+
+* Politics, ideology, and piety is brain-rot when the participant links their identity (exercised by the limbic system) to it and will be treated as such, phylosopy on the other hand (excercised by the cerebral cortex) is helpful when examined in good faith.

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,74 +1,15 @@
-# Jaseci Code of Conduct
+# Jac/Jaseci Code of Conduct
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to make participation in our project and our
-community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of
-experience, nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+Our brains can be categorized into the limbic system and the realm of the cerebellum, understand that our social and emotional competence lives in the libmic system, and our ability to solve problems and appreciate beauty lives in the realm of the cerebellum. These systems are often at odds, and one is more evolved than the other. Jac and Jaseci are products of the cerebellum and we should engage Jac and Jaseci with the competence the cerebellem affords. Therefore, any friction that comes from the realm of the limbic system will be smited out of our community. Thats all. 
 
-## Our Standards
+But with that, here are guidelines to follow: 
 
-Examples of behavior that contributes to creating a positive environment include:
+* Bring joy to others as a default. But not at the cost of what is logical and reasonably true in the realm of Jac realizing its potential.
 
-* Using welcoming and inclusive language.
-* Being respectful of differing viewpoints and experiences.
-* Gracefully accepting constructive criticism.
-* Focusing on what is best for the community.
-* Showing empathy towards other community members.
+* Celebrate the beauty of code and creations.
 
-Examples of unacceptable behavior by participants include:
+* Use your common sense.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-    advances.
-* Trolling, insulting/derogatory comments, and personal or political attacks.
-* Public or private harassment.
-* Publishing others' private information, such as a physical or electronic
-    address, without explicit permission.
-* Conduct which could reasonably be considered inappropriate for the forum in
-    which it occurs.
+* AI is a tool for learning and execution, it would be irrational to use it for only one of thoese things. 
 
-All Jaseci forums and spaces are meant for professional interactions, and any behavior which could reasonably be considered inappropriate in a professional setting is unacceptable.
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies to all content on jaseci.org, Jaseci’s GitHub organization, or any other official Jaseci web presence allowing for community interactions, as well as at all official Jaseci events, whether offline or online.
-
-The Code of Conduct also applies within project spaces and in public spaces whenever an individual is representing Jaseci or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed or de facto representative at an online or offline event.
-
-## Conflict Resolution
-
-Conflicts in an open source project can take many forms, from someone having a bad day and using harsh and hurtful language in the issue queue, to more serious instances such as sexist/racist statements or threats of violence, and everything in between.
-
-If the behavior is threatening or harassing, or for other reasons requires immediate escalation, please see below.
-
-However, for the vast majority of issues, we aim to empower individuals to first resolve conflicts themselves, asking for help when needed, and only after that fails to escalate further. This approach gives people more control over the outcome of their dispute.
-
-If you are experiencing or witnessing conflict, we ask you to use the following escalation strategy to address the conflict:
-
-1. Address the perceived conflict directly with those involved, preferably in a
-    real-time medium.
-2. If this fails, get a third party (e.g. a mutual friend, and/or someone with
-    background on the issue, but not involved in the conflict) to intercede.
-3. If you are still unable to resolve the conflict, and you believe it rises to
-    harassment or another code of conduct violation, report it.
-
-## Reporting Violations
-
-Violations of the Code of Conduct can be reported to Jason Mars (jason@mars.ninja) and Yiping Kang (yiping@jaseci.org). The Project Steward will determine whether the Code of Conduct was violated, and will issue an appropriate sanction, possibly including a written warning or expulsion from the project, project sponsored spaces, or project forums. We ask that you make a good-faith effort to resolve your conflict via the conflict resolution policy before submitting a report.
-
-Violations of the Code of Conduct can occur in any setting, even those unrelated to the project. We will only consider complaints about conduct that has occurred within one year of the report.
-
-## Enforcement
-
-If the Project Stewards receive a report alleging a violation of the Code of Conduct, the Project Stewards will notify the accused of the report, and provide them an opportunity to discuss the report before a sanction is issued. The Project Stewards will do their utmost to keep the reporter anonymous. If the act is ongoing (such as someone engaging in harassment), or involves a threat to anyone's safety (e.g. threats of violence), the Project Stewards may issue sanctions without notice.
-
-## Attribution
-
-This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://contributor-covenant.org/version/1/4, and includes some aspects of the Geek Feminism Code of Conduct and the Drupal Code of Conduct.
+* Only make the thing (Jac) better, never worse. 

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,8 +1,14 @@
 # Jac/Jaseci Code of Conduct
 
-Our brains can be categorized into the limbic system and the realm of the cerebellum, understand that our social and emotional competence lives in the libmic system, and our ability to solve problems and appreciate beauty lives in the realm of the cerebellum. These systems are often at odds, and one is more evolved than the other. Jac and Jaseci are products of the cerebellum and we should engage Jac and Jaseci with the competence the cerebellem affords. Therefore, any friction that comes from the realm of the limbic system will be smited out of our community. Thats all.
+This is what I say:
 
-But with that, here are guidelines to follow:
+Our brains can be categorized into the limbic system and the realm of the cerebral cortex, understand that our social and emotional competence lives in the limbic system, and our ability to solve problems and appreciate beauty lives in the realm of the cerebral cortex. These systems are often at odds, and one is more evolved than the other. Jac and Jaseci are products of the cerebral cortex and we should engage Jac and Jaseci with the competence the cerebral cortex affords. Therefore, any friction that comes from the realm of the limbic system will be smited out of our community. Thats all.
+
+This is what Claude said I should say when I asked it:
+
+Building well with Jac and Jaseci rewards a certain mindset: careful reasoning, curiosity, and a bias toward solving the problem in front of us. That's the energy we want here. Heat and ego—flame wars, status games, drama for its own sake--don't move the work forward, so we keep them out. Bring your judgment and your standards; leave the friction at the door.
+
+But with that, here are guidelines to follow (more of what I say):
 
 * Bring joy to others as a default. But not at the cost of what is logical and reasonably true in the realm of Jac realizing its potential.
 
@@ -12,4 +18,4 @@ But with that, here are guidelines to follow:
 
 * AI is a tool for learning and execution, it would be irrational to use it for only one of thoese things.
 
-* Only make the thing (Jac) better, never worse.
+* Only make Jac better, never worse.


### PR DESCRIPTION
## Summary

Rewrites `.github/CODE_OF_CONDUCT.md`, replacing the Contributor-Covenant-derived text with a concise Jac/Jaseci-ethos statement and a short set of guidelines.

## Changes
- Retitles to "Jac/Jaseci Code of Conduct"
- Replaces the standards / responsibilities / scope / conflict-resolution / reporting / enforcement / attribution sections with a brief ethos framing and five guiding principles.
