### PR TITLE
feat(jac-scale): raw response bodies via @restspec(envelope=False, produces=...)

### DIFF
--- a/jac/jaclang/runtimelib/server.jac
+++ b/jac/jaclang/runtimelib/server.jac
@@ -214,7 +214,9 @@ obj JacAPIServer {
         has method: str = "",
             path: str = "",
             protocol: APIProtocol = APIProtocol.HTTP,
-            broadcast: bool = False;
+            broadcast: bool = False,
+            produces: str = "",
+            envelope: bool = True;
     }
 
     def postinit -> None;

--- a/jac/jaclang/scale/server/impl/serve.endpoints.impl.jac
+++ b/jac/jaclang/scale/server/impl/serve.endpoints.impl.jac
@@ -242,13 +242,22 @@ impl JacAPIServerEndpoints.create_function_parameters(
 
 impl JacAPIServerEndpoints.create_function_callback(
     func_name: str
-) -> Callable[..., (TransportResponse | StreamingResponse)] {
+) -> Callable[..., (TransportResponse | StreamingResponse | Response)] {
     import from jaclang.runtimelib.transport { TransportResponse, Meta }
     import from fastapi { Request }
     requires_auth = self.introspector.is_auth_required_for_function(func_name);
+
+    func_spec = self.get_functions()[func_name].restspec
+        if self.get_functions()[func_name]?.restspec
+        else None;
+    raw_body = func_spec is not None and not func_spec.envelope;
+    raw_media_type = (func_spec.produces or 'text/plain')
+        if func_spec
+        else 'text/plain';
+
     async def callback(
         request: Request, **kwargs: JsonValue
-    ) -> (TransportResponse | StreamingResponse) {
+    ) -> (TransportResponse | StreamingResponse | Response) {
         username: (str | None) = request.state?.username if request?.state else None;
         if requires_auth and not username {
             return TransportResponse.fail(
@@ -288,6 +297,19 @@ impl JacAPIServerEndpoints.create_function_callback(
                 details=result.get('traceback') if 'traceback' in result else None,
                 meta=Meta(extra={'http_status': 500})
             );
+        }
+        if raw_body {
+            payload = result.get('result') if isinstance(result, dict) else result;
+            if isinstance(payload, bytes) {
+                body = payload;
+            } elif isinstance(payload, str) {
+                body = payload.encode('utf-8');
+            } elif payload is None {
+                body = b"";
+            } else {
+                body = json.dumps(payload).encode('utf-8');
+            }
+            return Response(content=body, media_type=raw_media_type);
         }
         return TransportResponse.success(
             data=result, meta=Meta(extra={'http_status': 200})

--- a/jac/jaclang/scale/tests/fixtures/restspec_fixtures.jac
+++ b/jac/jaclang/scale/tests/fixtures/restspec_fixtures.jac
@@ -319,3 +319,40 @@ def create_tree_func(`root: TreeNode) -> dict {
         "node_count": _tree_count(`root)
     };
 }
+
+# ============================================================================
+# Raw response body: @restspec(envelope=False) + produces
+# Public (`:pub`) so the raw-body path is exercised without an auth header --
+# the motivating case is an unauthenticated `curl | bash` installer script.
+# ============================================================================
+"""Raw body with an explicit content type."""
+@restspec(
+    method=HTTPMethod.GET,
+    path="/raw/script.sh",
+    produces="text/x-shellscript",
+    envelope=False
+)
+def:pub raw_script -> str {
+    return "#!/usr/bin/env bash\necho jac\n";
+}
+
+"""Raw body with no `produces` falls back to text/plain."""
+@restspec(method=HTTPMethod.GET, path="/raw/plain", envelope=False)
+def:pub raw_plain -> str {
+    return "plain body";
+}
+
+"""A non-str return under envelope=False is JSON-encoded into the body, but
+without the transport envelope wrapping it."""
+@restspec(
+    method=HTTPMethod.GET, path="/raw/json", produces="application/json", envelope=False
+)
+def:pub raw_json -> dict {
+    return {"a": 1};
+}
+
+"""Envelope stays on by default -- regression guard for the opt-in."""
+@restspec(method=HTTPMethod.GET, path="/raw/enveloped")
+def:pub still_enveloped -> str {
+    return "wrapped";
+}

--- a/jac/jaclang/scale/tests/server/test_restspec.jac
+++ b/jac/jaclang/scale/tests/server/test_restspec.jac
@@ -604,3 +604,58 @@ test "recursive obj body flows" {
         client.close();
     }
 }
+
+# ============================================================================
+# Raw response body -- @restspec(envelope=False, produces=...)
+# The endpoint that motivated this: a `curl | bash` installer cannot be handed
+# a JSON envelope, so the return value has to reach the wire verbatim.
+# ============================================================================
+test "raw body skips the transport envelope" {
+    client = make_client("restspec_fixtures.jac");
+    try {
+        r = client.get("/raw/script.sh");
+        assert r.status_code == 200 , r.text;
+        # Body is the return value verbatim -- no {"ok":..,"data":..} wrapper.
+        assert r.text == "#!/usr/bin/env bash\necho jac\n" , r.text;
+        assert r.headers["content-type"].startswith("text/x-shellscript");
+        assert "\"ok\"" not in r.text;
+    } finally {
+        client.close();
+    }
+}
+
+test "raw body defaults to text/plain without produces" {
+    client = make_client("restspec_fixtures.jac");
+    try {
+        r = client.get("/raw/plain");
+        assert r.status_code == 200 , r.text;
+        assert r.text == "plain body";
+        assert r.headers["content-type"].startswith("text/plain");
+    } finally {
+        client.close();
+    }
+}
+
+test "raw body json-encodes non-str returns without the envelope" {
+    client = make_client("restspec_fixtures.jac");
+    try {
+        r = client.get("/raw/json");
+        assert r.status_code == 200 , r.text;
+        assert r.json() == {"a": 1} , r.text;
+        assert r.headers["content-type"].startswith("application/json");
+    } finally {
+        client.close();
+    }
+}
+
+test "envelope remains the default" {
+    client = make_client("restspec_fixtures.jac");
+    try {
+        r = client.get("/raw/enveloped");
+        assert r.status_code == 200 , r.text;
+        assert r.headers["content-type"].startswith("application/json");
+        assert extract_data(r.json())["result"] == "wrapped";
+    } finally {
+        client.close();
+    }
+}


### PR DESCRIPTION
## The gap

`@restspec` declares the **request** side of an endpoint -- `method`, `path`, `protocol`, `broadcast` -- but there has never been a way to shape the **response**. Every walker and function return is wrapped in the JSON transport envelope, with one exception: the branch that infers SSE from a generator return type.

Returning a `fastapi.Response` does not escape it either. The value is reflectively serialized *into* the envelope:

```
{"data":{"result":{"__type__":"PlainTextResponse","__module__":"starlette.responses",
 "media_type":"text/x-shellscript","body":"b'#!/usr/bin/env bash\\n...'", ...}}}
```

That makes a whole class of endpoint inexpressible in user code. The motivating one: an installer served for `curl -fsSL https://host/install.sh | bash` cannot hand a shell `{"ok":true,"data":{...}}`.

## The change

Two response-side fields on `RestSpecs`, honored in `create_function_callback`:

```jac
@restspec(method=HTTPMethod.GET, path="/install.sh",
          produces="text/x-shellscript", envelope=False)
def:pub install_sh -> str { ... }
```

- `envelope=False` returns the function's value as the response body verbatim.
- `produces` sets its `Content-Type` (defaults to `text/plain`).

The declaration carries the HTTP concerns, so the body stays a pure `-> str` and the function remains transport-agnostic -- the same reason `method`/`path` live on the decorator rather than in the body. Routing already worked: function endpoints register ahead of the root-asset catch-all, so an arbitrary root path like `/install.sh` binds without touching asset resolution.

## Deliberate limits

- **Functions only.** A walker can `report` any number of times, so there is no single value to project onto a raw body.
- **Raw bodies are text.** A `bytes` return is stringified by `Serializer` before the response layer sees it, so binary payloads need a serializer bypass that does not exist yet. Documented rather than half-supported.
- **Error paths keep the envelope.** A 500 shaped like a valid payload is worse than an obviously wrong one.

## Tests

Four cases added to `jac/jaclang/scale/tests/server/test_restspec.jac`, with fixtures in `restspec_fixtures.jac`:

- raw body reaches the wire verbatim with the declared content type
- raw body defaults to `text/plain` when `produces` is omitted
- a non-str return is JSON-encoded into the body *without* the envelope
- the envelope remains the default (regression guard on the opt-in)

`jac test jac/jaclang/scale/tests/server/test_restspec.jac` -> **23 passed** (19 pre-existing + 4 new), verified against this PR's base.

## Follow-ups, not in this PR

`APIProtocol` has `HTTP`, `WEBHOOK`, `WEBSOCKET` but no `SSE` -- streaming is still inferred from the return type rather than declared, so the generated client stub cannot know an endpoint streams. Giving SSE the same declarative treatment would retire the last piece of magic on this axis.