### PR TITLE
fix(compiler): snapshot the hub before iterating in collect_placement_rows

### DIFF
--- a/jac/jaclang/jac0core/placement.jac
+++ b/jac/jaclang/jac0core/placement.jac
@@ -728,7 +728,7 @@ def collect_placement_rows(prog: any) -> dict {
     if isinstance(cur_ev, dict) {
         evidence = cur_ev;
     }
-    for (path, mod) in hub.items() {
+    for (path, mod) in list(hub.items()) {
         if not isinstance(mod, uni.Module) {
             continue;
         }


### PR DESCRIPTION
The crossings estimate in `collect_placement_rows` calls `resolve_import_source_module`, which can compile a missing source module and insert it into the hub while the report loop iterates `hub.items()`, raising `dictionary changed size during iteration`. Iterate a `list()` snapshot, matching the solver's own hub walks (follow-up to #7757; surfaced by `jac check --placements` on this_is_jac).