### PR TITLE
fix(jac-scale): experimental deploys stage the dev admin console, matching their dev binary

### DIFF
--- a/docs/docs/community/release_notes/unreleased/jaclang/7704.bugfix.md
+++ b/docs/docs/community/release_notes/unreleased/jaclang/7704.bugfix.md
@@ -1,0 +1,1 @@
+- **jac-scale: experimental deploys now stage the dev admin console**: the `[experimental]` channel ships the `dev` jac binary, but its admin console was silently resolved from the latest stable release, pairing mismatched versions inside the app bundle. The console now follows the binary to the `dev` release and shares its download cache slot.

--- a/jac/jaclang/scale/injector/binary.jac
+++ b/jac/jaclang/scale/injector/binary.jac
@@ -341,6 +341,9 @@ def _admin_dist_urls(channel: str) -> tuple[str, str] {
 
 
 def download_admin_dist(channel: str) -> bytes | None {
+    if channel == "experimental" {
+        channel = "dev";
+    }
     try {
         (dist_url, checksum_url) = _admin_dist_urls(channel);
         if not dist_url {

--- a/jac/jaclang/scale/tests/microservices/test_binary_cache.jac
+++ b/jac/jaclang/scale/tests/microservices/test_binary_cache.jac
@@ -53,3 +53,33 @@ test "an unchanged release is served from the local cache, not re-downloaded" {
         shutil.rmtree(cache_dir, ignore_errors=True);
     }
 }
+
+
+test "experimental channel fetches the dev admin console and shares its cache slot" {
+    import jaclang.scale.injector.binary as binmod;
+    _calls.clear();
+    cache_dir = tempfile.mkdtemp();
+    saved_env = os.environ.get("JAC_SCALE_CACHE_DIR");
+    saved_http = binmod._http_get_bytes;
+    os.environ["JAC_SCALE_CACHE_DIR"] = cache_dir;
+    binmod._http_get_bytes = _fake_http;
+    try {
+        assert binmod.download_admin_dist("experimental") == _payload;
+        assert any(
+            ["releases/download/dev/jac-dev-admin-dist.tar.gz" in c for c in _calls]
+        );
+        assert not any(["api.github.com" in c for c in _calls]);
+        assert os.path.exists(os.path.join(cache_dir, "jac-dev-admin-dist.tar.gz"));
+        assert not os.path.exists(
+            os.path.join(cache_dir, "jac-experimental-admin-dist.tar.gz")
+        );
+    } finally {
+        binmod._http_get_bytes = saved_http;
+        if saved_env is None {
+            os.environ.pop("JAC_SCALE_CACHE_DIR", None);
+        } else {
+            os.environ["JAC_SCALE_CACHE_DIR"] = saved_env;
+        }
+        shutil.rmtree(cache_dir, ignore_errors=True);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up 3 from the #7682 cleanup. `download_release_binary` rewrites `experimental -> dev` before downloading (the experimental channel ships the `dev` binary; pods run the PR's image), but the admin-console path never did: the literal string `"experimental"` fell through `_admin_dist_urls`'s dev/local branches into the release-API branch. Every `[experimental]` deploy therefore paired a **dev binary** with a **latest-stable admin console**, cached under `jac-experimental-admin-dist.tar.gz`.

The fix mirrors the binary path's rewrite at the top of `download_admin_dist`, so one rewrite covers the URL, the cache slot, and the log label together: experimental deploys now fetch `releases/download/dev/jac-dev-admin-dist.tar.gz` and share the `jac-dev-admin-dist.tar.gz` cache slot (content-identical, same dedup the binary path uses).

## Behavior change

`[experimental]` deploys switch from the latest-stable console to the dev console, which matches the binary they run. The stale `jac-experimental-admin-dist.tar.gz` cache entry is simply no longer read; nothing migrates or deletes it. Stable, dev, and local channels are byte-identical to before.

## Test

New regression test drives the real `download_admin_dist("experimental")` through a checksum-serving HTTP fake and asserts the dev URL is fetched, the API is never consulted, and the cache lands in the dev slot, not an experimental one. Fails on the pre-fix code at the API assertion.

## Merge interaction

#7698 touches the same function (adds a `version` parameter); whichever merges second resolves a small conflict in `download_admin_dist`'s opening lines. Semantics compose: the rewrite stays version-free because the resolver never produces a pinned experimental deploy.
