### PR TITLE
fix(ci): suppress no-print in validate_fragments.jac to unblock main CI

### DIFF
--- a/scripts/validate_fragments.jac
+++ b/scripts/validate_fragments.jac
@@ -28,7 +28,7 @@ def validate(files: list[str]) -> int {
             continue;
         }
         if not PATTERN.match(path.name) {
-            print(
+            print(  # jac:ignore[no-print]
                 f"ERROR: Invalid fragment filename: {filepath}\n"
                 "       Expected format: <PR_number>.<category>.md\n"
                 f"       Valid categories: {', '.join(sorted(VALID_CATEGORIES))}\n"


### PR DESCRIPTION
## Description

The CI workflow on `main` has been red since 2026-07-21 (every push since `ebe266823a`). The only failure is the `jac-check` job:

```
✖ Error: error[E3012]: Calling print() is disallowed by rule [no-print]
  --> scripts/validate_fragments.jac:31:13
scripts/validate_fragments.jac - 1 error, 1 warning
======================= 504 passed, 1 failed in 156.03s ========================
```

### Root cause

#7496 fixed the lint report path so `jac check` surfaces every diagnostic the mutation pass emits. That exposed a pre-existing `print()` in `scripts/validate_fragments.jac` — the one script under `scripts/` that is *not* in `.jacignore` (its siblings are all baselined there for type-check gaps).

### Fix

Suppress the rule at the call site with the sanctioned inline mechanism:

```jac
print(  # jac:ignore[no-print]
```

The `print()` is the script's entire purpose — it is the pre-commit hook that tells a contributor their release-note fragment filename is invalid. Inline suppression keeps the file under full `jac check` type coverage, unlike adding it to `.jacignore`. The comment survives CI's fmt/deslop step because `ci.yml` excludes `^scripts/` from `jac fmt --lintfix`.

### Verification

- `jac check scripts/validate_fragments.jac`: **1 passed** (was 1 failed with E3012)
- Runtime behavior unchanged: invalid fragment name still prints the error and exits 1; valid name exits 0

No release-note fragment: change is CI/tooling only (no `jac/jaclang/` paths touched).
