### PR TITLE
docs: add property diagrams and gradual borrow checking to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,54 @@ Four copies, three type systems, and one landmine: the fourth copy renames `disp
 
 None of this is required by computation. The pattern traces to two silent assumptions in the 1945 report that defined the stored-program computer: that *computation is stationary* (the site of processing is fixed, and data travels to it), and that *the machine is the program's world* (a program's semantics end at the edge of its process, so frontend and backend, managed and native, script and service are separate programs, joined by hand). Both were engineering defaults for a machine with one memory. Seventy years of habit made them look like laws. Jac is one bet against each.
 
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/synechic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/synechic-light.svg">
+    <img alt="A conventional stack is three separate programs (TypeScript frontend, Python backend, C native) joined by hand across unchecked JSON and FFI seams, so renaming a field ships a stale copy that fails in production; Jac is one continuous checked medium spanning cl, sv, and na tiers, importing npm, PyPI, and the C world directly, with one compiler seeing both sides of every call, so the same rename is a compile error" src="docs/docs/assets/readme/synechic-light.svg" width="880">
+  </picture>
+</div>
+
 **Against the second assumption, Jac is synechic** (from the Greek *synecheia*, continuity): one continuous, checked medium across ecosystems, tiers, and toolchains. One language spans frontend, backend, and native code, and inherits each one's ecosystem (PyPI, npm, the C world) through a plain `import`, so one compiler sees both sides of every call: rename a field and every stale use (server, client, or native) is a **compile error**, not a production incident. Building the first production synechic language is the whole point of Jac.
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/gradual-borrow-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/gradual-borrow-light.svg">
+    <img alt="In a conventional stack, outgrowing the garbage collector means rewriting the hot path in Rust or C++ across an FFI seam; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every value that crosses between the regimes" src="docs/docs/assets/readme/gradual-borrow-light.svg" width="880">
+  </picture>
+</div>
+
+That continuity runs all the way down. The deepest seam in computing is the one between managed and systems languages -- today, when the hot path outgrows the garbage collector, the answer is a second language, an FFI boundary, and a rewrite. Jac renders that divide as **gradual borrow checking**: unannotated code keeps fully managed semantics, `own` and `&`/`&mut` opt individual declarations into moves, borrows, and deterministic destruction, a checked boundary (the **membrane**) mediates every value that crosses between the regimes, and full adoption reaches native artifacts with **no reference counting and no collector**. The divide becomes a gradient walked by degrees, never a cliff crossed by starting over. [Gradual borrow checking →](https://docs.jaseci.org/reference/language/ownership-borrowing/)
+
+<details>
+<summary><strong>The gradient in code (opt in one declaration at a time)</strong></summary>
+
+<br>
+
+```jac
+obj Buffer { has n: int = 0; }
+
+with entry {
+    a: own Buffer = Buffer();   # this declaration opts in; the rest of the file is untouched
+    v: &Buffer = &a;            # shared borrow of the owner
+    a.n = 5;                    # error[E1303]: cannot mutate 'a' while a shared borrow of it is live
+    b = a;                      # moves the value out of 'a'
+    print(a);                   # error[E1301]: use of 'a' after it was moved
+}
+```
+
+The checker tracks only what you tag, so `node`, `edge`, and `walker` stay fully managed and the borrow rules never have to reason about the graph. When a module opts in fully, the native pathway compiles it with no RC and no collector in the artifact: systems-language machine code from the same language that serves your web app.
+
+</details>
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/topokinetic-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/topokinetic-light.svg">
+    <img alt="A conventional stack keeps the program stationary while data commutes to it over query and write-back round trips, and persistence is a commit call you must remember to fire; in Jac data lives as a persistent topology of nodes and edges, a walker carries computation through the graph dispatched by arrival, everything reachable from root persists while unreachable nodes do not, and the database dissolves into the language" src="docs/docs/assets/readme/topokinetic-light.svg" width="880">
+  </picture>
+</div>
 
 **Against the first assumption, Jac is topokinetic** (from the Greek *topos*, place, and *kinesis*, motion): the moving locus of computation is a language construct. In Jac's Object-Spatial Programming, data lives as a persistent topology of nodes and edges, and **walkers** carry computation through it, dispatched by arrival. Whatever is reachable from `root` persists: persistence is a predicate, not an event, and the database dissolves into the language.
 

--- a/docs/docs/assets/readme/gradual-borrow-dark.svg
+++ b/docs/docs/assets/readme/gradual-borrow-dark.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="Diagram: in a conventional stack, outgrowing the garbage collector means rewriting the hot path in a different systems language across an FFI seam; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every crossing">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #e6edf3; }
+    .dim { fill: #8b949e; }
+    .acc { fill: #ff9100; }
+    .bad { fill: #f85149; }
+    .good { fill: #3fb950; }
+  </style>
+
+  <!-- Top panel: the rewrite cliff -->
+  <rect x="16" y="16" width="848" height="152" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans dim" x="32" y="44" font-size="13" font-weight="bold" letter-spacing="1">OUTGROW THE LANGUAGE, REWRITE THE PROGRAM</text>
+
+  <g text-anchor="middle">
+    <rect x="48" y="64" width="310" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="203" y="88" font-size="13" font-weight="bold">Your app</text>
+    <text class="mono dim" x="203" y="106" font-size="10.5">Python · GC · quick to write</text>
+
+    <rect x="522" y="64" width="310" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="677" y="88" font-size="13" font-weight="bold">The hot path</text>
+    <text class="mono dim" x="677" y="106" font-size="10.5">Rust / C++ · fast · another world</text>
+
+    <line x1="366" y1="92" x2="514" y2="92" stroke="#8b949e" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text class="mono dim" x="440" y="82" font-size="10">the rewrite</text>
+    <text class="mono dim" x="440" y="110" font-size="10">FFI · two toolchains</text>
+  </g>
+
+  <text x="440" y="150" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg"># TODO: rewrite the hot path in Rust</tspan><tspan class="sans dim"> · the ceiling of a managed language is </tspan><tspan class="sans bad" font-weight="bold">a different language</tspan></text>
+
+  <!-- Bottom panel: Jac, gradual borrow checking -->
+  <rect x="16" y="188" width="848" height="216" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans acc" x="32" y="216" font-size="13" font-weight="bold" letter-spacing="1" xml:space="preserve">JAC · GRADUAL BORROW CHECKING<tspan class="sans dim" font-size="12" font-weight="normal" letter-spacing="0">  ·  one memory discipline, adopted by degrees</tspan></text>
+
+  <text class="sans dim" x="440" y="236" font-size="9.5" font-style="italic" text-anchor="middle">unannotated code is untouched; opt in one declaration at a time</text>
+
+  <rect x="48" y="244" width="784" height="64" rx="8" fill="#21262d" stroke="#30363d"/>
+  <g text-anchor="middle">
+    <text class="sans fg" x="179" y="272" font-size="12.5" font-weight="bold">fully managed</text>
+    <text class="sans dim" x="179" y="292" font-size="10.5">unannotated · RC/GC</text>
+    <text class="mono acc" x="440" y="272" font-size="13" font-weight="bold">own · &amp; · &amp;mut</text>
+    <text class="sans dim" x="440" y="292" font-size="10.5">moves · borrows · deterministic drop</text>
+    <text class="sans fg" x="701" y="272" font-size="12.5" font-weight="bold">enforced native</text>
+    <text class="sans dim" x="701" y="292" font-size="10.5">no refcounts · no collector</text>
+  </g>
+  <line x1="309" y1="248" x2="309" y2="304" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text class="sans good" x="309" y="324" font-size="10" font-weight="bold" text-anchor="middle">the membrane · every crossing checked</text>
+
+  <text class="sans acc" x="440" y="352" font-size="12" font-weight="bold" text-anchor="middle">no rewrite cliff: a gradient walked by degrees, never crossed</text>
+
+  <text x="440" y="380" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">b = a; print(a);</tspan><tspan class="sans dim"> is </tspan><tspan class="mono good" font-weight="bold">error[E1301]: use after move</tspan><tspan class="sans dim">, in the same file, in the same language</tspan></text>
+</svg>

--- a/docs/docs/assets/readme/gradual-borrow-light.svg
+++ b/docs/docs/assets/readme/gradual-borrow-light.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="Diagram: in a conventional stack, outgrowing the garbage collector means rewriting the hot path in a different systems language across an FFI seam; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every crossing">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #1f2328; }
+    .dim { fill: #57606a; }
+    .acc { fill: #bc4c00; }
+    .bad { fill: #cf222e; }
+    .good { fill: #1a7f37; }
+  </style>
+
+  <!-- Top panel: the rewrite cliff -->
+  <rect x="16" y="16" width="848" height="152" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans dim" x="32" y="44" font-size="13" font-weight="bold" letter-spacing="1">OUTGROW THE LANGUAGE, REWRITE THE PROGRAM</text>
+
+  <g text-anchor="middle">
+    <rect x="48" y="64" width="310" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="203" y="88" font-size="13" font-weight="bold">Your app</text>
+    <text class="mono dim" x="203" y="106" font-size="10.5">Python · GC · quick to write</text>
+
+    <rect x="522" y="64" width="310" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="677" y="88" font-size="13" font-weight="bold">The hot path</text>
+    <text class="mono dim" x="677" y="106" font-size="10.5">Rust / C++ · fast · another world</text>
+
+    <line x1="366" y1="92" x2="514" y2="92" stroke="#57606a" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text class="mono dim" x="440" y="82" font-size="10">the rewrite</text>
+    <text class="mono dim" x="440" y="110" font-size="10">FFI · two toolchains</text>
+  </g>
+
+  <text x="440" y="150" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg"># TODO: rewrite the hot path in Rust</tspan><tspan class="sans dim"> · the ceiling of a managed language is </tspan><tspan class="sans bad" font-weight="bold">a different language</tspan></text>
+
+  <!-- Bottom panel: Jac, gradual borrow checking -->
+  <rect x="16" y="188" width="848" height="216" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans acc" x="32" y="216" font-size="13" font-weight="bold" letter-spacing="1" xml:space="preserve">JAC · GRADUAL BORROW CHECKING<tspan class="sans dim" font-size="12" font-weight="normal" letter-spacing="0">  ·  one memory discipline, adopted by degrees</tspan></text>
+
+  <text class="sans dim" x="440" y="236" font-size="9.5" font-style="italic" text-anchor="middle">unannotated code is untouched; opt in one declaration at a time</text>
+
+  <rect x="48" y="244" width="784" height="64" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <g text-anchor="middle">
+    <text class="sans fg" x="179" y="272" font-size="12.5" font-weight="bold">fully managed</text>
+    <text class="sans dim" x="179" y="292" font-size="10.5">unannotated · RC/GC</text>
+    <text class="mono acc" x="440" y="272" font-size="13" font-weight="bold">own · &amp; · &amp;mut</text>
+    <text class="sans dim" x="440" y="292" font-size="10.5">moves · borrows · deterministic drop</text>
+    <text class="sans fg" x="701" y="272" font-size="12.5" font-weight="bold">enforced native</text>
+    <text class="sans dim" x="701" y="292" font-size="10.5">no refcounts · no collector</text>
+  </g>
+  <line x1="309" y1="248" x2="309" y2="304" stroke="#1a7f37" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text class="sans good" x="309" y="324" font-size="10" font-weight="bold" text-anchor="middle">the membrane · every crossing checked</text>
+
+  <text class="sans acc" x="440" y="352" font-size="12" font-weight="bold" text-anchor="middle">no rewrite cliff: a gradient walked by degrees, never crossed</text>
+
+  <text x="440" y="380" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">b = a; print(a);</tspan><tspan class="sans dim"> is </tspan><tspan class="mono good" font-weight="bold">error[E1301]: use after move</tspan><tspan class="sans dim">, in the same file, in the same language</tspan></text>
+</svg>

--- a/docs/docs/assets/readme/synechic-dark.svg
+++ b/docs/docs/assets/readme/synechic-dark.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Diagram: a conventional stack is three separate programs joined by hand across unchecked seams, each pulling its own ecosystem through its own installer, so a rename fails in production; Jac is one continuous checked medium across frontend, backend, and native, importing the same ecosystems through a plain import, so the same rename is a compile error">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #e6edf3; }
+    .dim { fill: #8b949e; }
+    .acc { fill: #ff9100; }
+    .bad { fill: #f85149; }
+    .good { fill: #3fb950; }
+  </style>
+
+  <!-- Top panel: the discontinuous stack -->
+  <rect x="16" y="16" width="848" height="180" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans dim" x="32" y="44" font-size="13" font-weight="bold" letter-spacing="1">SEPARATE PROGRAMS, JOINED BY HAND</text>
+
+  <g text-anchor="middle">
+    <rect x="104" y="52" width="96" height="22" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="152" y="67" font-size="11">npm</text>
+    <rect x="392" y="52" width="96" height="22" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="440" y="67" font-size="11">PyPI</text>
+    <rect x="680" y="52" width="96" height="22" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="728" y="67" font-size="11">the C world</text>
+
+    <line x1="152" y1="74" x2="152" y2="88" stroke="#8b949e" stroke-width="1.5"/>
+    <path d="M148,88 L156,88 L152,95 Z" fill="#8b949e"/>
+    <line x1="440" y1="74" x2="440" y2="88" stroke="#8b949e" stroke-width="1.5"/>
+    <path d="M436,88 L444,88 L440,95 Z" fill="#8b949e"/>
+    <line x1="728" y1="74" x2="728" y2="88" stroke="#8b949e" stroke-width="1.5"/>
+    <path d="M724,88 L732,88 L728,95 Z" fill="#8b949e"/>
+  </g>
+  <g class="mono dim" font-size="10">
+    <text x="160" y="87">npm install</text>
+    <text x="448" y="87">pip install</text>
+    <text x="736" y="87">make install</text>
+  </g>
+
+  <g text-anchor="middle">
+    <rect x="48" y="96" width="208" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="152" y="120" font-size="13" font-weight="bold">Frontend</text>
+    <text class="mono dim" x="152" y="138" font-size="10.5">TypeScript</text>
+
+    <rect x="336" y="96" width="208" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="440" y="120" font-size="13" font-weight="bold">Backend</text>
+    <text class="mono dim" x="440" y="138" font-size="10.5">Python</text>
+
+    <rect x="624" y="96" width="208" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="728" y="120" font-size="13" font-weight="bold">Native</text>
+    <text class="mono dim" x="728" y="138" font-size="10.5">C</text>
+
+    <line x1="260" y1="124" x2="332" y2="124" stroke="#8b949e" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text class="mono dim" x="296" y="114" font-size="10">JSON</text>
+    <text class="mono dim" x="296" y="142" font-size="10">unchecked</text>
+
+    <line x1="548" y1="124" x2="620" y2="124" stroke="#8b949e" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text class="mono dim" x="584" y="114" font-size="10">FFI</text>
+    <text class="mono dim" x="584" y="142" font-size="10">unchecked</text>
+  </g>
+
+  <text x="440" y="182" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">rename display_name</tspan><tspan class="sans dim"> on the server → the client's copy still compiles, ships, and </tspan><tspan class="sans bad" font-weight="bold">fails in production</tspan></text>
+
+  <!-- Bottom panel: Jac, one continuous medium -->
+  <rect x="16" y="216" width="848" height="216" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans acc" x="32" y="244" font-size="13" font-weight="bold" letter-spacing="1" xml:space="preserve">JAC · SYNECHIC<tspan class="sans dim" font-size="12" font-weight="normal" letter-spacing="0">  ·  one continuous, checked medium</tspan></text>
+
+  <g text-anchor="middle">
+    <rect x="130" y="252" width="96" height="22" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="178" y="267" font-size="11">npm</text>
+    <rect x="392" y="252" width="96" height="22" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="440" y="267" font-size="11">PyPI</text>
+    <rect x="654" y="252" width="96" height="22" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="702" y="267" font-size="11">the C world</text>
+
+    <line x1="178" y1="274" x2="178" y2="288" stroke="#ff9100" stroke-width="1.5"/>
+    <path d="M174,288 L182,288 L178,295 Z" fill="#ff9100"/>
+    <line x1="440" y1="274" x2="440" y2="288" stroke="#ff9100" stroke-width="1.5"/>
+    <path d="M436,288 L444,288 L440,295 Z" fill="#ff9100"/>
+    <line x1="702" y1="274" x2="702" y2="288" stroke="#ff9100" stroke-width="1.5"/>
+    <path d="M698,288 L706,288 L702,295 Z" fill="#ff9100"/>
+  </g>
+  <g class="mono dim" font-size="10">
+    <text x="186" y="287">import</text>
+    <text x="448" y="287">import</text>
+    <text x="710" y="287">import</text>
+  </g>
+
+  <rect x="48" y="296" width="784" height="62" rx="8" fill="#21262d" stroke="#30363d"/>
+  <g text-anchor="middle">
+    <text class="mono" x="179" y="322" font-size="13" xml:space="preserve"><tspan class="acc" font-weight="bold">cl</tspan><tspan class="fg"> · frontend</tspan></text>
+    <text class="sans dim" x="179" y="342" font-size="10.5">the browser</text>
+    <text class="mono" x="440" y="322" font-size="13" xml:space="preserve"><tspan class="acc" font-weight="bold">sv</tspan><tspan class="fg"> · backend</tspan></text>
+    <text class="sans dim" x="440" y="342" font-size="10.5">the server</text>
+    <text class="mono" x="701" y="322" font-size="13" xml:space="preserve"><tspan class="acc" font-weight="bold">na</tspan><tspan class="fg"> · native</tspan></text>
+    <text class="sans dim" x="701" y="342" font-size="10.5">the machine</text>
+  </g>
+
+  <path d="M48,364 V372 H832 V364" fill="none" stroke="#ff9100" stroke-width="2"/>
+  <text class="sans acc" x="440" y="392" font-size="12" font-weight="bold" text-anchor="middle">one compiler sees both sides of every call</text>
+
+  <text x="440" y="418" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">rename display_name</tspan><tspan class="sans dim"> → every stale use (server, client, or native) is a </tspan><tspan class="sans good" font-weight="bold">compile error</tspan><tspan class="sans dim">, not a production incident</tspan></text>
+</svg>

--- a/docs/docs/assets/readme/synechic-light.svg
+++ b/docs/docs/assets/readme/synechic-light.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Diagram: a conventional stack is three separate programs joined by hand across unchecked seams, each pulling its own ecosystem through its own installer, so a rename fails in production; Jac is one continuous checked medium across frontend, backend, and native, importing the same ecosystems through a plain import, so the same rename is a compile error">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #1f2328; }
+    .dim { fill: #57606a; }
+    .acc { fill: #bc4c00; }
+    .bad { fill: #cf222e; }
+    .good { fill: #1a7f37; }
+  </style>
+
+  <!-- Top panel: the discontinuous stack -->
+  <rect x="16" y="16" width="848" height="180" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans dim" x="32" y="44" font-size="13" font-weight="bold" letter-spacing="1">SEPARATE PROGRAMS, JOINED BY HAND</text>
+
+  <g text-anchor="middle">
+    <rect x="104" y="52" width="96" height="22" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="152" y="67" font-size="11">npm</text>
+    <rect x="392" y="52" width="96" height="22" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="440" y="67" font-size="11">PyPI</text>
+    <rect x="680" y="52" width="96" height="22" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="728" y="67" font-size="11">the C world</text>
+
+    <line x1="152" y1="74" x2="152" y2="88" stroke="#57606a" stroke-width="1.5"/>
+    <path d="M148,88 L156,88 L152,95 Z" fill="#57606a"/>
+    <line x1="440" y1="74" x2="440" y2="88" stroke="#57606a" stroke-width="1.5"/>
+    <path d="M436,88 L444,88 L440,95 Z" fill="#57606a"/>
+    <line x1="728" y1="74" x2="728" y2="88" stroke="#57606a" stroke-width="1.5"/>
+    <path d="M724,88 L732,88 L728,95 Z" fill="#57606a"/>
+  </g>
+  <g class="mono dim" font-size="10">
+    <text x="160" y="87">npm install</text>
+    <text x="448" y="87">pip install</text>
+    <text x="736" y="87">make install</text>
+  </g>
+
+  <g text-anchor="middle">
+    <rect x="48" y="96" width="208" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="152" y="120" font-size="13" font-weight="bold">Frontend</text>
+    <text class="mono dim" x="152" y="138" font-size="10.5">TypeScript</text>
+
+    <rect x="336" y="96" width="208" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="440" y="120" font-size="13" font-weight="bold">Backend</text>
+    <text class="mono dim" x="440" y="138" font-size="10.5">Python</text>
+
+    <rect x="624" y="96" width="208" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="728" y="120" font-size="13" font-weight="bold">Native</text>
+    <text class="mono dim" x="728" y="138" font-size="10.5">C</text>
+
+    <line x1="260" y1="124" x2="332" y2="124" stroke="#57606a" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text class="mono dim" x="296" y="114" font-size="10">JSON</text>
+    <text class="mono dim" x="296" y="142" font-size="10">unchecked</text>
+
+    <line x1="548" y1="124" x2="620" y2="124" stroke="#57606a" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text class="mono dim" x="584" y="114" font-size="10">FFI</text>
+    <text class="mono dim" x="584" y="142" font-size="10">unchecked</text>
+  </g>
+
+  <text x="440" y="182" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">rename display_name</tspan><tspan class="sans dim"> on the server → the client's copy still compiles, ships, and </tspan><tspan class="sans bad" font-weight="bold">fails in production</tspan></text>
+
+  <!-- Bottom panel: Jac, one continuous medium -->
+  <rect x="16" y="216" width="848" height="216" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans acc" x="32" y="244" font-size="13" font-weight="bold" letter-spacing="1" xml:space="preserve">JAC · SYNECHIC<tspan class="sans dim" font-size="12" font-weight="normal" letter-spacing="0">  ·  one continuous, checked medium</tspan></text>
+
+  <g text-anchor="middle">
+    <rect x="130" y="252" width="96" height="22" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="178" y="267" font-size="11">npm</text>
+    <rect x="392" y="252" width="96" height="22" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="440" y="267" font-size="11">PyPI</text>
+    <rect x="654" y="252" width="96" height="22" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="702" y="267" font-size="11">the C world</text>
+
+    <line x1="178" y1="274" x2="178" y2="288" stroke="#bc4c00" stroke-width="1.5"/>
+    <path d="M174,288 L182,288 L178,295 Z" fill="#bc4c00"/>
+    <line x1="440" y1="274" x2="440" y2="288" stroke="#bc4c00" stroke-width="1.5"/>
+    <path d="M436,288 L444,288 L440,295 Z" fill="#bc4c00"/>
+    <line x1="702" y1="274" x2="702" y2="288" stroke="#bc4c00" stroke-width="1.5"/>
+    <path d="M698,288 L706,288 L702,295 Z" fill="#bc4c00"/>
+  </g>
+  <g class="mono dim" font-size="10">
+    <text x="186" y="287">import</text>
+    <text x="448" y="287">import</text>
+    <text x="710" y="287">import</text>
+  </g>
+
+  <rect x="48" y="296" width="784" height="62" rx="8" fill="#f6f8fa" stroke="#d0d7de"/>
+  <g text-anchor="middle">
+    <text class="mono" x="179" y="322" font-size="13" xml:space="preserve"><tspan class="acc" font-weight="bold">cl</tspan><tspan class="fg"> · frontend</tspan></text>
+    <text class="sans dim" x="179" y="342" font-size="10.5">the browser</text>
+    <text class="mono" x="440" y="322" font-size="13" xml:space="preserve"><tspan class="acc" font-weight="bold">sv</tspan><tspan class="fg"> · backend</tspan></text>
+    <text class="sans dim" x="440" y="342" font-size="10.5">the server</text>
+    <text class="mono" x="701" y="322" font-size="13" xml:space="preserve"><tspan class="acc" font-weight="bold">na</tspan><tspan class="fg"> · native</tspan></text>
+    <text class="sans dim" x="701" y="342" font-size="10.5">the machine</text>
+  </g>
+
+  <path d="M48,364 V372 H832 V364" fill="none" stroke="#bc4c00" stroke-width="2"/>
+  <text class="sans acc" x="440" y="392" font-size="12" font-weight="bold" text-anchor="middle">one compiler sees both sides of every call</text>
+
+  <text x="440" y="418" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">rename display_name</tspan><tspan class="sans dim"> → every stale use (server, client, or native) is a </tspan><tspan class="sans good" font-weight="bold">compile error</tspan><tspan class="sans dim">, not a production incident</tspan></text>
+</svg>

--- a/docs/docs/assets/readme/topokinetic-dark.svg
+++ b/docs/docs/assets/readme/topokinetic-dark.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="432" viewBox="0 0 880 432" role="img" aria-label="Diagram: a conventional stack keeps computation stationary while data commutes to it and persistence is a commit call; in Jac data lives as a persistent topology of nodes and edges, walkers carry computation through it dispatched by arrival, whatever is reachable from root persists, and the database dissolves into the language">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #e6edf3; }
+    .dim { fill: #8b949e; }
+    .acc { fill: #ff9100; }
+    .bad { fill: #f85149; }
+    .good { fill: #3fb950; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#8b949e"/></marker>
+    <marker id="arrAcc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#ff9100"/></marker>
+  </defs>
+
+  <!-- Top panel: stationary computation, data commutes -->
+  <rect x="16" y="16" width="848" height="152" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans dim" x="32" y="44" font-size="13" font-weight="bold" letter-spacing="1">THE PROGRAM SITS STILL, THE DATA COMMUTES</text>
+
+  <g text-anchor="middle">
+    <rect x="48" y="64" width="250" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="173" y="88" font-size="13" font-weight="bold">Your program</text>
+    <text class="mono dim" x="173" y="106" font-size="10.5">the fixed site of processing</text>
+
+    <rect x="582" y="64" width="250" height="56" rx="6" fill="#21262d" stroke="#30363d"/>
+    <text class="sans fg" x="707" y="88" font-size="13" font-weight="bold">Database</text>
+    <text class="mono dim" x="707" y="106" font-size="10.5">where the data lives</text>
+
+    <line x1="566" y1="84" x2="316" y2="84" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+    <text class="mono dim" x="440" y="72" font-size="10.5">query · fetch · hydrate</text>
+    <text class="sans dim" x="440" y="100" font-size="9.5" font-style="italic">every touch of state is a round trip</text>
+    <line x1="316" y1="108" x2="566" y2="108" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+    <text class="mono dim" x="440" y="127" font-size="10.5">write back · commit</text>
+  </g>
+
+  <text x="440" y="150" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">user.name = x</tspan><tspan class="sans dim"> changes nothing durable until </tspan><tspan class="mono fg">db.commit()</tspan><tspan class="sans dim"> fires, and a missed call is silent data loss: </tspan><tspan class="sans bad" font-weight="bold">persistence is an event</tspan></text>
+
+  <!-- Bottom panel: Jac, the moving locus of computation -->
+  <rect x="16" y="188" width="848" height="228" rx="12" fill="#161b22" stroke="#30363d"/>
+  <text class="sans acc" x="32" y="216" font-size="13" font-weight="bold" letter-spacing="1" xml:space="preserve">JAC · TOPOKINETIC<tspan class="sans dim" font-size="12" font-weight="normal" letter-spacing="0">  ·  the moving locus of computation is a language construct</tspan></text>
+
+  <rect x="48" y="228" width="568" height="112" rx="10" fill="#3fb950" fill-opacity="0.05" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text class="sans good" x="604" y="246" font-size="10.5" font-weight="bold" text-anchor="end">reachable from root · persists</text>
+
+  <!-- Edges -->
+  <line x1="118" y1="292" x2="197" y2="312" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="227" y1="316" x2="329" y2="316" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="365" y1="262" x2="471" y2="285" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="358" y1="313" x2="471" y2="291" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Walker's route so far -->
+  <line x1="118" y1="284" x2="197" y2="264" stroke="#ff9100" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrAcc)"/>
+  <line x1="227" y1="260" x2="325" y2="258" stroke="#ff9100" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrAcc)"/>
+
+  <!-- Unreachable cluster -->
+  <g opacity="0.5">
+    <line x1="713" y1="264" x2="774" y2="293" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arr)"/>
+    <circle cx="700" cy="258" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+    <circle cx="788" cy="300" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+  </g>
+  <g class="mono dim" font-size="10" text-anchor="middle">
+    <text x="744" y="330">unreachable from root</text>
+    <text x="744" y="344">not persisted</text>
+  </g>
+
+  <!-- Nodes -->
+  <circle cx="104" cy="288" r="13" fill="#21262d" stroke="#ff9100" stroke-width="2"/>
+  <circle cx="212" cy="260" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+  <circle cx="212" cy="316" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+  <circle cx="344" cy="258" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+  <circle cx="344" cy="316" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+  <circle cx="486" cy="288" r="13" fill="#21262d" stroke="#30363d" stroke-width="1.5"/>
+  <circle cx="344" cy="258" r="17" fill="none" stroke="#ff9100" stroke-width="2"/>
+
+  <g text-anchor="middle">
+    <text class="mono acc" x="104" y="313" font-size="10.5" font-weight="bold">root</text>
+    <text class="mono dim" x="486" y="313" font-size="9.5">node</text>
+    <text class="mono dim" x="277" y="308" font-size="9.5">edge</text>
+  </g>
+  <text class="mono acc" x="368" y="246" font-size="11" font-weight="bold">walker</text>
+
+  <text x="440" y="360" font-size="11.5" text-anchor="middle" xml:space="preserve"><tspan class="mono acc" font-weight="bold">walker</tspan><tspan class="sans dim"> · carries the computation through the topology, dispatched by arrival</tspan></text>
+  <text class="sans acc" x="440" y="380" font-size="12" font-weight="bold" text-anchor="middle">the database dissolves into the language</text>
+  <text x="440" y="402" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">root ++> Post()</tspan><tspan class="sans dim"> is durable the moment it runs, no ORM, no commit call: </tspan><tspan class="sans good" font-weight="bold">persistence is a predicate</tspan><tspan class="sans dim">, not an event</tspan></text>
+</svg>

--- a/docs/docs/assets/readme/topokinetic-light.svg
+++ b/docs/docs/assets/readme/topokinetic-light.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="432" viewBox="0 0 880 432" role="img" aria-label="Diagram: a conventional stack keeps computation stationary while data commutes to it and persistence is a commit call; in Jac data lives as a persistent topology of nodes and edges, walkers carry computation through it dispatched by arrival, whatever is reachable from root persists, and the database dissolves into the language">
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }
+    .fg { fill: #1f2328; }
+    .dim { fill: #57606a; }
+    .acc { fill: #bc4c00; }
+    .bad { fill: #cf222e; }
+    .good { fill: #1a7f37; }
+  </style>
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#57606a"/></marker>
+    <marker id="arrAcc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#bc4c00"/></marker>
+  </defs>
+
+  <!-- Top panel: stationary computation, data commutes -->
+  <rect x="16" y="16" width="848" height="152" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans dim" x="32" y="44" font-size="13" font-weight="bold" letter-spacing="1">THE PROGRAM SITS STILL, THE DATA COMMUTES</text>
+
+  <g text-anchor="middle">
+    <rect x="48" y="64" width="250" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="173" y="88" font-size="13" font-weight="bold">Your program</text>
+    <text class="mono dim" x="173" y="106" font-size="10.5">the fixed site of processing</text>
+
+    <rect x="582" y="64" width="250" height="56" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+    <text class="sans fg" x="707" y="88" font-size="13" font-weight="bold">Database</text>
+    <text class="mono dim" x="707" y="106" font-size="10.5">where the data lives</text>
+
+    <line x1="566" y1="84" x2="316" y2="84" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+    <text class="mono dim" x="440" y="72" font-size="10.5">query · fetch · hydrate</text>
+    <text class="sans dim" x="440" y="100" font-size="9.5" font-style="italic">every touch of state is a round trip</text>
+    <line x1="316" y1="108" x2="566" y2="108" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+    <text class="mono dim" x="440" y="127" font-size="10.5">write back · commit</text>
+  </g>
+
+  <text x="440" y="150" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">user.name = x</tspan><tspan class="sans dim"> changes nothing durable until </tspan><tspan class="mono fg">db.commit()</tspan><tspan class="sans dim"> fires, and a missed call is silent data loss: </tspan><tspan class="sans bad" font-weight="bold">persistence is an event</tspan></text>
+
+  <!-- Bottom panel: Jac, the moving locus of computation -->
+  <rect x="16" y="188" width="848" height="228" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+  <text class="sans acc" x="32" y="216" font-size="13" font-weight="bold" letter-spacing="1" xml:space="preserve">JAC · TOPOKINETIC<tspan class="sans dim" font-size="12" font-weight="normal" letter-spacing="0">  ·  the moving locus of computation is a language construct</tspan></text>
+
+  <rect x="48" y="228" width="568" height="112" rx="10" fill="#1a7f37" fill-opacity="0.05" stroke="#1a7f37" stroke-width="1.5" stroke-dasharray="6 5"/>
+  <text class="sans good" x="604" y="246" font-size="10.5" font-weight="bold" text-anchor="end">reachable from root · persists</text>
+
+  <!-- Edges -->
+  <line x1="118" y1="292" x2="197" y2="312" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="227" y1="316" x2="329" y2="316" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="365" y1="262" x2="471" y2="285" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="358" y1="313" x2="471" y2="291" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Walker's route so far -->
+  <line x1="118" y1="284" x2="197" y2="264" stroke="#bc4c00" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrAcc)"/>
+  <line x1="227" y1="260" x2="325" y2="258" stroke="#bc4c00" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrAcc)"/>
+
+  <!-- Unreachable cluster -->
+  <g opacity="0.5">
+    <line x1="713" y1="264" x2="774" y2="293" stroke="#57606a" stroke-width="1.5" marker-end="url(#arr)"/>
+    <circle cx="700" cy="258" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+    <circle cx="788" cy="300" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  </g>
+  <g class="mono dim" font-size="10" text-anchor="middle">
+    <text x="744" y="330">unreachable from root</text>
+    <text x="744" y="344">not persisted</text>
+  </g>
+
+  <!-- Nodes -->
+  <circle cx="104" cy="288" r="13" fill="#f6f8fa" stroke="#bc4c00" stroke-width="2"/>
+  <circle cx="212" cy="260" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  <circle cx="212" cy="316" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  <circle cx="344" cy="258" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  <circle cx="344" cy="316" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  <circle cx="486" cy="288" r="13" fill="#f6f8fa" stroke="#d0d7de" stroke-width="1.5"/>
+  <circle cx="344" cy="258" r="17" fill="none" stroke="#bc4c00" stroke-width="2"/>
+
+  <g text-anchor="middle">
+    <text class="mono acc" x="104" y="313" font-size="10.5" font-weight="bold">root</text>
+    <text class="mono dim" x="486" y="313" font-size="9.5">node</text>
+    <text class="mono dim" x="277" y="308" font-size="9.5">edge</text>
+  </g>
+  <text class="mono acc" x="368" y="246" font-size="11" font-weight="bold">walker</text>
+
+  <text x="440" y="360" font-size="11.5" text-anchor="middle" xml:space="preserve"><tspan class="mono acc" font-weight="bold">walker</tspan><tspan class="sans dim"> · carries the computation through the topology, dispatched by arrival</tspan></text>
+  <text class="sans acc" x="440" y="380" font-size="12" font-weight="bold" text-anchor="middle">the database dissolves into the language</text>
+  <text x="440" y="402" font-size="12" text-anchor="middle" xml:space="preserve"><tspan class="mono fg">root ++> Post()</tspan><tspan class="sans dim"> is durable the moment it runs, no ORM, no commit call: </tspan><tspan class="sans good" font-weight="bold">persistence is a predicate</tspan><tspan class="sans dim">, not an event</tspan></text>
+</svg>


### PR DESCRIPTION
## Summary

The property paragraphs in "Why Jac exists" ("Against the second assumption, Jac is **synechic**..." and "Against the first assumption, Jac is **topokinetic**...") are the heart of the pitch, but they were text-only. This adds a before/after diagram above each one, in the same style as the existing README visuals (paired light/dark SVGs, GitHub palette, `<picture>` with `prefers-color-scheme`, hand-authored, no external assets), plus a third beat: **gradual borrow checking**, presented as the synechic property applied to the managed/systems divide.

Each diagram maps its paragraph clause by clause:

**Synechic** — top panel: three separate programs (TypeScript frontend, Python backend, C native), each pulling its ecosystem through its own installer (`npm install` / `pip install` / `make install`), joined by hand across unchecked `JSON`/`FFI` seams, where renaming a field ships a stale copy that fails in production. Bottom panel: one continuous checked medium spanning `cl`/`sv`/`na`, the same ecosystems flowing in through a plain `import`, one compiler bracketing every call, and the same rename becoming a compile error.

**Gradual borrow checking** — top panel: the rewrite cliff — a Python app and a Rust/C++ hot path as separate worlds, where the ceiling of a managed language is a different language. Bottom panel: one continuum from fully managed (unannotated, RC/GC) through `own`/`&`/`&mut` (moves, borrows, deterministic drop) to enforced native (no refcounts, no collector), with the checked membrane between regimes. Accompanied by a new prose paragraph and a collapsible code example sourced from the ownership reference docs (real `E1301`/`E1303` diagnostics).

**Topokinetic** — top panel: a stationary program with data commuting over query/write-back round trips, where persistence is a `db.commit()` event you must remember to fire. Bottom panel: a persistent node/edge topology with a walker mid-traversal (dispatched by arrival), a boundary marking "reachable from root persists" with an unreachable cluster outside it, and persistence as a predicate — the database dissolves into the language.

The diagrams are deliberately parallel: each top panel ends in the old assumption's red failure mode, each bottom panel in the green resolution, so the structure of the argument reads visually as well as in prose.

### Preview (light variants)

![Synechic diagram](https://raw.githubusercontent.com/marsninja/jaseci/readme-property-diagrams/docs/docs/assets/readme/synechic-light.svg)

![Gradual borrow checking diagram](https://raw.githubusercontent.com/marsninja/jaseci/readme-property-diagrams/docs/docs/assets/readme/gradual-borrow-light.svg)

![Topokinetic diagram](https://raw.githubusercontent.com/marsninja/jaseci/readme-property-diagrams/docs/docs/assets/readme/topokinetic-light.svg)

## Changes

- `README.md`: three `<picture>` blocks in "Why Jac exists" (one before each property paragraph, one for gradual borrow checking), a new gradual-borrow-checking paragraph continuing the synechic beat, and a collapsible code example matching the section's existing four-copy-record pattern
- `docs/docs/assets/readme/synechic-{light,dark}.svg`: new
- `docs/docs/assets/readme/gradual-borrow-{light,dark}.svg`: new
- `docs/docs/assets/readme/topokinetic-{light,dark}.svg`: new

No code changes; docs/README only.
