### PR TITLE
fix(scale): seal with the pod binary's own precompile, not the builder's

### DIFF
--- a/jac/jaclang/scale/injector/bundle.jac
+++ b/jac/jaclang/scale/injector/bundle.jac
@@ -206,9 +206,12 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
         jac_path = stage_root / ".pod-jac";
         jac_path.write_bytes(pod_binary);
         jac_path.chmod(0o755);
-        script = Path(str(__file__)).parent.parent.parent
-            / "utils"
-            / "precompile_bytecode.jac";
+        script = stage_root / "pod_seal_boot.jac";
+        script.write_text(
+            "import from jaclang.utils.precompile_bytecode { main }\n"
+            "with entry:__main__ { main(); }\n",
+            encoding="utf-8"
+        );
 
         result = subprocess.run(
             [str(jac_path), "run", str(script), str(stage_root), "--seal"],
@@ -217,6 +220,7 @@ def _precompile_app(base: Path, pod_binary: bytes) -> Path {
             timeout=600
         );
         jac_path.unlink();
+        script.unlink();
         if (
             result.returncode != 0
             or not (stage / "_precompiled" / "MANIFEST.json").is_file()
@@ -267,7 +271,12 @@ def _vendor_stage(stage: Path, sanitized_toml: (str | None), pod_binary: bytes) 
     jac_path = stage.parent / ".pod-jac";
     jac_path.write_bytes(pod_binary);
     jac_path.chmod(0o755);
-    script = Path(str(__file__)).parent.parent / "utils" / "vendor_wheels.jac";
+    script = stage.parent / "pod_vendor_boot.jac";
+    script.write_text(
+        "import from jaclang.scale.utils.vendor_wheels { main }\n"
+        "with entry:__main__ { main(); }\n",
+        encoding="utf-8"
+    );
     try {
         result = subprocess.run(
             [str(jac_path), "run", str(script), str(stage)],
@@ -277,6 +286,7 @@ def _vendor_stage(stage: Path, sanitized_toml: (str | None), pod_binary: bytes) 
         );
     } finally {
         jac_path.unlink(missing_ok=True);
+        script.unlink(missing_ok=True);
     }
     if (result.returncode != 0 or not (stage / "_vendor" / "VENDOR.json").is_file()) {
         raise RuntimeError(


### PR DESCRIPTION
## Problem

Deploying an app whose pinned jac version differs from the builder's own version fails at the app-seal step, so no `.jab` is produced. The failure goes both ways:

- 0.34.7 builder deploying a 0.35.0 pin: `module 'jaclang.jac0core.ext_registry' has no attribute 'is_native_module'`
- 0.35.0 builder deploying a 0.34.7 pin: `No module named 'jaclang.jac0core.placement_pins'`

```
App seal did not complete, so the deploy cannot produce a .jab
```

## Root cause

`_precompile_app` (and `_vendor_stage`) run the seal by handing the builder's own local `precompile_bytecode.jac` to the downloaded pod binary:

```
script = Path(__file__).../utils/precompile_bytecode.jac
subprocess.run([pod_binary, "run", script, stage_root, "--seal"])
```

The script source is the builder's version, but its `import from jaclang...` resolve to the pod binary's bundled runtime. When the two versions differ, script and runtime are incompatible (the native/client placement internals were rewritten between 0.34.x and 0.35.x), so the seal crashes.

## Fix

Run the pod binary's own bundled precompile (and vendor) via a small bootstrap that imports `main` from the binary's own module, so the seal logic is always version consistent with the binary it runs on:

```
import from jaclang.utils.precompile_bytecode { main }
with entry:__main__ { main(); }
```

`main` reads `sys.argv[1:]` on all versions and is guarded by `with entry:__main__`, so this is a transparent, import-safe swap. The same change is applied to the fat-bundle vendor step (`jaclang.scale.utils.vendor_wheels`).

## Verification

Reproduced and validated against the real release binaries in a linux/arm64 container:

- 0.34.7 builder + 0.35.0 target, old behavior: reproduces `ext_registry has no attribute is_native_module`, no `.jab`.
- 0.35.0 builder + 0.34.7 target, old behavior: reproduces `No module named 'jaclang.jac0core.placement_pins'`, no `.jab`.
- New behavior (bootstrap, binary's own precompile): produces `_precompiled/MANIFEST.json`, exit 0, in both directions.
- Same-version case (0.34.7 and 0.35.0 each running their own bundled precompile): produces the manifest, exit 0, no regression.
- Vendor bootstrap: the import resolves and `vendor_wheels`' own `main` runs.
- `jac fmt --check` and `jac check` pass on the changed file (checked with the 0.35.0 binary).

## Companion

Same fix for the stable branch: PR against `release/jaclang-0.34.7` (#7811).
