### PR TITLE
fix(nightly): install libasound2t64 -- noble offers two providers for virtual libasound2 and apt refuses to pick

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 \
           libcups2 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libpango-1.0-0 \
-          libasound2
+          libasound2t64
 
     - name: Build notes-app example
       run: |


### PR DESCRIPTION
## What

The Nightly CEF smoke job's display-deps step installs `libasound2t64` instead of the virtual `libasound2`.

## Why

`notes-app-cef-smoke` has been red daily since 07-25. The runner's Ubuntu 24.04 image now resolves `libasound2` as a virtual package with two providers, and apt refuses to choose:

```
Package libasound2 is a virtual package provided by:
  liboss4-salsa-asound2 4.2-build2020-1ubuntu3.1
  libasound2t64 1.2.11-1ubuntu0.3 (= 1.2.11-1ubuntu0.3)
E: Package 'libasound2' has no installation candidate
```

`libasound2t64` is the real ALSA library (post time64 transition) and the provider the job always wanted; the job is pinned to `blacksmith-4vcpu-ubuntu-2404`, so there is no older-distro compatibility concern.

Not touched here: the `installer-live (macos-x86_64)` nightly failure is separate -- the latest release (v0.34.7) predates #7752's Intel-mac binaries and the guard is correctly reporting that; it clears when the next release is published.