### PR TITLE
docs: repoint the osp.md anchor at the retitled Client Placement section

### DIFF
--- a/jac/jaclang/cli/docs/reference/language/osp.md
+++ b/jac/jaclang/cli/docs/reference/language/osp.md
@@ -639,7 +639,7 @@ These keywords have special meaning in specific contexts:
 | `super` | Subclass method | Parent class reference | [Part II](functions-objects.md#3-inheritance) |
 | `init` | Object body | Constructor method name | [Part II](functions-objects.md#1-objects-classes) |
 | `postinit` | Object body | Post-constructor hook | [Variables and Scope](variables-and-scope.md#2-instance-variables-has) |
-| `props` | JSX context | Component props reference | [jac-client Reference](../plugins/jac-client.md#client-sections) |
+| `props` | JSX context | Component props reference | [jac-client Reference](../plugins/jac-client.md#client-placement) |
 
 **Usage examples:**
 

--- a/release_notes/unreleased/jaclang/7782.docs.md
+++ b/release_notes/unreleased/jaclang/7782.docs.md
@@ -1,1 +1,0 @@
-- **Docs: osp.md anchor repointed**: the OSP reference's `props` row linked the jac-client section by its pre-#7780 anchor (`#client-sections`); it now targets the retitled Client Placement section, restoring the corpus link check.

--- a/release_notes/unreleased/jaclang/7782.docs.md
+++ b/release_notes/unreleased/jaclang/7782.docs.md
@@ -1,0 +1,1 @@
+- **Docs: osp.md anchor repointed**: the OSP reference's `props` row linked the jac-client section by its pre-#7780 anchor (`#client-sections`); it now targets the retitled Client Placement section, restoring the corpus link check.


### PR DESCRIPTION
One-line follow-up to #7780, which merged before this fix landed on its branch: osp.md still links to the old `#client-sections` anchor in the jac-client reference, retitled to Client Placement in #7780, so the corpus link check (`test_docs_content.jac`) fails on main. Verified locally: 3/3 passing.