### PR TITLE
docs: align routing docs with type-based JsxPage/JsxLayout route membership

### DIFF
--- a/docs/docs/reference/diagnostics.md
+++ b/docs/docs/reference/diagnostics.md
@@ -501,6 +501,39 @@ Emitted during code generation, formatting, and native compilation.
 |------|---------|
 | `E5060` | C library import declaration '{name}' must not have a body |
 
+### Client Code Generation
+
+| Code | Message |
+|------|---------|
+| `E5080` | Argument '{name}' for server function '{func}' is given both positionally and by keyword |
+| `E5081` | Unknown client framework '{framework}' |
+| `E5082` | Client code imports '{name}' from '{module}', but '{name}' has no client-side presence |
+
+`E5082` fires when a plain client import references a server symbol that does not bridge: server `def:pub` endpoints bridge automatically over RPC, so the fix is to make the symbol a `def:pub` endpoint, mark it (or its module) client, or move it into client code.
+
+---
+
+## Client Codespace Warnings (W6xxx)
+
+### Cross-Codespace Portability
+
+Emitted by `CapabilityCheckPass` when code uses JS-specific surface instead of Jac's common primitives, which work across all codespaces (Python, JS, native).
+
+| Code | Message |
+|------|---------|
+| `W6001` | Use of JS-specific global '{name}' -- use '{alternative}' for cross-codespace portability |
+| `W6002` | Use of JS-idiomatic method '.{method}()' -- use '{alternative}' for cross-codespace portability |
+| `W6003` | Use of JS-specific keyword '{name}' -- use '{alternative}' for cross-codespace portability |
+| `W6004` | Use of JS-specific property '.{prop}' -- use '{alternative}' for cross-codespace portability |
+
+### RPC Boundary
+
+| Code | Message |
+|------|---------|
+| `W6005` | Client call to server endpoint '{func}' passes function-typed parameter '{param}' -- functions cannot cross the RPC boundary |
+
+A `def:pub` function in a server-placed module is an HTTP endpoint whose arguments serialize over the wire, so a function-typed argument cannot cross it. Shared client-side logic should drop `:pub` so it is placed in the browser with its callers.
+
 ---
 
 ## Internal Compiler Errors (E9xxx)

--- a/docs/docs/reference/language/syntax-cheatsheet.md
+++ b/docs/docs/reference/language/syntax-cheatsheet.md
@@ -1473,24 +1473,23 @@ cl {
 # ============================================================
 # Routing (File-Based)
 # ============================================================
-# pages/index.jac          -> /
-# pages/about.jac          -> /about
-# pages/users/[id].jac     -> /users/:id  (dynamic param)
-# pages/[...notFound].jac  -> *            (catch-all)
-# pages/(auth)/layout.jac  -> route group  (no URL segment)
-# pages/layout.jac         -> root layout
+# pages/index.jac            -> /
+# pages/about.jac            -> /about
+# pages/users/[id].jac       -> /users/:id  (dynamic param)
+# pages/[...notFound].jac    -> *           (catch-all)
+# pages/(auth)/dashboard.jac -> /dashboard  (route group: no URL segment)
+# pages/layout.jac           -> root layout (filename is convention)
 
-# Page files export a `page` function inside a `cl { }` block:
-# cl {
-#     def:pub Home() -> JsxPage { ... }
-# }
+# A route is any export returning JsxPage; a layout returns JsxLayout.
+# Both are ambient builtin types (no import). Export name and filename
+# are free -- the filename only decides the URL. Exports returning
+# JsxElement are not routes (co-located components need no special name).
+# def:pub Home() -> JsxPage { ... }
 
-# Layout files use <Outlet /> for child routes:
-# cl import from "@jac/runtime" { Outlet }
-# cl {
-#     def:pub Shell() -> JsxLayout {
-#         return <><nav>...</nav><Outlet /></>;
-#     }
+# Layouts use <Outlet /> for child routes:
+# import from "@jac/runtime" { Outlet }
+# def:pub Shell() -> JsxLayout {
+#     return <><nav>...</nav><Outlet /></>;
 # }
 
 

--- a/docs/docs/reference/language/syntax-cheatsheet.md
+++ b/docs/docs/reference/language/syntax-cheatsheet.md
@@ -1482,8 +1482,9 @@ cl {
 
 # A route is any export returning JsxPage; a layout returns JsxLayout.
 # Both are ambient builtin types (no import). Export name and filename
-# are free -- the filename only decides the URL. Exports returning
-# JsxElement are not routes (co-located components need no special name).
+# are free -- the filename only decides the URL. One page export per
+# file (extra JsxPage exports are ignored); exports returning JsxElement
+# are not routes (co-located components need no special name).
 # def:pub Home() -> JsxPage { ... }
 
 # Layouts use <Outlet /> for child routes:

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -752,7 +752,7 @@ myapp/
 | `pages/(auth)/dashboard.jac` | `/dashboard` | Route group (no URL segment) |
 | `pages/layout.jac` | -- | Wraps child routes with `<Outlet />` |
 
-A page is any export that returns `JsxPage` (the name is free); a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed:
+A page is any export that returns `JsxPage`; a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed. Route membership comes from the return type alone -- both the export name and the filename are free, and the filename only decides the URL. Naming the layout file `layout.jac` is a convention: any file whose export returns `JsxLayout` becomes the layout for its directory, and two layout exports in one directory is a build error. A co-located component that returns `JsxElement` is simply not a route.
 
 ```jac
 # pages/users/[id].jac
@@ -853,7 +853,7 @@ def:pub RootShell() -> JsxLayout {
 }
 
 # pages/dashboard/layout.jac -- nested dashboard layout
-def:pub DashboardLayout() -> JsxElement {
+def:pub DashboardLayout() -> JsxLayout {
     # Child routes render where Outlet is placed
     return <div>
         <Sidebar />

--- a/docs/docs/reference/plugins/jac-client.md
+++ b/docs/docs/reference/plugins/jac-client.md
@@ -752,7 +752,7 @@ myapp/
 | `pages/(auth)/dashboard.jac` | `/dashboard` | Route group (no URL segment) |
 | `pages/layout.jac` | -- | Wraps child routes with `<Outlet />` |
 
-A page is any export that returns `JsxPage`; a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed. Route membership comes from the return type alone -- both the export name and the filename are free, and the filename only decides the URL. Naming the layout file `layout.jac` is a convention: any file whose export returns `JsxLayout` becomes the layout for its directory, and two layout exports in one directory is a build error. A co-located component that returns `JsxElement` is simply not a route.
+A page is any export that returns `JsxPage`; a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed. Route membership comes from the return type alone -- both the export name and the filename are free, and the filename only decides the URL. Because the URL comes from the filename, a file defines at most one page and one layout: if several exports return `JsxPage`, only the first is used, so keep one page export per file. Naming the layout file `layout.jac` is a convention: any file whose export returns `JsxLayout` becomes the layout for its directory, and two layout exports in one directory is a build error. A co-located component that returns `JsxElement` is simply not a route.
 
 ```jac
 # pages/users/[id].jac

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -68,7 +68,7 @@ myapp/
 
 ### Basic Page
 
-A page is any export that returns `JsxPage`; a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed. Route membership comes from the return type alone -- the export name and the filename are free, and the filename only decides the URL. A component that returns `JsxElement` is not a route, so helpers can live alongside pages with no special naming:
+A page is any export that returns `JsxPage`; a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed. Route membership comes from the return type alone -- the export name and the filename are free, and the filename only decides the URL. Because the URL comes from the filename, a file defines at most one page and one layout: if several exports return `JsxPage`, only the first is used, so keep one page export per file. A component that returns `JsxElement` is not a route, so helpers can live alongside pages with no special naming:
 
 ```jac
 # pages/about.jac

--- a/docs/docs/tutorials/fullstack/routing.md
+++ b/docs/docs/tutorials/fullstack/routing.md
@@ -68,7 +68,7 @@ myapp/
 
 ### Basic Page
 
-A page is any export that returns `JsxPage` (the name is free); a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed:
+A page is any export that returns `JsxPage`; a layout returns `JsxLayout`. `JsxPage` and `JsxLayout` are ambient builtin types, no import needed. Route membership comes from the return type alone -- the export name and the filename are free, and the filename only decides the URL. A component that returns `JsxElement` is not a route, so helpers can live alongside pages with no special naming:
 
 ```jac
 # pages/about.jac
@@ -79,6 +79,9 @@ def:pub About() -> JsxPage {
     </div>;
 }
 ```
+
+!!! warning "Blank page? Check your return types"
+    If no export under `pages/` returns `JsxPage`, the app mounts without a router and renders a blank page. The client build logs a console error when this happens, with a per-file hint for each export that returns `JsxElement` but should return `JsxPage` or `JsxLayout`.
 
 ### Dynamic Routes with `[param]`
 
@@ -173,7 +176,7 @@ The `(auth)` group automatically wraps pages with authentication checks.
 
 ### Layout Files
 
-Create `layout.jac` to wrap pages with shared UI:
+Any file whose export returns `JsxLayout` becomes the layout for its directory -- naming it `layout.jac` is a convention, not a requirement. A directory can have at most one layout export; a second one is a build error. Layouts wrap the directory's pages with shared UI:
 
 ```jac
 # pages/layout.jac
@@ -360,7 +363,7 @@ def:pub BlogPost() -> JsxElement {
 
 ### Layout Pattern (File-Based)
 
-Create a `layout.jac` file in a route group:
+Add a `JsxLayout` export to a directory (by convention in a file named `layout.jac`):
 
 ```
 


### PR DESCRIPTION
## Summary

The client routing docs still carried leftovers from before route membership became type-based (#7654, #7676). This PR brings them in line and fills two gaps in the diagnostics catalog.

- **`docs/reference/plugins/jac-client.md`** — fixes a nested-layout example that returned `JsxElement`, which the resolver no longer recognizes as a layout (it would silently produce no layout). Also expands the routing rule: membership comes from the return type alone, the export name and filename are free, the filename only decides the URL, `layout.jac` is a convention (one `JsxLayout` export per directory; a second is a build error), and a co-located `JsxElement` component is simply not a route.
- **`docs/tutorials/fullstack/routing.md`** — same rule clarification in the tutorial, reframes the two "Create `layout.jac`" sections as convention-not-mechanism, and adds a "Blank page? Check your return types" note documenting the zero-route console error added in #7677.
- **`docs/reference/language/syntax-cheatsheet.md`** — replaces the stale name-based wording ("export a `page` function inside a `cl { }` block") with the return-type rule, drops the now-optional `cl { }` wrappers, and fixes the route table line that conflated a route group with a layout file.
- **`docs/reference/diagnostics.md`** — adds the missing client entries to the catalog: a Client Code Generation subsection (`E5080`–`E5082`, with the RPC-bridging fix guidance for `E5082`) and a new Client Codespace Warnings (W6xxx) section (`W6001`–`W6004` portability warnings, `W6005` RPC-boundary function-argument warning). Messages taken verbatim from `jac0core/diagnostics.jac`.

Docs-only change; no fragment needed per `scripts/check-release-notes.sh` (only `jac/jaclang/` changes require one).