### PR TITLE
fix(byllm): stop forcing a default temperature on every LLM call

### DIFF
--- a/jac/jaclang/byllm/impl/config_loader.impl.jac
+++ b/jac/jaclang/byllm/impl/config_loader.impl.jac
@@ -13,7 +13,7 @@ impl JacByllmConfig.get_default_config(self: JacByllmConfig) -> dict[str, any] {
             'proxy': False,
             'verbose': False
         },
-        'call_params': {'temperature': 0.7, 'max_tokens': 0, 'max_output_retries': 3},
+        'call_params': {'max_tokens': 0, 'max_output_retries': 3},
         'litellm': {'local_cost_map': True, 'drop_params': True, 'debug': False},
         'fallback': {'strategy': 'fallback', 'num_retries': 1, 'timeout': 60.0},
         'prompt_caching': {'enabled': True},
@@ -60,12 +60,14 @@ impl JacByllmConfig.get_model_config(self: JacByllmConfig) -> dict[str, any] {
 impl JacByllmConfig.get_call_params_config(self: JacByllmConfig) -> dict[str, any] {
     config = self.load();
     call_params = config.get('call_params', {});
-    temperature = call_params.get('temperature', 0.7);
     max_tokens = call_params.get('max_tokens', 0);
     result: dict[str, any] = {
-        'temperature': temperature,
         'max_output_retries': int(call_params.get('max_output_retries', 3))
     };
+
+    if 'temperature' in call_params {
+        result['temperature'] = call_params['temperature'];
+    }
 
     if max_tokens > 0 {
         result['max_tokens'] = max_tokens;

--- a/jac/jaclang/byllm/llm.impl/basellm.impl.jac
+++ b/jac/jaclang/byllm/llm.impl/basellm.impl.jac
@@ -860,7 +860,7 @@ impl BaseLLM._invoke_react_loop(mt_run: MTRuntime) -> object {
 }
 
 impl BaseLLM.make_model_params(mt_run: MTRuntime) -> dict {
-    default_temp = _call_params_config.get("temperature", 0.7);
+    default_temp = _call_params_config.get("temperature");
     default_max_tokens = _call_params_config.get("max_tokens");
 
     agent_metadata = {};
@@ -957,11 +957,21 @@ impl BaseLLM.make_model_params(mt_run: MTRuntime) -> dict {
         "messages": messages,
         "tools": tools,
         "response_format": mt_run.get_output_schema(),
-        "temperature": self.call_params.get("temperature", default_temp),
-        "max_tokens": self.call_params.get("max_tokens", default_max_tokens),
         "metadata": agent_metadata,
 
     };
+
+    if "temperature" in self.call_params {
+        params["temperature"] = self.call_params["temperature"];
+    } elif default_temp is not None {
+        params["temperature"] = default_temp;
+    }
+
+    if "max_tokens" in self.call_params {
+        params["max_tokens"] = self.call_params["max_tokens"];
+    } elif default_max_tokens is not None {
+        params["max_tokens"] = default_max_tokens;
+    }
 
     if "tool_choice" in mt_run.call_params {
         params["tool_choice"] = mt_run.call_params["tool_choice"];

--- a/jac/jaclang/byllm/plugin_config.jac
+++ b/jac/jaclang/byllm/plugin_config.jac
@@ -50,8 +50,8 @@ class JacByllmPluginConfig {
                     "nested": {
                         "temperature": {
                             "type": "float",
-                            "default": 0.7,
-                            "description": "Model creativity/randomness (0.0-2.0, lower is more deterministic)"
+                            "default": None,
+                            "description": "Model creativity/randomness (0.0-2.0, lower is more deterministic). Unset by default; some models reject non-default values."
                         },
                         "max_tokens": {
                             "type": "int",

--- a/jac/jaclang/byllm/tests/fixtures/llm_params.jac
+++ b/jac/jaclang/byllm/tests/fixtures/llm_params.jac
@@ -17,7 +17,9 @@ def get_wind_speed_report(city: str) -> str by MockLLM(
         "verbose": True
     },
 )(
-    tools=[get_live_wind_speed]
+    tools=[get_live_wind_speed],
+    temperature=0.5,
+    max_tokens=256
 );
 
 glob result = get_wind_speed_report("Puttalam");

--- a/jac/jaclang/byllm/tests/test_byllm.jac
+++ b/jac/jaclang/byllm/tests/test_byllm.jac
@@ -98,6 +98,8 @@ test "params format" {
     for key in required_keys {
         assert key in extracted_dict , f"Missing key: {key}";
     }
+    assert extracted_dict["temperature"] == 0.5 , "Explicit call-site temperature should be passed through";
+    assert extracted_dict["max_tokens"] == 256 , "Explicit call-site max_tokens should be passed through";
 
     add_message = extracted_dict["messages"];
     assert add_message[0]["role"] == "system" , "First message should be of role 'system'";
@@ -111,6 +113,61 @@ test "params format" {
     assert add_tool["type"] == "function" , "First tool should be of type 'function'";
     assert add_tool["function"]["name"] == "get_live_wind_speed" , "First tool function should be 'get_live_wind_speed'";
     assert "city" in add_tool["function"]["parameters"]["properties"] , "get_live_wind_speed function should have 'city' parameter";
+}
+
+test "temperature and max_tokens omitted when caller never sets them" {
+    # byLLM must not force a temperature/max_tokens the caller never asked
+    # for: some models (GPT-5/o-series, Claude with extended thinking) 400
+    # on any value other than their own default. Regression test for jac#7687.
+    with unittest.mock.patch.dict(_byllm_llm_mod._call_params_config, {}, clear=True) {
+        model = Model(model_name="gpt-5", api_key="sk-test-key");
+        mt_run = MTRuntime(
+            messages=[],
+            resp_type=str,
+            stream=False,
+            tools=[],
+            call_params={},
+            mtir=None  # type: ignore[arg-type]
+        );
+        params = model.make_model_params(mt_run);
+        assert "temperature" not in params , "temperature should not be forced by default";
+        assert "max_tokens" not in params , "max_tokens should not be forced by default";
+    }
+}
+
+test "explicit call-site temperature and max_tokens are passed through" {
+    with unittest.mock.patch.dict(_byllm_llm_mod._call_params_config, {}, clear=True) {
+        model = Model(model_name="gpt-4o-mini", api_key="sk-test-key");
+        mt_run = MTRuntime(
+            messages=[],
+            resp_type=str,
+            stream=False,
+            tools=[],
+            call_params={},
+            mtir=None  # type: ignore[arg-type]
+        );
+        params = model(temperature=0.4, max_tokens=123).make_model_params(mt_run);
+        assert params["temperature"] == 0.4;
+        assert params["max_tokens"] == 123;
+    }
+}
+
+test "config-level temperature only applies when user configured it" {
+    with unittest.mock.patch.dict(
+        _byllm_llm_mod._call_params_config, {"temperature": 0.9}, clear=True
+    ) {
+        model = Model(model_name="gpt-4o-mini", api_key="sk-test-key");
+        mt_run = MTRuntime(
+            messages=[],
+            resp_type=str,
+            stream=False,
+            tools=[],
+            call_params={},
+            mtir=None  # type: ignore[arg-type]
+        );
+        params = model.make_model_params(mt_run);
+        assert params["temperature"] == 0.9;
+    }
 }
 
 test "image input" {


### PR DESCRIPTION
## Summary

`make_model_params()` always injected `temperature=0.7` (and a `max_tokens` default) into every `litellm.completion()` call, even when the caller never asked for one. `litellm.drop_params=True` only strips unsupported values on the direct-provider route (`custom_llm_provider="openai"`); it does **not** fire for aggregator routes such as OpenRouter, so `openrouter/openai/gpt-5.x` (and o-series models) forwarded the forced value straight to the upstream, which rejects it:

```
litellm.BadRequestError: OpenAIException - Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.
```

The same forced-param design also latently breaks Claude with extended thinking enabled, which requires `temperature=1`.

Fixes #7687.

## Before

```mermaid
flowchart TD
    A[Caller invokes LLM] --> B["make_model_params()"]
    B --> C["Always sets temperature=0.7\n(forced, caller never asked)"]
    C --> D{custom_llm_provider}
    D -->|"openai (direct)"| E["drop_params strips the\nunsupported value"]
    E --> F["✅ call succeeds"]
    D -->|"openrouter (aggregator)"| G["drop_params does NOT apply here\ntemperature forwarded as-is"]
    G --> H["❌ 400 BadRequestError\n'temperature does not support 0.7'"]
```

## After

```mermaid
flowchart TD
    A[Caller invokes LLM] --> B["make_model_params()"]
    B --> C{"Did the caller set temperature?\n(call-site kwargs or jac.toml)"}
    C -->|yes| D[Include temperature in params]
    C -->|no| E[Omit temperature entirely]
    D --> F["litellm.completion(...)"]
    E --> F
    F --> G["✅ works on every route\n(direct, OpenRouter, ...)\nand every model\n(GPT-5/o-series, Claude+thinking)"]
```

## Changes

- `temperature` / `max_tokens` are now only included in the litellm call params when the caller actually set them — either at the call site (`llm(temperature=...)`) or via `jac.toml`'s `[byllm.call_params]` — otherwise the key is omitted entirely so the provider's own default applies. This mirrors how `tool_choice` is already handled.
- `get_call_params_config()` / `get_default_config()` no longer bake in a hardcoded `temperature: 0.7` default, so config-level detection of "did the user actually set this" is possible.
- Updated the `call_params.temperature` config-schema description to reflect the new behavior.
- Updated the `llm_params` fixture/test to set `temperature`/`max_tokens` explicitly (verifying pass-through), and added regression tests covering: no forced temperature/max_tokens by default, explicit call-site values passing through, and jac.toml-configured values applying only when configured.