### PR TITLE
fix(scale): seal with the pod binary's own precompile, not the builder's

### DIFF
--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -206,7 +206,12 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
         jac_path = stage_root / ".pod-jac";
         jac_path.write_bytes(pod_binary);
         jac_path.chmod(0o755);
-        script = Path(str(__file__)).parent.parent.parent / "utils" / "precompile_bytecode.jac";
+        script = stage_root / "pod_seal_boot.jac";
+        script.write_text(
+            "import from jaclang.utils.precompile_bytecode { main }\n"
+            "with entry:__main__ { main(); }\n",
+            encoding="utf-8"
+        );
 
         result = subprocess.run(
             [str(jac_path), "run", str(script), str(stage_root), "--seal"],
@@ -215,6 +220,7 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
             timeout=600
         );
         jac_path.unlink();
+        script.unlink();
         if (
             result.returncode != 0
             or not (stage / "_precompiled" / "MANIFEST.json").is_file()
@@ -265,7 +271,12 @@ def _vendor_stage(stage: Path, sanitized_toml: (str | None), pod_binary: bytes) 
     jac_path = stage.parent / ".pod-jac";
     jac_path.write_bytes(pod_binary);
     jac_path.chmod(0o755);
-    script = Path(str(__file__)).parent.parent / "utils" / "vendor_wheels.jac";
+    script = stage.parent / "pod_vendor_boot.jac";
+    script.write_text(
+        "import from jaclang.scale.utils.vendor_wheels { main }\n"
+        "with entry:__main__ { main(); }\n",
+        encoding="utf-8"
+    );
     try {
         result = subprocess.run(
             [str(jac_path), "run", str(script), str(stage)],
@@ -275,6 +286,7 @@ def _vendor_stage(stage: Path, sanitized_toml: (str | None), pod_binary: bytes) 
         );
     } finally {
         jac_path.unlink(missing_ok=True);
+        script.unlink(missing_ok=True);
     }
     if (result.returncode != 0 or not (stage / "_vendor" / "VENDOR.json").is_file()) {
         raise RuntimeError(

--- a/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
+++ b/jac/jaclang/scale/tests/microservices/test_app_precompile.jac
@@ -3,7 +3,23 @@ import os;
 import tarfile;
 import tempfile;
 import from pathlib { Path }
-import from jaclang.scale.injector.bundle { pack_jab }
+import from unittest.mock { MagicMock, patch }
+import jaclang.scale.injector.bundle as bundle_mod;
+import from jaclang.scale.injector.bundle { pack_jab, _precompile_app }
+
+
+glob _seal_call: dict[str, str] = {};
+
+
+def _capture_seal(cmd: list[str], **kw: object) -> MagicMock {
+    # cmd = [pod_jac, "run", <seal script>, <stage_root>, "--seal"]
+    _seal_call["script_text"] = Path(cmd[2]).read_text(encoding="utf-8");
+    _seal_call["script_arg"] = cmd[2];
+    manifest = Path(cmd[3]) / "app" / "_precompiled" / "MANIFEST.json";
+    manifest.parent.mkdir(parents=True, exist_ok=True);
+    manifest.write_text("{}", encoding="utf-8");
+    return MagicMock(returncode=0, stdout="", stderr="");
+}
 
 
 def _mini_app -> str {
@@ -62,4 +78,24 @@ test "a real pod binary seals the app into a .jab (source + _precompiled + manif
         if n.startswith("_precompiled/")
     ];
     assert any([n.endswith("svc.jir") for n in pre]) , pre;
+}
+
+
+test "the seal runs the pod binary's own precompile, not the builder's script" {
+    # A builder deploying a pinned version runs a different-version pod binary.
+    # Handing it the builder's own precompile_bytecode.jac breaks across a
+    # version gap (jaseci-labs/jac#7811); the seal must instead import precompile
+    # from the running pod binary so it stays version-consistent.
+    _seal_call.clear();
+    base = Path(tempfile.mkdtemp(prefix="jac-app-"));
+    (base / "svc.jac").write_text("def:pub ping -> str { return \"pong\"; }\n");
+    with patch.object(bundle_mod.subprocess, "run", _capture_seal) {
+        _precompile_app(base, b"fake-pod-binary");
+    }
+    assert (
+        "import from jaclang.utils.precompile_bytecode { main }" in _seal_call[
+            "script_text"
+        ]
+    );
+    assert not _seal_call["script_arg"].endswith("precompile_bytecode.jac");
 }


### PR DESCRIPTION
## Problem

Deploying an app whose pinned jac version differs from the builder's own version fails at the app-seal step, so no `.jab` is produced:

```
App seal did not complete, so the deploy cannot produce a .jab
module 'jaclang.jac0core.ext_registry' has no attribute 'is_native_module'
  at sealable_sources() precompile_bytecode.jac:118
  at main() precompile_bytecode.jac:499
  at <module> precompile_bytecode.jac:598
```

Example: a builder running 0.34.7 deploying an app pinned to 0.35.0.

## Root cause

`_precompile_app` (and `_vendor_stage`) run the seal by handing the builder's own local `precompile_bytecode.jac` to the downloaded pod binary:

```
script = Path(__file__).../utils/precompile_bytecode.jac
subprocess.run([pod_binary, "run", script, stage_root, "--seal"])
```

The script source is the builder's version, but its `import from jaclang...` resolve to the pod binary's bundled runtime. When the two versions differ, script and runtime are incompatible. 0.34.7's precompile calls `ext_registry.is_native_module` / `is_client_module`, which were removed in 0.35.0 (the native/client placement was rewritten into the new `placement_solver.jac`), so the seal crashes.

## Fix

Run the pod binary's own bundled precompile (and vendor) via a small bootstrap that imports `main` from the binary's own module, so the seal logic is always version consistent with the binary it runs on:

```
import from jaclang.utils.precompile_bytecode { main }
with entry:__main__ { main(); }
```

`main` reads `sys.argv[1:]` on all versions and is guarded by `with entry:__main__`, so this is a transparent, import-safe swap. The same change is applied to the fat-bundle vendor step (`jaclang.scale.utils.vendor_wheels`).

## Verification

Reproduced and validated against the real release binaries in a linux/arm64 container:

- Old behavior (0.35.0 binary running the 0.34.7 seal script): reproduces the exact production error above, no `.jab`.
- New behavior (bootstrap, binary's own precompile): produces `_precompiled/MANIFEST.json`, exit 0.
- Same-version regression (0.34.7 binary + bootstrap): produces the manifest, exit 0, no regression.
- Vendor bootstrap: the import resolves and `vendor_wheels`' own `main` runs.
- `jac fmt --check` and `jac check` pass on the changed file.

## Companion

The same fix is needed on `main`: a 0.35.0 builder deploying any other pinned version hits the identical cross-version seal. A separate PR against `main` will follow.
