### PR TITLE
docs: document @restspec produces/envelope (raw response bodies)

### DIFF
--- a/docs/docs/internals/interop.md
+++ b/docs/docs/internals/interop.md
@@ -514,6 +514,14 @@ Everything crossing a marshalled boundary is **JSON** (for `cl↔sv` and the
   (functions), then runs typed values through `__from_wire`. Errors come
   back `{ "ok": false, "error": { "code", "message", "details" } }`.
 
+  A function declared `@restspec(envelope=False, produces=...)` skips this
+  wrapper: its return value is written to the body verbatim under the
+  declared content type, for callers that are not Jac clients (a
+  `curl | bash` installer, `robots.txt`, a feed). Serialisation still runs,
+  so the body is text; error paths keep the envelope. Walkers always keep it,
+  having no single value to project. See
+  [jac-scale HTTP](../reference/plugins/jac-scale-http.md#raw-response-bodies).
+
 ### C-ABI wire format (`na`)
 
 Scalars use the `JAC_TO_CTYPES` map (`int→c_int64`, `float→c_double`,

--- a/docs/docs/reference/language/syntax-cheatsheet.md
+++ b/docs/docs/reference/language/syntax-cheatsheet.md
@@ -1077,6 +1077,14 @@ walker:pub get_item {
     }
 }
 
+# envelope=False returns a function's value as the body verbatim
+# (functions only) -- for callers that cannot read the JSON envelope
+@restspec(method=HTTPMethod.GET, path="/robots.txt",
+          produces="text/plain", envelope=False)
+def:pub robots() -> str {
+    return "User-agent: *\nAllow: /\n";
+}
+
 
 # ============================================================
 # Async Walkers

--- a/docs/docs/reference/plugins/jac-scale-http.md
+++ b/docs/docs/reference/plugins/jac-scale-http.md
@@ -137,7 +137,31 @@ curl -X POST http://localhost:8000/walker/search \
 
 ### Response Format
 
-Walker `report` values become the response.
+Responses are wrapped in a JSON envelope. Walker `report` values arrive in
+`data.reports`; a function's return value arrives in `data.result`:
+
+```json
+{
+  "ok": true,
+  "type": "response",
+  "data": { "result": null, "reports": [ ... ] },
+  "error": null,
+  "meta": { }
+}
+```
+
+Failures keep the same shape with `"ok": false` and an `error` object:
+
+```json
+{ "ok": false, "error": { "code": "EXECUTION_ERROR", "message": "..." } }
+```
+
+Generated client stubs unwrap this for you. When calling from outside Jac,
+read `data.reports` for walkers and `data.result` for functions.
+
+Functions can opt out of the envelope entirely with
+`@restspec(envelope=False)` when the caller needs the raw bytes -- see
+[Raw Response Bodies](#raw-response-bodies).
 
 ---
 
@@ -194,6 +218,11 @@ The `@restspec` decorator customizes how walkers and functions are exposed as RE
 | `path` | `str` | `""` (auto-generated) | Custom URL path for the endpoint |
 | `protocol` | `APIProtocol` | `APIProtocol.HTTP` | Protocol for the endpoint (`HTTP`, `WEBHOOK`, or `WEBSOCKET`) |
 | `broadcast` | `bool` | `False` | Broadcast responses to all connected WebSocket clients (only valid with `WEBSOCKET` protocol) |
+| `produces` | `str` | `""` (`text/plain`) | `Content-Type` of the response body. Only meaningful with `envelope=False` |
+| `envelope` | `bool` | `True` | When `False`, the function's return value becomes the response body verbatim instead of being wrapped in the JSON envelope. **Functions only** |
+
+The first four options shape the **request** (how the endpoint is reached);
+`produces` and `envelope` shape the **response** (what comes back).
 
 > **Note:** `APIProtocol` and `restspec` are builtins and do not require an import statement. `HTTPMethod` must be imported with `import from http { HTTPMethod }`.
 
@@ -265,6 +294,74 @@ def :pub health_check() -> dict {
 @restspec(method=HTTPMethod.GET, path="/custom/status")
 def :pub app_status() -> dict {
     return {"status": "running", "version": "1.0.0"};
+}
+```
+
+### Raw Response Bodies
+
+By default every response is wrapped in the JSON transport envelope (see
+[Response Format](#response-format)). Some endpoints cannot be: a shell
+installer served for `curl | bash`, a `robots.txt`, an RSS feed, a
+`.well-known` document. `envelope=False` returns the function's value as the
+response body verbatim, and `produces` types it:
+
+```jac
+import from http { HTTPMethod }
+
+@restspec(
+    method=HTTPMethod.GET,
+    path="/install.sh",
+    produces="text/x-shellscript",
+    envelope=False
+)
+def :pub install_sh() -> str {
+    return "#!/usr/bin/env bash\necho installing...\n";
+}
+```
+
+```bash
+$ curl -sS -D- http://localhost:8000/install.sh
+HTTP/1.1 200 OK
+content-type: text/x-shellscript; charset=utf-8
+
+#!/usr/bin/env bash
+echo installing...
+```
+
+So `curl -fsSL http://localhost:8000/install.sh | bash` works. Without
+`envelope=False` the shell would instead receive
+`{"ok":true,"data":{"result":"#!/usr/bin/env bash\n..."}}`.
+
+The HTTP concerns stay on the declaration, so the body remains an ordinary
+`-> str` with no transport types in it.
+
+!!! note "Root paths are available"
+    Function endpoints are registered ahead of the static-asset catch-all, so
+    a `path` like `/install.sh` or `/robots.txt` binds to your function and
+    never reaches asset resolution.
+
+#### Limits
+
+- **Functions only.** A walker can `report` any number of times, so there is
+  no single value to project onto a raw body. `envelope=False` on a walker
+  has no effect.
+- **Text only.** A `bytes` return is stringified by `Serializer` before the
+  response layer sees it, so binary payloads are not yet expressible. Serve
+  those as static assets.
+- **Errors keep the envelope.** A failing call still returns the JSON error
+  envelope with its usual status code, so a 500 is never mistaken for a valid
+  payload of the declared content type. Callers should check the status, and
+  `curl -f` does this for you.
+
+Omitting `produces` yields `text/plain; charset=utf-8`. A non-`str` return is
+JSON-encoded into the body, but still without the envelope around it -- useful
+when a third-party client expects a bare JSON document:
+
+```jac
+@restspec(method=HTTPMethod.GET, path="/.well-known/jac.json",
+          produces="application/json", envelope=False)
+def :pub well_known() -> dict {
+    return {"version": "1.0"};   # body is exactly {"version": "1.0"}
 }
 ```
 


### PR DESCRIPTION
Documentation follow-up to #7727, which added the `produces` and `envelope` fields to `@restspec`.

While writing it I found the reference never actually documented the response envelope -- "Response Format" was one sentence, *"Walker `report` values become the response."* -- so an opt-out flag had nothing on the page to opt out of. This fills that in as well.

## Changes

**`reference/plugins/jac-scale-http.md`**

- `produces` and `envelope` added to the `@restspec` options table, with a note that the first four options shape the **request** and these two shape the **response**.
- New **Raw Response Bodies** section: the `curl | bash` motivation, what the envelope would otherwise hand the shell, and the cases people will hit -- omitting `produces` (defaults to `text/plain`), and a non-`str` return (JSON-encoded into the body, still unwrapped).
- The three limits stated plainly: functions only, text only, and errors keeping the envelope so a 500 is never mistaken for a valid payload of the declared content type.
- **Response Format** filled in with the real envelope shape (`data.reports` for walkers, `data.result` for functions), the error form, and a pointer to the opt-out.

**`internals/interop.md`** -- the envelope opt-out noted where the `cl → sv` wire format is specified.

**`reference/language/syntax-cheatsheet.md`** -- a `robots.txt` one-liner beside the existing `@restspec` example.

## Verification

Every claim was run against the merged implementation rather than reasoned about:

| Claim | Result |
|---|---|
| Omitting `produces` yields `text/plain` | `content-type: text/plain; charset=utf-8` |
| A dotted multi-segment path binds ahead of asset resolution | `GET /.well-known/jac.json` -> `200`, body exactly `{"version": "1.0"}` |
| Non-`str` return is JSON-encoded without the envelope | body is the bare document, no `{"ok":...}` wrapper |
| `envelope=False` on a walker has no effect | still returns the full envelope, as the "functions only" limit says |

`jac -m mkdocs build --strict` passes, so the new cross-page anchors resolve, and `docs/tests/test_docs.jac` passes.

No release-notes entry: that file is only touched by `release:` commits.