### PR TITLE
fix(tests): adopt the testcontainers 4.15 community namespace; pin the CI install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,7 +806,7 @@ jobs:
           "opentelemetry-exporter-otlp-proto-http>=1.27.0,<2.0.0" \
           "apscheduler>=3.11.2,<4.0.0" "kubernetes>=34.1.0,<35.0.0" \
           "docker>=7.1.0,<8.0.0" "boto3>=1.40.0,<2.0.0" \
-          requests "testcontainers[mongodb,redis]" "moto[s3]>=5.0.0" \
+          requests "testcontainers[mongodb,redis]>=4.15,<5" "moto[s3]>=5.0.0" \
           --global
 
     - name: Run ${{ matrix.group }} tests

--- a/jac/jaclang/scale/tests/data/test_async_drivers.jac
+++ b/jac/jaclang/scale/tests/data/test_async_drivers.jac
@@ -12,8 +12,8 @@ node CounterNode {
     has value: int = 0;
 }
 
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 
 with entry {
     try {

--- a/jac/jaclang/scale/tests/data/test_direct_db.jac
+++ b/jac/jaclang/scale/tests/data/test_direct_db.jac
@@ -1,8 +1,8 @@
 import contextlib;
 import os;
 import from collections.abc { Generator }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.scale.persistence.db { close_all_db_connections }
 import from jaclang.scale.persistence.lib { kvstore }
 

--- a/jac/jaclang/scale/tests/data/test_jwt_validation_overhead.jac
+++ b/jac/jaclang/scale/tests/data/test_jwt_validation_overhead.jac
@@ -16,7 +16,7 @@ import time;
 import from pathlib { Path }
 
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
 import from jaclang.scale.tests.server_support {
     call_walker,
     get_free_port,

--- a/jac/jaclang/scale/tests/data/test_memory_hierarchy.jac
+++ b/jac/jaclang/scale/tests/data/test_memory_hierarchy.jac
@@ -11,8 +11,8 @@ import from typing { cast }
 import redis;
 import requests;
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.jac0core.archetype { Root }
 import from jaclang.scale.memory.context { JScaleExecutionContext }
 import from jaclang.scale.memory.memory_hierarchy { _process_cache, MongoBackend }

--- a/jac/jaclang/scale/tests/data/test_mongo_layer123.jac
+++ b/jac/jaclang/scale/tests/data/test_mongo_layer123.jac
@@ -5,8 +5,8 @@ import redis;
 import from typing { cast }
 import from uuid { uuid4, UUID }
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 
 import from jaclang.jac0core.archetype {
     Anchor,

--- a/jac/jaclang/scale/tests/data/test_mongo_user_manager.jac
+++ b/jac/jaclang/scale/tests/data/test_mongo_user_manager.jac
@@ -3,7 +3,7 @@ import from jaclang.scale.identity.user_manager { JacScaleUserManager }
 import from jaclang.scale.config.config_loader { reset_scale_config }
 
 test "mongodb user operations" {
-    import from testcontainers.mongodb { MongoDbContainer }
+    import from testcontainers.community.mongodb { MongoDbContainer }
     import tempfile;
 
     with MongoDbContainer("mongo:7.0") as mongo {

--- a/jac/jaclang/scale/tests/data/test_occ_replay.jac
+++ b/jac/jaclang/scale/tests/data/test_occ_replay.jac
@@ -2,7 +2,7 @@ import atexit;
 import threading;
 import from uuid { uuid4 }
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
 
 import from jaclang.jac0core.archetype { EdgeAnchor, GenericEdge, Root }
 import from jaclang.runtimelib.changeset { ChangeSet }

--- a/jac/jaclang/scale/tests/data/test_persistence_race.jac
+++ b/jac/jaclang/scale/tests/data/test_persistence_race.jac
@@ -21,8 +21,8 @@ import from concurrent.futures { ThreadPoolExecutor, as_completed }
 import redis;
 import requests;
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.scale.tests.server_support {
     call_walker,
     extract,

--- a/jac/jaclang/scale/tests/data/test_redis_stream.jac
+++ b/jac/jaclang/scale/tests/data/test_redis_stream.jac
@@ -1,7 +1,7 @@
 import contextlib;
 import time;
 import threading;
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.scale.persistence.db { close_all_db_connections, get_redis_client }
 import from jaclang.scale.events.broker { Event, RetryPolicy }
 import from jaclang.scale.events.streams.redis { RedisEventStream }

--- a/jac/jaclang/scale/tests/data/test_scalar_clobber_cross_process.jac
+++ b/jac/jaclang/scale/tests/data/test_scalar_clobber_cross_process.jac
@@ -26,8 +26,8 @@ import from pathlib { Path }
 import from typing { cast }
 
 import requests;
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.scale.tests.server_support { call_walker, extract, get_free_port }
 
 glob FIXTURES_DIR = Path(__file__).parent.parent / "fixtures",

--- a/jac/jaclang/scale/tests/data/test_schema_repair_mongo.jac
+++ b/jac/jaclang/scale/tests/data/test_schema_repair_mongo.jac
@@ -2,7 +2,7 @@ import atexit;
 import from typing { cast }
 import from uuid { uuid4, UUID }
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
 
 import from jaclang.jac0core.archetype { Anchor, NodeAnchor, Root }
 import from jaclang.runtimelib.serializer { Serializer }

--- a/jac/jaclang/scale/tests/data/test_serializer_social.jac
+++ b/jac/jaclang/scale/tests/data/test_serializer_social.jac
@@ -10,7 +10,7 @@ import from jaclang.scale.tests.fixtures.social_graph {
 import from jaclang.scale.persistence.lib { kvstore }
 import from jaclang.scale.persistence.db { close_all_db_connections }
 import from jaclang.scale.config.config_loader { reset_scale_config }
-import from testcontainers.mongodb { MongoDbContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
 import from uuid { uuid4 }
 import from jaclang.jac0core.archetype { NodeAnchor, EdgeAnchor, ObjectAnchor }
 

--- a/jac/jaclang/scale/tests/data/test_topology_cross_pod_invalidation.jac
+++ b/jac/jaclang/scale/tests/data/test_topology_cross_pod_invalidation.jac
@@ -19,8 +19,8 @@ import redis;
 import from typing { cast }
 import from uuid { UUID }
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 
 import from jaclang.jac0core.runtime { JacRuntime }
 import from jaclang.jac0core.archetype { NodeAnchor, Root }

--- a/jac/jaclang/scale/tests/data/test_topology_slice_pushdown.jac
+++ b/jac/jaclang/scale/tests/data/test_topology_slice_pushdown.jac
@@ -4,8 +4,8 @@ import from typing { cast }
 import from pathlib { Path }
 import redis;
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 
 import from jaclang.jac0core.runtime { JacRuntime }
 import from jaclang.runtimelib.context { ExecutionContext }

--- a/jac/jaclang/scale/tests/quarantine/test_connection_overhead.jac
+++ b/jac/jaclang/scale/tests/quarantine/test_connection_overhead.jac
@@ -20,7 +20,7 @@ import time;
 import from pathlib { Path }
 
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
 import from jaclang.scale.tests.server_support {
     call_walker,
     get_free_port,

--- a/jac/jaclang/scale/tests/quarantine/test_redis_batch_overhead.jac
+++ b/jac/jaclang/scale/tests/quarantine/test_redis_batch_overhead.jac
@@ -17,8 +17,8 @@ import from pathlib { Path }
 
 import redis;
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.scale.tests.server_support {
     call_walker,
     get_free_port,

--- a/jac/jaclang/scale/tests/quarantine/test_redis_memory_leak.jac
+++ b/jac/jaclang/scale/tests/quarantine/test_redis_memory_leak.jac
@@ -17,8 +17,8 @@ import from pathlib { Path }
 
 import redis;
 import from pymongo { MongoClient }
-import from testcontainers.mongodb { MongoDbContainer }
-import from testcontainers.redis { RedisContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
+import from testcontainers.community.redis { RedisContainer }
 import from jaclang.scale.tests.server_support {
     call_walker,
     get_free_port,

--- a/jac/jaclang/scale/tests/server/test_webhook.jac
+++ b/jac/jaclang/scale/tests/server/test_webhook.jac
@@ -19,7 +19,7 @@ import from logging.handlers { MemoryHandler }
 import from pathlib { Path }
 import from typing { cast }
 
-import from testcontainers.mongodb { MongoDbContainer }
+import from testcontainers.community.mongodb { MongoDbContainer }
 import from pymongo { MongoClient }
 
 import from jaclang.scale.tests.scale_test_client {


### PR DESCRIPTION
## Summary

`testcontainers 4.15.0` (released 2026-07-24) moved container modules to `testcontainers.community.*` and made the old paths raise a `DeprecationWarning` at import, which the test harness treats as a collection failure. Since CI installs `testcontainers[mongodb,redis]` **unpinned** (`ci.yml`), the `test-scale (data)` and `test-scale (server)` legs went red on `main` and every open PR the day 4.15.0 shipped.

## Changes

- Migrate the 18 affected test files: `testcontainers.mongodb` → `testcontainers.community.mongodb`, `testcontainers.redis` → `testcontainers.community.redis` (`scale/tests/data/`, `scale/tests/server/test_webhook.jac`, `scale/tests/quarantine/`).
- Pin the CI install to `testcontainers[mongodb,redis]>=4.15,<5`. The pin and the imports must move together: the `community` namespace does not exist before 4.15 (verified on 4.14.2), so migrated imports on an older install would fail the other way.

`tests/project/test_dependencies.jac` also mentions `testcontainers[mongodb,redis]`, but only as extras-resolution test data (a TOML string, never imported) -- left untouched.

## Validation

- On 4.15.0 under warnings-as-errors: the old import raises `DeprecationWarning`; both community imports load cleanly.
- Through jac's own import machinery (`jac install "testcontainers[mongodb,redis]>=4.15,<5" --global`, mirroring the CI step): running a migrated test file now gets past collection and proceeds to the docker stage, while the unmigrated file on `main` against the same environment still fails collection with the exact `DeprecationWarning` seen in CI.
- Container startup itself is exercised by the `test-scale` legs on this PR (no docker on the local dev host).