### PR TITLE
docs(skills): make the cl-components dep-array effect example self-contained (fixes red test-runtime on main)

### DIFF
--- a/jac/jaclang/cli/skills/jac-cl-components.md
+++ b/jac/jaclang/cli/skills/jac-cl-components.md
@@ -119,12 +119,21 @@ Multiple `can with entry` blocks in one component are fine and good for separati
 `async` and dependency arrays compose freely - the "await something whenever a prop changes" effect (re-fetch on a new query, re-render a diagram from new source, reload on a route param) is a single entry ability, NOT a manual `useEffect` with `.then()` chains:
 
 ```jac
-async can with [query] entry {          # re-runs whenever `query` changes
-    try {
-        results = await search_items(query);
-    } except Exception {
-        failed = True;
+async def search_items(query: str) -> list[str];
+
+def:pub SearchResults(query: str) -> JsxElement {
+    has results: list[str] = [];
+    has failed: bool = False;
+
+    async can with [query] entry {          # re-runs whenever `query` changes
+        try {
+            results = await search_items(query);
+        } except Exception {
+            failed = True;
+        }
     }
+
+    <ul>{for r in results { <li>{r}</li> }}</ul>
 }
 ```
 

--- a/release_notes/unreleased/jaclang/7844.docs.md
+++ b/release_notes/unreleased/jaclang/7844.docs.md
@@ -1,0 +1,1 @@
+- **Docs: self-contained dep-array effect example in the cl-components guide**: the async+deps effect example was a bare ability fragment that failed the guide-examples gate (E2018 on `query`); it is now a complete component showing `query` as a prop, `has` state, and the `async can with [query] entry` re-run pattern.


### PR DESCRIPTION
## Problem

`test-runtime` is red on main since #7840: the new async+deps effect example in the `jac-cl-components` guide is a bare ability fragment inside a ```` ```jac ```` fence, and the guide-examples gate (`test_guide.jac::every jac example in a guide checks clean`) checks every such fence with `jac check`:

```
--- jac-cl-components block #4 ---
error[E2018]: Undefined name 'query' in ability trigger position
```

Every open PR inherits this failure through the merge preview (e.g. #7841's `test-runtime`).

## Fix

Per the gate's stated convention (a ```` ```jac ```` fence must be a complete example that checks clean; non-runnable fragments use a plain fence -- and self-contained is preferred), the fragment is now a full component in the guide's established shape: `query` as a prop, `results`/`failed` as `has` state, an `async def` server-stub declaration, and the same `async can with [query] entry` body the prose is teaching.

Verified with the exact failing gate: `jac test -t every jac/tests/language/test_guide.jac` passes (5 passed), which sweeps every ```` ```jac ```` block in every guide.
