### PR TITLE
fix(jacignore): restore 7 entries that still suppress full-run errors

### DIFF
--- a/.jacignore
+++ b/.jacignore
@@ -154,10 +154,12 @@ jac/jaclang/cli/commands/impl/build.impl.jac
 jac/jaclang/cli/commands/impl/db.impl.jac
 jac/jaclang/cli/commands/impl/eject.impl.jac
 jac/jaclang/cli/commands/tools.jac
+jac/jaclang/cli/executor.jac
 jac/jaclang/cli/impl/ai_agent.impl.jac
 jac/jaclang/cli/impl/browser_engine.impl.jac
 jac/jaclang/cli/impl/cli.impl.jac
 jac/jaclang/cli/impl/console.impl.jac
+jac/jaclang/cli/impl/executor.impl.jac
 jac/jaclang/cli/mcp/impl/protocol.impl.jac
 jac/jaclang/cli/mcp/protocol.jac
 jac/jaclang/cli/shadcn/cli.jac
@@ -194,6 +196,7 @@ jac/jaclang/compiler/symbol_utils.jac
 jac/jaclang/compiler/targets/abi.jac
 jac/jaclang/compiler/targets/foreign.jac
 jac/jaclang/compiler/type_system/impl/type_utils.impl.jac
+jac/jaclang/compiler/type_system/operations.jac
 jac/jaclang/compiler/type_system/type_evaluator.impl/jsx_type_check.impl.jac
 jac/jaclang/compiler/type_system/type_evaluator.impl/ts_declarations.impl.jac
 jac/jaclang/jac0core/archetype.jac
@@ -201,6 +204,7 @@ jac/jaclang/jac0core/gen_uni_dispatch.jac
 jac/jaclang/jac0core/impl/archetype.impl.jac
 jac/jaclang/jac0core/impl/helpers.impl.jac
 jac/jaclang/jac0core/impl/native_marshal.impl.jac
+jac/jaclang/jac0core/impl/program.impl.jac
 jac/jaclang/jac0core/impl/runtime.impl.jac
 jac/jaclang/jac0core/jaclib.jac
 jac/jaclang/jac0core/log.jac
@@ -213,11 +217,14 @@ jac/jaclang/jac0core/passes/impl/boundary_analysis_pass.impl.jac
 jac/jaclang/jac0core/passes/impl/transform.impl.jac
 jac/jaclang/jac0core/passes/impl/uni_pass.impl.jac
 jac/jaclang/jac0core/passes/transform.jac
+jac/jaclang/jac0core/program.jac
 jac/jaclang/jac0core/unitree.impl/accept.impl.jac
 jac/jaclang/jac0core/unitree.impl/dispatch.impl.jac
 jac/jaclang/langserve/utils.jac
 jac/jaclang/lib.jac
 jac/jaclang/project/config.jac
+jac/jaclang/project/impl/template_registry.impl.jac
+jac/jaclang/project/template_registry.jac
 jac/jaclang/publish/dts.jac
 jac/jaclang/publish/impl/dts.impl.jac
 jac/jaclang/publish/impl/jsdoc.impl.jac


### PR DESCRIPTION
## Problem

Main is red since #7794 (a47f06d51): the `jac-check` job fails with **594 passed, 7 failed** — 72 type errors (39× E1053, 27× E1002, 6× E1001) in:

- `jac/jaclang/cli/executor.jac` + `jac/jaclang/cli/impl/executor.impl.jac`
- `jac/jaclang/project/template_registry.jac` + `jac/jaclang/project/impl/template_registry.impl.jac`
- `jac/jaclang/jac0core/program.jac` + `jac/jaclang/jac0core/impl/program.impl.jac`
- `jac/jaclang/compiler/type_system/operations.jac`

Failing run: https://github.com/jaseci-labs/jac/actions/runs/30801432329

All 7 correspond to entries #7794 removed as "no longer suppressing anything". That verification was misleading: the errors are all of the duplicate type-identity flavor (`Cannot assign JacProgram to parameter 'target_program' of type JacProgram`) which only trigger in **full-repo** `jac check` — the same 7 files pass when checked in isolation. PR CI runs jac-check scoped to changed `.jac` files (and #7794 changed none), so it stayed green; push-to-main runs full mode and failed.

## Fix

Restore ignore entries for exactly those 7 files, as full paths in sorted position (the old entries for 5 of them were bare basenames like `program.jac`; full paths keep the suppression as narrow as possible).

## Follow-ups worth considering

- Run jac-check in full mode on PRs that touch `.jacignore`, so ignore-list changes can't land green without full-run coverage.
- The underlying checker duplicate-type-identity issue (same class imported via two paths treated as distinct types) is the real fix that would let these entries go.