### PR TITLE
fix(scale): stop Redis eviction from dropping live event streams (#7615)

### DIFF
--- a/docs/docs/reference/plugins/jac-scale-persistence.md
+++ b/docs/docs/reference/plugins/jac-scale-persistence.md
@@ -575,6 +575,7 @@ def drain(broker: EventStreamBroker) -> int {
 | `url` | `null` | Redis URL. If unset, falls back to `[scale.database].redis_url`. If neither is set or the `redis` extra is missing, `LocalEventStream` (in-memory) is used. |
 | `consumer_group` | `jac-scale` | Default consumer group name when `@subscribe` does not specify one. |
 | `serializer` | `json` | Wire format. JSON only. |
+| `stream_maxlen` | `10000` | Approximate cap on entries retained per stream, applied on publish. Bounds stream memory, since streams are excluded from Redis eviction. `0` disables trimming. |
 | `retry.max_attempts` | `3` | Number of delivery attempts before sending to the DLQ topic. |
 | `retry.backoff_seconds` | `[1, 5, 30]` | Backoff delays per attempt index, clamped to the last value. |
 | `retry.dead_letter_suffix` | `.dlq` | Suffix appended to a topic name to form its dead-letter topic. |
@@ -585,6 +586,7 @@ def drain(broker: EventStreamBroker) -> int {
 - **Retry.** A failing handler is retried `retry.max_attempts` times with delays from `retry.backoff_seconds`. The thread sleeps responsively to the broker stop event so shutdowns are not blocked by long backoffs.
 - **Dead-letter topic.** After retry exhaustion, the event is published to `<topic><retry.dead_letter_suffix>` and the original is acked so it is not redelivered indefinitely. The DLQ is a regular topic you can `consume()` like any other.
 - **Drain on shutdown.** On process exit, consumer threads are signaled to stop and joined under a 10-second deadline.
+- **Streams are not cache.** Events carry no TTL, so under the provisioned `volatile-lru` policy Redis evicts only expiring cache keys and a live stream survives memory pressure that would otherwise drop undelivered events. Against a Redis you provision yourself, use a `volatile-*` policy for the same guarantee; the broker warns at startup when it finds an `allkeys-*` policy with a memory cap, and `health()` reports the policy and eviction count.
 
 ### Operational notes
 

--- a/jac/jaclang/scale/config/impl/config_loader.impl.jac
+++ b/jac/jaclang/scale/config/impl/config_loader.impl.jac
@@ -23,8 +23,8 @@ impl JacScaleConfig.get_default_config(self: JacScaleConfig) -> dict[str, any] {
             'redis_url': None,
             'project_id': None,
             'shelf_db_path': '.jac/data/anchor_store.db',
-            'redis_max_memory': '200mb',
-            'redis_eviction_policy': 'allkeys-lru',
+            'redis_max_memory': None,
+            'redis_eviction_policy': 'volatile-lru',
             'redis_eviction_samples': 5,
             'redis_default_ttl': 3600,
             'redis_max_connections': 20,
@@ -216,8 +216,8 @@ impl JacScaleConfig.get_database_config(self: JacScaleConfig) -> dict[str, any] 
             FIRESTORE_PROJECT_ID_ENV, db_config.get('project_id')
         ),
         'shelf_db_path': db_config.get('shelf_db_path', '.jac/data/anchor_store.db'),
-        'redis_max_memory': db_config.get('redis_max_memory', '200mb'),
-        'redis_eviction_policy': db_config.get('redis_eviction_policy', 'allkeys-lru'),
+        'redis_max_memory': db_config.get('redis_max_memory'),
+        'redis_eviction_policy': db_config.get('redis_eviction_policy', 'volatile-lru'),
         'redis_eviction_samples': int(db_config.get('redis_eviction_samples', 5)),
         'redis_default_ttl': int(db_config.get('redis_default_ttl', 3600)),
         'redis_max_connections': int(db_config.get('redis_max_connections', 20)),
@@ -371,6 +371,7 @@ impl JacScaleConfig.get_events_config(self: JacScaleConfig) -> dict[str, any] {
         'url': events_config.get('url'),
         'consumer_group': events_config.get('consumer_group', 'jac-scale'),
         'serializer': events_config.get('serializer', 'json'),
+        'stream_maxlen': int(events_config.get('stream_maxlen', 10000)),
         'retry': {
             'max_attempts': retry_config.get(
                 'max_attempts', retry_defaults.max_attempts

--- a/jac/jaclang/scale/config/plugin_config.jac
+++ b/jac/jaclang/scale/config/plugin_config.jac
@@ -92,6 +92,21 @@ class JacScalePluginConfig {
                             "default": ".jac/data/anchor_store.db",
                             "description": "File-based storage path for ShelfDB fallback"
                         },
+                        "redis_max_memory": {
+                            "type": "string",
+                            "default": None,
+                            "description": "Redis maxmemory for the jac-scale provisioned Redis. Unset means derive it from redis_memory_limit (70%), so raising the pod limit raises the cap. Set it explicitly (e.g. 700mb) to override, but keep it under that fraction or the pod risks OOMKill from fragmentation and client buffers."
+                        },
+                        "redis_eviction_policy": {
+                            "type": "string",
+                            "default": "volatile-lru",
+                            "description": "Redis maxmemory-policy. The default evicts only keys carrying a TTL, which keeps the regenerable anchor cache evictable while event streams (written without a TTL) survive memory pressure. Requires redis_default_ttl > 0; with no TTL on cache keys the policy falls back to allkeys-lru, since nothing would be evictable and Redis would reject writes."
+                        },
+                        "redis_default_ttl": {
+                            "type": "int",
+                            "default": 3600,
+                            "description": "TTL in seconds applied to cached anchors. 0 disables expiry, which also disables the volatile-lru eviction default."
+                        },
                         "redis_cpu_request": {
                             "type": "string",
                             "default": "100m",
@@ -425,6 +440,11 @@ class JacScalePluginConfig {
                             "type": "string",
                             "default": "json",
                             "description": "Payload serializer: 'json' (default) or 'msgpack' (requires extra)."
+                        },
+                        "stream_maxlen": {
+                            "type": "int",
+                            "default": 10000,
+                            "description": "Approximate cap on entries retained per Redis stream, applied on publish. Bounds the memory a stream can hold since streams are never evicted under the volatile-lru default. 0 disables trimming."
                         },
                         "retry": {
                             "type": "dict",

--- a/jac/jaclang/scale/deploy/database/kubernetes_redis.jac
+++ b/jac/jaclang/scale/deploy/database/kubernetes_redis.jac
@@ -8,7 +8,22 @@ import from jaclang.scale.config.config_loader { get_scale_config }
 
 glob logger = logging.getLogger(__name__),
      REDIS_ACLFILE_DIR = '/etc/redis-acl',
-     REDIS_ACLFILE_PATH = '/etc/redis-acl/users.acl';
+     REDIS_ACLFILE_PATH = '/etc/redis-acl/users.acl',
+     REDIS_MAXMEMORY_FRACTION = 0.7,
+     REDIS_MAXMEMORY_FALLBACK = '200mb',
+     REDIS_LOW_MAXMEMORY_FRACTION = 0.35,
+     REDIS_DEFAULT_EVICTION_POLICY = 'volatile-lru',
+     REDIS_DEFAULT_TTL = 3600,
+     REDIS_EVICTION_POLICIES = [
+         'allkeys-lru',
+         'volatile-lru',
+         'allkeys-lfu',
+         'volatile-lfu',
+         'allkeys-random',
+         'volatile-random',
+         'volatile-ttl',
+         'noeviction'
+     ];
 
 obj KubernetesRedisProvider(DatabaseProvider) {
     has target: (DeploymentTarget | None) = None,
@@ -55,67 +70,117 @@ obj KubernetesRedisProvider(DatabaseProvider) {
         return f"redis://{redis_username}:{redis_password}@{host}:{port}/0";
     }
 
+    def _resolve_default_ttl(db_config: dict[str, any]) -> int {
+        try {
+            ttl = int(db_config.get('redis_default_ttl', REDIS_DEFAULT_TTL));
+        } except (ValueError, TypeError) {
+            logger.warning("Invalid redis_default_ttl value. Using 0 (no expiration).");
+            return 0;
+        }
+        if ttl < 0 {
+            logger.warning(
+                f"Redis default TTL {ttl} is negative. Using 0 (no expiration)."
+            );
+            return 0;
+        }
+        return ttl;
+    }
+
+    def _resolve_eviction_samples(db_config: dict[str, any]) -> int {
+        try {
+            samples = int(db_config.get('redis_eviction_samples', 5));
+        } except (ValueError, TypeError) {
+            logger.warning("Invalid eviction samples value. Using default 5.");
+            return 5;
+        }
+        if samples < 1 or samples > 10 {
+            logger.warning(
+                f"Redis eviction samples {samples} out of range [1-10]. Using default 5."
+            );
+            return 5;
+        }
+        return samples;
+    }
+
+    def _resolve_eviction_policy(db_config: dict[str, any], default_ttl: int) -> str {
+        policy = (
+            db_config.get('redis_eviction_policy') or REDIS_DEFAULT_EVICTION_POLICY
+        );
+        if policy not in REDIS_EVICTION_POLICIES {
+            logger.warning(
+                f"Invalid Redis eviction policy '{policy}'. Using "
+                f"'{REDIS_DEFAULT_EVICTION_POLICY}'. Valid options: "
+                f"{', '.join(REDIS_EVICTION_POLICIES)}"
+            );
+            policy = REDIS_DEFAULT_EVICTION_POLICY;
+        }
+        if policy.startswith('volatile-') and default_ttl <= 0 {
+            logger.warning(
+                f"redis_eviction_policy '{policy}' evicts only keys with a TTL, but "
+                f"redis_default_ttl is {default_ttl}, so no key would be evictable and "
+                f"Redis would reject writes once full. Using 'allkeys-lru'; set "
+                f"redis_default_ttl above 0 to keep event streams safe from eviction."
+            );
+            return 'allkeys-lru';
+        }
+        return policy;
+    }
+
+    def _resolve_max_memory(db_config: dict[str, any]) -> str {
+        configured = db_config.get('redis_max_memory');
+        if configured {
+            return str(configured);
+        }
+        memory_limit = str(db_config.get('redis_memory_limit', '1Gi'));
+        limit_bytes = self._parse_size_to_bytes(memory_limit);
+        if limit_bytes is None {
+            logger.warning(
+                f"Could not parse redis_memory_limit '{memory_limit}'; falling back to "
+                f"redis_max_memory {REDIS_MAXMEMORY_FALLBACK}."
+            );
+            return REDIS_MAXMEMORY_FALLBACK;
+        }
+        return str(int(limit_bytes * REDIS_MAXMEMORY_FRACTION));
+    }
+
+    def _warn_on_memory_sizing(db_config: dict[str, any], max_memory: str) -> None {
+        memory_limit = str(db_config.get('redis_memory_limit', '1Gi'));
+        limit_bytes = self._parse_size_to_bytes(memory_limit);
+        max_memory_bytes = self._parse_size_to_bytes(max_memory);
+        if limit_bytes is None or max_memory_bytes is None {
+            return;
+        }
+        if max_memory_bytes > limit_bytes * REDIS_MAXMEMORY_FRACTION {
+            logger.warning(
+                f"redis_max_memory ({max_memory}) exceeds "
+                f"{int(REDIS_MAXMEMORY_FRACTION * 100)}% of redis_memory_limit "
+                f"({memory_limit}); Redis needs headroom for fragmentation and client "
+                f"buffers and may be OOMKilled at runtime. Consider raising "
+                f"redis_memory_limit."
+            );
+        } elif max_memory_bytes < limit_bytes * REDIS_LOW_MAXMEMORY_FRACTION {
+            logger.warning(
+                f"redis_max_memory ({max_memory}) uses under "
+                f"{int(REDIS_LOW_MAXMEMORY_FRACTION * 100)}% of redis_memory_limit "
+                f"({memory_limit}); Redis will evict while the pod sits idle. Unset "
+                f"redis_max_memory to size it from the pod limit automatically."
+            );
+        }
+    }
+
     def _load_redis_config -> str {
         scale_config = get_scale_config();
         db_config = scale_config.get_database_config();
 
-        redis_max_memory = db_config.get('redis_max_memory', '200mb');
-        redis_eviction_policy = db_config.get('redis_eviction_policy', 'allkeys-lru');
-        redis_eviction_samples = db_config.get('redis_eviction_samples', 5);
-        redis_default_ttl = db_config.get('redis_default_ttl', 0);
+        redis_default_ttl = self._resolve_default_ttl(db_config);
+        redis_max_memory = self._resolve_max_memory(db_config);
+        redis_eviction_policy = self._resolve_eviction_policy(
+            db_config, redis_default_ttl
+        );
+        redis_eviction_samples = self._resolve_eviction_samples(db_config);
         redis_enable_keyspace_notifications = db_config.get(
             'redis_enable_keyspace_notifications', False
         );
-
-        valid_policies = [
-            'allkeys-lru',
-            'volatile-lru',
-            'allkeys-lfu',
-            'volatile-lfu',
-            'allkeys-random',
-            'volatile-random',
-            'volatile-ttl',
-            'noeviction'
-        ];
-        if redis_eviction_policy not in valid_policies {
-            logger.warning(
-                f"Invalid Redis eviction policy '{redis_eviction_policy}'. "
-                f"Using default 'allkeys-lru'. Valid options: {', '.join(
-                    valid_policies
-                )}"
-            );
-            redis_eviction_policy = 'allkeys-lru';
-        }
-
-        try {
-            samples = int(redis_eviction_samples);
-            if samples < 1 or samples > 10 {
-                logger.warning(
-                    f"Redis eviction samples {samples} out of range [1-10]. Using default 5."
-                );
-                redis_eviction_samples = 5;
-            } else {
-                redis_eviction_samples = samples;
-            }
-        } except (ValueError, TypeError) {
-            logger.warning(f"Invalid eviction samples value. Using default 5.");
-            redis_eviction_samples = 5;
-        }
-
-        try {
-            ttl = int(redis_default_ttl);
-            if ttl < 0 {
-                logger.warning(
-                    f"Redis default TTL {ttl} is negative. Using 0 (no expiration)."
-                );
-                redis_default_ttl = 0;
-            } else {
-                redis_default_ttl = ttl;
-            }
-        } except (ValueError, TypeError) {
-            logger.warning(f"Invalid TTL value. Using default 0 (no expiration).");
-            redis_default_ttl = 0;
-        }
 
         if redis_enable_keyspace_notifications {
             redis_keyspace_events_line = '\nnotify-keyspace-events Ex';
@@ -231,7 +296,7 @@ obj KubernetesRedisProvider(DatabaseProvider) {
         scale_config = get_scale_config();
         db_config = scale_config.get_database_config();
         k8s_config = scale_config.get_kubernetes_config();
-        redis_default_ttl = db_config.get('redis_default_ttl', 0);
+        redis_default_ttl = self._resolve_default_ttl(db_config);
         redis_enable_keyspace_notifications = db_config.get(
             'redis_enable_keyspace_notifications', False
         );
@@ -240,21 +305,7 @@ obj KubernetesRedisProvider(DatabaseProvider) {
         redis_memory_request = str(db_config['redis_memory_request']);
         redis_memory_limit = str(db_config['redis_memory_limit']);
 
-        redis_max_memory = str(db_config['redis_max_memory']);
-        limit_bytes = self._parse_size_to_bytes(redis_memory_limit);
-        max_memory_bytes = self._parse_size_to_bytes(redis_max_memory);
-        if (
-            limit_bytes is not None
-            and max_memory_bytes is not None
-            and limit_bytes < max_memory_bytes * 2
-        ) {
-            logger.warning(
-                f"redis_memory_limit ({redis_memory_limit}) leaves little headroom "
-                f"over redis_max_memory ({redis_max_memory}); Redis needs roughly 2x "
-                f"maxmemory for BGSAVE fork copy-on-write and may be OOMKilled at "
-                f"runtime. Consider raising redis_memory_limit."
-            );
-        }
+        self._warn_on_memory_sizing(db_config, self._resolve_max_memory(db_config));
 
         redis_username = str(k8s_config.get('redis_username', 'admin'));
         redis_password = str(k8s_config.get('redis_password', 'password'));

--- a/jac/jaclang/scale/events/streams/redis.jac
+++ b/jac/jaclang/scale/events/streams/redis.jac
@@ -25,7 +25,10 @@ def _to_str(value: any) -> str {
 }
 
 glob _logger = logging.getLogger(__name__),
-     _CONSUME_ERROR_BACKOFF: float = 0.5;
+     _CONSUME_ERROR_BACKOFF: float = 0.5,
+     _STREAM_MAXLEN_DEFAULT: int = 10000,
+     _NOGROUP_MAX_ATTEMPTS: int = 3,
+     _NOGROUP_RETRY_BACKOFF: float = 0.05;
 
 obj RedisEventStream(EventStreamBroker) {
     has config: dict[str, any] = {},
@@ -35,7 +38,9 @@ obj RedisEventStream(EventStreamBroker) {
         _default_retry: RetryPolicy = RetryPolicy(),
         _stop_event: _ThreadStop = _ThreadStop(),
         _threads: list[Thread] = [],
-        _ensured_groups: set[str] = set();
+        _ensured_groups: set[str] = set(),
+        _stream_maxlen: int = _STREAM_MAXLEN_DEFAULT,
+        _eviction_checked: bool = False;
 
     def postinit {
         try {
@@ -45,6 +50,9 @@ obj RedisEventStream(EventStreamBroker) {
         }
         self._consumer_name = f"{host}-{os.getpid()}-{str(uuid.uuid4())[:8]}";
         self._default_group = self.config.get("consumer_group", "jac-scale");
+        self._stream_maxlen = int(
+            self.config.get("stream_maxlen", _STREAM_MAXLEN_DEFAULT)
+        );
 
         retry_cfg = self.config.get("retry", {});
         defaults = RetryPolicy();
@@ -61,8 +69,43 @@ obj RedisEventStream(EventStreamBroker) {
         if self._client is None {
             url = self.config.get("url");
             self._client = get_redis_client(url);
+            self._warn_on_evictable_streams();
         }
         return self._client;
+    }
+
+    def _eviction_settings -> dict[str, str] {
+        try {
+            raw = self._client.config_get("maxmemory*");
+        } except Exception as e {
+            _logger.debug(f"CONFIG GET maxmemory failed: {e}");
+            return {};
+        }
+        settings = {_to_str(k): _to_str(v) for (k, v) in raw.items()};
+        return {
+            key: settings[key]
+            for key in ("maxmemory", "maxmemory-policy")
+            if key in settings
+        };
+    }
+
+    def _warn_on_evictable_streams -> None {
+        if self._eviction_checked {
+            return;
+        }
+        self._eviction_checked = True;
+        settings = self._eviction_settings();
+        policy = settings.get("maxmemory-policy", "");
+        max_memory = settings.get("maxmemory", "0");
+        if not policy.startswith("allkeys-") or max_memory in ("", "0") {
+            return;
+        }
+        _logger.warning(
+            f"Redis maxmemory-policy is '{policy}' with maxmemory {max_memory}; event "
+            f"streams carry no TTL and can be evicted under memory pressure, dropping "
+            f"undelivered events. Use a 'volatile-*' policy so only expiring cache keys "
+            f"are evicted."
+        );
     }
 
     def _serialize_event(event: Event) -> str {
@@ -81,7 +124,12 @@ obj RedisEventStream(EventStreamBroker) {
     }
 
     def _xadd_payload(stream: str, event: Event) {
-        self._get_client().xadd(stream, {"payload": self._serialize_event(event)});
+        self._get_client().xadd(
+            stream,
+            {"payload": self._serialize_event(event)},
+            maxlen=self._stream_maxlen if self._stream_maxlen > 0 else None,
+            approximate=True
+        );
     }
 
     def _deserialize_event(raw: any) -> Event {
@@ -178,16 +226,27 @@ obj RedisEventStream(EventStreamBroker) {
     def _read_group(
         topic: str, group: str, max_messages: int, block_ms: int, start_from: str
     ) -> any {
-        try {
-            return self._xreadgroup(topic, group, max_messages, block_ms);
-        } except Exception as e {
-            if "NOGROUP" not in str(e) {
-                raise;
+        last_error: Exception | None = None;
+        for attempt in range(_NOGROUP_MAX_ATTEMPTS) {
+            try {
+                return self._xreadgroup(topic, group, max_messages, block_ms);
+            } except Exception as e {
+                if "NOGROUP" not in str(e) {
+                    raise;
+                }
+                last_error = e;
+            }
+            _logger.error(
+                f"Event loss on {topic}: stream or group {group} disappeared "
+                f"(NOGROUP), undelivered events are gone; recreating "
+                f"(attempt {attempt + 1}/{_NOGROUP_MAX_ATTEMPTS})"
+            );
+            self._ensure_group(topic, group, start_from, force=True);
+            if wait_or_stop(self, _NOGROUP_RETRY_BACKOFF) {
+                return None;
             }
         }
-        _logger.warning(f"Consumer group {group} missing for {topic}; recreating");
-        self._ensure_group(topic, group, start_from, force=True);
-        return self._xreadgroup(topic, group, max_messages, block_ms);
+        raise last_error;
     }
 
     def consume(
@@ -313,17 +372,25 @@ obj RedisEventStream(EventStreamBroker) {
         thread.start();
     }
 
+    def _evicted_keys -> int | None {
+        try {
+            return int(self._client.info("stats").get("evicted_keys"));
+        } except Exception as e {
+            _logger.debug(f"INFO stats failed: {e}");
+            return None;
+        }
+    }
+
     def health -> HealthStatus {
         try {
             ok = bool(self._get_client().ping());
-            return HealthStatus(
-                healthy=ok,
-                broker="redis",
-                details={
-                    "consumer_name": self._consumer_name,
-                    "threads": len(self._threads)
-                }
-            );
+            details: dict[str, any] = {
+                "consumer_name": self._consumer_name,
+                "threads": len(self._threads),
+                "evicted_keys": self._evicted_keys()
+            };
+            details.update(self._eviction_settings());
+            return HealthStatus(healthy=ok, broker="redis", details=details);
         } except Exception as e {
             return HealthStatus(
                 healthy=False, broker="redis", details={"error": str(e)}

--- a/jac/jaclang/scale/tests/data/test_redis_stream_eviction.jac
+++ b/jac/jaclang/scale/tests/data/test_redis_stream_eviction.jac
@@ -1,0 +1,289 @@
+import contextlib;
+import logging;
+import from logging.handlers { MemoryHandler }
+import from testcontainers.redis { RedisContainer }
+import from jaclang.scale.persistence.db { close_all_db_connections, get_redis_client }
+import from jaclang.scale.events.broker { Event }
+import from jaclang.scale.events.streams.redis { RedisEventStream }
+import from jaclang.scale.deploy.database.kubernetes_redis { KubernetesRedisProvider }
+
+
+glob _redis_container = RedisContainer("redis:7.2-alpine"),
+     REDIS_URI: str = "",
+     CACHE_PAYLOAD: str = "x" * 4000,
+     CACHE_KEYS: int = 4000,
+     SMALL_MAXMEMORY: str = "8mb";
+
+with entry {
+    _redis_container.start();
+}
+
+glob REDIS_URI = (
+         f"redis://{_redis_container.get_container_host_ip()}:"
+         f"{_redis_container.get_exposed_port(6379)}/0"
+     );
+
+
+def cleanup_connections {
+    with contextlib.suppress(Exception) {
+        close_all_db_connections();
+    }
+}
+
+
+def _make_broker(group: str, stream_maxlen: int = 10000) -> RedisEventStream {
+    b = RedisEventStream(
+        config={
+            "url": REDIS_URI,
+            "consumer_group": group,
+            "stream_maxlen": stream_maxlen
+        }
+    );
+    b.start();
+    return b;
+}
+
+
+def _reset_redis {
+    client = get_redis_client(REDIS_URI);
+    client.config_set("maxmemory", "0");
+    client.config_set("maxmemory-policy", "noeviction");
+    client.flushall();
+}
+
+
+def _apply_memory_policy(max_memory: str, policy: str) {
+    client = get_redis_client(REDIS_URI);
+    client.config_set("maxmemory", max_memory);
+    client.config_set("maxmemory-policy", policy);
+}
+
+
+def _fill_cache(ttl: int) -> tuple[int, str | None] {
+    client = get_redis_client(REDIS_URI);
+    before = int(client.info("stats")["evicted_keys"]);
+    write_error: str | None = None;
+    for i in range(CACHE_KEYS) {
+        try {
+            if ttl > 0 {
+                client.setex(f"anchor:{i}", ttl, CACHE_PAYLOAD);
+            } else {
+                client.set(f"anchor:{i}", CACHE_PAYLOAD);
+            }
+        } except Exception as e {
+            write_error = str(e);
+            break;
+        }
+    }
+    evicted = int(client.info("stats")["evicted_keys"]) - before;
+    return (evicted, write_error);
+}
+
+
+def _buffer_event(broker: RedisEventStream, topic: str, group: str) {
+    broker.consume(topic, group=group, max_messages=1, timeout_seconds=0.1);
+    broker.publish(topic, Event(event_type="run.chunk", data={"turn": 1}));
+}
+
+
+def _attach_log_capture -> MemoryHandler {
+    handler = MemoryHandler(capacity=10000, flushLevel=logging.CRITICAL + 1);
+    logging.getLogger().addHandler(handler);
+    return handler;
+}
+
+
+def _captured(handler: MemoryHandler, level: int, needle: str) -> bool {
+    logging.getLogger().removeHandler(handler);
+    return any(
+        record.levelno == level and needle in record.getMessage()
+        for record in handler.buffer
+    );
+}
+
+
+test "allkeys-lru evicts an idle run stream and loses its buffered events" {
+    _reset_redis();
+    b = _make_broker(group="jc.coder.peer.lru");
+    _buffer_event(b, "jc.run.lru", "jc.coder.peer.lru");
+
+    _apply_memory_policy(SMALL_MAXMEMORY, "allkeys-lru");
+    (evicted, write_error) = _fill_cache(3600);
+
+    assert evicted > 0 , "cache pressure must actually evict under allkeys-lru";
+    assert write_error is None , "allkeys-lru must keep accepting cache writes";
+    assert get_redis_client(REDIS_URI).exists("jc.run.lru") == 0 , (
+        "allkeys-lru is expected to evict the idle run stream"
+    );
+
+    lost = b.consume(
+        "jc.run.lru",
+        group="jc.coder.peer.lru",
+        max_messages=10,
+        timeout_seconds=1.0,
+        start_from="earliest"
+    );
+    assert lost == [] , "evicted stream cannot deliver its buffered events";
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "volatile-lru keeps an idle run stream through the same cache pressure" {
+    _reset_redis();
+    b = _make_broker(group="jc.coder.peer.vol");
+    _buffer_event(b, "jc.run.vol", "jc.coder.peer.vol");
+
+    _apply_memory_policy(SMALL_MAXMEMORY, "volatile-lru");
+    (evicted, write_error) = _fill_cache(3600);
+
+    assert evicted > 0 , "cache pressure must actually evict under volatile-lru";
+    assert write_error is None , (
+        "volatile-lru must keep accepting cache writes while TTL keys are evictable"
+    );
+    assert get_redis_client(REDIS_URI).exists("jc.run.vol") == 1 , (
+        "volatile-lru must not evict a stream that carries no TTL"
+    );
+
+    delivered = b.consume(
+        "jc.run.vol",
+        group="jc.coder.peer.vol",
+        max_messages=10,
+        timeout_seconds=2.0,
+        start_from="earliest"
+    );
+    assert len(delivered) == 1 , "buffered events must survive cache pressure";
+    assert delivered[0].data["turn"] == 1;
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "volatile-lru without cache ttls rejects writes once full" {
+    _reset_redis();
+    _apply_memory_policy(SMALL_MAXMEMORY, "volatile-lru");
+    (evicted, write_error) = _fill_cache(0);
+
+    assert evicted == 0 , "no key carries a TTL, so nothing is evictable";
+    assert write_error is not None , (
+        "volatile-lru degenerates into noeviction when no key expires"
+    );
+    assert "maxmemory" in write_error;
+
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "provisioned redis settings keep run streams through cache pressure" {
+    _reset_redis();
+    provider = KubernetesRedisProvider(config={'app_name': 'evict-test'});
+    db_config = {'redis_memory_limit': '16Mi'};
+
+    max_memory = provider._resolve_max_memory(db_config);
+    default_ttl = provider._resolve_default_ttl(db_config);
+    policy = provider._resolve_eviction_policy(db_config, default_ttl);
+
+    assert int(max_memory) == int(16 * 1024 ** 2 * 0.7) , (
+        "maxmemory must be derived from the pod memory limit"
+    );
+    assert policy == 'volatile-lru';
+    assert default_ttl > 0;
+
+    b = _make_broker(group="jc.coder.peer.gen");
+    _buffer_event(b, "jc.run.gen", "jc.coder.peer.gen");
+
+    _apply_memory_policy(max_memory, policy);
+    (evicted, write_error) = _fill_cache(default_ttl);
+
+    assert evicted > 0;
+    assert write_error is None;
+    delivered = b.consume(
+        "jc.run.gen",
+        group="jc.coder.peer.gen",
+        max_messages=10,
+        timeout_seconds=2.0,
+        start_from="earliest"
+    );
+    assert len(delivered) == 1 , (
+        "the provisioned defaults must protect an active run's events"
+    );
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "publish trims a stream to the configured maxlen" {
+    _reset_redis();
+    b = _make_broker(group="t_maxlen", stream_maxlen=100);
+    for i in range(600) {
+        b.publish("trimmed", Event(event_type="x", data={"n": i}));
+    }
+
+    length = get_redis_client(REDIS_URI).xlen("trimmed");
+    assert length < 600 , "streams must be trimmed on publish";
+    assert length >= 100 , "trimming must not drop below the configured maxlen";
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "stream loss is reported as an error" {
+    _reset_redis();
+    b = _make_broker(group="t_loss");
+    _buffer_event(b, "loss.topic", "t_loss");
+    get_redis_client(REDIS_URI).delete("loss.topic");
+
+    handler = _attach_log_capture();
+    b.consume("loss.topic", group="t_loss", max_messages=1, timeout_seconds=0.5);
+
+    assert _captured(handler, logging.ERROR, "Event loss on loss.topic") , (
+        "a vanished stream must be reported as data loss, not a silent empty read"
+    );
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "broker warns when the connected redis can evict streams" {
+    _reset_redis();
+    _apply_memory_policy(SMALL_MAXMEMORY, "allkeys-lru");
+
+    handler = _attach_log_capture();
+    b = _make_broker(group="t_policy");
+    b.publish("policy.topic", Event(event_type="x", data={"n": 1}));
+
+    assert _captured(handler, logging.WARNING, "maxmemory-policy is 'allkeys-lru'") , (
+        "an evictable stream configuration must be reported at startup"
+    );
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}
+
+
+test "health reports the eviction settings of the connected redis" {
+    _reset_redis();
+    _apply_memory_policy(SMALL_MAXMEMORY, "volatile-lru");
+    b = _make_broker(group="t_health");
+
+    h = b.health();
+    assert h.healthy is True;
+    assert h.details["maxmemory-policy"] == "volatile-lru";
+    assert h.details["evicted_keys"] is not None;
+
+    b.stop(drain=False);
+    _reset_redis();
+    cleanup_connections();
+}

--- a/jac/jaclang/scale/tests/test_deploy_k8s.jac
+++ b/jac/jaclang/scale/tests/test_deploy_k8s.jac
@@ -433,7 +433,7 @@ test "default redis memory limit does not emit a headroom warning" {
     warned = any(
         'redis_memory_limit' in str(call) for call in mock_logger.warning.call_args_list
     );
-    assert not warned , "default 1Gi limit over 200mb maxmemory must not warn";
+    assert not warned , "a maxmemory derived from the pod limit must not warn";
 }
 
 test "redis pod resources propagate from [scale.database] config" {
@@ -495,6 +495,75 @@ test "redis warns when memory limit lacks headroom over maxmemory" {
         'redis_memory_limit' in str(call) for call in mock_logger.warning.call_args_list
     );
     assert warned , "expected a headroom warning when limit <= 2x maxmemory";
+}
+
+def _redis_conf_for(db_config: dict) -> str {
+    fake_config = SimpleNamespace(
+        get_database_config=lambda { db_config; }, get_kubernetes_config=lambda { {}; }
+    );
+    with unittest.mock.patch.object(
+        redis_module, 'get_scale_config', lambda { fake_config; }
+    ) {
+        provider = DatabaseProviderFactory.create(
+            'kubernetes_redis', None, {'app_name': 'test-app'}
+        );
+        return provider.deploy()['configmap']['data']['redis.conf'];
+    }
+}
+
+glob _REDIS_POD_DEFAULTS = {
+         'redis_cpu_request': '100m',
+         'redis_cpu_limit': '500m',
+         'redis_memory_request': '128Mi'
+     };
+
+test "redis maxmemory is derived from the pod memory limit" {
+    conf = _redis_conf_for(
+        _REDIS_POD_DEFAULTS | {'redis_max_memory': None, 'redis_memory_limit': '4Gi'}
+    );
+
+    assert f"maxmemory {int(4 * 1024 ** 3 * 0.7)}" in conf , (
+        "an unset redis_max_memory must scale with redis_memory_limit"
+    );
+}
+
+test "explicit redis_max_memory overrides the derived value" {
+    conf = _redis_conf_for(
+        _REDIS_POD_DEFAULTS | {'redis_max_memory': '700mb', 'redis_memory_limit': '4Gi'}
+    );
+
+    assert 'maxmemory 700mb' in conf;
+}
+
+test "redis eviction policy protects streams by default" {
+    conf = _redis_conf_for(
+        _REDIS_POD_DEFAULTS | {'redis_max_memory': None, 'redis_memory_limit': '1Gi'}
+    );
+
+    assert 'maxmemory-policy volatile-lru' in conf , (
+        "the default policy must leave keys without a TTL, such as event streams, "
+        "out of the eviction pool"
+    );
+}
+
+test "redis eviction policy falls back to allkeys-lru without a cache ttl" {
+    db_config = _REDIS_POD_DEFAULTS | {
+        'redis_max_memory': None,
+        'redis_memory_limit': '1Gi',
+        'redis_default_ttl': 0
+    };
+    mock_logger = unittest.mock.MagicMock();
+
+    with unittest.mock.patch.object(redis_module, 'logger', mock_logger) {
+        conf = _redis_conf_for(db_config);
+    }
+
+    assert 'maxmemory-policy allkeys-lru' in conf , (
+        "volatile-lru with no expiring keys would reject every write"
+    );
+    assert any(
+        'redis_default_ttl' in str(call) for call in mock_logger.warning.call_args_list
+    );
 }
 
 obj FakeNetworkingV1 {


### PR DESCRIPTION
Fixes #7615

## What was wrong

jac-scale runs the event bus (Redis Streams) and the graph anchor cache in the same Redis instance, and it told that instance to throw away whichever key had gone longest without being touched. That is fine for the cache, whose real copy lives in MongoDB, but an event stream has no other copy. When it is thrown away, a run's output is simply gone.

The stream is the one that gets thrown away, and not by bad luck. A `jc.run.*` stream is written in bursts and then sits quiet while the agent thinks or while the user types the next message. The anchor cache is read and written constantly. So the live stream is, by definition, the least recently used key in the instance, and it is first in line for eviction.

Two shipped defaults made this happen sooner than anyone expected. The Redis cache size was fixed at 200mb no matter how big the pod was, so a deployment that raised its pod to 1Gi still ran a 200mb Redis and filled it. And the eviction rule was `allkeys-lru`, which does not distinguish a disposable cache entry from an event nobody has read yet.

The user-visible result: a turn ran to completion on the server and the client received nothing.

The self-heal added in #7489 could not fix this. It recreates the consumer group, but the recreated stream is empty, so the buffered events are already gone by the time it runs.

## How it is fixed

**Streams are no longer eviction candidates.** Redis offers exactly one per-key eviction control: the `volatile-*` policies, which only ever evict keys that have an expiry set. It turns out jac-scale already writes cached anchors with an expiry and event streams without one, so switching the default to `volatile-lru` maps the two workloads apart with no new infrastructure. The cache stays disposable, the bus does not.

Two things had to come with it. If a deployment sets `redis_default_ttl = 0`, nothing has an expiry, `volatile-lru` has nothing it is allowed to evict, and Redis starts rejecting every write. The deploy step now detects that and falls back to `allkeys-lru` with a warning rather than shipping a Redis that cannot accept writes. And because streams can no longer be evicted, they must not be allowed to grow forever, so they are trimmed to `[scale.events].stream_maxlen` (default 10000) as events are published.

**The cache size follows the pod size.** When `redis_max_memory` is left unset it is now calculated as 70% of `redis_memory_limit`, so raising the pod limit actually gives Redis room. Setting it explicitly still overrides. The value is written in bytes because Redis does not accept the Kubernetes `Gi`/`Mi` suffixes.

The existing "not enough headroom" warning changed rule to match. It was written around the cost of a BGSAVE fork, but this Redis has persistence turned off and never forks, so the old rule would have complained about every correctly sized deployment. It now warns above 70% of the pod limit, and a second warning fires when an explicitly configured cache is so small it wastes most of the pod, which is the exact misconfiguration this issue was about.

**Two smaller changes for the cases the above cannot reach.** A deployment pointing at a managed Redis (ElastiCache, Memorystore, and similar) gets none of the provisioning fixes, so the broker now checks the policy on connect and warns if that Redis is configured in a way that can drop streams. And when events are lost anyway, the consumer says so: `NOGROUP` is now logged as data loss at error level instead of a warning whose empty result looks exactly like "no new events", it is retried a bounded number of times rather than once, and `health()` reports the eviction policy and eviction count so this is visible in monitoring instead of arriving as a user complaint.

## How it was verified

Everything below was run against a real Redis 7.2 container. No Redis behaviour is simulated; the memory pressure is real 4KB values written until the instance actually evicts.

The same scenario was run four ways, identical cache size and identical load each time:

| eviction policy | cache keys | stream survives | cache writes |
| --- | --- | --- | --- |
| `allkeys-lru` (the old default) | with expiry | **no**, consumer gets `NOGROUP` | accepted |
| `volatile-lru` (the new default) | with expiry | yes | accepted |
| `volatile-lru` | no expiry | yes | **rejected** |
| `noeviction` | with expiry | yes | **rejected** |

Row one reproduces the production failure exactly. Row two is the fix under identical pressure. Row three is why the TTL fallback exists. Row four independently confirms the issue author's finding that `noeviction` is not the answer, since it stops the whole app from writing.

One detail matters for anyone reading the tests: the stream has to sit idle before the pressure is applied. A test that publishes and immediately reads passes even on the broken configuration, because the stream is still recently used. The idle window is the bug.

Eight tests in `test_redis_stream_eviction.jac` cover the above plus stream trimming, the data-loss log, the startup warning, and the health output. One of them takes the settings the provisioner generates for a given pod size, applies those exact values to a live Redis, and checks an active run's events survive, so the shipped defaults are tied to observed behaviour rather than to a config string. Four more tests in `test_deploy_k8s.jac` cover what gets written into the Redis ConfigMap.

Locally: 8 new tests pass, the 10 existing event stream tests still pass, and 32 of the 33 deploy tests pass. The one failure, `early exit`, needs a live Kubernetes cluster and fails the same way on `main`.

## Upgrade note

Both defaults change on the next redeploy. `maxmemory` goes from 200mb to roughly 717Mi on the default 1Gi pod, and the policy goes from `allkeys-lru` to `volatile-lru`. The policy only changes for deployments that have not set it themselves and that keep a non-zero cache TTL. Both are ConfigMap changes, so the Redis pod rolls and starts with a cold cache once. Deployments that already set `redis_max_memory` by hand, such as the jacBuilder workaround, are unaffected.

Not included on purpose: raising the default `redis_memory_request` (128Mi) to track the new cache size. A Redis that grows to ~717Mi against a 128Mi request can be evicted by the node before it ever reaches its own limit, so this is a genuine gap, but changing it alters what every cluster has to reserve and could leave pods unschedulable. It deserves its own change where that capacity trade-off is the subject.

Scope, per the issue author's note: this addresses the event-loss half only. The duplicate assistant reply users saw has a separate cause in the relay layer (jaseci-labs/jacBuilder#778).
