### PR TITLE
ci: reuse the build-jac artifact instead of rebuilding per job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,14 @@ jobs:
 
   # Build (or cache-restore) the jac binary ONCE per run, smoke it hermetically,
   # and publish it (plus the gitignored typeshed stubs) as artifacts. Every
-  # Linux job below gates on this so a cold cache pays a single build.
+  # Linux job below gates on this and downloads the artifact instead of calling
+  # setup-jac again -- a second setup-jac is a ~3 min rebuild whenever
+  # jaclang/** changed (the binary cache key hashes it), paid once per job.
+  # Only jac-check and contribution-checks still run setup-jac: they are
+  # required checks that must not depend on this job (a skipped required check
+  # would satisfy branch protection). Jobs that ship or introspect the binary
+  # by path expect it at jac/zig-out/bin/jac, where setup-jac builds it, so
+  # the download steps below restore it there.
   build-jac:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -528,8 +535,18 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Run Solid jsdom runtime test
       env:
@@ -556,8 +573,18 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Set environment for testing
       run: echo "TEST_ENV=true" >> $GITHUB_ENV
@@ -591,8 +618,18 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Install byllm deps + test deps
       run: |
@@ -715,8 +752,18 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Build dispatch shim and subprocess binary
       working-directory: jac/jaclang/runtimelib/client/targets/desktop/native/cef
@@ -757,8 +804,21 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # MUST land at jac/zig-out/bin: the microservices bundle tests
+      # (test_fat_bundle, test_app_precompile, test_seed_determinism,
+      # test_pvc_injector) read the pod binary from that checkout path via a
+      # __file__-relative lookup and silently self-skip when it is missing.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Install scale deps + test deps
       # Pins mirror jac/jaclang/project/capabilities.jac.
@@ -807,6 +867,9 @@ jobs:
         jac test jac/jaclang/scale/tests/test_firestore_db.jac -x
         jac test jac/jaclang/scale/tests/test_firebase_auth_sso.jac -x
 
+  # One job, not a two-leg matrix: the deploy-core and failure-path phases
+  # partition a single test file and share one MicroK8s cluster (exactly how
+  # the suite runs locally), so the cluster + deps setup is paid once.
   test-scale-k8s:
     needs: [changes, build-jac]
     if: >-
@@ -815,18 +878,25 @@ jobs:
        needs.changes.outputs.scale == 'true') &&
       !contains(github.event.pull_request.labels.*.name, 'skip-k8s')
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [deploy-core, failure-path]
     steps:
       - name: Check out code
         uses: actions/checkout@v5
         with:
           submodules: true
 
-      - name: Set up jac (build the binary)
-        uses: ./.github/actions/setup-jac
+      - name: Download the jac binary (build-jac artifact)
+        uses: actions/download-artifact@v4
+        with:
+          name: jac-binary
+          path: jac/zig-out/bin
+
+      - name: Put jac on PATH
+        # upload-artifact strips the executable bit; restore it. The artifact
+        # MUST land at jac/zig-out/bin: JAC_SCALE_BINARY_PATH below ships that
+        # exact file to the pods.
+        run: |
+          chmod +x "$PWD/jac/zig-out/bin/jac"
+          echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
       - name: Install scale deploy deps
         # Pins mirror jac/jaclang/project/capabilities.jac.
@@ -861,7 +931,6 @@ jobs:
           kubectl get nodes -o wide
 
       - name: Run K8 tests (deploy-core)
-        if: matrix.group == 'deploy-core'
         env:
           JAC_TEST_JOBS: "0"
         run: |
@@ -870,7 +939,6 @@ jobs:
           jac test jac/jaclang/scale/tests/test_deploy_k8s.jac -x -f "not (early and exit)"
 
       - name: Run K8 tests (failure-path)
-        if: matrix.group == 'failure-path'
         env:
           JAC_TEST_JOBS: "0"
           # Seal + ship the jac built from this checkout (channel LOCAL) so the
@@ -903,8 +971,26 @@ jobs:
     - name: Set up Bun
       uses: oven-sh/setup-bun@v2
 
-    - name: Set up jac (build the binary)
-      uses: ./.github/actions/setup-jac
+    - name: Restore typeshed stdlib stubs into the checkout
+      # The precompile step below compiles the CHECKOUT tree, which needs the
+      # gitignored stubs that setup-jac used to materialize.
+      uses: actions/download-artifact@v4
+      with:
+        name: typeshed-stdlib
+        path: jac/jaclang/vendor/typeshed/stdlib
+
+    - name: Download the jac binary (build-jac artifact)
+      uses: actions/download-artifact@v4
+      with:
+        name: jac-binary
+        path: jac/zig-out/bin
+
+    - name: Put jac on PATH
+      # upload-artifact strips the executable bit; restore it. The artifact
+      # lands at jac/zig-out/bin, where setup-jac would have built it.
+      run: |
+        chmod +x "$PWD/jac/zig-out/bin/jac"
+        echo "$PWD/jac/zig-out/bin" >> "$GITHUB_PATH"
 
     - name: Precompile all packages
       run: |
@@ -933,18 +1019,12 @@ jobs:
     - name: Run integration tests
       run: jac run scripts/integration_tests.jac
 
-    - name: Install byllm deps (for the built-package byllm test)
-      run: |
-        jac install \
-          "litellm>=1.70.0,<=1.82.6" "pillow>=12.0.0,<13.0.0" \
-          "httpx>=0.27.0" "loguru>=0.7.2,<0.8.0" \
-          --global
-
     - name: Run tests on built packages
+      # test_byllm.jac is deliberately NOT re-run here: test-packages-and-docs
+      # already runs the full byllm suite against the same build-jac artifact,
+      # so a second pass bought no extra coverage.
       run: |
         jac check jac/tests/compiler/passes/main/fixtures/checker/checker_type_ref.jac
-        # Serial: byllm tests share a SQLite mock-LLM cache.
-        JAC_TEST_JOBS=0 jac test jac/jaclang/byllm/tests/test_byllm.jac
 
     # ========== jac_site fullstack smoke ==========
     # JAC_NO_DEV_SOURCE=1 on every jac_site step: the site's jac.toml carries a


### PR DESCRIPTION
## What

Three CI-only changes, no test-logic changes:

1. **Download the build-jac artifact instead of re-running setup-jac.** Seven jobs (11 run legs: test-solid-and-desktop, test-client, test-packages-and-docs, test-cef-build, test-scale x5, test-scale-k8s, test-pypi-build) called setup-jac after build-jac had already built and uploaded the binary. Any PR touching `jaclang/**` misses the binary cache (its key hashes that tree), so every one of those legs paid a ~3 min rebuild. They now download the `jac-binary` artifact, same as test-compiler / test-runtime / k8s-real-e2e already do. setup-jac remains only in build-jac itself, the independent required checks (jac-check, contribution-checks), and the macOS/aarch64 lanes that cannot use the Linux artifact.

2. **Drop the duplicate byllm run from test-pypi-build.** test-packages-and-docs already runs the full byllm suite against the same binary, so the `test_byllm.jac` re-run (and the litellm/pillow install that only served it) bought no coverage. The checker_type_ref `jac check` smoke stays.

3. **Merge test-scale-k8s's two matrix legs into one job.** deploy-core and failure-path partition a single test file (`-f "not (early and exit)"` vs `--test_name "early exit"`) and now share one MicroK8s cluster, exactly how the suite runs locally, so the snap install + cluster spin-up + dep install are paid once instead of twice. Branch protection only requires "Everything Passed", so the leg rename cannot strand an Expected check.

## Why the artifact lands at jac/zig-out/bin

Four microservices scale tests (test_fat_bundle, test_app_precompile, test_seed_determinism, test_pvc_injector) read the pod binary from the checkout's `jac/zig-out/bin/jac` via a `__file__`-relative lookup and **silently self-skip** when it is missing, and `JAC_SCALE_BINARY_PATH` in the k8s jobs points at the same path. Downloading to a scratch dir would have gone green while quietly dropping those tests, so the download steps restore the binary exactly where setup-jac builds it (with comments on the load-bearing spots).

test-pypi-build additionally restores the `typeshed-stdlib` artifact because its precompile step compiles the checkout tree, which setup-jac used to guarantee stubs for.

## Impact

Measured from recent runs (a full PR run is ~162 job-minutes): this removes ~30-35 Blacksmith job-minutes per source-touching run (~20%), and each converted job starts its tests ~3 min sooner. This PR is workflow-only, so CI on it exercises every converted path end to end.