### PR TITLE
fix(lint): W3005 false positive on paren-less defs; guides: endpoint shape rule

### DIFF
--- a/jac/jaclang/cli/skills/jac-fullstack-patterns.md
+++ b/jac/jaclang/cli/skills/jac-fullstack-patterns.md
@@ -23,15 +23,17 @@ That no-argument `app()` is the single-page / manual-routing shape. With file-ba
 
 ## Two call styles: function RPC vs walker spawn
 
-The client reaches the server two ways, with OPPOSITE argument rules:
+The client reaches the server two ways:
 
 | | `def:pub` function RPC | walker spawn |
 |---|---|---|
-| call form | `await save_profile(name, email)` | `result = root spawn add_task(title=t);` |
-| argument rule | **POSITIONAL only** - kwargs send an empty body → 422 | **KWARGS only** - they map to the walker's `has` fields |
+| call form | `await save_profile(name, email)` or `await doc_tree(version=v)` | `result = root spawn add_task(title=t);` |
+| argument rule | positional AND kwargs both work - resolved against the server signature | **KWARGS only** - they map to the walker's `has` fields |
 | return value | the function's return value (typed, hydrated) | a result object: read `result.reports` |
 
-**Function RPC:** `save_profile(a, b)` works; `save_profile(name=a, email=b)` → `422 Field required`. The caller's *variable names* become the JSON keys, so they must exactly match the server parameter names: if the server is `def:pub get_moves(game_id: str, row: int, col: int)`, calling `get_moves(game_id, r, c)` 422s - rename the caller's locals to `row`/`col`.
+**Function RPC:** the compiled stub resolves arguments against the *server's* declared parameter names - positional args map by position, kwargs by name, and the JSON body is keyed by the server's names regardless of the caller's local variable names (verified in the emitted JS: `get_moves(game_id, r, c)` wires `r`/`c` onto `row`/`col` by position). Passing the same parameter both ways is a compile error (E5080).
+
+**Pick the shape by whether the endpoint walks: no `visit`, no walker.** A single-`Root entry` walker that just `report`s is better written as a `def:pub` function - typed return instead of `reports[0]`, real parameters instead of `has` fields, identical `root` binding. The full rule lives in `jac-sv-endpoints`.
 
 **Walker spawn** (the docs' primary backend pattern): kwargs fill the walker's `has` fields; everything the walker `report`s lands in `result.reports` (a list - first report is `result.reports[0]`). Both styles are async on the client - inside an async context the spawn awaits implicitly:
 

--- a/jac/jaclang/cli/skills/jac-sv-endpoints.md
+++ b/jac/jaclang/cli/skills/jac-sv-endpoints.md
@@ -1,9 +1,11 @@
 ---
 name: jac-sv-endpoints
-description: Server endpoints - REST API endpoints (/walker/<name>, /function/<name>), walker:pub, the response envelope, @restspec custom routes/methods, file uploads, typed responses. For any REST consumer, not just the jac client. Pair with `jac-sv-persistence` (graph queries), `jac-sv-auth` (auth semantics), `jac-sv-streaming` (SSE).
+description: Server endpoints - REST API endpoints (/walker/<name>, /function/<name>), walker:pub, choosing walker vs function shape (no visit = def:pub), the response envelope, @restspec custom routes/methods, file uploads, typed responses. For any REST consumer, not just the jac client. Pair with `jac-sv-persistence` (graph queries), `jac-sv-auth` (auth semantics), `jac-sv-streaming` (SSE).
 ---
 
 A Jac server exposes two endpoint shapes. **Functions** (`def:pub` / `def:priv` / plain `def`) are the natural fit for full-stack RPC - the jac client calls them like local functions and the return type is the wire format. **Walkers** (`walker:pub`) are the docs' primary pattern for pure API services consumed over raw REST: `has` fields are the request body, `report` values are the response. Both live in `main.jac`, a plain `.jac` server module, or a `.sv.jac` module (server is the default context). Streaming endpoints (`-> Generator`, SSE): `jac-sv-streaming`.
+
+**Choose the shape by whether the endpoint walks: no `visit`, no walker.** A `walker:pub` whose only ability is one `can run with Root entry { ... report X; }` is a function in walker costume, and every caller pays the costume tax: `result.reports[0]` unwrapping instead of a typed return value, request params disguised as `has` fields, `report` bypassing return-type checking. Write it as a `def:pub` with a typed return instead - `root` binds identically (both shapes run in the caller's request context, so `root` / `root.shared` graph code moves over unchanged; verified against the serve runtime). Status probes, single-node CRUD, list queries, kick-off-a-job calls are all functions. Reserve `walker:pub` for endpoints that actually traverse: spawn, `visit` along edges, accumulate, report once.
 
 Auth/visibility is per-declaration (canonical semantics in `jac-sv-auth`):
 
@@ -64,6 +66,8 @@ jac start api.jac --no-client       # API only, no frontend bundling (NOT --no_c
 curl -X POST http://localhost:8000/walker/add_task \
   -H "Content-Type: application/json" -d '{"title": "Write docs"}'
 ```
+
+(The example is kept minimal to show the wire shape - by the shape rule above, an endpoint this simple belongs in a `def:pub`; a walker pays off once the body traverses.)
 
 For typed report accumulation (`has reports: list[T] = [];`, exit-collector pattern), load `jac-walker-patterns` - it owns that pattern.
 

--- a/jac/jaclang/cli/skills/jac-walker-patterns.md
+++ b/jac/jaclang/cli/skills/jac-walker-patterns.md
@@ -1,6 +1,6 @@
 ---
 name: jac-walker-patterns
-description: Writing walkers that traverse the graph - the core of Object-Spatial Programming (OSP) in Jac. Entry points, visit/report, spawn results, disengage/skip, exit abilities, get-or-create `visit ... else`, lookup-base walker inheritance, walker API responses. Load when creating, editing, or debugging walker traversal or OSP code. Pair with `jac-node-edge-patterns` (the graph shape the walker moves through).
+description: Writing walkers that traverse the graph - the core of Object-Spatial Programming (OSP) in Jac. Entry points, visit/report, spawn results, disengage/skip, exit abilities, get-or-create `visit ... else`, lookup-base walker inheritance, walker API responses, when NOT to use a walker (no visit = def:pub function). Load when creating, editing, or debugging walker traversal or OSP code. Pair with `jac-node-edge-patterns` (the graph shape the walker moves through).
 ---
 
 A walker is a mobile procedure that enters nodes and runs type-matched entry points. Walker state lives on the walker via `has`; traversal is driven by `visit`; results come back via `report`. Entry points can live on **both** sides - the walker reacts to nodes it enters, and nodes can react to arriving walkers.
@@ -116,6 +116,7 @@ walker like_tweet(find_tweet) {       # inherits target_id + locate
 
 ## Pitfalls
 
+- **A walker that never `visit`s should be a `def:pub` function.** If the whole walker is one `can run with Root entry { ... report X; }`, that's RPC in walker costume: convert it - parameters replace the `has` fields, a typed `return` replaces `report`, callers drop the `result.reports[0]` unwrap, and `root` binds the same in both shapes. Walkers earn their keep by walking. Shape rule and trade-offs: `jac-sv-endpoints`.
 - `Root` in type annotations, bare `root` as a value. The call form `root()` was removed - it is a hard error (E0049). Always write `root`, `root ++> node`, `[root -->]`.
 - **`visit` is a statement, not a method.** `visit [-->]` queues the *nodes* reachable over outgoing edges (`[edge -->]` is the form that yields edge objects); `visit (node_expr)` queues one specific node. Variants: `[<--]` incoming, `[->:EdgeType:->]` typed - single arrows; `[-->:EdgeType:]` is a parse error. Do NOT write `self.visit(...)` - a walker has no `visit` attribute (fails E1030).
 - Walkers don't `return` - they `report X;` (appears in `result.reports`) or `disengage;`.

--- a/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
+++ b/jac/jaclang/compiler/passes/tool/impl/jac_auto_lint_pass.impl.jac
@@ -1530,6 +1530,13 @@ impl JacAutoLintPass._remove_empty_parens_from_sig(
     if has_params {
         return;
     }
+    has_parens = any(
+        isinstance(kid, uni.Token) and kid.name in (Tok.LPAREN, Tok.RPAREN)
+        for kid in sig.kid
+    );
+    if not has_parens {
+        return;
+    }
     if sig.return_type is None {
         if not self.emit(W3005, node_override=target_node) {
             return;
@@ -1547,13 +1554,6 @@ impl JacAutoLintPass._remove_empty_parens_from_sig(
         target_node.kid = new_kid;
         target_node._invalidate_sub_node_tab();
     } else {
-        has_parens = any(
-            isinstance(kid, uni.Token) and kid.name in (Tok.LPAREN, Tok.RPAREN)
-            for kid in sig.kid
-        );
-        if not has_parens {
-            return;
-        }
         if not self.emit(W3005, node_override=target_node) {
             return;
         }

--- a/jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.jac
+++ b/jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.jac
@@ -536,6 +536,29 @@ test "empty parens removed" {
     assert "x: int" in formatted;
 }
 
+test "paren-less zero-arg def emits no W3005" {
+    src = "def already_clean {\n    return;\n}\n\n"
+    "def clean_with_return -> int {\n    return 1;\n}\n";
+    (fd, path) = tempfile.mkstemp(suffix=".jac");
+    os.close(fd);
+    with open(path, "w") as f {
+        f.write(src);
+    }
+    try {
+        prog = JacProgram.jac_file_formatter(path, auto_lint=True);
+        formatted = prog.mod.main.gen.jac;
+        assert "def already_clean {" in formatted;
+        assert "def clean_with_return -> int {" in formatted;
+        for w in (prog.warnings_had or []) {
+            assert "remove-empty-parens" not in str(w) , (
+                f"false W3005 on paren-less def: {w}"
+            );
+        }
+    } finally {
+        os.remove(path);
+    }
+}
+
 test "empty parens method preserved when has self" {
     input_path = auto_lint_fixture_path("empty_parens.jac");
 


### PR DESCRIPTION
## What

Two related changes from dogfooding jaclang.org's conversion of single-shot walkers to `def:pub` functions.

### W3005 false positive (compiler lint)

`W3005` (remove-empty-parens) fired on every zero-arg `def`/ability with no return type even when the declaration had no parentheses at all -- the no-return-type branch of `_remove_empty_parens_from_sig` emitted before checking for `LPAREN`/`RPAREN` tokens, so already-idiomatic `def finish {` warned on every lint run (19 spurious warnings across jaclang.org alone; the return-type branch already guarded correctly). The `has_parens` check is now hoisted so both branches require actual parens before emitting or rewriting.

Regression test added: a paren-less zero-arg def emits no W3005 and survives the formatter unchanged. `test_jac_auto_lint_pass.jac` (70) and `test_jac_lint_report.jac` (2) pass.

### Guide skills: choose endpoint shape by whether it walks

Converting jaclang.org's no-`visit` walkers (`docs_status`, `ensure_docs`, `doc_tree`, `ensure_install`, `submit_repo`, `leaderboard`, `board_status`) to `def:pub` functions surfaced a principle the guides never stated:

- **jac-sv-endpoints**: new shape rule -- a `walker:pub` whose only ability is one `can run with Root entry { ... report X; }` is a function in walker costume (callers pay `reports[0]` unwrapping, params masquerade as `has` fields, `report` bypasses return-type checking). `root` binds identically in both shapes (verified against the serve runtime's request context), so graph code moves over unchanged. Walkers are for endpoints that traverse.
- **jac-walker-patterns**: pitfall entry for the no-visit walker.
- **jac-fullstack-patterns**: corrected a stale claim that function RPC is positional-only with caller variable names as JSON keys. The compiled stub resolves positional and keyword args against the server signature and keys the body by server parameter names, with E5080 on duplicates -- verified against emitted client JS (`doc_tree(version=want_version)` compiles to `__jacCallFunction("doc_tree", {"version": want_version})`). Added the shape-rule pointer.

## Testing

- `jac test jac/tests/compiler/passes/tool/test_jac_auto_lint_pass.jac` -- 70 passed (includes new regression)
- `jac test jac/tests/compiler/passes/tool/test_jac_lint_report.jac` -- 2 passed (report/mutation parity holds)
- `jac check .` on jaclang.org: W3005 count 19 -> 0, no errors