### PR TITLE
docs: Why Jac subsections, prose tightening, and a richer mini_todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Install the self-contained `jac` binary. No Python, pip, Node, or C toolchain re
 curl -fsSL https://raw.githubusercontent.com/jaseci-labs/jaseci/main/scripts/install.sh | bash
 ```
 
-Then clone and run [**this_is_jac**](https://github.com/jaseci-labs/this_is_jac), a showcase site built entirely in Jac:
+Then clone and run [**this_is_jac**](https://github.com/jaseci-labs/this_is_jac), a showcase technology demo built entirely in Jac:
 
 ```bash
 git clone https://github.com/jaseci-labs/this_is_jac
@@ -74,15 +74,15 @@ jac install   # first run: pulls python + npm deps
 jac start     # builds the frontend + wasm, serves on http://localhost:8000
 ```
 
-Open <http://localhost:8000> and scroll.
+This one application demonstrates every claim above: a guestbook served by walkers and persisted to a real graph with no database, a walker traversing that graph live on screen, one module importing PyPI, npm, and C-ABI libraries at once, a function body delegated to an LLM with `by llm()`, an analytics microservice pulled in by `sv import`, one native shooter compiled both to machine code and to in-browser WebAssembly, and the whole littleX social app embedded as a single component writing to the same graph. All in one typechecked, contiguous, synechic codebase.
 
 > Prebuilt binaries ship for **macOS and Linux**; on Windows, use WSL (a native PowerShell installer is coming soon). See the [installation guide](https://docs.jaseci.org/quick-guide/install/) for versions, upgrading, and IDE setup.
 
 ## Why Jac exists
 
-Open the repository of any well-built product and count what a maintainer must read: TypeScript, Python, SQL, and shell where the logic lives; JSX and CSS for presentation; JSON, TOML, YAML, Dockerfile, HCL, and dotenv for configuration. Twelve notations, five package ecosystems, two lockfiles. Nobody chose that. It is what precipitates when every architectural seam is also a change of language, type system, package manager, and serialization format.
+Open the repository of any well-built product and count what a maintainer must read: TypeScript, Python, SQL, and shell where the logic lives; JSX and CSS for presentation; JSON, TOML, YAML, Dockerfile, HCL, and dotenv for configuration. Twelve notations, five package ecosystems, two lockfiles. Nobody chose that. It is what precipitates when every architectural boundary is also a change of language, type system, package manager, and serialization format.
 
-The deeper cost isn't the reading; it's that **no compiler can see across any of those seams**. Rename one field and TypeScript checks the frontend, Python checks the backend, and *nothing* checks the wire format, the ORM mapping, the OpenAPI document, or the prompt template between them. The whole-program type checker of the modern stack is `grep`. That is where bugs pool, and it's why teams staff a specialist per boundary: the org chart is a picture of the glue.
+The deeper cost isn't the reading; it's that **no compiler can see across any of those boundaries**. Rename one field and TypeScript checks the frontend, Python checks the backend, and *nothing* checks the wire format, the ORM mapping, the OpenAPI document, or the prompt template between them. The whole-program type checker of the modern stack is `grep`. That is where bugs pool, and it's why teams staff a specialist per boundary: the org chart is a picture of the glue.
 
 <details>
 <summary><strong>The four-copy record (what one field costs in a conventional stack)</strong></summary>
@@ -124,25 +124,29 @@ Four copies, three type systems, and one landmine: the fourth copy renames `disp
 
 None of this is required by computation. The pattern traces to two silent assumptions in the 1945 report that defined the stored-program computer: that *computation is stationary* (the site of processing is fixed, and data travels to it), and that *the machine is the program's world* (a program's semantics end at the edge of its process, so frontend and backend, managed and native, script and service are separate programs, joined by hand). Both were engineering defaults for a machine with one memory. Seventy years of habit made them look like laws. Jac is one bet against each.
 
+### Jac is synechic
+
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/synechic-dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/synechic-light.svg">
-    <img alt="A conventional stack is three separate programs (TypeScript frontend, Python backend, C native) joined by hand across unchecked JSON and FFI seams, so renaming a field ships a stale copy that fails in production; Jac is one continuous checked medium spanning cl, sv, and na tiers, importing npm, PyPI, and the C world directly, with one compiler seeing both sides of every call, so the same rename is a compile error" src="docs/docs/assets/readme/synechic-light.svg" width="880">
+    <img alt="A conventional stack is three separate programs (TypeScript frontend, Python backend, C native) joined by hand across unchecked JSON and FFI boundaries, so renaming a field ships a stale copy that fails in production; Jac is one continuous checked medium spanning cl, sv, and na tiers, importing npm, PyPI, and the C world directly, with one compiler seeing both sides of every call, so the same rename is a compile error" src="docs/docs/assets/readme/synechic-light.svg" width="880">
   </picture>
 </div>
 
-**Against the second assumption, Jac is synechic** (from the Greek *synecheia*, continuity): one continuous, checked medium across ecosystems, tiers, and toolchains. One language spans frontend, backend, and native code, and inherits each one's ecosystem (PyPI, npm, the C world) through a plain `import`, so one compiler sees both sides of every call: rename a field and every stale use (server, client, or native) is a **compile error**, not a production incident. Building the first production synechic language is the whole point of Jac.
+**Against the second assumption, Jac is synechic** (from the Greek *synecheia*, continuity): one continuous, checked medium across ecosystems, tiers, and toolchains. One language spans frontend, backend, and native code, and inherits each one's ecosystem (PyPI, npm, the C world) through a plain `import`, so one compiler sees both sides of every call. Rename a field and every stale use (server, client, or native) is a **compile error**, not a production incident. Building the first production synechic language is the whole point of Jac.
+
+Hand-written glue (serializers, route tables, ORM models, API clients) is most of a conventional codebase, and it is where bugs pool, because it is the code no compiler sees. A continuous medium attacks both facts: the compiler generates that layer instead of a human writing it, so it cannot drift, and what is no longer written is the ~5x reduction claimed above. [One App, Two Stacks](https://docs.jaseci.org/quick-guide/jac-vs-traditional-stack/) records the side-by-side count.
 
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/gradual-borrow-dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="docs/docs/assets/readme/gradual-borrow-light.svg">
-    <img alt="In a conventional stack, outgrowing the garbage collector means rewriting the hot path in Rust or C++ across an FFI seam; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every value that crosses between the regimes" src="docs/docs/assets/readme/gradual-borrow-light.svg" width="880">
+    <img alt="In a conventional stack, outgrowing the garbage collector means rewriting the hot path in Rust or C++ across an FFI boundary; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every value that crosses between the regimes" src="docs/docs/assets/readme/gradual-borrow-light.svg" width="880">
   </picture>
 </div>
 
-That continuity runs all the way down. The deepest seam in computing is the one between managed and systems languages -- today, when the hot path outgrows the garbage collector, the answer is a second language, an FFI boundary, and a rewrite. Jac renders that divide as **gradual borrow checking**: unannotated code keeps fully managed semantics, `own` and `&`/`&mut` opt individual declarations into moves, borrows, and deterministic destruction, a checked boundary (the **membrane**) mediates every value that crosses between the regimes, and full adoption reaches native artifacts with **no reference counting and no collector**. The divide becomes a gradient walked by degrees, never a cliff crossed by starting over. [Gradual borrow checking →](https://docs.jaseci.org/reference/language/ownership-borrowing/)
+The same continuity extends to the deepest discontinuity in computing, the divide between managed and systems languages. Today, when the hot path outgrows the garbage collector, the answer is a second language, an FFI boundary, and a rewrite. Jac replaces that divide with **gradual borrow checking**: unannotated code keeps fully managed semantics, and `own` and `&`/`&mut` opt individual declarations into moves, borrows, and deterministic destruction. A checked boundary (the **membrane**) mediates every value that crosses between the regimes, and full adoption reaches native artifacts with **no reference counting and no collector**. The divide is a gradient walked by degrees, never crossed. [Gradual borrow checking →](https://docs.jaseci.org/reference/language/ownership-borrowing/)
 
 <details>
 <summary><strong>The gradient in code (opt in one declaration at a time)</strong></summary>
@@ -165,6 +169,8 @@ The checker tracks only what you tag, so `node`, `edge`, and `walker` stay fully
 
 </details>
 
+### Jac is topokinetic
+
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/docs/assets/readme/topokinetic-dark.svg">
@@ -175,7 +181,7 @@ The checker tracks only what you tag, so `node`, `edge`, and `walker` stay fully
 
 **Against the first assumption, Jac is topokinetic** (from the Greek *topos*, place, and *kinesis*, motion): the moving locus of computation is a language construct. In Jac's Object-Spatial Programming, data lives as a persistent topology of nodes and edges, and **walkers** carry computation through it, dispatched by arrival. Whatever is reachable from `root` persists: persistence is a predicate, not an event, and the database dissolves into the language.
 
-The two properties compound, and the dissolved database is the proof: continuity without motion still calls a store outside the language's semantics, and motion without continuity is a graph paradigm marooned in one process. Jac is the first language that is both. And the boundaries that *are* physics stay visible on purpose: a cross-tier call is `async` because the network is real, write conflicts surface as typed errors, and sharing data across users takes an explicit `grant`. Jac deletes the paperwork, not the physics.
+The two properties compound, and the dissolved database is the proof: continuity without motion still calls a store outside the language's semantics, and motion without continuity is a graph paradigm confined to one process. Jac is the first language that is both. The boundaries that *are* physics stay visible on purpose: a cross-tier call is `async` because the network is real, write conflicts surface as typed errors, and sharing data across users takes an explicit `grant`. Jac deletes the paperwork, not the physics.
 
 The full argument can be found in "the ninja book": [*A Synechic and Topokinetic Programming Language*](https://zenodo.org/records/21498692) develops both language classes and the theory, design and implementation underlying Jac. ([DOI: 10.5281/zenodo.21498692](https://doi.org/10.5281/zenodo.21498692)).
 

--- a/docs/docs/assets/readme/gradual-borrow-dark.svg
+++ b/docs/docs/assets/readme/gradual-borrow-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="Diagram: in a conventional stack, outgrowing the garbage collector means rewriting the hot path in a different systems language across an FFI seam; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every crossing">
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="Diagram: in a conventional stack, outgrowing the garbage collector means rewriting the hot path in a different systems language across an FFI boundary; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every crossing">
   <style>
     .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
     .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }

--- a/docs/docs/assets/readme/gradual-borrow-light.svg
+++ b/docs/docs/assets/readme/gradual-borrow-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="Diagram: in a conventional stack, outgrowing the garbage collector means rewriting the hot path in a different systems language across an FFI seam; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every crossing">
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="Diagram: in a conventional stack, outgrowing the garbage collector means rewriting the hot path in a different systems language across an FFI boundary; Jac's gradual borrow checking is one continuum in one language, from fully managed code through own and borrow annotations to enforced zero-RC native artifacts, with a checked membrane mediating every crossing">
   <style>
     .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
     .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }

--- a/docs/docs/assets/readme/synechic-dark.svg
+++ b/docs/docs/assets/readme/synechic-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Diagram: a conventional stack is three separate programs joined by hand across unchecked seams, each pulling its own ecosystem through its own installer, so a rename fails in production; Jac is one continuous checked medium across frontend, backend, and native, importing the same ecosystems through a plain import, so the same rename is a compile error">
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Diagram: a conventional stack is three separate programs joined by hand across unchecked boundaries, each pulling its own ecosystem through its own installer, so a rename fails in production; Jac is one continuous checked medium across frontend, backend, and native, importing the same ecosystems through a plain import, so the same rename is a compile error">
   <style>
     .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
     .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }

--- a/docs/docs/assets/readme/synechic-light.svg
+++ b/docs/docs/assets/readme/synechic-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Diagram: a conventional stack is three separate programs joined by hand across unchecked seams, each pulling its own ecosystem through its own installer, so a rename fails in production; Jac is one continuous checked medium across frontend, backend, and native, importing the same ecosystems through a plain import, so the same rename is a compile error">
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="448" viewBox="0 0 880 448" role="img" aria-label="Diagram: a conventional stack is three separate programs joined by hand across unchecked boundaries, each pulling its own ecosystem through its own installer, so a rename fails in production; Jac is one continuous checked medium across frontend, backend, and native, importing the same ecosystems through a plain import, so the same rename is a compile error">
   <style>
     .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
     .mono { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; }

--- a/jac/examples/mini_todo/jac.toml
+++ b/jac/examples/mini_todo/jac.toml
@@ -4,7 +4,11 @@ version = "1.0.0"
 description = "Minimal full-stack AI todo app"
 entry-point = "main.jac"
 
+[dependencies]
+python-dateutil = ">=2.9.0"
+
 [dependencies.npm]
+canvas-confetti = "^1.9.3"
 react = "^18.2.0"
 react-dom = "^18.2.0"
 react-router-dom = "^6.22.0"

--- a/jac/examples/mini_todo/main.jac
+++ b/jac/examples/mini_todo/main.jac
@@ -1,5 +1,5 @@
-import from dateutil.parser { parse } #<-- from Python
-import from "canvas-confetti" { default as confetti } #
+import from dateutil.parser { parse }  #<-- from Python
+import from "canvas-confetti" { default as confetti }  #<-- from npm
 
 node Todo {
     has title: str,

--- a/jac/examples/mini_todo/main.jac
+++ b/jac/examples/mini_todo/main.jac
@@ -1,6 +1,10 @@
+import from dateutil.parser { parse } #<-- from Python
+import from "canvas-confetti" { default as confetti } #
+
 node Todo {
     has title: str,
         category: str = "other",
+        due: str = "",
         priority: int = 0,
         done: bool = False;
 }
@@ -32,7 +36,14 @@ def:pub add_todo(title: str) -> Todo {
     } except Exception {
         category = "other (setup AI key)";
     }
-    todo = Todo(title=title, category=category, priority=priority_score(title));
+    try {
+        due = parse(title, fuzzy=True).strftime("%a %b %d");
+    } except Exception {
+        due = "";
+    }
+    todo = Todo(
+        title=title, category=category, due=due, priority=priority_score(title)
+    );
     root ++> todo;
     return todo;
 }
@@ -54,6 +65,7 @@ def:pub app -> JsxElement {
             todo = await add_todo(text.strip());
             todos = todos + [todo];
             text = "";
+            confetti();
         }
     }
 
@@ -67,7 +79,11 @@ def:pub app -> JsxElement {
             />
             <button onClick={lambda { add(); }}>Add</button>
             {for t in todos {
-                <p key={jid(t)}>[{t.priority}]{t.title} ({t.category})</p>
+                <p key={jid(t)}>
+                    [{t.priority}]{t.title} ({t.category}){" — due " + t.due
+                        if t.due
+                        else ""}
+                </p>
             }}
         </div>;
 }


### PR DESCRIPTION
## Summary

Two related passes, one on the README's argument and one on the example it points to.

**README.** "Why Jac exists" is now structured as two subsections, **Jac is synechic** and **Jac is topokinetic**, matching how the intro (and the book) name the two properties; the gradual borrow checking material sits under the synechic heading, where its argument belongs. The synechic subsection gains a paragraph connecting the glue claim to the numbers: hand-written glue (serializers, route tables, ORM models, API clients) is most of a conventional codebase and where bugs pool because no compiler sees it, the compiler generates that layer instead, and the deleted glue is the ~5x reduction claimed in the intro ([One App, Two Stacks](https://docs.jaseci.org/quick-guide/jac-vs-traditional-stack/) records the side-by-side count). The subsection prose gets a discipline pass (long sentences split, one emphatic pivot per subsection, the gradient line restored to the docs' canonical "walked by degrees, never crossed"), "seam" is replaced by the boundary/discontinuity vocabulary throughout (prose and diagram aria-labels), and the this_is_jac walkthrough sentence now enumerates the eight capabilities the showcase actually runs, sourced from its own section table.

**mini_todo.** The one-file example now imports `python-dateutil` from PyPI and `canvas-confetti` from npm in the same module: `add_todo` fuzzy-parses a due date out of the todo title, and the client fires confetti on add. The demo that the README's "Frontend and backend in one file" section points to now also shows both ecosystems arriving through a plain `import`. `jac check` passes (unresolved-type warnings on the untyped npm module only).

## Changes

- `README.md`
- `docs/docs/assets/readme/{synechic,gradual-borrow}-{light,dark}.svg`: aria-label wording only; rendered graphics unchanged
- `jac/examples/mini_todo/{jac.toml,main.jac}`
