### PR TITLE
docs(scale): sync memory-trigger guard docs with the microservice parity fix

### DIFF
--- a/jac/jaclang/cli/docs/reference/plugins/jac-scale-kubernetes.md
+++ b/jac/jaclang/cli/docs/reference/plugins/jac-scale-kubernetes.md
@@ -383,7 +383,7 @@ jac-scale supports two autoscaler engines selected via `autoscaler_engine`. Both
 | `autoscaler_scale_up_stabilization` | `60` | Scale-up stabilization window in seconds (HPA `behavior.scaleUp`), applied under both engines. |
 | `autoscaler_scale_up_max_pods` | `2` | Maximum pods added per scale-up step, applied under both engines. |
 
-> **Note:** CPU-based scaling requires `cpu_request` to be set. Without a CPU request, Kubernetes cannot compute a utilization percentage. Likewise, memory triggers require `memory_request`; in single-app deployments a memory trigger configured without it is skipped with a warning (the microservice path currently applies no such guard).
+> **Note:** CPU-based scaling requires `cpu_request` to be set. Without a CPU request, Kubernetes cannot compute a utilization percentage. Likewise, memory triggers require `memory_request`; a memory trigger whose resolved request is empty is skipped with a warning under both deploy paths. In microservice deployments the request defaults to `1Gi` (`2Gi` for the gateway), so the skip only occurs when `memory_request` is explicitly set to `""`.
 
 #### HPA Engine (Default)
 
@@ -1022,7 +1022,7 @@ Each microservice entry takes optional per-service overrides under `[scale.micro
 | `hpa.enabled` | bool | Set to `false` to fix replicas at the configured `replicas` count. Applies to both `"hpa"` and `"keda"` engines. |
 | `hpa.min` / `hpa.max` | int | Autoscaler replica bounds. Applies to both engines. |
 | `hpa.cpu_target` | int (percent) | Target CPU utilization percentage. Default 50%. Applies to both engines. |
-| `hpa.memory_target` | int (percent) | Target memory utilization percentage (default 80). A memory trigger is added alongside CPU unconditionally -- set `memory_request` or the utilization percentage cannot be computed. |
+| `hpa.memory_target` | int (percent) | Target memory utilization percentage (default 80). A memory trigger is added alongside CPU whenever the service resolves a memory request -- always, unless `memory_request` is explicitly set to `""`. |
 | `pdb.enabled` / `pdb.max_unavailable` | bool / int | PodDisruptionBudget controls for this service. |
 | `deployment_overlay` | table | Raw manifest fragment deep-merged onto the generated Deployment (escape hatch for fields not exposed above). |
 | `[[services.NAME.triggers]]` | list | Per-service KEDA event-driven triggers. Each entry: `type` (str), `metadata` (dict), optional `name` (str), optional `auth.secret_refs` (dict). Requires `autoscaler_engine = "keda"` in `[scale.kubernetes]`. |

--- a/release_notes/unreleased/jaclang/7763.docs.md
+++ b/release_notes/unreleased/jaclang/7763.docs.md
@@ -1,0 +1,1 @@
+- **Docs: Scale memory-trigger guard**: Updated the Kubernetes reference to reflect the microservice/monolith parity fix from #7755 -- memory autoscaler triggers whose resolved request is empty are now skipped with a warning under both deploy paths.


### PR DESCRIPTION
Tiny follow-up closing the loop between #7754 and #7755: the k8s reference still described the pre-#7755 behavior in two places — the autoscaling note said "the microservice path currently applies no such guard", and the `hpa.memory_target` row said the memory trigger is added "unconditionally". Both now describe the unified post-#7755 behavior: a memory trigger whose resolved request is empty is skipped with a warning under both deploy paths, which in microservice deployments only occurs when `memory_request` is explicitly set to `""` (the `1Gi`/`2Gi` defaults apply otherwise).

Two-sentence diff, no code changes.