### PR TITLE
docs(skills): entry abilities cover async+deps effects; manual useEffect only for acquire/release pairs

### DIFF
--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -111,11 +111,24 @@ Use the matching type even when you don't read `e`; for an event not in the tabl
 | `async can with entry { ... }` | same, body wrapped in an async IIFE |
 | `can with [dep] entry { ... }` | `useEffect(fn, [dep])` - re-runs when `dep` changes |
 | `can with (a, b) entry { ... }` | `useEffect(fn, [a, b])` |
+| `async can with [dep] entry { ... }` | async IIFE + `[dep]` - async and deps COMPOSE |
 | `can with exit { ... }` | `useEffect(() => () => { ... }, [])` - cleanup on unmount |
 
 Multiple `can with entry` blocks in one component are fine and good for separating concerns - each compiles to its own `useEffect`, and dep-array effects (`can with [darkMode] entry`) sit alongside the mount effects.
 
-⚠ **`entry` and `exit` compile to SEPARATE `useEffect` closures.** A handle created in `can with entry` (interval id, WebSocket, listener) is **invisible** in `can with exit` - the cleanup silently no-ops. For acquire-then-release pairs, use a single manual `useEffect` whose body returns the cleanup - and the outer lambda must NOT be annotated `-> None` (it returns a function):
+`async` and dependency arrays compose freely - the "await something whenever a prop changes" effect (re-fetch on a new query, re-render a diagram from new source, reload on a route param) is a single entry ability, NOT a manual `useEffect` with `.then()` chains:
+
+```jac
+async can with [query] entry {          # re-runs whenever `query` changes
+    try {
+        results = await search_items(query);
+    } except Exception {
+        failed = True;
+    }
+}
+```
+
+⚠ **`entry` and `exit` compile to SEPARATE `useEffect` closures.** A handle created in `can with entry` (interval id, WebSocket, listener) is **invisible** in `can with exit` - the cleanup silently no-ops. That acquire-then-release pair - a handle created in the effect that its cleanup must release - is the ONLY reason to import `useEffect` and write it manually, with the body returning the cleanup (the outer lambda must NOT be annotated `-> None` - it returns a function). Async work, dep arrays, and promise-returning libraries are NOT reasons - the entry-ability forms above cover all of them. Litmus test: if your manual `useEffect` would end in an empty `return lambda { };`, you have no release to do - delete it and write `can with entry`:
 
 ```jac
 import from "react" { useEffect }

--- a/jac/jaclang/cli/skills/jac-cl-js-interop.md
+++ b/jac/jaclang/cli/skills/jac-cl-js-interop.md
@@ -74,7 +74,7 @@ Consuming a server-sent-event stream (raw `fetch` + `resp.body.getReader()` agai
 
 ## CustomEvent - cross-component bus
 
-Dispatch: `window.dispatchEvent(new(CustomEvent, "theme-change", {"detail": {"theme": t}}));`. Listen in a single manual `useEffect` (so add/remove share the handler closure - see the entry/exit split warning in `jac-cl-components`):
+Dispatch: `window.dispatchEvent(new(CustomEvent, "theme-change", {"detail": {"theme": t}}));`. Listening is an acquire-then-release pair (addEventListener/removeEventListener must share the handler closure), so this is one of the rare cases for a manual `useEffect` - see the entry/exit split warning in `jac-cl-components`. Effects with no handle to release stay `can with entry` abilities even here in interop land:
 
 ```
 useEffect(lambda {
@@ -90,7 +90,7 @@ useEffect(lambda {
 
 ## Timing patterns (all use `Ref` value fields - see `jac-npm-packages`)
 
-- **Polling:** single `useEffect` returning cleanup - `interval = setInterval(lambda { fetch_data(); }, 5000); return lambda { clearInterval(interval); };`. Outer lambda must NOT be `-> None`.
+- **Polling:** an acquire/release pair (setInterval/clearInterval), so a manual `useEffect` returning cleanup - `interval = setInterval(lambda { fetch_data(); }, 5000); return lambda { clearInterval(interval); };`. Outer lambda must NOT be `-> None`. (No interval/listener/socket to release? Then it's not this pattern - use `can with entry`, see `jac-cl-components`.)
 - **Debounce:** `has timerRef: Ref[any] = Ref(None);` - on each call `if timerRef.current { clearTimeout(timerRef.current); } timerRef.current = setTimeout(lambda { doSave(); }, 2000);`.
 - **RAF batching:** `if rafRef.current { return; } rafRef.current = requestAnimationFrame(lambda { rafRef.current = None; applyPosition(lastX.current); });`.
 - **Duplicate-submit guard:** `has sendingRef: Ref[bool] = Ref(False);` - check/set around the awaited call in a `try`/`finally`.


### PR DESCRIPTION
## Summary

Tightens the effect guidance in the two client skills so the entry-ability forms are used everywhere they can be, and manual `useEffect` is reserved for the one case that actually needs it.

- `jac-cl-components`: documents that `async` and dependency arrays compose (`async can with [dep] entry`), with an example for the await-on-prop-change pattern; sharpens the entry/exit split warning into a rule — manual `useEffect` is only for acquire-then-release pairs, with a litmus test (an empty `return lambda { };` cleanup means it should be an entry ability).
- `jac-cl-js-interop`: frames the CustomEvent listener and polling patterns explicitly as acquire/release pairs so they read as the exception, not the default, and points effects with nothing to release back to `can with entry`.