### PR TITLE
fix(fmt): reindent operator-chain wrap in compiler.jac missed by the #7785 sweep

### DIFF
--- a/jac/jaclang/jac0core/compiler.jac
+++ b/jac/jaclang/jac0core/compiler.jac
@@ -346,7 +346,7 @@ def hub_module_for_path(path: str, prog: object) -> (uni.Module | None) {
     normalized = os.path.normcase(os.path.realpath(abs_path));
     for (hub_path, hub_mod) in hub.items() {
         if os.path.normcase(os.path.realpath(os.path.abspath(hub_path)))
-        == normalized {
+            == normalized {
             return hub_mod;
         }
     }


### PR DESCRIPTION
## **Description**

Main CI's `jac-check` job is failing on the `jac fmt` check: `jac/jaclang/jac0core/compiler.jac` has an operator-chain continuation line indented under the pre-#7785 rules.

#7799 added the wrapped `==` comparison in `hub_module_for_path` formatted the old way, and #7785's repo-wide sweep was run on a branch that predated that line, so it was missed. The runs in between were cancelled by the concurrency group, so the failure only surfaced on later pushes to main.

One-line reindent; `jac fmt --check` now passes clean on the file.