### PR TITLE
feat(release): ship Intel-mac (macos-x86_64) binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -51,9 +51,13 @@ jobs:
         # zig_target pins each Linux binary's glibc floor (2.17, manylinux2014)
         # on the release channel; the dev channel builds host-native so it can
         # reuse the native-ABI LLVMPY shim cache (the shim cache key does not
-        # encode a target triple). macOS builds host-native on both channels.
-        # No Intel-Mac leg: LLVM ships no macOS-x64 prebuilt for the pinned
-        # release.
+        # encode a target triple). macOS-ARM builds host-native on both
+        # channels. The Intel-Mac leg pins the macOS floor (12.0) the same way
+        # the Linux legs pin glibc -- unpinned it would inherit the runner's
+        # macOS 15 and exclude older Intel Macs; its LLVM slice is llvm-slice's
+        # from-source build (upstream ships no macOS-x64 for the pinned
+        # release). macos-15-intel is GitHub's last Intel image (retires Fall
+        # 2027).
         include:
           - os: ubuntu-latest
             platform: linux-x86_64
@@ -63,6 +67,9 @@ jobs:
             zig_target: aarch64-linux-gnu.2.17
           - os: macos-14
             platform: macos-aarch64
+          - os: macos-15-intel
+            platform: macos-x86_64
+            zig_target: x86_64-macos.12.0
     runs-on: ${{ matrix.os }}
     env:
       # -Dtarget flag for zig build: set on release-channel Linux legs, empty
@@ -243,6 +250,35 @@ jobs:
           [ -f "$SHIM" ] || zig build jacllvm -Dtarget=${{ matrix.zig_target }} --summary all
           [ -f "$SHIM" ] || SHIM="zig-out/lib/libjacllvm.so"
           check "$SHIM"
+
+      # Intel-mac mirror of the glibc check: neither the launcher nor the shim
+      # may require a macOS newer than the zig_target floor, and the shim must
+      # carry no Homebrew load commands (its from-source slice is built with
+      # every external OFF, so a brew dep here means the slice regressed).
+      # Release channel only: dev binaries are host-native with no pinned floor.
+      - name: Verify macOS floor (from zig_target)
+        if: runner.os == 'macOS' && inputs.channel != 'dev' && matrix.zig_target
+        working-directory: jac
+        env:
+          ZIG_TARGET: ${{ matrix.zig_target }}
+        run: |
+          set -euxo pipefail
+          FLOOR="${ZIG_TARGET##*macos.}"
+          check() {
+            local f="$1" minos
+            [ -f "$f" ] || { echo "::error::missing $f"; exit 1; }
+            minos="$(otool -l "$f" | awk '/minos/ {print $2; exit}')"
+            echo "$f -> minos $minos (floor $FLOOR)"
+            if [ "$(printf '%s\n%s\n' "$FLOOR" "$minos" | sort -V | tail -1)" != "$FLOOR" ]; then
+              echo "::error::$f requires macOS $minos (> $FLOOR)"; exit 1
+            fi
+          }
+          check zig-out/bin/jac
+          SHIM="jaclang/compiler/passes/native/llvm/libjacllvm.dylib"
+          check "$SHIM"
+          if otool -L "$SHIM" | grep -E "/opt/homebrew|/usr/local"; then
+            echo "::error::$SHIM links Homebrew dylibs; the from-source slice must not."; exit 1
+          fi
 
       - name: Package asset (+ checksum)
         id: pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1315,6 +1315,8 @@ jobs:
             platform: linux-x86_64
           - os: macos-14
             platform: macos-aarch64
+          - os: macos-15-intel
+            platform: macos-x86_64
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,6 +84,8 @@ jobs:
             platform: linux-x86_64
           - os: macos-14
             platform: macos-aarch64
+          - os: macos-15-intel
+            platform: macos-x86_64
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
               continue
             fi
             missing=()
-            for p in linux-x86_64 linux-aarch64 macos-aarch64; do
+            for p in linux-x86_64 linux-aarch64 macos-aarch64 macos-x86_64; do
               printf '%s\n' "$assets" | grep -qx "jac-${VERSION}-${p}" || missing+=("jac-${VERSION}-${p}")
             done
             [ ${#missing[@]} -eq 0 ] && break

--- a/jac/build.zig
+++ b/jac/build.zig
@@ -770,6 +770,12 @@ fn macosShim(
     shim_flags: []const []const u8,
 ) std.Build.LazyPath {
     const io = b.graph.io;
+    // Upstream slice (repackaged official release) vs from-source llvm-slice
+    // build: decides the ThinLTO/libLTO plumbing and the external -l deps
+    // below. A custom -Dllvm-dir on an unpinned platform gets the upstream
+    // treatment (official releases are the only other supported layout).
+    const rel = llvm_release.llvmRelease(target.result.os.tag, target.result.cpu.arch);
+    const upstream = if (rel) |r| r.upstream else true;
     const cc = b.addSystemCommand(&.{"c++"});
     cc.addArg("-dynamiclib");
     // Target the resolved arch explicitly rather than the host c++'s default, so a
@@ -779,6 +785,12 @@ fn macosShim(
         .x86_64 => "x86_64",
         else => @panic("jacllvm: unsupported macOS arch for the c++ shim link"),
     } });
+    // Pin the shim's minos to the resolved target's floor, exactly like the
+    // zig-built launcher: with -Dtarget=x86_64-macos.12.0 the whole shipped
+    // binary floors at 12.0 instead of the build runner's macOS. Host-native
+    // builds resolve to the host version, matching clang's own default.
+    const macos_min = target.result.os.version_range.semver.min;
+    cc.addArg(b.fmt("-mmacosx-version-min={d}.{d}", .{ macos_min.major, macos_min.minor }));
     // Respect -Doptimize the way the Linux (Zig addLibrary) path does.
     cc.addArg(switch (optimize) {
         .Debug => "-O0",
@@ -801,29 +813,36 @@ fn macosShim(
             cc.addFileArg(.{ .cwd_relative = b.fmt("{s}/{s}", .{ libdir, entry.name }) });
         }
     }
-    // The LLVM release archives are ThinLTO bitcode, so ld64 must lower them to
-    // native code at link time via libLTO. Apple's bundled libLTO tracks Xcode and
-    // is too old on the CI runners ("Invalid summary version 12, should be in
-    // [1-10]" -> segfault), so point ld64 at the release's OWN libLTO.dylib (kept
-    // by payload.zig fetchLlvmSlice) -- it matches the bitcode it produced.
-    // This is link-time only; the output dylib gains no libLTO runtime dep.
+    // Upstream slices only: the official release archives are ThinLTO bitcode,
+    // so ld64 must lower them to native code at link time via libLTO. Apple's
+    // bundled libLTO tracks Xcode and is too old on the CI runners ("Invalid
+    // summary version 12, should be in [1-10]" -> segfault), so point ld64 at
+    // the release's OWN libLTO.dylib (kept by payload.zig fetchLlvmSlice) -- it
+    // matches the bitcode it produced. This is link-time only; the output dylib
+    // gains no libLTO runtime dep.
     //
     // The path MUST be absolute: ld64 silently falls back to its default libLTO
     // when -lto_library can't be resolved, and a relative path is not reliably
     // resolved from ld's cwd. Set LIBLTO_PATH too -- the env override ld honors
     // most reliably across ld64 / ld-prime.
-    const lto_dylib = b.fmt("{s}/lib/libLTO.dylib", .{llvm_dir});
-    const lto_abs = if (std.fs.path.isAbsolute(lto_dylib)) lto_dylib else b.pathFromRoot(lto_dylib);
-    cc.setEnvironmentVariable("LIBLTO_PATH", lto_abs);
-    cc.addPrefixedFileArg("-Wl,-lto_library,", .{ .cwd_relative = lto_abs });
-    // LLVM's system deps. zstd comes from Homebrew (not on the default search
-    // path); z/xml2 are in the macOS SDK, and clang++ links libc++ itself.
-    cc.addArgs(&.{ "-lz", "-lxml2" });
-    // Homebrew's prefix is /opt/homebrew on Apple Silicon, /usr/local on Intel;
-    // HOMEBREW_PREFIX overrides both for a custom install.
-    const brew = b.graph.environ_map.get("HOMEBREW_PREFIX") orelse
-        (if (target.result.cpu.arch == .aarch64) "/opt/homebrew" else "/usr/local");
-    cc.addArgs(&.{ b.fmt("-I{s}/opt/zstd/include", .{brew}), b.fmt("-L{s}/opt/zstd/lib", .{brew}), "-lzstd" });
+    //
+    // A from-source slice (macos-x86_64) is plain native Mach-O built with
+    // zlib/zstd/libxml2 OFF: no libLTO to point at, and no external -l deps
+    // either -- which keeps the shipped dylib free of Homebrew load commands.
+    if (upstream) {
+        const lto_dylib = b.fmt("{s}/lib/libLTO.dylib", .{llvm_dir});
+        const lto_abs = if (std.fs.path.isAbsolute(lto_dylib)) lto_dylib else b.pathFromRoot(lto_dylib);
+        cc.setEnvironmentVariable("LIBLTO_PATH", lto_abs);
+        cc.addPrefixedFileArg("-Wl,-lto_library,", .{ .cwd_relative = lto_abs });
+        // LLVM's system deps. zstd comes from Homebrew (not on the default search
+        // path); z/xml2 are in the macOS SDK, and clang++ links libc++ itself.
+        cc.addArgs(&.{ "-lz", "-lxml2" });
+        // Homebrew's prefix is /opt/homebrew on Apple Silicon, /usr/local on Intel;
+        // HOMEBREW_PREFIX overrides both for a custom install.
+        const brew = b.graph.environ_map.get("HOMEBREW_PREFIX") orelse
+            (if (target.result.cpu.arch == .aarch64) "/opt/homebrew" else "/usr/local");
+        cc.addArgs(&.{ b.fmt("-I{s}/opt/zstd/include", .{brew}), b.fmt("-L{s}/opt/zstd/lib", .{brew}), "-lzstd" });
+    }
     cc.addArgs(&.{ "-Wl,-exported_symbol,_LLVMPY_*", "-Wl,-install_name,@rpath/libjacllvm.dylib" });
     cc.addArg("-o");
     return cc.addOutputFileArg("libjacllvm.dylib");

--- a/jac/launcher/llvm_release.zig
+++ b/jac/launcher/llvm_release.zig
@@ -21,6 +21,13 @@ pub const LlvmRelease = struct {
     triple: []const u8,
     manifest_sha256: []const u8,
     zip_size: u64,
+    /// true = repackaged official upstream release binaries; false = built from
+    /// source by llvm-slice (externals like zlib/zstd/libxml2 OFF). On macOS
+    /// this decides the whole shim link shape: upstream archives are ThinLTO
+    /// bitcode that ld64 must lower via the slice's own libLTO.dylib and they
+    /// reference zlib/zstd/libxml2, while a from-source slice is plain native
+    /// Mach-O with no external deps (build.zig macosShim; payload.zig marker).
+    upstream: bool,
 };
 
 /// The pinned slice for an (os, arch), or null for platforms we don't pin.
@@ -39,6 +46,7 @@ pub fn llvmRelease(os: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) ?LlvmReleas
                 .triple = "x86_64-linux-libcxx",
                 .manifest_sha256 = "6c227bfc95829729a93b8af44eeae182489df5a2bb16fd5bb5fe9b36d8877d54",
                 .zip_size = 667452266,
+                .upstream = false,
             },
             // libc++ slice, same zig c++ @ 2.17 build as x86_64 (built natively
             // on ubuntu-24.04-arm, llvm-slice#4); isLibcxx routes the shim to
@@ -48,6 +56,7 @@ pub fn llvmRelease(os: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) ?LlvmReleas
                 .triple = "aarch64-linux-libcxx",
                 .manifest_sha256 = "0315f2d83f4cab6cc5e0ef94b5d6999306109b27d0955549e7af46897ca28c34",
                 .zip_size = 462054429,
+                .upstream = false,
             },
             else => null,
         },
@@ -57,6 +66,19 @@ pub fn llvmRelease(os: std.Target.Os.Tag, arch: std.Target.Cpu.Arch) ?LlvmReleas
                 .triple = "aarch64-apple-darwin",
                 .manifest_sha256 = "541721f3501de4bd4f19b0319d857b7d51651856b26fa8f600ad317edb8ea441",
                 .zip_size = 743879473,
+                .upstream = true,
+            },
+            // Upstream ships no macOS Intel binaries for 22.x, so this slice is
+            // built from source by llvm-slice (build-macos-x64.yml) on the
+            // macos-15-intel runner: plain native archives (no ThinLTO/libLTO),
+            // externals OFF, minos pinned to 12.0 so release binaries reach
+            // 2015-and-newer Intel Macs.
+            .x86_64 => .{
+                .dirname = "LLVM-22.1.8-macOS-X64",
+                .triple = "x86_64-apple-darwin",
+                .manifest_sha256 = "a984b4f7aef1978386f74ff2ea4b30d76f9e0b33d08dbae57bee9fea9bb16f9d",
+                .zip_size = 49613317,
+                .upstream = false,
             },
             else => null,
         },

--- a/jac/launcher/payload.zig
+++ b/jac/launcher/payload.zig
@@ -272,10 +272,12 @@ fn fetchPbs(io: Io, gpa: Allocator, a: Allocator, osarch: []const u8, dest: []co
 fn fetchLlvm(io: Io, gpa: Allocator, a: Allocator, dest: []const u8) !void {
     const rel = llvmRelease() orelse
         die("fetch-llvm: no pinned LLVM release for this host ({s}-{s}); add a row to llvmRelease().", .{ @tagName(builtin.cpu.arch), @tagName(builtin.os.tag) });
-    // Presence marker / success check. On macOS the shim link needs the release's
-    // own libLTO.dylib (ThinLTO bitcode archives; see build.zig macosShim, #6938),
-    // so require it there. A missing marker re-fetches (self-heals a stale cache).
-    const marker_lib = if (builtin.os.tag == .macos) "libLTO.dylib" else "libLLVMCore.a";
+    // Presence marker / success check. On macOS an UPSTREAM slice's shim link
+    // needs the release's own libLTO.dylib (ThinLTO bitcode archives; see
+    // build.zig macosShim, #6938), so require it there; a from-source slice
+    // (e.g. macos-x86_64) ships plain archives and no libLTO. A missing marker
+    // re-fetches (self-heals a stale cache).
+    const marker_lib = if (builtin.os.tag == .macos and rel.upstream) "libLTO.dylib" else "libLLVMCore.a";
     const marker = try std.fmt.allocPrint(a, "{s}/{s}/lib/{s}", .{ dest, rel.dirname, marker_lib });
     if (fileExists(io, marker)) {
         log("fetch-llvm: already present at {s}/{s}", .{ dest, rel.dirname });


### PR DESCRIPTION
Closes the Intel-Mac gap in the release matrix: GitHub releases now ship `jac-<version>-macos-x86_64`, floored at macOS 12 so 2015-and-newer Intel Macs are covered. `install.sh` already maps `Darwin/x86_64` to this asset name, so `curl | bash` starts working the moment a release ships the asset.

## The blocker, and how it's solved

Upstream LLVM ships no macOS Intel binaries for 22.x, which is why the old matrix comment said "No Intel-Mac leg". The pinned slice is now built from source in jaseci-labs/llvm-slice (`build-macos-x64.yml`, mirroring its Linux libc++ builds) on the `macos-15-intel` runner and published on the same `v22.1.8` release the other slices live on. Two deliberate differences from the official ARM64 repackage:

- **Plain native Mach-O archives** (upstream's are ThinLTO bitcode), so ld64 needs no matching `libLTO.dylib` -- the shim links in ~7s instead of a full LTO lowering pass.
- **Externals OFF** (zlib/zstd/libxml2), so the Intel shim's only load commands are `libc++` and `libSystem`. (The arm64 shim currently carries a `/opt/homebrew/opt/zstd/.../libzstd.1.dylib` load command from the runner's brew -- a latent portability issue on Homebrew-less machines; worth its own follow-up.)

## Changes

- **`llvm_release.zig`**: new `macos/x86_64` row (dirname `LLVM-22.1.8-macOS-X64`, triple `x86_64-apple-darwin`) + an `upstream` flag on `LlvmRelease` distinguishing repackaged-official slices from from-source ones.
- **`build.zig` macosShim**: from-source slices skip the libLTO plumbing and the `-lz -lxml2` + Homebrew-zstd deps; the link also pins `-mmacosx-version-min` from the resolved target so `-Dtarget=x86_64-macos.12.0` floors the shim exactly like the zig-built launcher.
- **`payload.zig`**: fetch-llvm's presence marker falls back to `libLLVMCore.a` when the slice ships no `libLTO.dylib`.
- **`build-binaries.yml`**: `macos-15-intel` leg, `zig_target: x86_64-macos.12.0` (release channel only, mirroring the Linux glibc pin; dev channel builds host-native like the ARM leg). New `Verify macOS floor` step enforces launcher+shim minos <= 12.0 and rejects Homebrew load commands.
- **`release.yml`**: `macos-x86_64` added to the asset-completeness gate.
- **`nightly.yml` / `ci.yml`**: installer checks get the Intel leg.

## Validation

- Local cross build on arm64: `zig build jacllvm -Dtarget=x86_64-macos.12.0` against the published slice -> `Mach-O x86_64`, `minos 12.0`, deps only `libc++`/`libSystem`, 310 exports all `_LLVMPY_*`.
- End-to-end artifact-only `build-binaries` dispatch (all four legs, Intel leg on real hardware incl. the range fetch, smoke tests, and the new floor verify): https://github.com/marsninja/jaseci/actions/runs/30222896735
- Prereqs checked: python-build-standalone 20260610 ships `cpython-3.14.6+...-x86_64-apple-darwin-pgo+lto-full`; bun 1.3.11 ships `bun-darwin-x64`.

## Rollout notes

- nightly `installer-live` and ci `installer-test` Intel legs will fail until the first release actually ships a `macos-x86_64` asset -- expected red, clears with the next release.
- `macos-15-intel` is GitHub's last Intel image (retires Fall 2027); the matrix comment records this.
- Each push to main now also runs a dev-channel Intel leg (one extra macos-15-intel job per push).