### PR TITLE
ci: the glibc floor check survives artifacts with no versioned glibc refs

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -238,7 +238,7 @@ jobs:
           check() {
             local f="$1" hi
             [ -f "$f" ] || { echo "::error::missing $f"; exit 1; }
-            hi="$(objdump -T "$f" 2>/dev/null | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/GLIBC_//' | sort -V | tail -1)"
+            hi="$(objdump -T "$f" 2>/dev/null | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/GLIBC_//' | sort -V | tail -1 || true)"
             : "${hi:=0}"
             echo "$f -> max GLIBC_$hi (floor $FLOOR)"
             if [ "$(printf '%s\n%s\n' "$FLOOR" "$hi" | sort -V | tail -1)" != "$FLOOR" ]; then


### PR DESCRIPTION
## Why the 0.35.0 Linux builds failed

Both Linux jobs of the v0.35.0 release run died in **Verify glibc floor (from zig_target)** at the same spot. The step's `check()` scans each payload artifact with:

```bash
hi="$(objdump -T "$f" | grep -oE 'GLIBC_...' | sed ... | sort -V | tail -1)"
: "${hi:=0}"
```

0.35.0 is the first release whose payload contains the sealed AOT lexer (`_precompiled/native/<target>/libjac_lexer.so`), and that artifact references **no versioned glibc symbols at all** -- so `grep` matches nothing and exits 1, and under `set -euo pipefail` the assignment aborts the script **before** the `hi:=0` default (which anticipated exactly this case) can run. The CI trace shows it verbatim: `+ hi=` followed by exit 1, no error message. `zig-out/bin/jac` and `libjacllvm.so` both carry refs, so they passed; the new artifact is the first no-refs file the check ever met.

## Fix

`|| true` on the pipeline inside the substitution: a no-match yields an empty `hi`, the existing default makes it `0`, and `GLIBC_0` trivially satisfies any floor -- which is also the semantically right verdict for a self-contained artifact. Verified with a standalone repro: the old form dies exactly like CI (`+ hi=`, exit 1), the patched form prints `max GLIBC_0 (floor 2.17)` and passes.

Note for the release: the failed run built from `release/jaclang-0.35.0`, and Actions executes the workflow at that commit -- re-running the failed jobs as-is will hit the same script. After this lands on main, cherry-pick it onto the release branch (or re-cut the release) before re-running build-binaries.