### PR TITLE
ci: keep the latest pointers off backport releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -501,13 +501,24 @@ jobs:
       - name: Compute image tags
         id: tags
         if: env.DOCKERHUB_USERNAME != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           IMAGE="jaseci/jaclang"
+          VERSION="${{ steps.ver.outputs.version }}"
           if [ "${{ inputs.channel }}" = "dev" ]; then
             TAGS="$IMAGE:dev"
           else
-            TAGS="$IMAGE:${{ steps.ver.outputs.version }},$IMAGE:latest"
+            # :latest never moves backwards: a backport (0.34.8 after 0.35.0)
+            # pushes its version tag only. Mirrors release.yml's publish guard.
+            TAGS="$IMAGE:${VERSION}"
+            latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || echo "")"
+            if [ "$(printf '%s\n%s\n' "${latest_tag#v}" "$VERSION" | sort -V | tail -1)" = "$VERSION" ]; then
+              TAGS="$TAGS,$IMAGE:latest"
+            else
+              echo "Backport: $latest_tag stays :latest, pushing $IMAGE:$VERSION only."
+            fi
           fi
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,18 +297,24 @@ jobs:
             sleep 5
           done
 
-          # Flip draft -> published + latest in one PATCH, but only while it is
-          # still a draft. A re-run, or an action=publish dispatch from an older
-          # commit, must not drag `--latest` back onto an older version --
-          # install.sh resolves latest, so that would silently downgrade users.
-          # (Same idempotency tag-and-release applies to draft/latest state.)
+          # Flip draft -> published, but `--latest` must never move backwards:
+          # install.sh resolves latest, so a re-run or a backport release
+          # (0.34.8 after 0.35.0) would silently downgrade users. The draft is
+          # invisible to /releases/latest, so that is the published newest.
           is_draft="$(gh release view "$VTAG" --json isDraft --jq '.isDraft' 2>/dev/null || echo true)"
           if [ "$is_draft" = "true" ]; then
+            latest_tag="$(gh api "repos/${GH_REPO}/releases/latest" --jq .tag_name 2>/dev/null || echo "")"
+            if [ "$(printf '%s\n%s\n' "${latest_tag#v}" "$VERSION" | sort -V | tail -1)" = "$VERSION" ]; then
+              latest_flag="--latest"
+            else
+              latest_flag="--latest=false"
+              echo "Backport: $latest_tag stays latest, $VTAG publishes without the pointer."
+            fi
             gh release edit "$VTAG" \
               --verify-tag \
               --draft=false \
-              --latest
-            echo "Published $VTAG as latest with all assets attached."
+              "$latest_flag"
+            echo "Published $VTAG ($latest_flag) with all assets attached."
           else
             echo "$VTAG is already published; leaving the latest pointer untouched."
           fi


### PR DESCRIPTION
## Problem

The release pipeline assumes every release is the newest one. On publish it always does two things:

1. marks the release as **Latest** on GitHub (which `install.sh` resolves), and
2. pushes the Docker image as `jaseci/jaclang:latest`.

That breaks for a **backport** — a patch for an older line cut after a newer version already shipped. Today: releasing 0.34.8 after 0.35.0 was out repointed both "latest" pointers at the *older* version, silently downgrading anyone installing or pulling latest, and both pointers had to be flipped back by hand.

## Fix

Before moving either pointer, compare the releasing version against the current latest release (`/releases/latest` + `sort -V` — the in-flight draft is invisible to that endpoint, so it is always the published newest):

- **release.yml (publish job)**: a backport publishes with `--latest=false` — fully public, pointer untouched.
- **build-binaries.yml (docker-image job)**: a backport pushes `jaseci/jaclang:<version>` only, skipping `:latest`.

Normal forward releases are unchanged (newer version wins the comparison → pointers move as before), including the first-ever release (no current latest → pointers move).

**In one line: release anything from any line, and "latest" always keeps meaning the highest version.**
